### PR TITLE
ci(bench): plot P90 RSS trend over last 10 main commits

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -379,6 +379,66 @@ jobs:
             echo "published: $j ($SHA)"
           done
 
+      # Plot P90 RSS over the last (≤10) main commits as Mermaid line charts in
+      # the run summary. Informational: a fetch hiccup drops a point, never fails.
+      - name: Trend (main only)
+        if: ${{ inputs.update_baseline && success() }}
+        env:
+          ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
+          CONTAINER: ${{ secrets.INFINO_REAL_AZURE_CONTAINER }}
+          VM_SIZE: ${{ inputs.vm_size }}
+          DOCS: ${{ inputs.docs }}
+          TARGETS: ${{ steps.resolve.outputs.targets }}
+        run: |
+          set -uo pipefail
+          SUMMARY="$GITHUB_STEP_SUMMARY"
+          jname() { case "$1" in supertable_all) echo supertable ;; *) echo "$1" ;; esac; }
+
+          # Headline series: "<bench-json>\t<P90-RSS-metric-key>\t<title>".
+          SERIES=$'sql\tbench/sql/build||1 writer|P90 RSS\tSQL 1-writer build — P90 RSS
+          sql\tbench/sql/query|Search table functions (bm25 / vector / hybrid / token / exact)|bm25_search|P90 RSS\tSQL bm25_search — P90 RSS
+          supertable\tbench/supertable/ingest||combined FTS + vector|P90 RSS\tSupertable ingest — P90 RSS'
+
+          built=""; for t in $TARGETS; do built="$built $(jname "$t")"; done
+          echo "## Trend — P90 RSS (last 10 main commits)" >> "$SUMMARY"
+
+          while IFS=$'\t' read -r jb key title; do
+            jb="${jb#"${jb%%[![:space:]]*}"}"   # strip leading indent from heredoc
+            case " $built " in *" $jb "*) ;; *) continue ;; esac
+
+            rows="$(az storage blob list -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
+                      --prefix "bench/${jb}/history/${VM_SIZE}-${DOCS}-" --include m \
+                      --query "[].{n:name, ts:metadata.ts, sha:metadata.sha}" -o tsv 2>/dev/null \
+                    | sort -k2 -n | tail -10)"
+
+            labels=(); values=(); n=0
+            while IFS=$'\t' read -r name ts sha; do
+              [ -n "$name" ] || continue
+              az storage blob download -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
+                -n "$name" -f /tmp/h.json -o none 2>/dev/null || continue
+              v="$(jq -r --arg k "$key" '.[$k] // empty' /tmp/h.json)"
+              [ -n "$v" ] || continue
+              labels+=("${sha:0:7}")
+              values+=("$(awk -v b="$v" 'BEGIN{printf "%.0f", b/1048576}')")
+              n=$((n+1))
+            done <<< "$rows"
+
+            if [ "$n" -lt 2 ]; then
+              echo "_${title}: ${n} data point(s) — need ≥2 to chart._" >> "$SUMMARY"
+              continue
+            fi
+            {
+              echo '```mermaid'
+              echo 'xychart-beta'
+              echo "    title \"${title} (MiB)\""
+              printf '    x-axis [%s]\n' "$(IFS=,; echo "${labels[*]}")"
+              echo '    y-axis "MiB"'
+              printf '    line [%s]\n' "$(IFS=,; echo "${values[*]}")"
+              echo '```'
+            } >> "$SUMMARY"
+          done <<< "$SERIES"
+
       - name: Summarize results
         if: always()
         run: |

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -260,7 +260,7 @@ jobs:
       # Seed the report's baseline with main's metrics so the run renders
       # deltas (vs main) instead of "(new)". Skipped on baseline runs, which
       # want a clean baseline. Best-effort: no blob = first run = "(new)".
-      - name: Restore baseline (diff vs latest main)
+      - name: Restore main baseline
         if: ${{ !inputs.update_baseline }}
         env:
           ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
@@ -327,11 +327,10 @@ jobs:
           done < "$HOME/bench-bins"
           REMOTE
 
-      # Main only: publish the metrics as the latest-main pointer (overwritten,
-      # what PRs diff against) and an immutable per-commit history blob (the
-      # trend). Runs only on a successful bench, so a broken run never
-      # poisons the baseline.
-      - name: Publish baseline + history (main only)
+      # Publish the metrics as the latest-main pointer (overwritten, what PRs
+      # diff against) and an immutable per-commit history blob (the trend).
+      # Runs only on a successful bench, so a broken run never poisons it.
+      - name: Publish baseline + history
         # success() is implicit, but explicit here: never publish from a
         # failed/partial bench run.
         if: ${{ inputs.update_baseline && success() }}
@@ -381,7 +380,7 @@ jobs:
 
       # Plot P90 RSS over the last (≤10) main commits as Mermaid line charts in
       # the run summary. Informational: a fetch hiccup drops a point, never fails.
-      - name: Trend (main only)
+      - name: Render P90 RSS trend chart
         if: ${{ inputs.update_baseline && success() }}
         env:
           ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
@@ -403,7 +402,9 @@ jobs:
           built=""; for t in $TARGETS; do built="$built $(jname "$t")"; done
           echo "## Trend — P90 RSS (last 10 main commits)" >> "$SUMMARY"
 
-          while IFS=$'\t' read -r jb key title; do
+          # Loops read on dedicated FDs (3, 4) so the az calls in the body —
+          # which read stdin — can't consume the loop input.
+          while IFS=$'\t' read -r -u 3 jb key title; do
             jb="${jb#"${jb%%[![:space:]]*}"}"   # strip leading indent from heredoc
             case " $built " in *" $jb "*) ;; *) continue ;; esac
 
@@ -413,7 +414,7 @@ jobs:
                     | sort -k2 -n | tail -10)"
 
             labels=(); values=(); n=0
-            while IFS=$'\t' read -r name ts sha; do
+            while IFS=$'\t' read -r -u 4 name ts sha; do
               [ -n "$name" ] || continue
               az storage blob download -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
                 -n "$name" -f /tmp/h.json -o none 2>/dev/null || continue
@@ -422,7 +423,7 @@ jobs:
               labels+=("${sha:0:7}")
               values+=("$(awk -v b="$v" 'BEGIN{printf "%.0f", b/1048576}')")
               n=$((n+1))
-            done <<< "$rows"
+            done 4<<< "$rows"
 
             if [ "$n" -lt 2 ]; then
               echo "_${title}: ${n} data point(s) — need ≥2 to chart._" >> "$SUMMARY"
@@ -437,7 +438,7 @@ jobs:
               printf '    line [%s]\n' "$(IFS=,; echo "${values[*]}")"
               echo '```'
             } >> "$SUMMARY"
-          done <<< "$SERIES"
+          done 3<<< "$SERIES"
 
       - name: Summarize results
         if: always()


### PR DESCRIPTION
## Goal

Show a graphical **P90 RSS trend over the last (≤10) main commits** in the bench run summary, using the per-commit history blobs the baseline work already writes. Spot drift over time at a glance.

## What changes

One new `Trend` step in `supertable-bench-azure.yml` (main/publish only) — **no Rust, no new deps** (`az`, `jq` already on the runner).

1. List `bench/<bench>/history/<vm>-<docs>-*` blobs, sort by commit-time (`ts`) metadata, take newest ≤10.
2. Download each, `jq` the P90 RSS key, convert bytes → MiB.
3. Emit a Mermaid `xychart-beta` line chart per series to `$GITHUB_STEP_SUMMARY` — GitHub renders it inline.

Headline series: SQL 1-writer build, SQL `bm25_search`, supertable combined ingest (all P90 RSS). Only series whose bench ran are charted.

## Reviewer notes

- **Smoke-tested against the real container**: list+sort+download+`jq`+MiB conversion verified end-to-end (2 real history points render correctly).
- **<10 points** → uses what exists; **<2** → prints a one-line note instead (a line needs two points).
- **Informational, non-failing**: `set -uo pipefail` (no `-e`); any `az`/`jq` hiccup drops that point and the trend still renders — consistent with the publish step.
- **Metric-key stability**: a renamed `Report` row label silently drops a point (same constraint as the baseline keys); series list is a one-line edit to adjust.
- **Fallback**: `xychart-beta` is a beta Mermaid block; if GitHub ever stops rendering it, the same arrays drop into a GFM table with no data change.

## Testing

Renders on the next merge to main (≥2 history points already exist). Sample output is a Mermaid line chart of P90 RSS (MiB) vs short sha.
