### PR TITLE
Add rerank codecs for vectors

### DIFF
--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -42,6 +42,7 @@ use infino::superfile::fts::builder::FtsBuilder;
 use infino::superfile::vector::builder::{VectorBuilder, VectorConfig};
 use infino::superfile::vector::distance::{Metric, normalize};
 use infino::superfile::vector::reader::{OpenOptions, VectorReader};
+use infino::superfile::vector::rerank_codec::RerankCodec;
 use infino::test_helpers::default_tokenizer;
 
 // ─── Scale constants ──────────────────────────────────────────────────
@@ -579,6 +580,14 @@ pub fn build_fts_index(docs: &[String]) -> FtsBuilder {
 }
 
 /// Build a stand-alone vector index. `vectors` is flat `n_docs * DIM`.
+///
+/// Bench harness picks `Sq8` by default to match the on-disk
+/// default for production segments. Per-cluster scale/offset
+/// quantizer is the active codec (drop ≤ 0.04 on the
+/// pathological planted-cluster synthetic; expected near-zero on
+/// real embeddings). Callers measuring the Fp32 baseline (recall
+/// oracles, bit-exact regression tests) construct their own
+/// `VectorConfig` with `RerankCodec::Fp32`.
 pub fn build_vector_index(
     vectors: &[f32],
     n_docs: usize,
@@ -592,6 +601,7 @@ pub fn build_vector_index(
         n_cent,
         rot_seed: 7,
         metric,
+        rerank_codec: RerankCodec::Sq8,
     })
     .expect("register column");
     for i in 0..n_docs {
@@ -636,6 +646,7 @@ pub fn build_superfile(docs: &[String], vectors: &[f32], n_cent: usize) -> Vec<u
             n_cent,
             rot_seed: 7,
             metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Sq8,
         }],
         Some(default_tokenizer()),
     );

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -596,7 +596,7 @@ pub fn build_vector_index(
 ) -> VectorBuilder {
     let mut b = VectorBuilder::new();
     b.register_column(VectorConfig {
-        name: "v".into(),
+        column: "v".into(),
         dim: DIM,
         n_cent,
         rot_seed: 7,
@@ -621,7 +621,7 @@ pub fn open_vector_reader(blob: Vec<u8>, n_cent: usize, metric: Metric) -> Vecto
         Metric::NegDot => "negdot",
     };
     let json = format!(
-        r#"[{{"name":"v","dim":{DIM},"n_cent":{n_cent},"rot_seed":7,"metric":"{metric_str}"}}]"#
+        r#"[{{"column":"v","dim":{DIM},"n_cent":{n_cent},"rot_seed":7,"metric":"{metric_str}"}}]"#
     );
     VectorReader::open_with(Bytes::from(blob), &json, OpenOptions { verify_crc: true })
         .expect("open VectorReader")

--- a/benches/utils/vector_superfile.rs
+++ b/benches/utils/vector_superfile.rs
@@ -116,7 +116,7 @@ fn build_infino_blob(vectors: &[f32]) -> Vec<u8> {
 fn open_infino_reader(blob: Vec<u8>) -> VectorReader {
     let n_cent = corpus::n_cent(N_DOCS);
     let json =
-        format!(r#"[{{"name":"v","dim":{DIM},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#);
+        format!(r#"[{{"column":"v","dim":{DIM},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#);
     VectorReader::open_with(Bytes::from(blob), &json, OpenOptions { verify_crc: true })
         .expect("open VectorReader")
 }

--- a/benches/utils/vector_supertable.rs
+++ b/benches/utils/vector_supertable.rs
@@ -136,6 +136,7 @@ fn build_supertable() -> Supertable {
             n_cent: n_cent_per_segment,
             rot_seed: 7,
             metric: Metric::Cosine,
+            rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8,
         }],
         None,
     )

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -82,7 +82,10 @@ use crate::superfile::format::footer::{ParquetParts, write_parquet_with_blobs};
 use crate::superfile::format::{self, kv};
 use crate::superfile::fts::builder::FtsBuilder;
 use crate::superfile::fts::tokenize::Tokenizer;
-use crate::superfile::vector::builder::{VectorBuilder, VectorConfig as VecBuildConfig};
+use crate::superfile::vector::builder::VectorBuilder;
+// `VectorConfig` lives in `vector::builder` and is re-exported below
+// (single source of truth post-collapse — see the `pub use` line).
+pub use crate::superfile::vector::builder::VectorConfig;
 use crate::superfile::vector::distance::Metric;
 use arrow_array::{Array, RecordBatch};
 use arrow_schema::{DataType, Schema};
@@ -96,19 +99,11 @@ pub struct FtsConfig {
     pub column: String,
 }
 
-/// Per-column vector configuration. Mirrors the inner
-/// [`VecBuildConfig`] but uses `column` to match the FTS naming for
-/// API consistency at the superfile level.
-#[derive(Clone)]
-pub struct VectorConfig {
-    pub column: String,
-    pub dim: usize,
-    pub n_cent: usize,
-    pub rot_seed: u64,
-    pub metric: Metric,
-    /// On-disk rerank codec. Defaults to [`RerankCodec::Sq8`].
-    pub rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec,
-}
+// `VectorConfig` (the per-column vector config used by
+// `BuilderOptions.vector_columns`) lives in
+// `crate::superfile::vector::builder` and is re-exported at this
+// module path above. Single source of truth — there's no outer
+// wrapper struct.
 
 /// All knobs needed to build a superfile.
 pub struct BuilderOptions {
@@ -336,14 +331,10 @@ impl SuperfileBuilder {
         } else {
             let mut vb = VectorBuilder::new();
             for vc in &opts.vector_columns {
-                vb.register_column(VecBuildConfig {
-                    name: vc.column.clone(),
-                    dim: vc.dim,
-                    n_cent: vc.n_cent,
-                    rot_seed: vc.rot_seed,
-                    metric: vc.metric,
-                    rerank_codec: vc.rerank_codec,
-                })?;
+                // VectorConfig is now the same type at both layers
+                // (re-exported from vector::builder), so the manual
+                // field-by-field bridge is gone — just clone.
+                vb.register_column(vc.clone())?;
             }
             Some(vb)
         };
@@ -548,7 +539,7 @@ fn fts_columns_json(cols: &[FtsConfig]) -> String {
 /// `Serialize` needed.
 ///
 /// Output shape per column:
-/// `{"name":"<escaped>","dim":<u>,"n_cent":<u>,"rot_seed":<u>,"metric":"<l2sq|cosine|negdot>"}`.
+/// `{"column":"<escaped>","dim":<u>,"n_cent":<u>,"rot_seed":<u>,"metric":"<l2sq|cosine|negdot>"}`.
 /// The reader at open time parses this back into
 /// `VectorConfig` to drive distance kernels + IVF probing.
 fn vec_columns_json(cols: &[VectorConfig]) -> String {
@@ -557,7 +548,7 @@ fn vec_columns_json(cols: &[VectorConfig]) -> String {
         if i > 0 {
             s.push(',');
         }
-        s.push_str(r#"{"name":""#);
+        s.push_str(r#"{"column":""#);
         s.push_str(&escape_json(&c.column));
         s.push_str(r#"","dim":"#);
         s.push_str(&c.dim.to_string());
@@ -951,7 +942,7 @@ mod tests {
             rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
         }];
         let s = vec_columns_json(&cols);
-        assert!(s.contains(r#""name":"emb""#));
+        assert!(s.contains(r#""column":"emb""#));
         assert!(s.contains(r#""dim":384"#));
         assert!(s.contains(r#""n_cent":64"#));
         assert!(s.contains(r#""rot_seed":99"#));

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -106,6 +106,8 @@ pub struct VectorConfig {
     pub n_cent: usize,
     pub rot_seed: u64,
     pub metric: Metric,
+    /// On-disk rerank codec. Defaults to [`RerankCodec::Sq8`].
+    pub rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec,
 }
 
 /// All knobs needed to build a superfile.
@@ -340,6 +342,7 @@ impl SuperfileBuilder {
                     n_cent: vc.n_cent,
                     rot_seed: vc.rot_seed,
                     metric: vc.metric,
+                    rerank_codec: vc.rerank_codec,
                 })?;
             }
             Some(vb)
@@ -945,6 +948,7 @@ mod tests {
             n_cent: 64,
             rot_seed: 99,
             metric: Metric::L2Sq,
+            rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
         }];
         let s = vec_columns_json(&cols);
         assert!(s.contains(r#""name":"emb""#));

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -36,6 +36,16 @@ pub enum BuildError {
     #[error("vector column {column:?} declares dim={dim}; must be in [16, 4096]")]
     VectorDimOutOfRange { column: String, dim: usize },
 
+    /// The column requested a rerank codec that this build of infino
+    /// does not implement. Supported codecs today: `fp32`, `bf16`,
+    /// `sq8`, `none` (see
+    /// [`crate::superfile::vector::rerank_codec::RerankCodec`]).
+    #[error(
+        "vector column {column:?}: rerank codec {codec:?} is not supported; \
+         supported codecs are fp32, bf16, sq8, none"
+    )]
+    VectorRerankCodecUnimplemented { column: String, codec: &'static str },
+
     #[error(
         "vector column {column:?}: query/added vector dim {actual} does not match declared dim {expected}"
     )]

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -14,6 +14,7 @@ use crate::superfile::format::{self, FST_SEPARATOR, RESERVED_PREFIX};
 use crate::superfile::vector::distance::{Metric, l2_sq};
 use crate::superfile::vector::kmeans::{assign_to_centroids, kmeans};
 use crate::superfile::vector::quant::BitQuantizer;
+use crate::superfile::vector::rerank_codec::RerankCodec;
 use crate::superfile::vector::reservoir::{Reservoir, default_kmeans_sample_size};
 use crate::superfile::vector::rotation::RandomRotation;
 use crate::superfile::vector::spill::{
@@ -45,6 +46,14 @@ fn metric_id(m: Metric) -> u32 {
 }
 
 /// Per-column user-supplied build configuration.
+///
+/// Cloneable — `register_column` takes ownership of one copy
+/// and stores the field-wise data on the corresponding
+/// `ColumnState`; subsequent reads (e.g. for diagnostic
+/// emission) clone from the column to keep the type. Field
+/// additions go behind an `Option` or default so VectorConfig
+/// extensions across minor releases don't force a code change
+/// at the call site.
 #[derive(Debug, Clone)]
 pub struct VectorConfig {
     pub name: String,
@@ -52,6 +61,32 @@ pub struct VectorConfig {
     pub n_cent: usize,
     pub rot_seed: u64,
     pub metric: Metric,
+    /// On-disk rerank codec for this column. See [`RerankCodec`]
+    /// for the supported codecs and their size/recall trade-offs.
+    pub rerank_codec: RerankCodec,
+}
+
+impl VectorConfig {
+    /// Construct a config with the default rerank codec
+    /// ([`RerankCodec::default()`]). Use the `with_*` setters to
+    /// override individual fields.
+    pub fn new(name: String, dim: usize, n_cent: usize, rot_seed: u64, metric: Metric) -> Self {
+        Self {
+            name,
+            dim,
+            n_cent,
+            rot_seed,
+            metric,
+            rerank_codec: RerankCodec::default(),
+        }
+    }
+
+    /// Override the rerank codec.
+    #[must_use]
+    pub fn with_rerank_codec(mut self, codec: RerankCodec) -> Self {
+        self.rerank_codec = codec;
+        self
+    }
 }
 
 /// Default spill threshold: total bytes the in-memory pre-spill
@@ -223,6 +258,12 @@ impl VectorBuilder {
         }
         if self.columns.iter().any(|c| c.config.name == config.name) {
             return Err(BuildError::DuplicateColumnName(config.name));
+        }
+        if !config.rerank_codec.is_implemented() {
+            return Err(BuildError::VectorRerankCodecUnimplemented {
+                column: config.name.clone(),
+                codec: config.rerank_codec.name(),
+            });
         }
         let column_id = self.columns.len() as u32;
         let sample_size = default_kmeans_sample_size(config.n_cent);
@@ -428,6 +469,11 @@ impl VectorBuilder {
             directory_offset + directory_size as u64 + 4 /* dir CRC */;
 
         // 3. Assemble directory entries with absolute offsets.
+        //    Byte 52 of each 64-byte entry carries the rerank-codec
+        //    discriminator; bytes 53..56 stay reserved. Existing fp32
+        //    segments had all-zero bytes here, which maps to
+        //    `RerankCodec::Fp32` (`codec_id() = 0`) and round-trips
+        //    identically.
         let mut directory: Vec<u8> = Vec::with_capacity(directory_size);
         for (i, sub) in subsections.iter().enumerate() {
             let (cfg, _) = &column_configs[i];
@@ -441,7 +487,9 @@ impl VectorBuilder {
             directory.extend_from_slice(&(sub.bytes.len() as u64).to_le_bytes()); // subsection_length (8)
             directory.extend_from_slice(&summary_offset_abs.to_le_bytes()); // summary_offset (8)
             directory.extend_from_slice(&((cfg.dim * 4) as u32).to_le_bytes()); // summary_length (4)
-            directory.extend_from_slice(&0u32.to_le_bytes()); // reserved (4)
+            // bytes 52..56 — codec_id (1) + reserved (3)
+            directory.push(cfg.rerank_codec.codec_id()); // codec_id (1)
+            directory.extend_from_slice(&[0u8; 3]); // reserved (3)
             directory.extend_from_slice(&0u64.to_le_bytes()); // future_reserved (8)
             debug_assert_eq!(directory.len() % DIR_ENTRY_SIZE, 0);
 
@@ -695,6 +743,7 @@ fn build_subsection_streaming(
             &mut bucket_writers,
             &mut bucket_counts,
             &mut summary_radius_sq_max,
+            cfg.rerank_codec,
         )?;
     }
 
@@ -716,15 +765,24 @@ fn build_subsection_streaming(
 
     // ---- Pass 3: read each bucket sequentially, materialise the
     // cluster-contiguous regions and the cluster index ----
+    //
+    // `RerankCodec::None` segments have no `full[]` region on disk
+    // and pass 2 did not spill the fp32 vectors at all, so we skip the
+    // `full_layout` allocation and the per-row `full_vec` read.
+    let codec = cfg.rerank_codec;
+    let has_full = !matches!(codec, RerankCodec::None);
     let mut codes_layout = vec![0u8; n_docs * code_bytes];
-    let mut full_layout = vec![0f32; n_docs * dim];
+    let mut full_layout: Vec<f32> = if has_full {
+        vec![0f32; n_docs * dim]
+    } else {
+        Vec::new()
+    };
     let mut doc_ids_layout = vec![0u32; n_docs];
     let mut cluster_index: Vec<(u32, u32)> = Vec::with_capacity(n_cent);
     let mut write_cursor: usize = 0;
-    // For each bucket file, read each row's three fields
-    // (`doc_id`, `code`, `full_vec`) directly into their
-    // destination slots in the cluster-contiguous layout arrays.
-    // Reading each field into its destination avoids the
+    // For each bucket file, read each row's fields directly into
+    // their destination slots in the cluster-contiguous layout
+    // arrays. Reading each field into its destination avoids the
     // alignment trap of a single `row_buf: Vec<u8>` cast (the
     // `full_vec` field starts at offset `4 + code_bytes` which is
     // not 4-aligned for the common dim=16/code_bytes=2 case).
@@ -746,20 +804,27 @@ fn build_subsection_streaming(
             let dst_code =
                 &mut codes_layout[write_cursor * code_bytes..(write_cursor + 1) * code_bytes];
             reader.read_exact(dst_code)?;
-            let dst_full = &mut full_layout[write_cursor * dim..(write_cursor + 1) * dim];
-            let dst_full_bytes: &mut [u8] = bytemuck::cast_slice_mut(dst_full);
-            reader.read_exact(dst_full_bytes)?;
+            if has_full {
+                let dst_full = &mut full_layout[write_cursor * dim..(write_cursor + 1) * dim];
+                let dst_full_bytes: &mut [u8] = bytemuck::cast_slice_mut(dst_full);
+                reader.read_exact(dst_full_bytes)?;
+            }
             write_cursor += 1;
         }
     }
     debug_assert_eq!(write_cursor, n_docs);
 
-    // 6. Build the subsection bytes.
+    // 6. Build the subsection bytes. Each codec contributes an
+    // optional `codec_meta` region between `codes` and `full`. `None`
+    // zeroes out both `codec_meta` and `full[]`, so the segment shrinks
+    // to summary + centroids + cluster_idx + codes + doc_ids.
+    let codec = cfg.rerank_codec;
     let summary_size = dim * 4;
     let centroids_size = n_cent * dim * 4;
     let cluster_idx_size = n_cent * 8;
     let codes_size = n_docs * code_bytes;
-    let full_size = n_docs * dim * 4;
+    let codec_meta_size = codec.codec_meta_bytes(dim, n_docs, n_cent, cfg.metric);
+    let full_size = codec.per_vector_bytes(dim) * n_docs;
     let doc_ids_size = n_docs * 4;
 
     // Offsets relative to subsection start.
@@ -767,7 +832,17 @@ fn build_subsection_streaming(
     let centroids_off = summary_off + summary_size;
     let cluster_idx_off = centroids_off + centroids_size;
     let codes_off = cluster_idx_off + cluster_idx_size;
-    let full_off = codes_off + codes_size;
+    // `codec_meta_off` is the on-disk slot in the sub-header for
+    // the codec metadata region's start. Zero means "no codec
+    // metadata in this subsection" — `Fp32` segments and legacy fp32
+    // segments write 0 here and stay
+    // byte-identical.
+    let codec_meta_off_value: u32 = if codec_meta_size == 0 {
+        0
+    } else {
+        (codes_off + codes_size) as u32
+    };
+    let full_off = codes_off + codes_size + codec_meta_size;
     // doc_ids start at full_off + full_size; not stored explicitly in the sub-header.
 
     let total_size_before_crc = SUB_HEADER_SIZE
@@ -775,15 +850,27 @@ fn build_subsection_streaming(
         + centroids_size
         + cluster_idx_size
         + codes_size
+        + codec_meta_size
         + full_size
         + doc_ids_size;
 
     let mut bytes: Vec<u8> = Vec::with_capacity(total_size_before_crc + 4);
 
     // Sub-header (56 bytes).
+    //   [0..8]   SUB_MAGIC
+    //   [8..12]  VERSION
+    //   [12..16] codec_meta_off (former reserved slot; zero for Fp32
+    //            and legacy fp32 segments).
+    //   [16..24] summary_centroid_offset
+    //   [24..28] summary_radius_x100
+    //   [28..32] reserved (4)
+    //   [32..40] centroids_off
+    //   [40..48] cluster_idx_off
+    //   [48..52] codes_off
+    //   [52..56] full_off
     bytes.extend_from_slice(format::vec::SUB_MAGIC); // 8
     bytes.extend_from_slice(&format::vec::VERSION.to_le_bytes()); // 4
-    bytes.extend_from_slice(&0u32.to_le_bytes()); // reserved (4)
+    bytes.extend_from_slice(&codec_meta_off_value.to_le_bytes()); // codec_meta_off (4)
     bytes.extend_from_slice(&(summary_off as u64).to_le_bytes()); // summary_centroid_offset (8)
     bytes.extend_from_slice(&summary_radius_x100.to_le_bytes()); // 4
     bytes.extend_from_slice(&0u32.to_le_bytes()); // reserved (4)
@@ -804,8 +891,66 @@ fn build_subsection_streaming(
     }
     // Codes.
     bytes.extend_from_slice(&codes_layout);
-    // Full.
-    bytes.extend_from_slice(bytemuck::cast_slice(&full_layout));
+
+    // Codec metadata region + full[] vector region — codec-
+    // dependent shape. The two are written together because Sq8
+    // needs the scale/offset arrays *before* it can encode u8
+    // codes, and it computes them from the same single pass over
+    // `full_layout` that does the encode.
+    //
+    //   Fp32: empty codec_meta; full[] is the fp32 buffer byte-
+    //         for-byte (matches legacy fp32 segments).
+    //   Bf16: empty codec_meta; full[] is each fp32 encoded to
+    //         bf16 via round-to-nearest-even (`fp32_to_bf16`).
+    //         Halves disk footprint with bounded relative error
+    //         ≤ 2⁻⁸ per lane.
+    //   Sq8:  codec_meta = per-cluster `scale[n_cent × dim]` +
+    //         `offset[n_cent × dim]` + optional per-doc norms for
+    //         L2Sq. full[] is n_docs × dim u8 codes encoded against
+    //         the owning cluster's scale/offset.
+    //   None: empty codec_meta; empty full[]. The on-disk
+    //         layout collapses to `doc_ids` starting at
+    //         `full_off` (= codes_off + codes_size). Search
+    //         returns the 1-bit shortlist's top-K directly.
+    match codec {
+        RerankCodec::Fp32 => {
+            debug_assert_eq!(codec_meta_size, 0);
+            bytes.extend_from_slice(bytemuck::cast_slice(&full_layout));
+        }
+        RerankCodec::Bf16 => {
+            debug_assert_eq!(codec_meta_size, 0);
+            bytes.reserve(full_layout.len() * 2);
+            for &x in &full_layout {
+                let bf = crate::superfile::vector::distance::fp32_to_bf16(x);
+                bytes.extend_from_slice(&bf.to_le_bytes());
+            }
+        }
+        RerankCodec::Sq8 => {
+            let bytes_before_meta = bytes.len();
+            write_sq8_codec_meta_and_codes(
+                &mut bytes,
+                &full_layout,
+                dim,
+                n_docs,
+                n_cent,
+                &cluster_index,
+                cfg.metric,
+            );
+            // Layout invariant: codec_meta_size + full_size bytes
+            // appended (pass 2 / pass 3 contract). Cheap to keep
+            // since the writer is the only producer of these regions.
+            debug_assert_eq!(bytes.len() - bytes_before_meta, codec_meta_size + full_size);
+        }
+        RerankCodec::None => {
+            // No codec_meta, no full[] — both regions are zero-
+            // length for `None`. `doc_ids` (appended next) starts
+            // exactly at `full_off` (= codes_off + codes_size),
+            // which is what the reader expects when it parses a
+            // `None` column.
+            debug_assert_eq!(codec_meta_size, 0);
+            debug_assert_eq!(full_size, 0);
+        }
+    }
     // Doc IDs.
     bytes.extend_from_slice(bytemuck::cast_slice(&doc_ids_layout));
     debug_assert_eq!(bytes.len(), total_size_before_crc);
@@ -818,6 +963,210 @@ fn build_subsection_streaming(
         bytes,
         summary_offset_in_sub: summary_off,
     })
+}
+
+/// Scan one cluster's rows for per-dim min/max and derive the
+/// Sq8 quantizer `(scale[dim], offset[dim])` for that cluster.
+///
+/// Quantization scheme: `q = clamp(round((x − offset[d]) /
+/// scale[d]), 0, 255)`. With `offset[d] = min_x[d]` and
+/// `scale[d] = (max_x[d] − min_x[d]) / 255`, this maps the
+/// cluster's observed range onto the full u8 grid. When a dim
+/// is constant within the cluster (`max == min`) we set
+/// `scale = 1.0` and `offset = min` — every code in that dim
+/// lands at 0 and the decoder recovers the constant exactly.
+///
+/// Per-cluster (not per-column) quantizers preserve recall on
+/// highly-clustered cosine corpora; see
+/// `RerankCodec::codec_meta_bytes` for the per-column failure mode.
+///
+/// Parallel reduce over `cluster_rows.chunks(dim)` for n_rows
+/// ≥ 64; sequential fallback for smaller clusters where
+/// rayon's fork-join overhead would dominate.
+fn compute_sq8_quantizer_for_cluster(
+    cluster_rows: &[f32],
+    dim: usize,
+    n_rows: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    debug_assert_eq!(cluster_rows.len(), n_rows * dim);
+
+    let (min_vec, max_vec) = if n_rows == 0 {
+        // Empty cluster — emit an identity quantizer. No doc
+        // ever encodes through this slot, but the reader still
+        // reads `dim` floats of each from disk so we must write
+        // something well-defined. scale=1, offset=0 makes the
+        // decoder a no-op on the all-zero codes (which the
+        // builder also never emits) and keeps the codec_meta
+        // arrays free of NaN sentinels that would break the
+        // float bit-pattern equality used in some tests.
+        (vec![0.0f32; dim], vec![0.0f32; dim])
+    } else if n_rows < 64 {
+        let mut min_vec = cluster_rows[..dim].to_vec();
+        let mut max_vec = cluster_rows[..dim].to_vec();
+        for row in 1..n_rows {
+            for d in 0..dim {
+                let x = cluster_rows[row * dim + d];
+                if x < min_vec[d] {
+                    min_vec[d] = x;
+                }
+                if x > max_vec[d] {
+                    max_vec[d] = x;
+                }
+            }
+        }
+        (min_vec, max_vec)
+    } else {
+        cluster_rows
+            .par_chunks(dim)
+            .fold(
+                || (vec![f32::INFINITY; dim], vec![f32::NEG_INFINITY; dim]),
+                |(mut mn, mut mx), row| {
+                    for (d, &x) in row.iter().enumerate() {
+                        if x < mn[d] {
+                            mn[d] = x;
+                        }
+                        if x > mx[d] {
+                            mx[d] = x;
+                        }
+                    }
+                    (mn, mx)
+                },
+            )
+            .reduce(
+                || (vec![f32::INFINITY; dim], vec![f32::NEG_INFINITY; dim]),
+                |(mut a_min, mut a_max), (b_min, b_max)| {
+                    for d in 0..dim {
+                        if b_min[d] < a_min[d] {
+                            a_min[d] = b_min[d];
+                        }
+                        if b_max[d] > a_max[d] {
+                            a_max[d] = b_max[d];
+                        }
+                    }
+                    (a_min, a_max)
+                },
+            )
+    };
+
+    let mut scale = vec![0.0f32; dim];
+    let mut offset = vec![0.0f32; dim];
+    for d in 0..dim {
+        offset[d] = min_vec[d];
+        let span = max_vec[d] - min_vec[d];
+        scale[d] = if span > 0.0 { span / 255.0 } else { 1.0 };
+    }
+    (scale, offset)
+}
+
+/// Sq8 finalize step (per-cluster quantizer). For each IVF
+/// cluster, scans its rows to derive `(scale[dim], offset[dim])`,
+/// then quantizes those rows against their cluster's quantizer
+/// and writes:
+///
+///   codec_meta: scale[n_cent × dim]
+///               offset[n_cent × dim]
+///               per_doc_norms[n_docs]  (L2Sq only)
+///   full[]:     codes[n_docs × dim]    (u8)
+///
+/// The `cluster_index` array (provided by pass 3) gives each
+/// cluster's `(off, cnt)` in the cluster-contiguous
+/// `full_layout` — the same `off + i = pos` index that the
+/// shortlist carries, so per-doc norms stay indexed by `pos`
+/// regardless of which cluster the doc lives in.
+///
+/// For the `L2Sq` metric we cache per-doc
+/// `Σ_d (x_decoded[i,d])²` at encode time so the search-side
+/// distance kernel can skip recomputing it (one `dim` u8 widen
+/// + multiply pass per rerank candidate saved). Cosine + NegDot
+/// don't need per-doc norms (the `Σx²` term cancels out).
+///
+/// Per-cluster (not per-column) quantizer recovers recall on
+/// highly clustered cosine corpora; see
+/// `RerankCodec::codec_meta_bytes` doc for the failure-mode
+/// analysis that motivated the switch.
+#[allow(clippy::too_many_arguments)]
+fn write_sq8_codec_meta_and_codes(
+    bytes: &mut Vec<u8>,
+    full_layout: &[f32],
+    dim: usize,
+    n_docs: usize,
+    n_cent: usize,
+    cluster_index: &[(u32, u32)],
+    metric: Metric,
+) {
+    debug_assert_eq!(cluster_index.len(), n_cent);
+    debug_assert_eq!(full_layout.len(), n_docs * dim);
+
+    // ---- compute per-cluster quantizers ----
+    let mut scales = vec![0.0f32; n_cent * dim];
+    let mut offsets = vec![0.0f32; n_cent * dim];
+    for (c, &(off, cnt)) in cluster_index.iter().enumerate() {
+        let start = (off as usize) * dim;
+        let end = start + (cnt as usize) * dim;
+        let (sc, oc) =
+            compute_sq8_quantizer_for_cluster(&full_layout[start..end], dim, cnt as usize);
+        scales[c * dim..(c + 1) * dim].copy_from_slice(&sc);
+        offsets[c * dim..(c + 1) * dim].copy_from_slice(&oc);
+    }
+
+    // ---- write codec_meta scale + offset blocks ----
+    bytes.extend_from_slice(bytemuck::cast_slice(&scales));
+    bytes.extend_from_slice(bytemuck::cast_slice(&offsets));
+
+    // ---- encode codes against each doc's cluster quantizer ----
+    // codes is materialised once (n_docs × dim bytes) so the
+    // L2Sq norm computation rereads the exact bytes we'll write
+    // to disk — keeps the cached norm bit-consistent with what
+    // the search-side dequant reconstructs (no fp drift from a
+    // re-quantize against the original fp32 row).
+    let mut codes = vec![0u8; n_docs * dim];
+    for (c, &(off, cnt)) in cluster_index.iter().enumerate() {
+        if cnt == 0 {
+            continue;
+        }
+        let scale_c = &scales[c * dim..(c + 1) * dim];
+        let offset_c = &offsets[c * dim..(c + 1) * dim];
+        for i in 0..cnt as usize {
+            let row = (off as usize) + i;
+            let src = &full_layout[row * dim..(row + 1) * dim];
+            let dst = &mut codes[row * dim..(row + 1) * dim];
+            for d in 0..dim {
+                let q = ((src[d] - offset_c[d]) / scale_c[d]).round();
+                // Clamp to [0, 255]. Anything outside is a fp
+                // rounding artefact at the boundary; the clamp
+                // keeps the cast safe.
+                dst[d] = q.clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+
+    if matches!(metric, Metric::L2Sq) {
+        // Per-doc decoded-norm cache, indexed by pos. Each doc
+        // lives in exactly one cluster (the IVF assignment from
+        // pass 2); we look up the doc's cluster to know which
+        // scale/offset slice to dequant with.
+        let mut norms = vec![0.0f32; n_docs];
+        for (c, &(off, cnt)) in cluster_index.iter().enumerate() {
+            if cnt == 0 {
+                continue;
+            }
+            let scale_c = &scales[c * dim..(c + 1) * dim];
+            let offset_c = &offsets[c * dim..(c + 1) * dim];
+            for i in 0..cnt as usize {
+                let row = (off as usize) + i;
+                let code = &codes[row * dim..(row + 1) * dim];
+                let mut acc = 0.0f64;
+                for d in 0..dim {
+                    let x = (code[d] as f32) * scale_c[d] + offset_c[d];
+                    acc += (x as f64) * (x as f64);
+                }
+                norms[row] = acc as f32;
+            }
+        }
+        bytes.extend_from_slice(bytemuck::cast_slice(&norms));
+    }
+
+    bytes.extend_from_slice(&codes);
 }
 
 /// Pass 2 of `build_subsection_streaming`: walk the input
@@ -843,6 +1192,7 @@ fn run_pass2(
     bucket_writers: &mut [BufWriter<File>],
     bucket_counts: &mut [u32],
     summary_radius_sq_max: &mut f32,
+    codec: RerankCodec,
 ) -> Result<(), BuildError> {
     let chunk_rows_cap = source.chunk_rows();
     // Pre-allocate per-chunk scratch reused across iterations to
@@ -897,19 +1247,20 @@ fn run_pass2(
             *summary_radius_sq_max = chunk_max;
         }
 
-        // Route rows to bucket writers. Sequential per-bucket
-        // — BufWriter is !Sync and a per-bucket Mutex would
-        // serialize anyway. The sequential write is dominated
-        // by the kernel-buffered write path (BufWriter
-        // amortises to ~one syscall per 64 KiB / 1 588 B ≈ 41
-        // rows at dim=384), not by the in-process loop body.
+        // Route rows to bucket writers. Sequential per-bucket:
+        // BufWriter is !Sync and a per-bucket Mutex would serialize
+        // anyway. `None` columns skip the fp32 vector spill because
+        // they have no `full[]` region on disk.
+        let write_full = !matches!(codec, RerankCodec::None);
         for r in 0..actual_rows {
             let cid = asgn[r] as usize;
             let local_doc_id = global_doc_id + r as u32;
             let writer = &mut bucket_writers[cid];
             writer.write_all(&local_doc_id.to_le_bytes())?;
             writer.write_all(&chunk_codes[r * code_bytes..(r + 1) * code_bytes])?;
-            writer.write_all(bytemuck::cast_slice(&chunk[r * dim..(r + 1) * dim]))?;
+            if write_full {
+                writer.write_all(bytemuck::cast_slice(&chunk[r * dim..(r + 1) * dim]))?;
+            }
             bucket_counts[cid] += 1;
         }
         global_doc_id += actual_rows as u32;
@@ -928,6 +1279,7 @@ mod tests {
             n_cent: 4,
             rot_seed: 7,
             metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
         }
     }
 
@@ -1074,6 +1426,7 @@ mod tests {
             n_cent,
             rot_seed: 7,
             metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
         })
         .expect("register column");
         // Generate a small but distinguishable corpus where each
@@ -1130,6 +1483,7 @@ mod tests {
                 n_cent,
                 rot_seed: 7,
                 metric: Metric::L2Sq,
+                rerank_codec: RerankCodec::Fp32,
             })
             .expect("register column");
             for d in 0..n_docs {
@@ -1174,6 +1528,35 @@ mod tests {
                 "spill path missed self-NN at q={q}"
             );
         }
+    }
+
+    /// `finish_to(Vec<u8>)` must produce byte-for-byte identical
+    /// output to `finish()` for the same logical builder state.
+    /// The build path is deterministic in everything that matters
+    /// (rot_seed, reservoir seed, bucket flush ordering), so any
+    /// drift here would indicate a regression in either the
+    /// streaming wrap or the underlying determinism contract.
+    #[test]
+    fn finish_to_matches_finish_byte_for_byte() {
+        let build = || -> VectorBuilder {
+            let mut b = VectorBuilder::new();
+            b.register_column(cfg("v", 16)).expect("register column");
+            for i in 0..32 {
+                let v: Vec<f32> = (0..16).map(|j| ((i + j) as f32) * 0.1).collect();
+                b.add(0, &v).expect("add to vector builder");
+            }
+            b
+        };
+
+        let blob_finish = build().finish().expect("finish");
+        let mut blob_finish_to: Vec<u8> = Vec::new();
+        build()
+            .finish_to(&mut blob_finish_to)
+            .expect("finish_to Vec<u8>");
+        assert_eq!(
+            blob_finish, blob_finish_to,
+            "finish_to must produce identical bytes to finish"
+        );
     }
 
     /// Streaming output to a `Cursor<Vec<u8>>`: the resulting bytes
@@ -1239,6 +1622,7 @@ mod tests {
             n_cent,
             rot_seed: 7,
             metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
         })
         .expect("register column");
         for d in 0..n_docs {

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -883,15 +883,13 @@ fn build_subsection_streaming(
     //   rabitq    → bytes[codes_off   + pos * code_bytes ..]
     //   full[]    → codec-dependent slot in bytes (see match below)
     //
-    // The only resident scratch is the Sq8 per-cluster fp32 buffer,
-    // bounded by `max_cluster_count * dim * 4` bytes (reused across
-    // clusters). Sq8 needs the whole cluster's fp32 rows in hand
-    // before it can derive `(scale, offset)`, so the fp32 read and
-    // u8 encode happen as separate per-cluster phases below.
-    let mut sq8_scratch: Vec<f32> = Vec::new();
-    let mut row_fp32_scratch: Vec<f32> = Vec::new();
-    let mut id_buf = [0u8; 4];
-
+    // The only resident scratch is the cluster's `full_block`
+    // (`cluster_count * dim * 4` bytes when the codec writes a
+    // full[] payload), reused across clusters. Sq8 needs the whole
+    // cluster's fp32 rows in hand before it can derive `(scale,
+    // offset)`, which is exactly what `full_block` already contains
+    // after the bulk read.
+    //
     // Sq8 codec_meta region layout (when present):
     //   [scale_block | offset_block | per_doc_norms?]
     //   scale_block  = n_cent * dim * 4 bytes
@@ -906,6 +904,18 @@ fn build_subsection_streaming(
             None
         };
 
+    // Per-cluster bucket payload is row-major
+    //   [doc_id u32 | code(code_bytes) | full_row?]
+    // and pass 2 wrote each row in one shot. In final assembly we
+    // mirror that on the read side: read all doc_ids, all codes, and
+    // (when present) all full-row payload as three contiguous block
+    // reads — one `read_exact` per block instead of three per row.
+    let full_row_bytes_in_bucket = if codec.writes_full() { dim * 4 } else { 0 };
+    let mut id_block: Vec<u8> = Vec::new();
+    let mut code_block: Vec<u8> = Vec::new();
+    let mut full_block: Vec<u8> = Vec::new();
+    let mut row_fp32_scratch: Vec<f32> = Vec::new();
+
     for (c, &(cluster_off_u32, cluster_count_u32)) in cluster_index.iter().enumerate() {
         if cluster_count_u32 == 0 {
             continue;
@@ -916,100 +926,82 @@ fn build_subsection_streaming(
         let path = scratch.join(format!("infino_bucket_col{column_id}_c{c}.bin"));
         let mut reader = BufReader::with_capacity(BUCKET_BUF_SIZE, File::open(&path)?);
 
-        if codec == RerankCodec::Sq8 {
-            sq8_scratch.clear();
-            sq8_scratch.resize(cluster_count * dim, 0.0);
+        // Bulk-read the cluster bucket in three blocks. Pass 2
+        // interleaves [doc_id | code | full?] per row, so we de-
+        // interleave on read into three flat block buffers and copy
+        // each block straight into its on-disk slot. This is the
+        // mirror of pass 2's per-row triple write (and avoids the
+        // per-doc syscall storm the previous loop incurred).
+        id_block.resize(cluster_count * 4, 0);
+        code_block.resize(cluster_count * code_bytes, 0);
+        if full_row_bytes_in_bucket > 0 {
+            full_block.resize(cluster_count * full_row_bytes_in_bucket, 0);
+        }
+        for i in 0..cluster_count {
+            reader.read_exact(&mut id_block[i * 4..(i + 1) * 4])?;
+            reader.read_exact(&mut code_block[i * code_bytes..(i + 1) * code_bytes])?;
+            if full_row_bytes_in_bucket > 0 {
+                let off = i * full_row_bytes_in_bucket;
+                reader.read_exact(&mut full_block[off..off + full_row_bytes_in_bucket])?;
+            }
         }
 
-        for i in 0..cluster_count {
-            let pos = cluster_off + i;
+        // doc_ids and rabitq codes are byte-identical to the on-disk
+        // layout, so each is a single block copy at this cluster's
+        // base offset.
+        let did_base = doc_ids_off + cluster_off * 4;
+        bytes[did_base..did_base + cluster_count * 4].copy_from_slice(&id_block);
+        let code_base = codes_off + cluster_off * code_bytes;
+        bytes[code_base..code_base + cluster_count * code_bytes].copy_from_slice(&code_block);
 
-            // doc_id (u32 LE).
-            reader.read_exact(&mut id_buf)?;
-            let did_off = doc_ids_off + pos * 4;
-            bytes[did_off..did_off + 4].copy_from_slice(&id_buf);
-
-            // 1-bit RaBitQ code.
-            let code_off_b = codes_off + pos * code_bytes;
-            reader.read_exact(&mut bytes[code_off_b..code_off_b + code_bytes])?;
-
-            // full[] region — codec-dependent. RabitqOnly never reads
-            // because pass 2 didn't spill the fp32 row for that codec.
-            match codec {
-                RerankCodec::RabitqOnly => {}
-                RerankCodec::Fp32 => {
-                    // Stream fp32 straight into the on-disk full[]
-                    // slot. The destination is aligned because
-                    // `pos * dim * 4` is a multiple of 4.
-                    let off = full_off + pos * dim * 4;
-                    reader.read_exact(&mut bytes[off..off + dim * 4])?;
+        // full[] region — codec-dependent. RabitqOnly has no full[]
+        // payload on disk and pass 2 didn't spill one. Fp32 is a
+        // direct block copy. Bf16/Sq8 transcode out of the fp32
+        // block buffer.
+        match codec {
+            RerankCodec::RabitqOnly => {}
+            RerankCodec::Fp32 => {
+                let dst_base = full_off + cluster_off * dim * 4;
+                bytes[dst_base..dst_base + cluster_count * dim * 4].copy_from_slice(&full_block);
+            }
+            RerankCodec::Bf16 => {
+                // bf16 destination is 2 bytes/lane; read the fp32
+                // block as &[f32] (Vec<u8> is f32-aligned only when
+                // we go through bytemuck on a fresh aligned slab —
+                // here we re-stage one row at a time to keep lane-
+                // wise rounding identical to the previous code path).
+                if row_fp32_scratch.len() < dim {
+                    row_fp32_scratch.resize(dim, 0.0);
                 }
-                RerankCodec::Bf16 => {
-                    // Buffer one row in `row_fp32_scratch` (4-aligned
-                    // since `Vec<f32>` storage is `f32`-aligned), then
-                    // shift each lane to bf16 and write into bytes.
-                    // The bf16 destination is `pos * dim * 2`-aligned
-                    // to 2 bytes which is the f32→bf16 contract.
-                    if row_fp32_scratch.len() < dim {
-                        row_fp32_scratch.resize(dim, 0.0);
-                    }
+                for i in 0..cluster_count {
+                    let pos = cluster_off + i;
+                    let src = &full_block[i * dim * 4..(i + 1) * dim * 4];
                     let row = &mut row_fp32_scratch[..dim];
-                    reader.read_exact(bytemuck::cast_slice_mut(row))?;
+                    bytemuck::cast_slice_mut::<f32, u8>(row).copy_from_slice(src);
                     let off = full_off + pos * dim * 2;
                     for (d, &x) in row.iter().enumerate() {
                         let bf = crate::superfile::vector::distance::fp32_to_bf16(x);
                         bytes[off + d * 2..off + d * 2 + 2].copy_from_slice(&bf.to_le_bytes());
                     }
                 }
-                RerankCodec::Sq8 => {
-                    // Buffer the cluster's fp32 rows; the per-cluster
-                    // quantizer needs the whole cluster before it can
-                    // emit codec_meta or u8 codes. Encoded in the
-                    // finalize block below.
-                    let slot = &mut sq8_scratch[i * dim..(i + 1) * dim];
-                    reader.read_exact(bytemuck::cast_slice_mut(slot))?;
-                }
             }
-        }
-
-        // ---- Sq8 per-cluster finalize ----
-        //
-        // Derive `(scale_c, offset_c)` from the cluster's fp32 rows,
-        // write them into the codec_meta scale/offset blocks for
-        // this cluster, and encode each row into the full[] region.
-        // For L2Sq/Cosine columns, also cache decoded `Σ x²` into
-        // the per-doc norms block so the search-side kernel can
-        // skip recomputing it.
-        if codec == RerankCodec::Sq8 {
-            let (scale_c, offset_c) =
-                compute_sq8_quantizer_for_cluster(&sq8_scratch, dim, cluster_count);
-
-            let sc_off = sq8_scale_block_off + c * dim * 4;
-            bytes[sc_off..sc_off + dim * 4].copy_from_slice(bytemuck::cast_slice(&scale_c));
-            let oc_off = sq8_offset_block_off + c * dim * 4;
-            bytes[oc_off..oc_off + dim * 4].copy_from_slice(bytemuck::cast_slice(&offset_c));
-
-            for i in 0..cluster_count {
-                let src = &sq8_scratch[i * dim..(i + 1) * dim];
-                let pos = cluster_off + i;
-                let code_off = full_off + pos * dim;
-                let mut acc = 0.0f64;
-                for d in 0..dim {
-                    let q = ((src[d] - offset_c[d]) / scale_c[d]).round();
-                    // Clamp on the boundary handles fp rounding
-                    // artefacts at the min/max ends; the cast is
-                    // then in-range by construction.
-                    let qc = q.clamp(0.0, 255.0) as u8;
-                    bytes[code_off + d] = qc;
-                    if sq8_norms_block_off.is_some() {
-                        let x = (qc as f32) * scale_c[d] + offset_c[d];
-                        acc += (x as f64) * (x as f64);
-                    }
-                }
-                if let Some(norms_off) = sq8_norms_block_off {
-                    let n_off = norms_off + pos * 4;
-                    bytes[n_off..n_off + 4].copy_from_slice(&(acc as f32).to_le_bytes());
-                }
+            RerankCodec::Sq8 => {
+                // The cluster's fp32 rows are already in `full_block`
+                // (one bulk read above). Hand the slice to the
+                // per-cluster encode helper below.
+                let cluster_rows: &[f32] = bytemuck::cast_slice(&full_block);
+                encode_sq8_cluster(
+                    cluster_rows,
+                    dim,
+                    cluster_count,
+                    cluster_off,
+                    c,
+                    full_off,
+                    sq8_scale_block_off,
+                    sq8_offset_block_off,
+                    sq8_norms_block_off,
+                    &mut bytes,
+                );
             }
         }
     }
@@ -1022,6 +1014,62 @@ fn build_subsection_streaming(
         bytes,
         summary_offset_in_sub: summary_off,
     })
+}
+
+/// Sq8 per-cluster encode for the final-assembly pass.
+///
+/// Given the cluster's fp32 rows (already loaded into the
+/// caller's `full_block` scratch and reinterpreted as `&[f32]`),
+/// derive `(scale_c, offset_c)`, write them into the codec_meta
+/// scale/offset blocks for cluster `c`, and emit u8 codes into
+/// the on-disk full[] region. When the column carries decoded
+/// per-doc `Σ x²` (L2Sq/Cosine), also fill the per-doc norms
+/// block — the search-side kernel reads it directly to skip
+/// recomputing the decoded norm at rerank time.
+#[allow(clippy::too_many_arguments)]
+fn encode_sq8_cluster(
+    cluster_rows: &[f32],
+    dim: usize,
+    cluster_count: usize,
+    cluster_off: usize,
+    c: usize,
+    full_off: usize,
+    sq8_scale_block_off: usize,
+    sq8_offset_block_off: usize,
+    sq8_norms_block_off: Option<usize>,
+    bytes: &mut [u8],
+) {
+    debug_assert_eq!(cluster_rows.len(), cluster_count * dim);
+
+    let (scale_c, offset_c) = compute_sq8_quantizer_for_cluster(cluster_rows, dim, cluster_count);
+
+    let sc_off = sq8_scale_block_off + c * dim * 4;
+    bytes[sc_off..sc_off + dim * 4].copy_from_slice(bytemuck::cast_slice(&scale_c));
+    let oc_off = sq8_offset_block_off + c * dim * 4;
+    bytes[oc_off..oc_off + dim * 4].copy_from_slice(bytemuck::cast_slice(&offset_c));
+
+    for i in 0..cluster_count {
+        let src = &cluster_rows[i * dim..(i + 1) * dim];
+        let pos = cluster_off + i;
+        let code_off = full_off + pos * dim;
+        let mut acc = 0.0f64;
+        for d in 0..dim {
+            let q = ((src[d] - offset_c[d]) / scale_c[d]).round();
+            // Clamp on the boundary handles fp rounding artefacts at
+            // the min/max ends; the cast is then in-range by
+            // construction.
+            let qc = q.clamp(0.0, 255.0) as u8;
+            bytes[code_off + d] = qc;
+            if sq8_norms_block_off.is_some() {
+                let x = (qc as f32) * scale_c[d] + offset_c[d];
+                acc += (x as f64) * (x as f64);
+            }
+        }
+        if let Some(norms_off) = sq8_norms_block_off {
+            let n_off = norms_off + pos * 4;
+            bytes[n_off..n_off + 4].copy_from_slice(&(acc as f32).to_le_bytes());
+        }
+    }
 }
 
 /// Scan one cluster's rows for per-dim min/max and derive the

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -56,7 +56,12 @@ fn metric_id(m: Metric) -> u32 {
 /// at the call site.
 #[derive(Debug, Clone)]
 pub struct VectorConfig {
-    pub name: String,
+    /// Logical column name. Must not collide with any other
+    /// column in the same superfile (FTS or vector). Named
+    /// `column` to align with `FtsConfig::column` and the
+    /// public superfile API surface; this is also the on-disk
+    /// JSON key in `inf.vec.columns`.
+    pub column: String,
     pub dim: usize,
     pub n_cent: usize,
     pub rot_seed: u64,
@@ -70,9 +75,9 @@ impl VectorConfig {
     /// Construct a config with the default rerank codec
     /// ([`RerankCodec::default()`]). Use the `with_*` setters to
     /// override individual fields.
-    pub fn new(name: String, dim: usize, n_cent: usize, rot_seed: u64, metric: Metric) -> Self {
+    pub fn new(column: String, dim: usize, n_cent: usize, rot_seed: u64, metric: Metric) -> Self {
         Self {
-            name,
+            column,
             dim,
             n_cent,
             rot_seed,
@@ -244,24 +249,28 @@ impl VectorBuilder {
     /// Register a vector column up-front. Returns the assigned
     /// `column_id` (declaration order).
     pub fn register_column(&mut self, config: VectorConfig) -> Result<u32, BuildError> {
-        if config.name.as_bytes().contains(&FST_SEPARATOR) {
-            return Err(BuildError::ReservedSeparatorInColumnName(config.name));
+        if config.column.as_bytes().contains(&FST_SEPARATOR) {
+            return Err(BuildError::ReservedSeparatorInColumnName(config.column));
         }
-        if config.name.starts_with(RESERVED_PREFIX) {
-            return Err(BuildError::ReservedPrefixInColumnName(config.name));
+        if config.column.starts_with(RESERVED_PREFIX) {
+            return Err(BuildError::ReservedPrefixInColumnName(config.column));
         }
         if !(16..=4096).contains(&config.dim) {
             return Err(BuildError::VectorDimOutOfRange {
-                column: config.name.clone(),
+                column: config.column.clone(),
                 dim: config.dim,
             });
         }
-        if self.columns.iter().any(|c| c.config.name == config.name) {
-            return Err(BuildError::DuplicateColumnName(config.name));
+        if self
+            .columns
+            .iter()
+            .any(|c| c.config.column == config.column)
+        {
+            return Err(BuildError::DuplicateColumnName(config.column));
         }
         if !config.rerank_codec.is_implemented() {
             return Err(BuildError::VectorRerankCodecUnimplemented {
-                column: config.name.clone(),
+                column: config.column.clone(),
                 codec: config.rerank_codec.name(),
             });
         }
@@ -332,7 +341,7 @@ impl VectorBuilder {
             let col = &mut self.columns[idx];
             if vec.len() != col.config.dim {
                 return Err(BuildError::FtsColumnTypeInvalid {
-                    column: col.config.name.clone(),
+                    column: col.config.column.clone(),
                     actual: format!("vec.len()={} != dim={}", vec.len(), col.config.dim),
                 });
             }
@@ -763,61 +772,14 @@ fn build_subsection_streaming(
         .max(0.0)
         .min(u32::MAX as f32) as u32;
 
-    // ---- Pass 3: read each bucket sequentially, materialise the
-    // cluster-contiguous regions and the cluster index ----
+    // ---- Pre-compute subsection layout ----
     //
-    // `RerankCodec::None` segments have no `full[]` region on disk
-    // and pass 2 did not spill the fp32 vectors at all, so we skip the
-    // `full_layout` allocation and the per-row `full_vec` read.
-    let codec = cfg.rerank_codec;
-    let has_full = !matches!(codec, RerankCodec::None);
-    let mut codes_layout = vec![0u8; n_docs * code_bytes];
-    let mut full_layout: Vec<f32> = if has_full {
-        vec![0f32; n_docs * dim]
-    } else {
-        Vec::new()
-    };
-    let mut doc_ids_layout = vec![0u32; n_docs];
-    let mut cluster_index: Vec<(u32, u32)> = Vec::with_capacity(n_cent);
-    let mut write_cursor: usize = 0;
-    // For each bucket file, read each row's fields directly into
-    // their destination slots in the cluster-contiguous layout
-    // arrays. Reading each field into its destination avoids the
-    // alignment trap of a single `row_buf: Vec<u8>` cast (the
-    // `full_vec` field starts at offset `4 + code_bytes` which is
-    // not 4-aligned for the common dim=16/code_bytes=2 case).
-    // The `dst_full` slice is `&mut [f32]` from the `full_layout`
-    // Vec; `cast_slice_mut` gives `&mut [u8]` aligned to the f32
-    // ABI alignment (4), which `read_exact` fills from BufReader.
-    let mut id_buf = [0u8; 4];
-    for (c, &cluster_count) in bucket_counts.iter().enumerate() {
-        let cluster_off = write_cursor as u32;
-        cluster_index.push((cluster_off, cluster_count));
-        if cluster_count == 0 {
-            continue;
-        }
-        let path = scratch.join(format!("infino_bucket_col{column_id}_c{c}.bin"));
-        let mut reader = BufReader::with_capacity(BUCKET_BUF_SIZE, File::open(&path)?);
-        for _ in 0..cluster_count {
-            reader.read_exact(&mut id_buf)?;
-            doc_ids_layout[write_cursor] = u32::from_le_bytes(id_buf);
-            let dst_code =
-                &mut codes_layout[write_cursor * code_bytes..(write_cursor + 1) * code_bytes];
-            reader.read_exact(dst_code)?;
-            if has_full {
-                let dst_full = &mut full_layout[write_cursor * dim..(write_cursor + 1) * dim];
-                let dst_full_bytes: &mut [u8] = bytemuck::cast_slice_mut(dst_full);
-                reader.read_exact(dst_full_bytes)?;
-            }
-            write_cursor += 1;
-        }
-    }
-    debug_assert_eq!(write_cursor, n_docs);
-
-    // 6. Build the subsection bytes. Each codec contributes an
-    // optional `codec_meta` region between `codes` and `full`. `None`
-    // zeroes out both `codec_meta` and `full[]`, so the segment shrinks
-    // to summary + centroids + cluster_idx + codes + doc_ids.
+    // Every region size is a pure function of (dim, n_docs, n_cent,
+    // codec, metric), all known by the end of pass 2. We allocate
+    // the full subsection buffer up front and stream pass-3 rows
+    // directly into their final on-disk slots — eliminates the
+    // O(n_docs · dim · 4) `full_layout` round-trip the old pipeline
+    // did between bucket-read and codec-encode.
     let codec = cfg.rerank_codec;
     let summary_size = dim * 4;
     let centroids_size = n_cent * dim * 4;
@@ -827,23 +789,24 @@ fn build_subsection_streaming(
     let full_size = codec.per_vector_bytes(dim) * n_docs;
     let doc_ids_size = n_docs * 4;
 
-    // Offsets relative to subsection start.
+    // Region offsets, relative to subsection start.
     let summary_off = SUB_HEADER_SIZE;
     let centroids_off = summary_off + summary_size;
     let cluster_idx_off = centroids_off + centroids_size;
     let codes_off = cluster_idx_off + cluster_idx_size;
-    // `codec_meta_off` is the on-disk slot in the sub-header for
-    // the codec metadata region's start. Zero means "no codec
-    // metadata in this subsection" — `Fp32` segments and legacy fp32
-    // segments write 0 here and stay
-    // byte-identical.
+    // `codec_meta_off` is the on-disk slot in the sub-header for the
+    // codec metadata region's start. Zero means "no codec metadata
+    // in this subsection" — Fp32 / Bf16 / RabitqOnly write 0 here
+    // and stay byte-identical to legacy fp32 segments that left the
+    // (formerly reserved) slot zero.
     let codec_meta_off_value: u32 = if codec_meta_size == 0 {
         0
     } else {
         (codes_off + codes_size) as u32
     };
+    let codec_meta_off_in_bytes = codec_meta_off_value as usize;
     let full_off = codes_off + codes_size + codec_meta_size;
-    // doc_ids start at full_off + full_size; not stored explicitly in the sub-header.
+    let doc_ids_off = full_off + full_size;
 
     let total_size_before_crc = SUB_HEADER_SIZE
         + summary_size
@@ -854,106 +817,202 @@ fn build_subsection_streaming(
         + full_size
         + doc_ids_size;
 
-    let mut bytes: Vec<u8> = Vec::with_capacity(total_size_before_crc + 4);
+    // Zero-init the full subsection so unwritten slots (RabitqOnly's
+    // empty full[], reserved subheader bytes) carry deterministic
+    // zeroes regardless of allocator state.
+    let mut bytes: Vec<u8> = vec![0u8; total_size_before_crc];
 
-    // Sub-header (56 bytes).
+    // ---- Sub-header (56 bytes) ----
     //   [0..8]   SUB_MAGIC
     //   [8..12]  VERSION
     //   [12..16] codec_meta_off (former reserved slot; zero for Fp32
     //            and legacy fp32 segments).
     //   [16..24] summary_centroid_offset
     //   [24..28] summary_radius_x100
-    //   [28..32] reserved (4)
+    //   [28..32] reserved (4) — left zero by the vec![0u8; ...] init
     //   [32..40] centroids_off
     //   [40..48] cluster_idx_off
     //   [48..52] codes_off
     //   [52..56] full_off
-    bytes.extend_from_slice(format::vec::SUB_MAGIC); // 8
-    bytes.extend_from_slice(&format::vec::VERSION.to_le_bytes()); // 4
-    bytes.extend_from_slice(&codec_meta_off_value.to_le_bytes()); // codec_meta_off (4)
-    bytes.extend_from_slice(&(summary_off as u64).to_le_bytes()); // summary_centroid_offset (8)
-    bytes.extend_from_slice(&summary_radius_x100.to_le_bytes()); // 4
-    bytes.extend_from_slice(&0u32.to_le_bytes()); // reserved (4)
-    bytes.extend_from_slice(&(centroids_off as u64).to_le_bytes()); // 8
-    bytes.extend_from_slice(&(cluster_idx_off as u64).to_le_bytes()); // 8
-    bytes.extend_from_slice(&(codes_off as u32).to_le_bytes()); // 4
-    bytes.extend_from_slice(&(full_off as u32).to_le_bytes()); // 4
-    debug_assert_eq!(bytes.len(), SUB_HEADER_SIZE);
+    bytes[0..8].copy_from_slice(format::vec::SUB_MAGIC);
+    bytes[8..12].copy_from_slice(&format::vec::VERSION.to_le_bytes());
+    bytes[12..16].copy_from_slice(&codec_meta_off_value.to_le_bytes());
+    bytes[16..24].copy_from_slice(&(summary_off as u64).to_le_bytes());
+    bytes[24..28].copy_from_slice(&summary_radius_x100.to_le_bytes());
+    // [28..32] reserved stays zero.
+    bytes[32..40].copy_from_slice(&(centroids_off as u64).to_le_bytes());
+    bytes[40..48].copy_from_slice(&(cluster_idx_off as u64).to_le_bytes());
+    bytes[48..52].copy_from_slice(&(codes_off as u32).to_le_bytes());
+    bytes[52..56].copy_from_slice(&(full_off as u32).to_le_bytes());
 
-    // Summary centroid (dim f32s).
-    bytes.extend_from_slice(bytemuck::cast_slice(&summary_centroid));
-    // Centroids.
-    bytes.extend_from_slice(bytemuck::cast_slice(&centroids));
-    // Cluster index.
-    for (off, count) in &cluster_index {
-        bytes.extend_from_slice(&off.to_le_bytes());
-        bytes.extend_from_slice(&count.to_le_bytes());
-    }
-    // Codes.
-    bytes.extend_from_slice(&codes_layout);
+    // ---- Summary centroid + centroids ----
+    bytes[summary_off..summary_off + summary_size]
+        .copy_from_slice(bytemuck::cast_slice(&summary_centroid));
+    bytes[centroids_off..centroids_off + centroids_size]
+        .copy_from_slice(bytemuck::cast_slice(&centroids));
 
-    // Codec metadata region + full[] vector region — codec-
-    // dependent shape. The two are written together because Sq8
-    // needs the scale/offset arrays *before* it can encode u8
-    // codes, and it computes them from the same single pass over
-    // `full_layout` that does the encode.
+    // ---- Cluster index, built from pass-2 bucket counts ----
     //
-    //   Fp32: empty codec_meta; full[] is the fp32 buffer byte-
-    //         for-byte (matches legacy fp32 segments).
-    //   Bf16: empty codec_meta; full[] is each fp32 encoded to
-    //         bf16 via round-to-nearest-even (`fp32_to_bf16`).
-    //         Halves disk footprint with bounded relative error
-    //         ≤ 2⁻⁸ per lane.
-    //   Sq8:  codec_meta = per-cluster `scale[n_cent × dim]` +
-    //         `offset[n_cent × dim]` + optional per-doc norms for
-    //         L2Sq. full[] is n_docs × dim u8 codes encoded against
-    //         the owning cluster's scale/offset.
-    //   None: empty codec_meta; empty full[]. The on-disk
-    //         layout collapses to `doc_ids` starting at
-    //         `full_off` (= codes_off + codes_size). Search
-    //         returns the 1-bit shortlist's top-K directly.
-    match codec {
-        RerankCodec::Fp32 => {
-            debug_assert_eq!(codec_meta_size, 0);
-            bytes.extend_from_slice(bytemuck::cast_slice(&full_layout));
+    // `cluster_index[c] = (off, count)` where `off` is the
+    // cumulative row count across clusters 0..c. The same indexing
+    // the shortlist carries — `pos = off + i` — so the per-doc
+    // norms and rerank codes stay co-indexed across regions.
+    let mut cluster_index: Vec<(u32, u32)> = Vec::with_capacity(n_cent);
+    {
+        let mut acc_off = 0u32;
+        let mut idx_cursor = cluster_idx_off;
+        for &cnt in &bucket_counts {
+            cluster_index.push((acc_off, cnt));
+            bytes[idx_cursor..idx_cursor + 4].copy_from_slice(&acc_off.to_le_bytes());
+            bytes[idx_cursor + 4..idx_cursor + 8].copy_from_slice(&cnt.to_le_bytes());
+            acc_off += cnt;
+            idx_cursor += 8;
         }
-        RerankCodec::Bf16 => {
-            debug_assert_eq!(codec_meta_size, 0);
-            bytes.reserve(full_layout.len() * 2);
-            for &x in &full_layout {
-                let bf = crate::superfile::vector::distance::fp32_to_bf16(x);
-                bytes.extend_from_slice(&bf.to_le_bytes());
+        debug_assert_eq!(acc_off as usize, n_docs);
+    }
+
+    // ---- Per-cluster streaming pass ----
+    //
+    // Replaces the old two-step "stage every row in
+    // full_layout/codes_layout/doc_ids_layout, then assemble into
+    // bytes" pipeline. For each cluster `c` we read its bucket file
+    // exactly once and write each row's fields directly into the
+    // correct on-disk slots:
+    //
+    //   doc_id    → bytes[doc_ids_off + pos * 4 ..]
+    //   rabitq    → bytes[codes_off   + pos * code_bytes ..]
+    //   full[]    → codec-dependent slot in bytes (see match below)
+    //
+    // The only resident scratch is the Sq8 per-cluster fp32 buffer,
+    // bounded by `max_cluster_count * dim * 4` bytes (reused across
+    // clusters). Sq8 needs the whole cluster's fp32 rows in hand
+    // before it can derive `(scale, offset)`, so the fp32 read and
+    // u8 encode happen as separate per-cluster phases below.
+    let mut sq8_scratch: Vec<f32> = Vec::new();
+    let mut row_fp32_scratch: Vec<f32> = Vec::new();
+    let mut id_buf = [0u8; 4];
+
+    // Sq8 codec_meta region layout (when present):
+    //   [scale_block | offset_block | per_doc_norms?]
+    //   scale_block  = n_cent * dim * 4 bytes
+    //   offset_block = n_cent * dim * 4 bytes
+    //   per_doc_norms (L2Sq/Cosine only) = n_docs * 4 bytes
+    let sq8_scale_block_off = codec_meta_off_in_bytes;
+    let sq8_offset_block_off = sq8_scale_block_off + n_cent * dim * 4;
+    let sq8_norms_block_off =
+        if codec == RerankCodec::Sq8 && matches!(cfg.metric, Metric::L2Sq | Metric::Cosine) {
+            Some(sq8_offset_block_off + n_cent * dim * 4)
+        } else {
+            None
+        };
+
+    for (c, &(cluster_off_u32, cluster_count_u32)) in cluster_index.iter().enumerate() {
+        if cluster_count_u32 == 0 {
+            continue;
+        }
+        let cluster_off = cluster_off_u32 as usize;
+        let cluster_count = cluster_count_u32 as usize;
+
+        let path = scratch.join(format!("infino_bucket_col{column_id}_c{c}.bin"));
+        let mut reader = BufReader::with_capacity(BUCKET_BUF_SIZE, File::open(&path)?);
+
+        if codec == RerankCodec::Sq8 {
+            sq8_scratch.clear();
+            sq8_scratch.resize(cluster_count * dim, 0.0);
+        }
+
+        for i in 0..cluster_count {
+            let pos = cluster_off + i;
+
+            // doc_id (u32 LE).
+            reader.read_exact(&mut id_buf)?;
+            let did_off = doc_ids_off + pos * 4;
+            bytes[did_off..did_off + 4].copy_from_slice(&id_buf);
+
+            // 1-bit RaBitQ code.
+            let code_off_b = codes_off + pos * code_bytes;
+            reader.read_exact(&mut bytes[code_off_b..code_off_b + code_bytes])?;
+
+            // full[] region — codec-dependent. RabitqOnly never reads
+            // because pass 2 didn't spill the fp32 row for that codec.
+            match codec {
+                RerankCodec::RabitqOnly => {}
+                RerankCodec::Fp32 => {
+                    // Stream fp32 straight into the on-disk full[]
+                    // slot. The destination is aligned because
+                    // `pos * dim * 4` is a multiple of 4.
+                    let off = full_off + pos * dim * 4;
+                    reader.read_exact(&mut bytes[off..off + dim * 4])?;
+                }
+                RerankCodec::Bf16 => {
+                    // Buffer one row in `row_fp32_scratch` (4-aligned
+                    // since `Vec<f32>` storage is `f32`-aligned), then
+                    // shift each lane to bf16 and write into bytes.
+                    // The bf16 destination is `pos * dim * 2`-aligned
+                    // to 2 bytes which is the f32→bf16 contract.
+                    if row_fp32_scratch.len() < dim {
+                        row_fp32_scratch.resize(dim, 0.0);
+                    }
+                    let row = &mut row_fp32_scratch[..dim];
+                    reader.read_exact(bytemuck::cast_slice_mut(row))?;
+                    let off = full_off + pos * dim * 2;
+                    for (d, &x) in row.iter().enumerate() {
+                        let bf = crate::superfile::vector::distance::fp32_to_bf16(x);
+                        bytes[off + d * 2..off + d * 2 + 2].copy_from_slice(&bf.to_le_bytes());
+                    }
+                }
+                RerankCodec::Sq8 => {
+                    // Buffer the cluster's fp32 rows; the per-cluster
+                    // quantizer needs the whole cluster before it can
+                    // emit codec_meta or u8 codes. Encoded in the
+                    // finalize block below.
+                    let slot = &mut sq8_scratch[i * dim..(i + 1) * dim];
+                    reader.read_exact(bytemuck::cast_slice_mut(slot))?;
+                }
             }
         }
-        RerankCodec::Sq8 => {
-            let bytes_before_meta = bytes.len();
-            write_sq8_codec_meta_and_codes(
-                &mut bytes,
-                &full_layout,
-                dim,
-                n_docs,
-                n_cent,
-                &cluster_index,
-                cfg.metric,
-            );
-            // Layout invariant: codec_meta_size + full_size bytes
-            // appended (pass 2 / pass 3 contract). Cheap to keep
-            // since the writer is the only producer of these regions.
-            debug_assert_eq!(bytes.len() - bytes_before_meta, codec_meta_size + full_size);
-        }
-        RerankCodec::None => {
-            // No codec_meta, no full[] — both regions are zero-
-            // length for `None`. `doc_ids` (appended next) starts
-            // exactly at `full_off` (= codes_off + codes_size),
-            // which is what the reader expects when it parses a
-            // `None` column.
-            debug_assert_eq!(codec_meta_size, 0);
-            debug_assert_eq!(full_size, 0);
+
+        // ---- Sq8 per-cluster finalize ----
+        //
+        // Derive `(scale_c, offset_c)` from the cluster's fp32 rows,
+        // write them into the codec_meta scale/offset blocks for
+        // this cluster, and encode each row into the full[] region.
+        // For L2Sq/Cosine columns, also cache decoded `Σ x²` into
+        // the per-doc norms block so the search-side kernel can
+        // skip recomputing it.
+        if codec == RerankCodec::Sq8 {
+            let (scale_c, offset_c) =
+                compute_sq8_quantizer_for_cluster(&sq8_scratch, dim, cluster_count);
+
+            let sc_off = sq8_scale_block_off + c * dim * 4;
+            bytes[sc_off..sc_off + dim * 4].copy_from_slice(bytemuck::cast_slice(&scale_c));
+            let oc_off = sq8_offset_block_off + c * dim * 4;
+            bytes[oc_off..oc_off + dim * 4].copy_from_slice(bytemuck::cast_slice(&offset_c));
+
+            for i in 0..cluster_count {
+                let src = &sq8_scratch[i * dim..(i + 1) * dim];
+                let pos = cluster_off + i;
+                let code_off = full_off + pos * dim;
+                let mut acc = 0.0f64;
+                for d in 0..dim {
+                    let q = ((src[d] - offset_c[d]) / scale_c[d]).round();
+                    // Clamp on the boundary handles fp rounding
+                    // artefacts at the min/max ends; the cast is
+                    // then in-range by construction.
+                    let qc = q.clamp(0.0, 255.0) as u8;
+                    bytes[code_off + d] = qc;
+                    if sq8_norms_block_off.is_some() {
+                        let x = (qc as f32) * scale_c[d] + offset_c[d];
+                        acc += (x as f64) * (x as f64);
+                    }
+                }
+                if let Some(norms_off) = sq8_norms_block_off {
+                    let n_off = norms_off + pos * 4;
+                    bytes[n_off..n_off + 4].copy_from_slice(&(acc as f32).to_le_bytes());
+                }
+            }
         }
     }
-    // Doc IDs.
-    bytes.extend_from_slice(bytemuck::cast_slice(&doc_ids_layout));
-    debug_assert_eq!(bytes.len(), total_size_before_crc);
 
     // Trailing CRC over the subsection body.
     let crc = crc32c(&bytes);
@@ -1058,117 +1117,6 @@ fn compute_sq8_quantizer_for_cluster(
     (scale, offset)
 }
 
-/// Sq8 finalize step (per-cluster quantizer). For each IVF
-/// cluster, scans its rows to derive `(scale[dim], offset[dim])`,
-/// then quantizes those rows against their cluster's quantizer
-/// and writes:
-///
-///   codec_meta: scale[n_cent × dim]
-///               offset[n_cent × dim]
-///               per_doc_norms[n_docs]  (L2Sq/Cosine only)
-///   full[]:     codes[n_docs × dim]    (u8)
-///
-/// The `cluster_index` array (provided by pass 3) gives each
-/// cluster's `(off, cnt)` in the cluster-contiguous
-/// `full_layout` — the same `off + i = pos` index that the
-/// shortlist carries, so per-doc norms stay indexed by `pos`
-/// regardless of which cluster the doc lives in.
-///
-/// For the `L2Sq` and `Cosine` metrics we cache per-doc
-/// `Σ_d (x_decoded[i,d])²` at encode time so the search-side
-/// distance kernel can skip recomputing it for L2Sq or use it to
-/// normalize the decoded vector for Cosine. NegDot does not need
-/// per-doc norms.
-///
-/// Per-cluster (not per-column) quantizer recovers recall on
-/// highly clustered cosine corpora; see
-/// `RerankCodec::codec_meta_bytes` doc for the failure-mode
-/// analysis that motivated the switch.
-#[allow(clippy::too_many_arguments)]
-fn write_sq8_codec_meta_and_codes(
-    bytes: &mut Vec<u8>,
-    full_layout: &[f32],
-    dim: usize,
-    n_docs: usize,
-    n_cent: usize,
-    cluster_index: &[(u32, u32)],
-    metric: Metric,
-) {
-    debug_assert_eq!(cluster_index.len(), n_cent);
-    debug_assert_eq!(full_layout.len(), n_docs * dim);
-
-    // ---- compute per-cluster quantizers ----
-    let mut scales = vec![0.0f32; n_cent * dim];
-    let mut offsets = vec![0.0f32; n_cent * dim];
-    for (c, &(off, cnt)) in cluster_index.iter().enumerate() {
-        let start = (off as usize) * dim;
-        let end = start + (cnt as usize) * dim;
-        let (sc, oc) =
-            compute_sq8_quantizer_for_cluster(&full_layout[start..end], dim, cnt as usize);
-        scales[c * dim..(c + 1) * dim].copy_from_slice(&sc);
-        offsets[c * dim..(c + 1) * dim].copy_from_slice(&oc);
-    }
-
-    // ---- write codec_meta scale + offset blocks ----
-    bytes.extend_from_slice(bytemuck::cast_slice(&scales));
-    bytes.extend_from_slice(bytemuck::cast_slice(&offsets));
-
-    // ---- encode codes against each doc's cluster quantizer ----
-    // codes is materialised once (n_docs × dim bytes) so the
-    // L2Sq norm computation rereads the exact bytes we'll write
-    // to disk — keeps the cached norm bit-consistent with what
-    // the search-side dequant reconstructs (no fp drift from a
-    // re-quantize against the original fp32 row).
-    let mut codes = vec![0u8; n_docs * dim];
-    for (c, &(off, cnt)) in cluster_index.iter().enumerate() {
-        if cnt == 0 {
-            continue;
-        }
-        let scale_c = &scales[c * dim..(c + 1) * dim];
-        let offset_c = &offsets[c * dim..(c + 1) * dim];
-        for i in 0..cnt as usize {
-            let row = (off as usize) + i;
-            let src = &full_layout[row * dim..(row + 1) * dim];
-            let dst = &mut codes[row * dim..(row + 1) * dim];
-            for d in 0..dim {
-                let q = ((src[d] - offset_c[d]) / scale_c[d]).round();
-                // Clamp to [0, 255]. Anything outside is a fp
-                // rounding artefact at the boundary; the clamp
-                // keeps the cast safe.
-                dst[d] = q.clamp(0.0, 255.0) as u8;
-            }
-        }
-    }
-
-    if matches!(metric, Metric::L2Sq | Metric::Cosine) {
-        // Per-doc decoded-norm cache, indexed by pos. Each doc
-        // lives in exactly one cluster (the IVF assignment from
-        // pass 2); we look up the doc's cluster to know which
-        // scale/offset slice to dequant with.
-        let mut norms = vec![0.0f32; n_docs];
-        for (c, &(off, cnt)) in cluster_index.iter().enumerate() {
-            if cnt == 0 {
-                continue;
-            }
-            let scale_c = &scales[c * dim..(c + 1) * dim];
-            let offset_c = &offsets[c * dim..(c + 1) * dim];
-            for i in 0..cnt as usize {
-                let row = (off as usize) + i;
-                let code = &codes[row * dim..(row + 1) * dim];
-                let mut acc = 0.0f64;
-                for d in 0..dim {
-                    let x = (code[d] as f32) * scale_c[d] + offset_c[d];
-                    acc += (x as f64) * (x as f64);
-                }
-                norms[row] = acc as f32;
-            }
-        }
-        bytes.extend_from_slice(bytemuck::cast_slice(&norms));
-    }
-
-    bytes.extend_from_slice(&codes);
-}
-
 /// Pass 2 of `build_subsection_streaming`: walk the input
 /// corpus chunk-by-chunk, assign each row to its centroid,
 /// rotate + 1-bit encode it, fold its un-rotated distance into
@@ -1249,9 +1197,9 @@ fn run_pass2(
 
         // Route rows to bucket writers. Sequential per-bucket:
         // BufWriter is !Sync and a per-bucket Mutex would serialize
-        // anyway. `None` columns skip the fp32 vector spill because
-        // they have no `full[]` region on disk.
-        let write_full = !matches!(codec, RerankCodec::None);
+        // anyway. `RabitqOnly` columns skip the fp32 vector spill
+        // because they have no `full[]` region on disk.
+        let write_full = codec.writes_full();
         for r in 0..actual_rows {
             let cid = asgn[r] as usize;
             let local_doc_id = global_doc_id + r as u32;
@@ -1272,9 +1220,9 @@ fn run_pass2(
 mod tests {
     use super::*;
 
-    fn cfg(name: &str, dim: usize) -> VectorConfig {
+    fn cfg(column: &str, dim: usize) -> VectorConfig {
         VectorConfig {
-            name: name.to_string(),
+            column: column.to_string(),
             dim,
             n_cent: 4,
             rot_seed: 7,
@@ -1421,7 +1369,7 @@ mod tests {
         let mut b = VectorBuilder::new();
         b.set_spill_threshold_bytes(0);
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 7,
@@ -1478,7 +1426,7 @@ mod tests {
                 b.set_spill_threshold_bytes(0);
             }
             b.register_column(VectorConfig {
-                name: "v".into(),
+                column: "v".into(),
                 dim,
                 n_cent,
                 rot_seed: 7,
@@ -1496,7 +1444,7 @@ mod tests {
         let blob_ram = build(false);
         let blob_spill = build(true);
         let json = format!(
-            r#"[{{"name":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"l2sq"}}]"#
+            r#"[{{"column":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"l2sq"}}]"#
         );
         let r_ram = VectorReader::open(Bytes::from(blob_ram), &json).expect("open ram");
         let r_spill = VectorReader::open(Bytes::from(blob_spill), &json).expect("open spill");
@@ -1617,7 +1565,7 @@ mod tests {
         let mut b = VectorBuilder::new();
         b.set_spill_threshold_bytes(0);
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 7,
@@ -1640,7 +1588,7 @@ mod tests {
         }
         let blob = std::fs::read(&path).expect("read blob file");
         let json = format!(
-            r#"[{{"name":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"l2sq"}}]"#
+            r#"[{{"column":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"l2sq"}}]"#
         );
         let reader = VectorReader::open(Bytes::from(blob), &json)
             .expect("open VectorReader from streamed blob");

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -1065,7 +1065,7 @@ fn compute_sq8_quantizer_for_cluster(
 ///
 ///   codec_meta: scale[n_cent × dim]
 ///               offset[n_cent × dim]
-///               per_doc_norms[n_docs]  (L2Sq only)
+///               per_doc_norms[n_docs]  (L2Sq/Cosine only)
 ///   full[]:     codes[n_docs × dim]    (u8)
 ///
 /// The `cluster_index` array (provided by pass 3) gives each
@@ -1074,11 +1074,11 @@ fn compute_sq8_quantizer_for_cluster(
 /// shortlist carries, so per-doc norms stay indexed by `pos`
 /// regardless of which cluster the doc lives in.
 ///
-/// For the `L2Sq` metric we cache per-doc
+/// For the `L2Sq` and `Cosine` metrics we cache per-doc
 /// `Σ_d (x_decoded[i,d])²` at encode time so the search-side
-/// distance kernel can skip recomputing it (one `dim` u8 widen
-/// + multiply pass per rerank candidate saved). Cosine + NegDot
-/// don't need per-doc norms (the `Σx²` term cancels out).
+/// distance kernel can skip recomputing it for L2Sq or use it to
+/// normalize the decoded vector for Cosine. NegDot does not need
+/// per-doc norms.
 ///
 /// Per-cluster (not per-column) quantizer recovers recall on
 /// highly clustered cosine corpora; see
@@ -1140,7 +1140,7 @@ fn write_sq8_codec_meta_and_codes(
         }
     }
 
-    if matches!(metric, Metric::L2Sq) {
+    if matches!(metric, Metric::L2Sq | Metric::Cosine) {
         // Per-doc decoded-norm cache, indexed by pos. Each doc
         // lives in exactly one cluster (the IVF assignment from
         // pass 2); we look up the doc's cluster to know which

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -214,8 +214,9 @@ pub(crate) fn distance_bytes_codec(
         RerankCodec::Sq8 => {
             unreachable!("distance_bytes_codec called with Sq8; Sq8 rerank goes through Sq8Kernel")
         }
-        RerankCodec::None => unreachable!(
-            "distance_bytes_codec called with None; None columns have no full[] region"
+        RerankCodec::RabitqOnly => unreachable!(
+            "distance_bytes_codec called with RabitqOnly; \
+             RabitqOnly columns have no full[] region"
         ),
     }
 }

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -11,6 +11,8 @@
 
 use wide::f32x8;
 
+use crate::superfile::vector::rerank_codec::RerankCodec;
+
 /// Distance metric for a vector column. Stored per-column in
 /// `inf.vec.columns` JSON, applied at query time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -183,6 +185,230 @@ fn l2_sq_le_bytes_unaligned(query: &[f32], bytes: &[u8]) -> f32 {
         let off = i * 4;
         let b = f32::from_le_bytes([bytes[off], bytes[off + 1], bytes[off + 2], bytes[off + 3]]);
         let d = query[i] - b;
+        sum += d * d;
+        i += 1;
+    }
+    sum
+}
+
+/// Distance against a vector stored in the column's `rerank_codec`
+/// representation. The `Fp32` fast path reuses [`distance_bytes`];
+/// `Bf16` widens 8 bf16 lanes to f32 per inner step and reuses the
+/// same `f32x8` math.
+///
+/// `Sq8` doesn't have a flat entry point because the decode needs the
+/// candidate cluster's scale/offset (and per-doc norm for L2Sq). Sq8
+/// callers go through [`Sq8Kernel`] which captures those once per query
+/// and cluster. `None` panics here because its column carries no
+/// `full[]` bytes to score.
+#[inline]
+pub(crate) fn distance_bytes_codec(
+    metric: Metric,
+    codec: RerankCodec,
+    query: &[f32],
+    bytes: &[u8],
+) -> f32 {
+    match codec {
+        RerankCodec::Fp32 => distance_bytes(metric, query, bytes),
+        RerankCodec::Bf16 => distance_bytes_bf16(metric, query, bytes),
+        RerankCodec::Sq8 => {
+            unreachable!("distance_bytes_codec called with Sq8; Sq8 rerank goes through Sq8Kernel")
+        }
+        RerankCodec::None => unreachable!(
+            "distance_bytes_codec called with None; None columns have no full[] region"
+        ),
+    }
+}
+
+/// Sq8 rerank context. Captures the per-column quantizer and the
+/// per-query precomputes that fold scale/offset into the query side so
+/// the per-doc inner loop is a plain u8-to-f32 widen + SIMD dot.
+pub(crate) struct Sq8Kernel<'a> {
+    metric: Metric,
+    dim: usize,
+    q_prime: Vec<f32>,
+    q_dot_offset: f32,
+    q_norm_sq: f32,
+    per_doc_norms: Option<&'a [f32]>,
+}
+
+impl<'a> Sq8Kernel<'a> {
+    /// Build the per-query kernel. `scale` + `offset` are the per-dim
+    /// quantizer arrays from the column's `codec_meta`. `per_doc_norms`
+    /// is `Some` iff the column metric is L2Sq.
+    pub fn new(
+        metric: Metric,
+        query: &[f32],
+        scale: &[f32],
+        offset: &[f32],
+        per_doc_norms: Option<&'a [f32]>,
+    ) -> Self {
+        let dim = query.len();
+        debug_assert_eq!(scale.len(), dim);
+        debug_assert_eq!(offset.len(), dim);
+        let mut q_prime = vec![0.0f32; dim];
+        let mut q_dot_offset_acc = f32x8::ZERO;
+        let mut i = 0;
+        while i + 8 <= dim {
+            let qc = f32x8::from(<[f32; 8]>::try_from(&query[i..i + 8]).expect("len-8 slice"));
+            let sc = f32x8::from(<[f32; 8]>::try_from(&scale[i..i + 8]).expect("len-8 slice"));
+            let oc = f32x8::from(<[f32; 8]>::try_from(&offset[i..i + 8]).expect("len-8 slice"));
+            let qp = qc * sc;
+            q_prime[i..i + 8].copy_from_slice(&qp.to_array());
+            q_dot_offset_acc += qc * oc;
+            i += 8;
+        }
+        let mut q_dot_offset = q_dot_offset_acc.reduce_add();
+        while i < dim {
+            q_prime[i] = query[i] * scale[i];
+            q_dot_offset += query[i] * offset[i];
+            i += 1;
+        }
+        let q_norm_sq = match metric {
+            Metric::L2Sq => dot(query, query),
+            Metric::Cosine | Metric::NegDot => 0.0,
+        };
+        Self {
+            metric,
+            dim,
+            q_prime,
+            q_dot_offset,
+            q_norm_sq,
+            per_doc_norms,
+        }
+    }
+
+    /// Distance for one rerank candidate at position `pos`, with
+    /// `dim` u8 codes at `code_bytes`. Smaller = closer for every
+    /// metric.
+    #[inline]
+    pub fn distance_at(&self, pos: u32, code_bytes: &[u8]) -> f32 {
+        debug_assert_eq!(code_bytes.len(), self.dim);
+        let mut acc = f32x8::ZERO;
+        let mut i = 0;
+        while i + 8 <= self.dim {
+            let qc: [f32; 8] = self.q_prime[i..i + 8]
+                .try_into()
+                .expect("q_prime[i..i+8] len 8");
+            let mut bc = [0f32; 8];
+            for (j, slot) in bc.iter_mut().enumerate() {
+                *slot = code_bytes[i + j] as f32;
+            }
+            let qv = f32x8::from(qc);
+            let bv = f32x8::from(bc);
+            acc += qv * bv;
+            i += 8;
+        }
+        let mut cross = acc.reduce_add();
+        while i < self.dim {
+            cross += self.q_prime[i] * (code_bytes[i] as f32);
+            i += 1;
+        }
+        let dot = cross + self.q_dot_offset;
+        match self.metric {
+            Metric::Cosine => 1.0 - dot,
+            Metric::NegDot => -dot,
+            Metric::L2Sq => {
+                let norms = self
+                    .per_doc_norms
+                    .expect("Sq8Kernel + L2Sq requires per_doc_norms");
+                let x_norm_sq = norms[pos as usize];
+                self.q_norm_sq - 2.0 * dot + x_norm_sq
+            }
+        }
+    }
+}
+
+/// Distance against a vector stored as little-endian bf16 bytes
+/// (2 bytes per dim). See [`distance_bytes_codec`] for context.
+#[inline]
+pub(crate) fn distance_bytes_bf16(metric: Metric, query: &[f32], bytes: &[u8]) -> f32 {
+    debug_assert_eq!(query.len() * 2, bytes.len());
+    match metric {
+        Metric::Cosine => 1.0 - dot_bf16_bytes(query, bytes),
+        Metric::L2Sq => l2_sq_bf16_bytes(query, bytes),
+        Metric::NegDot => -dot_bf16_bytes(query, bytes),
+    }
+}
+
+/// Encode an fp32 value as bf16 with round-to-nearest-even on the
+/// truncated low 16 bits. NaN inputs return a sign-preserving bf16
+/// NaN. Widening back to f32 is exact: the bf16 bits become the top
+/// 16 bits of the fp32 representation and the low 16 bits are zero.
+#[inline]
+pub(crate) fn fp32_to_bf16(x: f32) -> u16 {
+    let bits = x.to_bits();
+    if (bits & 0x7FFF_FFFF) > 0x7F80_0000 {
+        ((bits >> 16) | 0x0040) as u16
+    } else {
+        let lsb = (bits >> 16) & 1;
+        let bias = 0x7FFF_u32 + lsb;
+        (bits.wrapping_add(bias) >> 16) as u16
+    }
+}
+
+/// Widen bf16 to f32 exactly.
+#[inline]
+pub(crate) fn bf16_to_f32(bf: u16) -> f32 {
+    f32::from_bits((bf as u32) << 16)
+}
+
+#[inline]
+fn dot_bf16_bytes(query: &[f32], bytes: &[u8]) -> f32 {
+    debug_assert_eq!(query.len() * 2, bytes.len());
+    let mut acc = f32x8::ZERO;
+    let mut i = 0;
+    while i + 8 <= query.len() {
+        let qc: [f32; 8] = query[i..i + 8]
+            .try_into()
+            .expect("slice [i..i+8] has length 8");
+        let mut bc = [0f32; 8];
+        let off = i * 2;
+        for (j, slot) in bc.iter_mut().enumerate() {
+            let bf = u16::from_le_bytes([bytes[off + j * 2], bytes[off + j * 2 + 1]]);
+            *slot = bf16_to_f32(bf);
+        }
+        let qv = f32x8::from(qc);
+        let bv = f32x8::from(bc);
+        acc += qv * bv;
+        i += 8;
+    }
+    let mut sum = acc.reduce_add();
+    while i < query.len() {
+        let off = i * 2;
+        let bf = u16::from_le_bytes([bytes[off], bytes[off + 1]]);
+        sum += query[i] * bf16_to_f32(bf);
+        i += 1;
+    }
+    sum
+}
+
+#[inline]
+fn l2_sq_bf16_bytes(query: &[f32], bytes: &[u8]) -> f32 {
+    debug_assert_eq!(query.len() * 2, bytes.len());
+    let mut acc = f32x8::ZERO;
+    let mut i = 0;
+    while i + 8 <= query.len() {
+        let qc: [f32; 8] = query[i..i + 8]
+            .try_into()
+            .expect("slice [i..i+8] has length 8");
+        let mut bc = [0f32; 8];
+        let off = i * 2;
+        for (j, slot) in bc.iter_mut().enumerate() {
+            let bf = u16::from_le_bytes([bytes[off + j * 2], bytes[off + j * 2 + 1]]);
+            *slot = bf16_to_f32(bf);
+        }
+        let qv = f32x8::from(qc);
+        let bv = f32x8::from(bc);
+        let d = qv - bv;
+        acc += d * d;
+        i += 8;
+    }
+    let mut sum = acc.reduce_add();
+    while i < query.len() {
+        let off = i * 2;
+        let bf = u16::from_le_bytes([bytes[off], bytes[off + 1]]);
+        let d = query[i] - bf16_to_f32(bf);
         sum += d * d;
         i += 1;
     }
@@ -379,5 +605,301 @@ mod tests {
                 "metric {m:?}: near {d_near} should be < far {d_far}"
             );
         }
+    }
+
+    // --- bf16 round-trip + distance ------------------------------------
+
+    fn encode_bf16(values: &[f32]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(values.len() * 2);
+        for &x in values {
+            out.extend_from_slice(&fp32_to_bf16(x).to_le_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn bf16_round_trip_exact_for_representable_values() {
+        // Values whose low 16 mantissa bits are already zero round-trip
+        // exactly through bf16: 0, 1, integers with bf16 mantissa
+        // precision, powers of two.
+        for &x in &[0.0f32, 1.0, -1.0, 2.0, 4.0, 0.5, -0.5] {
+            let bf = fp32_to_bf16(x);
+            assert_eq!(bf16_to_f32(bf), x, "value {x} did not round-trip");
+        }
+    }
+
+    #[test]
+    fn bf16_round_trip_within_relative_tolerance() {
+        // Arbitrary fp32s round-trip within ~2⁻⁸ relative error.
+        for &x in &[1.234e-3f32, 0.123_456_7, 1.5e3, -7.7e-2, 42.0] {
+            let bf = fp32_to_bf16(x);
+            let r = bf16_to_f32(bf);
+            let err = ((r - x) / x).abs();
+            assert!(err <= 1.0 / 128.0, "value {x}: round-trip err {err}");
+        }
+    }
+
+    #[test]
+    fn bf16_ties_round_to_even() {
+        // Midpoint between two bf16 values: exact-half mantissa.
+        // 1.0 has bits 0x3F80_0000. A midpoint is 0x3F80_8000 (the
+        // mantissa LSB-of-bf16 is 0, low 16 = 0x8000). Tie should
+        // round DOWN to 1.0 (even mantissa), not up.
+        let mid_down = f32::from_bits(0x3F80_8000);
+        assert_eq!(bf16_to_f32(fp32_to_bf16(mid_down)), 1.0);
+        // Next bf16 is 0x3F81 → 1.0078125; midpoint at 0x3F81_8000
+        // rounds UP to 1.015625 because 0x3F81's mantissa LSB is 1
+        // (so down would be odd, up is even).
+        let mid_up = f32::from_bits(0x3F81_8000);
+        assert_eq!(
+            bf16_to_f32(fp32_to_bf16(mid_up)),
+            f32::from_bits(0x3F82_0000)
+        );
+    }
+
+    #[test]
+    fn distance_bytes_bf16_matches_fp32_within_tolerance() {
+        let q: Vec<f32> = (0..16).map(|i| (i as f32) * 0.1 - 0.7).collect();
+        let v: Vec<f32> = (0..16).map(|i| (i as f32) * 0.05 + 0.3).collect();
+        let bytes = encode_bf16(&v);
+        for m in [Metric::Cosine, Metric::L2Sq, Metric::NegDot] {
+            let d_ref = distance(m, &q, &v);
+            let d_bf16 = distance_bytes_bf16(m, &q, &bytes);
+            let abs_err = (d_ref - d_bf16).abs();
+            let rel_err = abs_err / d_ref.abs().max(1e-6);
+            // bf16 has 8 bits of mantissa → per-lane relative error
+            // ~2⁻⁸ ≈ 4e-3. Sum-of-products amplifies by √dim ≈ 4.
+            assert!(
+                rel_err <= 2e-2 || abs_err <= 1e-3,
+                "metric {m:?}: bf16 {d_bf16} vs fp32 {d_ref} (rel {rel_err})"
+            );
+        }
+    }
+
+    #[test]
+    fn distance_bytes_codec_dispatches_correctly() {
+        let q: Vec<f32> = (0..8).map(|i| i as f32 * 0.1).collect();
+        let v: Vec<f32> = (0..8).map(|i| (i as f32) * 0.2 - 0.5).collect();
+        let bytes_fp32: Vec<u8> = v.iter().flat_map(|x| x.to_le_bytes().into_iter()).collect();
+        let bytes_bf16 = encode_bf16(&v);
+
+        let d_fp32 = distance_bytes_codec(Metric::L2Sq, RerankCodec::Fp32, &q, &bytes_fp32);
+        let d_bf16 = distance_bytes_codec(Metric::L2Sq, RerankCodec::Bf16, &q, &bytes_bf16);
+
+        // fp32 path must equal the plain f32 reference exactly.
+        assert_eq!(d_fp32, distance(Metric::L2Sq, &q, &v));
+        // bf16 path must be within tolerance of the reference.
+        let err = (d_bf16 - d_fp32).abs();
+        assert!(err <= 5e-3, "bf16 dispatch err {err}");
+    }
+
+    // --- sq8 kernel -----------------------------------------------------
+
+    /// Encode `values` to u8 codes using the same per-dim
+    /// `scale`/`offset` the kernel will decode under.
+    fn encode_sq8(values: &[f32], dim: usize, scale: &[f32], offset: &[f32]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(values.len());
+        for row in values.chunks_exact(dim) {
+            for d in 0..dim {
+                let q = ((row[d] - offset[d]) / scale[d]).round().clamp(0.0, 255.0) as u8;
+                out.push(q);
+            }
+        }
+        out
+    }
+
+    /// Decode the same u8 codes back to fp32 — the reference the
+    /// kernel must agree with.
+    fn decode_sq8(codes: &[u8], dim: usize, scale: &[f32], offset: &[f32]) -> Vec<f32> {
+        codes
+            .iter()
+            .enumerate()
+            .map(|(i, &c)| (c as f32) * scale[i % dim] + offset[i % dim])
+            .collect()
+    }
+
+    #[test]
+    fn sq8_kernel_dot_matches_decoded_reference() {
+        let dim = 16usize;
+        let query: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.05 - 0.3).collect();
+        let scale: Vec<f32> = (0..dim).map(|i| 0.01 + (i as f32) * 0.002).collect();
+        let offset: Vec<f32> = (0..dim).map(|i| -1.0 + (i as f32) * 0.1).collect();
+        let codes: Vec<u8> = (0..dim).map(|i| ((i * 17 + 3) % 256) as u8).collect();
+        let decoded = decode_sq8(&codes, dim, &scale, &offset);
+
+        for m in [Metric::Cosine, Metric::NegDot] {
+            let want = distance(m, &query, &decoded);
+            let kernel = Sq8Kernel::new(m, &query, &scale, &offset, None);
+            let got = kernel.distance_at(0, &codes);
+            let err = (want - got).abs();
+            assert!(
+                err <= 1e-4,
+                "metric {m:?}: kernel {got} vs decoded ref {want} (err {err})"
+            );
+        }
+    }
+
+    #[test]
+    fn sq8_kernel_l2sq_matches_decoded_reference() {
+        let dim = 24usize;
+        let query: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.07 - 0.1).collect();
+        let scale: Vec<f32> = (0..dim).map(|i| 0.02 + (i as f32) * 0.003).collect();
+        let offset: Vec<f32> = (0..dim).map(|i| 0.5 - (i as f32) * 0.05).collect();
+        // Two docs with very different codes — exercise both
+        // pos=0 and pos=1 into the norms table.
+        let codes_doc0: Vec<u8> = (0..dim).map(|i| ((i * 7) % 256) as u8).collect();
+        let codes_doc1: Vec<u8> = (0..dim).map(|i| ((i * 31 + 12) % 256) as u8).collect();
+        let decoded0 = decode_sq8(&codes_doc0, dim, &scale, &offset);
+        let decoded1 = decode_sq8(&codes_doc1, dim, &scale, &offset);
+        let norm0: f32 = decoded0.iter().map(|x| x * x).sum();
+        let norm1: f32 = decoded1.iter().map(|x| x * x).sum();
+        let per_doc_norms = vec![norm0, norm1];
+
+        let kernel = Sq8Kernel::new(Metric::L2Sq, &query, &scale, &offset, Some(&per_doc_norms));
+
+        let got0 = kernel.distance_at(0, &codes_doc0);
+        let want0 = distance(Metric::L2Sq, &query, &decoded0);
+        assert!(
+            (want0 - got0).abs() <= 1e-3,
+            "doc0: kernel {got0} vs decoded ref {want0}"
+        );
+
+        let got1 = kernel.distance_at(1, &codes_doc1);
+        let want1 = distance(Metric::L2Sq, &query, &decoded1);
+        assert!(
+            (want1 - got1).abs() <= 1e-3,
+            "doc1: kernel {got1} vs decoded ref {want1}"
+        );
+    }
+
+    #[test]
+    fn sq8_kernel_handles_tail_dim_not_multiple_of_8() {
+        // Dim 13: one SIMD chunk + 5-lane tail. The kernel's
+        // per-query loop must merge the tail into q_prime /
+        // q_dot_offset; the per-doc loop must merge the tail
+        // into `cross`.
+        let dim = 13usize;
+        let query: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.03 + 0.1).collect();
+        let scale: Vec<f32> = (0..dim).map(|i| 0.01 + (i as f32) * 0.001).collect();
+        let offset: Vec<f32> = (0..dim).map(|i| -0.1 + (i as f32) * 0.02).collect();
+        let codes: Vec<u8> = (0..dim).map(|i| ((i * 11 + 5) % 256) as u8).collect();
+        let decoded = decode_sq8(&codes, dim, &scale, &offset);
+
+        let kernel = Sq8Kernel::new(Metric::NegDot, &query, &scale, &offset, None);
+        let got = kernel.distance_at(0, &codes);
+        let want = distance(Metric::NegDot, &query, &decoded);
+        assert!(
+            (want - got).abs() <= 1e-4,
+            "tail-dim Sq8 kernel: got {got} vs decoded ref {want}"
+        );
+    }
+
+    #[test]
+    fn sq8_full_round_trip_within_recall_tolerance_of_fp32() {
+        // Multi-doc corpus so per-dim min < max (a single-doc
+        // corpus collapses to scale=1.0/offset=x per dim — the
+        // degenerate-dim guard, not the real quantizer).
+        //
+        // Worst-case per-dim quantization error is `scale/2 ≈
+        // (max-min)/510`. For this corpus, per-dim span ≈ 32 →
+        // error ≈ 0.063 per dim. |q-x|² over 16 dims is bounded
+        // by ≈ Σ_d (2·|q_d-x_d|·0.063 + 0.063²) ≈ a few units.
+        // The test pins generous tolerances per metric to stay
+        // robust against rounding on different platforms.
+        let dim = 16usize;
+        let n_docs = 32usize;
+        let query: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.5).collect();
+        let corpus: Vec<f32> = (0..n_docs)
+            .flat_map(|i| (0..dim).map(move |j| ((i * 7 + j * 3) as f32 % 32.0) - 8.0))
+            .collect();
+
+        let mut min_v = vec![f32::INFINITY; dim];
+        let mut max_v = vec![f32::NEG_INFINITY; dim];
+        for row in corpus.chunks_exact(dim) {
+            for (d, &x) in row.iter().enumerate() {
+                min_v[d] = min_v[d].min(x);
+                max_v[d] = max_v[d].max(x);
+            }
+        }
+        // Sanity check: per-dim span is non-zero, so we're
+        // exercising real quantization rather than the
+        // degenerate-dim guard. Catches a future test edit that
+        // accidentally re-shrinks the corpus.
+        for d in 0..dim {
+            assert!(
+                max_v[d] - min_v[d] > 0.0,
+                "test corpus must span each dim: dim {d} has min == max"
+            );
+        }
+
+        let mut scale = vec![0.0f32; dim];
+        let mut offset = vec![0.0f32; dim];
+        for d in 0..dim {
+            offset[d] = min_v[d];
+            scale[d] = (max_v[d] - min_v[d]) / 255.0;
+        }
+        let codes_all = encode_sq8(&corpus, dim, &scale, &offset);
+        let decoded_all = decode_sq8(&codes_all, dim, &scale, &offset);
+
+        // Per-doc norms for the L2Sq branch — indexed by pos
+        // matching the builder's contract.
+        let per_doc_norms: Vec<f32> = decoded_all
+            .chunks_exact(dim)
+            .map(|row| row.iter().map(|x| x * x).sum::<f32>())
+            .collect();
+
+        for m in [Metric::Cosine, Metric::L2Sq, Metric::NegDot] {
+            let norms_arg: Option<&[f32]> = match m {
+                Metric::L2Sq => Some(&per_doc_norms),
+                _ => None,
+            };
+            let kernel = Sq8Kernel::new(m, &query, &scale, &offset, norms_arg);
+            // Probe a handful of doc positions — exercises both
+            // norms-table indexing and the per-doc inner loop on
+            // independent codes.
+            for pos in [0u32, 1, 5, 17, 31] {
+                let codes_doc = &codes_all[(pos as usize) * dim..(pos as usize + 1) * dim];
+                let decoded_doc = &decoded_all[(pos as usize) * dim..(pos as usize + 1) * dim];
+                let got = kernel.distance_at(pos, codes_doc);
+                let want_fp32 = distance(
+                    m,
+                    &query,
+                    &corpus[(pos as usize) * dim..(pos as usize + 1) * dim],
+                );
+                let want_decoded = distance(m, &query, decoded_doc);
+                // Kernel must match the decoded reference very
+                // tightly — it's doing the same math, just fused
+                // through the per-query precompute. Difference
+                // from fp32 is the quantization error itself.
+                assert!(
+                    (got - want_decoded).abs() <= 1e-3,
+                    "metric {m:?} pos {pos}: kernel {got} vs decoded ref {want_decoded}"
+                );
+                let rel = (got - want_fp32).abs() / want_fp32.abs().max(1e-2);
+                assert!(
+                    rel <= 0.1 || (got - want_fp32).abs() <= 1.0,
+                    "metric {m:?} pos {pos}: Sq8 {got} vs fp32 {want_fp32} (rel {rel})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn distance_bytes_bf16_handles_tail_dim_not_multiple_of_8() {
+        // Dim 11: 1 SIMD chunk of 8 + scalar tail of 3. Both branches
+        // must round-trip values consistently; the test catches a tail
+        // path that skipped bf16 widening (would surface as an
+        // order-of-magnitude error, not the ~0.3 % bf16 round-trip
+        // error we tolerate here).
+        let q: Vec<f32> = (0..11).map(|i| (i as f32) * 0.1).collect();
+        let v: Vec<f32> = (0..11).map(|i| (i as f32) * 0.2 + 0.1).collect();
+        let bytes = encode_bf16(&v);
+        let d_ref = distance(Metric::L2Sq, &q, &v);
+        let d_bf16 = distance_bytes_bf16(Metric::L2Sq, &q, &bytes);
+        let rel = (d_ref - d_bf16).abs() / d_ref.abs().max(1e-6);
+        assert!(
+            rel <= 1e-2,
+            "tail-dim bf16 {d_bf16} vs fp32 {d_ref} (rel {rel})"
+        );
     }
 }

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -235,7 +235,7 @@ pub(crate) struct Sq8Kernel<'a> {
 impl<'a> Sq8Kernel<'a> {
     /// Build the per-query kernel. `scale` + `offset` are the per-dim
     /// quantizer arrays from the column's `codec_meta`. `per_doc_norms`
-    /// is `Some` iff the column metric is L2Sq.
+    /// is `Some` iff the column metric is L2Sq or Cosine.
     pub fn new(
         metric: Metric,
         query: &[f32],
@@ -306,7 +306,17 @@ impl<'a> Sq8Kernel<'a> {
         }
         let dot = cross + self.q_dot_offset;
         match self.metric {
-            Metric::Cosine => 1.0 - dot,
+            Metric::Cosine => {
+                let norms = self
+                    .per_doc_norms
+                    .expect("Sq8Kernel + Cosine requires per_doc_norms");
+                let x_norm = norms[pos as usize].sqrt();
+                if x_norm > 0.0 {
+                    1.0 - dot / x_norm
+                } else {
+                    1.0 - dot
+                }
+            }
             Metric::NegDot => -dot,
             Metric::L2Sq => {
                 let norms = self
@@ -325,7 +335,15 @@ impl<'a> Sq8Kernel<'a> {
 pub(crate) fn distance_bytes_bf16(metric: Metric, query: &[f32], bytes: &[u8]) -> f32 {
     debug_assert_eq!(query.len() * 2, bytes.len());
     match metric {
-        Metric::Cosine => 1.0 - dot_bf16_bytes(query, bytes),
+        Metric::Cosine => {
+            let (dot, norm_sq) = dot_and_norm_sq_bf16_bytes(query, bytes);
+            let norm = norm_sq.sqrt();
+            if norm > 0.0 {
+                1.0 - dot / norm
+            } else {
+                1.0 - dot
+            }
+        }
         Metric::L2Sq => l2_sq_bf16_bytes(query, bytes),
         Metric::NegDot => -dot_bf16_bytes(query, bytes),
     }
@@ -381,6 +399,41 @@ fn dot_bf16_bytes(query: &[f32], bytes: &[u8]) -> f32 {
         i += 1;
     }
     sum
+}
+
+#[inline]
+fn dot_and_norm_sq_bf16_bytes(query: &[f32], bytes: &[u8]) -> (f32, f32) {
+    debug_assert_eq!(query.len() * 2, bytes.len());
+    let mut dot_acc = f32x8::ZERO;
+    let mut norm_acc = f32x8::ZERO;
+    let mut i = 0;
+    while i + 8 <= query.len() {
+        let qc: [f32; 8] = query[i..i + 8]
+            .try_into()
+            .expect("slice [i..i+8] has length 8");
+        let mut bc = [0f32; 8];
+        let off = i * 2;
+        for (j, slot) in bc.iter_mut().enumerate() {
+            let bf = u16::from_le_bytes([bytes[off + j * 2], bytes[off + j * 2 + 1]]);
+            *slot = bf16_to_f32(bf);
+        }
+        let qv = f32x8::from(qc);
+        let bv = f32x8::from(bc);
+        dot_acc += qv * bv;
+        norm_acc += bv * bv;
+        i += 8;
+    }
+    let mut dot_sum = dot_acc.reduce_add();
+    let mut norm_sum = norm_acc.reduce_add();
+    while i < query.len() {
+        let off = i * 2;
+        let bf = u16::from_le_bytes([bytes[off], bytes[off + 1]]);
+        let x = bf16_to_f32(bf);
+        dot_sum += query[i] * x;
+        norm_sum += x * x;
+        i += 1;
+    }
+    (dot_sum, norm_sum)
 }
 
 #[inline]
@@ -663,7 +716,13 @@ mod tests {
         let v: Vec<f32> = (0..16).map(|i| (i as f32) * 0.05 + 0.3).collect();
         let bytes = encode_bf16(&v);
         for m in [Metric::Cosine, Metric::L2Sq, Metric::NegDot] {
-            let d_ref = distance(m, &q, &v);
+            let d_ref = match m {
+                Metric::Cosine => {
+                    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+                    1.0 - dot(&q, &v) / norm
+                }
+                _ => distance(m, &q, &v),
+            };
             let d_bf16 = distance_bytes_bf16(m, &q, &bytes);
             let abs_err = (d_ref - d_bf16).abs();
             let rel_err = abs_err / d_ref.abs().max(1e-6);
@@ -727,9 +786,19 @@ mod tests {
         let codes: Vec<u8> = (0..dim).map(|i| ((i * 17 + 3) % 256) as u8).collect();
         let decoded = decode_sq8(&codes, dim, &scale, &offset);
 
+        let decoded_norm: f32 = decoded.iter().map(|x| x * x).sum();
         for m in [Metric::Cosine, Metric::NegDot] {
-            let want = distance(m, &query, &decoded);
-            let kernel = Sq8Kernel::new(m, &query, &scale, &offset, None);
+            let norms = [decoded_norm];
+            let want = match m {
+                Metric::Cosine => 1.0 - dot(&query, &decoded) / decoded_norm.sqrt(),
+                _ => distance(m, &query, &decoded),
+            };
+            let norms_arg = if matches!(m, Metric::Cosine) {
+                Some(&norms[..])
+            } else {
+                None
+            };
+            let kernel = Sq8Kernel::new(m, &query, &scale, &offset, norms_arg);
             let got = kernel.distance_at(0, &codes);
             let err = (want - got).abs();
             assert!(
@@ -841,7 +910,7 @@ mod tests {
         let codes_all = encode_sq8(&corpus, dim, &scale, &offset);
         let decoded_all = decode_sq8(&codes_all, dim, &scale, &offset);
 
-        // Per-doc norms for the L2Sq branch — indexed by pos
+        // Per-doc norms for the L2Sq/Cosine branches — indexed by pos
         // matching the builder's contract.
         let per_doc_norms: Vec<f32> = decoded_all
             .chunks_exact(dim)
@@ -850,8 +919,8 @@ mod tests {
 
         for m in [Metric::Cosine, Metric::L2Sq, Metric::NegDot] {
             let norms_arg: Option<&[f32]> = match m {
-                Metric::L2Sq => Some(&per_doc_norms),
-                _ => None,
+                Metric::L2Sq | Metric::Cosine => Some(&per_doc_norms),
+                Metric::NegDot => None,
             };
             let kernel = Sq8Kernel::new(m, &query, &scale, &offset, norms_arg);
             // Probe a handful of doc positions — exercises both
@@ -861,12 +930,21 @@ mod tests {
                 let codes_doc = &codes_all[(pos as usize) * dim..(pos as usize + 1) * dim];
                 let decoded_doc = &decoded_all[(pos as usize) * dim..(pos as usize + 1) * dim];
                 let got = kernel.distance_at(pos, codes_doc);
-                let want_fp32 = distance(
-                    m,
-                    &query,
-                    &corpus[(pos as usize) * dim..(pos as usize + 1) * dim],
-                );
-                let want_decoded = distance(m, &query, decoded_doc);
+                let fp32_doc = &corpus[(pos as usize) * dim..(pos as usize + 1) * dim];
+                let want_fp32 = match m {
+                    Metric::Cosine => {
+                        let norm = fp32_doc.iter().map(|x| x * x).sum::<f32>().sqrt();
+                        1.0 - dot(&query, fp32_doc) / norm
+                    }
+                    _ => distance(m, &query, fp32_doc),
+                };
+                let want_decoded = match m {
+                    Metric::Cosine => {
+                        let norm = per_doc_norms[pos as usize].sqrt();
+                        1.0 - dot(&query, decoded_doc) / norm
+                    }
+                    _ => distance(m, &query, decoded_doc),
+                };
                 // Kernel must match the decoded reference very
                 // tightly — it's doing the same math, just fused
                 // through the per-query precompute. Difference

--- a/src/superfile/vector/mod.rs
+++ b/src/superfile/vector/mod.rs
@@ -13,6 +13,7 @@ pub mod distance;
 pub mod kmeans;
 pub mod quant;
 pub mod reader;
+pub mod rerank_codec;
 pub mod reservoir;
 pub mod rotation;
 pub mod spill;

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -11,8 +11,9 @@
 use crate::superfile::format::checksum::crc32c;
 use crate::superfile::format::{self};
 use crate::superfile::lazy_source::{LazyByteSource, LazyByteSourceError};
-use crate::superfile::vector::distance::{Metric, distance_bytes};
+use crate::superfile::vector::distance::{Metric, Sq8Kernel, distance_bytes, distance_bytes_codec};
 use crate::superfile::vector::quant::BitQuantizer;
+use crate::superfile::vector::rerank_codec::RerankCodec;
 use crate::superfile::vector::rotation::RandomRotation;
 use crate::superfile::{ReadError, error::VectorError};
 use bytes::Bytes;
@@ -39,6 +40,34 @@ pub struct VectorColumnConfig {
     pub metric: String,
 }
 
+/// Sq8 quantizer state materialised from the on-disk `codec_meta`
+/// region at open time. The reader picks the candidate's cluster
+/// slice of `scale` / `offset` and passes it into [`Sq8Kernel::new`]
+/// once per (query, cluster) pair to build the per-query precomputes.
+///
+/// Per-cluster (not per-column) quantizer: each IVF cluster
+/// owns its own `(scale[dim], offset[dim])` pair, packed
+/// contiguously cluster-by-cluster. Per-cluster quantization avoids
+/// stretching 256 buckets over the whole column when the rerank signal
+/// lives inside much narrower IVF clusters.
+#[derive(Debug, Clone)]
+pub(super) struct Sq8ColumnMeta {
+    /// Per-cluster, per-dim quantizer scale. Length =
+    /// `n_cent × dim`, laid out cluster-major: cluster `c`'s
+    /// scale array is `scale[c·dim .. (c+1)·dim]`.
+    /// `x_decoded[d] = code[d] * scale[c·dim + d] + offset[c·dim + d]`
+    /// for a doc in cluster `c`.
+    pub scale: Vec<f32>,
+    /// Per-cluster, per-dim quantizer offset. Same layout as `scale`.
+    pub offset: Vec<f32>,
+    /// Per-doc `Σ_d x_decoded²`, length == n_docs, indexed by
+    /// position-in-full (matches the rerank shortlist's `pos`
+    /// field). `Some` for L2Sq columns; `None` for Cosine /
+    /// NegDot (the `Σx²` term cancels out of those distance
+    /// formulas).
+    pub per_doc_norms: Option<Vec<f32>>,
+}
+
 /// Per-column reader state; cached at open time.
 #[derive(Debug)]
 pub struct ColumnReader {
@@ -48,6 +77,11 @@ pub struct ColumnReader {
     pub n_docs: u32,
     pub metric: Metric,
     pub rot_seed: u64,
+    /// On-disk rerank codec for this column.
+    pub rerank_codec: RerankCodec,
+    /// `Sq8`-only quantizer metadata, materialised at open time from
+    /// the `codec_meta` region. `None` for every other codec.
+    pub(super) sq8_meta: Option<Sq8ColumnMeta>,
     /// Byte range of this column's subsection within the outer blob.
     subsection_range: Range<usize>,
     /// Offsets relative to the subsection start.
@@ -56,6 +90,10 @@ pub struct ColumnReader {
     centroids_off: usize,
     cluster_idx_off: usize,
     codes_off: usize,
+    /// Relative offset of the per-column `codec_meta` region inside
+    /// the subsection. `0` means "no codec_meta in this subsection".
+    #[allow(dead_code)]
+    codec_meta_off: usize,
     full_off: usize,
     doc_ids_off: usize,
     quant: BitQuantizer,
@@ -408,8 +446,24 @@ impl VectorReader {
             let rot_seed = read_u64_le(&dir_bytes[entry_off + 16..entry_off + 24]);
             let subsection_off = read_u64_le(&dir_bytes[entry_off + 24..entry_off + 32]) as usize;
             let subsection_len = read_u64_le(&dir_bytes[entry_off + 32..entry_off + 40]) as usize;
-            // bytes [40..48] = summary_offset (absolute), [48..52] = summary_length, then padding
+            // bytes [40..48] = summary_offset (absolute), [48..52] = summary_length,
+            // [52..56] = codec_id (1) + reserved (3)
             let _summary_off_abs = read_u64_le(&dir_bytes[entry_off + 40..entry_off + 48]);
+            let codec_id = dir_bytes[entry_off + 52];
+            let rerank_codec = RerankCodec::from_codec_id(codec_id).ok_or_else(|| {
+                VectorError::Read(ReadError::MalformedVersion(format!(
+                    "column '{}' has unknown rerank-codec id {codec_id} \
+                     (known ids: 0=fp32, 1=bf16, 2=sq8, 3=none)",
+                    cfg.name
+                )))
+            })?;
+            if !rerank_codec.is_implemented() {
+                return Err(VectorError::Read(ReadError::MalformedVersion(format!(
+                    "column '{}' uses rerank codec {} which is not implemented by this version",
+                    cfg.name,
+                    rerank_codec.name()
+                ))));
+            }
 
             // Validate against JSON.
             if dim != cfg.dim {
@@ -461,7 +515,8 @@ impl VectorReader {
 
             // Sub-header parse (SUB_HEADER_SIZE = 56 bytes):
             //   [8..12]  version  (cross-checked against outer header)
-            //   [12..16] reserved
+            //   [12..16] codec_meta_off (former reserved slot; zero
+            //            for Fp32 and legacy fp32 segments).
             //   [16..24] summary_centroid_offset (relative to sub start)
             //   [24..28] summary_radius_x100
             //   [28..32] reserved
@@ -469,12 +524,30 @@ impl VectorReader {
             //   [40..48] cluster_idx_offset
             //   [48..52] codes_offset
             //   [52..56] full_offset
+            let codec_meta_off = read_u32_le(&sub[12..16]) as usize;
             let summary_off = read_u64_le(&sub[16..24]) as usize;
             let summary_radius_x100 = read_u32_le(&sub[24..28]);
             let centroids_off = read_u64_le(&sub[32..40]) as usize;
             let cluster_idx_off = read_u64_le(&sub[40..48]) as usize;
             let codes_off = read_u32_le(&sub[48..52]) as usize;
             let full_off = read_u32_le(&sub[52..56]) as usize;
+            // Fp32 + Bf16 + None all keep zero-byte codec_meta; Sq8
+            // emits per-cluster scale/offset (+ per-doc
+            // norms for L2Sq). The per-codec layout check below
+            // validates the declared `codec_meta_off` against the
+            // codec's expected size once `col_n_docs` is known.
+            let codec_meta_required_zero = matches!(
+                rerank_codec,
+                RerankCodec::Fp32 | RerankCodec::Bf16 | RerankCodec::None
+            );
+            if codec_meta_required_zero && codec_meta_off != 0 {
+                return Err(VectorError::Read(ReadError::MalformedVersion(format!(
+                    "column '{}' has codec_meta_off={codec_meta_off} for codec {}; \
+                     fp32/bf16/none must write codec_meta_off=0 (zero-byte meta region)",
+                    cfg.name,
+                    rerank_codec.name()
+                ))));
+            }
 
             let summary_radius = (summary_radius_x100 as f32) / 100.0;
 
@@ -484,15 +557,23 @@ impl VectorReader {
             // cluster_idx + codes + full + doc_ids.
             let quant = BitQuantizer::new(dim);
             let code_bytes = quant.code_bytes();
-            // We can derive n_docs from the cluster index: sum of counts
-            // across clusters. Or from the layout: doc_ids region size
-            // / 4. Let's compute from doc_ids region:
-            //   doc_ids_size = sub.len() - 4 - doc_ids_off
-            // But we need doc_ids_off first. Use full_off + full_size:
-            // that requires n_docs, circular. Instead derive from
-            // codes region: codes region size = full_off - codes_off,
-            // and codes region size = n_docs * code_bytes.
-            let codes_size = full_off - codes_off;
+            // Derive `n_docs` from the codes region size. The codes
+            // region is [codes_off, end_of_codes), where end_of_codes
+            // is either `codec_meta_off` (Sq8) or `full_off` (Fp32 /
+            // Bf16 — no codec_meta region between codes and full).
+            let end_of_codes = if codec_meta_off != 0 {
+                if codec_meta_off <= codes_off || codec_meta_off > full_off {
+                    return Err(VectorError::Read(ReadError::MalformedVersion(format!(
+                        "column '{}' has codec_meta_off={codec_meta_off} outside \
+                         (codes_off={codes_off}, full_off={full_off}]",
+                        cfg.name
+                    ))));
+                }
+                codec_meta_off
+            } else {
+                full_off
+            };
+            let codes_size = end_of_codes - codes_off;
             if code_bytes == 0 || !codes_size.is_multiple_of(code_bytes) {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' codes size {codes_size} not divisible by {code_bytes}",
@@ -501,8 +582,58 @@ impl VectorReader {
             }
             let col_n_docs = (codes_size / code_bytes) as u32;
 
-            let full_size = (col_n_docs as usize) * dim * 4;
+            // `full[]` byte stride depends on the column's rerank codec.
+            // Centroids stay fp32 regardless (only the per-doc rerank
+            // region compresses).
+            let per_vec_bytes = rerank_codec.per_vector_bytes(dim);
+            let full_size = (col_n_docs as usize) * per_vec_bytes;
             let doc_ids_off = full_off + full_size;
+
+            let expected_codec_meta_size =
+                rerank_codec.codec_meta_bytes(dim, col_n_docs as usize, n_cent as usize, metric);
+            let actual_codec_meta_size = if codec_meta_off != 0 {
+                full_off - codec_meta_off
+            } else {
+                0
+            };
+            if actual_codec_meta_size != expected_codec_meta_size {
+                return Err(VectorError::Read(ReadError::MalformedVersion(format!(
+                    "column '{}' codec_meta region is {actual_codec_meta_size} bytes \
+                     on disk, but codec {} / metric {metric:?} expects \
+                     {expected_codec_meta_size} bytes",
+                    cfg.name,
+                    rerank_codec.name()
+                ))));
+            }
+
+            // Materialise Sq8 codec_meta (per-cluster scale + offset
+            // plus optional per-doc norms) at open time. Parse through
+            // `f32::from_le_bytes` because the codec_meta region is not
+            // guaranteed to be 4-byte aligned for all dimensions.
+            let sq8_meta = if rerank_codec == RerankCodec::Sq8 {
+                let meta_start = codec_meta_off;
+                let meta_end = meta_start + actual_codec_meta_size;
+                let meta_bytes = &sub[meta_start..meta_end];
+                let so_block_bytes = (n_cent as usize) * dim * 4;
+                let scale_end = so_block_bytes;
+                let offset_end = scale_end + so_block_bytes;
+                let scale = parse_f32_le_vec(&meta_bytes[0..scale_end]);
+                let offset = parse_f32_le_vec(&meta_bytes[scale_end..offset_end]);
+                let per_doc_norms = if matches!(metric, Metric::L2Sq) {
+                    let norms_end = offset_end + (col_n_docs as usize) * 4;
+                    debug_assert_eq!(norms_end, actual_codec_meta_size);
+                    Some(parse_f32_le_vec(&meta_bytes[offset_end..norms_end]))
+                } else {
+                    None
+                };
+                Some(Sq8ColumnMeta {
+                    scale,
+                    offset,
+                    per_doc_norms,
+                })
+            } else {
+                None
+            };
 
             // Bounds-check the cluster_idx + doc_ids regions without
             // reading them. Search carries `pos = off + i` inline
@@ -547,12 +678,15 @@ impl VectorReader {
                 n_docs: col_n_docs,
                 metric,
                 rot_seed,
+                rerank_codec,
+                sq8_meta,
                 subsection_range: subsection_off..sub_end,
                 summary_off,
                 summary_radius,
                 centroids_off,
                 cluster_idx_off,
                 codes_off,
+                codec_meta_off,
                 full_off,
                 doc_ids_off,
                 quant,
@@ -641,7 +775,10 @@ impl VectorReader {
         if !validated {
             return Ok(Vec::new());
         }
-        let dim_bytes = col.dim * 4;
+        // Centroids are always fp32 (4 bytes/dim) regardless of codec.
+        // `full[]` (rerank candidates) is codec-dependent.
+        let centroid_stride = col.dim * 4;
+        let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
         let sub_start = col.subsection_range.start;
 
         // 1. Centroids region. `n_cent × dim × 4` bytes,
@@ -651,7 +788,7 @@ impl VectorReader {
         //    Source::Lazy bridges to async range() via the
         //    sync→async pattern in Source::get_range.
         let centroids_start = sub_start + col.centroids_off;
-        let centroids_end = centroids_start + (col.n_cent as usize) * dim_bytes;
+        let centroids_end = centroids_start + (col.n_cent as usize) * centroid_stride;
         let centroids = self
             .source
             .get_range(centroids_start..centroids_end)
@@ -676,10 +813,14 @@ impl VectorReader {
         col.rot.apply(query, &mut q_rot);
 
         // 5. Per-cluster fetches (codes + doc_ids) and shortlist
-        //    build. Shortlist tuple is (doc_id, estimate, pos);
-        //    pos = off + i is captured inline.
+        //    build. Shortlist tuple is (doc_id, estimate, pos,
+        //    cluster_id); pos = off + i and cluster_id are
+        //    captured inline at no extra fetch cost. cluster_id
+        //    is consumed by the per-cluster Sq8 rerank dispatch to
+        //    pick each candidate's quantizer; Fp32/Bf16/None
+        //    rerank paths ignore it.
         let cb = col.quant.code_bytes();
-        let mut shortlist: Vec<(u32, f32, u32)> = Vec::new();
+        let mut shortlist: Vec<(u32, f32, u32, u32)> = Vec::new();
         for &(c, _) in &centroid_scores {
             let (off, cnt) = read_cluster_entry(&cluster_idx, c);
             if cnt == 0 {
@@ -702,10 +843,34 @@ impl VectorReader {
                 &doc_ids,
                 cnt,
                 off,
+                c as u32,
                 &col.quant,
                 &q_rot,
                 &mut shortlist,
             );
+        }
+
+        if shortlist.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // `None` columns have no `full[]` region to refine against:
+        // the 1-bit shortlist is the final ranking. Return sign-flipped
+        // estimates so the public `(doc_id, distance)` convention still
+        // means smaller is closer.
+        if matches!(col.rerank_codec, RerankCodec::None) {
+            let _ = rerank_mult;
+            if shortlist.len() > k {
+                shortlist.select_nth_unstable_by(k - 1, |a, b| {
+                    b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal)
+                });
+                shortlist.truncate(k);
+            }
+            shortlist.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+            return Ok(shortlist
+                .into_iter()
+                .map(|(did, est, _pos, _c)| (did, -est))
+                .collect());
         }
 
         // 6. Trim to `k × rerank_mult` by descending estimate.
@@ -716,9 +881,6 @@ impl VectorReader {
             });
             shortlist.truncate(want);
         }
-        if shortlist.is_empty() {
-            return Ok(Vec::new());
-        }
 
         // 7. Fat range over `full[]` covering all rerank
         //    candidates. `[min_pos..max_pos + 1]` over-fetches
@@ -728,7 +890,7 @@ impl VectorReader {
         //    ranges. Single get_range either way.
         let mut min_pos = shortlist[0].2;
         let mut max_pos = shortlist[0].2;
-        for &(_, _, pos) in &shortlist[1..] {
+        for &(_, _, pos, _) in &shortlist[1..] {
             if pos < min_pos {
                 min_pos = pos;
             }
@@ -736,16 +898,20 @@ impl VectorReader {
                 max_pos = pos;
             }
         }
-        let full_start = sub_start + col.full_off + (min_pos as usize) * dim_bytes;
-        let full_end = sub_start + col.full_off + ((max_pos as usize) + 1) * dim_bytes;
+        let full_start = sub_start + col.full_off + (min_pos as usize) * full_vec_bytes;
+        let full_end = sub_start + col.full_off + ((max_pos as usize) + 1) * full_vec_bytes;
         let full_run = self
             .source
             .get_range(full_start..full_end)
             .map_err(|e| VectorError::LazySource(e.to_string()))?;
 
-        // 8. CPU-only rerank using the true metric.
+        // 8. CPU-only rerank using the true metric. Sq8 columns
+        //    pre-build a per-query kernel that folds the per-dim
+        //    scale/offset into the query (one `dim/8` SIMD pass);
+        //    the per-doc inner step is then a plain u8→f32 widen
+        //    + SIMD dot. Fp32/Bf16 take the flat dispatch.
         Ok(rerank_candidates_in_run(
-            &full_run, min_pos, &shortlist, col.metric, col.dim, query, k,
+            &full_run, min_pos, &shortlist, col, query, k,
         ))
     }
 
@@ -788,10 +954,13 @@ impl VectorReader {
 /// helper through the same shape.
 #[inline]
 fn score_centroids(centroids_bytes: &[u8], col: &ColumnReader, query: &[f32]) -> Vec<(usize, f32)> {
-    let dim_bytes = col.dim * 4;
+    // Centroids are stored as fp32 regardless of the column's rerank
+    // codec — only the per-doc `full[]` region compresses. `distance_bytes`
+    // assumes fp32, which is correct here.
+    let centroid_stride = col.dim * 4;
     let mut scores: Vec<(usize, f32)> = (0..col.n_cent as usize)
         .map(|c| {
-            let bytes = &centroids_bytes[c * dim_bytes..(c + 1) * dim_bytes];
+            let bytes = &centroids_bytes[c * centroid_stride..(c + 1) * centroid_stride];
             (c, distance_bytes(col.metric, query, bytes))
         })
         .collect();
@@ -800,19 +969,26 @@ fn score_centroids(centroids_bytes: &[u8], col: &ColumnReader, query: &[f32]) ->
 }
 
 /// Score one cluster's 1-bit codes against the rotated query and
-/// append `(doc_id, estimate, pos_in_full)` tuples to `shortlist`.
-/// `pos = off + i` is the candidate's index in the column's
-/// `full[]` array — captured here at no extra cost so the rerank
-/// step doesn't need any lookup table.
+/// append `(doc_id, estimate, pos_in_full, cluster_id)` tuples to
+/// `shortlist`. `pos = off + i` is the candidate's index in the
+/// column's `full[]` array — captured here at no extra cost so the
+/// rerank step doesn't need any lookup table. `cluster_id` is
+/// captured for the per-cluster Sq8 rerank dispatch: each candidate
+/// knows which cluster's `(scale, offset)` quantizer to dequant
+/// against. For Fp32/Bf16/None the cluster_id is recorded but
+/// ignored by the rerank step (kept for layout simplicity — the
+/// extra 4 bytes per shortlist entry are noise next to the
+/// `k × rerank_mult` heap traffic).
 #[inline]
 fn score_cluster_codes(
     cluster_codes: &[u8],
     cluster_doc_ids: &[u8],
     cnt: u32,
     off: u32,
+    cluster_id: u32,
     quant: &BitQuantizer,
     q_rot: &[f32],
-    shortlist: &mut Vec<(u32, f32, u32)>,
+    shortlist: &mut Vec<(u32, f32, u32, u32)>,
 ) {
     let cb = quant.code_bytes();
     for i in 0..cnt as usize {
@@ -824,7 +1000,7 @@ fn score_cluster_codes(
             cluster_doc_ids[i * 4 + 2],
             cluster_doc_ids[i * 4 + 3],
         ]);
-        shortlist.push((did, est, off + i as u32));
+        shortlist.push((did, est, off + i as u32, cluster_id));
     }
 }
 
@@ -853,34 +1029,92 @@ fn read_cluster_entry(cluster_idx_slice: &[u8], c: usize) -> (u32, u32) {
 /// `(doc_id, distance)` pairs sorted by ascending distance.
 ///
 /// `full_run` is a contiguous run of `full[]` bytes covering at
-/// least the byte range `[base_pos × dim × 4 .. (max_pos + 1) ×
-/// dim × 4)` — every candidate's `pos` in `shortlist` must lie in
-/// `[base_pos, base_pos + full_run.len() / (dim × 4))`. For the
-/// sync path, `base_pos = 0` and `full_run` is the column's whole
-/// `full[]` slice; for the async path, `base_pos = min(pos)` and
-/// `full_run` is the per-query fat range. Zero-copy SIMD via
-/// `distance_bytes` over each candidate's slice.
+/// least the byte range `[base_pos × stride .. (max_pos + 1) ×
+/// stride)`, where `stride = col.rerank_codec.per_vector_bytes(
+/// col.dim)` — every candidate's `pos` in `shortlist` must lie
+/// in `[base_pos, base_pos + full_run.len() / stride)`. For the
+/// sync path, `base_pos = 0` and `full_run` is the column's
+/// whole `full[]` slice; for the async path, `base_pos =
+/// min(pos)` and `full_run` is the per-query fat range.
+///
+/// Dispatches on `col.rerank_codec`:
+/// - **Fp32 / Bf16**: flat dispatch via [`distance_bytes_codec`]
+///   (fp32 zero-copy SIMD or bf16-widen SIMD).
+/// - **Sq8**: builds a per-query [`Sq8Kernel`] from the column's
+///   `codec_meta` once (folds scale/offset into the query so the
+///   per-doc inner step is a plain u8→f32 widen + SIMD dot;
+///   per-doc decoded-norm cached at encode time short-circuits
+///   `Σx²` for L2Sq).
 #[inline]
 fn rerank_candidates_in_run(
     full_run: &[u8],
     base_pos: u32,
-    shortlist: &[(u32, f32, u32)],
-    metric: Metric,
-    dim: usize,
+    shortlist: &[(u32, f32, u32, u32)],
+    col: &ColumnReader,
     query: &[f32],
     k: usize,
 ) -> Vec<(u32, f32)> {
-    let dim_bytes = dim * 4;
-    let mut reranked: Vec<(u32, f32)> = shortlist
-        .iter()
-        .map(|&(did, _, pos)| {
-            let local = (pos - base_pos) as usize;
-            let start = local * dim_bytes;
-            let bytes = &full_run[start..start + dim_bytes];
-            let d = distance_bytes(metric, query, bytes);
-            (did, d)
-        })
-        .collect();
+    let stride = col.rerank_codec.per_vector_bytes(col.dim);
+    let mut reranked: Vec<(u32, f32)> = match col.rerank_codec {
+        RerankCodec::Fp32 | RerankCodec::Bf16 => shortlist
+            .iter()
+            .map(|&(did, _, pos, _)| {
+                let local = (pos - base_pos) as usize;
+                let start = local * stride;
+                let bytes = &full_run[start..start + stride];
+                let d = distance_bytes_codec(col.metric, col.rerank_codec, query, bytes);
+                (did, d)
+            })
+            .collect(),
+        RerankCodec::Sq8 => {
+            // Per-cluster Sq8: each candidate's cluster_id selects
+            // a `(scale[dim], offset[dim])` slice from the column
+            // meta. We build a fresh per-cluster `Sq8Kernel`
+            // lazily — at typical nprobe ≤ 64 we touch only a
+            // handful of clusters per query, and building a
+            // kernel is `O(dim)` SIMD work (one pass over the
+            // query × scale + one over query × offset). Caching
+            // by cluster_id avoids rebuilding the kernel for
+            // sibling candidates in the same cluster (most of
+            // the shortlist).
+            //
+            // Metadata is materialised at open time on every Sq8
+            // column; the unwrap can't fail unless someone
+            // constructs a `ColumnReader` outside `open_with`.
+            let meta = col
+                .sq8_meta
+                .as_ref()
+                .expect("Sq8 column must carry sq8_meta (built in open_with)");
+            let dim = col.dim;
+            let mut kernel_cache: HashMap<u32, Sq8Kernel> = HashMap::new();
+            shortlist
+                .iter()
+                .map(|&(did, _, pos, cluster_id)| {
+                    let local = (pos - base_pos) as usize;
+                    let start = local * stride;
+                    let bytes = &full_run[start..start + stride];
+                    let kernel = kernel_cache.entry(cluster_id).or_insert_with(|| {
+                        let c = cluster_id as usize;
+                        let scale_c = &meta.scale[c * dim..(c + 1) * dim];
+                        let offset_c = &meta.offset[c * dim..(c + 1) * dim];
+                        Sq8Kernel::new(
+                            col.metric,
+                            query,
+                            scale_c,
+                            offset_c,
+                            meta.per_doc_norms.as_deref(),
+                        )
+                    });
+                    let d = kernel.distance_at(pos, bytes);
+                    (did, d)
+                })
+                .collect()
+        }
+        RerankCodec::None => unreachable!(
+            "rerank_candidates_in_run reached with None codec — None columns \
+             have no full[] region and should short-circuit before the rerank step"
+        ),
+    };
     reranked.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
     reranked.truncate(k);
     reranked
@@ -889,6 +1123,25 @@ fn rerank_candidates_in_run(
 #[inline]
 fn read_u32_le(b: &[u8]) -> u32 {
     u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+}
+
+/// Decode an aligned-or-not `&[u8]` of length `4·N` as a
+/// `Vec<f32>` of length `N`. Used for Sq8's `codec_meta` arrays
+/// (scale, offset, per-doc norms) where the byte slice can land
+/// at any alignment relative to the `Bytes` backing — see the
+/// reader-side note where this is called for the alignment
+/// argument. Slow path (4 byte reads per f32) but only runs at
+/// open time over at-most-`8·n_cent·dim + 4·n_docs` bytes per Sq8
+/// column; the per-query inner loop never goes through here.
+#[inline]
+fn parse_f32_le_vec(bytes: &[u8]) -> Vec<f32> {
+    debug_assert!(bytes.len().is_multiple_of(4));
+    let n = bytes.len() / 4;
+    let mut out = Vec::with_capacity(n);
+    for chunk in bytes.chunks_exact(4) {
+        out.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    }
+    out
 }
 
 #[inline]
@@ -1014,6 +1267,7 @@ mod tests {
             n_cent,
             rot_seed: 7,
             metric,
+            rerank_codec: RerankCodec::Fp32,
         })
         .expect("register column");
         for i in 0..n_docs {
@@ -1111,6 +1365,7 @@ mod tests {
             n_cent: 4,
             rot_seed: 7,
             metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
         })
         .expect("register column");
         let mut all_vecs = Vec::new();
@@ -1288,6 +1543,827 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Rerank-codec discriminator round-trip
+    // -----------------------------------------------------------------
+    //
+    // The codec discriminator rides as byte 52 of the per-column
+    // directory entry; the codec_meta region offset rides as bytes
+    // 12..16 of the sub-header. Both are zero on legacy fp32
+    // segments. Today `Fp32` and `Bf16` are implemented; every other
+    // codec must fail loudly against a reader that does not yet know
+    // how to decode it.
+
+    /// A fresh `Fp32` build round-trips through the reader with the
+    /// codec byte preserved as `RerankCodec::Fp32`.
+    #[test]
+    fn open_round_trips_fp32_codec_discriminator() {
+        let (blob, json) = build_blob(64, 16, 4, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        assert_eq!(r.columns.len(), 1);
+        assert_eq!(
+            r.columns[0].rerank_codec,
+            RerankCodec::Fp32,
+            "Fp32 build must surface as RerankCodec::Fp32 on the reader"
+        );
+        assert_eq!(
+            r.columns[0].codec_meta_off, 0,
+            "Fp32 segments must write codec_meta_off = 0 (zero-size region)"
+        );
+    }
+
+    /// Every exposed rerank codec is wired end-to-end.
+    #[test]
+    fn register_column_accepts_every_codec() {
+        for codec in [
+            RerankCodec::Fp32,
+            RerankCodec::Bf16,
+            RerankCodec::Sq8,
+            RerankCodec::None,
+        ] {
+            let mut b = VectorBuilder::new();
+            b.register_column(VectorConfig {
+                name: "v".into(),
+                dim: 16,
+                n_cent: 4,
+                rot_seed: 7,
+                metric: Metric::L2Sq,
+                rerank_codec: codec,
+            })
+            .unwrap_or_else(|e| panic!("codec {codec:?} must register, got {e:?}"));
+        }
+    }
+
+    /// Building a column with `RerankCodec::Bf16` round-trips through
+    /// the reader. The codec discriminator surfaces on
+    /// `ColumnReader.rerank_codec`, the codec_meta region stays
+    /// zero-bytes, and the on-disk `full[]` region halves to
+    /// `n_docs * dim * 2` bytes.
+    #[test]
+    fn open_round_trips_bf16_codec_discriminator() {
+        let dim = 16usize;
+        let n_cent = 4usize;
+        let n_docs = 64u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 7,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Bf16,
+        })
+        .expect("register column");
+        for i in 0..n_docs {
+            let v: Vec<f32> = (0..dim).map(|j| (i + j as u32) as f32 * 0.1).collect();
+            b.add(0, &v).expect("add");
+        }
+        let blob = b.finish().expect("finish");
+
+        let json = r#"[{"name":"v","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        assert_eq!(r.columns.len(), 1);
+        assert_eq!(
+            r.columns[0].rerank_codec,
+            RerankCodec::Bf16,
+            "Bf16 build must surface as RerankCodec::Bf16 on the reader"
+        );
+        assert_eq!(
+            r.columns[0].codec_meta_off, 0,
+            "Bf16 segments must write codec_meta_off = 0 (zero-byte meta region)"
+        );
+        let col = &r.columns[0];
+        let expected_full_size = (col.n_docs as usize) * dim * 2;
+        assert_eq!(
+            col.doc_ids_off - col.full_off,
+            expected_full_size,
+            "Bf16 full[] region must be n_docs * dim * 2 bytes",
+        );
+    }
+
+    /// A Bf16 build + open + self-query recovers the planted
+    /// self-vector at top-1, end-to-end through the codec-aware rerank
+    /// dispatch.
+    #[test]
+    fn bf16_self_query_round_trips_top1() {
+        let dim = 32usize;
+        let n_cent = 4usize;
+        let n_docs = 64u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 13,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Bf16,
+        })
+        .expect("register column");
+        let make = |i: u32| -> Vec<f32> {
+            (0..dim)
+                .map(|j| ((i.wrapping_mul(17) + j as u32 * 3) % 64) as f32 * 0.5)
+                .collect()
+        };
+        let mut all = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs {
+            let v = make(i);
+            b.add(0, &v).expect("add");
+            all.push(v);
+        }
+        let blob = b.finish().expect("finish");
+
+        let json =
+            r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        let hits = r
+            .search("v", &all[17], 5, 4, 5)
+            .expect("search must succeed on Bf16 column");
+        assert_eq!(hits[0].0, 17, "Bf16 self-query must recover self at top-1");
+        assert!(
+            hits[0].1.abs() <= 1e-3,
+            "Bf16 self-query distance {} should be ~0",
+            hits[0].1
+        );
+    }
+
+    /// Building a column with `RerankCodec::Sq8` round-trips through
+    /// the reader. The codec discriminator surfaces on
+    /// `ColumnReader.rerank_codec`; the codec_meta region carries
+    /// `scale[dim] + offset[dim]` plus per-doc norms for L2Sq. The
+    /// on-disk `full[]` region shrinks to `n_docs * dim` u8 codes.
+    #[test]
+    fn open_round_trips_sq8_codec_discriminator_l2sq() {
+        let dim = 32usize;
+        let n_cent = 4usize;
+        let n_docs = 64u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 7,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Sq8,
+        })
+        .expect("register column");
+        for i in 0..n_docs {
+            let v: Vec<f32> = (0..dim).map(|j| (i + j as u32) as f32 * 0.1).collect();
+            b.add(0, &v).expect("add");
+        }
+        let blob = b.finish().expect("finish");
+
+        let json = r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        assert_eq!(r.columns.len(), 1);
+        let col = &r.columns[0];
+        assert_eq!(col.rerank_codec, RerankCodec::Sq8);
+        assert_ne!(col.codec_meta_off, 0, "Sq8 must declare codec_meta_off > 0");
+        assert_eq!(col.doc_ids_off - col.full_off, (col.n_docs as usize) * dim);
+
+        let meta = col
+            .sq8_meta
+            .as_ref()
+            .expect("Sq8 column must materialise sq8_meta at open");
+        assert_eq!(meta.scale.len(), (col.n_cent as usize) * dim);
+        assert_eq!(meta.offset.len(), (col.n_cent as usize) * dim);
+        let norms = meta
+            .per_doc_norms
+            .as_ref()
+            .expect("L2Sq Sq8 column must carry per-doc norms");
+        assert_eq!(norms.len(), col.n_docs as usize);
+    }
+
+    /// Cosine Sq8 columns omit per-doc norms because the `sum(x^2)`
+    /// term is not used by cosine or negative-dot rerank.
+    #[test]
+    fn open_sq8_cosine_omits_per_doc_norms() {
+        let dim = 16usize;
+        let n_cent = 4usize;
+        let n_docs = 32u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 11,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Sq8,
+        })
+        .expect("register column");
+        for i in 0..n_docs {
+            let mut v: Vec<f32> = (0..dim)
+                .map(|j| (i + j as u32) as f32 * 0.1 + 0.5)
+                .collect();
+            let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            for x in &mut v {
+                *x /= norm;
+            }
+            b.add(0, &v).expect("add");
+        }
+        let blob = b.finish().expect("finish");
+        let json =
+            r#"[{"name":"v","dim":16,"n_cent":4,"rot_seed":11,"metric":"cosine"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        let col = &r.columns[0];
+        let meta = col.sq8_meta.as_ref().expect("Sq8 must carry sq8_meta");
+        assert!(
+            meta.per_doc_norms.is_none(),
+            "Cosine Sq8 must omit per-doc norms"
+        );
+        assert_eq!(meta.scale.len(), n_cent * dim);
+        assert_eq!(meta.offset.len(), n_cent * dim);
+    }
+
+    /// Pins the per-doc-norms indexing contract: the on-disk norms
+    /// array is indexed by position in `full[]` (matching the rerank
+    /// shortlist's `pos`), not by `doc_id`.
+    #[test]
+    fn sq8_per_doc_norms_indexed_by_pos_not_doc_id() {
+        let dim = 16usize;
+        let n_cent = 4usize;
+        let n_docs = 32u32;
+        let make = |i: u32| -> Vec<f32> {
+            let s = 1.0 + (i as f32) * 0.5;
+            (0..dim).map(|j| s + (j as f32) * 0.1).collect()
+        };
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 23,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Sq8,
+        })
+        .expect("register column");
+        let mut planted = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs {
+            let v = make(i);
+            b.add(0, &v).expect("add");
+            planted.push(v);
+        }
+        let blob = b.finish().expect("finish");
+
+        let json =
+            r#"[{"name":"v","dim":16,"n_cent":4,"rot_seed":23,"metric":"l2sq"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        let col = &r.columns[0];
+        let meta = col.sq8_meta.as_ref().expect("Sq8 meta present");
+        let norms_by_pos = meta
+            .per_doc_norms
+            .as_ref()
+            .expect("L2Sq Sq8 carries per-doc norms");
+
+        let insertion_norms: Vec<f32> = planted
+            .iter()
+            .map(|v| v.iter().map(|x| x * x).sum::<f32>())
+            .collect();
+        let n_matching = insertion_norms
+            .iter()
+            .zip(norms_by_pos.iter())
+            .filter(|(ins, pos_n)| (**ins - **pos_n).abs() < 0.5)
+            .count();
+        assert!(
+            n_matching < (n_docs as usize) / 2,
+            "expected clustered build to reorder docs across positions, got {n_matching}/{n_docs} near insertion order"
+        );
+
+        for i in [0u32, 7, 15, 23, 31] {
+            let hits = r
+                .search("v", &planted[i as usize], 1, 4, 64)
+                .expect("self-query");
+            assert_eq!(hits[0].0, i, "self-query top-1 doc_id for doc {i}");
+            assert!(
+                hits[0].1 <= 0.5,
+                "doc {i}: self-query distance {} too large",
+                hits[0].1
+            );
+        }
+    }
+
+    /// Sq8 build + open + self-query recovers the planted self-vector
+    /// at top-1 through codec-aware rerank.
+    #[test]
+    fn sq8_self_query_round_trips_top1_l2sq() {
+        let dim = 32usize;
+        let n_cent = 4usize;
+        let n_docs = 64u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 13,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Sq8,
+        })
+        .expect("register column");
+        let make = |i: u32| -> Vec<f32> {
+            (0..dim)
+                .map(|j| ((i.wrapping_mul(17) + j as u32 * 3) % 64) as f32 * 0.5)
+                .collect()
+        };
+        let mut all = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs {
+            let v = make(i);
+            b.add(0, &v).expect("add");
+            all.push(v);
+        }
+        let blob = b.finish().expect("finish");
+
+        let json =
+            r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        let hits = r
+            .search("v", &all[17], 5, 4, 20)
+            .expect("search must succeed on Sq8 column");
+        assert_eq!(hits[0].0, 17, "Sq8 self-query must recover self at top-1");
+        assert!(
+            hits[0].1 <= 1.0,
+            "Sq8 self-query distance {} should be small",
+            hits[0].1
+        );
+    }
+
+    /// Sq8 self-query top-1 round-trips under cosine too. The corpus
+    /// uses hashed unit vectors so the self-vector has a wide margin
+    /// over neighbors after quantization.
+    #[test]
+    fn sq8_self_query_round_trips_top1_cosine() {
+        let dim = 32usize;
+        let n_cent = 4usize;
+        let n_docs = 64u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 19,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Sq8,
+        })
+        .expect("register column");
+        let make = |i: u32| -> Vec<f32> {
+            let raw: Vec<f32> = (0..dim)
+                .map(|j| {
+                    let h = (i.wrapping_mul(0x9E37_79B9)) ^ ((j as u32).wrapping_mul(0x85EB_CA77));
+                    let h = h.wrapping_mul(0xC2B2_AE35);
+                    ((h & 0xFFFF) as f32) / 65535.0
+                })
+                .collect();
+            let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+            raw.into_iter().map(|x| x / norm).collect()
+        };
+        let mut all = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs {
+            let v = make(i);
+            b.add(0, &v).expect("add");
+            all.push(v);
+        }
+        let blob = b.finish().expect("finish");
+
+        let json =
+            r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":19,"metric":"cosine"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        let hits = r
+            .search("v", &all[42], 5, 4, 20)
+            .expect("search must succeed on Sq8 cosine column");
+        assert_eq!(hits[0].0, 42, "Sq8 cosine self-query must recover self");
+    }
+
+    /// Building with `RerankCodec::None` succeeds and the on-disk
+    /// segment carries a zero-length `full[]` region.
+    #[test]
+    fn open_round_trips_none_codec_discriminator() {
+        let dim = 16usize;
+        let n_cent = 4usize;
+        let n_docs = 64u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 7,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::None,
+        })
+        .expect("register None column");
+        for i in 0..n_docs {
+            let v: Vec<f32> = (0..dim).map(|j| (i + j as u32) as f32 * 0.1).collect();
+            b.add(0, &v).expect("add");
+        }
+        let blob = b.finish().expect("finish");
+
+        let json = r#"[{"name":"v","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        assert_eq!(r.columns.len(), 1);
+        let col = &r.columns[0];
+        assert_eq!(col.rerank_codec, RerankCodec::None);
+        assert_eq!(col.codec_meta_off, 0);
+        assert_eq!(
+            col.doc_ids_off, col.full_off,
+            "None segments have zero-length full[]"
+        );
+        assert_eq!(col.n_docs, n_docs);
+    }
+
+    /// A `None`-codec column returns top-K directly from the 1-bit
+    /// shortlist. Distances are sign-flipped estimates so smaller is
+    /// still closer.
+    #[test]
+    fn none_self_query_in_top_k_via_shortlist_only() {
+        let dim = 128usize;
+        let n_cent = 4usize;
+        let n_docs = 64u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 11,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::None,
+        })
+        .expect("register None column");
+        let make = |i: u32| -> Vec<f32> {
+            let raw: Vec<f32> = (0..dim)
+                .map(|j| {
+                    let h = (i.wrapping_mul(0x9E37_79B9)) ^ ((j as u32).wrapping_mul(0x85EB_CA77));
+                    let h = h.wrapping_mul(0xC2B2_AE35);
+                    ((h & 0xFFFF) as f32) / 65535.0 - 0.5
+                })
+                .collect();
+            let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+            raw.into_iter().map(|x| x / norm).collect()
+        };
+        let mut all = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs {
+            let v = make(i);
+            b.add(0, &v).expect("add");
+            all.push(v);
+        }
+        let blob = b.finish().expect("finish");
+        let json =
+            r#"[{"name":"v","dim":128,"n_cent":4,"rot_seed":11,"metric":"l2sq"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+
+        let hits = r
+            .search("v", &all[17], 5, n_cent, 5)
+            .expect("None-codec search must succeed");
+        assert!(
+            hits.iter().any(|(did, _)| *did == 17),
+            "self-query must surface the planted vector in top-K, got {hits:?}"
+        );
+        assert!(hits.iter().all(|(_, d)| d.is_finite()));
+        for w in hits.windows(2) {
+            assert!(
+                w[0].1 <= w[1].1,
+                "None-codec hits must be sorted ascending by distance, got {hits:?}"
+            );
+        }
+    }
+
+    /// `None` search must not fetch a `full[]` range because the
+    /// column does not store one.
+    #[test]
+    fn none_search_issues_no_full_region_fetch() {
+        let dim = 32usize;
+        let n_cent = 4usize;
+        let n_docs = 32u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            name: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 13,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::None,
+        })
+        .expect("register None column");
+        for i in 0..n_docs {
+            let v: Vec<f32> = (0..dim).map(|j| (i + j as u32) as f32 * 0.1).collect();
+            b.add(0, &v).expect("add");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json =
+            r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
+
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        let async_calls = counting.async_counter();
+        let sync_calls = counting.sync_counter();
+        let r = VectorReader::open_with_source(
+            Source::Lazy(StdArc::clone(&counting) as StdArc<dyn LazyByteSource>),
+            &json,
+            OpenOptions::default(),
+        )
+        .expect("open lazy");
+
+        async_calls.store(0, AtomicOrdering::Relaxed);
+        sync_calls.store(0, AtomicOrdering::Relaxed);
+        let query: Vec<f32> = (0..dim).map(|j| j as f32 * 0.1).collect();
+        let _ = r.search("v", &query, 5, n_cent, 5).expect("search");
+
+        let sync_count = sync_calls.load(AtomicOrdering::Relaxed) as usize;
+        let async_count = async_calls.load(AtomicOrdering::Relaxed);
+        assert_eq!(
+            async_count, 0,
+            "None-codec search on warm lazy must not bridge to async"
+        );
+        let max_expected = 2 + 2 * n_cent;
+        assert!(
+            sync_count <= max_expected,
+            "None-codec search must issue at most {max_expected} sync fetches; got {sync_count}"
+        );
+        assert!(
+            sync_count >= 4,
+            "test corpus produced only empty clusters? got sync_count={sync_count}"
+        );
+    }
+
+    /// A directory entry carrying an unknown codec id errors as
+    /// `MalformedVersion` rather than guessing at a byte layout.
+    #[test]
+    fn open_rejects_segment_with_unknown_codec_id() {
+        let (blob, json) = build_blob(64, 16, 4, Metric::L2Sq);
+        let mut bytes = blob.to_vec();
+
+        const OUTER_HDR: usize = 32;
+        const DIR_ENTRY: usize = 64;
+        let dir_off = OUTER_HDR;
+        let codec_byte_off = dir_off + 52;
+        bytes[codec_byte_off] = 200u8; // unassigned
+
+        let dir_bytes = &bytes[dir_off..dir_off + DIR_ENTRY];
+        let new_crc = crc32c(dir_bytes);
+        let crc_off = dir_off + DIR_ENTRY;
+        bytes[crc_off..crc_off + 4].copy_from_slice(&new_crc.to_le_bytes());
+
+        let err =
+            VectorReader::open_with(Bytes::from(bytes), &json, OpenOptions { verify_crc: false })
+                .expect_err("unknown codec id must error at open");
+        assert!(
+            matches!(err, VectorError::Read(ReadError::MalformedVersion(_))),
+            "expected MalformedVersion for unknown codec id, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown") || msg.contains("200"),
+            "error must call out the unknown id, got: {msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Diagnostic — Sq8 vs Fp32 recall on planted-cluster
+    // cosine corpus
+    // -----------------------------------------------------------------
+    //
+    // Planted-cluster cosine corpora can push Sq8 recall well outside
+    // the "< 0.005 drop on normalized embeddings" target envelope.
+    // The hypothesis is that the **per-column** Sq8 quantizer wastes
+    // most of its 256 buckets on cross-cluster spread: the per-dim
+    // global range across the full corpus is much wider than the
+    // intra-cluster spread, so within any one cluster only a handful
+    // of buckets are used. The intra-cluster cosine differences
+    // between top-K candidates then fall below the per-bucket
+    // quantization noise → reranks flip.
+    //
+    // This `#[ignore]`-gated diagnostic reproduces the recall drop at
+    // a small scale and prints corpus geometry stats. Run with
+    // `cargo test --lib -- sq8_recall_diagnostic --ignored --nocapture`
+    // to inspect. Per-column-quantizer fix (or fallback to Bf16
+    // default) is decided based on what this prints.
+    #[test]
+    #[ignore = "Sq8 vs Fp32 recall diagnostic; ~10s; --ignored --nocapture"]
+    fn sq8_recall_diagnostic_planted_cluster_cosine() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+        use rand_distr::{Distribution, StandardNormal};
+
+        let n_docs = 16_000u32;
+        let dim = 384usize;
+        let n_cent_planted = 64usize;
+        let n_cent_ivf = 256usize;
+        let seed: u64 = 1;
+
+        // 1. Build the corpus — same shape as benches/utils/corpus.rs:
+        //    planted centers from 3·N(0,1) per dim, per-doc =
+        //    center + 0.3·N(0,1), L2-normalized.
+        let mut rng = StdRng::seed_from_u64(seed);
+        let dist = StandardNormal;
+        let centers: Vec<Vec<f32>> = (0..n_cent_planted)
+            .map(|_| {
+                (0..dim)
+                    .map(|_| {
+                        let s: f64 = dist.sample(&mut rng);
+                        (s as f32) * 3.0
+                    })
+                    .collect()
+            })
+            .collect();
+        let mut all: Vec<Vec<f32>> = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs as usize {
+            let center = &centers[i % n_cent_planted];
+            let mut v: Vec<f32> = center
+                .iter()
+                .map(|&c| {
+                    let s: f64 = dist.sample(&mut rng);
+                    c + (s as f32) * 0.3
+                })
+                .collect();
+            let nrm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            for x in v.iter_mut() {
+                *x /= nrm;
+            }
+            all.push(v);
+        }
+
+        // 2. Corpus geometry: per-dim global range vs intra-cluster spread.
+        let mut g_min = vec![f32::INFINITY; dim];
+        let mut g_max = vec![f32::NEG_INFINITY; dim];
+        for v in &all {
+            for d in 0..dim {
+                if v[d] < g_min[d] {
+                    g_min[d] = v[d];
+                }
+                if v[d] > g_max[d] {
+                    g_max[d] = v[d];
+                }
+            }
+        }
+        let g_ranges: Vec<f32> = (0..dim).map(|d| g_max[d] - g_min[d]).collect();
+        let mean_g_range: f32 = g_ranges.iter().sum::<f32>() / dim as f32;
+        let max_g_range: f32 = g_ranges.iter().cloned().fold(0.0f32, f32::max);
+
+        let mut c0_min = vec![f32::INFINITY; dim];
+        let mut c0_max = vec![f32::NEG_INFINITY; dim];
+        let mut c0_count = 0u32;
+        for (i, v) in all.iter().enumerate() {
+            if i % n_cent_planted == 0 {
+                c0_count += 1;
+                for d in 0..dim {
+                    if v[d] < c0_min[d] {
+                        c0_min[d] = v[d];
+                    }
+                    if v[d] > c0_max[d] {
+                        c0_max[d] = v[d];
+                    }
+                }
+            }
+        }
+        let intra_ranges: Vec<f32> = (0..dim).map(|d| c0_max[d] - c0_min[d]).collect();
+        let mean_intra: f32 = intra_ranges.iter().sum::<f32>() / dim as f32;
+
+        eprintln!("--- corpus geometry (16k × 384, 64 planted centers, cosine, L2-normalized) ---");
+        eprintln!(
+            "per-dim global range: mean={mean_g_range:.4}  max={max_g_range:.4}  \
+             bucket_width@255={:.6}",
+            mean_g_range / 255.0
+        );
+        eprintln!("per-dim intra-cluster-0 range ({c0_count} docs): mean={mean_intra:.4}");
+        eprintln!(
+            "bucket-waste factor (global / intra): {:.1}x — Sq8 uses ~{} of 256 buckets per cluster",
+            mean_g_range / mean_intra.max(1e-9),
+            (255.0 * mean_intra / mean_g_range).round() as i32
+        );
+
+        // 3. Build Fp32 + Sq8 segments from the same corpus.
+        let build = |codec: RerankCodec| -> Bytes {
+            let mut b = VectorBuilder::new();
+            b.register_column(VectorConfig {
+                name: "v".into(),
+                dim,
+                n_cent: n_cent_ivf,
+                rot_seed: 7,
+                metric: Metric::Cosine,
+                rerank_codec: codec,
+            })
+            .expect("register");
+            for v in &all {
+                b.add(0, v).expect("add");
+            }
+            Bytes::from(b.finish().expect("finish"))
+        };
+        let fp32_blob = build(RerankCodec::Fp32);
+        let bf16_blob = build(RerankCodec::Bf16);
+        let sq8_blob = build(RerankCodec::Sq8);
+        eprintln!(
+            "--- segment sizes ---\n\
+             fp32: {:.2} MiB (1.00x)\n\
+             bf16: {:.2} MiB ({:.2}x)\n\
+             sq8:  {:.2} MiB ({:.2}x)",
+            fp32_blob.len() as f64 / 1024.0 / 1024.0,
+            bf16_blob.len() as f64 / 1024.0 / 1024.0,
+            bf16_blob.len() as f64 / fp32_blob.len() as f64,
+            sq8_blob.len() as f64 / 1024.0 / 1024.0,
+            sq8_blob.len() as f64 / fp32_blob.len() as f64
+        );
+
+        let json = format!(
+            r#"[{{"name":"v","dim":{dim},"n_cent":{n_cent_ivf},"rot_seed":7,"metric":"cosine"}}]"#
+        );
+        let r_fp32 = VectorReader::open(fp32_blob, &json).expect("open fp32");
+        let r_bf16 = VectorReader::open(bf16_blob, &json).expect("open bf16");
+        let r_sq8 = VectorReader::open(sq8_blob, &json).expect("open sq8");
+
+        // 4. Brute-force ground truth (cosine sim descending = neg-dot
+        //    ascending — both engines return smaller-is-closer).
+        let n_queries = 100usize;
+        let k = 10usize;
+        let nprobe = n_cent_ivf / 4;
+        let rerank_mult = 50usize; // Sq8 calibration floor at dim ≤ 384
+        let ground_truth: Vec<std::collections::HashSet<u32>> = (0..n_queries)
+            .map(|qi| {
+                let q = &all[qi];
+                let mut sims: Vec<(u32, f32)> = (0..all.len())
+                    .map(|j| {
+                        let d: f32 = (0..dim).map(|i| q[i] * all[j][i]).sum();
+                        (j as u32, d)
+                    })
+                    .collect();
+                sims.sort_unstable_by(|a, b| {
+                    b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+                });
+                sims.into_iter().take(k).map(|(id, _)| id).collect()
+            })
+            .collect();
+
+        let recall_of = |reader: &VectorReader, label: &str| -> f32 {
+            let mut total_match = 0usize;
+            for qi in 0..n_queries {
+                let hits = reader
+                    .search("v", &all[qi], k, nprobe, rerank_mult)
+                    .expect("search");
+                let hit_ids: std::collections::HashSet<u32> =
+                    hits.into_iter().map(|(id, _)| id).collect();
+                let gt = &ground_truth[qi];
+                total_match += gt.iter().filter(|id| hit_ids.contains(id)).count();
+            }
+            let recall = total_match as f32 / (n_queries * k) as f32;
+            eprintln!("recall@{k} ({label}): {recall:.4}");
+            recall
+        };
+
+        eprintln!(
+            "--- recall@{k} on {n_queries} self-queries (nprobe={nprobe}, rerank_mult={rerank_mult}) ---"
+        );
+        let r_fp = recall_of(&r_fp32, "fp32");
+        let r_bf = recall_of(&r_bf16, "bf16");
+        let r_sq = recall_of(&r_sq8, "sq8 ");
+        eprintln!(
+            "drop (fp32 - bf16): {:.4}\ndrop (fp32 - sq8 ): {:.4}",
+            r_fp - r_bf,
+            r_fp - r_sq
+        );
+        eprintln!("(target acceptance: drop must be \u{2264} 0.01)");
+
+        // -- Probe: vary rerank_mult to isolate shortlist depth vs rerank noise --
+        eprintln!("\n--- rerank_mult sweep (Sq8, same corpus/queries) ---");
+        for &rm in &[20usize, 50, 100, 200, 400] {
+            let mut tm = 0usize;
+            for qi in 0..n_queries {
+                let hits = r_sq8.search("v", &all[qi], k, nprobe, rm).expect("search");
+                let hit_ids: std::collections::HashSet<u32> =
+                    hits.into_iter().map(|(id, _)| id).collect();
+                tm += ground_truth[qi]
+                    .iter()
+                    .filter(|id| hit_ids.contains(id))
+                    .count();
+            }
+            eprintln!(
+                "  rerank_mult={rm:>4}: sq8 recall@{k} = {:.4}",
+                tm as f32 / (n_queries * k) as f32
+            );
+        }
+
+        // -- Probe: typical top-10 cosine spread (signal that
+        //    Sq8 noise must beat).
+        let mut spreads = Vec::with_capacity(n_queries);
+        for qi in 0..n_queries.min(20) {
+            let q = &all[qi];
+            let mut sims: Vec<f32> = (0..all.len())
+                .map(|j| (0..dim).map(|i| q[i] * all[j][i]).sum::<f32>())
+                .collect();
+            sims.sort_unstable_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+            let top11: Vec<f32> = sims.iter().take(11).cloned().collect();
+            // Spread between top-1 (self, sim=1) and top-10
+            let span = top11[0] - top11[10];
+            // Median consecutive gap among top-10
+            let mut gaps: Vec<f32> = (1..11).map(|i| top11[i - 1] - top11[i]).collect();
+            gaps.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let med_gap = gaps[gaps.len() / 2];
+            spreads.push((span, med_gap));
+        }
+        let mean_span: f32 = spreads.iter().map(|(s, _)| s).sum::<f32>() / spreads.len() as f32;
+        let mean_gap: f32 = spreads.iter().map(|(_, g)| g).sum::<f32>() / spreads.len() as f32;
+        eprintln!("\n--- top-10 cosine geometry (the signal Sq8 noise must beat) ---");
+        eprintln!(
+            "  mean top1-to-top10 span:      {mean_span:.4}\n  \
+             mean consecutive median gap:  {mean_gap:.5}\n  \
+             Sq8 noise est. (3e-5) vs gap: ratio = {:.2}%",
+            3e-5_f32 / mean_gap.max(1e-9) * 100.0
+        );
+    }
+
+    // -----------------------------------------------------------------
     // Lazy open + inline-`pos` search
     // -----------------------------------------------------------------
     //
@@ -1311,6 +2387,7 @@ mod tests {
             n_cent,
             rot_seed: 7,
             metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
         })
         .expect("register column");
         let mut all = Vec::with_capacity(n_docs as usize);
@@ -1698,6 +2775,7 @@ mod tests {
             n_cent,
             rot_seed: 7,
             metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
         })
         .expect("register column");
         let mut v = vec![0f32; dim];

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -29,10 +29,12 @@ const DIR_ENTRY_SIZE: usize = 64;
 const SUB_HEADER_SIZE: usize = 56;
 
 /// JSON-deserialized form of one entry in `inf.vec.columns`. The KV
-/// value is a JSON array of these in declaration order.
+/// value is a JSON array of these in declaration order. Mirrors
+/// the build-time [`VectorConfig`] but with `metric` as a string
+/// so serde can read it straight from the KV blob.
 #[derive(Debug, Clone, Deserialize)]
 pub struct VectorColumnConfig {
-    pub name: String,
+    pub column: String,
     pub dim: usize,
     pub n_cent: usize,
     pub rot_seed: u64,
@@ -454,13 +456,13 @@ impl VectorReader {
                 VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' has unknown rerank-codec id {codec_id} \
                      (known ids: 0=fp32, 1=bf16, 2=sq8, 3=none)",
-                    cfg.name
+                    cfg.column
                 )))
             })?;
             if !rerank_codec.is_implemented() {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' uses rerank codec {} which is not implemented by this version",
-                    cfg.name,
+                    cfg.column,
                     rerank_codec.name()
                 ))));
             }
@@ -469,13 +471,13 @@ impl VectorReader {
             if dim != cfg.dim {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' dim mismatch: dir={dim} json={}",
-                    cfg.name, cfg.dim
+                    cfg.column, cfg.dim
                 ))));
             }
             if rot_seed != cfg.rot_seed {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' rot_seed mismatch",
-                    cfg.name
+                    cfg.column
                 ))));
             }
             let metric = match metric_id {
@@ -485,7 +487,7 @@ impl VectorReader {
                 _ => {
                     return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                         "unknown metric_id {metric_id} for column '{}'",
-                        cfg.name
+                        cfg.column
                     ))));
                 }
             };
@@ -531,20 +533,20 @@ impl VectorReader {
             let cluster_idx_off = read_u64_le(&sub[40..48]) as usize;
             let codes_off = read_u32_le(&sub[48..52]) as usize;
             let full_off = read_u32_le(&sub[52..56]) as usize;
-            // Fp32 + Bf16 + None all keep zero-byte codec_meta; Sq8
+            // Fp32 + Bf16 + RabitqOnly all keep zero-byte codec_meta; Sq8
             // emits per-cluster scale/offset (+ per-doc
             // norms for L2Sq/Cosine). The per-codec layout check below
             // validates the declared `codec_meta_off` against the
             // codec's expected size once `col_n_docs` is known.
             let codec_meta_required_zero = matches!(
                 rerank_codec,
-                RerankCodec::Fp32 | RerankCodec::Bf16 | RerankCodec::None
+                RerankCodec::Fp32 | RerankCodec::Bf16 | RerankCodec::RabitqOnly
             );
             if codec_meta_required_zero && codec_meta_off != 0 {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' has codec_meta_off={codec_meta_off} for codec {}; \
-                     fp32/bf16/none must write codec_meta_off=0 (zero-byte meta region)",
-                    cfg.name,
+                     fp32/bf16/rabitq_only must write codec_meta_off=0 (zero-byte meta region)",
+                    cfg.column,
                     rerank_codec.name()
                 ))));
             }
@@ -566,7 +568,7 @@ impl VectorReader {
                     return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                         "column '{}' has codec_meta_off={codec_meta_off} outside \
                          (codes_off={codes_off}, full_off={full_off}]",
-                        cfg.name
+                        cfg.column
                     ))));
                 }
                 codec_meta_off
@@ -577,7 +579,7 @@ impl VectorReader {
             if code_bytes == 0 || !codes_size.is_multiple_of(code_bytes) {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' codes size {codes_size} not divisible by {code_bytes}",
-                    cfg.name
+                    cfg.column
                 ))));
             }
             let col_n_docs = (codes_size / code_bytes) as u32;
@@ -601,7 +603,7 @@ impl VectorReader {
                     "column '{}' codec_meta region is {actual_codec_meta_size} bytes \
                      on disk, but codec {} / metric {metric:?} expects \
                      {expected_codec_meta_size} bytes",
-                    cfg.name,
+                    cfg.column,
                     rerank_codec.name()
                 ))));
             }
@@ -644,14 +646,14 @@ impl VectorReader {
             if cluster_idx_end > sub_crc_pos {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' cluster index runs past subsection",
-                    cfg.name
+                    cfg.column
                 ))));
             }
             let doc_ids_size = (col_n_docs as usize) * 4;
             if doc_ids_off + doc_ids_size > sub_crc_pos {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' doc_ids region runs past subsection",
-                    cfg.name
+                    cfg.column
                 ))));
             }
 
@@ -667,12 +669,12 @@ impl VectorReader {
             {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' metric mismatch: dir={metric:?} json={}",
-                    cfg.name, cfg.metric
+                    cfg.column, cfg.metric
                 ))));
             }
 
             columns.push(ColumnReader {
-                name: cfg.name.clone(),
+                name: cfg.column.clone(),
                 dim,
                 n_cent,
                 n_docs: col_n_docs,
@@ -692,7 +694,7 @@ impl VectorReader {
                 quant,
                 rot: RandomRotation::new(dim, rot_seed),
             });
-            column_id_by_name.insert(cfg.name.clone(), i as u32);
+            column_id_by_name.insert(cfg.column.clone(), i as u32);
         }
 
         Ok(VectorReader {
@@ -858,7 +860,7 @@ impl VectorReader {
         // the 1-bit shortlist is the final ranking. Return sign-flipped
         // estimates so the public `(doc_id, distance)` convention still
         // means smaller is closer.
-        if matches!(col.rerank_codec, RerankCodec::None) {
+        if !col.rerank_codec.writes_full() {
             let _ = rerank_mult;
             if shortlist.len() > k {
                 shortlist.select_nth_unstable_by(k - 1, |a, b| {
@@ -1110,9 +1112,10 @@ fn rerank_candidates_in_run(
                 })
                 .collect()
         }
-        RerankCodec::None => unreachable!(
-            "rerank_candidates_in_run reached with None codec — None columns \
-             have no full[] region and should short-circuit before the rerank step"
+        RerankCodec::RabitqOnly => unreachable!(
+            "rerank_candidates_in_run reached with RabitqOnly codec — RabitqOnly \
+             columns have no full[] region and should short-circuit before \
+             the rerank step"
         ),
     };
     reranked.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
@@ -1262,7 +1265,7 @@ mod tests {
     fn build_blob(n_docs: u32, dim: usize, n_cent: usize, metric: Metric) -> (Bytes, String) {
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "embedding".into(),
+            column: "embedding".into(),
             dim,
             n_cent,
             rot_seed: 7,
@@ -1284,7 +1287,7 @@ mod tests {
             Metric::NegDot => "negdot",
         };
         let json = format!(
-            r#"[{{"name":"embedding","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"{metric_s}"}}]"#
+            r#"[{{"column":"embedding","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"{metric_s}"}}]"#
         );
         (Bytes::from(bytes), json)
     }
@@ -1360,7 +1363,7 @@ mod tests {
         let dim = 16;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "embedding".into(),
+            column: "embedding".into(),
             dim,
             n_cent: 4,
             rot_seed: 7,
@@ -1377,7 +1380,7 @@ mod tests {
             all_vecs.push(v);
         }
         let bytes = b.finish().expect("finish vector builder");
-        let json = r#"[{"name":"embedding","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#;
+        let json = r#"[{"column":"embedding","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#;
         let r = VectorReader::open(Bytes::from(bytes), json).expect("open VectorReader");
 
         // Pick a doc, query with its own vector → top-1 is self with distance 0.
@@ -1534,7 +1537,7 @@ mod tests {
     fn open_rejects_columns_json_mismatch() {
         let (blob, _) = build_blob(32, 16, 4, Metric::L2Sq);
         // header says 1 column; pass 2-column JSON.
-        let bad_json = r#"[{"name":"a","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"},{"name":"b","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#;
+        let bad_json = r#"[{"column":"a","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"},{"column":"b","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#;
         let err = VectorReader::open(blob, bad_json).expect_err("expected error");
         assert!(matches!(
             err,
@@ -1578,11 +1581,11 @@ mod tests {
             RerankCodec::Fp32,
             RerankCodec::Bf16,
             RerankCodec::Sq8,
-            RerankCodec::None,
+            RerankCodec::RabitqOnly,
         ] {
             let mut b = VectorBuilder::new();
             b.register_column(VectorConfig {
-                name: "v".into(),
+                column: "v".into(),
                 dim: 16,
                 n_cent: 4,
                 rot_seed: 7,
@@ -1605,7 +1608,7 @@ mod tests {
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 7,
@@ -1619,7 +1622,8 @@ mod tests {
         }
         let blob = b.finish().expect("finish");
 
-        let json = r#"[{"name":"v","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
+        let json =
+            r#"[{"column":"v","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         assert_eq!(r.columns.len(), 1);
         assert_eq!(
@@ -1650,7 +1654,7 @@ mod tests {
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 13,
@@ -1672,7 +1676,7 @@ mod tests {
         let blob = b.finish().expect("finish");
 
         let json =
-            r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
+            r#"[{"column":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         let hits = r
             .search("v", &all[17], 5, 4, 5)
@@ -1697,7 +1701,7 @@ mod tests {
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 7,
@@ -1711,7 +1715,8 @@ mod tests {
         }
         let blob = b.finish().expect("finish");
 
-        let json = r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
+        let json =
+            r#"[{"column":"v","dim":32,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         assert_eq!(r.columns.len(), 1);
         let col = &r.columns[0];
@@ -1741,7 +1746,7 @@ mod tests {
         let n_docs = 32u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 11,
@@ -1761,7 +1766,7 @@ mod tests {
         }
         let blob = b.finish().expect("finish");
         let json =
-            r#"[{"name":"v","dim":16,"n_cent":4,"rot_seed":11,"metric":"cosine"}]"#.to_string();
+            r#"[{"column":"v","dim":16,"n_cent":4,"rot_seed":11,"metric":"cosine"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         let col = &r.columns[0];
         let meta = col.sq8_meta.as_ref().expect("Sq8 must carry sq8_meta");
@@ -1788,7 +1793,7 @@ mod tests {
         };
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 23,
@@ -1805,7 +1810,7 @@ mod tests {
         let blob = b.finish().expect("finish");
 
         let json =
-            r#"[{"name":"v","dim":16,"n_cent":4,"rot_seed":23,"metric":"l2sq"}]"#.to_string();
+            r#"[{"column":"v","dim":16,"n_cent":4,"rot_seed":23,"metric":"l2sq"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         let col = &r.columns[0];
         let meta = col.sq8_meta.as_ref().expect("Sq8 meta present");
@@ -1850,7 +1855,7 @@ mod tests {
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 13,
@@ -1872,7 +1877,7 @@ mod tests {
         let blob = b.finish().expect("finish");
 
         let json =
-            r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
+            r#"[{"column":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         let hits = r
             .search("v", &all[17], 5, 4, 20)
@@ -1895,7 +1900,7 @@ mod tests {
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 19,
@@ -1923,7 +1928,7 @@ mod tests {
         let blob = b.finish().expect("finish");
 
         let json =
-            r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":19,"metric":"cosine"}]"#.to_string();
+            r#"[{"column":"v","dim":32,"n_cent":4,"rot_seed":19,"metric":"cosine"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         let hits = r
             .search("v", &all[42], 5, 4, 20)
@@ -1931,60 +1936,68 @@ mod tests {
         assert_eq!(hits[0].0, 42, "Sq8 cosine self-query must recover self");
     }
 
-    /// Building with `RerankCodec::None` succeeds and the on-disk
-    /// segment carries a zero-length `full[]` region.
+    /// Building with `RerankCodec::RabitqOnly` succeeds and the
+    /// on-disk segment carries a zero-length `full[]` region.
     #[test]
-    fn open_round_trips_none_codec_discriminator() {
+    fn open_round_trips_rabitq_only_codec_discriminator() {
         let dim = 16usize;
         let n_cent = 4usize;
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 7,
             metric: Metric::L2Sq,
-            rerank_codec: RerankCodec::None,
+            rerank_codec: RerankCodec::RabitqOnly,
         })
-        .expect("register None column");
+        .expect("register RabitqOnly column");
         for i in 0..n_docs {
             let v: Vec<f32> = (0..dim).map(|j| (i + j as u32) as f32 * 0.1).collect();
             b.add(0, &v).expect("add");
         }
         let blob = b.finish().expect("finish");
 
-        let json = r#"[{"name":"v","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
+        let json =
+            r#"[{"column":"v","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         assert_eq!(r.columns.len(), 1);
         let col = &r.columns[0];
-        assert_eq!(col.rerank_codec, RerankCodec::None);
+        assert_eq!(col.rerank_codec, RerankCodec::RabitqOnly);
         assert_eq!(col.codec_meta_off, 0);
         assert_eq!(
             col.doc_ids_off, col.full_off,
-            "None segments have zero-length full[]"
+            "RabitqOnly segments have zero-length full[]"
         );
         assert_eq!(col.n_docs, n_docs);
     }
 
-    /// A `None`-codec column returns top-K directly from the 1-bit
+    /// A `RabitqOnly` column returns top-K directly from the 1-bit
     /// shortlist. Distances are sign-flipped estimates so smaller is
     /// still closer.
+    ///
+    /// Self-query must rank the planted vector at index 0 — the
+    /// 1-bit shortlist's score for the exact-match query is the
+    /// dot product against itself, which dominates every neighbour
+    /// at this dim/cluster shape. A weaker `.any(== self)` check
+    /// would mask a regression that demoted self into positions
+    /// 1–4.
     #[test]
-    fn none_self_query_in_top_k_via_shortlist_only() {
+    fn rabitq_only_self_query_ranks_self_first() {
         let dim = 128usize;
         let n_cent = 4usize;
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 11,
             metric: Metric::L2Sq,
-            rerank_codec: RerankCodec::None,
+            rerank_codec: RerankCodec::RabitqOnly,
         })
-        .expect("register None column");
+        .expect("register RabitqOnly column");
         let make = |i: u32| -> Vec<f32> {
             let raw: Vec<f32> = (0..dim)
                 .map(|j| {
@@ -2004,49 +2017,54 @@ mod tests {
         }
         let blob = b.finish().expect("finish");
         let json =
-            r#"[{"name":"v","dim":128,"n_cent":4,"rot_seed":11,"metric":"l2sq"}]"#.to_string();
+            r#"[{"column":"v","dim":128,"n_cent":4,"rot_seed":11,"metric":"l2sq"}]"#.to_string();
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
 
         let hits = r
             .search("v", &all[17], 5, n_cent, 5)
-            .expect("None-codec search must succeed");
-        assert!(
-            hits.iter().any(|(did, _)| *did == 17),
-            "self-query must surface the planted vector in top-K, got {hits:?}"
+            .expect("RabitqOnly search must succeed");
+        assert!(!hits.is_empty(), "search must return some hits");
+        // Self-query must rank itself at index 0. `.any` masked
+        // demotion regressions — the planted vector's 1-bit
+        // shortlist score against itself is strictly greater than
+        // any neighbour's at this dim/cluster shape.
+        assert_eq!(
+            hits[0].0, 17,
+            "self-query must rank the planted vector at index 0, got {hits:?}"
         );
         assert!(hits.iter().all(|(_, d)| d.is_finite()));
         for w in hits.windows(2) {
             assert!(
                 w[0].1 <= w[1].1,
-                "None-codec hits must be sorted ascending by distance, got {hits:?}"
+                "RabitqOnly hits must be sorted ascending by distance, got {hits:?}"
             );
         }
     }
 
-    /// `None` search must not fetch a `full[]` range because the
-    /// column does not store one.
+    /// `RabitqOnly` search must not fetch a `full[]` range because
+    /// the column does not store one.
     #[test]
-    fn none_search_issues_no_full_region_fetch() {
+    fn rabitq_only_search_issues_no_full_region_fetch() {
         let dim = 32usize;
         let n_cent = 4usize;
         let n_docs = 32u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 13,
             metric: Metric::L2Sq,
-            rerank_codec: RerankCodec::None,
+            rerank_codec: RerankCodec::RabitqOnly,
         })
-        .expect("register None column");
+        .expect("register RabitqOnly column");
         for i in 0..n_docs {
             let v: Vec<f32> = (0..dim).map(|j| (i + j as u32) as f32 * 0.1).collect();
             b.add(0, &v).expect("add");
         }
         let blob = Bytes::from(b.finish().expect("finish"));
         let json =
-            r#"[{"name":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
+            r#"[{"column":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
 
         let counting = StdArc::new(CountingLazyByteSource::new(blob));
         let async_calls = counting.async_counter();
@@ -2067,12 +2085,12 @@ mod tests {
         let async_count = async_calls.load(AtomicOrdering::Relaxed);
         assert_eq!(
             async_count, 0,
-            "None-codec search on warm lazy must not bridge to async"
+            "RabitqOnly search on warm lazy must not bridge to async"
         );
         let max_expected = 2 + 2 * n_cent;
         assert!(
             sync_count <= max_expected,
-            "None-codec search must issue at most {max_expected} sync fetches; got {sync_count}"
+            "RabitqOnly search must issue at most {max_expected} sync fetches; got {sync_count}"
         );
         assert!(
             sync_count >= 4,
@@ -2230,7 +2248,7 @@ mod tests {
         let build = |codec: RerankCodec| -> Bytes {
             let mut b = VectorBuilder::new();
             b.register_column(VectorConfig {
-                name: "v".into(),
+                column: "v".into(),
                 dim,
                 n_cent: n_cent_ivf,
                 rot_seed: 7,
@@ -2259,7 +2277,7 @@ mod tests {
         );
 
         let json = format!(
-            r#"[{{"name":"v","dim":{dim},"n_cent":{n_cent_ivf},"rot_seed":7,"metric":"cosine"}}]"#
+            r#"[{{"column":"v","dim":{dim},"n_cent":{n_cent_ivf},"rot_seed":7,"metric":"cosine"}}]"#
         );
         let r_fp32 = VectorReader::open(fp32_blob, &json).expect("open fp32");
         let r_bf16 = VectorReader::open(bf16_blob, &json).expect("open bf16");
@@ -2383,7 +2401,7 @@ mod tests {
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "embedding".into(),
+            column: "embedding".into(),
             dim,
             n_cent,
             rot_seed: 7,
@@ -2400,7 +2418,7 @@ mod tests {
             all.push(v);
         }
         let bytes = b.finish().expect("finish vector builder");
-        let json = r#"[{"name":"embedding","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#
+        let json = r#"[{"column":"embedding","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#
             .to_string();
         (Bytes::from(bytes), json, all)
     }
@@ -2771,7 +2789,7 @@ mod tests {
 
         let mut b = VectorBuilder::new();
         b.register_column(VectorConfig {
-            name: "embedding".into(),
+            column: "embedding".into(),
             dim,
             n_cent,
             rot_seed: 7,
@@ -2793,7 +2811,7 @@ mod tests {
         b.finish_to(writer).expect("finish_to BufWriter<File>");
 
         format!(
-            r#"[{{"name":"embedding","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"l2sq"}}]"#
+            r#"[{{"column":"embedding","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"l2sq"}}]"#
         )
     }
 

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -533,7 +533,7 @@ impl VectorReader {
             let full_off = read_u32_le(&sub[52..56]) as usize;
             // Fp32 + Bf16 + None all keep zero-byte codec_meta; Sq8
             // emits per-cluster scale/offset (+ per-doc
-            // norms for L2Sq). The per-codec layout check below
+            // norms for L2Sq/Cosine). The per-codec layout check below
             // validates the declared `codec_meta_off` against the
             // codec's expected size once `col_n_docs` is known.
             let codec_meta_required_zero = matches!(
@@ -619,7 +619,7 @@ impl VectorReader {
                 let offset_end = scale_end + so_block_bytes;
                 let scale = parse_f32_le_vec(&meta_bytes[0..scale_end]);
                 let offset = parse_f32_le_vec(&meta_bytes[scale_end..offset_end]);
-                let per_doc_norms = if matches!(metric, Metric::L2Sq) {
+                let per_doc_norms = if matches!(metric, Metric::L2Sq | Metric::Cosine) {
                     let norms_end = offset_end + (col_n_docs as usize) * 4;
                     debug_assert_eq!(norms_end, actual_codec_meta_size);
                     Some(parse_f32_le_vec(&meta_bytes[offset_end..norms_end]))
@@ -1732,10 +1732,10 @@ mod tests {
         assert_eq!(norms.len(), col.n_docs as usize);
     }
 
-    /// Cosine Sq8 columns omit per-doc norms because the `sum(x^2)`
-    /// term is not used by cosine or negative-dot rerank.
+    /// Cosine Sq8 columns carry per-doc decoded norms so rerank can
+    /// normalize the decoded vector before computing cosine distance.
     #[test]
-    fn open_sq8_cosine_omits_per_doc_norms() {
+    fn open_sq8_cosine_carries_per_doc_norms() {
         let dim = 16usize;
         let n_cent = 4usize;
         let n_docs = 32u32;
@@ -1765,10 +1765,11 @@ mod tests {
         let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
         let col = &r.columns[0];
         let meta = col.sq8_meta.as_ref().expect("Sq8 must carry sq8_meta");
-        assert!(
-            meta.per_doc_norms.is_none(),
-            "Cosine Sq8 must omit per-doc norms"
-        );
+        let norms = meta
+            .per_doc_norms
+            .as_ref()
+            .expect("Cosine Sq8 must carry per-doc norms");
+        assert_eq!(norms.len(), n_docs as usize);
         assert_eq!(meta.scale.len(), n_cent * dim);
         assert_eq!(meta.offset.len(), n_cent * dim);
     }

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -1,0 +1,421 @@
+//! Per-column rerank codec.
+//!
+//! Each vector column picks one codec at build time:
+//!
+//! - [`RerankCodec::Fp32`]: little-endian fp32, `dim × 4` bytes
+//!   per vector. Zero-copy on the rerank distance kernel.
+//! - [`RerankCodec::Bf16`]: top 16 bits of the fp32 bit pattern,
+//!   `dim × 2` bytes per vector. SIMD widen via `u16 → u32 → fp32`
+//!   shift.
+//! - [`RerankCodec::Sq8`]: per-column per-dim 8-bit scalar
+//!   quantization, `dim × 1` bytes per vector. The quantizer
+//!   (`scale[dim]`, `offset[dim]`) lives in a sibling
+//!   `codec_meta` region at `codec_meta_off` inside the
+//!   subsection.
+//! - [`RerankCodec::None`]: no rerank column at all. The 1-bit
+//!   shortlist is the final ranking — opt-in, recall-degraded,
+//!   shrinks the segment by ~30× at 1M × 384.
+//!
+//! ## On-disk discriminator
+//!
+//! The codec choice rides as a single byte in the per-column
+//! subsection-directory entry at offset 52 (bytes 53..55 stay
+//! reserved). A zero byte at slot 52 deserializes to
+//! [`RerankCodec::Fp32`], so fp32-only segments that left the
+//! slot zero round-trip identically.
+//!
+//! ## `codec_meta` region
+//!
+//! For codecs that need per-column auxiliary data (today: just
+//! `Sq8`'s scale + offset arrays), the subsection carries a
+//! `codec_meta` region between the `codes` region and the
+//! `full[]` region. The region's relative offset within the
+//! subsection is recorded in sub-header bytes 12..16 as
+//! `codec_meta_off: u32`. `Fp32` / `Bf16` / `None` segments
+//! write `codec_meta_off = 0`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::superfile::vector::distance::Metric;
+
+/// `dim` at and below which a column counts as "low-dim" for the
+/// rerank-floor calibration table in
+/// [`RerankCodec::recommended_rerank_mult_floor`]. Set at 384 to
+/// match the dominant embedding-model bucket (e5, MiniLM, etc.).
+const LOW_DIM_RERANK_FLOOR_THRESHOLD: usize = 384;
+
+/// Recommended floor on `rerank_mult` for `Fp32` / `Bf16` columns
+/// at `dim ≤ 384`. Fp32 and Bf16 share the same floor — bf16's
+/// rounding noise sits well below the 1-bit shortlist's noise
+/// floor, so the recall-driven candidate budget is the same.
+const FP32_BF16_LOW_DIM_RERANK_FLOOR: usize = 20;
+
+/// Recommended floor on `rerank_mult` for `Fp32` / `Bf16` columns
+/// at `dim > 384`. Higher dim widens the gap between the 1-bit
+/// shortlist score and the true distance; more candidates are
+/// needed to recover the same recall.
+const FP32_BF16_HIGH_DIM_RERANK_FLOOR: usize = 50;
+
+/// Recommended floor on `rerank_mult` for `Sq8` columns at
+/// `dim ≤ 384`. Sq8 needs more candidates than fp32 / bf16 to
+/// recover equivalent recall because the dequant noise floor is
+/// higher.
+const SQ8_LOW_DIM_RERANK_FLOOR: usize = 50;
+
+/// Recommended floor on `rerank_mult` for `Sq8` columns at
+/// `dim > 384`. See [`SQ8_LOW_DIM_RERANK_FLOOR`] and
+/// [`FP32_BF16_HIGH_DIM_RERANK_FLOOR`] for the underlying
+/// calibration rationale.
+const SQ8_HIGH_DIM_RERANK_FLOOR: usize = 100;
+
+/// Per-column rerank codec. Picks the on-disk byte layout of the
+/// per-vector rerank values inside the subsection's `full[]`
+/// region.
+///
+/// See the module docs for the on-disk discriminator + lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RerankCodec {
+    /// fp32 little-endian, `dim` contiguous f32s per vector.
+    /// The rerank distance kernel reads it via
+    /// `bytemuck::try_cast_slice` → zero-copy SIMD.
+    Fp32,
+    /// bf16 — top 16 bits of the fp32 bit pattern. `dim × 2`
+    /// bytes per vector. SIMD widen via `(u16 → u32 → f32 shift)`
+    /// in front of the distance kernel.
+    Bf16,
+    /// 8-bit scalar quantization. Per-column per-dim
+    /// `(scale[dim], offset[dim])` arrays live in the sibling
+    /// `codec_meta` region; per-vector body is `dim` u8s. The
+    /// distance kernel fuses dequant with the per-candidate
+    /// distance.
+    Sq8,
+    /// No rerank column at all. The shortlist (1-bit RaBitQ
+    /// scores) is the final ranking. Opt-in — recall drops
+    /// 0.05–0.15 on typical normalized-Gaussian / image-
+    /// embedding corpora; trade-off is a ~30× segment-size
+    /// shrink at 1M × 384.
+    None,
+}
+
+impl Default for RerankCodec {
+    /// `Sq8` shrinks the `full[]` rerank region to `dim × 1`
+    /// bytes per vector — 4× smaller than fp32, ~3.5× smaller
+    /// overall segment at 1M × 384 — at a typical recall drop
+    /// < 0.005 vs fp32 on normalized embeddings. Callers that
+    /// need bit-exact fp32 (oracles, regression fixtures,
+    /// recall-floor reference runs) opt in to
+    /// [`RerankCodec::Fp32`] explicitly.
+    fn default() -> Self {
+        Self::Sq8
+    }
+}
+
+impl RerankCodec {
+    /// On-disk discriminator byte. Lives at offset 52 inside the
+    /// 64-byte per-column directory entry. `0` is reserved for
+    /// [`Self::Fp32`] so fp32-only segments that left the slot
+    /// zero round-trip identically.
+    #[inline]
+    pub const fn codec_id(self) -> u8 {
+        match self {
+            Self::Fp32 => 0,
+            Self::Bf16 => 1,
+            Self::Sq8 => 2,
+            Self::None => 3,
+        }
+    }
+
+    /// Inverse of [`Self::codec_id`]. Returns `None` for unknown
+    /// discriminator bytes — the reader treats that as a
+    /// `MalformedVersion` failure so a corrupted / future segment
+    /// fails loud rather than mis-decoding.
+    #[inline]
+    pub const fn from_codec_id(id: u8) -> Option<Self> {
+        match id {
+            0 => Some(Self::Fp32),
+            1 => Some(Self::Bf16),
+            2 => Some(Self::Sq8),
+            3 => Some(Self::None),
+            _ => None,
+        }
+    }
+
+    /// Stable human-readable name, used in JSON-config + error
+    /// strings.
+    #[inline]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Fp32 => "fp32",
+            Self::Bf16 => "bf16",
+            Self::Sq8 => "sq8",
+            Self::None => "none",
+        }
+    }
+
+    /// Per-vector body size in bytes inside the `full[]` region.
+    /// `0` for [`Self::None`] (no rerank bytes at all).
+    #[inline]
+    pub const fn per_vector_bytes(self, dim: usize) -> usize {
+        match self {
+            Self::Fp32 => dim * 4,
+            Self::Bf16 => dim * 2,
+            Self::Sq8 => dim,
+            Self::None => 0,
+        }
+    }
+
+    /// Whether the build + search paths implement this codec.
+    /// All four enum variants are currently implemented; this
+    /// hook exists so future codecs can be added to the enum
+    /// (and the on-disk discriminator table) before their build
+    /// path lands — call sites use it to fail fast with a
+    /// targeted `Unimplemented` error rather than silently
+    /// writing a byte format that the reader can't decode.
+    #[inline]
+    pub const fn is_implemented(self) -> bool {
+        matches!(self, Self::Fp32 | Self::Bf16 | Self::Sq8 | Self::None)
+    }
+
+    /// Recommended **lower bound** on `rerank_mult` for this
+    /// codec at the given `dim`. Returns `None` for codecs
+    /// where rerank is meaningless (today: just [`Self::None`],
+    /// which skips the rerank step entirely).
+    ///
+    /// Sq8 needs more candidates to recover fp32-equivalent
+    /// recall because the dequant noise floor is higher than
+    /// fp32 / bf16. Bf16's rounding noise at ~2⁻⁸ per lane is
+    /// well below the 1-bit shortlist's noise floor — same
+    /// recommended floor as fp32. The bench harness uses this
+    /// as the calibration-grid lower bound; direct
+    /// `search(.., rerank_mult)` callers are unaffected.
+    ///
+    /// Numbers calibrated against FAISS-doc peer benchmarks.
+    #[inline]
+    pub const fn recommended_rerank_mult_floor(self, dim: usize) -> Option<usize> {
+        let high_dim = dim > LOW_DIM_RERANK_FLOOR_THRESHOLD;
+        match self {
+            Self::Fp32 | Self::Bf16 => Some(if high_dim {
+                FP32_BF16_HIGH_DIM_RERANK_FLOOR
+            } else {
+                FP32_BF16_LOW_DIM_RERANK_FLOOR
+            }),
+            Self::Sq8 => Some(if high_dim {
+                SQ8_HIGH_DIM_RERANK_FLOOR
+            } else {
+                SQ8_LOW_DIM_RERANK_FLOOR
+            }),
+            Self::None => None,
+        }
+    }
+
+    /// Returns the per-column `codec_meta` region size in bytes
+    /// for this codec at the given dim + n_docs + n_cent + metric.
+    /// Stored immediately before the subsection's `full[]` region.
+    ///
+    /// - `Fp32` / `Bf16` / `None`: `0` (no codec metadata).
+    /// - `Sq8`: **per-cluster** per-dim `(scale, offset)` arrays
+    ///   (`2 × n_cent × dim × 4` bytes) plus, for `L2Sq`-metric
+    ///   columns, a per-doc `sum_x_decoded² : f32` table
+    ///   (`n_docs × 4` bytes) used to short-circuit the `Σx²`
+    ///   term in the L2Sq distance formula at search time
+    ///   (dim u8-widens + multiplies saved per rerank candidate).
+    ///   Cosine / NegDot columns drop the per-doc norms.
+    ///
+    /// **Why per-cluster, not per-column.** A naive design uses
+    /// one `(scale[dim], offset[dim])` pair for the whole
+    /// column. On highly clustered cosine corpora (real sentence
+    /// embeddings, the bench's planted-cluster generator) the
+    /// per-column min/max spans the cross-cluster spread — but the
+    /// rerank step's ranking signal lives in the *intra-cluster*
+    /// spread, which is several times narrower. With 256 buckets
+    /// stretched across the wider global range, only a small slice
+    /// of them is used within any one cluster; the quantization
+    /// noise dominates intra-cluster cosine differences and recall
+    /// collapses (the planted-cluster diagnostic in `reader.rs`
+    /// reproduces the failure mode at small scale). Per-cluster
+    /// quantizer recovers full recall by giving each cluster's docs
+    /// the finest possible buckets over their local range. Cost is
+    /// `n_cent × dim × 8` codec_meta bytes — small relative to
+    /// the Sq8 `full[]` region at typical IVF shapes.
+    #[inline]
+    pub const fn codec_meta_bytes(
+        self,
+        dim: usize,
+        n_docs: usize,
+        n_cent: usize,
+        metric: Metric,
+    ) -> usize {
+        match self {
+            Self::Fp32 | Self::Bf16 | Self::None => 0,
+            Self::Sq8 => {
+                let scale_offset_bytes = 2 * n_cent * dim * 4;
+                let norms_bytes = match metric {
+                    Metric::L2Sq => n_docs * 4,
+                    Metric::Cosine | Metric::NegDot => 0,
+                };
+                scale_offset_bytes + norms_bytes
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for RerankCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Default codec is `Sq8`. Any change here is a load-bearing
+    /// format choice — every caller that uses
+    /// `RerankCodec::default()` silently follows this pick, so
+    /// the test pins the contract.
+    #[test]
+    fn default_is_sq8() {
+        assert_eq!(RerankCodec::default(), RerankCodec::Sq8);
+    }
+
+    /// `Fp32`'s codec_id is zero. Pre-012 segments have all-zero
+    /// reserved bytes in the directory-entry slot we squat on
+    /// for the codec discriminator; the zero match keeps them
+    /// readable as `Fp32` without a format bump.
+    #[test]
+    fn fp32_codec_id_is_zero() {
+        assert_eq!(RerankCodec::Fp32.codec_id(), 0u8);
+    }
+
+    /// Round-trip every defined variant through `codec_id` /
+    /// `from_codec_id`. Catches accidental enum reordering — the
+    /// discriminator is on-disk so the numeric mapping is part of
+    /// the format contract.
+    #[test]
+    fn codec_id_roundtrips_every_variant() {
+        for c in [
+            RerankCodec::Fp32,
+            RerankCodec::Bf16,
+            RerankCodec::Sq8,
+            RerankCodec::None,
+        ] {
+            assert_eq!(
+                RerankCodec::from_codec_id(c.codec_id()),
+                Some(c),
+                "round-trip mismatch for {c:?}"
+            );
+        }
+    }
+
+    /// Unknown discriminator bytes (any value not currently
+    /// assigned, e.g. `5`, `255`) return `None`. The reader
+    /// upgrades that into a `MalformedVersion` error rather than
+    /// guessing.
+    #[test]
+    fn unknown_codec_id_is_none() {
+        for id in [4u8, 5, 16, 200, 255] {
+            assert_eq!(
+                RerankCodec::from_codec_id(id),
+                None,
+                "unknown id {id} must not map to a codec"
+            );
+        }
+    }
+
+    /// Per-vector body sizes match the on-disk spec. `None`'s
+    /// zero is what lets that codec drop the entire `full[]`
+    /// region.
+    #[test]
+    fn per_vector_bytes_matches_spec() {
+        assert_eq!(RerankCodec::Fp32.per_vector_bytes(384), 1536);
+        assert_eq!(RerankCodec::Bf16.per_vector_bytes(384), 768);
+        assert_eq!(RerankCodec::Sq8.per_vector_bytes(384), 384);
+        assert_eq!(RerankCodec::None.per_vector_bytes(384), 0);
+    }
+
+    /// All four codecs are wired end-to-end (build + open + search).
+    #[test]
+    fn all_codecs_implemented() {
+        assert!(RerankCodec::Fp32.is_implemented());
+        assert!(RerankCodec::Bf16.is_implemented());
+        assert!(RerankCodec::Sq8.is_implemented());
+        assert!(RerankCodec::None.is_implemented());
+    }
+
+    /// Calibration-floor table the bench harness threads into
+    /// its calibration grid. The hard contract is the values +
+    /// the `None`-returns-`None` behaviour; the dim split
+    /// (`> 384`) is one of two load-bearing knobs the bench
+    /// harness reads.
+    #[test]
+    fn recommended_rerank_mult_floor_matches_calibration_table() {
+        // dim ≤ 384 column.
+        assert_eq!(
+            RerankCodec::Fp32.recommended_rerank_mult_floor(384),
+            Some(20)
+        );
+        assert_eq!(
+            RerankCodec::Bf16.recommended_rerank_mult_floor(384),
+            Some(20)
+        );
+        assert_eq!(
+            RerankCodec::Sq8.recommended_rerank_mult_floor(384),
+            Some(50)
+        );
+        assert_eq!(RerankCodec::None.recommended_rerank_mult_floor(384), None);
+        // 384 < dim ≤ 1024 column.
+        assert_eq!(
+            RerankCodec::Fp32.recommended_rerank_mult_floor(1024),
+            Some(50)
+        );
+        assert_eq!(
+            RerankCodec::Bf16.recommended_rerank_mult_floor(1024),
+            Some(50)
+        );
+        assert_eq!(
+            RerankCodec::Sq8.recommended_rerank_mult_floor(1024),
+            Some(100)
+        );
+        assert_eq!(RerankCodec::None.recommended_rerank_mult_floor(1024), None);
+        // Split point: dim == 384 is the low-dim cell; dim == 385
+        // crosses into high-dim.
+        assert_eq!(
+            RerankCodec::Sq8.recommended_rerank_mult_floor(385),
+            Some(100)
+        );
+    }
+
+    /// Sq8's codec_meta size: `8·n_cent·dim` for cosine / negdot,
+    /// `8·n_cent·dim + 4·n_docs` for L2Sq (per-doc decoded-norm
+    /// cache). Fp32 / Bf16 / None always contribute zero bytes.
+    /// Per-cluster scale/offset is the recall-recovery fix
+    /// landed in the Sq8PerCluster patch (see fn-doc above).
+    #[test]
+    fn codec_meta_bytes_matches_layout_spec() {
+        // Fp32 + Bf16 + None never carry codec_meta.
+        for c in [RerankCodec::Fp32, RerankCodec::Bf16, RerankCodec::None] {
+            for m in [Metric::L2Sq, Metric::Cosine, Metric::NegDot] {
+                assert_eq!(
+                    c.codec_meta_bytes(384, 1_000_000, 1024, m),
+                    0,
+                    "{c:?} / {m:?}"
+                );
+            }
+        }
+        // Sq8 cosine / negdot: per-cluster scale + offset arrays.
+        let so_bytes = 2 * 1024 * 384 * 4;
+        assert_eq!(
+            RerankCodec::Sq8.codec_meta_bytes(384, 1_000_000, 1024, Metric::Cosine),
+            so_bytes
+        );
+        assert_eq!(
+            RerankCodec::Sq8.codec_meta_bytes(384, 1_000_000, 1024, Metric::NegDot),
+            so_bytes
+        );
+        // Sq8 L2Sq: per-cluster scale + offset + per-doc norms.
+        assert_eq!(
+            RerankCodec::Sq8.codec_meta_bytes(384, 1_000_000, 1024, Metric::L2Sq),
+            so_bytes + 1_000_000 * 4
+        );
+    }
+}

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -214,12 +214,12 @@ impl RerankCodec {
     ///
     /// - `Fp32` / `Bf16` / `None`: `0` (no codec metadata).
     /// - `Sq8`: **per-cluster** per-dim `(scale, offset)` arrays
-    ///   (`2 × n_cent × dim × 4` bytes) plus, for `L2Sq`-metric
+    ///   (`2 × n_cent × dim × 4` bytes) plus, for `L2Sq`/`Cosine`-metric
     ///   columns, a per-doc `sum_x_decoded² : f32` table
     ///   (`n_docs × 4` bytes) used to short-circuit the `Σx²`
-    ///   term in the L2Sq distance formula at search time
-    ///   (dim u8-widens + multiplies saved per rerank candidate).
-    ///   Cosine / NegDot columns drop the per-doc norms.
+    ///   term in the L2Sq distance formula or normalize the decoded
+    ///   vector for Cosine at search time. NegDot columns drop the
+    ///   per-doc norms.
     ///
     /// **Why per-cluster, not per-column.** A naive design uses
     /// one `(scale[dim], offset[dim])` pair for the whole
@@ -250,8 +250,8 @@ impl RerankCodec {
             Self::Sq8 => {
                 let scale_offset_bytes = 2 * n_cent * dim * 4;
                 let norms_bytes = match metric {
-                    Metric::L2Sq => n_docs * 4,
-                    Metric::Cosine | Metric::NegDot => 0,
+                    Metric::L2Sq | Metric::Cosine => n_docs * 4,
+                    Metric::NegDot => 0,
                 };
                 scale_offset_bytes + norms_bytes
             }
@@ -385,8 +385,8 @@ mod tests {
         );
     }
 
-    /// Sq8's codec_meta size: `8·n_cent·dim` for cosine / negdot,
-    /// `8·n_cent·dim + 4·n_docs` for L2Sq (per-doc decoded-norm
+    /// Sq8's codec_meta size: `8·n_cent·dim` for negdot,
+    /// `8·n_cent·dim + 4·n_docs` for L2Sq/Cosine (per-doc decoded-norm
     /// cache). Fp32 / Bf16 / None always contribute zero bytes.
     /// Per-cluster scale/offset is the recall-recovery fix
     /// landed in the Sq8PerCluster patch (see fn-doc above).
@@ -402,17 +402,17 @@ mod tests {
                 );
             }
         }
-        // Sq8 cosine / negdot: per-cluster scale + offset arrays.
+        // Sq8 negdot: per-cluster scale + offset arrays.
         let so_bytes = 2 * 1024 * 384 * 4;
-        assert_eq!(
-            RerankCodec::Sq8.codec_meta_bytes(384, 1_000_000, 1024, Metric::Cosine),
-            so_bytes
-        );
         assert_eq!(
             RerankCodec::Sq8.codec_meta_bytes(384, 1_000_000, 1024, Metric::NegDot),
             so_bytes
         );
-        // Sq8 L2Sq: per-cluster scale + offset + per-doc norms.
+        // Sq8 L2Sq/Cosine: per-cluster scale + offset + per-doc norms.
+        assert_eq!(
+            RerankCodec::Sq8.codec_meta_bytes(384, 1_000_000, 1024, Metric::Cosine),
+            so_bytes + 1_000_000 * 4
+        );
         assert_eq!(
             RerankCodec::Sq8.codec_meta_bytes(384, 1_000_000, 1024, Metric::L2Sq),
             so_bytes + 1_000_000 * 4

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -12,9 +12,12 @@
 //!   (`scale[dim]`, `offset[dim]`) lives in a sibling
 //!   `codec_meta` region at `codec_meta_off` inside the
 //!   subsection.
-//! - [`RerankCodec::None`]: no rerank column at all. The 1-bit
-//!   shortlist is the final ranking — opt-in, recall-degraded,
-//!   shrinks the segment by ~30× at 1M × 384.
+//! - [`RerankCodec::RabitqOnly`]: no rerank column at all. The
+//!   1-bit RaBitQ shortlist is the final ranking — opt-in,
+//!   recall-degraded, shrinks the segment by ~30× at 1M × 384.
+//!   Named `RabitqOnly` rather than `None` to (a) avoid shadowing
+//!   `Option::None` at every call site and (b) describe the search
+//!   behaviour rather than the absence of a codec.
 //!
 //! ## On-disk discriminator
 //!
@@ -31,7 +34,7 @@
 //! `codec_meta` region between the `codes` region and the
 //! `full[]` region. The region's relative offset within the
 //! subsection is recorded in sub-header bytes 12..16 as
-//! `codec_meta_off: u32`. `Fp32` / `Bf16` / `None` segments
+//! `codec_meta_off: u32`. `Fp32` / `Bf16` / `RabitqOnly` segments
 //! write `codec_meta_off = 0`.
 
 use serde::{Deserialize, Serialize};
@@ -89,12 +92,16 @@ pub enum RerankCodec {
     /// distance kernel fuses dequant with the per-candidate
     /// distance.
     Sq8,
-    /// No rerank column at all. The shortlist (1-bit RaBitQ
-    /// scores) is the final ranking. Opt-in — recall drops
-    /// 0.05–0.15 on typical normalized-Gaussian / image-
-    /// embedding corpora; trade-off is a ~30× segment-size
-    /// shrink at 1M × 384.
-    None,
+    /// No rerank column at all. The 1-bit RaBitQ shortlist is
+    /// the final ranking. Opt-in — recall drops 0.05–0.15 on
+    /// typical normalized-Gaussian / image-embedding corpora;
+    /// trade-off is a ~30× segment-size shrink at 1M × 384.
+    ///
+    /// Spelled `RabitqOnly` rather than `None` so call sites
+    /// don't collide with `Option::None` and the variant name
+    /// describes the search behaviour rather than the absence
+    /// of a codec.
+    RabitqOnly,
 }
 
 impl Default for RerankCodec {
@@ -121,7 +128,7 @@ impl RerankCodec {
             Self::Fp32 => 0,
             Self::Bf16 => 1,
             Self::Sq8 => 2,
-            Self::None => 3,
+            Self::RabitqOnly => 3,
         }
     }
 
@@ -135,7 +142,7 @@ impl RerankCodec {
             0 => Some(Self::Fp32),
             1 => Some(Self::Bf16),
             2 => Some(Self::Sq8),
-            3 => Some(Self::None),
+            3 => Some(Self::RabitqOnly),
             _ => None,
         }
     }
@@ -148,20 +155,30 @@ impl RerankCodec {
             Self::Fp32 => "fp32",
             Self::Bf16 => "bf16",
             Self::Sq8 => "sq8",
-            Self::None => "none",
+            Self::RabitqOnly => "rabitq_only",
         }
     }
 
     /// Per-vector body size in bytes inside the `full[]` region.
-    /// `0` for [`Self::None`] (no rerank bytes at all).
+    /// `0` for [`Self::RabitqOnly`] (no rerank bytes at all).
     #[inline]
     pub const fn per_vector_bytes(self, dim: usize) -> usize {
         match self {
             Self::Fp32 => dim * 4,
             Self::Bf16 => dim * 2,
             Self::Sq8 => dim,
-            Self::None => 0,
+            Self::RabitqOnly => 0,
         }
+    }
+
+    /// Whether this codec writes a per-vector `full[]` region
+    /// to disk. `false` only for [`Self::RabitqOnly`], which
+    /// drops the rerank column entirely. Build + open paths use
+    /// this to skip the `full[]` allocation, the per-row spill
+    /// in pass 2, and the bucket-read load in pass 3.
+    #[inline]
+    pub const fn writes_full(self) -> bool {
+        !matches!(self, Self::RabitqOnly)
     }
 
     /// Whether the build + search paths implement this codec.
@@ -173,13 +190,14 @@ impl RerankCodec {
     /// writing a byte format that the reader can't decode.
     #[inline]
     pub const fn is_implemented(self) -> bool {
-        matches!(self, Self::Fp32 | Self::Bf16 | Self::Sq8 | Self::None)
+        matches!(self, Self::Fp32 | Self::Bf16 | Self::Sq8 | Self::RabitqOnly)
     }
 
     /// Recommended **lower bound** on `rerank_mult` for this
     /// codec at the given `dim`. Returns `None` for codecs
-    /// where rerank is meaningless (today: just [`Self::None`],
-    /// which skips the rerank step entirely).
+    /// where rerank is meaningless (today: just
+    /// [`Self::RabitqOnly`], which skips the rerank step
+    /// entirely).
     ///
     /// Sq8 needs more candidates to recover fp32-equivalent
     /// recall because the dequant noise floor is higher than
@@ -204,7 +222,7 @@ impl RerankCodec {
             } else {
                 SQ8_LOW_DIM_RERANK_FLOOR
             }),
-            Self::None => None,
+            Self::RabitqOnly => None,
         }
     }
 
@@ -212,7 +230,7 @@ impl RerankCodec {
     /// for this codec at the given dim + n_docs + n_cent + metric.
     /// Stored immediately before the subsection's `full[]` region.
     ///
-    /// - `Fp32` / `Bf16` / `None`: `0` (no codec metadata).
+    /// - `Fp32` / `Bf16` / `RabitqOnly`: `0` (no codec metadata).
     /// - `Sq8`: **per-cluster** per-dim `(scale, offset)` arrays
     ///   (`2 × n_cent × dim × 4` bytes) plus, for `L2Sq`/`Cosine`-metric
     ///   columns, a per-doc `sum_x_decoded² : f32` table
@@ -246,7 +264,7 @@ impl RerankCodec {
         metric: Metric,
     ) -> usize {
         match self {
-            Self::Fp32 | Self::Bf16 | Self::None => 0,
+            Self::Fp32 | Self::Bf16 | Self::RabitqOnly => 0,
             Self::Sq8 => {
                 let scale_offset_bytes = 2 * n_cent * dim * 4;
                 let norms_bytes = match metric {
@@ -297,7 +315,7 @@ mod tests {
             RerankCodec::Fp32,
             RerankCodec::Bf16,
             RerankCodec::Sq8,
-            RerankCodec::None,
+            RerankCodec::RabitqOnly,
         ] {
             assert_eq!(
                 RerankCodec::from_codec_id(c.codec_id()),
@@ -322,7 +340,7 @@ mod tests {
         }
     }
 
-    /// Per-vector body sizes match the on-disk spec. `None`'s
+    /// Per-vector body sizes match the on-disk spec. `RabitqOnly`'s
     /// zero is what lets that codec drop the entire `full[]`
     /// region.
     #[test]
@@ -330,7 +348,27 @@ mod tests {
         assert_eq!(RerankCodec::Fp32.per_vector_bytes(384), 1536);
         assert_eq!(RerankCodec::Bf16.per_vector_bytes(384), 768);
         assert_eq!(RerankCodec::Sq8.per_vector_bytes(384), 384);
-        assert_eq!(RerankCodec::None.per_vector_bytes(384), 0);
+        assert_eq!(RerankCodec::RabitqOnly.per_vector_bytes(384), 0);
+    }
+
+    /// `writes_full` is the inverse of "this codec is
+    /// `RabitqOnly`" — pins the build/open fast-path predicate
+    /// to the codec's identity rather than scattered
+    /// `matches!(_, RabitqOnly)` checks.
+    #[test]
+    fn writes_full_matches_per_vector_bytes() {
+        for c in [
+            RerankCodec::Fp32,
+            RerankCodec::Bf16,
+            RerankCodec::Sq8,
+            RerankCodec::RabitqOnly,
+        ] {
+            assert_eq!(
+                c.writes_full(),
+                c.per_vector_bytes(384) > 0,
+                "writes_full disagrees with per_vector_bytes for {c:?}"
+            );
+        }
     }
 
     /// All four codecs are wired end-to-end (build + open + search).
@@ -339,7 +377,7 @@ mod tests {
         assert!(RerankCodec::Fp32.is_implemented());
         assert!(RerankCodec::Bf16.is_implemented());
         assert!(RerankCodec::Sq8.is_implemented());
-        assert!(RerankCodec::None.is_implemented());
+        assert!(RerankCodec::RabitqOnly.is_implemented());
     }
 
     /// Calibration-floor table the bench harness threads into
@@ -362,7 +400,10 @@ mod tests {
             RerankCodec::Sq8.recommended_rerank_mult_floor(384),
             Some(50)
         );
-        assert_eq!(RerankCodec::None.recommended_rerank_mult_floor(384), None);
+        assert_eq!(
+            RerankCodec::RabitqOnly.recommended_rerank_mult_floor(384),
+            None
+        );
         // 384 < dim ≤ 1024 column.
         assert_eq!(
             RerankCodec::Fp32.recommended_rerank_mult_floor(1024),
@@ -376,7 +417,10 @@ mod tests {
             RerankCodec::Sq8.recommended_rerank_mult_floor(1024),
             Some(100)
         );
-        assert_eq!(RerankCodec::None.recommended_rerank_mult_floor(1024), None);
+        assert_eq!(
+            RerankCodec::RabitqOnly.recommended_rerank_mult_floor(1024),
+            None
+        );
         // Split point: dim == 384 is the low-dim cell; dim == 385
         // crosses into high-dim.
         assert_eq!(
@@ -387,13 +431,17 @@ mod tests {
 
     /// Sq8's codec_meta size: `8·n_cent·dim` for negdot,
     /// `8·n_cent·dim + 4·n_docs` for L2Sq/Cosine (per-doc decoded-norm
-    /// cache). Fp32 / Bf16 / None always contribute zero bytes.
-    /// Per-cluster scale/offset is the recall-recovery fix
-    /// landed in the Sq8PerCluster patch (see fn-doc above).
+    /// cache). Fp32 / Bf16 / RabitqOnly always contribute zero
+    /// bytes. Per-cluster scale/offset is the recall-recovery
+    /// fix landed in the Sq8PerCluster patch (see fn-doc above).
     #[test]
     fn codec_meta_bytes_matches_layout_spec() {
-        // Fp32 + Bf16 + None never carry codec_meta.
-        for c in [RerankCodec::Fp32, RerankCodec::Bf16, RerankCodec::None] {
+        // Fp32 + Bf16 + RabitqOnly never carry codec_meta.
+        for c in [
+            RerankCodec::Fp32,
+            RerankCodec::Bf16,
+            RerankCodec::RabitqOnly,
+        ] {
             for m in [Metric::L2Sq, Metric::Cosine, Metric::NegDot] {
                 assert_eq!(
                     c.codec_meta_bytes(384, 1_000_000, 1024, m),

--- a/src/superfile/vector/reservoir.rs
+++ b/src/superfile/vector/reservoir.rs
@@ -1,5 +1,5 @@
 //! Reservoir sampling for k-means training in the streaming
-//! `VectorBuilder` (plan 010, M2).
+//! `VectorBuilder`.
 //!
 //! The build path is k-means-bound, not corpus-bound — the
 //! information k-means needs to converge is a representative

--- a/src/superfile/vector/spill.rs
+++ b/src/superfile/vector/spill.rs
@@ -1,5 +1,4 @@
-//! Streaming spill primitives for the bounded-memory build path
-//! introduced by plan 010 (`claude_plans/010_streaming_vector_build.md`).
+//! Streaming spill primitives for the bounded-memory build path.
 //!
 //! Two cooperating abstractions:
 //!
@@ -20,9 +19,6 @@
 //! chunk slice returned per iteration is valid for the duration
 //! of the `&mut self` borrow, which is the scope the pass-2
 //! per-chunk loop runs inside.
-//!
-//! M1 of 010 lands the primitives but does not wire them into
-//! the builder. Wiring is M3.
 
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
@@ -109,8 +105,8 @@ impl SpillWriter {
     }
 
     /// Path of the underlying spill file. Stable for the
-    /// lifetime of this `SpillWriter`. Useful for tests + the
-    /// `MmapVectorSource::open` call site in M3.
+    /// lifetime of this `SpillWriter`. Useful for tests and the
+    /// `MmapVectorSource::open` call site.
     pub fn path(&self) -> &Path {
         &self.path
     }

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -865,6 +865,7 @@ mod tests {
             n_cent: 4,
             rot_seed: 0,
             metric: Metric::Cosine,
+            rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
         }
     }
 

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -244,6 +244,7 @@ mod tests {
                     n_cent: 4,
                     rot_seed: 0,
                     metric: Metric::Cosine,
+                    rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
                 }],
                 None,
             )

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -533,6 +533,7 @@ mod tests {
                 n_cent: 4,
                 rot_seed: 0,
                 metric: Metric::Cosine,
+                rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
             }],
             Some(tok()),
         )

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -229,6 +229,7 @@ mod tests {
                 n_cent: 4,
                 rot_seed: 7,
                 metric: Metric::Cosine,
+                rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
             }],
             Some(tok()),
         )
@@ -297,6 +298,7 @@ mod tests {
                 n_cent: 4,
                 rot_seed: 7,
                 metric: Metric::Cosine,
+                rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
             }],
             Some(tok()),
         );

--- a/src/supertable/utils/vector_split.rs
+++ b/src/supertable/utils/vector_split.rs
@@ -215,6 +215,7 @@ mod tests {
             n_cent: 4,
             rot_seed: 0,
             metric: Metric::Cosine,
+            rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
         }
     }
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1602,6 +1602,7 @@ mod tests {
                 n_cent: 4,
                 rot_seed: 7,
                 metric: Metric::Cosine,
+                rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
             }],
             None,
         )

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -85,6 +85,7 @@ pub fn default_vector_config(column: &str, rot_seed: u64) -> VectorConfig {
         n_cent: 4,
         rot_seed,
         metric: Metric::Cosine,
+        rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Fp32,
     }
 }
 

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -11,6 +11,7 @@ use infino::superfile::builder::{
 };
 use infino::superfile::fts::reader::BoolMode;
 use infino::superfile::vector::distance::{Metric, normalize};
+use infino::superfile::vector::rerank_codec::RerankCodec;
 use infino::superfile::{SuperfileReader, VectorSearchOptions};
 use infino::test_helpers::{decimal128_ids, default_tokenizer};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -46,6 +47,7 @@ fn build_pipeline_superfile() -> Bytes {
             n_cent: 4,
             rot_seed: 17,
             metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
         }],
         Some(default_tokenizer()),
     );

--- a/tests/superfile/vector/brute_force_oracle.rs
+++ b/tests/superfile/vector/brute_force_oracle.rs
@@ -85,7 +85,7 @@ fn build_reader(
 ) -> VectorReader {
     let mut b = VectorBuilder::new();
     b.register_column(VectorConfig {
-        name: "v".into(),
+        column: "v".into(),
         dim,
         n_cent,
         rot_seed,
@@ -103,7 +103,7 @@ fn build_reader(
         Metric::NegDot => "negdot",
     };
     let json = format!(
-        r#"[{{"name":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":{rot_seed},"metric":"{metric_str}"}}]"#
+        r#"[{{"column":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":{rot_seed},"metric":"{metric_str}"}}]"#
     );
     VectorReader::open(Bytes::from(bytes), &json).expect("open VectorReader")
 }

--- a/tests/superfile/vector/brute_force_oracle.rs
+++ b/tests/superfile/vector/brute_force_oracle.rs
@@ -27,6 +27,7 @@ use bytes::Bytes;
 use infino::superfile::vector::builder::{VectorBuilder, VectorConfig};
 use infino::superfile::vector::distance::{Metric, distance, normalize};
 use infino::superfile::vector::reader::VectorReader;
+use infino::superfile::vector::rerank_codec::RerankCodec;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, StandardNormal};
@@ -89,6 +90,7 @@ fn build_reader(
         n_cent,
         rot_seed,
         metric,
+        rerank_codec: RerankCodec::Fp32,
     })
     .expect("register column");
     for v in corpus {

--- a/tests/superfile/vector/pipeline.rs
+++ b/tests/superfile/vector/pipeline.rs
@@ -14,7 +14,7 @@ use infino::superfile::vector::rerank_codec::RerankCodec;
 fn build_two_column_blob(n_docs: u32) -> (Bytes, String) {
     let mut b = VectorBuilder::new();
     b.register_column(VectorConfig {
-        name: "text_emb".into(),
+        column: "text_emb".into(),
         dim: 16,
         n_cent: 4,
         rot_seed: 11,
@@ -23,7 +23,7 @@ fn build_two_column_blob(n_docs: u32) -> (Bytes, String) {
     })
     .expect("register column");
     b.register_column(VectorConfig {
-        name: "image_emb".into(),
+        column: "image_emb".into(),
         dim: 24,
         n_cent: 4,
         rot_seed: 22,
@@ -49,8 +49,8 @@ fn build_two_column_blob(n_docs: u32) -> (Bytes, String) {
 
     let bytes = b.finish().expect("finish vector builder");
     let json = r#"[
-        {"name":"text_emb","dim":16,"n_cent":4,"rot_seed":11,"metric":"cosine"},
-        {"name":"image_emb","dim":24,"n_cent":4,"rot_seed":22,"metric":"l2sq"}
+        {"column":"text_emb","dim":16,"n_cent":4,"rot_seed":11,"metric":"cosine"},
+        {"column":"image_emb","dim":24,"n_cent":4,"rot_seed":22,"metric":"l2sq"}
     ]"#;
     (Bytes::from(bytes), json.to_string())
 }
@@ -142,7 +142,7 @@ fn end_to_end_planted_clusters_recovered() {
     let dim = 16;
     let mut b = VectorBuilder::new();
     b.register_column(VectorConfig {
-        name: "v".into(),
+        column: "v".into(),
         dim,
         n_cent: 3,
         rot_seed: 42,
@@ -179,7 +179,7 @@ fn end_to_end_planted_clusters_recovered() {
     assert_eq!(next_doc_id, 60);
 
     let bytes = b.finish().expect("finish vector builder");
-    let json = r#"[{"name":"v","dim":16,"n_cent":3,"rot_seed":42,"metric":"l2sq"}]"#;
+    let json = r#"[{"column":"v","dim":16,"n_cent":3,"rot_seed":42,"metric":"l2sq"}]"#;
     let r = VectorReader::open(Bytes::from(bytes), json).expect("open VectorReader");
 
     // Query at exactly the first cluster's center → top-k should all

--- a/tests/superfile/vector/pipeline.rs
+++ b/tests/superfile/vector/pipeline.rs
@@ -7,6 +7,7 @@ use bytes::Bytes;
 use infino::superfile::vector::builder::{VectorBuilder, VectorConfig};
 use infino::superfile::vector::distance::{Metric, normalize};
 use infino::superfile::vector::reader::VectorReader;
+use infino::superfile::vector::rerank_codec::RerankCodec;
 
 /// Build a 2-column vector blob: text_emb (dim=16, cosine) and
 /// image_emb (dim=24, l2sq), each with `n_docs` deterministic vectors.
@@ -18,6 +19,7 @@ fn build_two_column_blob(n_docs: u32) -> (Bytes, String) {
         n_cent: 4,
         rot_seed: 11,
         metric: Metric::Cosine,
+        rerank_codec: RerankCodec::Fp32,
     })
     .expect("register column");
     b.register_column(VectorConfig {
@@ -26,6 +28,7 @@ fn build_two_column_blob(n_docs: u32) -> (Bytes, String) {
         n_cent: 4,
         rot_seed: 22,
         metric: Metric::L2Sq,
+        rerank_codec: RerankCodec::Fp32,
     })
     .expect("register column");
 
@@ -144,6 +147,7 @@ fn end_to_end_planted_clusters_recovered() {
         n_cent: 3,
         rot_seed: 42,
         metric: Metric::L2Sq,
+        rerank_codec: RerankCodec::Fp32,
     })
     .expect("register column");
 

--- a/tests/superfile/vector/reservoir_recall.rs
+++ b/tests/superfile/vector/reservoir_recall.rs
@@ -1,11 +1,11 @@
-//! Recall test that exercises the M2 reservoir sampling path
+//! Recall test that exercises the reservoir sampling path
 //! end-to-end with `n_docs > sample_size`.
 //!
 //! Default reservoir size is `max(100K, min(500K, 64 × n_cent))`, so
 //! the normal-scale tests in `brute_force_oracle.rs` and
 //! `against_lance.rs` run with `n_docs ≤ sample_size` — the
 //! reservoir holds the full corpus, and k-means training is
-//! exactly equivalent to the pre-M2 path. That's necessary for
+//! exactly equivalent to the full-corpus training path. That's necessary for
 //! "no regression on small corpora" but doesn't probe the
 //! actual sampling logic.
 //!
@@ -21,6 +21,7 @@ use bytes::Bytes;
 use infino::superfile::vector::builder::{VectorBuilder, VectorConfig};
 use infino::superfile::vector::distance::{Metric, distance, normalize};
 use infino::superfile::vector::reader::VectorReader;
+use infino::superfile::vector::rerank_codec::RerankCodec;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, StandardNormal};
@@ -96,6 +97,7 @@ fn build_reader_with_sample_size(
             n_cent,
             rot_seed: 7,
             metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
         })
         .expect("register column");
     b.set_kmeans_sample_size(cid, sample_size)
@@ -162,19 +164,19 @@ fn recall_under_undersized_reservoir_matches_brute_force() {
     // delivers in this regime (empirically ≥ 0.95). A failure
     // here means either the reservoir is biased or
     // `assign_to_centroids` produced wrong assignments — both
-    // would be M2 implementation bugs.
+    // would be implementation bugs.
     assert!(
         mean_recall >= 0.85,
-        "M2 reservoir-trained recall@{top_k} = {mean_recall:.3} \
+        "reservoir-trained recall@{top_k} = {mean_recall:.3} \
          under sample_size={sample_size}; expected ≥ 0.85"
     );
 }
 
 #[test]
-fn recall_with_default_reservoir_equivalent_to_pre_m2() {
+fn recall_with_default_reservoir_equivalent_to_full_corpus_training() {
     // Sanity check: when the corpus fits inside the default
     // reservoir (which is the normal regime for unit tests), the
-    // result should be self-NN-perfect just like the pre-M2 path.
+    // result should be self-NN-perfect just like the full-corpus path.
     let dim = 32;
     let n_cent = 4;
     let n_docs = 200;
@@ -191,6 +193,7 @@ fn recall_with_default_reservoir_equivalent_to_pre_m2() {
         n_cent,
         rot_seed: 7,
         metric: Metric::Cosine,
+        rerank_codec: RerankCodec::Fp32,
     })
     .expect("register column");
     for i in 0..n_docs {

--- a/tests/superfile/vector/reservoir_recall.rs
+++ b/tests/superfile/vector/reservoir_recall.rs
@@ -88,16 +88,17 @@ fn build_reader_with_sample_size(
     n_docs: usize,
     n_cent: usize,
     sample_size: usize,
+    rerank_codec: RerankCodec,
 ) -> VectorReader {
     let mut b = VectorBuilder::new();
     let cid = b
         .register_column(VectorConfig {
-            name: "v".into(),
+            column: "v".into(),
             dim,
             n_cent,
             rot_seed: 7,
             metric: Metric::Cosine,
-            rerank_codec: RerankCodec::Fp32,
+            rerank_codec,
         })
         .expect("register column");
     b.set_kmeans_sample_size(cid, sample_size)
@@ -107,8 +108,9 @@ fn build_reader_with_sample_size(
             .expect("add to vector builder");
     }
     let bytes = b.finish().expect("finish vector builder");
-    let json =
-        format!(r#"[{{"name":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#);
+    let json = format!(
+        r#"[{{"column":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#
+    );
     VectorReader::open(Bytes::from(bytes), &json).expect("open VectorReader")
 }
 
@@ -125,7 +127,6 @@ fn recall_under_undersized_reservoir_matches_brute_force() {
     let top_k = 10;
 
     let flat = corpus(n_docs, dim, n_cent, /*seed=*/ 42);
-    let reader = build_reader_with_sample_size(&flat, dim, n_docs, n_cent, sample_size);
 
     // Maximal-coverage retrieval: full nprobe sweep and a wide
     // rerank pool. Any recall loss here is k-means-related, not
@@ -134,42 +135,57 @@ fn recall_under_undersized_reservoir_matches_brute_force() {
     let rerank_mult = (n_docs / top_k + 1).max(64);
 
     let queries: [usize; 8] = [0, 137, 251, 503, 911, 1234, 1567, 1999];
-    let mut total_recall = 0.0f32;
-    for q_idx in queries {
-        let query = &flat[q_idx * dim..(q_idx + 1) * dim];
-        let approx: Vec<u32> = reader
-            .search("v", query, top_k, nprobe, rerank_mult)
-            .expect("search")
-            .into_iter()
-            .map(|(d, _)| d)
-            .collect();
-        let exact = brute_force_top_k(&flat, dim, n_docs, query, Metric::Cosine, top_k);
 
-        // Self-NN invariant: query is exactly a corpus row, so its
-        // own doc id must be top-1 regardless of training set.
-        assert_eq!(
-            approx[0] as usize, q_idx,
-            "self-NN broken at query {q_idx}: top-1={}",
-            approx[0]
+    // Parameterize across every reranking codec. All three share
+    // the same 0.85 recall floor on this corpus: Fp32 is bit-exact,
+    // Bf16's rounding noise sits at ≤2⁻⁸ per lane (well below the
+    // 1-bit shortlist noise floor), and Sq8's per-cluster quantizer
+    // recovers fp32-equivalent recall at this dim/cluster shape.
+    // `RabitqOnly` is excluded because it skips the rerank step
+    // entirely and is covered separately by
+    // `rabitq_only_self_query_ranks_self_first` in reader.rs.
+    for codec in [RerankCodec::Fp32, RerankCodec::Bf16, RerankCodec::Sq8] {
+        let reader = build_reader_with_sample_size(&flat, dim, n_docs, n_cent, sample_size, codec);
+        let mut total_recall = 0.0f32;
+        for q_idx in queries {
+            let query = &flat[q_idx * dim..(q_idx + 1) * dim];
+            let approx: Vec<u32> = reader
+                .search("v", query, top_k, nprobe, rerank_mult)
+                .expect("search")
+                .into_iter()
+                .map(|(d, _)| d)
+                .collect();
+            let exact = brute_force_top_k(&flat, dim, n_docs, query, Metric::Cosine, top_k);
+
+            // Self-NN invariant: query is exactly a corpus row, so
+            // its own doc id must be top-1 regardless of codec.
+            // True for every reranking codec because the rerank
+            // step distinguishes the exact-match candidate.
+            assert_eq!(
+                approx[0] as usize, q_idx,
+                "self-NN broken at query {q_idx} under codec {codec:?}: top-1={}",
+                approx[0]
+            );
+
+            let a: HashSet<u32> = approx.iter().copied().collect();
+            let e: HashSet<u32> = exact.iter().copied().collect();
+            let intersect = a.intersection(&e).count() as f32;
+            let recall = intersect / (top_k as f32);
+            total_recall += recall;
+        }
+        let mean_recall = total_recall / queries.len() as f32;
+        // 0.85 is comfortably below what a properly-sampled
+        // reservoir delivers in this regime (empirically ≥ 0.95).
+        // A failure here means either the reservoir is biased,
+        // `assign_to_centroids` produced wrong assignments, or
+        // the codec's rerank kernel regressed — all
+        // implementation bugs.
+        assert!(
+            mean_recall >= 0.85,
+            "reservoir-trained recall@{top_k} = {mean_recall:.3} \
+             under sample_size={sample_size} codec={codec:?}; expected ≥ 0.85"
         );
-
-        let a: HashSet<u32> = approx.iter().copied().collect();
-        let e: HashSet<u32> = exact.iter().copied().collect();
-        let intersect = a.intersection(&e).count() as f32;
-        let recall = intersect / (top_k as f32);
-        total_recall += recall;
     }
-    let mean_recall = total_recall / queries.len() as f32;
-    // 0.85 is comfortably below what a properly-sampled reservoir
-    // delivers in this regime (empirically ≥ 0.95). A failure
-    // here means either the reservoir is biased or
-    // `assign_to_centroids` produced wrong assignments — both
-    // would be implementation bugs.
-    assert!(
-        mean_recall >= 0.85,
-        "reservoir-trained recall@{top_k} = {mean_recall:.3} \
-         under sample_size={sample_size}; expected ≥ 0.85"
-    );
 }
 
 #[test]
@@ -188,7 +204,7 @@ fn recall_with_default_reservoir_equivalent_to_full_corpus_training() {
     // holds the full 200-doc corpus.
     let mut b = VectorBuilder::new();
     b.register_column(VectorConfig {
-        name: "v".into(),
+        column: "v".into(),
         dim,
         n_cent,
         rot_seed: 7,
@@ -201,8 +217,9 @@ fn recall_with_default_reservoir_equivalent_to_full_corpus_training() {
             .expect("add to vector builder");
     }
     let bytes = b.finish().expect("finish vector builder");
-    let json =
-        format!(r#"[{{"name":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#);
+    let json = format!(
+        r#"[{{"column":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"cosine"}}]"#
+    );
     let reader = VectorReader::open(Bytes::from(bytes), &json).expect("open VectorReader");
 
     for q_idx in [0usize, 73, 142, 199] {


### PR DESCRIPTION
Adds configurable per-column rerank codecs for vector columns. Each vector column now selects one of four on-disk rerank representations at build time. Default is 8-bit quantization and trades some latency for a significant decrease in memory usage, as we have to do some extra work in reranking to achieve reasonable recall.

- `Fp32`
  - Little-endian fp32
  - `dim * 4` bytes per vector
  - Zero-copy into rerank distance kernels

- `Bf16`
  - Top 16 bits of fp32
  - `dim * 2` bytes per vector
  - SIMD widened via `u16 -> u32 -> fp32` shift before distance compute

- `Sq8`
  - Per-cluster, per-dimension 8-bit scalar quantization
  - `dim * 1` bytes per vector
  - Uses local cluster quantizers rather than global per-column
    quantizers to recover recall on tightly clustered cosine corpora,
    where intra-cluster spread is significantly narrower than
    cross-cluster spread

- `None`
  - No rerank column
  - 1-bit RaBitQ shortlist becomes the final ranking
  - Lowest storage footprint, but reduced recall
  - Shrinks segment size by roughly ~30x at `1M x 384`

## Format changes

The codec discriminator is stored as a single byte at offset `52`
inside the per-column directory entry.

## Sq8 layout

`Sq8` columns now include a sibling `codec_meta` region located between
the `codes` region and the `full[]` region.

The metadata region stores:

- Per-cluster `scale[dim]`
- Per-cluster `offset[dim]`
- Optional per-document decoded norm cache for `L2Sq` columns

The decoded norm cache avoids the per-candidate:
- `u8` widen
- multiply
- dim-wide reduction

during rerank distance evaluation.


## Benchmark Evidence
Metric | main | PR6 (Sq8Residual) | Δ
-- | -- | -- | --
correctness recall@10 | 1.000 | 1.000 | no change
Criterion mean build | 20.691 s | 22.014 s | +6.4% slower
throughput | 48.33 K/s | 45.4 K/s | −6.1%
artifact size | 1515.94 MiB | 790.34 MiB | −48%
peak RSS | 10.47 GiB | 8.06 GiB | −23%
median RSS | 4.89 GiB | 3.50 GiB | −28%
p90 RSS | 7.51 GiB | 5.57 GiB | −26%
cold open | 159.68 ms | 84.31 ms | −47%
first query | 0.61 ms | 0.61 ms | no change

