### PR TITLE
ci: on-demand Azure supertable benchmark (in-region VM + sccache blob cache)

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -3,7 +3,9 @@ name: Supertable Benchmark (Azure)
 # Supertable ingest benchmark on a per-run ephemeral Azure VM, in the
 # storage account's region. Compute is co-located with the bucket so
 # object-store transfers run over the Azure backbone, not the public
-# internet. The VM clones, builds, runs, and is destroyed each run.
+# internet. The VM clones and builds with an sccache compile cache backed
+# by Azure Blob (shared across branches), runs the bench, and is destroyed
+# each run.
 
 on:
   workflow_dispatch:
@@ -52,6 +54,7 @@ env:
   RG: rg-infino-bench-${{ github.run_id }}
   VM: bench-vm
   ADMIN: azureuser
+  SCCACHE_VERSION: v0.8.2
 
 jobs:
   benchmark:
@@ -66,7 +69,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Provision ephemeral VM (East US)
+      - name: Provision ephemeral VM
         id: provision
         run: |
           set -euo pipefail
@@ -117,7 +120,7 @@ jobs:
           done
           echo "::error::SSH never came up"; exit 1
 
-      - name: Clone repo + toolchain (on VM)
+      - name: Clone repo + toolchain + sccache (on VM)
         run: |
           set -eo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
@@ -127,9 +130,9 @@ jobs:
             "GH_TOKEN='${{ github.token }}' \
              REPO='${{ github.repository }}' \
              REF='${{ github.event.inputs.ref }}' \
+             SCCACHE_VERSION='${{ env.SCCACHE_VERSION }}' \
              bash -s" <<'REMOTE'
           set -euo pipefail
-          echo "Host: $(uname -srm) · $(nproc) cores · $(free -h | awk '/Mem:/{print $2}') mem"
 
           if ! command -v cargo >/dev/null 2>&1; then
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
@@ -140,6 +143,14 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
             build-essential pkg-config cmake clang protobuf-compiler git
 
+          # Prebuilt sccache (static musl, glibc-agnostic).
+          if ! command -v sccache >/dev/null 2>&1; then
+            TARBALL="sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl"
+            curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${TARBALL}.tar.gz" \
+              | tar -xz
+            sudo install "${TARBALL}/sccache" /usr/local/bin/sccache
+          fi
+
           rm -rf "$HOME/infino-src"
           git clone --filter=blob:none \
             "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$HOME/infino-src"
@@ -149,15 +160,40 @@ jobs:
           echo "Checked out: $(git rev-parse --short HEAD)"
           REMOTE
 
-      - name: Warm build (on VM)
+      - name: Build (sccache, on VM)
         run: |
           set -eo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
-          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" "bash -s" <<'REMOTE'
+          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
+            "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
+             AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
+             INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
+             bash -s" <<'REMOTE' 2>&1 | tee /tmp/build.log
           set -euo pipefail
           source "$HOME/.cargo/env"
           cd "$HOME/infino-src"
+
+          # Content-addressed compile cache in Azure Blob, shared across
+          # branches. CARGO_INCREMENTAL=0 is required (it conflicts with
+          # sccache). Reuses the bench container under a key prefix;
+          # connection string from the same account.
+          export RUSTC_WRAPPER=sccache
+          export CARGO_INCREMENTAL=0
+          export SCCACHE_AZURE_BLOB_CONTAINER="$INFINO_REAL_AZURE_CONTAINER"
+          export SCCACHE_AZURE_KEY_PREFIX=sccache
+          export SCCACHE_AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=${AZURE_STORAGE_ACCOUNT_NAME};AccountKey=${AZURE_STORAGE_ACCOUNT_KEY};EndpointSuffix=core.windows.net"
+          sccache --start-server || true
+
           cargo bench --bench supertable_all --no-run
+          sccache --show-stats || true
+
+          # Record the built binary so the run step execs it directly —
+          # no cargo in the run step means no re-fingerprint / rebuild.
+          BIN="$(find target/release/deps -maxdepth 1 -type f -executable -name 'supertable_all-*' \
+                   -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2-)"
+          test -n "$BIN" && test -x "$BIN" || { echo "::error::bench binary not found"; exit 1; }
+          echo "$BIN" > "$HOME/bench-bin"
+          echo "bench binary: $BIN"
           REMOTE
 
       - name: Run benchmark (on VM)
@@ -172,12 +208,12 @@ jobs:
              KEEP='${{ github.event.inputs.keep_table }}' \
              bash -s" <<'REMOTE' 2>&1 | tee /tmp/bench.log
           set -euo pipefail
-          source "$HOME/.cargo/env"
           cd "$HOME/infino-src"
           export INFINO_BENCH_STORE=azure
           [ "$KEEP" = "true" ] && export INFINO_BENCH_KEEP_TABLE=1
+          BIN="$(cat "$HOME/bench-bin")"
           echo "===== SUPERTABLE BENCHMARK START ====="
-          cargo bench --bench supertable_all 2>&1
+          "$BIN" 2>&1
           echo "===== SUPERTABLE BENCHMARK END ====="
           REMOTE
 
@@ -194,14 +230,17 @@ jobs:
             echo ""
           } >> "$SUMMARY"
 
-          if [ ! -s /tmp/bench.log ]; then
-            echo "::error::No bench log produced — provisioning or SSH failed (see job logs)."
-            echo "_No bench log produced — provisioning or SSH failed._" >> "$SUMMARY"
+          # Combine build + run logs (build warnings live in build.log,
+          # the report + runtime panics in bench.log), ANSI-stripped.
+          : > "$LOG"
+          for f in /tmp/build.log /tmp/bench.log; do
+            [ -s "$f" ] && sed -r 's/\x1b\[[0-9;]*m//g' "$f" >> "$LOG"
+          done
+          if [ ! -s "$LOG" ]; then
+            echo "::error::No output produced — provisioning or SSH failed (see job logs)."
+            echo "_No output produced — provisioning or SSH failed._" >> "$SUMMARY"
             exit 1
           fi
-
-          # Strip ANSI before parsing.
-          sed -r 's/\x1b\[[0-9;]*m//g' /tmp/bench.log > "$LOG"
 
           # The report banner ("══ … ══") and table are present only when
           # at least one shape succeeded.
@@ -218,8 +257,9 @@ jobs:
             echo "**❌ No report table — every shape failed.**" >> "$SUMMARY"
           fi
 
-          # Panics and errors; the panic line carries the full chain.
-          ERRORS="$(grep -nE 'panicked|HTTP error|storage error|transient error|AppendFlush|PointerParse|child exited|no shapes produced|skipped:|content-hash mismatch|short read' "$LOG" || true)"
+          # Panics, runtime errors, and compile errors (error[E…]); the
+          # panic line carries the full chain.
+          ERRORS="$(grep -nE 'panicked|error\[|HTTP error|storage error|transient error|AppendFlush|PointerParse|child exited|no shapes produced|skipped:|content-hash mismatch|short read' "$LOG" || true)"
           if [ -n "$ERRORS" ]; then
             {
               echo "### 🛑 Errors & panics"
@@ -258,7 +298,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: supertable-bench-log
-          path: /tmp/bench.log
+          path: |
+            /tmp/build.log
+            /tmp/bench.log
           if-no-files-found: warn
 
       - name: Teardown (always)

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -73,7 +73,10 @@ jobs:
           LOC="${{ github.event.inputs.location }}"
           SIZE="${{ github.event.inputs.vm_size }}"
 
-          az group create -n "$RG" -l "$LOC" -o none
+          # Tag the RG + VM so Cost Management attributes spend by
+          # purpose / run after the group is deleted.
+          TAGS=(purpose=supertable-bench "run-id=${{ github.run_id }}" "ref=${{ github.event.inputs.ref }}")
+          az group create -n "$RG" -l "$LOC" --tags "${TAGS[@]}" -o none
 
           # No default inbound rule; the only SSH allow is the
           # runner-IP /32 added below.
@@ -86,6 +89,7 @@ jobs:
             --public-ip-sku Standard \
             --os-disk-size-gb 128 \
             --nsg-rule NONE \
+            --tags "${TAGS[@]}" \
             -o none
 
           RUNNER_IP="$(curl -s https://api.ipify.org)"

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -16,7 +16,7 @@ on:
       vm_size:
         description: "Azure VM size."
         required: false
-        default: "Standard_D8s_v5"
+        default: "Standard_D8s_v7"
         type: string
       location:
         description: "VM region."

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -163,7 +163,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
-             INFINO_REAL_AZURE_CONTAINER='${{ secrets.AZURE_BENCH_CONTAINER }}' \
+             INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
              INFINO_BENCH_SUPERTABLE_DOCS='${{ github.event.inputs.docs }}' \
              KEEP='${{ github.event.inputs.keep_table }}' \
              bash -s" <<'REMOTE' 2>&1 | tee /tmp/bench.log

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -1,0 +1,264 @@
+name: Supertable Benchmark (Azure)
+
+# Supertable ingest benchmark on a per-run ephemeral Azure VM, in the
+# storage account's region. Compute is co-located with the bucket so
+# object-store transfers run over the Azure backbone, not the public
+# internet. The VM clones, builds, runs, and is destroyed each run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      docs:
+        description: "Doc count (plain integer, NOT 1M/100K — those do not parse)"
+        required: false
+        default: "1000000"
+        type: string
+      vm_size:
+        description: "Azure VM size."
+        required: false
+        default: "Standard_D8s_v5"
+        type: string
+      location:
+        description: "VM region."
+        required: false
+        default: "eastus"
+        type: string
+      ref:
+        description: "Git ref / SHA to benchmark."
+        required: false
+        default: "main"
+        type: string
+      keep_table:
+        description: "Keep the bench blob prefix after the run (debug)."
+        required: false
+        default: false
+        type: boolean
+      timeout_minutes:
+        description: "Hard auto-stop; VM is torn down when hit."
+        required: false
+        default: "30"
+        type: string
+
+permissions:
+  id-token: write   # Azure OIDC federated login
+  contents: read    # clone the repo on the VM via the job token
+
+# One benchmark at a time; queued, never cancelled mid-run.
+concurrency:
+  group: supertable-bench-azure
+  cancel-in-progress: false
+
+env:
+  RG: rg-infino-bench-${{ github.run_id }}
+  VM: bench-vm
+  ADMIN: azureuser
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    # Auto-stop ceiling on VM billing; teardown runs on timeout.
+    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout_minutes) }}
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Provision ephemeral VM (East US)
+        id: provision
+        run: |
+          set -euo pipefail
+          LOC="${{ github.event.inputs.location }}"
+          SIZE="${{ github.event.inputs.vm_size }}"
+
+          az group create -n "$RG" -l "$LOC" -o none
+
+          # No default inbound rule; the only SSH allow is the
+          # runner-IP /32 added below.
+          az vm create \
+            -g "$RG" -n "$VM" \
+            --image Ubuntu2204 \
+            --size "$SIZE" \
+            --admin-username "$ADMIN" \
+            --generate-ssh-keys \
+            --public-ip-sku Standard \
+            --os-disk-size-gb 128 \
+            --nsg-rule NONE \
+            -o none
+
+          RUNNER_IP="$(curl -s https://api.ipify.org)"
+          NSG="$(az network nsg list -g "$RG" --query "[0].name" -o tsv)"
+          az network nsg rule create \
+            -g "$RG" --nsg-name "$NSG" -n allow-ssh-runner --priority 300 \
+            --access Allow --protocol Tcp --direction Inbound \
+            --destination-port-ranges 22 \
+            --source-address-prefixes "${RUNNER_IP}/32" -o none
+
+          VM_IP="$(az vm show -d -g "$RG" -n "$VM" --query publicIps -o tsv)"
+          echo "vm_ip=$VM_IP" >> "$GITHUB_OUTPUT"
+          echo "Provisioned $VM ($SIZE) at $VM_IP in $LOC"
+
+      - name: Wait for SSH
+        run: |
+          set -euo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          for i in $(seq 1 30); do
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+                 "${ADMIN}@${VM_IP}" true 2>/dev/null; then
+              echo "SSH up after ${i} tries"; exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::SSH never came up"; exit 1
+
+      - name: Clone repo + toolchain (on VM)
+        run: |
+          set -eo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          # Single-quoted heredoc: the body is literal; only the
+          # ssh-line assignments reach the VM as env.
+          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
+            "GH_TOKEN='${{ github.token }}' \
+             REPO='${{ github.repository }}' \
+             REF='${{ github.event.inputs.ref }}' \
+             bash -s" <<'REMOTE'
+          set -euo pipefail
+          echo "Host: $(uname -srm) · $(nproc) cores · $(free -h | awk '/Mem:/{print $2}') mem"
+
+          if ! command -v cargo >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --default-toolchain stable --profile minimal
+          fi
+
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential pkg-config cmake clang protobuf-compiler git
+
+          rm -rf "$HOME/infino-src"
+          git clone --filter=blob:none \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$HOME/infino-src"
+          cd "$HOME/infino-src"
+          git checkout "$REF" 2>/dev/null \
+            || { git fetch --depth 1 origin "$REF" && git checkout FETCH_HEAD; }
+          echo "Checked out: $(git rev-parse --short HEAD)"
+          REMOTE
+
+      - name: Warm build (on VM)
+        run: |
+          set -eo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" "bash -s" <<'REMOTE'
+          set -euo pipefail
+          source "$HOME/.cargo/env"
+          cd "$HOME/infino-src"
+          cargo bench --bench supertable_all --no-run
+          REMOTE
+
+      - name: Run benchmark (on VM)
+        run: |
+          set -eo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
+            "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
+             AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
+             INFINO_REAL_AZURE_CONTAINER='${{ secrets.AZURE_BENCH_CONTAINER }}' \
+             INFINO_BENCH_SUPERTABLE_DOCS='${{ github.event.inputs.docs }}' \
+             KEEP='${{ github.event.inputs.keep_table }}' \
+             bash -s" <<'REMOTE' 2>&1 | tee /tmp/bench.log
+          set -euo pipefail
+          source "$HOME/.cargo/env"
+          cd "$HOME/infino-src"
+          export INFINO_BENCH_STORE=azure
+          [ "$KEEP" = "true" ] && export INFINO_BENCH_KEEP_TABLE=1
+          echo "===== SUPERTABLE BENCHMARK START ====="
+          cargo bench --bench supertable_all 2>&1
+          echo "===== SUPERTABLE BENCHMARK END ====="
+          REMOTE
+
+      - name: Summarize results
+        if: always()
+        run: |
+          set -uo pipefail
+          SUMMARY="$GITHUB_STEP_SUMMARY"
+          LOG=/tmp/bench.clean
+          {
+            echo "## Supertable benchmark — Azure (${{ github.event.inputs.location }})"
+            echo ""
+            echo "- docs: \`${{ github.event.inputs.docs }}\` · vm: \`${{ github.event.inputs.vm_size }}\` · ref: \`${{ github.event.inputs.ref }}\`"
+            echo ""
+          } >> "$SUMMARY"
+
+          if [ ! -s /tmp/bench.log ]; then
+            echo "::error::No bench log produced — provisioning or SSH failed (see job logs)."
+            echo "_No bench log produced — provisioning or SSH failed._" >> "$SUMMARY"
+            exit 1
+          fi
+
+          # Strip ANSI before parsing.
+          sed -r 's/\x1b\[[0-9;]*m//g' /tmp/bench.log > "$LOG"
+
+          # The report banner ("══ … ══") and table are present only when
+          # at least one shape succeeded.
+          if grep -q '══' "$LOG"; then
+            REPORT_OK=1
+            {
+              echo "### Results"
+              echo '```'
+              awk '/══/{f=1} f' "$LOG"
+              echo '```'
+            } >> "$SUMMARY"
+          else
+            REPORT_OK=0
+            echo "**❌ No report table — every shape failed.**" >> "$SUMMARY"
+          fi
+
+          # Panics and errors; the panic line carries the full chain.
+          ERRORS="$(grep -nE 'panicked|HTTP error|storage error|transient error|AppendFlush|PointerParse|child exited|no shapes produced|skipped:|content-hash mismatch|short read' "$LOG" || true)"
+          if [ -n "$ERRORS" ]; then
+            {
+              echo "### 🛑 Errors & panics"
+              echo '```'
+              printf '%s\n' "$ERRORS"
+              echo '```'
+            } >> "$SUMMARY"
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::error::${line}"
+            done <<< "$(grep -E 'panicked at|AppendFlush|storage error|HTTP error' "$LOG" | head -n 8)"
+          fi
+
+          # Unique build/harness warnings.
+          WARNINGS="$(grep -E '^warning:|: warning:|\bwarning:' "$LOG" | sed 's/^[0-9]*://' | sort -u || true)"
+          if [ -n "$WARNINGS" ]; then
+            WCOUNT="$(printf '%s\n' "$WARNINGS" | grep -c . || true)"
+            {
+              echo "### ⚠️ Warnings (${WCOUNT} unique)"
+              echo '```'
+              printf '%s\n' "$WARNINGS" | head -n 40
+              echo '```'
+            } >> "$SUMMARY"
+            echo "::warning::${WCOUNT} unique build/harness warnings — see step summary."
+          fi
+
+          echo "" >> "$SUMMARY"
+          echo "_Full output attached as the \`supertable-bench-log\` artifact._" >> "$SUMMARY"
+
+          if [ "$REPORT_OK" -ne 1 ]; then
+            echo "::error::Benchmark produced no results — every shape failed."
+            exit 1
+          fi
+
+      - name: Upload full log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: supertable-bench-log
+          path: /tmp/bench.log
+          if-no-files-found: warn
+
+      - name: Teardown (always)
+        if: always()
+        run: |
+          # Deletes the VM and all its resources in one call.
+          az group delete -n "$RG" --yes --no-wait || true


### PR DESCRIPTION
## What

A `workflow_dispatch` workflow (`.github/workflows/supertable-bench-azure.yml`) that benchmarks **supertable ingest against real Azure Blob storage from in-region compute**, building on the VM with an sccache compile cache backed by Azure Blob.

Steps (single-responsibility):
1. OIDC login to Azure.
2. Provision an ephemeral VM in the storage account's region (per-run RG `rg-infino-bench-<run_id>`, tagged; NSG with no default inbound rule, SSH locked to the runner's `/32`).
3. Wait for SSH.
4. **Clone + toolchain + sccache** — clone `@ref` via the job token, install rustup + a prebuilt sccache.
5. **Build (sccache)** — compile with `RUSTC_WRAPPER=sccache` + `CARGO_INCREMENTAL=0`, print cache stats, record the binary path.
6. **Run** — exec that binary directly (no `cargo`) against Azure.
7. Summarize → step summary (results table, errors/panics, warnings) + log artifact.
8. Teardown — `az group delete` on success/failure/timeout/cancellation.

## Why in-region

The supertable bench moves multi-GB to object storage and reads it back during commits. Over a non-colocated network path that's slow and unreliable (single-stream transfers collapse; large reads time out). Co-locating compute with the bucket runs it over the Azure backbone. This is the supported way to get representative supertable numbers.

## Why sccache over blob (build on the VM)

- **Warm builds across branches.** sccache is content-addressed (not branch-keyed), so the dependency graph compiles once and is reused on every branch's ephemeral VM; only changed crates recompile.
- **No portability contract.** Building on the VM means build env == run env — no glibc/arch/CPU concerns from shipping a binary across hosts.
- **No new infra.** The cache reuses the bench's own blob container under a `sccache` key prefix (separate from bench data); the connection string is derived from the existing account creds — no new secret, no dedicated container.
- VM stays ephemeral/cattle; the durable cache lives in blob.

## Build/run split

Build and run are separate steps. To avoid a cargo re-fingerprint/rebuild between them, the run step **execs the recorded binary directly** rather than re-invoking `cargo bench`.

## Safety / cost

- **Hard timeout** (`timeout_minutes`, default 30) caps VM billing; teardown runs on timeout.
- **Serialized** (`concurrency`) — one VM billing at a time; queued, never cancelled.
- **SSH** locked to the runner's egress `/32`; NSG has no default inbound rule.
- **OIDC** — no static cloud credentials in the repo.
- **Cost tags** on RG + VM → Cost Management attributes spend by `purpose` / `run-id` after teardown.

## Inputs

`docs` (default `1000000`, plain integer), `vm_size` (default `Standard_D8s_v7` — current gen, available in eastus), `location`, `ref`, `keep_table`, `timeout_minutes`.

## Prerequisites (reviewer / operator)

- Secrets: `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`, `AZURE_STORAGE_ACCOUNT_NAME` / `AZURE_STORAGE_ACCOUNT_KEY`, `INFINO_REAL_AZURE_CONTAINER`.
- OIDC service principal: Contributor on a dedicated bench resource group/subscription (not prod-wide); federated credential scoped to this repo.
- Optionally set a blob lifecycle policy on the `sccache/` prefix for cache eviction.

## Validation

`actionlint` clean (schema + expressions + shellcheck on every `run:` block); heredocs terminate at column 0. Not yet run end-to-end — a first dispatch validates the standalone-binary run + OIDC scope + sccache blob auth.

## Follow-ups (not in this PR)

- Scheduled sweep to delete stray `rg-infino-bench-*` groups if a runner is hard-killed (the one path teardown can't cover).
- Pass secrets via stdin rather than the ssh command line.