### PR TITLE
benches/ci: configurable bench selection + unified doc-count env

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -1,13 +1,20 @@
-name: Supertable Benchmark (Azure)
+name: Benchmark (Azure)
 
-# Supertable ingest benchmark on a per-run ephemeral Azure VM in the
-# storage account's region (transfers ride the Azure backbone, not the
-# public internet). The VM builds with an sccache compile cache in Azure
-# Blob — shared across branches — runs the bench, and is torn down.
+# Runs a selected benchmark (`bench` input) on a per-run ephemeral Azure
+# VM in the storage account's region (transfers ride the Azure backbone,
+# not the public internet). The VM builds with an sccache compile cache
+# in Azure Blob — shared across branches — runs the bench, and is torn
+# down.
 
 on:
   workflow_dispatch:
     inputs:
+      bench:
+        description: "What to run."
+        required: false
+        default: supertable_all
+        type: choice
+        options: [supertable_all, fts, vector, combined, sql, all]
       docs:
         description: "Doc count (plain integer, NOT 1M/100K — those do not parse)"
         required: false
@@ -67,6 +74,23 @@ jobs:
     # Auto-stop ceiling on VM billing; teardown runs on timeout.
     timeout-minutes: ${{ fromJSON(github.event.inputs.timeout_minutes) }}
     steps:
+      - name: Resolve bench selection
+        id: resolve
+        run: |
+          set -euo pipefail
+          # Map the single `bench` input to the cargo target(s) to build
+          # and the supertable shape filter (empty = all three).
+          case "${{ github.event.inputs.bench }}" in
+            supertable_all)      targets="supertable_all";     shapes="" ;;
+            fts|vector|combined) targets="supertable_all";     shapes="${{ github.event.inputs.bench }}" ;;
+            sql)                 targets="sql";                shapes="" ;;
+            all)                 targets="supertable_all sql"; shapes="" ;;
+            *) echo "::error::unknown bench ${{ github.event.inputs.bench }}"; exit 1 ;;
+          esac
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          echo "shapes=$shapes"   >> "$GITHUB_OUTPUT"
+          echo "targets=[$targets] shapes=[$shapes]"
+
       - name: Azure login (OIDC)
         uses: azure/login@v2
         with:
@@ -177,6 +201,7 @@ jobs:
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
              INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
+             BENCH_TARGETS='${{ steps.resolve.outputs.targets }}' \
              bash -s" <<'REMOTE' 2>&1 | tee /tmp/build.log
           set -euo pipefail
           source "$HOME/.cargo/env"
@@ -193,16 +218,21 @@ jobs:
           export SCCACHE_AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=${AZURE_STORAGE_ACCOUNT_NAME};AccountKey=${AZURE_STORAGE_ACCOUNT_KEY};EndpointSuffix=core.windows.net"
           sccache --start-server || true
 
-          cargo bench --bench supertable_all --no-run
+          # Build each selected target and record "<target><TAB><binary>"
+          # so the run step execs each directly — no cargo at run time
+          # means no re-fingerprint / rebuild. Cargo underscores the
+          # artifact name, so a hyphenated target maps via ${t//-/_}.
+          : > "$HOME/bench-bins"
+          for t in $BENCH_TARGETS; do
+            cargo bench --bench "$t" --no-run
+            stem="${t//-/_}"
+            BIN="$(find target/release/deps -maxdepth 1 -type f -executable -name "${stem}-*" \
+                     -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2-)"
+            test -n "$BIN" && test -x "$BIN" || { echo "::error::binary for $t not found"; exit 1; }
+            printf '%s\t%s\n' "$t" "$BIN" >> "$HOME/bench-bins"
+            echo "built $t: $BIN"
+          done
           sccache --show-stats || true
-
-          # Record the built binary so the run step execs it directly —
-          # no cargo in the run step means no re-fingerprint / rebuild.
-          BIN="$(find target/release/deps -maxdepth 1 -type f -executable -name 'supertable_all-*' \
-                   -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2-)"
-          test -n "$BIN" && test -x "$BIN" || { echo "::error::bench binary not found"; exit 1; }
-          echo "$BIN" > "$HOME/bench-bin"
-          echo "bench binary: $BIN"
           REMOTE
 
       - name: Run benchmark (on VM)
@@ -213,7 +243,8 @@ jobs:
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
              INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
-             INFINO_BENCH_SUPERTABLE_DOCS='${{ github.event.inputs.docs }}' \
+             INFINO_BENCH_DOC_COUNT='${{ github.event.inputs.docs }}' \
+             BENCH_SHAPES='${{ steps.resolve.outputs.shapes }}' \
              KEEP='${{ github.event.inputs.keep_table }}' \
              bash -s" <<'REMOTE' 2>&1 | tee /tmp/bench.log
           set -euo pipefail
@@ -225,10 +256,16 @@ jobs:
           # max so commits don't hit EMFILE ("too many open files").
           ulimit -n "$(ulimit -Hn)"
           echo "fd limit: $(ulimit -n)"
-          BIN="$(cat "$HOME/bench-bin")"
-          echo "===== SUPERTABLE BENCHMARK START ====="
-          "$BIN" 2>&1
-          echo "===== SUPERTABLE BENCHMARK END ====="
+
+          # Exec each built target. The supertable target honours the
+          # shape filter; others ignore it.
+          while IFS=$'\t' read -r t BIN; do
+            [ "$t" = "supertable_all" ] && export INFINO_BENCH_SUPERTABLE_SHAPES="$BENCH_SHAPES"
+            echo "===== BENCH ${t} START ====="
+            "$BIN" 2>&1
+            echo "===== BENCH ${t} END ====="
+            unset INFINO_BENCH_SUPERTABLE_SHAPES
+          done < "$HOME/bench-bins"
           REMOTE
 
       - name: Summarize results
@@ -240,7 +277,7 @@ jobs:
           SUMMARY="$GITHUB_STEP_SUMMARY"
           LOG=/tmp/bench.clean
           {
-            echo "## Supertable benchmark — Azure (${{ github.event.inputs.location }})"
+            echo "## Benchmark \`${{ github.event.inputs.bench }}\` — Azure (${{ github.event.inputs.location }})"
             echo ""
             echo "- docs: \`${{ github.event.inputs.docs }}\` · vm: \`${{ github.event.inputs.vm_size }}\` · ref: \`${{ github.event.inputs.ref }}\`"
             echo ""

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bench:
 	cargo bench
 
 bench-quick:
-	INFINO_BENCH_SUPERFILE_DOCS=100000 cargo bench --bench superfile_fts
+	INFINO_BENCH_DOC_COUNT=100000 cargo bench --bench superfile_fts
 
 # Memory safety oracles for the FTS / format `unsafe` surface.
 # The remaining `unsafe` surface is one bumpalo lifetime

--- a/benches/README.md
+++ b/benches/README.md
@@ -23,10 +23,10 @@ second copy just to run correctness or object-store reads.
 ## Bench Shapes
 
 - **Superfile** — single-artifact, in-memory read path. Default scale: `1M`
-  docs, controlled by `INFINO_BENCH_SUPERFILE_DOCS`.
+  docs, controlled by `INFINO_BENCH_DOC_COUNT`.
 - **Supertable** — multi-artifact table committed to object storage and read
   through hot/cold table paths. Default scale: `10M` docs, controlled by
-  `INFINO_BENCH_SUPERTABLE_DOCS`.
+  `INFINO_BENCH_DOC_COUNT`.
 - **Writer count** — build rows report `1 writer` and `N writers`. `N` defaults
   to the machine's logical core count and is controlled by
   `INFINO_BENCH_WRITERS`.
@@ -40,7 +40,7 @@ cargo bench --bench supertable_all
 
 # Smaller local loop. Doc counts are plain integers (a `100K`/`1M`-style
 # suffix is not parsed and silently falls back to the default).
-INFINO_BENCH_SUPERFILE_DOCS=100000 cargo bench --bench superfile_fts
+INFINO_BENCH_DOC_COUNT=100000 cargo bench --bench superfile_fts
 
 # Override the N-writers build row.
 INFINO_BENCH_WRITERS=4 cargo bench --bench superfile_fts

--- a/benches/sql/main.rs
+++ b/benches/sql/main.rs
@@ -8,7 +8,7 @@
 //!
 //! ```text
 //! cargo bench --bench sql
-//! INFINO_BENCH_SUPERFILE_DOCS=100000 cargo bench --bench sql
+//! INFINO_BENCH_DOC_COUNT=100000 cargo bench --bench sql
 //! INFINO_BENCH_UPDATE_README=1 cargo bench --bench sql
 //! ```
 

--- a/benches/supertable/main.rs
+++ b/benches/supertable/main.rs
@@ -8,7 +8,7 @@
 //!
 //! ```text
 //! cargo bench --bench supertable_all
-//! INFINO_BENCH_SUPERTABLE_DOCS=100000 cargo bench --bench supertable_all
+//! INFINO_BENCH_DOC_COUNT=100000 cargo bench --bench supertable_all
 //! INFINO_BENCH_UPDATE_README=1 cargo bench --bench supertable_all
 //! ```
 

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -101,20 +101,16 @@ pub const SUPERFILE_DOCS: usize = 1_000_000;
 /// over the object store.
 pub const SUPERTABLE_DOCS: usize = 10_000_000;
 
-/// Document count for the **superfile** test — a single-segment index
-/// built and queried entirely **in memory**. Defaults to
-/// [`SUPERFILE_DOCS`] (1M); override with `INFINO_BENCH_SUPERFILE_DOCS`
-/// for a quicker local loop or a larger stress run.
+/// Superfile doc count — single-segment, in-memory. Default 1M; override
+/// with `INFINO_BENCH_DOC_COUNT`.
 pub fn superfile_docs() -> usize {
-    docs_from_env("INFINO_BENCH_SUPERFILE_DOCS", SUPERFILE_DOCS)
+    docs_from_env("INFINO_BENCH_DOC_COUNT", SUPERFILE_DOCS)
 }
 
-/// Document count for the **supertable** test — a multi-segment table
-/// committed to and queried from **object storage**. Defaults to
-/// [`SUPERTABLE_DOCS`] (10M); override with
-/// `INFINO_BENCH_SUPERTABLE_DOCS`.
+/// Supertable doc count — multi-segment, object storage. Default 10M;
+/// override with `INFINO_BENCH_DOC_COUNT`.
 pub fn supertable_docs() -> usize {
-    docs_from_env("INFINO_BENCH_SUPERTABLE_DOCS", SUPERTABLE_DOCS)
+    docs_from_env("INFINO_BENCH_DOC_COUNT", SUPERTABLE_DOCS)
 }
 
 /// Parse a positive doc-count override from `var`, falling back to

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -19,7 +19,7 @@ use crate::tiers;
 
 /// Supertable-shape document count — the supplied parameter. Default 10M
 /// ([`crate::corpus::supertable_docs`]); override with
-/// `INFINO_BENCH_SUPERTABLE_DOCS`.
+/// `INFINO_BENCH_DOC_COUNT`.
 pub fn n_docs() -> usize {
     corpus::supertable_docs()
 }

--- a/benches/utils/sql_bench.rs
+++ b/benches/utils/sql_bench.rs
@@ -14,7 +14,7 @@
 //!
 //! ```text
 //! cargo bench --bench sql
-//! INFINO_BENCH_SUPERFILE_DOCS=100000 cargo bench --bench sql
+//! INFINO_BENCH_DOC_COUNT=100000 cargo bench --bench sql
 //! INFINO_BENCH_UPDATE_README=1 cargo bench --bench sql
 //! ```
 

--- a/benches/utils/sql_diag.rs
+++ b/benches/utils/sql_diag.rs
@@ -41,7 +41,7 @@
 //!
 //! ```text
 //! cargo bench --bench sql-diag
-//! INFINO_BENCH_SUPERFILE_DOCS=1000000 cargo bench --bench sql-diag
+//! INFINO_BENCH_DOC_COUNT=1000000 cargo bench --bench sql-diag
 //! INFINO_SQL_DIAG_ITERS=20 cargo bench --bench sql-diag
 //! # delegate to the kernel-vs-query_sql TVF dispatch-tax diagnostic:
 //! INFINO_SQL_DIAG=tvf cargo bench --bench sql-diag
@@ -263,7 +263,7 @@ pub fn run() {
         .unwrap_or(15);
     eprintln!(
         "[sql-diag] scalar scan decomposition: n_docs={} iters={iters} \
-         (knobs: INFINO_BENCH_SUPERFILE_DOCS, INFINO_SQL_DIAG_ITERS)",
+         (knobs: INFINO_BENCH_DOC_COUNT, INFINO_SQL_DIAG_ITERS)",
         fmt_count(n)
     );
 

--- a/benches/utils/supertable_bench.rs
+++ b/benches/utils/supertable_bench.rs
@@ -4,11 +4,12 @@
 //! Supertable object-store bench (infino-only entry point).
 //!
 //! Multi-segment ingest to object storage at the supertable scale
-//! (`INFINO_BENCH_SUPERTABLE_DOCS`, default 10M), built through the
-//! production `SupertableWriter::append` + `commit` path. Three index
-//! shapes are measured for apples-to-apples comparison against
-//! single-modality peers: FTS-only, vector-only, and combined FTS +
-//! vector.
+//! (`INFINO_BENCH_DOC_COUNT`, default 10M), built through the production
+//! `SupertableWriter::append` + `commit` path. Three index shapes are
+//! measured for apples-to-apples comparison against single-modality
+//! peers: FTS-only, vector-only, and combined FTS + vector. Pick a
+//! subset with `INFINO_BENCH_SUPERTABLE_SHAPES` (e.g. `fts,vector`);
+//! unset builds all three.
 //!
 //! **Real object store only** (`INFINO_BENCH_STORE=s3` or `azure`). The
 //! multi-commit build relies on conditional `If-Match` PUTs that the
@@ -34,7 +35,8 @@
 //! INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket cargo bench --bench supertable_all
 //! INFINO_BENCH_STORE=azure INFINO_REAL_AZURE_CONTAINER=my-container \
 //!   AZURE_STORAGE_ACCOUNT_NAME=... AZURE_STORAGE_ACCOUNT_KEY=... cargo bench --bench supertable_all
-//! INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket INFINO_BENCH_SUPERTABLE_DOCS=100000 cargo bench --bench supertable_all
+//! INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket INFINO_BENCH_DOC_COUNT=100000 cargo bench --bench supertable_all
+//! INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket INFINO_BENCH_SUPERTABLE_SHAPES=vector cargo bench --bench supertable_all
 //! ```
 
 use std::process::{Command, Stdio};
@@ -116,6 +118,37 @@ fn modality_for_key(key: &str) -> Option<Modality> {
         .iter()
         .find(|(_, k, _)| *k == key)
         .map(|(_, _, m)| *m)
+}
+
+/// `(label, key)` of the shapes to build, in `SHAPES` order. Reads
+/// `INFINO_BENCH_SUPERTABLE_SHAPES` (e.g. `fts,vector`); unset selects
+/// all. An unknown key exits — silently running the wrong subset would
+/// waste a full run.
+fn selected_shapes() -> Vec<(&'static str, &'static str)> {
+    let requested = match std::env::var("INFINO_BENCH_SUPERTABLE_SHAPES") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => return SHAPES.iter().map(|(l, k, _)| (*l, *k)).collect(),
+    };
+    let keys: Vec<&str> = requested
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect();
+    for key in &keys {
+        if !SHAPES.iter().any(|(_, k, _)| k == key) {
+            let valid: Vec<&str> = SHAPES.iter().map(|(_, k, _)| *k).collect();
+            eprintln!(
+                "[supertable] unknown shape {key:?}; valid: {}",
+                valid.join(", ")
+            );
+            std::process::exit(2);
+        }
+    }
+    SHAPES
+        .iter()
+        .filter(|(_, k, _)| keys.contains(k))
+        .map(|(l, k, _)| (*l, *k))
+        .collect()
 }
 
 /// Child entry point: build exactly one shape, sample its RSS in this
@@ -225,18 +258,21 @@ pub fn run() {
         return;
     }
 
-    // Parent mode: build each shape in its own isolated subprocess so the
-    // per-shape RSS numbers are independent (see the module docs).
+    // Parent mode: build each selected shape in its own isolated
+    // subprocess so the per-shape RSS numbers are independent (see the
+    // module docs).
+    let shapes = selected_shapes();
     let n_docs = supertable::n_docs();
     eprintln!(
         "[supertable] ingesting {} docs ({} commits) per shape to object storage, \
-         one isolated process per shape...",
+         one isolated process per shape ({} shape(s) selected)...",
         fmt_count(n_docs),
-        supertable::N_COMMIT_CHUNKS
+        supertable::N_COMMIT_CHUNKS,
+        shapes.len()
     );
 
-    let mut rows: Vec<Vec<Cell>> = Vec::with_capacity(SHAPES.len());
-    for (label, key, _) in SHAPES {
+    let mut rows: Vec<Vec<Cell>> = Vec::with_capacity(shapes.len());
+    for (label, key) in shapes {
         eprintln!("[supertable] === shape {label} (isolated process) ===");
         if let Some(metrics) = build_shape_isolated(key) {
             rows.push(ingest_row(n_docs, label, &metrics));


### PR DESCRIPTION
Make the Azure bench workflow drive *which* benchmark runs, and let `supertable_all` build a subset of its index shapes. Follows #62/#65/#66 (the dispatch workflow).

## Why

Two points of tight coupling:
- The workflow was wired to one hardcoded target (`supertable_all`); the `sql` target existed but was unreachable.
- `supertable_all` always built all three shapes (fts/vector/combined) — no way to pick one.

Plus an env foot-gun: two doc-count vars (`INFINO_BENCH_SUPERFILE_DOCS` / `INFINO_BENCH_SUPERTABLE_DOCS`) — setting the wrong one silently ran the default scale.

## What

**Workflow** — new `bench` choice input → `supertable_all` (default) / `fts` / `vector` / `combined` / `sql` / `all`. A `Resolve` step maps it to the cargo target(s) to build and the shape filter (step outputs, not ambient env). Build/run loop the resolved targets; binary glob is `${t//-/_}-*` (cargo underscores artifact names). Summary header + workflow name generalized.

**Rust**
- `supertable_all` honours `INFINO_BENCH_SUPERTABLE_SHAPES` (e.g. `fts,vector`) to build a subset; canonical `SHAPES` order, free dedup, unknown key fails fast. Internal per-shape child dispatch unchanged.
- Unify the two doc-count overrides into one `INFINO_BENCH_DOC_COUNT`; per-bench defaults (1M superfile / 10M supertable) unchanged. Repo-wide rename incl. Makefile + README + module docs.

## Validation

`cargo fmt --check`, `clippy --benches`, and `cargo bench --no-run` (supertable_all + sql) all clean. `actionlint` clean.

End-to-end on real Azure (the in-region VM workflow):
- `bench=sql docs=1000` → resolved `targets=[sql]`, built `sql-…`, `INFINO_BENCH_DOC_COUNT=1000` honoured (`generating 1K-row corpus`), both SQL report banners rendered + parsed into the summary.
- `bench=supertable_all` (full 10M) → ran, summarized, torn down.

## Notes

- The `bench=all` option runs supertable + sql sequentially on one VM under one timeout — bump `timeout_minutes` for it.
- No behaviour change to the default dispatch (`supertable_all`, all shapes).
