### PR TITLE
bench/supertable-update: correctly update using mutation counter across criterion calls

### DIFF
--- a/benches/supertable_update/main.rs
+++ b/benches/supertable_update/main.rs
@@ -129,12 +129,18 @@ fn bench_deletes(c: &mut Criterion) {
     });
     g.finish();
 
-    // Delete shrinks the table: the reused supertable must have
-    // fewer rows than the baseline — guards against a regression
-    // where deletes silently match nothing.
-    assert!(
-        count_rows(&st) < n as i64,
-        "deletes left the row count at the baseline {n} — nothing was removed"
+    // Exact end-state: each of the `i` delete attempts removed a
+    // distinct row while one was still present, so exactly
+    // `min(i, n)` rows are gone and `n - min(i, n)` remain. Asserting
+    // the exact count (not just `< n`) catches both under- and
+    // over-deletion — e.g. a predicate that silently matched nothing
+    // or matched more than one row.
+    let expected = (n as u64).saturating_sub(i) as i64;
+    assert_eq!(
+        count_rows(&st),
+        expected,
+        "after {i} single-row deletes over an {n}-row table, \
+         expected {expected} rows to remain"
     );
 }
 

--- a/benches/supertable_update/main.rs
+++ b/benches/supertable_update/main.rs
@@ -7,8 +7,9 @@
 //! - **Mutation throughput** — updates/sec + deletes/sec
 //!   measured over the full WAL pipeline (resolve + append +
 //!   tombstone + state-doc CAS + cleanup).
-//! - **End-state correctness** — a closing query asserts the
-//!   row count + presence/absence shape the bench expects.
+//! - **End-state correctness** — a closing assertion checks the
+//!   row-count invariant each mutation implies: updates preserve
+//!   the count, deletes shrink it.
 //!
 //! Defaults are sized so the bench runs in seconds on a
 //! developer laptop. Larger sizes are gated behind env vars
@@ -65,6 +66,19 @@ fn build_supertable_with_ingest(n: usize) -> (TempDir, Supertable) {
     (dir, st)
 }
 
+/// Total live row count via SQL `COUNT(*)`.
+fn count_rows(st: &Supertable) -> i64 {
+    let batches = st
+        .query_sql("SELECT COUNT(*) AS n FROM supertable")
+        .expect("sql");
+    batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow_array::Int64Array>()
+        .expect("count column")
+        .value(0)
+}
+
 // ─── Bench: ingest ───────────────────────────────────────────────────
 
 fn bench_ingest(c: &mut Criterion) {
@@ -88,46 +102,39 @@ fn bench_deletes(c: &mut Criterion) {
     let mut g = c.benchmark_group("supertable_update_delete");
     g.sample_size(10);
     g.throughput(Throughput::Elements(m as u64));
+    // `i` lives outside the bench closure on purpose: criterion calls
+    // that closure several times (estimate, warm-up, measurement), and
+    // the deletes mutate the one reused supertable. A counter reset to
+    // 0 on a later invocation would re-target already-tombstoned rows
+    // and silently no-op, so it must run monotonically across them.
+    let mut i: u64 = 0;
     g.bench_function("single_row_predicate_deletes", |b| {
-        // Each iteration buffers `m` deletes + one `commit()`
-        // to drive them all through the WAL pipeline.
-        // Criterion times the whole batch and divides by `m`
-        // via Throughput.
+        // Delete distinct rows by predicate, one `commit()` per delete,
+        // against a single reused supertable — no per-iteration
+        // rebuild. Each delete targets a fresh, still-present row
+        // (`row{i:08}`). Unlike the update chain a delete is terminal,
+        // so this consumes the corpus: the `n`-row pool bounds how many
+        // deletes a run can make before predicates start matching
+        // nothing (ample at the scale-out sizes).
         b.iter(|| {
-            let mut w = st.writer().expect("writer");
-            for i in 0..m {
+            for _ in 0..m {
+                let mut w = st.writer().expect("writer");
                 let title = format!("row{i:08}");
-                let pending = w
-                    .delete(col("title").eq(lit(title.clone())))
-                    .expect("delete");
+                let pending = w.delete(col("title").eq(lit(title))).expect("delete");
                 black_box(pending);
+                black_box(w.commit().expect("commit"));
+                i += 1;
             }
-            let result = w.commit().expect("commit");
-            black_box(result);
-            drop(w);
         });
     });
     g.finish();
 
-    // End-state correctness check: after this group runs, the
-    // first `m` rows should be gone.
-    let batches = st
-        .query_sql("SELECT COUNT(*) AS n FROM supertable")
-        .expect("sql");
-    let total = batches[0]
-        .column(0)
-        .as_any()
-        .downcast_ref::<arrow_array::Int64Array>()
-        .expect("count column")
-        .value(0);
-    // The bench may run multiple iterations; we only assert the
-    // count never exceeds the baseline (no extra rows
-    // appeared) and is below the baseline by at least m on
-    // the first iteration. Use ≤ baseline to stay
-    // iteration-count agnostic.
+    // Delete shrinks the table: the reused supertable must have
+    // fewer rows than the baseline — guards against a regression
+    // where deletes silently match nothing.
     assert!(
-        total <= n as i64,
-        "row count {total} exceeded baseline {n} — mutations leaked rows"
+        count_rows(&st) < n as i64,
+        "deletes left the row count at the baseline {n} — nothing was removed"
     );
 }
 
@@ -138,26 +145,59 @@ fn bench_updates(c: &mut Criterion) {
     let m = n_mutations();
     let (_dir, st) = build_supertable_with_ingest(n);
 
+    // Seed the single row this bench rewrites, at generation 0. It
+    // sits alongside the `n`-row corpus, so each update's predicate
+    // still resolves against a realistically-sized table.
+    {
+        let mut w = st.writer().expect("writer");
+        w.append(&build_title_batch(&["target-0"])).expect("append");
+        w.commit().expect("commit");
+    }
+
     let mut g = c.benchmark_group("supertable_update_update");
     g.sample_size(10);
     g.throughput(Throughput::Elements(m as u64));
+    // `i` lives outside the bench closure on purpose: criterion calls
+    // that closure several times (estimate, warm-up, measurement), and
+    // the chain's state lives in the one reused supertable. A counter
+    // reset to 0 on a later invocation would look for `target-0` —
+    // long since rewritten to `target-{N}` — and fail the cardinality
+    // contract with `matched: 0`. It must run monotonically across all
+    // invocations.
+    let mut i: u64 = 0;
     g.bench_function("single_row_predicate_updates", |b| {
+        // Rewrite one row over and over, advancing a generation suffix:
+        // `target-{i}` -> `target-{i+1}`. Each step must `commit()`
+        // before the next, because `update` resolves its predicate
+        // against the *committed* manifest snapshot — the previous
+        // rename has to be durable for the next predicate to match.
+        // The same supertable is reused throughout — no per-iteration
+        // rebuild.
         b.iter(|| {
-            let mut w = st.writer().expect("writer");
-            for i in 0..m {
-                let title = format!("row{i:08}");
-                let replacement = build_title_batch(&[&format!("row{i:08}-prime")]);
+            for _ in 0..m {
+                let mut w = st.writer().expect("writer");
+                let from = format!("target-{i}");
+                let to = format!("target-{}", i + 1);
+                let replacement = build_title_batch(&[&to]);
                 let pending = w
-                    .update(col("title").eq(lit(title.clone())), replacement)
+                    .update(col("title").eq(lit(from)), replacement)
                     .expect("update");
                 black_box(pending);
+                black_box(w.commit().expect("commit"));
+                i += 1;
             }
-            let result = w.commit().expect("commit");
-            black_box(result);
-            drop(w);
         });
     });
     g.finish();
+
+    // Update preserves the row count: the `n`-row corpus plus the
+    // single rewritten target row.
+    assert_eq!(
+        count_rows(&st),
+        (n + 1) as i64,
+        "update changed the row count; expected {}",
+        n + 1
+    );
 }
 
 criterion_group!(benches, bench_ingest, bench_deletes, bench_updates);


### PR DESCRIPTION
## Problem

The `supertable-update` bench panics partway through the `single_row_predicate_updates` group:

```
thread 'main' panicked at benches/supertable_update/main.rs:
update: CardinalityMismatch { matched: 0, new_rows: 1 }
```

## Original root cause

The bench updated `row{i}` → `row{i}-prime` against a **single shared supertable** inside `b.iter`. Criterion runs that closure many times (warm-up + measurement). The first run renames the matched rows to `…-prime`; every subsequent run replays the same predicate `row{i}`, which now matches **zero** rows — so `update` fails its cardinality contract (`matched: 0, new_rows: 1`) and panics. (The delete group had the same shape but didn't panic — a delete that matches nothing is a tolerated no-op, so it silently measured empty commits after the first run.)

In short: the mutation was destructive to its own match set, but the bench replayed an identical, now-stale predicate on every iteration.

## Fix

Rework both mutation benches to advance a **generation counter** against a reused supertable, so each iteration targets a fresh, still-present row:

- updates roll one row's title forward — `target-{i}` → `target-{i+1}`
- deletes consume distinct rows — `row{i:08}`

Each step commits, because `update` resolves its predicate against the **committed** manifest snapshot (an uncommitted rename isn't visible to the next predicate).

### Subtlety hit while implementing the fix

With the rolling counter, the panic initially persisted — because the counter `i` was declared **inside** the `|b|` closure. Criterion invokes that closure multiple times (estimate → warm-up → measurement) while the chain's state lives in the reused supertable, so on a later invocation `i` reset to `0` and the first update looked for `target-0` — long since rewritten — reproducing `matched: 0`. The counter is therefore hoisted **out** of the closure so it runs monotonically across every invocation.

Also adds a row-count invariant to each bench (update preserves the count; delete shrinks it) to guard against a future regression where mutations silently match nothing.

## Verification

Ran the bench exactly as the nightly does — `cargo bench --bench supertable-update`, default scale (10k docs / 20 mutations), default criterion timing. All three groups now complete, no panic:

| group | time | throughput |
|---|---|---|
| ingest | 6.63 ms | 1.51 M elem/s |
| delete | 29.5 ms | 678 elem/s |
| update | 1.24 s | 16 elem/s |

`cargo fmt --check` and `cargo clippy --bench supertable-update` are clean.

### Known follow-up (not addressed here)

The update group is slow (~16 elem/s) because the reuse-chain mints a new superfile per update and never compacts, so predicate resolution rescans a set that grows across the sampled iterations — the reported number trends slower the longer criterion samples. Worth a separate pass to make it a steady-state metric.
