### PR TITLE
bench: faithful cold vector measurement at supertable scale

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -100,6 +100,30 @@ A real-backend run writes under a unique prefix and deletes it on exit; set
 `INFINO_BENCH_KEEP_TABLE=1` to keep it (the prefix is logged). The s3s-fs
 emulator self-cleans and reproduces request/byte volume, not network latency.
 
+## Vector search tuning
+
+The vector benches calibrate each recall target by sweeping a probe/refine
+grid, then report a user-facing `default` row. Three knobs control that row
+and let you skip the sweep:
+
+- `INFINO_BENCH_VECTOR_NPROBE` — probe count for the `default` row (default 8).
+- `INFINO_BENCH_VECTOR_RERANK` — rerank multiplier for the `default` row
+  (default 20).
+- `INFINO_BENCH_SKIP_CALIBRATION=1` — measure **only** the fixed
+  `(nprobe, rerank)` `default` row: skips the correctness gate, the
+  recall-target calibration sweep, and brute-force ground-truth generation.
+  This is the fast path for a fixed-config **cold-only** latency number on a
+  many-segment supertable, where sweeping the full grid over a cold table is
+  prohibitively slow.
+- `INFINO_BENCH_PREFETCH_CONCURRENCY` — disk-cache prefetch fan-out for the
+  cold-fill / promotion path on many-segment tables (default 8).
+
+```sh
+# Fast fixed-config cold vector latency (no calibration sweep):
+INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket INFINO_BENCH_SKIP_CALIBRATION=1 \
+  INFINO_BENCH_VECTOR_NPROBE=8 INFINO_BENCH_VECTOR_RERANK=4 cargo bench -- supertable vector cold
+```
+
 ## Test Matrix
 
 The matrix is tier × modality — six cells:

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -830,62 +830,74 @@ pub mod vector {
         include_warm: bool,
         include_cold: bool,
         cold_iters: usize,
+        skip_calibration: bool,
         log_prefix: &str,
         anchor: &str,
         title: String,
         note: &str,
     ) {
-        eprintln!(
-            "[{log_prefix}] correctness: recall@{k} on {} queries (nprobe={CORRECTNESS_NPROBE}, rerank={CORRECTNESS_RERANK_MULT})...",
-            q_correct.len(),
-        );
-        let recall = mean_recall(
-            warm_reader,
-            column,
-            q_correct,
-            gt_correct,
-            k,
-            CORRECTNESS_NPROBE,
-            CORRECTNESS_RERANK_MULT,
-        );
-        assert!(
-            recall >= CORRECTNESS_RECALL_FLOOR,
-            "{log_prefix} vector recall@{k} {recall:.3} < floor {CORRECTNESS_RECALL_FLOOR:.2}"
-        );
-        eprintln!("[{log_prefix}] correctness OK: recall@{k} = {recall:.3}");
-
-        let cal: Vec<Option<Calibrated>> = RECALL_TARGETS
-            .iter()
-            .map(|&target| {
-                eprintln!(
-                    "[{log_prefix}] calibrating recall@{target:.2}: grid over probes/refines ({} queries)...",
-                    q_cal.len(),
-                );
-                calibrate(warm_reader, column, q_cal, gt_cal, target, k, log_prefix)
-            })
-            .collect();
-
         let q0 = &q_cal[0];
         let mut rows: Vec<RecallRow> = Vec::new();
-        for (i, &target) in RECALL_TARGETS.iter().enumerate() {
-            match cal[i] {
-                Some(c) => rows.push(RecallRow {
-                    target: format!("{target:.2}"),
-                    params: format!("p={}, r={}", c.probe, c.refine),
-                    recall: format!("{:.3}", c.recall),
-                    warm: include_warm
-                        .then(|| measure_warm(warm_reader, column, q0, k, c.probe, c.refine)),
-                    cold: include_cold.then(|| {
-                        measure_cold(&open_cold, column, q0, k, c.probe, c.refine, cold_iters)
+        if skip_calibration {
+            // Skip-calibration mode (INFINO_BENCH_SKIP_CALIBRATION): no
+            // correctness gate, no recall-target grid — just the fixed
+            // `(default_nprobe, default_rerank)` row below. Needs no ground
+            // truth and no warmed reader, so a cold-only run is fast and
+            // prod-shaped.
+            eprintln!(
+                "[{log_prefix}] skip-calibration: measuring only fixed (p={default_nprobe}, r={default_rerank})",
+            );
+        } else {
+            eprintln!(
+                "[{log_prefix}] correctness: recall@{k} on {} queries (nprobe={CORRECTNESS_NPROBE}, rerank={CORRECTNESS_RERANK_MULT})...",
+                q_correct.len(),
+            );
+            let recall = mean_recall(
+                warm_reader,
+                column,
+                q_correct,
+                gt_correct,
+                k,
+                CORRECTNESS_NPROBE,
+                CORRECTNESS_RERANK_MULT,
+            );
+            assert!(
+                recall >= CORRECTNESS_RECALL_FLOOR,
+                "{log_prefix} vector recall@{k} {recall:.3} < floor {CORRECTNESS_RECALL_FLOOR:.2}"
+            );
+            eprintln!("[{log_prefix}] correctness OK: recall@{k} = {recall:.3}");
+
+            let cal: Vec<Option<Calibrated>> = RECALL_TARGETS
+                .iter()
+                .map(|&target| {
+                    eprintln!(
+                        "[{log_prefix}] calibrating recall@{target:.2}: grid over probes/refines ({} queries)...",
+                        q_cal.len(),
+                    );
+                    calibrate(warm_reader, column, q_cal, gt_cal, target, k, log_prefix)
+                })
+                .collect();
+
+            for (i, &target) in RECALL_TARGETS.iter().enumerate() {
+                match cal[i] {
+                    Some(c) => rows.push(RecallRow {
+                        target: format!("{target:.2}"),
+                        params: format!("p={}, r={}", c.probe, c.refine),
+                        recall: format!("{:.3}", c.recall),
+                        warm: include_warm
+                            .then(|| measure_warm(warm_reader, column, q0, k, c.probe, c.refine)),
+                        cold: include_cold.then(|| {
+                            measure_cold(&open_cold, column, q0, k, c.probe, c.refine, cold_iters)
+                        }),
                     }),
-                }),
-                None => rows.push(RecallRow {
-                    target: format!("{target:.2}"),
-                    params: "—".into(),
-                    recall: "—".into(),
-                    warm: None,
-                    cold: None,
-                }),
+                    None => rows.push(RecallRow {
+                        target: format!("{target:.2}"),
+                        params: "—".into(),
+                        recall: "—".into(),
+                        warm: None,
+                        cold: None,
+                    }),
+                }
             }
         }
         rows.push(RecallRow {

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -44,21 +44,43 @@ pub struct ColdTiming {
 pub fn open_all_segments(consumer: &infino::supertable::Supertable) {
     let reader = consumer.reader();
     let manifest = reader.manifest();
-    let store = &manifest.options.store;
-    let disk_cache = manifest.options.disk_cache.as_ref();
-    let storage = manifest.options.storage.as_ref();
-    crate::tiers::block_on(async {
-        futures::future::try_join_all(manifest.superfiles.iter().map(|e| {
-            infino::supertable::query::superfile_reader::superfile_reader(
-                store,
-                disk_cache,
-                storage,
-                &e.uri,
-                e.subsection_offsets.as_ref(),
-            )
-        }))
-        .await
-        .expect("cold open: open segment readers");
+    let store = manifest.options.store.clone();
+    let disk_cache = manifest.options.disk_cache.clone();
+    let storage = manifest.options.storage.clone();
+    // Snapshot the per-segment open inputs up front so each spawned task
+    // owns its data ('static). `tokio::spawn` per segment distributes the
+    // per-open CPU parse across the runtime's worker threads — matching the
+    // production vector fan-out (`tokio::spawn` per segment) instead of
+    // serializing all 256 parses on a single `try_join_all` poller.
+    let segments: Vec<_> = manifest
+        .superfiles
+        .iter()
+        .map(|e| (e.uri, e.subsection_offsets.clone()))
+        .collect();
+    crate::tiers::block_on(async move {
+        let handles: Vec<_> = segments
+            .into_iter()
+            .map(|(uri, offsets)| {
+                let store = store.clone();
+                let disk_cache = disk_cache.clone();
+                let storage = storage.clone();
+                tokio::spawn(async move {
+                    infino::supertable::query::superfile_reader::superfile_reader(
+                        &store,
+                        disk_cache.as_ref(),
+                        storage.as_ref(),
+                        &uri,
+                        offsets.as_ref(),
+                    )
+                    .await
+                })
+            })
+            .collect();
+        for h in handles {
+            h.await
+                .expect("cold open: join segment open task")
+                .expect("cold open: open segment readers");
+        }
     });
 }
 

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -740,6 +740,7 @@ pub mod vector {
                 phases.warm,
                 phases.cold,
                 3,
+                false,
                 "superfile_vec",
                 "bench/vector/superfile/search",
                 format!(

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -591,6 +591,30 @@ pub mod vector {
     const QUERY_CALIBRATION_SEED: u64 = 99;
     const QUERY_SIGMA: f32 = 0.05;
 
+    /// `INFINO_BENCH_SKIP_CALIBRATION=1` measures only the fixed
+    /// `(nprobe, rerank)` config — no correctness gate, no recall-target
+    /// grid, no brute-force ground truth. Gives a fast, prod-shaped
+    /// cold-only run without the 54-config calibration sweep.
+    fn skip_calibration() -> bool {
+        std::env::var_os("INFINO_BENCH_SKIP_CALIBRATION").is_some()
+    }
+    /// Fixed probe count for the `default` row, overridable with
+    /// `INFINO_BENCH_VECTOR_NPROBE` (defaults to [`DEFAULT_NPROBE`]).
+    fn fixed_nprobe() -> usize {
+        std::env::var("INFINO_BENCH_VECTOR_NPROBE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_NPROBE)
+    }
+    /// Fixed rerank multiplier for the `default` row, overridable with
+    /// `INFINO_BENCH_VECTOR_RERANK` (defaults to [`DEFAULT_RERANK_MULT`]).
+    fn fixed_rerank_mult() -> usize {
+        std::env::var("INFINO_BENCH_VECTOR_RERANK")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_RERANK_MULT)
+    }
+
     /// Build a vector-only supertable, then measure warm + cold kNN search
     /// at calibrated recall targets (and a default config), with a
     /// correctness recall gate — the same measurement the superfile vector
@@ -658,12 +682,15 @@ pub mod vector {
         }
 
         if phases.warm || phases.cold {
+            let skip_cal = skip_calibration();
+            let nprobe = fixed_nprobe();
+            let rerank = fixed_rerank_mult();
+
             // The ingested vectors are still mmapped from the prepared
             // corpus — reuse them for brute-force ground truth instead
-            // of regenerating 10M×384 floats.
-            eprintln!(
-                "[supertable_vector] computing brute-force ground truth over the ingested corpus...",
-            );
+            // of regenerating 10M×384 floats. Skip-calibration needs no
+            // ground truth (no recall gate / grid), so the expensive
+            // brute-force pass is elided there.
             let vslice = corpus
                 .vectors()
                 .expect("vector modality prepared a vector corpus")
@@ -676,7 +703,6 @@ pub mod vector {
                 true,
                 QUERY_SIGMA,
             );
-            let gt_correct = corpus::ground_truth(vslice, n_docs, &q_correct, TOP_K);
             let q_cal = corpus::generate_realistic_queries(
                 vslice,
                 n_docs,
@@ -685,7 +711,17 @@ pub mod vector {
                 true,
                 QUERY_SIGMA,
             );
-            let gt_cal = corpus::ground_truth(vslice, n_docs, &q_cal, TOP_K);
+            let (gt_correct, gt_cal): (Vec<Vec<u32>>, Vec<Vec<u32>>) = if skip_cal {
+                (Vec::new(), Vec::new())
+            } else {
+                eprintln!(
+                    "[supertable_vector] computing brute-force ground truth over the ingested corpus...",
+                );
+                (
+                    corpus::ground_truth(vslice, n_docs, &q_correct, TOP_K),
+                    corpus::ground_truth(vslice, n_docs, &q_cal, TOP_K),
+                )
+            };
 
             // One consumer drives correctness + calibration. Full cache
             // promotion (prewarm + wait_until_warm) only matters for the
@@ -703,7 +739,7 @@ pub mod vector {
                         supertable::VEC_COLUMN,
                         &q_cal[0],
                         TOP_K,
-                        exec_vec::search_opts(DEFAULT_NPROBE, DEFAULT_RERANK_MULT),
+                        exec_vec::search_opts(nprobe, rerank),
                         None,
                     )
                     .expect("warm prewarm vector_search");
@@ -723,8 +759,8 @@ pub mod vector {
                 || SupertableVecColdGuard::open(&built),
                 supertable::VEC_COLUMN,
                 TOP_K,
-                DEFAULT_NPROBE,
-                DEFAULT_RERANK_MULT,
+                nprobe,
+                rerank,
                 &q_correct,
                 &gt_correct,
                 &q_cal,
@@ -732,6 +768,7 @@ pub mod vector {
                 phases.warm,
                 phases.cold,
                 COLD_ITERS,
+                skip_cal,
                 "supertable_vector",
                 "bench/vector/supertable/search",
                 title,

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -487,10 +487,6 @@ fn supertable_search_cache_gib() -> Option<u64> {
 /// `ceil(256 / concurrency)` waves). Background memory scales as
 /// `concurrency × cold_fetch_streams × cold_fetch_chunk_bytes`, so e.g.
 /// 64 × 8 × 8 MiB ≈ 4 GiB of in-flight fill buffers.
-///
-/// Unset, it falls back to the library default sourced from
-/// `DiskCacheConfig::default()` rather than a duplicated literal, so the
-/// bench tracks the library if that default ever changes.
 fn bench_prefetch_concurrency() -> usize {
     std::env::var("INFINO_BENCH_PREFETCH_CONCURRENCY")
         .ok()

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -40,6 +40,13 @@ const INDEX_CACHE_HEADROOM_DIVISOR: u64 = 10;
 const SUPERFILE_CACHE_GIB: u64 = 4;
 /// Parallel cold-fetch streams used by the bench disk cache.
 const BENCH_COLD_FETCH_STREAMS: usize = 8;
+/// Default concurrent background-fill permits (mirrors the library
+/// default). Override with `INFINO_BENCH_PREFETCH_CONCURRENCY`: warm
+/// promotion runs at most this many segment fills at once, so a
+/// many-segment supertable promotes in `ceil(n_segments / this)` waves —
+/// at the default 8, a 256-segment table needs 32 waves and can miss the
+/// `wait_until_warm` timeout; 64 brings it to 4 waves.
+const BENCH_DEFAULT_PREFETCH_CONCURRENCY: usize = 8;
 /// Cold-fetch range chunk size (8 MiB) used by the bench disk cache.
 const BENCH_COLD_FETCH_CHUNK_BYTES: u64 = 8 * MIB_BYTES;
 /// Mmap promotion timers disabled in benches (no idle eviction).
@@ -481,6 +488,20 @@ fn supertable_search_cache_gib() -> Option<u64> {
         .filter(|&v| v > 0)
 }
 
+/// Concurrent background-fill permits for the bench disk cache. Raising
+/// `INFINO_BENCH_PREFETCH_CONCURRENCY` lets a many-segment supertable
+/// finish `wait_until_warm` within the timeout (256 segments promote in
+/// `ceil(256 / concurrency)` waves). Background memory scales as
+/// `concurrency × cold_fetch_streams × cold_fetch_chunk_bytes`, so e.g.
+/// 64 × 8 × 8 MiB ≈ 4 GiB of in-flight fill buffers.
+fn bench_prefetch_concurrency() -> usize {
+    std::env::var("INFINO_BENCH_PREFETCH_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(BENCH_DEFAULT_PREFETCH_CONCURRENCY)
+}
+
 /// Fresh disk cache for ingest producers (8 GiB budget).
 ///
 /// Ingest attaches this cache only to keep segment bytes out of the
@@ -565,6 +586,7 @@ fn fresh_disk_cache_with_mode(
         cold_fetch_mode,
         cold_fetch_streams: BENCH_COLD_FETCH_STREAMS,
         cold_fetch_chunk_bytes: BENCH_COLD_FETCH_CHUNK_BYTES,
+        prefetch_concurrency: bench_prefetch_concurrency(),
         mmap_cold_threshold_secs: MMAP_TIMER_DISABLED_SECS,
         mmap_sweep_interval_secs: MMAP_TIMER_DISABLED_SECS,
         eviction: Box::new(LruPolicy::new()),

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -40,13 +40,6 @@ const INDEX_CACHE_HEADROOM_DIVISOR: u64 = 10;
 const SUPERFILE_CACHE_GIB: u64 = 4;
 /// Parallel cold-fetch streams used by the bench disk cache.
 const BENCH_COLD_FETCH_STREAMS: usize = 8;
-/// Default concurrent background-fill permits (mirrors the library
-/// default). Override with `INFINO_BENCH_PREFETCH_CONCURRENCY`: warm
-/// promotion runs at most this many segment fills at once, so a
-/// many-segment supertable promotes in `ceil(n_segments / this)` waves —
-/// at the default 8, a 256-segment table needs 32 waves and can miss the
-/// `wait_until_warm` timeout; 64 brings it to 4 waves.
-const BENCH_DEFAULT_PREFETCH_CONCURRENCY: usize = 8;
 /// Cold-fetch range chunk size (8 MiB) used by the bench disk cache.
 const BENCH_COLD_FETCH_CHUNK_BYTES: u64 = 8 * MIB_BYTES;
 /// Mmap promotion timers disabled in benches (no idle eviction).
@@ -494,12 +487,16 @@ fn supertable_search_cache_gib() -> Option<u64> {
 /// `ceil(256 / concurrency)` waves). Background memory scales as
 /// `concurrency × cold_fetch_streams × cold_fetch_chunk_bytes`, so e.g.
 /// 64 × 8 × 8 MiB ≈ 4 GiB of in-flight fill buffers.
+///
+/// Unset, it falls back to the library default sourced from
+/// `DiskCacheConfig::default()` rather than a duplicated literal, so the
+/// bench tracks the library if that default ever changes.
 fn bench_prefetch_concurrency() -> usize {
     std::env::var("INFINO_BENCH_PREFETCH_CONCURRENCY")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|&v| v > 0)
-        .unwrap_or(BENCH_DEFAULT_PREFETCH_CONCURRENCY)
+        .unwrap_or_else(|| DiskCacheConfig::default().prefetch_concurrency)
 }
 
 /// Fresh disk cache for ingest producers (8 GiB budget).

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -591,7 +591,6 @@ fn fresh_disk_cache_with_mode(
         mmap_sweep_interval_secs: MMAP_TIMER_DISABLED_SECS,
         eviction: Box::new(LruPolicy::new()),
         verify_crc_on_open: false,
-        ..Default::default()
     };
     let cache = DiskCacheStore::new_unpinned(storage, cfg).expect("DiskCacheStore");
     (dir, cache)


### PR DESCRIPTION
Part of #49 (optimize cold vector queries) — lands the bench tooling to measure cold vector latency at supertable scale (256 segments), and corrects the cold-open measurement to reflect what production actually does.

## What

- `INFINO_BENCH_SKIP_CALIBRATION=1` — measure only the fixed `(nprobe, rerank)` `default` row; skip the correctness gate, the recall-target calibration sweep, and brute-force ground-truth generation.
- `INFINO_BENCH_VECTOR_NPROBE` / `INFINO_BENCH_VECTOR_RERANK` — override the `default` row's probe count / rerank multiplier.
- `INFINO_BENCH_PREFETCH_CONCURRENCY` — disk-cache prefetch fan-out for the cold-fill / promotion path.
- **Parallel cold open** — `open_all_segments` now `tokio::spawn`s each per-segment open instead of `try_join_all`, so the 256 per-segment parses distribute across the runtime workers, matching the production fan-out.

## Why — measuring cold at scale

At supertable scale (256 segments, 10M docs) the vector bench could not produce a cold number — two paths block it:

**1. The calibration sweep stalls.** A cold-only run enters the per-target probe/refine sweep (probes up to 800, refines up to 1024, 100 queries each) against the cold 256-segment table and effectively hangs on the first target:

```
[supertable_vector] calibrating recall@0.90: grid over probes/refines (100 queries)...
```

**2. Warm promotion times out.** The warm phase promotes every segment into the mmap cache, which does not converge within the 600s budget — even at `INFINO_BENCH_PREFETCH_CONCURRENCY=64`:

```
thread 'main' panicked at benches/utils/supertable.rs:
supertable warm promotion: SuperfileOpen("segment SuperfileUri(c629b8c0-...) not mmap-promoted within 600s")
```

`INFINO_BENCH_SKIP_CALIBRATION=1` with a cold-only run skips both and lands a fixed-config number directly:

```
[supertable_vector] skip-calibration: measuring only fixed (p=8, r=4)
```

## Why — faithful cold open

The cold measurement times open separately from search, but `open_all_segments` used `try_join_all`: it overlaps the 256 segment GETs yet runs all 256 `SuperfileReader` parses on the single poller thread, inflating reported cold-open by ~1s of serialized CPU. Production's fan-out (`query/dispatch.rs`) `tokio::spawn`s per segment, distributing the parses. Switching the bench to match:

| cold open | before (`try_join_all`) | after (`tokio::spawn`) |
|---|---|---|
| 1M  | 1.82 s | 0.82 s |
| 10M | 3.01 s | 1.98 s |

~1s of serialized parse recovered at both scales — the bench was overstating cold-open; production (which already spawns) never had it.

## Scope / safety

- **Bench-harness only** (`benches/utils/`). No changes to `src/`, the on-disk format, the manifest/commit path, or the public API.
- **Recall unaffected.** Skip-calibration only elides the measurement grid and its ground truth; the parallel-open change only affects how the bench opens segments, not the search/scoring math.
