### PR TITLE
ci: run the bench group on every PR (informational)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,32 @@ jobs:
             cargo install cargo-llvm-cov --locked
           fi
       - run: make ci
+
+  # Informational benchmark on each PR push — supertable_all + sql, one
+  # in-region Azure VM each, in parallel. Never blocks merge. Same-repo
+  # only (fork PRs can't use the Azure OIDC secrets).
+  bench:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    strategy:
+      fail-fast: false   # one member failing must not cancel the other
+      matrix:
+        include:
+          - { bench: supertable_all, docs: "10000000" }
+          - { bench: sql, docs: "1000000" }
+    # A new push cancels this PR's in-flight run for that member.
+    concurrency:
+      group: bench-${{ github.event.pull_request.number }}-${{ matrix.bench }}
+      cancel-in-progress: true
+    permissions:
+      id-token: write
+      contents: read
+    # Informational: keep these checks out of branch-protection's required
+    # set so a red bench never blocks merge.
+    uses: ./.github/workflows/supertable-bench-azure.yml
+    with:
+      bench: ${{ matrix.bench }}
+      docs: ${{ matrix.docs }}
+      ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,11 @@ jobs:
     strategy:
       fail-fast: false   # one member failing must not cancel the other
       matrix:
+        # `suffix` makes each leg's Azure resources unique — both legs
+        # share one run_id, so without it they'd collide / cross-delete.
         include:
-          - { bench: supertable_all, docs: "10000000" }
-          - { bench: sql, docs: "1000000" }
+          - { bench: supertable_all, docs: "10000000", suffix: st }
+          - { bench: sql, docs: "1000000", suffix: sql }
     # A new push cancels this PR's in-flight run for that member.
     concurrency:
       group: bench-${{ github.event.pull_request.number }}-${{ matrix.bench }}
@@ -73,4 +75,5 @@ jobs:
       bench: ${{ matrix.bench }}
       docs: ${{ matrix.docs }}
       ref: ${{ github.event.pull_request.head.sha }}
+      name_suffix: -${{ matrix.suffix }}
     secrets: inherit

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -45,15 +45,24 @@ on:
         required: false
         default: "30"
         type: string
+  # Callable from other workflows (e.g. the PR group in ci.yml). Same
+  # inputs; `choice` isn't valid here so `bench` is a string.
+  workflow_call:
+    inputs:
+      bench:           { type: string, required: false, default: supertable_all }
+      docs:            { type: string, required: false, default: "1000000" }
+      vm_size:         { type: string, required: false, default: "Standard_D8s_v7" }
+      location:        { type: string, required: false, default: eastus }
+      ref:             { type: string, required: false, default: main }
+      keep_table:      { type: boolean, required: false, default: false }
+      timeout_minutes: { type: string, required: false, default: "30" }
 
 permissions:
   id-token: write   # Azure OIDC federated login
   contents: read    # clone the repo on the VM via the job token
 
-# One benchmark at a time; queued, never cancelled mid-run.
-concurrency:
-  group: supertable-bench-azure
-  cancel-in-progress: false
+# Concurrency is owned by the caller (per-PR cancel in ci.yml); a manual
+# dispatch needs none — runs are isolated by run_id and self-clean.
 
 env:
   # Pre-existing RG the bench service principal is scoped to (Contributor
@@ -72,7 +81,7 @@ jobs:
     # credential authorizes runs from any branch.
     environment: ci
     # Auto-stop ceiling on VM billing; teardown runs on timeout.
-    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout_minutes) }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     steps:
       - name: Resolve bench selection
         id: resolve
@@ -80,12 +89,12 @@ jobs:
           set -euo pipefail
           # Map the single `bench` input to the cargo target(s) to build
           # and the supertable shape filter (empty = all three).
-          case "${{ github.event.inputs.bench }}" in
+          case "${{ inputs.bench }}" in
             supertable_all)      targets="supertable_all";     shapes="" ;;
-            fts|vector|combined) targets="supertable_all";     shapes="${{ github.event.inputs.bench }}" ;;
+            fts|vector|combined) targets="supertable_all";     shapes="${{ inputs.bench }}" ;;
             sql)                 targets="sql";                shapes="" ;;
             all)                 targets="supertable_all sql"; shapes="" ;;
-            *) echo "::error::unknown bench ${{ github.event.inputs.bench }}"; exit 1 ;;
+            *) echo "::error::unknown bench ${{ inputs.bench }}"; exit 1 ;;
           esac
           echo "targets=$targets" >> "$GITHUB_OUTPUT"
           echo "shapes=$shapes"   >> "$GITHUB_OUTPUT"
@@ -102,11 +111,11 @@ jobs:
         id: provision
         run: |
           set -euo pipefail
-          LOC="${{ github.event.inputs.location }}"
-          SIZE="${{ github.event.inputs.vm_size }}"
+          LOC="${{ inputs.location }}"
+          SIZE="${{ inputs.vm_size }}"
 
           # Tag the VM so Cost Management attributes spend by purpose / run.
-          TAGS=(purpose=supertable-bench "run-id=${{ github.run_id }}" "ref=${{ github.event.inputs.ref }}")
+          TAGS=(purpose=supertable-bench "run-id=${{ github.run_id }}" "ref=${{ inputs.ref }}")
 
           # Every resource is named with the unique per-run VM name so
           # teardown can delete this run's resources by exact name (never
@@ -162,7 +171,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
             "GH_TOKEN='${{ github.token }}' \
              REPO='${{ github.repository }}' \
-             REF='${{ github.event.inputs.ref }}' \
+             REF='${{ inputs.ref }}' \
              SCCACHE_VERSION='${{ env.SCCACHE_VERSION }}' \
              bash -s" <<'REMOTE'
           set -euo pipefail
@@ -243,9 +252,9 @@ jobs:
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
              INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
-             INFINO_BENCH_DOC_COUNT='${{ github.event.inputs.docs }}' \
+             INFINO_BENCH_DOC_COUNT='${{ inputs.docs }}' \
              BENCH_SHAPES='${{ steps.resolve.outputs.shapes }}' \
-             KEEP='${{ github.event.inputs.keep_table }}' \
+             KEEP='${{ inputs.keep_table }}' \
              bash -s" <<'REMOTE' 2>&1 | tee /tmp/bench.log
           set -euo pipefail
           cd "$HOME/infino-src"
@@ -277,9 +286,9 @@ jobs:
           SUMMARY="$GITHUB_STEP_SUMMARY"
           LOG=/tmp/bench.clean
           {
-            echo "## Benchmark \`${{ github.event.inputs.bench }}\` — Azure (${{ github.event.inputs.location }})"
+            echo "## Benchmark \`${{ inputs.bench }}\` — Azure (${{ inputs.location }})"
             echo ""
-            echo "- docs: \`${{ github.event.inputs.docs }}\` · vm: \`${{ github.event.inputs.vm_size }}\` · ref: \`${{ github.event.inputs.ref }}\`"
+            echo "- docs: \`${{ inputs.docs }}\` · vm: \`${{ inputs.vm_size }}\` · ref: \`${{ inputs.ref }}\`"
             echo ""
           } >> "$SUMMARY"
 

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -56,6 +56,9 @@ on:
       ref:             { type: string, required: false, default: main }
       keep_table:      { type: boolean, required: false, default: false }
       timeout_minutes: { type: string, required: false, default: "30" }
+      # Discriminator appended to resource names so parallel callers
+      # (e.g. matrix legs sharing one run_id) don't collide / cross-delete.
+      name_suffix:     { type: string, required: false, default: "" }
 
 permissions:
   id-token: write   # Azure OIDC federated login
@@ -69,7 +72,9 @@ env:
   # on this RG only). The workflow creates per-run resources inside it,
   # never the RG itself.
   RG: rg-infino-bench
-  VM: bench-vm-${{ github.run_id }}
+  # Unique per run; `name_suffix` keeps parallel callers that share a
+  # run_id (matrix legs) from colliding on the same VM.
+  VM: bench-vm-${{ github.run_id }}${{ inputs.name_suffix }}
   ADMIN: azureuser
   SCCACHE_VERSION: v0.8.2
 


### PR DESCRIPTION
Adds an **informational** benchmark to CI that runs on every PR push — `supertable_all` (10M) and `sql` (1M), one in-region Azure VM each, in parallel. Builds on the dispatch workflow (#62/#65/#66) and configurable selection (#69).

## What

**`ci.yml`** — new `bench` job beside `check`:
- **matrix** over `{supertable_all: 10M, sql: 1M}` → two reusable-workflow callers, parallel (own VM each).
- **`concurrency: bench-<pr>-${{ matrix.bench }}` + `cancel-in-progress`** → a new push stops this PR's in-flight run per member; members independent.
- **`fail-fast: false`** → one member failing doesn't cancel the other.
- **same-repo `if`** → fork PRs skip (they can't use the Azure OIDC secrets).
- per-job `permissions` (`id-token`/`contents`) so `check` stays least-privilege; `secrets: inherit`.

**`supertable-bench-azure.yml`** — made callable:
- added a `workflow_call` trigger mirroring the dispatch inputs (`bench` is `string` — `choice` is dispatch-only).
- switched every reference to the `inputs` context (populated for both `workflow_dispatch` and `workflow_call`) — one code path.
- removed the global `concurrency`; the caller owns it now (a manual dispatch needs none — runs are run_id-isolated and self-clean).

## Informational, by design

These checks (`bench (supertable_all)`, `bench (sql)`) must be left **out of branch-protection's required set** — that's the lever that keeps a red bench from blocking merge (`continue-on-error` is invalid on a `uses:` job). Results land in each run's step summary + the uploaded log artifact.

## Notes / follow-ups (kept out to stay simple)

- No sticky PR comment, no `RUN_PR_BENCH` kill-switch — easy to add later.
- Cost: two VMs per push (10M + 1M). Bounded by per-member cancel-in-progress, guaranteed teardown, and the per-run timeout.
- `sql` is in-memory and doesn't need Azure; it provisions a VM here for uniformity. A cheaper hosted-runner path for it is a possible follow-up.

## Validation

`actionlint` clean on both workflows. The reusable workflow's dispatch + the configurable selection were already validated end-to-end on real Azure (sql 1k, supertable 10M) in #69. First merge keeps `bench` non-required until the PR-trigger + reusable-call path is confirmed green on a live PR.
