### PR TITLE
fts: leapfrog AND intersection over the skip table

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -51,21 +51,73 @@ which is the structured source of truth the markdown is derived from.
 ### FTS — superfile (single-segment, 1M docs)
 
 <!-- BEGIN: bench/fts/superfile/ingest -->
-_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- superfile_fts_build` to populate_
+### Superfile FTS — ingest (1000000 docs, Zipfian, 200 tokens/doc, 10K vocab)
+
+| Engine                       | Time       | Throughput | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |
+|------------------------------|------------|------------|-----------|------------|-----------|------------|
+| infino_1thread               | 9.30 s     | 107.5 K/s  | 0 B       | 0 B        | 0 B       | —          |
+| infino_rayon_default_threads | 815.44 ms  | 1.23 M/s   | 0 B       | 0 B        | 0 B       | —          |
+
 <!-- END: bench/fts/superfile/ingest -->
 
 <!-- BEGIN: bench/fts/superfile/search -->
-_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- superfile_fts_search` to populate_
+### Superfile FTS — search (1000000 docs)
+
+| Query          | infino     | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |
+|----------------|------------|-----------|------------|-----------|------------|
+**OR queries:**
+
+| single_rare    | 260 ns     | 0 B       | 0 B        | 0 B       | —          |
+| single_df1     | 119 ns     | 0 B       | 0 B        | 0 B       | —          |
+| single_common  | 14.83 µs   | 0 B       | 0 B        | 0 B       | —          |
+| two_term_or    | 106.07 µs  | 0 B       | 0 B        | 0 B       | —          |
+| three_wide_or  | 1.61 ms    | 0 B       | 0 B        | 0 B       | —          |
+| three_similar_or | 9.07 ms    | 0 B       | 0 B        | 0 B       | —          |
+| five_term_or   | 15.69 ms   | 0 B       | 0 B        | 0 B       | —          |
+
+**AND queries:**
+
+| two_term_and   | 4.44 ms    | 0 B       | 0 B        | 0 B       | —          |
+| three_wide_and | 3.33 ms    | 0 B       | 0 B        | 0 B       | —          |
+| three_similar_and | 4.58 ms    | 0 B       | 0 B        | 0 B       | —          |
+| five_term_and  | 5.11 ms    | 0 B       | 0 B        | 0 B       | —          |
+
+**Per-algorithm probes** (WAND+BMW vs MaxScore+BMM):
+
+| Shape         | WAND+BMW   | MaxScore+BMM |
+|---------------|------------|--------------|
+| wide_3_or     | 4.80 ms    | 1.34 ms      |
+| similar_3_or  | 9.17 ms    | 5.98 ms      |
+| similar_5_or  | 26.35 ms   | 10.07 ms     |
+
 <!-- END: bench/fts/superfile/search -->
 
 ### FTS — supertable (multi-segment, 10M docs)
 
 <!-- BEGIN: bench/fts/supertable/ingest -->
-_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- supertable_fts_build` to populate_
+### Supertable FTS — ingest (10000000 docs, Zipfian, 200 tokens/doc, 10K vocab)
+
+| Engine                  | Time       | Throughput | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |
+|-------------------------|------------|------------|-----------|------------|-----------|------------|
+| infino_auto_writer_pool | 41.97 s    | 238.3 K/s  | 0 B       | 0 B        | 0 B       | —          |
+
+*Output cardinality: infino emits `min(writer_pool.threads, total_rows)` superfiles per commit (auto = cpus/2). Override with `INFINO_SUPERTABLE__WRITER_THREADS=N` for a specific shard count.*
+
 <!-- END: bench/fts/supertable/ingest -->
 
 <!-- BEGIN: bench/fts/supertable/search -->
-_run `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- supertable_fts_search` to populate_
+### Supertable FTS — search (10000000 docs)
+
+| Query          | infino     | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |
+|----------------|------------|-----------|------------|-----------|------------|
+| single_rare    | 42.69 µs   | 0 B       | 0 B        | 0 B       | —          |
+| single_common  | 57.57 µs   | 0 B       | 0 B        | 0 B       | —          |
+| two_term_or    | 301.85 µs  | 0 B       | 0 B        | 0 B       | —          |
+| three_wide_or  | 2.67 ms    | 0 B       | 0 B        | 0 B       | —          |
+| three_similar_or | 8.32 ms    | 0 B       | 0 B        | 0 B       | —          |
+| five_term_or   | 14.18 ms   | 0 B       | 0 B        | 0 B       | —          |
+| prefix         | 33.19 ms   | 0 B       | 0 B        | 0 B       | —          |
+
 <!-- END: bench/fts/supertable/search -->
 
 ### Vector — superfile (single-segment, 1M × 384)

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -389,30 +389,6 @@ impl FtsReader {
             .collect()
     }
 
-    /// Read one doc's length (u16, LE) from the column's doc-lengths
-    /// array. Manual byte extraction — avoids any alignment requirement
-    /// on the underlying `Bytes` buffer.
-    ///
-    /// Hot path: called once per (doc, term) during BM25 scoring. Kept
-    /// branch-free in release.
-    #[inline(always)]
-    fn doc_len(&self, column_id: u32, doc_id: u32) -> u16 {
-        debug_assert!(
-            doc_id < self.n_docs,
-            "doc_id {doc_id} out of range vs n_docs {} — caller invariant violation",
-            self.n_docs,
-        );
-        let r = &self.columns[column_id as usize].doc_lengths_range;
-        // 64-bit-only crate: `(doc_id as usize) * 2` cannot overflow
-        // (max doc_id is u32::MAX, max product is ~2^33). The bounds
-        // check below catches any column-internal range mismatch.
-        let off = r.start + (doc_id as usize) * 2;
-        if off + 2 > r.end {
-            return 0;
-        }
-        u16::from_le_bytes([self.blob[off], self.blob[off + 1]])
-    }
-
     /// Single-column BM25 search.
     ///
     /// `terms` are the *already-tokenized* query terms — caller-tokenized
@@ -445,111 +421,27 @@ impl FtsReader {
             return self.search_single_term_bmw(column_id, terms[0], k);
         }
 
-        // Multi-term OR routes to MaxScore+BMM via
-        // `dispatch_multi_term_or`. WAND+BMW remains in-tree for
-        // the bench harness (`search_with_algo_for_bench`) but is
-        // not used by `search`; see the routing-decision table on
-        // `dispatch_multi_term_or` for why BMM wins on the shapes
-        // we benchmark. AND mode continues to use the full-decode
-        // + HashMap intersection path below.
-        if mode == BoolMode::Or {
-            return self.dispatch_multi_term_or(column_id, terms, k);
-        }
-
-        let dict = self.dict();
-        let col_meta = &self.columns[column_id as usize];
-        let avgdl = col_meta.avgdl;
-
-        // Decode each term's full posting list. Build per-doc score map.
-        // For OR/AND simplicity, we accumulate scores into a HashMap.
-        let mut term_postings: Vec<(f32 /* idf_t */, Vec<(u32, u32)>)> = Vec::new();
-        for term in terms {
-            let key = make_key(&col_meta.name, term);
-            let value = dict.lookup(&key);
-            match value {
-                Some(packed) => {
-                    let pl: Vec<(u32, u32)> = match FstValue::unpack(packed) {
-                        FstValue::Inline { doc_id, tf } => vec![(doc_id, tf)],
-                        FstValue::Pfor { metadata_offset } => {
-                            self.decode_term_postings(metadata_offset as usize)?
-                        }
-                    };
-                    let df = pl.len() as u64;
-                    let idf_t = crate::superfile::fts::bm25::idf(self.n_docs as u64, df);
-                    term_postings.push((idf_t, pl));
-                }
-                None => {
-                    if mode == BoolMode::And {
-                        // AND: any missing term short-circuits.
-                        return Ok(Vec::new());
-                    }
-                    // OR: missing terms simply contribute nothing.
-                }
-            }
-        }
-
-        if term_postings.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Score docs:
-        //   AND: only docs present in EVERY term posting list.
-        //   OR:  union of doc ids across term posting lists; sum scores.
-        let scored: HashMap<u32, f32> = match mode {
-            BoolMode::Or => {
-                let mut scores: HashMap<u32, f32> = HashMap::new();
-                for (idf_t, postings) in &term_postings {
-                    for (doc_id, tf) in postings {
-                        let dl = self.doc_len(column_id, *doc_id) as u32;
-                        let s = crate::superfile::fts::bm25::score(*idf_t, *tf, dl, avgdl);
-                        *scores.entry(*doc_id).or_insert(0.0) += s;
-                    }
-                }
-                scores
-            }
+        // Multi-term routing:
+        //   OR  → MaxScore+BMM via `dispatch_multi_term_or`. WAND+BMW
+        //         remains in-tree for `search_with_algo_for_bench` but
+        //         is not on the production path; see the routing-
+        //         decision table on `dispatch_multi_term_or`.
+        //   AND → leapfrog intersection over the skip table via
+        //         `run_and_intersect`. Both share cursor construction
+        //         with the OR path so neither pays for cursor work
+        //         twice when the bench harness compares them.
+        match mode {
+            BoolMode::Or => self.dispatch_multi_term_or(column_id, terms, k),
             BoolMode::And => {
-                if term_postings.iter().any(|(_, pl)| pl.is_empty()) {
+                // Build cursors; if any term is missing, the
+                // intersection is empty.
+                let cursors = self.build_term_cursors(column_id, terms)?;
+                if cursors.len() != terms.len() {
                     return Ok(Vec::new());
                 }
-                // Use the smallest posting list to drive the AND-merge.
-                let (smallest_idx, _) = term_postings
-                    .iter()
-                    .enumerate()
-                    .min_by_key(|(_, (_, pl))| pl.len())
-                    .expect("term_postings non-empty by the early-return above");
-                let driver = &term_postings[smallest_idx].1;
-                let other_sets: Vec<HashMap<u32, u32>> = term_postings
-                    .iter()
-                    .enumerate()
-                    .filter(|(i, _)| *i != smallest_idx)
-                    .map(|(_, (_, pl))| pl.iter().copied().collect())
-                    .collect();
-                let mut scores: HashMap<u32, f32> = HashMap::new();
-                for (doc_id, tf) in driver {
-                    if other_sets.iter().all(|s| s.contains_key(doc_id)) {
-                        let dl = self.doc_len(column_id, *doc_id) as u32;
-                        let mut total = crate::superfile::fts::bm25::score(
-                            term_postings[smallest_idx].0,
-                            *tf,
-                            dl,
-                            avgdl,
-                        );
-                        for (i, (idf_t, _)) in term_postings.iter().enumerate() {
-                            if i == smallest_idx {
-                                continue;
-                            }
-                            let other_tf = other_sets[other_idx(i, smallest_idx)][doc_id];
-                            total +=
-                                crate::superfile::fts::bm25::score(*idf_t, other_tf, dl, avgdl);
-                        }
-                        scores.insert(*doc_id, total);
-                    }
-                }
-                scores
+                self.run_and_intersect(column_id, cursors, k)
             }
-        };
-
-        Ok(top_k(scored, k))
+        }
     }
 
     /// Multi-term OR BM25 search constrained to a doc_id sub-range.
@@ -1127,6 +1019,135 @@ impl FtsReader {
         k: usize,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
         self.run_max_score_bmm_range(column_id, cursors, k, 0, u32::MAX)
+    }
+
+    /// Multi-term AND via leapfrog intersection over the skip table.
+    ///
+    /// The smallest-df cursor is the leader: every matching doc must
+    /// be in its posting list. For each leader doc, every other
+    /// cursor runs `skip_to(candidate)` — a skip-table-driven jump
+    /// that decodes at most one block per call (and zero if the
+    /// target lies in the already-decoded block). If any cursor
+    /// lands past the candidate, that doc isn't in the intersection;
+    /// the candidate is bumped to the new high-water mark and the
+    /// remaining cursors re-skip. When all cursors converge on the
+    /// same doc, the BM25 contribution from each is summed.
+    ///
+    /// Cost is bounded by `min_df` leader steps × `n_terms` skip_to
+    /// calls, with each skip_to a constant-or-O(log) skip-table walk.
+    /// The old `run_and` did a full PFOR decode of every term's full
+    /// posting list (dominated by the largest list, e.g. ~hundreds of
+    /// K postings for a common Zipfian term) followed by a HashMap
+    /// intersection — orders of magnitude more work than this when
+    /// any term is rare.
+    fn run_and_intersect(
+        &self,
+        column_id: u32,
+        mut cursors: Vec<TermCursor>,
+        k: usize,
+    ) -> Result<Vec<(u32, f32)>, FtsError> {
+        if cursors.is_empty() {
+            return Ok(Vec::new());
+        }
+        let col_meta = &self.columns[column_id as usize];
+        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let postings = &self.blob[self.postings_range.clone()];
+
+        // Smallest-df cursor at index 0 = leader. The remaining order
+        // doesn't matter for correctness but ascending-df reduces the
+        // expected number of leapfrog bumps per candidate.
+        cursors.sort_by_key(|c| c.block_count());
+
+        // Top-k min-heap. Same shape as `run_max_score_bmm`/`run_wand_bmw`:
+        // peek returns the smallest score so we can compare against
+        // a new candidate without a full sort.
+        #[derive(Debug, Copy, Clone)]
+        struct HeapEntry(f32, u32);
+        impl PartialEq for HeapEntry {
+            fn eq(&self, other: &Self) -> bool {
+                self.0 == other.0 && self.1 == other.1
+            }
+        }
+        impl Eq for HeapEntry {}
+        impl PartialOrd for HeapEntry {
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+        impl Ord for HeapEntry {
+            fn cmp(&self, other: &Self) -> Ordering {
+                other
+                    .0
+                    .partial_cmp(&self.0)
+                    .unwrap_or(Ordering::Equal)
+                    .then_with(|| other.1.cmp(&self.1))
+            }
+        }
+
+        let initial_cap = k.min(self.n_docs as usize).max(1);
+        let mut heap: BinaryHeap<HeapEntry> = BinaryHeap::with_capacity(initial_cap);
+
+        let n = cursors.len();
+        'outer: loop {
+            if cursors[0].is_exhausted() {
+                break;
+            }
+            let mut candidate = cursors[0].current_doc_id();
+
+            // Converge: re-skip all cursors until each lands on the
+            // same candidate. A cursor that ends up past candidate
+            // raises the candidate to its position; the next pass
+            // catches up the others.
+            loop {
+                let mut bumped = false;
+                for i in 0..n {
+                    cursors[i].skip_to(candidate, postings);
+                    if cursors[i].is_exhausted() {
+                        break 'outer;
+                    }
+                    let here = cursors[i].current_doc_id();
+                    if here != candidate {
+                        candidate = here;
+                        bumped = true;
+                        break;
+                    }
+                }
+                if !bumped {
+                    break;
+                }
+            }
+
+            // All cursors at `candidate` — sum BM25 contributions.
+            let norm = dl_norm_k1[candidate as usize];
+            let mut score = 0.0_f32;
+            for c in &cursors {
+                score += crate::superfile::fts::bm25::score_with_dl_norm_k1(
+                    c.idf_x_k1p1,
+                    c.current_tf(),
+                    norm,
+                );
+            }
+
+            if heap.len() < k {
+                heap.push(HeapEntry(score, candidate));
+            } else if let Some(&worst) = heap.peek() {
+                // Tie-break by ascending doc_id (matches OR paths).
+                if score > worst.0 || (score == worst.0 && candidate < worst.1) {
+                    heap.pop();
+                    heap.push(HeapEntry(score, candidate));
+                }
+            }
+
+            cursors[0].next(postings);
+        }
+
+        let mut out: Vec<(u32, f32)> = heap.into_iter().map(|e| (e.1, e.0)).collect();
+        out.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        Ok(out)
     }
 
     /// MaxScore+BMM constrained to the doc_id half-open range
@@ -1737,70 +1758,13 @@ impl FtsReader {
             OrAlgo::Exhaustive => self.run_exhaustive_union(column_id, cursors, k),
         }
     }
-
-    /// Decode the full posting list for a (col, term) by walking every
-    /// block. Used by the AND-merge path; OR queries go through
-    /// [`Self::dispatch_multi_term_or`], single-term queries through
-    /// [`Self::search_single_term_bmw`].
-    fn decode_term_postings(
-        &self,
-        metadata_offset_in_postings_region: usize,
-    ) -> Result<Vec<(u32, u32)>, FtsError> {
-        let postings = &self.blob[self.postings_range.clone()];
-        let off = metadata_offset_in_postings_region;
-        if off + 20 > postings.len() {
-            return Err(FtsError::Read(ReadError::MalformedVersion(
-                "term metadata offset out of postings region".into(),
-            )));
-        }
-        let df = read_u32_le(&postings[off..off + 4]) as usize;
-        let _meta_self_offset = read_u64_le(&postings[off + 4..off + 12]);
-        let _length = read_u32_le(&postings[off + 12..off + 16]);
-        let num_blocks = u32::from_le_bytes([
-            postings[off + 16],
-            postings[off + 17],
-            postings[off + 18],
-            postings[off + 19],
-        ]) as usize;
-
-        // Skip table follows: num_blocks × 16 bytes. We don't use it for
-        // BMW yet; just step over to find the first block.
-        let skip_table_end = off + 20 + num_blocks * 16;
-
-        let mut block_off = skip_table_end;
-        let mut out: Vec<(u32, u32)> = Vec::with_capacity(df);
-        let mut buf_d = vec![0u32; BLOCK_LEN];
-        let mut buf_t = vec![0u32; BLOCK_LEN];
-        for _ in 0..num_blocks {
-            // Block layout: 8-byte header (doc_count, delta_bits, tf_bits, reserved, base) + bit-packed bytes.
-            // Compute its size from the header and decode in place.
-            let header = &postings[block_off..block_off + 8];
-            let delta_bits = header[1] as usize;
-            let tf_bits = header[2] as usize;
-            let block_size = 8 + (BLOCK_LEN * delta_bits / 8) + (BLOCK_LEN * tf_bits / 8);
-            let n = decode_block(
-                &postings[block_off..block_off + block_size],
-                &mut buf_d,
-                &mut buf_t,
-            );
-            for i in 0..n {
-                out.push((buf_d[i], buf_t[i]));
-            }
-            block_off += block_size;
-        }
-        Ok(out)
-    }
 }
 
-fn other_idx(i: usize, smallest: usize) -> usize {
-    // Helper to translate a "term_postings index" to the corresponding
-    // "other_sets index" (which excludes `smallest`).
-    if i < smallest { i } else { i - 1 }
-}
-
+/// Merge a `doc_id -> score` map into top-k by descending score, ties
+/// broken by ascending doc_id. Used by `search_multi`'s cross-column
+/// combiner, where the per-column scores have already been weighted
+/// and summed into `scores`.
 fn top_k(scores: HashMap<u32, f32>, k: usize) -> Vec<(u32, f32)> {
-    // Min-heap of size k: pop the smallest when inserting a better
-    // score. Tie-break on doc_id ascending so the output is deterministic.
     #[derive(Debug)]
     struct Entry(u32, f32);
     impl PartialEq for Entry {
@@ -1816,10 +1780,8 @@ fn top_k(scores: HashMap<u32, f32>, k: usize) -> Vec<(u32, f32)> {
     }
     impl Ord for Entry {
         fn cmp(&self, other: &Self) -> Ordering {
-            // Reverse ordering for a min-heap: smaller score = "greater"
-            // in the heap so it pops first. Tie-break: larger doc_id is
-            // "greater" so it pops first (preferring smaller doc_id at
-            // the top in equal-score case).
+            // Min-heap by score (smaller score "greater" so it pops
+            // first); tie-break with smaller doc_id at the top.
             other
                 .1
                 .partial_cmp(&self.1)
@@ -1828,12 +1790,9 @@ fn top_k(scores: HashMap<u32, f32>, k: usize) -> Vec<(u32, f32)> {
         }
     }
 
-    // Iterate in ascending doc_id order so ties resolve deterministically
-    // (smaller doc_ids enter the heap first; the strict `score > peek`
-    // check below means subsequent equal-score entries don't displace
-    // them). Without this, HashMap's hash-order iteration would make the
-    // tied result non-deterministic and would disagree with the BMW
-    // single-term path (which naturally iterates in doc_id order).
+    // Iterate in ascending doc_id order so equal-score ties resolve
+    // deterministically — HashMap's hash order would otherwise make
+    // the top-k output non-deterministic.
     let mut sorted: Vec<(u32, f32)> = scores.into_iter().collect();
     sorted.sort_by_key(|(d, _)| *d);
 
@@ -1849,7 +1808,6 @@ fn top_k(scores: HashMap<u32, f32>, k: usize) -> Vec<(u32, f32)> {
         }
     }
     let mut out: Vec<(u32, f32)> = heap.into_iter().map(|Entry(d, s)| (d, s)).collect();
-    // Sort descending by score, ascending by doc_id on ties.
     out.sort_by(|a, b| {
         b.1.partial_cmp(&a.1)
             .unwrap_or(Ordering::Equal)
@@ -2069,6 +2027,16 @@ impl TermCursor {
 
     fn is_exhausted(&self) -> bool {
         self.current_block >= self.blocks.len()
+    }
+
+    /// Total number of postings (df) for this term. Used by AND
+    /// intersection to pick the rarest cursor as the leader.
+    /// Block count is an exact upper bound on df (df = (n-1)*BLOCK_LEN
+    /// + last_block_n); cursor count comparison via this method gives
+    /// stable smallest-first ordering. Inline cursors return 1.
+    #[inline(always)]
+    fn block_count(&self) -> usize {
+        self.blocks.len()
     }
 
     #[inline(always)]

--- a/src/test_helpers/brute_force_bm25.rs
+++ b/src/test_helpers/brute_force_bm25.rs
@@ -149,6 +149,49 @@ impl BruteForceBm25 {
         scored
     }
 
+    /// Same as [`Self::top_k_terms`] but with AND semantics: only docs
+    /// that contain *every* query term contribute a score. Used by the
+    /// AND-mode oracle tests against the reader's leapfrog
+    /// intersection. Each term still contributes its own BM25 score to
+    /// the per-doc sum; tie-break is ascending doc_id, identical to
+    /// the OR helper.
+    pub fn top_k_terms_and(&self, terms: &[String], k: usize) -> Vec<(u64, f32)> {
+        if k == 0 || terms.is_empty() || self.n == 0 {
+            return Vec::new();
+        }
+
+        let n = self.n as f32;
+        let avgdl = self.avgdl;
+
+        let mut scored: Vec<(u64, f32)> = Vec::with_capacity(self.docs.len());
+        'docs: for doc in &self.docs {
+            let dl = doc.dl as f32;
+            let dl_norm = K1 * (1.0 - B + B * dl / avgdl.max(f32::MIN_POSITIVE));
+            let mut score: f32 = 0.0;
+            for term in terms {
+                let Some(&tf) = doc.tf.get(term) else {
+                    continue 'docs;
+                };
+                let df = *self.df.get(term).unwrap_or(&0) as f32;
+                if df == 0.0 {
+                    continue 'docs;
+                }
+                let idf = (1.0 + (n - df + 0.5) / (df + 0.5)).ln();
+                let tf_f = tf as f32;
+                score += idf * tf_f * (K1 + 1.0) / (tf_f + dl_norm);
+            }
+            scored.push((doc.doc_id, score));
+        }
+
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.0.cmp(&b.0))
+        });
+        scored.truncate(k);
+        scored
+    }
+
     /// Number of indexed docs.
     pub fn n_docs(&self) -> u32 {
         self.n

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -275,6 +275,161 @@ fn oracle_no_match_query_returns_empty() {
     );
 }
 
+// ─── AND-mode oracles ─────────────────────────────────────────────────
+
+fn infino_top_k_and(reader: &SuperfileReader, query: &str, k: usize) -> Vec<u64> {
+    // The reader's `bm25_search` consumes a pre-built query string,
+    // tokenizes it column-internally, and runs the AND intersection.
+    // Returned `local_doc_id` == user `doc_id` thanks to the planted
+    // 0..N row layout.
+    let hits = reader
+        .bm25_search("title", query, k, BoolMode::And)
+        .expect("AND BM25 search");
+    hits.into_iter().map(|(d, _)| d as u64).collect()
+}
+
+fn assert_top_k_and_set_matches(
+    infino: &SuperfileReader,
+    oracle: &BruteForceBm25,
+    query: &str,
+    head_size: usize,
+    k: usize,
+) {
+    let tok = default_tokenizer();
+    let mut terms: Vec<String> = Vec::new();
+    use infino::superfile::fts::tokenize::Tokenizer as _;
+    tok.tokenize_each(query, &mut |t| terms.push(t.to_owned()));
+    let infino_hits = infino_top_k_and(infino, query, k);
+    let oracle_hits: Vec<u64> = oracle
+        .top_k_terms_and(&terms, k)
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+    assert!(
+        infino_hits.len() >= head_size && oracle_hits.len() >= head_size,
+        "AND query {query:?}: not enough hits — infino={infino_hits:?} oracle={oracle_hits:?}"
+    );
+    let infino_head: HashSet<u64> = infino_hits.into_iter().take(head_size).collect();
+    let oracle_head: HashSet<u64> = oracle_hits.into_iter().take(head_size).collect();
+    assert_eq!(
+        infino_head, oracle_head,
+        "AND query {query:?}: top-{head_size} sets disagree"
+    );
+}
+
+#[test]
+fn oracle_and_two_term_overlap_top3_matches() {
+    // "rust" and "async" co-occur only in docs 0, 20, 22. Both engines
+    // must return exactly that set as the AND result.
+    let corp = corpus();
+    let infino = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    let infino_set: HashSet<u64> = infino_top_k_and(&infino, "rust async", 10).into_iter().collect();
+    assert_eq!(
+        infino_set,
+        HashSet::from([0u64, 20, 22]),
+        "AND(rust, async) must be exactly {{0, 20, 22}}; got {infino_set:?}"
+    );
+    assert_top_k_and_set_matches(&infino, &oracle, "rust async", 3, 10);
+}
+
+#[test]
+fn oracle_and_three_term_singleton_match() {
+    // "rust async tokio" all co-occur only in doc 0. Tightens the
+    // intersection to one doc and verifies the leapfrog over three
+    // cursors reduces correctly.
+    let corp = corpus();
+    let infino = build_infino_superfile(&corp);
+    let infino_hits = infino_top_k_and(&infino, "rust async tokio", 10);
+    assert_eq!(
+        infino_hits, vec![0u64],
+        "AND(rust, async, tokio) must be exactly [0]; got {infino_hits:?}"
+    );
+}
+
+#[test]
+fn oracle_and_missing_term_returns_empty() {
+    // A term that's absent from the entire corpus must short-circuit
+    // AND to empty — even though "rust" alone has many hits.
+    let corp = corpus();
+    let infino = build_infino_superfile(&corp);
+    let hits = infino_top_k_and(&infino, "rust definitely-not-a-token", 10);
+    assert!(
+        hits.is_empty(),
+        "AND with missing term must return []; got {hits:?}"
+    );
+}
+
+#[test]
+fn oracle_and_disjoint_terms_return_empty() {
+    // Two terms that both appear in the corpus but never co-occur
+    // ("python" in docs 2-3; "kafka" in doc 15). AND yields no docs.
+    let corp = corpus();
+    let infino = build_infino_superfile(&corp);
+    let hits = infino_top_k_and(&infino, "python kafka", 10);
+    assert!(
+        hits.is_empty(),
+        "AND with disjoint posting lists must return []; got {hits:?}"
+    );
+}
+
+#[test]
+fn oracle_and_scores_match_brute_force_ordering() {
+    // For docs in the AND intersection of "rust" and "framework"
+    // (only doc 8), the per-doc BM25 score must match brute force
+    // bit-exactly — there's no rank ambiguity, so we can compare
+    // values directly.
+    let corp = corpus();
+    let infino = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    let mut terms: Vec<String> = Vec::new();
+    use infino::superfile::fts::tokenize::Tokenizer as _;
+    tok.tokenize_each("rust framework", &mut |t| terms.push(t.to_owned()));
+
+    let infino_hits: Vec<(u64, f32)> = infino
+        .bm25_search("title", "rust framework", 10, BoolMode::And)
+        .expect("AND search")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    let oracle_hits = oracle.top_k_terms_and(&terms, 10);
+    assert_eq!(
+        infino_hits.len(),
+        oracle_hits.len(),
+        "AND(rust, framework) hit counts disagree: infino={infino_hits:?} oracle={oracle_hits:?}"
+    );
+    for ((i_doc, i_score), (o_doc, o_score)) in infino_hits.iter().zip(oracle_hits.iter()) {
+        assert_eq!(*i_doc, *o_doc, "doc-id mismatch");
+        // f32 BM25 sums diverge by ~1e-4 between the two scorers due
+        // to operand ordering (infino precomputes idf_x_k1p1 and
+        // dl_norm_k1; the oracle multiplies term-by-term). 1e-3 is
+        // tighter than any meaningful BM25 score gap on this corpus.
+        let delta = (i_score - o_score).abs();
+        assert!(
+            delta < 1e-3,
+            "score divergence on doc {i_doc}: infino={i_score} oracle={o_score} delta={delta}"
+        );
+    }
+}
+
+#[test]
+fn oracle_and_single_term_routed_consistently() {
+    // BoolMode::And with a single term must route the same as
+    // BoolMode::Or (both fall through to the single-term BMW path).
+    // Asserting symmetry catches the case where AND's branch
+    // accidentally skips the early single-term short-circuit.
+    let corp = corpus();
+    let infino = build_infino_superfile(&corp);
+    let and_hits = infino_top_k_and(&infino, "rare-token-zzz", 5);
+    let or_hits = infino_top_k(&infino, "rare-token-zzz", 5);
+    assert_eq!(and_hits, or_hits);
+    assert_eq!(and_hits, vec![17u64]);
+}
+
+// ─── (resume existing OR oracles) ─────────────────────────────────────
+
 #[test]
 fn oracle_long_doc_vs_short_doc_dl_norm() {
     // BM25's dl-norm should make short docs that contain a term rank

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -191,6 +191,19 @@ fn supertable_search_global(st: &Supertable, query: &str, k: usize, chunk_size: 
     supertable_to_global_ids(st, hits, chunk_size)
 }
 
+fn supertable_search_and_global(
+    st: &Supertable,
+    query: &str,
+    k: usize,
+    chunk_size: usize,
+) -> Vec<u64> {
+    let r = st.reader();
+    let hits = r
+        .bm25_search("title", query, k, BoolMode::And)
+        .expect("supertable bm25 AND");
+    supertable_to_global_ids(st, hits, chunk_size)
+}
+
 fn supertable_prefix_global(
     st: &Supertable,
     prefix: &str,
@@ -230,6 +243,27 @@ fn brute_force_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> Vec<u
     let mut all: Vec<(u64, f32)> = Vec::new();
     for o in oracles {
         all.extend(o.top_k(query, k, tok.as_ref()));
+    }
+    all.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0))
+    });
+    all.truncate(k);
+    all.into_iter().map(|(d, _)| d).collect()
+}
+
+/// Same as [`brute_force_top_k`] but for a multi-term explicit
+/// AND query. Each segment scores its AND intersection
+/// independently; the global merge keeps the highest-scoring docs
+/// across segments. Mirrors the supertable's AND fan-out shape.
+fn brute_force_and_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> Vec<u64> {
+    let tok = default_tokenizer();
+    let mut terms: Vec<String> = Vec::new();
+    tok.tokenize_each(query, &mut |t| terms.push(t.to_owned()));
+    let mut all: Vec<(u64, f32)> = Vec::new();
+    for o in oracles {
+        all.extend(o.top_k_terms_and(&terms, k));
     }
     all.sort_by(|a, b| {
         b.1.partial_cmp(&a.1)
@@ -362,6 +396,55 @@ fn oracle_five_term_or_top5_matches() {
     let ora_top: HashSet<u64> = ora_hits.iter().take(5).copied().collect();
     assert_eq!(inf_top, want);
     assert_eq!(ora_top, want);
+}
+
+// ---- Tests: AND-mode oracle (multi-segment intersection) ------------
+
+#[test]
+fn oracle_two_term_and_matches() {
+    // "rust" + "async" co-occur in docs 0, 20, 22 — split across
+    // segments 0 (doc 0) and 1 (docs 20, 22), so this exercises
+    // multi-segment AND fan-out.
+    let f = &*STANDARD_FIXTURE;
+    let inf_hits = supertable_search_and_global(&f.infino, "rust async", 10, CHUNK_SIZE);
+    let ora_hits = brute_force_and_top_k(&f.oracles, "rust async", 10);
+    let want: HashSet<u64> = [0u64, 20, 22].into_iter().collect();
+    let inf_set: HashSet<u64> = inf_hits.iter().copied().collect();
+    let ora_set: HashSet<u64> = ora_hits.iter().copied().collect();
+    assert_eq!(inf_set, want, "supertable AND={inf_hits:?}");
+    assert_eq!(ora_set, want, "oracle AND={ora_hits:?}");
+}
+
+#[test]
+fn oracle_three_term_and_singleton_match() {
+    // "rust" + "async" + "tokio" intersect only at doc 0 (segment 0).
+    let f = &*STANDARD_FIXTURE;
+    let inf_hits = supertable_search_and_global(&f.infino, "rust async tokio", 10, CHUNK_SIZE);
+    assert_eq!(inf_hits, vec![0u64], "got {inf_hits:?}");
+}
+
+#[test]
+fn oracle_and_missing_term_returns_empty() {
+    // A globally absent term must short-circuit AND to empty even
+    // when the other term has many hits.
+    let f = &*STANDARD_FIXTURE;
+    let inf_hits = supertable_search_and_global(&f.infino, "rust definitelynotpresent", 10, CHUNK_SIZE);
+    assert!(inf_hits.is_empty(), "got {inf_hits:?}");
+}
+
+#[test]
+fn oracle_and_segment_locally_missing_term_still_intersects_elsewhere() {
+    // "rust" + "kafka" — "rust" appears in every segment, but
+    // "kafka" only appears in doc 15 (segment 1) where "rust" does
+    // not co-occur. The intersection is empty across the whole
+    // table, but the test confirms that segments with the missing
+    // term contribute nothing and segments without the missing term
+    // also contribute nothing.
+    let f = &*STANDARD_FIXTURE;
+    let inf_hits = supertable_search_and_global(&f.infino, "rust kafka", 10, CHUNK_SIZE);
+    let ora_hits = brute_force_and_top_k(&f.oracles, "rust kafka", 10);
+    assert!(inf_hits.is_empty(), "supertable AND must be empty; got {inf_hits:?}");
+    assert!(ora_hits.is_empty(), "oracle AND must be empty; got {ora_hits:?}");
 }
 
 // ---- Tests: prefix-row exercise ---------------------------------------


### PR DESCRIPTION
## Summary

- Multi-term AND queries now use a leapfrog intersection over the existing TermCursor skip table instead of full-decoding every term's posting list and intersecting via HashMap. The smallest-df cursor leads; the others jump with `skip_to(candidate)` and bump the candidate when they land past it.
- AND result at 1M docs, single superfile:

| Shape | Before | After | Speedup |
|---|---|---|---|
| `two_term_and` | 27.0 ms | **4.4 ms** | 6.1× |
| `three_wide_and` | 19.3 ms | **3.3 ms** | 5.8× |
| `three_similar_and` | 14.1 ms | **4.6 ms** | 3.1× |
| `five_term_and` | 18.7 ms | **5.1 ms** | 3.7× |

- `top_k_terms_and` added to `BruteForceBm25`; 6 new superfile oracles + 4 new supertable oracles cover overlap, singleton intersection, missing term short-circuit, disjoint lists, score tolerance, and multi-segment fan-out.
- Now-dead helpers (`doc_len`, `decode_term_postings`, `other_idx`) removed.
- README refreshed in place via `INFINO_BENCH_UPDATE_README=1`.

## Test plan

- [x] `cargo test --lib` (513 passing).
- [x] `cargo test --test superfile -- brute_force_oracle` (20 passing incl. 6 new AND).
- [x] `cargo test --test supertable -- brute_force_oracle` (14 passing incl. 4 new AND).
- [x] `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- superfile_fts_search` confirms the AND speedup and refreshes the README.