### PR TITLE
docs: add initial CONTRIBUTING guide and README Development section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to infino
+
+Thanks for your interest in infino. This guide gets you from a fresh
+clone to a green pull request.
+
+## Prerequisites
+
+- **Rust** — install via [rustup](https://www.rust-lang.org/tools/install).
+  You do not need to pick a version: `rust-toolchain.toml` pins the
+  exact stable toolchain and `rustup` installs it automatically the
+  first time you build.
+- **Nightly Rust** — only required for the memory-safety lanes
+  (`make miri`, `make asan`). Install with
+  `rustup toolchain install nightly` and, for miri,
+  `rustup +nightly component add miri`.
+- **cargo-llvm-cov** — only required to run the coverage gate locally:
+  `cargo install cargo-llvm-cov --locked`.
+
+## Build
+
+```bash
+git clone git@github.com:infino-ai/infino.git
+cd infino
+cargo build
+```
+
+## Run the demo
+
+The fastest way to see the whole stack work end to end — a superfile
+built in memory, queried by BM25 and vector kNN, then read back as a
+plain Parquet table:
+
+```bash
+cargo run --example demo
+```
+
+## Test
+
+```bash
+cargo test --workspace        # full suite
+cargo test <name_substring>   # a single test or module
+cargo test bm25_oracle -- --nocapture   # ...with stdout
+```
+
+## Before you open a pull request
+
+Run the same gates CI runs:
+
+```bash
+make ci
+```
+
+`make ci` is `make check` + `make coverage`; it must pass before a PR
+is merged. The individual targets:
+
+| Target | What it does |
+|---|---|
+| `make check` | `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` |
+| `make test` | `cargo test` (full suite) |
+| `make ci` | `check` + `coverage` — the pre-PR gate |
+| `make coverage` | `cargo llvm-cov --summary-only` (≥90% overall) |
+| `make bench` / `make bench-quick` | criterion benches (`bench-quick` for a fast pass) |
+| `make miri` | language-level UB detection on the FTS surface (nightly) |
+| `make asan` | LLVM AddressSanitizer on the FTS surface (nightly) |
+
+If your change touches any `unsafe` code, also run `make miri` and
+`make asan`.
+
+## Code conventions
+
+- **No `.unwrap()`.** The crate is `#![deny(clippy::unwrap_used)]`
+  crate-wide (reasserted in `tests/` and `benches/`). Use `?` to
+  propagate, or `.expect("invariant: ...")` on paths that are
+  infallible by construction. Tests and benches use
+  `.expect("description")`.
+- **Match the surrounding code** — naming, comment density, and idiom.
+- Source comments document the *what*; keep them focused and accurate.
+
+## Workflow
+
+1. Fork the repository and create a branch off `main`.
+2. Make your change with tests — we do not merge code without tests.
+3. Run `make ci` until it is green.
+4. Open a pull request against `main`; CI runs the same gates.
+
+For the design rationale behind a subsystem, read the architecture
+references in [`docs/architecture/`](docs/architecture/) —
+[`superfile.md`](docs/architecture/superfile.md) (the on-disk format
+and single-file reader/builder) and
+[`supertable.md`](docs/architecture/supertable.md) (the in-memory
+cross-segment query and manifest layer).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ let hits = vector_search(&reader, "embedding", &query, 10,
 // with DataFusion / DuckDB / pyarrow and treat as a regular table.
 ```
 
+## Development
+
+```bash
+git clone git@github.com:infino-ai/infino.git
+cd infino
+cargo build
+cargo run --example demo   # end-to-end tour: build, BM25 + vector search, read back as Parquet
+```
+
+The toolchain is pinned by `rust-toolchain.toml`, so `rustup` installs
+the right stable Rust on first build. Run `cargo test --workspace` for
+the suite and `make ci` before opening a pull request. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
+
 ## Performance
 
 Absolute runtime numbers come from the in-tree criterion harness


### PR DESCRIPTION
### What does this PR do?

Adds a getting-started path for new contributors:

  - **`CONTRIBUTING.md`**: clone, build, run the demo, test, the `make ci` pre-PR gate, and the fork → PR workflow in one place.
  - README **"Development" section**:  the first few commands to type, linking to the full guide.

### Why do we need this change?
- The README jumped straight to the Rust API with no clone/build/run steps, so a new engineer had no clear way to get the project running. This gives them one.
- All documented commands were verified against a fresh build.


Docs only, no code changes.
