### PR TITLE
fix benchmarks: make benchmarks runnable using criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,8 +227,10 @@ path = "tests/supertable/main.rs"
 [[bench]]
 name = "fts"
 path = "benches/fts/main.rs"
+harness = false
 
 [[bench]]
 name = "vector"
 path = "benches/vector/main.rs"
+harness = false
 


### PR DESCRIPTION
### What does this PR do?
- Sets the `harness: false` for the "bench" targets in Cargo.toml to run them using criterion

### Why do we need this change?
- To make the benches runnable using criterion. Without this change, the benches do not run