### PR TITLE
fix manifest commit: validates manifest_id before commiting manifest

### DIFF
--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -46,6 +46,7 @@ use std::sync::Arc;
 use futures::future;
 
 use crate::storage::{StorageError, StorageProvider};
+use crate::supertable::Manifest;
 use crate::supertable::error::CommitError;
 use crate::supertable::manifest::list::{self as list_mod, ManifestList};
 use crate::supertable::manifest::part::{
@@ -393,6 +394,30 @@ fn translate_contention(e: CommitError) -> CommitError {
         }
         other => other,
     }
+}
+
+/// Verifies the current in-memory manifest is the latest one and returns
+/// the current manifest etag for the given manifest, or `None` if the
+/// manifest is not yet committed.
+pub async fn get_current_manifest_etag(
+    storage: &Arc<dyn StorageProvider>,
+    current: Arc<Manifest>,
+) -> Result<Option<String>, CommitError> {
+    let (bytes, meta) = match storage.get(POINTER_PATH).await {
+        Ok((bytes, meta)) => (bytes, meta),
+        Err(StorageError::NotFound { .. }) => return Ok(None),
+        Err(e) => return Err(crate::supertable::CommitError::from(e)),
+    };
+
+    let pointer_file = PointerFile::from_bytes(&bytes)?;
+    let Some(meta_list) = current.list.as_ref() else {
+        // no manifest list for in-memory supertables
+        return Ok(None);
+    };
+    if pointer_file.manifest_id == meta_list.manifest_id {
+        return Ok(meta.etag);
+    }
+    Err(CommitError::WriteContentionExhausted)
 }
 
 #[cfg(test)]

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -59,6 +59,7 @@ use chrono::Utc;
 use rayon::prelude::*;
 
 use crate::superfile::builder::SuperfileBuilder;
+use crate::supertable::manifest::commit::get_current_manifest_etag;
 
 use super::build::fanout_shards;
 use super::error::BuildError;
@@ -1702,7 +1703,7 @@ async fn try_commit_attempt(
     pending_storage_writes: Vec<(SuperfileUri, Bytes)>,
 ) -> Result<crate::supertable::manifest::list::ManifestList, crate::supertable::CommitError> {
     use crate::storage::StorageError;
-    use crate::supertable::manifest::commit::{self as commit_mod, POINTER_PATH};
+    use crate::supertable::manifest::commit::{self as commit_mod};
     use crate::supertable::manifest::list::{
         FORMAT_VERSION as LIST_FORMAT_VERSION, ManifestList, ManifestListEntry, PartitionStrategy,
     };
@@ -1908,28 +1909,7 @@ async fn try_commit_attempt(
     // 6. Read the prior pointer's etag for the CAS. Fresh
     //    supertable → no pointer yet → None etag (initial
     //    commit).
-    let prev_etag = match storage.head(POINTER_PATH).await {
-        // Pointer exists with an etag: CAS against it.
-        Ok(meta) if meta.etag.is_some() => meta.etag,
-        // Pointer exists but HEAD returned no etag. Some
-        // S3-compatible stores (e.g. the `s3s-fs` test emulator)
-        // omit the ETag on HeadObject while still returning it on
-        // GetObject. Recover the etag via get() so the CAS uses
-        // `put_if_match` against the live pointer. Treating a
-        // missing etag as "no prior pointer" would downgrade to a
-        // create-only put that fails PreconditionFailed against
-        // the existing pointer on every retry, deadlocking the
-        // OCC loop.
-        Ok(_) => {
-            let (_, meta) = storage
-                .get(POINTER_PATH)
-                .await
-                .map_err(crate::supertable::CommitError::from)?;
-            meta.etag
-        }
-        Err(StorageError::NotFound { .. }) => None,
-        Err(e) => return Err(crate::supertable::CommitError::from(e)),
-    };
+    let prev_etag = get_current_manifest_etag(&storage, old).await?;
 
     // 7. Parallel-issue (touched parts) + list PUTs, then
     //    conditional pointer PUT (the visibility barrier).


### PR DESCRIPTION
### What does this PR do?
- Before this change, it is possible ( although rare ) for a manifest to be updated during `try_commit_attempt`. Since we read the etag before the manifest commit, the manifest write will succeed – causing data loss.
- This change verifies that the remote manifest version matches the local one.
- This fix is also a requirement to ensure that the CAS during compaction works as expected

### How do we do this?
- When we get the current etag for the manifest pointer file, we also verify that the manifest id matches with the id of the manifest we have in memory.