### PR TITLE
storage: bring Azure resilience to S3 parity via shared retry path

### DIFF
--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -22,7 +22,7 @@ use object_store::{
     PutPayload, UpdateVersion,
 };
 
-use super::{ObjectMeta, StorageError, StorageProvider};
+use super::{ObjectMeta, StorageError, StorageProvider, retry};
 
 /// Azure Blob-backed `StorageProvider`. Cheap to clone; the inner
 /// `MicrosoftAzure` shares its HTTP client across clones.
@@ -42,6 +42,7 @@ impl AzureStorageProvider {
         let store = MicrosoftAzureBuilder::from_env()
             .with_container_name(&container)
             .with_client_options(tuned_client_options())
+            .with_retry(retry::config())
             .build()
             .map_err(|e| StorageError::Permanent {
                 uri: format!("azure://{container}"),
@@ -131,31 +132,27 @@ fn normalize_prefix(prefix: impl Into<String>) -> String {
     prefix.into().trim_matches('/').to_string()
 }
 
-/// Warm idle connections kept per host, so a wide concurrent
-/// range-GET fan-out reuses established TLS sessions rather than
-/// re-handshaking on the cold tail.
+/// Warm idle connections per host, so a wide range-GET fan-out reuses
+/// TLS sessions instead of re-handshaking on the cold tail.
 const AZURE_POOL_MAX_IDLE_PER_HOST: usize = 1024;
 
-/// Client idle-connection timeout. Longer than the S3 backend's
-/// because Azure's server-side keep-alive window is more generous.
+/// Idle-connection keep-alive, below Azure's server-side close window.
 const AZURE_POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
 
-/// Connect-phase timeout. Bounds a single slow SYN/TLS so it can't
-/// dominate the fan-out's p99.
+/// Connect-phase timeout, so one slow SYN/TLS can't dominate the p99.
 const AZURE_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// Tuned HTTP client options for the object-store-native fan-out.
-///
-/// The supertable query path fans out one cold-open + cold-search
-/// batch per segment concurrently. A deep, long-lived idle pool lets
-/// the fan-out reuse warm connections instead of paying a TLS
-/// handshake RTT per range GET, which otherwise inflates the p99 tail
-/// under load.
+/// Whole-request timeout (incl. body). The 30s default is too tight for
+/// a multi-MB segment PUT on a modest uplink — it aborts mid-upload.
+const AZURE_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// HTTP client options: deep warm idle pool + bounded connect/request.
 fn tuned_client_options() -> object_store::ClientOptions {
     object_store::ClientOptions::new()
         .with_pool_max_idle_per_host(AZURE_POOL_MAX_IDLE_PER_HOST)
         .with_pool_idle_timeout(AZURE_POOL_IDLE_TIMEOUT)
         .with_connect_timeout(AZURE_CONNECT_TIMEOUT)
+        .with_timeout(AZURE_REQUEST_TIMEOUT)
 }
 
 /// Translate an `object_store::Error` to our `StorageError`. Kept
@@ -195,24 +192,29 @@ impl StorageProvider for AzureStorageProvider {
 
     async fn get(&self, uri: &str) -> Result<(Bytes, ObjectMeta), StorageError> {
         let path = self.path(uri)?;
-        let result = self.store.get(&path).await.map_err(|e| translate(uri, e))?;
-        // `GetResult.meta` is the version whose bytes we're about to
-        // read — etag and bytes are atomically paired, so no follow-up
-        // HEAD is needed.
-        let meta = ObjectMeta {
-            size: result.meta.size as u64,
-            etag: result.meta.e_tag.clone(),
-        };
-        let bytes = result.bytes().await.map_err(|e| translate(uri, e))?;
-        Ok((bytes, meta))
+        // etag and bytes are atomically paired in the same response, so
+        // no follow-up HEAD is needed.
+        retry::with_reissue(|| async {
+            let result = self.store.get(&path).await.map_err(|e| translate(uri, e))?;
+            let meta = ObjectMeta {
+                size: result.meta.size as u64,
+                etag: result.meta.e_tag.clone(),
+            };
+            let bytes = result.bytes().await.map_err(|e| translate(uri, e))?;
+            Ok((bytes, meta))
+        })
+        .await
     }
 
     async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
         let path = self.path(uri)?;
-        self.store
-            .get_range(&path, range)
-            .await
-            .map_err(|e| translate(uri, e))
+        retry::complete_range(uri, range, |r| async {
+            self.store
+                .get_range(&path, r)
+                .await
+                .map_err(|e| translate(uri, e))
+        })
+        .await
     }
 
     /// Single-RTT tail fetch via Azure's native `Range: bytes=-len`
@@ -226,18 +228,21 @@ impl StorageProvider for AzureStorageProvider {
             return Ok((Bytes::new(), meta.size));
         }
         let path = self.path(uri)?;
-        let opts = GetOptions {
-            range: Some(GetRange::Suffix(len)),
-            ..Default::default()
-        };
-        let result = self
-            .store
-            .get_opts(&path, opts)
-            .await
-            .map_err(|e| translate(uri, e))?;
-        let size = result.meta.size as u64;
-        let bytes = result.bytes().await.map_err(|e| translate(uri, e))?;
-        Ok((bytes, size))
+        retry::with_reissue(|| async {
+            let opts = GetOptions {
+                range: Some(GetRange::Suffix(len)),
+                ..Default::default()
+            };
+            let result = self
+                .store
+                .get_opts(&path, opts)
+                .await
+                .map_err(|e| translate(uri, e))?;
+            let size = result.meta.size as u64;
+            let bytes = result.bytes().await.map_err(|e| translate(uri, e))?;
+            Ok((bytes, size))
+        })
+        .await
     }
 
     async fn put_atomic(&self, uri: &str, bytes: Bytes) -> Result<Option<String>, StorageError> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -38,6 +38,7 @@ use thiserror::Error;
 
 pub mod azure;
 pub mod local_fs;
+mod retry;
 pub mod s3;
 
 pub use azure::AzureStorageProvider;

--- a/src/storage/retry.rs
+++ b/src/storage/retry.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Shared transient-retry + range-completion helpers for the
+//! object-store-backed providers. One copy so retry semantics can't
+//! drift between backends; each backend keeps its own error
+//! translation and feeds already-translated results in.
+
+use std::ops::Range;
+use std::time::Duration;
+
+use bytes::{Bytes, BytesMut};
+
+use super::StorageError;
+
+/// `object_store` retry depth. Deeper than the library default, which
+/// exhausts before a flaky/high-latency connection recovers.
+pub(crate) const MAX_RETRIES: usize = 20;
+
+/// Overall `object_store` retry window, paired with [`MAX_RETRIES`].
+pub(crate) const RETRY_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Transient re-issue backoff: `BASE × 2^min(attempt, MAX_SHIFT)` ms, capped.
+const BACKOFF_BASE_MS: u64 = 50;
+const BACKOFF_MAX_SHIFT: u32 = 5;
+const BACKOFF_CAP_MS: u64 = 2000;
+
+/// App-level re-issue budget for transient transport failures that
+/// `object_store` won't retry itself (e.g. "error sending request" on a
+/// socket the service dropped under us).
+const MAX_TRANSIENT_RETRIES: u32 = 8;
+
+/// Retry budget applied to a store builder via `.with_retry(...)`.
+pub(crate) fn config() -> object_store::RetryConfig {
+    object_store::RetryConfig {
+        max_retries: MAX_RETRIES,
+        retry_timeout: RETRY_TIMEOUT,
+        ..Default::default()
+    }
+}
+
+/// Transient flakiness worth re-issuing an idempotent op for. Stable
+/// errors (NotFound / PreconditionFailed / Permanent) are not.
+fn is_retryable(err: &StorageError) -> bool {
+    matches!(err, StorageError::TransientExhausted { .. })
+}
+
+/// Exponential backoff (50ms→2s) to drain a dead pooled connection
+/// before a fresh dial.
+fn backoff(attempt: u32) -> Duration {
+    let ms = BACKOFF_BASE_MS.saturating_mul(1 << attempt.min(BACKOFF_MAX_SHIFT));
+    Duration::from_millis(ms.min(BACKOFF_CAP_MS))
+}
+
+/// Permanent error: the object returned fewer bytes than requested and
+/// made no progress. Stable, so callers don't retry.
+fn short_read(uri: &str, start: u64, requested: u64, got: u64) -> StorageError {
+    let source: Box<dyn std::error::Error + Send + Sync> = format!(
+        "get_range short read: object returned {got} of {requested} bytes from offset {start}"
+    )
+    .into();
+    StorageError::Permanent {
+        uri: uri.into(),
+        source,
+    }
+}
+
+/// Re-issue an idempotent whole-object op (get / tail) through the
+/// app-level transient budget. `op` must already map to `StorageError`.
+pub(crate) async fn with_reissue<T, F, Fut>(mut op: F) -> Result<T, StorageError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, StorageError>>,
+{
+    let mut attempt = 0u32;
+    loop {
+        match op().await {
+            Ok(v) => return Ok(v),
+            Err(e) if is_retryable(&e) && attempt < MAX_TRANSIENT_RETRIES => {
+                tokio::time::sleep(backoff(attempt)).await;
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Range-fetch with short-read completion + transient re-issue.
+///
+/// A GET can return short (truncated body) or fail transiently without
+/// `object_store` retrying it. Both corrupt callers (over-slice /
+/// zero-gap cache fill), so re-issue the still-missing tail; a fresh
+/// dial also drops the dead socket. `fetch` performs one range GET,
+/// already translated to `StorageError`.
+pub(crate) async fn complete_range<F, Fut>(
+    uri: &str,
+    range: Range<u64>,
+    mut fetch: F,
+) -> Result<Bytes, StorageError>
+where
+    F: FnMut(Range<u64>) -> Fut,
+    Fut: std::future::Future<Output = Result<Bytes, StorageError>>,
+{
+    let want = range.end.saturating_sub(range.start);
+    if want == 0 {
+        return Ok(Bytes::new());
+    }
+    let mut cursor = range.start;
+    let mut filled: u64 = 0;
+    let mut parts: Vec<Bytes> = Vec::new();
+    let mut attempt = 0u32;
+    loop {
+        let chunk = match fetch(cursor..range.end).await {
+            Ok(c) => c,
+            Err(e) if is_retryable(&e) && attempt < MAX_TRANSIENT_RETRIES => {
+                tokio::time::sleep(backoff(attempt)).await;
+                attempt += 1;
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
+        if chunk.is_empty() {
+            // Empty body for an in-bounds range is a transport glitch,
+            // not end-of-object (that surfaces as a typed error).
+            if attempt < MAX_TRANSIENT_RETRIES {
+                tokio::time::sleep(backoff(attempt)).await;
+                attempt += 1;
+                continue;
+            }
+            return Err(short_read(uri, range.start, want, filled));
+        }
+        let take = (chunk.len() as u64).min(want - filled);
+        filled += take;
+        cursor += take;
+        if take as usize == chunk.len() {
+            parts.push(chunk);
+        } else {
+            parts.push(chunk.slice(0..take as usize));
+        }
+        if filled >= want {
+            break;
+        }
+        // Short non-empty chunks are normal for a large range; `filled`
+        // advances each iteration so the loop is bounded.
+    }
+    if parts.len() == 1 {
+        return Ok(parts.pop().expect("len checked == 1"));
+    }
+    let mut out = BytesMut::with_capacity(want as usize);
+    for p in &parts {
+        out.extend_from_slice(p);
+    }
+    Ok(out.freeze())
+}

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -37,7 +37,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use futures::TryStreamExt;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path as ObjPath;
@@ -46,7 +46,7 @@ use object_store::{
     PutPayload, UpdateVersion,
 };
 
-use super::{ObjectMeta, StorageError, StorageProvider};
+use super::{ObjectMeta, StorageError, StorageProvider, retry};
 
 /// S3-backed `StorageProvider`. Cheap to clone; the inner
 /// `AmazonS3` shares its HTTP client across clones.
@@ -68,7 +68,7 @@ impl S3StorageProvider {
             .with_bucket_name(&bucket)
             .with_conditional_put(object_store::aws::S3ConditionalPut::ETagMatch)
             .with_client_options(tuned_client_options())
-            .with_retry(tuned_retry_config())
+            .with_retry(retry::config())
             .build()
             .map_err(|e| StorageError::Permanent {
                 uri: format!("s3://{bucket}"),
@@ -224,27 +224,6 @@ const S3_POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 /// dominate the fan-out's p99; the retry layer covers genuine drops.
 const S3_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// `object_store` retry budget for real-S3 fan-out. Deep enough to
-/// ride out a transient transport error in a burst of hundreds of
-/// concurrent range GETs rather than failing the query.
-const S3_MAX_RETRIES: usize = 20;
-
-/// Overall `object_store` retry window, paired with [`S3_MAX_RETRIES`].
-const S3_RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
-
-/// Base delay for the application-level transient-GET backoff. The
-/// nth attempt waits `base × 2^min(n, shift cap)` ms.
-const S3_TRANSIENT_BACKOFF_BASE_MS: u64 = 50;
-
-/// Cap on the backoff doubling exponent, so the delay plateaus
-/// instead of growing unboundedly with the attempt count.
-const S3_TRANSIENT_BACKOFF_MAX_SHIFT: u32 = 5;
-
-/// Ceiling on a single transient-GET backoff sleep. Brief by design:
-/// the goal is to drain a dead pooled connection, not wait out an
-/// outage.
-const S3_TRANSIENT_BACKOFF_CAP_MS: u64 = 2000;
-
 /// Tuned HTTP client options for the object-store-native fan-out.
 ///
 /// The supertable vector/FTS query path fans out one cold-open +
@@ -278,68 +257,6 @@ fn tuned_client_options() -> object_store::ClientOptions {
         // Bound the connect phase so a single slow SYN/TLS doesn't
         // dominate the fan-out's p99; the retry layer covers drops.
         .with_connect_timeout(S3_CONNECT_TIMEOUT)
-}
-
-/// Tuned retry budget for real-S3 fan-out.
-///
-/// The cold vector/FTS query path fires a burst of hundreds of
-/// concurrent range GETs per query. A single wave can momentarily
-/// trip a transient transport error (a connection reset, or an
-/// `error sending request` on a socket S3 closed under us) that
-/// `object_store`'s retry layer would otherwise exhaust — surfacing
-/// as `TransientExhausted` straight into the query. A deeper budget
-/// (and a longer overall window) lets the client ride out a burst
-/// instead of failing the query. Paired with the sub-S3-idle-close
-/// `pool_idle_timeout` above, which removes the dominant cause of
-/// those errors in the first place.
-fn tuned_retry_config() -> object_store::RetryConfig {
-    object_store::RetryConfig {
-        max_retries: S3_MAX_RETRIES,
-        retry_timeout: S3_RETRY_TIMEOUT,
-        ..Default::default()
-    }
-}
-
-/// Application-level re-issue budget for a transient transport
-/// failure on a range GET (e.g. reqwest "error sending request"
-/// that `object_store` does not retry itself). Each attempt dials
-/// a fresh connection, so a healthy host recovers within a couple
-/// of tries; the cap bounds a genuinely-unreachable endpoint.
-const MAX_TRANSIENT_RETRIES: u32 = 8;
-
-/// `true` for storage errors worth re-issuing an idempotent GET
-/// against — transport-level flakiness that cleared object_store's
-/// own (ineffective for this class) retry without succeeding.
-/// `NotFound` / `PreconditionFailed` / `Permanent` are stable and
-/// never retried here.
-fn is_retryable_transient(err: &StorageError) -> bool {
-    matches!(err, StorageError::TransientExhausted { .. })
-}
-
-/// Exponential backoff for transient GET retries: 50ms, 100, 200,
-/// 400, ... capped at 2s. Brief by design — the goal is to let the
-/// dead pooled connection drain and a fresh dial succeed, not to
-/// wait out a long outage.
-fn transient_backoff(attempt: u32) -> std::time::Duration {
-    let ms = S3_TRANSIENT_BACKOFF_BASE_MS
-        .saturating_mul(1 << attempt.min(S3_TRANSIENT_BACKOFF_MAX_SHIFT));
-    std::time::Duration::from_millis(ms.min(S3_TRANSIENT_BACKOFF_CAP_MS))
-}
-
-/// Definitive error for a range the backing object can't satisfy
-/// (it returned fewer bytes than requested and made no further
-/// progress). Surfaced as `Permanent` — callers do not retry; a
-/// shorter-than-requested object is a stable condition, not a
-/// transient one.
-fn short_read(uri: &str, start: u64, requested: u64, got: u64) -> StorageError {
-    let boxed: Box<dyn std::error::Error + Send + Sync> = format!(
-        "get_range short read: object returned {got} of {requested} bytes from offset {start}"
-    )
-    .into();
-    StorageError::Permanent {
-        uri: uri.into(),
-        source: boxed,
-    }
 }
 
 /// Translate an `object_store::Error` to our `StorageError`.
@@ -381,109 +298,29 @@ impl StorageProvider for S3StorageProvider {
 
     async fn get(&self, uri: &str) -> Result<(Bytes, ObjectMeta), StorageError> {
         let path = self.path(uri)?;
-        let result = self.store.get(&path).await.map_err(|e| translate(uri, e))?;
-        // `GetResult.meta` is the version whose bytes we're
-        // about to read — etag and bytes are atomically paired
-        // by S3, so no follow-up HEAD is needed.
-        let meta = ObjectMeta {
-            size: result.meta.size as u64,
-            etag: result.meta.e_tag.clone(),
-        };
-        let bytes = result.bytes().await.map_err(|e| translate(uri, e))?;
-        Ok((bytes, meta))
+        // etag and bytes are atomically paired in the same response, so
+        // no follow-up HEAD is needed.
+        retry::with_reissue(|| async {
+            let result = self.store.get(&path).await.map_err(|e| translate(uri, e))?;
+            let meta = ObjectMeta {
+                size: result.meta.size as u64,
+                etag: result.meta.e_tag.clone(),
+            };
+            let bytes = result.bytes().await.map_err(|e| translate(uri, e))?;
+            Ok((bytes, meta))
+        })
+        .await
     }
 
     async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
         let path = self.path(uri)?;
-        let want = range.end.saturating_sub(range.start);
-        if want == 0 {
-            return Ok(Bytes::new());
-        }
-
-        // Completion loop. `object_store::get_range` is expected to
-        // return exactly the requested span, but an S3 GET can come
-        // back *short* without erroring — a body truncated by a
-        // transient transport hiccup. A short buffer that slips
-        // through here corrupts callers in two ways: the foreground
-        // lazy reader slices past the end (panic), and the background
-        // cache fill `pwrite`s it at the chunk offset, leaving a zero
-        // gap in the mmap'd file. Re-issue the GET for the
-        // still-missing tail; surface a definitive error only when
-        // the object genuinely can't satisfy the range.
-        let mut cursor = range.start;
-        let mut filled: u64 = 0;
-        let mut parts: Vec<Bytes> = Vec::new();
-        let mut transient_retries = 0u32;
-        loop {
-            // Application-level retry for transient connection/transport
-            // failures. `object_store`'s own retry layer does NOT cover
-            // reqwest "error sending request" (a send-side failure on a
-            // socket the server closed under us): it gives up in
-            // milliseconds, well inside its configured window, and
-            // surfaces the error straight into the query. Under the cold
-            // vector/FTS fan-out (a burst of hundreds of concurrent GETs)
-            // those send failures are common. A range GET is idempotent,
-            // so re-issuing the still-missing tail with backoff is safe;
-            // a fresh attempt also forces reqwest to discard the dead
-            // pooled connection and dial a new one.
-            let chunk = match self.store.get_range(&path, cursor..range.end).await {
-                Ok(chunk) => chunk,
-                Err(e) => {
-                    let err = translate(uri, e);
-                    if is_retryable_transient(&err) && transient_retries < MAX_TRANSIENT_RETRIES {
-                        tokio::time::sleep(transient_backoff(transient_retries)).await;
-                        transient_retries += 1;
-                        continue;
-                    }
-                    return Err(err);
-                }
-            };
-            if chunk.is_empty() {
-                // A zero-byte body for an *in-bounds* range is a
-                // transport glitch (a reset/truncated response delivered
-                // as a 200/206 with no payload), NOT a real end-of-object
-                // — object_store surfaces a genuinely past-the-end range
-                // as a typed `NotFound`/`Generic` error, never as an empty
-                // `Ok`. The original bug here treated the first empty reply
-                // as a permanent short read, which aborted cold queries
-                // mid-fan-out at scale (e.g. 0 of 120576 bytes at an offset
-                // well inside a 59 MiB segment). Re-issue with backoff (which
-                // also forces a fresh connection) and only surface the
-                // definitive short read once the transient budget is spent.
-                if transient_retries < MAX_TRANSIENT_RETRIES {
-                    tokio::time::sleep(transient_backoff(transient_retries)).await;
-                    transient_retries += 1;
-                    continue;
-                }
-                return Err(short_read(uri, range.start, want, filled));
-            }
-            let take = (chunk.len() as u64).min(want - filled);
-            filled += take;
-            cursor += take;
-            if take as usize == chunk.len() {
-                parts.push(chunk);
-            } else {
-                parts.push(chunk.slice(0..take as usize));
-            }
-            if filled >= want {
-                break;
-            }
-            // A non-empty chunk shorter than requested is normal for a
-            // large range (S3 may split it): `filled` strictly advances
-            // every iteration, so the loop is bounded and terminates.
-            // No-progress (empty) iterations are handled above via the
-            // transient-retry budget, so there is no separate stall cap.
-        }
-
-        // Fast path: a single full-length response is zero-copy.
-        if parts.len() == 1 {
-            return Ok(parts.pop().expect("len checked == 1"));
-        }
-        let mut out = BytesMut::with_capacity(want as usize);
-        for p in &parts {
-            out.extend_from_slice(p);
-        }
-        Ok(out.freeze())
+        retry::complete_range(uri, range, |r| async {
+            self.store
+                .get_range(&path, r)
+                .await
+                .map_err(|e| translate(uri, e))
+        })
+        .await
     }
 
     /// Tail-fetch path: — single-RTT tail fetch via S3's native
@@ -505,18 +342,21 @@ impl StorageProvider for S3StorageProvider {
             return Ok((Bytes::new(), meta.size));
         }
         let path = self.path(uri)?;
-        let opts = GetOptions {
-            range: Some(GetRange::Suffix(len)),
-            ..Default::default()
-        };
-        let result = self
-            .store
-            .get_opts(&path, opts)
-            .await
-            .map_err(|e| translate(uri, e))?;
-        let size = result.meta.size as u64;
-        let bytes = result.bytes().await.map_err(|e| translate(uri, e))?;
-        Ok((bytes, size))
+        retry::with_reissue(|| async {
+            let opts = GetOptions {
+                range: Some(GetRange::Suffix(len)),
+                ..Default::default()
+            };
+            let result = self
+                .store
+                .get_opts(&path, opts)
+                .await
+                .map_err(|e| translate(uri, e))?;
+            let size = result.meta.size as u64;
+            let bytes = result.bytes().await.map_err(|e| translate(uri, e))?;
+            Ok((bytes, size))
+        })
+        .await
     }
 
     async fn put_atomic(&self, uri: &str, bytes: Bytes) -> Result<Option<String>, StorageError> {

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -295,7 +295,7 @@ pub enum ManifestLoadError {
     #[error("part_id not in manifest list: {part_id}")]
     PartNotInList { part_id: part::PartId },
     /// Storage backend returned an error.
-    #[error("storage error during part load")]
+    #[error("storage error during part load: {0}")]
     Storage(#[source] crate::storage::StorageError),
     /// Computed blake3 of the loaded bytes didn't match the
     /// manifest list's recorded `content_hash`. The bad bytes


### PR DESCRIPTION
## Why

The Azure `StorageProvider` was never hardened the way the S3 provider was. On a high-latency or lossy path, a single transient read — reloading a manifest part during a commit's partition rewrite (`Manifest::part` → `storage.get`) — exhausted object_store's shallow default retry budget and surfaced as a commit **panic**:

```
storage error during part load: transient error after retry:
manifests/part-….avro.zst — HTTP error: request or response body error
```

Four gaps vs. S3, all addressed here:

| Hardening | S3 (before) | Azure (before) |
|---|---|---|
| Tuned `RetryConfig` (`.with_retry`) | ✅ | ❌ default |
| App-level transient re-issue | ✅ `get_range` only | ❌ |
| Short-read completion | ✅ | ❌ |
| Request timeout (large PUT) | default 30s | default 30s — aborts mid-upload |

## What

- **New `storage::retry`** — single home for the retry/short-read logic (`config`, `with_reissue`, `complete_range`). Removes the copy that previously lived inline in `s3.rs` so the two backends can't drift. Each backend keeps its own `translate` and feeds already-translated results in.
- **Azure now at parity**: deeper `RetryConfig`, a 300s request timeout (the 30s default aborted multi-MB segment PUTs), and the transient re-issue now wraps **`get` / `get_range` / `tail`** — previously the loop existed only on S3, and only in `get_range`. The failing path here was `get()`, which had no app-level retry on either backend.
- **Better diagnostics**: `ManifestLoadError::Storage` now Displays its underlying `StorageError`, so the failing object + root cause are visible instead of a bare "storage error during part load".

## Reviewer notes

- **S3 behavior is unchanged** — same constants (20 retries / 300s window / 50ms→2s backoff / 8 transient re-issues) and the same loop, relocated to `storage::retry`. Diff looks large on `s3.rs` because ~120 duplicated lines were removed.
- `complete_range` preserves the original loop semantics exactly: one transient counter across the whole range fetch (not per chunk), no reset on progress, short-read surfaced as `Permanent` only after the budget is spent.
- `cargo check --lib --tests` and `cargo clippy --lib` are clean; no `unwrap`.

## Testing

- Compile + clippy clean.
- ⚠️ Not yet covered by a new unit test for the transient/short-read path — worth adding against a fault-injecting fake before merge. The existing `s3s`-backed integration tests exercise the relocated S3 path unchanged.