### PR TITLE
bench: report RSS median and p90

### DIFF
--- a/benches/utils/fts_superfile.rs
+++ b/benches/utils/fts_superfile.rs
@@ -269,15 +269,15 @@ fn bench(c: &mut Criterion) {
         g.bench_function(one_thread_id.clone(), |b| {
             b.iter_with_large_drop(|| build_infino_blob_1thread(black_box(docs_for_ingest)));
         });
-        let peak = rss_sample.stop();
-        let _ = rss::write_peak_rss(group_name::SUPERFILE_FTS_BUILD, &one_thread_id, peak);
+        let stats = rss_sample.stop_stats();
+        let _ = rss::write_rss_stats(group_name::SUPERFILE_FTS_BUILD, &one_thread_id, stats);
 
         let rss_sample = rss::PeakSampler::start_default();
         g.bench_function(rayon_id.clone(), |b| {
             b.iter_with_large_drop(|| build_infino_blobs_rayon(black_box(docs_for_ingest)));
         });
-        let peak = rss_sample.stop();
-        let _ = rss::write_peak_rss(group_name::SUPERFILE_FTS_BUILD, &rayon_id, peak);
+        let stats = rss_sample.stop_stats();
+        let _ = rss::write_rss_stats(group_name::SUPERFILE_FTS_BUILD, &rayon_id, stats);
 
         g.finish();
 
@@ -388,7 +388,7 @@ fn bench(c: &mut Criterion) {
         );
 
         g.finish();
-        let peak = rss_sample.stop();
+        let stats = rss_sample.stop_stats();
         // Single sampler covers every search closure in this group;
         // record the same peak against each criterion id so the
         // markdown lookup matches the bench id verbatim.
@@ -412,7 +412,7 @@ fn bench(c: &mut Criterion) {
             "similar_5_bmm_top10",
         ];
         for bid in search_ids {
-            let _ = rss::write_peak_rss(group_name::SUPERFILE_FTS_SEARCH, bid, peak);
+            let _ = rss::write_rss_stats(group_name::SUPERFILE_FTS_SEARCH, bid, stats);
         }
 
         emit_search_markdown();
@@ -434,10 +434,10 @@ fn emit_ingest_markdown() {
         "### Superfile FTS — ingest ({N_DOCS} docs, Zipfian, 200 tokens/doc, 10K vocab)\n\n"
     ));
     body.push_str(
-        "| Engine                       | Time       | Throughput | Peak RSS  | Peak RSS Δ |\n",
+        "| Engine                       | Time       | Throughput | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |\n",
     );
     body.push_str(
-        "|------------------------------|------------|------------|-----------|------------|\n",
+        "|------------------------------|------------|------------|-----------|------------|-----------|------------|\n",
     );
 
     let group = group_name::SUPERFILE_FTS_BUILD;
@@ -454,8 +454,12 @@ fn emit_ingest_markdown() {
             .map(|n| fmt_throughput((N_DOCS as f64) / (n / 1e9)))
             .unwrap_or_else(|| "—".into());
         let rss_cell = peak.map(rss::fmt_bytes).unwrap_or_else(|| "—".into());
+        let median_rss = rss::fmt_median_rss(group, bench_id);
+        let p90_rss = rss::fmt_p90_rss(group, bench_id);
         let rss_delta = rss::fmt_peak_rss_delta(group, bench_id);
-        format!("| {label:28} | {time:10} | {thrpt:10} | {rss_cell:9} | {rss_delta:10} |\n")
+        format!(
+            "| {label:28} | {time:10} | {thrpt:10} | {rss_cell:9} | {median_rss:10} | {p90_rss:9} | {rss_delta:10} |\n"
+        )
     };
 
     body.push_str(&row(
@@ -482,8 +486,12 @@ fn emit_search_markdown() {
 
     let mut body = String::new();
     body.push_str(&format!("### Superfile FTS — search ({N_DOCS} docs)\n\n"));
-    body.push_str("| Query          | infino     | Peak RSS  | Peak RSS Δ |\n");
-    body.push_str("|----------------|------------|-----------|------------|\n");
+    body.push_str(
+        "| Query          | infino     | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |\n",
+    );
+    body.push_str(
+        "|----------------|------------|-----------|------------|-----------|------------|\n",
+    );
 
     let group = group_name::SUPERFILE_FTS_SEARCH;
     let queries_or = [
@@ -510,9 +518,11 @@ fn emit_search_markdown() {
         let rss_cell = rss::read_peak_rss_bytes(group, &bid)
             .map(rss::fmt_bytes)
             .unwrap_or_else(|| "—".into());
+        let median_rss = rss::fmt_median_rss(group, &bid);
+        let p90_rss = rss::fmt_p90_rss(group, &bid);
         let rss_delta = rss::fmt_peak_rss_delta(group, &bid);
         body.push_str(&format!(
-            "| {q:14} | {inf_s:10} | {rss_cell:9} | {rss_delta:10} |\n"
+            "| {q:14} | {inf_s:10} | {rss_cell:9} | {median_rss:10} | {p90_rss:9} | {rss_delta:10} |\n"
         ));
     }
 
@@ -524,9 +534,11 @@ fn emit_search_markdown() {
         let rss_cell = rss::read_peak_rss_bytes(group, &bid)
             .map(rss::fmt_bytes)
             .unwrap_or_else(|| "—".into());
+        let median_rss = rss::fmt_median_rss(group, &bid);
+        let p90_rss = rss::fmt_p90_rss(group, &bid);
         let rss_delta = rss::fmt_peak_rss_delta(group, &bid);
         body.push_str(&format!(
-            "| {q:14} | {inf_s:10} | {rss_cell:9} | {rss_delta:10} |\n"
+            "| {q:14} | {inf_s:10} | {rss_cell:9} | {median_rss:10} | {p90_rss:9} | {rss_delta:10} |\n"
         ));
     }
 

--- a/benches/utils/fts_supertable.rs
+++ b/benches/utils/fts_supertable.rs
@@ -189,11 +189,11 @@ fn bench_ingest(c: &mut Criterion) {
     });
 
     g.finish();
-    let peak = rss_sample.stop();
-    let _ = rss::write_peak_rss(
+    let stats = rss_sample.stop_stats();
+    let _ = rss::write_rss_stats(
         group_name::SUPERTABLE_FTS_BUILD,
         "infino_auto_writer_pool",
-        peak,
+        stats,
     );
 
     emit_ingest_markdown();
@@ -256,7 +256,7 @@ fn bench_search(c: &mut Criterion) {
     });
 
     g.finish();
-    let peak = rss_sample.stop();
+    let stats = rss_sample.stop_stats();
     let search_ids = [
         "single_rare_supertable_top10",
         "single_common_supertable_top10",
@@ -267,7 +267,7 @@ fn bench_search(c: &mut Criterion) {
         "prefix_supertable_top10",
     ];
     for bid in search_ids {
-        let _ = rss::write_peak_rss(group_name::SUPERTABLE_FTS_SEARCH, bid, peak);
+        let _ = rss::write_rss_stats(group_name::SUPERTABLE_FTS_SEARCH, bid, stats);
     }
 
     emit_search_markdown();
@@ -293,19 +293,21 @@ fn emit_ingest_markdown() {
         "### Supertable FTS — ingest ({N_DOCS} docs, Zipfian, 200 tokens/doc, 10K vocab)\n\n"
     ));
     body.push_str(
-        "| Engine                  | Time       | Throughput | Peak RSS  | Peak RSS Δ |\n",
+        "| Engine                  | Time       | Throughput | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |\n",
     );
     body.push_str(
-        "|-------------------------|------------|------------|-----------|------------|\n",
+        "|-------------------------|------------|------------|-----------|------------|-----------|------------|\n",
     );
     let time = ns.map(fmt_time).unwrap_or_else(|| "—".into());
     let thrpt = ns
         .map(|n| fmt_throughput((N_DOCS as f64) / (n / 1e9)))
         .unwrap_or_else(|| "—".into());
     let rss_cell = peak_rss.map(rss::fmt_bytes).unwrap_or_else(|| "—".into());
+    let median_rss = rss::fmt_median_rss(group, bench);
+    let p90_rss = rss::fmt_p90_rss(group, bench);
     let rss_delta = rss::fmt_peak_rss_delta(group, bench);
     body.push_str(&format!(
-        "| infino_auto_writer_pool | {time:10} | {thrpt:10} | {rss_cell:9} | {rss_delta:10} |\n"
+        "| infino_auto_writer_pool | {time:10} | {thrpt:10} | {rss_cell:9} | {median_rss:10} | {p90_rss:9} | {rss_delta:10} |\n"
     ));
     body.push_str(
         "\n*Output cardinality: infino emits `min(writer_pool.threads, total_rows)` superfiles \
@@ -325,8 +327,12 @@ fn emit_search_markdown() {
     let group = group_name::SUPERTABLE_FTS_SEARCH;
     let mut body = String::new();
     body.push_str(&format!("### Supertable FTS — search ({N_DOCS} docs)\n\n"));
-    body.push_str("| Query          | infino     | Peak RSS  | Peak RSS Δ |\n");
-    body.push_str("|----------------|------------|-----------|------------|\n");
+    body.push_str(
+        "| Query          | infino     | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |\n",
+    );
+    body.push_str(
+        "|----------------|------------|-----------|------------|-----------|------------|\n",
+    );
     let queries = [
         "single_rare",
         "single_common",
@@ -343,9 +349,11 @@ fn emit_search_markdown() {
         let rss_cell = rss::read_peak_rss_bytes(group, &bid)
             .map(rss::fmt_bytes)
             .unwrap_or_else(|| "—".into());
+        let median_rss = rss::fmt_median_rss(group, &bid);
+        let p90_rss = rss::fmt_p90_rss(group, &bid);
         let rss_delta = rss::fmt_peak_rss_delta(group, &bid);
         body.push_str(&format!(
-            "| {q:14} | {inf_s:10} | {rss_cell:9} | {rss_delta:10} |\n"
+            "| {q:14} | {inf_s:10} | {rss_cell:9} | {median_rss:10} | {p90_rss:9} | {rss_delta:10} |\n"
         ));
     }
 

--- a/benches/utils/rss.rs
+++ b/benches/utils/rss.rs
@@ -6,7 +6,7 @@
 //!   current `VmRSS` (Linux `/proc/self/status`). Returns
 //!   `None` on platforms without procfs.
 //! - [`PeakSampler`] — background thread that polls VmRSS at
-//!   a fixed cadence and records the maximum observed value
+//!   a fixed cadence and records peak / median / p90 values
 //!   over the sampler's lifetime. Use [`PeakSampler::start`]
 //!   (or [`PeakSampler::start_default`]) before the work you
 //!   want to bound, [`PeakSampler::stop`] after — returns the
@@ -30,15 +30,15 @@
 //! training + assignment plateaus are seconds long). Faster
 //! sampling adds noise without adding signal.
 //!
-//! [`write_peak_rss`] / [`read_peak_rss_bytes`] persist + read
+//! [`write_rss_stats`] / [`read_peak_rss_bytes`] persist + read
 //! a per-bench `rss.json` next to criterion's `estimates.json`
-//! so the markdown emitters can pick the number up by the same
-//! `(group, bench)` lookup shape they use for timings.
+//! so the markdown emitters can pick memory stats up by the
+//! same `(group, bench)` lookup shape they use for timings.
 
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -72,8 +72,42 @@ pub fn current_rss_bytes() -> Option<u64> {
 /// to the work the sampler watches.
 pub struct PeakSampler {
     stop: Arc<AtomicBool>,
-    peak: Arc<AtomicU64>,
-    handle: Option<JoinHandle<()>>,
+    handle: Option<JoinHandle<Vec<u64>>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RssStats {
+    pub peak_rss_bytes: u64,
+    pub median_rss_bytes: u64,
+    pub p90_rss_bytes: u64,
+}
+
+impl RssStats {
+    fn from_samples(mut samples: Vec<u64>) -> Self {
+        if samples.is_empty() {
+            samples.push(current_rss_bytes().unwrap_or(0));
+        }
+        samples.sort_unstable();
+        Self {
+            peak_rss_bytes: *samples.last().expect("rss samples is non-empty"),
+            median_rss_bytes: percentile_nearest_rank(&samples, 50),
+            p90_rss_bytes: percentile_nearest_rank(&samples, 90),
+        }
+    }
+
+    fn peak_only(peak_rss_bytes: u64) -> Self {
+        Self {
+            peak_rss_bytes,
+            median_rss_bytes: peak_rss_bytes,
+            p90_rss_bytes: peak_rss_bytes,
+        }
+    }
+}
+
+fn percentile_nearest_rank(sorted: &[u64], percentile: usize) -> u64 {
+    debug_assert!(!sorted.is_empty());
+    let rank = ((percentile as f64 / 100.0) * sorted.len() as f64).ceil() as usize;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
 }
 
 impl PeakSampler {
@@ -88,40 +122,28 @@ impl PeakSampler {
     /// lands still see at least the start-time RSS.
     pub fn start(interval: Duration) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
-        let peak = Arc::new(AtomicU64::new(current_rss_bytes().unwrap_or(0)));
+        let initial = current_rss_bytes().unwrap_or(0);
 
         let stop_t = Arc::clone(&stop);
-        let peak_t = Arc::clone(&peak);
         let handle = thread::Builder::new()
             .name("rss-sampler".into())
             .spawn(move || {
+                let mut samples = vec![initial];
                 while !stop_t.load(Ordering::Acquire) {
                     if let Some(rss) = current_rss_bytes() {
-                        // Lock-free max: CAS-loop on the peak
-                        // atomic; tolerates concurrent updates
-                        // from rapid restarts (not expected
-                        // here, but cheap to be correct about).
-                        let mut cur = peak_t.load(Ordering::Acquire);
-                        while rss > cur {
-                            match peak_t.compare_exchange_weak(
-                                cur,
-                                rss,
-                                Ordering::AcqRel,
-                                Ordering::Acquire,
-                            ) {
-                                Ok(_) => break,
-                                Err(observed) => cur = observed,
-                            }
-                        }
+                        samples.push(rss);
                     }
                     thread::sleep(interval);
                 }
+                if let Some(rss) = current_rss_bytes() {
+                    samples.push(rss);
+                }
+                samples
             })
             .expect("spawn rss-sampler thread");
 
         Self {
             stop,
-            peak,
             handle: Some(handle),
         }
     }
@@ -129,12 +151,20 @@ impl PeakSampler {
     /// Stop the sampler, join the background thread, return
     /// the peak VmRSS observed (in bytes). Consumes the
     /// sampler.
-    pub fn stop(mut self) -> u64 {
+    pub fn stop(self) -> u64 {
+        self.stop_stats().peak_rss_bytes
+    }
+
+    /// Stop the sampler, join the background thread, and return
+    /// peak / median / p90 VmRSS observed over the sampler's lifetime.
+    pub fn stop_stats(mut self) -> RssStats {
         self.stop.store(true, Ordering::Release);
-        if let Some(h) = self.handle.take() {
-            let _ = h.join();
-        }
-        self.peak.load(Ordering::Acquire)
+        let samples = self
+            .handle
+            .take()
+            .and_then(|h| h.join().ok())
+            .unwrap_or_else(|| vec![current_rss_bytes().unwrap_or(0)]);
+        RssStats::from_samples(samples)
     }
 }
 
@@ -166,6 +196,10 @@ pub fn fmt_bytes(b: u64) -> String {
 /// `estimates.json` makes the markdown emitters use the same
 /// `(group, bench)` lookup shape for both latency and memory.
 pub fn write_peak_rss(group: &str, bench: &str, peak_rss_bytes: u64) -> std::io::Result<()> {
+    write_rss_stats(group, bench, RssStats::peak_only(peak_rss_bytes))
+}
+
+pub fn write_rss_stats(group: &str, bench: &str, stats: RssStats) -> std::io::Result<()> {
     let dir = criterion_bench_dir(group, bench);
     let new_dir = dir.join("new");
     let base_dir = dir.join("base");
@@ -175,7 +209,9 @@ pub fn write_peak_rss(group: &str, bench: &str, peak_rss_bytes: u64) -> std::io:
         std::fs::write(base_dir.join("rss.json"), existing)?;
     }
     let body = serde_json::json!({
-        "peak_rss_bytes": peak_rss_bytes,
+        "peak_rss_bytes": stats.peak_rss_bytes,
+        "median_rss_bytes": stats.median_rss_bytes,
+        "p90_rss_bytes": stats.p90_rss_bytes,
     });
     std::fs::write(
         new_dir.join("rss.json"),
@@ -187,13 +223,39 @@ pub fn write_peak_rss(group: &str, bench: &str, peak_rss_bytes: u64) -> std::io:
 /// file doesn't exist (bench was filtered out or hasn't run
 /// yet) or the JSON can't be parsed.
 pub fn read_peak_rss_bytes(group: &str, bench: &str) -> Option<u64> {
+    read_rss_field(group, bench, "peak_rss_bytes")
+}
+
+pub fn read_median_rss_bytes(group: &str, bench: &str) -> Option<u64> {
+    read_rss_field(group, bench, "median_rss_bytes")
+}
+
+pub fn read_p90_rss_bytes(group: &str, bench: &str) -> Option<u64> {
+    read_rss_field(group, bench, "p90_rss_bytes")
+}
+
+pub fn fmt_median_rss(group: &str, bench: &str) -> String {
+    read_median_rss_bytes(group, bench)
+        .map(fmt_bytes)
+        .unwrap_or_else(|| "—".into())
+}
+
+pub fn fmt_p90_rss(group: &str, bench: &str) -> String {
+    read_p90_rss_bytes(group, bench)
+        .map(fmt_bytes)
+        .unwrap_or_else(|| "—".into())
+}
+
+fn read_rss_field(group: &str, bench: &str, field: &str) -> Option<u64> {
     let dir = criterion_bench_dir(group, bench);
     let path = dir.join("new").join("rss.json");
     let text = std::fs::read_to_string(&path)
         .or_else(|_| std::fs::read_to_string(dir.join("rss.json")))
         .ok()?;
     let v: Value = serde_json::from_str(&text).ok()?;
-    v.get("peak_rss_bytes")?.as_u64()
+    v.get(field)
+        .and_then(Value::as_u64)
+        .or_else(|| v.get("peak_rss_bytes")?.as_u64())
 }
 
 /// Read the previous run's peak RSS sample (`base/rss.json`).
@@ -295,5 +357,13 @@ mod tests {
             "sampler missed the 32 MiB faulted allocation: \
              baseline={baseline}, peak={peak}"
         );
+    }
+
+    #[test]
+    fn rss_stats_use_nearest_rank_percentiles() {
+        let stats = RssStats::from_samples(vec![50, 10, 40, 20, 30]);
+        assert_eq!(stats.peak_rss_bytes, 50);
+        assert_eq!(stats.median_rss_bytes, 30);
+        assert_eq!(stats.p90_rss_bytes, 50);
     }
 }

--- a/benches/utils/vector_superfile.rs
+++ b/benches/utils/vector_superfile.rs
@@ -201,8 +201,8 @@ fn bench(c: &mut Criterion) {
             b.iter_with_large_drop(|| build_infino_blob(black_box(v)));
         });
         g.finish();
-        let peak = rss_sample.stop();
-        let _ = rss::write_peak_rss(group_name::SUPERFILE_VEC_BUILD, &bench_id, peak);
+        let stats = rss_sample.stop_stats();
+        let _ = rss::write_rss_stats(group_name::SUPERFILE_VEC_BUILD, &bench_id, stats);
 
         emit_ingest_markdown();
     }
@@ -288,7 +288,7 @@ fn bench(c: &mut Criterion) {
         }
 
         g.finish();
-        let peak = rss_sample.stop();
+        let stats = rss_sample.stop_stats();
         // Single sampler covers every (probe, refine) point in this
         // group; record the same peak against each criterion id so the
         // markdown lookup matches the bench id verbatim.
@@ -296,13 +296,13 @@ fn bench(c: &mut Criterion) {
             let label = format!("recall_at_least_{:02}", (target * 100.0) as u32);
             if cal.infino[i].is_some() {
                 let bid = format!("infino_{label}");
-                let _ = rss::write_peak_rss(group_name::SUPERFILE_VEC_SEARCH, &bid, peak);
+                let _ = rss::write_rss_stats(group_name::SUPERFILE_VEC_SEARCH, &bid, stats);
             }
         }
-        let _ = rss::write_peak_rss(
+        let _ = rss::write_rss_stats(
             group_name::SUPERFILE_VEC_SEARCH,
             "infino_default_options_top10",
-            peak,
+            stats,
         );
 
         emit_search_markdown();
@@ -328,16 +328,22 @@ fn emit_ingest_markdown() {
     body.push_str(&format!(
         "### Superfile vector — ingest ({N_DOCS} docs × dim={DIM}, Gaussian planted clusters, cosine)\n\n"
     ));
-    body.push_str("| Engine | Time | Throughput | Peak RSS | Peak RSS Δ |\n");
-    body.push_str("|--------|------|------------|----------|------------|\n");
+    body.push_str(
+        "| Engine | Time | Throughput | Peak RSS | Median RSS | P90 RSS | Peak RSS Δ |\n",
+    );
+    body.push_str(
+        "|--------|------|------------|----------|------------|---------|------------|\n",
+    );
     let time = ns.map(fmt_time).unwrap_or_else(|| "—".into());
     let thrpt = ns
         .map(|n| fmt_throughput((N_DOCS as f64) / (n / 1e9)))
         .unwrap_or_else(|| "—".into());
     let rss_cell = peak_rss.map(rss::fmt_bytes).unwrap_or_else(|| "—".into());
+    let median_rss = rss::fmt_median_rss(group, &bench);
+    let p90_rss = rss::fmt_p90_rss(group, &bench);
     let rss_delta = rss::fmt_peak_rss_delta(group, &bench);
     body.push_str(&format!(
-        "| infino | {time} | {thrpt} | {rss_cell} | {rss_delta} |\n"
+        "| infino | {time} | {thrpt} | {rss_cell} | {median_rss} | {p90_rss} | {rss_delta} |\n"
     ));
 
     markdown::emit(&MarkdownSection {
@@ -357,10 +363,10 @@ fn emit_search_markdown() {
         "### Superfile vector — search ({N_DOCS} docs × dim={DIM}, calibrated at recall targets)\n\n"
     ));
     body.push_str(
-        "| Recall target | infino (probe, refine) | infino p50 | Peak RSS | Peak RSS Δ |\n",
+        "| Recall target | infino (probe, refine) | infino p50 | Peak RSS | Median RSS | P90 RSS | Peak RSS Δ |\n",
     );
     body.push_str(
-        "|---------------|------------------------|------------|----------|------------|\n",
+        "|---------------|------------------------|------------|----------|------------|---------|------------|\n",
     );
 
     for (i, &target) in RECALL_TARGETS.iter().enumerate() {
@@ -372,13 +378,15 @@ fn emit_search_markdown() {
             let peak = rss::read_peak_rss_bytes(group, &id);
             let p50 = ns.map(fmt_time).unwrap_or_else(|| "—".into());
             let rss_cell = peak.map(rss::fmt_bytes).unwrap_or_else(|| "—".into());
+            let median_rss = rss::fmt_median_rss(group, &id);
+            let p90_rss = rss::fmt_p90_rss(group, &id);
             let rss_delta = rss::fmt_peak_rss_delta(group, &id);
             body.push_str(&format!(
-                "| {row_target:13} | (p={}, r={}) | {p50:10} | {rss_cell} | {rss_delta} |\n",
+                "| {row_target:13} | (p={}, r={}) | {p50:10} | {rss_cell} | {median_rss} | {p90_rss} | {rss_delta} |\n",
                 c_inf.probe, c_inf.refine
             ));
         } else {
-            body.push_str(&format!("| {row_target:13} | — | — | — | — |\n"));
+            body.push_str(&format!("| {row_target:13} | — | — | — | — | — | — |\n"));
         }
     }
 
@@ -393,9 +401,17 @@ fn emit_search_markdown() {
     let def_rss = rss::read_peak_rss_bytes(group, "infino_default_options_top10")
         .map(rss::fmt_bytes)
         .unwrap_or_else(|| "—".into());
+    let def_median = rss::fmt_median_rss(group, "infino_default_options_top10");
+    let def_p90 = rss::fmt_p90_rss(group, "infino_default_options_top10");
     body.push_str(&format!("| infino_default_options_top10 | {def_s} |\n"));
     body.push_str(&format!(
         "| infino_default_options_top10_peak_rss | {def_rss} |\n"
+    ));
+    body.push_str(&format!(
+        "| infino_default_options_top10_median_rss | {def_median} |\n"
+    ));
+    body.push_str(&format!(
+        "| infino_default_options_top10_p90_rss | {def_p90} |\n"
     ));
 
     markdown::emit(&MarkdownSection {

--- a/benches/utils/vector_supertable.rs
+++ b/benches/utils/vector_supertable.rs
@@ -347,8 +347,8 @@ fn bench(c: &mut Criterion) {
         });
 
         g.finish();
-        let peak = rss_sample.stop();
-        let _ = rss::write_peak_rss(group_name::SUPERTABLE_VEC_BUILD, &bench_id, peak);
+        let stats = rss_sample.stop_stats();
+        let _ = rss::write_rss_stats(group_name::SUPERTABLE_VEC_BUILD, &bench_id, stats);
 
         emit_ingest_markdown();
     }
@@ -384,12 +384,12 @@ fn bench(c: &mut Criterion) {
         }
 
         g.finish();
-        let peak = rss_sample.stop();
+        let stats = rss_sample.stop_stats();
         for (i, &target) in RECALL_TARGETS.iter().enumerate() {
             let label = format!("recall_at_least_{:02}", (target * 100.0) as u32);
             if cal.supertable[i].is_some() {
                 let bid = format!("supertable_{label}");
-                let _ = rss::write_peak_rss(group_name::SUPERTABLE_VEC_SEARCH, &bid, peak);
+                let _ = rss::write_rss_stats(group_name::SUPERTABLE_VEC_SEARCH, &bid, stats);
             }
         }
 
@@ -416,16 +416,22 @@ fn emit_ingest_markdown() {
     body.push_str(&format!(
         "### Supertable vector — ingest ({N_DOCS} docs × dim={DIM}, sharded into {N_SEGMENTS} superfiles)\n\n"
     ));
-    body.push_str("| Engine | Time | Throughput | Peak RSS | Peak RSS Δ |\n");
-    body.push_str("|--------|------|------------|----------|------------|\n");
+    body.push_str(
+        "| Engine | Time | Throughput | Peak RSS | Median RSS | P90 RSS | Peak RSS Δ |\n",
+    );
+    body.push_str(
+        "|--------|------|------------|----------|------------|---------|------------|\n",
+    );
     let time = ns.map(fmt_time).unwrap_or_else(|| "—".into());
     let thrpt = ns
         .map(|n| fmt_throughput((N_DOCS as f64) / (n / 1e9)))
         .unwrap_or_else(|| "—".into());
     let rss_cell = peak_rss.map(rss::fmt_bytes).unwrap_or_else(|| "—".into());
+    let median_rss = rss::fmt_median_rss(group, &bench);
+    let p90_rss = rss::fmt_p90_rss(group, &bench);
     let rss_delta = rss::fmt_peak_rss_delta(group, &bench);
     body.push_str(&format!(
-        "| supertable | {time} | {thrpt} | {rss_cell} | {rss_delta} |\n"
+        "| supertable | {time} | {thrpt} | {rss_cell} | {median_rss} | {p90_rss} | {rss_delta} |\n"
     ));
 
     markdown::emit(&MarkdownSection {
@@ -445,34 +451,45 @@ fn emit_search_markdown() {
         "### Supertable vector — search ({N_DOCS} docs × dim={DIM}, calibrated at recall targets)\n\n"
     ));
     body.push_str(
-        "| Recall target | supertable (probe/seg, refine) | supertable p50 | Peak RSS | Peak RSS Δ |\n",
+        "| Recall target | supertable (probe/seg, refine) | supertable p50 | Peak RSS | Median RSS | P90 RSS | Peak RSS Δ |\n",
     );
     body.push_str(
-        "|---------------|--------------------------------|----------------|----------|------------|\n",
+        "|---------------|--------------------------------|----------------|----------|------------|---------|------------|\n",
     );
 
     for (i, &target) in RECALL_TARGETS.iter().enumerate() {
         let label = format!("recall_at_least_{:02}", (target * 100.0) as u32);
         let row_target = format!("{target:.2}");
-        let (cell, ns, rss_cell, rss_delta) = match cal.supertable[i] {
+        let (cell, ns, rss_cell, median_rss, p90_rss, rss_delta) = match cal.supertable[i] {
             Some(c) => {
                 let bid = format!("supertable_{label}");
                 let ns = read_mean_ns(group, &bid);
                 let peak = rss::read_peak_rss_bytes(group, &bid);
                 let rss_cell = peak.map(rss::fmt_bytes).unwrap_or_else(|| "—".into());
+                let median_rss = rss::fmt_median_rss(group, &bid);
+                let p90_rss = rss::fmt_p90_rss(group, &bid);
                 let rss_delta = rss::fmt_peak_rss_delta(group, &bid);
                 (
                     format!("(p={}, r={})", c.probe, c.refine),
                     ns,
                     rss_cell,
+                    median_rss,
+                    p90_rss,
                     rss_delta,
                 )
             }
-            None => ("—".into(), None, "—".into(), "—".into()),
+            None => (
+                "—".into(),
+                None,
+                "—".into(),
+                "—".into(),
+                "—".into(),
+                "—".into(),
+            ),
         };
         let t = ns.map(fmt_time).unwrap_or_else(|| "—".into());
         body.push_str(&format!(
-            "| {row_target} | {cell} | {t} | {rss_cell} | {rss_delta} |\n"
+            "| {row_target} | {cell} | {t} | {rss_cell} | {median_rss} | {p90_rss} | {rss_delta} |\n"
         ));
     }
 


### PR DESCRIPTION
- Extend the bench RSS sampler to retain observed VmRSS samples and persist peak, median, and p90 values in rss.json.
- Keep peak_rss_bytes backward-compatible while adding median_rss_bytes and p90_rss_bytes for new runs.
- Add Median RSS and P90 RSS columns to FTS/vector superfile and supertable markdown output.