### PR TITLE
benchmarks: allow running superfile and supertable benchmarks seperately

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,10 +223,22 @@ path = "tests/supertable/main.rs"
 
 # Bench bundles. One criterion binary per topic (FTS, vector), each
 # wrapping superfile + supertable sub-groups so the topic ships as
-# a single `[[bench]]` stanza.
+# a single `[[bench]]` stanza. Additionally, fts is split into
+# fts-superfile and fts-supertable to avoid unnecessary setup overhead
+# when running only one benchmark type.
 [[bench]]
 name = "fts"
 path = "benches/fts/main.rs"
+harness = false
+
+[[bench]]
+name = "fts-superfile"
+path = "benches/fts/main_superfile.rs"
+harness = false
+
+[[bench]]
+name = "fts-supertable"
+path = "benches/fts/main_supertable.rs"
 harness = false
 
 [[bench]]

--- a/benches/fts/main_superfile.rs
+++ b/benches/fts/main_superfile.rs
@@ -1,0 +1,18 @@
+//! Superfile FTS bench (1M docs). Standalone binary.
+//!
+//! ## Invocation
+//!
+//! ```text
+//! cargo bench --bench fts-superfile                            # all superfile FTS
+//! cargo bench --bench fts-superfile -- superfile_fts_build     # ingest only
+//! cargo bench --bench fts-superfile -- superfile_fts_search    # search only
+//! INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts-superfile
+//! ```
+
+#[path = "../utils/markdown.rs"]
+mod markdown;
+
+#[path = "superfile.rs"]
+mod superfile;
+
+criterion::criterion_main!(superfile::benches);

--- a/benches/fts/main_supertable.rs
+++ b/benches/fts/main_supertable.rs
@@ -1,0 +1,18 @@
+//! Supertable FTS bench (10M docs). Standalone binary.
+//!
+//! ## Invocation
+//!
+//! ```text
+//! cargo bench --bench fts-supertable                            # all supertable FTS
+//! cargo bench --bench fts-supertable -- supertable_fts_build    # ingest only
+//! cargo bench --bench fts-supertable -- supertable_fts_search   # search only
+//! INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts-supertable
+//! ```
+
+#[path = "../utils/markdown.rs"]
+mod markdown;
+
+#[path = "supertable.rs"]
+mod supertable;
+
+criterion::criterion_main!(supertable::benches);


### PR DESCRIPTION
Before this change, running only superfile benchmarks also performed expensive setup for supertable