### PR TITLE
runtime: consolidate sync→async bridging into one bridge + runtime

### DIFF
--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -18,21 +18,12 @@
 //!   bridge; a current-thread runtime serializes that and can't be
 //!   `block_in_place`d. Building one per call also pays a setup cost.
 //! - **Not `multi_thread` with N workers** — the work is await/IO-bound
-//!   (CPU work lives on rayon), so extra OS threads buy nothing.
+//!   (CPU work lives on rayon), so extra OS threads buy nothing. Parallel
+//!   GETs aren't worker-bound anyway: they run on the reactor (remote) or
+//!   the blocking pool (local), with the worker only polling them.
 //! - **`multi_thread` + 1 worker** — a real runtime (so `spawn` and
 //!   `block_in_place` are legal and tasks make progress) at one thread
 //!   of overhead. Revisit only if a CPU-bound async path appears.
-//!
-//! One worker does **not** serialize parallel I/O. A `join_all` over N
-//! storage GETs is single-task *concurrency*, not multi-thread
-//! parallelism — it polls all N futures on one task and never fans them
-//! across workers (no `spawn`), so worker count is irrelevant to it. The
-//! actual GET parallelism lives below the worker pool and is unbounded
-//! by it: `object_store`'s remote backends are reactor-async (one worker
-//! drives many in-flight requests), and the local backend offloads reads
-//! to `spawn_blocking` (the separate blocking-thread pool). The single
-//! worker only bottlenecks CPU-bound *spawned* async tasks — which is
-//! why CPU work stays on rayon.
 //!
 //! ## Two modes
 //!

--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -4,26 +4,8 @@
 //! tombstone-cache refresh, lazy byte-source range fetches) is sync,
 //! but the storage trait + downstream object_store calls are async.
 //! **Every** call site that crosses that boundary routes through
-//! [`bridge_sync_to_async`] — there is exactly one bridge and one
-//! owned runtime, so the policy below holds uniformly.
-//!
-//! ## The owned runtime
-//!
-//! When a sync caller is *not* already inside a tokio runtime, futures
-//! are driven on a single process-wide owned runtime: a `multi_thread`
-//! runtime pinned to **one worker thread**. The flavor is deliberate:
-//!
-//! - **Not `current_thread`** — storage work fans out (parallel range
-//!   GETs, multi-segment query, `spawn`ed tasks) and may re-enter the
-//!   bridge; a current-thread runtime serializes that and can't be
-//!   `block_in_place`d. Building one per call also pays a setup cost.
-//! - **Not `multi_thread` with N workers** — the work is await/IO-bound
-//!   (CPU work lives on rayon), so extra OS threads buy nothing. Parallel
-//!   GETs aren't worker-bound anyway: they run on the reactor (remote) or
-//!   the blocking pool (local), with the worker only polling them.
-//! - **`multi_thread` + 1 worker** — a real runtime (so `spawn` and
-//!   `block_in_place` are legal and tasks make progress) at one thread
-//!   of overhead. Revisit only if a CPU-bound async path appears.
+//! [`bridge_sync_to_async`] — there is exactly one bridge, so the
+//! policy below holds uniformly.
 //!
 //! ## Two modes
 //!
@@ -31,56 +13,83 @@
 //!   tells the scheduler "I'm about to block this worker; rearrange,"
 //!   then `Handle::block_on` drives the future on the current thread.
 //!   Sibling workers keep making progress.
-//! - **No ambient runtime** — drive on the owned runtime. Sync callers
-//!   (CLI tools, rayon workers, Python bindings via PyO3) land here.
+//! - **No ambient runtime** — drive on a per-thread owned runtime (see
+//!   below). Sync callers (CLI tools, rayon reader/writer pool threads,
+//!   Python bindings via PyO3) land here.
 //!
-//! ## Unsupported: `current_thread` ambient runtime
+//! ## The owned runtime: thread-local `current_thread`
 //!
-//! `tokio::task::block_in_place` requires `multi_thread`. If a caller
-//! invokes this from inside a `current_thread` tokio runtime,
-//! `Handle::try_current()` returns `Ok(...)`, we take the
-//! `block_in_place` branch, and tokio panics. tokio exposes no clean
-//! way to detect a current-thread handle, so this stays a documented
-//! requirement: async callers must run on a `multi_thread` runtime
-//! (the default for `#[tokio::main]`, axum, actix, etc.). Lifting it
-//! requires offloading the future to the owned runtime via `spawn`,
-//! which needs `Send + 'static` futures — deferred to the async-core
-//! work, where the futures get reshaped anyway.
-
-use std::sync::OnceLock;
+//! Each thread that reaches the no-ambient path lazily builds and
+//! caches its **own `current_thread`** runtime in a `thread_local!`,
+//! reused for every later bridged call on that thread. Two properties
+//! matter:
+//!
+//! - **`current_thread`, not `multi_thread`.** The bridged work is a
+//!   short async drive (load N manifest parts, fetch a byte range, run
+//!   a commit) on the *calling* thread. A `current_thread` runtime polls
+//!   it inline — no worker thread, no cross-thread scheduler hand-off.
+//!   A `multi_thread` runtime's `block_on` adds per-poll coordination
+//!   with its worker that, on these sub-millisecond reads, measured
+//!   **+6–17%** on multi-term FTS search at 10M docs (the cost grows
+//!   with the per-query async work, e.g. the `join_all` over kept manifest
+//!   parts). Storage fan-out doesn't need worker threads anyway —
+//!   concurrent `join_all` GETs run on the reactor (remote) or the
+//!   blocking pool (local), neither bounded by the runtime's worker count.
+//! - **Thread-local, not shared.** A `current_thread` runtime can't be
+//!   driven by concurrent `block_on` calls from multiple threads, and
+//!   the reader pool calls the bridge from many rayon threads at once.
+//!   One runtime per thread keeps them independent (no shared-worker
+//!   contention) and amortizes the build cost across that thread's
+//!   calls — so this is not the per-call runtime construction the bridge
+//!   exists to avoid.
+//!
+//! ## Unsupported: re-entrancy and `current_thread` ambient runtimes
+//!
+//! `tokio::task::block_in_place` requires `multi_thread`. Two
+//! consequences, both documented requirements rather than handled cases:
+//!
+//! - A bridged future must **not synchronously re-enter the bridge** on
+//!   the same thread: inside `block_on`, `Handle::try_current()` returns
+//!   `Ok(...)`, so the nested call takes the `block_in_place` branch and
+//!   tokio panics (the owned runtime is `current_thread`). No current
+//!   path nests — the bridged futures are async all the way down.
+//! - Calling the sync API from inside a **`current_thread` ambient**
+//!   runtime panics for the same reason. Async callers must run on a
+//!   `multi_thread` runtime (the default for `#[tokio::main]`, axum,
+//!   actix, etc.) or wrap the call in `spawn_blocking`.
 
 use tokio::runtime::Runtime;
 
-/// The single process-wide runtime that drives infino's async I/O when
-/// a sync caller is not already inside a tokio runtime. See the module
-/// docs for why it's `multi_thread` pinned to one worker.
-fn owned_runtime() -> &'static Runtime {
-    static RT: OnceLock<Runtime> = OnceLock::new();
-    RT.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .enable_all()
-            .thread_name("supertable-bridge")
-            .build()
-            .expect(
-                "invariant: tokio Runtime build only fails on \
-                 catastrophic OS resource exhaustion",
-            )
-    })
+thread_local! {
+    /// Per-thread `current_thread` runtime for the no-ambient path,
+    /// built on first use and reused for the thread's lifetime. See the
+    /// module docs for why it's thread-local `current_thread`.
+    static OWNED_RT: Runtime = new_owned_runtime();
+}
+
+fn new_owned_runtime() -> Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect(
+            "invariant: tokio current_thread Runtime build only fails on \
+             catastrophic OS resource exhaustion",
+        )
 }
 
 /// Drive `fut` to completion from a sync context. Uses the ambient
 /// tokio runtime if present (via `block_in_place + Handle::block_on`),
-/// otherwise the process-wide owned runtime.
+/// otherwise this thread's owned `current_thread` runtime.
 ///
-/// Panics if called from inside a `current_thread` tokio runtime
-/// (`block_in_place` requires `multi_thread`). See the module docs.
+/// Panics if called from inside a `current_thread` tokio runtime, or if
+/// a bridged future synchronously re-enters the bridge on the same
+/// thread (`block_in_place` requires `multi_thread`). See the module docs.
 pub(crate) fn bridge_sync_to_async<F, T>(fut: F) -> T
 where
     F: std::future::Future<Output = T>,
 {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => tokio::task::block_in_place(|| handle.block_on(fut)),
-        Err(_) => owned_runtime().block_on(fut),
+        Err(_) => OWNED_RT.with(|rt| rt.block_on(fut)),
     }
 }

--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -1,55 +1,83 @@
-//! Sync→async bridge for sync public API on top of async storage.
+//! Sync→async bridge for the sync public API on top of async storage.
 //!
 //! The supertable's public surface (writer.commit, reader queries,
 //! tombstone-cache refresh, lazy byte-source range fetches) is sync,
 //! but the storage trait + downstream object_store calls are async.
-//! Every call site that crosses that boundary lands here.
+//! **Every** call site that crosses that boundary routes through
+//! [`bridge_sync_to_async`] — there is exactly one bridge and one
+//! owned runtime, so the policy below holds uniformly.
+//!
+//! ## The owned runtime
+//!
+//! When a sync caller is *not* already inside a tokio runtime, futures
+//! are driven on a single process-wide owned runtime: a `multi_thread`
+//! runtime pinned to **one worker thread**. The flavor is deliberate:
+//!
+//! - **Not `current_thread`** — storage work fans out (parallel range
+//!   GETs, multi-segment query, `spawn`ed tasks) and may re-enter the
+//!   bridge; a current-thread runtime serializes that and can't be
+//!   `block_in_place`d. Building one per call also pays a setup cost.
+//! - **Not `multi_thread` with N workers** — the work is await/IO-bound
+//!   (CPU work lives on rayon), so extra OS threads buy nothing.
+//! - **`multi_thread` + 1 worker** — a real runtime (so `spawn` and
+//!   `block_in_place` are legal and tasks make progress) at one thread
+//!   of overhead. Revisit only if a CPU-bound async path appears.
 //!
 //! ## Two modes
 //!
-//! - **Ambient `multi_thread` tokio runtime present** — `block_in_place`
+//! - **Ambient `multi_thread` runtime present** — `block_in_place`
 //!   tells the scheduler "I'm about to block this worker; rearrange,"
 //!   then `Handle::block_on` drives the future on the current thread.
-//!   Other tasks keep making progress on sibling workers.
-//! - **No ambient runtime** — build a one-shot `current_thread` runtime
-//!   and drive the future on it. Sync callers (CLI tools, rayon
-//!   workers, Python bindings via PyO3) land here.
+//!   Sibling workers keep making progress.
+//! - **No ambient runtime** — drive on the owned runtime. Sync callers
+//!   (CLI tools, rayon workers, Python bindings via PyO3) land here.
 //!
 //! ## Unsupported: `current_thread` ambient runtime
 //!
 //! `tokio::task::block_in_place` requires `multi_thread`. If a caller
 //! invokes this from inside a `current_thread` tokio runtime,
 //! `Handle::try_current()` returns `Ok(...)`, we take the
-//! `block_in_place` branch, and tokio panics. There is no good
-//! detection primitive in tokio's public API for "this handle is from
-//! a current_thread runtime"; surfacing a typed error would require
-//! parsing `format!("{handle:?}")` or shipping our own probe. For now
-//! this is a documented requirement: async callers must run on a
-//! `multi_thread` runtime (the default for `#[tokio::main]`, axum,
-//! actix, etc.).
+//! `block_in_place` branch, and tokio panics. tokio exposes no clean
+//! way to detect a current-thread handle, so this stays a documented
+//! requirement: async callers must run on a `multi_thread` runtime
+//! (the default for `#[tokio::main]`, axum, actix, etc.). Lifting it
+//! requires offloading the future to the owned runtime via `spawn`,
+//! which needs `Send + 'static` futures — deferred to the async-core
+//! work, where the futures get reshaped anyway.
+
+use std::sync::OnceLock;
+
+use tokio::runtime::Runtime;
+
+/// The single process-wide runtime that drives infino's async I/O when
+/// a sync caller is not already inside a tokio runtime. See the module
+/// docs for why it's `multi_thread` pinned to one worker.
+fn owned_runtime() -> &'static Runtime {
+    static RT: OnceLock<Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect(
+                "invariant: tokio Runtime build only fails on \
+                 catastrophic OS resource exhaustion",
+            )
+    })
+}
 
 /// Drive `fut` to completion from a sync context. Uses the ambient
 /// tokio runtime if present (via `block_in_place + Handle::block_on`),
-/// otherwise builds a tiny `current_thread` runtime for the call.
+/// otherwise the process-wide owned runtime.
 ///
 /// Panics if called from inside a `current_thread` tokio runtime
-/// (`block_in_place` requires `multi_thread`). See the module-level
-/// docs.
+/// (`block_in_place` requires `multi_thread`). See the module docs.
 pub(crate) fn bridge_sync_to_async<F, T>(fut: F) -> T
 where
     F: std::future::Future<Output = T>,
 {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => tokio::task::block_in_place(|| handle.block_on(fut)),
-        Err(_) => {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect(
-                    "invariant: tokio Runtime build only fails on \
-                     catastrophic OS resource exhaustion",
-                );
-            rt.block_on(fut)
-        }
+        Err(_) => owned_runtime().block_on(fut),
     }
 }

--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -23,6 +23,17 @@
 //!   `block_in_place` are legal and tasks make progress) at one thread
 //!   of overhead. Revisit only if a CPU-bound async path appears.
 //!
+//! One worker does **not** serialize parallel I/O. A `join_all` over N
+//! storage GETs is single-task *concurrency*, not multi-thread
+//! parallelism — it polls all N futures on one task and never fans them
+//! across workers (no `spawn`), so worker count is irrelevant to it. The
+//! actual GET parallelism lives below the worker pool and is unbounded
+//! by it: `object_store`'s remote backends are reactor-async (one worker
+//! drives many in-flight requests), and the local backend offloads reads
+//! to `spawn_blocking` (the separate blocking-thread pool). The single
+//! worker only bottlenecks CPU-bound *spawned* async tasks — which is
+//! why CPU work stays on rayon.
+//!
 //! ## Two modes
 //!
 //! - **Ambient `multi_thread` runtime present** — `block_in_place`

--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -58,6 +58,7 @@ fn owned_runtime() -> &'static Runtime {
         tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .enable_all()
+            .thread_name("supertable-bridge")
             .build()
             .expect(
                 "invariant: tokio Runtime build only fails on \

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -12,10 +12,9 @@
 //! and (via `Drop`) flips it false on release.
 
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
-use tokio::runtime::Runtime;
 
 use super::error::{BuildError, OpenError};
 use super::manifest::Manifest;
@@ -65,14 +64,6 @@ pub(super) struct SupertableInner {
     /// supertable, constructed fresh on `create()` /
     /// `open()` with a 40-bit random worker_id.
     pub(super) id_generator: Mutex<crate::supertable::utils::idgen::IdGenerator>,
-    /// Lazily-initialized tokio Runtime that drives DataFusion
-    /// plans for `query_sql`. Tokio is single-worker here — it
-    /// runs the async I/O state machine, not CPU-bound work
-    /// (that lives on `options.reader_pool`). One Runtime per
-    /// supertable, shared across all SQL queries; allocated on
-    /// first use rather than at `create()` so supertables that
-    /// never run SQL don't pay the runtime cost.
-    pub(super) sql_runtime: OnceLock<Arc<Runtime>>,
     /// Per-process reader-side cache of per-superfile tombstone
     /// bitmaps. `Some` when storage is attached (the cache
     /// fetches sidecars from `superfiles/<id>.tombstones`);
@@ -89,25 +80,6 @@ pub(super) struct SupertableInner {
     /// opens five supertables holds five distinct ids). Minted
     /// via `IdGenerator::next_id()` once at create / open.
     pub(super) handle_id: crate::supertable::wal::state_doc::SupertableHandleId,
-}
-
-impl SupertableInner {
-    /// Get (or lazily build) the SQL Runtime.
-    pub(super) fn sql_runtime(&self) -> Arc<Runtime> {
-        Arc::clone(self.sql_runtime.get_or_init(|| {
-            Arc::new(
-                tokio::runtime::Builder::new_multi_thread()
-                    .worker_threads(1)
-                    .enable_all()
-                    .thread_name("supertable-sql")
-                    .build()
-                    .expect(
-                        "invariant: tokio Runtime build only fails on \
-                         catastrophic OS resource exhaustion",
-                    ),
-            )
-        }))
-    }
 }
 
 impl Supertable {
@@ -127,9 +99,8 @@ impl Supertable {
     ///   shadows existing committed state" footgun.
     ///
     /// Sync API. Internally bridges to async I/O for the
-    /// pointer probe + the open delegation via the same
-    /// `Handle::try_current() + block_in_place` pattern the
-    /// rest of the supertable's sync paths use. Works from
+    /// pointer probe + the open delegation via the shared
+    /// `runtime_bridge::bridge_sync_to_async`. Works from
     /// sync `#[test]` contexts and from multi-thread
     /// `#[tokio::test]` contexts; calling from a
     /// `current_thread` runtime panics (use the async
@@ -173,7 +144,6 @@ impl Supertable {
             manifest: ArcSwap::new(Arc::new(initial)),
             writer_outstanding: AtomicBool::new(false),
             id_generator: Mutex::new(id_generator),
-            sql_runtime: OnceLock::new(),
             tombstone_cache,
             handle_id,
         });
@@ -350,7 +320,6 @@ impl Supertable {
             manifest: ArcSwap::new(Arc::new(manifest)),
             writer_outstanding: AtomicBool::new(false),
             id_generator: Mutex::new(id_generator),
-            sql_runtime: OnceLock::new(),
             tombstone_cache,
             handle_id,
         });
@@ -575,11 +544,7 @@ impl Supertable {
         crate::supertable::wal::recovery::RecoveryReport,
         crate::supertable::wal::recovery::RecoveryError,
     > {
-        let drive = self.run_recovery_sweep_once();
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(drive)),
-            Err(_) => self.inner.sql_runtime().block_on(drive),
-        }
+        bridge_sync_to_async(self.run_recovery_sweep_once())
     }
 
     /// Operator hatch: run one GC sweep over this supertable's
@@ -652,14 +617,6 @@ impl Supertable {
     /// the public API.
     pub(super) fn inner(&self) -> &Arc<SupertableInner> {
         &self.inner
-    }
-
-    /// SQL Runtime accessor, exposed within the crate for the
-    /// `query::sql` module's `block_on`. Lazy: first call
-    /// allocates a single-worker tokio Runtime cached on
-    /// `SupertableInner`; subsequent calls clone the `Arc`.
-    pub(crate) fn sql_runtime(&self) -> Arc<Runtime> {
-        self.inner.sql_runtime()
     }
 }
 

--- a/src/supertable/query/hierarchical_iter.rs
+++ b/src/supertable/query/hierarchical_iter.rs
@@ -16,15 +16,13 @@
 //!      that the existing segment-level skip + fan-out
 //!      code consumes.
 //!
-//! Sync bridge via the same ambient-runtime detection the
-//! writer's `persist_commit` uses (`Handle::try_current` →
-//! `block_in_place + handle.block_on` when in an async
-//! context; `sql_runtime.block_on` otherwise). The query
-//! paths stay sync end-to-end; callers don't acquire any
+//! Sync bridge via the shared `runtime_bridge::bridge_sync_to_async`.
+//! The query paths stay sync end-to-end; callers don't acquire any
 //! runtime knowledge.
 
 use std::sync::Arc;
 
+use crate::runtime_bridge::bridge_sync_to_async;
 use crate::supertable::error::QueryError;
 use crate::supertable::manifest::part::{ManifestPart, PartId};
 use crate::supertable::manifest::{Manifest, SuperfileEntry};
@@ -40,11 +38,8 @@ use crate::supertable::manifest::{Manifest, SuperfileEntry};
 /// parallel so wall-clock is `max(per-part GET latency)`
 /// not the serial sum.
 ///
-/// Sync→async bridge via the standard pattern:
-/// `Handle::try_current` → `block_in_place + handle.block_on`
-/// inside an ambient runtime; build a `new_current_thread`
-/// runtime ad-hoc outside one. Mirrors `superfile_reader`'s
-/// disk-cache bridge.
+/// Sync→async bridge via the shared
+/// [`bridge_sync_to_async`].
 pub fn load_kept_parts(
     manifest: &Manifest,
     kept_part_ids: &[PartId],
@@ -69,18 +64,7 @@ pub fn load_kept_parts(
         Ok::<Vec<Arc<ManifestPart>>, QueryError>(out)
     };
 
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(drive)),
-        Err(_) => {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| {
-                    QueryError::Store(format!("tokio runtime build for hierarchical_iter: {e}"))
-                })?;
-            rt.block_on(drive)
-        }
-    }
+    bridge_sync_to_async(drive)
 }
 
 /// Concatenate the loaded parts' superfiles into a flat

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -69,6 +69,7 @@ use datafusion::datasource::MemTable;
 use datafusion::execution::context::SessionContext;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
+use crate::runtime_bridge::bridge_sync_to_async;
 use crate::supertable::error::QueryError;
 use crate::supertable::handle::Supertable;
 use crate::supertable::manifest::Manifest;
@@ -118,18 +119,10 @@ impl Supertable {
                 .map_err(|e| QueryError::Execute(e.to_string()))
         };
 
-        // M14b: same ambient-runtime detection pattern the
-        // writer's persist_commit uses. Lazy-init the owned
-        // sql_runtime only when there's NO ambient runtime —
-        // calling `Builder::new_multi_thread().build()` from
-        // inside another runtime panics with "Cannot start a
-        // runtime from within a runtime". Web handlers,
-        // `#[tokio::test]`s, and any async caller now get a
-        // working query_sql.
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(drive)),
-            Err(_) => self.sql_runtime().block_on(drive),
-        }
+        // Cross the sync→async boundary through the one shared
+        // bridge: ride the ambient runtime when present, the
+        // process-wide owned runtime otherwise.
+        bridge_sync_to_async(drive)
     }
 
     /// Resolve a predicate to the matching `_id` values. Used by
@@ -182,10 +175,7 @@ impl Supertable {
             extract_id_column(&batches)
         };
 
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(drive)),
-            Err(_) => self.sql_runtime().block_on(drive),
-        }
+        bridge_sync_to_async(drive)
     }
 }
 
@@ -603,15 +593,10 @@ mod tests {
     }
 
     #[test]
-    fn query_sql_runtime_is_cached_across_calls() {
-        // Two queries on the same supertable must share one
-        // Runtime — the OnceLock guarantees this; we assert by
-        // checking that both calls succeed without spawning a
-        // fresh Runtime per call (observed indirectly via the
-        // `.await` over `block_on` not double-allocating; if the
-        // cache regressed, tests would still pass but would leak
-        // a Runtime per call. The functional check below is
-        // adequate for correctness; benchmarks would catch leak).
+    fn query_sql_succeeds_across_repeated_calls() {
+        // Repeated queries on the same supertable all succeed —
+        // they share the one process-wide bridge runtime, so there's
+        // no per-call runtime build to regress on.
         let st = Supertable::create(options_id_cat_title()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_cat_batch(0, &["x"], &["t"])).expect("a");

--- a/src/supertable/query/superfile_reader.rs
+++ b/src/supertable/query/superfile_reader.rs
@@ -31,6 +31,7 @@
 
 use std::sync::Arc;
 
+use crate::runtime_bridge::bridge_sync_to_async;
 use crate::superfile::SuperfileReader;
 use crate::supertable::manifest::SuperfileUri;
 use crate::supertable::reader_cache::DiskCacheStore;
@@ -61,36 +62,8 @@ pub fn superfile_reader(
     };
 
     let uri_copy = *uri;
-    let result = match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            // Ambient tokio runtime — block_in_place + block_on
-            // is the same pattern the writer's commit path uses
-            // for its sync→async bridge.
-            tokio::task::block_in_place(|| handle.block_on(cache.reader(&uri_copy)))
-        }
-        Err(_) => {
-            // No ambient runtime. Build a tiny one just for
-            // this fetch. Cold path; the overhead (≈ 1 ms to
-            // create a current_thread Runtime) is negligible
-            // compared to the parallel range-fetch the cache
-            // is about to issue. Falls out of scope at end of
-            // statement.
-            let rt = match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(rt) => rt,
-                Err(e) => {
-                    return Err(ReaderCacheError::OpenFailed {
-                        source: crate::superfile::ReadError::Io(std::io::Error::other(format!(
-                            "tokio runtime build for disk cache fetch: {e}"
-                        ))),
-                    });
-                }
-            };
-            rt.block_on(cache.reader(&uri_copy))
-        }
-    };
+    // Cross the sync→async boundary through the one shared bridge.
+    let result = bridge_sync_to_async(cache.reader(&uri_copy));
 
     result.map_err(|e| ReaderCacheError::OpenFailed {
         source: crate::superfile::ReadError::Io(std::io::Error::other(format!(

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -55,6 +55,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use rayon::prelude::*;
 
+use crate::runtime_bridge::bridge_sync_to_async;
 use crate::superfile::builder::SuperfileBuilder;
 
 use super::error::BuildError;
@@ -717,10 +718,7 @@ impl SupertableWriter {
             let _ = wal_store.delete_state(wal_id).await;
             Ok::<_, MutationError>((n_t, n_nf))
         };
-        let (n_tombstoned, n_not_found) = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(drive))?,
-            Err(_) => self.inner.sql_runtime().block_on(drive)?,
-        };
+        let (n_tombstoned, n_not_found) = bridge_sync_to_async(drive)?;
         Ok(OperationOutcome {
             wal_id: entry.wal_id,
             matched: entry.target_ids.len(),
@@ -790,10 +788,7 @@ impl SupertableWriter {
             let _ = wal_store.delete_state(wal_id).await;
             Ok::<_, MutationError>((n_t, n_nf))
         };
-        let (n_tombstoned, n_not_found) = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(drive))?,
-            Err(_) => self.inner.sql_runtime().block_on(drive)?,
-        };
+        let (n_tombstoned, n_not_found) = bridge_sync_to_async(drive)?;
         Ok(OperationOutcome {
             wal_id: entry.wal_id,
             matched: entry.target_ids.len(),
@@ -1145,7 +1140,7 @@ fn publish_superfiles(
         if !pending_cache_inserts.is_empty()
             && let Some(cache) = inner.options.disk_cache.as_ref().cloned()
         {
-            warm_cache_after_commit(inner, &cache, pending_cache_inserts);
+            warm_cache_after_commit(&cache, pending_cache_inserts);
         }
 
         // Best-effort memory-budget enforcement. Each commit
@@ -1241,19 +1236,10 @@ pub(in crate::supertable) fn persist_commit(
     let storage_async = Arc::clone(&storage);
     let opts = Arc::clone(&inner.options);
 
-    // The writer's commit path is sync but the persistence
-    // layer is async. Two cases:
-    //
-    // - **Sync caller** (no ambient tokio runtime): drive
-    //   the future on the supertable's owned `sql_runtime`
-    //   (lazy-init the first time we hit this branch).
-    // - **Async caller** (inside a tokio runtime): use the
-    //   ambient runtime via `Handle::current().block_on`
-    //   wrapped in `block_in_place`. This avoids creating
-    //   (and later dropping) a second owned runtime — which
-    //   would otherwise panic at Drop with "cannot drop a
-    //   runtime in a context where blocking is not allowed".
-    //   Requires the ambient runtime to be `multi_thread`.
+    // The writer's commit path is sync but the persistence layer is
+    // async. Cross the boundary through the shared
+    // `bridge_sync_to_async` (ambient `multi_thread` runtime when
+    // present, the process-wide owned runtime otherwise).
     let max_retries = opts.max_commit_retries.max(1);
     let drive = async move {
         let mut last_err: Option<crate::supertable::CommitError> = None;
@@ -1298,20 +1284,7 @@ pub(in crate::supertable) fn persist_commit(
         Err(last_err.unwrap_or(crate::supertable::CommitError::WriteContentionExhausted))
     };
 
-    let (new_list, new_segment_list) = match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            // Ambient tokio runtime present — use it. Don't
-            // touch `inner.sql_runtime()` so we don't risk
-            // dropping our owned runtime from within
-            // another's worker context.
-            tokio::task::block_in_place(|| handle.block_on(drive))?
-        }
-        Err(_) => {
-            // Sync caller; lazy-init the supertable's
-            // owned runtime.
-            inner.sql_runtime().block_on(drive)?
-        }
-    };
+    let (new_list, new_segment_list) = bridge_sync_to_async(drive)?;
 
     // Build the new in-memory Manifest with the persisted
     // list + a fresh ManifestPartLoader installed.
@@ -1833,10 +1806,8 @@ async fn put_segment_multipart(
 }
 
 /// M14b.2 — drive `DiskCacheStore::insert_warm` for each
-/// just-published segment via the same sync→async bridge
-/// the rest of the writer uses (`block_in_place +
-/// Handle::block_on` when an ambient runtime is present;
-/// `inner.sql_runtime()` otherwise).
+/// just-published segment via the shared sync→async
+/// [`bridge_sync_to_async`].
 ///
 /// Failures are swallowed with an `eprintln!` log line —
 /// the superfiles are already durable in storage and the
@@ -1844,7 +1815,6 @@ async fn put_segment_multipart(
 /// becomes a "warm load fails → next query cold-fetches"
 /// degradation, not a correctness break.
 fn warm_cache_after_commit(
-    inner: &SupertableInner,
     cache: &Arc<crate::supertable::reader_cache::DiskCacheStore>,
     pending: Vec<(SuperfileUri, Bytes)>,
 ) {
@@ -1860,14 +1830,7 @@ fn warm_cache_after_commit(
             }
         }
     };
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            tokio::task::block_in_place(|| handle.block_on(drive));
-        }
-        Err(_) => {
-            inner.sql_runtime().block_on(drive);
-        }
-    }
+    bridge_sync_to_async(drive);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Consolidate every sync→async bridge in the supertable into a single `runtime_bridge::bridge_sync_to_async`, backed by one process-wide runtime.

## Why

There were **three** divergent sync→async bridging patterns:

1. `bridge_sync_to_async` (built a throwaway `current_thread` runtime per call for the no-ambient case);
2. a per-supertable `sql_runtime` (`multi_thread`, 1 worker);
3. ~8 copy-pasted `match tokio::runtime::Handle::try_current() { … }` blocks across `query` / `writer` / `recovery`.

Two of them even disagreed on the no-ambient path (throwaway `current_thread` vs the owned `multi_thread(1)`). This is the cleanup tracked in #32 (item 1).

## How

- One `bridge_sync_to_async`, backed by a single process-wide `multi_thread().worker_threads(1)` runtime (lazy `OnceLock`).
- Routed every call site through it; deleted `sql_runtime` (field, accessor, lazy-init) and the dead `Runtime`/`OnceLock` imports.
- Documented the runtime-flavor policy: `multi_thread(1)` for the owned runtime (a real runtime so `spawn`/`block_in_place` work, one worker since the work is IO-bound), `current_thread` never used for an owned runtime.
- The `multi_thread`-ambient requirement is unchanged; lifting the `current_thread`-ambient panic needs `Send + 'static` futures and is deferred.

## Scope / not in this PR

No public API change; the user-facing read/write surface stays sync. The async public surface (async `Connection`/`Table` facade) is separate, deferred work — benchmarking showed an async read path costs ~10–16% on sub-millisecond queries with no consumer today, so async will be added uniformly later when there's a real async caller.

## Testing

Behavior-preserving (the owned runtime was already `multi_thread(1)`). `make ci` green — full suite incl. multi-process + crash-injection. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.
