### PR TITLE
ci: drop inter-bench noise from the benchmark result summary

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -296,13 +296,16 @@ jobs:
           fi
 
           # The report banner ("══ … ══") and table are present only when
-          # at least one shape succeeded.
+          # at least one shape succeeded. Capture from the first banner to
+          # the end, then drop the inter-bench noise that falls between
+          # report tables: the run-step "===== …" markers and the benches'
+          # "[tag] …" progress lines. Report rows never start that way.
           if grep -q '══' "$LOG"; then
             REPORT_OK=1
             {
               echo "### Results"
               echo '```'
-              awk '/══/{f=1} f' "$LOG"
+              awk '/══/{f=1} f' "$LOG" | grep -vE '^=====|^\[[a-z][a-z_]*\]'
               echo '```'
             } >> "$SUMMARY"
           else


### PR DESCRIPTION
The benchmark result summary captured everything from the first report banner to end-of-output. For a multi-target run (`bench=all`) that swept up the run-step `===== BENCH … =====` markers and the benches' `[sql]/[supertable]/[tiers] …` progress lines that sit *between* the report tables — visible garbage in the summary.

## Fix

One-line filter in the Results block:
```diff
- awk '/══/{f=1} f' "$LOG"
+ awk '/══/{f=1} f' "$LOG" | grep -vE '^=====|^\[[a-z][a-z_]*\]'
```
Drops lines starting with `=====` (markers) or `[<lowercase-tag>]` (progress). Report rows begin with `══`, `Host:`, `|`, or a capitalized subtitle — never that way — so every banner and table row is preserved. The raw `supertable-bench-log` artifact still carries the full output.

## Validation

`actionlint` clean. Tested the exact pipeline against the real logs of three runs:
- `bench=all` → removed both `===== BENCH …` markers + 8 `[sql] …` lines; all three report sections (Supertable / SQL ingest / SQL query) intact.
- `bench=sql` (1k) and `bench=supertable_all` (10M) → removed only a trailing `===== … END =====`; tables untouched.

Sanity-grepped each: no `|` table row or `══` banner ever dropped.