### PR TITLE
vector/distance: gate x86_64-only test helpers so make ci passes on aarch64

### DIFF
--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -1010,6 +1010,7 @@ mod tests {
     /// Generate a pseudo-random `f32` vector. Deterministic — uses the
     /// same monotone-noise pattern as the planted-cluster test fixtures
     /// elsewhere in this file so failures are reproducible.
+    #[cfg(target_arch = "x86_64")]
     fn fake_vec(dim: usize, seed: u32) -> Vec<f32> {
         (0..dim)
             .map(|i| {
@@ -1367,6 +1368,7 @@ mod tests {
     /// Compiler will autovectorize this on most x86_64 targets but
     /// the scalar source is what we measure, so the result is
     /// representative of "what you get with no hand-tuned SIMD".
+    #[cfg(target_arch = "x86_64")]
     fn dot_scalar(a: &[f32], b: &[f32]) -> f32 {
         let mut s = 0.0f32;
         for i in 0..a.len() {
@@ -1376,6 +1378,7 @@ mod tests {
     }
 
     /// Scalar fp32 L2².
+    #[cfg(target_arch = "x86_64")]
     fn l2_sq_scalar(a: &[f32], b: &[f32]) -> f32 {
         let mut s = 0.0f32;
         for i in 0..a.len() {
@@ -1388,6 +1391,7 @@ mod tests {
     /// Scalar Sq8 dot-product kernel core: `Σ q'[d] * code[d]`
     /// after per-lane u8→f32 widening. Used inside `Sq8Kernel::
     /// distance_at`; this is the part the SIMD paths accelerate.
+    #[cfg(target_arch = "x86_64")]
     fn sq8_dot_scalar(q_prime: &[f32], code_bytes: &[u8], dim: usize) -> f32 {
         let mut s = 0.0f32;
         for d in 0..dim {


### PR DESCRIPTION
## Summary

- Adds `#[cfg(target_arch = "x86_64")]` to four test helpers in `superfile/vector/distance.rs` — `fake_vec`, `dot_scalar`, `l2_sq_scalar`, `sq8_dot_scalar`.
- Every call site for these helpers is already inside an `#[cfg(target_arch = "x86_64")]` test or microbench (AVX-512 parity tests, `simd_microbench_all_tiers`). On aarch64 their definitions had no callers, so `cargo clippy --all-targets -- -D warnings` tripped four `dead_code` errors and `make ci` failed before reaching the test or coverage stages.
- Pure cfg-gating — no behavioural change on x86_64, no code path moved.

## Why

`make ci` was red on Apple Silicon / any non-x86_64 host. The helpers were introduced in #24 alongside the SIMD fast paths; the callers carry the cfg gate but the helper bodies didn't, so the platform that hosts the tests is also the only platform that compiles them — except `cargo clippy` checks every cfg in the workspace and flags the orphans.

## Test plan

- [x] `make ci` passes on aarch64 (Apple Silicon): fmt-check ✓, clippy `-D warnings` ✓, full test suite 685 passing, coverage gate ✓.
- [x] CI re-runs the gate on its build host to confirm parity.