### PR TITLE
test: stabilize commit::stats RSS readings under parallel exec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,17 @@ memmap2 = "0.9"
 # Mach task_info on macOS / /proc/self/statm on Linux. We
 # read it once per `stats()` call (cheap syscall) so the
 # observability hook stays allocation-free on the hot path.
-memory-stats = "1.2"
+#
+# `always_use_statm` forces the Linux path to read
+# /proc/self/statm instead of the default /proc/self/smaps.
+# smaps is a multi-page file whose contents the kernel
+# regenerates per-read by walking the process's VMA list;
+# under heavy concurrent allocation (e.g. cargo's parallel
+# test execution) the read can return a partial / malformed
+# buffer, parsing zero `Rss:` lines and surfacing as
+# `physical_mem = 0`. statm is one line of fixed-format
+# integers and doesn't suffer the same race.
+memory-stats = { version = "1.2", features = ["always_use_statm"] }
 
 # Advisory file locks for the LocalFs pointer-rename window
 # (003 D4). The LocalFs `put_if_match` is implemented as

--- a/tests/supertable/commit/stats.rs
+++ b/tests/supertable/commit/stats.rs
@@ -124,27 +124,50 @@ async fn stats_show_manifest_parts_when_storage_attached() {
 #[test]
 fn process_rss_bytes_matches_independent_reading_within_pct() {
     // Both stats() and memory-stats::memory_stats() read the
-    // same OS-reported RSS via the same crate, so the values
-    // are expected to be extremely close (taken back-to-back).
-    // The ±10% bound is generous slack to absorb in-between
-    // allocations from rayon worker bring-up + tokio runtime
-    // initialization on the very first call.
+    // same OS-reported RSS via the same crate, so back-to-back
+    // calls should match closely. Under parallel cargo-test
+    // execution, however, RSS is whole-process and drifts
+    // because *other* tests on the same binary are allocating
+    // concurrently — a fixed ±10% bound on a single independent
+    // reading is not robust to that drift.
+    //
+    // Sandwich the stats() reading between two independent
+    // reads, then bound stats() by [min(i1, i2), max(i1, i2)]
+    // expanded by the natural drift between i1 and i2 plus a
+    // small absolute slack for short-lived intra-syscall
+    // allocations. This makes the tolerance self-calibrating to
+    // whatever concurrent allocator activity the process is
+    // experiencing during the test run.
     let st = Supertable::create(default_supertable_options());
-    let s1 = st.stats();
-    let independent = memory_stats::memory_stats()
-        .map(|m| m.physical_mem as u64)
-        .expect("RSS available");
 
-    assert!(s1.process_rss_bytes > 0);
-    assert!(independent > 0);
+    let read = || {
+        memory_stats::memory_stats()
+            .map(|m| m.physical_mem as u64)
+            .expect("RSS available")
+    };
 
-    let lo = independent.saturating_sub(independent / 10);
-    let hi = independent.saturating_add(independent / 10);
+    let i1 = read();
+    let s = st.stats().process_rss_bytes;
+    let i2 = read();
+
+    assert!(s > 0, "stats.process_rss_bytes must be non-zero");
     assert!(
-        s1.process_rss_bytes >= lo && s1.process_rss_bytes <= hi,
-        "stats.process_rss_bytes={} not within ±10% of independent reading={}",
-        s1.process_rss_bytes,
-        independent
+        i1 > 0 && i2 > 0,
+        "independent RSS readings must be non-zero"
+    );
+
+    // Slack = the drift observed between i1 and i2 (concurrent
+    // process activity) + 64 MiB absolute floor for in-between
+    // allocations the test thread itself may incur.
+    const ABS_SLACK_BYTES: u64 = 64 * 1024 * 1024;
+    let drift = i1.abs_diff(i2);
+    let slack = drift.saturating_add(ABS_SLACK_BYTES);
+    let lo = i1.min(i2).saturating_sub(slack);
+    let hi = i1.max(i2).saturating_add(slack);
+    assert!(
+        s >= lo && s <= hi,
+        "stats.process_rss_bytes={s} outside [{lo}, {hi}] \
+         (independent reads: {i1}, {i2}; drift={drift}, slack={slack})"
     );
 }
 


### PR DESCRIPTION
Two flakes in tests/supertable/commit/stats.rs surfaced under cargo's default parallel test execution; both root-caused to /proc/self/smaps behavior on Linux + a too-tight tolerance.

  1. memory-stats v1.2 reads /proc/self/smaps by default (despite our Cargo.toml comment claiming statm). smaps is a multi-page file that the kernel regenerates per-read by walking the process's VMA list; under heavy concurrent allocation (cargo running other tests on the same binary) the read can return a partial buffer, parsing zero `Rss:` lines and surfacing as physical_mem = 0, which trips the > 0 assertions in two stats tests. Enabling the crate's `always_use_statm` feature pins the Linux path to /proc/self/statm — one line of fixed-format integers, no parser race. Cargo.toml comment also corrected to match reality.

  2. process_rss_bytes_matches_independent_reading_within_pct compared stats() against a single independent reading with a fixed ±10% tolerance. Whole-process RSS drifts under parallel test execution because *other* tests are allocating concurrently. Sandwich the stats() reading between two independent reads and bound it by [min, max] of those reads + the natural drift between them + 64 MiB absolute slack. Self-calibrating to whatever concurrent allocator pressure the run sees.

Stress-tested at 200 iterations of `commit::stats` filter (all 8 tests in parallel): 0/200 failures with both fixes; before, ~5-15% of runs failed with one or the other root cause.