### PR TITLE
chore: populate subsection_offsets.total_size for mutations

### DIFF
--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -78,6 +78,7 @@ use crate::supertable::wal::state_doc::{
     IdSpan, OpKind, RowId, TombstoneOutcome, WalState, WalStateDoc,
 };
 use crate::supertable::wal::tombstones_codec::TombstonesSidecar;
+use crate::supertable::writer::build_subsection_offsets;
 
 /// Outcome of one append-phase invocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -416,11 +417,10 @@ async fn do_apply(
         // which is correct for the Hash{n_buckets=1} default.
         partition_key: Vec::new(),
         partition_hint: None,
-        // WAL-committed segments don't yet embed open hints;
-        // the reader falls back to fetching vec/fts open ranges
-        // over the wire. Correct, just not 1-RTT-optimized — a
-        // follow-up can mirror the writer's `build_subsection_offsets`.
-        subsection_offsets: None,
+        // Mirror the commit path's 1-RTT cold-open hint; `None`
+        // only if the bytes don't parse (same fallback as the
+        // writer).
+        subsection_offsets: build_subsection_offsets(&bytes),
     });
 
     // ---- Step 6: PUT bytes + CAS-commit the manifest ----

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1054,7 +1054,7 @@ fn build_one_shard(
 /// can carry it forward as a [`SubsectionOffsets`]. Returns `None`
 /// if the bytes don't parse — that path falls back to the
 /// 2-RTT cold open shape rather than failing the publish.
-fn build_subsection_offsets(bytes: &Bytes) -> Option<SubsectionOffsets> {
+pub(crate) fn build_subsection_offsets(bytes: &Bytes) -> Option<SubsectionOffsets> {
     use crate::superfile::format::{footer::read_kv_metadata, kv};
     let kvs = read_kv_metadata(bytes).ok()?;
     let get = |k: &str| -> Option<u64> { kvs.get(k).and_then(|s| s.parse::<u64>().ok()) };

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -257,3 +257,44 @@ async fn writer_update_cardinality_mismatch_is_rejected() {
         }
     ));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_emitted_segment_carries_subsection_offsets() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache_dir = TempDir::new().expect("cache");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let disk_cache = make_disk_cache(Arc::clone(&storage), cache_dir.path());
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(disk_cache),
+    )
+    .expect("create");
+
+    let mut w = st.writer().expect("writer");
+    w.append(&build_title_batch(&["alpha", "bravo", "charlie"]))
+        .expect("append");
+    w.commit().expect("commit");
+    w.update(
+        col("title").eq(lit("bravo")),
+        build_title_batch(&["bravo-prime"]),
+    )
+    .expect("update");
+    w.commit().expect("commit update");
+    drop(w);
+
+    let reader = st.reader();
+    let manifest = reader.manifest();
+    let emitted = manifest
+        .superfile_list
+        .superfiles
+        .iter()
+        .find(|e| e.n_docs == 1)
+        .expect("update-emitted single-row segment present");
+    let offsets = emitted
+        .subsection_offsets
+        .as_ref()
+        .expect("update-emitted segment carries subsection_offsets");
+    assert!(offsets.total_size > 0, "total_size is stamped");
+}


### PR DESCRIPTION
The update/delete WAL pipeline left subsection_offsets as None, so cold opens of update-emitted segments fell back to the 2-RTT shape (parquet tail, then vec/fts). Mirror the commit path: stamp the hint from the merged bytes via build_subsection_offsets so these segments get the same 1-RTT cold open as commit-built ones.

This is also requried for compaction when we want to figure out which all superfiles to combine for merges