### PR TITLE
ci(bench): compare PR benchmarks against main + track history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,13 @@ jobs:
           fi
       - run: make ci
 
-  # Informational benchmark on each PR push — supertable_all + sql, one
-  # in-region Azure VM each, in parallel. Never blocks merge. Same-repo
-  # only (fork PRs can't use the Azure OIDC secrets).
+  # Informational benchmark — supertable_all + sql, one in-region Azure VM
+  # each, in parallel. Never blocks merge. On a PR: diff vs main's baseline.
+  # On merge to main: publish the run as that baseline + a per-commit history
+  # point. Same-repo only (fork PRs can't use the Azure OIDC secrets).
   bench:
     if: >-
-      github.event_name == 'pull_request' &&
+      github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false   # one member failing must not cancel the other
@@ -61,10 +62,11 @@ jobs:
         include:
           - { bench: supertable_all, docs: "10000000", suffix: st }
           - { bench: sql, docs: "1000000", suffix: sql }
-    # A new push cancels this PR's in-flight run for that member.
+    # PR: a new push cancels the in-flight run. main: serialize per bench so
+    # concurrent merges don't race the baseline blob (never cancel).
     concurrency:
-      group: bench-${{ github.event.pull_request.number }}-${{ matrix.bench }}
-      cancel-in-progress: true
+      group: bench-${{ github.event_name == 'push' && 'main' || github.event.pull_request.number }}-${{ matrix.bench }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     permissions:
       id-token: write
       contents: read
@@ -74,6 +76,7 @@ jobs:
     with:
       bench: ${{ matrix.bench }}
       docs: ${{ matrix.docs }}
-      ref: ${{ github.event.pull_request.head.sha }}
+      ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
       name_suffix: -${{ matrix.suffix }}
+      update_baseline: ${{ github.event_name == 'push' }}
     secrets: inherit

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: "30"
         type: string
+      update_baseline:
+        description: "Publish this run as the main baseline + history (main only)."
+        required: false
+        default: false
+        type: boolean
   # Callable from other workflows (e.g. the PR group in ci.yml). Same
   # inputs; `choice` isn't valid here so `bench` is a string.
   workflow_call:
@@ -59,6 +64,9 @@ on:
       # Discriminator appended to resource names so parallel callers
       # (e.g. matrix legs sharing one run_id) don't collide / cross-delete.
       name_suffix:     { type: string, required: false, default: "" }
+      # On main: publish the run as the baseline pointer + per-commit
+      # history. On a PR: false — restore main's baseline and diff against it.
+      update_baseline: { type: boolean, required: false, default: false }
 
 permissions:
   id-token: write   # Azure OIDC federated login
@@ -249,6 +257,43 @@ jobs:
           sccache --show-stats || true
           REMOTE
 
+      # Seed the report's baseline with main's metrics so the run renders
+      # deltas (vs main) instead of "(new)". Skipped on baseline runs, which
+      # want a clean baseline. Best-effort: no blob = first run = "(new)".
+      - name: Restore baseline (diff vs latest main)
+        if: ${{ !inputs.update_baseline }}
+        env:
+          ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
+          CONTAINER: ${{ secrets.INFINO_REAL_AZURE_CONTAINER }}
+          VM_SIZE: ${{ inputs.vm_size }}
+          DOCS: ${{ inputs.docs }}
+          TARGETS: ${{ steps.resolve.outputs.targets }}
+        run: |
+          set -euo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          # supertable_all's report is named "supertable"; others match.
+          jname() { case "$1" in supertable_all) echo supertable ;; *) echo "$1" ;; esac; }
+          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
+            "mkdir -p infino-src/target/infino-bench"
+          for t in $TARGETS; do
+            j="$(jname "$t")"
+            blob="bench/${j}/baseline/${VM_SIZE}-${DOCS}.json"
+            if az storage blob download --account-name "$ACC" --account-key "$KEY" \
+                 -c "$CONTAINER" -n "$blob" -f "${j}.json" 2>/dev/null; then
+              # Best-effort: a transient scp flake must not fail the bench —
+              # the run just renders "(new)" without the baseline.
+              if scp -o StrictHostKeyChecking=no "${j}.json" \
+                   "${ADMIN}@${VM_IP}:infino-src/target/infino-bench/${j}.json"; then
+                echo "baseline restored: $j"
+              else
+                echo "::warning::scp failed for $j — running without baseline"
+              fi
+            else
+              echo "no baseline for $j — first run, all (new)"
+            fi
+          done
+
       - name: Run benchmark (on VM)
         run: |
           set -euo pipefail
@@ -281,6 +326,46 @@ jobs:
             unset INFINO_BENCH_SUPERTABLE_SHAPES
           done < "$HOME/bench-bins"
           REMOTE
+
+      # Main only: publish the metrics as the latest-main pointer (overwritten,
+      # what PRs diff against) and an immutable per-commit history blob (the
+      # trend). Runs only on a successful bench, so a broken run never
+      # poisons the baseline.
+      - name: Publish baseline + history (main only)
+        # success() is implicit, but explicit here: never publish from a
+        # failed/partial bench run.
+        if: ${{ inputs.update_baseline && success() }}
+        env:
+          ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
+          CONTAINER: ${{ secrets.INFINO_REAL_AZURE_CONTAINER }}
+          VM_SIZE: ${{ inputs.vm_size }}
+          DOCS: ${{ inputs.docs }}
+          TARGETS: ${{ steps.resolve.outputs.targets }}
+        run: |
+          set -euo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          jname() { case "$1" in supertable_all) echo supertable ;; *) echo "$1" ;; esac; }
+          # Commit identity from the VM checkout: sha keys the history blob,
+          # commit time (unix s) rides as metadata for chronological sorting.
+          meta="$(ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
+            'cd infino-src && git rev-parse --short HEAD && git show -s --format=%ct HEAD')"
+          SHA="$(echo "$meta" | sed -n 1p)"
+          TS="$(echo "$meta" | sed -n 2p)"
+          for t in $TARGETS; do
+            j="$(jname "$t")"
+            scp -o StrictHostKeyChecking=no \
+              "${ADMIN}@${VM_IP}:infino-src/target/infino-bench/${j}.json" "${j}.json" \
+              || { echo "::warning::no metrics for $j — skipping"; continue; }
+            az storage blob upload --overwrite --account-name "$ACC" --account-key "$KEY" \
+              -c "$CONTAINER" -n "bench/${j}/baseline/${VM_SIZE}-${DOCS}.json" -f "${j}.json"
+            # No --overwrite: a commit's record is immutable once written.
+            az storage blob upload --account-name "$ACC" --account-key "$KEY" \
+              -c "$CONTAINER" -n "bench/${j}/history/${VM_SIZE}-${DOCS}-${SHA}.json" \
+              -f "${j}.json" --metadata "sha=${SHA}" "ts=${TS}" "ref=main" \
+              || echo "::notice::history for ${SHA} already exists"
+            echo "published: $j ($SHA)"
+          done
 
       - name: Summarize results
         if: always()

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -357,13 +357,25 @@ jobs:
             scp -o StrictHostKeyChecking=no \
               "${ADMIN}@${VM_IP}:infino-src/target/infino-bench/${j}.json" "${j}.json" \
               || { echo "::warning::no metrics for $j — skipping"; continue; }
+
+            # Informational: warn on a real az failure rather than failing the
+            # whole run (az already retries transient storage errors itself).
             az storage blob upload --overwrite --account-name "$ACC" --account-key "$KEY" \
-              -c "$CONTAINER" -n "bench/${j}/baseline/${VM_SIZE}-${DOCS}.json" -f "${j}.json"
-            # No --overwrite: a commit's record is immutable once written.
-            az storage blob upload --account-name "$ACC" --account-key "$KEY" \
-              -c "$CONTAINER" -n "bench/${j}/history/${VM_SIZE}-${DOCS}-${SHA}.json" \
-              -f "${j}.json" --metadata "sha=${SHA}" "ts=${TS}" "ref=main" \
-              || echo "::notice::history for ${SHA} already exists"
+              -c "$CONTAINER" -n "bench/${j}/baseline/${VM_SIZE}-${DOCS}.json" -f "${j}.json" \
+              || { echo "::warning::baseline upload failed for $j — skipping"; continue; }
+
+            # History is immutable per commit. Check existence explicitly so a
+            # genuine az error isn't silently mistaken for "already written".
+            hist="bench/${j}/history/${VM_SIZE}-${DOCS}-${SHA}.json"
+            if [ "$(az storage blob exists --account-name "$ACC" --account-key "$KEY" \
+                      -c "$CONTAINER" -n "$hist" --query exists -o tsv 2>/dev/null)" = "true" ]; then
+              echo "::notice::history for $j ($SHA) already exists — skipping"
+            else
+              az storage blob upload --account-name "$ACC" --account-key "$KEY" \
+                -c "$CONTAINER" -n "$hist" -f "${j}.json" \
+                --metadata "sha=${SHA}" "ts=${TS}" "ref=main" \
+                || echo "::warning::history upload failed for $j ($SHA)"
+            fi
             echo "published: $j ($SHA)"
           done
 


### PR DESCRIPTION
## Goal

Make the informational PR benchmark show **how this PR moved performance vs `main`** instead of `(new)` on every cell — and keep a per-commit **history of main** so we can see the trend over time.

## What changes

Two workflow files; **no Rust change** — the report already computes per-cell deltas from a baseline JSON, it was just never fed main's numbers.

- **PR run** → downloads main's metrics from Azure Blob into the report's baseline path, so the run renders `+x% better / -y% worse` vs main.
- **Merge to main** → publishes the run as:
  - `bench/<bench>/baseline/<vm>-<docs>.json` — mutable "latest main" pointer (what PRs diff against),
  - `bench/<bench>/history/<vm>-<docs>-<sha>.json` — immutable per-commit record (sha-keyed filename, commit-time in blob metadata) = the trend.
- One `bench` job handles both, switching on `github.event_name` (PR diffs, push publishes).

## Behavior

| Event | Result |
| --- | --- |
| push to `main` | bench → publish baseline + history |
| PR → `main` (same repo) | restore main baseline → bench → diff, no publish |
| PR from a fork | skipped (no OIDC) |
| push to any other branch | nothing (workflow only triggers on `main`) |

Still informational and out of the required-checks set — a red bench never blocks merge.

## Reviewer notes

- **Verified against real Blob** locally (mimicking the workflow's `az` calls, namespaced + cleaned up): publish, list-with-metadata, **immutability** (same-sha re-upload is blocked, no `--overwrite`), and a byte-identical restore round-trip.
- **Apples-to-apples**: baseline keyed by `vm_size` + `docs`; a shape/doc-count mismatch falls back to `(new)`, never a false delta.
- **Safety**: publish is gated on `success()` — a failed/partial run never publishes. Restore is best-effort — a transient `scp` flake warns and continues rather than failing the PR bench.
- **Deltas are informational**: shared-tenant VM jitter means treat <~5–10% as noise.
- **Accepted trade-offs**: (1) benches now also run on every merge to `main` (the baseline producer — 2 VMs/merge, serialized per bench); (2) rapid back-to-back merges can skip a history point for the superseded middle commit (`cancel-in-progress: false` keeps one running + one pending).

## Testing

Local round-trip of the blob logic confirmed end-to-end (publish → list → immutability → restore → delta render). Full VM path validates on this PR's own bench run.
