### PR TITLE
superfile: shared lazy-source infra for object-store

### DIFF
--- a/src/superfile/format/footer.rs
+++ b/src/superfile/format/footer.rs
@@ -21,9 +21,10 @@
 //! rebuilding the `ParquetMetaData` around it.
 
 use crate::superfile::format::kv;
+use crate::superfile::lazy_source::{LazyByteSource, LazyByteSourceError};
 use arrow::record_batch::RecordBatch;
 use arrow_schema::Schema;
-use parquet::arrow::ArrowWriter;
+use parquet::arrow::{ArrowWriter, parquet_to_arrow_schema};
 use parquet::basic::Compression;
 use parquet::file::metadata::{
     FileMetaData, KeyValue, ParquetMetaDataBuilder, ParquetMetaDataReader, ParquetMetaDataWriter,
@@ -58,6 +59,13 @@ pub enum FooterError {
     Arrow(#[from] arrow::error::ArrowError),
     #[error("malformed parquet: {0}")]
     Malformed(&'static str),
+    /// Underlying [`LazyByteSource`] failure (network /
+    /// storage / out-of-bounds) on the lazy-open footer
+    /// read path. Distinct from `Parquet` so the lazy-open
+    /// flow can surface storage failures without
+    /// stringifying.
+    #[error("lazy source: {0}")]
+    Lazy(#[from] LazyByteSourceError),
 }
 
 /// Write `batches` (matching `schema`) as Parquet, then splice the
@@ -214,6 +222,80 @@ pub fn read_kv_metadata(bytes: &[u8]) -> Result<KvMap, FooterError> {
     Ok(out)
 }
 
+/// Lazy-open variant of [`read_kv_metadata`] + Arrow-schema
+/// extraction. Issues two range GETs against `source`:
+///
+/// 1. Trailing 8 bytes (`[footer_len:u32 LE][PAR1]`) to learn
+///    the footer length.
+/// 2. The footer body itself.
+///
+/// Both the `inf.*` KV map *and* the Arrow schema come from
+/// the same decoded `ParquetMetaData`, so returning them in
+/// one call avoids re-decoding (or re-fetching) the footer
+/// on the caller's behalf.
+///
+/// This is the polymorphism point for the lazy
+/// [`crate::superfile::reader::SuperfileReader::open_lazy_with`]
+/// flow: callers hand a [`LazyByteSource`] (e.g. an object-
+/// store range-fetcher, a broadcast coalescer, or a mmap-
+/// backed [`crate::superfile::lazy_source::BytesLazyByteSource`])
+/// and pay only the footer cost up-front — not the full
+/// segment.
+///
+/// Total bytes pulled: `8 + footer_len`, typically a few KB
+/// at default Parquet writer settings.
+pub async fn read_footer_lazy(
+    source: &dyn LazyByteSource,
+) -> Result<(KvMap, Arc<Schema>), FooterError> {
+    let size = source.size();
+    if size < 12 {
+        return Err(FooterError::Malformed(
+            "file smaller than minimum Parquet trailer",
+        ));
+    }
+
+    // Step 1: trailing 8 bytes carry the footer length + PAR1 magic.
+    let trailer = source.range(size - 8, 8).await?;
+    if &trailer[4..8] != b"PAR1" {
+        return Err(FooterError::Malformed("not a Parquet file (missing PAR1)"));
+    }
+    let footer_len_bytes: [u8; 4] = trailer[0..4]
+        .try_into()
+        .map_err(|_| FooterError::Malformed("footer length not 4 bytes"))?;
+    let footer_len = u32::from_le_bytes(footer_len_bytes) as u64;
+    if size < 8 + footer_len {
+        return Err(FooterError::Malformed("footer length out of range"));
+    }
+    let footer_start = size - 8 - footer_len;
+
+    // Step 2: pull the footer body (no PAR1, no length suffix —
+    // `decode_metadata` wants just the thrift-encoded metadata).
+    let footer_bytes = source.range(footer_start, footer_len).await?;
+    let metadata = ParquetMetaDataReader::decode_metadata(&footer_bytes)?;
+
+    // Extract KVs.
+    let mut kvs: KvMap = HashMap::new();
+    if let Some(entries) = metadata.file_metadata().key_value_metadata() {
+        for entry in entries {
+            if let Some(v) = &entry.value {
+                kvs.insert(entry.key.clone(), v.clone());
+            }
+        }
+    }
+
+    // Extract Arrow schema. parquet-rs honours the
+    // arrow-encoded schema KV (`ARROW:schema`) when present
+    // and falls back to inference from the Parquet schema
+    // descriptor — same semantics as
+    // `ParquetRecordBatchReaderBuilder::try_new`'s schema(),
+    // without needing the full file as a ChunkReader.
+    let arrow_schema = parquet_to_arrow_schema(
+        metadata.file_metadata().schema_descr(),
+        metadata.file_metadata().key_value_metadata(),
+    )?;
+    Ok((kvs, Arc::new(arrow_schema)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -368,5 +450,115 @@ mod tests {
     fn read_kv_metadata_rejects_non_parquet_input() {
         let err = read_kv_metadata(&[0u8; 16]).expect_err("expected error");
         assert!(matches!(err, FooterError::Malformed(_)));
+    }
+
+    /// `read_footer_lazy` must agree with `read_kv_metadata` +
+    /// `ParquetRecordBatchReaderBuilder` on both the KV map
+    /// and the Arrow schema, while only ever touching the
+    /// footer suffix of the file.
+    #[tokio::test]
+    async fn read_footer_lazy_matches_eager_kv_and_schema() {
+        use crate::superfile::lazy_source::BytesLazyByteSource;
+        use bytes::Bytes;
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+        let schema = small_schema();
+        let batch = small_batch(&schema);
+        let extra = vec![
+            ("inf.format".to_string(), "infino-superfile".to_string()),
+            ("inf.format_version".to_string(), "1.0.0".to_string()),
+            ("inf.id_column".to_string(), "id".to_string()),
+            ("inf.fts.columns".to_string(), "[\"category\"]".to_string()),
+        ];
+        let parts = write_parquet_with_blobs(
+            &schema,
+            &[batch],
+            &[],
+            &[],
+            &extra,
+            Compression::SNAPPY,
+            1024,
+        )
+        .expect("write parquet with blobs");
+
+        let eager_kv = read_kv_metadata(&parts.bytes).expect("eager kv");
+        let eager_schema =
+            ParquetRecordBatchReaderBuilder::try_new(Bytes::from(parts.bytes.clone()))
+                .expect("eager builder")
+                .schema()
+                .clone();
+
+        let src = BytesLazyByteSource::new(Bytes::from(parts.bytes.clone()));
+        let (lazy_kv, lazy_schema) = read_footer_lazy(&src).await.expect("lazy footer");
+
+        assert_eq!(lazy_kv, eager_kv);
+        assert_eq!(lazy_schema.fields(), eager_schema.fields());
+    }
+
+    /// `read_footer_lazy` must only fetch the footer suffix —
+    /// not the whole file — even when the file is large and
+    /// the bulk of bytes are in row groups. Asserted with a
+    /// counting `LazyByteSource` wrapper.
+    #[tokio::test]
+    async fn read_footer_lazy_fetches_only_footer_suffix() {
+        use crate::superfile::lazy_source::{
+            BytesLazyByteSource, LazyByteSource, LazyByteSourceError,
+        };
+        use async_trait::async_trait;
+        use bytes::Bytes;
+        use std::sync::Mutex;
+
+        struct Counting {
+            inner: BytesLazyByteSource,
+            ranges: Mutex<Vec<(u64, u64)>>,
+        }
+        #[async_trait]
+        impl LazyByteSource for Counting {
+            fn size(&self) -> u64 {
+                self.inner.size()
+            }
+            async fn range(&self, start: u64, len: u64) -> Result<Bytes, LazyByteSourceError> {
+                self.ranges
+                    .lock()
+                    .expect("ranges mutex poisoned")
+                    .push((start, len));
+                self.inner.range(start, len).await
+            }
+        }
+
+        let schema = small_schema();
+        // Eight repeats of the small batch so the row-group region is
+        // an order of magnitude larger than the footer.
+        let batches: Vec<_> = (0..8).map(|_| small_batch(&schema)).collect();
+        let parts = write_parquet_with_blobs(
+            &schema,
+            &batches,
+            &[],
+            &[],
+            &[("inf.format".to_string(), "infino-superfile".to_string())],
+            Compression::SNAPPY,
+            1024,
+        )
+        .expect("write parquet");
+        let total = parts.bytes.len() as u64;
+
+        let src = Counting {
+            inner: BytesLazyByteSource::new(Bytes::from(parts.bytes)),
+            ranges: Mutex::new(Vec::new()),
+        };
+        let (_kv, _schema) = read_footer_lazy(&src).await.expect("lazy footer");
+
+        let ranges = src.ranges.lock().expect("ranges mutex poisoned").clone();
+        // Exactly two range GETs: the 8-byte trailer + the footer body.
+        assert_eq!(ranges.len(), 2, "ranges: {ranges:?}");
+        // First is the trailing 8 bytes.
+        assert_eq!(ranges[0], (total - 8, 8));
+        // Second is the footer body, which is a tail-aligned region.
+        let (start, len) = ranges[1];
+        assert_eq!(start + len, total - 8);
+        // Total bytes pulled must be strictly less than the file
+        // (proves we're not materializing the row groups).
+        let pulled: u64 = ranges.iter().map(|(_, l)| *l).sum();
+        assert!(pulled < total, "pulled {pulled} of {total}");
     }
 }

--- a/src/superfile/lazy_source.rs
+++ b/src/superfile/lazy_source.rs
@@ -21,16 +21,18 @@
 //! broadcaster that fans one fetch out to many
 //! subscribers).
 //!
-//! What it doesn't do *yet*: fetch only the bytes a
-//! specific BM25 / vector query touches. The inner FTS
-//! posting reader + vector cluster reader still take a
-//! full materialized buffer, so each `open_lazy` call
-//! still pulls the whole segment regardless of which
-//! queries will run against the resulting reader. Making
-//! per-query laziness work needs those inner readers to
-//! thread the source through their own lookups — the trait
-//! shape here is what makes that change source-compatible
-//! when it lands.
+//! Per-query laziness — fetch only the bytes a specific
+//! BM25 / vector query touches — is rolled out a subsystem
+//! at a time. PR1 of plan 013 lands the vector half:
+//! `VectorReader::open_with_source` parses just the per-
+//! column sub-header + Sq8 codec-meta region on the lazy
+//! path, instead of materializing whole subsections. The
+//! supertable layer composes a parent `LazyByteSource`
+//! (over the segment) with [`SubLazyByteSource`] to scope
+//! the view to the vector blob's byte window before
+//! handing it to `VectorReader::open_with_source` — so the
+//! inner reader stays oblivious to where in the file its
+//! blob lives. The FTS half follows in plan-013 PR4.
 //!
 //! See [`SuperfileReader::open_lazy`].
 //!
@@ -38,6 +40,8 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use std::ops::Range;
+use std::sync::Arc;
 
 /// Source of byte ranges from an arbitrary backing.
 ///
@@ -149,6 +153,249 @@ impl LazyByteSource for BytesLazyByteSource {
     }
 }
 
+/// Window over a parent [`LazyByteSource`]. `range(s, l)`
+/// translates to `parent.range(offset + s, l)` and
+/// `try_get_range_sync(s, l)` to the same on the sync path.
+///
+/// Used by `SuperfileReader::open_lazy_with` to hand each
+/// sub-blob (FTS, vector) a [`LazyByteSource`] view scoped to
+/// its byte region inside the parent segment, without the
+/// sub-readers having to know about the supertable layer's
+/// offset arithmetic. Composing this with a counting source
+/// in tests also lets us assert per-blob byte / range budgets
+/// directly.
+///
+/// Out-of-bounds inside the window surfaces as
+/// [`LazyByteSourceError::OutOfBounds`] with the *window's*
+/// size (`length`), not the parent's, so error messages
+/// reflect the sub-reader's view.
+#[derive(Clone)]
+pub struct SubLazyByteSource {
+    parent: Arc<dyn LazyByteSource>,
+    offset: u64,
+    length: u64,
+}
+
+impl std::fmt::Debug for SubLazyByteSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubLazyByteSource")
+            .field("offset", &self.offset)
+            .field("length", &self.length)
+            .finish()
+    }
+}
+
+impl SubLazyByteSource {
+    /// Build a window `[offset, offset + length)` over
+    /// `parent`. The window must fit inside the parent's
+    /// `size()`; this is enforced at construction so callers
+    /// see a typed error up-front instead of at the first
+    /// `range()`.
+    pub fn new(
+        parent: Arc<dyn LazyByteSource>,
+        offset: u64,
+        length: u64,
+    ) -> Result<Self, LazyByteSourceError> {
+        let parent_size = parent.size();
+        if offset.saturating_add(length) > parent_size {
+            return Err(LazyByteSourceError::OutOfBounds {
+                start: offset,
+                len: length,
+                size: parent_size,
+            });
+        }
+        Ok(Self {
+            parent,
+            offset,
+            length,
+        })
+    }
+}
+
+#[async_trait]
+impl LazyByteSource for SubLazyByteSource {
+    fn size(&self) -> u64 {
+        self.length
+    }
+
+    async fn range(&self, start: u64, len: u64) -> Result<Bytes, LazyByteSourceError> {
+        if start.checked_add(len).is_none_or(|end| end > self.length) {
+            return Err(LazyByteSourceError::OutOfBounds {
+                start,
+                len,
+                size: self.length,
+            });
+        }
+        self.parent.range(self.offset + start, len).await
+    }
+
+    fn try_get_range_sync(&self, start: u64, len: u64) -> Option<Bytes> {
+        if start.checked_add(len).is_none_or(|end| end > self.length) {
+            return None;
+        }
+        self.parent.try_get_range_sync(self.offset + start, len)
+    }
+}
+
+/// Polymorphic byte source for the structural decode path of
+/// every reader in `superfile::*` (vector, FTS, supertable
+/// top-level). Two variants:
+///
+/// - [`Source::InMemory`] — caller already materialised the
+///   bytes. Every fetch is a zero-copy [`Bytes::slice`].
+///   Sync `try_get_range_sync` always succeeds for in-bounds
+///   ranges; `get_range` resolves on the same fast path.
+/// - [`Source::Lazy`] — a [`LazyByteSource`] behind an
+///   `Arc`. Production impls today: mmap-backed
+///   [`BytesLazyByteSource`] (zero-copy sync via
+///   `try_get_range_sync`), `StorageRangeSource` (cold
+///   range-GETs against an object store), or a future
+///   broadcast / coalescing source.
+///
+/// Both variants expose **sync-only** byte access — every
+/// public surface in `src/` is sync. The async
+/// [`LazyByteSource::range`] is hidden behind
+/// [`Source::get_range`]'s `block_in_place + Handle::block_on`
+/// / one-shot `current_thread` `Runtime` bridge, the same
+/// pattern the supertable's `superfile_reader` uses for its
+/// disk-cache fetch path.
+///
+/// Hot-path callers (`Source::InMemory`, mmap-backed
+/// `BytesLazyByteSource`) never hit the bridge — both
+/// override [`LazyByteSource::try_get_range_sync`] to
+/// return zero-copy slices, so [`Source::get_range`]
+/// resolves on the sync fast path.
+///
+/// `Source: Clone` so `Arc`-shared instances can be handed
+/// to multiple readers / supertable segments without
+/// forking the underlying state. `Lazy` clones the `Arc`;
+/// `InMemory` clones the `Bytes` (refcount bump only, no
+/// allocation).
+///
+/// Lives in `superfile::lazy_source` (cross-reader) rather
+/// than under any one reader because it's the *shared*
+/// open-time + search-time byte-fetch abstraction across
+/// the whole superfile stack. Vector landed it first
+/// (013 prerequisite); FTS adopts it in 013 PR4.
+#[derive(Clone)]
+pub enum Source {
+    InMemory(Bytes),
+    Lazy(Arc<dyn LazyByteSource>),
+}
+
+impl std::fmt::Debug for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InMemory(b) => f.debug_tuple("InMemory").field(&b.len()).finish(),
+            Self::Lazy(_) => f.debug_struct("Lazy").finish_non_exhaustive(),
+        }
+    }
+}
+
+impl Source {
+    /// Total backing size in bytes — matches what a single
+    /// `get_range(0..len())` would cover.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::InMemory(b) => b.len(),
+            Self::Lazy(s) => s.size() as usize,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Sync best-effort fetch. Always succeeds on
+    /// `Source::InMemory` (zero-copy `Bytes::slice`); on
+    /// `Source::Lazy` returns `Some` only if the range is
+    /// already resident in the source's in-process cache
+    /// (warm disk cache, mmap-backed `BytesLazyByteSource`,
+    /// etc.).
+    ///
+    /// Returns `None` for out-of-bounds ranges so callers
+    /// can distinguish "not available sync" from a hard
+    /// error; callers that need a typed error should fall
+    /// through to [`Self::get_range`].
+    pub fn try_get_range_sync(&self, range: Range<usize>) -> Option<Bytes> {
+        let start = range.start as u64;
+        let len = range.len() as u64;
+        match self {
+            Self::InMemory(b) => {
+                if range.end > b.len() {
+                    return None;
+                }
+                Some(b.slice(range))
+            }
+            Self::Lazy(s) => s.try_get_range_sync(start, len),
+        }
+    }
+
+    /// Sync range fetch with internal async bridging on
+    /// cold `Source::Lazy` misses.
+    ///
+    /// Fast path: [`Self::try_get_range_sync`] (zero-copy
+    /// `Bytes::slice` on `InMemory`; same on
+    /// `BytesLazyByteSource` / mmap-backed sources). This
+    /// covers every production caller today and every
+    /// hot-path read at default open
+    /// (`Source::Lazy(BytesLazyByteSource over
+    /// Bytes::from_owner(mmap))`).
+    ///
+    /// Cold path (`Source::Lazy` and `try_get_range_sync`
+    /// returned `None`): bridge to the source's
+    /// `async fn range(...)` via
+    /// `block_in_place + Handle::block_on` when there's an
+    /// ambient tokio runtime, or build a throwaway
+    /// `current_thread` `Runtime` when there isn't. Same
+    /// pattern the supertable's `superfile_reader` uses for
+    /// its sync disk-cache fetch path. The runtime-build
+    /// cost on the no-ambient fallback is ≈ 1 ms —
+    /// negligible vs the network round-trip the source is
+    /// about to issue. In production the supertable always
+    /// has an ambient runtime, so the no-ambient branch
+    /// fires only in standalone tests / scripts.
+    ///
+    /// Convention: every public surface in `src/` stays
+    /// sync, async is hidden behind well-defined bridge
+    /// points. `Source::get_range` is one of those bridge
+    /// points.
+    pub fn get_range(&self, range: Range<usize>) -> Result<Bytes, LazyByteSourceError> {
+        if let Some(bytes) = self.try_get_range_sync(range.clone()) {
+            return Ok(bytes);
+        }
+        let Self::Lazy(s) = self else {
+            // `Source::InMemory` always satisfies `try_get_range_sync`
+            // for in-bounds ranges. Reaching this arm means the
+            // request was out of bounds.
+            return Err(LazyByteSourceError::OutOfBounds {
+                start: range.start as u64,
+                len: range.len() as u64,
+                size: self.len() as u64,
+            });
+        };
+        let start = range.start as u64;
+        let len = range.len() as u64;
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(s.range(start, len))),
+            Err(_) => {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| {
+                        LazyByteSourceError::Storage(crate::storage::StorageError::Permanent {
+                            uri: "lazy-source://superfile".to_string(),
+                            source: Box::new(std::io::Error::other(format!(
+                                "tokio runtime build for lazy source fetch: {e}"
+                            ))),
+                        })
+                    })?;
+                rt.block_on(s.range(start, len))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,5 +450,116 @@ mod tests {
         let src = BytesLazyByteSource::new(Bytes::from(vec![0u8; 4]));
         assert!(src.try_get_range_sync(2, 100).is_none());
         assert!(src.try_get_range_sync(100, 0).is_none());
+    }
+
+    /// Counting wrapper used by SubLazyByteSource tests + by
+    /// downstream tests that assert per-blob byte / range
+    /// budgets. Records every `range` / `try_get_range_sync`
+    /// invocation as (start, len).
+    struct CountingLazySource {
+        inner: BytesLazyByteSource,
+        ranges: std::sync::Mutex<Vec<(u64, u64)>>,
+        sync_ranges: std::sync::Mutex<Vec<(u64, u64)>>,
+    }
+
+    impl CountingLazySource {
+        fn new(bytes: Bytes) -> Self {
+            Self {
+                inner: BytesLazyByteSource::new(bytes),
+                ranges: Default::default(),
+                sync_ranges: Default::default(),
+            }
+        }
+        fn ranges(&self) -> Vec<(u64, u64)> {
+            self.ranges.lock().expect("ranges mutex poisoned").clone()
+        }
+        fn sync_ranges(&self) -> Vec<(u64, u64)> {
+            self.sync_ranges
+                .lock()
+                .expect("sync_ranges mutex poisoned")
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl LazyByteSource for CountingLazySource {
+        fn size(&self) -> u64 {
+            self.inner.size()
+        }
+        async fn range(&self, start: u64, len: u64) -> Result<Bytes, LazyByteSourceError> {
+            self.ranges
+                .lock()
+                .expect("ranges mutex poisoned")
+                .push((start, len));
+            self.inner.range(start, len).await
+        }
+        fn try_get_range_sync(&self, start: u64, len: u64) -> Option<Bytes> {
+            self.sync_ranges
+                .lock()
+                .expect("sync_ranges mutex poisoned")
+                .push((start, len));
+            self.inner.try_get_range_sync(start, len)
+        }
+    }
+
+    #[tokio::test]
+    async fn sub_lazy_byte_source_translates_offsets_into_parent() {
+        // Parent payload: 0..32, sub window [10..22) → length 12.
+        let payload = Bytes::from((0u8..32).collect::<Vec<u8>>());
+        let counting = Arc::new(CountingLazySource::new(payload.clone()));
+        let sub = SubLazyByteSource::new(Arc::clone(&counting) as Arc<dyn LazyByteSource>, 10, 12)
+            .expect("sub window in bounds");
+        assert_eq!(sub.size(), 12);
+
+        // range(0, 4) -> parent.range(10, 4) -> bytes 10..14
+        let r0 = sub.range(0, 4).await.expect("sub range start");
+        assert_eq!(r0.as_ref(), &payload[10..14]);
+        // range(8, 4) -> parent.range(18, 4) -> bytes 18..22
+        let r1 = sub.range(8, 4).await.expect("sub range end");
+        assert_eq!(r1.as_ref(), &payload[18..22]);
+
+        // Calls reach the parent at the translated offsets, not the
+        // sub-relative ones.
+        let recorded = counting.ranges();
+        assert_eq!(recorded, vec![(10, 4), (18, 4)]);
+
+        // sync path mirrors the async one — offsets are
+        // translated into the parent's coordinate space, not the
+        // sub-relative ones.
+        let s0 = sub.try_get_range_sync(2, 6).expect("sub sync");
+        assert_eq!(s0.as_ref(), &payload[12..18]);
+        assert_eq!(counting.sync_ranges(), vec![(12, 6)]);
+    }
+
+    #[tokio::test]
+    async fn sub_lazy_byte_source_window_oob_rejected_at_ctor() {
+        let parent = Arc::new(BytesLazyByteSource::new(Bytes::from(vec![0u8; 16])))
+            as Arc<dyn LazyByteSource>;
+        let err = SubLazyByteSource::new(parent, 10, 100).expect_err("window exceeds parent");
+        match err {
+            LazyByteSourceError::OutOfBounds { start, len, size } => {
+                assert_eq!((start, len, size), (10, 100, 16));
+            }
+            other => panic!("expected OutOfBounds, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn sub_lazy_byte_source_range_oob_uses_window_size() {
+        // Sub window is [4..12); a request that fits in the parent
+        // but pokes past the window must error with size = 8 (the
+        // window), not 16 (the parent).
+        let parent = Arc::new(BytesLazyByteSource::new(Bytes::from(vec![0u8; 16])))
+            as Arc<dyn LazyByteSource>;
+        let sub = SubLazyByteSource::new(parent, 4, 8).expect("sub in bounds");
+        let err = sub.range(6, 4).await.expect_err("sub oob");
+        match err {
+            LazyByteSourceError::OutOfBounds { start, len, size } => {
+                assert_eq!((start, len, size), (6, 4, 8));
+            }
+            other => panic!("expected OutOfBounds, got {other:?}"),
+        }
+        // sync path same shape.
+        assert!(sub.try_get_range_sync(6, 4).is_none());
     }
 }

--- a/src/superfile/mod.rs
+++ b/src/superfile/mod.rs
@@ -24,5 +24,7 @@ pub mod reader;
 pub mod vector;
 
 pub use error::{BuildError, FtsError, ReadError, VectorError};
-pub use lazy_source::{BytesLazyByteSource, LazyByteSource, LazyByteSourceError};
+pub use lazy_source::{
+    BytesLazyByteSource, LazyByteSource, LazyByteSourceError, Source, SubLazyByteSource,
+};
 pub use reader::{OpenOptions, SuperfileReader, VectorSearchOptions};

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -10,7 +10,13 @@
 
 use crate::superfile::format::checksum::crc32c;
 use crate::superfile::format::{self};
-use crate::superfile::lazy_source::{LazyByteSource, LazyByteSourceError};
+// Re-export the shared `Source` enum so existing
+// `crate::superfile::vector::reader::Source` import sites
+// (tests, supertable query paths) keep working after 013-A0
+// promoted the enum to `superfile::lazy_source`. New code
+// should prefer the canonical path
+// `crate::superfile::Source`.
+pub use crate::superfile::lazy_source::Source;
 use crate::superfile::vector::distance::{Metric, Sq8Kernel, distance_bytes, distance_bytes_codec};
 use crate::superfile::vector::quant::BitQuantizer;
 use crate::superfile::vector::rerank_codec::RerankCodec;
@@ -22,7 +28,6 @@ use serde::Deserialize;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ops::Range;
-use std::sync::Arc;
 
 const OUTER_HEADER_SIZE: usize = 32;
 const DIR_ENTRY_SIZE: usize = 64;
@@ -128,152 +133,6 @@ pub struct OpenOptions {
 impl Default for OpenOptions {
     fn default() -> Self {
         Self { verify_crc: true }
-    }
-}
-
-/// Backing for a [`VectorReader`].
-///
-/// Two variants, plumbed through every byte-fetch point:
-///
-/// - `InMemory(Bytes)`: caller materialised the full
-///   subsection before opening. Every byte fetch is a
-///   zero-copy `Bytes::slice` against the buffer.
-/// - `Lazy(Arc<dyn LazyByteSource>)`: a range-fetching source
-///   (mmap, object-store range GET, broadcast subscription).
-///   Every byte access in the open + search paths routes
-///   through the same call sites so swapping the backing in
-///   doesn't require a second rewrite.
-///
-/// Both variants expose **sync-only** byte access — every
-/// public surface in `src/` is sync. The
-/// `LazyByteSource::range` trait method is async because
-/// production impls (object store, network sources) are;
-/// [`Source::get_range`] hides that under the same
-/// `block_in_place + Handle::block_on` / one-shot
-/// `current_thread` `Runtime` bridge the supertable's
-/// per-segment reader uses for the disk-cache fetch path.
-/// Hot-path callers (`Source::InMemory`, mmap-backed
-/// `BytesLazyByteSource`) never hit the bridge — both override
-/// `try_get_range_sync` to return zero-copy slices, so
-/// `get_range` resolves on the sync fast path.
-///
-/// `Source: Clone` so `Arc`-shared instances can be handed to
-/// multiple readers / supertable segments without forking the
-/// underlying state. Lazy variant clones the `Arc`; in-memory
-/// clones the `Bytes` (refcount bump).
-#[derive(Clone)]
-pub enum Source {
-    InMemory(Bytes),
-    Lazy(Arc<dyn LazyByteSource>),
-}
-
-impl std::fmt::Debug for Source {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InMemory(b) => f.debug_tuple("InMemory").field(&b.len()).finish(),
-            Self::Lazy(_) => f.debug_struct("Lazy").finish_non_exhaustive(),
-        }
-    }
-}
-
-impl Source {
-    /// Total backing size in bytes — matches what a single
-    /// `get_range(0..len())` would cover.
-    pub fn len(&self) -> usize {
-        match self {
-            Self::InMemory(b) => b.len(),
-            Self::Lazy(s) => s.size() as usize,
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Sync best-effort fetch. Always succeeds on
-    /// `Source::InMemory` (zero-copy `Bytes::slice`); on
-    /// `Source::Lazy` returns `Some` only if the range is
-    /// already resident in the source's in-process cache.
-    ///
-    /// Returns `None` for out-of-bounds ranges so callers can
-    /// distinguish "not available sync" from a hard error;
-    /// callers that need a typed error should fall through to
-    /// [`Self::get_range`].
-    pub fn try_get_range_sync(&self, range: Range<usize>) -> Option<Bytes> {
-        let start = range.start as u64;
-        let len = range.len() as u64;
-        match self {
-            Self::InMemory(b) => {
-                if range.end > b.len() {
-                    return None;
-                }
-                Some(b.slice(range))
-            }
-            Self::Lazy(s) => s.try_get_range_sync(start, len),
-        }
-    }
-
-    /// Sync range fetch with internal async bridging on cold
-    /// `Source::Lazy` misses.
-    ///
-    /// Fast path: `try_get_range_sync` (zero-copy `Bytes::slice`
-    /// on `InMemory`; same on `BytesLazyByteSource` / mmap-
-    /// backed sources). This covers every production caller
-    /// today and every hot-path read at default open
-    /// (`Source::Lazy(BytesLazyByteSource over
-    /// Bytes::from_owner(mmap))`).
-    ///
-    /// Cold path (`Source::Lazy` and `try_get_range_sync`
-    /// returned `None`): bridge to the source's `async fn
-    /// range(...)` via `block_in_place + Handle::block_on`
-    /// when there's an ambient tokio runtime, or build a
-    /// throwaway `current_thread` `Runtime` when there isn't.
-    /// This is the same pattern `supertable::query::
-    /// segment_reader` uses for its sync disk-cache fetch path
-    /// (see `segment_reader::segment_reader` for the canonical
-    /// reference). The runtime-build cost on the no-ambient
-    /// fallback is ≈ 1 ms — negligible vs the network
-    /// round-trip the source is about to issue. In production
-    /// the supertable always has an ambient runtime, so the
-    /// no-ambient branch fires only in standalone tests /
-    /// scripts.
-    ///
-    /// Convention: every public surface in `src/` stays sync,
-    /// async is hidden behind well-defined bridge points.
-    /// `Source::get_range` is one of those bridge points.
-    pub fn get_range(&self, range: Range<usize>) -> Result<Bytes, LazyByteSourceError> {
-        if let Some(bytes) = self.try_get_range_sync(range.clone()) {
-            return Ok(bytes);
-        }
-        let Self::Lazy(s) = self else {
-            // `Source::InMemory` always satisfies `try_get_range_sync`
-            // for in-bounds ranges. Reaching this arm means the
-            // request was out of bounds.
-            return Err(LazyByteSourceError::OutOfBounds {
-                start: range.start as u64,
-                len: range.len() as u64,
-                size: self.len() as u64,
-            });
-        };
-        let start = range.start as u64;
-        let len = range.len() as u64;
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(s.range(start, len))),
-            Err(_) => {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|e| {
-                        LazyByteSourceError::Storage(crate::storage::StorageError::Permanent {
-                            uri: "lazy-source://vector-reader".to_string(),
-                            source: Box::new(std::io::Error::other(format!(
-                                "tokio runtime build for lazy source fetch: {e}"
-                            ))),
-                        })
-                    })?;
-                rt.block_on(s.range(start, len))
-            }
-        }
     }
 }
 
@@ -1260,7 +1119,9 @@ fn fetch_sync(source: &Source, range: Range<usize>, what: &str) -> Result<Bytes,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::superfile::lazy_source::{LazyByteSource, LazyByteSourceError};
     use crate::superfile::vector::builder::{VectorBuilder, VectorConfig};
+    use std::sync::Arc;
 
     fn build_blob(n_docs: u32, dim: usize, n_cent: usize, metric: Metric) -> (Bytes, String) {
         let mut b = VectorBuilder::new();
@@ -2460,7 +2321,7 @@ mod tests {
     // disabled) — exposes any silent fallthrough that would
     // bypass the block_on bridge.
 
-    use crate::superfile::lazy_source::{BytesLazyByteSource, LazyByteSource, LazyByteSourceError};
+    use crate::superfile::lazy_source::BytesLazyByteSource;
     use std::sync::Arc as StdArc;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
 


### PR DESCRIPTION
Sets up the shared byte-source substrate for the upcoming object-store work.

- Source enum promoted from vector::reader to lazy_source. It's been the shared open-time + search-time byte-fetch abstraction since vector landed it; moving it to the cross-reader module lets FTS and SuperfileReader adopt it in follow-up PRs without a circular dep. Re-exported at the old path so every existing import keeps compiling.

- SubLazyByteSource — windowed adapter over Arc<dyn LazyByteSource>. Translates (start, len) into the parent's coordinate space and passes try_get_range_sync straight through so warm-cache / mmap-backed sources stay zero-copy. Vector subsection reader uses this in the next PR to carve a sub-source over one subsection without fetching the whole thing; FTS adopts the same pattern.

- format::footer::read_footer_lazy — fetches the Parquet footer + KV map from a LazyByteSource in exactly 2 range GETs (8-byte trailer + footer body). Returns the same (KvMap, Arc<Schema>) pair as the eager read_kv_metadata. This is the entry point SuperfileReader::open_lazy_with and the per-subsection sub-source carve-outs all call before any blob-region decode.