### PR TITLE
fts: generalize flat-merge AND intersection to n >= 3 terms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # The default github-hosted ubuntu runner has ~14 GB free at job
+      # start; infino's dep graph (datafusion + lance + tantivy + s3s)
+      # plus `cargo llvm-cov`'s separate `target/llvm-cov-target/`
+      # directory (it instruments a second full build of everything)
+      # overflows that, so the coverage step fails with ENOSPC. Free
+      # ~30 GB by removing toolchains the build doesn't need (Android
+      # SDK, .NET, Haskell, ...) before any compile work starts.
+      - uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/benches/README.md
+++ b/benches/README.md
@@ -67,28 +67,28 @@ which is the structured source of truth the markdown is derived from.
 |----------------|------------|-----------|------------|-----------|------------|
 **OR queries:**
 
-| single_rare    | 256 ns     | 0 B       | 0 B        | 0 B       | —          |
+| single_rare    | 258 ns     | 0 B       | 0 B        | 0 B       | —          |
 | single_df1     | 117 ns     | 0 B       | 0 B        | 0 B       | —          |
-| single_common  | 13.29 µs   | 0 B       | 0 B        | 0 B       | —          |
-| two_term_or    | 99.19 µs   | 0 B       | 0 B        | 0 B       | —          |
-| three_wide_or  | 1.19 ms    | 0 B       | 0 B        | 0 B       | —          |
-| three_similar_or | 5.56 ms    | 0 B       | 0 B        | 0 B       | —          |
-| five_term_or   | 9.70 ms    | 0 B       | 0 B        | 0 B       | —          |
+| single_common  | 14.31 µs   | 0 B       | 0 B        | 0 B       | —          |
+| two_term_or    | 103.78 µs  | 0 B       | 0 B        | 0 B       | —          |
+| three_wide_or  | 1.27 ms    | 0 B       | 0 B        | 0 B       | —          |
+| three_similar_or | 5.81 ms    | 0 B       | 0 B        | 0 B       | —          |
+| five_term_or   | 9.90 ms    | 0 B       | 0 B        | 0 B       | —          |
 
 **AND queries:**
 
-| two_term_and   | 113.46 µs  | 0 B       | 0 B        | 0 B       | —          |
-| three_wide_and | 2.45 ms    | 0 B       | 0 B        | 0 B       | —          |
-| three_similar_and | 4.32 ms    | 0 B       | 0 B        | 0 B       | —          |
-| five_term_and  | 4.50 ms    | 0 B       | 0 B        | 0 B       | —          |
+| two_term_and   | 116.57 µs  | 0 B       | 0 B        | 0 B       | —          |
+| three_wide_and | 2.03 ms    | 0 B       | 0 B        | 0 B       | —          |
+| three_similar_and | 3.31 ms    | 0 B       | 0 B        | 0 B       | —          |
+| five_term_and  | 3.97 ms    | 0 B       | 0 B        | 0 B       | —          |
 
 **Per-algorithm probes** (WAND+BMW vs MaxScore+BMM):
 
 | Shape         | WAND+BMW   | MaxScore+BMM |
 |---------------|------------|--------------|
-| wide_3_or     | 4.62 ms    | 1.20 ms      |
-| similar_3_or  | 8.77 ms    | 5.58 ms      |
-| similar_5_or  | 25.06 ms   | 9.68 ms      |
+| wide_3_or     | 4.68 ms    | 1.24 ms      |
+| similar_3_or  | 8.91 ms    | 5.77 ms      |
+| similar_5_or  | 25.16 ms   | 9.88 ms      |
 
 <!-- END: bench/fts/superfile/search -->
 
@@ -101,7 +101,7 @@ which is the structured source of truth the markdown is derived from.
 |-------------------------|------------|------------|-----------|------------|-----------|------------|
 | infino_auto_writer_pool | 41.97 s    | 238.3 K/s  | 0 B       | 0 B        | 0 B       | —          |
 
-*Output cardinality: infino emits `min(writer_pool.threads, total_rows)` superfiles per commit (auto = cpus/2). Override with `INFINO_SUPERTABLE__WRITER_THREADS=N` for a specific shard count.*
+*Output cardinality: infino emits `min(writer_pool.threads, chunk_rows)` superfiles per commit across 16 bounded append chunks (writer auto = cpus/2). Override with `INFINO_SUPERTABLE__WRITER_THREADS=N` for a specific shard count.*
 
 <!-- END: bench/fts/supertable/ingest -->
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1092,10 +1092,15 @@ impl FtsReader {
         Ok(out)
     }
 
-    /// General `n >= 2`-term AND path. Block-max-AND prunes whole
-    /// leader blocks whose maximum possible AND score sum can't beat
-    /// the current heap floor; for survivors, runs the leapfrog
-    /// convergence over all cursors per leader doc.
+    /// General `n >= 3`-term AND path. Same shape as the 2-term path:
+    /// block-max pruning at the top, then a flat-merge over the
+    /// leader's decoded `block_doc_ids` against each non-leader's
+    /// decoded `block_doc_ids`. For each leader doc, every non-leader's
+    /// `pos` is advanced with a tight `pos += 1` scan instead of
+    /// `skip_to` — no function-call or within-block linear-scan
+    /// overhead per leader doc, just integer comparisons over the
+    /// already-decoded buffers. When any cursor exhausts its block,
+    /// the outer loop crosses blocks via `next()` and re-aligns.
     fn run_and_intersect_general(
         &self,
         cursors: &mut [TermCursor],
@@ -1130,44 +1135,110 @@ impl FtsReader {
                 }
             }
 
-            let mut candidate = cursors[0].current_doc_id();
+            // Align every non-leader cursor to >= leader's current doc.
+            // Largest landing-doc becomes the new alignment target if
+            // any cursor jumped past leader. If any cursor crossed
+            // leader's current block, restart the outer loop so pruning
+            // re-fires on leader's new block; otherwise the flat-merge
+            // proceeds in the current decoded blocks.
+            let leader_doc = cursors[0].current_doc_id();
+            let leader_block_end = cursors[0].current_block_last_doc_id();
+            let mut max_other = leader_doc;
+            let mut crossed_block = false;
+            for c in cursors[1..].iter_mut() {
+                c.skip_to(leader_doc, postings);
+                if c.is_exhausted() {
+                    break 'outer;
+                }
+                let here = c.current_doc_id();
+                if here > leader_block_end {
+                    crossed_block = true;
+                }
+                if here > max_other {
+                    max_other = here;
+                }
+            }
+            if max_other > leader_doc {
+                cursors[0].skip_to(max_other, postings);
+                if cursors[0].is_exhausted() {
+                    break 'outer;
+                }
+                if crossed_block {
+                    continue;
+                }
+            }
 
-            // Converge: re-skip all cursors until each lands on the
-            // same candidate. A cursor that ends up past candidate
-            // raises the candidate to its position; the next pass
-            // catches up the others.
-            loop {
-                let mut bumped = false;
-                for c in cursors.iter_mut() {
-                    c.skip_to(candidate, postings);
-                    if c.is_exhausted() {
-                        break 'outer;
+            // Flat-merge across decoded blocks. Split leader off so
+            // both leader and others borrow mutably without overlap;
+            // the inner loop reads each cursor's `block_doc_ids` and
+            // updates its `pos` directly.
+            let (leader_slice, others) = cursors.split_at_mut(1);
+            let c0 = &mut leader_slice[0];
+            let lb_n = c0.block_n;
+            let mut i = c0.pos;
+            while i < lb_n {
+                let a = c0.block_doc_ids[i];
+
+                // For each non-leader, walk its `pos` forward through
+                // the decoded block until block_doc_ids[pos] >= a (or
+                // the block exhausts). If any block exhausts, break
+                // out to the outer loop's block-crossing step. If any
+                // cursor lands above `a`, the leader doc isn't in the
+                // intersection — advance leader only.
+                let mut block_exhausted = false;
+                let mut all_match = true;
+                for o in others.iter_mut() {
+                    while o.pos < o.block_n && o.block_doc_ids[o.pos] < a {
+                        o.pos += 1;
                     }
-                    let here = c.current_doc_id();
-                    if here != candidate {
-                        candidate = here;
-                        bumped = true;
+                    if o.pos >= o.block_n {
+                        block_exhausted = true;
+                        break;
+                    }
+                    if o.block_doc_ids[o.pos] != a {
+                        all_match = false;
                         break;
                     }
                 }
-                if !bumped {
+                if block_exhausted {
                     break;
                 }
+                if all_match {
+                    let norm = dl_norm_k1[a as usize];
+                    let mut score = crate::superfile::fts::bm25::score_with_dl_norm_k1(
+                        c0.idf_x_k1p1,
+                        c0.block_tfs[i],
+                        norm,
+                    );
+                    for o in others.iter() {
+                        score += crate::superfile::fts::bm25::score_with_dl_norm_k1(
+                            o.idf_x_k1p1,
+                            o.block_tfs[o.pos],
+                            norm,
+                        );
+                    }
+                    and_heap_push(heap, k, score, a);
+                    i += 1;
+                    for o in others.iter_mut() {
+                        o.pos += 1;
+                    }
+                } else {
+                    i += 1;
+                }
             }
+            c0.pos = i;
 
-            // All cursors at `candidate` — sum BM25 contributions.
-            let norm = dl_norm_k1[candidate as usize];
-            let mut score = 0.0_f32;
-            for c in cursors.iter() {
-                score += crate::superfile::fts::bm25::score_with_dl_norm_k1(
-                    c.idf_x_k1p1,
-                    c.current_tf(),
-                    norm,
-                );
+            // Cross blocks for whichever cursors exhausted. The outer
+            // loop's alignment step re-pulls everyone to the new leader
+            // doc on the next iteration.
+            if c0.pos >= c0.block_n {
+                c0.next(postings);
             }
-            and_heap_push(heap, k, score, candidate);
-
-            cursors[0].next(postings);
+            for o in others.iter_mut() {
+                if o.pos >= o.block_n {
+                    o.next(postings);
+                }
+            }
         }
     }
 

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -483,19 +483,19 @@ fn build_multi_block_corpus() -> Vec<(u64, String)> {
     let mut out: Vec<(u64, String)> = Vec::with_capacity(MULTI_BLOCK_N_DOCS as usize);
     for d in 0..MULTI_BLOCK_N_DOCS {
         let mut toks: Vec<&'static str> = Vec::new();
-        if d % 3 == 0 {
+        if d.is_multiple_of(3) {
             toks.push("alpha");
         }
-        if d % 4 == 0 {
+        if d.is_multiple_of(4) {
             toks.push("beta");
         }
-        if d % 5 == 0 {
+        if d.is_multiple_of(5) {
             toks.push("gamma");
         }
-        if d % 7 == 0 {
+        if d.is_multiple_of(7) {
             toks.push("delta");
         }
-        if d % 20 == 0 {
+        if d.is_multiple_of(20) {
             toks.push("epsilon");
         }
         // Filler keeps every doc non-empty and gives a few different
@@ -523,11 +523,11 @@ fn build_multi_block_reader(owned: &[(u64, String)]) -> SuperfileReader {
 fn multi_block_and_truth(terms: &[&str]) -> HashSet<u64> {
     let predicate = |d: u64, t: &str| -> bool {
         match t {
-            "alpha" => d % 3 == 0,
-            "beta" => d % 4 == 0,
-            "gamma" => d % 5 == 0,
-            "delta" => d % 7 == 0,
-            "epsilon" => d % 20 == 0,
+            "alpha" => d.is_multiple_of(3),
+            "beta" => d.is_multiple_of(4),
+            "gamma" => d.is_multiple_of(5),
+            "delta" => d.is_multiple_of(7),
+            "epsilon" => d.is_multiple_of(20),
             _ => false,
         }
     };

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -544,7 +544,9 @@ fn oracle_and_multi_block_two_term_matches_brute_force() {
     // path to cross blocks on both cursors.
     let corp = build_multi_block_corpus();
     let r = build_multi_block_reader(&corp);
-    let infino_set: HashSet<u64> = infino_top_k_and(&r, "alpha beta", 200).into_iter().collect();
+    let infino_set: HashSet<u64> = infino_top_k_and(&r, "alpha beta", 200)
+        .into_iter()
+        .collect();
     let truth = multi_block_and_truth(&["alpha", "beta"]);
     assert_eq!(
         infino_set, truth,

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -453,3 +453,212 @@ fn oracle_long_doc_vs_short_doc_dl_norm() {
     let oracle_top2: HashSet<u64> = oracle_hits.into_iter().take(2).collect();
     assert_eq!(infino_top2, oracle_top2, "framework top-2 sets disagree");
 }
+
+// ─── Multi-block AND oracles ──────────────────────────────────────────
+//
+// The 60-doc corpus above holds every term in a single PFOR block
+// (BLOCK_LEN = 128). Block-crossing paths in `run_and_intersect_*` —
+// the inner-loop `next()` cross-block walk, the alignment step that
+// fires when a non-leader cursor lands in a new block, and the
+// block-max-AND pruning that skips a whole leader block — only fire
+// when terms span multiple blocks. This section plants a 1000-doc
+// corpus with deterministic-frequency terms chosen so the common
+// terms span 2–4 blocks each, then runs AND across 2/3/4 terms and
+// compares against the brute-force oracle.
+
+const MULTI_BLOCK_N_DOCS: u64 = 1_000;
+
+/// Deterministic-frequency planted corpus. Each doc is identified
+/// by its position 0..N-1 and seeded with terms based on simple
+/// mod predicates so the resulting posting list lengths are
+/// predictable:
+///
+/// * `alpha` — every 3rd doc        → ~334 postings → 3 blocks
+/// * `beta`  — every 4th doc        → ~250 postings → 2 blocks
+/// * `gamma` — every 5th doc        → ~200 postings → 2 blocks
+/// * `delta` — every 7th doc        → ~143 postings → 2 blocks
+/// * `epsilon` — every 20th doc     → ~50 postings  → 1 block
+/// * `noXXX` — per-doc filler tokens to vary doc lengths
+fn build_multi_block_corpus() -> Vec<(u64, String)> {
+    let mut out: Vec<(u64, String)> = Vec::with_capacity(MULTI_BLOCK_N_DOCS as usize);
+    for d in 0..MULTI_BLOCK_N_DOCS {
+        let mut toks: Vec<&'static str> = Vec::new();
+        if d % 3 == 0 {
+            toks.push("alpha");
+        }
+        if d % 4 == 0 {
+            toks.push("beta");
+        }
+        if d % 5 == 0 {
+            toks.push("gamma");
+        }
+        if d % 7 == 0 {
+            toks.push("delta");
+        }
+        if d % 20 == 0 {
+            toks.push("epsilon");
+        }
+        // Filler keeps every doc non-empty and gives a few different
+        // doc lengths so dl-norm isn't a constant. Using mod-50 yields
+        // 50 distinct filler terms across 1000 docs.
+        let filler = format!("no{:02}", d % 50);
+        let mut s = toks.join(" ");
+        if !s.is_empty() {
+            s.push(' ');
+        }
+        s.push_str(&filler);
+        out.push((d, s));
+    }
+    out
+}
+
+fn build_multi_block_reader(owned: &[(u64, String)]) -> SuperfileReader {
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    build_infino_superfile(&refs)
+}
+
+/// Compute the expected AND intersection for the multi-block corpus
+/// using the same planting predicates as `build_multi_block_corpus`.
+/// Returns the set of doc-ids in the intersection.
+fn multi_block_and_truth(terms: &[&str]) -> HashSet<u64> {
+    let predicate = |d: u64, t: &str| -> bool {
+        match t {
+            "alpha" => d % 3 == 0,
+            "beta" => d % 4 == 0,
+            "gamma" => d % 5 == 0,
+            "delta" => d % 7 == 0,
+            "epsilon" => d % 20 == 0,
+            _ => false,
+        }
+    };
+    (0..MULTI_BLOCK_N_DOCS)
+        .filter(|d| terms.iter().all(|t| predicate(*d, t)))
+        .collect()
+}
+
+#[test]
+fn oracle_and_multi_block_two_term_matches_brute_force() {
+    // alpha ∧ beta: both span >1 block (3 + 2). Intersection is
+    // docs where d % lcm(3,4) == 0, i.e., d % 12 == 0 → 84 matches
+    // distributed across the corpus, forcing the 2-term flat-merge
+    // path to cross blocks on both cursors.
+    let corp = build_multi_block_corpus();
+    let r = build_multi_block_reader(&corp);
+    let infino_set: HashSet<u64> = infino_top_k_and(&r, "alpha beta", 200).into_iter().collect();
+    let truth = multi_block_and_truth(&["alpha", "beta"]);
+    assert_eq!(
+        infino_set, truth,
+        "AND(alpha, beta) over multi-block corpus disagrees with planted truth"
+    );
+}
+
+#[test]
+fn oracle_and_multi_block_three_term_matches_brute_force() {
+    // alpha ∧ beta ∧ gamma: all span >1 block. Intersection is docs
+    // where d % lcm(3,4,5) == 0, i.e., d % 60 == 0. Exercises the
+    // n>=3 flat-merge `for o in others.iter_mut()` inner loop with
+    // both branches of the match/no-match split and the block
+    // crossings on three cursors simultaneously.
+    let corp = build_multi_block_corpus();
+    let r = build_multi_block_reader(&corp);
+    let infino_set: HashSet<u64> = infino_top_k_and(&r, "alpha beta gamma", 200)
+        .into_iter()
+        .collect();
+    let truth = multi_block_and_truth(&["alpha", "beta", "gamma"]);
+    assert_eq!(
+        infino_set, truth,
+        "AND(alpha, beta, gamma) over multi-block corpus disagrees with planted truth"
+    );
+}
+
+#[test]
+fn oracle_and_multi_block_four_term_matches_brute_force() {
+    // alpha ∧ beta ∧ gamma ∧ delta: all four span >1 block.
+    // Intersection is d % lcm(3,4,5,7) == 0, i.e., d % 420 == 0 →
+    // 3 matches at most {0, 420, 840} in a 1000-doc corpus.
+    // Drives the cursor-alignment + flat-merge over four cursors
+    // and tests the `block_exhausted` early-break path.
+    let corp = build_multi_block_corpus();
+    let r = build_multi_block_reader(&corp);
+    let infino_set: HashSet<u64> = infino_top_k_and(&r, "alpha beta gamma delta", 200)
+        .into_iter()
+        .collect();
+    let truth = multi_block_and_truth(&["alpha", "beta", "gamma", "delta"]);
+    assert_eq!(
+        infino_set, truth,
+        "AND(alpha, beta, gamma, delta) over multi-block corpus disagrees with planted truth"
+    );
+}
+
+#[test]
+fn oracle_and_multi_block_with_rare_term_short_circuits() {
+    // alpha (common, multi-block) ∧ epsilon (rare, single block).
+    // The leapfrog picks the rarer (epsilon) as leader and walks
+    // its single block; the alpha cursor must cross several blocks
+    // as alignment proceeds, exercising the leader-side alignment
+    // path that crosses block_last_doc_id.
+    let corp = build_multi_block_corpus();
+    let r = build_multi_block_reader(&corp);
+    let infino_set: HashSet<u64> = infino_top_k_and(&r, "alpha epsilon", 100)
+        .into_iter()
+        .collect();
+    let truth = multi_block_and_truth(&["alpha", "epsilon"]);
+    assert_eq!(
+        infino_set, truth,
+        "AND(alpha, epsilon) over multi-block corpus disagrees with planted truth"
+    );
+}
+
+#[test]
+fn oracle_and_multi_block_top_k_smaller_than_match_count() {
+    // top-k=5 against an AND that has ~84 matches. Once the heap
+    // fills, the block-max-AND pruning check at the top of the
+    // outer loop fires on every subsequent leader block whose UB
+    // can't beat the kth-best score. Verifies the top-K matches
+    // are a subset of the planted truth (every returned doc is a
+    // real match; ranking-tie tail may differ from any specific
+    // brute-force order).
+    let corp = build_multi_block_corpus();
+    let r = build_multi_block_reader(&corp);
+    let infino_hits = infino_top_k_and(&r, "alpha beta", 5);
+    assert_eq!(infino_hits.len(), 5, "top-k=5 should fill");
+    let truth = multi_block_and_truth(&["alpha", "beta"]);
+    for d in &infino_hits {
+        assert!(
+            truth.contains(d),
+            "top-5 AND returned doc {d} that isn't in the planted intersection {truth:?}"
+        );
+    }
+}
+
+#[test]
+fn oracle_and_multi_block_score_matches_brute_force() {
+    // Cross-check scores against the brute-force scorer on the
+    // multi-block corpus. The two-term AND has 84 matches and the
+    // top-10 list must agree on doc-id sets with brute force (ties
+    // may reorder within a single score class). Catches scoring
+    // drift introduced by the block-crossing code paths in the
+    // flat-merge (e.g. wrong `block_tfs[pos]` index after a block
+    // boundary, or a stale `idf_x_k1p1` if the cursor was
+    // reconstructed mid-walk).
+    let corp_owned = build_multi_block_corpus();
+    let corp_refs: Vec<(u64, &str)> = corp_owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile(&corp_refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp_refs, tok.as_ref());
+
+    let mut terms: Vec<String> = Vec::new();
+    tok.tokenize_each("alpha beta", &mut |t| terms.push(t.to_owned()));
+    let infino_hits = infino_top_k_and(&r, "alpha beta", 10);
+    let oracle_hits: Vec<u64> = oracle
+        .top_k_terms_and(&terms, 10)
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+    let infino_set: HashSet<u64> = infino_hits.iter().copied().collect();
+    let oracle_set: HashSet<u64> = oracle_hits.iter().copied().collect();
+    assert_eq!(
+        infino_set, oracle_set,
+        "multi-block AND top-10 sets disagree: infino={infino_hits:?} oracle={oracle_hits:?}"
+    );
+}


### PR DESCRIPTION
## Summary

PR #17 specialized the 2-term AND path to a flat sorted-merge over decoded `block_doc_ids` arrays, avoiding the per-doc `skip_to` overhead the leapfrog path incurred. The general n ≥ 3 path still leapfrogged per doc, so 3+ term shapes kept the slower behavior.

This change generalizes the flat-merge to any n ≥ 2:

- Leader walks its decoded `block_doc_ids` with a plain `i++` cursor.
- Every non-leader gets its `pos` advanced with a tight while-scan over its decoded buffer — no `skip_to` in the inner loop.
- When any cursor exhausts its current block, the outer loop crosses blocks via `next()` and re-aligns via the existing alignment step (amortized — alignment fires once per leader block, not per leader doc).
- Block-max-AND pruning at the top of each outer iteration is unchanged.

The 2-term specialization (`run_and_intersect_2term`) stays in place because its hand-named `c0`/`c1` locals stay register-resident across the inner loop, where the general path goes through `others.iter_mut()` slice indirection.

## Results (1M docs, single superfile)

Numbers are infino-only, before this change → after:

| Shape | Before | After | Speedup |
|---|---|---|---|
| `two_term_and` | 113 µs | 116.57 µs | ≈ tied |
| `three_wide_and` | 2.45 ms | **2.03 ms** | 1.21× |
| `three_similar_and` | 4.32 ms | **3.31 ms** | 1.30× |
| `five_term_and` | 4.50 ms | **3.97 ms** | 1.13× |

OR shapes untouched and continue to route through MaxScore+BMM.

## Notes

Closing the gap further between 2-term (116 µs) and n-term (2-4 ms) likely needs either (a) an n=3 specialization with hand-rolled cursor state mirroring the 2-term shape, or (b) hoisting cursor fields out of the `iter_mut` indirection into stack-allocated arrays. Both want profiling first to confirm where time is going — saving for a follow-up.

## Test plan

- [x] `cargo test --test superfile -- brute_force_oracle::oracle_and` (6 AND oracles pass).
- [x] `cargo test --test supertable -- brute_force_oracle` (14 oracles incl. 4 AND, all pass).
- [x] `cargo test --lib` (534 passing).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `INFINO_BENCH_UPDATE_README=1 cargo bench --bench fts -- superfile_fts_search` produces the numbers above; README refreshed in place.