### PR TITLE
ci: raise fd limit before the benchmark to avoid EMFILE on commit

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -220,6 +220,11 @@ jobs:
           cd "$HOME/infino-src"
           export INFINO_BENCH_STORE=azure
           [ "$KEEP" = "true" ] && export INFINO_BENCH_KEEP_TABLE=1
+          # The multi-commit build holds many segment files + object-store
+          # connections open at once; raise the fd soft limit to the hard
+          # max so commits don't hit EMFILE ("too many open files").
+          ulimit -n "$(ulimit -Hn)"
+          echo "fd limit: $(ulimit -n)"
           BIN="$(cat "$HOME/bench-bin")"
           echo "===== SUPERTABLE BENCHMARK START ====="
           "$BIN" 2>&1


### PR DESCRIPTION
## Problem

A supertable benchmark run failed during commit:
```
commit: AppendFlush(Superfile(Io(Os { code: 24, kind: Uncategorized, message: "Too many open files" })))
```

The multi-commit build (16 commits × segments + concurrent object-store connections) holds many file descriptors open at once, exceeding the VM's default **1024** soft fd limit → `EMFILE`.

## Fix

Raise the soft fd limit to the session's hard max right before exec'ing the bench (in the run step):
```bash
ulimit -n "$(ulimit -Hn)"
echo "fd limit: $(ulimit -n)"
```
The bench binary is a child of this shell, so it inherits the raised limit. The `echo` logs the effective limit for visibility.

## Note

This raises the **soft** limit up to the existing **hard** limit (typically ≈524288–1048576 on Ubuntu 22.04 Azure images), which clears the EMFILE. If a future image shipped an unusually low *hard* limit, a privileged `prlimit` would be needed instead — the logged `fd limit:` line makes that immediately visible.

## Validation

`actionlint` clean. One-line operational change to the run step; no change to provisioning, build, or teardown.