### PR TITLE
feat superfile writer: ignore deleted documents when creating batch from superfile

### DIFF
--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -93,6 +93,7 @@ use crate::superfile::vector::distance::Metric;
 use arrow_array::{Array, RecordBatch};
 use arrow_schema::{DataType, Schema};
 use parquet::basic::Compression;
+use roaring::RoaringBitmap;
 use std::sync::Arc;
 
 /// Per-column FTS configuration. The `column` must exist in
@@ -546,7 +547,11 @@ impl SuperfileBuilder {
     ///
     /// Returns `BuildError::VectorDimMismatch` if vector column names or
     /// dimensions don't match the builder's configuration.
-    pub fn add_batch_from_reader(&mut self, reader: &SuperfileReader) -> Result<(), BuildError> {
+    pub fn add_batch_from_reader(
+        &mut self,
+        reader: &SuperfileReader,
+        deleted_docs_bitmap: Option<Arc<RoaringBitmap>>,
+    ) -> Result<(), BuildError> {
         self.opts.check_mergeability(
             reader.id_column(),
             reader.schema(),
@@ -556,7 +561,7 @@ impl SuperfileBuilder {
                 .map(|v| v.vector_columns_config().collect::<Vec<_>>()),
         )?;
         let record_batch = reader
-            .get_record_batch()
+            .get_record_batch(deleted_docs_bitmap.clone())
             .map_err(|_| BuildError::BatchReadError)?;
 
         let num_rows = record_batch.num_rows();
@@ -590,7 +595,13 @@ impl SuperfileBuilder {
                 let result = v
                     .get_vectors_fp32(&reader_col.name)
                     .map_err(|_| BuildError::VectorReadError)?;
-                for single_row in result {
+                for (row_idx, single_row) in result.iter().enumerate() {
+                    // Skip deleted documents: only include rows not in the deleted_docs_bitmap
+                    if let Some(ref bitmap) = deleted_docs_bitmap
+                        && bitmap.contains(row_idx as u32)
+                    {
+                        continue;
+                    }
                     this_col_vectors.extend_from_slice(single_row.as_slice());
                 }
                 vectors.push(this_col_vectors);
@@ -1202,7 +1213,7 @@ mod tests {
 
         // Create a new builder and add from reader
         let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b2.add_batch_from_reader(&reader)
+        b2.add_batch_from_reader(&reader, None)
             .expect("add_batch_from_reader");
         let merged_bytes = b2.finish().expect("finish builder");
 
@@ -1233,7 +1244,7 @@ mod tests {
         // Read and verify parquet data
         let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open superfile reader");
         let reader_batch = reader
-            .get_record_batch()
+            .get_record_batch(None)
             .expect("get_record_batch from reader");
 
         // Should have 2 rows
@@ -1241,7 +1252,7 @@ mod tests {
 
         // Now add to a new builder
         let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b2.add_batch_from_reader(&reader)
+        b2.add_batch_from_reader(&reader, None)
             .expect("add_batch_from_reader");
         let merged_bytes = b2.finish().expect("finish builder");
 
@@ -1249,7 +1260,7 @@ mod tests {
         let reader2 =
             SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged superfile reader");
         let merged_batch = reader2
-            .get_record_batch()
+            .get_record_batch(None)
             .expect("get_record_batch from merged reader");
         assert_eq!(merged_batch.num_rows(), 2);
     }
@@ -1281,7 +1292,7 @@ mod tests {
             .expect("get vectors fp32");
 
         let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b2.add_batch_from_reader(&reader)
+        b2.add_batch_from_reader(&reader, None)
             .expect("add_batch_from_reader");
         let merged_bytes = b2.finish().expect("finish builder");
 
@@ -1333,7 +1344,7 @@ mod tests {
 
         // Add to new builder
         let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b2.add_batch_from_reader(&reader)
+        b2.add_batch_from_reader(&reader, None)
             .expect("add_batch_from_reader");
         let merged_bytes = b2.finish().expect("finish builder");
 
@@ -1397,7 +1408,7 @@ mod tests {
             .add_batch(&batch2, &[v2.as_slice()])
             .expect("add_batch");
         merged
-            .add_batch_from_reader(&reader1)
+            .add_batch_from_reader(&reader1, None)
             .expect("add_batch_from_reader");
         let merged_bytes = merged.finish().expect("finish builder");
 
@@ -1406,7 +1417,9 @@ mod tests {
             SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged reader");
 
         // Should have 4 docs total (2 from batch2 + 2 from reader1)
-        let merged_batch = merged_reader.get_record_batch().expect("get_record_batch");
+        let merged_batch = merged_reader
+            .get_record_batch(None)
+            .expect("get_record_batch");
         assert_eq!(merged_batch.num_rows(), 4);
 
         // Verify vectors are correct
@@ -1548,7 +1561,7 @@ mod tests {
         // Create merged superfile with data from reader
         let mut b_merged = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         b_merged
-            .add_batch_from_reader(&reader1)
+            .add_batch_from_reader(&reader1, None)
             .expect("add_batch_from_reader");
         let merged_bytes = b_merged.finish().expect("finish builder");
 
@@ -1583,7 +1596,9 @@ mod tests {
         assert!(!fts_results.is_empty(), "fts search should return results");
 
         // Verify parquet query works
-        let batch = reader_merged.get_record_batch().expect("get_record_batch");
+        let batch = reader_merged
+            .get_record_batch(None)
+            .expect("get_record_batch");
         assert_eq!(batch.num_rows(), 2);
     }
 }

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -25,6 +25,7 @@ use crate::superfile::format::{self, footer, kv};
 use crate::superfile::fts::reader::{BoolMode, FtsReader};
 use crate::superfile::fts::tokenize::Tokenizer as _;
 use crate::superfile::vector::reader::VectorReader;
+use crate::supertable::query::provider::tombstone_access_plan;
 use arrow::compute::{concat_batches, take};
 use arrow_array::{ArrayRef, Decimal128Array, RecordBatch, RecordBatchReader, UInt32Array};
 use arrow_schema::{Field, Schema};
@@ -35,6 +36,7 @@ use parquet::arrow::arrow_reader::{
     RowSelector,
 };
 use parquet::file::metadata::PageIndexPolicy;
+use roaring::RoaringBitmap;
 use std::sync::Arc;
 
 /// Speculative Parquet-footer tail length for a lazy open. 64 KiB
@@ -441,18 +443,39 @@ impl SuperfileReader {
         self.bytes.as_ref()
     }
     /// Returns a record batch containing all documents with all columns
-    pub fn get_record_batch(&self) -> Result<RecordBatch, ReadError> {
+    pub fn get_record_batch(
+        &self,
+        deleted_docs_bitmap: Option<Arc<RoaringBitmap>>,
+    ) -> Result<RecordBatch, ReadError> {
         let bytes = self
             .bytes
             .as_ref()
-            .ok_or(ReadError::LazyReaderUnsupported)?
-            .clone();
+            .ok_or(ReadError::LazyReaderUnsupported)?;
         let arrow_meta = self
             .arrow_meta
             .as_ref()
             .ok_or(ReadError::LazyReaderUnsupported)?
             .clone();
-        let builder = ParquetRecordBatchReaderBuilder::new_with_metadata(bytes, arrow_meta);
+        let plan = if let Some(deleted_docs_bitmap) = deleted_docs_bitmap {
+            tombstone_access_plan(bytes, deleted_docs_bitmap.as_ref())
+                .map_err(|e| ReadError::Columnar(e.to_string()))?
+        } else {
+            None
+        };
+
+        let mut builder =
+            ParquetRecordBatchReaderBuilder::new_with_metadata(bytes.clone(), arrow_meta);
+        if let Some(plan) = plan {
+            let row_groups = plan.row_group_indexes();
+            let selection = plan
+                .into_overall_row_selection(builder.metadata().row_groups())
+                .map_err(|e| ReadError::Columnar(e.to_string()))?;
+
+            builder = builder.with_row_groups(row_groups);
+            if let Some(selection) = selection {
+                builder = builder.with_row_selection(selection);
+            }
+        }
         let reader = builder
             .build()
             .map_err(|e| ReadError::Columnar(e.to_string()))?;

--- a/src/supertable/manifest/part.rs
+++ b/src/supertable/manifest/part.rs
@@ -97,6 +97,7 @@ impl ContentHash {
     }
 
     /// Hex representation, lower-case, 64 chars.
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_hex(&self) -> String {
         let mut out = String::with_capacity(BLAKE3_HEX_LEN);
         for byte in self.0 {

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -511,7 +511,7 @@ impl TableProvider for SupertableProvider {
 /// Parsing the footer via [`ParquetRecordBatchReaderBuilder`] only
 /// touches metadata, not column data, and only happens when the
 /// segment actually has tombstones — clean tables pay nothing.
-fn tombstone_access_plan(
+pub fn tombstone_access_plan(
     parquet_bytes: &Bytes,
     bitmap: &RoaringBitmap,
 ) -> DfResult<Option<ParquetAccessPlan>> {

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -392,9 +392,9 @@ fn add_batch_from_reader_mergeability_compatible_superfiles() {
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
     // Should not error on compatible configuration
-    b.add_batch_from_reader(&r1)
+    b.add_batch_from_reader(&r1, None)
         .expect("add_batch_from_reader succeeds for compatible superfiles");
-    b.add_batch_from_reader(&r2)
+    b.add_batch_from_reader(&r2, None)
         .expect("add_batch_from_reader succeeds for compatible superfiles");
 }
 
@@ -445,7 +445,7 @@ fn add_batch_from_reader_mergeability_id_column_mismatch() {
     let orig_opts = BuilderOptions::new(builder_schema, "doc_id", vec![], vec![], None);
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
-    let err = orig_builder.add_batch_from_reader(&reader);
+    let err = orig_builder.add_batch_from_reader(&reader, None);
     assert!(
         err.is_err(),
         "expected mergeability error for id column mismatch"
@@ -481,7 +481,7 @@ fn add_batch_from_reader_mergeability_schema_mismatch() {
     let orig_opts = BuilderOptions::new(orig_schema, "doc_id", vec![], vec![], None);
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
-    let err = orig_builder.add_batch_from_reader(&reader);
+    let err = orig_builder.add_batch_from_reader(&reader, None);
     assert!(
         err.is_err(),
         "expected mergeability error for schema mismatch"
@@ -538,7 +538,7 @@ fn add_batch_from_reader_mergeability_fts_column_count_mismatch() {
     );
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
-    let err = orig_builder.add_batch_from_reader(&reader);
+    let err = orig_builder.add_batch_from_reader(&reader, None);
     assert!(
         err.is_err(),
         "expected mergeability error for FTS column count mismatch"
@@ -590,7 +590,7 @@ fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
     );
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
-    let err = orig_builder.add_batch_from_reader(&reader);
+    let err = orig_builder.add_batch_from_reader(&reader, None);
     assert!(
         err.is_err(),
         "expected mergeability error for FTS column name mismatch"
@@ -643,7 +643,7 @@ fn add_batch_from_reader_mergeability_vector_column_count_mismatch() {
     let orig_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
-    let err = orig_builder.add_batch_from_reader(&reader);
+    let err = orig_builder.add_batch_from_reader(&reader, None);
     assert!(
         err.is_err(),
         "expected mergeability error for vector column count mismatch"
@@ -709,7 +709,7 @@ fn add_batch_from_reader_mergeability_vector_column_name_mismatch() {
     );
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
-    let err = orig_builder.add_batch_from_reader(&reader);
+    let err = orig_builder.add_batch_from_reader(&reader, None);
     assert!(
         err.is_err(),
         "expected mergeability error for vector column name mismatch"
@@ -775,9 +775,491 @@ fn add_batch_from_reader_mergeability_vector_dimension_mismatch() {
     );
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
-    let err = orig_builder.add_batch_from_reader(&reader);
+    let err = orig_builder.add_batch_from_reader(&reader, None);
     assert!(
         err.is_err(),
         "expected mergeability error for vector dimension mismatch"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_records() {
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![100u64, 101, 102]);
+    let titles = LargeStringArray::from(vec!["doc0", "doc1", "doc2"]);
+    let bodies = LargeStringArray::from(vec!["body0", "body1", "body2"]);
+    let scores = Float32Array::from(vec![1.0, 2.0, 3.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Create bitmap to delete documents at local_doc_id 1 (doc_id=101)
+    let mut deleted = roaring::RoaringBitmap::new();
+    deleted.insert(1);
+
+    // Merge with deleted_docs_bitmap
+    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
+    let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
+
+    builder2
+        .add_batch_from_reader(&reader, Some(Arc::new(deleted)))
+        .expect("add_batch_from_reader with deleted docs");
+
+    let bytes2 = Bytes::from(builder2.finish().expect("finish builder"));
+    let reader2 = SuperfileReader::open(bytes2).expect("open merged superfile");
+
+    // The merged superfile should only have 2 docs (doc 0 and doc 2)
+    assert_eq!(
+        reader2.n_docs(),
+        2,
+        "Expected 2 documents after filtering 1 deletion"
+    );
+
+    let parquet = reader2
+        .parquet_bytes()
+        .expect("eager open retains parquet bytes")
+        .clone();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(parquet)
+        .expect("try_new ParquetRecordBatchReaderBuilder");
+    let mut parquet_reader = builder.build().expect("build parquet reader");
+    let read_batch = parquet_reader
+        .next()
+        .expect("at least one batch")
+        .expect("decode batch");
+
+    assert_eq!(read_batch.num_rows(), 2, "Parquet batch should have 2 rows");
+
+    // Verify the correct documents remain
+    let ids_array = read_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Decimal128Array>()
+        .expect("downcast to Decimal128Array");
+    let id_vals: Vec<i128> = (0..ids_array.len()).map(|i| ids_array.value(i)).collect();
+    assert_eq!(id_vals, vec![100, 102], "Expected doc_ids 100 and 102");
+}
+
+#[test]
+fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_fts() {
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![100u64, 101, 102]);
+    let titles = LargeStringArray::from(vec!["rust async", "python data", "rust embedded"]);
+    let bodies = LargeStringArray::from(vec!["body0", "body1", "body2"]);
+    let scores = Float32Array::from(vec![1.0, 2.0, 3.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Create bitmap to delete document at local_doc_id 1 (python data)
+    let mut deleted = roaring::RoaringBitmap::new();
+    deleted.insert(1);
+
+    let builder2_opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
+
+    builder2
+        .add_batch_from_reader(&reader, Some(Arc::new(deleted)))
+        .expect("add_batch_from_reader with deleted docs");
+
+    let bytes2 = Bytes::from(builder2.finish().expect("finish builder"));
+    let reader2 = SuperfileReader::open(bytes2).expect("open merged superfile");
+
+    assert_eq!(
+        reader2.n_docs(),
+        2,
+        "Expected 2 documents after FTS filtering"
+    );
+
+    // Search for "rust" should find 2 docs (original doc 0 and 2, now local_doc_ids 0 and 1)
+    let hits = futures::executor::block_on(async {
+        reader2
+            .bm25_search("title", "rust", SEARCH_K, BoolMode::Or)
+            .await
+            .expect("BM25 search")
+    });
+
+    assert_eq!(hits.len(), 2, "Expected 2 rust docs");
+    let local_doc_ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+    // After filtering and merging, local_doc_ids are 0 and 1
+    assert_eq!(
+        local_doc_ids,
+        vec![0, 1].into_iter().collect(),
+        "Expected local_doc_ids 0 and 1"
+    );
+
+    // Search for "python" should find 0 docs (it was deleted)
+    let python_hits = futures::executor::block_on(async {
+        reader2
+            .bm25_search("title", "python", SEARCH_K, BoolMode::Or)
+            .await
+            .expect("BM25 search")
+    });
+
+    assert_eq!(
+        python_hits.len(),
+        0,
+        "Expected 0 python docs (it was deleted)"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_vectors() {
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: EMB_DIM,
+            n_cent: N_CENT,
+            rot_seed: ROT_SEED,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        None,
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![100u64, 101, 102]);
+    let titles = LargeStringArray::from(vec!["doc0", "doc1", "doc2"]);
+    let bodies = LargeStringArray::from(vec!["body0", "body1", "body2"]);
+    let scores = Float32Array::from(vec![1.0, 2.0, 3.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    // Create 3 unit-norm vectors with distinct axes
+    let mut flat = Vec::<f32>::with_capacity(3 * EMB_DIM);
+    let axes: [usize; 3] = [0, 1, 2];
+    for &a in &axes {
+        let mut v = vec![0.0f32; EMB_DIM];
+        v[a] = 1.0;
+        v[(a + 1) % EMB_DIM] = SECONDARY_AXIS_WEIGHT;
+        normalize(&mut v);
+        flat.extend_from_slice(&v);
+    }
+    b.add_batch(&batch, &[flat.as_slice()]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Create bitmap to delete document at local_doc_id 1 (axis 1)
+    let mut deleted = roaring::RoaringBitmap::new();
+    deleted.insert(1);
+
+    let builder2_opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: EMB_DIM,
+            n_cent: N_CENT,
+            rot_seed: ROT_SEED,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        None,
+    );
+    let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
+
+    builder2
+        .add_batch_from_reader(&reader, Some(Arc::new(deleted)))
+        .expect("add_batch_from_reader with deleted docs");
+
+    let bytes2 = Bytes::from(builder2.finish().expect("finish builder"));
+    let reader2 = SuperfileReader::open(bytes2).expect("open merged superfile");
+
+    assert_eq!(
+        reader2.n_docs(),
+        2,
+        "Expected 2 documents after vector filtering"
+    );
+
+    // Query with a vector aligned to axis 0 (doc 0's axis)
+    let mut q = vec![0.0f32; EMB_DIM];
+    q[0] = 1.0;
+    q[1] = SECONDARY_AXIS_WEIGHT;
+    normalize(&mut q);
+
+    let hits = futures::executor::block_on(async {
+        reader2
+            .vector_search("emb", &q, 2, VectorSearchOptions::new().with_nprobe(NPROBE))
+            .await
+            .expect("vector search")
+    });
+
+    assert_eq!(hits.len(), 2, "Expected 2 results from vector search");
+    // After filtering, doc 0 is local_doc_id 0, doc 2 is local_doc_id 1
+    assert_eq!(
+        hits[0].0, 0,
+        "Top result should be local_doc_id 0 (original doc 0)"
+    );
+    let local_doc_ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+    assert_eq!(
+        local_doc_ids,
+        vec![0, 1].into_iter().collect(),
+        "Expected local_doc_ids 0 and 1"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_with_deleted_docs_bitmap_all_deletes() {
+    // Edge case: delete all documents
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![100u64, 101, 102]);
+    let titles = LargeStringArray::from(vec!["doc0", "doc1", "doc2"]);
+    let bodies = LargeStringArray::from(vec!["body0", "body1", "body2"]);
+    let scores = Float32Array::from(vec![1.0, 2.0, 3.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Create bitmap to delete all documents
+    let mut deleted = roaring::RoaringBitmap::new();
+    deleted.insert(0);
+    deleted.insert(1);
+    deleted.insert(2);
+
+    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
+    let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
+
+    builder2
+        .add_batch_from_reader(&reader, Some(Arc::new(deleted)))
+        .expect("add_batch_from_reader with all docs deleted");
+
+    let bytes2 = builder2.finish().expect("finish builder");
+    // Empty superfile should return empty bytes
+    assert!(bytes2.is_empty(), "All-deleted superfile should be empty");
+}
+
+#[test]
+fn add_batch_from_reader_with_deleted_docs_bitmap_no_deletes() {
+    // Edge case: bitmap is provided but empty (no deletions)
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![100u64, 101]);
+    let titles = LargeStringArray::from(vec!["doc0", "doc1"]);
+    let bodies = LargeStringArray::from(vec!["body0", "body1"]);
+    let scores = Float32Array::from(vec![1.0, 2.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Create empty bitmap (no deletions)
+    let deleted = roaring::RoaringBitmap::new();
+
+    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
+    let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
+
+    builder2
+        .add_batch_from_reader(&reader, Some(Arc::new(deleted)))
+        .expect("add_batch_from_reader with empty bitmap");
+
+    let bytes2 = Bytes::from(builder2.finish().expect("finish builder"));
+    let reader2 = SuperfileReader::open(bytes2).expect("open merged superfile");
+
+    // All documents should be present
+    assert_eq!(
+        reader2.n_docs(),
+        2,
+        "Expected all 2 documents with empty deletion bitmap"
+    );
+}
+
+#[test]
+fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes() {
+    // Test with both FTS and vectors, deleting documents in between
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: EMB_DIM,
+            n_cent: N_CENT,
+            rot_seed: ROT_SEED,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        Some(default_tokenizer()),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+
+    let ids = decimal128_ids(vec![100u64, 101, 102, 103]);
+    let titles = LargeStringArray::from(vec!["rust one", "python two", "rust three", "go four"]);
+    let bodies = LargeStringArray::from(vec!["body0", "body1", "body2", "body3"]);
+    let scores = Float32Array::from(vec![1.0, 2.0, 3.0, 4.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+
+    // Create 4 distinct vectors
+    let mut flat = Vec::<f32>::with_capacity(4 * EMB_DIM);
+    for a in 0..4 {
+        let mut v = vec![0.0f32; EMB_DIM];
+        v[a] = 1.0;
+        normalize(&mut v);
+        flat.extend_from_slice(&v);
+    }
+    b.add_batch(&batch, &[flat.as_slice()]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+
+    // Delete docs 1 and 3 (indices 1 and 3)
+    let mut deleted = roaring::RoaringBitmap::new();
+    deleted.insert(1);
+    deleted.insert(3);
+
+    let builder2_opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![SfVectorConfig {
+            column: "emb".into(),
+            dim: EMB_DIM,
+            n_cent: N_CENT,
+            rot_seed: ROT_SEED,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        Some(default_tokenizer()),
+    );
+    let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
+
+    builder2
+        .add_batch_from_reader(&reader, Some(Arc::new(deleted)))
+        .expect("add_batch_from_reader with partial deletes");
+
+    let bytes2 = Bytes::from(builder2.finish().expect("finish builder"));
+    let reader2 = SuperfileReader::open(bytes2).expect("open merged superfile");
+
+    // Should have 2 documents (indices 0 and 2)
+    assert_eq!(
+        reader2.n_docs(),
+        2,
+        "Expected 2 documents after deleting 1 and 3"
+    );
+
+    // FTS: search for "rust" should find 2 docs (original docs 0 and 2)
+    let hits = futures::executor::block_on(async {
+        reader2
+            .bm25_search("title", "rust", SEARCH_K, BoolMode::Or)
+            .await
+            .expect("BM25 search")
+    });
+    assert_eq!(hits.len(), 2, "Expected 2 rust docs");
+    let local_doc_ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+    // After filtering out docs 1 and 3, only docs 0 and 2 remain (reassigned as 0 and 1)
+    assert_eq!(
+        local_doc_ids,
+        vec![0, 1].into_iter().collect(),
+        "Expected local_doc_ids 0 and 1"
+    );
+
+    // Vector search: search with axis-0 vector should find doc 0 (highest relevance)
+    let mut q = vec![0.0f32; EMB_DIM];
+    q[0] = 1.0;
+    normalize(&mut q);
+    let vec_hits = futures::executor::block_on(async {
+        reader2
+            .vector_search("emb", &q, 2, VectorSearchOptions::new().with_nprobe(NPROBE))
+            .await
+            .expect("vector search")
+    });
+    assert_eq!(vec_hits.len(), 2, "Expected 2 vector results");
+    assert_eq!(
+        vec_hits[0].0, 0,
+        "Top result should be local_doc_id 0 (original doc 0)"
     );
 }


### PR DESCRIPTION
### What does this PR do?
- Modifies the `add_batch_from_reader` to accept a list of deleted doc ids, to be ignored and not added in the new batch

### Why do we need this change?
- This allows us to remove the deleted documents from the superfiles during compaction

### How do we do this change?
- For parquet, we rely on the `with_row_groups` and `with_row_selection` methods to speed up retrieval by ignoring deleted rows
- For vector, we use bitmap's membership method to ignore rows which have been deleted