### PR TITLE
improv superfile builder: return superfile stats when building from readers

### DIFF
--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -83,6 +83,7 @@ use crate::superfile::format::footer::{encode_parquet_body, splice_index_blobs};
 use crate::superfile::format::{self, kv};
 use crate::superfile::fts::builder::FtsBuilder;
 use crate::superfile::fts::tokenize::{AsciiLowerTokenizer, Tokenizer};
+use crate::superfile::stats::SuperfileStats;
 use crate::superfile::vector::builder::VectorBuilder;
 use crate::superfile::vector::reader::ColumnReader;
 use crate::superfile::{BuildError, SuperfileReader};
@@ -590,7 +591,7 @@ impl SuperfileBuilder {
         &mut self,
         reader: &SuperfileReader,
         deleted_docs_bitmap: Option<Arc<RoaringBitmap>>,
-    ) -> Result<(), BuildError> {
+    ) -> Result<SuperfileStats, BuildError> {
         self.opts.check_mergeability(
             reader.id_column(),
             reader.schema(),
@@ -602,6 +603,8 @@ impl SuperfileBuilder {
         let record_batch = reader
             .get_record_batch(deleted_docs_bitmap.clone())
             .map_err(|_| BuildError::BatchReadError)?;
+
+        let superfile_stats = SuperfileStats::try_compute_from_record_batch(&record_batch)?;
 
         let num_rows = record_batch.num_rows();
         let mut vectors: Vec<Vec<f32>> = Vec::new();
@@ -649,24 +652,28 @@ impl SuperfileBuilder {
 
         let slices: Vec<&[f32]> = vectors.iter().map(|row| row.as_slice()).collect();
         self.add_batch(&record_batch, &slices)?;
-        Ok(())
+        Ok(superfile_stats)
     }
 
     /// Builds a superfile from the given readers, merging them into one.
     pub fn build_from_readers(
         readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
-    ) -> Result<Vec<u8>, BuildError> {
+    ) -> Result<(Vec<u8>, SuperfileStats), BuildError> {
         let first = readers.first().ok_or(BuildError::BatchReadError)?;
 
         let builder_opts = BuilderOptions::new_from_reader(&first.0);
         let mut superfile_builder = SuperfileBuilder::new(builder_opts)?;
+
+        let mut stats_collector = Vec::with_capacity(readers.len());
         for reader in readers {
-            superfile_builder.add_batch_from_reader(&reader.0, reader.1.clone())?;
+            let stats = superfile_builder.add_batch_from_reader(&reader.0, reader.1.clone())?;
+            stats_collector.push(stats);
         }
 
         let bytes = superfile_builder.finish()?;
+        let stats = SuperfileStats::from_children(stats_collector.as_slice());
 
-        Ok(bytes)
+        Ok((bytes, stats))
     }
 
     /// Consume the builder and emit one self-contained superfile.
@@ -888,7 +895,7 @@ fn escape_json(s: &str) -> String {
 mod tests {
     use super::*;
     use crate::test_helpers::{decimal128_ids, default_tokenizer, default_vector_config};
-    use arrow_array::LargeStringArray;
+    use arrow_array::{Decimal128Array, LargeStringArray};
     use arrow_schema::Field;
     use bytes::Bytes;
     use roaring::RoaringBitmap;
@@ -1271,9 +1278,94 @@ mod tests {
 
         // Create a new builder and add from reader
         let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b2.add_batch_from_reader(&reader, None)
+        let stats = b2
+            .add_batch_from_reader(&reader, None)
             .expect("add_batch_from_reader");
         let merged_bytes = b2.finish().expect("finish builder");
+
+        // Verify stats are populated correctly
+        assert_eq!(stats.n_docs, 2, "stats should report 2 documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 11, "id_max should be 11");
+
+        // Verify scalar_stats contains entries for all scalar columns
+        assert!(
+            !stats.scalar_stats.cols.is_empty(),
+            "scalar_stats should have column entries"
+        );
+        assert!(
+            stats.scalar_stats.cols.contains_key("doc_id"),
+            "scalar_stats should contain id_column"
+        );
+        assert!(
+            stats.scalar_stats.cols.contains_key("title"),
+            "scalar_stats should contain FTS column"
+        );
+        assert!(
+            stats.scalar_stats.cols.contains_key("body"),
+            "scalar_stats should contain body column"
+        );
+
+        // Verify scalar_stats values match expected min/max
+        // doc_id: IDs are [10, 11], so min=10, max=11
+        let (id_min_arr, id_max_arr) = stats
+            .scalar_stats
+            .cols
+            .get("doc_id")
+            .expect("doc_id should have stats");
+        let id_min = id_min_arr
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .expect("id min should be Decimal128")
+            .value(0);
+        let id_max = id_max_arr
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .expect("id max should be Decimal128")
+            .value(0);
+        assert_eq!(id_min, 10i128, "doc_id min should be 10");
+        assert_eq!(id_max, 11i128, "doc_id max should be 11");
+
+        // title: ["hello world", "rust async"], so min="hello world", max="rust async"
+        let (title_min_arr, title_max_arr) = stats
+            .scalar_stats
+            .cols
+            .get("title")
+            .expect("title should have stats");
+        let title_min = title_min_arr
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("title min should be LargeUtf8")
+            .value(0);
+        let title_max = title_max_arr
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("title max should be LargeUtf8")
+            .value(0);
+        assert_eq!(
+            title_min, "hello world",
+            "title min should be 'hello world'"
+        );
+        assert_eq!(title_max, "rust async", "title max should be 'rust async'");
+
+        // body: ["foo bar", "baz quux"], so min="baz quux", max="foo bar"
+        let (body_min_arr, body_max_arr) = stats
+            .scalar_stats
+            .cols
+            .get("body")
+            .expect("body should have stats");
+        let body_min = body_min_arr
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("body min should be LargeUtf8")
+            .value(0);
+        let body_max = body_max_arr
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("body max should be LargeUtf8")
+            .value(0);
+        assert_eq!(body_min, "baz quux", "body min should be 'baz quux'");
+        assert_eq!(body_max, "foo bar", "body max should be 'foo bar'");
 
         // The two superfiles should be identical
         assert_eq!(
@@ -1310,8 +1402,16 @@ mod tests {
 
         // Now add to a new builder
         let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b2.add_batch_from_reader(&reader, None)
+        let stats = b2
+            .add_batch_from_reader(&reader, None)
             .expect("add_batch_from_reader");
+        assert_eq!(stats.n_docs, 2, "stats should report 2 documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 11, "id_max should be 11");
+        assert!(
+            !stats.scalar_stats.cols.is_empty(),
+            "scalar_stats should have column entries"
+        );
         let merged_bytes = b2.finish().expect("finish builder");
 
         // Read back and verify parquet data is correct
@@ -1350,8 +1450,16 @@ mod tests {
             .expect("get vectors fp32");
 
         let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b2.add_batch_from_reader(&reader, None)
+        let stats = b2
+            .add_batch_from_reader(&reader, None)
             .expect("add_batch_from_reader");
+        assert_eq!(stats.n_docs, 2, "stats should report 2 documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 11, "id_max should be 11");
+        assert!(
+            !stats.scalar_stats.cols.is_empty(),
+            "scalar_stats should have column entries"
+        );
         let merged_bytes = b2.finish().expect("finish builder");
 
         // Read vectors from merged superfile
@@ -1402,8 +1510,16 @@ mod tests {
 
         // Add to new builder
         let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b2.add_batch_from_reader(&reader, None)
+        let stats = b2
+            .add_batch_from_reader(&reader, None)
             .expect("add_batch_from_reader");
+        assert_eq!(stats.n_docs, 2, "stats should report 2 documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 11, "id_max should be 11");
+        assert!(
+            !stats.scalar_stats.cols.is_empty(),
+            "scalar_stats should have column entries"
+        );
         let merged_bytes = b2.finish().expect("finish builder");
 
         // Verify FTS still works after merge
@@ -1465,9 +1581,16 @@ mod tests {
         merged
             .add_batch(&batch2, &[v2.as_slice()])
             .expect("add_batch");
-        merged
+        let stats = merged
             .add_batch_from_reader(&reader1, None)
             .expect("add_batch_from_reader");
+        assert_eq!(stats.n_docs, 2, "stats should report 2 documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 11, "id_max should be 11");
+        assert!(
+            !stats.scalar_stats.cols.is_empty(),
+            "scalar_stats should have column entries"
+        );
         let merged_bytes = merged.finish().expect("finish builder");
 
         // Verify merged result
@@ -1618,9 +1741,16 @@ mod tests {
 
         // Create merged superfile with data from reader
         let mut b_merged = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-        b_merged
+        let stats = b_merged
             .add_batch_from_reader(&reader1, None)
             .expect("add_batch_from_reader");
+        assert_eq!(stats.n_docs, 2, "stats should report 2 documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 11, "id_max should be 11");
+        assert!(
+            !stats.scalar_stats.cols.is_empty(),
+            "scalar_stats should have column entries"
+        );
         let merged_bytes = b_merged.finish().expect("finish builder");
 
         // Read merged superfile
@@ -1690,13 +1820,21 @@ mod tests {
         let reader = SuperfileReader::open(Bytes::from(original_bytes.clone()))
             .expect("open superfile reader");
 
-        let merged_bytes =
+        let (merged_bytes, stats) =
             SuperfileBuilder::build_from_readers(&[(Arc::new(reader), empty_bitmap())])
                 .expect("build_from_readers");
 
         // Verify result is a valid superfile
         assert_eq!(&merged_bytes[..4], b"PAR1");
         assert_eq!(&merged_bytes[merged_bytes.len() - 4..], b"PAR1");
+
+        // Verify stats are correct
+        assert_eq!(stats.n_docs, 2);
+        assert_eq!(stats.id_min, 10);
+        assert_eq!(stats.id_max, 11);
+        assert!(stats.scalar_stats.cols.contains_key("doc_id"));
+        assert!(stats.scalar_stats.cols.contains_key("title"));
+        assert!(stats.scalar_stats.cols.contains_key("body"));
 
         // Verify data is preserved
         let merged_reader =
@@ -1742,11 +1880,17 @@ mod tests {
         let reader1 = SuperfileReader::open(Bytes::from(bytes1)).expect("open reader1");
         let reader2 = SuperfileReader::open(Bytes::from(bytes2)).expect("open reader2");
 
-        let merged_bytes = SuperfileBuilder::build_from_readers(&[
+        let (merged_bytes, stats) = SuperfileBuilder::build_from_readers(&[
             (Arc::new(reader1), empty_bitmap()),
             (Arc::new(reader2), empty_bitmap()),
         ])
         .expect("build_from_readers");
+
+        // Verify stats are correct
+        assert_eq!(stats.n_docs, 4, "should have 4 total documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 21, "id_max should be 21");
+        assert_eq!(stats.scalar_stats.cols.len(), 3, "should have 3 columns");
 
         // Verify merged superfile
         let merged_reader =
@@ -1783,9 +1927,14 @@ mod tests {
 
         let reader = SuperfileReader::open(Bytes::from(bytes1)).expect("open reader");
 
-        let merged_bytes =
+        let (merged_bytes, stats) =
             SuperfileBuilder::build_from_readers(&[(Arc::new(reader), empty_bitmap())])
                 .expect("build_from_readers");
+
+        // Verify stats
+        assert_eq!(stats.n_docs, 2);
+        assert_eq!(stats.id_min, 10);
+        assert_eq!(stats.id_max, 11);
 
         // Verify merged superfile has both FTS and vector indexes
         let merged_reader =
@@ -1830,11 +1979,16 @@ mod tests {
         let reader2 = SuperfileReader::open(Bytes::from(bytes)).expect("open reader");
 
         // Build merged superfile
-        let merged_bytes = SuperfileBuilder::build_from_readers(&[
+        let (merged_bytes, stats) = SuperfileBuilder::build_from_readers(&[
             (Arc::new(reader1), empty_bitmap()),
             (Arc::new(reader2), empty_bitmap()),
         ])
         .expect("build_from_readers");
+
+        // Verify stats
+        assert_eq!(stats.n_docs, 4, "should have 4 documents (2 + 2)");
+        assert_eq!(stats.id_min, 10);
+        assert_eq!(stats.id_max, 11);
 
         // Verify FTS search works on merged
         let merged_reader =
@@ -1886,8 +2040,13 @@ mod tests {
             .collect();
 
         // Merge all three
-        let merged_bytes =
+        let (merged_bytes, stats) =
             SuperfileBuilder::build_from_readers(&readers).expect("build_from_readers");
+
+        // Verify stats
+        assert_eq!(stats.n_docs, 6, "should have 6 total documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 31, "id_max should be 31");
 
         // Verify merged result has all rows
         let merged_reader =
@@ -1940,11 +2099,16 @@ mod tests {
         let reader2 = SuperfileReader::open(Bytes::from(bytes2)).expect("open reader2");
 
         // Merge both readers
-        let merged_bytes = SuperfileBuilder::build_from_readers(&[
+        let (merged_bytes, stats) = SuperfileBuilder::build_from_readers(&[
             (Arc::new(reader1), empty_bitmap()),
             (Arc::new(reader2), empty_bitmap()),
         ])
         .expect("build_from_readers");
+
+        // Verify stats
+        assert_eq!(stats.n_docs, 4, "should have 4 total documents");
+        assert_eq!(stats.id_min, 10, "id_min should be 10");
+        assert_eq!(stats.id_max, 21, "id_max should be 21");
 
         // Verify merged superfile
         let merged_reader =
@@ -2012,20 +2176,25 @@ mod tests {
         let reader2 = SuperfileReader::open(Bytes::from(bytes2)).expect("open reader2");
 
         // Create bitmaps to mark deleted rows
-        // For reader1: mark row 0 as deleted (keep row 1)
+        // For reader1: mark row 0 as deleted (keep row 1, id=11)
         let mut bitmap1 = RoaringBitmap::new();
         bitmap1.insert(0);
 
-        // For reader2: mark row 1 as deleted (keep row 0)
+        // For reader2: mark row 1 as deleted (keep row 0, id=20)
         let mut bitmap2 = RoaringBitmap::new();
         bitmap2.insert(1);
 
         // Merge with deletion bitmaps
-        let merged_bytes = SuperfileBuilder::build_from_readers(&[
+        let (merged_bytes, stats) = SuperfileBuilder::build_from_readers(&[
             (Arc::new(reader1), Some(Arc::new(bitmap1))),
             (Arc::new(reader2), Some(Arc::new(bitmap2))),
         ])
         .expect("build_from_readers");
+
+        // Verify stats: should have 2 rows after deletion (id_min=11 from reader1, id_max=20 from reader2)
+        assert_eq!(stats.n_docs, 2, "should have 2 documents after filtering");
+        assert_eq!(stats.id_min, 11, "id_min should be 11 (from reader1 row 1)");
+        assert_eq!(stats.id_max, 20, "id_max should be 20 (from reader2 row 0)");
 
         // Verify merged superfile has only 2 rows (1 from each superfile after deletion)
         let merged_reader =
@@ -2040,17 +2209,255 @@ mod tests {
             2,
             "merged superfile should have 2 rows after filtering deleted documents"
         );
+    }
 
-        // Verify the correct rows are present by checking the parquet data
-        let title_col = merged_batch
-            .column(1)
+    #[test]
+    fn build_from_readers_validates_scalar_stats_min_max_single_reader() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        );
+        let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        let schema = b.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        b.add_batch(&batch, &[]).expect("add_batch");
+        let bytes = b.finish().expect("finish builder");
+
+        let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open reader");
+        let (_, stats) =
+            SuperfileBuilder::build_from_readers(&[(Arc::new(reader), empty_bitmap())])
+                .expect("build_from_readers");
+
+        // Verify doc_id min/max (10, 11)
+        let (doc_id_min_arr, doc_id_max_arr) = stats
+            .scalar_stats
+            .cols
+            .get("doc_id")
+            .expect("doc_id column");
+        let doc_id_min = doc_id_min_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<arrow_array::Decimal128Array>()
+            .expect("downcast to Decimal128")
+            .value(0);
+        let doc_id_max = doc_id_max_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<arrow_array::Decimal128Array>()
+            .expect("downcast to Decimal128")
+            .value(0);
+        assert_eq!(doc_id_min, 10, "doc_id min should be 10");
+        assert_eq!(doc_id_max, 11, "doc_id max should be 11");
+
+        // Verify title min/max (from batch_two_rows: ["hello world", "rust async"])
+        let (title_min_arr, title_max_arr) =
+            stats.scalar_stats.cols.get("title").expect("title column");
+        let title_min = title_min_arr
+            .as_ref()
             .as_any()
             .downcast_ref::<LargeStringArray>()
-            .expect("title column");
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        let title_max = title_max_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        assert_eq!(
+            title_min, "hello world",
+            "title min should be 'hello world'"
+        );
+        assert_eq!(title_max, "rust async", "title max should be 'rust async'");
 
-        // Row from reader1: "rust async" (second row from batch_two_rows)
-        // Row from reader2: "foo bar" (first row from second batch)
-        assert_eq!(title_col.value(0), "rust async");
-        assert_eq!(title_col.value(1), "foo bar");
+        // Verify body min/max (from batch_two_rows: ["foo bar", "baz quux"])
+        let (body_min_arr, body_max_arr) =
+            stats.scalar_stats.cols.get("body").expect("body column");
+        let body_min = body_min_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        let body_max = body_max_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        assert_eq!(body_min, "baz quux", "body min should be 'baz quux'");
+        assert_eq!(body_max, "foo bar", "body max should be 'foo bar'");
+    }
+
+    #[test]
+    fn build_from_readers_validates_scalar_stats_across_multiple_readers() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        );
+
+        // Create first superfile with ids 10, 11, titles ["hello world", "rust async"]
+        let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+        let schema = b1.opts.schema.clone();
+        let batch1 = batch_two_rows(&schema);
+        b1.add_batch(&batch1, &[]).expect("add_batch");
+        let bytes1 = b1.finish().expect("finish builder");
+
+        // Create second superfile with ids 20, 21, titles ["alpha", "zeta"]
+        let mut b2 = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        let ids2 = decimal128_ids(vec![20u64, 21]);
+        let title2 = LargeStringArray::from(vec!["alpha", "zeta"]);
+        let body2 = LargeStringArray::from(vec!["aaa", "zzz"]);
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(ids2), Arc::new(title2), Arc::new(body2)],
+        )
+        .expect("build RecordBatch");
+        b2.add_batch(&batch2, &[]).expect("add_batch");
+        let bytes2 = b2.finish().expect("finish builder");
+
+        let reader1 = SuperfileReader::open(Bytes::from(bytes1)).expect("open reader1");
+        let reader2 = SuperfileReader::open(Bytes::from(bytes2)).expect("open reader2");
+
+        let (_, stats) = SuperfileBuilder::build_from_readers(&[
+            (Arc::new(reader1), empty_bitmap()),
+            (Arc::new(reader2), empty_bitmap()),
+        ])
+        .expect("build_from_readers");
+
+        // Verify doc_id: min should be 10, max should be 21 (merged from both readers)
+        let (doc_id_min_arr, doc_id_max_arr) = stats
+            .scalar_stats
+            .cols
+            .get("doc_id")
+            .expect("doc_id column");
+        let doc_id_min = doc_id_min_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<arrow_array::Decimal128Array>()
+            .expect("downcast to Decimal128")
+            .value(0);
+        let doc_id_max = doc_id_max_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<arrow_array::Decimal128Array>()
+            .expect("downcast to Decimal128")
+            .value(0);
+        assert_eq!(doc_id_min, 10, "merged doc_id min should be 10");
+        assert_eq!(doc_id_max, 21, "merged doc_id max should be 21");
+
+        // Verify title: min should be "alpha", max should be "zeta" (lexicographically from both readers)
+        let (title_min_arr, title_max_arr) =
+            stats.scalar_stats.cols.get("title").expect("title column");
+        let title_min = title_min_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        let title_max = title_max_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        assert_eq!(title_min, "alpha", "merged title min should be 'alpha'");
+        assert_eq!(title_max, "zeta", "merged title max should be 'zeta'");
+
+        // Verify body: min should be "aaa", max should be "zzz" (lexicographically from both readers)
+        let (body_min_arr, body_max_arr) =
+            stats.scalar_stats.cols.get("body").expect("body column");
+        let body_min = body_min_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        let body_max = body_max_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        assert_eq!(body_min, "aaa", "merged body min should be 'aaa'");
+        assert_eq!(body_max, "zzz", "merged body max should be 'zzz'");
+    }
+
+    #[test]
+    fn build_from_readers_validates_scalar_stats_with_string_columns() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        );
+
+        // Create superfile with specific string values to validate min/max ordering
+        let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        let schema = b.opts.schema.clone();
+        let ids = decimal128_ids(vec![1u64, 2]);
+        let titles = LargeStringArray::from(vec!["zebra", "apple"]);
+        let bodies = LargeStringArray::from(vec!["xyz", "abc"]);
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(ids), Arc::new(titles), Arc::new(bodies)],
+        )
+        .expect("build RecordBatch");
+        b.add_batch(&batch, &[]).expect("add_batch");
+        let bytes = b.finish().expect("finish builder");
+
+        let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open reader");
+        let (_, stats) =
+            SuperfileBuilder::build_from_readers(&[(Arc::new(reader), empty_bitmap())])
+                .expect("build_from_readers");
+
+        // Verify title min/max (values: ["zebra", "apple"] => min="apple", max="zebra")
+        let (title_min_arr, title_max_arr) =
+            stats.scalar_stats.cols.get("title").expect("title column");
+        let title_min = title_min_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        let title_max = title_max_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        assert_eq!(title_min, "apple", "title min should be 'apple'");
+        assert_eq!(title_max, "zebra", "title max should be 'zebra'");
+
+        // Verify body min/max (values: ["xyz", "abc"] => min="abc", max="xyz")
+        let (body_min_arr, body_max_arr) =
+            stats.scalar_stats.cols.get("body").expect("body column");
+        let body_min = body_min_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        let body_max = body_max_arr
+            .as_ref()
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("downcast to LargeStringArray")
+            .value(0);
+        assert_eq!(body_min, "abc", "body min should be 'abc'");
+        assert_eq!(body_max, "xyz", "body max should be 'xyz'");
     }
 }

--- a/src/superfile/mod.rs
+++ b/src/superfile/mod.rs
@@ -24,6 +24,7 @@ pub mod format;
 pub mod fts;
 pub mod lazy_source;
 pub mod reader;
+pub mod stats;
 pub mod vector;
 
 pub use error::{BuildError, FtsError, ReadError, VectorError};

--- a/src/superfile/stats.rs
+++ b/src/superfile/stats.rs
@@ -1,0 +1,305 @@
+use arrow_array::{Decimal128Array, RecordBatch};
+
+use crate::{superfile::BuildError, supertable::ScalarStatsTable};
+
+/// Statistics for a superfile, including the number of documents,
+/// id range, and scalar statistics. Usually used during build time.
+/// These stats are later stored in SuperfileEntry
+#[derive(Debug)]
+pub struct SuperfileStats {
+    pub n_docs: u64,
+    pub id_min: i128,
+    pub id_max: i128,
+    pub scalar_stats: ScalarStatsTable,
+    // TODO: Vector & FTS related stats could also be added here
+}
+
+impl SuperfileStats {
+    pub fn try_compute_from_record_batch(batch: &RecordBatch) -> Result<Self, BuildError> {
+        let schema = batch.schema();
+        let id_idx = 0;
+
+        let mut id_min = i128::MAX;
+        let mut id_max = i128::MIN;
+        let mut n_docs: u64 = 0;
+
+        let id_col = batch
+            .column(id_idx)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .ok_or_else(|| {
+                BuildError::IdColumnWrongType(
+                    schema.fields[id_idx].name().clone(),
+                    "<id column not Decimal128 at runtime>".to_string(),
+                )
+            })?;
+        for i in 0..id_col.len() {
+            let v = id_col.value(i);
+            id_min = id_min.min(v);
+            id_max = id_max.max(v);
+        }
+        n_docs += id_col.len() as u64;
+
+        let scalar_stats = ScalarStatsTable::from_batch(&schema, batch);
+        Ok(Self {
+            n_docs,
+            id_min,
+            id_max,
+            scalar_stats,
+        })
+    }
+
+    pub fn from_children(stats: &[Self]) -> Self {
+        let mut n_docs: u64 = 0;
+        let mut id_min = i128::MAX;
+        let mut id_max = i128::MIN;
+        let mut scalar_stats = ScalarStatsTable::default();
+        for stat in stats {
+            n_docs += stat.n_docs;
+            id_min = id_min.min(stat.id_min);
+            id_max = id_max.max(stat.id_max);
+            scalar_stats.merge(&stat.scalar_stats);
+        }
+        Self {
+            n_docs,
+            id_min,
+            id_max,
+            scalar_stats,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::decimal128_ids;
+    use arrow_array::LargeStringArray;
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    #[test]
+    fn try_compute_from_record_batch_single_row() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("title", DataType::LargeUtf8, false),
+        ]));
+        let ids = decimal128_ids(vec![42u64]);
+        let titles = LargeStringArray::from(vec!["hello"]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
+            .expect("build RecordBatch");
+
+        let stats = SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats");
+        assert_eq!(stats.n_docs, 1);
+        assert_eq!(stats.id_min, 42);
+        assert_eq!(stats.id_max, 42);
+        assert_eq!(stats.scalar_stats.cols.len(), 2);
+        assert!(stats.scalar_stats.cols.contains_key("doc_id"));
+        assert!(stats.scalar_stats.cols.contains_key("title"));
+    }
+
+    #[test]
+    fn try_compute_from_record_batch_multiple_rows() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("text", DataType::LargeUtf8, false),
+        ]));
+        let ids = decimal128_ids(vec![10u64, 50, 30]);
+        let text = LargeStringArray::from(vec!["a", "b", "c"]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(text)])
+            .expect("build RecordBatch");
+
+        let stats = SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats");
+        assert_eq!(stats.n_docs, 3);
+        assert_eq!(stats.id_min, 10);
+        assert_eq!(stats.id_max, 50);
+    }
+
+    #[test]
+    fn try_compute_from_record_batch_non_decimal128_id_column_errors() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Int64, false),
+            Field::new("text", DataType::LargeUtf8, false),
+        ]));
+        let ids = arrow_array::Int64Array::from(vec![1i64, 2, 3]);
+        let text = LargeStringArray::from(vec!["a", "b", "c"]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(text)])
+            .expect("build RecordBatch");
+
+        let err = SuperfileStats::try_compute_from_record_batch(&batch)
+            .expect_err("expected error for non-Decimal128 id column");
+        assert!(matches!(err, BuildError::IdColumnWrongType(_, _)));
+    }
+
+    #[test]
+    fn try_compute_from_record_batch_computes_scalar_stats() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("count", DataType::Int64, false),
+        ]));
+        let ids = decimal128_ids(vec![5u64, 10, 15]);
+        let titles = LargeStringArray::from(vec!["apple", "banana", "cherry"]);
+        let counts = arrow_array::Int64Array::from(vec![1i64, 2, 3]);
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(ids), Arc::new(titles), Arc::new(counts)],
+        )
+        .expect("build RecordBatch");
+
+        let stats = SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats");
+        assert_eq!(stats.scalar_stats.cols.len(), 3);
+        assert!(stats.scalar_stats.cols.contains_key("doc_id"));
+        assert!(stats.scalar_stats.cols.contains_key("title"));
+        assert!(stats.scalar_stats.cols.contains_key("count"));
+    }
+
+    #[test]
+    fn from_children_empty_returns_defaults() {
+        let result = SuperfileStats::from_children(&[]);
+        assert_eq!(result.n_docs, 0);
+        assert_eq!(result.id_min, i128::MAX);
+        assert_eq!(result.id_max, i128::MIN);
+        assert_eq!(result.scalar_stats.cols.len(), 0);
+    }
+
+    #[test]
+    fn from_children_single_stat_preserves_values() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("title", DataType::LargeUtf8, false),
+        ]));
+        let ids = decimal128_ids(vec![100u64, 200]);
+        let titles = LargeStringArray::from(vec!["first", "second"]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
+            .expect("build RecordBatch");
+
+        let stat = SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats");
+        let merged = SuperfileStats::from_children(&[stat]);
+
+        assert_eq!(merged.n_docs, 2);
+        assert_eq!(merged.id_min, 100);
+        assert_eq!(merged.id_max, 200);
+        assert_eq!(merged.scalar_stats.cols.len(), 2);
+    }
+
+    #[test]
+    fn from_children_multiple_stats_sums_n_docs() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("title", DataType::LargeUtf8, false),
+        ]));
+
+        let stats1 = {
+            let ids = decimal128_ids(vec![10u64, 20]);
+            let titles = LargeStringArray::from(vec!["a", "b"]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(titles)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let stats2 = {
+            let ids = decimal128_ids(vec![30u64, 40]);
+            let titles = LargeStringArray::from(vec!["c", "d"]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(titles)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let merged = SuperfileStats::from_children(&[stats1, stats2]);
+        assert_eq!(merged.n_docs, 4);
+    }
+
+    #[test]
+    fn from_children_multiple_stats_computes_id_min_max() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("text", DataType::LargeUtf8, false),
+        ]));
+
+        let stats1 = {
+            let ids = decimal128_ids(vec![50u64, 75]);
+            let text = LargeStringArray::from(vec!["x", "y"]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(text)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let stats2 = {
+            let ids = decimal128_ids(vec![25u64, 100]);
+            let text = LargeStringArray::from(vec!["a", "b"]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(text)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let merged = SuperfileStats::from_children(&[stats1, stats2]);
+        assert_eq!(merged.id_min, 25);
+        assert_eq!(merged.id_max, 100);
+    }
+
+    #[test]
+    fn from_children_multiple_stats_merges_scalar_stats() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("value", DataType::Int64, false),
+        ]));
+
+        let stats1 = {
+            let ids = decimal128_ids(vec![1u64, 2]);
+            let values = arrow_array::Int64Array::from(vec![10i64, 20]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(values)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let stats2 = {
+            let ids = decimal128_ids(vec![3u64, 4]);
+            let values = arrow_array::Int64Array::from(vec![5i64, 15]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(values)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let merged = SuperfileStats::from_children(&[stats1, stats2]);
+        assert_eq!(merged.scalar_stats.cols.len(), 2);
+        assert!(merged.scalar_stats.cols.contains_key("doc_id"));
+        assert!(merged.scalar_stats.cols.contains_key("value"));
+    }
+
+    #[test]
+    fn from_children_three_stats_maintains_correct_min_max() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("text", DataType::LargeUtf8, false),
+        ]));
+
+        let stats1 = {
+            let ids = decimal128_ids(vec![50u64]);
+            let text = LargeStringArray::from(vec!["first"]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(text)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let stats2 = {
+            let ids = decimal128_ids(vec![10u64]);
+            let text = LargeStringArray::from(vec!["second"]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(text)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let stats3 = {
+            let ids = decimal128_ids(vec![100u64]);
+            let text = LargeStringArray::from(vec!["third"]);
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(text)])
+                .expect("build RecordBatch");
+            SuperfileStats::try_compute_from_record_batch(&batch).expect("compute stats")
+        };
+
+        let merged = SuperfileStats::from_children(&[stats1, stats2, stats3]);
+        assert_eq!(merged.n_docs, 3);
+        assert_eq!(merged.id_min, 10);
+        assert_eq!(merged.id_max, 100);
+    }
+}

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -520,6 +520,177 @@ impl ScalarStatsTable {
         }
         Self { cols }
     }
+
+    pub fn from_batch(scalar_schema: &Schema, batch: &RecordBatch) -> Self {
+        let mut cols: HashMap<String, (ArrayRef, ArrayRef)> = HashMap::new();
+        for (idx, field) in scalar_schema.fields().iter().enumerate() {
+            let arrays = batch.column(idx);
+            if let Some(pair) = column_min_max(arrays) {
+                cols.insert(field.name().clone(), pair);
+            }
+        }
+        Self { cols }
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        for (name, (other_min, other_max)) in &other.cols {
+            if let Some(existing) = self.cols.get_mut(name) {
+                // Merge by comparing and keeping the actual min and max across both stats
+                if let Some((merged_min, merged_max)) =
+                    merge_min_max_arrays(&existing.0, other_min, &existing.1, other_max)
+                {
+                    existing.0 = merged_min;
+                    existing.1 = merged_max;
+                }
+            } else {
+                self.cols
+                    .insert(name.clone(), (other_min.clone(), other_max.clone()));
+            }
+        }
+    }
+}
+
+/// Merge min/max arrays by comparing values and keeping the actual min and max.
+///
+/// Takes existing (min, max) and other (min, max) arrays and returns the
+/// merged (min, max) where min is the smaller value and max is the larger.
+/// Both arrays are assumed to be length-1 and of the same type.
+fn merge_min_max_arrays(
+    existing_min: &ArrayRef,
+    other_min: &ArrayRef,
+    existing_max: &ArrayRef,
+    other_max: &ArrayRef,
+) -> Option<(ArrayRef, ArrayRef)> {
+    use arrow_array::*;
+    use arrow_schema::DataType;
+
+    macro_rules! prim_merge {
+        ($array_ty:ty) => {{
+            let ex_min_arr = existing_min.as_any().downcast_ref::<$array_ty>()?;
+            let ot_min_arr = other_min.as_any().downcast_ref::<$array_ty>()?;
+            let ex_max_arr = existing_max.as_any().downcast_ref::<$array_ty>()?;
+            let ot_max_arr = other_max.as_any().downcast_ref::<$array_ty>()?;
+
+            let ex_min = ex_min_arr.value(0);
+            let ot_min = ot_min_arr.value(0);
+            let ex_max = ex_max_arr.value(0);
+            let ot_max = ot_max_arr.value(0);
+
+            let merged_min = if ex_min < ot_min { ex_min } else { ot_min };
+            let merged_max = if ex_max > ot_max { ex_max } else { ot_max };
+
+            Some((
+                Arc::new(<$array_ty>::from(vec![merged_min])) as ArrayRef,
+                Arc::new(<$array_ty>::from(vec![merged_max])) as ArrayRef,
+            ))
+        }};
+    }
+
+    match existing_min.data_type() {
+        DataType::UInt8 => prim_merge!(UInt8Array),
+        DataType::UInt16 => prim_merge!(UInt16Array),
+        DataType::UInt32 => prim_merge!(UInt32Array),
+        DataType::UInt64 => prim_merge!(UInt64Array),
+        DataType::Int8 => prim_merge!(Int8Array),
+        DataType::Int16 => prim_merge!(Int16Array),
+        DataType::Int32 => prim_merge!(Int32Array),
+        DataType::Int64 => prim_merge!(Int64Array),
+        DataType::Float32 => prim_merge!(Float32Array),
+        DataType::Float64 => prim_merge!(Float64Array),
+        DataType::Boolean => {
+            let ex_min = existing_min
+                .as_any()
+                .downcast_ref::<BooleanArray>()?
+                .value(0);
+            let ot_min = other_min.as_any().downcast_ref::<BooleanArray>()?.value(0);
+            let ex_max = existing_max
+                .as_any()
+                .downcast_ref::<BooleanArray>()?
+                .value(0);
+            let ot_max = other_max.as_any().downcast_ref::<BooleanArray>()?.value(0);
+            let merged_min = ex_min && ot_min;
+            let merged_max = ex_max || ot_max;
+            Some((
+                Arc::new(BooleanArray::from(vec![merged_min])),
+                Arc::new(BooleanArray::from(vec![merged_max])),
+            ))
+        }
+        DataType::Utf8 => {
+            let ex_min = existing_min
+                .as_any()
+                .downcast_ref::<StringArray>()?
+                .value(0);
+            let ot_min = other_min.as_any().downcast_ref::<StringArray>()?.value(0);
+            let ex_max = existing_max
+                .as_any()
+                .downcast_ref::<StringArray>()?
+                .value(0);
+            let ot_max = other_max.as_any().downcast_ref::<StringArray>()?.value(0);
+            let merged_min = if ex_min < ot_min { ex_min } else { ot_min };
+            let merged_max = if ex_max > ot_max { ex_max } else { ot_max };
+            Some((
+                Arc::new(StringArray::from(vec![merged_min])),
+                Arc::new(StringArray::from(vec![merged_max])),
+            ))
+        }
+        DataType::LargeUtf8 => {
+            let ex_min = existing_min
+                .as_any()
+                .downcast_ref::<LargeStringArray>()?
+                .value(0);
+            let ot_min = other_min
+                .as_any()
+                .downcast_ref::<LargeStringArray>()?
+                .value(0);
+            let ex_max = existing_max
+                .as_any()
+                .downcast_ref::<LargeStringArray>()?
+                .value(0);
+            let ot_max = other_max
+                .as_any()
+                .downcast_ref::<LargeStringArray>()?
+                .value(0);
+            let merged_min = if ex_min < ot_min { ex_min } else { ot_min };
+            let merged_max = if ex_max > ot_max { ex_max } else { ot_max };
+            Some((
+                Arc::new(LargeStringArray::from(vec![merged_min])),
+                Arc::new(LargeStringArray::from(vec![merged_max])),
+            ))
+        }
+        DataType::Decimal128(precision, scale) => {
+            let ex_min = existing_min
+                .as_any()
+                .downcast_ref::<Decimal128Array>()?
+                .value(0);
+            let ot_min = other_min
+                .as_any()
+                .downcast_ref::<Decimal128Array>()?
+                .value(0);
+            let ex_max = existing_max
+                .as_any()
+                .downcast_ref::<Decimal128Array>()?
+                .value(0);
+            let ot_max = other_max
+                .as_any()
+                .downcast_ref::<Decimal128Array>()?
+                .value(0);
+            let merged_min = if ex_min < ot_min { ex_min } else { ot_min };
+            let merged_max = if ex_max > ot_max { ex_max } else { ot_max };
+            Some((
+                Arc::new(
+                    Decimal128Array::from(vec![merged_min])
+                        .with_precision_and_scale(*precision, *scale)
+                        .ok()?,
+                ),
+                Arc::new(
+                    Decimal128Array::from(vec![merged_max])
+                        .with_precision_and_scale(*precision, *scale)
+                        .ok()?,
+                ),
+            ))
+        }
+        _ => None,
+    }
 }
 
 /// Compute (min, max) for one Arrow array as length-1 `ArrayRef`s.
@@ -907,6 +1078,206 @@ mod tests {
         };
         assert_eq!(s.centroid.len(), 3);
         assert!((s.radius - 0.5).abs() < 1e-9);
+    }
+
+    // ============================================================
+    // ScalarStatsTable::merge tests — verify min/max comparison
+    // across different types (integers, floats, strings, decimal128)
+    // ============================================================
+
+    #[test]
+    fn merge_integer_columns_keeps_actual_min_max() {
+        use arrow_array::Int64Array;
+        let mut stats1 = ScalarStatsTable::new();
+        stats1.cols.insert(
+            "id".to_string(),
+            (
+                Arc::new(Int64Array::from(vec![10])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![50])) as ArrayRef,
+            ),
+        );
+
+        let mut stats2 = ScalarStatsTable::new();
+        stats2.cols.insert(
+            "id".to_string(),
+            (
+                Arc::new(Int64Array::from(vec![5])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![100])) as ArrayRef,
+            ),
+        );
+
+        stats1.merge(&stats2);
+
+        let (min_arr, max_arr) = stats1.cols.get("id").expect("column should exist");
+        let min_val = min_arr
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("should be Int64Array")
+            .value(0);
+        let max_val = max_arr
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("should be Int64Array")
+            .value(0);
+
+        assert_eq!(min_val, 5, "min should be the smaller value");
+        assert_eq!(max_val, 100, "max should be the larger value");
+    }
+
+    #[test]
+    fn merge_string_columns_keeps_lexicographic_min_max() {
+        use arrow_array::LargeStringArray;
+        let mut stats1 = ScalarStatsTable::new();
+        stats1.cols.insert(
+            "name".to_string(),
+            (
+                Arc::new(LargeStringArray::from(vec!["bob"])) as ArrayRef,
+                Arc::new(LargeStringArray::from(vec!["zebra"])) as ArrayRef,
+            ),
+        );
+
+        let mut stats2 = ScalarStatsTable::new();
+        stats2.cols.insert(
+            "name".to_string(),
+            (
+                Arc::new(LargeStringArray::from(vec!["alice"])) as ArrayRef,
+                Arc::new(LargeStringArray::from(vec!["charlie"])) as ArrayRef,
+            ),
+        );
+
+        stats1.merge(&stats2);
+
+        let (min_arr, max_arr) = stats1.cols.get("name").expect("column should exist");
+        let min_val = min_arr
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("should be LargeStringArray")
+            .value(0);
+        let max_val = max_arr
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("should be LargeStringArray")
+            .value(0);
+
+        assert_eq!(min_val, "alice", "min should be lexicographically smaller");
+        assert_eq!(max_val, "zebra", "max should be lexicographically larger");
+    }
+
+    #[test]
+    fn merge_float_columns_keeps_numeric_min_max() {
+        use arrow_array::Float64Array;
+        let mut stats1 = ScalarStatsTable::new();
+        stats1.cols.insert(
+            "value".to_string(),
+            (
+                Arc::new(Float64Array::from(vec![1.5])) as ArrayRef,
+                Arc::new(Float64Array::from(vec![9.9])) as ArrayRef,
+            ),
+        );
+
+        let mut stats2 = ScalarStatsTable::new();
+        stats2.cols.insert(
+            "value".to_string(),
+            (
+                Arc::new(Float64Array::from(vec![0.5])) as ArrayRef,
+                Arc::new(Float64Array::from(vec![10.5])) as ArrayRef,
+            ),
+        );
+
+        stats1.merge(&stats2);
+
+        let (min_arr, max_arr) = stats1.cols.get("value").expect("column should exist");
+        let min_val = min_arr
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("should be Float64Array")
+            .value(0);
+        let max_val = max_arr
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("should be Float64Array")
+            .value(0);
+
+        assert!((min_val - 0.5).abs() < 1e-9, "min should be 0.5");
+        assert!((max_val - 10.5).abs() < 1e-9, "max should be 10.5");
+    }
+
+    #[test]
+    fn merge_adds_new_columns() {
+        use arrow_array::UInt32Array;
+        let mut stats1 = ScalarStatsTable::new();
+        stats1.cols.insert(
+            "col1".to_string(),
+            (
+                Arc::new(UInt32Array::from(vec![1])) as ArrayRef,
+                Arc::new(UInt32Array::from(vec![10])) as ArrayRef,
+            ),
+        );
+
+        let mut stats2 = ScalarStatsTable::new();
+        stats2.cols.insert(
+            "col2".to_string(),
+            (
+                Arc::new(UInt32Array::from(vec![20])) as ArrayRef,
+                Arc::new(UInt32Array::from(vec![30])) as ArrayRef,
+            ),
+        );
+
+        stats1.merge(&stats2);
+
+        assert_eq!(stats1.cols.len(), 2, "should have both columns");
+        assert!(stats1.cols.contains_key("col1"), "col1 should exist");
+        assert!(stats1.cols.contains_key("col2"), "col2 should exist");
+    }
+
+    #[test]
+    fn merge_multiple_times_maintains_correct_min_max() {
+        use arrow_array::Int32Array;
+        let mut stats = ScalarStatsTable::new();
+        stats.cols.insert(
+            "count".to_string(),
+            (
+                Arc::new(Int32Array::from(vec![50])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![150])) as ArrayRef,
+            ),
+        );
+
+        // First merge
+        let mut stats2 = ScalarStatsTable::new();
+        stats2.cols.insert(
+            "count".to_string(),
+            (
+                Arc::new(Int32Array::from(vec![30])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![200])) as ArrayRef,
+            ),
+        );
+        stats.merge(&stats2);
+
+        // Second merge
+        let mut stats3 = ScalarStatsTable::new();
+        stats3.cols.insert(
+            "count".to_string(),
+            (
+                Arc::new(Int32Array::from(vec![10])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![100])) as ArrayRef,
+            ),
+        );
+        stats.merge(&stats3);
+
+        let (min_arr, max_arr) = stats.cols.get("count").expect("column should exist");
+        let min_val = min_arr
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("should be Int32Array")
+            .value(0);
+        let max_val = max_arr
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("should be Int32Array")
+            .value(0);
+
+        assert_eq!(min_val, 10, "min should be 10 after two merges");
+        assert_eq!(max_val, 200, "max should be 200 after two merges");
     }
 
     // ============================================================


### PR DESCRIPTION
### What does this PR do?
- Returns superfile stats ( n_docs, min_id, max_id, scalar_stats ( min & max of each col ) ) when merging multiple superfiles

### Why do we need this change?
- These are required to generate a SuperfileEntry for the merged superfile.

### How do we do this change?
- Every append from a reader returns the statistics for the append ( in the future, this can be done for all appends - instead of doing this calculation at supertable level )
- These superfile stats for all appends are then merged together to get a cummulative SuperfileStats for the merged file, which is passed to the caller