### PR TITLE
test: tier-1 coverage push (+1.34 pp lines, 90.14% → 91.48%)

### DIFF
--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -257,3 +257,155 @@ impl StorageProvider for S3StorageProvider {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the parts of `s3.rs` that don't need a
+    //! real HTTP backend: error translation, path parsing,
+    //! the with-endpoint constructor, and the `from_object_store`
+    //! escape hatch. The trait impls (`head`, `get`, `put_*`,
+    //! `delete`, `get_range`) are exercised end-to-end by the
+    //! `supertable_smoke_via_s3_wire_protocol` integration
+    //! test against an in-process `s3s-fs` server.
+    use super::*;
+
+    // ---- translate -----------------------------------------------------
+
+    #[test]
+    fn translate_not_found_to_typed_variant() {
+        let err = translate(
+            "some/key",
+            ObjError::NotFound {
+                path: "some/key".into(),
+                source: "raw".into(),
+            },
+        );
+        match err {
+            StorageError::NotFound { uri } => assert_eq!(uri, "some/key"),
+            other => panic!("expected NotFound; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_already_exists_to_precondition_failed() {
+        let err = translate(
+            "k",
+            ObjError::AlreadyExists {
+                path: "k".into(),
+                source: "raw".into(),
+            },
+        );
+        assert!(matches!(err, StorageError::PreconditionFailed { uri } if uri == "k"));
+    }
+
+    #[test]
+    fn translate_precondition_to_precondition_failed() {
+        let err = translate(
+            "k",
+            ObjError::Precondition {
+                path: "k".into(),
+                source: "raw".into(),
+            },
+        );
+        assert!(matches!(err, StorageError::PreconditionFailed { uri } if uri == "k"));
+    }
+
+    #[test]
+    fn translate_generic_to_transient_exhausted() {
+        let err = translate(
+            "k",
+            ObjError::Generic {
+                store: "S3",
+                source: "boom".into(),
+            },
+        );
+        match err {
+            StorageError::TransientExhausted { uri, .. } => assert_eq!(uri, "k"),
+            other => panic!("expected TransientExhausted; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_other_variant_to_permanent() {
+        // Any object_store error variant that isn't one of the
+        // explicit arms above maps to Permanent. UnknownConfigurationKey
+        // is a stable variant we can construct without an API quirk.
+        let err = translate(
+            "k",
+            ObjError::UnknownConfigurationKey {
+                store: "S3",
+                key: "foo".into(),
+            },
+        );
+        match err {
+            StorageError::Permanent { uri, .. } => assert_eq!(uri, "k"),
+            other => panic!("expected Permanent; got {other:?}"),
+        }
+    }
+
+    // ---- path ----------------------------------------------------------
+
+    #[test]
+    fn path_parses_simple_uri() {
+        let p = S3StorageProvider::path("foo/bar.txt").expect("parse");
+        assert_eq!(p.to_string(), "foo/bar.txt");
+    }
+
+    #[test]
+    fn path_parses_nested_uri() {
+        let p = S3StorageProvider::path("manifest-lists/list-000042.json").expect("parse");
+        assert_eq!(p.to_string(), "manifest-lists/list-000042.json");
+    }
+
+    // ---- constructors --------------------------------------------------
+
+    fn endpoint_provider() -> S3StorageProvider {
+        // Pure construction — no I/O. Builds the inner
+        // AmazonS3 with explicit credentials targeting a
+        // fake endpoint. Useful for testing `bucket()` and
+        // `path()` without spinning up the s3s-fs harness.
+        S3StorageProvider::new_with_endpoint(
+            "http://127.0.0.1:1",
+            "test-bucket",
+            "AKIATESTKEY",
+            "secret/example",
+            "us-east-1",
+        )
+        .expect("construct with endpoint")
+    }
+
+    #[test]
+    fn new_with_endpoint_builds_succeeds_and_exposes_bucket() {
+        let p = endpoint_provider();
+        assert_eq!(p.bucket(), "test-bucket");
+    }
+
+    #[test]
+    fn from_object_store_preserves_bucket() {
+        // Construct an AmazonS3 directly and wrap it via the
+        // escape-hatch constructor. Exercises the wrapping
+        // path without going through `new_with_endpoint`'s
+        // builder.
+        let store = AmazonS3Builder::new()
+            .with_endpoint("http://127.0.0.1:1")
+            .with_bucket_name("hatch-bucket")
+            .with_access_key_id("AKIATESTKEY")
+            .with_secret_access_key("secret")
+            .with_region("us-east-1")
+            .with_allow_http(true)
+            .with_virtual_hosted_style_request(false)
+            .build()
+            .expect("build AmazonS3");
+        let p = S3StorageProvider::from_object_store("hatch-bucket", store);
+        assert_eq!(p.bucket(), "hatch-bucket");
+    }
+
+    #[test]
+    fn debug_impl_does_not_panic() {
+        // S3StorageProvider derives Debug; print it to ensure
+        // the impl block isn't dropped accidentally.
+        let p = endpoint_provider();
+        let s = format!("{p:?}");
+        assert!(s.contains("S3StorageProvider"));
+    }
+}

--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -389,3 +389,317 @@ fn translate_contention(e: CommitError) -> CommitError {
         other => other,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- URI helpers ---------------------------------------------------
+
+    #[test]
+    fn list_uri_zero_pads_to_six_digits() {
+        // 6-digit zero-pad gives stable lexicographic ordering
+        // for `aws s3 ls`-style listings up to 999,999 versions.
+        assert_eq!(list_uri(0), "manifest-lists/list-000000.json");
+        assert_eq!(list_uri(42), "manifest-lists/list-000042.json");
+        assert_eq!(list_uri(123_456), "manifest-lists/list-123456.json");
+    }
+
+    #[test]
+    fn list_uri_overflows_padding_for_large_ids_intentionally() {
+        // Past 6 digits the format widens — no truncation, just
+        // breaks lex ordering. Spec'd behaviour; locked in to
+        // catch accidental width changes.
+        assert_eq!(list_uri(1_000_000), "manifest-lists/list-1000000.json");
+    }
+
+    #[test]
+    fn part_uri_uses_content_hash_hex() {
+        // Content-addressed: two writers producing identical
+        // bytes resolve to the same URI. Verified by computing
+        // the same hash twice and confirming URI equality.
+        let h = ContentHash::of(b"hello manifest part");
+        let uri_a = part_uri(&h);
+        let uri_b = part_uri(&ContentHash::of(b"hello manifest part"));
+        assert_eq!(uri_a, uri_b);
+        assert!(uri_a.starts_with("manifests/part-"));
+        assert!(uri_a.ends_with(".avro.zst"));
+        assert_eq!(uri_a, format!("manifests/part-{}.avro.zst", h.to_hex()));
+    }
+
+    // ---- PointerFile round-trip ----------------------------------------
+
+    fn sample_pointer() -> PointerFile {
+        let mut bytes = [0u8; 32];
+        for (i, b) in bytes.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        PointerFile {
+            manifest_id: 7,
+            manifest_list_uri: "manifest-lists/list-000007.json".into(),
+            content_hash: ContentHash(bytes),
+        }
+    }
+
+    #[test]
+    fn pointer_file_text_roundtrip() {
+        // to_bytes ↔ from_bytes is the on-disk wire format —
+        // any change to either side that drops a field or
+        // changes line-ordering rules surfaces here.
+        let p = sample_pointer();
+        let bytes = p.to_bytes();
+        let s = std::str::from_utf8(&bytes).expect("utf-8");
+        assert!(s.contains("manifest_id=7"));
+        assert!(s.contains("manifest_list_uri=manifest-lists/list-000007.json"));
+        assert!(s.contains("content_hash=blake3:"));
+        let parsed = PointerFile::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed, p);
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_skips_blank_lines() {
+        let bytes = b"\nmanifest_id=1\n\nmanifest_list_uri=foo.json\ncontent_hash=blake3:0000000000000000000000000000000000000000000000000000000000000000\n";
+        let parsed = PointerFile::from_bytes(bytes).expect("parse");
+        assert_eq!(parsed.manifest_id, 1);
+        assert_eq!(parsed.manifest_list_uri, "foo.json");
+        assert_eq!(parsed.content_hash.0, [0u8; 32]);
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_ignores_unknown_keys() {
+        // Forward-compat: unknown keys must not error so that
+        // an older reader can open a pointer that a future
+        // writer extended.
+        let bytes = b"manifest_id=2\nmanifest_list_uri=x.json\ncontent_hash=blake3:1111111111111111111111111111111111111111111111111111111111111111\nfuture_field=ignored\n";
+        let parsed = PointerFile::from_bytes(bytes).expect("parse");
+        assert_eq!(parsed.manifest_id, 2);
+    }
+
+    // ---- PointerFile parse errors --------------------------------------
+
+    fn assert_parse_err(bytes: &[u8], needle: &str) {
+        let err = PointerFile::from_bytes(bytes).expect_err("must error");
+        match err {
+            CommitError::PointerParse(msg) => assert!(
+                msg.contains(needle),
+                "expected `{needle}` in error; got: {msg}"
+            ),
+            other => panic!("expected PointerParse; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_invalid_utf8() {
+        // 0xff is invalid UTF-8 as a standalone byte. Catches
+        // garbage in the pointer file (e.g. partial write) at
+        // parse time instead of letting it propagate.
+        let bytes = [0xff, 0xfe, 0xfd];
+        assert_parse_err(&bytes, "not utf-8");
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_missing_equals() {
+        // A non-blank line without `=` can't be a key/value
+        // pair, so we surface the bad line text in the error.
+        assert_parse_err(b"manifest_id 1\n", "no '='");
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_bad_manifest_id() {
+        // `manifest_id` is a u64; non-numeric values must fail
+        // with a clear parse error rather than silently rolling
+        // forward.
+        assert_parse_err(
+            b"manifest_id=abc\nmanifest_list_uri=x\ncontent_hash=blake3:0000000000000000000000000000000000000000000000000000000000000000\n",
+            "manifest_id",
+        );
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_content_hash_without_prefix() {
+        assert_parse_err(
+            b"manifest_id=1\nmanifest_list_uri=x\ncontent_hash=cafebabe\n",
+            "blake3:",
+        );
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_short_hex() {
+        // blake3 is always 32 bytes → 64 hex chars; anything
+        // else is malformed.
+        assert_parse_err(
+            b"manifest_id=1\nmanifest_list_uri=x\ncontent_hash=blake3:dead\n",
+            "64 chars",
+        );
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_bad_hex_chars() {
+        // 64 chars but containing a non-hex char → parse error
+        // from u8::from_str_radix.
+        let mut hex = String::from("blake3:");
+        hex.push_str(&"z".repeat(64));
+        let payload = format!("manifest_id=1\nmanifest_list_uri=x\ncontent_hash={hex}\n");
+        assert_parse_err(payload.as_bytes(), "content_hash hex");
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_missing_manifest_id() {
+        assert_parse_err(
+            b"manifest_list_uri=x\ncontent_hash=blake3:0000000000000000000000000000000000000000000000000000000000000000\n",
+            "missing manifest_id",
+        );
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_missing_list_uri() {
+        assert_parse_err(
+            b"manifest_id=1\ncontent_hash=blake3:0000000000000000000000000000000000000000000000000000000000000000\n",
+            "missing manifest_list_uri",
+        );
+    }
+
+    #[test]
+    fn pointer_file_from_bytes_rejects_missing_content_hash() {
+        assert_parse_err(
+            b"manifest_id=1\nmanifest_list_uri=x\n",
+            "missing content_hash",
+        );
+    }
+
+    // ---- translate_contention ------------------------------------------
+
+    #[test]
+    fn translate_contention_maps_precondition_failed() {
+        let in_err = CommitError::Storage(StorageError::PreconditionFailed { uri: "x".into() });
+        match translate_contention(in_err) {
+            CommitError::WriteContentionExhausted => {}
+            other => panic!("expected WriteContentionExhausted; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_contention_passes_through_other_storage_errors() {
+        // Anything other than PreconditionFailed must pass
+        // through unchanged — those are real errors the caller
+        // mustn't mask as "lost a race".
+        let in_err = CommitError::Encode("downstream zstd".into());
+        match translate_contention(in_err) {
+            CommitError::Encode(_) => {}
+            other => panic!("expected Encode passthrough; got {other:?}"),
+        }
+    }
+
+    // ---- read_pointer / write_pointer / write_manifest_list -------------
+    //
+    // Drive the storage-touching helpers through LocalFs so the
+    // success + storage-not-found + CAS-failure branches all
+    // get coverage without spinning up the s3s test harness.
+
+    use crate::storage::LocalFsStorageProvider;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn local_storage() -> (TempDir, Arc<dyn StorageProvider>) {
+        let dir = TempDir::new().expect("tempdir");
+        let store: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("local"));
+        (dir, store)
+    }
+
+    #[tokio::test]
+    async fn read_pointer_returns_none_when_absent() {
+        // Fresh supertable: no pointer file. read_pointer must
+        // surface this as Ok(None), not Err.
+        let (_dir, storage) = local_storage();
+        let p = read_pointer(storage.as_ref()).await.expect("read");
+        assert!(p.is_none());
+    }
+
+    #[tokio::test]
+    async fn write_pointer_create_then_read_roundtrip() {
+        // Initial commit shape: no expected_prev_etag, so
+        // write_pointer routes through put_atomic and lands
+        // the new pointer file.
+        let (_dir, storage) = local_storage();
+        let p = sample_pointer();
+        write_pointer(storage.as_ref(), &p, None)
+            .await
+            .expect("write");
+        let read = read_pointer(storage.as_ref())
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(read, p);
+    }
+
+    #[tokio::test]
+    async fn write_pointer_second_create_surfaces_contention() {
+        // put_atomic against an existing path is the on-disk
+        // contention case for the first-commit branch: the
+        // CAS fence already lost a race. The function must
+        // translate the storage's PreconditionFailed into
+        // WriteContentionExhausted so the OCC retry loop can
+        // recognise it.
+        let (_dir, storage) = local_storage();
+        let p = sample_pointer();
+        write_pointer(storage.as_ref(), &p, None)
+            .await
+            .expect("first");
+        let err = write_pointer(storage.as_ref(), &p, None)
+            .await
+            .expect_err("second must lose");
+        assert!(
+            matches!(err, CommitError::WriteContentionExhausted),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_manifest_list_succeeds_and_addresses_uri() {
+        // write_manifest_list encodes JSON, computes a hash,
+        // and PUTs at list_uri(manifest_id). Verify the
+        // returned URI matches the deterministic naming rule
+        // and the bytes are reachable through `get`.
+        use crate::supertable::manifest::list::{
+            FORMAT_VERSION as LIST_FORMAT_VERSION, ManifestList, PartitionStrategy,
+        };
+        let (_dir, storage) = local_storage();
+        // Smallest valid ManifestList shape — no parts, no
+        // columns, an empty schema. Encoding only requires the
+        // format header + the empty collections.
+        let list = ManifestList {
+            format_version: LIST_FORMAT_VERSION.into(),
+            manifest_id: 1,
+            options_hash: ContentHash([0u8; 32]),
+            schema: Vec::new(),
+            id_column: "_id".into(),
+            fts_columns: Vec::new(),
+            vector_columns: Vec::new(),
+            partition_strategy: PartitionStrategy::TimeRange {
+                column: "_id".into(),
+                granularity_secs: 86_400,
+            },
+            parts: Vec::new(),
+        };
+        let res = write_manifest_list(storage.as_ref(), &list)
+            .await
+            .expect("write");
+        assert_eq!(res.uri, list_uri(1));
+        assert!(res.size_bytes > 0);
+        // Read back to confirm bytes land at the URI.
+        let _ = storage.get(&res.uri).await.expect("get list back");
+    }
+
+    #[test]
+    fn point_constants_match_layout_doc() {
+        // Smoke that the directory-layout constants haven't
+        // drifted from the module docs. A rename of any of
+        // these is observable through the on-disk shape and
+        // would silently invalidate existing supertables on
+        // upgrade — surfaces it as a test failure first.
+        assert_eq!(POINTER_PATH, "_supertable/current");
+        assert_eq!(MANIFEST_LISTS_DIR, "manifest-lists");
+        assert_eq!(MANIFEST_PARTS_DIR, "manifests");
+    }
+}

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -183,3 +183,410 @@ fn push_str(buf: &mut Vec<u8>, s: &str) {
     buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
     buf.extend_from_slice(s.as_bytes());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::superfile::builder::{FtsConfig, VectorConfig};
+    use crate::superfile::vector::distance::Metric;
+    use crate::supertable::manifest::list::PartitionStrategy;
+    use crate::supertable::manifest::part::ContentHash;
+    use crate::supertable::options::SupertableOptions;
+    use crate::test_helpers::default_tokenizer;
+    use arrow_array::FixedSizeListArray;
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn schema_title_only() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new(
+            "title",
+            DataType::LargeUtf8,
+            false,
+        )]))
+    }
+
+    fn schema_title_emb(dim: usize) -> Arc<Schema> {
+        let list_field = Field::new("item", DataType::Float32, false);
+        let list_type = DataType::FixedSizeList(Arc::new(list_field), dim as i32);
+        Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("emb", list_type, false),
+        ]))
+    }
+
+    fn fts_opts() -> SupertableOptions {
+        SupertableOptions::new(
+            schema_title_only(),
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        )
+        .expect("opts")
+    }
+
+    fn time_range() -> PartitionStrategy {
+        PartitionStrategy::TimeRange {
+            column: "_id".into(),
+            granularity_secs: 86_400,
+        }
+    }
+
+    // ---- compute_options_hash determinism --------------------------------
+
+    #[test]
+    fn compute_options_hash_deterministic() {
+        // Same options + strategy yield byte-identical hashes
+        // across calls. Guards against accidental
+        // nondeterminism from HashMap iteration order or
+        // similar.
+        let h1 = compute_options_hash(&fts_opts(), &time_range());
+        let h2 = compute_options_hash(&fts_opts(), &time_range());
+        assert_eq!(h1.0, h2.0);
+    }
+
+    #[test]
+    fn compute_options_hash_changes_with_schema() {
+        // Renaming a column changes the schema field name, which
+        // is part of the hash. Same column type, different name.
+        let opts_a = fts_opts();
+        let opts_b = SupertableOptions::new(
+            Arc::new(Schema::new(vec![Field::new(
+                "body",
+                DataType::LargeUtf8,
+                false,
+            )])),
+            vec![FtsConfig {
+                column: "body".into(),
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        )
+        .expect("opts");
+        let h_a = compute_options_hash(&opts_a, &time_range());
+        let h_b = compute_options_hash(&opts_b, &time_range());
+        assert_ne!(h_a.0, h_b.0);
+    }
+
+    #[test]
+    fn compute_options_hash_changes_with_nullability() {
+        // The nullable byte is included in the schema encoding,
+        // so flipping nullable changes the hash even when
+        // names and types match.
+        let opts_a = fts_opts();
+        let opts_b = SupertableOptions::new(
+            Arc::new(Schema::new(vec![Field::new(
+                "title",
+                DataType::LargeUtf8,
+                true, // nullable
+            )])),
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        )
+        .expect("opts");
+        let h_a = compute_options_hash(&opts_a, &time_range());
+        let h_b = compute_options_hash(&opts_b, &time_range());
+        assert_ne!(h_a.0, h_b.0);
+    }
+
+    #[test]
+    fn compute_options_hash_changes_with_fts_column_set() {
+        // Adding another FTS column changes the fts_columns
+        // length prefix + content. The schema must still be
+        // compatible, so the second variant adds a `subtitle`
+        // field.
+        let opts_a = fts_opts();
+        let schema_two = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("subtitle", DataType::LargeUtf8, false),
+        ]));
+        let opts_b = SupertableOptions::new(
+            schema_two,
+            vec![
+                FtsConfig {
+                    column: "title".into(),
+                },
+                FtsConfig {
+                    column: "subtitle".into(),
+                },
+            ],
+            vec![],
+            Some(default_tokenizer()),
+        )
+        .expect("opts");
+        let h_a = compute_options_hash(&opts_a, &time_range());
+        let h_b = compute_options_hash(&opts_b, &time_range());
+        assert_ne!(h_a.0, h_b.0);
+    }
+
+    #[test]
+    fn compute_options_hash_changes_with_fts_column_order() {
+        // FTS column order is part of the schema identity
+        // (FtsBuilder assigns ids by position). Swapping the
+        // two FTS column declarations must produce a different
+        // hash even though the underlying set is the same.
+        let schema_two = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("subtitle", DataType::LargeUtf8, false),
+        ]));
+        let opts_a = SupertableOptions::new(
+            schema_two.clone(),
+            vec![
+                FtsConfig {
+                    column: "title".into(),
+                },
+                FtsConfig {
+                    column: "subtitle".into(),
+                },
+            ],
+            vec![],
+            Some(default_tokenizer()),
+        )
+        .expect("opts");
+        let opts_b = SupertableOptions::new(
+            schema_two,
+            vec![
+                FtsConfig {
+                    column: "subtitle".into(),
+                },
+                FtsConfig {
+                    column: "title".into(),
+                },
+            ],
+            vec![],
+            Some(default_tokenizer()),
+        )
+        .expect("opts");
+        let h_a = compute_options_hash(&opts_a, &time_range());
+        let h_b = compute_options_hash(&opts_b, &time_range());
+        assert_ne!(h_a.0, h_b.0);
+    }
+
+    #[test]
+    fn compute_options_hash_changes_with_vector_columns() {
+        // Adding a vector column changes the vector_columns
+        // count + per-column field bytes (dim, n_cent, rot_seed,
+        // metric).
+        let opts_a = fts_opts();
+        let opts_b = SupertableOptions::new(
+            schema_title_emb(16),
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![VectorConfig {
+                column: "emb".into(),
+                dim: 16,
+                n_cent: 4,
+                rot_seed: 0,
+                metric: Metric::Cosine,
+            }],
+            Some(default_tokenizer()),
+        )
+        .expect("opts");
+        let h_a = compute_options_hash(&opts_a, &time_range());
+        let h_b = compute_options_hash(&opts_b, &time_range());
+        assert_ne!(h_a.0, h_b.0);
+    }
+
+    #[test]
+    fn compute_options_hash_changes_with_vector_metric() {
+        // The metric is encoded via lowercased `format!("{:?}",
+        // metric)`, so changing Cosine → NegDot at otherwise
+        // equal options must produce a different hash. Verifies
+        // the per-metric encoding actually contributes.
+        let mk = |metric: Metric| {
+            SupertableOptions::new(
+                schema_title_emb(16),
+                vec![],
+                vec![VectorConfig {
+                    column: "emb".into(),
+                    dim: 16,
+                    n_cent: 4,
+                    rot_seed: 0,
+                    metric,
+                }],
+                Some(default_tokenizer()),
+            )
+            .expect("opts")
+        };
+        let h_a = compute_options_hash(&mk(Metric::Cosine), &time_range());
+        let h_b = compute_options_hash(&mk(Metric::NegDot), &time_range());
+        assert_ne!(h_a.0, h_b.0);
+    }
+
+    // ---- PartitionStrategy variants ------------------------------------
+
+    #[test]
+    fn compute_options_hash_distinguishes_partition_strategy_variants() {
+        // Same options, different partition-strategy variants
+        // must produce different hashes — the variant tag is
+        // pushed before any per-variant fields. Covers all three
+        // arms of the match in compute_options_hash.
+        let opts = fts_opts();
+        let h_time = compute_options_hash(
+            &opts,
+            &PartitionStrategy::TimeRange {
+                column: "_id".into(),
+                granularity_secs: 86_400,
+            },
+        );
+        let h_hash = compute_options_hash(
+            &opts,
+            &PartitionStrategy::Hash {
+                column: "_id".into(),
+                n_buckets: 16,
+            },
+        );
+        let h_range = compute_options_hash(
+            &opts,
+            &PartitionStrategy::ColumnRange {
+                column: "_id".into(),
+                boundaries: vec![vec![1, 2, 3], vec![4, 5, 6]],
+            },
+        );
+        assert_ne!(h_time.0, h_hash.0);
+        assert_ne!(h_hash.0, h_range.0);
+        assert_ne!(h_time.0, h_range.0);
+    }
+
+    #[test]
+    fn compute_options_hash_partition_field_changes_propagate() {
+        // Within each PartitionStrategy variant, mutating a
+        // per-variant field must change the hash. Catches the
+        // case where a field is added to the enum but forgotten
+        // in the hash encoding.
+        let opts = fts_opts();
+
+        // TimeRange: granularity differs.
+        let h_t1 = compute_options_hash(
+            &opts,
+            &PartitionStrategy::TimeRange {
+                column: "_id".into(),
+                granularity_secs: 86_400,
+            },
+        );
+        let h_t2 = compute_options_hash(
+            &opts,
+            &PartitionStrategy::TimeRange {
+                column: "_id".into(),
+                granularity_secs: 3600,
+            },
+        );
+        assert_ne!(h_t1.0, h_t2.0);
+
+        // Hash: bucket count differs.
+        let h_h1 = compute_options_hash(
+            &opts,
+            &PartitionStrategy::Hash {
+                column: "_id".into(),
+                n_buckets: 16,
+            },
+        );
+        let h_h2 = compute_options_hash(
+            &opts,
+            &PartitionStrategy::Hash {
+                column: "_id".into(),
+                n_buckets: 32,
+            },
+        );
+        assert_ne!(h_h1.0, h_h2.0);
+
+        // ColumnRange: one extra boundary.
+        let h_r1 = compute_options_hash(
+            &opts,
+            &PartitionStrategy::ColumnRange {
+                column: "_id".into(),
+                boundaries: vec![vec![1, 2]],
+            },
+        );
+        let h_r2 = compute_options_hash(
+            &opts,
+            &PartitionStrategy::ColumnRange {
+                column: "_id".into(),
+                boundaries: vec![vec![1, 2], vec![3, 4]],
+            },
+        );
+        assert_ne!(h_r1.0, h_r2.0);
+    }
+
+    // ---- verify_options_hash --------------------------------------------
+
+    #[test]
+    fn verify_options_hash_accepts_matching_pair() {
+        let opts = fts_opts();
+        let h = compute_options_hash(&opts, &time_range());
+        verify_options_hash(h, h).expect("matching pair accepted");
+    }
+
+    #[test]
+    fn verify_options_hash_skips_zero_sentinel() {
+        // Pre-D15 manifests + synthetic test fixtures with an
+        // all-zero stored hash bypass validation: the caller's
+        // computed hash can be anything.
+        let opts = fts_opts();
+        let computed = compute_options_hash(&opts, &time_range());
+        let zero = ContentHash([0u8; 32]);
+        verify_options_hash(computed, zero).expect("zero sentinel bypasses verification");
+    }
+
+    #[test]
+    fn verify_options_hash_rejects_mismatch_with_hex_payload() {
+        // Two clearly different hashes must produce
+        // OptionsHashMismatch whose Display includes both hex
+        // strings prefixed with `blake3:`.
+        let h_a = ContentHash([1u8; 32]);
+        let h_b = ContentHash([2u8; 32]);
+        let err = verify_options_hash(h_a, h_b).expect_err("mismatch must error");
+        let rendered = format!("{err}");
+        assert!(
+            rendered.contains("options_hash mismatch"),
+            "got: {rendered}"
+        );
+        assert!(rendered.contains("blake3:"), "got: {rendered}");
+        // 32 bytes of 0x01 → 64-char hex string.
+        assert!(rendered.contains(&"01".repeat(32)), "got: {rendered}");
+        assert!(rendered.contains(&"02".repeat(32)), "got: {rendered}");
+    }
+
+    #[test]
+    fn options_hash_mismatch_is_error_impl() {
+        // Trait-object usage exercises the
+        // `impl std::error::Error for OptionsHashMismatch` — a
+        // no-op body but the impl block needs to compile and
+        // the dyn-error conversion needs to succeed.
+        let h_a = ContentHash([3u8; 32]);
+        let h_b = ContentHash([4u8; 32]);
+        let err = verify_options_hash(h_a, h_b).expect_err("mismatch");
+        let dyn_err: Box<dyn std::error::Error> = Box::new(err);
+        assert!(dyn_err.to_string().contains("options_hash mismatch"));
+    }
+
+    // ---- helpers (light coverage on push_tag / push_str) ----------------
+
+    #[test]
+    fn push_helpers_emit_length_prefixed_bytes() {
+        // The hash encoding's correctness rests on these
+        // helpers; cover them directly so a regression in
+        // either is caught at unit-test scale rather than at
+        // an integration mismatch later.
+        let mut buf = Vec::new();
+        push_tag(&mut buf, b"schema");
+        assert_eq!(buf, vec![6u8, b's', b'c', b'h', b'e', b'm', b'a']);
+
+        let mut buf = Vec::new();
+        push_str(&mut buf, "ok");
+        // 8-byte LE length prefix + 2 ASCII bytes.
+        assert_eq!(buf, vec![2u8, 0, 0, 0, 0, 0, 0, 0, b'o', b'k']);
+    }
+
+    // Compiler-only smoke that the FixedSizeListArray import
+    // is exercised (the schema-builder uses it via DataType,
+    // not the array itself). Keeps the import non-dead even if
+    // some future test removes its only use.
+    #[allow(dead_code)]
+    fn _silence_fixed_size_list_array(_arr: FixedSizeListArray) {}
+}

--- a/src/supertable/manifest/partition.rs
+++ b/src/supertable/manifest/partition.rs
@@ -268,3 +268,385 @@ fn downcast_i64(
         ),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supertable::manifest::{ScalarStatsTable, SuperfileEntry, SuperfileUri};
+    use arrow_array::{
+        ArrayRef, Int32Array, Int64Array, TimestampMicrosecondArray, TimestampMillisecondArray,
+        TimestampNanosecondArray, TimestampSecondArray,
+    };
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // ---- Helpers --------------------------------------------------------
+
+    fn empty_seg() -> SuperfileEntry {
+        SuperfileEntry {
+            superfile_id: uuid::Uuid::nil(),
+            uri: SuperfileUri(uuid::Uuid::nil()),
+            n_docs: 0,
+            id_min: 0,
+            id_max: 0,
+            scalar_stats: ScalarStatsTable::new(),
+            fts_summary: HashMap::new(),
+            vector_summary: HashMap::new(),
+            partition_key: Vec::new(),
+            partition_hint: None,
+        }
+    }
+
+    fn seg_with_i64(column: &str, min: i64, max: i64) -> SuperfileEntry {
+        let mut s = empty_seg();
+        let mn: ArrayRef = Arc::new(Int64Array::from(vec![min]));
+        let mx: ArrayRef = Arc::new(Int64Array::from(vec![max]));
+        s.scalar_stats.cols.insert(column.to_string(), (mn, mx));
+        s
+    }
+
+    fn assert_spans_partition(err: CommitError, needle: &str) {
+        match err {
+            CommitError::SuperfileSpansPartition { detail } => assert!(
+                detail.contains(needle),
+                "expected `{needle}` in detail; got: {detail}"
+            ),
+            other => panic!("expected SuperfileSpansPartition; got {other:?}"),
+        }
+    }
+
+    // ---- encode_partition_key ------------------------------------------
+
+    #[test]
+    fn encode_partition_key_time_range_emits_le_u64() {
+        let bytes = encode_partition_key(&PartitionKey::TimeRange(0x01_02_03_04_05_06_07_08));
+        assert_eq!(bytes.len(), 8);
+        assert_eq!(bytes, 0x01_02_03_04_05_06_07_08u64.to_le_bytes().to_vec());
+    }
+
+    #[test]
+    fn encode_partition_key_hash_emits_le_u32() {
+        let bytes = encode_partition_key(&PartitionKey::Hash(0xCAFEBABE));
+        assert_eq!(bytes.len(), 4);
+        assert_eq!(bytes, 0xCAFEBABEu32.to_le_bytes().to_vec());
+    }
+
+    #[test]
+    fn encode_partition_key_column_range_emits_le_u16() {
+        let bytes = encode_partition_key(&PartitionKey::ColumnRange(0xDEAD));
+        assert_eq!(bytes.len(), 2);
+        assert_eq!(bytes, 0xDEADu16.to_le_bytes().to_vec());
+    }
+
+    // ---- decode_partition_key — success roundtrip ----------------------
+
+    #[test]
+    fn decode_partition_key_round_trips_time_range() {
+        let original = PartitionKey::TimeRange(42);
+        let bytes = encode_partition_key(&original);
+        let strategy = PartitionStrategy::TimeRange {
+            column: "_id".into(),
+            granularity_secs: 86_400,
+        };
+        let decoded = decode_partition_key(&bytes, &strategy).expect("decode");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn decode_partition_key_round_trips_hash() {
+        let original = PartitionKey::Hash(5);
+        let bytes = encode_partition_key(&original);
+        let strategy = PartitionStrategy::Hash {
+            column: "_id".into(),
+            n_buckets: 16,
+        };
+        let decoded = decode_partition_key(&bytes, &strategy).expect("decode");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn decode_partition_key_round_trips_column_range() {
+        let original = PartitionKey::ColumnRange(3);
+        let bytes = encode_partition_key(&original);
+        let strategy = PartitionStrategy::ColumnRange {
+            column: "_id".into(),
+            boundaries: vec![vec![]],
+        };
+        let decoded = decode_partition_key(&bytes, &strategy).expect("decode");
+        assert_eq!(decoded, original);
+    }
+
+    // ---- decode_partition_key — size mismatch errors -------------------
+
+    #[test]
+    fn decode_partition_key_rejects_wrong_size_time_range() {
+        let strategy = PartitionStrategy::TimeRange {
+            column: "_id".into(),
+            granularity_secs: 1,
+        };
+        let err = decode_partition_key(&[1, 2, 3], &strategy).expect_err("must error");
+        match err {
+            CommitError::PointerParse(msg) => {
+                assert!(msg.contains("TimeRange"), "{msg}");
+                assert!(msg.contains("8 bytes"), "{msg}");
+            }
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_partition_key_rejects_wrong_size_hash() {
+        let strategy = PartitionStrategy::Hash {
+            column: "_id".into(),
+            n_buckets: 4,
+        };
+        let err = decode_partition_key(&[1, 2, 3], &strategy).expect_err("must error");
+        match err {
+            CommitError::PointerParse(msg) => {
+                assert!(msg.contains("Hash"), "{msg}");
+                assert!(msg.contains("4 bytes"), "{msg}");
+            }
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_partition_key_rejects_wrong_size_column_range() {
+        let strategy = PartitionStrategy::ColumnRange {
+            column: "_id".into(),
+            boundaries: vec![vec![]],
+        };
+        let err = decode_partition_key(&[1, 2, 3], &strategy).expect_err("must error");
+        match err {
+            CommitError::PointerParse(msg) => {
+                assert!(msg.contains("ColumnRange"), "{msg}");
+                assert!(msg.contains("2 bytes"), "{msg}");
+            }
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    // ---- assign_partition: TimeRange -----------------------------------
+
+    #[test]
+    fn assign_partition_time_range_single_bucket() {
+        // min and max sit in the same daily bucket → success.
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: 86_400,
+        };
+        // 100 .. 90_000 → both buckets are 0..1 → same bucket 0.
+        let seg = seg_with_i64("ts", 100, 80_000);
+        let key = assign_partition(&seg, &strategy).expect("assign");
+        assert_eq!(key, PartitionKey::TimeRange(0));
+    }
+
+    #[test]
+    fn assign_partition_time_range_rejects_segment_spanning_buckets() {
+        // min in bucket 0, max in bucket 1 → SuperfileSpansPartition.
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: 86_400,
+        };
+        let seg = seg_with_i64("ts", 100, 100_000);
+        let err = assign_partition(&seg, &strategy).expect_err("must span");
+        assert_spans_partition(err, "spans buckets");
+    }
+
+    #[test]
+    fn assign_partition_time_range_rejects_zero_granularity() {
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: 0,
+        };
+        let seg = seg_with_i64("ts", 0, 0);
+        let err = assign_partition(&seg, &strategy).expect_err("must reject");
+        assert_spans_partition(err, "granularity_secs must be > 0");
+    }
+
+    #[test]
+    fn assign_partition_time_range_rejects_negative_granularity() {
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: -1,
+        };
+        let seg = seg_with_i64("ts", 0, 0);
+        let err = assign_partition(&seg, &strategy).expect_err("must reject");
+        assert_spans_partition(err, "granularity_secs must be > 0");
+    }
+
+    #[test]
+    fn assign_partition_time_range_rejects_missing_column_stats() {
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: 86_400,
+        };
+        let seg = empty_seg(); // no scalar_stats at all
+        let err = assign_partition(&seg, &strategy).expect_err("missing stats");
+        assert_spans_partition(err, "no scalar_stats");
+    }
+
+    #[test]
+    fn assign_partition_time_range_supports_timestamp_columns() {
+        // Each timestamp width must downcast cleanly so users can
+        // configure granularity_secs against the column's actual
+        // unit. Covers Second/Milli/Micro/Nano arms in downcast_i64.
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: 86_400,
+        };
+        let cases: Vec<(ArrayRef, ArrayRef)> = vec![
+            (
+                Arc::new(TimestampSecondArray::from(vec![100])),
+                Arc::new(TimestampSecondArray::from(vec![200])),
+            ),
+            (
+                Arc::new(TimestampMillisecondArray::from(vec![100])),
+                Arc::new(TimestampMillisecondArray::from(vec![200])),
+            ),
+            (
+                Arc::new(TimestampMicrosecondArray::from(vec![100])),
+                Arc::new(TimestampMicrosecondArray::from(vec![200])),
+            ),
+            (
+                Arc::new(TimestampNanosecondArray::from(vec![100])),
+                Arc::new(TimestampNanosecondArray::from(vec![200])),
+            ),
+        ];
+        for (mn, mx) in cases {
+            let mut seg = empty_seg();
+            seg.scalar_stats.cols.insert("ts".into(), (mn, mx));
+            let key = assign_partition(&seg, &strategy).expect("assign");
+            assert_eq!(key, PartitionKey::TimeRange(0));
+        }
+    }
+
+    #[test]
+    fn assign_partition_time_range_rejects_unsupported_column_type() {
+        // Int32 isn't supported (only Int64 + Timestamp widths).
+        // Surfaces as SuperfileSpansPartition with a type-name hint.
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: 86_400,
+        };
+        let mut seg = empty_seg();
+        let mn: ArrayRef = Arc::new(Int32Array::from(vec![100]));
+        let mx: ArrayRef = Arc::new(Int32Array::from(vec![200]));
+        seg.scalar_stats.cols.insert("ts".into(), (mn, mx));
+        let err = assign_partition(&seg, &strategy).expect_err("unsupported");
+        assert_spans_partition(err, "unsupported type");
+    }
+
+    #[test]
+    fn assign_partition_time_range_rejects_null_stats_array() {
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: 86_400,
+        };
+        let mut seg = empty_seg();
+        // Length-1 array with a single null value.
+        let nulls: Vec<Option<i64>> = vec![None];
+        let mn: ArrayRef = Arc::new(Int64Array::from(nulls.clone()));
+        let mx: ArrayRef = Arc::new(Int64Array::from(nulls));
+        seg.scalar_stats.cols.insert("ts".into(), (mn, mx));
+        let err = assign_partition(&seg, &strategy).expect_err("null stats");
+        assert_spans_partition(err, "empty or null at index 0");
+    }
+
+    #[test]
+    fn assign_partition_time_range_handles_negative_values_with_div_euclid() {
+        // `div_euclid` (not bare `/`) ensures negative timestamps
+        // bucket consistently — same-bucket pairs across the
+        // negative range must succeed. Catches an accidental
+        // `min / g != max / g` regression that breaks at the
+        // sign flip.
+        let strategy = PartitionStrategy::TimeRange {
+            column: "ts".into(),
+            granularity_secs: 10,
+        };
+        // -25 div_euclid 10 = -3; -21 div_euclid 10 = -3.
+        let seg = seg_with_i64("ts", -25, -21);
+        let key = assign_partition(&seg, &strategy).expect("assign");
+        assert_eq!(key, PartitionKey::TimeRange(-3i64 as u64));
+    }
+
+    // ---- assign_partition: Hash ----------------------------------------
+
+    #[test]
+    fn assign_partition_hash_single_bucket_short_circuits() {
+        // n_buckets=1 → always bucket 0, no partition_hint needed.
+        // This is the M15a default; tests rely on it staying
+        // hint-less.
+        let strategy = PartitionStrategy::Hash {
+            column: "_id".into(),
+            n_buckets: 1,
+        };
+        let seg = empty_seg();
+        let key = assign_partition(&seg, &strategy).expect("assign");
+        assert_eq!(key, PartitionKey::Hash(0));
+    }
+
+    #[test]
+    fn assign_partition_hash_zero_buckets_treats_as_one() {
+        // Defensive: n_buckets=0 falls into the <=1 short-circuit
+        // rather than panicking on a later modulo.
+        let strategy = PartitionStrategy::Hash {
+            column: "_id".into(),
+            n_buckets: 0,
+        };
+        let seg = empty_seg();
+        let key = assign_partition(&seg, &strategy).expect("assign");
+        assert_eq!(key, PartitionKey::Hash(0));
+    }
+
+    #[test]
+    fn assign_partition_hash_uses_partition_hint() {
+        let strategy = PartitionStrategy::Hash {
+            column: "_id".into(),
+            n_buckets: 4,
+        };
+        let mut seg = empty_seg();
+        seg.partition_hint = Some(2);
+        let key = assign_partition(&seg, &strategy).expect("assign");
+        assert_eq!(key, PartitionKey::Hash(2));
+    }
+
+    #[test]
+    fn assign_partition_hash_requires_hint_when_multi_bucket() {
+        let strategy = PartitionStrategy::Hash {
+            column: "_id".into(),
+            n_buckets: 4,
+        };
+        let seg = empty_seg(); // hint = None
+        let err = assign_partition(&seg, &strategy).expect_err("must reject");
+        assert_spans_partition(err, "requires pre-sharded");
+    }
+
+    #[test]
+    fn assign_partition_hash_rejects_out_of_range_hint() {
+        let strategy = PartitionStrategy::Hash {
+            column: "_id".into(),
+            n_buckets: 4,
+        };
+        let mut seg = empty_seg();
+        seg.partition_hint = Some(4); // == n_buckets, off-by-one
+        let err = assign_partition(&seg, &strategy).expect_err("out of range");
+        assert_spans_partition(err, "out of range");
+    }
+
+    // ---- assign_partition: ColumnRange (currently unimplemented) -------
+
+    #[test]
+    fn assign_partition_column_range_is_not_yet_supported() {
+        // The implementation explicitly bails on ColumnRange until
+        // M15a follow-up. Locking the message keeps it visible
+        // when the follow-up lands.
+        let strategy = PartitionStrategy::ColumnRange {
+            column: "_id".into(),
+            boundaries: vec![vec![]],
+        };
+        let seg = empty_seg();
+        let err = assign_partition(&seg, &strategy).expect_err("not impl");
+        assert_spans_partition(err, "ColumnRange partition assignment lands");
+    }
+}


### PR DESCRIPTION
## Summary

Adds inline \`#[cfg(test)]\` modules to four files that were the biggest line-coverage gaps on main. No behavioural changes; lifts the buffer above the 90% CI floor from 0.14 pp → 1.48 pp.

| File | Before | After | Notes |
|---|---|---|---|
| \`storage/s3.rs\` | 0% | covered | 10 tests for \`translate\` / \`path\` / constructors / \`Debug\`. HTTP trait impls stay on the gated smoke test against in-process s3s-fs. |
| \`supertable/manifest/partition.rs\` | 45.57% | covered | 24 tests across \`encode_partition_key\` / \`decode_partition_key\` round-trips + size errors, and \`assign_partition\` across all 3 \`PartitionStrategy\` variants (TimeRange + Hash + ColumnRange-not-yet-supported sentinel) including all 4 \`Timestamp\` widths in \`downcast_i64\`. |
| \`supertable/manifest/commit.rs\` | 83.71% | covered | 22 tests across URI builders, \`PointerFile\` round-trip + 9 parse-error branches, \`translate_contention\`, and LocalFs-backed \`write_pointer\` / \`write_manifest_list\` / \`read_pointer\`. |
| \`supertable/manifest/options_hash.rs\` | 72.29% | covered | 14 tests across \`compute_options_hash\` sensitivity (schema / nullable / FTS column set+order / vector dim / vector metric / partition strategy variant + per-variant-field), \`verify_options_hash\` (success / zero-sentinel / mismatch with hex payload / Error trait object), and direct \`push_tag\` / \`push_str\` byte layouts. |

## Coverage delta

| Metric | Before (main) | After | Δ |
|---|---|---|---|
| Lines | 90.14% | **91.48%** | +1.34 pp |
| Regions | 91.39% | **92.21%** | +0.82 pp |
| Functions | 86.62% | **88.40%** | +1.78 pp |

## Test plan

- [x] \`cargo test --lib\` (594 lib tests pass, 70 new).
- [x] \`cargo fmt --check\` clean.
- [x] \`cargo clippy --all-targets -- -D warnings\` clean.
- [x] \`make ci\` — \`✓ ready to PR\`.