### PR TITLE
bench: suffix multi-term OR query labels with _or

### DIFF
--- a/benches/utils/fts_superfile.rs
+++ b/benches/utils/fts_superfile.rs
@@ -133,10 +133,10 @@ fn assert_bmw_matches_brute_force(reader: &FtsReader) -> usize {
         ("single_rare", &["term09999"]),
         ("single_common", &["term00001"]),
         ("two_term_or", &["term00001", "term00050"]),
-        ("three_wide", &["term00001", "term00050", "term00100"]),
-        ("three_similar", &["term00050", "term00051", "term00052"]),
+        ("three_wide_or", &["term00001", "term00050", "term00100"]),
+        ("three_similar_or", &["term00050", "term00051", "term00052"]),
         (
-            "five_term",
+            "five_term_or",
             &[
                 "term00050",
                 "term00051",
@@ -301,21 +301,21 @@ fn bench(c: &mut Criterion) {
         );
         bench_infino(
             &mut g,
-            "three_wide",
+            "three_wide_or",
             &r,
             &["term00001", "term00050", "term00100"],
             BoolMode::Or,
         );
         bench_infino(
             &mut g,
-            "three_similar",
+            "three_similar_or",
             &r,
             &["term00050", "term00051", "term00052"],
             BoolMode::Or,
         );
         bench_infino(
             &mut g,
-            "five_term",
+            "five_term_or",
             &r,
             &[
                 "term00050",
@@ -364,19 +364,19 @@ fn bench(c: &mut Criterion) {
         // Per-algo probes
         bench_per_algo_probe(
             &mut g,
-            "wide_3",
+            "wide_3_or",
             &r,
             &["term00001", "term00050", "term00100"],
         );
         bench_per_algo_probe(
             &mut g,
-            "similar_3",
+            "similar_3_or",
             &r,
             &["term00050", "term00051", "term00052"],
         );
         bench_per_algo_probe(
             &mut g,
-            "similar_5",
+            "similar_5_or",
             &r,
             &[
                 "term00050",
@@ -397,19 +397,19 @@ fn bench(c: &mut Criterion) {
             "single_df1_infino_top10",
             "single_common_infino_top10",
             "two_term_or_infino_top10",
-            "three_wide_infino_top10",
-            "three_similar_infino_top10",
-            "five_term_infino_top10",
+            "three_wide_or_infino_top10",
+            "three_similar_or_infino_top10",
+            "five_term_or_infino_top10",
             "two_term_and_infino_top10",
             "three_wide_and_infino_top10",
             "three_similar_and_infino_top10",
             "five_term_and_infino_top10",
-            "wide_3_wand_top10",
-            "wide_3_bmm_top10",
-            "similar_3_wand_top10",
-            "similar_3_bmm_top10",
-            "similar_5_wand_top10",
-            "similar_5_bmm_top10",
+            "wide_3_or_wand_top10",
+            "wide_3_or_bmm_top10",
+            "similar_3_or_wand_top10",
+            "similar_3_or_bmm_top10",
+            "similar_5_or_wand_top10",
+            "similar_5_or_bmm_top10",
         ];
         for bid in search_ids {
             let _ = rss::write_rss_stats(group_name::SUPERFILE_FTS_SEARCH, bid, stats);
@@ -499,9 +499,9 @@ fn emit_search_markdown() {
         "single_df1",
         "single_common",
         "two_term_or",
-        "three_wide",
-        "three_similar",
-        "five_term",
+        "three_wide_or",
+        "three_similar_or",
+        "five_term_or",
     ];
     let queries_and = [
         "two_term_and",
@@ -546,7 +546,7 @@ fn emit_search_markdown() {
     body.push_str("**Per-algorithm probes** (WAND+BMW vs MaxScore+BMM):\n\n");
     body.push_str("| Shape         | WAND+BMW   | MaxScore+BMM |\n");
     body.push_str("|---------------|------------|--------------|\n");
-    for shape in ["wide_3", "similar_3", "similar_5"] {
+    for shape in ["wide_3_or", "similar_3_or", "similar_5_or"] {
         let wand = read_mean_ns(group, &format!("{shape}_wand_top10"));
         let bmm = read_mean_ns(group, &format!("{shape}_bmm_top10"));
         let wand_s = wand.map(fmt_time).unwrap_or_else(|| "—".into());

--- a/benches/utils/fts_supertable.rs
+++ b/benches/utils/fts_supertable.rs
@@ -226,10 +226,10 @@ fn bench_search(c: &mut Criterion) {
         ("single_rare", "term09999"),
         ("single_common", "term00001"),
         ("two_term_or", "term00001 term00050"),
-        ("three_wide", "term00001 term00050 term00100"),
-        ("three_similar", "term00050 term00051 term00052"),
+        ("three_wide_or", "term00001 term00050 term00100"),
+        ("three_similar_or", "term00050 term00051 term00052"),
         (
-            "five_term",
+            "five_term_or",
             "term00050 term00051 term00052 term00053 term00054",
         ),
     ];
@@ -261,9 +261,9 @@ fn bench_search(c: &mut Criterion) {
         "single_rare_supertable_top10",
         "single_common_supertable_top10",
         "two_term_or_supertable_top10",
-        "three_wide_supertable_top10",
-        "three_similar_supertable_top10",
-        "five_term_supertable_top10",
+        "three_wide_or_supertable_top10",
+        "three_similar_or_supertable_top10",
+        "five_term_or_supertable_top10",
         "prefix_supertable_top10",
     ];
     for bid in search_ids {
@@ -337,9 +337,9 @@ fn emit_search_markdown() {
         "single_rare",
         "single_common",
         "two_term_or",
-        "three_wide",
-        "three_similar",
-        "five_term",
+        "three_wide_or",
+        "three_similar_or",
+        "five_term_or",
         "prefix",
     ];
     for q in queries {

--- a/docs/architecture/superfile.md
+++ b/docs/architecture/superfile.md
@@ -592,11 +592,11 @@ of textbook MaxScore:
    score by `essential_score + sum_others_term_max`; if even this
    can't beat the heap threshold, skip the non-essential probe +
    heap update entirely. Most rank-100 docs in the
-   `three_wide` query (`term00001 + term00050 + term00100`) score
+   `three_wide_or` query (`term00001 + term00050 + term00100`) score
    around 2.7 alone, so with `others_term_ub ≈ 2.5` their max is
    ~5.2 — well below the steady-state threshold of ~6.5, and the
    bail fires for ~70% of docs. This single optimization moved
-   `three_wide` from 4× *slower* than a naive multi-term walk to
+   `three_wide_or` from 4× *slower* than a naive multi-term walk to
    3.5× *faster*.
 
 3. **Shallow-advance bail in `f >= 2` paths.** For multi-essential
@@ -613,7 +613,7 @@ of textbook MaxScore:
 - *Heap-of-cursors plain WAND without block-max augmentation.*
   Skips by term-max alone. Vastly weaker pruning than BMW: doesn't
   use the skip table's per-block UB at all. Measured ~5× slower
-  than BMW on `three_similar`. Easy first thing to ship; we
+  than BMW on `three_similar_or`. Easy first thing to ship; we
   iterated past it.
 - *Always WAND+BMW.* The straightforward initial choice. BMW's
   pivot bound becomes loose when many query terms have similar
@@ -661,9 +661,9 @@ This single fix accounts for these post-fix improvements (1M docs):
 
 | query | before | after |
 |---|---|---|
-| `three_wide` | 2.54 ms | **1.28 ms** |
-| `three_similar` | 24.2 ms | **5.94 ms** |
-| `five_term` | 14.8 ms | **10.0 ms** |
+| `three_wide_or` | 2.54 ms | **1.28 ms** |
+| `three_similar_or` | 24.2 ms | **5.94 ms** |
+| `five_term_or` | 14.8 ms | **10.0 ms** |
 
 See `git log -p src/superfile/fts/reader.rs | grep -A40 "skip_to within-block fast path"`
 for the diff.


### PR DESCRIPTION
## Summary

- FTS bench labels now consistently distinguish boolean mode: multi-term queries carry `_or` / `_and`; single-term labels stay unsuffixed.
- Renames six bare labels — `three_wide`, `three_similar`, `five_term`, `wide_3`, `similar_3`, `similar_5` — to their `_or` form in `benches/utils/fts_superfile.rs` and `benches/utils/fts_supertable.rs`.
- Cascading updates: BMW-vs-brute-force correctness battery, criterion bench IDs in the RSS write loop, markdown writers (`queries_or`, per-algo `shape` list, derived `_wand_top10` / `_bmm_top10` IDs), and the prose + result table in `docs/architecture/superfile.md`.

## Test plan

- [x] `cargo check --benches` passes.
- [x] `cargo bench --bench fts_superfile` (spot-check that the renamed labels appear in criterion output and the markdown table).
- [x] `cargo bench --bench fts_supertable` (same spot-check).