### PR TITLE
benches: doc-count override is a plain integer, fix README example

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -38,8 +38,9 @@ cargo bench --bench superfile_fts
 cargo bench --bench superfile_vector
 cargo bench --bench supertable_all
 
-# Smaller local loop.
-INFINO_BENCH_SUPERFILE_DOCS=100K cargo bench --bench superfile_fts
+# Smaller local loop. Doc counts are plain integers (a `100K`/`1M`-style
+# suffix is not parsed and silently falls back to the default).
+INFINO_BENCH_SUPERFILE_DOCS=100000 cargo bench --bench superfile_fts
 
 # Override the N-writers build row.
 INFINO_BENCH_WRITERS=4 cargo bench --bench superfile_fts


### PR DESCRIPTION
## Context (re: #50)

Investigated running the superfile bench against real S3 from a laptop.

**Credentials already work.** Exporting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` works as expected — those env vars are honored already (via `AmazonS3Builder::from_env()`), no IMDS / instance IAM role required. So the original concern is a non-issue on current code.

**What actually bit me — two things, neither about credentials:**

1. **`INFINO_BENCH_SUPERFILE_DOCS=100K` as documented in the README is not honored.** The parser takes a plain integer, so a `100K` / `1M`-style suffix fails to parse and silently falls back to the default (1M) scale. This is what this PR fixes — the README example now uses a plain integer and notes the behavior.

2. **Laptop upload bandwidth hits the S3 PUT timeout for large doc counts.** The bench commits the superfile as a single `PutObject` with a 30s request timeout. From my laptop in India to a `us-east-1` bucket, even `INFINO_BENCH_SUPERFILE_DOCS=100000` timed out on the upload; `50000` passed. (The AWS CLI avoids this via multipart upload.) Not fixing that here — just the README for now.

The command that worked end-to-end:

```sh
INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=mkp-bucket-infino INFINO_BENCH_SUPERFILE_DOCS=50000 cargo bench --bench superfile_fts
```

## Change

Documentation only: `benches/README.md` — `INFINO_BENCH_SUPERFILE_DOCS=100K` → `=100000`, with a note that doc counts are plain integers and a suffix silently falls back to the default.

## Possible follow-ups (not in this PR)

- Multipart upload (or a longer/configurable request timeout) in the bench commit path so large superfiles upload over slow links.
- Optionally teach the doc-count parser to accept `K`/`M`/`G` suffixes instead of silently ignoring them.