### PR TITLE
feat superfile writer: add fn to create batch from another superfile

### DIFF
--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -76,13 +76,13 @@
 //! `inf.fts.columns` JSON already carries a `"tokenizer"` field on
 //! each entry (currently always `"ascii_lower"`), so the on-disk
 //! format is forward-compatible without a file rewrite.
-
-use crate::superfile::BuildError;
 use crate::superfile::format::footer::{encode_parquet_body, splice_index_blobs};
 use crate::superfile::format::{self, kv};
 use crate::superfile::fts::builder::FtsBuilder;
 use crate::superfile::fts::tokenize::Tokenizer;
 use crate::superfile::vector::builder::VectorBuilder;
+use crate::superfile::vector::reader::ColumnReader;
+use crate::superfile::{BuildError, SuperfileReader};
 // `VectorConfig` lives in `vector::builder` and is re-exported below
 // (single source of truth post-collapse — see the `pub use` line).
 pub use crate::superfile::vector::builder::VectorConfig;
@@ -106,6 +106,7 @@ pub struct FtsConfig {
 // wrapper struct.
 
 /// All knobs needed to build a superfile.
+#[derive(Clone)]
 pub struct BuilderOptions {
     /// Arrow schema. Must contain `id_column` (typed
     /// `Decimal128(38, 0)`) and every FTS column listed in
@@ -225,6 +226,79 @@ impl BuilderOptions {
             ),
             id_page_size_limit: DEFAULT_ID_PAGE_SIZE_LIMIT,
         }
+    }
+
+    fn check_mergeability(
+        &self,
+        remote_id_col: &str,
+        remote_schema: &Arc<Schema>,
+        remote_fts_columns: Option<Vec<&str>>,
+        remote_vector_columns: Option<Vec<&ColumnReader>>,
+    ) -> Result<bool, BuildError> {
+        if self.id_column != *remote_id_col {
+            return Err(BuildError::IdColumnMismatch(
+                self.id_column.clone(),
+                remote_id_col.to_string(),
+            ));
+        }
+
+        if self.schema.fields() != remote_schema.fields() {
+            return Err(BuildError::SchemaMismatch {
+                mine: self.schema.to_string(),
+                other: remote_schema.to_string(),
+            });
+        }
+
+        if let Some(remote_fts_columns) = remote_fts_columns {
+            let self_fts_columns = &self.fts_columns;
+            if self_fts_columns.len() != remote_fts_columns.len() {
+                return Err(BuildError::FTSSchemaMismatch(format!(
+                    "mismatched column len. self {} vs other {}",
+                    self_fts_columns.len(),
+                    remote_fts_columns.len()
+                )));
+            }
+            for (self_fts_column, remote_fts_column) in
+                self_fts_columns.iter().zip(remote_fts_columns.iter())
+            {
+                if self_fts_column.column != *remote_fts_column {
+                    return Err(BuildError::FTSSchemaMismatch(format!(
+                        "mismatched column name. self {} vs other {}",
+                        self_fts_column.column, remote_fts_column
+                    )));
+                }
+            }
+        }
+
+        if let Some(remote_vector_columns) = remote_vector_columns {
+            let self_vec_columns = &self.vector_columns;
+            if self_vec_columns.len() != remote_vector_columns.len() {
+                return Err(BuildError::VectorSchemaMismatch(format!(
+                    "mismatched column len. self {} vs other {}",
+                    self_vec_columns.len(),
+                    remote_vector_columns.len()
+                )));
+            }
+
+            for (self_vec_column, remote_vector_column) in
+                self_vec_columns.iter().zip(remote_vector_columns.iter())
+            {
+                if self_vec_column.column != remote_vector_column.name {
+                    return Err(BuildError::VectorSchemaMismatch(format!(
+                        "mismatched column name. self {} vs other {}",
+                        self_vec_column.column, remote_vector_column.name
+                    )));
+                }
+                if self_vec_column.dim != remote_vector_column.dim {
+                    return Err(BuildError::VectorSchemaMismatch(format!(
+                        "mismatched column dim. self {} vs other {}",
+                        self_vec_column.dim, remote_vector_column.dim
+                    )));
+                }
+            }
+        }
+
+        Ok(true)
     }
 }
 
@@ -441,6 +515,87 @@ impl SuperfileBuilder {
 
         self.next_local_doc_id += n_rows;
         self.batches.push(batch.clone());
+        Ok(())
+    }
+
+    /// Add all data (Parquet + fts + vectors) from another [`SuperfileReader`] to this builder.
+    ///
+    /// Extracts the record batch and vectors from the reader and adds them via
+    /// [`Self::add_batch`]. This is useful for merging superfiles or copying data
+    /// between builders.
+    ///
+    /// **Requirements:**
+    /// - The reader's vector columns must use the **Fp32 codec**. Other codecs
+    ///   (Sq8Residual, RabitqOnly) will fail with `BuildError::VectorReadError`.
+    /// - Vector column names and dimensions in the reader must match those in
+    ///   `self.opts.vector_columns` in the exact same order. Mismatches will
+    ///   return `BuildError::VectorDimMismatch` error.
+    ///
+    /// **Memory:** Loads the reader's entire vector dataset into memory at once.
+    /// For very large superfiles, consider the memory overhead.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BuildError::BatchReadError` if reading the record batch fails.
+    ///
+    /// Returns `BuildError::VectorReadError` if reading vectors fails
+    /// (e.g., codec is not Fp32).
+    ///
+    /// Returns `BuildError::VectorDimMismatch` if vector column names or
+    /// dimensions don't match the builder's configuration.
+    pub fn add_batch_from_reader(&mut self, reader: &SuperfileReader) -> Result<(), BuildError> {
+        self.opts.check_mergeability(
+            reader.id_column(),
+            reader.schema(),
+            reader.fts().map(|f| f.fts_columns().collect::<Vec<_>>()),
+            reader
+                .vec()
+                .map(|v| v.vector_columns_config().collect::<Vec<_>>()),
+        )?;
+        let record_batch = reader
+            .get_record_batch()
+            .map_err(|_| BuildError::BatchReadError)?;
+
+        let num_rows = record_batch.num_rows();
+        let mut vectors: Vec<Vec<f32>> = Vec::new();
+        if let Some(v) = reader.vec() {
+            let reader_columns: Vec<_> = v.vector_columns_config().collect();
+
+            // Validate that reader's vector columns match builder's configuration
+            if reader_columns.len() != self.opts.vector_columns.len() {
+                return Err(BuildError::VectorDimMismatch {
+                    column: format!(
+                        "vector column count mismatch: expected {}, got {}",
+                        self.opts.vector_columns.len(),
+                        reader_columns.len()
+                    ),
+                    expected: self.opts.vector_columns.len(),
+                    actual: reader_columns.len(),
+                });
+            }
+
+            for (reader_col, builder_col) in reader_columns.iter().zip(&self.opts.vector_columns) {
+                if reader_col.name != builder_col.column || reader_col.dim != builder_col.dim {
+                    return Err(BuildError::VectorDimMismatch {
+                        column: reader_col.name.clone(),
+                        expected: builder_col.dim,
+                        actual: reader_col.dim,
+                    });
+                }
+
+                let mut this_col_vectors = Vec::with_capacity(builder_col.dim * num_rows);
+                let result = v
+                    .get_vectors_fp32(&reader_col.name)
+                    .map_err(|_| BuildError::VectorReadError)?;
+                for single_row in result {
+                    this_col_vectors.extend_from_slice(single_row.as_slice());
+                }
+                vectors.push(this_col_vectors);
+            }
+        }
+
+        let slices: Vec<&[f32]> = vectors.iter().map(|row| row.as_slice()).collect();
+        self.add_batch(&record_batch, &slices)?;
         Ok(())
     }
 
@@ -665,6 +820,7 @@ mod tests {
     use crate::test_helpers::{decimal128_ids, default_tokenizer, default_vector_config};
     use arrow_array::LargeStringArray;
     use arrow_schema::Field;
+    use bytes::Bytes;
 
     fn schema_with_fts() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
@@ -1014,5 +1170,417 @@ mod tests {
         assert_eq!(escape_json("a\\b"), "a\\\\b");
         assert_eq!(escape_json("a\nb"), "a\\nb");
         assert_eq!(escape_json("a\x01b"), "a\\u0001b");
+    }
+
+    #[test]
+    fn add_batch_from_reader_on_empty_builder_produces_identical_superfile() {
+        // Build original superfile with FTS and vectors
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![default_vector_config("emb", 7)],
+            Some(default_tokenizer()),
+        );
+        let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        let schema = b1.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        let mut v: Vec<f32> = vec![0.0; 32]; // 2 rows × 16 dim
+        v[0] = 1.0;
+        v[16 + 1] = 1.0;
+        b1.add_batch(&batch, &[v.as_slice()]).expect("add_batch");
+        let original_bytes = b1.finish().expect("finish builder");
+
+        // Read the superfile
+        let reader = SuperfileReader::open(Bytes::from(original_bytes.clone()))
+            .expect("open superfile reader");
+
+        // Create a new builder and add from reader
+        let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        b2.add_batch_from_reader(&reader)
+            .expect("add_batch_from_reader");
+        let merged_bytes = b2.finish().expect("finish builder");
+
+        // The two superfiles should be identical
+        assert_eq!(
+            original_bytes, merged_bytes,
+            "superfile created from reader should be identical to original"
+        );
+    }
+
+    #[test]
+    fn add_batch_from_reader_adds_parquet_data_correctly() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        );
+        let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        let schema = b1.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        b1.add_batch(&batch, &[]).expect("add_batch");
+        let bytes = b1.finish().expect("finish builder");
+
+        // Read and verify parquet data
+        let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open superfile reader");
+        let reader_batch = reader
+            .get_record_batch()
+            .expect("get_record_batch from reader");
+
+        // Should have 2 rows
+        assert_eq!(reader_batch.num_rows(), 2);
+
+        // Now add to a new builder
+        let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        b2.add_batch_from_reader(&reader)
+            .expect("add_batch_from_reader");
+        let merged_bytes = b2.finish().expect("finish builder");
+
+        // Read back and verify parquet data is correct
+        let reader2 =
+            SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged superfile reader");
+        let merged_batch = reader2
+            .get_record_batch()
+            .expect("get_record_batch from merged reader");
+        assert_eq!(merged_batch.num_rows(), 2);
+    }
+
+    #[test]
+    fn add_batch_from_reader_adds_vectors_correctly() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![],
+            vec![default_vector_config("emb", 7)],
+            None,
+        );
+        let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        let schema = b1.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        let mut v: Vec<f32> = vec![0.0; 32]; // 2 rows × 16 dim
+        v[0] = 1.0;
+        v[16 + 1] = 1.0;
+        b1.add_batch(&batch, &[v.as_slice()]).expect("add_batch");
+        let bytes = b1.finish().expect("finish builder");
+
+        // Read vectors from original superfile
+        let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open superfile reader");
+        let vectors_before = reader
+            .vec()
+            .expect("get vector reader")
+            .get_vectors_fp32("emb")
+            .expect("get vectors fp32");
+
+        let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        b2.add_batch_from_reader(&reader)
+            .expect("add_batch_from_reader");
+        let merged_bytes = b2.finish().expect("finish builder");
+
+        // Read vectors from merged superfile
+        let reader2 =
+            SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged superfile reader");
+        let vectors_after = reader2
+            .vec()
+            .expect("get vector reader")
+            .get_vectors_fp32("emb")
+            .expect("get vectors fp32");
+
+        // Vectors should match
+        assert_eq!(vectors_before.len(), vectors_after.len());
+        for (v1, v2) in vectors_before.iter().zip(vectors_after.iter()) {
+            for (val1, val2) in v1.iter().zip(v2.iter()) {
+                assert!((val1 - val2).abs() < 1e-6);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn add_batch_from_reader_adds_fts_correctly() {
+        use crate::superfile::fts::reader::BoolMode;
+
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        );
+        let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        let schema = b1.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        b1.add_batch(&batch, &[]).expect("add_batch");
+        let bytes = b1.finish().expect("finish builder");
+
+        // Read FTS data from original
+        let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open superfile reader");
+        let fts_reader = reader.fts().expect("get fts reader");
+        let results = fts_reader
+            .search("title", &["hello"], 10, BoolMode::Or)
+            .await
+            .expect("search fts");
+        assert_eq!(results.len(), 1);
+
+        // Add to new builder
+        let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        b2.add_batch_from_reader(&reader)
+            .expect("add_batch_from_reader");
+        let merged_bytes = b2.finish().expect("finish builder");
+
+        // Verify FTS still works after merge
+        let reader2 =
+            SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged superfile reader");
+        let fts_reader2 = reader2.fts().expect("get fts reader");
+        let results2 = fts_reader2
+            .search("title", &["hello"], 10, BoolMode::Or)
+            .await
+            .expect("search fts in merged");
+        assert_eq!(results2.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn add_batch_from_reader_to_non_empty_builder_includes_both_datasets() {
+        use crate::superfile::fts::reader::BoolMode;
+
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![default_vector_config("emb", 7)],
+            Some(default_tokenizer()),
+        );
+
+        // Create first superfile
+        let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        let schema = b1.opts.schema.clone();
+        let batch1 = batch_two_rows(&schema);
+        let mut v1: Vec<f32> = vec![0.0; 32];
+        v1[0] = 1.0;
+        v1[16 + 1] = 1.0;
+        b1.add_batch(&batch1, &[v1.as_slice()]).expect("add_batch");
+        let bytes1 = b1.finish().expect("finish builder");
+
+        // Create second superfile
+        let mut b2 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        let ids2 = decimal128_ids(vec![20u64, 21]);
+        let title2 = LargeStringArray::from(vec!["foo bar", "baz qux"]);
+        let body2 = LargeStringArray::from(vec!["quux corge", "grault garply"]);
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(ids2), Arc::new(title2), Arc::new(body2)],
+        )
+        .expect("build RecordBatch");
+        let mut v2: Vec<f32> = vec![0.0; 32];
+        v2[1] = 1.0;
+        v2[16] = 1.0;
+        b2.add_batch(&batch2, &[v2.as_slice()]).expect("add_batch");
+        let _bytes2 = b2.finish().expect("finish builder");
+
+        // Read first superfile
+        let reader1 = SuperfileReader::open(Bytes::from(bytes1)).expect("open reader1");
+
+        // Create merged builder - add existing data + reader data
+        let mut merged = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        merged
+            .add_batch(&batch2, &[v2.as_slice()])
+            .expect("add_batch");
+        merged
+            .add_batch_from_reader(&reader1)
+            .expect("add_batch_from_reader");
+        let merged_bytes = merged.finish().expect("finish builder");
+
+        // Verify merged result
+        let merged_reader =
+            SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged reader");
+
+        // Should have 4 docs total (2 from batch2 + 2 from reader1)
+        let merged_batch = merged_reader.get_record_batch().expect("get_record_batch");
+        assert_eq!(merged_batch.num_rows(), 4);
+
+        // Verify vectors are correct
+        let merged_vectors = merged_reader
+            .vec()
+            .expect("get vector reader")
+            .get_vectors_fp32("emb")
+            .expect("get vectors");
+        assert_eq!(merged_vectors.len(), 4);
+
+        // Verify FTS works and finds both datasets
+        let fts_reader = merged_reader.fts().expect("get fts reader");
+        let hello_results = fts_reader
+            .search("title", &["hello"], 10, BoolMode::Or)
+            .await
+            .expect("search for hello");
+        assert!(
+            !hello_results.is_empty(),
+            "should find 'hello' from first dataset"
+        );
+
+        let foo_results = fts_reader
+            .search("title", &["foo"], 10, BoolMode::Or)
+            .await
+            .expect("search for foo");
+        assert!(
+            !foo_results.is_empty(),
+            "should find 'foo' from second dataset"
+        );
+    }
+
+    #[test]
+    fn add_vector_fp32_returns_correct_vectors() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![],
+            vec![default_vector_config("emb", 7)],
+            None,
+        );
+        let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        let schema = b.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        let mut v: Vec<f32> = vec![0.0; 32]; // 2 rows × 16 dim
+        v[0] = 1.0;
+        v[16] = 1.0;
+        v[17] = 1.0;
+        v[31] = 1.0;
+        b.add_batch(&batch, &[v.as_slice()]).expect("add_batch");
+        let bytes = b.finish().expect("finish builder");
+
+        let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open superfile reader");
+        let vectors = reader
+            .vec()
+            .expect("get vector reader")
+            .get_vectors_fp32("emb")
+            .expect("get vectors fp32");
+
+        // Verify structure
+        assert_eq!(vectors.len(), 2, "should have 2 vectors");
+        assert_eq!(
+            vectors[0].len(),
+            16,
+            "first vector should have 16 dimensions"
+        );
+        assert_eq!(
+            vectors[1].len(),
+            16,
+            "second vector should have 16 dimensions"
+        );
+
+        // Verify values
+        assert!((vectors[0][0] - 1.0).abs() < 1e-6);
+        assert!((vectors[0][1] - 0.0).abs() < 1e-6);
+        assert!((vectors[1][0] - 1.0).abs() < 1e-6);
+        assert!((vectors[1][1] - 1.0).abs() < 1e-6);
+        assert!((vectors[1][15] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn add_vector_fp32_rejects_non_fp32_codec() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![],
+            vec![crate::superfile::vector::builder::VectorConfig {
+                column: "emb".into(),
+                dim: 16,
+                n_cent: 4,
+                rot_seed: 7,
+                metric: Metric::L2Sq,
+                rerank_codec: crate::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
+            }],
+            None,
+        );
+        let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        let schema = b.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        let v: Vec<f32> = vec![0.0; 32];
+        b.add_batch(&batch, &[v.as_slice()]).expect("add_batch");
+        let bytes = b.finish().expect("finish builder");
+
+        let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open superfile reader");
+        let result = reader
+            .vec()
+            .expect("get vector reader")
+            .get_vectors_fp32("emb");
+
+        assert!(result.is_err(), "should reject Sq8Residual codec");
+    }
+
+    #[tokio::test]
+    async fn add_batch_from_reader_queries_work_correctly() {
+        use crate::superfile::fts::reader::BoolMode;
+
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![default_vector_config("emb", 7)],
+            Some(default_tokenizer()),
+        );
+
+        // Create original superfile
+        let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        let schema = b1.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        let mut v: Vec<f32> = vec![0.0; 32]; // 2 rows × 16 dim
+        v[0] = 1.0;
+        v[16 + 1] = 1.0;
+        b1.add_batch(&batch, &[v.as_slice()]).expect("add_batch");
+        let bytes1 = b1.finish().expect("finish builder");
+
+        // Read original superfile
+        let reader1 = SuperfileReader::open(Bytes::from(bytes1)).expect("open reader1");
+
+        // Create merged superfile with data from reader
+        let mut b_merged = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        b_merged
+            .add_batch_from_reader(&reader1)
+            .expect("add_batch_from_reader");
+        let merged_bytes = b_merged.finish().expect("finish builder");
+
+        // Read merged superfile
+        let reader_merged =
+            SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged reader");
+
+        // Verify vector search works
+        let vec_reader = reader_merged.vec().expect("get vector reader");
+        let search_results = vec_reader
+            .search(
+                "emb",
+                &[
+                    1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                ],
+                10,
+                4,
+                100,
+            )
+            .expect("vector search");
+        assert!(
+            !search_results.is_empty(),
+            "vector search should return results"
+        );
+
+        // Verify FTS search works
+        let fts_reader = reader_merged.fts().expect("get fts reader");
+        let fts_results = fts_reader
+            .search("title", &["hello"], 10, BoolMode::Or)
+            .await
+            .expect("fts search");
+        assert!(!fts_results.is_empty(), "fts search should return results");
+
+        // Verify parquet query works
+        let batch = reader_merged.get_record_batch().expect("get_record_batch");
+        assert_eq!(batch.num_rows(), 2);
     }
 }

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -15,11 +15,17 @@ pub enum BuildError {
     #[error("id_column {0:?} must be Decimal128(38, 0); found {1:?}")]
     IdColumnWrongType(String, String),
 
+    #[error("id column mismatch: self={0:?} other={1:?}")]
+    IdColumnMismatch(String, String),
+
     #[error("FTS column {column:?} must be LargeUtf8; found {actual:?}")]
     FtsColumnMustBeLargeUtf8 { column: String, actual: String },
 
     #[error("FTS column {column:?} has invalid type {actual:?}")]
     FtsColumnTypeInvalid { column: String, actual: String },
+
+    #[error("fts schema mismatch {0:?}")]
+    FTSSchemaMismatch(String),
 
     #[error("duplicate column name {0:?}")]
     DuplicateColumnName(String),
@@ -29,6 +35,9 @@ pub enum BuildError {
 
     #[error("user column name {0:?} contains reserved \\x1F separator")]
     ReservedSeparatorInColumnName(String),
+
+    #[error("schema mismatch: self={mine:?} other={other:?}")]
+    SchemaMismatch { mine: String, other: String },
 
     #[error("user column name {0:?} starts with reserved prefix 'inf.'")]
     ReservedPrefixInColumnName(String),
@@ -55,6 +64,12 @@ pub enum BuildError {
         actual: usize,
     },
 
+    #[error("vector schema mismatch {0:?}")]
+    VectorSchemaMismatch(String),
+
+    #[error("vectors could not be read")]
+    VectorReadError,
+
     #[error("vectors slice has {actual} entries but {expected} vector columns are declared")]
     VectorCountMismatch { expected: usize, actual: usize },
 
@@ -63,6 +78,9 @@ pub enum BuildError {
 
     #[error("RecordBatch schema does not match builder schema")]
     BatchSchemaMismatch,
+
+    #[error("RecordBatch could not be read")]
+    BatchReadError,
 
     #[error("FTS column {0:?} not found in schema")]
     FtsColumnMissing(String),

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -437,6 +437,31 @@ impl SuperfileReader {
     pub fn parquet_bytes(&self) -> Option<&Bytes> {
         self.bytes.as_ref()
     }
+    /// Returns a record batch containing all documents with all columns
+    pub fn get_record_batch(&self) -> Result<RecordBatch, ReadError> {
+        let bytes = self
+            .bytes
+            .as_ref()
+            .ok_or(ReadError::LazyReaderUnsupported)?
+            .clone();
+        let arrow_meta = self
+            .arrow_meta
+            .as_ref()
+            .ok_or(ReadError::LazyReaderUnsupported)?
+            .clone();
+        let builder = ParquetRecordBatchReaderBuilder::new_with_metadata(bytes, arrow_meta);
+        let reader = builder
+            .build()
+            .map_err(|e| ReadError::Columnar(e.to_string()))?;
+        let read_schema = reader.schema();
+        let batches = reader
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ReadError::Columnar(e.to_string()))?;
+        let record_batch = concat_batches(&read_schema, &batches)
+            .map_err(|e| ReadError::Columnar(e.to_string()))?;
+
+        Ok(record_batch)
+    }
 
     /// Resolve in-segment row offsets to their durable identity.
     ///

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -145,7 +145,6 @@ impl ColumnReader {
     /// (`cluster_rerank_row_range`), so this whole-block range is
     /// retained for the layout-invariant test that pins the on-disk
     /// shape.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn cluster_block_range(
         &self,
         cluster_doc_off: u32,
@@ -1011,6 +1010,9 @@ impl VectorReader {
     pub fn vector_columns(&self) -> impl Iterator<Item = &str> {
         self.columns.iter().map(|c| c.name.as_str())
     }
+    pub fn vector_columns_config(&self) -> impl Iterator<Item = &ColumnReader> {
+        self.columns.iter()
+    }
 
     pub(crate) fn public_rerank_mult(&self, _column: &str, base: usize) -> usize {
         base
@@ -1500,6 +1502,127 @@ impl VectorReader {
     /// `Ok((col, true))` = real search to follow; `Ok((col, false))`
     /// = empty-result short circuit, caller returns `Ok(Vec::new())`.
     #[inline]
+    /// Retrieve original vectors in their insertion order for fp32-encoded columns.
+    /// Returns an error if the column uses a different encoding (Sq8Residual or RabitqOnly).
+    pub fn get_vectors_fp32(&self, column: &str) -> Result<Vec<Vec<f32>>, VectorError> {
+        let cid = *self
+            .column_id_by_name
+            .get(column)
+            .ok_or_else(|| VectorError::UnknownColumn(column.to_string()))?;
+        let col = &self.columns[cid as usize];
+
+        if col.rerank_codec != RerankCodec::Fp32 {
+            return Err(VectorError::Read(ReadError::MalformedVersion(format!(
+                "column '{}' uses rerank codec {} instead of Fp32",
+                col.name,
+                col.rerank_codec.name()
+            ))));
+        }
+
+        if col.n_docs == 0 {
+            return Ok(Vec::new());
+        }
+
+        let sub_start = col.subsection_range.start;
+        let idx_start = sub_start + col.cluster_idx_off;
+        let idx_end = idx_start + (col.n_cent as usize) * 8;
+        let cluster_idx = self
+            .source
+            .get_range(idx_start..idx_end)
+            .map_err(|e| VectorError::LazySource(e.to_string()))?;
+
+        let cb = col.quant.code_bytes();
+        let per_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
+
+        // Collect all cluster ranges needed for fetching
+        let mut cluster_ranges: Vec<Range<usize>> = Vec::new();
+        let mut cluster_meta: Vec<(usize, u32, u32)> = Vec::new();
+
+        for c in 0..col.n_cent as usize {
+            let (off, cnt) = read_cluster_entry(&cluster_idx, c);
+            if cnt == 0 {
+                continue;
+            }
+            cluster_ranges.push(col.cluster_block_range(off, cnt));
+            cluster_meta.push((c, off, cnt));
+        }
+
+        if cluster_ranges.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Fetch all cluster blocks
+        let cluster_blocks = self
+            .source
+            .get_ranges_parallel(&cluster_ranges)
+            .map_err(|e| VectorError::LazySource(e.to_string()))?;
+
+        // Allocate output vector with doc_id -> vector mapping
+        let mut result: Vec<Option<Vec<f32>>> = vec![None; col.n_docs as usize];
+
+        // Process each cluster block
+        for (bi, block) in cluster_blocks.iter().enumerate() {
+            let (_, _off, cnt) = cluster_meta[bi];
+            let cnt_usize = cnt as usize;
+
+            // Layout within the block: [codes_chunk][doc_ids_chunk][full_chunk]
+            let codes_len = cnt_usize * cb;
+            let doc_ids_len = cnt_usize * 4;
+            let full_start = codes_len + doc_ids_len;
+
+            // Extract doc_ids from the block
+            let doc_ids_slice = block.slice(codes_len..codes_len + doc_ids_len);
+
+            // Extract and reconstruct vectors
+            for i in 0..cnt_usize {
+                let doc_id = u32::from_le_bytes([
+                    doc_ids_slice[i * 4],
+                    doc_ids_slice[i * 4 + 1],
+                    doc_ids_slice[i * 4 + 2],
+                    doc_ids_slice[i * 4 + 3],
+                ]) as usize;
+
+                let vec_start = full_start + i * per_vec_bytes;
+                let vec_end = vec_start + per_vec_bytes;
+                let vec_bytes = block.slice(vec_start..vec_end);
+
+                // Convert bytes to f32 vector
+                // For Fp32 codec, per_vec_bytes = dim * 4, so we expect dim f32s
+                let vec_f32: Vec<f32> = vec_bytes
+                    .as_ref()
+                    .chunks_exact(4)
+                    .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                    .collect();
+
+                if vec_f32.len() != col.dim {
+                    return Err(VectorError::Read(ReadError::MalformedVersion(format!(
+                        "vector size mismatch: got {}, expected {}",
+                        vec_f32.len(),
+                        col.dim
+                    ))));
+                }
+
+                if doc_id < col.n_docs as usize {
+                    result[doc_id] = Some(vec_f32);
+                }
+            }
+        }
+
+        // Convert to final result, checking all vectors were found
+        result
+            .into_iter()
+            .enumerate()
+            .map(|(idx, vec_opt)| {
+                vec_opt.ok_or_else(|| {
+                    VectorError::Read(ReadError::MalformedVersion(format!(
+                        "missing vector for doc_id {}",
+                        idx
+                    )))
+                })
+            })
+            .collect()
+    }
+
     fn resolve_column(
         &self,
         column: &str,
@@ -5285,5 +5408,132 @@ mod tests {
             matches!(meta_lazy, Sq8ColumnMeta::Lazy { .. }),
             "lazy open should defer Sq8 metadata to search"
         );
+    }
+
+    #[test]
+    fn get_vectors_fp32_returns_vectors_in_original_order() {
+        let n_docs = 64u32;
+        let dim = 16;
+        let n_cent = 4;
+
+        // Build a blob with Fp32 encoding
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            column: "embedding".into(),
+            dim,
+            n_cent,
+            rot_seed: 7,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
+        })
+        .expect("register column");
+
+        // Create deterministic vectors
+        let mut input_vectors = Vec::new();
+        for i in 0..n_docs {
+            let v: Vec<f32> = (0..dim)
+                .map(|j| ((i.wrapping_mul(31) + j as u32) % 100) as f32 * 0.01)
+                .collect();
+            input_vectors.push(v.clone());
+            b.add(0, &v).expect("add to vector builder");
+        }
+
+        let bytes = b.finish().expect("finish vector builder");
+        let json = format!(
+            r#"[{{"column":"embedding","dim":{dim},"n_cent":{n_cent},"rot_seed":7,"metric":"l2sq"}}]"#
+        );
+        let reader = VectorReader::open(Bytes::from(bytes), &json).expect("open should succeed");
+
+        // Retrieve vectors via the new function
+        let retrieved = reader
+            .get_vectors_fp32("embedding")
+            .expect("get_vectors_fp32 should succeed");
+
+        // Verify all vectors are returned
+        assert_eq!(retrieved.len(), n_docs as usize);
+
+        // Verify vectors match original vectors (within floating point precision)
+        for (i, retrieved_vec) in retrieved.iter().enumerate() {
+            assert_eq!(retrieved_vec.len(), dim);
+            for (j, &val) in retrieved_vec.iter().enumerate() {
+                let expected = input_vectors[i][j];
+                assert!(
+                    (val - expected).abs() < 1e-6,
+                    "vector {} dimension {} mismatch: got {}, expected {}",
+                    i,
+                    j,
+                    val,
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn get_vectors_fp32_rejects_non_fp32_codec() {
+        // blob was built with Sq8Residual by default, not Fp32
+        let mut builder = VectorBuilder::new();
+        builder
+            .register_column(VectorConfig {
+                column: "embedding".into(),
+                dim: 16,
+                n_cent: 4,
+                rot_seed: 7,
+                metric: Metric::L2Sq,
+                rerank_codec: RerankCodec::Sq8Residual,
+            })
+            .expect("register column");
+        for i in 0u32..32 {
+            let v: Vec<f32> = (0..16)
+                .map(|j| ((i.wrapping_mul(31) + j as u32) % 100) as f32 * 0.01)
+                .collect();
+            builder.add(0, &v).expect("add");
+        }
+        let sq8_bytes = builder.finish().expect("finish");
+        let sq8_json =
+            r#"[{"column":"embedding","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#
+                .to_string();
+        let reader = VectorReader::open(Bytes::from(sq8_bytes), &sq8_json).expect("open");
+
+        // Should error because codec is Sq8Residual, not Fp32
+        let result = reader.get_vectors_fp32("embedding");
+        assert!(result.is_err());
+        if let Err(VectorError::Read(ReadError::MalformedVersion(msg))) = result {
+            assert!(msg.contains("Fp32"));
+        } else {
+            panic!("expected MalformedVersion error, got {:?}", result);
+        }
+    }
+
+    #[test]
+    fn get_vectors_fp32_rejects_unknown_column() {
+        let (blob, json) = build_blob(32, 16, 4, Metric::L2Sq);
+        let reader = VectorReader::open(blob, &json).expect("open should succeed");
+
+        let result = reader.get_vectors_fp32("nonexistent");
+        assert!(matches!(result, Err(VectorError::UnknownColumn(_))));
+    }
+
+    #[test]
+    fn get_vectors_fp32_returns_empty_for_no_docs() {
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            column: "embedding".into(),
+            dim: 16,
+            n_cent: 4,
+            rot_seed: 7,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
+        })
+        .expect("register column");
+        let bytes = b.finish().expect("finish vector builder");
+        let json = r#"[{"column":"embedding","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#
+            .to_string();
+        let reader = VectorReader::open(Bytes::from(bytes), &json).expect("open should succeed");
+
+        let retrieved = reader
+            .get_vectors_fp32("embedding")
+            .expect("get_vectors_fp32 should succeed");
+        assert!(retrieved.is_empty());
     }
 }

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -320,3 +320,426 @@ async fn end_to_end_three_batches_doc_ids_continuous() {
     assert!(doc_ids.contains(&2));
     assert!(doc_ids.contains(&4));
 }
+
+#[test]
+fn add_batch_from_reader_mergeability_compatible_superfiles() {
+    // Both superfiles have identical configurations; merge succeeds.
+    let bytes1 = build_pipeline_superfile();
+    let r1 = SuperfileReader::open(bytes1).expect("open superfile 1");
+
+    let bytes2 = build_pipeline_superfile();
+    let r2 = SuperfileReader::open(bytes2).expect("open superfile 2");
+
+    let opts = BuilderOptions::new(
+        r1.schema().clone(),
+        r1.id_column(),
+        vec![
+            FtsConfig {
+                column: "title".into(),
+            },
+            FtsConfig {
+                column: "body".into(),
+            },
+        ],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: 16,
+            n_cent: 4,
+            rot_seed: 17,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        Some(default_tokenizer()),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    // Should not error on compatible configuration
+    b.add_batch_from_reader(&r1)
+        .expect("add_batch_from_reader succeeds for compatible superfiles");
+    b.add_batch_from_reader(&r2)
+        .expect("add_batch_from_reader succeeds for compatible superfiles");
+}
+
+#[test]
+fn add_batch_from_reader_mergeability_id_column_mismatch() {
+    // Build superfile with "different_id" as id column
+    let schema_with_alt_id = Arc::new(Schema::new(vec![
+        Field::new("different_id", DataType::Decimal128(38, 0), false),
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("body", DataType::LargeUtf8, false),
+        Field::new("score", DataType::Float32, true),
+    ]));
+    let opts = BuilderOptions::new(
+        schema_with_alt_id.clone(),
+        "different_id",
+        vec![],
+        vec![],
+        None,
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let bodies = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema_with_alt_id,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Build a builder with "doc_id" as id column using a matching schema
+    // Map the reader's schema: rename "different_id" to "doc_id" for the builder
+    let builder_schema = Arc::new(Schema::new(vec![
+        Field::new("doc_id", DataType::Decimal128(38, 0), false),
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("body", DataType::LargeUtf8, false),
+        Field::new("score", DataType::Float32, true),
+    ]));
+    let orig_opts = BuilderOptions::new(builder_schema, "doc_id", vec![], vec![], None);
+    let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
+
+    let err = orig_builder.add_batch_from_reader(&reader);
+    assert!(
+        err.is_err(),
+        "expected mergeability error for id column mismatch"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_mergeability_schema_mismatch() {
+    // Build superfile with schema missing a column
+    let schema_short = Arc::new(Schema::new(vec![
+        Field::new("doc_id", DataType::Decimal128(38, 0), false),
+        Field::new("title", DataType::LargeUtf8, false),
+        // missing "body" column compared to pipeline_schema
+        Field::new("score", DataType::Float32, true),
+    ]));
+    let opts = BuilderOptions::new(schema_short.clone(), "doc_id", vec![], vec![], None);
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema_short,
+        vec![Arc::new(ids), Arc::new(titles), Arc::new(scores)],
+    )
+    .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Try to merge into builder with full pipeline schema
+    let orig_schema = pipeline_schema();
+    let orig_opts = BuilderOptions::new(orig_schema, "doc_id", vec![], vec![], None);
+    let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
+
+    let err = orig_builder.add_batch_from_reader(&reader);
+    assert!(
+        err.is_err(),
+        "expected mergeability error for schema mismatch"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_mergeability_fts_column_count_mismatch() {
+    // Build superfile with FTS on only one column
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let bodies = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Try to merge into builder with FTS on two columns
+    let orig_opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![
+            FtsConfig {
+                column: "title".into(),
+            },
+            FtsConfig {
+                column: "body".into(),
+            },
+        ],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
+
+    let err = orig_builder.add_batch_from_reader(&reader);
+    assert!(
+        err.is_err(),
+        "expected mergeability error for FTS column count mismatch"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
+    // Build superfile with FTS on "body"
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "body".into(),
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let bodies = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Try to merge into builder with FTS on "title"
+    let orig_opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
+
+    let err = orig_builder.add_batch_from_reader(&reader);
+    assert!(
+        err.is_err(),
+        "expected mergeability error for FTS column name mismatch"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_mergeability_vector_column_count_mismatch() {
+    // Build superfile with one vector column
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: 16,
+            n_cent: 4,
+            rot_seed: 17,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        None,
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let bodies = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    let mut emb = vec![0.0f32; 16];
+    emb[0] = 1.0;
+    normalize(&mut emb);
+    b.add_batch(&batch, &[emb.as_slice()]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Try to merge into builder with no vector columns
+    let orig_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
+    let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
+
+    let err = orig_builder.add_batch_from_reader(&reader);
+    assert!(
+        err.is_err(),
+        "expected mergeability error for vector column count mismatch"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_mergeability_vector_column_name_mismatch() {
+    // Build superfile with vector column "emb"
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: 16,
+            n_cent: 4,
+            rot_seed: 17,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        None,
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let bodies = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    let mut emb = vec![0.0f32; 16];
+    emb[0] = 1.0;
+    normalize(&mut emb);
+    b.add_batch(&batch, &[emb.as_slice()]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Try to merge into builder with different vector column name
+    let orig_opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![],
+        vec![SfVectorConfig {
+            column: "other_vec".into(),
+            dim: 16,
+            n_cent: 4,
+            rot_seed: 17,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        None,
+    );
+    let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
+
+    let err = orig_builder.add_batch_from_reader(&reader);
+    assert!(
+        err.is_err(),
+        "expected mergeability error for vector column name mismatch"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_mergeability_vector_dimension_mismatch() {
+    // Build superfile with vector dim=16
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: 16,
+            n_cent: 4,
+            rot_seed: 17,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        None,
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let bodies = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    let mut emb = vec![0.0f32; 16];
+    emb[0] = 1.0;
+    normalize(&mut emb);
+    b.add_batch(&batch, &[emb.as_slice()]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Try to merge into builder with different dimension
+    let orig_opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: 32, // different dimension
+            n_cent: 4,
+            rot_seed: 17,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        None,
+    );
+    let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
+
+    let err = orig_builder.add_batch_from_reader(&reader);
+    assert!(
+        err.is_err(),
+        "expected mergeability error for vector dimension mismatch"
+    );
+}


### PR DESCRIPTION
### What does this PR do?
- Adds a `add_batch_from_reader` fn to create a new batch from an existing reader

### Why do we need this change?
- Building blocks needed for compaction. This change exposes an api to build a superfile from existing superfiles

### How do we do this change?
- From the reader, we read the parquet data to get the RecordBatches
- For vectors, we read the raw vectors written ( using the new `get_vectors_fp32` fn )
- Both these are passed to the existing `add_batch` fn

### Gotchas
- Merging for non fp32 vector config ( e.g sp8 ) is non-trivial. This will be handled separately
- FTS's may also be merged directly, but would require some modifications with the doc_ids. This will also be handled separately 

### How has this been tested?
- Unit tests added for both new fns