### PR TITLE
supertable/query: FTS token_match + exact_match APIs and WHERE pushdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,21 @@ let hits = table.reader().bm25_search("title", "rust async", 10, BoolMode::Or)?;
 let query = vec![/* dim=384 f32s */];
 let knn = table.reader().vector_search("embedding", &query, 10, VectorSearchOptions::default())?;
 
-// SQL (DataFusion under the hood; every segment is also valid Parquet):
-let rows = table.query_sql("SELECT _id, title FROM bm25_search('title', 'rust async', 10)")?;
+// Unranked retrieval — boolean token match and exact raw-value match
+// (candidate sets, no scoring); the same primitives the SQL WHERE
+// pushdown uses to answer FTS-column filters from the index:
+let any_token = table.reader().token_match("title", "rust async", BoolMode::Or)?;
+let exact = table.reader().exact_match("title", "rust async")?;
 
-// Hybrid — keyword + vector fused in one query (reciprocal-rank fusion):
-let fused = table.query_sql(
+// Hybrid — keyword + vector fused with reciprocal-rank fusion. As a method:
+let fused = table.reader().hybrid_search(
+    "title", "rust async", BoolMode::Or,
+    "embedding", &query, VectorSearchOptions::default(), 10,
+)?;
+
+// Every retriever is also a SQL table function (DataFusion under the hood;
+// each segment is valid Parquet), so you can filter, join, and fuse in SQL:
+let rows = table.query_sql(
     "SELECT _id, title, score \
      FROM hybrid_search('title', 'rust async', 'embedding', '<query vector>', 10)",
 )?;

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -64,8 +64,11 @@ To minimize latency and cost, infino tries to optimize data layout and data acce
    on scalar, keyword, *and* vector signals together before touching a
    single byte of a segment.
 3. **Fetches only what it needs** — for surviving files it pulls just
-  the relevant byte ranges from object storage (a posting list, a
-   handful of vector clusters), not the whole file.
+   the relevant byte ranges from object storage (a posting list, a
+   handful of vector clusters), not the whole file. This holds for SQL
+   too: a keyword filter on an indexed text column is answered from the
+   index and decodes only the matching rows, rather than scanning the
+   whole column.
 4. **Merges** the per-file results into one ranked answer.
 
 The cost model that falls out of this is the headline: **you pay for

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -64,11 +64,14 @@ To minimize latency and cost, infino tries to optimize data layout and data acce
    on scalar, keyword, *and* vector signals together before touching a
    single byte of a segment.
 3. **Fetches only what it needs** — for surviving files it pulls just
-   the relevant byte ranges from object storage (a posting list, a
+  the relevant byte ranges from object storage (a posting list, a
    handful of vector clusters), not the whole file. This holds for SQL
    too: a keyword filter on an indexed text column is answered from the
    index and decodes only the matching rows, rather than scanning the
-   whole column.
+   whole column. The same index answers unranked retrieval directly —
+   boolean token matching and exact raw-value matching — so an
+   equality or `IN` predicate on an indexed column resolves to a small
+   candidate row set before any column data is read.
 4. **Merges** the per-file results into one ranked answer.
 
 The cost model that falls out of this is the headline: **you pay for
@@ -179,13 +182,7 @@ easy interop with existing data tooling.
 SQL, BM25, and IVF + RaBitQ vectors share one copy of the data and
 one consistency model, instead of syncing a DB + a search engine + a
 vector DB.
-- **Hybrid search is first-class, not glued on.** Because every modality
-shares that one copy and one query path, you fuse keyword (BM25) and
-vector relevance — with SQL filters — in a single query against a
-single snapshot, with no second system to keep in sync and no
-client-side result stitching. The same index machinery prunes segments
-across SQL, full-text, and vector together, so the hybrid query is also
-the well-pruned, cheap one.
+- **Hybrid search is a first-class citizen.** Because every modality shares that one copy and one query path, you fuse keyword (BM25) and vector relevance — with SQL filters — in a single query against a single snapshot, with no second system to keep in sync and no client-side result stitching. The same index machinery prunes segments across SQL, full-text, and vector together, so the hybrid query is also the well-pruned, cheap one.
 
 ### At a glance
 
@@ -193,12 +190,12 @@ Read these as **design center and typical tradeoff**, not hard limits —
 most systems are extending across the row over time.
 
 
-|                          | Built around                             | Modalities (today)                                           | Cold-data cost curve                         | Format              |
-| ------------------------ | ---------------------------------------- | ------------------------------------------------------------ | -------------------------------------------- | ------------------- |
-| **Traditional DB**       | Transactions, single node                | Scalar core; full-text + vectors added (e.g. pgvector)       | Rises with total data (coupled)              | Proprietary         |
-| **Search engine**        | Node/shard cluster                       | Full-text core; vectors maturing; object-storage tiers added | Lower with frozen tiers, but cluster-centric | Proprietary         |
-| **Vector DB**            | ANN over embeddings                      | Vector core; hybrid + filtering increasingly common          | Varies; RAM/SSD-heavy if latency-pinned      | Proprietary         |
-| **Object Store Engines** | Object storage + multi-modal, by default | Scalar + full-text + vector + hybrid as a baseline           | Low; pay for what you query                  | Infino: **Parquet** |
+|                          | Built around                             | Modalities (today)                                           | Cold-data cost curve                         | Format                                     |
+| ------------------------ | ---------------------------------------- | ------------------------------------------------------------ | -------------------------------------------- | ------------------------------------------ |
+| **Traditional DB**       | Transactions, single node                | Scalar core; full-text + vectors added (e.g. pgvector)       | Rises with total data (coupled)              | Some prorietary, many support **Parquet**. |
+| **Search engine**        | Node/shard cluster                       | Full-text core; vectors maturing; object-storage tiers added | Lower with frozen tiers, but cluster-centric | Proprietary                                |
+| **Vector DB**            | ANN over embeddings                      | Vector core; hybrid + filtering increasingly common          | Varies; RAM/SSD-heavy if latency-pinned      | Proprietary                                |
+| **Object Store Engines** | Object storage + multi-modal, by default | Scalar + full-text + vector + hybrid as a baseline           | Low; pay for what you query                  | Infino: **Parquet**                        |
 
 
 ## What Infino optimizes for

--- a/docs/architecture/superfile.md
+++ b/docs/architecture/superfile.md
@@ -102,6 +102,13 @@ A query runs in two stages:
    bounds to skip blocks that cannot improve the current top results,
    and rank the surviving documents with BM25.
 
+The same inverted index also answers **unranked token matching**:
+resolve the query tokens to their posting lists and intersect them (all
+tokens present) or union them (any token present) to get the matching
+document set, with no BM25 scoring. This is the boolean retrieval the
+table layer's SQL `WHERE` pushdown builds on; ranking and matching share
+one set of posting lists.
+
 Document identifiers in the index are local to the superfile.
 
 ## Vector index
@@ -181,5 +188,10 @@ first.
   table layer's responsibility (see [supertable](./supertable.md)).
 - A superfile is immutable and is queryable only once it is fully
   written.
-- Full-text search is bag-of-words BM25; phrase and positional queries
-  are not part of the format.
+- Full-text search is bag-of-words: BM25 ranking and unranked token
+  matching (AND/OR) both run over the same posting lists. The format
+  stores **no token positions**, so there is no positional/phrase index.
+  Exact-string matching is therefore done as a two-pass operation — a
+  token-AND prune on the index to gather candidate rows, then a
+  raw-value verification against the stored column — not by storing
+  positions.

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -57,6 +57,17 @@ unset.
   all terms) and default to matching any term.
 - **Full-text prefix search.** BM25 over a text column where the query
   is expanded as a term prefix, returning the `k` highest-scoring rows.
+- **Token match.** The *unranked* counterpart of full-text search:
+  given a token list and a combination mode, return every row whose
+  text contains all the tokens (`And`) or any of them (`Or`). No
+  scoring and no top-k — the score is left unset. This is a set
+  membership question ("which rows match"), not a ranking.
+- **Exact match.** Given a raw string, return every row whose stored
+  value equals that string exactly. It runs in two passes — a token
+  match prunes candidate rows from the index, then the candidates' text
+  is verified against the raw string — so it never scans the whole
+  column. Tokenization is used only to prune; the match itself is a
+  raw-string comparison. Also unranked.
 - **SQL.** A SQL query over the table's scalar and full-text columns,
   returning the matching rows. Search is also reachable from SQL
   through table-valued functions, so a query can filter, project, join,
@@ -64,6 +75,11 @@ unset.
   - `vector_search(column, query, k)` — vector kNN as a relation.
   - `bm25_search(column, query, k)` and
     `bm25_search_prefix(column, prefix, k)` — full-text / prefix BM25.
+  - `token_match(column, query, mode)` and `exact_match(column, value)`
+    — the unranked token / exact-match relations. Negation is then a
+    SQL composition over them (e.g. `token_match(..,'rust') EXCEPT
+    token_match(..,'compiler')`), keeping it index-bounded rather than a
+    dedicated `NOT` engine feature.
   - `hybrid_search(text_col, q_text, vec_col, q_vec, k)` — BM25 and
     vector results fused with reciprocal-rank fusion into one `score`.
 
@@ -280,13 +296,26 @@ search the single-segment reader runs) and merge globally. SQL is
 executed over the columnar (Parquet) data and does not require the
 search indexes — but it can still reach them through the search
 table-valued functions (`vector_search`, `bm25_search`,
-`bm25_search_prefix`), which run the same per-segment index fan-out and
-hand their results back into the SQL plan as a relation. Hybrid ranking
-is expressed in SQL: join or union the `vector_search` and `bm25_search`
-relations and rank by a fusion score. `hybrid_search` packages the
-common case, running the BM25 and vector kernels concurrently and fusing
-their rankings with reciprocal-rank fusion so a row found by both
-retrievers ranks above one found by a single retriever.
+`bm25_search_prefix`, `token_match`, `exact_match`), which run the same
+per-segment index fan-out and hand their results back into the SQL plan
+as a relation.
+
+A SQL `WHERE` predicate on a full-text column also uses the index
+directly, as the **row-level** companion to the segment-level term
+skip: an equality (and its `AND`/`OR`/`IN` combinations) is resolved
+through the term postings to a candidate set of rows, so only those
+rows are decoded and the engine re-checks the exact predicate over
+them — instead of decoding the whole column and filtering. A predicate
+the index cannot bound (negation, range, a non-indexed column) falls
+back to a column scan. So a selective filter on an indexed text column
+reads work proportional to the matches, not the column size. A hybrid
+ranking is then expressed *in SQL* — fuse the `vector_search` and
+`bm25_search` relations with a join/union and a fusion score. The
+`hybrid_search` table function is a convenience that packages the
+common case: it runs the BM25 and vector kernels concurrently and fuses
+the two rankings with reciprocal-rank fusion, so a row surfaced by both
+retrievers ranks above one surfaced by a single retriever. It is a
+SQL-level fusion, not a separate engine kernel.
 
 ## Concurrency
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -670,6 +670,73 @@ impl FtsReader {
         }
     }
 
+    /// Unranked token match over a **token list** — the no-scoring
+    /// sibling of [`Self::search`]. `mode = And` returns the
+    /// `local_doc_id`s present in *every* token's posting list
+    /// (intersection); `mode = Or` returns those in *any* (union), in
+    /// ascending doc-id order.
+    ///
+    /// Reuses the same [`build_term_cursors`](Self::build_term_cursors)
+    /// the scored path uses, then walks the cursors with
+    /// [`walk_cursors_unranked`] — no BM25 scoring and no top-k heap, so
+    /// nothing is ranked. Cursors traverse blocks in doc-id order, so
+    /// the result is already ascending (no re-sort).
+    pub async fn token_match(
+        &self,
+        column: &str,
+        tokens: &[&str],
+        mode: BoolMode,
+    ) -> Result<Vec<u32>, FtsError> {
+        let column_id = self.resolve_column_id(column)?;
+        if tokens.is_empty() {
+            return Ok(Vec::new());
+        }
+        let cursors = self.build_term_cursors(column_id, tokens).await?;
+        // AND needs every token present; a missing token ⇒ empty set.
+        if mode == BoolMode::And && cursors.len() != tokens.len() {
+            return Ok(Vec::new());
+        }
+        Ok(walk_cursors_unranked(cursors, mode))
+    }
+
+    /// Document frequency of `token` in `column` — the number of docs
+    /// containing it — read cheaply from the index **without** decoding
+    /// the posting list: an inline (df=1) term is known from the FST
+    /// value, and a PFOR term's `df` is the first 4 bytes of its 20-byte
+    /// metadata header. Returns `0` if the token isn't in the column's
+    /// dictionary. Used by the candidate planner to estimate a `WHERE`
+    /// predicate's match count *ahead of* running `token_match`, so a
+    /// predicate that would match a large fraction of the segment can
+    /// fall back to a plain scan instead of a (losing) index pushdown.
+    pub async fn term_df(&self, column: &str, token: &str) -> Result<u64, FtsError> {
+        let column_id = self.resolve_column_id(column)?;
+        let fst_bytes = self.dict_bytes_async().await?;
+        let dict = DictReader::open(&fst_bytes).map_err(|e| {
+            FtsError::Read(ReadError::MalformedVersion(format!(
+                "FST parse failed: {e}"
+            )))
+        })?;
+        let col_meta = &self.columns[column_id as usize];
+        let key = make_key(&col_meta.name, token);
+        Ok(match dict.lookup(&key) {
+            None => 0,
+            Some(packed) => match FstValue::unpack(packed) {
+                FstValue::Inline { .. } => 1,
+                FstValue::Pfor {
+                    metadata_offset, ..
+                } => {
+                    // Fetch only the 20-byte header (TERM_META_SIZE);
+                    // `df` is its first 4 bytes — no posting-list decode.
+                    let fetched = self
+                        .fetch_term_postings(&[(metadata_offset as usize, TERM_META_SIZE)])
+                        .await?;
+                    let header = fetched.first().expect("one fetched header range");
+                    read_u32_le(&header.as_ref()[0..4]) as u64
+                }
+            },
+        })
+    }
+
     /// Multi-term OR BM25 search constrained to a doc_id sub-range.
     ///
     /// Same scoring semantics as [`Self::search`] in `BoolMode::Or`
@@ -2184,9 +2251,61 @@ fn read_u64_le(b: &[u8]) -> u64 {
 /// [`TermMeta::parse`] is the single place that validates untrusted
 /// offsets (the FST value points here) against the postings region:
 /// both the fixed 20-byte header and the skip table it declares are
+/// Drive already-built [`TermCursor`]s to their matching doc-ids with no
+/// scoring and no heap — the unranked analog of
+/// [`FtsReader::run_and_intersect`] (And) / the OR merge. Cursors
+/// traverse blocks in doc-id order, so the result is ascending with no
+/// extra sort. Used by [`FtsReader::token_match`].
+fn walk_cursors_unranked(mut cursors: Vec<TermCursor>, mode: BoolMode) -> Vec<u32> {
+    let mut out = Vec::new();
+    match mode {
+        BoolMode::And => {
+            // Rarest term leads so the leapfrog converges fastest — the
+            // same cursor ordering `run_and_intersect` uses.
+            cursors.sort_by_key(|c| c.block_count());
+            'and: loop {
+                if cursors[0].is_exhausted() {
+                    break;
+                }
+                let leader = cursors[0].current_doc_id();
+                let mut max_doc = leader;
+                for c in cursors[1..].iter_mut() {
+                    c.skip_to(leader);
+                    if c.is_exhausted() {
+                        break 'and;
+                    }
+                    max_doc = max_doc.max(c.current_doc_id());
+                }
+                if max_doc == leader {
+                    out.push(leader);
+                    cursors.iter_mut().for_each(TermCursor::next);
+                } else {
+                    cursors[0].skip_to(max_doc);
+                }
+            }
+        }
+        BoolMode::Or => loop {
+            let min_doc = cursors
+                .iter()
+                .filter(|c| !c.is_exhausted())
+                .map(TermCursor::current_doc_id)
+                .min();
+            let Some(min_doc) = min_doc else { break };
+            out.push(min_doc);
+            for c in cursors.iter_mut() {
+                if !c.is_exhausted() && c.current_doc_id() == min_doc {
+                    c.next();
+                }
+            }
+        },
+    }
+    out
+}
+
 /// bounds-checked before any caller touches a byte. Both the
 /// single-term BMW path and [`TermCursor::new`] go through here, so
 /// the header layout is interpreted in exactly one spot.
+
 #[derive(Debug, Copy, Clone)]
 struct TermMeta {
     /// Document frequency — number of docs containing the term.
@@ -2745,6 +2864,77 @@ mod tests {
         assert!(ids.contains(&0), "doc 0 should match");
         assert!(ids.contains(&1), "doc 1 should match");
         assert!(!ids.contains(&2), "doc 2 should not match");
+    }
+
+    #[tokio::test]
+    async fn token_match_or_unions_and_intersects_unranked() {
+        // build_blob: doc0 "rust async runtime", doc1 "tokio is a rust
+        // runtime", doc2 "java spring boot".
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open FtsReader");
+
+        // Single token → its posting list, ascending.
+        assert_eq!(
+            r.token_match("body", &["rust"], BoolMode::Or)
+                .await
+                .expect("single"),
+            vec![0, 1]
+        );
+        // OR = union (rust ∪ java).
+        assert_eq!(
+            r.token_match("body", &["rust", "java"], BoolMode::Or)
+                .await
+                .expect("or"),
+            vec![0, 1, 2]
+        );
+        // AND = intersection (rust ∩ runtime).
+        assert_eq!(
+            r.token_match("body", &["rust", "runtime"], BoolMode::And)
+                .await
+                .expect("and"),
+            vec![0, 1]
+        );
+        // AND with an absent token → empty.
+        assert!(
+            r.token_match("body", &["rust", "zzz"], BoolMode::And)
+                .await
+                .expect("and absent")
+                .is_empty()
+        );
+        // OR ignores an absent token.
+        assert_eq!(
+            r.token_match("body", &["java", "zzz"], BoolMode::Or)
+                .await
+                .expect("or absent"),
+            vec![2]
+        );
+        // Empty token list → empty.
+        assert!(
+            r.token_match("body", &[], BoolMode::And)
+                .await
+                .expect("empty")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn token_match_doc_set_matches_bm25_for_same_terms() {
+        // token_match(Or) must return exactly the doc set bm25 ranks.
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open FtsReader");
+        let mut bm25: Vec<u32> = r
+            .search("body", &["rust", "java"], 10, BoolMode::Or)
+            .await
+            .expect("search")
+            .into_iter()
+            .map(|(d, _)| d)
+            .collect();
+        bm25.sort_unstable();
+        let boolean = r
+            .token_match("body", &["rust", "java"], BoolMode::Or)
+            .await
+            .expect("boolean");
+        assert_eq!(bm25, boolean, "boolean Or doc set == bm25 doc set");
     }
 
     #[tokio::test]

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -715,6 +715,89 @@ impl SuperfileReader {
         Ok(fts.search(column, terms, k, mode).await?)
     }
 
+    /// Unranked token match: the `local_doc_id`s matching the
+    /// `tokens` under `mode` (`And` = every token, `Or` = any token),
+    /// in ascending order. No BM25 scoring. `tokens` are already
+    /// tokenized terms. Delegates to [`FtsReader::token_match`].
+    pub async fn token_match(
+        &self,
+        column: &str,
+        tokens: &[&str],
+        mode: BoolMode,
+    ) -> Result<Vec<u32>, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.token_match(column, tokens, mode).await?)
+    }
+
+    /// Document frequency of `token` in `column` (0 if absent) — a cheap
+    /// header-only read used to estimate a predicate's match count
+    /// before running `token_match`. Delegates to
+    /// [`FtsReader::term_df`].
+    pub async fn term_df(&self, column: &str, token: &str) -> Result<u64, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.term_df(column, token).await?)
+    }
+
+    /// Two-pass exact match of a **raw string** `value` against
+    /// `column`'s stored values. The input is a raw string, **not**
+    /// tokens — tokenization is used only to prune candidates, never as
+    /// the match:
+    ///
+    ///   1. **Prune (index).** Tokenize `value` and `token_match` its
+    ///      tokens under `And` to get candidate rows that contain all of
+    ///      them. (An empty token set — e.g. punctuation-only `value` —
+    ///      can't prune, so every row is a candidate.)
+    ///   2. **Verify (text).** Decode `column` for those candidates and
+    ///      keep the rows whose stored value **equals `value` exactly**.
+    ///
+    /// Returns the verified `local_doc_id`s in ascending order. Works
+    /// for single-word and multi-word strings alike — the token count
+    /// only affects pruning, never the raw-string comparison.
+    pub async fn exact_match(&self, column: &str, value: &str) -> Result<Vec<u32>, ReadError> {
+        use crate::superfile::fts::tokenize::{AsciiLowerTokenizer, Tokenizer};
+        use arrow_array::Array as _;
+
+        // Pass 1 — candidate rows via the index: the term-AND of the
+        // string's tokens (a superset of the exact matches).
+        let tokens: Vec<String> = AsciiLowerTokenizer.tokenize(value).collect();
+        let candidates: Vec<u32> = if tokens.is_empty() {
+            // No tokens to prune with: every row is a candidate.
+            (0..self.n_docs() as u32).collect()
+        } else {
+            let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
+            self.token_match(column, &refs, BoolMode::And).await?
+        };
+        if candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Pass 2 — verify raw-string equality on the decoded text.
+        let batch = self.take_by_local_doc_ids(&candidates, &[column])?;
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow_array::LargeStringArray>()
+            .ok_or_else(|| {
+                ReadError::Io(std::io::Error::other(format!(
+                    "exact_match: column '{column}' is not LargeUtf8"
+                )))
+            })?;
+        // `take_by_local_doc_ids` returns rows in `candidates` order, so
+        // row `i` is `candidates[i]`; candidates are ascending, so the
+        // kept ids stay ascending.
+        let mut out = Vec::new();
+        for (i, &doc) in candidates.iter().enumerate() {
+            if !col.is_null(i) && col.value(i) == value {
+                out.push(doc);
+            }
+        }
+        Ok(out)
+    }
+
     /// Prefix-expanded BM25 search.
     ///
     /// Expands `prefix` to the lex-ordered list of indexed terms

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -1,0 +1,483 @@
+//! Two-pass candidate planning for SQL `WHERE` predicates over
+//! FTS-indexed columns.
+//!
+//! ## Why
+//!
+//! Without an index, `SELECT title FROM supertable WHERE title = 'rust
+//! async runtime'` decodes the whole `title` column and drops the
+//! non-matching rows. The inverted index already knows which rows
+//! contain a term, so we resolve a small **candidate row set** from the
+//! postings and decode only those rows — the row-level analog of the
+//! term-bloom *segment* prune.
+//!
+//! ## How (two passes)
+//!
+//!   1. **Candidate generation (this module).** The `WHERE` `Expr` tree
+//!      is lowered to a [`CandidatePlan`] — a boolean tree whose leaves
+//!      retrieve rows via [`SuperfileReader::token_match`]. Evaluated
+//!      against one segment it yields a `RoaringBitmap` of candidate
+//!      `local_doc_id`s, or `None` ("no usable bound — scan the
+//!      segment").
+//!   2. **Verification (DataFusion).** The provider turns the candidate
+//!      set into a Parquet row selection so only those rows decode, and
+//!      DataFusion's `FilterExec` (filters are reported `Inexact`)
+//!      re-applies the **exact** predicate. The candidate set only has
+//!      to be a *superset* of the true matches.
+//!
+//! ## Soundness
+//!
+//! A row equal to `'a b'` tokenizes to a set containing both `a` and
+//! `b`, so it is in the term-AND `token_match(col, [a, b], And)`.
+//! Requiring the literal's tokens can only keep a non-matching row
+//! (wrong order, extra words, different spacing), never drop a matching
+//! one — the exact equality is verified in pass 2. `AND` with an
+//! un-boundable child drops that child (keeps more rows — still a
+//! superset); `OR` with any un-boundable child is itself `Unbounded`;
+//! `NOT`, non-FTS columns, range ops, and `LIKE` are `Unbounded` (a
+//! word-token index can't soundly bound substring / negation).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion::logical_expr::{Expr, Operator};
+use datafusion::scalar::ScalarValue;
+use futures::future::BoxFuture;
+use roaring::RoaringBitmap;
+
+use crate::superfile::ReadError;
+use crate::superfile::SuperfileReader;
+use crate::superfile::fts::reader::BoolMode;
+use crate::superfile::fts::tokenize::Tokenizer;
+
+/// A segment-independent boolean plan over FTS term retrievals, lowered
+/// once from a SQL `WHERE` clause and [`evaluate`](CandidatePlan::evaluate)d
+/// per segment to a superset of the rows satisfying the FTS-resolvable
+/// part of the predicate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CandidatePlan {
+    /// Rows whose `column` contains every one of `tokens` (term-AND).
+    /// The candidate superset of `column = '<text tokenizing to tokens>'`;
+    /// the exact predicate is re-verified by the `FilterExec` above the
+    /// scan (filters are reported `Inexact`). Resolved per segment by a
+    /// single `token_match(.., And)` — postings only, no column decode —
+    /// so verification + projection happen together in DataFusion's one
+    /// scan pass. (An `exact_match`-per-leaf alternative was measured and
+    /// rejected: it decodes the predicate column in its own pass 2, once
+    /// per `OR`/`IN` branch, on top of the scan — multi-decode.)
+    TermsAll { column: String, tokens: Vec<String> },
+    /// Intersection of children (logical `AND`).
+    And(Vec<CandidatePlan>),
+    /// Union of children (logical `OR`).
+    Or(Vec<CandidatePlan>),
+    /// No usable bound: scan the segment and let `FilterExec` verify.
+    Unbounded,
+}
+
+impl CandidatePlan {
+    /// Lower the conjunction of top-level `filters` (DataFusion ANDs the
+    /// provider's filters together) into one plan. `fts_cols` is the set
+    /// of FTS-indexed column names; `tokenizer` is the index tokenizer
+    /// (absent ⇒ no FTS columns ⇒ always [`Unbounded`]).
+    pub(crate) fn from_filters(
+        filters: &[Expr],
+        fts_cols: &HashSet<String>,
+        tokenizer: Option<&Arc<dyn Tokenizer>>,
+    ) -> CandidatePlan {
+        let Some(tok) = tokenizer else {
+            return CandidatePlan::Unbounded;
+        };
+        if fts_cols.is_empty() {
+            return CandidatePlan::Unbounded;
+        }
+        and_combine(
+            filters
+                .iter()
+                .map(|f| lower(f, fts_cols, tok.as_ref()))
+                .collect(),
+        )
+    }
+
+    /// Evaluate against one segment's reader. `Ok(None)` means "no bound
+    /// — scan all rows"; `Ok(Some(bitmap))` is the candidate
+    /// `local_doc_id` superset (possibly empty). `TermsAll` is one
+    /// `token_match(.., And)`; `And`/`Or` intersect/union children.
+    pub(crate) fn evaluate<'a>(
+        &'a self,
+        reader: &'a SuperfileReader,
+    ) -> BoxFuture<'a, Result<Option<RoaringBitmap>, ReadError>> {
+        Box::pin(async move {
+            match self {
+                CandidatePlan::Unbounded => Ok(None),
+                CandidatePlan::TermsAll { column, tokens } => {
+                    let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
+                    let docs = reader.token_match(column, &refs, BoolMode::And).await?;
+                    Ok(Some(docs.into_iter().collect()))
+                }
+                CandidatePlan::And(children) => {
+                    let mut acc: Option<RoaringBitmap> = None;
+                    for c in children {
+                        if let Some(bm) = c.evaluate(reader).await? {
+                            acc = Some(match acc {
+                                Some(a) => a & bm,
+                                None => bm,
+                            });
+                            if acc.as_ref().is_some_and(RoaringBitmap::is_empty) {
+                                return Ok(Some(RoaringBitmap::new()));
+                            }
+                        }
+                        // A `None` (unbounded) child adds no constraint.
+                    }
+                    Ok(acc)
+                }
+                CandidatePlan::Or(children) => {
+                    let mut acc = RoaringBitmap::new();
+                    for c in children {
+                        match c.evaluate(reader).await? {
+                            Some(bm) => acc |= bm,
+                            // An unbounded branch makes the union unbounded.
+                            None => return Ok(None),
+                        }
+                    }
+                    Ok(Some(acc))
+                }
+            }
+        })
+    }
+}
+
+impl CandidatePlan {
+    /// Cheap upper-bound estimate of how many rows this plan would match
+    /// in `reader`'s segment, computed from per-term `df` only (no
+    /// `token_match`, no posting decode). The bound follows the boolean
+    /// tree: a term-`AND` can't exceed the **smallest** term's `df`
+    /// (`min`); an `OR`/`IN` union can't exceed the **sum** of branch
+    /// estimates (capped at `n_docs`); `Unbounded` is `n_docs` (no
+    /// bound). The provider uses this to skip the index pushdown when a
+    /// predicate would match a large fraction of the segment — there the
+    /// matches saturate the data pages so an index `RowSelection` can't
+    /// skip any, and a plain scan is cheaper.
+    pub(crate) fn estimate<'a>(
+        &'a self,
+        reader: &'a SuperfileReader,
+    ) -> BoxFuture<'a, Result<u64, ReadError>> {
+        Box::pin(async move {
+            let n_docs = reader.n_docs();
+            match self {
+                CandidatePlan::Unbounded => Ok(n_docs),
+                CandidatePlan::TermsAll { column, tokens } => {
+                    if tokens.is_empty() {
+                        return Ok(n_docs);
+                    }
+                    // Intersection ≤ the rarest token's df.
+                    let mut min_df = u64::MAX;
+                    for t in tokens {
+                        min_df = min_df.min(reader.term_df(column, t).await?);
+                    }
+                    Ok(min_df.min(n_docs))
+                }
+                CandidatePlan::And(children) => {
+                    let mut m = n_docs;
+                    for c in children {
+                        m = m.min(c.estimate(reader).await?);
+                    }
+                    Ok(m)
+                }
+                CandidatePlan::Or(children) => {
+                    let mut sum: u64 = 0;
+                    for c in children {
+                        sum = sum.saturating_add(c.estimate(reader).await?);
+                    }
+                    Ok(sum.min(n_docs))
+                }
+            }
+        })
+    }
+}
+
+/// Lower one `Expr` node.
+fn lower(expr: &Expr, fts_cols: &HashSet<String>, tok: &dyn Tokenizer) -> CandidatePlan {
+    match expr {
+        Expr::BinaryExpr(be) => match be.op {
+            Operator::And => and_combine(vec![
+                lower(&be.left, fts_cols, tok),
+                lower(&be.right, fts_cols, tok),
+            ]),
+            Operator::Or => or_combine(vec![
+                lower(&be.left, fts_cols, tok),
+                lower(&be.right, fts_cols, tok),
+            ]),
+            Operator::Eq => eq_leaf(&be.left, &be.right, fts_cols, tok),
+            // Range / inequality / arithmetic ops aren't term-bounded.
+            _ => CandidatePlan::Unbounded,
+        },
+        // `IN (a, b, …)` on an FTS column is an OR of equalities.
+        Expr::InList(il) if !il.negated => in_list_leaf(il, fts_cols, tok),
+        // NOT, LIKE, IS NULL, functions, etc. — not soundly term-bounded.
+        _ => CandidatePlan::Unbounded,
+    }
+}
+
+/// Lower `col = 'literal'` (either operand order) on an FTS column.
+fn eq_leaf(
+    left: &Expr,
+    right: &Expr,
+    fts_cols: &HashSet<String>,
+    tok: &dyn Tokenizer,
+) -> CandidatePlan {
+    let (column, value) = match (left, right) {
+        (Expr::Column(c), Expr::Literal(v, _)) => (&c.name, v),
+        (Expr::Literal(v, _), Expr::Column(c)) => (&c.name, v),
+        _ => return CandidatePlan::Unbounded,
+    };
+    terms_all(column, value, fts_cols, tok)
+}
+
+/// Lower `col IN ('a', 'b', …)` on an FTS column to an OR of term-ANDs.
+fn in_list_leaf(
+    il: &datafusion::logical_expr::expr::InList,
+    fts_cols: &HashSet<String>,
+    tok: &dyn Tokenizer,
+) -> CandidatePlan {
+    let Expr::Column(c) = il.expr.as_ref() else {
+        return CandidatePlan::Unbounded;
+    };
+    let mut branches = Vec::with_capacity(il.list.len());
+    for item in &il.list {
+        let Expr::Literal(v, _) = item else {
+            return CandidatePlan::Unbounded;
+        };
+        branches.push(terms_all(&c.name, v, fts_cols, tok));
+    }
+    or_combine(branches)
+}
+
+/// Build a `TermsAll` leaf for `column = value`, or `Unbounded` if the
+/// column isn't FTS-indexed, the value isn't a string, or it tokenizes
+/// to nothing (e.g. the empty string — no tokens to bound with).
+fn terms_all(
+    column: &str,
+    value: &ScalarValue,
+    fts_cols: &HashSet<String>,
+    tok: &dyn Tokenizer,
+) -> CandidatePlan {
+    if !fts_cols.contains(column) {
+        return CandidatePlan::Unbounded;
+    }
+    let Some(s) = scalar_str(value) else {
+        return CandidatePlan::Unbounded;
+    };
+    let tokens: Vec<String> = tok.tokenize(s).collect();
+    if tokens.is_empty() {
+        return CandidatePlan::Unbounded;
+    }
+    CandidatePlan::TermsAll {
+        column: column.to_owned(),
+        tokens,
+    }
+}
+
+/// Extract a UTF-8 string from a scalar literal, if it is one.
+fn scalar_str(v: &ScalarValue) -> Option<&str> {
+    match v {
+        ScalarValue::Utf8(Some(s))
+        | ScalarValue::LargeUtf8(Some(s))
+        | ScalarValue::Utf8View(Some(s)) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+/// Combine children under `AND`: an `Unbounded` child drops out (adds
+/// no constraint), nested `And`s flatten, all-unbounded → `Unbounded`.
+fn and_combine(children: Vec<CandidatePlan>) -> CandidatePlan {
+    let mut flat = Vec::with_capacity(children.len());
+    for c in children {
+        match c {
+            CandidatePlan::Unbounded => {}
+            CandidatePlan::And(inner) => flat.extend(inner),
+            other => flat.push(other),
+        }
+    }
+    collapse(flat, true)
+}
+
+/// Combine children under `OR`: any `Unbounded` child makes the whole
+/// union `Unbounded`; nested `Or`s flatten.
+fn or_combine(children: Vec<CandidatePlan>) -> CandidatePlan {
+    let mut flat = Vec::with_capacity(children.len());
+    for c in children {
+        match c {
+            CandidatePlan::Unbounded => return CandidatePlan::Unbounded,
+            CandidatePlan::Or(inner) => flat.extend(inner),
+            other => flat.push(other),
+        }
+    }
+    collapse(flat, false)
+}
+
+/// Wrap a flattened child list back into `And`/`Or`, collapsing the
+/// 0- and 1-child degenerate cases.
+fn collapse(mut flat: Vec<CandidatePlan>, is_and: bool) -> CandidatePlan {
+    match flat.len() {
+        0 => CandidatePlan::Unbounded,
+        1 => flat.pop().expect("len checked == 1"),
+        _ if is_and => CandidatePlan::And(flat),
+        _ => CandidatePlan::Or(flat),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::logical_expr::expr::InList;
+    use datafusion::prelude::{col, lit};
+
+    use crate::superfile::fts::tokenize::AsciiLowerTokenizer;
+
+    fn fts_cols() -> HashSet<String> {
+        let mut s = HashSet::new();
+        s.insert("title".to_string());
+        s
+    }
+
+    fn tok() -> Arc<dyn Tokenizer> {
+        Arc::new(AsciiLowerTokenizer)
+    }
+
+    fn plan(expr: Expr) -> CandidatePlan {
+        CandidatePlan::from_filters(&[expr], &fts_cols(), Some(&tok()))
+    }
+
+    #[test]
+    fn eq_on_fts_column_lowers_to_terms_all() {
+        let p = plan(col("title").eq(lit("rust async")));
+        assert_eq!(
+            p,
+            CandidatePlan::TermsAll {
+                column: "title".into(),
+                tokens: vec!["rust".into(), "async".into()],
+            }
+        );
+    }
+
+    #[test]
+    fn eq_operands_reversed_still_lowers() {
+        let p = plan(lit("rust").eq(col("title")));
+        assert_eq!(
+            p,
+            CandidatePlan::TermsAll {
+                column: "title".into(),
+                tokens: vec!["rust".into()],
+            }
+        );
+    }
+
+    #[test]
+    fn eq_on_non_fts_column_is_unbounded() {
+        assert_eq!(plan(col("category").eq(lit("rust"))), CandidatePlan::Unbounded);
+    }
+
+    #[test]
+    fn empty_literal_is_unbounded() {
+        assert_eq!(plan(col("title").eq(lit(""))), CandidatePlan::Unbounded);
+    }
+
+    #[test]
+    fn range_op_is_unbounded() {
+        assert_eq!(plan(col("title").gt(lit("m"))), CandidatePlan::Unbounded);
+    }
+
+    #[test]
+    fn and_of_fts_and_non_fts_keeps_only_fts_branch() {
+        let p = plan(col("title").eq(lit("rust")).and(col("category").eq(lit("lang"))));
+        assert_eq!(
+            p,
+            CandidatePlan::TermsAll {
+                column: "title".into(),
+                tokens: vec!["rust".into()],
+            }
+        );
+    }
+
+    #[test]
+    fn and_of_two_fts_equalities_intersects() {
+        let p = plan(col("title").eq(lit("rust")).and(col("title").eq(lit("async"))));
+        match p {
+            CandidatePlan::And(children) => assert_eq!(children.len(), 2),
+            other => panic!("expected And, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn or_of_two_fts_equalities_unions() {
+        let p = plan(col("title").eq(lit("rust")).or(col("title").eq(lit("python"))));
+        match p {
+            CandidatePlan::Or(children) => assert_eq!(children.len(), 2),
+            other => panic!("expected Or, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn or_with_non_fts_branch_is_unbounded() {
+        let p = plan(col("title").eq(lit("rust")).or(col("category").eq(lit("lang"))));
+        assert_eq!(p, CandidatePlan::Unbounded);
+    }
+
+    #[test]
+    fn not_is_unbounded() {
+        assert_eq!(plan(!col("title").eq(lit("rust"))), CandidatePlan::Unbounded);
+    }
+
+    #[test]
+    fn not_eq_is_unbounded() {
+        // `title != 'rust'` (Operator::NotEq) can't be term-bounded.
+        assert_eq!(plan(col("title").not_eq(lit("rust"))), CandidatePlan::Unbounded);
+    }
+
+    #[test]
+    fn and_with_not_child_keeps_fts_branch() {
+        // `title = 'rust' AND NOT (title = 'compiler')` — the NOT branch
+        // is un-boundable and drops out of candidate generation (verified
+        // in pass 2), so candidates still come from the FTS branch.
+        let p = plan(col("title").eq(lit("rust")).and(!col("title").eq(lit("compiler"))));
+        assert_eq!(
+            p,
+            CandidatePlan::TermsAll {
+                column: "title".into(),
+                tokens: vec!["rust".into()],
+            }
+        );
+    }
+
+    #[test]
+    fn like_is_unbounded() {
+        assert_eq!(plan(col("title").like(lit("rust%"))), CandidatePlan::Unbounded);
+    }
+
+    #[test]
+    fn in_list_on_fts_column_is_or_of_terms_all() {
+        let expr = Expr::InList(InList::new(
+            Box::new(col("title")),
+            vec![lit("rust"), lit("python")],
+            false,
+        ));
+        match plan(expr) {
+            CandidatePlan::Or(children) => {
+                assert_eq!(children.len(), 2);
+                assert!(matches!(children[0], CandidatePlan::TermsAll { .. }));
+            }
+            other => panic!("expected Or, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn negated_in_list_is_unbounded() {
+        let expr = Expr::InList(InList::new(Box::new(col("title")), vec![lit("rust")], true));
+        assert_eq!(plan(expr), CandidatePlan::Unbounded);
+    }
+
+    #[test]
+    fn no_tokenizer_is_unbounded() {
+        let p = CandidatePlan::from_filters(&[col("title").eq(lit("rust"))], &fts_cols(), None);
+        assert_eq!(p, CandidatePlan::Unbounded);
+    }
+}

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -373,7 +373,10 @@ mod tests {
 
     #[test]
     fn eq_on_non_fts_column_is_unbounded() {
-        assert_eq!(plan(col("category").eq(lit("rust"))), CandidatePlan::Unbounded);
+        assert_eq!(
+            plan(col("category").eq(lit("rust"))),
+            CandidatePlan::Unbounded
+        );
     }
 
     #[test]
@@ -388,7 +391,11 @@ mod tests {
 
     #[test]
     fn and_of_fts_and_non_fts_keeps_only_fts_branch() {
-        let p = plan(col("title").eq(lit("rust")).and(col("category").eq(lit("lang"))));
+        let p = plan(
+            col("title")
+                .eq(lit("rust"))
+                .and(col("category").eq(lit("lang"))),
+        );
         assert_eq!(
             p,
             CandidatePlan::TermsAll {
@@ -400,7 +407,11 @@ mod tests {
 
     #[test]
     fn and_of_two_fts_equalities_intersects() {
-        let p = plan(col("title").eq(lit("rust")).and(col("title").eq(lit("async"))));
+        let p = plan(
+            col("title")
+                .eq(lit("rust"))
+                .and(col("title").eq(lit("async"))),
+        );
         match p {
             CandidatePlan::And(children) => assert_eq!(children.len(), 2),
             other => panic!("expected And, got {other:?}"),
@@ -409,7 +420,11 @@ mod tests {
 
     #[test]
     fn or_of_two_fts_equalities_unions() {
-        let p = plan(col("title").eq(lit("rust")).or(col("title").eq(lit("python"))));
+        let p = plan(
+            col("title")
+                .eq(lit("rust"))
+                .or(col("title").eq(lit("python"))),
+        );
         match p {
             CandidatePlan::Or(children) => assert_eq!(children.len(), 2),
             other => panic!("expected Or, got {other:?}"),
@@ -418,19 +433,29 @@ mod tests {
 
     #[test]
     fn or_with_non_fts_branch_is_unbounded() {
-        let p = plan(col("title").eq(lit("rust")).or(col("category").eq(lit("lang"))));
+        let p = plan(
+            col("title")
+                .eq(lit("rust"))
+                .or(col("category").eq(lit("lang"))),
+        );
         assert_eq!(p, CandidatePlan::Unbounded);
     }
 
     #[test]
     fn not_is_unbounded() {
-        assert_eq!(plan(!col("title").eq(lit("rust"))), CandidatePlan::Unbounded);
+        assert_eq!(
+            plan(!col("title").eq(lit("rust"))),
+            CandidatePlan::Unbounded
+        );
     }
 
     #[test]
     fn not_eq_is_unbounded() {
         // `title != 'rust'` (Operator::NotEq) can't be term-bounded.
-        assert_eq!(plan(col("title").not_eq(lit("rust"))), CandidatePlan::Unbounded);
+        assert_eq!(
+            plan(col("title").not_eq(lit("rust"))),
+            CandidatePlan::Unbounded
+        );
     }
 
     #[test]
@@ -438,7 +463,11 @@ mod tests {
         // `title = 'rust' AND NOT (title = 'compiler')` — the NOT branch
         // is un-boundable and drops out of candidate generation (verified
         // in pass 2), so candidates still come from the FTS branch.
-        let p = plan(col("title").eq(lit("rust")).and(!col("title").eq(lit("compiler"))));
+        let p = plan(
+            col("title")
+                .eq(lit("rust"))
+                .and(!col("title").eq(lit("compiler"))),
+        );
         assert_eq!(
             p,
             CandidatePlan::TermsAll {
@@ -450,7 +479,10 @@ mod tests {
 
     #[test]
     fn like_is_unbounded() {
-        assert_eq!(plan(col("title").like(lit("rust%"))), CandidatePlan::Unbounded);
+        assert_eq!(
+            plan(col("title").like(lit("rust%"))),
+            CandidatePlan::Unbounded
+        );
     }
 
     #[test]

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -387,7 +387,7 @@ impl ExecutionPlan for Bm25Exec {
 }
 
 /// Parse the optional `mode` argument: `'or'` (default) or `'and'`.
-fn arg_to_bool_mode(expr: &Expr) -> DfResult<BoolMode> {
+pub(crate) fn arg_to_bool_mode(expr: &Expr) -> DfResult<BoolMode> {
     let s = arg_to_string(expr, "bm25_search mode")?;
     match s.to_ascii_lowercase().as_str() {
         "or" => Ok(BoolMode::Or),

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -68,6 +68,7 @@ use super::vector_exec::arg_to_query_vector;
 use crate::superfile::fts::reader::BoolMode;
 use crate::superfile::reader::VectorSearchOptions;
 use crate::supertable::handle::SupertableReader;
+use crate::supertable::QueryError;
 use crate::supertable::manifest::SuperfileUri;
 use crate::supertable::query::SuperfileHit;
 
@@ -97,6 +98,55 @@ pub(crate) fn register_hybrid_search(
         HYBRID_SEARCH_UDTF,
         Arc::new(HybridSearchFunc::new(reader, scalar_schema)),
     );
+}
+
+impl SupertableReader {
+    /// Async kernel: run BM25 (`mode`) and vector kNN concurrently over
+    /// this reader's pinned snapshot and fuse the two rankings with
+    /// reciprocal-rank fusion, returning the top-`k` fused hits (each
+    /// carrying its RRF score; higher is better). The hits are
+    /// unresolved — the caller resolves `_id` / scalar columns.
+    /// `pub(crate)` kernel; the public surface is the sync
+    /// [`SupertableReader::hybrid_search`].
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn hybrid_search_async(
+        &self,
+        text_col: &str,
+        q_text: &str,
+        mode: BoolMode,
+        vec_col: &str,
+        q_vec: &[f32],
+        options: VectorSearchOptions,
+        k: usize,
+    ) -> Result<Vec<SuperfileHit>, QueryError> {
+        // Both retrievers run concurrently on the query runtime; each
+        // inherits its own manifest skip and returns hits best-first.
+        let (bm25_res, vector_res) = futures::future::join(
+            self.bm25_search_async(text_col, q_text, k, mode),
+            self.vector_search_async(vec_col, q_vec, k, options),
+        )
+        .await;
+        Ok(rrf_fuse(&bm25_res?, &vector_res?, k))
+    }
+
+    /// Hybrid BM25 + vector search fused with reciprocal-rank fusion
+    /// over this reader's pinned snapshot. Returns up to `k` fused hits
+    /// carrying the RRF score (higher is better). Sync wrapper over
+    /// [`SupertableReader::hybrid_search_async`] — the same fusion the
+    /// `hybrid_search` SQL table function runs.
+    #[allow(clippy::too_many_arguments)]
+    pub fn hybrid_search(
+        &self,
+        text_col: &str,
+        q_text: &str,
+        mode: BoolMode,
+        vec_col: &str,
+        q_vec: &[f32],
+        options: VectorSearchOptions,
+        k: usize,
+    ) -> Result<Vec<SuperfileHit>, QueryError> {
+        self.block_on(self.hybrid_search_async(text_col, q_text, mode, vec_col, q_vec, options, k))
+    }
 }
 
 /// `TableFunctionImpl` for `hybrid_search`. Holds the query's pinned
@@ -356,19 +406,12 @@ impl ExecutionPlan for HybridSearchExec {
         let projected_schema = Arc::clone(&self.projected_schema);
 
         let fut = async move {
-            // Run both retrievers concurrently on the query runtime;
-            // each inherits its own manifest skip and returns hits
-            // best-first.
-            let (bm25_res, vector_res) = futures::future::join(
-                reader.bm25_search_async(&text_col, &q_text, k, mode),
-                reader.vector_search_async(&vec_col, &q_vec, k, options),
-            )
-            .await;
-            let bm25_hits = bm25_res.map_err(|e| DataFusionError::Execution(e.to_string()))?;
-            let vector_hits = vector_res.map_err(|e| DataFusionError::Execution(e.to_string()))?;
-
-            // Fuse on hit identity, then resolve the fused set once.
-            let fused = rrf_fuse(&bm25_hits, &vector_hits, k);
+            // Run both retrievers concurrently and fuse with RRF via the
+            // shared kernel, then resolve the fused set once.
+            let fused = reader
+                .hybrid_search_async(&text_col, &q_text, mode, &vec_col, &q_vec, options, k)
+                .await
+                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
             resolve_hits(
                 &reader,
                 &fused,

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -67,8 +67,8 @@ use super::common::{arg_to_string, arg_to_usize, output_schema_with_score, resol
 use super::vector_exec::arg_to_query_vector;
 use crate::superfile::fts::reader::BoolMode;
 use crate::superfile::reader::VectorSearchOptions;
-use crate::supertable::handle::SupertableReader;
 use crate::supertable::QueryError;
+use crate::supertable::handle::SupertableReader;
 use crate::supertable::manifest::SuperfileUri;
 use crate::supertable::query::SuperfileHit;
 

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -1,0 +1,497 @@
+//! Unranked token / exact match as DataFusion table-valued functions.
+//!
+//! `token_match(column, query [, mode])` and `exact_match(column,
+//! value)` are the **unranked** siblings of `bm25_search`. They register
+//! via `register_udtf` and lower to [`MatchExec`], a custom
+//! `ExecutionPlan` that calls the unranked kernels
+//! ([`SupertableReader::token_match`](crate::supertable::handle::SupertableReader::token_match)
+//! / `exact_match`) inside `execute()` and resolves each
+//! [`SuperfileHit`](crate::supertable::query::SuperfileHit) to the
+//! supertable's `_id` + projected scalar columns + `score` via the
+//! shared [`resolve_hits`](super::common::resolve_hits).
+//!
+//! ## Query shape
+//!
+//! ```sql
+//! -- rows whose `title` contains every token (AND) / any token (OR):
+//! SELECT _id FROM token_match('title', 'rust async', 'and');
+//! SELECT _id FROM token_match('title', 'rust async');          -- OR (default)
+//! -- rows whose `title` equals the raw string exactly:
+//! SELECT _id FROM exact_match('title', 'Rust Compiler');
+//! ```
+//!
+//! These are unranked: the `score` column is present (for schema
+//! uniformity with the other search TVFs) but constant `0.0`. Order is
+//! unspecified — add a SQL `ORDER BY` / `LIMIT` for control.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use datafusion::catalog::{Session, TableFunctionImpl, TableProvider};
+use datafusion::error::{DataFusionError, Result as DfResult};
+use datafusion::execution::TaskContext;
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::{Expr, TableType};
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream,
+};
+
+use super::common::{arg_to_string, output_schema_with_score, resolve_hits};
+use super::fts_exec::arg_to_bool_mode;
+use crate::superfile::fts::reader::BoolMode;
+use crate::supertable::handle::SupertableReader;
+
+/// SQL name for the unranked token-match TVF.
+pub(crate) const TOKEN_MATCH_UDTF: &str = "token_match";
+/// SQL name for the unranked exact-match TVF.
+pub(crate) const EXACT_MATCH_UDTF: &str = "exact_match";
+
+/// Register `token_match` + `exact_match` on `ctx`, bound to the
+/// query's pinned `reader` + scalar `schema`. Called from
+/// [`Supertable::query_sql`](crate::supertable::handle::Supertable::query_sql).
+pub(crate) fn register_match(
+    ctx: &SessionContext,
+    reader: Arc<SupertableReader>,
+    scalar_schema: SchemaRef,
+) {
+    ctx.register_udtf(
+        TOKEN_MATCH_UDTF,
+        Arc::new(TokenMatchFunc::new(
+            Arc::clone(&reader),
+            Arc::clone(&scalar_schema),
+        )),
+    );
+    ctx.register_udtf(
+        EXACT_MATCH_UDTF,
+        Arc::new(ExactMatchFunc::new(reader, scalar_schema)),
+    );
+}
+
+/// Which unranked kernel a `MatchExec` invocation runs.
+#[derive(Debug, Clone)]
+enum MatchQuery {
+    /// `token_match(col, query, mode)` — token AND/OR retrieval.
+    Token { query: String, mode: BoolMode },
+    /// `exact_match(col, value)` — two-pass raw-string match.
+    Exact { value: String },
+}
+
+/// `TableFunctionImpl` for `token_match`.
+#[derive(Debug)]
+pub(crate) struct TokenMatchFunc {
+    reader: Arc<SupertableReader>,
+    scalar_schema: SchemaRef,
+    output_schema: SchemaRef,
+}
+
+impl TokenMatchFunc {
+    fn new(reader: Arc<SupertableReader>, scalar_schema: SchemaRef) -> Self {
+        let output_schema = output_schema_with_score(&scalar_schema);
+        Self {
+            reader,
+            scalar_schema,
+            output_schema,
+        }
+    }
+}
+
+impl TableFunctionImpl for TokenMatchFunc {
+    fn call(&self, args: &[Expr]) -> DfResult<Arc<dyn TableProvider>> {
+        if args.len() != 2 && args.len() != 3 {
+            return Err(DataFusionError::Plan(format!(
+                "token_match expects 2 or 3 arguments (column, query[, mode]), got {}",
+                args.len()
+            )));
+        }
+        let column = arg_to_string(&args[0], "token_match column")?;
+        let query = arg_to_string(&args[1], "token_match query")?;
+        let mode = match args.get(2) {
+            Some(expr) => arg_to_bool_mode(expr)?,
+            None => BoolMode::Or,
+        };
+        Ok(Arc::new(MatchTable {
+            reader: Arc::clone(&self.reader),
+            column,
+            query: MatchQuery::Token { query, mode },
+            scalar_schema: Arc::clone(&self.scalar_schema),
+            output_schema: Arc::clone(&self.output_schema),
+        }))
+    }
+}
+
+/// `TableFunctionImpl` for `exact_match`.
+#[derive(Debug)]
+pub(crate) struct ExactMatchFunc {
+    reader: Arc<SupertableReader>,
+    scalar_schema: SchemaRef,
+    output_schema: SchemaRef,
+}
+
+impl ExactMatchFunc {
+    fn new(reader: Arc<SupertableReader>, scalar_schema: SchemaRef) -> Self {
+        let output_schema = output_schema_with_score(&scalar_schema);
+        Self {
+            reader,
+            scalar_schema,
+            output_schema,
+        }
+    }
+}
+
+impl TableFunctionImpl for ExactMatchFunc {
+    fn call(&self, args: &[Expr]) -> DfResult<Arc<dyn TableProvider>> {
+        if args.len() != 2 {
+            return Err(DataFusionError::Plan(format!(
+                "exact_match expects 2 arguments (column, value), got {}",
+                args.len()
+            )));
+        }
+        let column = arg_to_string(&args[0], "exact_match column")?;
+        let value = arg_to_string(&args[1], "exact_match value")?;
+        Ok(Arc::new(MatchTable {
+            reader: Arc::clone(&self.reader),
+            column,
+            query: MatchQuery::Exact { value },
+            scalar_schema: Arc::clone(&self.scalar_schema),
+            output_schema: Arc::clone(&self.output_schema),
+        }))
+    }
+}
+
+/// One parsed match invocation as a `TableProvider`. `scan` lowers to
+/// [`MatchExec`].
+struct MatchTable {
+    reader: Arc<SupertableReader>,
+    column: String,
+    query: MatchQuery,
+    scalar_schema: SchemaRef,
+    output_schema: SchemaRef,
+}
+
+impl fmt::Debug for MatchTable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MatchTable")
+            .field("column", &self.column)
+            .field("query", &self.query)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl TableProvider for MatchTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.output_schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        let exec = MatchExec::try_new(
+            Arc::clone(&self.reader),
+            self.column.clone(),
+            self.query.clone(),
+            Arc::clone(&self.scalar_schema),
+            Arc::clone(&self.output_schema),
+            projection.cloned(),
+        )?;
+        Ok(Arc::new(exec))
+    }
+}
+
+/// Custom `ExecutionPlan` that runs an unranked match kernel on the
+/// query runtime inside `execute()` and emits the resolved `_id` +
+/// scalar columns + (constant) `score`.
+struct MatchExec {
+    reader: Arc<SupertableReader>,
+    column: String,
+    query: MatchQuery,
+    scalar_schema: SchemaRef,
+    output_schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    projected_schema: SchemaRef,
+    cache: Arc<PlanProperties>,
+}
+
+impl MatchExec {
+    fn try_new(
+        reader: Arc<SupertableReader>,
+        column: String,
+        query: MatchQuery,
+        scalar_schema: SchemaRef,
+        output_schema: SchemaRef,
+        projection: Option<Vec<usize>>,
+    ) -> DfResult<Self> {
+        let projected_schema = match &projection {
+            Some(indices) => Arc::new(
+                output_schema
+                    .project(indices)
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))?,
+            ),
+            None => Arc::clone(&output_schema),
+        };
+        let cache = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&projected_schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        Ok(Self {
+            reader,
+            column,
+            query,
+            scalar_schema,
+            output_schema,
+            projection,
+            projected_schema,
+            cache,
+        })
+    }
+
+    fn describe(&self) -> String {
+        match &self.query {
+            MatchQuery::Token { mode, .. } => {
+                format!("MatchExec: kind=token, column={}, mode={:?}", self.column, mode)
+            }
+            MatchQuery::Exact { .. } => {
+                format!("MatchExec: kind=exact, column={}", self.column)
+            }
+        }
+    }
+}
+
+impl fmt::Debug for MatchExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.describe())
+    }
+}
+
+impl DisplayAs for MatchExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.describe())
+    }
+}
+
+impl ExecutionPlan for MatchExec {
+    fn name(&self) -> &'static str {
+        "MatchExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DfResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "MatchExec has a single partition; asked for {partition}"
+            )));
+        }
+        let reader = Arc::clone(&self.reader);
+        let column = self.column.clone();
+        let query = self.query.clone();
+        let scalar_schema = Arc::clone(&self.scalar_schema);
+        let output_schema = Arc::clone(&self.output_schema);
+        let projection = self.projection.clone();
+        let projected_schema = Arc::clone(&self.projected_schema);
+
+        let fut = async move {
+            let hits = match &query {
+                MatchQuery::Token { query, mode } => {
+                    reader.token_match(&column, query, *mode).await
+                }
+                MatchQuery::Exact { value } => reader.exact_match(&column, value).await,
+            }
+            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            resolve_hits(
+                &reader,
+                &hits,
+                &scalar_schema,
+                &output_schema,
+                projection.as_deref(),
+            )
+            .await
+        };
+
+        let stream = futures::stream::once(fut);
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            projected_schema,
+            stream,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{LargeStringArray, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+
+    use crate::superfile::builder::FtsConfig;
+    use crate::supertable::{Supertable, SupertableOptions};
+    use crate::test_helpers::default_tokenizer as tok;
+
+    fn title_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new(
+            "title",
+            DataType::LargeUtf8,
+            false,
+        )]))
+    }
+
+    fn options_title_fts() -> SupertableOptions {
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        SupertableOptions::new(
+            title_schema(),
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(tok()),
+        )
+        .expect("valid options")
+        .with_writer_pool(pool)
+    }
+
+    fn supertable_with_titles(titles: &[&str]) -> Supertable {
+        let st = Supertable::create(options_title_fts()).expect("create");
+        let mut w = st.writer().expect("writer");
+        let arr = LargeStringArray::from(titles.to_vec());
+        let batch = RecordBatch::try_new(title_schema(), vec![Arc::new(arr)]).expect("batch");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+        st
+    }
+
+    fn rows(st: &Supertable, sql: &str) -> usize {
+        st.query_sql(sql)
+            .expect("query_sql")
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum()
+    }
+
+    fn demo() -> Supertable {
+        supertable_with_titles(&[
+            "rust async runtime",       // 0
+            "python data science",      // 1
+            "rust systems programming", // 2
+            "go routines",              // 3
+        ])
+    }
+
+    #[test]
+    fn token_match_tvf_or_unions_and_intersects() {
+        let st = demo();
+        // OR (default): rows containing `rust` OR `python` → 0, 1, 2.
+        assert_eq!(
+            rows(&st, "SELECT _id FROM token_match('title', 'rust python')"),
+            3
+        );
+        // AND: rows containing both `rust` and `systems` → only doc 2.
+        assert_eq!(
+            rows(
+                &st,
+                "SELECT _id FROM token_match('title', 'rust systems', 'and')"
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn exact_match_tvf_matches_only_exact_value() {
+        let st = supertable_with_titles(&["rust async", "rust async runtime"]);
+        // Both rows contain {rust, async}, but only one equals the string.
+        assert_eq!(
+            rows(&st, "SELECT _id FROM exact_match('title', 'rust async')"),
+            1
+        );
+        assert_eq!(
+            rows(&st, "SELECT _id FROM exact_match('title', 'rust async runtime')"),
+            1
+        );
+        assert_eq!(
+            rows(&st, "SELECT _id FROM exact_match('title', 'rust')"),
+            0
+        );
+    }
+
+    #[test]
+    fn token_match_tvf_star_projection_appends_score() {
+        let st = demo();
+        let batches = st
+            .query_sql("SELECT * FROM token_match('title', 'rust')")
+            .expect("query_sql");
+        let b = &batches[0];
+        // scalar schema (_id, title) + score.
+        assert_eq!(b.num_columns(), 3);
+        assert_eq!(b.schema().field(2).name(), "score");
+    }
+
+    #[test]
+    fn match_tvf_arity_errors() {
+        let st = demo();
+        assert!(
+            st.query_sql("SELECT _id FROM token_match('title')").is_err(),
+            "token_match needs >= 2 args"
+        );
+        assert!(
+            st.query_sql("SELECT _id FROM exact_match('title')").is_err(),
+            "exact_match needs 2 args"
+        );
+    }
+
+    #[test]
+    fn public_methods_agree_with_tvfs() {
+        let st = demo();
+        let method = st
+            .token_match("title", "rust systems", crate::superfile::fts::reader::BoolMode::And)
+            .expect("token_match");
+        assert_eq!(method.len(), 1);
+        let exact = st.exact_match("title", "go routines").expect("exact_match");
+        assert_eq!(exact.len(), 1);
+    }
+}

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -501,7 +501,9 @@ mod tests {
             )
             .expect("token_match");
         assert_eq!(method.len(), 1);
-        let exact = reader.exact_match("title", "go routines").expect("exact_match");
+        let exact = reader
+            .exact_match("title", "go routines")
+            .expect("exact_match");
         assert_eq!(exact.len(), 1);
     }
 }

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -269,7 +269,10 @@ impl MatchExec {
     fn describe(&self) -> String {
         match &self.query {
             MatchQuery::Token { mode, .. } => {
-                format!("MatchExec: kind=token, column={}, mode={:?}", self.column, mode)
+                format!(
+                    "MatchExec: kind=token, column={}, mode={:?}",
+                    self.column, mode
+                )
             }
             MatchQuery::Exact { .. } => {
                 format!("MatchExec: kind=exact, column={}", self.column)
@@ -450,13 +453,13 @@ mod tests {
             1
         );
         assert_eq!(
-            rows(&st, "SELECT _id FROM exact_match('title', 'rust async runtime')"),
+            rows(
+                &st,
+                "SELECT _id FROM exact_match('title', 'rust async runtime')"
+            ),
             1
         );
-        assert_eq!(
-            rows(&st, "SELECT _id FROM exact_match('title', 'rust')"),
-            0
-        );
+        assert_eq!(rows(&st, "SELECT _id FROM exact_match('title', 'rust')"), 0);
     }
 
     #[test]
@@ -475,11 +478,13 @@ mod tests {
     fn match_tvf_arity_errors() {
         let st = demo();
         assert!(
-            st.query_sql("SELECT _id FROM token_match('title')").is_err(),
+            st.query_sql("SELECT _id FROM token_match('title')")
+                .is_err(),
             "token_match needs >= 2 args"
         );
         assert!(
-            st.query_sql("SELECT _id FROM exact_match('title')").is_err(),
+            st.query_sql("SELECT _id FROM exact_match('title')")
+                .is_err(),
             "exact_match needs 2 args"
         );
     }
@@ -488,7 +493,11 @@ mod tests {
     fn public_methods_agree_with_tvfs() {
         let st = demo();
         let method = st
-            .token_match("title", "rust systems", crate::superfile::fts::reader::BoolMode::And)
+            .token_match(
+                "title",
+                "rust systems",
+                crate::superfile::fts::reader::BoolMode::And,
+            )
             .expect("token_match");
         assert_eq!(method.len(), 1);
         let exact = st.exact_match("title", "go routines").expect("exact_match");

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -338,9 +338,9 @@ impl ExecutionPlan for MatchExec {
         let fut = async move {
             let hits = match &query {
                 MatchQuery::Token { query, mode } => {
-                    reader.token_match(&column, query, *mode).await
+                    reader.token_match_async(&column, query, *mode).await
                 }
-                MatchQuery::Exact { value } => reader.exact_match(&column, value).await,
+                MatchQuery::Exact { value } => reader.exact_match_async(&column, value).await,
             }
             .map_err(|e| DataFusionError::Execution(e.to_string()))?;
             resolve_hits(
@@ -492,7 +492,8 @@ mod tests {
     #[test]
     fn public_methods_agree_with_tvfs() {
         let st = demo();
-        let method = st
+        let reader = st.reader();
+        let method = reader
             .token_match(
                 "title",
                 "rust systems",
@@ -500,7 +501,7 @@ mod tests {
             )
             .expect("token_match");
         assert_eq!(method.len(), 1);
-        let exact = st.exact_match("title", "go routines").expect("exact_match");
+        let exact = reader.exact_match("title", "go routines").expect("exact_match");
         assert_eq!(exact.len(), 1);
     }
 }

--- a/src/supertable/query/exec/mod.rs
+++ b/src/supertable/query/exec/mod.rs
@@ -15,4 +15,5 @@
 pub mod common;
 pub mod fts_exec;
 pub mod hybrid_exec;
+pub mod match_exec;
 pub mod vector_exec;

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -263,8 +263,8 @@ impl SupertableReader {
     /// skip uses the same term-bloom prune as BM25.
     ///
     /// `pub(crate)` async kernel; the public surface is the sync
-    /// [`Supertable::token_match`].
-    pub(crate) async fn token_match(
+    /// [`SupertableReader::token_match`].
+    pub(crate) async fn token_match_async(
         &self,
         column: &str,
         query: &str,
@@ -313,8 +313,8 @@ impl SupertableReader {
     /// for the per-segment two-pass (token-AND prune + raw verify).
     ///
     /// `pub(crate)` async kernel; the public surface is the sync
-    /// [`Supertable::exact_match`].
-    pub(crate) async fn exact_match(
+    /// [`SupertableReader::exact_match`].
+    pub(crate) async fn exact_match_async(
         &self,
         column: &str,
         value: &str,
@@ -383,33 +383,29 @@ impl SupertableReader {
         self.block_on(self.bm25_search_prefix_async(column, prefix, k))
     }
 
-    /// Unranked token match over the current snapshot. Returns
+    /// Unranked token match over this reader's pinned snapshot. Returns
     /// every row whose `column` matches `query`'s tokens under `mode`
     /// (`Or` = any token, `And` = every token). The returned hits are
     /// **unranked** — `score` is `0.0` and order is unspecified — unlike
-    /// the ranked [`Supertable::bm25_search`]. Same sync→async bridge
-    /// and freshness policy as the other search methods.
+    /// the ranked [`SupertableReader::bm25_search`]. Drives the async
+    /// kernel via the sync→async bridge ([`SupertableReader::block_on`]).
     pub fn token_match(
         &self,
         column: &str,
         query: &str,
         mode: BoolMode,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
-        self.ensure_fresh();
-        let reader = self.reader();
-        self.block_on_query(reader.token_match(column, query, mode))
+        self.block_on(self.token_match_async(column, query, mode))
     }
 
     /// Unranked exact match of the raw string `value` against `column`
-    /// over the current snapshot — the two-pass index-pruned, text-
-    /// verified match (see
+    /// over this reader's pinned snapshot — the two-pass index-pruned,
+    /// text-verified match (see
     /// [`SuperfileReader::exact_match`](crate::superfile::SuperfileReader::exact_match)).
     /// Returns the rows whose stored value equals `value` exactly;
     /// hits are **unranked** (`score` is `0.0`).
     pub fn exact_match(&self, column: &str, value: &str) -> Result<Vec<SuperfileHit>, QueryError> {
-        self.ensure_fresh();
-        let reader = self.reader();
-        self.block_on_query(reader.exact_match(column, value))
+        self.block_on(self.exact_match_async(column, value))
     }
 }
 

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -255,6 +255,107 @@ impl SupertableReader {
 
         Ok(top_k_descending(per_unit, k))
     }
+
+    /// Unranked token match across the pinned snapshot. Returns
+    /// every row matching `query`'s tokens under `mode` (`Or` = any
+    /// token, `And` = every token) as [`SuperfileHit`]s — **no scoring**
+    /// (`score` is left `0.0`; these results are unordered). Segment
+    /// skip uses the same term-bloom prune as BM25.
+    ///
+    /// `pub(crate)` async kernel; the public surface is the sync
+    /// [`Supertable::token_match`].
+    pub(crate) async fn token_match(
+        &self,
+        column: &str,
+        query: &str,
+        mode: BoolMode,
+    ) -> Result<Vec<SuperfileHit>, QueryError> {
+        let manifest = self.manifest();
+        let term_strings: Vec<String> = AsciiLowerTokenizer.tokenize(query).collect();
+        if term_strings.is_empty() {
+            return Ok(Vec::new());
+        }
+        let kept = crate::supertable::query::prune::select_segments(
+            manifest.as_ref(),
+            &[crate::supertable::query::prune::PruneLeaf::TermPresence {
+                column: column.to_owned(),
+                terms: term_strings.clone(),
+                mode,
+            }],
+        )
+        .await?;
+        if kept.is_empty() {
+            return Ok(Vec::new());
+        }
+        let units: Vec<(Arc<SuperfileEntry>, ())> =
+            kept.into_iter().map(|e| (e, ())).collect();
+        let column_arc = Arc::new(column.to_owned());
+        let term_arc: Arc<Vec<String>> = Arc::new(term_strings);
+        let kernel = move |r: Arc<SuperfileReader>, _: ()| {
+            let column_arc = Arc::clone(&column_arc);
+            let term_arc = Arc::clone(&term_arc);
+            async move {
+                let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
+                let docs = r
+                    .token_match(&column_arc, &refs, mode)
+                    .await
+                    .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                Ok(docs.into_iter().map(|d| (d, 0.0f32)).collect::<Vec<_>>())
+            }
+        };
+        let per_unit = crate::supertable::query::dispatch::fanout(self, units, kernel).await?;
+        Ok(per_unit.into_iter().flatten().collect())
+    }
+
+    /// Unranked two-pass exact match of the **raw string** `value`
+    /// against `column` across the pinned snapshot. Returns the rows
+    /// whose stored value equals `value` exactly as [`SuperfileHit`]s —
+    /// **no scoring**. See [`crate::superfile::SuperfileReader::exact_match`]
+    /// for the per-segment two-pass (token-AND prune + raw verify).
+    ///
+    /// `pub(crate)` async kernel; the public surface is the sync
+    /// [`Supertable::exact_match`].
+    pub(crate) async fn exact_match(
+        &self,
+        column: &str,
+        value: &str,
+    ) -> Result<Vec<SuperfileHit>, QueryError> {
+        let manifest = self.manifest();
+        let term_strings: Vec<String> = AsciiLowerTokenizer.tokenize(value).collect();
+        // Tokens prune segments via the term bloom (AND); a token-less
+        // value (e.g. punctuation only) can't prune, so keep all.
+        let leaves = if term_strings.is_empty() {
+            Vec::new()
+        } else {
+            vec![crate::supertable::query::prune::PruneLeaf::TermPresence {
+                column: column.to_owned(),
+                terms: term_strings,
+                mode: BoolMode::And,
+            }]
+        };
+        let kept =
+            crate::supertable::query::prune::select_segments(manifest.as_ref(), &leaves).await?;
+        if kept.is_empty() {
+            return Ok(Vec::new());
+        }
+        let units: Vec<(Arc<SuperfileEntry>, ())> =
+            kept.into_iter().map(|e| (e, ())).collect();
+        let column_arc = Arc::new(column.to_owned());
+        let value_arc = Arc::new(value.to_owned());
+        let kernel = move |r: Arc<SuperfileReader>, _: ()| {
+            let column_arc = Arc::clone(&column_arc);
+            let value_arc = Arc::clone(&value_arc);
+            async move {
+                let docs = r
+                    .exact_match(&column_arc, &value_arc)
+                    .await
+                    .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                Ok(docs.into_iter().map(|d| (d, 0.0f32)).collect::<Vec<_>>())
+            }
+        };
+        let per_unit = crate::supertable::query::dispatch::fanout(self, units, kernel).await?;
+        Ok(per_unit.into_iter().flatten().collect())
+    }
 }
 
 impl Supertable {
@@ -287,6 +388,39 @@ impl Supertable {
         self.ensure_fresh();
         let reader = self.reader();
         self.block_on_query(reader.bm25_search_prefix(column, prefix, k))
+    }
+
+    /// Unranked token match over the current snapshot. Returns
+    /// every row whose `column` matches `query`'s tokens under `mode`
+    /// (`Or` = any token, `And` = every token). The returned hits are
+    /// **unranked** — `score` is `0.0` and order is unspecified — unlike
+    /// the ranked [`Supertable::bm25_search`]. Same sync→async bridge
+    /// and freshness policy as the other search methods.
+    pub fn token_match(
+        &self,
+        column: &str,
+        query: &str,
+        mode: BoolMode,
+    ) -> Result<Vec<SuperfileHit>, QueryError> {
+        self.ensure_fresh();
+        let reader = self.reader();
+        self.block_on_query(reader.token_match(column, query, mode))
+    }
+
+    /// Unranked exact match of the raw string `value` against `column`
+    /// over the current snapshot — the two-pass index-pruned, text-
+    /// verified match (see
+    /// [`SuperfileReader::exact_match`](crate::superfile::SuperfileReader::exact_match)).
+    /// Returns the rows whose stored value equals `value` exactly;
+    /// hits are **unranked** (`score` is `0.0`).
+    pub fn exact_match(
+        &self,
+        column: &str,
+        value: &str,
+    ) -> Result<Vec<SuperfileHit>, QueryError> {
+        self.ensure_fresh();
+        let reader = self.reader();
+        self.block_on_query(reader.exact_match(column, value))
     }
 }
 

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -287,8 +287,7 @@ impl SupertableReader {
         if kept.is_empty() {
             return Ok(Vec::new());
         }
-        let units: Vec<(Arc<SuperfileEntry>, ())> =
-            kept.into_iter().map(|e| (e, ())).collect();
+        let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
         let column_arc = Arc::new(column.to_owned());
         let term_arc: Arc<Vec<String>> = Arc::new(term_strings);
         let kernel = move |r: Arc<SuperfileReader>, _: ()| {
@@ -338,8 +337,7 @@ impl SupertableReader {
         if kept.is_empty() {
             return Ok(Vec::new());
         }
-        let units: Vec<(Arc<SuperfileEntry>, ())> =
-            kept.into_iter().map(|e| (e, ())).collect();
+        let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
         let column_arc = Arc::new(column.to_owned());
         let value_arc = Arc::new(value.to_owned());
         let kernel = move |r: Arc<SuperfileReader>, _: ()| {
@@ -413,11 +411,7 @@ impl Supertable {
     /// [`SuperfileReader::exact_match`](crate::superfile::SuperfileReader::exact_match)).
     /// Returns the rows whose stored value equals `value` exactly;
     /// hits are **unranked** (`score` is `0.0`).
-    pub fn exact_match(
-        &self,
-        column: &str,
-        value: &str,
-    ) -> Result<Vec<SuperfileHit>, QueryError> {
+    pub fn exact_match(&self, column: &str, value: &str) -> Result<Vec<SuperfileHit>, QueryError> {
         self.ensure_fresh();
         let reader = self.reader();
         self.block_on_query(reader.exact_match(column, value))

--- a/src/supertable/query/mod.rs
+++ b/src/supertable/query/mod.rs
@@ -19,6 +19,7 @@
 //! [`skip`] holds the manifest-only skip helpers (bloom +
 //! term-range + centroid) shared across the query paths.
 
+pub mod candidate;
 pub mod dispatch;
 pub mod exec;
 pub mod fts;

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -369,8 +369,8 @@ impl TableProvider for SupertableProvider {
                 .estimate(reader.as_ref())
                 .await
                 .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-            let gate = ((reader.n_docs() as f64 * PUSHDOWN_MAX_FRACTION) as u64)
-                .max(PUSHDOWN_MIN_ROWS);
+            let gate =
+                ((reader.n_docs() as f64 * PUSHDOWN_MAX_FRACTION) as u64).max(PUSHDOWN_MIN_ROWS);
             let candidates = if est > gate {
                 None
             } else {
@@ -449,8 +449,7 @@ impl TableProvider for SupertableProvider {
             crate::supertable::query::candidate::CandidatePlan::Unbounded
         );
         let mut source = ParquetSource::new(Arc::clone(&self.schema));
-        if !index_bounded
-            && let Some(predicate) = row_group_predicate(state, filters, &self.schema)
+        if !index_bounded && let Some(predicate) = row_group_predicate(state, filters, &self.schema)
         {
             source = source
                 .with_predicate(predicate)
@@ -567,7 +566,10 @@ fn tombstone_access_plan(
 /// Parquet body — which partition contiguously across row groups laid
 /// out in append order. An empty `keep` produces an all-skip plan (zero
 /// rows decoded), the correct result for a segment with no candidate.
-fn selection_access_plan(parquet_bytes: &Bytes, keep: &RoaringBitmap) -> DfResult<ParquetAccessPlan> {
+fn selection_access_plan(
+    parquet_bytes: &Bytes,
+    keep: &RoaringBitmap,
+) -> DfResult<ParquetAccessPlan> {
     let builder = ParquetRecordBatchReaderBuilder::try_new(parquet_bytes.clone())
         .map_err(|e| DataFusionError::Execution(format!("parquet metadata: {e}")))?;
     let row_groups = builder.metadata().row_groups();

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -90,6 +90,18 @@ pub(crate) const TABLE_NAME: &str = "supertable";
 /// only a key into the session's object-store registry.
 const MEMORY_STORE_URL: &str = "memory://supertable/";
 
+/// Selectivity gate for the FTS `WHERE` pushdown: only push an index
+/// candidate set into the scan when the estimated match count is at
+/// most this fraction of the segment's rows. Above it, matches saturate
+/// the Parquet data pages so an index `RowSelection` can't skip any —
+/// a plain scan is cheaper than the posting walk + selection overhead.
+const PUSHDOWN_MAX_FRACTION: f64 = 0.01;
+
+/// Floor for the gate so the pushdown stays active on small segments
+/// (where `n_docs * fraction` rounds to ~0 but there's no page-skip
+/// tradeoff to lose anyway).
+const PUSHDOWN_MIN_ROWS: u64 = 4096;
+
 /// A [`TableProvider`] over a pinned supertable snapshot.
 ///
 /// Cheap to build (just `Arc` clones); all real work happens in
@@ -194,6 +206,18 @@ impl SupertableProvider {
             .map_err(|e| DataFusionError::Execution(e.to_string()))
     }
 
+    /// The set of FTS-indexed column names — used by the candidate
+    /// planner and by `supports_filters_pushdown` to decide which
+    /// filters the index can resolve.
+    fn fts_cols_set(&self) -> std::collections::HashSet<String> {
+        self.manifest
+            .options
+            .fts_columns
+            .iter()
+            .map(|c| c.column.clone())
+            .collect()
+    }
+
     /// Test hook: how many segments survive pruning for `filters` — the
     /// observable behind "did the index prune more than min/max?".
     #[cfg(test)]
@@ -231,9 +255,12 @@ impl TableProvider for SupertableProvider {
     /// Report every filter as `Inexact`: DataFusion hands us the
     /// predicates (for both pruning tiers) **and** keeps a
     /// `FilterExec` above the scan, so correctness never depends on
-    /// our conservative pruning. Returning `Unsupported` (the
-    /// default) would withhold the filters from [`scan`] entirely,
-    /// disabling segment + row-group skip.
+    /// our conservative pruning. The `FilterExec` also does the
+    /// candidate-superset verification in the same scan pass as the
+    /// projection (one decode), which a self-verifying `exact_match`
+    /// candidate would split into an extra pass — measured slower.
+    /// Returning `Unsupported` (the default) would withhold the filters
+    /// from [`scan`] entirely, disabling segment + row-group skip.
     fn supports_filters_pushdown(
         &self,
         filters: &[&Expr],
@@ -287,6 +314,17 @@ impl TableProvider for SupertableProvider {
             cache.prefetch(&ids, now).await;
         }
 
+        // Pass 1 — build the index candidate plan once for this scan. It
+        // lowers the FTS-resolvable part of the `WHERE` clause to a
+        // boolean tree over `token_match`; evaluated per segment below
+        // it yields a candidate row-id superset (or `Unbounded` = scan
+        // the segment). See `crate::supertable::query::candidate`.
+        let candidate_plan = crate::supertable::query::candidate::CandidatePlan::from_filters(
+            filters,
+            &self.fts_cols_set(),
+            self.manifest.options.tokenizer.as_ref(),
+        );
+
         // In-memory object store exposing the surviving segment bytes
         // to DataFusion's Parquet source for the duration of this scan.
         let mem_store = Arc::new(InMemory::new());
@@ -315,24 +353,64 @@ impl TableProvider for SupertableProvider {
             let path = entry.uri.storage_path();
             let size = bytes.len() as u64;
 
-            // Lazy delete path: translate this segment's tombstone
-            // bitmap into a Parquet row selection so deleted rows are
-            // never decoded. Absent/empty overlay → full scan, zero
-            // overhead. The `local_doc_id` in the bitmap is the row's
-            // global position within the segment's Parquet body, which
-            // is exactly the coordinate `ParquetAccessPlan` selects on.
-            let access_plan = match self.tombstone_cache.as_ref() {
-                Some(cache) => {
-                    let bitmap = cache
-                        .bitmap_for(entry.superfile_id, now)
-                        .map_err(|e| DataFusionError::Execution(format!("tombstone cache: {e}")))?;
-                    if bitmap.is_empty() {
+            // Pass 1 (per segment): resolve candidate rows from the
+            // index. `None` ⇒ no usable bound, scan the segment.
+            //
+            // Selectivity gate: estimate the match count from per-term
+            // `df` first (cheap, header-only — no posting decode). If a
+            // predicate would match more than `PUSHDOWN_MAX_FRACTION` of
+            // this segment, skip the index path and let DataFusion scan:
+            // at that match density the rows saturate the data pages, so
+            // an index `RowSelection` can't skip any page and only adds
+            // the posting-walk + selection overhead. The floor keeps the
+            // pushdown active on small segments (where there's no page to
+            // skip-vs-scan tradeoff anyway).
+            let est = candidate_plan
+                .estimate(reader.as_ref())
+                .await
+                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            let gate = ((reader.n_docs() as f64 * PUSHDOWN_MAX_FRACTION) as u64)
+                .max(PUSHDOWN_MIN_ROWS);
+            let candidates = if est > gate {
+                None
+            } else {
+                candidate_plan
+                    .evaluate(reader.as_ref())
+                    .await
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))?
+            };
+
+            // This segment's tombstoned rows (empty when no overlay).
+            let tombstones = match self.tombstone_cache.as_ref() {
+                Some(cache) => cache
+                    .bitmap_for(entry.superfile_id, now)
+                    .map_err(|e| DataFusionError::Execution(format!("tombstone cache: {e}")))?,
+                None => Arc::new(RoaringBitmap::new()),
+            };
+
+            // Build the Parquet row selection. `local_doc_id`s are global
+            // row positions in the Parquet body — exactly the coordinate
+            // `ParquetAccessPlan` selects on.
+            let access_plan = match candidates {
+                // Index-driven row selection: decode only the candidate
+                // rows minus any tombstoned row. The term-AND candidate is
+                // a superset of the SQL predicate, so the `FilterExec`
+                // above still verifies it exactly — this never drops a
+                // true match, only avoids decoding non-candidates.
+                Some(mut keep) => {
+                    keep -= tombstones.as_ref();
+                    Some(selection_access_plan(&bytes, &keep)?)
+                }
+                // No index bound: lazy-delete-only path — translate the
+                // tombstone bitmap into a row selection so deleted rows
+                // are never decoded; absent/empty overlay → full scan.
+                None => {
+                    if tombstones.is_empty() {
                         None
                     } else {
-                        tombstone_access_plan(&bytes, &bitmap)?
+                        tombstone_access_plan(&bytes, &tombstones)?
                     }
                 }
-                None => None,
             };
 
             mem_store
@@ -351,13 +429,33 @@ impl TableProvider for SupertableProvider {
             .runtime_env()
             .register_object_store(url.as_ref(), mem_store);
 
-        // Tier 2 — DataFusion-owned row-group / page pruning. Hand
-        // the same predicate to ParquetSource as a physical expr;
-        // on any lowering failure we simply skip row-group pruning
-        // (FilterExec above still guarantees correctness).
+        // Tier 2 — DataFusion-owned row-group / page pruning + row-level
+        // filter pushdown, used **only when the index could not bound the
+        // rows** (`Unbounded` candidate plan). In that fallback the
+        // predicate becomes a Parquet `RowFilter` (`with_pushdown_filters`)
+        // so the predicate columns are decoded first and only surviving
+        // rows materialize — pull-up avoided.
+        //
+        // When the index *did* bound the rows, the per-segment access plan
+        // already selects exactly the candidate rows and the `FilterExec`
+        // above (filters are `Inexact`) verifies the exact predicate over
+        // that tiny set. Handing DataFusion the same predicate here would
+        // turn it into a `RowFilter` that decodes the whole predicate
+        // column to re-test it — scanning the very column the index just
+        // let us skip. So we attach the pushdown predicate only on the
+        // unbounded path.
+        let index_bounded = !matches!(
+            candidate_plan,
+            crate::supertable::query::candidate::CandidatePlan::Unbounded
+        );
         let mut source = ParquetSource::new(Arc::clone(&self.schema));
-        if let Some(predicate) = row_group_predicate(state, filters, &self.schema) {
-            source = source.with_predicate(predicate);
+        if !index_bounded
+            && let Some(predicate) = row_group_predicate(state, filters, &self.schema)
+        {
+            source = source
+                .with_predicate(predicate)
+                .with_pushdown_filters(true)
+                .with_reorder_filters(true);
         }
 
         // Only push the LIMIT into the scan when there are no
@@ -456,6 +554,73 @@ fn tombstone_access_plan(
     }
 
     Ok(any.then_some(plan))
+}
+
+/// Build a [`ParquetAccessPlan`] that decodes **only** the rows in
+/// `keep`, skipping everything else — the inverse of
+/// [`tombstone_access_plan`]. Used for index-driven row selection: the
+/// candidate planner yields a small set of `local_doc_id`s (already
+/// minus tombstones), and we want the Parquet reader to materialize the
+/// payload columns for just those rows rather than scanning the segment.
+///
+/// `keep`'s ids are `local_doc_id`s — global row positions in the
+/// Parquet body — which partition contiguously across row groups laid
+/// out in append order. An empty `keep` produces an all-skip plan (zero
+/// rows decoded), the correct result for a segment with no candidate.
+fn selection_access_plan(parquet_bytes: &Bytes, keep: &RoaringBitmap) -> DfResult<ParquetAccessPlan> {
+    let builder = ParquetRecordBatchReaderBuilder::try_new(parquet_bytes.clone())
+        .map_err(|e| DataFusionError::Execution(format!("parquet metadata: {e}")))?;
+    let row_groups = builder.metadata().row_groups();
+    // Ascending — `RoaringBitmap::iter` yields sorted, so each row group
+    // binary-searches its contiguous slice of kept ids.
+    let kept: Vec<u32> = keep.iter().collect();
+
+    let mut plan = ParquetAccessPlan::new_all(row_groups.len());
+    let mut base: u32 = 0;
+    for (idx, rg) in row_groups.iter().enumerate() {
+        let n = rg.num_rows() as u32;
+        if n == 0 {
+            continue;
+        }
+        let lo = kept.partition_point(|&x| x < base);
+        let hi = kept.partition_point(|&x| x < base + n);
+        let rg_kept = &kept[lo..hi];
+        if rg_kept.is_empty() {
+            plan.skip(idx);
+            base += n;
+            continue;
+        }
+        if rg_kept.len() as u32 == n {
+            // Every row in this group is a candidate — leave it as Scan.
+            base += n;
+            continue;
+        }
+        // Emit alternating skip(gap) / select(run) selectors so only the
+        // kept rows are decoded.
+        let mut selectors: Vec<RowSelector> = Vec::new();
+        let mut cursor: u32 = 0; // next un-emitted position within the row group
+        let mut i = 0usize;
+        while i < rg_kept.len() {
+            let start_rel = rg_kept[i] - base;
+            if start_rel > cursor {
+                selectors.push(RowSelector::skip((start_rel - cursor) as usize));
+            }
+            let mut j = i;
+            while j + 1 < rg_kept.len() && rg_kept[j + 1] == rg_kept[j] + 1 {
+                j += 1;
+            }
+            let run = (rg_kept[j] - rg_kept[i] + 1) as usize;
+            selectors.push(RowSelector::select(run));
+            cursor = (rg_kept[j] - base) + 1;
+            i = j + 1;
+        }
+        if cursor < n {
+            selectors.push(RowSelector::skip((n - cursor) as usize));
+        }
+        plan.scan_selection(idx, RowSelection::from(selectors));
+        base += n;
+    }
+    Ok(plan)
 }
 
 /// Lower a conjunction of DataFusion filter `Expr`s into infino's

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -162,6 +162,12 @@ impl Supertable {
             Arc::clone(&reader),
             Arc::clone(&scalar_schema),
         );
+        // Unranked token / exact match TVFs (siblings of bm25_search).
+        crate::supertable::query::exec::match_exec::register_match(
+            &ctx,
+            Arc::clone(&reader),
+            Arc::clone(&scalar_schema),
+        );
         crate::supertable::query::exec::hybrid_exec::register_hybrid_search(
             &ctx,
             Arc::clone(&reader),
@@ -516,6 +522,162 @@ mod tests {
                 "SELECT COUNT(*) FROM supertable WHERE title = 'rust async'"
             ),
             0
+        );
+    }
+
+    #[test]
+    fn query_sql_fts_equality_superset_is_narrowed_to_exact_match() {
+        // Index-driven row selection: the candidate plan resolves
+        // `WHERE title = 'rust async'` to the term-AND posting set, which
+        // within one segment is a *superset* — both rows below contain
+        // {rust, async}. The FilterExec above the scan must narrow that
+        // candidate superset to the single exact-equality row, proving
+        // the row-level prune never over-returns.
+        let st = Supertable::create(options_id_cat_title()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_cat_batch(
+            0,
+            &["x", "y"],
+            &["rust async", "rust async runtime"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE title = 'rust async'",
+            ),
+            1,
+        );
+        let batches = st
+            .query_sql("SELECT title FROM supertable WHERE title = 'rust async'")
+            .expect("query");
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn query_sql_fts_or_and_in_are_exact() {
+        // OR of two FTS equalities, AND with a non-FTS conjunct, and IN —
+        // all index-bounded except where a branch is un-boundable, and
+        // all verified exact by FilterExec.
+        let st = Supertable::create(options_id_cat_title()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_cat_batch(
+            0,
+            &["rust", "python", "rust", "go"],
+            &["alpha", "beta", "gamma", "delta"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+
+        // OR of two FTS equalities → union, exact.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE title = 'alpha' OR title = 'beta'",
+            ),
+            2,
+        );
+        // AND with a non-FTS conjunct: FTS branch bounds candidates, the
+        // category check is verified in pass 2.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable \
+                 WHERE title = 'alpha' AND category = 'rust'",
+            ),
+            1,
+        );
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable \
+                 WHERE title = 'alpha' AND category = 'python'",
+            ),
+            0,
+        );
+        // IN on the FTS column → OR of equalities.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE title IN ('alpha', 'delta', 'zzz')",
+            ),
+            2,
+        );
+    }
+
+    #[test]
+    fn query_sql_not_predicates_are_exact() {
+        // NOT / != aren't index-prefiltered (Unbounded → scan), but must
+        // still be exact; and `= AND !=` prefilters on the `=` branch
+        // while FilterExec applies the negation.
+        let st = Supertable::create(options_id_cat_title()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_cat_batch(
+            0,
+            &["rust", "python", "rust", "go"],
+            &["alpha", "beta", "alpha", "delta"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+
+        // Standalone NOT (scan fallback): 4 rows, 2 are 'alpha' → 2 left.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE NOT (title = 'alpha')",
+            ),
+            2,
+        );
+        // `!=` (NotEq) likewise.
+        assert_eq!(
+            run_count(&st, "SELECT COUNT(*) FROM supertable WHERE title != 'alpha'"),
+            2,
+        );
+        // `= AND !=`: candidates from the `title='alpha'` branch (2 rows),
+        // then FilterExec drops category='rust' → 1 remains.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable \
+                 WHERE title = 'alpha' AND category != 'rust'",
+            ),
+            0,
+        );
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable \
+                 WHERE title = 'alpha' AND category != 'python'",
+            ),
+            2,
+        );
+    }
+
+    #[test]
+    fn query_sql_or_with_non_fts_branch_matches_full_scan() {
+        // `title = 'alpha' OR category = 'go'` is un-boundable (the
+        // category branch could match any row), so the planner falls back
+        // to a full scan + FilterExec — and must still be exact.
+        let st = Supertable::create(options_id_cat_title()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_cat_batch(
+            0,
+            &["rust", "python", "go", "go"],
+            &["alpha", "beta", "gamma", "delta"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+
+        // alpha (1 row) ∪ category=go (2 rows), disjoint → 3.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE title = 'alpha' OR category = 'go'",
+            ),
+            3,
         );
     }
 

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -633,7 +633,10 @@ mod tests {
         );
         // `!=` (NotEq) likewise.
         assert_eq!(
-            run_count(&st, "SELECT COUNT(*) FROM supertable WHERE title != 'alpha'"),
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE title != 'alpha'"
+            ),
             2,
         );
         // `= AND !=`: candidates from the `title='alpha'` branch (2 rows),

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Direct integration coverage for the sync reader search methods that
+//! mirror `bm25_search` / `vector_search`: `token_match`, `exact_match`,
+//! and `hybrid_search`.
+//!
+//! The in-crate unit tests (`match_exec.rs`, `hybrid_exec.rs`) cover the
+//! SQL table-valued functions and the RRF math on a single segment.
+//! This file exercises the published
+//! `SupertableReader::{token_match, exact_match, hybrid_search}` surface
+//! the way a Rust consumer calls it — `st.reader().token_match(..)` —
+//! over a committed **multi-segment** corpus so the per-segment work
+//! fans out and merges across segments.
+//!
+//! Hits are identified by their `(segment, local_doc_id)` pair (the same
+//! identity RRF fuses on); expectations are pinned by comparing against
+//! the `bm25_search` / `vector_search` sub-searches rather than by
+//! hand-mapping doc positions, so the assertions hold regardless of how
+//! a commit shards rows into superfiles.
+
+#![deny(clippy::unwrap_used)]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+
+use infino::superfile::builder::FtsConfig;
+use infino::superfile::fts::reader::BoolMode;
+use infino::supertable::query::SuperfileHit;
+use infino::supertable::query::vector::VectorSearchOptions;
+use infino::supertable::{SuperfileUri, Supertable, SupertableOptions};
+use infino::test_helpers::{default_tokenizer, default_vector_config};
+
+/// `default_vector_config` is dim=16, cosine, n_cent=4.
+const DIM: usize = 16;
+/// Random-rotation seed for the fixture's vector index.
+const VECTOR_ROT_SEED: u64 = 7;
+/// Rayon pool size for deterministic builds.
+const RAYON_POOL_THREADS: usize = 2;
+/// One-hot query dimension; doc 0 ("rust async") is one-hot at dim 0, so
+/// this query's exact nearest neighbour is doc 0.
+const QUERY_DIM: usize = 0;
+/// Top-k ≥ the corpus size, so a retriever returns its whole candidate
+/// set and RRF never truncates the fused union.
+const TOP_K: usize = 32;
+/// Smaller top-k for the ranking-order assertions.
+const RANK_TOP_K: usize = 8;
+/// `rust` is sprinkled across both segments; this guards against corpus
+/// drift silently making the cross-segment assertions trivial.
+const MIN_RUST_HITS: usize = 4;
+
+/// First segment's titles; doc `i`'s embedding is one-hot at dim `i`.
+const SEG1_TITLES: &[&str] = &[
+    "rust async",   // 0  — `async` is unique to this doc
+    "python data",  // 1
+    "java spring",  // 2
+    "go rust",      // 3
+    "ruby rails",   // 4
+    "scala akka",   // 5
+    "kotlin flow",  // 6
+    "rust systems", // 7  — only doc with both `rust` and `systems`
+];
+/// Second segment's titles; doc `i` (global) is one-hot at dim `i`.
+const SEG2_TITLES: &[&str] = &[
+    "swift ui",      // 8
+    "rust web",      // 9
+    "haskell pure",  // 10
+    "elixir beam",   // 11
+    "rust embedded", // 12
+    "clojure lisp",  // 13
+    "erlang otp",    // 14
+    "rust macro",    // 15
+];
+
+fn fixed_list_f32(dim: usize) -> DataType {
+    DataType::FixedSizeList(
+        Arc::new(Field::new("item", DataType::Float32, true)),
+        dim as i32,
+    )
+}
+
+/// Schema `[title (FTS), emb (vector)]`. The vector column never
+/// surfaces as a scalar SQL column; here it backs `vector_search` /
+/// `hybrid_search` only.
+fn options_title_emb() -> SupertableOptions {
+    let writer_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(RAYON_POOL_THREADS)
+            .build()
+            .expect("writer pool"),
+    );
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("emb", fixed_list_f32(DIM), false),
+    ]));
+    SupertableOptions::new(
+        schema,
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![default_vector_config("emb", VECTOR_ROT_SEED)],
+        Some(default_tokenizer()),
+    )
+    .expect("valid options")
+    .with_writer_pool(writer_pool)
+}
+
+/// Doc `i` (within the batch) gets `titles[i]` and a one-hot embedding
+/// at global dim `base_dim + i`.
+fn build_batch(titles: &[&str], base_dim: usize, schema: Arc<Schema>) -> RecordBatch {
+    let title_arr = LargeStringArray::from(titles.to_vec());
+    let mut flat = Vec::<f32>::with_capacity(titles.len() * DIM);
+    for i in 0..titles.len() {
+        let active = base_dim + i;
+        for d in 0..DIM {
+            flat.push(if d == active { 1.0 } else { 0.0 });
+        }
+    }
+    let fsl = FixedSizeListArray::try_new(
+        Arc::new(Field::new("item", DataType::Float32, true)),
+        DIM as i32,
+        Arc::new(Float32Array::from(flat)) as ArrayRef,
+        None,
+    )
+    .expect("FSL");
+    RecordBatch::try_new(schema, vec![Arc::new(title_arr), Arc::new(fsl)]).expect("batch")
+}
+
+/// Two committed segments built from [`SEG1_TITLES`] then [`SEG2_TITLES`].
+fn demo_two_segments() -> Supertable {
+    let st = Supertable::create(options_title_emb()).expect("create");
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    w.append(&build_batch(SEG1_TITLES, 0, schema.clone()))
+        .expect("append seg1");
+    w.commit().expect("commit seg1");
+    w.append(&build_batch(SEG2_TITLES, SEG1_TITLES.len(), schema))
+        .expect("append seg2");
+    w.commit().expect("commit seg2");
+    drop(w);
+    st
+}
+
+fn one_hot(active: usize) -> Vec<f32> {
+    (0..DIM)
+        .map(|d| if d == active { 1.0 } else { 0.0 })
+        .collect()
+}
+
+/// Stable per-row identity: the `(segment, local_doc_id)` pair RRF and
+/// the resolve path both key on.
+fn hit_ids(hits: &[SuperfileHit]) -> HashSet<(SuperfileUri, u32)> {
+    hits.iter().map(|h| (h.segment, h.local_doc_id)).collect()
+}
+
+#[test]
+fn token_match_or_is_the_unranked_bm25_candidate_set() {
+    let st = demo_two_segments();
+    let reader = st.reader();
+    let token = reader
+        .token_match("title", "rust", BoolMode::Or)
+        .expect("token_match OR");
+    let bm25 = reader
+        .bm25_search("title", "rust", TOP_K, BoolMode::Or)
+        .expect("bm25_search OR");
+
+    assert!(
+        bm25.len() >= MIN_RUST_HITS,
+        "'rust' should match across both segments"
+    );
+    assert_eq!(
+        hit_ids(&token),
+        hit_ids(&bm25),
+        "token_match OR must return exactly the BM25 OR candidate set, unranked"
+    );
+    assert!(
+        token.iter().all(|h| h.score == 0.0),
+        "token_match is unranked; score must be 0.0"
+    );
+}
+
+#[test]
+fn token_match_and_intersects_tokens() {
+    let st = demo_two_segments();
+    let reader = st.reader();
+    // Only "rust systems" carries both tokens.
+    let token = reader
+        .token_match("title", "rust systems", BoolMode::And)
+        .expect("token_match AND");
+    let bm25 = reader
+        .bm25_search("title", "rust systems", TOP_K, BoolMode::And)
+        .expect("bm25_search AND");
+
+    assert!(!token.is_empty(), "AND of present tokens must match a doc");
+    assert_eq!(
+        hit_ids(&token),
+        hit_ids(&bm25),
+        "token_match AND must equal the BM25 AND candidate set"
+    );
+}
+
+#[test]
+fn exact_match_is_raw_value_equality_not_token() {
+    let st = demo_two_segments();
+    let reader = st.reader();
+    // The raw title "rust async" equals exactly the docs that the
+    // token-AND prune leaves (only doc 0 has both `rust` and `async`).
+    let exact = reader
+        .exact_match("title", "rust async")
+        .expect("exact_match hit");
+    let token_and = reader
+        .token_match("title", "rust async", BoolMode::And)
+        .expect("token_match AND");
+
+    assert!(!exact.is_empty(), "raw value present must match");
+    assert_eq!(
+        hit_ids(&exact),
+        hit_ids(&token_and),
+        "exact 'rust async' must equal the docs whose whole title is that string"
+    );
+    assert!(
+        exact.iter().all(|h| h.score == 0.0),
+        "exact_match is unranked; score must be 0.0"
+    );
+
+    // A bare token no title *equals* returns nothing, even though many
+    // titles *contain* it — exact_match compares the whole stored value.
+    let none = reader
+        .exact_match("title", "rust")
+        .expect("exact_match miss");
+    assert!(
+        none.is_empty(),
+        "exact_match compares the whole stored value, not tokens"
+    );
+}
+
+#[test]
+fn hybrid_search_unions_bm25_and_vector_and_orders_by_score() {
+    let st = demo_two_segments();
+    let reader = st.reader();
+    let q = one_hot(QUERY_DIM);
+
+    let hybrid = reader
+        .hybrid_search(
+            "title",
+            "rust",
+            BoolMode::Or,
+            "emb",
+            &q,
+            VectorSearchOptions::new(),
+            TOP_K,
+        )
+        .expect("hybrid_search");
+    let bm25 = reader
+        .bm25_search("title", "rust", TOP_K, BoolMode::Or)
+        .expect("bm25_search");
+    let vector = reader
+        .vector_search("emb", &q, TOP_K, VectorSearchOptions::new())
+        .expect("vector_search");
+
+    assert!(
+        bm25.len() >= MIN_RUST_HITS,
+        "'rust' should match across both segments"
+    );
+    assert!(!vector.is_empty(), "vector retriever returned nothing");
+
+    let expected: HashSet<(SuperfileUri, u32)> =
+        hit_ids(&bm25).union(&hit_ids(&vector)).copied().collect();
+    assert_eq!(
+        hit_ids(&hybrid),
+        expected,
+        "hybrid identity set must equal bm25 ∪ vector at the same k"
+    );
+
+    for w in hybrid.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "fused RRF scores must be descending"
+        );
+    }
+}
+
+#[test]
+fn hybrid_search_doc_top_in_both_retrievers_ranks_first() {
+    let st = demo_two_segments();
+    let reader = st.reader();
+    let q = one_hot(QUERY_DIM);
+
+    // `async` is unique to doc 0 (BM25 #1); the one-hot query at
+    // `QUERY_DIM` makes doc 0 the exact vector match (#1). Top in both
+    // retrievers ⇒ highest RRF ⇒ emitted first.
+    let hybrid = reader
+        .hybrid_search(
+            "title",
+            "async",
+            BoolMode::Or,
+            "emb",
+            &q,
+            VectorSearchOptions::new(),
+            RANK_TOP_K,
+        )
+        .expect("hybrid_search");
+    let bm25 = reader
+        .bm25_search("title", "async", RANK_TOP_K, BoolMode::Or)
+        .expect("bm25_search");
+    let vector = reader
+        .vector_search("emb", &q, RANK_TOP_K, VectorSearchOptions::new())
+        .expect("vector_search");
+
+    assert!(
+        !hybrid.is_empty() && !bm25.is_empty() && !vector.is_empty(),
+        "all retrievers must return hits"
+    );
+    let top = (hybrid[0].segment, hybrid[0].local_doc_id);
+    assert_eq!(
+        top,
+        (bm25[0].segment, bm25[0].local_doc_id),
+        "fused #1 must be the BM25 #1"
+    );
+    assert_eq!(
+        top,
+        (vector[0].segment, vector[0].local_doc_id),
+        "fused #1 must also be the vector #1 (top in both ⇒ first)"
+    );
+}

--- a/tests/supertable/query/mod.rs
+++ b/tests/supertable/query/mod.rs
@@ -5,5 +5,6 @@ pub mod brute_force_oracle;
 pub mod fanout_concurrency;
 pub mod hierarchical;
 pub mod hybrid_search;
+pub mod match_search;
 pub mod skip_pruning;
 pub mod tombstone_filter;


### PR DESCRIPTION
Addresses #52. See benchmark results there.

Add two unranked retrieval primitives over the FTS index and wire them into SQL so selective predicates on indexed text columns are answered from the term postings instead of a full column scan.

- token_match: boolean (AND/OR) token retrieval returning doc-ids with no scoring or top-k heap, via a dedicated unranked cursor walk.
- exact_match: two-pass raw-string match — token_match prunes a candidate superset, then verifies exact stored-value equality.
- Exposed as Supertable methods, as SQL table-valued functions, and as transparent WHERE pushdown through the DataFusion TableProvider: an FTS-column equality / IN lowers to a token-AND candidate plan that drives a Parquet RowSelection, with FilterExec verifying the superset.
- A df-based selectivity gate (AND -> min(df), OR/IN -> sum(df) capped at n_docs) skips the index path when the candidate set is too large, falling back to a plain scan so high-selectivity predicates never regress.

Architecture docs updated to describe the new relations and the row-level WHERE pushdown as the companion to segment-level term skip.