### PR TITLE
Add bench harness for fts and for vector search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,3 +221,15 @@ path = "tests/superfile/main.rs"
 name = "supertable"
 path = "tests/supertable/main.rs"
 
+# Infino-only bench bundles. One criterion binary per topic, with
+# superfile + supertable sub-groups inside each. Head-to-head numbers
+# vs Tantivy / LanceDB live in the sibling retrievalbench repo —
+# nothing in this crate's bench tree depends on either competitor.
+[[bench]]
+name = "fts"
+path = "benches/fts/main.rs"
+
+[[bench]]
+name = "vector"
+path = "benches/vector/main.rs"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,10 +221,9 @@ path = "tests/superfile/main.rs"
 name = "supertable"
 path = "tests/supertable/main.rs"
 
-# Infino-only bench bundles. One criterion binary per topic, with
-# superfile + supertable sub-groups inside each. Head-to-head numbers
-# vs Tantivy / LanceDB live in the sibling retrievalbench repo —
-# nothing in this crate's bench tree depends on either competitor.
+# Bench bundles. One criterion binary per topic (FTS, vector), each
+# wrapping superfile + supertable sub-groups so the topic ships as
+# a single `[[bench]]` stanza.
 [[bench]]
 name = "fts"
 path = "benches/fts/main.rs"

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,91 @@
+# infino benches
+
+Infino-only performance + correctness benches. Two criterion binaries:
+
+- `fts` — superfile (1M docs Zipfian) + supertable (10M docs)
+- `vector` — superfile (1M × 384 cosine) + supertable (10M × 384, 4 superfiles)
+
+Head-to-head numbers against Tantivy / LanceDB live in the sibling
+`retrievalbench` repo. The deliberate split: anyone building against
+infino in isolation gets the perf surface here without pulling in any
+competitor crates as transitive deps.
+
+## Invocation
+
+```sh
+cargo bench --bench fts                            # all FTS (1M + 10M)
+cargo bench --bench vector                         # all vector (1M + 10M)
+
+# Filter to one sub-group (criterion regex/prefix on the group name)
+cargo bench --bench fts -- superfile_fts_build     # superfile FTS ingest
+cargo bench --bench fts -- supertable_fts_search   # supertable FTS search
+cargo bench --bench vector -- superfile_vec_build  # superfile vector ingest
+cargo bench --bench vector -- supertable_vec_search # supertable vector search
+
+# Knobs
+INFINO_SUPERTABLE__WRITER_THREADS=32 cargo bench --bench fts -- supertable_fts_build
+INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts        # rewrite FTS result tables in place
+INFINO_BENCH_UPDATE_README=1 cargo bench --bench vector     # rewrite vector result tables in place
+```
+
+Every invocation runs the correctness phase unconditionally
+(criterion filters skip timing, not setup), so a filter to a search
+group still validates the BMW oracle (FTS) and the recall-floor gate
+(vector) before timing starts.
+
+## Result anchors
+
+Each table below is wrapped in
+`<!-- BEGIN: bench/... --> <!-- END: bench/... -->` markers; the bench's
+markdown emitter rewrites the content between these markers when
+`INFINO_BENCH_UPDATE_README=1` is set. Re-running a single bench with
+a criterion filter refreshes only the matching section.
+
+The retrievalbench sibling reads infino's measurements from
+`target/criterion/<group>/<bench>/new/estimates.json` directly (no
+parsing of this markdown is involved); the markdown here exists purely
+for human readers.
+
+---
+
+## Results
+
+### FTS — superfile (single-segment, 1M docs)
+
+<!-- BEGIN: bench/fts/superfile/ingest -->
+_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- superfile_fts_build` to populate_
+<!-- END: bench/fts/superfile/ingest -->
+
+<!-- BEGIN: bench/fts/superfile/search -->
+_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- superfile_fts_search` to populate_
+<!-- END: bench/fts/superfile/search -->
+
+### FTS — supertable (multi-segment, 10M docs)
+
+<!-- BEGIN: bench/fts/supertable/ingest -->
+_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- supertable_fts_build` to populate_
+<!-- END: bench/fts/supertable/ingest -->
+
+<!-- BEGIN: bench/fts/supertable/search -->
+_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- supertable_fts_search` to populate_
+<!-- END: bench/fts/supertable/search -->
+
+### Vector — superfile (single-segment, 1M × 384)
+
+<!-- BEGIN: bench/vector/superfile/ingest -->
+_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench vector -- superfile_vec_build` to populate_
+<!-- END: bench/vector/superfile/ingest -->
+
+<!-- BEGIN: bench/vector/superfile/search -->
+_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench vector -- superfile_vec_search` to populate_
+<!-- END: bench/vector/superfile/search -->
+
+### Vector — supertable (multi-segment, 10M × 384)
+
+<!-- BEGIN: bench/vector/supertable/ingest -->
+_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench vector -- supertable_vec_build` to populate_
+<!-- END: bench/vector/supertable/ingest -->
+
+<!-- BEGIN: bench/vector/supertable/search -->
+_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench vector -- supertable_vec_search` to populate_
+<!-- END: bench/vector/supertable/search -->

--- a/benches/README.md
+++ b/benches/README.md
@@ -5,10 +5,8 @@ Infino-only performance + correctness benches. Two criterion binaries:
 - `fts` — superfile (1M docs Zipfian) + supertable (10M docs)
 - `vector` — superfile (1M × 384 cosine) + supertable (10M × 384, 4 superfiles)
 
-Head-to-head numbers against Tantivy / LanceDB live in the sibling
-`retrievalbench` repo. The deliberate split: anyone building against
-infino in isolation gets the perf surface here without pulling in any
-competitor crates as transitive deps.
+These benches measure infino in isolation — no third-party crates
+enter this tree's dependency graph.
 
 ## Invocation
 
@@ -41,10 +39,10 @@ markdown emitter rewrites the content between these markers when
 `INFINO_BENCH_UPDATE_README=1` is set. Re-running a single bench with
 a criterion filter refreshes only the matching section.
 
-The retrievalbench sibling reads infino's measurements from
-`target/criterion/<group>/<bench>/new/estimates.json` directly (no
-parsing of this markdown is involved); the markdown here exists purely
-for human readers.
+The markdown here is purely for human readers. Programmatic
+consumers should read criterion's own
+`target/criterion/<group>/<bench>/new/estimates.json` directly,
+which is the structured source of truth the markdown is derived from.
 
 ---
 

--- a/benches/fts/main.rs
+++ b/benches/fts/main.rs
@@ -1,0 +1,30 @@
+//! FTS bench bundle (infino-only). Wraps the superfile (1M docs) and
+//! supertable (10M docs) FTS benches in a single criterion binary so
+//! the topic has one `[[bench]]` stanza in `Cargo.toml`.
+//!
+//! Head-to-head numbers against Tantivy live in the sibling
+//! `retrievalbench` repo — this bench is purely infino-only timing and
+//! correctness, suitable for shipping with the public infino release.
+//!
+//! ## Invocation
+//!
+//! ```text
+//! cargo bench --bench fts                                    # all FTS benches
+//! cargo bench --bench fts -- superfile_fts_build             # only superfile ingest
+//! cargo bench --bench fts -- superfile_fts_search            # only superfile search
+//! cargo bench --bench fts -- supertable_fts_build            # only supertable ingest
+//! cargo bench --bench fts -- supertable_fts_search           # only supertable search
+//! cargo bench --bench fts -- _build                          # both ingest groups
+//! cargo bench --bench fts -- _search                         # both search groups
+//! INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts       # rewrite README sections
+//! ```
+
+#[path = "../utils/markdown.rs"]
+mod markdown;
+
+#[path = "superfile.rs"]
+mod superfile;
+#[path = "supertable.rs"]
+mod supertable;
+
+criterion::criterion_main!(superfile::benches, supertable::benches);

--- a/benches/fts/main.rs
+++ b/benches/fts/main.rs
@@ -2,9 +2,8 @@
 //! supertable (10M docs) FTS benches in a single criterion binary so
 //! the topic has one `[[bench]]` stanza in `Cargo.toml`.
 //!
-//! Head-to-head numbers against Tantivy live in the sibling
-//! `retrievalbench` repo — this bench is purely infino-only timing and
-//! correctness, suitable for shipping with the public infino release.
+//! Infino-only timing and correctness — no third-party crates in
+//! the dependency graph of these benches.
 //!
 //! ## Invocation
 //!

--- a/benches/fts/superfile.rs
+++ b/benches/fts/superfile.rs
@@ -1,0 +1,391 @@
+//! Infino-only FTS bench for the superfile layer:
+//!
+//!   ingest timing (single-thread + rayon-sharded multi-thread)
+//! + 7-query search timing
+//! + 3 per-algorithm (WAND+BMW vs MaxScore+BMM) probes
+//! + correctness gates (BMW-vs-brute-force, df=1 + common-term ordering)
+//!
+//! Pinned to 1M-doc Zipfian (200 tokens/doc, 10K vocab). The
+//! single-superfile shape is rarely much larger in production —
+//! `benches/fts/supertable.rs` covers the 10M+ supertable scale.
+//!
+//! ## Invocation
+//!
+//! ```text
+//! cargo bench --bench fts                            # all FTS benches
+//! cargo bench --bench fts -- superfile_fts_build     # only superfile ingest
+//! cargo bench --bench fts -- superfile_fts_search    # only superfile search
+//! cargo bench --bench fts -- _build                  # ingest across superfile + supertable
+//! ```
+//!
+//! Correctness phase runs unconditionally on every invocation
+//! (criterion filters skip timing, not setup), so a filter to
+//! `superfile_fts_search` still validates the BMW oracle before
+//! timing kicks in.
+
+use bytes::Bytes;
+use criterion::{Criterion, Throughput, criterion_group};
+use infino::superfile::fts::builder::FtsBuilder;
+use infino::superfile::fts::reader::{BoolMode, FtsReader, OrAlgo};
+use infino::test_helpers::bench_corpus;
+use infino::test_helpers::default_tokenizer;
+use rayon::prelude::*;
+use std::hint::black_box;
+use std::sync::OnceLock;
+
+// ─── Constants ────────────────────────────────────────────────────────
+
+const FTS_COLUMNS_JSON: &str = r#"[{"name":"title","tokenizer":"ascii_lower"}]"#;
+
+/// Doc count for every FTS-superfile bench. Pinned to 1M.
+const N_DOCS: usize = 1_000_000;
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+
+static DOCS: OnceLock<Vec<String>> = OnceLock::new();
+static INFINO_BLOB: OnceLock<Vec<u8>> = OnceLock::new();
+
+fn docs() -> &'static [String] {
+    DOCS.get_or_init(|| bench_corpus::generate_text_corpus(N_DOCS, 1))
+        .as_slice()
+}
+
+fn infino_reader() -> FtsReader {
+    let blob = INFINO_BLOB.get_or_init(|| build_infino_blob_1thread(docs()));
+    open_infino(blob)
+}
+
+// ─── Builders ─────────────────────────────────────────────────────────
+
+/// Build an FTS blob single-threaded. Used as both correctness fixture
+/// and ingest-timing closure body.
+fn build_infino_blob_1thread(docs: &[String]) -> Vec<u8> {
+    let mut builder = FtsBuilder::new(default_tokenizer());
+    builder
+        .register_column("title".to_string())
+        .expect("register column");
+    for (i, text) in docs.iter().enumerate() {
+        builder.add_doc(0, i as u32, text).expect("add doc");
+    }
+    builder.finish()
+}
+
+/// Rayon-sharded parallel build. Each shard runs its own `FtsBuilder`
+/// and emits a self-contained FTS blob — composes with
+/// `SuperfileBuilder::commit()`'s multi-segment output shape.
+fn build_infino_blobs_rayon(docs: &[String]) -> Vec<Vec<u8>> {
+    let n_shards = rayon::current_num_threads();
+    let docs_per_shard = docs.len().div_ceil(n_shards);
+    docs.chunks(docs_per_shard)
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(build_infino_blob_1thread)
+        .collect()
+}
+
+fn open_infino(blob: &[u8]) -> FtsReader {
+    FtsReader::open(Bytes::from(blob.to_vec()), FTS_COLUMNS_JSON).expect("open FtsReader")
+}
+
+// ─── Correctness ──────────────────────────────────────────────────────
+
+/// Self-consistency sanity on an infino blob: a known df=1 token
+/// returns exactly one hit at the matching doc_id; a known
+/// Zipfian-common term fills top-10 in descending-score order.
+fn assert_infino_self_consistent(reader: &FtsReader) {
+    let hits = reader
+        .search("title", &["doc0500000"], 10, BoolMode::Or)
+        .expect("search df=1");
+    assert_eq!(hits.len(), 1, "df=1 term should return exactly one hit");
+    assert_eq!(hits[0].0, 500_000, "doc0500000 should match doc_id 500000");
+
+    let hits = reader
+        .search("title", &["term00001"], 10, BoolMode::Or)
+        .expect("search common");
+    assert_eq!(hits.len(), 10, "common term should fill top-10");
+    for w in hits.windows(2) {
+        assert!(
+            w[0].1 >= w[1].1,
+            "results must be sorted by score desc; got {} then {}",
+            w[0].1,
+            w[1].1
+        );
+    }
+}
+
+/// BMW correctness oracle: for each query, compare BMW's top-10 against
+/// an effectively-brute-force ranking from the same engine. Catches BMW
+/// skip bugs, BMM partition bugs, and posting-decode bugs that affect
+/// ranking — without needing an external oracle.
+///
+/// How it works: `search(... k=usize::MAX, BoolMode::Or)` makes BMW's
+/// pruning never fire (heap never threshold-tightens because k > df),
+/// so the result is the brute-force BM25 ranking. We sort + truncate to
+/// top-10 and compare position-by-position.
+///
+/// Comparing scores not doc_ids: at score ties (common at the top-K
+/// boundary on Zipfian corpora), BMW's heap keeps the first-arrived doc
+/// while brute-force sort breaks ties by smallest doc_id. Same correct
+/// result, different choice from the tied set. Comparing scores
+/// sidesteps that.
+fn assert_bmw_matches_brute_force(reader: &FtsReader) -> usize {
+    let battery: &[(&str, &[&str])] = &[
+        ("single_rare", &["term09999"]),
+        ("single_common", &["term00001"]),
+        ("two_term_or", &["term00001", "term00050"]),
+        ("three_wide", &["term00001", "term00050", "term00100"]),
+        ("three_similar", &["term00050", "term00051", "term00052"]),
+        (
+            "five_term",
+            &[
+                "term00050", "term00051", "term00052", "term00053", "term00054",
+            ],
+        ),
+    ];
+    const SCORE_EPSILON: f32 = 1e-4;
+
+    for (label, terms) in battery {
+        let bmw_top10: Vec<(u32, f32)> = reader
+            .search("title", terms, 10, BoolMode::Or)
+            .expect("bmw search");
+        let mut brute_full = reader
+            .search("title", terms, usize::MAX, BoolMode::Or)
+            .expect("brute-force search");
+        brute_full.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.0.cmp(&b.0))
+        });
+        let brute_top10: Vec<(u32, f32)> = brute_full.into_iter().take(10).collect();
+
+        assert_eq!(
+            bmw_top10.len(),
+            brute_top10.len(),
+            "result lengths must match on {label}: BMW {} vs brute {}",
+            bmw_top10.len(),
+            brute_top10.len()
+        );
+        for i in 0..bmw_top10.len() {
+            let (bmw_doc, bmw_score) = bmw_top10[i];
+            let (brute_doc, brute_score) = brute_top10[i];
+            let diff = (bmw_score - brute_score).abs();
+            if diff > SCORE_EPSILON {
+                let bmw_seq: Vec<f32> = bmw_top10.iter().map(|(_, s)| *s).collect();
+                let brute_seq: Vec<f32> = brute_top10.iter().map(|(_, s)| *s).collect();
+                panic!(
+                    "BMW vs brute-force score divergence at position {i} on {label} ({terms:?}):\n  \
+                     BMW score = {bmw_score} (doc {bmw_doc})\n  \
+                     brute score = {brute_score} (doc {brute_doc})\n  \
+                     diff = {diff} > epsilon {SCORE_EPSILON}\n  \
+                     BMW scores  : {bmw_seq:?}\n  \
+                     brute scores: {brute_seq:?}"
+                );
+            }
+        }
+    }
+    battery.len()
+}
+
+// ─── Bench helpers ────────────────────────────────────────────────────
+
+fn bench_infino(c: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+                name: &str, r: &FtsReader, terms: &'static [&'static str]) {
+    c.bench_function(format!("{name}_infino_top10"), |b| {
+        b.iter(|| {
+            let hits = r
+                .search(
+                    black_box("title"),
+                    black_box(terms),
+                    black_box(10),
+                    BoolMode::Or,
+                )
+                .expect("infino search");
+            black_box(hits)
+        });
+    });
+}
+
+fn bench_per_algo_probe(c: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+                        name: &str, r: &FtsReader, terms: &'static [&'static str]) {
+    c.bench_function(format!("{name}_wand_top10"), |b| {
+        b.iter(|| {
+            let hits = r
+                .search_with_algo_for_bench(
+                    black_box("title"),
+                    black_box(terms),
+                    black_box(10),
+                    OrAlgo::WandBmw,
+                )
+                .expect("WAND+BMW search");
+            black_box(hits)
+        });
+    });
+    c.bench_function(format!("{name}_bmm_top10"), |b| {
+        b.iter(|| {
+            let hits = r
+                .search_with_algo_for_bench(
+                    black_box("title"),
+                    black_box(terms),
+                    black_box(10),
+                    OrAlgo::Bmm,
+                )
+                .expect("MaxScore+BMM search");
+            black_box(hits)
+        });
+    });
+}
+
+// ─── Bench entry ──────────────────────────────────────────────────────
+
+fn bench(c: &mut Criterion) {
+    // ---- Correctness phase (runs regardless of criterion filter) ---
+    eprintln!("[fts/superfile] correctness: building infino ({N_DOCS} docs)...");
+    let r = infino_reader();
+    assert_infino_self_consistent(&r);
+    let n_bmw = assert_bmw_matches_brute_force(&r);
+    eprintln!(
+        "[fts/superfile] correctness OK: infino self-consistent + {n_bmw} queries BMW==brute-force"
+    );
+
+    // ---- Ingest sub-bench (group: superfile_fts_build) -------------
+    {
+        let n = N_DOCS;
+        let docs_for_ingest = docs();
+        let mut g = c.benchmark_group("superfile_fts_build");
+        g.sample_size(10);
+        g.throughput(Throughput::Elements(n as u64));
+
+        g.bench_function(format!("infino_1thread_{n}docs"), |b| {
+            b.iter_with_large_drop(|| build_infino_blob_1thread(black_box(docs_for_ingest)));
+        });
+        g.bench_function(format!("infino_rayon_default_threads_{n}docs"), |b| {
+            b.iter_with_large_drop(|| build_infino_blobs_rayon(black_box(docs_for_ingest)));
+        });
+        g.finish();
+
+        emit_ingest_markdown();
+    }
+
+    // ---- Search sub-bench (group: superfile_fts_search) ------------
+    {
+        let mut g = c.benchmark_group("superfile_fts_search");
+
+        bench_infino(&mut g, "single_rare", &r, &["term09999"]);
+        bench_infino(&mut g, "single_df1", &r, &["doc0500000"]);
+        bench_infino(&mut g, "single_common", &r, &["term00001"]);
+        bench_infino(&mut g, "two_term_or", &r, &["term00001", "term00050"]);
+        bench_infino(&mut g, "three_wide", &r, &["term00001", "term00050", "term00100"]);
+        bench_infino(&mut g, "three_similar", &r, &["term00050", "term00051", "term00052"]);
+        bench_infino(
+            &mut g,
+            "five_term",
+            &r,
+            &[
+                "term00050", "term00051", "term00052", "term00053", "term00054",
+            ],
+        );
+
+        // Per-algo probes
+        bench_per_algo_probe(
+            &mut g,
+            "wide_3",
+            &r,
+            &["term00001", "term00050", "term00100"],
+        );
+        bench_per_algo_probe(
+            &mut g,
+            "similar_3",
+            &r,
+            &["term00050", "term00051", "term00052"],
+        );
+        bench_per_algo_probe(
+            &mut g,
+            "similar_5",
+            &r,
+            &[
+                "term00050", "term00051", "term00052", "term00053", "term00054",
+            ],
+        );
+
+        g.finish();
+
+        emit_search_markdown();
+    }
+}
+
+// ─── Markdown summary emitters ────────────────────────────────────────
+
+fn emit_ingest_markdown() {
+    use crate::markdown::{MarkdownSection, fmt_throughput, fmt_time, read_mean_ns};
+
+    let mut body = String::new();
+    body.push_str(&format!(
+        "### Superfile FTS — ingest ({N_DOCS} docs, Zipfian, 200 tokens/doc, 10K vocab)\n\n"
+    ));
+    body.push_str("| Engine                       | Time       | Throughput |\n");
+    body.push_str("|------------------------------|------------|------------|\n");
+
+    let group = "superfile_fts_build";
+    let one_thread = read_mean_ns(group, &format!("infino_1thread_{N_DOCS}docs"));
+    let rayon = read_mean_ns(group, &format!("infino_rayon_default_threads_{N_DOCS}docs"));
+
+    let row = |label: &str, ns: Option<f64>| -> String {
+        let time = ns.map(fmt_time).unwrap_or_else(|| "—".into());
+        let thrpt = ns
+            .map(|n| fmt_throughput((N_DOCS as f64) / (n / 1e9)))
+            .unwrap_or_else(|| "—".into());
+        format!("| {label:28} | {time:10} | {thrpt:10} |\n")
+    };
+
+    body.push_str(&row("infino_1thread", one_thread));
+    body.push_str(&row("infino_rayon_default_threads", rayon));
+
+    crate::markdown::emit(&MarkdownSection {
+        anchor_id: "bench/fts/superfile/ingest".into(),
+        body,
+    });
+}
+
+fn emit_search_markdown() {
+    use crate::markdown::{MarkdownSection, fmt_time, read_mean_ns};
+
+    let mut body = String::new();
+    body.push_str(&format!("### Superfile FTS — search ({N_DOCS} docs)\n\n"));
+    body.push_str("| Query          | infino     |\n");
+    body.push_str("|----------------|------------|\n");
+
+    let group = "superfile_fts_search";
+    let queries = [
+        "single_rare",
+        "single_df1",
+        "single_common",
+        "two_term_or",
+        "three_wide",
+        "three_similar",
+        "five_term",
+    ];
+    for q in queries {
+        let inf = read_mean_ns(group, &format!("{q}_infino_top10"));
+        let inf_s = inf.map(fmt_time).unwrap_or_else(|| "—".into());
+        body.push_str(&format!("| {q:14} | {inf_s:10} |\n"));
+    }
+
+    body.push('\n');
+    body.push_str("**Per-algorithm probes** (WAND+BMW vs MaxScore+BMM):\n\n");
+    body.push_str("| Shape         | WAND+BMW   | MaxScore+BMM |\n");
+    body.push_str("|---------------|------------|--------------|\n");
+    for shape in ["wide_3", "similar_3", "similar_5"] {
+        let wand = read_mean_ns(group, &format!("{shape}_wand_top10"));
+        let bmm = read_mean_ns(group, &format!("{shape}_bmm_top10"));
+        let wand_s = wand.map(fmt_time).unwrap_or_else(|| "—".into());
+        let bmm_s = bmm.map(fmt_time).unwrap_or_else(|| "—".into());
+        body.push_str(&format!("| {shape:13} | {wand_s:10} | {bmm_s:12} |\n"));
+    }
+
+    crate::markdown::emit(&MarkdownSection {
+        anchor_id: "bench/fts/superfile/search".into(),
+        body,
+    });
+}
+
+criterion_group!(benches, bench);

--- a/benches/fts/supertable.rs
+++ b/benches/fts/supertable.rs
@@ -1,0 +1,312 @@
+//! Infino-only FTS bench for the supertable layer:
+//!
+//!   ingest timing (10M docs sharded into [`SEGMENTS`] commits)
+//! + 7-query search timing (single rare, single common, OR-2,
+//!   wide-3, similar-3, OR-5, prefix-10)
+//! + self-consistency correctness gate
+//!
+//! Multi-segment shape: the corpus is sharded into [`SEGMENTS`]
+//! commits. Infino's `commit()` row-shards into
+//! `min(writer_pool.threads, total_rows)` superfiles — the writer-pool
+//! size doubles as the output-cardinality dial (auto = `cpus/2`;
+//! override with `INFINO_SUPERTABLE__WRITER_THREADS=N`).
+//!
+//! ## Invocation
+//!
+//! ```text
+//! cargo bench --bench fts -- supertable_fts            # both groups
+//! cargo bench --bench fts -- supertable_fts_build      # ingest only
+//! cargo bench --bench fts -- supertable_fts_search     # search only
+//! INFINO_SUPERTABLE__WRITER_THREADS=32 cargo bench --bench fts -- supertable_fts_build
+//! ```
+
+use std::hint::black_box;
+use std::sync::{Arc, OnceLock};
+
+use arrow_array::{LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use criterion::{Criterion, Throughput, criterion_group};
+use infino::superfile::builder::FtsConfig;
+use infino::superfile::fts::reader::BoolMode;
+use infino::superfile::fts::tokenize::Tokenizer;
+use infino::supertable::{Supertable, SupertableOptions};
+use infino::test_helpers::bench_corpus;
+use infino::test_helpers::default_tokenizer;
+use rayon::ThreadPool;
+
+// ─── Constants ────────────────────────────────────────────────────────
+
+/// Doc count for every FTS-supertable bench. Pinned to 10M.
+const N_DOCS: usize = 10_000_000;
+
+/// Input chunk count. Drives the `append()`-batching shape; output
+/// superfile count is governed by writer_pool threads, not this knob.
+const SEGMENTS: usize = 4;
+
+const TOP_K: usize = 10;
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+
+static DOCS: OnceLock<Vec<String>> = OnceLock::new();
+static INFINO: OnceLock<Supertable> = OnceLock::new();
+
+fn docs() -> &'static [String] {
+    DOCS.get_or_init(|| bench_corpus::generate_text_corpus(N_DOCS, 1))
+        .as_slice()
+}
+
+fn infino_supertable() -> &'static Supertable {
+    INFINO.get_or_init(|| build_supertable_infino(docs(), parallel_pool()))
+}
+
+// ─── Shared rayon pool ────────────────────────────────────────────────
+
+/// `num_cpus`-sized pool used as infino's reader pool. Sized to the
+/// machine so the supertable's per-segment fan-out doesn't bottleneck
+/// on threads.
+fn parallel_pool() -> Arc<ThreadPool> {
+    static POOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
+    POOL.get_or_init(|| {
+        Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(num_cpus::get().max(1))
+                .thread_name(|i| format!("supertable-fts-bench-par-{i}"))
+                .build()
+                .expect("parallel pool"),
+        )
+    })
+    .clone()
+}
+
+// ─── Builder ──────────────────────────────────────────────────────────
+
+fn schema_id_title() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![Field::new(
+        "title",
+        DataType::LargeUtf8,
+        false,
+    )]))
+}
+
+fn supertable_options(reader_pool: Arc<ThreadPool>) -> SupertableOptions {
+    let tk: Arc<dyn Tokenizer> = default_tokenizer();
+    SupertableOptions::new(
+        schema_id_title(),
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![],
+        Some(tk),
+    )
+    .expect("opts")
+    .with_reader_pool(reader_pool)
+    // Bench raises the commit-threshold sky-high so `append()` doesn't
+    // auto-flush mid-build. With a 1 GiB default at ~4.5 GB / chunk,
+    // default options would auto-commit after every single append — but
+    // the supertable's `commit()` runs per-shard work in parallel only
+    // **within** a commit. By buffering all chunks before the explicit
+    // final commit below, `commit()` row-shards across all writer-pool
+    // threads in one go.
+    .with_commit_threshold_size_mb(0)
+}
+
+/// Build an FTS-only supertable from `docs`. Append-many-then-commit-
+/// once: each chunk is appended to the writer's buffer; a single
+/// `commit()` at the end drains and row-shards across the writer pool.
+/// Output superfile count is `min(writer_pool.threads, total_rows)`.
+fn build_supertable_infino(docs: &[String], reader_pool: Arc<ThreadPool>) -> Supertable {
+    let st = Supertable::create(supertable_options(reader_pool));
+    let mut w = st.writer().expect("writer");
+    let chunk_size = docs.len().div_ceil(SEGMENTS);
+    for chunk in docs.chunks(chunk_size) {
+        let titles = LargeStringArray::from(chunk.iter().map(String::as_str).collect::<Vec<_>>());
+        let batch = RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)])
+            .expect("batch");
+        w.append(&batch).expect("append");
+    }
+    w.commit().expect("commit");
+    drop(w);
+    st
+}
+
+// ─── Correctness ──────────────────────────────────────────────────────
+
+/// Self-consistency on the built supertable: the corpus's df=1
+/// identifier `doc<id:07>` returns exactly one hit; a Zipfian-common
+/// term fills top-10 in score-desc order.
+fn assert_infino_self_consistent(st: &Supertable) {
+    let r = st.reader();
+    let probe_doc_id = (N_DOCS / 2) as u32;
+    let probe_token = format!("doc{probe_doc_id:07}");
+    let hits = r
+        .bm25_search("title", &probe_token, 10, BoolMode::Or)
+        .expect("bm25");
+    assert_eq!(
+        hits.len(),
+        1,
+        "df=1 token {probe_token:?} should return exactly one hit; got {}",
+        hits.len()
+    );
+    assert!(
+        hits[0].score > 0.0,
+        "df=1 score must be positive; got {}",
+        hits[0].score
+    );
+
+    let hits = r
+        .bm25_search("title", "term00001", 10, BoolMode::Or)
+        .expect("bm25");
+    assert_eq!(hits.len(), 10, "common term should fill top-10");
+    for w in hits.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "results must be sorted by score desc; got {} then {}",
+            w[0].score,
+            w[1].score
+        );
+    }
+}
+
+// ─── Bench: ingest (group: supertable_fts_build) ──────────────────────
+
+fn bench_ingest(c: &mut Criterion) {
+    eprintln!(
+        "[supertable_fts_build] correctness: building infino ({N_DOCS} docs)..."
+    );
+    let infino = build_supertable_infino(docs(), parallel_pool());
+    assert_infino_self_consistent(&infino);
+    eprintln!("[supertable_fts_build] correctness OK: infino self-consistent");
+    drop(infino);
+
+    let mut g = c.benchmark_group("supertable_fts_build");
+    g.sample_size(10);
+    g.throughput(Throughput::Elements(N_DOCS as u64));
+
+    g.bench_function("infino_auto_writer_pool", |b| {
+        b.iter_with_large_drop(|| build_supertable_infino(black_box(docs()), parallel_pool()));
+    });
+
+    g.finish();
+
+    emit_ingest_markdown();
+}
+
+// ─── Bench: search (group: supertable_fts_search) ─────────────────────
+
+fn bench_search(c: &mut Criterion) {
+    let st = infino_supertable();
+    let pool = parallel_pool();
+
+    eprintln!("[supertable_fts_search] correctness check...");
+    assert_infino_self_consistent(st);
+    eprintln!(
+        "[supertable_fts_search] correctness OK (rayon pool: {} threads)",
+        pool.current_num_threads()
+    );
+
+    let r = st.reader();
+
+    let mut g = c.benchmark_group("supertable_fts_search");
+    g.sample_size(10);
+
+    let queries: &[(&str, &str)] = &[
+        ("single_rare", "term09999"),
+        ("single_common", "term00001"),
+        ("two_term_or", "term00001 term00050"),
+        ("three_wide", "term00001 term00050 term00100"),
+        ("three_similar", "term00050 term00051 term00052"),
+        (
+            "five_term",
+            "term00050 term00051 term00052 term00053 term00054",
+        ),
+    ];
+    for (name, q) in queries {
+        let name = *name;
+        let q = *q;
+        g.bench_function(format!("{name}_supertable_top10"), |b| {
+            b.iter(|| {
+                let hits = r
+                    .bm25_search(black_box("title"), black_box(q), TOP_K, BoolMode::Or)
+                    .expect("bm25");
+                black_box(hits)
+            });
+        });
+    }
+
+    g.bench_function("prefix_supertable_top10", |b| {
+        b.iter(|| {
+            let hits = r
+                .bm25_search_prefix(black_box("title"), black_box("term0009"), TOP_K)
+                .expect("bm25_prefix");
+            black_box(hits)
+        });
+    });
+
+    g.finish();
+
+    emit_search_markdown();
+}
+
+// ─── Markdown summary emitters ────────────────────────────────────────
+
+fn emit_ingest_markdown() {
+    use crate::markdown::{MarkdownSection, fmt_throughput, fmt_time, read_mean_ns};
+
+    let group = "supertable_fts_build";
+    let ns = read_mean_ns(group, "infino_auto_writer_pool");
+
+    let mut body = String::new();
+    body.push_str(&format!(
+        "### Supertable FTS — ingest ({N_DOCS} docs, Zipfian, 200 tokens/doc, 10K vocab)\n\n"
+    ));
+    body.push_str("| Engine                  | Time       | Throughput |\n");
+    body.push_str("|-------------------------|------------|------------|\n");
+    let time = ns.map(fmt_time).unwrap_or_else(|| "—".into());
+    let thrpt = ns
+        .map(|n| fmt_throughput((N_DOCS as f64) / (n / 1e9)))
+        .unwrap_or_else(|| "—".into());
+    body.push_str(&format!(
+        "| infino_auto_writer_pool | {time:10} | {thrpt:10} |\n"
+    ));
+    body.push_str(
+        "\n*Output cardinality: infino emits `min(writer_pool.threads, total_rows)` superfiles \
+         per commit (auto = cpus/2). Override with `INFINO_SUPERTABLE__WRITER_THREADS=N` for a \
+         specific shard count.*\n",
+    );
+
+    crate::markdown::emit(&MarkdownSection {
+        anchor_id: "bench/fts/supertable/ingest".into(),
+        body,
+    });
+}
+
+fn emit_search_markdown() {
+    use crate::markdown::{MarkdownSection, fmt_time, read_mean_ns};
+
+    let group = "supertable_fts_search";
+    let mut body = String::new();
+    body.push_str(&format!("### Supertable FTS — search ({N_DOCS} docs)\n\n"));
+    body.push_str("| Query          | infino     |\n");
+    body.push_str("|----------------|------------|\n");
+    let queries = [
+        "single_rare",
+        "single_common",
+        "two_term_or",
+        "three_wide",
+        "three_similar",
+        "five_term",
+        "prefix",
+    ];
+    for q in queries {
+        let inf = read_mean_ns(group, &format!("{q}_supertable_top10"));
+        let inf_s = inf.map(fmt_time).unwrap_or_else(|| "—".into());
+        body.push_str(&format!("| {q:14} | {inf_s:10} |\n"));
+    }
+
+    crate::markdown::emit(&MarkdownSection {
+        anchor_id: "bench/fts/supertable/search".into(),
+        body,
+    });
+}
+
+criterion_group!(benches, bench_ingest, bench_search);

--- a/benches/utils/markdown.rs
+++ b/benches/utils/markdown.rs
@@ -1,0 +1,137 @@
+//! Shared markdown summary emitter for the infino-only bench harnesses.
+//!
+//! After criterion finishes timing, each topic's bench function builds
+//! a markdown block summarizing the infino numbers. The block is always
+//! written to stderr framed by sentinel comments
+//! (`<!-- BEGIN: <anchor_id> -->` / `<!-- END: <anchor_id> -->`).
+//! When `INFINO_BENCH_UPDATE_README=1` is set, the same block also
+//! replaces the matching section in `benches/README.md` in place.
+//!
+//! The retrievalbench sibling repo reads infino's measurements from
+//! `target/criterion/<group>/<bench>/new/estimates.json` directly — no
+//! parsing of this markdown is involved. The markdown here exists
+//! purely for human readers of infino's README.
+
+use serde_json::Value;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// One markdown section to emit. `anchor_id` is the stable key that
+/// matches the `<!-- BEGIN/END: ... -->` markers in
+/// `benches/README.md`. `body` is the inner markdown (markers
+/// themselves are added by [`emit`]).
+pub struct MarkdownSection {
+    pub anchor_id: String,
+    pub body: String,
+}
+
+/// Emit `section` to stderr framed by sentinel markers. When
+/// `INFINO_BENCH_UPDATE_README=1`, additionally replace the matching
+/// block in `benches/README.md`.
+pub fn emit(section: &MarkdownSection) {
+    let stderr = std::io::stderr();
+    let mut out = stderr.lock();
+    let _ = writeln!(out);
+    let _ = writeln!(out, "<!-- BEGIN: {} -->", section.anchor_id);
+    let _ = writeln!(out, "{}", section.body);
+    let _ = writeln!(out, "<!-- END: {} -->", section.anchor_id);
+    let _ = writeln!(out);
+
+    if std::env::var_os("INFINO_BENCH_UPDATE_README").is_some() {
+        let path = std::path::PathBuf::from("benches/README.md");
+        if let Err(e) = update_readme(&path, section) {
+            eprintln!("[markdown] failed to update {}: {e}", path.display());
+        } else {
+            eprintln!(
+                "[markdown] updated {} ({})",
+                path.display(),
+                section.anchor_id
+            );
+        }
+    }
+}
+
+fn update_readme(path: &Path, section: &MarkdownSection) -> std::io::Result<()> {
+    let begin = format!("<!-- BEGIN: {} -->", section.anchor_id);
+    let end = format!("<!-- END: {} -->", section.anchor_id);
+    let content = fs::read_to_string(path)?;
+
+    let begin_pos = content.find(&begin).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("marker not found: {begin}"),
+        )
+    })?;
+    let after_begin = begin_pos + begin.len();
+    let end_pos = content[after_begin..].find(&end).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("end marker not found after begin: {end}"),
+        )
+    })? + after_begin;
+
+    let mut new = String::with_capacity(content.len() + section.body.len());
+    new.push_str(&content[..after_begin]);
+    new.push('\n');
+    new.push_str(&section.body);
+    new.push('\n');
+    new.push_str(&content[end_pos..]);
+    fs::write(path, new)?;
+    Ok(())
+}
+
+// ─── Number formatting ────────────────────────────────────────────────
+
+/// Human-readable duration with magnitude-selected units (ns / µs / ms / s).
+pub fn fmt_time(ns: f64) -> String {
+    if ns < 1_000.0 {
+        format!("{ns:.0} ns")
+    } else if ns < 1_000_000.0 {
+        format!("{:.2} µs", ns / 1_000.0)
+    } else if ns < 1_000_000_000.0 {
+        format!("{:.2} ms", ns / 1_000_000.0)
+    } else {
+        format!("{:.2} s", ns / 1_000_000_000.0)
+    }
+}
+
+/// Throughput (elements per second) with K/M units.
+pub fn fmt_throughput(elements_per_sec: f64) -> String {
+    if elements_per_sec >= 1_000_000.0 {
+        format!("{:.2} M/s", elements_per_sec / 1_000_000.0)
+    } else if elements_per_sec >= 1_000.0 {
+        format!("{:.1} K/s", elements_per_sec / 1_000.0)
+    } else {
+        format!("{elements_per_sec:.0}/s")
+    }
+}
+
+// ─── estimates.json reader ────────────────────────────────────────────
+
+/// Read criterion's `mean.point_estimate` (in nanoseconds) for a given
+/// group + bench id from the local `target/criterion/...` tree.
+/// Returns `None` if the file doesn't exist (bench was filtered out or
+/// hasn't run yet) or the JSON can't be parsed.
+pub fn read_mean_ns(group: &str, bench: &str) -> Option<f64> {
+    let path = format!("target/criterion/{group}/{bench}/new/estimates.json");
+    let text = fs::read_to_string(&path).ok()?;
+    let v: Value = serde_json::from_str(&text).ok()?;
+    v.get("mean")?.get("point_estimate")?.as_f64()
+}
+
+/// Mean time + throughput per second given a per-iteration element
+/// count. `None` if the bench result isn't on disk.
+#[allow(dead_code)]
+pub fn read_mean_with_throughput(
+    group: &str,
+    bench: &str,
+    elements: u64,
+) -> Option<(f64, f64)> {
+    let ns = read_mean_ns(group, bench)?;
+    if ns <= 0.0 {
+        return None;
+    }
+    let throughput = (elements as f64) / (ns / 1_000_000_000.0);
+    Some((ns, throughput))
+}

--- a/benches/utils/markdown.rs
+++ b/benches/utils/markdown.rs
@@ -7,10 +7,11 @@
 //! When `INFINO_BENCH_UPDATE_README=1` is set, the same block also
 //! replaces the matching section in `benches/README.md` in place.
 //!
-//! The retrievalbench sibling repo reads infino's measurements from
-//! `target/criterion/<group>/<bench>/new/estimates.json` directly — no
-//! parsing of this markdown is involved. The markdown here exists
-//! purely for human readers of infino's README.
+//! The markdown is purely for human readers. Programmatic consumers
+//! should read criterion's own
+//! `target/criterion/<group>/<bench>/new/estimates.json` directly —
+//! that's the structured source of truth this markdown is derived
+//! from.
 
 use serde_json::Value;
 use std::fs;

--- a/benches/vector/main.rs
+++ b/benches/vector/main.rs
@@ -2,9 +2,8 @@
 //! supertable (10M × 384) vector benches in a single criterion binary
 //! so the topic has one `[[bench]]` stanza in `Cargo.toml`.
 //!
-//! Head-to-head numbers against LanceDB live in the sibling
-//! `retrievalbench` repo — this bench is purely infino-only timing and
-//! correctness, suitable for shipping with the public infino release.
+//! Infino-only timing and correctness — no third-party crates in
+//! the dependency graph of these benches.
 //!
 //! ## Invocation
 //!

--- a/benches/vector/main.rs
+++ b/benches/vector/main.rs
@@ -1,0 +1,28 @@
+//! Vector bench bundle (infino-only). Wraps superfile (1M × 384) and
+//! supertable (10M × 384) vector benches in a single criterion binary
+//! so the topic has one `[[bench]]` stanza in `Cargo.toml`.
+//!
+//! Head-to-head numbers against LanceDB live in the sibling
+//! `retrievalbench` repo — this bench is purely infino-only timing and
+//! correctness, suitable for shipping with the public infino release.
+//!
+//! ## Invocation
+//!
+//! ```text
+//! cargo bench --bench vector                                  # all vector benches
+//! cargo bench --bench vector -- superfile_vec_build           # only superfile ingest
+//! cargo bench --bench vector -- superfile_vec_search          # only superfile search
+//! cargo bench --bench vector -- supertable_vec_build          # only supertable ingest
+//! cargo bench --bench vector -- supertable_vec_search         # only supertable search
+//! INFINO_BENCH_UPDATE_README=1 cargo bench --bench vector     # rewrite README sections
+//! ```
+
+#[path = "../utils/markdown.rs"]
+mod markdown;
+
+#[path = "superfile.rs"]
+mod superfile;
+#[path = "supertable.rs"]
+mod supertable;
+
+criterion::criterion_main!(superfile::benches, supertable::benches);

--- a/benches/vector/superfile.rs
+++ b/benches/vector/superfile.rs
@@ -1,0 +1,409 @@
+//! Infino-only vector bench for the superfile layer:
+//!
+//!   ingest timing (1M × 384 Gaussian planted clusters, cosine)
+//! + calibrated kNN search at recall targets {0.90, 0.95, 0.99}
+//! + nprobe/rerank sweeps
+//! + correctness gate (`recall@10 ≥ 0.80` at high-recall config)
+//!
+//! Pinned to 1M × 384. Supertable scale (10M × 384, sharded into N
+//! superfiles) lives in `benches/vector/supertable.rs`.
+//!
+//! ## Invocation
+//!
+//! ```text
+//! cargo bench --bench vector -- superfile_vec_build      # ingest only
+//! cargo bench --bench vector -- superfile_vec_search     # search only
+//! ```
+
+use std::hint::black_box;
+use std::sync::OnceLock;
+
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
+use infino::superfile::vector::distance::Metric;
+use infino::superfile::vector::reader::VectorReader;
+use infino::test_helpers::bench_corpus;
+use infino::test_helpers::bench_corpus::{Calibrated, DIM};
+
+// ─── Constants ────────────────────────────────────────────────────────
+
+const N_DOCS: usize = 1_000_000;
+const TOP_K: usize = 10;
+const N_CORRECTNESS_QUERIES: usize = 20;
+const N_CALIBRATION_QUERIES: usize = 100;
+
+/// Recall floor for the correctness gate. Any infino regression that
+/// drops below this fails the bench.
+const CORRECTNESS_RECALL_FLOOR: f32 = 0.80;
+
+/// High-recall config used as the correctness probe.
+const CORRECTNESS_NPROBE: usize = 64;
+const CORRECTNESS_RERANK_MULT: usize = 256;
+
+/// Default options for the user-facing "what does it cost in
+/// production?" baseline reported in the search markdown.
+const DEFAULT_NPROBE: usize = 8;
+const DEFAULT_RERANK_MULT: usize = 20;
+
+const RECALL_TARGETS: &[f32] = &[0.90, 0.95, 0.99];
+
+/// (probe, refine) calibration grids. The lowest-p50 point clearing
+/// each recall target is what the search table reports.
+const PROBES: &[usize] = &[1, 5, 10, 25, 50, 100, 200, 400, 800];
+const REFINES: &[usize] = &[1, 4, 16, 64, 256, 1024];
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+
+static VECTORS: OnceLock<Vec<f32>> = OnceLock::new();
+static QUERIES_CORRECTNESS: OnceLock<Vec<Vec<f32>>> = OnceLock::new();
+static QUERIES_CALIBRATION: OnceLock<Vec<Vec<f32>>> = OnceLock::new();
+static GROUND_TRUTH_CORRECTNESS: OnceLock<Vec<Vec<u32>>> = OnceLock::new();
+static GROUND_TRUTH_CALIBRATION: OnceLock<Vec<Vec<u32>>> = OnceLock::new();
+static INFINO_BLOB: OnceLock<Vec<u8>> = OnceLock::new();
+static CALIBRATIONS: OnceLock<Calibrations> = OnceLock::new();
+
+fn vectors() -> &'static [f32] {
+    VECTORS.get_or_init(|| {
+        bench_corpus::generate_vector_corpus(N_DOCS, bench_corpus::n_cent(N_DOCS), 1, true)
+    })
+}
+
+fn queries_correctness() -> &'static [Vec<f32>] {
+    QUERIES_CORRECTNESS.get_or_init(|| {
+        bench_corpus::generate_realistic_queries(
+            vectors(),
+            N_DOCS,
+            N_CORRECTNESS_QUERIES,
+            17,
+            true,
+            0.05,
+        )
+    })
+}
+
+fn queries_calibration() -> &'static [Vec<f32>] {
+    QUERIES_CALIBRATION.get_or_init(|| {
+        bench_corpus::generate_realistic_queries(
+            vectors(),
+            N_DOCS,
+            N_CALIBRATION_QUERIES,
+            99,
+            true,
+            0.05,
+        )
+    })
+}
+
+fn ground_truth_correctness() -> &'static [Vec<u32>] {
+    GROUND_TRUTH_CORRECTNESS
+        .get_or_init(|| bench_corpus::ground_truth(vectors(), N_DOCS, queries_correctness(), TOP_K))
+}
+
+fn ground_truth_calibration() -> &'static [Vec<u32>] {
+    GROUND_TRUTH_CALIBRATION
+        .get_or_init(|| bench_corpus::ground_truth(vectors(), N_DOCS, queries_calibration(), TOP_K))
+}
+
+fn infino_reader() -> VectorReader {
+    let blob = INFINO_BLOB.get_or_init(|| build_infino_blob(vectors()));
+    open_infino_reader(blob.clone())
+}
+
+// ─── Builder ──────────────────────────────────────────────────────────
+
+fn build_infino_blob(vectors: &[f32]) -> Vec<u8> {
+    let n_cent = bench_corpus::n_cent(N_DOCS);
+    let builder = bench_corpus::build_vector_index(vectors, N_DOCS, n_cent, Metric::Cosine);
+    builder.finish()
+}
+
+fn open_infino_reader(blob: Vec<u8>) -> VectorReader {
+    let n_cent = bench_corpus::n_cent(N_DOCS);
+    let json = format!(
+        r#"[{{"name":"v","dim":{DIM},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#
+    );
+    VectorReader::open(Bytes::from(blob), &json).expect("open VectorReader")
+}
+
+// ─── Correctness ──────────────────────────────────────────────────────
+
+fn assert_infino_self_consistent(reader: &VectorReader) -> f32 {
+    let qs = queries_correctness();
+    let gt = ground_truth_correctness();
+    let mut total_recall = 0.0_f32;
+    for (q, truth) in qs.iter().zip(gt.iter()) {
+        let hits = reader
+            .search("v", q, TOP_K, CORRECTNESS_NPROBE, CORRECTNESS_RERANK_MULT)
+            .expect("vector search");
+        assert_eq!(
+            hits.len(),
+            TOP_K,
+            "infino kNN should fill top-{TOP_K}; got {}",
+            hits.len()
+        );
+        total_recall += bench_corpus::recall_at_k(&hits, truth);
+    }
+    let mean_recall = total_recall / (qs.len() as f32);
+    assert!(
+        mean_recall >= CORRECTNESS_RECALL_FLOOR,
+        "infino mean recall@{TOP_K} at correctness config \
+         (p={CORRECTNESS_NPROBE}, r={CORRECTNESS_RERANK_MULT}) \
+         below floor: {mean_recall:.3} < {CORRECTNESS_RECALL_FLOOR:.3}"
+    );
+    mean_recall
+}
+
+// ─── Calibration ──────────────────────────────────────────────────────
+
+struct Calibrations {
+    infino: [Option<Calibrated>; 3],
+}
+
+fn calibrations() -> &'static Calibrations {
+    CALIBRATIONS.get_or_init(|| {
+        let reader = infino_reader();
+        let qs = queries_calibration();
+        let gt = ground_truth_calibration();
+
+        eprintln!(
+            "[superfile_vec_search] calibrating infino at recall targets {RECALL_TARGETS:?}..."
+        );
+        let mut inf: [Option<Calibrated>; 3] = [None; 3];
+        for (i, &target) in RECALL_TARGETS.iter().enumerate() {
+            inf[i] = bench_corpus::calibrate_infino(
+                &reader, qs, gt, target, PROBES, REFINES, 21, TOP_K,
+            );
+            eprintln!("  recall ≥ {target:.2} | infino: {:?}", inf[i]);
+        }
+        Calibrations { infino: inf }
+    })
+}
+
+// ─── Bench entry ──────────────────────────────────────────────────────
+
+fn bench(c: &mut Criterion) {
+    // ---- Correctness phase (runs regardless of criterion filter) ---
+    eprintln!("[superfile_vec] correctness: building infino ({N_DOCS} docs)...");
+    let reader = infino_reader();
+    let recall = assert_infino_self_consistent(&reader);
+    eprintln!(
+        "[superfile_vec] correctness OK: infino recall@{TOP_K} = {recall:.3} (≥ {:.2})",
+        CORRECTNESS_RECALL_FLOOR
+    );
+
+    artifact_report(N_DOCS, bench_corpus::n_cent(N_DOCS), vectors());
+
+    // ---- Ingest sub-bench (group: superfile_vec_build) -------------
+    {
+        let v = vectors();
+        let mut g = c.benchmark_group("superfile_vec_build");
+        g.sample_size(10);
+        g.throughput(Throughput::Elements(N_DOCS as u64));
+
+        g.bench_function(format!("infino_build_{N_DOCS}docs"), |b| {
+            b.iter_with_large_drop(|| build_infino_blob(black_box(v)));
+        });
+        g.finish();
+
+        emit_ingest_markdown();
+    }
+
+    // ---- Search sub-bench (group: superfile_vec_search) ------------
+    {
+        let cal = calibrations();
+        let qs = queries_calibration();
+
+        let mut g = c.benchmark_group("superfile_vec_search");
+        g.sample_size(10);
+
+        for (i, &target) in RECALL_TARGETS.iter().enumerate() {
+            let label = format!("recall_at_least_{:02}", (target * 100.0) as u32);
+            if let Some(c_inf) = cal.infino[i] {
+                g.bench_with_input(
+                    BenchmarkId::new(
+                        format!("infino_{label}"),
+                        format!("p={},r={}", c_inf.probe, c_inf.refine),
+                    ),
+                    &(c_inf.probe, c_inf.refine),
+                    |b, &(p, r)| {
+                        let q = &qs[0];
+                        b.iter(|| {
+                            let hits =
+                                reader.search("v", black_box(q), TOP_K, p, r).expect("kNN");
+                            black_box(hits)
+                        });
+                    },
+                );
+            }
+        }
+
+        // Default-options baseline (what users get with no tuning).
+        let q = &qs[0];
+        g.bench_function("infino_default_options_top10", |b| {
+            b.iter(|| {
+                let hits = reader
+                    .search(
+                        black_box("v"),
+                        black_box(q),
+                        TOP_K,
+                        DEFAULT_NPROBE,
+                        DEFAULT_RERANK_MULT,
+                    )
+                    .expect("kNN");
+                black_box(hits)
+            });
+        });
+
+        // nprobe sweep (rerank fixed at default)
+        let n_cent = bench_corpus::n_cent(N_DOCS);
+        for &nprobe in &[1, 4, 8, 16, 32, 64, 128] {
+            if nprobe > n_cent {
+                continue;
+            }
+            g.bench_with_input(
+                BenchmarkId::new("infino_nprobe_sweep_rerank20", nprobe),
+                &nprobe,
+                |b, &np| {
+                    b.iter(|| {
+                        let hits = reader
+                            .search("v", black_box(q), TOP_K, np, DEFAULT_RERANK_MULT)
+                            .expect("kNN");
+                        black_box(hits)
+                    });
+                },
+            );
+        }
+
+        // rerank_mult sweep (nprobe fixed at default)
+        for &rerank in &[1, 5, 10, 20, 50, 100] {
+            g.bench_with_input(
+                BenchmarkId::new("infino_rerank_sweep_nprobe8", rerank),
+                &rerank,
+                |b, &rm| {
+                    b.iter(|| {
+                        let hits = reader
+                            .search("v", black_box(q), TOP_K, DEFAULT_NPROBE, rm)
+                            .expect("kNN");
+                        black_box(hits)
+                    });
+                },
+            );
+        }
+
+        g.finish();
+
+        emit_search_markdown();
+    }
+}
+
+// ─── Markdown summary emitters ────────────────────────────────────────
+
+fn emit_ingest_markdown() {
+    use crate::markdown::{MarkdownSection, fmt_throughput, fmt_time, read_mean_ns};
+
+    let group = "superfile_vec_build";
+    let ns = read_mean_ns(group, &format!("infino_build_{N_DOCS}docs"));
+
+    let mut body = String::new();
+    body.push_str(&format!(
+        "### Superfile vector — ingest ({N_DOCS} docs × dim={DIM}, Gaussian planted clusters, cosine)\n\n"
+    ));
+    body.push_str("| Engine | Time | Throughput |\n");
+    body.push_str("|--------|------|------------|\n");
+    let time = ns.map(fmt_time).unwrap_or_else(|| "—".into());
+    let thrpt = ns
+        .map(|n| fmt_throughput((N_DOCS as f64) / (n / 1e9)))
+        .unwrap_or_else(|| "—".into());
+    body.push_str(&format!("| infino | {time} | {thrpt} |\n"));
+
+    crate::markdown::emit(&MarkdownSection {
+        anchor_id: "bench/vector/superfile/ingest".into(),
+        body,
+    });
+}
+
+fn emit_search_markdown() {
+    use crate::markdown::{MarkdownSection, fmt_time, read_mean_ns};
+
+    let group = "superfile_vec_search";
+    let cal = calibrations();
+
+    let mut body = String::new();
+    body.push_str(&format!(
+        "### Superfile vector — search ({N_DOCS} docs × dim={DIM}, calibrated at recall targets)\n\n"
+    ));
+    body.push_str("| Recall target | infino (probe, refine) | infino p50 |\n");
+    body.push_str("|---------------|------------------------|------------|\n");
+
+    for (i, &target) in RECALL_TARGETS.iter().enumerate() {
+        let label = format!("recall_at_least_{:02}", (target * 100.0) as u32);
+        let row_target = format!("{target:.2}");
+        if let Some(c_inf) = cal.infino[i] {
+            let id = format!(
+                "infino_{label}/p={},r={}",
+                c_inf.probe, c_inf.refine,
+            );
+            let ns = read_mean_ns(group, &id);
+            let p50 = ns.map(fmt_time).unwrap_or_else(|| "—".into());
+            body.push_str(&format!(
+                "| {row_target:13} | (p={}, r={}) | {p50:10} |\n",
+                c_inf.probe, c_inf.refine
+            ));
+        } else {
+            body.push_str(&format!("| {row_target:13} | — | — |\n"));
+        }
+    }
+
+    body.push('\n');
+    body.push_str(
+        "**infino default options** (`nprobe=8, rerank_mult=20` — user-facing latency baseline):\n\n",
+    );
+    body.push_str("| Metric | Value |\n");
+    body.push_str("|--------|-------|\n");
+    let def = read_mean_ns(group, "infino_default_options_top10");
+    let def_s = def.map(fmt_time).unwrap_or_else(|| "—".into());
+    body.push_str(&format!("| infino_default_options_top10 | {def_s} |\n"));
+
+    crate::markdown::emit(&MarkdownSection {
+        anchor_id: "bench/vector/superfile/search".into(),
+        body,
+    });
+}
+
+// ─── Artifact size + first-query report ──────────────────────────────
+
+fn artifact_report(n: usize, n_cent: usize, vectors: &[f32]) {
+    // Build once and time the cold open + first query so the
+    // user-visible "first-query latency" number isn't hidden inside
+    // criterion's warm-up loop.
+    use std::time::Instant;
+
+    let t0 = Instant::now();
+    let blob = build_infino_blob(vectors);
+    let build_elapsed = t0.elapsed();
+
+    let size_mib = blob.len() as f64 / (1024.0 * 1024.0);
+
+    let t0 = Instant::now();
+    let reader = open_infino_reader(blob);
+    let open_elapsed = t0.elapsed();
+
+    let q = &queries_calibration()[0];
+    let t0 = Instant::now();
+    let _ = reader
+        .search("v", q, TOP_K, DEFAULT_NPROBE, DEFAULT_RERANK_MULT)
+        .expect("kNN");
+    let first_q_elapsed = t0.elapsed();
+
+    eprintln!(
+        "\n--- artifact-size + cold-load report ({n} docs, {n_cent} clusters, dim={DIM}) ---"
+    );
+    eprintln!(
+        "infino:  build {:>7.2}s  size {size_mib:>6.2} MiB  open {:>6.2} ms  first-query {:>5.2} ms",
+        build_elapsed.as_secs_f64(),
+        open_elapsed.as_secs_f64() * 1e3,
+        first_q_elapsed.as_secs_f64() * 1e3,
+    );
+}
+
+criterion_group!(benches, bench);

--- a/benches/vector/supertable.rs
+++ b/benches/vector/supertable.rs
@@ -1,0 +1,459 @@
+//! Infino-only vector bench for the supertable layer:
+//!
+//!   ingest timing (10M × 384, sharded into [`N_SEGMENTS`] superfiles)
+//! + calibrated kNN search at recall targets {0.90, 0.95, 0.99}
+//! + correctness gate (`recall@10 ≥ 0.80` at high-recall config)
+//!
+//! Multi-segment shape: the corpus is sharded into [`N_SEGMENTS`]
+//! commits with `n_cent_per_segment = n_cent(N_DOCS) / N_SEGMENTS`. A
+//! supertable query's per-segment `nprobe` applies to every segment, so
+//! the effective probe count is `nprobe × n_superfiles`.
+//!
+//! ## Invocation
+//!
+//! ```text
+//! cargo bench --bench vector -- supertable_vec_build       # ingest only
+//! cargo bench --bench vector -- supertable_vec_search      # search only
+//! ```
+
+use std::hint::black_box;
+use std::sync::{Arc, OnceLock};
+use std::time::Instant;
+
+use arrow_array::{Array, FixedSizeListArray, Float32Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
+use infino::superfile::builder::VectorConfig;
+use infino::superfile::vector::distance::Metric;
+use infino::supertable::query::SuperfileHit;
+use infino::supertable::query::vector::VectorSearchOptions;
+use infino::supertable::{Supertable, SupertableOptions};
+use infino::test_helpers::bench_corpus;
+use infino::test_helpers::bench_corpus::{Calibrated, DIM};
+
+// ─── Constants ────────────────────────────────────────────────────────
+
+/// Doc count for every vector-supertable bench. Pinned to 10M — the
+/// supertable is the scale-out shape.
+const N_DOCS: usize = 10_000_000;
+
+const N_SEGMENTS: usize = 4;
+const TOP_K: usize = 10;
+
+const N_CORRECTNESS_QUERIES: usize = 20;
+const N_CALIBRATION_QUERIES: usize = 100;
+
+const RECALL_TARGETS: &[f32] = &[0.90, 0.95, 0.99];
+
+/// Per-segment probe grid. The supertable applies a single `nprobe`
+/// to every segment, so the effective probe count is `nprobe ×
+/// n_superfiles`. This grid approximates the single-superfile probe
+/// grid scaled down by [`N_SEGMENTS`].
+const SUPERTABLE_PROBES_PER_SEG: &[usize] = &[1, 2, 4, 8, 12, 16];
+const SUPERTABLE_REFINES: &[usize] = &[4, 16, 64, 256, 1024];
+
+const CORRECTNESS_RECALL_FLOOR: f32 = 0.80;
+const CORRECTNESS_SUPERTABLE_NPROBE: usize = 16;
+const CORRECTNESS_SUPERTABLE_RERANK_MULT: usize = 256;
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+
+static VECTORS: OnceLock<Vec<f32>> = OnceLock::new();
+static QUERIES_CORRECTNESS: OnceLock<Vec<Vec<f32>>> = OnceLock::new();
+static QUERIES_CALIBRATION: OnceLock<Vec<Vec<f32>>> = OnceLock::new();
+static GROUND_TRUTH_CORRECTNESS: OnceLock<Vec<Vec<u32>>> = OnceLock::new();
+static GROUND_TRUTH_CALIBRATION: OnceLock<Vec<Vec<u32>>> = OnceLock::new();
+static SUPERTABLE: OnceLock<Supertable> = OnceLock::new();
+static CALIBRATIONS: OnceLock<Calibrations> = OnceLock::new();
+
+fn vectors() -> &'static [f32] {
+    VECTORS.get_or_init(|| {
+        bench_corpus::generate_vector_corpus(N_DOCS, bench_corpus::n_cent(N_DOCS), 1, true)
+    })
+}
+
+fn queries_correctness() -> &'static [Vec<f32>] {
+    QUERIES_CORRECTNESS.get_or_init(|| {
+        bench_corpus::generate_realistic_queries(
+            vectors(),
+            N_DOCS,
+            N_CORRECTNESS_QUERIES,
+            17,
+            true,
+            0.05,
+        )
+    })
+}
+
+fn queries_calibration() -> &'static [Vec<f32>] {
+    QUERIES_CALIBRATION.get_or_init(|| {
+        bench_corpus::generate_realistic_queries(
+            vectors(),
+            N_DOCS,
+            N_CALIBRATION_QUERIES,
+            99,
+            true,
+            0.05,
+        )
+    })
+}
+
+fn ground_truth_correctness() -> &'static [Vec<u32>] {
+    GROUND_TRUTH_CORRECTNESS
+        .get_or_init(|| bench_corpus::ground_truth(vectors(), N_DOCS, queries_correctness(), TOP_K))
+}
+
+fn ground_truth_calibration() -> &'static [Vec<u32>] {
+    GROUND_TRUTH_CALIBRATION
+        .get_or_init(|| bench_corpus::ground_truth(vectors(), N_DOCS, queries_calibration(), TOP_K))
+}
+
+fn supertable() -> &'static Supertable {
+    SUPERTABLE.get_or_init(build_supertable)
+}
+
+// ─── Builder ──────────────────────────────────────────────────────────
+
+fn supertable_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![Field::new(
+        "emb",
+        DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            DIM as i32,
+        ),
+        false,
+    )]))
+}
+
+fn build_supertable() -> Supertable {
+    let n_cent_total = bench_corpus::n_cent(N_DOCS);
+    let n_cent_per_segment = (n_cent_total / N_SEGMENTS).max(1);
+
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(num_cpus::get().max(1))
+            .build()
+            .expect("pool"),
+    );
+    let opts = SupertableOptions::new(
+        supertable_schema(),
+        vec![],
+        vec![VectorConfig {
+            column: "emb".into(),
+            dim: DIM,
+            n_cent: n_cent_per_segment,
+            rot_seed: 7,
+            metric: Metric::Cosine,
+        }],
+        None,
+    )
+    .expect("opts")
+    .with_writer_pool(pool);
+
+    let st = Supertable::create(opts);
+    let mut w = st.writer().expect("writer");
+
+    let chunk_size = N_DOCS / N_SEGMENTS;
+    let v = vectors();
+    for chunk_idx in 0..N_SEGMENTS {
+        let start = chunk_idx * chunk_size;
+        let end = start + chunk_size;
+        let flat: Vec<f32> = v[start * DIM..end * DIM].to_vec();
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let values = Float32Array::from(flat);
+        let fsl = FixedSizeListArray::try_new(
+            item_field,
+            DIM as i32,
+            Arc::new(values) as Arc<dyn Array>,
+            None,
+        )
+        .expect("FSL");
+        let batch =
+            RecordBatch::try_new(supertable_schema(), vec![Arc::new(fsl)]).expect("batch");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+    }
+    drop(w);
+    st
+}
+
+/// Run a supertable kNN search and resolve per-superfile hits to
+/// global doc-ids via cumulative-`n_docs` offsets in manifest order.
+/// `commit()` row-shards into `min(writer_pool.threads, total_rows)`
+/// superfiles, so the bench can't assume "one superfile per append
+/// batch." Prefix-sum gives the global base for each superfile.
+fn supertable_topk(
+    st: &Supertable,
+    query: &[f32],
+    k: usize,
+    options: VectorSearchOptions,
+) -> Vec<u32> {
+    let r = st.reader();
+    let hits: Vec<SuperfileHit> = r
+        .vector_search("emb", query, k, options)
+        .expect("vector_search");
+    let manifest = r.manifest();
+    let mut offsets: Vec<u32> = Vec::with_capacity(manifest.superfiles.len());
+    let mut acc: u32 = 0;
+    for entry in manifest.superfiles.iter() {
+        offsets.push(acc);
+        acc = acc.saturating_add(entry.n_docs as u32);
+    }
+    hits.into_iter()
+        .map(|h| {
+            let seg_idx = manifest
+                .superfiles
+                .iter()
+                .position(|e| e.uri == h.segment)
+                .expect("superfile in manifest");
+            offsets[seg_idx] + h.local_doc_id
+        })
+        .collect()
+}
+
+fn mean_recall_supertable(
+    st: &Supertable,
+    queries: &[Vec<f32>],
+    truths: &[Vec<u32>],
+    options: VectorSearchOptions,
+) -> f32 {
+    let mut sum = 0f32;
+    for (q, t) in queries.iter().zip(truths) {
+        let hits = supertable_topk(st, q, TOP_K, options);
+        let truth_set: std::collections::HashSet<u32> = t.iter().copied().collect();
+        let recall = if t.is_empty() {
+            1.0
+        } else {
+            hits.iter().filter(|id| truth_set.contains(id)).count() as f32 / t.len() as f32
+        };
+        sum += recall;
+    }
+    sum / queries.len() as f32
+}
+
+// ─── Correctness ──────────────────────────────────────────────────────
+
+fn assert_supertable_self_consistent(st: &Supertable) -> f32 {
+    let opts = VectorSearchOptions::new()
+        .with_nprobe(CORRECTNESS_SUPERTABLE_NPROBE)
+        .with_rerank_mult(CORRECTNESS_SUPERTABLE_RERANK_MULT);
+    let mean_recall =
+        mean_recall_supertable(st, queries_correctness(), ground_truth_correctness(), opts);
+    assert!(
+        mean_recall >= CORRECTNESS_RECALL_FLOOR,
+        "supertable mean recall@{TOP_K} at correctness config \
+         (p={CORRECTNESS_SUPERTABLE_NPROBE}, r={CORRECTNESS_SUPERTABLE_RERANK_MULT}) \
+         below floor: {mean_recall:.3} < {CORRECTNESS_RECALL_FLOOR:.3}"
+    );
+    mean_recall
+}
+
+// ─── Calibration ──────────────────────────────────────────────────────
+
+struct Calibrations {
+    supertable: [Option<Calibrated>; 3],
+}
+
+fn calibrate_supertable_at_target(
+    st: &Supertable,
+    queries: &[Vec<f32>],
+    truths: &[Vec<u32>],
+    target_recall: f32,
+) -> Option<Calibrated> {
+    let mut best: Option<Calibrated> = None;
+    let mut peak_recall = 0f32;
+    for &probe in SUPERTABLE_PROBES_PER_SEG {
+        for &refine in SUPERTABLE_REFINES {
+            let opts = VectorSearchOptions::new()
+                .with_nprobe(probe)
+                .with_rerank_mult(refine);
+            let recall = mean_recall_supertable(st, queries, truths, opts);
+            if recall > peak_recall {
+                peak_recall = recall;
+            }
+            if recall < target_recall {
+                continue;
+            }
+            let q = &queries[0];
+            let n_iter = 21;
+            let mut samples = Vec::with_capacity(n_iter);
+            for _ in 0..n_iter {
+                let t0 = Instant::now();
+                let _ = supertable_topk(st, q, TOP_K, opts);
+                samples.push(t0.elapsed().as_secs_f32() * 1e6);
+            }
+            samples.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let p50 = samples[samples.len() / 2];
+            let cand = Calibrated {
+                probe,
+                refine,
+                recall,
+                p50_micros: p50,
+            };
+            best = match best {
+                None => Some(cand),
+                Some(b) if cand.p50_micros < b.p50_micros => Some(cand),
+                Some(b) => Some(b),
+            };
+        }
+    }
+    if best.is_none() {
+        eprintln!(
+            "    [supertable] no point hit recall ≥ {target_recall:.2}; peak observed = {peak_recall:.3}"
+        );
+    }
+    best
+}
+
+fn calibrations() -> &'static Calibrations {
+    CALIBRATIONS.get_or_init(|| {
+        let st = supertable();
+        let qs = queries_calibration();
+        let gt = ground_truth_calibration();
+
+        eprintln!(
+            "[supertable_vec_search] calibrating supertable at recall targets {RECALL_TARGETS:?}..."
+        );
+        let mut s: [Option<Calibrated>; 3] = [None; 3];
+        for (i, &target) in RECALL_TARGETS.iter().enumerate() {
+            s[i] = calibrate_supertable_at_target(st, qs, gt, target);
+            eprintln!("  recall ≥ {target:.2} | supertable: {:?}", s[i]);
+        }
+        Calibrations { supertable: s }
+    })
+}
+
+// ─── Bench entry ──────────────────────────────────────────────────────
+
+fn bench(c: &mut Criterion) {
+    eprintln!(
+        "[supertable_vec] correctness: building supertable ({N_DOCS} docs × {N_SEGMENTS} superfiles)..."
+    );
+    let st = supertable();
+    let recall = assert_supertable_self_consistent(st);
+    eprintln!(
+        "[supertable_vec] correctness OK: supertable recall@{TOP_K} = {recall:.3} (≥ {:.2})",
+        CORRECTNESS_RECALL_FLOOR
+    );
+
+    // ---- Ingest sub-bench (group: supertable_vec_build) ------------
+    {
+        let v = vectors();
+        let mut g = c.benchmark_group("supertable_vec_build");
+        g.sample_size(10);
+        g.throughput(Throughput::Elements(N_DOCS as u64));
+
+        g.bench_function(
+            format!("supertable_{N_DOCS}docs_{N_SEGMENTS}superfiles"),
+            |b| {
+                b.iter_with_large_drop(|| {
+                    let _ = black_box(v);
+                    build_supertable()
+                });
+            },
+        );
+
+        g.finish();
+
+        emit_ingest_markdown();
+    }
+
+    // ---- Search sub-bench (group: supertable_vec_search) -----------
+    {
+        let cal = calibrations();
+        let qs = queries_calibration();
+
+        let mut g = c.benchmark_group("supertable_vec_search");
+        g.sample_size(10);
+
+        for (i, &target) in RECALL_TARGETS.iter().enumerate() {
+            let label = format!("recall_at_least_{:02}", (target * 100.0) as u32);
+            if let Some(c_st) = cal.supertable[i] {
+                g.bench_with_input(
+                    BenchmarkId::new(
+                        format!("supertable_{label}"),
+                        format!("p={},r={}", c_st.probe, c_st.refine),
+                    ),
+                    &(c_st.probe, c_st.refine),
+                    |b, &(p, r)| {
+                        let q = &qs[0];
+                        let opts = VectorSearchOptions::new()
+                            .with_nprobe(p)
+                            .with_rerank_mult(r);
+                        b.iter(|| {
+                            let hits = supertable_topk(st, black_box(q), TOP_K, opts);
+                            black_box(hits)
+                        });
+                    },
+                );
+            }
+        }
+
+        g.finish();
+
+        emit_search_markdown();
+    }
+}
+
+// ─── Markdown summary emitters ────────────────────────────────────────
+
+fn emit_ingest_markdown() {
+    use crate::markdown::{MarkdownSection, fmt_throughput, fmt_time, read_mean_ns};
+
+    let group = "supertable_vec_build";
+    let bench = format!("supertable_{N_DOCS}docs_{N_SEGMENTS}superfiles");
+    let ns = read_mean_ns(group, &bench);
+
+    let mut body = String::new();
+    body.push_str(&format!(
+        "### Supertable vector — ingest ({N_DOCS} docs × dim={DIM}, sharded into {N_SEGMENTS} superfiles)\n\n"
+    ));
+    body.push_str("| Engine | Time | Throughput |\n");
+    body.push_str("|--------|------|------------|\n");
+    let time = ns.map(fmt_time).unwrap_or_else(|| "—".into());
+    let thrpt = ns
+        .map(|n| fmt_throughput((N_DOCS as f64) / (n / 1e9)))
+        .unwrap_or_else(|| "—".into());
+    body.push_str(&format!("| supertable | {time} | {thrpt} |\n"));
+
+    crate::markdown::emit(&MarkdownSection {
+        anchor_id: "bench/vector/supertable/ingest".into(),
+        body,
+    });
+}
+
+fn emit_search_markdown() {
+    use crate::markdown::{MarkdownSection, fmt_time, read_mean_ns};
+
+    let cal = calibrations();
+    let group = "supertable_vec_search";
+
+    let mut body = String::new();
+    body.push_str(&format!(
+        "### Supertable vector — search ({N_DOCS} docs × dim={DIM}, calibrated at recall targets)\n\n"
+    ));
+    body.push_str("| Recall target | supertable (probe/seg, refine) | supertable p50 |\n");
+    body.push_str("|---------------|--------------------------------|----------------|\n");
+
+    for (i, &target) in RECALL_TARGETS.iter().enumerate() {
+        let label = format!("recall_at_least_{:02}", (target * 100.0) as u32);
+        let row_target = format!("{target:.2}");
+        let (cell, ns) = match cal.supertable[i] {
+            Some(c) => {
+                let bid = format!("supertable_{label}/p={},r={}", c.probe, c.refine);
+                let ns = read_mean_ns(group, &bid);
+                (format!("(p={}, r={})", c.probe, c.refine), ns)
+            }
+            None => ("—".into(), None),
+        };
+        let t = ns.map(fmt_time).unwrap_or_else(|| "—".into());
+        body.push_str(&format!("| {row_target} | {cell} | {t} |\n"));
+    }
+
+    crate::markdown::emit(&MarkdownSection {
+        anchor_id: "bench/vector/supertable/search".into(),
+        body,
+    });
+}
+
+criterion_group!(benches, bench);

--- a/docs/architecture/superfile.md
+++ b/docs/architecture/superfile.md
@@ -49,7 +49,7 @@ integration — are deliberately deferred and noted in
   - [Ingestion durability and `commit()`](#ingestion-durability-and-commit)
     - [The five options considered](#the-five-options-considered)
     - [Multi-threaded ingestion](#multi-threaded-ingestion)
-- [Performance: head-to-head vs reference engines](#performance-head-to-head-vs-reference-engines)
+- [Performance](#performance)
 - [Test strategy](#test-strategy)
 - [Known limitations](#known-limitations)
 - [Phase 2 plans](#phase-2-plans)

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -40,7 +40,7 @@ format (Parquet body + embedded BM25 + vector blobs).
   - [Skip pruning](#skip-pruning)
   - [Dual-pool concurrency](#dual-pool-concurrency)
   - [SQL surface via DataFusion](#sql-surface-via-datafusion)
-- [Performance: head-to-head vs reference engines](#performance-head-to-head-vs-reference-engines)
+- [Performance](#performance)
 - [Test strategy](#test-strategy)
 - [Known limitations](#known-limitations)
 - [Phase 2 plans](#phase-2-plans)

--- a/src/test_helpers/bench_corpus.rs
+++ b/src/test_helpers/bench_corpus.rs
@@ -2,12 +2,11 @@
 //! brute-force ground truth, recall calibration, and thin builder
 //! wrappers around infino's public API.
 //!
-//! Both `infino/benches/` (infino-only timings) and the head-to-head
-//! benches in the sibling `retrievalbench` repo source corpus,
-//! queries, and ground truth from here so the two harnesses measure
-//! the **same** workload. Without that shared source, comparison
-//! tables in retrievalbench would mix runs against different
-//! corpora.
+//! `infino/benches/` consumes these directly. Centralizing the
+//! generators here means a single deterministic source of truth for
+//! the corpus, queries, and ground truth — without that, every
+//! re-run would silently risk mixing measurements against drifted
+//! data.
 //!
 //! ## Scale knob
 //!
@@ -335,8 +334,8 @@ pub fn mean_recall_infino(
 // ─── Recall-floor calibration ─────────────────────────────────────────
 
 /// p50 wall time (microseconds) over `n_iter` repetitions of one closure.
-/// Accepts any `FnMut()` so it can wrap either engine's search call from
-/// retrievalbench's head-to-head.
+/// Generic over `FnMut()` so calibration can wrap any search call
+/// with one timing implementation.
 pub fn p50_micros<F: FnMut()>(mut f: F, n_iter: usize) -> f32 {
     let mut samples = Vec::with_capacity(n_iter);
     for _ in 0..n_iter {

--- a/src/test_helpers/bench_corpus.rs
+++ b/src/test_helpers/bench_corpus.rs
@@ -1,0 +1,502 @@
+//! Shared bench fixtures: deterministic corpora, query batteries,
+//! brute-force ground truth, recall calibration, and thin builder
+//! wrappers around infino's public API.
+//!
+//! Both `infino/benches/` (infino-only timings) and the head-to-head
+//! benches in the sibling `retrievalbench` repo source corpus,
+//! queries, and ground truth from here so the two harnesses measure
+//! the **same** workload. Without that shared source, comparison
+//! tables in retrievalbench would mix runs against different
+//! corpora.
+//!
+//! ## Scale knob
+//!
+//! [`n_docs`] returns `10_000_000` when `INFINO_BENCH_FULL=1` is set
+//! in the environment, otherwise `1_000_000`. Vector at 10M × 384 (f32)
+//! = 14.6 GB resident — needs a 32 GB+ machine. Superfile-shape benches
+//! pin themselves to 1M (one-segment scale); supertable-shape benches
+//! pin to 10M (sharding scale). Each topic's bench files name the
+//! pinned constant directly rather than calling this helper at
+//! benchmark time.
+
+#![allow(clippy::too_many_arguments)]
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow_array::{LargeStringArray, RecordBatch, UInt64Array};
+use arrow_schema::{DataType, Field, Schema};
+use bytes::Bytes;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, StandardNormal};
+
+use crate::superfile::SuperfileReader;
+use crate::superfile::builder::{
+    BuilderOptions, FtsConfig, SuperfileBuilder, VectorConfig as SfVectorConfig,
+};
+use crate::superfile::fts::builder::FtsBuilder;
+use crate::superfile::vector::builder::{VectorBuilder, VectorConfig};
+use crate::superfile::vector::distance::{Metric, normalize};
+use crate::superfile::vector::reader::VectorReader;
+use crate::test_helpers::default_tokenizer;
+
+// ─── Scale constants ──────────────────────────────────────────────────
+
+/// Tokens per doc — chosen to land in the same magnitude as a typical
+/// short article (~200 words). The product `n_docs * tokens_per_doc`
+/// drives FTS posting volume.
+pub const TOKENS_PER_DOC: usize = 200;
+
+/// Vocabulary size — controls term-frequency distribution. Small
+/// enough that common terms appear in many docs (exercising long
+/// posting lists); large enough that rare terms exist (exercising the
+/// FST + skip-table cold path).
+pub const VOCAB_SIZE: usize = 10_000;
+
+/// Vector dimension — matches modern sentence-embedding models
+/// (all-MiniLM-L6-v2 = 384, BGE-small = 384).
+pub const DIM: usize = 384;
+
+/// One `(local_doc_id, distance)` hit — same shape `VectorReader::search`
+/// returns. Re-exported here so recall helpers stay engine-agnostic.
+pub type Hit = (u32, f32);
+
+/// Resolved doc count for the current bench run, gated by the
+/// `INFINO_BENCH_FULL` env var (10M when set, 1M otherwise).
+pub fn n_docs() -> usize {
+    if std::env::var("INFINO_BENCH_FULL").is_ok() {
+        10_000_000
+    } else {
+        1_000_000
+    }
+}
+
+/// IVF cluster count. Conventionally `~sqrt(n_docs)`, snapped to a
+/// fixed value per scale band so 1M and 10M runs share a stable
+/// `n_cent`.
+pub fn n_cent(n_docs: usize) -> usize {
+    if n_docs >= 5_000_000 {
+        4096
+    } else if n_docs >= 100_000 {
+        1024
+    } else {
+        64
+    }
+}
+
+// ─── Text corpus ──────────────────────────────────────────────────────
+
+/// Deterministic Zipfian sampler over `[1, n]`. Inverse-CDF; O(log n)
+/// per draw. Avoids `rand_distr::Zipf`'s f64-parameter overhead.
+pub struct ZipfDistribution {
+    /// Cumulative `1/i` weights up to rank `n`. Index 0 == rank 1.
+    cum_weights: Vec<f64>,
+}
+
+impl ZipfDistribution {
+    pub fn new(n: usize) -> Self {
+        let mut cum = Vec::with_capacity(n);
+        let mut acc = 0.0f64;
+        for i in 1..=n {
+            acc += 1.0 / (i as f64);
+            cum.push(acc);
+        }
+        Self { cum_weights: cum }
+    }
+
+    pub fn sample<R: rand::Rng>(&self, rng: &mut R) -> usize {
+        use rand::RngExt;
+        let total = *self.cum_weights.last().expect("non-empty");
+        let target: f64 = rng.random::<f64>() * total;
+        match self
+            .cum_weights
+            .binary_search_by(|p| p.partial_cmp(&target).unwrap_or(std::cmp::Ordering::Equal))
+        {
+            Ok(i) | Err(i) => i.min(self.cum_weights.len() - 1) + 1,
+        }
+    }
+}
+
+/// Generate a Zipfian token corpus. Returns `n_docs` strings, each
+/// `TOKENS_PER_DOC` body tokens drawn from a closed [`VOCAB_SIZE`]
+/// vocabulary prefixed by one doc-unique identifier token
+/// (`doc<7-digit-id>`).
+///
+/// The closed-vocab body alone has no singletons — the rarest body
+/// term still has df ≈ N / (V · H_V) ≈ 2000 at 1M docs × 200 tokens ×
+/// 10K vocab — which underexercises the format's `df=1` paths (per-term
+/// metadata, BMW upper bound on one-doc terms, the inline-encoding
+/// short-circuit). The per-doc identifier creates a singleton long
+/// tail proportional to `n_docs`, matching production text where every
+/// real doc carries some unique token (URL hash, ISBN, headline number).
+pub fn generate_text_corpus(n_docs: usize, seed: u64) -> Vec<String> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let zipf = ZipfDistribution::new(VOCAB_SIZE);
+    let mut out = Vec::with_capacity(n_docs);
+    for doc_id in 0..n_docs {
+        let mut doc = String::with_capacity((TOKENS_PER_DOC + 1) * 8);
+        doc.push_str(&format!("doc{doc_id:07}"));
+        for _ in 0..TOKENS_PER_DOC {
+            let idx = zipf.sample(&mut rng);
+            doc.push(' ');
+            doc.push_str(&format!("term{idx:05}"));
+        }
+        out.push(doc);
+    }
+    out
+}
+
+// ─── Vector corpus ────────────────────────────────────────────────────
+
+/// Generate `n_docs` planted-cluster vectors of [`DIM`] dimensions,
+/// optionally per-doc normalized for cosine. `n_cent` planted centers
+/// drawn from `3·N(0, 1)` per dim; each doc lives near a center with
+/// `sigma = 0.3` per-dim Gaussian noise.
+///
+/// **Centers are intentionally NOT normalized.** At `DIM=384` the
+/// un-normalized center magnitude is ~58 and per-doc noise norm is
+/// ~5.9 (about 10% of center magnitude), so docs sit tightly around
+/// their planted center direction. If centers were unit-normalized
+/// first, the same noise would dominate (`||noise|| ≈ 5.9 ≫ 1`) and
+/// per-doc normalization would destroy the cluster signal entirely —
+/// IVF + RaBitQ trained on that data can't recover any meaningful
+/// cluster structure even at full sweep + maximal rerank.
+pub fn generate_vector_corpus(
+    n_docs: usize,
+    n_cent: usize,
+    seed: u64,
+    normalize_each: bool,
+) -> Vec<f32> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let dist = StandardNormal;
+
+    let centers: Vec<Vec<f32>> = (0..n_cent)
+        .map(|_| {
+            (0..DIM)
+                .map(|_| {
+                    let s: f64 = dist.sample(&mut rng);
+                    (s as f32) * 3.0
+                })
+                .collect()
+        })
+        .collect();
+
+    let mut out: Vec<f32> = Vec::with_capacity(n_docs * DIM);
+    for i in 0..n_docs {
+        let center = &centers[i % n_cent];
+        let mut v: Vec<f32> = center
+            .iter()
+            .map(|&c| {
+                let s: f64 = dist.sample(&mut rng);
+                c + (s as f32) * 0.3
+            })
+            .collect();
+        if normalize_each {
+            normalize(&mut v);
+        }
+        out.extend_from_slice(&v);
+    }
+    out
+}
+
+// ─── Query batteries ──────────────────────────────────────────────────
+
+/// `n_queries` deterministic Gaussian queries (no corpus dependency),
+/// normalized. Useful only for smoke wiring — real benches should use
+/// [`generate_realistic_queries`] so recall is meaningful at modest
+/// nprobe.
+pub fn generate_queries(n_queries: usize, seed: u64) -> Vec<Vec<f32>> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let dist = StandardNormal;
+    (0..n_queries)
+        .map(|_| {
+            let mut q: Vec<f32> = (0..DIM)
+                .map(|_| {
+                    let s: f64 = dist.sample(&mut rng);
+                    (s as f32) * 3.0
+                })
+                .collect();
+            normalize(&mut q);
+            q
+        })
+        .collect()
+}
+
+/// Pick `n_queries` corpus members and perturb each by small Gaussian
+/// noise. A pure-Gaussian query lands far from any doc in embedding
+/// space, so the top-10 NN are spread across many planted clusters and
+/// IVF recall stays low even at high nprobe. Perturbed corpus members
+/// match the same workload `tests/recall.rs` uses.
+pub fn generate_realistic_queries(
+    vectors: &[f32],
+    n_docs: usize,
+    n_queries: usize,
+    seed: u64,
+    normalize_each: bool,
+    sigma: f32,
+) -> Vec<Vec<f32>> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let dist = StandardNormal;
+    let mut out = Vec::with_capacity(n_queries);
+    for i in 0..n_queries {
+        // Coprime stride so consecutive queries don't all sit in the
+        // first planted cluster.
+        let base_idx = (i * 7919) % n_docs;
+        let off = base_idx * DIM;
+        let mut q: Vec<f32> = (0..DIM)
+            .map(|d| {
+                let s: f64 = dist.sample(&mut rng);
+                vectors[off + d] + (s as f32) * sigma
+            })
+            .collect();
+        if normalize_each {
+            normalize(&mut q);
+        }
+        out.push(q);
+    }
+    out
+}
+
+// ─── Brute-force ground truth + recall ────────────────────────────────
+
+/// Brute-force kNN ground truth for cosine distance on L2-normalized
+/// vectors. Returns top-k local doc_ids (no distances — recall only
+/// needs the id set).
+pub fn brute_force_topk_cosine(
+    vectors: &[f32],
+    n_docs: usize,
+    query: &[f32],
+    k: usize,
+) -> Vec<u32> {
+    assert_eq!(vectors.len(), n_docs * DIM);
+    assert_eq!(query.len(), DIM);
+    // For L2-normalized inputs cosine distance is monotone in -dot.
+    let mut scored: Vec<(u32, f32)> = (0..n_docs as u32)
+        .map(|i| {
+            let off = (i as usize) * DIM;
+            let mut dot = 0f32;
+            for d in 0..DIM {
+                dot += vectors[off + d] * query[d];
+            }
+            (i, -dot)
+        })
+        .collect();
+    scored.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(k);
+    scored.into_iter().map(|(i, _)| i).collect()
+}
+
+/// Brute-force top-k per query for a whole batch.
+pub fn ground_truth(
+    vectors: &[f32],
+    n_docs: usize,
+    queries: &[Vec<f32>],
+    k: usize,
+) -> Vec<Vec<u32>> {
+    queries
+        .iter()
+        .map(|q| brute_force_topk_cosine(vectors, n_docs, q, k))
+        .collect()
+}
+
+/// Recall@k between a predicted top-k id list and ground truth.
+pub fn recall_at_k(predicted: &[Hit], truth: &[u32]) -> f32 {
+    if truth.is_empty() {
+        return 1.0;
+    }
+    let truth_set: std::collections::HashSet<u32> = truth.iter().copied().collect();
+    let hits = predicted
+        .iter()
+        .filter(|(id, _)| truth_set.contains(id))
+        .count();
+    hits as f32 / truth.len() as f32
+}
+
+/// Mean recall for one (engine, config) point across a query batch.
+pub fn mean_recall_infino(
+    reader: &VectorReader,
+    queries: &[Vec<f32>],
+    truths: &[Vec<u32>],
+    k: usize,
+    nprobe: usize,
+    rerank_mult: usize,
+) -> f32 {
+    let mut sum = 0f32;
+    for (q, t) in queries.iter().zip(truths) {
+        let hits = reader
+            .search("v", q, k, nprobe, rerank_mult)
+            .expect("vector search");
+        sum += recall_at_k(&hits, t);
+    }
+    sum / queries.len() as f32
+}
+
+// ─── Recall-floor calibration ─────────────────────────────────────────
+
+/// p50 wall time (microseconds) over `n_iter` repetitions of one closure.
+/// Accepts any `FnMut()` so it can wrap either engine's search call from
+/// retrievalbench's head-to-head.
+pub fn p50_micros<F: FnMut()>(mut f: F, n_iter: usize) -> f32 {
+    let mut samples = Vec::with_capacity(n_iter);
+    for _ in 0..n_iter {
+        let t0 = Instant::now();
+        f();
+        samples.push(t0.elapsed().as_secs_f32() * 1e6);
+    }
+    samples.sort_unstable_by(|a, b| a.partial_cmp(b).expect("partial_cmp"));
+    samples[samples.len() / 2]
+}
+
+/// Calibration result for one engine at one recall target.
+#[derive(Debug, Clone, Copy)]
+pub struct Calibrated {
+    pub probe: usize,
+    pub refine: usize,
+    pub recall: f32,
+    pub p50_micros: f32,
+}
+
+/// Sweep a `(probe, refine)` grid for infino; return the lowest-p50
+/// point that hits `recall ≥ target_recall`. `None` if no grid point
+/// meets the target.
+pub fn calibrate_infino(
+    reader: &VectorReader,
+    queries: &[Vec<f32>],
+    truths: &[Vec<u32>],
+    target_recall: f32,
+    probes: &[usize],
+    refines: &[usize],
+    p50_iter: usize,
+    k: usize,
+) -> Option<Calibrated> {
+    let mut best: Option<Calibrated> = None;
+    let mut peak_recall = 0f32;
+    for &probe in probes {
+        for &refine in refines {
+            let recall = mean_recall_infino(reader, queries, truths, k, probe, refine);
+            if recall > peak_recall {
+                peak_recall = recall;
+            }
+            if recall < target_recall {
+                continue;
+            }
+            // Single-query timing fixture; Gaussian queries are
+            // statistically interchangeable so p50 over n_iter on one
+            // query approximates the mean shape across the battery.
+            let q = &queries[0];
+            let p50 = p50_micros(
+                || {
+                    let _ = reader.search("v", q, k, probe, refine).expect("search");
+                },
+                p50_iter,
+            );
+            let cand = Calibrated {
+                probe,
+                refine,
+                recall,
+                p50_micros: p50,
+            };
+            best = match best {
+                None => Some(cand),
+                Some(b) if cand.p50_micros < b.p50_micros => Some(cand),
+                Some(b) => Some(b),
+            };
+        }
+    }
+    if best.is_none() {
+        eprintln!(
+            "    [infino] no point hit recall ≥ {target_recall:.2}; peak observed = {peak_recall:.3}"
+        );
+    }
+    best
+}
+
+// ─── Thin builder wrappers ────────────────────────────────────────────
+
+/// Build a stand-alone FTS index from a token corpus. Wrapper exists so
+/// both bench harnesses construct the index identically.
+pub fn build_fts_index(docs: &[String]) -> FtsBuilder {
+    let mut b = FtsBuilder::new(default_tokenizer());
+    b.register_column("title".to_string())
+        .expect("register column");
+    for (i, text) in docs.iter().enumerate() {
+        b.add_doc(0, i as u32, text).expect("add doc");
+    }
+    b
+}
+
+/// Build a stand-alone vector index. `vectors` is flat `n_docs * DIM`.
+pub fn build_vector_index(
+    vectors: &[f32],
+    n_docs: usize,
+    n_cent: usize,
+    metric: Metric,
+) -> VectorBuilder {
+    let mut b = VectorBuilder::new();
+    b.register_column(VectorConfig {
+        name: "v".into(),
+        dim: DIM,
+        n_cent,
+        rot_seed: 7,
+        metric,
+    })
+    .expect("register column");
+    for i in 0..n_docs {
+        let off = i * DIM;
+        b.add(0, &vectors[off..off + DIM])
+            .expect("add to vector builder");
+    }
+    b
+}
+
+/// Open a built vector blob as a reader. Encodes the directory JSON
+/// inline so callers don't reinvent it.
+pub fn open_vector_reader(blob: Vec<u8>, n_cent: usize, metric: Metric) -> VectorReader {
+    let metric_str = match metric {
+        Metric::L2Sq => "l2sq",
+        Metric::Cosine => "cosine",
+        Metric::NegDot => "negdot",
+    };
+    let json = format!(
+        r#"[{{"name":"v","dim":{DIM},"n_cent":{n_cent},"rot_seed":7,"metric":"{metric_str}"}}]"#
+    );
+    VectorReader::open(Bytes::from(blob), &json).expect("open VectorReader")
+}
+
+/// Build a full superfile (FTS + vector) for end-to-end benches.
+pub fn build_superfile(docs: &[String], vectors: &[f32], n_cent: usize) -> Vec<u8> {
+    let n = docs.len();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("doc_id", DataType::UInt64, false),
+        Field::new("title", DataType::LargeUtf8, false),
+    ]));
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: DIM,
+            n_cent,
+            rot_seed: 7,
+            metric: Metric::Cosine,
+        }],
+        Some(default_tokenizer()),
+    );
+
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let ids = UInt64Array::from((0..n as u64).collect::<Vec<_>>());
+    let titles = LargeStringArray::from(docs.iter().map(String::as_str).collect::<Vec<_>>());
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
+        .expect("build RecordBatch");
+    b.add_batch(&batch, &[vectors]).expect("add_batch");
+    b.finish().expect("finish builder")
+}
+
+/// Open a finished superfile blob.
+pub fn open_superfile(bytes: Vec<u8>) -> SuperfileReader {
+    SuperfileReader::open(Bytes::from(bytes)).expect("open superfile")
+}

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -25,6 +25,7 @@
 //! [`brute_force_bm25`] is the textbook BM25 reference impl
 //! used as the FTS correctness oracle.
 
+pub mod bench_corpus;
 pub mod brute_force_bm25;
 
 use std::sync::Arc;


### PR DESCRIPTION
Two criterion binaries — `fts` and `vector` — each bundling superfile (1M docs) and supertable (10M docs) sub-groups. Pure infino timing plus correctness gates (BMW-vs-brute-force on FTS, recall floor on vector).  

Shared corpus + queries + ground-truth + recall calibration live in `src/test_helpers/bench_corpus.rs`, gated behind the existing `test-helpers` feature. 

Each bench's `emit_*_markdown` reads measurements back out of criterion's `target/criterion/<group>/<bench>/new/estimates.json`, formats a table, and (when `INFINO_BENCH_UPDATE_README=1` is set) rewrites the matching `<!-- BEGIN/END -->` block in `benches/README.md` in place. `benches/README.md` ships with placeholder bodies pointing at the right `cargo bench` invocation; first run populates them.

Both bench binaries compile clean in the `bench` profile (no warnings, no errors). First run at 1M + 10M scale is left to a follow-up — the deferred wall time is the only reason this commit doesn't include populated numbers.