### PR TITLE
[1/n] improv superfile id_lookup: only read id rows from parquet

### DIFF
--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -24,6 +24,7 @@ use crate::superfile::vector::reader::VectorReader;
 use arrow_array::Decimal128Array;
 use arrow_schema::Schema;
 use bytes::Bytes;
+use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use std::sync::Arc;
 
@@ -294,7 +295,10 @@ impl SuperfileReader {
     pub fn id_lookup(&self, target: i128) -> Result<Option<u32>, ReadError> {
         let builder = ParquetRecordBatchReaderBuilder::try_new(self.bytes.clone())
             .map_err(|e| ReadError::Footer(footer::FooterError::Parquet(e)))?;
+        // _id is always at index 0
+        let descriptor = builder.parquet_schema().clone();
         let reader = builder
+            .with_projection(ProjectionMask::leaves(&descriptor, vec![0]))
             .build()
             .map_err(|e| ReadError::Footer(footer::FooterError::Parquet(e)))?;
 
@@ -681,6 +685,19 @@ mod tests {
         assert_eq!(s.fields().len(), 2);
         assert_eq!(s.field(0).name(), "doc_id");
         assert_eq!(s.field(1).name(), "title");
+    }
+
+    #[test]
+    fn id_lookup_returns_only_matching_ids() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open superfile");
+        let s = r.id_lookup(10).expect("should return result");
+        assert_eq!(s.expect("should find id"), 0);
+        let s = r.id_lookup(12).expect("should return result");
+        assert_eq!(s.expect("should find id"), 2);
+
+        let s = r.id_lookup(20).expect("should return result");
+        assert!(s.is_none());
     }
 
     #[test]


### PR DESCRIPTION
### What does this PR do?
- Modifies the Paraquet Builder to only read the `_id` field