### PR TITLE
ci: run benchmark under the ci environment for branch-agnostic OIDC

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -60,6 +60,10 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    # Run under the `ci` environment so the OIDC subject is
+    # repo:…:environment:ci — branch-independent, so one federated
+    # credential authorizes runs from any branch.
+    environment: ci
     # Auto-stop ceiling on VM billing; teardown runs on timeout.
     timeout-minutes: ${{ fromJSON(github.event.inputs.timeout_minutes) }}
     steps:


### PR DESCRIPTION
Follow-up to #62/#65. Makes the supertable benchmark workflow dispatchable from **any branch** via OIDC.

## Problem

GitHub's OIDC token subject is branch-specific (`repo:…:ref:refs/heads/<branch>`). The federated credential trusts only `refs/heads/main`, so a `workflow_dispatch` on any other branch fails login:
```
AADSTS700213: No matching federated identity record found for presented assertion
subject 'repo:infino-ai/infino:ref:refs/heads/<branch>'
```

## Fix

Run the job under the **`ci` GitHub environment**. With `environment: ci`, the OIDC subject becomes `repo:infino-ai/infino:environment:ci` — **independent of branch** — so a single federated credential authorizes runs from every branch. No per-branch credentials, no wildcards.

- Workflow: `environment: ci` on the `benchmark` job (this PR).
- Azure (done): federated credential `repo:infino-ai/infino:environment:ci` added; the temporary per-branch credential removed. `refs/heads/main` is kept so `main` keeps working until this merges.

## Notes

- The `ci` environment currently has no protection rules. Since this job provisions a VM (spends money), adding **required reviewers** to the environment would gate each dispatch behind an approval — recommended, optional.
- After merge, `refs/heads/main` becomes redundant (main runs also use `environment: ci`); it can be pruned later.

## Validation

`actionlint` clean. The end-to-end mechanics (provision → sccache build → run → teardown) were already rehearsed on real Azure in #62/#65; this PR only changes how the run authenticates.