### PR TITLE
ci: scope bench VM to a fixed RG with exact per-run teardown

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -1,11 +1,9 @@
 name: Supertable Benchmark (Azure)
 
-# Supertable ingest benchmark on a per-run ephemeral Azure VM, in the
-# storage account's region. Compute is co-located with the bucket so
-# object-store transfers run over the Azure backbone, not the public
-# internet. The VM clones and builds with an sccache compile cache backed
-# by Azure Blob (shared across branches), runs the bench, and is destroyed
-# each run.
+# Supertable ingest benchmark on a per-run ephemeral Azure VM in the
+# storage account's region (transfers ride the Azure backbone, not the
+# public internet). The VM builds with an sccache compile cache in Azure
+# Blob — shared across branches — runs the bench, and is torn down.
 
 on:
   workflow_dispatch:
@@ -51,8 +49,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  RG: rg-infino-bench-${{ github.run_id }}
-  VM: bench-vm
+  # Pre-existing RG the bench service principal is scoped to (Contributor
+  # on this RG only). The workflow creates per-run resources inside it,
+  # never the RG itself.
+  RG: rg-infino-bench
+  VM: bench-vm-${{ github.run_id }}
   ADMIN: azureuser
   SCCACHE_VERSION: v0.8.2
 
@@ -76,13 +77,13 @@ jobs:
           LOC="${{ github.event.inputs.location }}"
           SIZE="${{ github.event.inputs.vm_size }}"
 
-          # Tag the RG + VM so Cost Management attributes spend by
-          # purpose / run after the group is deleted.
+          # Tag the VM so Cost Management attributes spend by purpose / run.
           TAGS=(purpose=supertable-bench "run-id=${{ github.run_id }}" "ref=${{ github.event.inputs.ref }}")
-          az group create -n "$RG" -l "$LOC" --tags "${TAGS[@]}" -o none
 
-          # No default inbound rule; the only SSH allow is the
-          # runner-IP /32 added below.
+          # Every resource is named with the unique per-run VM name so
+          # teardown can delete this run's resources by exact name (never
+          # a prefix that could match another run). No default inbound
+          # rule; the only SSH allow is the runner-IP /32 added below.
           az vm create \
             -g "$RG" -n "$VM" \
             --image Ubuntu2204 \
@@ -92,13 +93,17 @@ jobs:
             --public-ip-sku Standard \
             --os-disk-size-gb 128 \
             --nsg-rule NONE \
+            --nsg "${VM}-nsg" \
+            --public-ip-address "${VM}-pip" \
+            --vnet-name "${VM}-vnet" \
+            --subnet "${VM}-subnet" \
+            --os-disk-name "${VM}-osdisk" \
             --tags "${TAGS[@]}" \
             -o none
 
           RUNNER_IP="$(curl -s https://api.ipify.org)"
-          NSG="$(az network nsg list -g "$RG" --query "[0].name" -o tsv)"
           az network nsg rule create \
-            -g "$RG" --nsg-name "$NSG" -n allow-ssh-runner --priority 300 \
+            -g "$RG" --nsg-name "${VM}-nsg" -n allow-ssh-runner --priority 300 \
             --access Allow --protocol Tcp --direction Inbound \
             --destination-port-ranges 22 \
             --source-address-prefixes "${RUNNER_IP}/32" -o none
@@ -122,7 +127,7 @@ jobs:
 
       - name: Clone repo + toolchain + sccache (on VM)
         run: |
-          set -eo pipefail
+          set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
           # Single-quoted heredoc: the body is literal; only the
           # ssh-line assignments reach the VM as env.
@@ -162,7 +167,7 @@ jobs:
 
       - name: Build (sccache, on VM)
         run: |
-          set -eo pipefail
+          set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
           ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
@@ -198,7 +203,7 @@ jobs:
 
       - name: Run benchmark (on VM)
         run: |
-          set -eo pipefail
+          set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
           ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
@@ -220,7 +225,9 @@ jobs:
       - name: Summarize results
         if: always()
         run: |
-          set -uo pipefail
+          # Best-effort parser: never abort early; exit codes are set
+          # explicitly below.
+          set +e -u -o pipefail
           SUMMARY="$GITHUB_STEP_SUMMARY"
           LOG=/tmp/bench.clean
           {
@@ -305,6 +312,19 @@ jobs:
 
       - name: Teardown (always)
         if: always()
+        env:
+          # The auto-created NIC is the only resource az names for us:
+          # "<vm>VMNic".
+          NIC: ${{ env.VM }}VMNic
         run: |
-          # Deletes the VM and all its resources in one call.
-          az group delete -n "$RG" --yes --no-wait || true
+          # Delete exactly this run's resources by name (VM is unique per
+          # run, so no name can collide with another run), keeping the
+          # shared RG. Ordered so dependencies release: VM frees the NIC
+          # and disk; the NIC frees the IP/NSG/subnet. Each is best-effort
+          # so a missing resource doesn't fail teardown.
+          az vm delete            -g "$RG" -n "$VM"          --yes        || true
+          az network nic delete   -g "$RG" -n "$NIC"                      || true
+          az disk delete          -g "$RG" -n "${VM}-osdisk" --yes        || true
+          az network public-ip delete -g "$RG" -n "${VM}-pip"             || true
+          az network nsg delete   -g "$RG" -n "${VM}-nsg"                 || true
+          az network vnet delete  -g "$RG" -n "${VM}-vnet"                || true


### PR DESCRIPTION
Follow-up to #62. Reworks the supertable benchmark workflow to run under a **least-privilege OIDC identity** and tears down each run's resources by exact name.

## Why

#62 created a **new resource group per run** and deleted it on teardown — clean, but creating resource groups requires **subscription-scope** rights for the service principal. To keep the SP minimal, the workflow now runs in a single, pre-existing RG that the SP is scoped to (**Contributor on `rg-infino-bench` only** — no access to storage data, Key Vault, other RGs, or the rest of the subscription).

## What

- **Fixed RG.** The workflow no longer creates/deletes the RG; it creates per-run resources inside the shared RG and removes them on teardown.
- **Exact-name, run-scoped teardown.** Every resource is named with the unique per-run VM name (`bench-vm-<run_id>`): NSG, public IP, vnet/subnet, OS disk (all explicit), plus the auto NIC `…VMNic`. Teardown deletes them **by exact name** in dependency order (VM → NIC → disk → IP → NSG → vnet), best-effort, keeping the RG.
  - This replaces a `starts_with(name, …)` prefix match, which could over-match across runs whose numeric `run_id` is a prefix of another. Exact names make teardown correct regardless of concurrency.
- **Shell hygiene.** Every block uses `set -euo pipefail`; the summary parser is explicitly `set +e` (it controls its own exit codes). Header comment tightened.

## Correctness (concurrency)

Two independent guarantees:
1. `concurrency` serializes runs (one VM billing at a time; queued, never cancelled).
2. Even if that were bypassed, exact-name deletes are intrinsically run-scoped — run A's teardown can only ever touch run A's resources.

The one residual: a hard-killed runner leaves that run's (uniquely-named) resources in the RG — no conflict, but accumulates → a scheduled orphan sweep is the planned follow-up.

## Operator prerequisites

- Pre-create `rg-infino-bench`; grant the bench SP **Contributor on that RG only**.
- App registration + federated credential (`repo:infino-ai/infino:ref:refs/heads/main`).
- Repo secrets: `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`, `AZURE_STORAGE_ACCOUNT_NAME` / `AZURE_STORAGE_ACCOUNT_KEY`, `INFINO_REAL_AZURE_CONTAINER`.

## Validation

`actionlint` clean. Rehearsed end to end on a real eastus VM (mirroring the workflow exactly): named-resource provisioning in the fixed RG, sccache warm-cache build (**~99% hits**, ~3 min vs ~12 min cold), all three shapes pass in-region, and teardown left the RG **empty** (zero orphans).