### PR TITLE
benches: selectable object-store backend (Azure + S3) with ephemeral cleanup

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -49,6 +49,47 @@ Superfile benches (1M) build their own fixture per binary; supertable
 search groups run correctness (FTS oracle / vector recall floor) before timing
 when ingest is already available.
 
+## Object-store backends
+
+The warm/cold supertable and superfile benches run against an object
+store. The backend is chosen **explicitly** by `INFINO_BENCH_STORE` — it
+is never inferred from which credentials happen to be exported:
+
+| `INFINO_BENCH_STORE` | Store | Extra env |
+|---|---|---|
+| _unset_ / `s3s_fs` | in-process s3s-fs emulator (default, no credentials) | — |
+| `s3` | real AWS S3 | `INFINO_REAL_S3_BUCKET` + the standard `AWS_*` credentials |
+| `azure` | Azure Blob | `INFINO_REAL_AZURE_CONTAINER` + `AZURE_STORAGE_ACCOUNT_NAME` + `AZURE_STORAGE_ACCOUNT_KEY` |
+
+```sh
+# Default — emulator, no credentials, no network
+cargo bench --bench supertable_all -- supertable_fts
+
+# Real AWS S3
+INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket \
+  cargo bench --bench supertable_all -- supertable_fts
+
+# Azure Blob
+INFINO_BENCH_STORE=azure INFINO_REAL_AZURE_CONTAINER=my-container \
+  AZURE_STORAGE_ACCOUNT_NAME=... AZURE_STORAGE_ACCOUNT_KEY=... \
+  cargo bench --bench supertable_all -- supertable_fts
+```
+
+The chosen backend appears as the storage label in warm/cold group
+names (`s3s_fs` / `s3` / `azure`), e.g. `supertable_fts_cold_search_s3`.
+A run with no real backend selected writes only to the emulator.
+
+**Cleanup.** A real-backend run writes its table under a unique prefix
+and deletes it when the process exits — no manual cleanup. The emulator
+is in-process and self-cleans on drop.
+
+**Emulator caveat.** The in-process s3s-fs emulator can be unstable
+during the supertable's concurrent multi-commit ingest (dropped
+connections / commit-retry exhaustion). Use a real backend
+(`INFINO_BENCH_STORE=s3|azure`) for trustworthy object-store numbers;
+the emulator is a quick, credential-free wire-path check, best suited to
+the single-commit superfile benches.
+
 ## Code layout (`infino-bench-utils`)
 
 ```text

--- a/benches/README.md
+++ b/benches/README.md
@@ -52,55 +52,59 @@ when ingest is already available.
 ## Object-store backends
 
 The warm/cold supertable and superfile benches run against an object
-store. The backend is chosen **explicitly** by `INFINO_BENCH_STORE` — it
-is never inferred from which credentials happen to be exported:
+store, chosen **explicitly** on two orthogonal axes — never inferred from
+which credentials happen to be exported:
 
-| `INFINO_BENCH_STORE` | Store | Extra env |
-|---|---|---|
-| _unset_ / `s3s_fs` | in-process s3s-fs emulator (default, no credentials) | — |
-| `azurite` | local Azurite emulator (no credentials) | Azurite running on `:10000` + the `infino-bench` container (override: `INFINO_AZURITE_CONTAINER`) |
-| `s3` | real AWS S3 | `INFINO_REAL_S3_BUCKET` + the standard `AWS_*` credentials |
-| `azure` | Azure Blob | `INFINO_REAL_AZURE_CONTAINER` + `AZURE_STORAGE_ACCOUNT_NAME` + `AZURE_STORAGE_ACCOUNT_KEY` |
+- `INFINO_BENCH_STORE` = `s3` (default) | `azure` — the provider.
+- `INFINO_BENCH_MODE` = `local` (default) | `remote` — the deployment.
+
+| store | mode | Backend | Extra env |
+|---|---|---|---|
+| `s3` | `local` (default) | in-process s3s-fs emulator | — |
+| `azure` | `local` | Azurite emulator | Azurite on `:10000` + the `infino-bench` container (override: `INFINO_AZURITE_CONTAINER`) |
+| `s3` | `remote` | real AWS S3 | `INFINO_REAL_S3_BUCKET` + the standard `AWS_*` credentials |
+| `azure` | `remote` | Azure Blob | `INFINO_REAL_AZURE_CONTAINER` + `AZURE_STORAGE_ACCOUNT_NAME` + `AZURE_STORAGE_ACCOUNT_KEY` |
 
 ```sh
-# Default — emulator, no credentials, no network
+# Default — s3 local = in-process s3s-fs, no credentials, no network
 cargo bench --bench supertable_all -- supertable_fts
 
-# Real AWS S3
-INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket \
-  cargo bench --bench supertable_all -- supertable_fts
-
-# Azure Blob
-INFINO_BENCH_STORE=azure INFINO_REAL_AZURE_CONTAINER=my-container \
-  AZURE_STORAGE_ACCOUNT_NAME=... AZURE_STORAGE_ACCOUNT_KEY=... \
-  cargo bench --bench supertable_all -- supertable_fts
-
-# Local Azurite emulator (credential-free, completes the full supertable path)
+# Azure local — Azurite (credential-free, completes the full supertable path)
 docker run -d --name infino-azurite -p 10000:10000 \
   mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0
 az storage container create -n infino-bench \
   --connection-string "UseDevelopmentStorage=true"
-INFINO_BENCH_STORE=azurite cargo bench --bench supertable_all -- supertable_fts
+INFINO_BENCH_STORE=azure INFINO_BENCH_MODE=local \
+  cargo bench --bench supertable_all -- supertable_fts
+
+# S3 remote — real AWS S3
+INFINO_BENCH_STORE=s3 INFINO_BENCH_MODE=remote INFINO_REAL_S3_BUCKET=my-bucket \
+  cargo bench --bench supertable_all -- supertable_fts
+
+# Azure remote — real Azure Blob
+INFINO_BENCH_STORE=azure INFINO_BENCH_MODE=remote INFINO_REAL_AZURE_CONTAINER=my-container \
+  AZURE_STORAGE_ACCOUNT_NAME=... AZURE_STORAGE_ACCOUNT_KEY=... \
+  cargo bench --bench supertable_all -- supertable_fts
 ```
 
-The chosen backend appears as the storage label in warm/cold group names
-(`s3s_fs` / `azurite` / `s3` / `azure`), e.g.
-`supertable_fts_cold_search_azurite`. A run with no real backend selected
-writes only to the emulator.
+The chosen backend appears as the storage label in warm/cold group names —
+`{store}_{mode}`: `s3_local` / `s3_remote` / `azure_local` / `azure_remote`,
+e.g. `supertable_fts_cold_search_azure_local`. The default (`s3` `local`)
+writes only to the in-process emulator.
 
 **Cleanup.** A real-backend run writes its table under a unique prefix
 and deletes it when the process exits — no manual cleanup. The emulator
 is in-process and self-cleans on drop.
 
-**Emulator caveat.** The in-process **s3s-fs** emulator can't survive the
+**Emulator caveat.** `s3` `local` (in-process s3s-fs) can't survive the
 supertable's concurrent multi-commit ingest (it reuses connections it has
 already closed, and mishandles a conditional PUT replayed after a dropped
 response — the commit panics). It's fine for the single-commit superfile
 benches and as a zero-setup wire-path check, but **for a full supertable
-run locally use `azurite`** — the official Azure emulator completes the
-whole ingest → search path credential-free. For *representative timings*,
-use a real backend (`INFINO_BENCH_STORE=s3|azure`): every emulator
-(s3s-fs or Azurite) reproduces request/byte volume, not network latency.
+run locally use `azure` `local`** (Azurite) — the official Azure emulator
+completes the whole ingest → search path credential-free. For
+*representative timings* use `mode=remote` (real S3 / Azure): every
+emulator reproduces request/byte volume, not network latency.
 
 ## Code layout (`infino-bench-utils`)
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -58,6 +58,7 @@ is never inferred from which credentials happen to be exported:
 | `INFINO_BENCH_STORE` | Store | Extra env |
 |---|---|---|
 | _unset_ / `s3s_fs` | in-process s3s-fs emulator (default, no credentials) | — |
+| `azurite` | local Azurite emulator (no credentials) | Azurite running on `:10000` + the `infino-bench` container (override: `INFINO_AZURITE_CONTAINER`) |
 | `s3` | real AWS S3 | `INFINO_REAL_S3_BUCKET` + the standard `AWS_*` credentials |
 | `azure` | Azure Blob | `INFINO_REAL_AZURE_CONTAINER` + `AZURE_STORAGE_ACCOUNT_NAME` + `AZURE_STORAGE_ACCOUNT_KEY` |
 
@@ -73,22 +74,33 @@ INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket \
 INFINO_BENCH_STORE=azure INFINO_REAL_AZURE_CONTAINER=my-container \
   AZURE_STORAGE_ACCOUNT_NAME=... AZURE_STORAGE_ACCOUNT_KEY=... \
   cargo bench --bench supertable_all -- supertable_fts
+
+# Local Azurite emulator (credential-free, completes the full supertable path)
+docker run -d --name infino-azurite -p 10000:10000 \
+  mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0
+az storage container create -n infino-bench \
+  --connection-string "UseDevelopmentStorage=true"
+INFINO_BENCH_STORE=azurite cargo bench --bench supertable_all -- supertable_fts
 ```
 
-The chosen backend appears as the storage label in warm/cold group
-names (`s3s_fs` / `s3` / `azure`), e.g. `supertable_fts_cold_search_s3`.
-A run with no real backend selected writes only to the emulator.
+The chosen backend appears as the storage label in warm/cold group names
+(`s3s_fs` / `azurite` / `s3` / `azure`), e.g.
+`supertable_fts_cold_search_azurite`. A run with no real backend selected
+writes only to the emulator.
 
 **Cleanup.** A real-backend run writes its table under a unique prefix
 and deletes it when the process exits — no manual cleanup. The emulator
 is in-process and self-cleans on drop.
 
-**Emulator caveat.** The in-process s3s-fs emulator can be unstable
-during the supertable's concurrent multi-commit ingest (dropped
-connections / commit-retry exhaustion). Use a real backend
-(`INFINO_BENCH_STORE=s3|azure`) for trustworthy object-store numbers;
-the emulator is a quick, credential-free wire-path check, best suited to
-the single-commit superfile benches.
+**Emulator caveat.** The in-process **s3s-fs** emulator can't survive the
+supertable's concurrent multi-commit ingest (it reuses connections it has
+already closed, and mishandles a conditional PUT replayed after a dropped
+response — the commit panics). It's fine for the single-commit superfile
+benches and as a zero-setup wire-path check, but **for a full supertable
+run locally use `azurite`** — the official Azure emulator completes the
+whole ingest → search path credential-free. For *representative timings*,
+use a real backend (`INFINO_BENCH_STORE=s3|azure`): every emulator
+(s3s-fs or Azurite) reproduces request/byte volume, not network latency.
 
 ## Code layout (`infino-bench-utils`)
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -94,9 +94,9 @@ writes only to the in-process emulator.
 
 **Cleanup.** A remote/Azurite run writes its table under a unique prefix
 and deletes it when the process exits — no manual cleanup. Set
-`INFINO_BENCH_KEEP=1` to retain it instead (the kept prefix is logged, so
-you can inspect, re-query, or delete it yourself). The in-process s3s-fs
-self-cleans on drop regardless.
+`INFINO_BENCH_KEEP_TABLE=1` to retain the table instead (the kept prefix
+is logged, so you can inspect, re-query, or delete it yourself). The
+in-process s3s-fs self-cleans on drop regardless.
 
 **Emulator caveat.** `s3` `local` (in-process s3s-fs) can't survive the
 supertable's concurrent multi-commit ingest (it reuses connections it has

--- a/benches/README.md
+++ b/benches/README.md
@@ -92,9 +92,11 @@ The chosen backend appears as the storage label in warm/cold group names —
 e.g. `supertable_fts_cold_search_azure_local`. The default (`s3` `local`)
 writes only to the in-process emulator.
 
-**Cleanup.** A real-backend run writes its table under a unique prefix
-and deletes it when the process exits — no manual cleanup. The emulator
-is in-process and self-cleans on drop.
+**Cleanup.** A remote/Azurite run writes its table under a unique prefix
+and deletes it when the process exits — no manual cleanup. Set
+`INFINO_BENCH_KEEP=1` to retain it instead (the kept prefix is logged, so
+you can inspect, re-query, or delete it yourself). The in-process s3s-fs
+self-cleans on drop regardless.
 
 **Emulator caveat.** `s3` `local` (in-process s3s-fs) can't survive the
 supertable's concurrent multi-commit ingest (it reuses connections it has

--- a/benches/README.md
+++ b/benches/README.md
@@ -138,7 +138,7 @@ Hot = `SuperfileReader::open` in memory; warm/cold = same `.parquet` on object s
 <!-- BEGIN: bench/fts/supertable/search -->
 ### Supertable FTS — search (10000000 docs, shared combined supertable)
 
-hot = in-process, segments already cached (warm steady state). cold = fresh disk cache → object-store range GETs (s3s-fs or `INFINO_REAL_S3_BUCKET`). Cold excludes the one-time manifest open. The mmap-promoted "warm" tier was dropped: nothing is pinned in memory, so it measured identically to hot.
+hot = in-process, segments already cached (warm steady state). cold = fresh disk cache → object-store range GETs (s3s-fs, or a real store via `INFINO_BENCH_STORE=s3|azure`). Cold excludes the one-time manifest open. The mmap-promoted "warm" tier was dropped: nothing is pinned in memory, so it measured identically to hot.
 
 | Query          | hot        | cold       | Peak RSS  | Median RSS | P90 RSS   | Peak RSS Δ |
 |----------------|------------|------------|-----------|------------|-----------|------------|
@@ -211,7 +211,7 @@ Hot = `SuperfileReader::open` in memory; warm/cold = same `.parquet` on object s
 <!-- BEGIN: bench/vector/supertable/search -->
 ### Supertable vector — search (10000000 docs × dim=384, calibrated at recall targets)
 
-hot = in-process, segments already cached (warm steady state). cold = fresh disk cache → object-store range GETs (s3s-fs or `INFINO_REAL_S3_BUCKET`), excluding the one-time manifest open. The mmap-promoted "warm" tier was dropped: nothing is pinned in memory, so it measured identically to hot.
+hot = in-process, segments already cached (warm steady state). cold = fresh disk cache → object-store range GETs (s3s-fs, or a real store via `INFINO_BENCH_STORE=s3|azure`), excluding the one-time manifest open. The mmap-promoted "warm" tier was dropped: nothing is pinned in memory, so it measured identically to hot.
 
 | Recall target | (p/seg, r) | hot | cold | Peak RSS | Median RSS | P90 RSS | Peak RSS Δ |
 |---------------|------------|-----|------|----------|------------|---------|------------|

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,6 +1,6 @@
 # infino benches
 
-Infino-only performance + correctness benches. Three criterion binaries:
+Performance + correctness benches. Three criterion binaries:
 
 - `superfile_fts` — FTS over one 1M-doc superfile
 - `superfile_vector` — vector search over one 1M × 384 superfile

--- a/benches/fts/main.rs
+++ b/benches/fts/main.rs
@@ -15,5 +15,14 @@
 //! ```
 
 use infino_bench_utils::fts_superfile;
+use infino_bench_utils::tiers;
 
-criterion::criterion_main!(fts_superfile::benches);
+// Hand-rolled `criterion_main!` so a real-backend run deletes its
+// ephemeral remote prefix after the benches (no-op for s3s-fs / persisted).
+fn main() {
+    fts_superfile::benches();
+    criterion::Criterion::default()
+        .configure_from_args()
+        .final_summary();
+    tiers::cleanup_ephemeral();
+}

--- a/benches/fts/main.rs
+++ b/benches/fts/main.rs
@@ -1,28 +1,23 @@
-//! FTS superfile bench bundle (infino-only). Supertable FTS benches
-//! live in `benches/supertable/main.rs`, where they share one combined
-//! 10M-row supertable with the vector supertable benches.
-//!
-//! Infino-only timing and correctness — no third-party crates in
-//! the dependency graph of these benches.
+//! FTS benches over a 1M single superfile. The 10M supertable FTS benches
+//! live in `benches/supertable/main.rs`.
 //!
 //! ## Invocation
 //!
 //! ```text
-//! cargo bench --bench superfile_fts                         # 1M superfile FTS benches
-//! cargo bench --bench superfile_fts -- superfile_fts_build  # only superfile ingest
-//! cargo bench --bench superfile_fts -- superfile_fts_search # only superfile search
+//! cargo bench --bench superfile_fts                         # all
+//! cargo bench --bench superfile_fts -- superfile_fts_build  # ingest only
+//! cargo bench --bench superfile_fts -- superfile_fts_search # search only
 //! INFINO_BENCH_UPDATE_README=1 cargo bench --bench superfile_fts
 //! ```
 
 use infino_bench_utils::fts_superfile;
 use infino_bench_utils::tiers;
 
-// Hand-rolled `criterion_main!` so a real-backend run deletes its
-// ephemeral remote prefix after the benches (no-op for s3s-fs / persisted).
 fn main() {
     fts_superfile::benches();
     criterion::Criterion::default()
         .configure_from_args()
         .final_summary();
+    // Statics don't run `Drop` at exit; delete ephemeral remote prefixes here.
     tiers::cleanup_ephemeral();
 }

--- a/benches/object_store/main.rs
+++ b/benches/object_store/main.rs
@@ -1,4 +1,4 @@
-//! Unified object-store cold/warm bench (infino-only). Stands an
+//! Unified object-store cold/warm bench. Stands an
 //! in-process `s3s-fs` server in for AWS S3 and measures the
 //! lazy cold-open + first-search path over the network for a
 //! single superfile that carries **both** a vector subsection and

--- a/benches/supertable/main.rs
+++ b/benches/supertable/main.rs
@@ -1,15 +1,13 @@
-//! Supertable bench bundle (infino-only).
-//!
-//! Flow: `corpus` (synthetic stream) → `ingest` (object storage) →
-//! `bench/supertable` (ingest timing + FTS search + vector search).
+//! Supertable benches over a shared 10M combined supertable: ingest
+//! timing + FTS search + vector search.
 //!
 //! ## Invocation
 //!
 //! ```text
-//! cargo bench --bench supertable_all                         # all supertable benches
+//! cargo bench --bench supertable_all                         # all
 //! cargo bench --bench supertable_all -- supertable_vec       # vector groups
 //! cargo bench --bench supertable_all -- supertable_fts       # FTS groups
-//! cargo bench --bench supertable_all -- _build               # shared ingest group
+//! cargo bench --bench supertable_all -- _build               # ingest groups
 //! cargo bench --bench supertable_all -- _search              # search groups
 //! INFINO_BENCH_UPDATE_README=1 cargo bench --bench supertable_all
 //! ```
@@ -17,13 +15,11 @@
 use infino_bench_utils::bench::supertable;
 use infino_bench_utils::tiers;
 
-// Hand-rolled `criterion_main!` so we can delete any ephemeral remote
-// prefix after the run. Statics don't run `Drop` at process exit, so the
-// teardown is explicit; it's a no-op for s3s-fs and persisted runs.
 fn main() {
     supertable::benches();
     criterion::Criterion::default()
         .configure_from_args()
         .final_summary();
+    // Statics don't run `Drop` at exit; delete ephemeral remote prefixes here.
     tiers::cleanup_ephemeral();
 }

--- a/benches/supertable/main.rs
+++ b/benches/supertable/main.rs
@@ -15,5 +15,15 @@
 //! ```
 
 use infino_bench_utils::bench::supertable;
+use infino_bench_utils::tiers;
 
-criterion::criterion_main!(supertable::benches);
+// Hand-rolled `criterion_main!` so we can delete any ephemeral remote
+// prefix after the run. Statics don't run `Drop` at process exit, so the
+// teardown is explicit; it's a no-op for s3s-fs and persisted runs.
+fn main() {
+    supertable::benches();
+    criterion::Criterion::default()
+        .configure_from_args()
+        .final_summary();
+    tiers::cleanup_ephemeral();
+}

--- a/benches/utils/Cargo.toml
+++ b/benches/utils/Cargo.toml
@@ -25,7 +25,7 @@ hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 infino = { path = "../..", features = ["test-helpers"] }
 memmap2 = "0.9"
 num_cpus = "1"
-object_store = { version = "0.13", features = ["aws"] }
+object_store = { version = "0.13", features = ["aws", "azure"] }
 parquet = "58"
 rand = "0.10"
 rand_distr = "0.6"

--- a/benches/utils/bench/supertable/fts_search.rs
+++ b/benches/utils/bench/supertable/fts_search.rs
@@ -79,14 +79,9 @@ fn assert_fts_self_consistent(st: &infino::supertable::Supertable) {
 }
 
 pub fn bench(c: &mut Criterion) {
-    if !fixture::criterion_filter_selects(
-        &["supertable_fts", "supertable_fts_search"],
-        &[
-            "supertable_fts_hot_search",
-            "supertable_fts_warm_search_real_s3",
-            "supertable_fts_cold_search_real_s3",
-        ],
-    ) {
+    // No explicit group list: every emitted group name starts with the
+    // family alias, so the alias already selects them.
+    if !fixture::criterion_filter_selects(&["supertable_fts", "supertable_fts_search"], &[]) {
         return;
     }
     fixture::ensure_ingest_for_search("FTS correctness/search");

--- a/benches/utils/bench/supertable/vector_search.rs
+++ b/benches/utils/bench/supertable/vector_search.rs
@@ -163,14 +163,9 @@ fn calibrations(st: &Supertable, g: &grading::SupertableGrading) -> &'static Cal
 }
 
 pub fn bench(c: &mut Criterion) {
-    if !fixture::criterion_filter_selects(
-        &["supertable_vec", "supertable_vec_search"],
-        &[
-            "supertable_vec_hot_search",
-            "supertable_vec_warm_search_real_s3",
-            "supertable_vec_cold_search_real_s3",
-        ],
-    ) {
+    // No explicit group list: every emitted group name starts with the
+    // family alias, so the alias already selects them.
+    if !fixture::criterion_filter_selects(&["supertable_vec", "supertable_vec_search"], &[]) {
         return;
     }
     fixture::ensure_ingest_for_search("vector correctness/search");

--- a/benches/utils/fts_superfile.rs
+++ b/benches/utils/fts_superfile.rs
@@ -1,4 +1,4 @@
-//! Infino-only FTS bench for the superfile layer:
+//! FTS benches for the superfile layer:
 //!
 //!   ingest timing (single-thread + rayon-sharded multi-thread)
 //! + 7-query search timing
@@ -7,8 +7,8 @@
 //!
 //! Every phase uses the production path: [`SuperfileBuilder`] → unified
 //! `.parquet` → [`SuperfileReader`] → `bm25_search` / embedded [`FtsReader`].
-//! Hot opens the finished `.parquet` in memory; warm/cold commit the same bytes
-//! to object storage and read through [`DiskCacheStore::reader`].
+//! Hot opens the finished `.parquet` in memory; cold commits the same bytes
+//! to object storage and reads through [`DiskCacheStore::reader`].
 //!
 //! Pinned to 1M-doc Zipfian (200 tokens/doc, 10K vocab). The
 //! single-superfile shape is rarely much larger in production —

--- a/benches/utils/markdown.rs
+++ b/benches/utils/markdown.rs
@@ -118,12 +118,13 @@ pub fn fmt_throughput(elements_per_sec: f64) -> String {
 ///
 /// Returns `None` if the file doesn't exist (bench was filtered out or
 /// hasn't run yet) or the JSON can't be parsed.
-/// Read a tiered search group (`{family}_hot_search` or `{family}_{tier}_search_{s3s_fs|real_s3}`).
+/// Read a tiered search group (`{family}_hot_search` or
+/// `{family}_{tier}_search_{label}` for each [`crate::tiers::STORAGE_LABELS`]).
 pub fn read_tier_mean_ns(family: &str, tier: &str, bench: &str) -> Option<f64> {
     if tier == "hot" {
         return read_mean_ns(&format!("{family}_hot_search"), bench);
     }
-    for storage in ["s3s_fs", "real_s3"] {
+    for storage in crate::tiers::STORAGE_LABELS {
         let group = format!("{family}_{tier}_search_{storage}");
         if let Some(ns) = read_mean_ns(&group, bench) {
             return Some(ns);

--- a/benches/utils/markdown.rs
+++ b/benches/utils/markdown.rs
@@ -1,7 +1,7 @@
-//! Shared markdown summary emitter for the infino-only bench harnesses.
+//! Shared markdown summary emitter for the bench harnesses.
 //!
 //! After criterion finishes timing, each topic's bench function builds
-//! a markdown block summarizing the infino numbers. The block is always
+//! a markdown block summarizing the numbers. The block is always
 //! written to stderr framed by sentinel comments
 //! (`<!-- BEGIN: <anchor_id> -->` / `<!-- END: <anchor_id> -->`).
 //! When `INFINO_BENCH_UPDATE_README=1` is set, the same block also

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -49,10 +49,11 @@ impl Tier {
 }
 
 /// Storage labels that can appear in a warm/cold search group name
-/// (`{family}_{tier}_search_{label}`). The emulator is `s3s_fs`; real
-/// backends use [`RemoteBackend::label`]. Markdown report generation
-/// iterates this set; a unit test guards it against `RemoteBackend::label`.
-pub const STORAGE_LABELS: &[&str] = &["s3s_fs", "s3", "azure", "azurite"];
+/// (`{family}_{tier}_search_{label}`) — one per (store, mode): `s3_local`
+/// (in-process s3s-fs), `s3_remote`, `azure_local` (Azurite), `azure_remote`.
+/// Markdown report generation iterates this set; a unit test guards it
+/// against the backend `label()` methods.
+pub const STORAGE_LABELS: &[&str] = &["s3_local", "s3_remote", "azure_local", "azure_remote"];
 
 /// Default Azurite container (must already exist in the emulator).
 const AZURITE_CONTAINER_DEFAULT: &str = "infino-bench";
@@ -175,21 +176,34 @@ fn azurite_container_env() -> Option<String> {
 /// Object store the warm/cold benches run against. Chosen **explicitly**
 /// via `INFINO_BENCH_STORE` — never inferred from which credential happens
 /// to be exported.
+///
+/// Two orthogonal axes: `INFINO_BENCH_STORE` (`s3` | `azure`) picks the
+/// provider, `INFINO_BENCH_MODE` (`local` | `remote`) picks the deployment.
+/// The four combinations:
+///
+/// | store | mode   | backend                         |
+/// |-------|--------|---------------------------------|
+/// | s3    | local  | in-process s3s-fs (zero-setup)  |
+/// | s3    | remote | AWS S3                          |
+/// | azure | local  | Azurite emulator                |
+/// | azure | remote | Azure Blob                      |
 #[derive(Debug, PartialEq, Eq)]
 enum BenchStore {
-    /// In-process s3s-fs emulator (default; no credentials, no network).
+    /// store=s3, mode=local — in-process s3s-fs (no creds, no network).
     S3sFs,
-    /// A real remote object store.
-    Remote(RemoteBackend),
+    /// The other three combos — an endpoint reached over a socket.
+    External(ExternalBackend),
 }
 
 impl BenchStore {
-    /// Resolve from `INFINO_BENCH_STORE` (`s3s_fs` default | `s3` | `azure`
-    /// | `azurite`).
+    /// Resolve from `INFINO_BENCH_STORE` (`s3` default | `azure`) ×
+    /// `INFINO_BENCH_MODE` (`local` default | `remote`).
     fn from_env() -> Self {
-        let store = std::env::var("INFINO_BENCH_STORE").unwrap_or_else(|_| "s3s_fs".into());
+        let store = std::env::var("INFINO_BENCH_STORE").unwrap_or_else(|_| "s3".into());
+        let mode = std::env::var("INFINO_BENCH_MODE").unwrap_or_else(|_| "local".into());
         Self::parse(
             &store,
+            &mode,
             real_s3_bucket_env(),
             real_azure_container_env(),
             azurite_container_env(),
@@ -197,52 +211,62 @@ impl BenchStore {
         .unwrap_or_else(|e| panic!("{e}"))
     }
 
-    /// Pure resolution — the chosen backend must have its location env set.
-    /// Split out so selection is unit-testable without mutating process env.
+    /// Pure resolution of (store × mode). Remote backends require their
+    /// location env; local backends are credential-free. Split out so
+    /// selection is unit-testable without mutating process env.
     fn parse(
         store: &str,
+        mode: &str,
         s3_bucket: Option<String>,
         azure_container: Option<String>,
         azurite_container: Option<String>,
     ) -> Result<Self, String> {
-        match store {
-            "s3s_fs" => Ok(Self::S3sFs),
-            "s3" => s3_bucket
-                .map(|bucket| Self::Remote(RemoteBackend::S3 { bucket }))
-                .ok_or_else(|| "INFINO_BENCH_STORE=s3 requires INFINO_REAL_S3_BUCKET".to_string()),
-            "azure" => azure_container
-                .map(|container| Self::Remote(RemoteBackend::Azure { container }))
+        match (store, mode) {
+            ("s3", "local") => Ok(Self::S3sFs),
+            ("s3", "remote") => s3_bucket
+                .map(|bucket| Self::External(ExternalBackend::S3Remote { bucket }))
                 .ok_or_else(|| {
-                    "INFINO_BENCH_STORE=azure requires INFINO_REAL_AZURE_CONTAINER".to_string()
+                    "INFINO_BENCH_STORE=s3 INFINO_BENCH_MODE=remote requires INFINO_REAL_S3_BUCKET"
+                        .to_string()
                 }),
-            // Local Azurite emulator: credential-free (well-known
-            // devstoreaccount1), so no required env — the container defaults
-            // to `infino-bench` and must already exist in the emulator.
-            "azurite" => Ok(Self::Remote(RemoteBackend::Azurite {
+            // Credential-free (well-known devstoreaccount1); the container
+            // defaults to `infino-bench` and must already exist in Azurite.
+            ("azure", "local") => Ok(Self::External(ExternalBackend::AzureLocal {
                 container: azurite_container.unwrap_or_else(|| AZURITE_CONTAINER_DEFAULT.into()),
             })),
-            other => Err(format!(
-                "unknown INFINO_BENCH_STORE={other} (want s3s_fs|s3|azure|azurite)"
-            )),
+            ("azure", "remote") => azure_container
+                .map(|container| Self::External(ExternalBackend::AzureRemote { container }))
+                .ok_or_else(|| {
+                    "INFINO_BENCH_STORE=azure INFINO_BENCH_MODE=remote requires \
+                     INFINO_REAL_AZURE_CONTAINER"
+                        .to_string()
+                }),
+            ("s3" | "azure", other) => {
+                Err(format!("unknown INFINO_BENCH_MODE={other} (want local|remote)"))
+            }
+            (other, _) => Err(format!("unknown INFINO_BENCH_STORE={other} (want s3|azure)")),
         }
     }
 }
 
-/// A real (non-emulator) object store for warm/cold tiers.
+/// A bench store reached over a socket — everything except the in-process
+/// s3s-fs: AWS S3, Azure Blob, or local Azurite.
 #[derive(Debug, PartialEq, Eq)]
-enum RemoteBackend {
-    S3 { bucket: String },
-    Azure { container: String },
-    /// Local Azurite emulator (well-known credentials, no network).
-    Azurite { container: String },
+enum ExternalBackend {
+    /// store=s3, mode=remote — AWS S3.
+    S3Remote { bucket: String },
+    /// store=azure, mode=remote — Azure Blob.
+    AzureRemote { container: String },
+    /// store=azure, mode=local — Azurite emulator.
+    AzureLocal { container: String },
 }
 
-impl RemoteBackend {
+impl ExternalBackend {
     fn label(&self) -> &'static str {
         match self {
-            Self::S3 { .. } => "s3",
-            Self::Azure { .. } => "azure",
-            Self::Azurite { .. } => "azurite",
+            Self::S3Remote { .. } => "s3_remote",
+            Self::AzureRemote { .. } => "azure_remote",
+            Self::AzureLocal { .. } => "azure_local",
         }
     }
 
@@ -250,11 +274,11 @@ impl RemoteBackend {
     /// else `default`.
     fn prefix_root(&self, default: &str) -> String {
         match self {
-            Self::S3 { .. } => real_s3_prefix_root(default),
-            Self::Azure { .. } => {
+            Self::S3Remote { .. } => real_s3_prefix_root(default),
+            Self::AzureRemote { .. } => {
                 std::env::var("INFINO_REAL_AZURE_PREFIX").unwrap_or_else(|_| default.to_string())
             }
-            Self::Azurite { .. } => {
+            Self::AzureLocal { .. } => {
                 std::env::var("INFINO_AZURITE_PREFIX").unwrap_or_else(|_| default.to_string())
             }
         }
@@ -264,14 +288,14 @@ impl RemoteBackend {
     /// site; adding a backend is one arm here.
     fn provider(&self, prefix: &str) -> Arc<dyn StorageProvider> {
         match self {
-            Self::S3 { bucket } => Arc::new(
+            Self::S3Remote { bucket } => Arc::new(
                 S3StorageProvider::new_with_prefix(bucket, prefix).expect("real S3 provider"),
             ),
-            Self::Azure { container } => Arc::new(
+            Self::AzureRemote { container } => Arc::new(
                 AzureStorageProvider::new_with_prefix(container, prefix)
                     .expect("real Azure provider"),
             ),
-            Self::Azurite { container } => Arc::new(
+            Self::AzureLocal { container } => Arc::new(
                 AzureStorageProvider::new_with_emulator_and_prefix(container, prefix)
                     .expect("Azurite provider"),
             ),
@@ -325,9 +349,9 @@ async fn spawn_s3s_fs(s3s_bucket: &str) -> (SocketAddr, TempDir) {
 }
 
 async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture {
-    // s3s-fs returns directly; the remote backends share the construction below.
+    // s3s-fs returns directly; the external backends share the construction below.
     let backend = match BenchStore::from_env() {
-        BenchStore::Remote(backend) => backend,
+        BenchStore::External(backend) => backend,
         BenchStore::S3sFs => {
             let (addr, fs_root) = spawn_s3s_fs(s3s_bucket).await;
             let endpoint = format!("http://{addr}");
@@ -344,16 +368,17 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
             eprintln!(
                 "\n\
                  ################################################################################\n\
-                 ##  WARNING: benchmarking against the s3s-fs emulator, NOT a real object store.##\n\
-                 ##  The emulator reproduces request count and byte volume, not network         ##\n\
-                 ##  latency, so warm/cold timings here are not representative.                  ##\n\
-                 ##  Set INFINO_BENCH_STORE=s3|azure (+ the backend's container env) for real.   ##\n\
+                 ##  WARNING: store=s3 mode=local → in-process s3s-fs, NOT a real object store. ##\n\
+                 ##  It reproduces request count and byte volume, not network latency, so       ##\n\
+                 ##  warm/cold timings here are not representative — and it can't complete the   ##\n\
+                 ##  supertable's multi-commit ingest. For a full local run use store=azure     ##\n\
+                 ##  mode=local (Azurite); for real timings use mode=remote (S3 / Azure).        ##\n\
                  ################################################################################\n\
-                 [tiers] s3s-fs endpoint={endpoint}  storage_label=s3s_fs  (NOT a real store)\n"
+                 [tiers] s3s-fs endpoint={endpoint}  storage_label=s3_local  (NOT a real store)\n"
             );
             return StorageFixture {
                 storage,
-                storage_label: "s3s_fs",
+                storage_label: "s3_local",
                 _keepalive: StorageKeepalive::S3sFs { _fs_root: fs_root },
             };
         }
@@ -544,64 +569,66 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_defaults_to_emulator() {
+    fn parse_default_combo_is_s3_local() {
+        // store=s3, mode=local → in-process s3s-fs (the zero-setup default).
         assert_eq!(
-            BenchStore::parse("s3s_fs", None, None, None),
+            BenchStore::parse("s3", "local", None, None, None),
             Ok(BenchStore::S3sFs)
         );
     }
 
     #[test]
-    fn parse_s3_needs_bucket() {
+    fn parse_s3_remote_needs_bucket() {
         assert_eq!(
-            BenchStore::parse("s3", Some("bkt".into()), None, None),
-            Ok(BenchStore::Remote(RemoteBackend::S3 {
+            BenchStore::parse("s3", "remote", Some("bkt".into()), None, None),
+            Ok(BenchStore::External(ExternalBackend::S3Remote {
                 bucket: "bkt".into()
             }))
         );
-        assert!(BenchStore::parse("s3", None, None, None).is_err());
+        assert!(BenchStore::parse("s3", "remote", None, None, None).is_err());
     }
 
     #[test]
-    fn parse_azure_needs_container() {
+    fn parse_azure_remote_needs_container() {
         assert_eq!(
-            BenchStore::parse("azure", None, Some("c".into()), None),
-            Ok(BenchStore::Remote(RemoteBackend::Azure {
+            BenchStore::parse("azure", "remote", None, Some("c".into()), None),
+            Ok(BenchStore::External(ExternalBackend::AzureRemote {
                 container: "c".into()
             }))
         );
-        assert!(BenchStore::parse("azure", None, None, None).is_err());
+        assert!(BenchStore::parse("azure", "remote", None, None, None).is_err());
     }
 
     #[test]
-    fn parse_azurite_defaults_container_and_needs_no_creds() {
-        // No required env: the emulator is credential-free.
+    fn parse_azure_local_defaults_container_and_needs_no_creds() {
+        // store=azure, mode=local → Azurite, credential-free.
         assert_eq!(
-            BenchStore::parse("azurite", None, None, None),
-            Ok(BenchStore::Remote(RemoteBackend::Azurite {
+            BenchStore::parse("azure", "local", None, None, None),
+            Ok(BenchStore::External(ExternalBackend::AzureLocal {
                 container: AZURITE_CONTAINER_DEFAULT.into()
             }))
         );
         // Override honored.
         assert_eq!(
-            BenchStore::parse("azurite", None, None, Some("custom".into())),
-            Ok(BenchStore::Remote(RemoteBackend::Azurite {
+            BenchStore::parse("azure", "local", None, None, Some("custom".into())),
+            Ok(BenchStore::External(ExternalBackend::AzureLocal {
                 container: "custom".into()
             }))
         );
     }
 
     #[test]
-    fn parse_rejects_unknown_store() {
-        assert!(BenchStore::parse("gcs", None, None, None).is_err());
+    fn parse_rejects_unknown_store_and_mode() {
+        assert!(BenchStore::parse("gcs", "local", None, None, None).is_err());
+        assert!(BenchStore::parse("s3", "sideways", None, None, None).is_err());
     }
 
     #[test]
     fn parse_does_not_infer_from_creds() {
-        // Both creds present but store=s3s_fs → still the emulator. No
-        // backend is ever picked from which credential happens to be set.
+        // Creds present but store=s3 mode=local → still s3s-fs. The backend
+        // is the (store, mode) axes, never inferred from which cred is set.
         assert_eq!(
-            BenchStore::parse("s3s_fs", Some("bkt".into()), Some("c".into()), None),
+            BenchStore::parse("s3", "local", Some("bkt".into()), Some("c".into()), None),
             Ok(BenchStore::S3sFs)
         );
     }
@@ -609,33 +636,36 @@ mod tests {
     #[test]
     fn label_matches_backend() {
         assert_eq!(
-            RemoteBackend::Azure {
-                container: "c".into()
-            }
-            .label(),
-            "azure"
+            ExternalBackend::S3Remote { bucket: "b".into() }.label(),
+            "s3_remote"
         );
-        assert_eq!(RemoteBackend::S3 { bucket: "b".into() }.label(), "s3");
         assert_eq!(
-            RemoteBackend::Azurite {
+            ExternalBackend::AzureRemote {
                 container: "c".into()
             }
             .label(),
-            "azurite"
+            "azure_remote"
+        );
+        assert_eq!(
+            ExternalBackend::AzureLocal {
+                container: "c".into()
+            }
+            .label(),
+            "azure_local"
         );
     }
 
     #[test]
-    fn storage_labels_cover_every_remote_backend() {
+    fn storage_labels_cover_every_backend() {
         // STORAGE_LABELS is the single source markdown/report code iterates;
-        // every real backend's label must be in it (plus the emulator).
+        // every backend's label must be in it (incl. the s3s-fs `s3_local`).
         for label in [
-            RemoteBackend::S3 { bucket: "b".into() }.label(),
-            RemoteBackend::Azure {
+            ExternalBackend::S3Remote { bucket: "b".into() }.label(),
+            ExternalBackend::AzureRemote {
                 container: "c".into(),
             }
             .label(),
-            RemoteBackend::Azurite {
+            ExternalBackend::AzureLocal {
                 container: "c".into(),
             }
             .label(),
@@ -645,6 +675,6 @@ mod tests {
                 "{label} missing from STORAGE_LABELS"
             );
         }
-        assert!(STORAGE_LABELS.contains(&"s3s_fs"));
+        assert!(STORAGE_LABELS.contains(&"s3_local"));
     }
 }

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -4,9 +4,10 @@
 //! - **Warm**: same, with explicit mmap promotion before timing.
 //! - **Cold**: fresh disk cache per iteration → object-store range GETs.
 //!
-//! Default backing store is in-process `s3s-fs`. Set `INFINO_REAL_S3_BUCKET`
-//! for AWS S3, or `INFINO_REAL_AZURE_CONTAINER` for Azure Blob (Azure wins
-//! when both are set).
+//! Backend is chosen explicitly via `INFINO_BENCH_STORE` (`s3s_fs` default
+//! | `s3` | `azure`); `s3` reads `INFINO_REAL_S3_BUCKET`, `azure` reads
+//! `INFINO_REAL_AZURE_CONTAINER`. Never inferred from which credential is
+//! set.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -122,8 +123,50 @@ fn real_azure_container_env() -> Option<String> {
         .ok()
 }
 
-/// A real (non-emulator) object store selected by env for warm/cold tiers.
-/// Azure takes precedence over S3 when both are configured.
+/// Object store the warm/cold benches run against. Chosen **explicitly**
+/// via `INFINO_BENCH_STORE` — never inferred from which credential happens
+/// to be exported.
+#[derive(Debug, PartialEq, Eq)]
+enum BenchStore {
+    /// In-process s3s-fs emulator (default; no credentials, no network).
+    S3sFs,
+    /// A real remote object store.
+    Remote(RemoteBackend),
+}
+
+impl BenchStore {
+    /// Resolve from `INFINO_BENCH_STORE` (`s3s_fs` default | `s3` | `azure`).
+    fn from_env() -> Self {
+        let store = std::env::var("INFINO_BENCH_STORE").unwrap_or_else(|_| "s3s_fs".into());
+        Self::parse(&store, real_s3_bucket_env(), real_azure_container_env())
+            .unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Pure resolution — the chosen backend must have its location env set.
+    /// Split out so selection is unit-testable without mutating process env.
+    fn parse(
+        store: &str,
+        s3_bucket: Option<String>,
+        azure_container: Option<String>,
+    ) -> Result<Self, String> {
+        match store {
+            "s3s_fs" => Ok(Self::S3sFs),
+            "s3" => s3_bucket
+                .map(|bucket| Self::Remote(RemoteBackend::S3 { bucket }))
+                .ok_or_else(|| "INFINO_BENCH_STORE=s3 requires INFINO_REAL_S3_BUCKET".to_string()),
+            "azure" => azure_container
+                .map(|container| Self::Remote(RemoteBackend::Azure { container }))
+                .ok_or_else(|| {
+                    "INFINO_BENCH_STORE=azure requires INFINO_REAL_AZURE_CONTAINER".to_string()
+                }),
+            other => Err(format!(
+                "unknown INFINO_BENCH_STORE={other} (want s3s_fs|s3|azure)"
+            )),
+        }
+    }
+}
+
+/// A real (non-emulator) object store for warm/cold tiers.
 #[derive(Debug, PartialEq, Eq)]
 enum RemoteBackend {
     S3 { bucket: String },
@@ -131,20 +174,6 @@ enum RemoteBackend {
 }
 
 impl RemoteBackend {
-    fn from_env() -> Option<Self> {
-        Self::select(real_azure_container_env(), real_s3_bucket_env())
-    }
-
-    /// Pure selection (Azure over S3) — split out so precedence is unit-
-    /// testable without mutating process env.
-    fn select(azure_container: Option<String>, s3_bucket: Option<String>) -> Option<Self> {
-        match (azure_container, s3_bucket) {
-            (Some(container), _) => Some(Self::Azure { container }),
-            (None, Some(bucket)) => Some(Self::S3 { bucket }),
-            (None, None) => None,
-        }
-    }
-
     fn label(&self) -> &'static str {
         match self {
             Self::S3 { .. } => "real_s3",
@@ -224,45 +253,49 @@ async fn spawn_s3s_fs(s3s_bucket: &str) -> (SocketAddr, TempDir) {
 }
 
 async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture {
-    if let Some(backend) = RemoteBackend::from_env() {
-        let prefix = unique_bench_prefix(&backend.prefix_root(prefix_default));
-        let storage = backend.provider(&prefix);
-        eprintln!("[tiers] {} prefix={prefix}", backend.label());
-        StorageFixture {
-            storage,
-            storage_label: backend.label(),
-            remote: true,
-            _keepalive: StorageKeepalive::Remote,
+    // s3s-fs returns directly; the remote backends share the construction below.
+    let backend = match BenchStore::from_env() {
+        BenchStore::Remote(backend) => backend,
+        BenchStore::S3sFs => {
+            let (addr, fs_root) = spawn_s3s_fs(s3s_bucket).await;
+            let endpoint = format!("http://{addr}");
+            let storage: Arc<dyn StorageProvider> = Arc::new(
+                S3StorageProvider::new_with_endpoint(
+                    &endpoint,
+                    s3s_bucket,
+                    S3S_ACCESS_KEY,
+                    S3S_SECRET_KEY,
+                    S3S_REGION,
+                )
+                .expect("s3s-fs S3StorageProvider"),
+            );
+            eprintln!(
+                "\n\
+                 ################################################################################\n\
+                 ##  WARNING: benchmarking against the s3s-fs emulator, NOT a real object store.##\n\
+                 ##  The emulator reproduces request count and byte volume, not network         ##\n\
+                 ##  latency, so warm/cold timings here are not representative.                  ##\n\
+                 ##  Set INFINO_BENCH_STORE=s3|azure (+ the backend's container env) for real.   ##\n\
+                 ################################################################################\n\
+                 [tiers] s3s-fs endpoint={endpoint}  storage_label=s3s_fs  (NOT a real store)\n"
+            );
+            return StorageFixture {
+                storage,
+                storage_label: "s3s_fs",
+                remote: false,
+                _keepalive: StorageKeepalive::S3sFs { _fs_root: fs_root },
+            };
         }
-    } else {
-        let (addr, fs_root) = spawn_s3s_fs(s3s_bucket).await;
-        let endpoint = format!("http://{addr}");
-        let storage: Arc<dyn StorageProvider> = Arc::new(
-            S3StorageProvider::new_with_endpoint(
-                &endpoint,
-                s3s_bucket,
-                S3S_ACCESS_KEY,
-                S3S_SECRET_KEY,
-                S3S_REGION,
-            )
-            .expect("s3s-fs S3StorageProvider"),
-        );
-        eprintln!(
-            "\n\
-             ################################################################################\n\
-             ##  WARNING: benchmarking against the s3s-fs emulator, NOT real AWS S3.        ##\n\
-             ##  The emulator reproduces request count and byte volume, not network         ##\n\
-             ##  latency, so warm/cold timings here are not representative of S3.            ##\n\
-             ##  Set INFINO_REAL_S3_BUCKET (+ AWS creds) to benchmark against real S3.       ##\n\
-             ################################################################################\n\
-             [tiers] s3s-fs endpoint={endpoint}  storage_label=s3s_fs  (NOT real S3)\n"
-        );
-        StorageFixture {
-            storage,
-            storage_label: "s3s_fs",
-            remote: false,
-            _keepalive: StorageKeepalive::S3sFs { _fs_root: fs_root },
-        }
+    };
+
+    let prefix = unique_bench_prefix(&backend.prefix_root(prefix_default));
+    let storage = backend.provider(&prefix);
+    eprintln!("[tiers] {} prefix={prefix}", backend.label());
+    StorageFixture {
+        storage,
+        storage_label: backend.label(),
+        remote: true,
+        _keepalive: StorageKeepalive::Remote,
     }
 }
 
@@ -443,30 +476,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn select_prefers_azure_over_s3() {
-        let b = RemoteBackend::select(Some("c".into()), Some("bkt".into()));
+    fn parse_defaults_to_emulator() {
         assert_eq!(
-            b,
-            Some(RemoteBackend::Azure {
-                container: "c".into()
-            })
+            BenchStore::parse("s3s_fs", None, None),
+            Ok(BenchStore::S3sFs)
         );
     }
 
     #[test]
-    fn select_falls_back_to_s3() {
-        let b = RemoteBackend::select(None, Some("bkt".into()));
+    fn parse_s3_needs_bucket() {
         assert_eq!(
-            b,
-            Some(RemoteBackend::S3 {
+            BenchStore::parse("s3", Some("bkt".into()), None),
+            Ok(BenchStore::Remote(RemoteBackend::S3 {
                 bucket: "bkt".into()
-            })
+            }))
         );
+        assert!(BenchStore::parse("s3", None, None).is_err());
     }
 
     #[test]
-    fn select_none_when_unset() {
-        assert_eq!(RemoteBackend::select(None, None), None);
+    fn parse_azure_needs_container() {
+        assert_eq!(
+            BenchStore::parse("azure", None, Some("c".into())),
+            Ok(BenchStore::Remote(RemoteBackend::Azure {
+                container: "c".into()
+            }))
+        );
+        assert!(BenchStore::parse("azure", None, None).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_unknown_store() {
+        assert!(BenchStore::parse("gcs", None, None).is_err());
+    }
+
+    #[test]
+    fn parse_does_not_infer_from_creds() {
+        // Both creds present but store=s3s_fs → still the emulator. No
+        // backend is ever picked from which credential happens to be set.
+        assert_eq!(
+            BenchStore::parse("s3s_fs", Some("bkt".into()), Some("c".into())),
+            Ok(BenchStore::S3sFs)
+        );
     }
 
     #[test]

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -1,12 +1,12 @@
-//! Shared hot / cold storage tier helpers for canonical benches.
+//! Shared hot / cold storage tier helpers for the search benches.
 //!
-//! - **Hot**: `Supertable::open` from object storage + `DiskCacheStore` (local cache hits).
+//! - **Hot**: open from object storage, all segments mmap-promoted (reads
+//!   hit resident pages).
 //! - **Cold**: fresh disk cache per iteration → object-store range GETs.
 //!
-//! Backend is chosen explicitly via `INFINO_BENCH_STORE` (`s3s_fs` default
-//! | `s3` | `azure`); `s3` reads `INFINO_REAL_S3_BUCKET`, `azure` reads
-//! `INFINO_REAL_AZURE_CONTAINER`. Never inferred from which credential is
-//! set.
+//! Backend is chosen on two axes — `INFINO_BENCH_STORE` (`s3` | `azure`) ×
+//! `INFINO_BENCH_MODE` (`local` | `remote`) — never inferred from which
+//! credential is set.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -48,8 +48,8 @@ impl Tier {
     }
 }
 
-/// Storage labels that can appear in a warm/cold search group name
-/// (`{family}_{tier}_search_{label}`) — one per (store, mode): `s3_local`
+/// Storage labels that can appear in a cold search group name
+/// (`{family}_cold_search_{label}`) — one per (store, mode): `s3_local`
 /// (in-process s3s-fs), `s3_remote`, `azure_local` (Azurite), `azure_remote`.
 /// Markdown report generation iterates this set; a unit test guards it
 /// against the backend `label()` methods.
@@ -69,7 +69,7 @@ pub fn search_group_name(family: &str, tier: Tier, storage_label: Option<&str>) 
     }
 }
 
-/// Selected object-store backend for warm/cold tiers.
+/// Selected object-store backend for hot/cold tiers.
 pub struct StorageFixture {
     pub storage: Arc<dyn StorageProvider>,
     pub storage_label: &'static str,
@@ -92,7 +92,7 @@ pub struct SuperfileCommitted {
 /// One runtime for the whole bench process. `spawn_s3s_fs` binds its
 /// accept loop to this runtime; creating a fresh `Runtime` per
 /// `block_on` call would drop the previous one and kill in-process
-/// s3s-fs before warm/cold tiers run.
+/// s3s-fs before the cold tier runs.
 static TIER_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 fn tier_runtime() -> &'static Runtime {
@@ -173,13 +173,10 @@ fn azurite_container_env() -> Option<String> {
     std::env::var("INFINO_AZURITE_CONTAINER").ok()
 }
 
-/// Object store the warm/cold benches run against. Chosen **explicitly**
-/// via `INFINO_BENCH_STORE` — never inferred from which credential happens
-/// to be exported.
-///
-/// Two orthogonal axes: `INFINO_BENCH_STORE` (`s3` | `azure`) picks the
-/// provider, `INFINO_BENCH_MODE` (`local` | `remote`) picks the deployment.
-/// The four combinations:
+/// Object store the hot/cold benches run against — two orthogonal axes,
+/// never inferred from which credential is set: `INFINO_BENCH_STORE`
+/// (`s3` | `azure`) picks the provider, `INFINO_BENCH_MODE`
+/// (`local` | `remote`) the deployment:
 ///
 /// | store | mode   | backend                         |
 /// |-------|--------|---------------------------------|
@@ -370,7 +367,7 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
                  ################################################################################\n\
                  ##  WARNING: store=s3 mode=local → in-process s3s-fs, NOT a real object store. ##\n\
                  ##  It reproduces request count and byte volume, not network latency, so       ##\n\
-                 ##  warm/cold timings here are not representative — and it can't complete the   ##\n\
+                 ##  hot/cold timings here are not representative — and it can't complete the   ##\n\
                  ##  supertable's multi-commit ingest. For a full local run use store=azure     ##\n\
                  ##  mode=local (Azurite); for real timings use mode=remote (S3 / Azure).        ##\n\
                  ################################################################################\n\
@@ -409,12 +406,12 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
     }
 }
 
-/// Supertable-shaped backing store (10M warm/cold benches).
+/// Supertable-shaped backing store (10M hot/cold benches).
 pub async fn supertable_storage_fixture() -> StorageFixture {
     backing_store(SUPERTABLE_S3S_BUCKET, "infino-supertable-bench").await
 }
 
-/// Upload one superfile blob for superfile-shaped warm/cold benches (1M).
+/// Upload one superfile blob for superfile-shaped hot/cold benches (1M).
 pub async fn commit_superfile(bytes: &Bytes) -> SuperfileCommitted {
     let fixture = backing_store(SUPERFILE_S3S_BUCKET, "infino-superfile-bench").await;
     let uri = SuperfileUri::new_v4();

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -67,9 +67,6 @@ pub fn search_group_name(family: &str, tier: Tier, storage_label: Option<&str>) 
 pub struct StorageFixture {
     pub storage: Arc<dyn StorageProvider>,
     pub storage_label: &'static str,
-    /// True for a real remote store (S3/Azure) that needs explicit
-    /// cleanup; false for the ephemeral in-process s3s-fs emulator.
-    pub remote: bool,
     _keepalive: StorageKeepalive,
 }
 
@@ -82,14 +79,7 @@ enum StorageKeepalive {
 pub struct SuperfileCommitted {
     pub storage: Arc<dyn StorageProvider>,
     pub uri: SuperfileUri,
-    /// Object key under the storage provider (same bytes the hot
-    /// path built — uploaded verbatim for lazy vector open).
-    pub object_path: String,
-    pub object_size: u64,
     pub storage_label: &'static str,
-    /// See [`StorageFixture::remote`].
-    pub remote: bool,
-    pub cleanup_path: Option<String>,
     _keepalive: StorageKeepalive,
 }
 
@@ -120,10 +110,11 @@ struct CleanupTarget {
 
 static CLEANUP: Mutex<Vec<CleanupTarget>> = Mutex::new(Vec::new());
 
-/// Delete every remote prefix registered this run. Call once after the
-/// criterion groups finish (statics don't run `Drop` at process exit, so
-/// teardown is explicit). No-op for s3s-fs (its tempdir self-cleans) and
-/// for persisted runs (nothing is registered).
+/// Delete every remote prefix registered this run. Call once from the
+/// `main` of any bench that goes through `backing_store` against a real
+/// store, after the criterion groups finish — statics don't run `Drop`
+/// at process exit, so teardown is explicit. No-op for s3s-fs (its
+/// tempdir self-cleans) and for persisted runs (nothing is registered).
 pub fn cleanup_ephemeral() {
     let targets = std::mem::take(&mut *CLEANUP.lock().expect("cleanup registry"));
     if targets.is_empty() {
@@ -301,15 +292,7 @@ async fn spawn_s3s_fs(s3s_bucket: &str) -> (SocketAddr, TempDir) {
     (addr, fs_root)
 }
 
-/// `register_cleanup`: when true, an ephemeral remote run records its
-/// unique prefix for deletion by `cleanup_ephemeral`. Only callers whose
-/// bench `main` drains the registry pass true (the supertable path); the
-/// superfile path passes false.
-async fn backing_store(
-    s3s_bucket: &str,
-    prefix_default: &str,
-    register_cleanup: bool,
-) -> StorageFixture {
+async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture {
     // s3s-fs returns directly; the remote backends share the construction below.
     let backend = match BenchStore::from_env() {
         BenchStore::Remote(backend) => backend,
@@ -339,7 +322,6 @@ async fn backing_store(
             return StorageFixture {
                 storage,
                 storage_label: "s3s_fs",
-                remote: false,
                 _keepalive: StorageKeepalive::S3sFs { _fs_root: fs_root },
             };
         }
@@ -352,7 +334,7 @@ async fn backing_store(
     // Ephemeral runs (no persisted dataset) own this unique prefix and must
     // delete it at the end; persisted runs (`INFINO_BENCH_DATASET`) keep the
     // table for reuse, so they register nothing.
-    if register_cleanup && std::env::var("INFINO_BENCH_DATASET").is_err() {
+    if std::env::var("INFINO_BENCH_DATASET").is_err() {
         CLEANUP
             .lock()
             .expect("cleanup registry")
@@ -366,19 +348,18 @@ async fn backing_store(
     StorageFixture {
         storage,
         storage_label: backend.label(),
-        remote: true,
         _keepalive: StorageKeepalive::Remote,
     }
 }
 
 /// Supertable-shaped backing store (10M warm/cold benches).
 pub async fn supertable_storage_fixture() -> StorageFixture {
-    backing_store(SUPERTABLE_S3S_BUCKET, "infino-supertable-bench", true).await
+    backing_store(SUPERTABLE_S3S_BUCKET, "infino-supertable-bench").await
 }
 
 /// Upload one superfile blob for superfile-shaped warm/cold benches (1M).
 pub async fn commit_superfile(bytes: &Bytes) -> SuperfileCommitted {
-    let fixture = backing_store(SUPERFILE_S3S_BUCKET, "infino-superfile-bench", false).await;
+    let fixture = backing_store(SUPERFILE_S3S_BUCKET, "infino-superfile-bench").await;
     let uri = SuperfileUri::new_v4();
     let path = uri.storage_path();
     fixture
@@ -394,11 +375,7 @@ pub async fn commit_superfile(bytes: &Bytes) -> SuperfileCommitted {
     SuperfileCommitted {
         storage: fixture.storage,
         uri,
-        object_path: path.clone(),
-        object_size: bytes.len() as u64,
         storage_label: fixture.storage_label,
-        remote: fixture.remote,
-        cleanup_path: if fixture.remote { Some(path) } else { None },
         _keepalive: fixture._keepalive,
     }
 }

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -238,10 +238,12 @@ impl BenchStore {
                      INFINO_REAL_AZURE_CONTAINER"
                         .to_string()
                 }),
-            ("s3" | "azure", other) => {
-                Err(format!("unknown INFINO_BENCH_MODE={other} (want local|remote)"))
-            }
-            (other, _) => Err(format!("unknown INFINO_BENCH_STORE={other} (want s3|azure)")),
+            ("s3" | "azure", other) => Err(format!(
+                "unknown INFINO_BENCH_MODE={other} (want local|remote)"
+            )),
+            (other, _) => Err(format!(
+                "unknown INFINO_BENCH_STORE={other} (want s3|azure)"
+            )),
         }
     }
 }
@@ -391,7 +393,10 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
     if std::env::var_os("INFINO_BENCH_KEEP_TABLE").is_some()
         || std::env::var_os("INFINO_BENCH_DATASET").is_some()
     {
-        eprintln!("[tiers] keeping {} prefix={prefix} (cleanup skipped)", backend.label());
+        eprintln!(
+            "[tiers] keeping {} prefix={prefix} (cleanup skipped)",
+            backend.label()
+        );
     } else {
         CLEANUP
             .lock()

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -385,10 +385,10 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
     let storage = backend.provider(&prefix);
     eprintln!("[tiers] {} prefix={prefix}", backend.label());
 
-    // The unique prefix is deleted after the run, unless the caller keeps it
-    // (`INFINO_BENCH_KEEP`, e.g. to inspect or re-query the table) or it's a
-    // persisted dataset run (`INFINO_BENCH_DATASET`).
-    if std::env::var_os("INFINO_BENCH_KEEP").is_some()
+    // The unique prefix is deleted after the run, unless the caller keeps the
+    // table (`INFINO_BENCH_KEEP_TABLE`, e.g. to inspect or re-query it) or it's
+    // a persisted dataset run (`INFINO_BENCH_DATASET`).
+    if std::env::var_os("INFINO_BENCH_KEEP_TABLE").is_some()
         || std::env::var_os("INFINO_BENCH_DATASET").is_some()
     {
         eprintln!("[tiers] keeping {} prefix={prefix} (cleanup skipped)", backend.label());

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -5,7 +5,8 @@
 //! - **Cold**: fresh disk cache per iteration → object-store range GETs.
 //!
 //! Default backing store is in-process `s3s-fs`. Set `INFINO_REAL_S3_BUCKET`
-//! (or `INFINO_TEST_REAL_S3_BUCKET`) for AWS S3.
+//! for AWS S3, or `INFINO_REAL_AZURE_CONTAINER` for Azure Blob (Azure wins
+//! when both are set).
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -14,7 +15,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use infino::supertable::reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy};
-use infino::supertable::storage::{S3StorageProvider, StorageProvider};
+use infino::supertable::storage::{AzureStorageProvider, S3StorageProvider, StorageProvider};
 use infino::supertable::{SuperfileUri, Supertable, SupertableOptions};
 use s3s::auth::SimpleAuth;
 use s3s::service::S3ServiceBuilder;
@@ -65,13 +66,15 @@ pub fn search_group_name(family: &str, tier: Tier, storage_label: Option<&str>) 
 pub struct StorageFixture {
     pub storage: Arc<dyn StorageProvider>,
     pub storage_label: &'static str,
-    pub real_s3: bool,
+    /// True for a real remote store (S3/Azure) that needs explicit
+    /// cleanup; false for the ephemeral in-process s3s-fs emulator.
+    pub remote: bool,
     _keepalive: StorageKeepalive,
 }
 
 enum StorageKeepalive {
     S3sFs { _fs_root: TempDir },
-    RealS3,
+    Remote,
 }
 
 /// A single superfile committed to object storage (1M tier benches).
@@ -83,7 +86,8 @@ pub struct SuperfileCommitted {
     pub object_path: String,
     pub object_size: u64,
     pub storage_label: &'static str,
-    pub real_s3: bool,
+    /// See [`StorageFixture::remote`].
+    pub remote: bool,
     pub cleanup_path: Option<String>,
     _keepalive: StorageKeepalive,
 }
@@ -110,6 +114,68 @@ pub fn real_s3_bucket_env() -> Option<String> {
 
 pub fn real_s3_prefix_root(default: &str) -> String {
     std::env::var("INFINO_REAL_S3_PREFIX").unwrap_or_else(|_| default.to_string())
+}
+
+fn real_azure_container_env() -> Option<String> {
+    std::env::var("INFINO_REAL_AZURE_CONTAINER")
+        .or_else(|_| std::env::var("INFINO_TEST_REAL_AZURE_CONTAINER"))
+        .ok()
+}
+
+/// A real (non-emulator) object store selected by env for warm/cold tiers.
+/// Azure takes precedence over S3 when both are configured.
+#[derive(Debug, PartialEq, Eq)]
+enum RemoteBackend {
+    S3 { bucket: String },
+    Azure { container: String },
+}
+
+impl RemoteBackend {
+    fn from_env() -> Option<Self> {
+        Self::select(real_azure_container_env(), real_s3_bucket_env())
+    }
+
+    /// Pure selection (Azure over S3) — split out so precedence is unit-
+    /// testable without mutating process env.
+    fn select(azure_container: Option<String>, s3_bucket: Option<String>) -> Option<Self> {
+        match (azure_container, s3_bucket) {
+            (Some(container), _) => Some(Self::Azure { container }),
+            (None, Some(bucket)) => Some(Self::S3 { bucket }),
+            (None, None) => None,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::S3 { .. } => "real_s3",
+            Self::Azure { .. } => "real_azure",
+        }
+    }
+
+    /// Namespace root for this run's objects: a per-backend env override,
+    /// else `default`.
+    fn prefix_root(&self, default: &str) -> String {
+        match self {
+            Self::S3 { .. } => real_s3_prefix_root(default),
+            Self::Azure { .. } => {
+                std::env::var("INFINO_REAL_AZURE_PREFIX").unwrap_or_else(|_| default.to_string())
+            }
+        }
+    }
+
+    /// Provider scoped to `prefix`. The single per-backend construction
+    /// site; adding a backend is one arm here.
+    fn provider(&self, prefix: &str) -> Arc<dyn StorageProvider> {
+        match self {
+            Self::S3 { bucket } => Arc::new(
+                S3StorageProvider::new_with_prefix(bucket, prefix).expect("real S3 provider"),
+            ),
+            Self::Azure { container } => Arc::new(
+                AzureStorageProvider::new_with_prefix(container, prefix)
+                    .expect("real Azure provider"),
+            ),
+        }
+    }
 }
 
 fn unique_bench_prefix(root: &str) -> String {
@@ -158,17 +224,15 @@ async fn spawn_s3s_fs(s3s_bucket: &str) -> (SocketAddr, TempDir) {
 }
 
 async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture {
-    if let Some(bucket) = real_s3_bucket_env() {
-        let prefix = unique_bench_prefix(&real_s3_prefix_root(prefix_default));
-        let storage: Arc<dyn StorageProvider> = Arc::new(
-            S3StorageProvider::new_with_prefix(&bucket, &prefix).expect("real S3 provider"),
-        );
-        eprintln!("[tiers] real S3: bucket={bucket} prefix={prefix}");
+    if let Some(backend) = RemoteBackend::from_env() {
+        let prefix = unique_bench_prefix(&backend.prefix_root(prefix_default));
+        let storage = backend.provider(&prefix);
+        eprintln!("[tiers] {} prefix={prefix}", backend.label());
         StorageFixture {
             storage,
-            storage_label: "real_s3",
-            real_s3: true,
-            _keepalive: StorageKeepalive::RealS3,
+            storage_label: backend.label(),
+            remote: true,
+            _keepalive: StorageKeepalive::Remote,
         }
     } else {
         let (addr, fs_root) = spawn_s3s_fs(s3s_bucket).await;
@@ -196,7 +260,7 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
         StorageFixture {
             storage,
             storage_label: "s3s_fs",
-            real_s3: false,
+            remote: false,
             _keepalive: StorageKeepalive::S3sFs { _fs_root: fs_root },
         }
     }
@@ -228,8 +292,8 @@ pub async fn commit_superfile(bytes: &Bytes) -> SuperfileCommitted {
         object_path: path.clone(),
         object_size: bytes.len() as u64,
         storage_label: fixture.storage_label,
-        real_s3: fixture.real_s3,
-        cleanup_path: if fixture.real_s3 { Some(path) } else { None },
+        remote: fixture.remote,
+        cleanup_path: if fixture.remote { Some(path) } else { None },
         _keepalive: fixture._keepalive,
     }
 }
@@ -372,4 +436,48 @@ pub async fn wait_for_superfile_promotion(
 pub fn empty_pinned()
 -> Arc<dyn Fn() -> HashSet<infino::supertable::manifest::SuperfileUri> + Send + Sync> {
     Arc::new(HashSet::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_prefers_azure_over_s3() {
+        let b = RemoteBackend::select(Some("c".into()), Some("bkt".into()));
+        assert_eq!(
+            b,
+            Some(RemoteBackend::Azure {
+                container: "c".into()
+            })
+        );
+    }
+
+    #[test]
+    fn select_falls_back_to_s3() {
+        let b = RemoteBackend::select(None, Some("bkt".into()));
+        assert_eq!(
+            b,
+            Some(RemoteBackend::S3 {
+                bucket: "bkt".into()
+            })
+        );
+    }
+
+    #[test]
+    fn select_none_when_unset() {
+        assert_eq!(RemoteBackend::select(None, None), None);
+    }
+
+    #[test]
+    fn label_matches_backend() {
+        assert_eq!(
+            RemoteBackend::Azure {
+                container: "c".into()
+            }
+            .label(),
+            "real_azure"
+        );
+        assert_eq!(RemoteBackend::S3 { bucket: "b".into() }.label(), "real_s3");
+    }
 }

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -385,10 +385,14 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
     let storage = backend.provider(&prefix);
     eprintln!("[tiers] {} prefix={prefix}", backend.label());
 
-    // Ephemeral runs (no persisted dataset) own this unique prefix and must
-    // delete it at the end; persisted runs (`INFINO_BENCH_DATASET`) keep the
-    // table for reuse, so they register nothing.
-    if std::env::var("INFINO_BENCH_DATASET").is_err() {
+    // The unique prefix is deleted after the run, unless the caller keeps it
+    // (`INFINO_BENCH_KEEP`, e.g. to inspect or re-query the table) or it's a
+    // persisted dataset run (`INFINO_BENCH_DATASET`).
+    if std::env::var_os("INFINO_BENCH_KEEP").is_some()
+        || std::env::var_os("INFINO_BENCH_DATASET").is_some()
+    {
+        eprintln!("[tiers] keeping {} prefix={prefix} (cleanup skipped)", backend.label());
+    } else {
         CLEANUP
             .lock()
             .expect("cleanup registry")

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -105,6 +105,44 @@ fn tier_runtime() -> &'static Runtime {
 
 pub fn block_on<F: std::future::Future>(fut: F) -> F::Output {
     tier_runtime().block_on(fut)
+}
+
+/// A remote prefix to delete when the process ends. Registered only for
+/// ephemeral runs (no `INFINO_BENCH_DATASET`): each such run writes a
+/// throwaway table under a unique prefix and must not leave it behind.
+struct CleanupTarget {
+    /// Provider scoped to the bucket root, so `prefix` is listed/deleted
+    /// as an absolute path.
+    root: Arc<dyn StorageProvider>,
+    prefix: String,
+    label: &'static str,
+}
+
+static CLEANUP: Mutex<Vec<CleanupTarget>> = Mutex::new(Vec::new());
+
+/// Delete every remote prefix registered this run. Call once after the
+/// criterion groups finish (statics don't run `Drop` at process exit, so
+/// teardown is explicit). No-op for s3s-fs (its tempdir self-cleans) and
+/// for persisted runs (nothing is registered).
+pub fn cleanup_ephemeral() {
+    let targets = std::mem::take(&mut *CLEANUP.lock().expect("cleanup registry"));
+    if targets.is_empty() {
+        return;
+    }
+    block_on(async {
+        for t in targets {
+            let keys = t.root.list_with_prefix(&t.prefix).await.unwrap_or_default();
+            for key in &keys {
+                let _ = t.root.delete(key).await;
+            }
+            eprintln!(
+                "[tiers] cleaned {} objects under {} ({})",
+                keys.len(),
+                t.prefix,
+                t.label
+            );
+        }
+    });
 }
 
 pub fn real_s3_bucket_env() -> Option<String> {
@@ -291,6 +329,21 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
     let prefix = unique_bench_prefix(&backend.prefix_root(prefix_default));
     let storage = backend.provider(&prefix);
     eprintln!("[tiers] {} prefix={prefix}", backend.label());
+
+    // Ephemeral runs (no persisted dataset) own this unique prefix and must
+    // delete it at the end; persisted runs (`INFINO_BENCH_DATASET`) keep the
+    // table for reuse, so they register nothing.
+    if std::env::var("INFINO_BENCH_DATASET").is_err() {
+        CLEANUP
+            .lock()
+            .expect("cleanup registry")
+            .push(CleanupTarget {
+                root: backend.provider(""),
+                prefix: prefix.clone(),
+                label: backend.label(),
+            });
+    }
+
     StorageFixture {
         storage,
         storage_label: backend.label(),

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -52,6 +52,12 @@ impl Tier {
     }
 }
 
+/// Storage labels that can appear in a warm/cold search group name
+/// (`{family}_{tier}_search_{label}`). The emulator is `s3s_fs`; real
+/// backends use [`RemoteBackend::label`]. Markdown report generation
+/// iterates this set; a unit test guards it against `RemoteBackend::label`.
+pub const STORAGE_LABELS: &[&str] = &["s3s_fs", "s3", "azure"];
+
 /// Criterion group name for a tiered search bench family (`superfile_vec`, `supertable_fts`, …).
 pub fn search_group_name(family: &str, tier: Tier, storage_label: Option<&str>) -> String {
     match tier {
@@ -216,8 +222,8 @@ enum RemoteBackend {
 impl RemoteBackend {
     fn label(&self) -> &'static str {
         match self {
-            Self::S3 { .. } => "real_s3",
-            Self::Azure { .. } => "real_azure",
+            Self::S3 { .. } => "s3",
+            Self::Azure { .. } => "azure",
         }
     }
 
@@ -576,8 +582,27 @@ mod tests {
                 container: "c".into()
             }
             .label(),
-            "real_azure"
+            "azure"
         );
-        assert_eq!(RemoteBackend::S3 { bucket: "b".into() }.label(), "real_s3");
+        assert_eq!(RemoteBackend::S3 { bucket: "b".into() }.label(), "s3");
+    }
+
+    #[test]
+    fn storage_labels_cover_every_remote_backend() {
+        // STORAGE_LABELS is the single source markdown/report code iterates;
+        // every real backend's label must be in it (plus the emulator).
+        for label in [
+            RemoteBackend::S3 { bucket: "b".into() }.label(),
+            RemoteBackend::Azure {
+                container: "c".into(),
+            }
+            .label(),
+        ] {
+            assert!(
+                STORAGE_LABELS.contains(&label),
+                "{label} missing from STORAGE_LABELS"
+            );
+        }
+        assert!(STORAGE_LABELS.contains(&"s3s_fs"));
     }
 }

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -52,7 +52,10 @@ impl Tier {
 /// (`{family}_{tier}_search_{label}`). The emulator is `s3s_fs`; real
 /// backends use [`RemoteBackend::label`]. Markdown report generation
 /// iterates this set; a unit test guards it against `RemoteBackend::label`.
-pub const STORAGE_LABELS: &[&str] = &["s3s_fs", "s3", "azure"];
+pub const STORAGE_LABELS: &[&str] = &["s3s_fs", "s3", "azure", "azurite"];
+
+/// Default Azurite container (must already exist in the emulator).
+const AZURITE_CONTAINER_DEFAULT: &str = "infino-bench";
 
 /// Criterion group name for a tiered search bench family (`superfile_vec`, `supertable_fts`, …).
 pub fn search_group_name(family: &str, tier: Tier, storage_label: Option<&str>) -> String {
@@ -165,6 +168,10 @@ fn real_azure_container_env() -> Option<String> {
         .ok()
 }
 
+fn azurite_container_env() -> Option<String> {
+    std::env::var("INFINO_AZURITE_CONTAINER").ok()
+}
+
 /// Object store the warm/cold benches run against. Chosen **explicitly**
 /// via `INFINO_BENCH_STORE` — never inferred from which credential happens
 /// to be exported.
@@ -177,11 +184,17 @@ enum BenchStore {
 }
 
 impl BenchStore {
-    /// Resolve from `INFINO_BENCH_STORE` (`s3s_fs` default | `s3` | `azure`).
+    /// Resolve from `INFINO_BENCH_STORE` (`s3s_fs` default | `s3` | `azure`
+    /// | `azurite`).
     fn from_env() -> Self {
         let store = std::env::var("INFINO_BENCH_STORE").unwrap_or_else(|_| "s3s_fs".into());
-        Self::parse(&store, real_s3_bucket_env(), real_azure_container_env())
-            .unwrap_or_else(|e| panic!("{e}"))
+        Self::parse(
+            &store,
+            real_s3_bucket_env(),
+            real_azure_container_env(),
+            azurite_container_env(),
+        )
+        .unwrap_or_else(|e| panic!("{e}"))
     }
 
     /// Pure resolution — the chosen backend must have its location env set.
@@ -190,6 +203,7 @@ impl BenchStore {
         store: &str,
         s3_bucket: Option<String>,
         azure_container: Option<String>,
+        azurite_container: Option<String>,
     ) -> Result<Self, String> {
         match store {
             "s3s_fs" => Ok(Self::S3sFs),
@@ -201,8 +215,14 @@ impl BenchStore {
                 .ok_or_else(|| {
                     "INFINO_BENCH_STORE=azure requires INFINO_REAL_AZURE_CONTAINER".to_string()
                 }),
+            // Local Azurite emulator: credential-free (well-known
+            // devstoreaccount1), so no required env — the container defaults
+            // to `infino-bench` and must already exist in the emulator.
+            "azurite" => Ok(Self::Remote(RemoteBackend::Azurite {
+                container: azurite_container.unwrap_or_else(|| AZURITE_CONTAINER_DEFAULT.into()),
+            })),
             other => Err(format!(
-                "unknown INFINO_BENCH_STORE={other} (want s3s_fs|s3|azure)"
+                "unknown INFINO_BENCH_STORE={other} (want s3s_fs|s3|azure|azurite)"
             )),
         }
     }
@@ -213,6 +233,8 @@ impl BenchStore {
 enum RemoteBackend {
     S3 { bucket: String },
     Azure { container: String },
+    /// Local Azurite emulator (well-known credentials, no network).
+    Azurite { container: String },
 }
 
 impl RemoteBackend {
@@ -220,6 +242,7 @@ impl RemoteBackend {
         match self {
             Self::S3 { .. } => "s3",
             Self::Azure { .. } => "azure",
+            Self::Azurite { .. } => "azurite",
         }
     }
 
@@ -230,6 +253,9 @@ impl RemoteBackend {
             Self::S3 { .. } => real_s3_prefix_root(default),
             Self::Azure { .. } => {
                 std::env::var("INFINO_REAL_AZURE_PREFIX").unwrap_or_else(|_| default.to_string())
+            }
+            Self::Azurite { .. } => {
+                std::env::var("INFINO_AZURITE_PREFIX").unwrap_or_else(|_| default.to_string())
             }
         }
     }
@@ -244,6 +270,10 @@ impl RemoteBackend {
             Self::Azure { container } => Arc::new(
                 AzureStorageProvider::new_with_prefix(container, prefix)
                     .expect("real Azure provider"),
+            ),
+            Self::Azurite { container } => Arc::new(
+                AzureStorageProvider::new_with_emulator_and_prefix(container, prefix)
+                    .expect("Azurite provider"),
             ),
         }
     }
@@ -516,7 +546,7 @@ mod tests {
     #[test]
     fn parse_defaults_to_emulator() {
         assert_eq!(
-            BenchStore::parse("s3s_fs", None, None),
+            BenchStore::parse("s3s_fs", None, None, None),
             Ok(BenchStore::S3sFs)
         );
     }
@@ -524,28 +554,46 @@ mod tests {
     #[test]
     fn parse_s3_needs_bucket() {
         assert_eq!(
-            BenchStore::parse("s3", Some("bkt".into()), None),
+            BenchStore::parse("s3", Some("bkt".into()), None, None),
             Ok(BenchStore::Remote(RemoteBackend::S3 {
                 bucket: "bkt".into()
             }))
         );
-        assert!(BenchStore::parse("s3", None, None).is_err());
+        assert!(BenchStore::parse("s3", None, None, None).is_err());
     }
 
     #[test]
     fn parse_azure_needs_container() {
         assert_eq!(
-            BenchStore::parse("azure", None, Some("c".into())),
+            BenchStore::parse("azure", None, Some("c".into()), None),
             Ok(BenchStore::Remote(RemoteBackend::Azure {
                 container: "c".into()
             }))
         );
-        assert!(BenchStore::parse("azure", None, None).is_err());
+        assert!(BenchStore::parse("azure", None, None, None).is_err());
+    }
+
+    #[test]
+    fn parse_azurite_defaults_container_and_needs_no_creds() {
+        // No required env: the emulator is credential-free.
+        assert_eq!(
+            BenchStore::parse("azurite", None, None, None),
+            Ok(BenchStore::Remote(RemoteBackend::Azurite {
+                container: AZURITE_CONTAINER_DEFAULT.into()
+            }))
+        );
+        // Override honored.
+        assert_eq!(
+            BenchStore::parse("azurite", None, None, Some("custom".into())),
+            Ok(BenchStore::Remote(RemoteBackend::Azurite {
+                container: "custom".into()
+            }))
+        );
     }
 
     #[test]
     fn parse_rejects_unknown_store() {
-        assert!(BenchStore::parse("gcs", None, None).is_err());
+        assert!(BenchStore::parse("gcs", None, None, None).is_err());
     }
 
     #[test]
@@ -553,7 +601,7 @@ mod tests {
         // Both creds present but store=s3s_fs → still the emulator. No
         // backend is ever picked from which credential happens to be set.
         assert_eq!(
-            BenchStore::parse("s3s_fs", Some("bkt".into()), Some("c".into())),
+            BenchStore::parse("s3s_fs", Some("bkt".into()), Some("c".into()), None),
             Ok(BenchStore::S3sFs)
         );
     }
@@ -568,6 +616,13 @@ mod tests {
             "azure"
         );
         assert_eq!(RemoteBackend::S3 { bucket: "b".into() }.label(), "s3");
+        assert_eq!(
+            RemoteBackend::Azurite {
+                container: "c".into()
+            }
+            .label(),
+            "azurite"
+        );
     }
 
     #[test]
@@ -577,6 +632,10 @@ mod tests {
         for label in [
             RemoteBackend::S3 { bucket: "b".into() }.label(),
             RemoteBackend::Azure {
+                container: "c".into(),
+            }
+            .label(),
+            RemoteBackend::Azurite {
                 container: "c".into(),
             }
             .label(),

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -131,7 +131,18 @@ pub fn cleanup_ephemeral() {
     }
     block_on(async {
         for t in targets {
-            let keys = t.root.list_with_prefix(&t.prefix).await.unwrap_or_default();
+            let keys = match t.root.list_with_prefix(&t.prefix).await {
+                Ok(keys) => keys,
+                // Surface rather than swallow: a failed list means the
+                // prefix may be leaking, which is worth seeing.
+                Err(e) => {
+                    eprintln!(
+                        "[tiers] cleanup list failed for {} ({}): {e}",
+                        t.prefix, t.label
+                    );
+                    continue;
+                }
+            };
             for key in &keys {
                 let _ = t.root.delete(key).await;
             }
@@ -290,7 +301,15 @@ async fn spawn_s3s_fs(s3s_bucket: &str) -> (SocketAddr, TempDir) {
     (addr, fs_root)
 }
 
-async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture {
+/// `register_cleanup`: when true, an ephemeral remote run records its
+/// unique prefix for deletion by `cleanup_ephemeral`. Only callers whose
+/// bench `main` drains the registry pass true (the supertable path); the
+/// superfile path passes false.
+async fn backing_store(
+    s3s_bucket: &str,
+    prefix_default: &str,
+    register_cleanup: bool,
+) -> StorageFixture {
     // s3s-fs returns directly; the remote backends share the construction below.
     let backend = match BenchStore::from_env() {
         BenchStore::Remote(backend) => backend,
@@ -333,7 +352,7 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
     // Ephemeral runs (no persisted dataset) own this unique prefix and must
     // delete it at the end; persisted runs (`INFINO_BENCH_DATASET`) keep the
     // table for reuse, so they register nothing.
-    if std::env::var("INFINO_BENCH_DATASET").is_err() {
+    if register_cleanup && std::env::var("INFINO_BENCH_DATASET").is_err() {
         CLEANUP
             .lock()
             .expect("cleanup registry")
@@ -354,12 +373,12 @@ async fn backing_store(s3s_bucket: &str, prefix_default: &str) -> StorageFixture
 
 /// Supertable-shaped backing store (10M warm/cold benches).
 pub async fn supertable_storage_fixture() -> StorageFixture {
-    backing_store(SUPERTABLE_S3S_BUCKET, "infino-supertable-bench").await
+    backing_store(SUPERTABLE_S3S_BUCKET, "infino-supertable-bench", true).await
 }
 
 /// Upload one superfile blob for superfile-shaped warm/cold benches (1M).
 pub async fn commit_superfile(bytes: &Bytes) -> SuperfileCommitted {
-    let fixture = backing_store(SUPERFILE_S3S_BUCKET, "infino-superfile-bench").await;
+    let fixture = backing_store(SUPERFILE_S3S_BUCKET, "infino-superfile-bench", false).await;
     let uri = SuperfileUri::new_v4();
     let path = uri.storage_path();
     fixture

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -510,7 +510,7 @@ async fn setup_bench_fixture(superfile: &Bytes) -> BenchFixture {
         BenchFixture {
             storage,
             uri,
-            storage_label: "real_s3",
+            storage_label: "s3",
             real_s3: true,
             cleanup_path: Some(path),
             _fs_root: None,

--- a/benches/utils/vector_superfile.rs
+++ b/benches/utils/vector_superfile.rs
@@ -1,4 +1,4 @@
-//! Infino-only vector bench for the superfile layer:
+//! Vector benches for the superfile layer:
 //!
 //!   ingest timing (1M × 384 Gaussian planted clusters, cosine)
 //! + calibrated kNN search at recall targets {0.90, 0.95, 0.99}

--- a/benches/vector/main.rs
+++ b/benches/vector/main.rs
@@ -1,28 +1,23 @@
-//! Vector superfile bench bundle (infino-only). Supertable vector
-//! benches live in `benches/supertable/main.rs`, where they share one
-//! combined 10M-row supertable with the FTS supertable benches.
-//!
-//! Infino-only timing and correctness — no third-party crates in
-//! the dependency graph of these benches.
+//! Vector benches over a 1M single superfile. The 10M supertable vector
+//! benches live in `benches/supertable/main.rs`.
 //!
 //! ## Invocation
 //!
 //! ```text
-//! cargo bench --bench superfile_vector                         # 1M superfile vector benches
-//! cargo bench --bench superfile_vector -- superfile_vec_build  # only superfile ingest
-//! cargo bench --bench superfile_vector -- superfile_vec_search # only superfile search
+//! cargo bench --bench superfile_vector                         # all
+//! cargo bench --bench superfile_vector -- superfile_vec_build  # ingest only
+//! cargo bench --bench superfile_vector -- superfile_vec_search # search only
 //! INFINO_BENCH_UPDATE_README=1 cargo bench --bench superfile_vector
 //! ```
 
 use infino_bench_utils::tiers;
 use infino_bench_utils::vector_superfile;
 
-// Hand-rolled `criterion_main!` so a real-backend run deletes its
-// ephemeral remote prefix after the benches (no-op for s3s-fs / persisted).
 fn main() {
     vector_superfile::benches();
     criterion::Criterion::default()
         .configure_from_args()
         .final_summary();
+    // Statics don't run `Drop` at exit; delete ephemeral remote prefixes here.
     tiers::cleanup_ephemeral();
 }

--- a/benches/vector/main.rs
+++ b/benches/vector/main.rs
@@ -14,6 +14,15 @@
 //! INFINO_BENCH_UPDATE_README=1 cargo bench --bench superfile_vector
 //! ```
 
+use infino_bench_utils::tiers;
 use infino_bench_utils::vector_superfile;
 
-criterion::criterion_main!(vector_superfile::benches);
+// Hand-rolled `criterion_main!` so a real-backend run deletes its
+// ephemeral remote prefix after the benches (no-op for s3s-fs / persisted).
+fn main() {
+    vector_superfile::benches();
+    criterion::Criterion::default()
+        .configure_from_args()
+        .final_summary();
+    tiers::cleanup_ephemeral();
+}

--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -86,6 +86,17 @@ impl AzureStorageProvider {
         })
     }
 
+    /// Azurite-emulator variant scoped to a logical table prefix —
+    /// the emulator counterpart of [`Self::new_with_prefix`].
+    pub fn new_with_emulator_and_prefix(
+        container: impl Into<String>,
+        prefix: impl Into<String>,
+    ) -> Result<Self, StorageError> {
+        let mut provider = Self::new_with_emulator(container)?;
+        provider.prefix = normalize_prefix(prefix);
+        Ok(provider)
+    }
+
     /// Wrap an already-constructed `MicrosoftAzure` — for callers
     /// that want full control over the `MicrosoftAzureBuilder`.
     pub fn from_object_store(container: impl Into<String>, store: MicrosoftAzure) -> Self {


### PR DESCRIPTION
## What

Lets the supertable/superfile warm/cold benches run against **Azure Blob** (on par with S3), with the backend chosen **explicitly**, and makes every real-backend run clean up after itself.

## Why

`benches/utils/tiers.rs` picked the warm/cold backing store by **inferring** from which credential env happened to be set (real S3 if `INFINO_REAL_S3_BUCKET`, else the in-process s3s-fs emulator). Problems:
- no Azure option (`object_store` enabled `["aws"]` only);
- implicit selection — exporting two credential sets silently picked one;
- a real-backend run wrote a throwaway table under a unique prefix and **never deleted it**, leaking an index on the object store every run.

## Changes

**Explicit backend selection.** `INFINO_BENCH_STORE` = `s3s_fs` (default) | `s3` | `azure` — never inferred. The chosen backend must have its location env set or it errors. `BenchStore { S3sFs, Remote(RemoteBackend) }` with a pure, unit-tested `parse`. `RemoteBackend { S3, Azure }` is the single per-backend construction site (provider / label / prefix_root) — adding a backend is one arm.

| `INFINO_BENCH_STORE` | Store | Extra env |
|---|---|---|
| _unset_ / `s3s_fs` | in-process s3s-fs emulator | — |
| `s3` | AWS S3 | `INFINO_REAL_S3_BUCKET` + `AWS_*` |
| `azure` | Azure Blob | `INFINO_REAL_AZURE_CONTAINER` + `AZURE_STORAGE_ACCOUNT_NAME` + `AZURE_STORAGE_ACCOUNT_KEY` |

**Honest, single-sourced labels.** Storage labels are `s3` / `azure` / `s3s_fs` — dropped the misleading `real_` prefix (the emulator already has its own distinct name, so `real_azure` implied a fake counterpart). The set lives once in `tiers::STORAGE_LABELS` (guarded by a test against `RemoteBackend::label`); markdown report-gen iterates it, and the redundant hardcoded group-name lists in the FTS/vector search benches are gone (the family alias already prefixes every group name).

**Ephemeral cleanup.** A real-backend run registers its unique prefix; each real-backend bench `main` drains it (`tiers::cleanup_ephemeral`, list + delete) after the run — statics don't `Drop` at process exit, so teardown is explicit, and a failed cleanup list is surfaced, not swallowed. Removed the now-dead `StorageFixture.remote` and `SuperfileCommitted.{remote, cleanup_path, object_path, object_size}` (no readers; the prefix-level registry supersedes the never-consumed per-object cleanup).

**Docs.** `benches/README.md` gains an "Object-store backends" section: selection table, run examples, group labels, cleanup, and the emulator caveat.

## How to run

```sh
# Default — emulator, no credentials
cargo bench --bench supertable_all -- supertable_fts

# Real AWS S3
INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket \
  cargo bench --bench supertable_all -- supertable_fts

# Azure Blob
INFINO_BENCH_STORE=azure INFINO_REAL_AZURE_CONTAINER=my-container \
  AZURE_STORAGE_ACCOUNT_NAME=... AZURE_STORAGE_ACCOUNT_KEY=... \
  cargo bench --bench supertable_all -- supertable_fts
```

## Testing

- 7 `tiers` unit tests (selector defaults / required-env / unknown-store error / no-inference-from-creds / label / `STORAGE_LABELS` covers every backend).
- `supertable_all`, `superfile_fts`, `superfile_vector`, `object-store` benches compile; clippy + fmt clean.
- Verified end-to-end on a live Azure account at reduced scale: `INFINO_BENCH_STORE=azure` → ingest → open → BM25 correctness → `cleaned 193 objects … (azure)`, exit 0. The ephemeral run self-cleans.

## Notes for reviewers

- **Scope** is backend selection + Azure + cleanup. Building a table once and scoring it on later runs without re-ingesting is a follow-up.
- **Pre-existing, not introduced here:** the in-process s3s-fs emulator is unstable during the supertable's concurrent multi-commit ingest (dropped connections / commit-retry exhaustion). Reproduced on `main` too. Real backends (`s3` / `azure`) are the reliable object-store path; the emulator is a credential-free wire-path check, best for the single-commit superfile benches. A dedicated fix is its own task.
- This branch is benches-only; no library code changes.
