### PR TITLE
chore: add rustfmt.toml for uniform formatting

### DIFF
--- a/benches/fts/superfile.rs
+++ b/benches/fts/superfile.rs
@@ -138,7 +138,11 @@ fn assert_bmw_matches_brute_force(reader: &FtsReader) -> usize {
         (
             "five_term",
             &[
-                "term00050", "term00051", "term00052", "term00053", "term00054",
+                "term00050",
+                "term00051",
+                "term00052",
+                "term00053",
+                "term00054",
             ],
         ),
     ];
@@ -188,8 +192,12 @@ fn assert_bmw_matches_brute_force(reader: &FtsReader) -> usize {
 
 // ─── Bench helpers ────────────────────────────────────────────────────
 
-fn bench_infino(c: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
-                name: &str, r: &FtsReader, terms: &'static [&'static str]) {
+fn bench_infino(
+    c: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+    name: &str,
+    r: &FtsReader,
+    terms: &'static [&'static str],
+) {
     c.bench_function(format!("{name}_infino_top10"), |b| {
         b.iter(|| {
             let hits = r
@@ -205,8 +213,12 @@ fn bench_infino(c: &mut criterion::BenchmarkGroup<criterion::measurement::WallTi
     });
 }
 
-fn bench_per_algo_probe(c: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
-                        name: &str, r: &FtsReader, terms: &'static [&'static str]) {
+fn bench_per_algo_probe(
+    c: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+    name: &str,
+    r: &FtsReader,
+    terms: &'static [&'static str],
+) {
     c.bench_function(format!("{name}_wand_top10"), |b| {
         b.iter(|| {
             let hits = r
@@ -274,14 +286,28 @@ fn bench(c: &mut Criterion) {
         bench_infino(&mut g, "single_df1", &r, &["doc0500000"]);
         bench_infino(&mut g, "single_common", &r, &["term00001"]);
         bench_infino(&mut g, "two_term_or", &r, &["term00001", "term00050"]);
-        bench_infino(&mut g, "three_wide", &r, &["term00001", "term00050", "term00100"]);
-        bench_infino(&mut g, "three_similar", &r, &["term00050", "term00051", "term00052"]);
+        bench_infino(
+            &mut g,
+            "three_wide",
+            &r,
+            &["term00001", "term00050", "term00100"],
+        );
+        bench_infino(
+            &mut g,
+            "three_similar",
+            &r,
+            &["term00050", "term00051", "term00052"],
+        );
         bench_infino(
             &mut g,
             "five_term",
             &r,
             &[
-                "term00050", "term00051", "term00052", "term00053", "term00054",
+                "term00050",
+                "term00051",
+                "term00052",
+                "term00053",
+                "term00054",
             ],
         );
 
@@ -303,7 +329,11 @@ fn bench(c: &mut Criterion) {
             "similar_5",
             &r,
             &[
-                "term00050", "term00051", "term00052", "term00053", "term00054",
+                "term00050",
+                "term00051",
+                "term00052",
+                "term00053",
+                "term00054",
             ],
         );
 

--- a/benches/fts/supertable.rs
+++ b/benches/fts/supertable.rs
@@ -120,8 +120,7 @@ fn build_supertable_infino(docs: &[String], reader_pool: Arc<ThreadPool>) -> Sup
     let chunk_size = docs.len().div_ceil(SEGMENTS);
     for chunk in docs.chunks(chunk_size) {
         let titles = LargeStringArray::from(chunk.iter().map(String::as_str).collect::<Vec<_>>());
-        let batch = RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)])
-            .expect("batch");
+        let batch = RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)]).expect("batch");
         w.append(&batch).expect("append");
     }
     w.commit().expect("commit");
@@ -170,9 +169,7 @@ fn assert_infino_self_consistent(st: &Supertable) {
 // ─── Bench: ingest (group: supertable_fts_build) ──────────────────────
 
 fn bench_ingest(c: &mut Criterion) {
-    eprintln!(
-        "[supertable_fts_build] correctness: building infino ({N_DOCS} docs)..."
-    );
+    eprintln!("[supertable_fts_build] correctness: building infino ({N_DOCS} docs)...");
     let infino = build_supertable_infino(docs(), parallel_pool());
     assert_infino_self_consistent(&infino);
     eprintln!("[supertable_fts_build] correctness OK: infino self-consistent");

--- a/benches/utils/markdown.rs
+++ b/benches/utils/markdown.rs
@@ -124,11 +124,7 @@ pub fn read_mean_ns(group: &str, bench: &str) -> Option<f64> {
 /// Mean time + throughput per second given a per-iteration element
 /// count. `None` if the bench result isn't on disk.
 #[allow(dead_code)]
-pub fn read_mean_with_throughput(
-    group: &str,
-    bench: &str,
-    elements: u64,
-) -> Option<(f64, f64)> {
+pub fn read_mean_with_throughput(group: &str, bench: &str, elements: u64) -> Option<(f64, f64)> {
     let ns = read_mean_ns(group, bench)?;
     if ns <= 0.0 {
         return None;

--- a/benches/vector/superfile.rs
+++ b/benches/vector/superfile.rs
@@ -119,9 +119,8 @@ fn build_infino_blob(vectors: &[f32]) -> Vec<u8> {
 
 fn open_infino_reader(blob: Vec<u8>) -> VectorReader {
     let n_cent = bench_corpus::n_cent(N_DOCS);
-    let json = format!(
-        r#"[{{"name":"v","dim":{DIM},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#
-    );
+    let json =
+        format!(r#"[{{"name":"v","dim":{DIM},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#);
     VectorReader::open(Bytes::from(blob), &json).expect("open VectorReader")
 }
 
@@ -170,9 +169,8 @@ fn calibrations() -> &'static Calibrations {
         );
         let mut inf: [Option<Calibrated>; 3] = [None; 3];
         for (i, &target) in RECALL_TARGETS.iter().enumerate() {
-            inf[i] = bench_corpus::calibrate_infino(
-                &reader, qs, gt, target, PROBES, REFINES, 21, TOP_K,
-            );
+            inf[i] =
+                bench_corpus::calibrate_infino(&reader, qs, gt, target, PROBES, REFINES, 21, TOP_K);
             eprintln!("  recall ≥ {target:.2} | infino: {:?}", inf[i]);
         }
         Calibrations { infino: inf }
@@ -228,8 +226,7 @@ fn bench(c: &mut Criterion) {
                     |b, &(p, r)| {
                         let q = &qs[0];
                         b.iter(|| {
-                            let hits =
-                                reader.search("v", black_box(q), TOP_K, p, r).expect("kNN");
+                            let hits = reader.search("v", black_box(q), TOP_K, p, r).expect("kNN");
                             black_box(hits)
                         });
                     },
@@ -330,8 +327,8 @@ fn emit_search_markdown() {
 
     let mut body = String::new();
     body.push_str(&format!(
-        "### Superfile vector — search ({N_DOCS} docs × dim={DIM}, calibrated at recall targets)\n\n"
-    ));
+    "### Superfile vector — search ({N_DOCS} docs × dim={DIM}, calibrated at recall targets)\n\n"
+  ));
     body.push_str("| Recall target | infino (probe, refine) | infino p50 |\n");
     body.push_str("|---------------|------------------------|------------|\n");
 
@@ -339,10 +336,7 @@ fn emit_search_markdown() {
         let label = format!("recall_at_least_{:02}", (target * 100.0) as u32);
         let row_target = format!("{target:.2}");
         if let Some(c_inf) = cal.infino[i] {
-            let id = format!(
-                "infino_{label}/p={},r={}",
-                c_inf.probe, c_inf.refine,
-            );
+            let id = format!("infino_{label}/p={},r={}", c_inf.probe, c_inf.refine,);
             let ns = read_mean_ns(group, &id);
             let p50 = ns.map(fmt_time).unwrap_or_else(|| "—".into());
             body.push_str(&format!(
@@ -356,8 +350,8 @@ fn emit_search_markdown() {
 
     body.push('\n');
     body.push_str(
-        "**infino default options** (`nprobe=8, rerank_mult=20` — user-facing latency baseline):\n\n",
-    );
+    "**infino default options** (`nprobe=8, rerank_mult=20` — user-facing latency baseline):\n\n",
+  );
     body.push_str("| Metric | Value |\n");
     body.push_str("|--------|-------|\n");
     let def = read_mean_ns(group, "infino_default_options_top10");

--- a/benches/vector/supertable.rs
+++ b/benches/vector/supertable.rs
@@ -168,8 +168,7 @@ fn build_supertable() -> Supertable {
             None,
         )
         .expect("FSL");
-        let batch =
-            RecordBatch::try_new(supertable_schema(), vec![Arc::new(fsl)]).expect("batch");
+        let batch = RecordBatch::try_new(supertable_schema(), vec![Arc::new(fsl)]).expect("batch");
         w.append(&batch).expect("append");
         w.commit().expect("commit");
     }
@@ -430,8 +429,8 @@ fn emit_search_markdown() {
 
     let mut body = String::new();
     body.push_str(&format!(
-        "### Supertable vector — search ({N_DOCS} docs × dim={DIM}, calibrated at recall targets)\n\n"
-    ));
+    "### Supertable vector — search ({N_DOCS} docs × dim={DIM}, calibrated at recall targets)\n\n"
+  ));
     body.push_str("| Recall target | supertable (probe/seg, refine) | supertable p50 |\n");
     body.push_str("|---------------|--------------------------------|----------------|\n");
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+tab_spaces = 4
+edition = "2024"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -283,12 +283,7 @@ mod tests {
     fn env_overrides_default() {
         let _g = ENV_LOCK.lock().expect("acquire lock");
         // SAFETY: serialized via ENV_LOCK; cleanup at end.
-        unsafe {
-            std::env::set_var(
-                "INFINO_SUPERTABLE__COMMIT_THRESHOLD_SIZE_MB",
-                "2048",
-            )
-        };
+        unsafe { std::env::set_var("INFINO_SUPERTABLE__COMMIT_THRESHOLD_SIZE_MB", "2048") };
         let cfg = Config::load().expect("load with env override");
         assert_eq!(cfg.supertable.commit_threshold_size_mb, 2048);
         unsafe { std::env::remove_var("INFINO_SUPERTABLE__COMMIT_THRESHOLD_SIZE_MB") };

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -99,7 +99,11 @@ fn translate(uri: &str, e: ObjError) -> StorageError {
 impl StorageProvider for LocalFsStorageProvider {
     async fn head(&self, uri: &str) -> Result<ObjectMeta, StorageError> {
         let path = Self::path(uri)?;
-        let meta = self.store.head(&path).await.map_err(|e| translate(uri, e))?;
+        let meta = self
+            .store
+            .head(&path)
+            .await
+            .map_err(|e| translate(uri, e))?;
         Ok(ObjectMeta {
             size: meta.size as u64,
             etag: meta.e_tag,
@@ -190,10 +194,12 @@ impl StorageProvider for LocalFsStorageProvider {
                         uri: uri.into(),
                         source: Box::new(e),
                     })?;
-                lock_file.lock_exclusive().map_err(|e| StorageError::Permanent {
-                    uri: uri.into(),
-                    source: Box::new(e),
-                })?;
+                lock_file
+                    .lock_exclusive()
+                    .map_err(|e| StorageError::Permanent {
+                        uri: uri.into(),
+                        source: Box::new(e),
+                    })?;
                 // Lock held below until `lock_file` drops at
                 // end of branch (or early-return). Holding it
                 // across `.await` points blocks the
@@ -202,7 +208,11 @@ impl StorageProvider for LocalFsStorageProvider {
                 // bounded.
 
                 let result: Result<(), StorageError> = async {
-                    let current = self.store.head(&path).await.map_err(|e| translate(uri, e))?;
+                    let current = self
+                        .store
+                        .head(&path)
+                        .await
+                        .map_err(|e| translate(uri, e))?;
                     let current_etag = current.e_tag.as_deref().unwrap_or("");
                     if current_etag != expected {
                         return Err(StorageError::PreconditionFailed { uri: uri.into() });
@@ -289,7 +299,9 @@ mod tests {
     async fn head_returns_accurate_size() {
         let (_dir, p) = provider();
         let payload = Bytes::from_static(&[0xABu8; 1024]);
-        p.put_atomic("data/seg-head.sf", payload).await.expect("put");
+        p.put_atomic("data/seg-head.sf", payload)
+            .await
+            .expect("put");
 
         let meta = p.head("data/seg-head.sf").await.expect("head");
         assert_eq!(meta.size, 1024);
@@ -415,10 +427,7 @@ mod tests {
     #[tokio::test]
     async fn missing_object_returns_not_found() {
         let (_dir, p) = provider();
-        let err = p
-            .head("data/no-such.sf")
-            .await
-            .expect_err("head missing");
+        let err = p.head("data/no-such.sf").await.expect_err("head missing");
         assert!(matches!(err, StorageError::NotFound { .. }));
 
         let err = p.get("data/no-such.sf").await.expect_err("get missing");
@@ -457,7 +466,12 @@ mod tests {
         p.put_atomic("ptr/current", Bytes::from_static(b"v1"))
             .await
             .expect("initial");
-        let etag = p.head("ptr/current").await.expect("head").etag.expect("etag");
+        let etag = p
+            .head("ptr/current")
+            .await
+            .expect("head")
+            .etag
+            .expect("etag");
         p.put_if_match("ptr/current", Bytes::from_static(b"v2"), Some(&etag))
             .await
             .expect("conditional update");

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -117,11 +117,7 @@ pub trait StorageProvider: Send + Sync + std::fmt::Debug {
     async fn get(&self, uri: &str) -> Result<Bytes, StorageError>;
 
     /// Range-fetch. `range.end` is exclusive.
-    async fn get_range(
-        &self,
-        uri: &str,
-        range: Range<u64>,
-    ) -> Result<Bytes, StorageError>;
+    async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError>;
 
     /// Atomic write — succeeds only if the target doesn't
     /// exist. Maps to `If-None-Match: *` on S3,

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -38,8 +38,7 @@ use bytes::Bytes;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path as ObjPath;
 use object_store::{
-    Error as ObjError, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload,
-    UpdateVersion,
+    Error as ObjError, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
 };
 
 use super::{ObjectMeta, StorageError, StorageProvider};
@@ -167,7 +166,11 @@ fn translate(uri: &str, e: ObjError) -> StorageError {
 impl StorageProvider for S3StorageProvider {
     async fn head(&self, uri: &str) -> Result<ObjectMeta, StorageError> {
         let path = Self::path(uri)?;
-        let meta = self.store.head(&path).await.map_err(|e| translate(uri, e))?;
+        let meta = self
+            .store
+            .head(&path)
+            .await
+            .map_err(|e| translate(uri, e))?;
         Ok(ObjectMeta {
             size: meta.size as u64,
             etag: meta.e_tag,

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -664,8 +664,8 @@ mod tests {
                 vec![],
                 Some(default_tokenizer()),
             );
-            let err = SuperfileBuilder::new(opts)
-                .expect_err(&format!("expected rejection for {ty:?}"));
+            let err =
+                SuperfileBuilder::new(opts).expect_err(&format!("expected rejection for {ty:?}"));
             assert!(
                 matches!(err, BuildError::IdColumnWrongType(_, _)),
                 "wrong error variant for {ty:?}: {err:?}",
@@ -796,8 +796,11 @@ mod tests {
             DataType::UInt64,
             false,
         )]));
-        let bad = RecordBatch::try_new(other, vec![Arc::new(arrow_array::UInt64Array::from(vec![1u64]))])
-            .expect("build RecordBatch");
+        let bad = RecordBatch::try_new(
+            other,
+            vec![Arc::new(arrow_array::UInt64Array::from(vec![1u64]))],
+        )
+        .expect("build RecordBatch");
         let err = b.add_batch(&bad, &[]).expect_err("expected error");
         assert!(matches!(err, BuildError::BatchSchemaMismatch));
     }

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -263,7 +263,10 @@ impl FtsBuilder {
         let n_columns = self.columns.len() as u32;
         let n_docs = self.n_docs;
         let n_terms_total_usize: usize = self.postings.iter().map(|m| m.len()).sum();
-        debug_assert!(n_terms_total_usize <= u32::MAX as usize, "term count overflows u32");
+        debug_assert!(
+            n_terms_total_usize <= u32::MAX as usize,
+            "term count overflows u32"
+        );
         let n_terms_total = n_terms_total_usize as u32;
 
         // 1. Canonical FST order is lex-sorted full keys
@@ -315,7 +318,9 @@ impl FtsBuilder {
 
             // Drain this column's terms and sort lex by term bytes.
             let mut term_entries: Vec<(Box<str>, PostingAcc)> =
-                std::mem::take(&mut postings_by_col[col_idx]).into_iter().collect();
+                std::mem::take(&mut postings_by_col[col_idx])
+                    .into_iter()
+                    .collect();
             term_entries.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
 
             for (term, acc) in &term_entries {
@@ -374,10 +379,8 @@ impl FtsBuilder {
                 // Skip-table size = num_blocks × SKIP_ENTRY_SIZE.
                 let skip_table_size = encoded_blocks.len() * SKIP_ENTRY_SIZE;
                 // Total per-term posting bytes = metadata + skip table + blocks.
-                let blocks_total_size: usize =
-                    encoded_blocks.iter().map(|b| b.bytes.len()).sum();
-                let postings_length =
-                    (TERM_META_SIZE + skip_table_size + blocks_total_size) as u64;
+                let blocks_total_size: usize = encoded_blocks.iter().map(|b| b.bytes.len()).sum();
+                let postings_length = (TERM_META_SIZE + skip_table_size + blocks_total_size) as u64;
 
                 // Metadata header (20 bytes). df, postings_length,
                 // and num_blocks fit u32 even at the 16 GB segment
@@ -419,8 +422,7 @@ impl FtsBuilder {
                         min_dl_per_block[i],
                         avgdl,
                     );
-                    let max_bm25_x1000 =
-                        (max_bm25 * 1000.0).max(0.0).min(u32::MAX as f32) as u32;
+                    let max_bm25_x1000 = (max_bm25 * 1000.0).max(0.0).min(u32::MAX as f32) as u32;
                     postings_buf.extend_from_slice(&last_doc_id.to_le_bytes()); // 4
                     postings_buf.extend_from_slice(&block_offset.to_le_bytes()); // 4
                     postings_buf.extend_from_slice(&max_bm25_x1000.to_le_bytes()); // 4
@@ -615,7 +617,8 @@ mod tests {
         // Doc 0: "rust" + "tokio" in title, "rust" + "async" in body.
         // Doc 1: only in body — "rust".
         // Doc 2: only in title — "rust".
-        b.add_doc(title_id, 0, "rust tokio").expect("add title doc 0");
+        b.add_doc(title_id, 0, "rust tokio")
+            .expect("add title doc 0");
         b.add_doc(body_id, 0, "rust async").expect("add body doc 0");
         b.add_doc(body_id, 1, "rust").expect("add body doc 1");
         b.add_doc(title_id, 1, "rust").expect("add title doc 1");
@@ -650,7 +653,9 @@ mod tests {
         let r = FtsReader::open(blob, json).expect("open");
 
         // "rust" in title returns title's docs (0, 1) and no others.
-        let hits_t = r.search("title", &["rust"], 10, BoolMode::Or).expect("title search");
+        let hits_t = r
+            .search("title", &["rust"], 10, BoolMode::Or)
+            .expect("title search");
         let ids_t: Vec<u32> = hits_t.iter().map(|(d, _)| *d).collect();
         assert_eq!(ids_t.len(), 2, "title 'rust' hit count");
         assert!(ids_t.contains(&0));
@@ -659,7 +664,9 @@ mod tests {
         // "rust" in body also returns its own docs (0, 1). Same ids
         // by coincidence; what matters is the search is scoped to
         // body's posting list, not title's.
-        let hits_b = r.search("body", &["rust"], 10, BoolMode::Or).expect("body search");
+        let hits_b = r
+            .search("body", &["rust"], 10, BoolMode::Or)
+            .expect("body search");
         let ids_b: Vec<u32> = hits_b.iter().map(|(d, _)| *d).collect();
         assert_eq!(ids_b.len(), 2, "body 'rust' hit count");
         assert!(ids_b.contains(&0));
@@ -743,8 +750,14 @@ mod tests {
         let blob = b.finish();
         assert_eq!(&blob[0..8], format::fts::MAGIC);
         // n_docs == 0 (u32 at 16..20), n_terms_total == 0 (u32 at 20..24).
-        assert_eq!(u32::from_le_bytes([blob[16], blob[17], blob[18], blob[19]]), 0);
-        assert_eq!(u32::from_le_bytes([blob[20], blob[21], blob[22], blob[23]]), 0);
+        assert_eq!(
+            u32::from_le_bytes([blob[16], blob[17], blob[18], blob[19]]),
+            0
+        );
+        assert_eq!(
+            u32::from_le_bytes([blob[20], blob[21], blob[22], blob[23]]),
+            0
+        );
     }
 
     #[test]

--- a/src/superfile/fts/fst_value.rs
+++ b/src/superfile/fts/fst_value.rs
@@ -48,7 +48,9 @@ impl FstValue {
     #[inline]
     pub(crate) fn unpack(packed: u64) -> Self {
         if packed & 1 == 0 {
-            Self::Pfor { metadata_offset: packed >> DOC_ID_SHIFT }
+            Self::Pfor {
+                metadata_offset: packed >> DOC_ID_SHIFT,
+            }
         } else {
             let doc_id = (packed >> DOC_ID_SHIFT) as u32;
             let tf = ((packed >> TF_SHIFT) as u32) & INLINE_TF_MAX;
@@ -88,13 +90,23 @@ mod tests {
         for &offset in &[0u64, 1, 20, 1 << 20, (1 << 34) - 1, 1 << 34] {
             let packed = FstValue::pack_pfor(offset);
             assert_eq!(packed & 1, 0, "PFOR form must have low bit clear");
-            assert_eq!(FstValue::unpack(packed), FstValue::Pfor { metadata_offset: offset });
+            assert_eq!(
+                FstValue::unpack(packed),
+                FstValue::Pfor {
+                    metadata_offset: offset
+                }
+            );
         }
     }
 
     #[test]
     fn inline_round_trip() {
-        let cases = [(0u32, 0u32), (1, 1), (500_000, 7), (u32::MAX, INLINE_TF_MAX)];
+        let cases = [
+            (0u32, 0u32),
+            (1, 1),
+            (500_000, 7),
+            (u32::MAX, INLINE_TF_MAX),
+        ];
         for &(doc_id, tf) in &cases {
             let packed = FstValue::pack_inline(doc_id, tf);
             assert_eq!(packed & 1, 1, "inline form must have low bit set");

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -134,11 +134,7 @@ impl FtsReader {
     /// `OpenOptions { verify_crc: false }` to skip the
     /// four per-section CRC scans on trusted-storage cold
     /// opens.
-    pub fn open_with(
-        blob: Bytes,
-        columns_json: &str,
-        opts: OpenOptions,
-    ) -> Result<Self, FtsError> {
+    pub fn open_with(blob: Bytes, columns_json: &str, opts: OpenOptions) -> Result<Self, FtsError> {
         if blob.len() < 48 {
             return Err(FtsError::Read(ReadError::MissingKv("fts header")));
         }
@@ -265,7 +261,8 @@ impl FtsReader {
                 dir_bytes[entry_off + 2],
                 dir_bytes[entry_off + 3],
             ]);
-            let doc_lengths_offset = read_u64_le(&dir_bytes[entry_off + 4..entry_off + 12]) as usize;
+            let doc_lengths_offset =
+                read_u64_le(&dir_bytes[entry_off + 4..entry_off + 12]) as usize;
             let avgdl_x1000 = read_u32_le(&dir_bytes[entry_off + 12..entry_off + 16]) as u64;
 
             // Verify column_id matches the JSON's positional column_id.
@@ -303,7 +300,9 @@ impl FtsReader {
             if avgdl > 0.0 {
                 let inv_avgdl = 1.0_f32 / avgdl;
                 for d in 0..(n_docs as usize) {
-                    let dl = read_u32_le(&blob[doc_lengths_offset + d * 4..doc_lengths_offset + d * 4 + 4]) as f32;
+                    let dl = read_u32_le(
+                        &blob[doc_lengths_offset + d * 4..doc_lengths_offset + d * 4 + 4],
+                    ) as f32;
                     let norm = 1.0 - crate::superfile::fts::bm25::B
                         + crate::superfile::fts::bm25::B * dl * inv_avgdl;
                     dl_norm_k1.push(crate::superfile::fts::bm25::K1 * norm);
@@ -661,11 +660,8 @@ impl FtsReader {
                 let idf_t = crate::superfile::fts::bm25::idf(self.n_docs as u64, 1);
                 let idf_x_k1p1 = idf_t * (crate::superfile::fts::bm25::K1 + 1.0);
                 let dl_norm_k1 = col_meta.dl_norm_k1[doc_id as usize];
-                let score = crate::superfile::fts::bm25::score_with_dl_norm_k1(
-                    idf_x_k1p1,
-                    tf,
-                    dl_norm_k1,
-                );
+                let score =
+                    crate::superfile::fts::bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
                 return Ok(vec![(doc_id, score)]);
             }
             FstValue::Pfor { metadata_offset } => metadata_offset as usize,
@@ -2033,9 +2029,8 @@ impl TermCursor {
     fn new_inline(doc_id: u32, tf: u32, n_docs: u64, dl_norm_k1: f32) -> Self {
         let idf = crate::superfile::fts::bm25::idf(n_docs, 1);
         let idf_x_k1p1 = idf * (crate::superfile::fts::bm25::K1 + 1.0);
-        let block_max_bm25 = crate::superfile::fts::bm25::score_with_dl_norm_k1(
-            idf_x_k1p1, tf, dl_norm_k1,
-        );
+        let block_max_bm25 =
+            crate::superfile::fts::bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
 
         let blocks = vec![BlockMeta {
             last_doc_id: doc_id,
@@ -2323,11 +2318,26 @@ mod tests {
         b.register_column("body".into()).expect("register column");
         // 20 docs sprinkled with mixed term combinations.
         let docs = [
-            "alpha", "beta", "gamma", "alpha beta", "alpha gamma",
-            "beta gamma", "alpha beta gamma", "delta", "epsilon", "alpha delta",
-            "beta epsilon", "gamma delta", "alpha beta delta", "alpha epsilon gamma",
-            "delta epsilon", "alpha alpha alpha", "beta beta beta", "gamma gamma",
-            "alpha beta gamma delta epsilon", "epsilon",
+            "alpha",
+            "beta",
+            "gamma",
+            "alpha beta",
+            "alpha gamma",
+            "beta gamma",
+            "alpha beta gamma",
+            "delta",
+            "epsilon",
+            "alpha delta",
+            "beta epsilon",
+            "gamma delta",
+            "alpha beta delta",
+            "alpha epsilon gamma",
+            "delta epsilon",
+            "alpha alpha alpha",
+            "beta beta beta",
+            "gamma gamma",
+            "alpha beta gamma delta epsilon",
+            "epsilon",
         ];
         for (i, text) in docs.iter().enumerate() {
             b.add_doc(0, i as u32, text).expect("add doc");
@@ -2560,7 +2570,9 @@ mod tests {
         let tok = Arc::new(AsciiLowerTokenizer);
 
         let mut b_inline = FtsBuilder::new(tok.clone());
-        b_inline.register_column("body".into()).expect("register column");
+        b_inline
+            .register_column("body".into())
+            .expect("register column");
         for i in 0..20 {
             b_inline
                 .add_doc(0, i, &format!("uniq{i:03}"))
@@ -2569,7 +2581,9 @@ mod tests {
         let blob_inline = b_inline.finish();
 
         let mut b_pfor = FtsBuilder::new(tok);
-        b_pfor.register_column("body".into()).expect("register column");
+        b_pfor
+            .register_column("body".into())
+            .expect("register column");
         // Same 20 terms but all appearing in every doc → df = 20 → PFOR.
         for i in 0..20 {
             let text = (0..20)

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -122,13 +122,11 @@ impl SuperfileReader {
             crate::superfile::LazyByteSourceError::Storage(se) => {
                 ReadError::MalformedKv(format!("lazy source storage: {se}"))
             }
-            crate::superfile::LazyByteSourceError::OutOfBounds {
-                start,
-                len,
-                size,
-            } => ReadError::MalformedKv(format!(
-                "lazy source out-of-bounds: start={start} len={len} size={size}"
-            )),
+            crate::superfile::LazyByteSourceError::OutOfBounds { start, len, size } => {
+                ReadError::MalformedKv(format!(
+                    "lazy source out-of-bounds: start={start} len={len} size={size}"
+                ))
+            }
         })?;
         Self::open_with(bytes, opts)
     }
@@ -425,13 +423,7 @@ impl SuperfileReader {
             .iter()
             .filter_map(|b| std::str::from_utf8(b).ok())
             .collect();
-        Ok(fts.search_or_range_pretokenized(
-            column,
-            &term_strings,
-            k,
-            doc_id_start,
-            doc_id_end,
-        )?)
+        Ok(fts.search_or_range_pretokenized(column, &term_strings, k, doc_id_start, doc_id_end)?)
     }
 
     /// Multi-column BM25 search with per-column weights ("most

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -14,8 +14,8 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
-use crate::superfile::error::BuildError as SuperfileBuildError;
 use crate::storage::StorageError;
+use crate::superfile::error::BuildError as SuperfileBuildError;
 
 /// Errors raised when constructing or operating against a
 /// `SupertableOptions` / `SupertableWriter`.

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -136,9 +136,9 @@ impl Supertable {
     ///   failures.
     pub async fn open(options: SupertableOptions) -> Result<Self, OpenError> {
         use crate::supertable::ManifestPartLoader;
-        use crate::supertable::manifest::{Manifest, SuperfileList};
         use crate::supertable::manifest::commit::read_pointer;
         use crate::supertable::manifest::list as list_mod;
+        use crate::supertable::manifest::{Manifest, SuperfileList};
 
         let storage = options
             .storage
@@ -179,17 +179,14 @@ impl Supertable {
         // manifest's stamped digest. The all-zero stored
         // hash bypasses validation (legacy + synthetic
         // fixtures).
-        let expected_hash =
-            crate::supertable::manifest::options_hash::compute_options_hash(
-                &options,
-                &list.partition_strategy,
-            );
-        if let Err(mismatch) =
-            crate::supertable::manifest::options_hash::verify_options_hash(
-                expected_hash,
-                list.options_hash,
-            )
-        {
+        let expected_hash = crate::supertable::manifest::options_hash::compute_options_hash(
+            &options,
+            &list.partition_strategy,
+        );
+        if let Err(mismatch) = crate::supertable::manifest::options_hash::verify_options_hash(
+            expected_hash,
+            list.options_hash,
+        ) {
             return Err(OpenError::OptionsHashMismatch {
                 expected: mismatch.expected,
                 actual: mismatch.actual,
@@ -298,9 +295,9 @@ impl Supertable {
     /// no-op refresh path).
     pub async fn refresh(&self) -> Result<bool, OpenError> {
         use crate::supertable::ManifestPartLoader;
-        use crate::supertable::manifest::{Manifest, SuperfileList};
         use crate::supertable::manifest::commit::read_pointer;
         use crate::supertable::manifest::list as list_mod;
+        use crate::supertable::manifest::{Manifest, SuperfileList};
 
         let storage = self
             .inner
@@ -392,9 +389,7 @@ impl Supertable {
         let mut all_segments: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
         if eager {
             for entry in &new_list.parts {
-                let cell = new_parts
-                    .get(&entry.part_id)
-                    .expect("part inserted above");
+                let cell = new_parts.get(&entry.part_id).expect("part inserted above");
                 let part = cell
                     .value()
                     .get()
@@ -506,9 +501,9 @@ fn install_disk_cache_pinning(inner: &Arc<SupertableInner>) {
         None => return,
     };
     let weak = Arc::downgrade(inner);
-    let pinned_fn: Arc<dyn Fn() -> std::collections::HashSet<crate::supertable::SuperfileUri>
-        + Send
-        + Sync> = Arc::new(move || {
+    let pinned_fn: Arc<
+        dyn Fn() -> std::collections::HashSet<crate::supertable::SuperfileUri> + Send + Sync,
+    > = Arc::new(move || {
         let strong = match weak.upgrade() {
             Some(s) => s,
             // Supertable already dropped; nothing to pin.
@@ -590,7 +585,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::superfile::builder::FtsConfig;
-    
+
     use crate::supertable::manifest::{ScalarStatsTable, SuperfileEntry, SuperfileUri};
 
     fn schema() -> Arc<Schema> {

--- a/src/supertable/lazy_source.rs
+++ b/src/supertable/lazy_source.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use crate::superfile::{LazyByteSource, LazyByteSourceError};
 use crate::storage::{StorageError, StorageProvider};
+use crate::superfile::{LazyByteSource, LazyByteSourceError};
 
 /// `LazyByteSource` over a `StorageProvider::get_range`.
 ///

--- a/src/supertable/manifest/aggregates.rs
+++ b/src/supertable/manifest/aggregates.rs
@@ -33,9 +33,7 @@ use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::{Field, Schema};
 
 use crate::supertable::manifest::SuperfileEntry;
-use crate::supertable::manifest::list::{
-    FtsSummaryAgg, ScalarStatsAgg, VectorSummaryAgg,
-};
+use crate::supertable::manifest::list::{FtsSummaryAgg, ScalarStatsAgg, VectorSummaryAgg};
 
 /// All four aggregate buckets for one [`ManifestListEntry`].
 /// Built by [`compute`] and inserted verbatim into the entry.
@@ -242,26 +240,21 @@ fn fts_summary_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, FtsSu
     // n_blocks). The union bloom starts at zero-init the
     // first time we see a segment with a populated bloom for
     // that column; subsequent superfiles bit-OR into it.
-    let mut per_column: HashMap<
-        String,
-        (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>, u32),
-    > = HashMap::new();
+    let mut per_column: HashMap<String, (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>, u32)> =
+        HashMap::new();
     for seg in superfiles {
         for (col, summary) in &seg.fts_summary {
             let entry = per_column.entry(col.clone()).or_default();
             // Range update (skipping superfiles with empty FST
             // ranges; they contribute neither min nor max).
-            let has_range = !(summary.term_range.0.is_empty()
-                && summary.term_range.1.is_empty());
+            let has_range = !(summary.term_range.0.is_empty() && summary.term_range.1.is_empty());
             if has_range {
                 match &entry.0 {
-                    Some(curr_min)
-                        if curr_min.as_slice() <= summary.term_range.0.as_slice() => {}
+                    Some(curr_min) if curr_min.as_slice() <= summary.term_range.0.as_slice() => {}
                     _ => entry.0 = Some(summary.term_range.0.clone()),
                 }
                 match &entry.1 {
-                    Some(curr_max)
-                        if curr_max.as_slice() >= summary.term_range.1.as_slice() => {}
+                    Some(curr_max) if curr_max.as_slice() >= summary.term_range.1.as_slice() => {}
                     _ => entry.1 = Some(summary.term_range.1.clone()),
                 }
             }
@@ -400,12 +393,7 @@ mod tests {
     use arrow_array::{ArrayRef, LargeStringArray, StringArray};
     use std::collections::HashMap;
 
-    fn seg_with_string_minmax(
-        col: &str,
-        min: &str,
-        max: &str,
-        large: bool,
-    ) -> Arc<SuperfileEntry> {
+    fn seg_with_string_minmax(col: &str, min: &str, max: &str, large: bool) -> Arc<SuperfileEntry> {
         let (mn, mx): (ArrayRef, ArrayRef) = if large {
             (
                 Arc::new(LargeStringArray::from(vec![Some(min)])),
@@ -445,7 +433,10 @@ mod tests {
         if let Some(a) = col.as_any().downcast_ref::<LargeStringArray>() {
             return a.value(0).to_string();
         }
-        panic!("expected Utf8 or LargeUtf8 column; got {:?}", col.data_type());
+        panic!(
+            "expected Utf8 or LargeUtf8 column; got {:?}",
+            col.data_type()
+        );
     }
 
     #[test]

--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -42,10 +42,10 @@ use std::sync::Arc;
 
 use futures::future;
 
+use crate::storage::{StorageError, StorageProvider};
 use crate::supertable::error::CommitError;
 use crate::supertable::manifest::list::{self as list_mod, ManifestList};
 use crate::supertable::manifest::part::{self as part_mod, ContentHash, ManifestPart, PartId};
-use crate::storage::{StorageError, StorageProvider};
 
 /// Pointer-file location under the supertable root. The only
 /// path that ever gets atomically renamed; everything else is
@@ -71,7 +71,10 @@ pub fn list_uri(manifest_id: u64) -> String {
 /// bytes resolve to the same URI — the load-bearing property
 /// for cross-version part reuse.
 pub fn part_uri(content_hash: &ContentHash) -> String {
-    format!("{MANIFEST_PARTS_DIR}/part-{}.avro.zst", content_hash.to_hex())
+    format!(
+        "{MANIFEST_PARTS_DIR}/part-{}.avro.zst",
+        content_hash.to_hex()
+    )
 }
 
 /// In-memory pointer file. Lives at [`POINTER_PATH`]; its
@@ -119,9 +122,11 @@ impl PointerFile {
                 .ok_or_else(|| CommitError::PointerParse(format!("no '=' in line: {line:?}")))?;
             match key {
                 "manifest_id" => {
-                    manifest_id = Some(value.parse::<u64>().map_err(|e| {
-                        CommitError::PointerParse(format!("manifest_id: {e}"))
-                    })?);
+                    manifest_id = Some(
+                        value
+                            .parse::<u64>()
+                            .map_err(|e| CommitError::PointerParse(format!("manifest_id: {e}")))?,
+                    );
                 }
                 "manifest_list_uri" => {
                     manifest_list_uri = Some(value.to_string());
@@ -140,8 +145,8 @@ impl PointerFile {
                     }
                     let mut bytes = [0u8; 32];
                     for i in 0..32 {
-                        bytes[i] = u8::from_str_radix(&hex[2 * i..2 * i + 2], 16)
-                            .map_err(|_| {
+                        bytes[i] =
+                            u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).map_err(|_| {
                                 CommitError::PointerParse(format!("content_hash hex: {hex}"))
                             })?;
                     }
@@ -155,15 +160,12 @@ impl PointerFile {
         }
 
         Ok(Self {
-            manifest_id: manifest_id.ok_or_else(|| {
-                CommitError::PointerParse("missing manifest_id".into())
-            })?,
-            manifest_list_uri: manifest_list_uri.ok_or_else(|| {
-                CommitError::PointerParse("missing manifest_list_uri".into())
-            })?,
-            content_hash: content_hash.ok_or_else(|| {
-                CommitError::PointerParse("missing content_hash".into())
-            })?,
+            manifest_id: manifest_id
+                .ok_or_else(|| CommitError::PointerParse("missing manifest_id".into()))?,
+            manifest_list_uri: manifest_list_uri
+                .ok_or_else(|| CommitError::PointerParse("missing manifest_list_uri".into()))?,
+            content_hash: content_hash
+                .ok_or_else(|| CommitError::PointerParse("missing content_hash".into()))?,
         })
     }
 }
@@ -260,9 +262,7 @@ pub async fn write_manifest_list(
     let content_hash = ContentHash::of(&json);
     let uri = list_uri(list.manifest_id);
     let size = json.len() as u64;
-    storage
-        .put_atomic(&uri, bytes::Bytes::from(json))
-        .await?;
+    storage.put_atomic(&uri, bytes::Bytes::from(json)).await?;
     Ok(ListWriteResult {
         uri,
         content_hash,
@@ -289,13 +289,15 @@ pub async fn write_pointer(
     let bytes = bytes::Bytes::from(pointer.to_bytes());
     let result = match expected_prev_etag {
         None => storage.put_atomic(POINTER_PATH, bytes).await,
-        Some(_) => storage.put_if_match(POINTER_PATH, bytes, expected_prev_etag).await,
+        Some(_) => {
+            storage
+                .put_if_match(POINTER_PATH, bytes, expected_prev_etag)
+                .await
+        }
     };
     match result {
         Ok(()) => Ok(()),
-        Err(StorageError::PreconditionFailed { .. }) => {
-            Err(CommitError::WriteContentionExhausted)
-        }
+        Err(StorageError::PreconditionFailed { .. }) => Err(CommitError::WriteContentionExhausted),
         Err(e) => Err(e.into()),
     }
 }

--- a/src/supertable/manifest/encoding.rs
+++ b/src/supertable/manifest/encoding.rs
@@ -124,7 +124,8 @@ pub fn encode_scalar_stats(stats: &ScalarStatsTable) -> Vec<u8> {
         arrays.push(mx.clone());
     }
     let schema = Arc::new(Schema::new(fields));
-    let batch = RecordBatch::try_new(schema.clone(), arrays).expect("schema/array match by construction");
+    let batch =
+        RecordBatch::try_new(schema.clone(), arrays).expect("schema/array match by construction");
 
     let mut out = Vec::new();
     {
@@ -139,8 +140,8 @@ pub fn decode_scalar_stats(bytes: &[u8]) -> Result<ScalarStatsTable, DecodeError
     if bytes.is_empty() {
         return Ok(ScalarStatsTable::new());
     }
-    let reader =
-        StreamReader::try_new(Cursor::new(bytes), None).map_err(|e| DecodeError::ArrowIpc(e.to_string()))?;
+    let reader = StreamReader::try_new(Cursor::new(bytes), None)
+        .map_err(|e| DecodeError::ArrowIpc(e.to_string()))?;
     let batches: Vec<RecordBatch> = reader
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| DecodeError::ArrowIpc(e.to_string()))?;
@@ -214,8 +215,8 @@ pub fn decode_fts_summary(bytes: &[u8]) -> Result<FtsSummary, DecodeError> {
     let mut c = Cursor::new(bytes);
     let bloom_len = read_u32(&mut c, "bloom_len")? as usize;
     let bloom_bytes = read_n(&mut c, bloom_len, "bloom_bytes")?;
-    let term_bloom = Bloom::from_bytes(&bloom_bytes)
-        .ok_or(DecodeError::InvalidBloomLayout(bloom_len))?;
+    let term_bloom =
+        Bloom::from_bytes(&bloom_bytes).ok_or(DecodeError::InvalidBloomLayout(bloom_len))?;
     let n_terms_distinct = read_u32(&mut c, "n_terms_distinct")?;
     let min_len = read_u32(&mut c, "min_term_len")? as usize;
     let min_term = read_n(&mut c, min_len, "min_term")?;
@@ -330,7 +331,9 @@ pub fn encode_vector_summary_map(map: &HashMap<String, VectorSummary>) -> Vec<u8
     out
 }
 
-pub fn decode_vector_summary_map(bytes: &[u8]) -> Result<HashMap<String, VectorSummary>, DecodeError> {
+pub fn decode_vector_summary_map(
+    bytes: &[u8],
+) -> Result<HashMap<String, VectorSummary>, DecodeError> {
     let mut c = Cursor::new(bytes);
     let n = read_u32(&mut c, "vec_map_n")? as usize;
     let mut out = HashMap::with_capacity(n);
@@ -355,11 +358,7 @@ fn read_u32(c: &mut Cursor<&[u8]>, what: &'static str) -> Result<u32, DecodeErro
     Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
 }
 
-fn read_n(
-    c: &mut Cursor<&[u8]>,
-    n: usize,
-    what: &'static str,
-) -> Result<Vec<u8>, DecodeError> {
+fn read_n(c: &mut Cursor<&[u8]>, n: usize, what: &'static str) -> Result<Vec<u8>, DecodeError> {
     let pos = c.position() as usize;
     let buf = *c.get_ref();
     if pos + n > buf.len() {

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -293,7 +293,7 @@ struct ManifestListEntryDto {
     n_superfiles: u64,
     size_bytes_compressed: u64,
     size_bytes_uncompressed: u64,
-    content_hash: String, // "blake3:<hex>"
+    content_hash: String,  // "blake3:<hex>"
     partition_key: String, // base64
     // i128 stringified as decimal — JSON numbers are bounded
     // to f64 precision (~53 bits) so we can't round-trip a
@@ -430,8 +430,7 @@ fn entry_to_dto(e: &ManifestListEntry) -> ManifestListEntryDto {
 
 fn entry_from_dto(d: ManifestListEntryDto) -> Result<ManifestListEntry, ListParseError> {
     let part_id = PartId(
-        uuid::Uuid::parse_str(&d.part_id)
-            .map_err(|e| ListParseError::BadPartId(e.to_string()))?,
+        uuid::Uuid::parse_str(&d.part_id).map_err(|e| ListParseError::BadPartId(e.to_string()))?,
     );
     let content_hash = decode_hash(&d.content_hash)?;
     let partition_key = decode_b64(&d.partition_key, "partition_key")?;
@@ -482,12 +481,14 @@ fn entry_from_dto(d: ManifestListEntryDto) -> Result<ManifestListEntry, ListPars
         content_hash,
         partition_key,
         id_range: {
-            let lo = d.id_range.0.parse::<i128>().map_err(|_| {
-                ListParseError::BadFieldValue("id_range[0]", d.id_range.0.clone())
-            })?;
-            let hi = d.id_range.1.parse::<i128>().map_err(|_| {
-                ListParseError::BadFieldValue("id_range[1]", d.id_range.1.clone())
-            })?;
+            let lo =
+                d.id_range.0.parse::<i128>().map_err(|_| {
+                    ListParseError::BadFieldValue("id_range[0]", d.id_range.0.clone())
+                })?;
+            let hi =
+                d.id_range.1.parse::<i128>().map_err(|_| {
+                    ListParseError::BadFieldValue("id_range[1]", d.id_range.1.clone())
+                })?;
             (lo, hi)
         },
         scalar_stats_agg,
@@ -652,8 +653,8 @@ mod tests {
     //! major/minor compat; part reuse across versions
     //! decodes to bit-equal entries; top-level JSON keys are
     //! jq-friendly.
-    use super::*;
     use super::super::part::{ContentHash, PartId};
+    use super::*;
     use std::collections::BTreeMap;
     use uuid::Uuid;
 
@@ -968,7 +969,10 @@ mod tests {
             assert!(obj.contains_key(key), "missing top-level key {key}");
         }
         assert!(
-            obj["options_hash"].as_str().unwrap_or("").starts_with("blake3:"),
+            obj["options_hash"]
+                .as_str()
+                .unwrap_or("")
+                .starts_with("blake3:"),
             "options_hash should be 'blake3:<hex>' for jq-debuggability"
         );
     }

--- a/src/supertable/manifest/list_prune.rs
+++ b/src/supertable/manifest/list_prune.rs
@@ -40,11 +40,7 @@ use crate::supertable::manifest::part::PartId;
 /// Parts without an `fts_summary_agg` entry for this column
 /// (no info) survive — same "always-keep" treatment the
 /// list-level pruner gives to missing aggregates.
-pub fn prune_parts_for_fts_prefix(
-    list: &ManifestList,
-    column: &str,
-    prefix: &[u8],
-) -> Vec<PartId> {
+pub fn prune_parts_for_fts_prefix(list: &ManifestList, column: &str, prefix: &[u8]) -> Vec<PartId> {
     let upper = prefix_upper_bound(prefix);
     list.parts
         .iter()
@@ -155,8 +151,7 @@ fn part_matches_terms(
     if agg.term_bloom_union.is_empty() || agg.term_bloom_n_blocks == 0 {
         return true; // empty union → always-keep
     }
-    let Some(bloom) =
-        crate::supertable::manifest::bloom::Bloom::from_bytes(&agg.term_bloom_union)
+    let Some(bloom) = crate::supertable::manifest::bloom::Bloom::from_bytes(&agg.term_bloom_union)
     else {
         // Corrupt / unexpected shape → fall back to
         // always-keep (correctness over selectivity).
@@ -347,10 +342,7 @@ mod tests {
         })
     }
 
-    fn entry_from_segments(
-        superfiles: &[Arc<SuperfileEntry>],
-        seed: u8,
-    ) -> ManifestListEntry {
+    fn entry_from_segments(superfiles: &[Arc<SuperfileEntry>], seed: u8) -> ManifestListEntry {
         let aggs = aggregates::compute(superfiles);
         ManifestListEntry {
             part_id: PartId(Uuid::from_bytes([seed; 16])),
@@ -602,18 +594,11 @@ mod tests {
 
     #[test]
     fn prune_parts_for_fts_prefix_filters_disjoint_term_ranges() {
-        let part0 = entry_from_segments(
-            &[seg(0, 10, &["alpha", "bravo", "charlie"], None, 0.0)],
-            0,
-        );
-        let part1 = entry_from_segments(
-            &[seg(11, 20, &["delta", "echo", "foxtrot"], None, 0.0)],
-            1,
-        );
-        let part2 = entry_from_segments(
-            &[seg(21, 30, &["hotel", "kilo", "lima"], None, 0.0)],
-            2,
-        );
+        let part0 =
+            entry_from_segments(&[seg(0, 10, &["alpha", "bravo", "charlie"], None, 0.0)], 0);
+        let part1 =
+            entry_from_segments(&[seg(11, 20, &["delta", "echo", "foxtrot"], None, 0.0)], 1);
+        let part2 = entry_from_segments(&[seg(21, 30, &["hotel", "kilo", "lima"], None, 0.0)], 2);
         let list = list_with(vec![part0, part1.clone(), part2]);
 
         let survivors = prune_parts_for_fts_prefix(&list, "title", b"echo");
@@ -633,14 +618,8 @@ mod tests {
 
     #[test]
     fn prune_parts_for_vector_filters_far_parts() {
-        let part_a = entry_from_segments(
-            &[seg(0, 10, &[], Some(vec![10.0, 0.0, 0.0]), 0.5)],
-            0,
-        );
-        let part_b = entry_from_segments(
-            &[seg(11, 20, &[], Some(vec![-10.0, 0.0, 0.0]), 0.5)],
-            1,
-        );
+        let part_a = entry_from_segments(&[seg(0, 10, &[], Some(vec![10.0, 0.0, 0.0]), 0.5)], 0);
+        let part_b = entry_from_segments(&[seg(11, 20, &[], Some(vec![-10.0, 0.0, 0.0]), 0.5)], 1);
         let list = list_with(vec![part_a.clone(), part_b]);
         let survivors = prune_parts_for_vector(&list, "emb", &[10.0, 0.0, 0.0], 1.0);
         assert_eq!(survivors.len(), 1);
@@ -649,17 +628,15 @@ mod tests {
 
     #[test]
     fn prune_parts_for_vector_keeps_overlapping_envelope() {
-        let part_a = entry_from_segments(
-            &[seg(0, 10, &[], Some(vec![1.0, 0.0, 0.0]), 1.0)],
-            0,
-        );
-        let part_b = entry_from_segments(
-            &[seg(11, 20, &[], Some(vec![-1.0, 0.0, 0.0]), 1.0)],
-            1,
-        );
+        let part_a = entry_from_segments(&[seg(0, 10, &[], Some(vec![1.0, 0.0, 0.0]), 1.0)], 0);
+        let part_b = entry_from_segments(&[seg(11, 20, &[], Some(vec![-1.0, 0.0, 0.0]), 1.0)], 1);
         let list = list_with(vec![part_a, part_b]);
         let survivors = prune_parts_for_vector(&list, "emb", &[0.0, 0.0, 0.0], 1.0);
-        assert_eq!(survivors.len(), 2, "both envelopes contain origin within cutoff");
+        assert_eq!(
+            survivors.len(),
+            2,
+            "both envelopes contain origin within cutoff"
+        );
     }
 
     #[test]
@@ -681,7 +658,10 @@ mod tests {
         let list = list_with(vec![part0.clone(), part1.clone()]);
 
         let survivors = prune_parts_for_fts_prefix(&list, "title", b"ban");
-        assert!(survivors.contains(&part0.part_id), "must keep matching part");
+        assert!(
+            survivors.contains(&part0.part_id),
+            "must keep matching part"
+        );
 
         let survivors2 = prune_parts_for_fts_prefix(&list, "title", b"ec");
         assert!(survivors2.contains(&part1.part_id));

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -130,7 +130,10 @@ impl SuperfileList {
 pub struct Manifest {
     pub superfile_list: SuperfileList,
     pub list: Option<list::ManifestList>,
-    pub parts: dashmap::DashMap<part::PartId, std::sync::Arc<tokio::sync::OnceCell<std::sync::Arc<part::ManifestPart>>>>,
+    pub parts: dashmap::DashMap<
+        part::PartId,
+        std::sync::Arc<tokio::sync::OnceCell<std::sync::Arc<part::ManifestPart>>>,
+    >,
     pub loader: Option<std::sync::Arc<ManifestPartLoader>>,
 }
 
@@ -140,7 +143,10 @@ impl std::fmt::Debug for Manifest {
             .field("manifest_id", &self.superfile_list.manifest_id)
             .field("n_superfiles", &self.superfile_list.superfiles.len())
             .field("has_list", &self.list.is_some())
-            .field("n_parts", &self.list.as_ref().map(|l| l.parts.len()).unwrap_or(0))
+            .field(
+                "n_parts",
+                &self.list.as_ref().map(|l| l.parts.len()).unwrap_or(0),
+            )
             .field("n_parts_loaded", &self.parts.len())
             .field("has_loader", &self.loader.is_some())
             .finish()
@@ -208,9 +214,7 @@ impl Manifest {
             .entry(part_id)
             .or_insert_with(|| std::sync::Arc::new(tokio::sync::OnceCell::new()))
             .clone();
-        let loaded = cell
-            .get_or_try_init(|| loader.load(part_id))
-            .await?;
+        let loaded = cell.get_or_try_init(|| loader.load(part_id)).await?;
         Ok(std::sync::Arc::clone(loaded))
     }
 }
@@ -225,8 +229,7 @@ pub struct ManifestPartLoader {
     storage: std::sync::Arc<dyn crate::storage::StorageProvider>,
     /// Maps `PartId → (expected content_hash, uri)`. Built from
     /// the manifest list at construction; immutable per-`Manifest`.
-    parts_index:
-        std::collections::HashMap<part::PartId, (part::ContentHash, String)>,
+    parts_index: std::collections::HashMap<part::PartId, (part::ContentHash, String)>,
 }
 
 impl ManifestPartLoader {
@@ -250,10 +253,10 @@ impl ManifestPartLoader {
         &self,
         part_id: part::PartId,
     ) -> Result<std::sync::Arc<part::ManifestPart>, ManifestLoadError> {
-        let (expected_hash, uri) =
-            self.parts_index
-                .get(&part_id)
-                .ok_or(ManifestLoadError::PartNotInList { part_id })?;
+        let (expected_hash, uri) = self
+            .parts_index
+            .get(&part_id)
+            .ok_or(ManifestLoadError::PartNotInList { part_id })?;
         let bytes = self
             .storage
             .get(uri)
@@ -555,7 +558,6 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
 
     use crate::superfile::builder::FtsConfig;
-    
 
     fn schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![Field::new(
@@ -866,8 +868,8 @@ mod tests {
         }
 
         fn options_for_test() -> Arc<crate::supertable::SupertableOptions> {
-            use arrow_schema::{DataType, Field, Schema};
             use crate::supertable::SupertableOptions;
+            use arrow_schema::{DataType, Field, Schema};
             let s = Arc::new(Schema::new(vec![Field::new(
                 "title",
                 DataType::LargeUtf8,
@@ -895,10 +897,8 @@ mod tests {
             let (objects, entries) = encode_and_index(&[part.clone()]);
             let storage = Arc::new(CountingMockStorage::new(objects));
             let list = fresh_list(entries);
-            let manifest = build_manifest_with_loader(
-                list,
-                Arc::clone(&storage) as Arc<dyn StorageProvider>,
-            );
+            let manifest =
+                build_manifest_with_loader(list, Arc::clone(&storage) as Arc<dyn StorageProvider>);
 
             let loaded = manifest.part(part.part_id).await.expect("load");
             assert_eq!(loaded.part_id, part.part_id);
@@ -911,10 +911,8 @@ mod tests {
             let (objects, entries) = encode_and_index(&[part.clone()]);
             let storage = Arc::new(CountingMockStorage::new(objects));
             let list = fresh_list(entries);
-            let manifest = build_manifest_with_loader(
-                list,
-                Arc::clone(&storage) as Arc<dyn StorageProvider>,
-            );
+            let manifest =
+                build_manifest_with_loader(list, Arc::clone(&storage) as Arc<dyn StorageProvider>);
 
             let a = manifest.part(part.part_id).await.expect("first load");
             let b = manifest.part(part.part_id).await.expect("second load");
@@ -974,10 +972,8 @@ mod tests {
             let list = fresh_list(fresh_entries);
 
             let storage = Arc::new(CountingMockStorage::new(objects));
-            let manifest = build_manifest_with_loader(
-                list,
-                Arc::clone(&storage) as Arc<dyn StorageProvider>,
-            );
+            let manifest =
+                build_manifest_with_loader(list, Arc::clone(&storage) as Arc<dyn StorageProvider>);
 
             let err = manifest
                 .part(part.part_id)
@@ -997,7 +993,10 @@ mod tests {
                 .part(part.part_id)
                 .await
                 .expect_err("must reject on retry too");
-            assert!(matches!(err2, ManifestLoadError::ContentHashMismatch { .. }));
+            assert!(matches!(
+                err2,
+                ManifestLoadError::ContentHashMismatch { .. }
+            ));
         }
 
         #[tokio::test]
@@ -1006,10 +1005,8 @@ mod tests {
             let (objects, entries) = encode_and_index(&[part]);
             let storage = Arc::new(CountingMockStorage::new(objects));
             let list = fresh_list(entries);
-            let manifest = build_manifest_with_loader(
-                list,
-                Arc::clone(&storage) as Arc<dyn StorageProvider>,
-            );
+            let manifest =
+                build_manifest_with_loader(list, Arc::clone(&storage) as Arc<dyn StorageProvider>);
 
             let stranger = PartId(Uuid::from_bytes([0xff; 16]));
             let err = manifest.part(stranger).await.expect_err("must reject");

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -52,10 +52,7 @@ use crate::supertable::options::SupertableOptions;
 /// Compute the canonical options-hash from `opts` + the
 /// resolved `strategy`. See the module-level docs for the
 /// encoding layout.
-pub fn compute_options_hash(
-    opts: &SupertableOptions,
-    strategy: &PartitionStrategy,
-) -> ContentHash {
+pub fn compute_options_hash(opts: &SupertableOptions, strategy: &PartitionStrategy) -> ContentHash {
     let mut buf: Vec<u8> = Vec::with_capacity(256);
 
     // 1. schema (field-by-field).
@@ -100,7 +97,10 @@ pub fn compute_options_hash(
     // 5. partition_strategy.
     push_tag(&mut buf, b"partition_strategy");
     match strategy {
-        PartitionStrategy::TimeRange { column, granularity_secs } => {
+        PartitionStrategy::TimeRange {
+            column,
+            granularity_secs,
+        } => {
             push_tag(&mut buf, b"time_range");
             push_str(&mut buf, column);
             buf.extend_from_slice(&granularity_secs.to_le_bytes());

--- a/src/supertable/manifest/part.rs
+++ b/src/supertable/manifest/part.rs
@@ -201,19 +201,28 @@ pub fn encode(part: &ManifestPart, zstd_level: i32) -> Vec<u8> {
             let vector_bytes = encode_vector_summary_map(&seg.vector_summary);
 
             AvroValue::Record(vec![
-                ("superfile_id".into(), AvroValue::String(seg.superfile_id.to_string())),
+                (
+                    "superfile_id".into(),
+                    AvroValue::String(seg.superfile_id.to_string()),
+                ),
                 ("uri".into(), AvroValue::String(seg.uri.0.to_string())),
                 ("n_docs".into(), AvroValue::Long(seg.n_docs as i64)),
-                ("id_min".into(), AvroValue::Fixed(16, seg.id_min.to_be_bytes().to_vec())),
-                ("id_max".into(), AvroValue::Fixed(16, seg.id_max.to_be_bytes().to_vec())),
-                ("partition_key".into(), AvroValue::Bytes(seg.partition_key.clone())),
+                (
+                    "id_min".into(),
+                    AvroValue::Fixed(16, seg.id_min.to_be_bytes().to_vec()),
+                ),
+                (
+                    "id_max".into(),
+                    AvroValue::Fixed(16, seg.id_max.to_be_bytes().to_vec()),
+                ),
+                (
+                    "partition_key".into(),
+                    AvroValue::Bytes(seg.partition_key.clone()),
+                ),
                 (
                     "partition_hint".into(),
                     match seg.partition_hint {
-                        Some(b) => AvroValue::Union(
-                            1,
-                            Box::new(AvroValue::Int(b as i32)),
-                        ),
+                        Some(b) => AvroValue::Union(1, Box::new(AvroValue::Int(b as i32))),
                         None => AvroValue::Union(0, Box::new(AvroValue::Null)),
                     },
                 ),
@@ -229,7 +238,10 @@ pub fn encode(part: &ManifestPart, zstd_level: i32) -> Vec<u8> {
             "format_version".into(),
             AvroValue::String(part.format_version.clone()),
         ),
-        ("part_id".into(), AvroValue::String(part.part_id.0.to_string())),
+        (
+            "part_id".into(),
+            AvroValue::String(part.part_id.0.to_string()),
+        ),
         ("superfiles".into(), AvroValue::Array(segment_records)),
     ]);
 
@@ -244,7 +256,8 @@ pub fn encode(part: &ManifestPart, zstd_level: i32) -> Vec<u8> {
 /// the constant [`FORMAT_VERSION`]; minor differences are
 /// accepted).
 pub fn decode(bytes: &[u8]) -> Result<ManifestPart, PartParseError> {
-    let avro_bytes = zstd::stream::decode_all(bytes).map_err(|e| PartParseError::Zstd(e.to_string()))?;
+    let avro_bytes =
+        zstd::stream::decode_all(bytes).map_err(|e| PartParseError::Zstd(e.to_string()))?;
     // Schemaless datum decode — mirrors `to_avro_datum` in
     // `encode`. The schema is in-source (compiled in), so the
     // reader doesn't need a wire-side schema.
@@ -254,7 +267,11 @@ pub fn decode(bytes: &[u8]) -> Result<ManifestPart, PartParseError> {
 
     let fields = match value {
         AvroValue::Record(r) => r,
-        _ => return Err(PartParseError::SchemaMismatch("top-level not a record".into())),
+        _ => {
+            return Err(PartParseError::SchemaMismatch(
+                "top-level not a record".into(),
+            ));
+        }
     };
     let mut map: HashMap<String, AvroValue> = fields.into_iter().collect();
 
@@ -266,7 +283,9 @@ pub fn decode(bytes: &[u8]) -> Result<ManifestPart, PartParseError> {
         Uuid::parse_str(&part_id_str).map_err(|e| PartParseError::BadSuperfileId(e.to_string()))?,
     );
 
-    let segments_val = map.remove("superfiles").ok_or(PartParseError::MissingField("superfiles"))?;
+    let segments_val = map
+        .remove("superfiles")
+        .ok_or(PartParseError::MissingField("superfiles"))?;
     let segs = match segments_val {
         AvroValue::Array(a) => a,
         _ => return Err(PartParseError::WrongFieldType("superfiles")),
@@ -286,7 +305,11 @@ pub fn decode(bytes: &[u8]) -> Result<ManifestPart, PartParseError> {
 fn decode_segment(v: AvroValue) -> Result<SuperfileEntry, PartParseError> {
     let fields = match v {
         AvroValue::Record(r) => r,
-        _ => return Err(PartParseError::SchemaMismatch("segment not a record".into())),
+        _ => {
+            return Err(PartParseError::SchemaMismatch(
+                "segment not a record".into(),
+            ));
+        }
     };
     let mut map: HashMap<String, AvroValue> = fields.into_iter().collect();
 
@@ -628,8 +651,7 @@ mod tests {
 
     #[test]
     fn multi_segment_with_full_summaries_roundtrip() {
-        let superfiles: Vec<Arc<SuperfileEntry>> =
-            (0..5).map(|_| make_rich_segment()).collect();
+        let superfiles: Vec<Arc<SuperfileEntry>> = (0..5).map(|_| make_rich_segment()).collect();
         let part = fresh_part(superfiles);
         let bytes = encode(&part, 3);
         let decoded = decode(&bytes).expect("decode rich");

--- a/src/supertable/manifest/partition.rs
+++ b/src/supertable/manifest/partition.rs
@@ -150,16 +150,16 @@ pub fn assign_partition(
             }
             // Multi-bucket: writer must have stamped
             // partition_hint at pre-shard time.
-            let bucket = seg.partition_hint.ok_or_else(|| {
-                CommitError::SuperfileSpansPartition {
-                    detail: format!(
-                        "Hash{{n_buckets:{n_buckets}}} strategy requires pre-sharded \
+            let bucket =
+                seg.partition_hint
+                    .ok_or_else(|| CommitError::SuperfileSpansPartition {
+                        detail: format!(
+                            "Hash{{n_buckets:{n_buckets}}} strategy requires pre-sharded \
                          superfiles; SuperfileEntry.partition_hint must be Some(bucket) \
                          (segment {})",
-                        seg.uri.0
-                    ),
-                }
-            })?;
+                            seg.uri.0
+                        ),
+                    })?;
             if bucket >= *n_buckets {
                 return Err(CommitError::SuperfileSpansPartition {
                     detail: format!(
@@ -197,10 +197,7 @@ pub fn assign_partition(
 /// `granularity_secs` are responsible for matching it to
 /// the column's actual unit (seconds for `Int64`,
 /// microseconds for `TimestampMicrosecond`, etc.).
-fn scalar_i64_minmax(
-    seg: &SuperfileEntry,
-    column: &str,
-) -> Result<(i64, i64), CommitError> {
+fn scalar_i64_minmax(seg: &SuperfileEntry, column: &str) -> Result<(i64, i64), CommitError> {
     let (mn_arr, mx_arr) =
         seg.scalar_stats
             .cols

--- a/src/supertable/mod.rs
+++ b/src/supertable/mod.rs
@@ -39,17 +39,17 @@ pub mod writer;
 /// existing call-site paths.
 pub use crate::storage;
 
+pub use crate::storage::{
+    LocalFsStorageProvider, ObjectMeta, S3StorageProvider, StorageError, StorageProvider,
+};
 pub use error::{BuildError, CommitError, OpenError, QueryError};
-pub use lazy_source::StorageRangeSource;
 pub use handle::{Supertable, SupertableReader};
+pub use lazy_source::StorageRangeSource;
 pub use manifest::{
     FtsSummary, Manifest, ManifestLoadError, ManifestPartLoader, ScalarStatsTable, SuperfileEntry,
     SuperfileList, SuperfileUri, VectorSummary,
 };
 pub use options::SupertableOptions;
-pub use stats::SupertableStats;
-pub use crate::storage::{
-    LocalFsStorageProvider, ObjectMeta, S3StorageProvider, StorageError, StorageProvider,
-};
 pub use reader_cache::{InMemoryReaderCache, ReaderCacheError, SuperfileReaderCache};
+pub use stats::SupertableStats;
 pub use writer::SupertableWriter;

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -204,9 +204,7 @@ pub struct SupertableOptions {
     /// At [`Supertable::open`] time, this field is read from
     /// the persisted manifest list — config changes after
     /// creation have no effect.
-    pub partition_strategy: Option<
-        crate::supertable::manifest::list::PartitionStrategy,
-    >,
+    pub partition_strategy: Option<crate::supertable::manifest::list::PartitionStrategy>,
     /// Soft cap on superfiles per `ManifestPart`.
     /// When a partition's existing part reaches this count,
     /// the next commit's superfiles for that partition go into
@@ -486,10 +484,7 @@ impl SupertableOptions {
     /// Rejects names that already appear in the user schema
     /// (same check as construction) by returning
     /// [`BuildError::IdColumnReserved`].
-    pub fn with_id_column(
-        mut self,
-        name: impl Into<String>,
-    ) -> Result<Self, BuildError> {
+    pub fn with_id_column(mut self, name: impl Into<String>) -> Result<Self, BuildError> {
         let name = name.into();
         if self.schema.fields().iter().any(|f| f.name() == &name) {
             return Err(BuildError::IdColumnReserved(name));
@@ -532,10 +527,7 @@ impl SupertableOptions {
     ///
     /// Reads still go through `store` unless a `disk_cache`
     /// is also attached.
-    pub fn with_storage(
-        mut self,
-        storage: Arc<dyn crate::storage::StorageProvider>,
-    ) -> Self {
+    pub fn with_storage(mut self, storage: Arc<dyn crate::storage::StorageProvider>) -> Self {
         self.storage = Some(storage);
         self
     }
@@ -810,7 +802,6 @@ mod tests {
 
     use arrow_schema::{DataType, Field};
 
-    
     use crate::superfile::vector::distance::Metric;
 
     fn fixed_list_f32(dim: usize) -> DataType {
@@ -851,13 +842,8 @@ mod tests {
     #[test]
     fn valid_options_with_fts_and_vector_succeeds() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            s,
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options should succeed");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options should succeed");
         assert_eq!(opts.id_column, "_id");
         assert_eq!(opts.fts_columns.len(), 1);
         assert_eq!(opts.vector_columns.len(), 1);
@@ -891,11 +877,7 @@ mod tests {
     #[test]
     fn fts_column_wrong_type_rejected() {
         // `body` is Utf8 not LargeUtf8 — must reject.
-        let s = Arc::new(Schema::new(vec![Field::new(
-            "body",
-            DataType::Utf8,
-            false,
-        )]));
+        let s = Arc::new(Schema::new(vec![Field::new("body", DataType::Utf8, false)]));
         let err = SupertableOptions::new(s, vec![fc("body")], vec![], Some(tok()))
             .expect_err("expected error");
         assert!(
@@ -1001,13 +983,9 @@ mod tests {
         ]));
         // Duplicate `emb` between two vector_columns entries —
         // hits the cross-list dedup check.
-        let err = SupertableOptions::new(
-            s.clone(),
-            vec![],
-            vec![vc("emb", 16), vc("emb", 16)],
-            None,
-        )
-        .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s.clone(), vec![], vec![vc("emb", 16), vc("emb", 16)], None)
+                .expect_err("expected error");
         assert!(matches!(err, BuildError::DuplicateLogicalName(n) if n == "emb"));
     }
 
@@ -1042,8 +1020,8 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![fc("title")], vec![], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![fc("title")], vec![], None).expect_err("expected error");
         assert!(matches!(err, BuildError::MissingTokenizer));
     }
 
@@ -1056,20 +1034,14 @@ mod tests {
         )]));
         // No FTS, no vectors, no tokenizer — the supertable becomes
         // a thin wrapper over scalar Parquet data. Must succeed.
-        SupertableOptions::new(s, vec![], vec![], None)
-            .expect("empty fts + vector should succeed");
+        SupertableOptions::new(s, vec![], vec![], None).expect("empty fts + vector should succeed");
     }
 
     #[test]
     fn scalar_schema_drops_vector_columns_and_prepends_id() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            s,
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options");
         let scalar = opts.scalar_schema();
         let names: Vec<_> = scalar.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(names, vec!["_id", "title"]);
@@ -1098,13 +1070,8 @@ mod tests {
     #[test]
     fn effective_schema_prepends_id_keeps_vector_columns() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            s,
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options");
         let eff = opts.effective_schema();
         let names: Vec<_> = eff.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(names, vec!["_id", "title", "emb"]);
@@ -1130,15 +1097,10 @@ mod tests {
     #[test]
     fn with_id_column_overrides_default() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            s,
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .with_id_column("row_id")
-        .expect("override accepted");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options")
+            .with_id_column("row_id")
+            .expect("override accepted");
         assert_eq!(opts.id_column, "row_id");
         // effective_schema now uses the new name.
         let eff = opts.effective_schema();
@@ -1148,13 +1110,8 @@ mod tests {
     #[test]
     fn with_id_column_rejects_name_that_collides_with_user_schema() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            s,
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options");
         let err = opts.with_id_column("title").expect_err("collision");
         assert!(matches!(err, BuildError::IdColumnReserved(c) if c == "title"));
     }
@@ -1174,15 +1131,10 @@ supertable:
             .expect("parse config");
 
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            s,
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .apply_config(&cfg)
-        .expect("apply_config");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options")
+            .apply_config(&cfg)
+            .expect("apply_config");
 
         assert_eq!(opts.commit_threshold_size_mb, 7);
         assert_eq!(opts.reader_pool.current_num_threads(), 3);
@@ -1196,15 +1148,10 @@ supertable:
         let cfg = crate::config::Config::defaults().expect("embedded default");
 
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            s,
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .apply_config(&cfg)
-        .expect("apply_config");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options")
+            .apply_config(&cfg)
+            .expect("apply_config");
 
         let reader_default = num_cpus::get().max(1);
         let writer_default = num_cpus::get().div_ceil(2).max(1);
@@ -1217,13 +1164,8 @@ supertable:
     #[test]
     fn debug_format_doesnt_explode() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            s,
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options");
         let s = format!("{:?}", opts);
         assert!(s.contains("SupertableOptions"));
         assert!(s.contains("_id"));

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -130,11 +130,9 @@ impl SupertableReader {
                     &kept,
                 )?
             }
-            None => {
-                crate::supertable::query::hierarchical_iter::fallback_to_flat_segments(
-                    manifest.as_ref(),
-                )
-            }
+            None => crate::supertable::query::hierarchical_iter::fallback_to_flat_segments(
+                manifest.as_ref(),
+            ),
         };
         if superfiles.is_empty() {
             return Ok(Vec::new());
@@ -158,12 +156,8 @@ impl SupertableReader {
         if kept.is_empty() {
             return Ok(Vec::new());
         }
-        let work_units = build_or_work_units(
-            &kept,
-            mode,
-            term_refs.len(),
-            pool.current_num_threads(),
-        );
+        let work_units =
+            build_or_work_units(&kept, mode, term_refs.len(), pool.current_num_threads());
 
         let per_unit: Result<Vec<Vec<SuperfileHit>>, QueryError> = pool.install(|| {
             work_units
@@ -231,22 +225,19 @@ impl SupertableReader {
         // term-range skip + fan-out.
         let superfiles: Vec<Arc<SuperfileEntry>> = match manifest.list.as_ref() {
             Some(list) => {
-                let kept =
-                    crate::supertable::manifest::list_prune::prune_parts_for_fts_prefix(
-                        list,
-                        &column_owned,
-                        prefix_lower.as_bytes(),
-                    );
+                let kept = crate::supertable::manifest::list_prune::prune_parts_for_fts_prefix(
+                    list,
+                    &column_owned,
+                    prefix_lower.as_bytes(),
+                );
                 crate::supertable::query::hierarchical_iter::load_and_flatten(
                     manifest.as_ref(),
                     &kept,
                 )?
             }
-            None => {
-                crate::supertable::query::hierarchical_iter::fallback_to_flat_segments(
-                    manifest.as_ref(),
-                )
-            }
+            None => crate::supertable::query::hierarchical_iter::fallback_to_flat_segments(
+                manifest.as_ref(),
+            ),
         };
         if superfiles.is_empty() {
             return Ok(Vec::new());
@@ -275,8 +266,7 @@ impl SupertableReader {
         // since the prefix path always runs BoolMode::Or and the
         // expansion typically yields ≥2 terms at the scales we
         // care about.
-        let work_units =
-            build_or_work_units(&kept, BoolMode::Or, 2, pool.current_num_threads());
+        let work_units = build_or_work_units(&kept, BoolMode::Or, 2, pool.current_num_threads());
 
         let per_unit: Result<Vec<Vec<SuperfileHit>>, QueryError> = pool.install(|| {
             work_units
@@ -285,13 +275,7 @@ impl SupertableReader {
                     let r = open_reader(&store, disk_cache.as_ref(), &unit.entry)?;
                     let hits = match unit.range {
                         Some((start, end)) => r
-                            .bm25_search_prefix_range(
-                                &column_owned,
-                                &prefix_owned,
-                                k,
-                                start,
-                                end,
-                            )
+                            .bm25_search_prefix_range(&column_owned, &prefix_owned, k, start, end)
                             .map_err(|e| QueryError::Parquet(e.to_string()))?,
                         None => r
                             .bm25_search_prefix(&column_owned, &prefix_owned, k)
@@ -444,7 +428,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
 
     use crate::superfile::builder::{FtsConfig, SuperfileBuilder};
-    
+
     use crate::supertable::error::QueryError;
     use crate::supertable::{Supertable, SupertableOptions};
 
@@ -521,8 +505,8 @@ mod tests {
             )
             .expect("decimal128");
         let titles_arr = LargeStringArray::from(titles.to_vec());
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles_arr)])
-            .expect("batch");
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles_arr)]).expect("batch");
         b.add_batch(&batch, &[]).expect("add_batch");
         let bytes = bytes::Bytes::from(b.finish().expect("finish"));
         Arc::new(crate::superfile::SuperfileReader::open(bytes).expect("open"))

--- a/src/supertable/query/hierarchical_iter.rs
+++ b/src/supertable/query/hierarchical_iter.rs
@@ -76,9 +76,7 @@ pub fn load_kept_parts(
                 .enable_all()
                 .build()
                 .map_err(|e| {
-                    QueryError::Store(format!(
-                        "tokio runtime build for hierarchical_iter: {e}"
-                    ))
+                    QueryError::Store(format!("tokio runtime build for hierarchical_iter: {e}"))
                 })?;
             rt.block_on(drive)
         }

--- a/src/supertable/query/mod.rs
+++ b/src/supertable/query/mod.rs
@@ -18,9 +18,9 @@
 
 pub mod fts;
 pub mod hierarchical_iter;
-pub mod superfile_reader;
 pub mod skip;
 pub mod sql;
+pub mod superfile_reader;
 pub mod vector;
 
 pub use vector::VectorSearchOptions;

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -106,7 +106,11 @@ pub fn fts_bloom_skip(
 ///
 /// An empty `prefix` (every term matches) short-circuits to
 /// all-keep.
-pub fn fts_prefix_skip(superfiles: &[Arc<SuperfileEntry>], column: &str, prefix: &[u8]) -> Vec<bool> {
+pub fn fts_prefix_skip(
+    superfiles: &[Arc<SuperfileEntry>],
+    column: &str,
+    prefix: &[u8],
+) -> Vec<bool> {
     if prefix.is_empty() {
         return vec![true; superfiles.len()];
     }
@@ -186,7 +190,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::superfile::builder::{FtsConfig, VectorConfig};
-    
+
     use crate::superfile::vector::distance::Metric;
     use crate::supertable::SupertableOptions;
     use crate::supertable::manifest::{
@@ -293,7 +297,10 @@ mod tests {
         Arc::new(e)
     }
 
-    fn manifest_with(opts: Arc<SupertableOptions>, superfiles: Vec<Arc<SuperfileEntry>>) -> Manifest {
+    fn manifest_with(
+        opts: Arc<SupertableOptions>,
+        superfiles: Vec<Arc<SuperfileEntry>>,
+    ) -> Manifest {
         // M2c: build via `with_appended` so the new outer
         // Manifest's metadata fields (list, parts, loader) get
         // initialized correctly. Equivalent to the old direct-

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -168,10 +168,7 @@ fn build_mem_table(
     let superfiles: Vec<Arc<crate::supertable::SuperfileEntry>> = match manifest.list.as_ref() {
         Some(list) => {
             let kept: Vec<_> = list.parts.iter().map(|p| p.part_id).collect();
-            crate::supertable::query::hierarchical_iter::load_and_flatten(
-                manifest.as_ref(),
-                &kept,
-            )?
+            crate::supertable::query::hierarchical_iter::load_and_flatten(manifest.as_ref(), &kept)?
         }
         None => crate::supertable::query::hierarchical_iter::fallback_to_flat_segments(
             manifest.as_ref(),
@@ -221,7 +218,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
 
     use crate::superfile::builder::{FtsConfig, VectorConfig};
-    
+
     use crate::superfile::vector::distance::Metric;
     use crate::supertable::{Supertable, SupertableOptions};
 

--- a/src/supertable/query/superfile_reader.rs
+++ b/src/supertable/query/superfile_reader.rs
@@ -32,9 +32,9 @@
 use std::sync::Arc;
 
 use crate::superfile::SuperfileReader;
-use crate::supertable::reader_cache::DiskCacheStore;
 use crate::supertable::manifest::SuperfileUri;
-use crate::supertable::reader_cache::{SuperfileReaderCache, ReaderCacheError};
+use crate::supertable::reader_cache::DiskCacheStore;
+use crate::supertable::reader_cache::{ReaderCacheError, SuperfileReaderCache};
 
 /// Look up `uri`'s `SuperfileReader`, preferring the in-
 /// memory tier and falling back to the disk cache when
@@ -66,9 +66,7 @@ pub fn superfile_reader(
             // Ambient tokio runtime — block_in_place + block_on
             // is the same pattern the writer's commit path uses
             // for its sync→async bridge.
-            tokio::task::block_in_place(|| {
-                handle.block_on(cache.reader(&uri_copy))
-            })
+            tokio::task::block_in_place(|| handle.block_on(cache.reader(&uri_copy)))
         }
         Err(_) => {
             // No ambient runtime. Build a tiny one just for
@@ -84,9 +82,9 @@ pub fn superfile_reader(
                 Ok(rt) => rt,
                 Err(e) => {
                     return Err(ReaderCacheError::OpenFailed {
-                        source: crate::superfile::ReadError::Io(std::io::Error::other(
-                            format!("tokio runtime build for disk cache fetch: {e}"),
-                        )),
+                        source: crate::superfile::ReadError::Io(std::io::Error::other(format!(
+                            "tokio runtime build for disk cache fetch: {e}"
+                        ))),
                     });
                 }
             };

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -113,11 +113,9 @@ impl SupertableReader {
                     &kept,
                 )?
             }
-            None => {
-                crate::supertable::query::hierarchical_iter::fallback_to_flat_segments(
-                    manifest.as_ref(),
-                )
-            }
+            None => crate::supertable::query::hierarchical_iter::fallback_to_flat_segments(
+                manifest.as_ref(),
+            ),
         };
         if superfiles.is_empty() {
             return Ok(Vec::new());
@@ -180,13 +178,11 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::Array;
-    use arrow_array::{
-        FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch,
-    };
+    use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
 
     use crate::superfile::builder::{FtsConfig, SuperfileBuilder, VectorConfig};
-    
+
     use crate::superfile::vector::distance::Metric;
     use crate::supertable::error::QueryError;
     use crate::supertable::{Supertable, SupertableOptions};

--- a/src/supertable/reader_cache/config.rs
+++ b/src/supertable/reader_cache/config.rs
@@ -182,8 +182,10 @@ impl CacheEvictionPolicy for LruPolicy {
         // Filter pinned, sort by ascending last_access_us
         // (oldest first), take until cumulative size ≥
         // bytes_needed.
-        let mut eligible: Vec<&EvictionCandidate> =
-            candidates.iter().filter(|c| !pinned.contains(&c.uri)).collect();
+        let mut eligible: Vec<&EvictionCandidate> = candidates
+            .iter()
+            .filter(|c| !pinned.contains(&c.uri))
+            .collect();
         eligible.sort_by_key(|c| c.last_access_us);
         let mut victims = Vec::new();
         let mut freed = 0u64;

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -16,9 +16,9 @@ use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::OnceCell;
 
 use super::config::{ColdFetchMode, DiskCacheConfig, EvictionCandidate};
+use crate::storage::{StorageError, StorageProvider};
 use crate::superfile::reader::{OpenOptions, SuperfileReader};
 use crate::supertable::manifest::SuperfileUri;
-use crate::storage::{StorageError, StorageProvider};
 
 /// Errors surfaced by [`DiskCacheStore::reader`].
 #[derive(Debug, Error)]
@@ -132,7 +132,10 @@ impl std::fmt::Debug for DiskCacheStore {
             .field("budget_bytes", &self.config.disk_budget_bytes)
             .field("current_bytes", &self.current_bytes.load(Ordering::Acquire))
             .field("n_entries", &self.cached.len())
-            .field("n_cold_fetches", &self.n_cold_fetches.load(Ordering::Acquire))
+            .field(
+                "n_cold_fetches",
+                &self.n_cold_fetches.load(Ordering::Acquire),
+            )
             .finish()
     }
 }
@@ -216,7 +219,10 @@ impl DiskCacheStore {
     /// eviction during the sweep — `madvise` on a multi-GB
     /// mmap can take milliseconds.
     pub fn sweep_once(&self) -> u64 {
-        let threshold_us = self.config.mmap_cold_threshold_secs.saturating_mul(1_000_000);
+        let threshold_us = self
+            .config
+            .mmap_cold_threshold_secs
+            .saturating_mul(1_000_000);
         let now_us = self.now_us();
         // Snapshot: clone the Arc<Mmap> + last-access into an
         // owned Vec, then drop the iterator.
@@ -249,9 +255,7 @@ impl DiskCacheStore {
                 // file is immutable for the lifetime of this
                 // mapping; pages dropped by `MADV_DONTNEED`
                 // re-fault from disk on next read.
-                let _ = unsafe {
-                    mmap.unchecked_advise(memmap2::UncheckedAdvice::DontNeed)
-                };
+                let _ = unsafe { mmap.unchecked_advise(memmap2::UncheckedAdvice::DontNeed) };
                 n_advised += 1;
             }
         }
@@ -308,9 +312,7 @@ impl DiskCacheStore {
         uri: &SuperfileUri,
     ) -> Result<Arc<SuperfileReader>, DiskCacheError> {
         if let Some(entry) = self.cached.get(uri) {
-            entry
-                .last_access_us
-                .store(self.now_us(), Ordering::Release);
+            entry.last_access_us.store(self.now_us(), Ordering::Release);
             return Ok(Arc::clone(&entry.reader));
         }
         let cell = self
@@ -318,7 +320,9 @@ impl DiskCacheStore {
             .entry(*uri)
             .or_insert_with(|| Arc::new(OnceCell::new()))
             .clone();
-        let result = cell.get_or_init(|| async { self.cold_fetch(uri).await }).await;
+        let result = cell
+            .get_or_init(|| async { self.cold_fetch(uri).await })
+            .await;
         match result {
             Ok(entry) => {
                 self.coordinators.remove(uri);
@@ -326,9 +330,11 @@ impl DiskCacheStore {
             }
             Err(_e) => {
                 self.coordinators.remove(uri);
-                Err(self.cold_fetch(uri).await.err().unwrap_or(
-                    DiskCacheError::SuperfileOpen("cold fetch error".into()),
-                ))
+                Err(self
+                    .cold_fetch(uri)
+                    .await
+                    .err()
+                    .unwrap_or(DiskCacheError::SuperfileOpen("cold fetch error".into())))
             }
         }
     }
@@ -342,9 +348,7 @@ impl DiskCacheStore {
         uri: &SuperfileUri,
     ) -> Result<Arc<SuperfileReader>, DiskCacheError> {
         if let Some(entry) = self.cached.get(uri) {
-            entry
-                .last_access_us
-                .store(self.now_us(), Ordering::Release);
+            entry.last_access_us.store(self.now_us(), Ordering::Release);
             return Ok(Arc::clone(&entry.reader));
         }
         let cell = self
@@ -399,14 +403,8 @@ impl DiskCacheStore {
     /// recent `set_pinned_fn` call wins. The closure can
     /// itself walk multiple `Weak<...>` references if a
     /// caller needs to pin URIs from several supertables.
-    pub fn set_pinned_fn(
-        &self,
-        pinned_fn: Arc<dyn Fn() -> HashSet<SuperfileUri> + Send + Sync>,
-    ) {
-        let mut g = self
-            .pinned_fn
-            .lock()
-            .expect("pinned_fn mutex poisoned");
+    pub fn set_pinned_fn(&self, pinned_fn: Arc<dyn Fn() -> HashSet<SuperfileUri> + Send + Sync>) {
+        let mut g = self.pinned_fn.lock().expect("pinned_fn mutex poisoned");
         *g = pinned_fn;
     }
 
@@ -501,10 +499,7 @@ impl DiskCacheStore {
     /// / [`crate::supertable::Supertable::open`].
     pub fn current_pinned_uris(&self) -> HashSet<SuperfileUri> {
         let f = {
-            let g = self
-                .pinned_fn
-                .lock()
-                .expect("pinned_fn mutex poisoned");
+            let g = self.pinned_fn.lock().expect("pinned_fn mutex poisoned");
             Arc::clone(&g)
         };
         f()
@@ -640,17 +635,13 @@ impl DiskCacheStore {
 
     /// Build a per-URI cache file path under `cache_root`.
     fn cache_path(&self, uri: &SuperfileUri) -> PathBuf {
-        self.config
-            .cache_root
-            .join(format!("seg-{}.sf", uri.0))
+        self.config.cache_root.join(format!("seg-{}.sf", uri.0))
     }
 
     /// Build a per-URI tempfile path (sparse destination
     /// during cold fetch; renamed to `cache_path` on success).
     fn tmp_path(&self, uri: &SuperfileUri) -> PathBuf {
-        self.config
-            .cache_root
-            .join(format!("seg-{}.sf.tmp", uri.0))
+        self.config.cache_root.join(format!("seg-{}.sf.tmp", uri.0))
     }
 
     /// The storage-side URI for a segment, mirroring the
@@ -691,7 +682,11 @@ impl DiskCacheStore {
             .config
             .cold_fetch_chunk_bytes
             .max(size.div_ceil(n_streams));
-        let n_chunks = if size == 0 { 0 } else { size.div_ceil(chunk_size) };
+        let n_chunks = if size == 0 {
+            0
+        } else {
+            size.div_ceil(chunk_size)
+        };
 
         let file = tokio::fs::File::create(&tmp).await?;
         file.set_len(size).await?;
@@ -715,8 +710,9 @@ impl DiskCacheStore {
             // Spawn the fetch task. It captures a Sender for
             // its pwrite handle so the outer task can join
             // pwrites separately from fetches.
-            let (write_tx, write_rx) =
-                tokio::sync::oneshot::channel::<tokio::task::JoinHandle<Result<(), DiskCacheError>>>();
+            let (write_tx, write_rx) = tokio::sync::oneshot::channel::<
+                tokio::task::JoinHandle<Result<(), DiskCacheError>>,
+            >();
             write_handles.push(write_rx);
 
             fetch_handles.push(tokio::spawn(async move {
@@ -818,10 +814,7 @@ impl DiskCacheStore {
 
     /// Run the cold-fetch coordinator for `uri`. Reserves
     /// budget, fetches, mmap's, registers in `cached`.
-    async fn cold_fetch(
-        &self,
-        uri: &SuperfileUri,
-    ) -> Result<Arc<CachedEntry>, DiskCacheError> {
+    async fn cold_fetch(&self, uri: &SuperfileUri) -> Result<Arc<CachedEntry>, DiskCacheError> {
         let storage_uri = Self::storage_path(uri);
         let head = self.storage.head(&storage_uri).await?;
         let size = head.size;
@@ -875,12 +868,7 @@ impl DiskCacheStore {
             if cur + bytes <= self.config.disk_budget_bytes {
                 if self
                     .current_bytes
-                    .compare_exchange_weak(
-                        cur,
-                        cur + bytes,
-                        Ordering::AcqRel,
-                        Ordering::Acquire,
-                    )
+                    .compare_exchange_weak(cur, cur + bytes, Ordering::AcqRel, Ordering::Acquire)
                     .is_ok()
                 {
                     return Ok(());
@@ -901,12 +889,7 @@ impl DiskCacheStore {
             if cur + bytes <= self.config.disk_budget_bytes {
                 if self
                     .current_bytes
-                    .compare_exchange_weak(
-                        cur,
-                        cur + bytes,
-                        Ordering::AcqRel,
-                        Ordering::Acquire,
-                    )
+                    .compare_exchange_weak(cur, cur + bytes, Ordering::AcqRel, Ordering::Acquire)
                     .is_ok()
                 {
                     return Ok(Reservation {
@@ -939,10 +922,7 @@ impl DiskCacheStore {
         // pinned_fn mutex across that call invites
         // deadlocks.
         let pinned_fn = {
-            let g = self
-                .pinned_fn
-                .lock()
-                .expect("pinned_fn mutex poisoned");
+            let g = self.pinned_fn.lock().expect("pinned_fn mutex poisoned");
             Arc::clone(&g)
         };
         let pinned = pinned_fn();
@@ -955,8 +935,10 @@ impl DiskCacheStore {
                 last_access_us: e.value().last_access_us.load(Ordering::Acquire),
             })
             .collect();
-        let victims =
-            self.config.eviction.select_for_eviction(&candidates, &pinned, bytes_needed);
+        let victims = self
+            .config
+            .eviction
+            .select_for_eviction(&candidates, &pinned, bytes_needed);
         if victims.is_empty() {
             return Err(DiskCacheError::BudgetExceeded);
         }
@@ -996,7 +978,11 @@ impl DiskCacheStore {
         file.set_len(size).await?;
         let file = Arc::new(tokio::sync::Mutex::new(file));
 
-        let n_chunks = if size == 0 { 0 } else { size.div_ceil(chunk_size) };
+        let n_chunks = if size == 0 {
+            0
+        } else {
+            size.div_ceil(chunk_size)
+        };
         let mut joins = Vec::with_capacity(n_chunks as usize);
         for i in 0..n_chunks {
             let start = i * chunk_size;
@@ -1013,9 +999,8 @@ impl DiskCacheStore {
             }));
         }
         for h in joins {
-            h.await.map_err(|e| {
-                DiskCacheError::SuperfileOpen(format!("join error: {e}"))
-            })??;
+            h.await
+                .map_err(|e| DiskCacheError::SuperfileOpen(format!("join error: {e}")))??;
         }
         let mut guard = file.lock().await;
         guard.flush().await?;
@@ -1112,9 +1097,7 @@ async fn finalize_to_mmap(
                     reader: Arc::new(reader),
                     mmap: Some(mmap_arc),
                     size_bytes: size,
-                    last_access_us: AtomicU64::new(
-                        store.started_at.elapsed().as_micros() as u64,
-                    ),
+                    last_access_us: AtomicU64::new(store.started_at.elapsed().as_micros() as u64),
                 });
             }
             Entry::Vacant(_) => {

--- a/src/supertable/reader_cache/in_memory.rs
+++ b/src/supertable/reader_cache/in_memory.rs
@@ -31,7 +31,7 @@ use bytes::Bytes;
 use crate::superfile::SuperfileReader;
 use crate::supertable::manifest::SuperfileUri;
 
-use super::{SuperfileReaderCache, ReaderCacheError};
+use super::{ReaderCacheError, SuperfileReaderCache};
 
 /// Per-URI entry. Holds the raw bytes alongside the parsed reader
 /// so `resident_bytes()` can attribute storage back to specific
@@ -178,7 +178,9 @@ mod tests {
         let bytes = minimal_superfile_bytes();
         let uri = fresh_uri();
 
-        store.insert(uri, bytes.clone()).expect("insert should succeed");
+        store
+            .insert(uri, bytes.clone())
+            .expect("insert should succeed");
 
         let r = store.reader(&uri).expect("reader should find uri");
         assert_eq!(r.n_docs(), 3, "minimal superfile carries 3 docs");
@@ -249,8 +251,12 @@ mod tests {
         let store = InMemoryReaderCache::new();
         let bytes_a = minimal_superfile_bytes();
         let bytes_b = minimal_superfile_bytes();
-        store.insert(fresh_uri(), bytes_a.clone()).expect("insert a");
-        store.insert(fresh_uri(), bytes_b.clone()).expect("insert b");
+        store
+            .insert(fresh_uri(), bytes_a.clone())
+            .expect("insert a");
+        store
+            .insert(fresh_uri(), bytes_b.clone())
+            .expect("insert b");
         assert_eq!(store.n_superfiles(), 2);
         assert_eq!(store.resident_bytes(), bytes_a.len() + bytes_b.len());
     }
@@ -263,7 +269,9 @@ mod tests {
         // same underlying SuperfileReader.
         let store = InMemoryReaderCache::new();
         let uri = fresh_uri();
-        store.insert(uri, minimal_superfile_bytes()).expect("insert");
+        store
+            .insert(uri, minimal_superfile_bytes())
+            .expect("insert");
         let a = store.reader(&uri).expect("a");
         let b = store.reader(&uri).expect("b");
         assert!(Arc::ptr_eq(&a, &b));

--- a/src/supertable/stats.rs
+++ b/src/supertable/stats.rs
@@ -31,7 +31,6 @@
 #[derive(Debug, Clone, Default)]
 pub struct SupertableStats {
     // ---- Manifest-side observables ---------------------------------
-
     /// Current pinned `manifest_id`. Monotonically increasing
     /// across commits; `0` for a freshly `create`'d supertable
     /// with no commits.
@@ -60,7 +59,6 @@ pub struct SupertableStats {
     pub n_manifest_parts_loaded: usize,
 
     // ---- Process memory --------------------------------------------
-
     /// Resident set size of this **process**, as reported by
     /// the OS (Mach `task_info` on macOS, `/proc/self/statm`
     /// on Linux, etc.). The whole-process RSS includes
@@ -75,7 +73,6 @@ pub struct SupertableStats {
     pub process_rss_bytes: u64,
 
     // ---- Disk cache (when attached) --------------------------------
-
     /// Disk cache's mmap virtual-size sum.
     /// `None` for supertables without a disk cache attached.
     /// Upper bound on the cache's resident memory — actual

--- a/src/supertable/utils/idgen.rs
+++ b/src/supertable/utils/idgen.rs
@@ -241,7 +241,10 @@ mod tests {
                     ts > prev_ts || prev_ts == 0,
                     "ts must be non-decreasing: prev_ts={prev_ts} ts={ts}"
                 );
-                assert_eq!(seq, 0, "new-ms seq must be 0; got {seq} after ts={prev_ts} → {ts}");
+                assert_eq!(
+                    seq, 0,
+                    "new-ms seq must be 0; got {seq} after ts={prev_ts} → {ts}"
+                );
             }
             prev_ts = ts;
             prev_seq = seq;

--- a/src/supertable/utils/vector_split.rs
+++ b/src/supertable/utils/vector_split.rs
@@ -191,7 +191,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
 
     use crate::superfile::builder::{FtsConfig, VectorConfig};
-    
+
     use crate::superfile::vector::distance::Metric;
 
     fn fixed_list_f32(dim: usize) -> DataType {
@@ -303,8 +303,8 @@ mod tests {
             false,
         )]));
         let fsl = build_fsl(vec![0.0; 2 * dim], dim);
-        let other_batch = RecordBatch::try_new(other_schema, vec![Arc::new(fsl)])
-            .expect("build batch");
+        let other_batch =
+            RecordBatch::try_new(other_schema, vec![Arc::new(fsl)]).expect("build batch");
 
         let err = split_vectors(&other_batch, &opts).expect_err("expected error");
         assert!(matches!(err, BuildError::BatchSchemaMismatch));
@@ -362,13 +362,8 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(schema.clone(), vec![fc("title")], vec![], Some(tok()))
+            .expect("valid options");
 
         let titles = LargeStringArray::from(vec!["x", "y"]);
         let batch = RecordBatch::try_new(schema, vec![Arc::new(titles)]).expect("build batch");

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -348,7 +348,6 @@ impl SupertableWriter {
         publish_superfiles(&self.inner, outputs)?;
         Ok(())
     }
-
 }
 
 impl Drop for SupertableWriter {
@@ -486,13 +485,8 @@ fn prepare_segment(
 
     let uri = SuperfileUri::new_v4();
 
-    let bytes_for_storage = inner
-        .options
-        .storage
-        .is_some()
-        .then(|| shard.bytes.clone());
-    let cache_attached =
-        inner.options.disk_cache.is_some() && inner.options.storage.is_some();
+    let bytes_for_storage = inner.options.storage.is_some().then(|| shard.bytes.clone());
+    let cache_attached = inner.options.disk_cache.is_some() && inner.options.storage.is_some();
     let bytes_for_store = (!cache_attached).then(|| shard.bytes.clone());
     let bytes_for_cache = cache_attached.then(|| shard.bytes.clone());
 
@@ -537,10 +531,7 @@ fn prepare_segment(
     if let Some(vec_reader) = reader.vec() {
         for vc in &inner.options.vector_columns {
             if let Some((centroid, radius)) = vec_reader.summary(&vc.column) {
-                vector_summary.insert(
-                    vc.column.clone(),
-                    VectorSummary { centroid, radius },
-                );
+                vector_summary.insert(vc.column.clone(), VectorSummary { centroid, radius });
             }
         }
     }
@@ -579,7 +570,10 @@ fn prepare_segment(
 /// O(n_terms_distinct) per FTS column per shard, which at 10M
 /// docs × 4 superfiles is the dominant cost. Manifest swap +
 /// storage write-through stay serial after the join.
-fn publish_superfiles(inner: &SupertableInner, outputs: Vec<ShardOutput>) -> Result<(), BuildError> {
+fn publish_superfiles(
+    inner: &SupertableInner,
+    outputs: Vec<ShardOutput>,
+) -> Result<(), BuildError> {
     let prepared: Vec<PreparedSegment> = inner.options.writer_pool.install(|| {
         outputs
             .into_par_iter()
@@ -762,8 +756,7 @@ fn persist_commit(
             // iteration) feeds into our successor's
             // `new_segment_list`.
             let old = inner.manifest.load_full();
-            let new_segment_list =
-                old.superfile_list.with_appended(new_entries.clone());
+            let new_segment_list = old.superfile_list.with_appended(new_entries.clone());
             let pending_writes = pending_storage_writes.clone();
 
             match try_commit_attempt(
@@ -851,15 +844,13 @@ async fn try_commit_attempt(
     new_manifest_id: u64,
     pending_storage_writes: Vec<(SuperfileUri, Bytes)>,
 ) -> Result<crate::supertable::manifest::list::ManifestList, crate::supertable::CommitError> {
+    use crate::storage::StorageError;
     use crate::supertable::manifest::commit::{self as commit_mod, POINTER_PATH};
     use crate::supertable::manifest::list::{
         FORMAT_VERSION as LIST_FORMAT_VERSION, ManifestList, ManifestListEntry, PartitionStrategy,
     };
     use crate::supertable::manifest::part::{self as part_mod, ManifestPart, PartId};
-    use crate::supertable::manifest::partition::{
-        assign_partition, encode_partition_key,
-    };
-    use crate::storage::StorageError;
+    use crate::supertable::manifest::partition::{assign_partition, encode_partition_key};
     use std::collections::{BTreeMap, HashMap, HashSet};
 
     // 1. Write each new segment's bytes to storage in parallel.
@@ -978,14 +969,10 @@ async fn try_commit_attempt(
                     // emit a fresh part with just the new
                     // superfiles for this partition.
                     out_list_entries.push(entry.clone());
-                    let new_segs: Vec<Arc<SuperfileEntry>> = combined_segments
-                        [existing_part.superfiles.len()..]
-                        .to_vec();
-                    let (fresh_entry, fresh_part) = build_part_and_entry(
-                        &opts,
-                        new_segs,
-                        entry.partition_key.clone(),
-                    )?;
+                    let new_segs: Vec<Arc<SuperfileEntry>> =
+                        combined_segments[existing_part.superfiles.len()..].to_vec();
+                    let (fresh_entry, fresh_part) =
+                        build_part_and_entry(&opts, new_segs, entry.partition_key.clone())?;
                     out_list_entries.push(fresh_entry);
                     parts_to_write.push(fresh_part);
                 } else {
@@ -1030,10 +1017,7 @@ async fn try_commit_attempt(
     //    typed error rather than a downstream decode
     //    failure.
     let opts_hash =
-        crate::supertable::manifest::options_hash::compute_options_hash(
-            opts.as_ref(),
-            &strategy,
-        );
+        crate::supertable::manifest::options_hash::compute_options_hash(opts.as_ref(), &strategy);
     let new_list = ManifestList {
         format_version: LIST_FORMAT_VERSION.into(),
         manifest_id: new_manifest_id,
@@ -1158,10 +1142,10 @@ async fn refresh_inner_state_async(
     inner: &SupertableInner,
     storage: &Arc<dyn crate::storage::StorageProvider>,
 ) -> Result<(), crate::supertable::CommitError> {
+    use crate::supertable::manifest::ManifestPartLoader;
     use crate::supertable::manifest::commit::read_pointer;
     use crate::supertable::manifest::list as list_mod;
     use crate::supertable::manifest::{Manifest, SuperfileList};
-    use crate::supertable::manifest::ManifestPartLoader;
 
     let pointer = match read_pointer(storage.as_ref()).await? {
         Some(p) => p,
@@ -1224,9 +1208,7 @@ async fn refresh_inner_state_async(
 
     let mut all_segments: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
     for entry in &new_list.parts {
-        let cell = new_parts
-            .get(&entry.part_id)
-            .expect("part inserted above");
+        let cell = new_parts.get(&entry.part_id).expect("part inserted above");
         let part = cell
             .value()
             .get()
@@ -1366,15 +1348,13 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    use arrow_array::{
-        FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch,
-    };
+    use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use rayon::ThreadPoolBuilder;
 
     use crate::superfile::builder::FtsConfig;
     use crate::superfile::builder::VectorConfig;
-    
+
     use crate::superfile::vector::distance::Metric;
     use crate::supertable::SupertableOptions;
     use crate::supertable::handle::Supertable;
@@ -1704,7 +1684,11 @@ supertable:
         w.commit().expect("commit");
 
         let r = st.reader();
-        assert_eq!(r.n_superfiles(), 4, "writer_threads=4 should yield 4 shards");
+        assert_eq!(
+            r.n_superfiles(),
+            4,
+            "writer_threads=4 should yield 4 shards"
+        );
         assert_eq!(r.n_docs_total(), 24);
     }
 

--- a/src/test_helpers/brute_force_bm25.rs
+++ b/src/test_helpers/brute_force_bm25.rs
@@ -124,7 +124,9 @@ impl BruteForceBm25 {
             let dl = doc.dl as f32;
             let dl_norm = K1 * (1.0 - B + B * dl / avgdl.max(f32::MIN_POSITIVE));
             for term in terms {
-                let Some(&tf) = doc.tf.get(term) else { continue };
+                let Some(&tf) = doc.tf.get(term) else {
+                    continue;
+                };
                 let df = *self.df.get(term).unwrap_or(&0) as f32;
                 if df == 0.0 {
                     continue;

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -186,12 +186,8 @@ fn corrupt_parquet_footer_rejected() {
     // field type or id and Parquet's decoder rejects the result.
     let bytes = build_corruptable_superfile();
     let n = bytes.len();
-    let footer_len = u32::from_le_bytes([
-        bytes[n - 8],
-        bytes[n - 7],
-        bytes[n - 6],
-        bytes[n - 5],
-    ]) as usize;
+    let footer_len =
+        u32::from_le_bytes([bytes[n - 8], bytes[n - 7], bytes[n - 6], bytes[n - 5]]) as usize;
     let target = n - 8 - footer_len;
     assert_corruption_rejected(bytes, target, "parquet/footer thrift");
 }

--- a/tests/superfile/format/lazy_byte_source.rs
+++ b/tests/superfile/format/lazy_byte_source.rs
@@ -29,7 +29,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use infino::superfile::builder::{BuilderOptions, FtsConfig, SuperfileBuilder};
 use infino::superfile::fts::reader::BoolMode;
-use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use infino::superfile::{
     BytesLazyByteSource, LazyByteSource, LazyByteSourceError, SuperfileReader,
 };
@@ -37,6 +36,7 @@ use infino::supertable::StorageRangeSource;
 use infino::supertable::storage::{
     LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider,
 };
+use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use tempfile::TempDir;
 
 // ============================================================
@@ -65,8 +65,7 @@ fn build_test_bytes() -> Bytes {
         "echo special foxtrot",
         "gamma hotel",
     ]);
-    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
-        .expect("batch");
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
     b.add_batch(&batch, &[]).expect("add_batch");
     Bytes::from(b.finish().expect("finish"))
 }
@@ -81,7 +80,9 @@ async fn open_lazy_via_bytes_source_matches_open() {
     let eager = SuperfileReader::open(bytes.clone()).expect("eager open");
 
     let source = BytesLazyByteSource::new(bytes);
-    let lazy = SuperfileReader::open_lazy(&source).await.expect("lazy open");
+    let lazy = SuperfileReader::open_lazy(&source)
+        .await
+        .expect("lazy open");
 
     assert_eq!(lazy.schema(), eager.schema());
     assert_eq!(lazy.id_column(), eager.id_column());
@@ -153,17 +154,13 @@ impl StorageProvider for CountingProxy {
 #[tokio::test]
 async fn storage_range_source_drives_open_lazy_against_localfs() {
     let dir = TempDir::new().expect("tempdir");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("local"));
     let bytes = build_test_bytes();
 
     // Seed the segment at a stable URI.
     let uri = "data/seg-test.sf";
-    local
-        .put_atomic(uri, bytes.clone())
-        .await
-        .expect("seed");
+    local.put_atomic(uri, bytes.clone()).await.expect("seed");
 
     // Counting proxy so we can assert the trait is actually
     // driving I/O (not a hidden path).
@@ -178,7 +175,9 @@ async fn storage_range_source_drives_open_lazy_against_localfs() {
         "StorageRangeSource::new must HEAD the object once"
     );
 
-    let reader = SuperfileReader::open_lazy(&source).await.expect("open_lazy");
+    let reader = SuperfileReader::open_lazy(&source)
+        .await
+        .expect("open_lazy");
     let range_after_open = proxy.get_range_calls.load(Ordering::Acquire);
     assert!(
         range_after_open >= 1,
@@ -196,15 +195,11 @@ async fn storage_range_source_drives_open_lazy_against_localfs() {
 #[tokio::test]
 async fn open_lazy_via_storage_matches_open_via_bytes() {
     let dir = TempDir::new().expect("tempdir");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = "data/seg-equiv.sf";
-    local
-        .put_atomic(uri, bytes.clone())
-        .await
-        .expect("seed");
+    local.put_atomic(uri, bytes.clone()).await.expect("seed");
 
     let eager = SuperfileReader::open(bytes).expect("eager");
     let source = StorageRangeSource::new(Arc::clone(&local), uri)
@@ -235,24 +230,17 @@ async fn open_lazy_via_storage_matches_open_via_bytes() {
 #[tokio::test]
 async fn storage_range_source_out_of_bounds_surfaces_typed_error() {
     let dir = TempDir::new().expect("tempdir");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = "data/seg-oob.sf";
-    local
-        .put_atomic(uri, bytes.clone())
-        .await
-        .expect("seed");
+    local.put_atomic(uri, bytes.clone()).await.expect("seed");
 
     let source = StorageRangeSource::new(Arc::clone(&local), uri)
         .await
         .expect("source");
     let size = source.size();
-    let err = source
-        .range(size, 1024)
-        .await
-        .expect_err("must reject");
+    let err = source.range(size, 1024).await.expect_err("must reject");
     assert!(
         matches!(err, LazyByteSourceError::OutOfBounds { .. }),
         "expected OutOfBounds, got {err:?}"

--- a/tests/superfile/format/mod.rs
+++ b/tests/superfile/format/mod.rs
@@ -1,3 +1,3 @@
 pub mod crc_corruption;
-pub mod parquet_compat;
 pub mod lazy_byte_source;
+pub mod parquet_compat;

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -295,8 +295,5 @@ fn oracle_long_doc_vs_short_doc_dl_norm() {
         .collect();
     let infino_top2: HashSet<u64> = infino_hits.into_iter().take(2).collect();
     let oracle_top2: HashSet<u64> = oracle_hits.into_iter().take(2).collect();
-    assert_eq!(
-        infino_top2, oracle_top2,
-        "framework top-2 sets disagree"
-    );
+    assert_eq!(infino_top2, oracle_top2, "framework top-2 sets disagree");
 }

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -1,2 +1,2 @@
-pub mod pipeline;
 pub mod brute_force_oracle;
+pub mod pipeline;

--- a/tests/superfile/main.rs
+++ b/tests/superfile/main.rs
@@ -19,7 +19,7 @@
 //!   cargo test --test superfile vector::brute_force_oracle::
 //!   cargo test --test superfile format::crc_corruption::
 
-mod pipeline;
-mod fts;
-mod vector;
 mod format;
+mod fts;
+mod pipeline;
+mod vector;

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -10,9 +10,9 @@ use infino::superfile::builder::{
     BuilderOptions, FtsConfig, SuperfileBuilder, VectorConfig as SfVectorConfig,
 };
 use infino::superfile::fts::reader::BoolMode;
-use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use infino::superfile::vector::distance::{Metric, normalize};
 use infino::superfile::{SuperfileReader, VectorSearchOptions};
+use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use std::sync::Arc;
 

--- a/tests/superfile/vector/mod.rs
+++ b/tests/superfile/vector/mod.rs
@@ -1,2 +1,2 @@
-pub mod pipeline;
 pub mod brute_force_oracle;
+pub mod pipeline;

--- a/tests/supertable/commit/id_uniqueness.rs
+++ b/tests/supertable/commit/id_uniqueness.rs
@@ -35,10 +35,10 @@ use std::thread;
 
 use arrow_array::{LargeStringArray, RecordBatch};
 
-use infino::test_helpers::{default_supertable_options, schema_id_title};
-use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
 use infino::supertable::Supertable;
+use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
 use infino::supertable::utils::idgen::IdGenerator;
+use infino::test_helpers::{default_supertable_options, schema_id_title};
 use tempfile::TempDir;
 
 const STRESS_N_WORKERS: usize = 16;
@@ -152,9 +152,10 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
     // pulling segment bytes back from storage just to
     // verify ids — the manifest already carries everything
     // we need.
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     let reader = consumer.reader();
     let segs = &reader.manifest().superfile_list.superfiles;
     assert_eq!(

--- a/tests/supertable/commit/mod.rs
+++ b/tests/supertable/commit/mod.rs
@@ -1,7 +1,7 @@
-pub mod persistence;
-pub mod pointer_atomic;
+pub mod concurrent_threads;
 pub mod id_uniqueness;
 pub mod open_refresh;
 pub mod partition_assignment;
-pub mod concurrent_threads;
+pub mod persistence;
+pub mod pointer_atomic;
 pub mod stats;

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -17,25 +17,21 @@
 
 use std::sync::Arc;
 
-
 use infino::superfile::builder::FtsConfig;
 use infino::superfile::fts::tokenize::Tokenizer;
-use infino::test_helpers::{build_title_batch, default_supertable_options, default_tokenizer};
 use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
 use infino::supertable::{OpenError, Supertable, SupertableOptions};
+use infino::test_helpers::{build_title_batch, default_supertable_options, default_tokenizer};
 use tempfile::TempDir;
-
-
-
 
 #[tokio::test(flavor = "multi_thread")]
 async fn open_sees_writes_made_by_a_different_handle() {
     // Producer: create + commit + drop.
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
-    let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let producer =
+        Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
     let mut w = producer.writer().expect("writer");
     w.append(&build_title_batch(&["alpha bravo", "charlie delta"]))
         .expect("append");
@@ -44,9 +40,10 @@ async fn open_sees_writes_made_by_a_different_handle() {
     drop(producer); // simulate "process exit"
 
     // Consumer: open against the same storage.
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     assert_eq!(consumer.manifest_id(), 1);
     assert_eq!(consumer.reader().n_superfiles(), 1);
     // Note: full query parity post-open requires the deferred
@@ -65,9 +62,8 @@ async fn open_on_fresh_tempdir_returns_pointer_unreadable() {
     // open() must surface a typed error the caller can
     // pattern-match on for fallback to Supertable::create.
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let err = Supertable::open(default_supertable_options().with_storage(storage))
         .await
         .expect_err("must reject fresh dir");
@@ -89,21 +85,22 @@ async fn open_without_storage_rejects() {
 #[tokio::test(flavor = "multi_thread")]
 async fn refresh_picks_up_new_commits() {
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
 
     // Producer commits v1.
-    let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+    let producer =
+        Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
     let mut w = producer.writer().expect("w1");
     w.append(&build_title_batch(&["initial"])).expect("append1");
     w.commit().expect("commit1");
     drop(w);
 
     // Consumer opens at v1.
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     assert_eq!(consumer.manifest_id(), 1);
     let pre_refresh_reader = consumer.reader(); // pinned at v1
 
@@ -137,19 +134,20 @@ async fn refresh_picks_up_new_commits() {
 #[tokio::test(flavor = "multi_thread")]
 async fn refresh_no_op_when_pointer_unchanged() {
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
 
-    let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+    let producer =
+        Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
     let mut w = producer.writer().expect("w");
     w.append(&build_title_batch(&["only"])).expect("append");
     w.commit().expect("commit");
     drop(w);
 
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
 
     // No producer commits between open and refresh.
     let advanced = consumer.refresh().await.expect("refresh");
@@ -163,9 +161,8 @@ async fn refresh_no_op_returns_false_when_no_pointer_yet() {
     // refresh against a storage that has no pointer yet.
     // Should be a no-op (false), not an error.
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let st = Supertable::create(default_supertable_options().with_storage(storage));
     let advanced = st.refresh().await.expect("refresh");
     assert!(!advanced);
@@ -179,13 +176,13 @@ async fn open_rejects_mismatched_options_via_options_hash() {
     // name) must surface a typed `OptionsHashMismatch`
     // before any decode work happens.
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
 
     // Producer: standard schema.
     {
-        let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+        let producer =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
         let mut w = producer.writer().expect("writer");
         w.append(&build_title_batch(&["alpha"])).expect("append");
         w.commit().expect("commit");
@@ -218,9 +215,9 @@ async fn open_rejects_mismatched_options_via_options_hash() {
     .with_writer_pool(pool)
     .with_storage(Arc::clone(&storage));
 
-    let err = Supertable::open(mismatched_opts).await.expect_err(
-        "open must surface OptionsHashMismatch for a reordered schema",
-    );
+    let err = Supertable::open(mismatched_opts)
+        .await
+        .expect_err("open must surface OptionsHashMismatch for a reordered schema");
     assert!(
         matches!(err, OpenError::OptionsHashMismatch { .. }),
         "expected OptionsHashMismatch; got {err:?}"
@@ -232,17 +229,18 @@ async fn open_with_matching_options_succeeds_under_options_hash_validation() {
     // D15 happy path: producer + consumer with identical
     // options round-trip cleanly.
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     {
-        let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+        let producer =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
         let mut w = producer.writer().expect("writer");
         w.append(&build_title_batch(&["alpha"])).expect("append");
         w.commit().expect("commit");
     }
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open must succeed when options match");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open must succeed when options match");
     assert_eq!(consumer.manifest_id(), 1);
 }

--- a/tests/supertable/commit/partition_assignment.rs
+++ b/tests/supertable/commit/partition_assignment.rs
@@ -44,16 +44,13 @@
 
 use std::sync::Arc;
 
-
 use infino::superfile::builder::FtsConfig;
 use infino::superfile::fts::tokenize::Tokenizer;
-use infino::test_helpers::{build_title_batch, default_supertable_options, default_tokenizer};
+use infino::supertable::Supertable;
 use infino::supertable::manifest::list::PartitionStrategy;
 use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
-use infino::supertable::Supertable;
+use infino::test_helpers::{build_title_batch, default_supertable_options, default_tokenizer};
 use tempfile::TempDir;
-
-
 
 #[test]
 fn default_strategy_is_single_bucket_hash_observationally_equivalent_to_pre_m15a() {
@@ -132,7 +129,9 @@ fn target_superfiles_per_partition_triggers_part_split() {
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-    let opts = default_supertable_options().with_storage(Arc::clone(&storage)).with_target_superfiles_per_partition(2);
+    let opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_target_superfiles_per_partition(2);
     let st = Supertable::create(opts);
 
     for _i in 0..3 {
@@ -169,12 +168,12 @@ fn hash_strategy_with_multiple_buckets_errors_without_partition_hint() {
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-    let opts = default_supertable_options().with_storage(Arc::clone(&storage)).with_partition_strategy(
-        PartitionStrategy::Hash {
+    let opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_partition_strategy(PartitionStrategy::Hash {
             column: "doc_id".into(),
             n_buckets: 4,
-        },
-    );
+        });
     let st = Supertable::create(opts);
 
     let mut w = st.writer().expect("writer");
@@ -201,17 +200,19 @@ fn time_range_strategy_on_unsupported_column_type_errors_cleanly() {
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-    let opts = default_supertable_options().with_storage(Arc::clone(&storage)).with_partition_strategy(
-        PartitionStrategy::TimeRange {
+    let opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_partition_strategy(PartitionStrategy::TimeRange {
             column: "_id".into(),
             granularity_secs: 86_400,
-        },
-    );
+        });
     let st = Supertable::create(opts);
 
     let mut w = st.writer().expect("writer");
     w.append(&build_title_batch(&["alpha"])).expect("append");
-    let err = w.commit().expect_err("commit must fail on unsupported column type");
+    let err = w
+        .commit()
+        .expect_err("commit must fail on unsupported column type");
     let s = format!("{err}");
     assert!(
         s.contains("unsupported type") || s.contains("expected Int64 or Timestamp"),
@@ -273,12 +274,17 @@ fn time_range_assigns_int64_segments_to_bucket_zero() {
     {
         let mut w = st.writer().expect("writer");
         w.append(&batch).expect("append");
-        w.commit().expect("TimeRange commit must succeed for a single-bucket batch");
+        w.commit()
+            .expect("TimeRange commit must succeed for a single-bucket batch");
     }
     let r = st.reader();
     let m = r.manifest();
     let list = m.list.as_ref().expect("list");
-    assert_eq!(list.parts.len(), 1, "single-bucket commit produces one part");
+    assert_eq!(
+        list.parts.len(),
+        1,
+        "single-bucket commit produces one part"
+    );
     // TimeRange partition_key is 8 bytes LE bucket index.
     assert_eq!(list.parts[0].partition_key.len(), 8);
     let bucket = u64::from_le_bytes(

--- a/tests/supertable/commit/persistence.rs
+++ b/tests/supertable/commit/persistence.rs
@@ -23,22 +23,17 @@
 
 use std::sync::Arc;
 
-
-use infino::test_helpers::{build_title_batch, default_supertable_options};
+use infino::supertable::Supertable;
 use infino::supertable::manifest::commit::read_pointer;
 use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
-use infino::supertable::Supertable;
+use infino::test_helpers::{build_title_batch, default_supertable_options};
 use tempfile::TempDir;
-
-
-
 
 #[test]
 fn commit_persists_pointer_list_part_and_segment() {
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
     let mut w = st.writer().expect("writer");
     w.append(&build_title_batch(&["alpha bravo", "charlie delta"]))
@@ -51,11 +46,15 @@ fn commit_persists_pointer_list_part_and_segment() {
         .expect("read")
         .expect("pointer present");
     assert_eq!(pointer.manifest_id, 1);
-    assert!(pointer.manifest_list_uri.starts_with("manifest-lists/list-"));
+    assert!(
+        pointer
+            .manifest_list_uri
+            .starts_with("manifest-lists/list-")
+    );
 
     // Manifest list file exists and is non-empty.
-    let list_bytes = futures::executor::block_on(storage.get(&pointer.manifest_list_uri))
-        .expect("get list");
+    let list_bytes =
+        futures::executor::block_on(storage.get(&pointer.manifest_list_uri)).expect("get list");
     assert!(!list_bytes.is_empty());
 
     // At least one manifest part exists in manifests/.
@@ -91,13 +90,13 @@ fn commit_persists_pointer_list_part_and_segment() {
 #[test]
 fn two_successive_commits_both_publish() {
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
 
     let mut w = st.writer().expect("w1");
-    w.append(&build_title_batch(&["foo", "bar"])).expect("append1");
+    w.append(&build_title_batch(&["foo", "bar"]))
+        .expect("append1");
     w.commit().expect("commit1");
     drop(w);
 
@@ -156,11 +155,11 @@ async fn multipart_threshold_forces_segment_through_put_multipart() {
     // `Supertable::open` to assert the segment bytes were
     // correctly assembled by the multipart path.
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
-    let opts =
-        default_supertable_options().with_storage(Arc::clone(&storage)).with_put_multipart_threshold_bytes(1);
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_put_multipart_threshold_bytes(1);
     let producer = Supertable::create(opts);
     {
         let mut w = producer.writer().expect("writer");
@@ -188,9 +187,10 @@ async fn multipart_threshold_forces_segment_through_put_multipart() {
     // Cross-process open recovers correctly — proof the
     // multipart-uploaded segment is byte-identical to what
     // the writer produced.
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open after multipart commit");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open after multipart commit");
     let r = consumer.reader();
     assert_eq!(r.manifest_id(), 1);
     assert_eq!(r.n_superfiles(), 1);
@@ -232,13 +232,14 @@ fn committed_supertable_remains_in_memory_queryable_for_now() {
     // 002 query paths keep working unchanged. Verifies no
     // regression to the FTS read path.
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
     let mut w = st.writer().expect("writer");
-    w.append(&build_title_batch(&["nimblefox special token", "ordinary common text"],
-    ))
+    w.append(&build_title_batch(&[
+        "nimblefox special token",
+        "ordinary common text",
+    ]))
     .expect("append");
     w.commit().expect("commit");
     drop(w);
@@ -261,9 +262,8 @@ fn manifest_id_increments_only_on_non_empty_commits() {
     // Storage write-through should preserve this — no spurious
     // pointer rewrites on empty commits.
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
 
     let mut w = st.writer().expect("w");
@@ -276,7 +276,8 @@ fn manifest_id_increments_only_on_non_empty_commits() {
 
     // Now do a real commit; pointer appears at manifest_id=1.
     let mut w = st.writer().expect("w");
-    w.append(&build_title_batch(&["only", "real"])).expect("append");
+    w.append(&build_title_batch(&["only", "real"]))
+        .expect("append");
     w.commit().expect("real commit");
     drop(w);
 

--- a/tests/supertable/commit/pointer_atomic.rs
+++ b/tests/supertable/commit/pointer_atomic.rs
@@ -40,9 +40,7 @@ use infino::supertable::manifest::commit::{
 use infino::supertable::manifest::list::{
     FORMAT_VERSION as LIST_FORMAT_VERSION, ManifestList, ManifestListEntry, PartitionStrategy,
 };
-use infino::supertable::manifest::part::{
-    self as part_mod, ContentHash, ManifestPart, PartId,
-};
+use infino::supertable::manifest::part::{self as part_mod, ContentHash, ManifestPart, PartId};
 use infino::supertable::storage::{
     LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider,
 };
@@ -163,7 +161,10 @@ async fn initial_commit_writes_list_part_pointer() {
     // List + part are at their expected URIs.
     let list_bytes = storage.get(&list_uri(0)).await.expect("list bytes");
     assert!(!list_bytes.is_empty());
-    let part_bytes = storage.get(&entry_for(&part).uri).await.expect("part bytes");
+    let part_bytes = storage
+        .get(&entry_for(&part).uri)
+        .await
+        .expect("part bytes");
     assert!(!part_bytes.is_empty());
 }
 
@@ -233,9 +234,15 @@ async fn stale_prev_etag_surfaces_write_contention_exhausted() {
     // Stale writer tries to publish with v0's etag — must fail.
     let part_v1_stale = fresh_part(6);
     let list_v1_stale = empty_list(1, vec![entry_for(&part_v1_stale)]);
-    let err = commit_manifest(&storage, Some(&etag_v0), &list_v1_stale, &[&part_v1_stale], 3)
-        .await
-        .expect_err("stale etag must fail");
+    let err = commit_manifest(
+        &storage,
+        Some(&etag_v0),
+        &list_v1_stale,
+        &[&part_v1_stale],
+        3,
+    )
+    .await
+    .expect_err("stale etag must fail");
     assert!(
         matches!(err, CommitError::WriteContentionExhausted),
         "expected WriteContentionExhausted, got {err:?}"
@@ -555,4 +562,3 @@ fn directory_layout_constants_match_plan() {
     assert!(u.starts_with("manifests/part-"));
     assert!(u.ends_with(".avro.zst"));
 }
-

--- a/tests/supertable/commit/stats.rs
+++ b/tests/supertable/commit/stats.rs
@@ -25,14 +25,10 @@
 
 use std::sync::Arc;
 
-
-use infino::test_helpers::{build_title_batch, default_supertable_options};
-use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
 use infino::supertable::Supertable;
+use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
+use infino::test_helpers::{build_title_batch, default_supertable_options};
 use tempfile::TempDir;
-
-
-
 
 #[test]
 fn fresh_supertable_returns_empty_stats() {
@@ -83,10 +79,10 @@ fn stats_track_commits_on_in_process_supertable() {
 #[tokio::test(flavor = "multi_thread")]
 async fn stats_show_manifest_parts_when_storage_attached() {
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
-    let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let producer =
+        Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
     {
         let mut w = producer.writer().expect("writer");
         w.append(&build_title_batch(&["initial"])).expect("append");
@@ -112,9 +108,10 @@ async fn stats_show_manifest_parts_when_storage_attached() {
 
     // Open-side: Supertable::open eager-fetches all parts, so
     // n_manifest_parts_loaded should equal n_manifest_parts.
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     let consumer_stats = consumer.stats();
     assert_eq!(consumer_stats.manifest_id, 1);
     assert_eq!(consumer_stats.n_manifest_parts, Some(1));
@@ -196,17 +193,16 @@ fn stats_with_disk_cache_attached_surface_zero_counters_on_fresh_cache() {
     // before any activity, so downstream consumers can
     // sample them on a timer without worrying about
     // initialization order.
-    use std::collections::HashSet;
     use infino::supertable::SuperfileUri;
     use infino::supertable::reader_cache::{
         ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy,
     };
+    use std::collections::HashSet;
 
     let storage_dir = TempDir::new().expect("storage dir");
     let cache_dir = TempDir::new().expect("cache dir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
     let cfg = DiskCacheConfig {
         cache_root: cache_dir.path().to_path_buf(),
         disk_budget_bytes: 1 << 30,
@@ -218,19 +214,16 @@ fn stats_with_disk_cache_attached_surface_zero_counters_on_fresh_cache() {
         eviction: Box::new(LruPolicy::new()),
         verify_crc_on_open: true,
     };
-    let pinned: Arc<dyn Fn() -> HashSet<SuperfileUri> + Send + Sync> =
-        Arc::new(HashSet::new);
+    let pinned: Arc<dyn Fn() -> HashSet<SuperfileUri> + Send + Sync> = Arc::new(HashSet::new);
     let cache = DiskCacheStore::new(Arc::clone(&storage), cfg, pinned).expect("cache");
 
-    let opts = default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache));
+    let opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_disk_cache(Arc::clone(&cache));
     let st = Supertable::create(opts);
 
     let s = st.stats();
-    assert_eq!(
-        s.n_cold_fetches,
-        Some(0),
-        "fresh cache: zero cold fetches"
-    );
+    assert_eq!(s.n_cold_fetches, Some(0), "fresh cache: zero cold fetches");
     assert_eq!(s.n_cache_evictions, Some(0));
     assert_eq!(s.n_cache_madvise_calls, Some(0));
     assert_eq!(s.n_cache_entries, Some(0));
@@ -260,8 +253,7 @@ fn rss_growth_under_in_process_commits_is_observable() {
         let mut w = st.writer().expect("writer");
         let titles: Vec<String> = (0..1000).map(|i| format!("doc_{c}_{i}")).collect();
         let titles_refs: Vec<&str> = titles.iter().map(|s| s.as_str()).collect();
-        w.append(&build_title_batch(&titles_refs))
-            .expect("append");
+        w.append(&build_title_batch(&titles_refs)).expect("append");
         w.commit().expect("commit");
     }
 

--- a/tests/supertable/disk_cache/basic.rs
+++ b/tests/supertable/disk_cache/basic.rs
@@ -33,13 +33,13 @@ use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use bytes::Bytes;
 use infino::superfile::builder::{BuilderOptions, FtsConfig, SuperfileBuilder};
-use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use infino::supertable::SuperfileUri;
-use infino::supertable::reader_cache::{DiskCacheConfig, DiskCacheStore, LruPolicy};
 use infino::supertable::reader_cache::disk::DiskCacheError;
+use infino::supertable::reader_cache::{DiskCacheConfig, DiskCacheStore, LruPolicy};
 use infino::supertable::storage::{
     LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider,
 };
+use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use tempfile::TempDir;
 
 // ============================================================
@@ -130,22 +130,14 @@ fn build_test_superfile_bytes() -> Bytes {
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3]);
     let titles = LargeStringArray::from(vec!["alpha bravo", "charlie delta", "echo foxtrot"]);
-    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
-        .expect("batch");
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
     b.add_batch(&batch, &[]).expect("add_batch");
     Bytes::from(b.finish().expect("finish"))
 }
 
-async fn seed_segment(
-    storage: &dyn StorageProvider,
-    uri: SuperfileUri,
-    bytes: Bytes,
-) {
+async fn seed_segment(storage: &dyn StorageProvider, uri: SuperfileUri, bytes: Bytes) {
     let path = format!("data/seg-{}.sf", uri.0);
-    storage
-        .put_atomic(&path, bytes)
-        .await
-        .expect("seed put");
+    storage.put_atomic(&path, bytes).await.expect("seed put");
 }
 
 fn fresh_cache_with_storage(
@@ -175,9 +167,7 @@ fn fresh_cache_with_storage(
 #[tokio::test]
 async fn cold_miss_triggers_range_fetches_warm_hit_does_not() {
     let store_dir = TempDir::new().expect("storage tempdir");
-    let local = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local = Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let proxy = CountingProxy::new(local);
 
     let uri = SuperfileUri::new_v4();
@@ -213,9 +203,7 @@ async fn cold_miss_triggers_range_fetches_warm_hit_does_not() {
 #[tokio::test]
 async fn concurrent_cold_readers_coalesce_to_one_fetch() {
     let store_dir = TempDir::new().expect("storage tempdir");
-    let local = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local = Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let proxy = CountingProxy::new(local);
 
     let uri = SuperfileUri::new_v4();
@@ -251,9 +239,8 @@ async fn reader_returns_working_superfile_reader() {
     // SuperfileReader::open path produces a reader that
     // actually serves queries.
     let store_dir = TempDir::new().expect("storage tempdir");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
 
     let uri = SuperfileUri::new_v4();
     let bytes = build_test_superfile_bytes();
@@ -279,9 +266,8 @@ async fn eviction_respects_pinned_set() {
     // (BudgetExceeded surfaces because the policy can't evict
     // A and B alone exceeds budget when A is held).
     let store_dir = TempDir::new().expect("storage tempdir");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
 
     let uri_a = SuperfileUri::new_v4();
     let uri_b = SuperfileUri::new_v4();
@@ -336,9 +322,8 @@ async fn lru_evicts_oldest_unpinned_when_budget_pressure_hits() {
     // newer). Touch C → forces eviction; A (older) should be
     // the victim.
     let store_dir = TempDir::new().expect("storage tempdir");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
 
     let uri_a = SuperfileUri::new_v4();
     let uri_b = SuperfileUri::new_v4();
@@ -362,8 +347,7 @@ async fn lru_evicts_oldest_unpinned_when_budget_pressure_hits() {
         eviction: Box::new(LruPolicy::new()),
         verify_crc_on_open: true,
     };
-    let cache =
-        DiskCacheStore::new_unpinned(Arc::clone(&local), cfg).expect("cache");
+    let cache = DiskCacheStore::new_unpinned(Arc::clone(&local), cfg).expect("cache");
 
     let _ra = cache.reader(&uri_a).await.expect("a");
     // Tiny sleep so B's last_access_us > A's. Avoids relying
@@ -386,9 +370,8 @@ async fn reservation_race_preserves_budget_invariant() {
     // current_bytes ≤ budget at every observation, never
     // overshooting transiently.
     let store_dir = TempDir::new().expect("storage tempdir");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
 
     let bytes = build_test_superfile_bytes();
     let size = bytes.len() as u64;
@@ -412,8 +395,7 @@ async fn reservation_race_preserves_budget_invariant() {
         eviction: Box::new(LruPolicy::new()),
         verify_crc_on_open: true,
     };
-    let cache =
-        DiskCacheStore::new_unpinned(Arc::clone(&local), cfg).expect("cache");
+    let cache = DiskCacheStore::new_unpinned(Arc::clone(&local), cfg).expect("cache");
 
     // Spawn 8 concurrent readers. With budget for ~3 and
     // 8 distinct URIs, some readers may legitimately hit

--- a/tests/supertable/disk_cache/end_to_end.rs
+++ b/tests/supertable/disk_cache/end_to_end.rs
@@ -30,18 +30,16 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-
-use infino::test_helpers::{build_title_batch, default_supertable_options};
-use infino::supertable::reader_cache::{
-    ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy,
-};
-use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
 use infino::supertable::Supertable;
+use infino::supertable::reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy};
+use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
+use infino::test_helpers::{build_title_batch, default_supertable_options};
 use tempfile::TempDir;
 
-
-
-fn make_cache(storage: Arc<dyn StorageProvider>, cache_root: &std::path::Path) -> Arc<DiskCacheStore> {
+fn make_cache(
+    storage: Arc<dyn StorageProvider>,
+    cache_root: &std::path::Path,
+) -> Arc<DiskCacheStore> {
     let cfg = DiskCacheConfig {
         cache_root: cache_root.to_path_buf(),
         disk_budget_bytes: 1 << 30, // 1 GiB — plenty for tests
@@ -58,26 +56,22 @@ fn make_cache(storage: Arc<dyn StorageProvider>, cache_root: &std::path::Path) -
     // commit notes: Arc<SuperfileReader> keeps the
     // Arc<Mmap> alive even after the cache evicts the
     // entry, so in-flight queries finish correctly).
-    let pinned_fn: Arc<dyn Fn() -> HashSet<_> + Send + Sync> =
-        Arc::new(HashSet::new);
+    let pinned_fn: Arc<dyn Fn() -> HashSet<_> + Send + Sync> = Arc::new(HashSet::new);
     DiskCacheStore::new(storage, cfg, pinned_fn).expect("cache")
 }
-
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cross_process_consumer_routes_reads_through_disk_cache() {
     let storage_dir = TempDir::new().expect("storage tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
 
     // ---- Producer: commit + drop. -----------------------------
     // Producer doesn't need a cache for this test — we're
     // validating the consumer's read path.
     {
-        let producer = Supertable::create(
-            default_supertable_options().with_storage(Arc::clone(&storage)),
-        );
+        let producer =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
         let mut w = producer.writer().expect("producer writer");
         w.append(&build_title_batch(&["alpha bravo", "charlie delta"]))
             .expect("append");
@@ -87,7 +81,9 @@ async fn cross_process_consumer_routes_reads_through_disk_cache() {
     // ---- Consumer: open with disk cache attached. -------------
     let consumer_cache_dir = TempDir::new().expect("cache tempdir");
     let cache = make_cache(Arc::clone(&storage), consumer_cache_dir.path());
-    let consumer_opts = default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache));
+    let consumer_opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_disk_cache(Arc::clone(&cache));
     let consumer = Supertable::open(consumer_opts).await.expect("open");
     assert_eq!(consumer.manifest_id(), 1);
 
@@ -145,12 +141,15 @@ async fn producer_with_cache_reads_through_cache_path() {
     // hits the warm cache.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
 
-    let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache)));
+    let producer = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(Arc::clone(&cache)),
+    );
     let mut w = producer.writer().expect("writer");
     w.append(&build_title_batch(&["alpha"])).expect("append");
     w.commit().expect("commit");
@@ -183,12 +182,15 @@ fn writer_warms_cache_on_commit_so_producer_query_skips_cold_fetch() {
     // round-trip through storage.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
 
-    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache)));
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(Arc::clone(&cache)),
+    );
 
     // Pre-commit: cache empty.
     assert_eq!(cache.stats().n_entries, 0);
@@ -240,12 +242,15 @@ fn writer_warm_cache_is_idempotent_under_writer_retry() {
     // but the cache itself never panics or double-inserts.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
 
-    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache)));
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(Arc::clone(&cache)),
+    );
 
     for _i in 0..3 {
         let mut w = st.writer().expect("writer");
@@ -268,12 +273,15 @@ fn manifest_segments_are_auto_pinned_by_supertable_create() {
     // Post-commit: contains the published segment's URI.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
 
-    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache)));
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(Arc::clone(&cache)),
+    );
 
     // Before any commit: empty segment list → empty pinned
     // set.
@@ -283,7 +291,8 @@ fn manifest_segments_are_auto_pinned_by_supertable_create() {
     // Commit one segment.
     {
         let mut w = st.writer().expect("writer");
-        w.append(&build_title_batch(&["pinned alpha"])).expect("append");
+        w.append(&build_title_batch(&["pinned alpha"]))
+            .expect("append");
         w.commit().expect("commit");
     }
 
@@ -311,22 +320,27 @@ async fn manifest_segments_are_auto_pinned_by_supertable_open() {
     // too — important because the cross-process consumer
     // wires the cache + supertable in open, not in create.
     let storage_dir = TempDir::new().expect("storage tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
 
     // Producer (no cache attached): commit + drop.
     {
-        let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+        let producer =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
         let mut w = producer.writer().expect("writer");
-        w.append(&build_title_batch(&["from producer"])).expect("append");
+        w.append(&build_title_batch(&["from producer"]))
+            .expect("append");
         w.commit().expect("commit");
     }
 
     // Consumer with cache.
     let cache_dir = TempDir::new().expect("cache tempdir");
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache)))
+    let consumer = Supertable::open(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(Arc::clone(&cache)),
+    )
     .await
     .expect("open");
 
@@ -353,13 +367,16 @@ fn pinned_fn_releases_via_weak_when_supertable_drops() {
     // holding inner alive" property.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
 
     {
-        let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache)));
+        let st = Supertable::create(
+            default_supertable_options()
+                .with_storage(Arc::clone(&storage))
+                .with_disk_cache(Arc::clone(&cache)),
+        );
         let mut w = st.writer().expect("writer");
         w.append(&build_title_batch(&["temp"])).expect("append");
         w.commit().expect("commit");
@@ -384,15 +401,16 @@ fn memory_budget_drives_post_commit_madvise_sweep() {
     // budget, it doesn't.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
 
     // Budget of 1 byte → every commit's mmap exceeds it
     // → sweep fires.
     let st = Supertable::create(
-        default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache))
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(Arc::clone(&cache))
             .with_memory_budget(1),
     );
 
@@ -408,7 +426,8 @@ fn memory_budget_drives_post_commit_madvise_sweep() {
     assert!(
         after > before,
         "post-commit sweep must have called madvise; n_madvise_calls {} → {}",
-        before, after
+        before,
+        after
     );
 
     // Confirm the budget + mmap_resident shows up in stats.
@@ -425,12 +444,15 @@ fn memory_budget_unset_does_not_force_sweep() {
     // trigger it.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
 
-    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache)));
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(Arc::clone(&cache)),
+    );
 
     let before = cache.stats().n_madvise_calls;
 

--- a/tests/supertable/disk_cache/hybrid.rs
+++ b/tests/supertable/disk_cache/hybrid.rs
@@ -30,15 +30,13 @@ use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use bytes::Bytes;
 use infino::superfile::builder::{BuilderOptions, FtsConfig, SuperfileBuilder};
-use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use infino::supertable::SuperfileUri;
 use infino::supertable::reader_cache::disk::DiskCacheError;
-use infino::supertable::reader_cache::{
-    ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy,
-};
+use infino::supertable::reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy};
 use infino::supertable::storage::{
     LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider,
 };
+use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use tempfile::TempDir;
 
 // ============================================================
@@ -125,8 +123,7 @@ fn build_test_bytes() -> Bytes {
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3]);
     let titles = LargeStringArray::from(vec!["alpha bravo", "charlie delta", "echo foxtrot"]);
-    let batch =
-        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
     b.add_batch(&batch, &[]).expect("add_batch");
     Bytes::from(b.finish().expect("finish"))
 }
@@ -170,9 +167,8 @@ async fn hybrid_mode_is_default() {
 #[tokio::test]
 async fn hybrid_reader_returns_working_superfile_reader() {
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
@@ -191,9 +187,8 @@ async fn hybrid_bandwidth_per_cold_miss_equals_segment_size() {
     // the same range responses serve both foreground and
     // cache fill; no re-fetching.
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let segment_size = bytes.len();
     let uri = SuperfileUri::new_v4();
@@ -223,9 +218,8 @@ async fn hybrid_bandwidth_per_cold_miss_equals_segment_size() {
 #[tokio::test]
 async fn hybrid_warm_hit_issues_zero_range_fetches() {
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
@@ -252,9 +246,8 @@ async fn hybrid_warm_hit_issues_zero_range_fetches() {
 #[tokio::test]
 async fn hybrid_concurrent_readers_coalesce_to_one_fetch_fan_out() {
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let segment_size = bytes.len();
     let uri = SuperfileUri::new_v4();
@@ -294,15 +287,17 @@ async fn range_only_mode_bypasses_disk_cache() {
     // `StorageRangeSource` + `SuperfileReader::open_lazy`
     // directly).
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
 
     let (_d, cache) = fresh_cache(local, ColdFetchMode::RangeOnly);
-    let err = cache.reader(&uri).await.expect_err("range-only must reject");
+    let err = cache
+        .reader(&uri)
+        .await
+        .expect_err("range-only must reject");
     assert!(
         matches!(err, DiskCacheError::SuperfileOpen(_)),
         "expected typed reject, got {err:?}"

--- a/tests/supertable/disk_cache/mod.rs
+++ b/tests/supertable/disk_cache/mod.rs
@@ -1,4 +1,4 @@
 pub mod basic;
+pub mod end_to_end;
 pub mod hybrid;
 pub mod sweep;
-pub mod end_to_end;

--- a/tests/supertable/disk_cache/sweep.rs
+++ b/tests/supertable/disk_cache/sweep.rs
@@ -24,12 +24,10 @@ use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use infino::superfile::builder::{BuilderOptions, FtsConfig, SuperfileBuilder};
 use infino::superfile::fts::reader::BoolMode;
-use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use infino::supertable::SuperfileUri;
-use infino::supertable::reader_cache::{
-    ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy,
-};
+use infino::supertable::reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy};
 use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
+use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use tempfile::TempDir;
 
 // ============================================================
@@ -57,8 +55,7 @@ fn build_test_bytes() -> Bytes {
         "charlie delta",
         "echo special foxtrot",
     ]);
-    let batch =
-        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
     b.add_batch(&batch, &[]).expect("add_batch");
     Bytes::from(b.finish().expect("finish"))
 }
@@ -99,9 +96,8 @@ async fn sweep_once_advises_mmapped_entries_when_threshold_is_zero() {
     // microseconds since last access). The sweep returns
     // n_advised == n entries.
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
@@ -131,9 +127,8 @@ async fn data_remains_correct_after_madv_dontneed() {
     // bit-identical. Verify via an FTS query that survives a
     // sweep.
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
@@ -165,9 +160,8 @@ async fn recent_access_skipped_by_sweep_when_threshold_nonzero() {
     // threshold=3600s; the entry was just accessed → idle <
     // threshold → sweep skips it.
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
@@ -202,9 +196,8 @@ async fn in_memory_entries_not_yet_mmapped_are_skipped() {
     // perfectly time this, so instead we test the post-
     // finalize state has the expected n_advised count.
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
@@ -242,9 +235,8 @@ async fn threshold_zero_disables_background_sweep_thread() {
     // stays 0 over an interval that would otherwise have
     // included a sweep tick.
     let store_dir = TempDir::new().expect("storage");
-    let local: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(store_dir.path()).expect("local"),
-    );
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;

--- a/tests/supertable/main.rs
+++ b/tests/supertable/main.rs
@@ -21,7 +21,7 @@
 //! `tests/` because they need their own binary.
 
 mod commit;
-mod query;
-mod manifest;
 mod disk_cache;
+mod manifest;
+mod query;
 mod storage;

--- a/tests/supertable/manifest/lazy_open.rs
+++ b/tests/supertable/manifest/lazy_open.rs
@@ -23,13 +23,10 @@
 
 use std::sync::Arc;
 
-
-use infino::test_helpers::{build_title_batch, default_supertable_options};
-use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
 use infino::supertable::Supertable;
+use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
+use infino::test_helpers::{build_title_batch, default_supertable_options};
 use tempfile::TempDir;
-
-
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn one_part_eager_fetches_under_default_threshold() {
@@ -39,7 +36,8 @@ async fn one_part_eager_fetches_under_default_threshold() {
 
     // Producer: 1 commit → 1 part.
     {
-        let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+        let producer =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
         let mut w = producer.writer().expect("writer");
         w.append(&build_title_batch(&["alpha"])).expect("append");
         w.commit().expect("commit");
@@ -47,9 +45,10 @@ async fn one_part_eager_fetches_under_default_threshold() {
 
     // Consumer with default threshold (4) opens a 1-part
     // manifest → eager-fetch.
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
 
     let r = consumer.reader();
     let m = r.manifest();
@@ -61,10 +60,7 @@ async fn one_part_eager_fetches_under_default_threshold() {
         "eager mode must populate superfile_list.superfiles"
     );
     // Eager-mode populates the OnceCell.
-    let cell = m
-        .parts
-        .get(&list.parts[0].part_id)
-        .expect("part in cache");
+    let cell = m.parts.get(&list.parts[0].part_id).expect("part in cache");
     assert!(
         cell.value().get().is_some(),
         "eager-fetched OnceCell should be initialized"
@@ -81,8 +77,9 @@ async fn many_parts_skip_eager_fetch() {
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
 
-    let producer_opts =
-        default_supertable_options().with_storage(Arc::clone(&storage)).with_target_superfiles_per_partition(1);
+    let producer_opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_target_superfiles_per_partition(1);
     let producer = Supertable::create(producer_opts);
     for _i in 0..5 {
         let mut w = producer.writer().expect("writer");
@@ -93,9 +90,10 @@ async fn many_parts_skip_eager_fetch() {
 
     // Consumer with default threshold (4) — 5 parts triggers
     // lazy mode.
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     let r = consumer.reader();
     let m = r.manifest();
     let list = m.list.as_ref().expect("list");
@@ -135,8 +133,9 @@ async fn manifest_part_lazy_loads_on_first_access() {
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-    let producer_opts =
-        default_supertable_options().with_storage(Arc::clone(&storage)).with_target_superfiles_per_partition(1);
+    let producer_opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_target_superfiles_per_partition(1);
     let producer = Supertable::create(producer_opts);
     for _i in 0..5 {
         let mut w = producer.writer().expect("writer");
@@ -145,9 +144,10 @@ async fn manifest_part_lazy_loads_on_first_access() {
     }
     drop(producer);
 
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     let r = consumer.reader();
     let m = r.manifest();
     let list = m.list.as_ref().expect("list");
@@ -212,14 +212,17 @@ async fn with_eager_load_threshold_zero_forces_lazy_on_tiny_manifest() {
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
 
     {
-        let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+        let producer =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
         let mut w = producer.writer().expect("writer");
         w.append(&build_title_batch(&["x"])).expect("append");
         w.commit().expect("commit");
     }
 
     let consumer = Supertable::open(
-        default_supertable_options().with_storage(Arc::clone(&storage)).with_eager_load_threshold(0),
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_eager_load_threshold(0),
     )
     .await
     .expect("open");

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -154,8 +154,7 @@ fn build_supertable(corpus: &[(u64, String)], n_superfiles: usize) -> Supertable
     for chunk in corpus.chunks(chunk_size) {
         let titles =
             LargeStringArray::from(chunk.iter().map(|(_, t)| t.as_str()).collect::<Vec<_>>());
-        let batch = RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)])
-            .expect("batch");
+        let batch = RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)]).expect("batch");
         w.append(&batch).expect("append");
         w.commit().expect("commit");
     }
@@ -184,12 +183,7 @@ fn supertable_to_global_ids(
         .collect()
 }
 
-fn supertable_search_global(
-    st: &Supertable,
-    query: &str,
-    k: usize,
-    chunk_size: usize,
-) -> Vec<u64> {
+fn supertable_search_global(st: &Supertable, query: &str, k: usize, chunk_size: usize) -> Vec<u64> {
     let r = st.reader();
     let hits = r
         .bm25_search("title", query, k, BoolMode::Or)
@@ -231,11 +225,7 @@ fn build_oracles(corpus: &[(u64, String)], n_superfiles: usize) -> Vec<BruteForc
 
 /// Run per-segment brute-force BM25 and merge into a global top-k
 /// in the same shape the supertable's fan-out produces.
-fn brute_force_top_k(
-    oracles: &[BruteForceBm25],
-    query: &str,
-    k: usize,
-) -> Vec<u64> {
+fn brute_force_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> Vec<u64> {
     let tok = default_tokenizer();
     let mut all: Vec<(u64, f32)> = Vec::new();
     for o in oracles {
@@ -252,11 +242,7 @@ fn brute_force_top_k(
 
 /// Same as [`brute_force_top_k`] but for a multi-term explicit
 /// OR query (used to mirror the supertable's prefix expansion).
-fn brute_force_terms_top_k(
-    oracles: &[BruteForceBm25],
-    terms: &[String],
-    k: usize,
-) -> Vec<u64> {
+fn brute_force_terms_top_k(oracles: &[BruteForceBm25], terms: &[String], k: usize) -> Vec<u64> {
     let mut all: Vec<(u64, f32)> = Vec::new();
     for o in oracles {
         all.extend(o.top_k_terms(terms, k));
@@ -356,8 +342,7 @@ fn oracle_three_wide_or_top3_matches() {
 fn oracle_three_similar_or_top3_matches() {
     // Three single-doc terms (docs 14, 15, 16).
     let f = &*STANDARD_FIXTURE;
-    let inf_hits =
-        supertable_search_global(&f.infino, "redis kafka elasticsearch", 5, CHUNK_SIZE);
+    let inf_hits = supertable_search_global(&f.infino, "redis kafka elasticsearch", 5, CHUNK_SIZE);
     let ora_hits = brute_force_top_k(&f.oracles, "redis kafka elasticsearch", 5);
     let want: HashSet<u64> = [14u64, 15, 16].into_iter().collect();
     let inf_top: HashSet<u64> = inf_hits.iter().take(3).copied().collect();
@@ -370,8 +355,7 @@ fn oracle_three_similar_or_top3_matches() {
 fn oracle_five_term_or_top5_matches() {
     // Five single-doc terms (docs 30..34).
     let f = &*STANDARD_FIXTURE;
-    let inf_hits =
-        supertable_search_global(&f.infino, "tcp udp http2 http3 tls", 10, CHUNK_SIZE);
+    let inf_hits = supertable_search_global(&f.infino, "tcp udp http2 http3 tls", 10, CHUNK_SIZE);
     let ora_hits = brute_force_top_k(&f.oracles, "tcp udp http2 http3 tls", 10);
     let want: HashSet<u64> = [30u64, 31, 32, 33, 34].into_iter().collect();
     let inf_top: HashSet<u64> = inf_hits.iter().take(5).copied().collect();
@@ -389,7 +373,9 @@ fn oracle_prefix_query_matches_explicit_term_or() {
     // by running a brute-force OR over the same explicit term list.
     let f = &*STANDARD_FIXTURE;
     let prefix = "alphafox";
-    let expanded: Vec<String> = (0..N_PREFIX_TERMS).map(|i| format!("alphafox{i:02}")).collect();
+    let expanded: Vec<String> = (0..N_PREFIX_TERMS)
+        .map(|i| format!("alphafox{i:02}"))
+        .collect();
 
     let inf_hits = supertable_prefix_global(&f.infino, prefix, 10, CHUNK_SIZE);
     let ora_hits = brute_force_terms_top_k(&f.oracles, &expanded, 10);

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -30,16 +30,13 @@
 
 use std::sync::Arc;
 
-
 use std::collections::HashSet;
 
 use infino::superfile::fts::reader::BoolMode;
-use infino::test_helpers::{build_title_batch, default_supertable_options};
-use infino::supertable::reader_cache::{
-    ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy,
-};
-use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
 use infino::supertable::Supertable;
+use infino::supertable::reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy};
+use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
+use infino::test_helpers::{build_title_batch, default_supertable_options};
 use tempfile::TempDir;
 
 fn make_cache(
@@ -61,17 +58,16 @@ fn make_cache(
     DiskCacheStore::new(storage, cfg, pinned).expect("cache")
 }
 
-
-
 /// Build a producer that creates one part per commit (via
 /// target_superfiles_per_partition=1, the M15a split path),
 /// then drop it. Returns the path to the storage root for
 /// the consumer to open against.
 fn build_5_parts_with_distinct_terms(storage_dir: &std::path::Path) {
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(storage_dir).expect("provider"),
-    );
-    let opts = default_supertable_options().with_storage(Arc::clone(&storage)).with_target_superfiles_per_partition(1);
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir).expect("provider"));
+    let opts = default_supertable_options()
+        .with_storage(Arc::clone(&storage))
+        .with_target_superfiles_per_partition(1);
     let producer = Supertable::create(opts);
 
     // Each commit's batch uses a distinct vocabulary so the
@@ -96,9 +92,8 @@ async fn bm25_exact_term_loads_only_the_matching_part() {
     let dir = TempDir::new().expect("tempdir");
     build_5_parts_with_distinct_terms(dir.path());
 
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     // Force lazy mode so the OnceCell occupancy delta is
     // observable. (Default threshold=4 + 5 parts also
     // produces lazy mode but eager_load_threshold=0 is
@@ -106,7 +101,8 @@ async fn bm25_exact_term_loads_only_the_matching_part() {
     let cache_dir = TempDir::new().expect("cache");
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
     let consumer = Supertable::open(
-        default_supertable_options().with_storage(Arc::clone(&storage))
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
             .with_eager_load_threshold(0)
             .with_disk_cache(Arc::clone(&cache)),
     )
@@ -170,13 +166,13 @@ async fn bm25_term_in_no_part_loads_nothing() {
     let dir = TempDir::new().expect("tempdir");
     build_5_parts_with_distinct_terms(dir.path());
 
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let cache_dir = TempDir::new().expect("cache");
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
     let consumer = Supertable::open(
-        default_supertable_options().with_storage(Arc::clone(&storage))
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
             .with_eager_load_threshold(0)
             .with_disk_cache(Arc::clone(&cache)),
     )
@@ -226,13 +222,13 @@ async fn bm25_prefix_with_narrow_prefix_loads_one_part() {
     let dir = TempDir::new().expect("tempdir");
     build_5_parts_with_distinct_terms(dir.path());
 
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let cache_dir = TempDir::new().expect("cache");
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
     let consumer = Supertable::open(
-        default_supertable_options().with_storage(Arc::clone(&storage))
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
             .with_eager_load_threshold(0)
             .with_disk_cache(Arc::clone(&cache)),
     )
@@ -245,7 +241,10 @@ async fn bm25_prefix_with_narrow_prefix_loads_one_part() {
         .reader()
         .bm25_search_prefix("title", "ech", 10)
         .expect("prefix");
-    assert!(!hits.is_empty(), "prefix search must find 'echo'-rooted terms");
+    assert!(
+        !hits.is_empty(),
+        "prefix search must find 'echo'-rooted terms"
+    );
 
     let r = consumer.reader();
     let m = r.manifest();
@@ -282,13 +281,13 @@ async fn sql_loads_all_parts_returns_correct_count() {
     let dir = TempDir::new().expect("tempdir");
     build_5_parts_with_distinct_terms(dir.path());
 
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let cache_dir = TempDir::new().expect("cache");
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
     let consumer = Supertable::open(
-        default_supertable_options().with_storage(Arc::clone(&storage))
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
             .with_eager_load_threshold(0)
             .with_disk_cache(Arc::clone(&cache)),
     )
@@ -335,11 +334,11 @@ async fn eager_mode_query_paths_observationally_unchanged() {
     // M15c, and the OnceCell is populated from open (not
     // first query).
     let dir = TempDir::new().expect("tempdir");
-    let storage: Arc<dyn StorageProvider> = Arc::new(
-        LocalFsStorageProvider::new(dir.path()).expect("provider"),
-    );
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     {
-        let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+        let producer =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
         let mut w = producer.writer().expect("writer");
         w.append(&build_title_batch(&["alpha bravo", "charlie delta"]))
             .expect("append");
@@ -349,7 +348,9 @@ async fn eager_mode_query_paths_observationally_unchanged() {
     let cache_dir = TempDir::new().expect("cache");
     let cache = make_cache(Arc::clone(&storage), cache_dir.path());
     let consumer = Supertable::open(
-        default_supertable_options().with_storage(Arc::clone(&storage)).with_disk_cache(Arc::clone(&cache)),
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(Arc::clone(&cache)),
     )
     .await
     .expect("open");

--- a/tests/supertable/query/mod.rs
+++ b/tests/supertable/query/mod.rs
@@ -1,3 +1,3 @@
+pub mod brute_force_oracle;
 pub mod hierarchical;
 pub mod skip_pruning;
-pub mod brute_force_oracle;

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -38,10 +38,12 @@ use bytes::Bytes;
 use infino::superfile::SuperfileReader;
 use infino::superfile::builder::FtsConfig;
 use infino::superfile::fts::tokenize::Tokenizer;
-use infino::test_helpers::{build_title_batch, schema_id_title, default_tokenizer};
 use infino::supertable::manifest::SuperfileUri;
-use infino::supertable::reader_cache::{InMemoryReaderCache, SuperfileReaderCache, ReaderCacheError};
+use infino::supertable::reader_cache::{
+    InMemoryReaderCache, ReaderCacheError, SuperfileReaderCache,
+};
 use infino::supertable::{Supertable, SupertableOptions};
+use infino::test_helpers::{build_title_batch, default_tokenizer, schema_id_title};
 
 /// Decorator over an `InMemoryReaderCache` that counts
 /// per-URI `reader` calls. Wraps without behavior change.
@@ -100,7 +102,6 @@ impl SuperfileReaderCache for CountingStore {
     }
 }
 
-
 fn options_with_counting_store(store: Arc<CountingStore>) -> SupertableOptions {
     let pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
@@ -122,7 +123,6 @@ fn options_with_counting_store(store: Arc<CountingStore>) -> SupertableOptions {
     .with_store(store)
 }
 
-
 #[test]
 fn bm25_exact_term_skip_opens_only_matching_segment() {
     let store = Arc::new(CountingStore::new());
@@ -132,20 +132,23 @@ fn bm25_exact_term_skip_opens_only_matching_segment() {
     // only; the other three superfiles share generic terms only.
     let mut w = st.writer().expect("writer");
     w.append(&build_title_batch(&[
-            "lookup nimblefox special token",
-            "ordinary common everyday text",
-        ],
-    ))
+        "lookup nimblefox special token",
+        "ordinary common everyday text",
+    ]))
     .expect("append");
     w.commit().expect("commit");
 
-    w.append(&build_title_batch(&["another generic page", "more filler text"],
-    ))
+    w.append(&build_title_batch(&[
+        "another generic page",
+        "more filler text",
+    ]))
     .expect("append");
     w.commit().expect("commit");
 
-    w.append(&build_title_batch(&["yet another normal title", "wrapping up the corpus"],
-    ))
+    w.append(&build_title_batch(&[
+        "yet another normal title",
+        "wrapping up the corpus",
+    ]))
     .expect("append");
     w.commit().expect("commit");
 
@@ -251,8 +254,10 @@ fn bm25_search_with_no_matching_segments_opens_no_segments_at_all() {
     // Three superfiles — none contains the rare query term.
     let mut w = st.writer().expect("writer");
     for _i in 0..3u64 {
-        w.append(&build_title_batch(&["ordinary term filler", "another mundane title"],
-        ))
+        w.append(&build_title_batch(&[
+            "ordinary term filler",
+            "another mundane title",
+        ]))
         .expect("append");
         w.commit().expect("commit");
     }
@@ -290,8 +295,11 @@ fn bm25_and_mode_skip_requires_all_terms_present_in_segment() {
     w.append(&build_title_batch(&["alpha beta gamma", "doc with beta"]))
         .expect("append");
     w.commit().expect("commit");
-    w.append(&build_title_batch(&["alpha only here", "no betas whatever"]))
-        .expect("append");
+    w.append(&build_title_batch(&[
+        "alpha only here",
+        "no betas whatever",
+    ]))
+    .expect("append");
     w.commit().expect("commit");
     drop(w);
 

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -54,13 +54,10 @@ use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-
-use infino::test_helpers::{build_title_batch, default_supertable_options};
-use infino::supertable::reader_cache::{
-    ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy,
-};
-use infino::supertable::storage::{S3StorageProvider, StorageProvider};
 use infino::supertable::Supertable;
+use infino::supertable::reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy};
+use infino::supertable::storage::{S3StorageProvider, StorageProvider};
+use infino::test_helpers::{build_title_batch, default_supertable_options};
 use s3s::auth::SimpleAuth;
 use s3s::service::S3ServiceBuilder;
 use s3s_fs::FileSystem;
@@ -89,10 +86,7 @@ async fn spawn_s3s_fs() -> (SocketAddr, TempDir) {
     // signed request.
     let service = {
         let mut b = S3ServiceBuilder::new(fs_backend);
-        b.set_auth(SimpleAuth::from_single(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-        ));
+        b.set_auth(SimpleAuth::from_single(TEST_ACCESS_KEY, TEST_SECRET_KEY));
         b.build()
     };
     // S3Service derives Clone (internally Arc<Inner>); clones
@@ -113,17 +107,13 @@ async fn spawn_s3s_fs() -> (SocketAddr, TempDir) {
             let service = service.clone();
             let http = http.clone();
             tokio::spawn(async move {
-                let _ = http
-                    .serve_connection(TokioIo::new(stream), service)
-                    .await;
+                let _ = http.serve_connection(TokioIo::new(stream), service).await;
             });
         }
     });
 
     (addr, fs_root)
 }
-
-
 
 fn make_cache(
     storage: Arc<dyn StorageProvider>,
@@ -193,13 +183,17 @@ async fn supertable_smoke_via_s3_wire_protocol() {
             )
             .expect("s3 provider for producer"),
         );
-        let producer = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
+        let producer =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)));
         let mut w = producer.writer().expect("producer writer");
         w.append(&build_title_batch(&["alpha bravo", "charlie delta"]))
             .expect("append");
         w.commit().expect("producer commit via S3");
         assert_eq!(producer.manifest_id(), 1);
-        eprintln!("[m16] producer commit OK; manifest_id={}", producer.manifest_id());
+        eprintln!(
+            "[m16] producer commit OK; manifest_id={}",
+            producer.manifest_id()
+        );
     }
 
     // Consumer: opens via the same S3 endpoint + a disk

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -58,11 +58,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use infino::test_helpers::{build_title_batch, default_supertable_options};
 use infino::supertable::storage::{
     LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider,
 };
 use infino::supertable::{OpenError, Supertable};
+use infino::test_helpers::{build_title_batch, default_supertable_options};
 
 const ENV_DIR: &str = "INFINO_M12_CRASH_DIR";
 const ENV_KILL_POINT: &str = "INFINO_M12_CRASH_KILL_POINT";
@@ -130,11 +130,7 @@ impl StorageProvider for CrashStorage {
     async fn get(&self, uri: &str) -> Result<Bytes, StorageError> {
         self.inner.get(uri).await
     }
-    async fn get_range(
-        &self,
-        uri: &str,
-        range: Range<u64>,
-    ) -> Result<Bytes, StorageError> {
+    async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
         self.inner.get_range(uri, range).await
     }
     async fn put_atomic(&self, uri: &str, bytes: Bytes) -> Result<(), StorageError> {
@@ -165,8 +161,6 @@ impl StorageProvider for CrashStorage {
     }
 }
 
-
-
 /// Translate a kill point name into (trigger_path_prefix,
 /// trigger_after_nth_match, n_commits). The child uses this
 /// to configure `CrashStorage` and decide how many successful
@@ -193,8 +187,7 @@ fn kill_point_config(kp: &str) -> (&'static str, usize, usize) {
 fn run_crash_child(dir: PathBuf, kill_point: &str) -> ! {
     let (prefix, nth, n_commits) = kill_point_config(kill_point);
 
-    let local =
-        LocalFsStorageProvider::new(&dir).expect("local fs provider");
+    let local = LocalFsStorageProvider::new(&dir).expect("local fs provider");
     let wrapped = Arc::new(CrashStorage::new(local, prefix, nth, kill_point));
     let storage: Arc<dyn StorageProvider> = wrapped;
 
@@ -360,10 +353,7 @@ async fn crash_post_list_on_second_commit_yields_v1() {
     if dispatch_child_if_set().is_some() {
         return;
     }
-    let dir = spawn_crash_child(
-        "crash_post_list_on_second_commit_yields_v1",
-        KP_LIST_SECOND,
-    );
+    let dir = spawn_crash_child("crash_post_list_on_second_commit_yields_v1", KP_LIST_SECOND);
 
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));

--- a/tests/supertable_concurrent_processes.rs
+++ b/tests/supertable_concurrent_processes.rs
@@ -24,13 +24,10 @@
 
 use std::sync::Arc;
 
-
-use infino::test_helpers::{build_title_batch, default_supertable_options};
-use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
 use infino::supertable::Supertable;
+use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
+use infino::test_helpers::{build_title_batch, default_supertable_options};
 use tempfile::TempDir;
-
-
 
 /// Two independent handles racing to commit. The OCC retry
 /// loop must ensure both commits eventually succeed and the
@@ -89,9 +86,10 @@ async fn two_handles_concurrent_commits_both_succeed_via_occ_retry() {
     // Fresh open against the same storage sees the union.
     drop(st_a);
     drop(st_b);
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     assert_eq!(consumer.manifest_id(), 2);
     assert_eq!(
         consumer.reader().n_superfiles(),
@@ -145,9 +143,10 @@ async fn three_handles_concurrent_commits_all_succeed() {
     drop(st_a);
     drop(st_b);
     drop(st_c);
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     assert_eq!(
         consumer.manifest_id(),
         3,
@@ -264,8 +263,7 @@ async fn sequential_commits_across_handles_no_retry_needed() {
     assert_eq!(st_b.manifest_id(), 1, "B opens at A's last manifest_id");
     {
         let mut w = st_b.writer().expect("writer B");
-        w.append(&build_title_batch(&["second"]))
-            .expect("append B");
+        w.append(&build_title_batch(&["second"])).expect("append B");
         w.commit().expect("commit B");
     }
     assert_eq!(st_b.manifest_id(), 2);
@@ -296,7 +294,9 @@ async fn max_commit_retries_is_plumbed_through_options() {
         let dir = TempDir::new().expect("tempdir");
         let storage: Arc<dyn StorageProvider> =
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-        let opts = default_supertable_options().with_storage(Arc::clone(&storage)).with_max_commit_retries(42);
+        let opts = default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_max_commit_retries(42);
         assert_eq!(opts.max_commit_retries, 42);
     }
 
@@ -308,10 +308,14 @@ async fn max_commit_retries_is_plumbed_through_options() {
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let st_a = Supertable::create(
-        default_supertable_options().with_storage(Arc::clone(&storage)).with_max_commit_retries(20),
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_max_commit_retries(20),
     );
     let st_b = Supertable::create(
-        default_supertable_options().with_storage(Arc::clone(&storage)).with_max_commit_retries(20),
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_max_commit_retries(20),
     );
 
     let t_a = tokio::task::spawn_blocking({
@@ -336,8 +340,9 @@ async fn max_commit_retries_is_plumbed_through_options() {
 
     drop(st_a);
     drop(st_b);
-    let consumer = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .await
-        .expect("open");
+    let consumer =
+        Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+            .await
+            .expect("open");
     assert_eq!(consumer.manifest_id(), 2);
 }


### PR DESCRIPTION
### What does this PR do?
- Adds a basic rustfmt.toml file and runs `cargo fmt` to format codebase using this file

### Why do we need this change?
- Keep a consistent style guide that agents and human contributors can follow