### PR TITLE
bench: prepare/benchmark split — run search on a pre-uploaded dataset

### DIFF
--- a/.github/workflows/dataset-bench-azure.yml
+++ b/.github/workflows/dataset-bench-azure.yml
@@ -1,0 +1,301 @@
+name: Benchmark prepared dataset (Azure)
+
+# Runs ONLY the read phases (warm / cold query + search) of a supertable
+# bench against a dataset already in Azure Blob — no corpus generation, no
+# ingest. Pick the dataset name, the workflow opens it and reports query
+# latency. Build the dataset first with the regular "Benchmark (Azure)"
+# workflow in dataset mode (INFINO_BENCH_DATASET_PREFIX set, a `build` phase).
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: "Dataset prefix in the blob container (e.g. datasets/bench-10m)."
+        required: true
+        type: string
+      modality:
+        description: "Which index to query."
+        required: false
+        default: vector
+        type: choice
+        options: [fts, vector, sql]
+      docs:
+        description: "Doc count the dataset was prepared with (must match; plain integer)."
+        required: true
+        type: string
+      phase:
+        description: "search = warm + cold; warm or cold to run one tier."
+        required: false
+        default: search
+        type: choice
+        options: [search, warm, cold]
+      cache_gib:
+        description: "Force the read disk-cache budget (GiB). Empty = auto-size from the index."
+        required: false
+        default: ""
+        type: string
+      vm_size:
+        description: "Azure VM size."
+        required: false
+        default: "Standard_D8s_v7"
+        type: string
+      location:
+        description: "VM region."
+        required: false
+        default: "eastus"
+        type: string
+      ref:
+        description: "Git ref / SHA to build the bench from."
+        required: false
+        default: "main"
+        type: string
+      timeout_minutes:
+        description: "Hard auto-stop; VM is torn down when hit."
+        required: false
+        default: "30"
+        type: string
+
+permissions:
+  id-token: write   # Azure OIDC federated login
+  contents: read    # clone the repo on the VM via the job token
+
+env:
+  RG: rg-infino-bench
+  VM: dataset-bench-vm-${{ github.run_id }}
+  ADMIN: azureuser
+  SCCACHE_VERSION: v0.8.2
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    environment: ci
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
+    steps:
+      # Fail before spending a VM if the dataset (its sidecar) isn't there.
+      # `modality` is also the dataset's sub-prefix (see Modality::dataset_dir).
+      - name: Pre-flight — dataset exists
+        env:
+          ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
+          CONTAINER: ${{ secrets.INFINO_REAL_AZURE_CONTAINER }}
+        run: |
+          set -euo pipefail
+          sidecar="${{ inputs.dataset }}/${{ inputs.modality }}/dataset.json"
+          exists="$(az storage blob exists --account-name "$ACC" --account-key "$KEY" \
+                     -c "$CONTAINER" -n "$sidecar" --query exists -o tsv)"
+          if [ "$exists" != "true" ]; then
+            echo "::error::dataset not found: container=$CONTAINER blob=$sidecar — prepare it first."
+            exit 1
+          fi
+          echo "dataset OK: $sidecar"
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Provision ephemeral VM
+        id: provision
+        run: |
+          set -euo pipefail
+          SIZE="${{ inputs.vm_size }}"
+          TAGS=(purpose=dataset-bench "run-id=${{ github.run_id }}" "ref=${{ inputs.ref }}")
+          az vm create \
+            -g "$RG" -n "$VM" \
+            --image Ubuntu2204 \
+            --size "$SIZE" \
+            --admin-username "$ADMIN" \
+            --generate-ssh-keys \
+            --public-ip-sku Standard \
+            --os-disk-size-gb 128 \
+            --nsg-rule NONE \
+            --nsg "${VM}-nsg" \
+            --public-ip-address "${VM}-pip" \
+            --vnet-name "${VM}-vnet" \
+            --subnet "${VM}-subnet" \
+            --os-disk-name "${VM}-osdisk" \
+            --tags "${TAGS[@]}" \
+            -o none
+          RUNNER_IP="$(curl -s https://api.ipify.org)"
+          az network nsg rule create \
+            -g "$RG" --nsg-name "${VM}-nsg" -n allow-ssh-runner --priority 300 \
+            --access Allow --protocol Tcp --direction Inbound \
+            --destination-port-ranges 22 \
+            --source-address-prefixes "${RUNNER_IP}/32" -o none
+          VM_IP="$(az vm show -d -g "$RG" -n "$VM" --query publicIps -o tsv)"
+          echo "vm_ip=$VM_IP" >> "$GITHUB_OUTPUT"
+          echo "Provisioned $VM ($SIZE) at $VM_IP"
+
+      - name: Wait for SSH
+        run: |
+          set -euo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          for i in $(seq 1 30); do
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+                 "${ADMIN}@${VM_IP}" true 2>/dev/null; then
+              echo "SSH up after ${i} tries"; exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::SSH never came up"; exit 1
+
+      - name: Clone repo + toolchain + sccache (on VM)
+        run: |
+          set -euo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
+            "GH_TOKEN='${{ github.token }}' \
+             REPO='${{ github.repository }}' \
+             REF='${{ inputs.ref }}' \
+             SCCACHE_VERSION='${{ env.SCCACHE_VERSION }}' \
+             bash -s" <<'REMOTE'
+          set -euo pipefail
+          if ! command -v cargo >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --default-toolchain stable --profile minimal
+          fi
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential pkg-config cmake clang protobuf-compiler git
+          if ! command -v sccache >/dev/null 2>&1; then
+            TARBALL="sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl"
+            curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${TARBALL}.tar.gz" \
+              | tar -xz
+            sudo install "${TARBALL}/sccache" /usr/local/bin/sccache
+          fi
+          rm -rf "$HOME/infino-src"
+          git clone --filter=blob:none \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$HOME/infino-src"
+          cd "$HOME/infino-src"
+          git checkout "$REF" 2>/dev/null \
+            || { git fetch --depth 1 origin "$REF" && git checkout FETCH_HEAD; }
+          echo "Checked out: $(git rev-parse --short HEAD)"
+          REMOTE
+
+      - name: Build (sccache, on VM)
+        run: |
+          set -euo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
+            "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
+             AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
+             INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
+             bash -s" <<'REMOTE' 2>&1 | tee /tmp/build.log
+          set -euo pipefail
+          source "$HOME/.cargo/env"
+          cd "$HOME/infino-src"
+          export RUSTC_WRAPPER=sccache
+          export CARGO_INCREMENTAL=0
+          export SCCACHE_AZURE_BLOB_CONTAINER="$INFINO_REAL_AZURE_CONTAINER"
+          export SCCACHE_AZURE_KEY_PREFIX=sccache
+          export SCCACHE_AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=${AZURE_STORAGE_ACCOUNT_NAME};AccountKey=${AZURE_STORAGE_ACCOUNT_KEY};EndpointSuffix=core.windows.net"
+          sccache --start-server || true
+          cargo bench --no-run
+          BIN="$(find target/release/deps -maxdepth 1 -type f -executable -name 'bench-*' \
+                   -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2-)"
+          test -n "$BIN" && test -x "$BIN" || { echo "::error::bench binary not found"; exit 1; }
+          printf '%s\n' "$BIN" > "$HOME/bench-bin"
+          echo "built bench: $BIN"
+          sccache --show-stats || true
+          REMOTE
+
+      - name: Run benchmark (on VM)
+        run: |
+          set -euo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
+            "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
+             AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
+             INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
+             INFINO_BENCH_SUPERTABLE_DOCS='${{ inputs.docs }}' \
+             INFINO_BENCH_DATASET_PREFIX='${{ inputs.dataset }}' \
+             CACHE_GIB='${{ inputs.cache_gib }}' \
+             MODALITY='${{ inputs.modality }}' \
+             PHASE='${{ inputs.phase }}' \
+             bash -s" <<'REMOTE' 2>&1 | tee /tmp/bench.log
+          set -euo pipefail
+          cd "$HOME/infino-src"
+          export INFINO_BENCH_STORE=azure
+          [ -n "$CACHE_GIB" ] && export INFINO_SUPERTABLE_SEARCH_CACHE_GIB="$CACHE_GIB"
+          ulimit -n "$(ulimit -Hn)"
+          BIN="$(cat "$HOME/bench-bin")"
+          echo "===== BENCH ${MODALITY} ${PHASE} START ====="
+          "$BIN" supertable "$MODALITY" "$PHASE" 2>&1
+          echo "===== BENCH ${MODALITY} ${PHASE} END ====="
+          REMOTE
+
+      - name: Summarize results
+        if: always()
+        run: |
+          set +e -u -o pipefail
+          SUMMARY="$GITHUB_STEP_SUMMARY"
+          LOG=/tmp/bench.clean
+          {
+            echo "## Dataset bench — \`${{ inputs.modality }}\` on \`${{ inputs.dataset }}\`"
+            echo ""
+            echo "- docs: \`${{ inputs.docs }}\` · phase: \`${{ inputs.phase }}\` · vm: \`${{ inputs.vm_size }}\` · ref: \`${{ inputs.ref }}\`"
+            echo ""
+          } >> "$SUMMARY"
+          : > "$LOG"
+          for f in /tmp/build.log /tmp/bench.log; do
+            [ -s "$f" ] && sed -r 's/\x1b\[[0-9;]*m//g' "$f" >> "$LOG"
+          done
+          if [ ! -s "$LOG" ]; then
+            echo "::error::No output produced — provisioning or SSH failed (see job logs)."
+            echo "_No output produced._" >> "$SUMMARY"
+            exit 1
+          fi
+          if grep -q '══' "$LOG"; then
+            REPORT_OK=1
+            {
+              echo "### Results"
+              echo '```'
+              awk '/══/{f=1} f' "$LOG" | grep -vE '^=====|^\[[a-z][a-z_]*\]'
+              echo '```'
+            } >> "$SUMMARY"
+          else
+            REPORT_OK=0
+            echo "**❌ No report table — the run failed.**" >> "$SUMMARY"
+          fi
+          ERRORS="$(grep -nE 'panicked|error\[|knob mismatch|UnsupportedVersion|HTTP error|storage error|skipped:' "$LOG" || true)"
+          if [ -n "$ERRORS" ]; then
+            {
+              echo "### 🛑 Errors & panics"
+              echo '```'
+              printf '%s\n' "$ERRORS"
+              echo '```'
+            } >> "$SUMMARY"
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::error::${line}"
+            done <<< "$(grep -E 'panicked at|knob mismatch|storage error|HTTP error' "$LOG" | head -n 8)"
+          fi
+          echo "" >> "$SUMMARY"
+          echo "_Full output attached as the \`dataset-bench-log\` artifact._" >> "$SUMMARY"
+          if [ "$REPORT_OK" -ne 1 ]; then
+            echo "::error::Dataset bench produced no results."
+            exit 1
+          fi
+
+      - name: Upload full log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dataset-bench-log
+          path: |
+            /tmp/build.log
+            /tmp/bench.log
+          if-no-files-found: warn
+
+      - name: Teardown (always)
+        if: always()
+        env:
+          NIC: ${{ env.VM }}VMNic
+        run: |
+          az vm delete            -g "$RG" -n "$VM"          --yes        || true
+          az network nic delete   -g "$RG" -n "$NIC"                      || true
+          az disk delete          -g "$RG" -n "${VM}-osdisk" --yes        || true
+          az network public-ip delete -g "$RG" -n "${VM}-pip"             || true
+          az network nsg delete   -g "$RG" -n "${VM}-nsg"                 || true
+          az network vnet delete  -g "$RG" -n "${VM}-vnet"                || true

--- a/.github/workflows/dataset-bench-azure.yml
+++ b/.github/workflows/dataset-bench-azure.yml
@@ -1,10 +1,10 @@
-name: Benchmark prepared dataset (Azure)
+name: Dataset bench (Azure)
 
-# Runs ONLY the read phases (warm / cold query + search) of a supertable
-# bench against a dataset already in Azure Blob — no corpus generation, no
-# ingest. Pick the dataset name, the workflow opens it and reports query
-# latency. Build the dataset first with the regular "Benchmark (Azure)"
-# workflow in dataset mode (INFINO_BENCH_DATASET_PREFIX set, a `build` phase).
+# Prepare and/or benchmark a reusable dataset in Azure Blob, via the bench
+# binary's `dataset` verbs:
+#   prepare — generate the corpus, ingest it to the prefix, write the sidecar
+#   bench   — open the existing dataset and run the read phases (no ingest)
+#   run     — prepare if absent, then bench
 
 on:
   workflow_dispatch:
@@ -13,8 +13,14 @@ on:
         description: "Dataset prefix in the blob container (e.g. datasets/bench-10m)."
         required: true
         type: string
+      mode:
+        description: "prepare the dataset, bench an existing one, or run end-to-end."
+        required: false
+        default: bench
+        type: choice
+        options: [bench, prepare, run]
       modality:
-        description: "Which index to query."
+        description: "Which index to prepare/query."
         required: false
         default: vector
         type: choice
@@ -71,9 +77,10 @@ jobs:
     environment: ci
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     steps:
-      # Fail before spending a VM if the dataset (its sidecar) isn't there.
+      # Fail before spending a VM when the mode can't succeed: bench needs
+      # the dataset (its sidecar) present, prepare needs the prefix free.
       # `modality` is also the dataset's sub-prefix (see Modality::dataset_dir).
-      - name: Pre-flight — dataset exists
+      - name: Pre-flight — dataset state vs mode
         env:
           ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
           KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
@@ -83,11 +90,17 @@ jobs:
           sidecar="${{ inputs.dataset }}/${{ inputs.modality }}/dataset.json"
           exists="$(az storage blob exists --account-name "$ACC" --account-key "$KEY" \
                      -c "$CONTAINER" -n "$sidecar" --query exists -o tsv)"
-          if [ "$exists" != "true" ]; then
-            echo "::error::dataset not found: container=$CONTAINER blob=$sidecar — prepare it first."
-            exit 1
-          fi
-          echo "dataset OK: $sidecar"
+          case "${{ inputs.mode }}" in
+            bench)
+              [ "$exists" = "true" ] \
+                || { echo "::error::dataset not found: $sidecar — prepare it first."; exit 1; } ;;
+            prepare)
+              [ "$exists" != "true" ] \
+                || { echo "::error::dataset already exists: $sidecar — bench it or pick a new prefix."; exit 1; } ;;
+            run)
+              echo "dataset exists=$exists — run will $([ "$exists" = "true" ] && echo 'skip prepare' || echo 'prepare first')" ;;
+          esac
+          echo "pre-flight OK: mode=${{ inputs.mode }} sidecar=$sidecar"
 
       - name: Azure login (OIDC)
         uses: azure/login@v2
@@ -210,8 +223,9 @@ jobs:
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
              INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
              INFINO_BENCH_SUPERTABLE_DOCS='${{ inputs.docs }}' \
-             INFINO_BENCH_DATASET_PREFIX='${{ inputs.dataset }}' \
              CACHE_GIB='${{ inputs.cache_gib }}' \
+             MODE='${{ inputs.mode }}' \
+             DATASET='${{ inputs.dataset }}' \
              MODALITY='${{ inputs.modality }}' \
              PHASE='${{ inputs.phase }}' \
              bash -s" <<'REMOTE' 2>&1 | tee /tmp/bench.log
@@ -221,9 +235,9 @@ jobs:
           [ -n "$CACHE_GIB" ] && export INFINO_SUPERTABLE_SEARCH_CACHE_GIB="$CACHE_GIB"
           ulimit -n "$(ulimit -Hn)"
           BIN="$(cat "$HOME/bench-bin")"
-          echo "===== BENCH ${MODALITY} ${PHASE} START ====="
-          "$BIN" supertable "$MODALITY" "$PHASE" 2>&1
-          echo "===== BENCH ${MODALITY} ${PHASE} END ====="
+          echo "===== DATASET ${MODE} ${DATASET} ${MODALITY} ${PHASE} START ====="
+          "$BIN" dataset "$MODE" "$DATASET" "$MODALITY" "$PHASE" 2>&1
+          echo "===== DATASET ${MODE} ${DATASET} ${MODALITY} ${PHASE} END ====="
           REMOTE
 
       - name: Summarize results
@@ -233,7 +247,7 @@ jobs:
           SUMMARY="$GITHUB_STEP_SUMMARY"
           LOG=/tmp/bench.clean
           {
-            echo "## Dataset bench — \`${{ inputs.modality }}\` on \`${{ inputs.dataset }}\`"
+            echo "## Dataset \`${{ inputs.mode }}\` — \`${{ inputs.modality }}\` on \`${{ inputs.dataset }}\`"
             echo ""
             echo "- docs: \`${{ inputs.docs }}\` · phase: \`${{ inputs.phase }}\` · vm: \`${{ inputs.vm_size }}\` · ref: \`${{ inputs.ref }}\`"
             echo ""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,7 @@ dependencies = [
  "rayon",
  "s3s",
  "s3s-fs",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",

--- a/benches/README.md
+++ b/benches/README.md
@@ -100,6 +100,32 @@ A real-backend run writes under a unique prefix and deletes it on exit; set
 `INFINO_BENCH_KEEP_TABLE=1` to keep it (the prefix is logged). The s3s-fs
 emulator self-cleans and reproduces request/byte volume, not network latency.
 
+## Prepared datasets
+
+The supertable corpus is fully seeded, so an ingested table is reusable.
+`dataset` verbs split the run: **prepare** once (ingest to a fixed prefix and
+write a `dataset.json` sidecar), then **bench** the read phases against it as
+many times as needed — no corpus generation, no ingest. Real object store
+only.
+
+```sh
+# Prepare a dataset (one sub-prefix per modality: <prefix>/{fts,vector,sql}).
+INFINO_BENCH_STORE=azure INFINO_REAL_AZURE_CONTAINER=my-container \
+  cargo bench -- dataset prepare datasets/bench-10m
+
+# Benchmark an existing dataset (fails fast if it is not there).
+cargo bench -- dataset bench datasets/bench-10m vector warm
+
+# End-to-end: prepare if absent, then bench.
+cargo bench -- dataset run datasets/bench-10m fts
+```
+
+The sidecar records the corpus/index knobs the dataset was built with; the
+bench refuses to open a dataset whose knobs don't match its own config
+(re-prepare instead). `INFINO_BENCH_SUPERTABLE_DOCS` must therefore match the
+prepare-time count. The `Dataset bench (Azure)` workflow drives the same
+verbs from CI.
+
 ## Test Matrix
 
 The matrix is tier × modality — six cells:

--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -19,6 +19,11 @@
 //! cargo bench -- diagnostic              # all five
 //! cargo bench -- diagnostic scale        # a subset, grouped
 //! cargo bench -- tombstone               # bare names also work
+//!
+//! # Prepared datasets (supertable, real object store only):
+//! cargo bench -- dataset prepare datasets/bench-10m          # ingest + sidecar
+//! cargo bench -- dataset bench   datasets/bench-10m vector   # read phases only
+//! cargo bench -- dataset run     datasets/bench-10m          # prepare if absent, then bench
 //! ```
 //!
 //! Token vocabulary:
@@ -109,9 +114,130 @@ fn run_cell(tier: Tier, modality: Modality, phases: Phases) {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DatasetVerb {
+    Prepare,
+    Bench,
+    Run,
+}
+
+fn dataset_usage_and_exit(code: i32) -> ! {
+    eprintln!(
+        "Usage:\n  cargo bench -- dataset <prepare|bench|run> <prefix> [fts|vector|sql ...] [warm|cold|search]\n\
+         \n\
+         prepare : ingest the corpus to <prefix> and write the sidecar (fails if already there)\n\
+         bench   : open the dataset at <prefix> and run the read phases (fails if absent)\n\
+         run     : prepare if absent, then bench\n\
+         \n\
+         Modality defaults to all three; phase (bench/run only) defaults to search (warm+cold).\n\
+         Doc count: INFINO_BENCH_SUPERTABLE_DOCS. Store: INFINO_BENCH_STORE (s3 | azure).\n"
+    );
+    std::process::exit(code);
+}
+
+fn ingest_modality(m: Modality) -> infino_bench_utils::ingest::supertable::Modality {
+    use infino_bench_utils::ingest::supertable::Modality as M;
+    match m {
+        Modality::Fts => M::Fts,
+        Modality::Vector => M::Vector,
+        Modality::Sql => M::Sql,
+    }
+}
+
+/// `dataset <verb> <prefix> [modality ...] [phase ...]` — prepare a reusable
+/// dataset on object storage, benchmark an existing one, or both.
+fn run_dataset_command(tokens: &[String]) {
+    use infino_bench_utils::{dataset, ingest::supertable as ingest, tiers};
+
+    let verb = match tokens.first().map(String::as_str) {
+        Some("prepare") => DatasetVerb::Prepare,
+        Some("bench") => DatasetVerb::Bench,
+        Some("run") => DatasetVerb::Run,
+        _ => dataset_usage_and_exit(2),
+    };
+    let mut prefix: Option<&str> = None;
+    let mut modalities: Vec<Modality> = Vec::new();
+    let (mut warm, mut cold) = (false, false);
+    for tok in &tokens[1..] {
+        match tok.as_str() {
+            "fts" if !modalities.contains(&Modality::Fts) => modalities.push(Modality::Fts),
+            "vector" if !modalities.contains(&Modality::Vector) => {
+                modalities.push(Modality::Vector)
+            }
+            "sql" if !modalities.contains(&Modality::Sql) => modalities.push(Modality::Sql),
+            "fts" | "vector" | "sql" => {}
+            "warm" => warm = true,
+            "cold" => cold = true,
+            "search" => {
+                warm = true;
+                cold = true;
+            }
+            other if prefix.is_none() => prefix = Some(other),
+            other => {
+                eprintln!("[dataset] unexpected token {other:?}");
+                dataset_usage_and_exit(2);
+            }
+        }
+    }
+    let Some(prefix) = prefix else {
+        dataset_usage_and_exit(2)
+    };
+    if let Err(reason) = tiers::supertable_backend_check() {
+        eprintln!("[dataset] {reason}");
+        std::process::exit(2);
+    }
+    dataset::set_prefix(prefix);
+    if modalities.is_empty() {
+        modalities = vec![Modality::Fts, Modality::Vector, Modality::Sql];
+    }
+    if !(warm || cold) {
+        warm = true;
+        cold = true;
+    }
+
+    for &m in &modalities {
+        let dir = ingest_modality(m).dataset_dir();
+        let exists = ingest::dataset_exists(ingest_modality(m));
+        let phases = match (verb, exists) {
+            (DatasetVerb::Prepare, true) => {
+                eprintln!(
+                    "[dataset] {prefix}/{dir} already exists — bench it or pick a new prefix"
+                );
+                std::process::exit(1);
+            }
+            (DatasetVerb::Bench, false) => {
+                eprintln!("[dataset] {prefix}/{dir} not found — prepare it first");
+                std::process::exit(1);
+            }
+            (DatasetVerb::Prepare, false) => Phases {
+                build: true,
+                warm: false,
+                cold: false,
+            },
+            (DatasetVerb::Bench, true) => Phases {
+                build: false,
+                warm,
+                cold,
+            },
+            (DatasetVerb::Run, exists) => {
+                if exists {
+                    eprintln!("[dataset] {prefix}/{dir} exists — skipping prepare");
+                }
+                Phases {
+                    build: !exists,
+                    warm,
+                    cold,
+                }
+            }
+        };
+        run_cell(Tier::Supertable, m, phases);
+    }
+}
+
 fn print_usage_and_exit(code: i32) -> ! {
     eprintln!(
         "Usage:\n  cargo bench -- [tier] [modality] [phase ...]\n  cargo bench -- <diagnostic>\n\
+         \x20 cargo bench -- dataset <prepare|bench|run> <prefix> [modality ...] [phase]\n\
          \n\
          Tier      : superfile | supertable        (omitted => both)\n\
          Modality  : fts | vector | sql            (omitted => all three)\n\
@@ -249,6 +375,16 @@ fn parse_args() -> Selection {
 fn main() {
     // Isolated per-shape supertable ingest child (`INFINO_BENCH_SUPERTABLE_SHAPE`).
     if infino_bench_utils::supertable::handle_shape_child_from_env() {
+        return;
+    }
+
+    // `dataset <verb> ...` is its own grammar, separate from the matrix.
+    let args: Vec<String> = std::env::args()
+        .skip(1)
+        .filter(|a| !a.starts_with('-'))
+        .collect();
+    if args.first().map(String::as_str) == Some("dataset") {
+        run_dataset_command(&args[1..]);
         return;
     }
 

--- a/benches/utils/Cargo.toml
+++ b/benches/utils/Cargo.toml
@@ -35,6 +35,7 @@ rand_distr = "0.6"
 rayon = "1"
 s3s = "0.13"
 s3s-fs = "0.13"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "fs", "time"] }

--- a/benches/utils/dataset.rs
+++ b/benches/utils/dataset.rs
@@ -51,6 +51,12 @@ pub struct DatasetMeta {
     pub total_index_bytes: u64,
     /// Which build wrote the data. Provenance only — never a reuse gate.
     pub builder_id: String,
+    /// SQL query sample row (SQL datasets only). Deterministic from the corpus,
+    /// persisted so the consumer needn't regenerate it to run SQL predicates.
+    #[serde(default)]
+    pub sql_sample_title: Option<String>,
+    #[serde(default)]
+    pub sql_sample_key: Option<String>,
 }
 
 /// The dataset prefix from the environment, or `None` when not in dataset mode.
@@ -99,6 +105,8 @@ mod tests {
             n_superfiles: 13,
             total_index_bytes: 1_234_567_890,
             builder_id: "infino/0.1.0+abc1234".into(),
+            sql_sample_title: None,
+            sql_sample_key: None,
         };
         let bytes = serde_json::to_vec(&meta).expect("serialize");
         let back: DatasetMeta = serde_json::from_slice(&bytes).expect("deserialize");
@@ -113,6 +121,8 @@ mod tests {
             n_superfiles: 1,
             total_index_bytes: 0,
             builder_id: "x".into(),
+            sql_sample_title: None,
+            sql_sample_key: None,
         };
         verify(&meta, &knobs());
     }
@@ -125,6 +135,8 @@ mod tests {
             n_superfiles: 1,
             total_index_bytes: 0,
             builder_id: "x".into(),
+            sql_sample_title: None,
+            sql_sample_key: None,
         };
         let mut expected = knobs();
         expected.dim = 256;
@@ -140,6 +152,8 @@ mod tests {
             n_superfiles: 1,
             total_index_bytes: 0,
             builder_id: "infino/9.9.9+deadbee".into(),
+            sql_sample_title: None,
+            sql_sample_key: None,
         };
         verify(&meta, &knobs());
     }

--- a/benches/utils/dataset.rs
+++ b/benches/utils/dataset.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Prepared-dataset metadata for the search-on-pre-uploaded-data path.
+//!
+//! A bench normally generates its corpus and ingests it every run. When
+//! `INFINO_BENCH_DATASET_PREFIX` is set ("dataset mode"), it instead opens a
+//! frozen supertable already in object storage and runs only the search/query
+//! groups. This module owns the sidecar that travels with such a dataset
+//! ([`DatasetMeta`]) and the guard that refuses to benchmark one built with a
+//! different corpus shape ([`verify`]).
+//!
+//! Everything here is inert unless `INFINO_BENCH_DATASET_PREFIX` is set.
+
+use serde::{Deserialize, Serialize};
+
+/// Object key of the metadata sidecar, relative to the dataset's
+/// prefix-scoped storage provider.
+pub const SIDECAR: &str = "dataset.json";
+
+const PREFIX_ENV: &str = "INFINO_BENCH_DATASET_PREFIX";
+
+/// The corpus + index knobs that determine a dataset's bytes. The synthetic
+/// corpus is fully seeded, so two datasets with equal knobs are byte-identical
+/// — making structural equality a sound reuse gate (see [`verify`]).
+///
+/// Deliberately excludes the writer's `BUILDER_ID`: it embeds a git hash that
+/// changes every commit, so gating on it would reject every dataset across any
+/// two builds. On-disk format compatibility is the reader's concern
+/// (`ReadError::UnsupportedVersion` on open), not this guard's.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct Knobs {
+    pub doc_count: usize,
+    pub dim: usize,
+    pub n_cent_total: usize,
+    pub vec_seed: u64,
+    pub text_seed: u64,
+    pub rot_seed: u64,
+    pub metric: String,
+    pub rerank_codec: String,
+    pub modality: String,
+}
+
+/// Sidecar written next to a prepared dataset. `knobs` is the reuse gate;
+/// the rest is provenance + what the consumer needs to size its disk cache
+/// without a probe open.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DatasetMeta {
+    pub knobs: Knobs,
+    pub n_superfiles: usize,
+    pub total_index_bytes: u64,
+    /// Which build wrote the data. Provenance only — never a reuse gate.
+    pub builder_id: String,
+}
+
+/// The dataset prefix from the environment, or `None` when not in dataset mode.
+pub fn dataset_prefix() -> Option<String> {
+    std::env::var(PREFIX_ENV).ok().filter(|s| !s.is_empty())
+}
+
+/// Whether the bench should open a pre-uploaded dataset instead of ingesting.
+pub fn dataset_mode() -> bool {
+    dataset_prefix().is_some()
+}
+
+/// Panic unless the dataset's corpus shape matches what this bench expects.
+/// A mismatch means the queries / ground truth would be measured against the
+/// wrong bytes, so there is no safe way to proceed.
+pub fn verify(meta: &DatasetMeta, expected: &Knobs) {
+    assert!(
+        &meta.knobs == expected,
+        "prepared dataset knob mismatch — re-prepare the dataset.\n  dataset: {:?}\n  bench:   {expected:?}",
+        meta.knobs
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn knobs() -> Knobs {
+        Knobs {
+            doc_count: 10_000_000,
+            dim: 384,
+            n_cent_total: 4096,
+            vec_seed: 1,
+            text_seed: 1,
+            rot_seed: 7,
+            metric: "Cosine".into(),
+            rerank_codec: "Sq8Residual".into(),
+            modality: "Combined".into(),
+        }
+    }
+
+    #[test]
+    fn meta_round_trips() {
+        let meta = DatasetMeta {
+            knobs: knobs(),
+            n_superfiles: 13,
+            total_index_bytes: 1_234_567_890,
+            builder_id: "infino/0.1.0+abc1234".into(),
+        };
+        let bytes = serde_json::to_vec(&meta).expect("serialize");
+        let back: DatasetMeta = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(back.knobs, meta.knobs);
+        assert_eq!(back.total_index_bytes, meta.total_index_bytes);
+    }
+
+    #[test]
+    fn verify_accepts_matching_knobs() {
+        let meta = DatasetMeta {
+            knobs: knobs(),
+            n_superfiles: 1,
+            total_index_bytes: 0,
+            builder_id: "x".into(),
+        };
+        verify(&meta, &knobs());
+    }
+
+    #[test]
+    #[should_panic(expected = "knob mismatch")]
+    fn verify_rejects_mismatched_knobs() {
+        let meta = DatasetMeta {
+            knobs: knobs(),
+            n_superfiles: 1,
+            total_index_bytes: 0,
+            builder_id: "x".into(),
+        };
+        let mut expected = knobs();
+        expected.dim = 256;
+        verify(&meta, &expected);
+    }
+
+    #[test]
+    fn builder_id_is_not_part_of_the_gate() {
+        // Same knobs, different builder ⇒ still accepted: the gate is knobs,
+        // not provenance.
+        let meta = DatasetMeta {
+            knobs: knobs(),
+            n_superfiles: 1,
+            total_index_bytes: 0,
+            builder_id: "infino/9.9.9+deadbee".into(),
+        };
+        verify(&meta, &knobs());
+    }
+}

--- a/benches/utils/dataset.rs
+++ b/benches/utils/dataset.rs
@@ -12,13 +12,24 @@
 //!
 //! Everything here is inert unless `INFINO_BENCH_DATASET_PREFIX` is set.
 
+use std::sync::OnceLock;
+
 use serde::{Deserialize, Serialize};
 
 /// Object key of the metadata sidecar, relative to the dataset's
 /// prefix-scoped storage provider.
 pub const SIDECAR: &str = "dataset.json";
 
-const PREFIX_ENV: &str = "INFINO_BENCH_DATASET_PREFIX";
+/// Env var naming the dataset prefix.
+pub const PREFIX_ENV: &str = "INFINO_BENCH_DATASET_PREFIX";
+
+static CONFIGURED_PREFIX: OnceLock<String> = OnceLock::new();
+
+/// Set the dataset prefix for this process. First call wins; overrides the
+/// env var.
+pub fn set_prefix(prefix: &str) {
+    let _ = CONFIGURED_PREFIX.set(prefix.trim_matches('/').to_string());
+}
 
 /// The corpus + index knobs that determine a dataset's bytes. The synthetic
 /// corpus is fully seeded, so two datasets with equal knobs are byte-identical
@@ -59,8 +70,11 @@ pub struct DatasetMeta {
     pub sql_sample_key: Option<String>,
 }
 
-/// The dataset prefix from the environment, or `None` when not in dataset mode.
+/// The dataset prefix, or `None` when not in dataset mode.
 pub fn dataset_prefix() -> Option<String> {
+    if let Some(p) = CONFIGURED_PREFIX.get() {
+        return Some(p.clone());
+    }
     std::env::var(PREFIX_ENV).ok().filter(|s| !s.is_empty())
 }
 
@@ -96,6 +110,14 @@ mod tests {
             rerank_codec: "Sq8Residual".into(),
             modality: "Combined".into(),
         }
+    }
+
+    #[test]
+    fn set_prefix_wins_and_first_call_sticks() {
+        set_prefix("/datasets/a/");
+        set_prefix("datasets/b");
+        assert_eq!(dataset_prefix().as_deref(), Some("datasets/a"));
+        assert!(dataset_mode());
     }
 
     #[test]

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -421,6 +421,13 @@ pub fn open_dataset(modality: Modality) -> IngestResult {
     }
 }
 
+/// Whether a prepared dataset (its sidecar) exists for `modality` at the
+/// configured prefix.
+pub fn dataset_exists(modality: Modality) -> bool {
+    let fixture = tiers::block_on(tiers::dataset_storage_fixture(modality.dataset_dir()));
+    tiers::block_on(fixture.storage.head(crate::dataset::SIDECAR)).is_ok()
+}
+
 fn read_sidecar(storage: &Arc<dyn StorageProvider>) -> crate::dataset::DatasetMeta {
     let (bytes, _) = tiers::block_on(storage.get(crate::dataset::SIDECAR))
         .expect("read dataset sidecar — is the dataset prepared at this prefix?");

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -12,6 +12,7 @@ use arrow_schema::{DataType, Field, Schema};
 use infino::superfile::builder::{FtsConfig, VectorConfig};
 use infino::superfile::fts::tokenize::Tokenizer;
 use infino::superfile::vector::distance::Metric;
+use infino::superfile::vector::rerank_codec::RerankCodec;
 use infino::supertable::storage::StorageProvider;
 use infino::supertable::{Supertable, SupertableOptions};
 use infino::test_helpers::default_tokenizer;
@@ -39,6 +40,10 @@ const CORPUS_TEXT_SEED: u64 = 1;
 
 /// Random-rotation RNG seed for the bench vector index.
 const ROT_SEED: u64 = 7;
+/// Distance metric for the bench vector index.
+const BENCH_METRIC: Metric = Metric::Cosine;
+/// Rerank residual codec for the bench vector index.
+const BENCH_RERANK: RerankCodec = RerankCodec::Sq8Residual;
 /// Writer auto-flush threshold (MiB) per segment roll.
 const COMMIT_THRESHOLD_SIZE_MB: u64 = 1024;
 /// Producer memory budget (8 GiB) capping resident RSS during ingest.
@@ -164,8 +169,8 @@ pub fn options_for(
             dim: DIM,
             n_cent: n_cent_per_segment,
             rot_seed: ROT_SEED,
-            metric: Metric::Cosine,
-            rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
+            metric: BENCH_METRIC,
+            rerank_codec: BENCH_RERANK,
         }]
     } else {
         vec![]
@@ -183,6 +188,21 @@ pub fn options_for(
 
 pub fn combined_options(storage: Option<Arc<dyn StorageProvider>>) -> SupertableOptions {
     options_for(Modality::Combined, storage)
+}
+
+/// The corpus + index knobs this bench config builds with.
+pub fn current_knobs(modality: Modality) -> crate::dataset::Knobs {
+    crate::dataset::Knobs {
+        doc_count: n_docs(),
+        dim: DIM,
+        n_cent_total: corpus::n_cent(n_docs()),
+        vec_seed: CORPUS_VEC_SEED,
+        text_seed: CORPUS_TEXT_SEED,
+        rot_seed: ROT_SEED,
+        metric: format!("{BENCH_METRIC:?}"),
+        rerank_codec: format!("{BENCH_RERANK:?}"),
+        modality: format!("{modality:?}"),
+    }
 }
 
 /// Corpus artifacts for one supertable build, generated to disk and

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -333,14 +333,6 @@ pub fn build_on_storage(modality: Modality, corpus: &PreparedCorpus) -> IngestRe
         total_index_bytes as f64 / (1u64 << 30) as f64,
         storage_backend.storage_label,
     );
-    if crate::dataset::dataset_mode() {
-        write_sidecar(
-            &storage_backend.storage,
-            modality,
-            n_superfiles,
-            total_index_bytes,
-        );
-    }
     // SQL query predicates sample the mid-corpus row (one mmap page
     // touch — not a corpus materialization).
     let mid = n_docs / 2;
@@ -353,6 +345,16 @@ pub fn build_on_storage(modality: Modality, corpus: &PreparedCorpus) -> IngestRe
     } else {
         (None, None)
     };
+    if crate::dataset::dataset_mode() {
+        write_sidecar(
+            &storage_backend.storage,
+            modality,
+            n_superfiles,
+            total_index_bytes,
+            sql_sample_title.clone(),
+            sql_sample_key.clone(),
+        );
+    }
     IngestResult {
         storage: storage_backend.storage,
         storage_label: storage_backend.storage_label,
@@ -372,12 +374,16 @@ fn write_sidecar(
     modality: Modality,
     n_superfiles: usize,
     total_index_bytes: u64,
+    sql_sample_title: Option<String>,
+    sql_sample_key: Option<String>,
 ) {
     let meta = crate::dataset::DatasetMeta {
         knobs: current_knobs(modality),
         n_superfiles,
         total_index_bytes,
         builder_id: infino::BUILDER_ID.to_string(),
+        sql_sample_title,
+        sql_sample_key,
     };
     let json = serde_json::to_vec_pretty(&meta).expect("serialize dataset sidecar");
     tiers::block_on(storage.put_atomic(crate::dataset::SIDECAR, Bytes::from(json)))
@@ -387,6 +393,38 @@ fn write_sidecar(
         crate::dataset::SIDECAR,
         modality.dataset_dir(),
     );
+}
+
+/// Open a pre-uploaded dataset for the read phases: resolve storage at the
+/// fixed prefix, load and verify the sidecar, and return an [`IngestResult`]
+/// the warm/cold runners consume exactly like a freshly built one — no corpus
+/// generation, no ingest.
+pub fn open_dataset(modality: Modality) -> IngestResult {
+    let storage_backend = tiers::block_on(tiers::dataset_storage_fixture(modality.dataset_dir()));
+    let meta = read_sidecar(&storage_backend.storage);
+    crate::dataset::verify(&meta, &current_knobs(modality));
+    eprintln!(
+        "[supertable_dataset] opened {} dataset: {} superfiles, {:.2} GiB index bytes on {}",
+        modality.dataset_dir(),
+        meta.n_superfiles,
+        meta.total_index_bytes as f64 / (1u64 << 30) as f64,
+        storage_backend.storage_label,
+    );
+    IngestResult {
+        storage: storage_backend.storage,
+        storage_label: storage_backend.storage_label,
+        n_superfiles: meta.n_superfiles,
+        total_index_bytes: meta.total_index_bytes,
+        cleanup: None,
+        sql_sample_title: meta.sql_sample_title,
+        sql_sample_key: meta.sql_sample_key,
+    }
+}
+
+fn read_sidecar(storage: &Arc<dyn StorageProvider>) -> crate::dataset::DatasetMeta {
+    let (bytes, _) = tiers::block_on(storage.get(crate::dataset::SIDECAR))
+        .expect("read dataset sidecar — is the dataset prepared at this prefix?");
+    serde_json::from_slice(&bytes).expect("parse dataset sidecar")
 }
 
 /// One commit chunk's `RecordBatch` for `modality`, borrowing the text

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -9,6 +9,7 @@ use arrow_array::{
     Array, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray, RecordBatch,
 };
 use arrow_schema::{DataType, Field, Schema};
+use bytes::Bytes;
 use infino::superfile::builder::{FtsConfig, VectorConfig};
 use infino::superfile::fts::tokenize::Tokenizer;
 use infino::superfile::vector::distance::Metric;
@@ -93,6 +94,15 @@ impl Modality {
     }
     pub fn has_sql(self) -> bool {
         matches!(self, Modality::Sql)
+    }
+    /// Path token namespacing a prepared dataset by modality.
+    pub fn dataset_dir(self) -> &'static str {
+        match self {
+            Modality::Fts => "fts",
+            Modality::Vector => "vector",
+            Modality::Sql => "sql",
+            Modality::Combined => "combined",
+        }
     }
 }
 
@@ -262,7 +272,13 @@ pub fn build_on_storage(modality: Modality, corpus: &PreparedCorpus) -> IngestRe
         modality_label(modality),
         N_COMMIT_CHUNKS,
     );
-    let storage_backend = tiers::block_on(tiers::supertable_storage_fixture());
+    let storage_backend = tiers::block_on(async {
+        if crate::dataset::dataset_mode() {
+            tiers::dataset_storage_fixture(modality.dataset_dir()).await
+        } else {
+            tiers::supertable_storage_fixture().await
+        }
+    });
     let cleanup = storage_backend.cleanup.clone();
     // Disk cache attached only to keep segment bytes out of the unbounded
     // in-memory store; this producer is dropped right after ingest, so skip
@@ -317,6 +333,14 @@ pub fn build_on_storage(modality: Modality, corpus: &PreparedCorpus) -> IngestRe
         total_index_bytes as f64 / (1u64 << 30) as f64,
         storage_backend.storage_label,
     );
+    if crate::dataset::dataset_mode() {
+        write_sidecar(
+            &storage_backend.storage,
+            modality,
+            n_superfiles,
+            total_index_bytes,
+        );
+    }
     // SQL query predicates sample the mid-corpus row (one mmap page
     // touch — not a corpus materialization).
     let mid = n_docs / 2;
@@ -338,6 +362,31 @@ pub fn build_on_storage(modality: Modality, corpus: &PreparedCorpus) -> IngestRe
         sql_sample_title,
         sql_sample_key,
     }
+}
+
+/// Write the dataset sidecar next to a freshly prepared dataset. Atomic
+/// create: a pre-existing sidecar means the prefix already holds a dataset, so
+/// this fails rather than clobbering it — re-prepare into a fresh prefix.
+fn write_sidecar(
+    storage: &Arc<dyn StorageProvider>,
+    modality: Modality,
+    n_superfiles: usize,
+    total_index_bytes: u64,
+) {
+    let meta = crate::dataset::DatasetMeta {
+        knobs: current_knobs(modality),
+        n_superfiles,
+        total_index_bytes,
+        builder_id: infino::BUILDER_ID.to_string(),
+    };
+    let json = serde_json::to_vec_pretty(&meta).expect("serialize dataset sidecar");
+    tiers::block_on(storage.put_atomic(crate::dataset::SIDECAR, Bytes::from(json)))
+        .expect("write dataset sidecar");
+    eprintln!(
+        "[supertable_ingest] wrote {} for the {} dataset",
+        crate::dataset::SIDECAR,
+        modality.dataset_dir(),
+    );
 }
 
 /// One commit chunk's `RecordBatch` for `modality`, borrowing the text

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -10,6 +10,7 @@
 // - `tiers`, `markdown`, `rss` — storage backends + reporting
 
 pub mod corpus;
+pub mod dataset;
 pub mod executors;
 pub mod fixture;
 pub mod harness;

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -384,7 +384,10 @@ fn build_or_open(
     modality: Modality,
     phases: Phases,
 ) -> (supertable::IngestResult, Option<ShapeMetrics>) {
-    if crate::dataset::dataset_mode() {
+    // Dataset mode opens the pre-uploaded dataset only for read phases; a
+    // build phase is the prepare step, which still ingests (to the fixed
+    // prefix).
+    if crate::dataset::dataset_mode() && !phases.build {
         return (supertable::open_dataset(modality), None);
     }
     // Corpus to disk + mmap BEFORE the sampler — engine-only window.
@@ -621,7 +624,7 @@ pub mod vector {
         // so dataset mode regenerates it too (skipping only the ingest).
         let corpus = supertable::prepare_corpus(Modality::Vector);
         let mut report = Report::load("supertable_vector");
-        let (built, ingest_metrics) = if crate::dataset::dataset_mode() {
+        let (built, ingest_metrics) = if crate::dataset::dataset_mode() && !phases.build {
             (supertable::open_dataset(Modality::Vector), None)
         } else {
             build_measured(Modality::Vector, &corpus, phases)

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -182,8 +182,13 @@ fn run_child_shape(key: &str) {
 fn build_shape_isolated(key: &str) -> Option<ShapeMetrics> {
     eprintln!("[supertable] spawning isolated subprocess for shape {key:?}...");
     let exe = std::env::current_exe().expect("current_exe for supertable child");
-    let output = Command::new(exe)
-        .env(SHAPE_ENV, key)
+    let mut cmd = Command::new(exe);
+    cmd.env(SHAPE_ENV, key);
+    // Forward a CLI-set dataset prefix; the child only inherits the env.
+    if let Some(prefix) = crate::dataset::dataset_prefix() {
+        cmd.env(crate::dataset::PREFIX_ENV, prefix);
+    }
+    let output = cmd
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .output()

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -354,6 +354,44 @@ impl Phases {
     };
 }
 
+/// Ingest a prepared corpus, sampling RSS over the build window. Returns the
+/// ingest measurements only for the build phase (it emits them).
+fn build_measured(
+    modality: Modality,
+    corpus: &supertable::PreparedCorpus,
+    phases: Phases,
+) -> (supertable::IngestResult, Option<ShapeMetrics>) {
+    let sampler = PeakSampler::start_default();
+    let t0 = Instant::now();
+    let built = supertable::build_on_storage(modality, corpus);
+    let wall = t0.elapsed();
+    let rss = sampler.stop_stats();
+    let metrics = phases.build.then_some(ShapeMetrics {
+        wall_ns: wall.as_secs_f64() * 1e9,
+        n_superfiles: built.n_superfiles,
+        peak_rss_bytes: rss.peak_rss_bytes,
+        median_rss_bytes: rss.median_rss_bytes,
+        p90_rss_bytes: rss.p90_rss_bytes,
+    });
+    (built, metrics)
+}
+
+/// Obtain the search artifact for modalities that don't need the corpus after
+/// build (FTS, SQL): in dataset mode open the pre-uploaded dataset (no corpus,
+/// no ingest); otherwise generate the corpus and ingest it. Vector keeps its
+/// corpus for recall ground truth and calls [`build_measured`] directly.
+fn build_or_open(
+    modality: Modality,
+    phases: Phases,
+) -> (supertable::IngestResult, Option<ShapeMetrics>) {
+    if crate::dataset::dataset_mode() {
+        return (supertable::open_dataset(modality), None);
+    }
+    // Corpus to disk + mmap BEFORE the sampler — engine-only window.
+    let corpus = supertable::prepare_corpus(modality);
+    build_measured(modality, &corpus, phases)
+}
+
 fn open_consumer(modality: Modality, built: &supertable::IngestResult) -> (TempDir, Supertable) {
     let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
         Arc::clone(&built.storage),
@@ -397,33 +435,9 @@ pub mod fts {
             return;
         }
 
-        if phases.build {
-            eprintln!(
-                "[supertable_fts] ingesting {} docs to object storage...",
-                fmt_count(n_docs),
-            );
-        } else {
-            eprintln!(
-                "[supertable_fts] building search artifact ({} docs) for warm/cold phases...",
-                fmt_count(n_docs),
-            );
-        }
-        // Corpus to disk + mmap BEFORE the sampler — engine-only window.
-        let corpus = supertable::prepare_corpus(Modality::Fts);
-        let sampler = PeakSampler::start_default();
-        let t0 = Instant::now();
-        let built = supertable::build_on_storage(Modality::Fts, &corpus);
-        let wall = t0.elapsed();
-        let rss = sampler.stop_stats();
-        let metrics = ShapeMetrics {
-            wall_ns: wall.as_secs_f64() * 1e9,
-            n_superfiles: built.n_superfiles,
-            peak_rss_bytes: rss.peak_rss_bytes,
-            median_rss_bytes: rss.median_rss_bytes,
-            p90_rss_bytes: rss.p90_rss_bytes,
-        };
-        if phases.build {
-            emit_ingest(&mut report, n_docs, &metrics);
+        let (built, ingest_metrics) = build_or_open(Modality::Fts, phases);
+        if let Some(metrics) = &ingest_metrics {
+            emit_ingest(&mut report, n_docs, metrics);
         }
 
         if phases.warm || phases.cold {
@@ -602,36 +616,17 @@ pub mod vector {
         }
 
         let n_docs = supertable::n_docs();
-        if phases.build {
-            eprintln!(
-                "[supertable_vector] ingesting {} docs × dim={DIM} to object storage...",
-                fmt_count(n_docs),
-            );
-        } else {
-            eprintln!(
-                "[supertable_vector] building search artifact ({} docs) for warm/cold phases...",
-                fmt_count(n_docs),
-            );
-        }
-        // Corpus to disk + mmap BEFORE the sampler — engine-only window.
-        // Kept alive for the search phase: the same mmap backs the
-        // ground-truth recall measurement instead of a regeneration.
+        // Corpus to disk + mmap (engine-only window). Kept alive for the
+        // search phase: the same vectors back the brute-force ground truth,
+        // so dataset mode regenerates it too (skipping only the ingest).
         let corpus = supertable::prepare_corpus(Modality::Vector);
-        let sampler = PeakSampler::start_default();
-        let t0 = Instant::now();
-        let built = supertable::build_on_storage(Modality::Vector, &corpus);
-        let wall = t0.elapsed();
-        let rss = sampler.stop_stats();
-
         let mut report = Report::load("supertable_vector");
-        let metrics = ShapeMetrics {
-            wall_ns: wall.as_secs_f64() * 1e9,
-            n_superfiles: built.n_superfiles,
-            peak_rss_bytes: rss.peak_rss_bytes,
-            median_rss_bytes: rss.median_rss_bytes,
-            p90_rss_bytes: rss.p90_rss_bytes,
+        let (built, ingest_metrics) = if crate::dataset::dataset_mode() {
+            (supertable::open_dataset(Modality::Vector), None)
+        } else {
+            build_measured(Modality::Vector, &corpus, phases)
         };
-        if phases.build {
+        if let Some(metrics) = &ingest_metrics {
             report.emit(&Section {
                 anchor: "bench/vector/supertable/ingest".into(),
                 title: format!(
@@ -652,7 +647,7 @@ pub mod vector {
                         "Median RSS".into(),
                         "P90 RSS".into(),
                     ],
-                    rows: vec![ingest_row(n_docs, "vector-only", &metrics)],
+                    rows: vec![ingest_row(n_docs, "vector-only", metrics)],
                 }],
             });
         }
@@ -794,34 +789,9 @@ pub mod sql {
         }
 
         let n_docs = supertable::n_docs();
-        if phases.build {
-            eprintln!(
-                "[supertable_sql] ingesting {} rows to object storage...",
-                fmt_count(n_docs)
-            );
-        } else {
-            eprintln!(
-                "[supertable_sql] building query artifact ({} rows) for warm/cold phases...",
-                fmt_count(n_docs),
-            );
-        }
-        // Corpus to disk + mmap BEFORE the sampler — engine-only window.
-        let corpus = supertable::prepare_corpus(Modality::Sql);
-        let sampler = PeakSampler::start_default();
-        let t0 = Instant::now();
-        let built = supertable::build_on_storage(Modality::Sql, &corpus);
-        let wall = t0.elapsed();
-        let rss = sampler.stop_stats();
-
         let mut report = Report::load("supertable_sql");
-        let metrics = ShapeMetrics {
-            wall_ns: wall.as_secs_f64() * 1e9,
-            n_superfiles: built.n_superfiles,
-            peak_rss_bytes: rss.peak_rss_bytes,
-            median_rss_bytes: rss.median_rss_bytes,
-            p90_rss_bytes: rss.p90_rss_bytes,
-        };
-        if phases.build {
+        let (built, ingest_metrics) = build_or_open(Modality::Sql, phases);
+        if let Some(metrics) = &ingest_metrics {
             report.emit(&Section {
                 anchor: "bench/sql/supertable/ingest".into(),
                 title: format!(
@@ -841,7 +811,7 @@ pub mod sql {
                         "Median RSS".into(),
                         "P90 RSS".into(),
                     ],
-                    rows: vec![ingest_row(n_docs, "SQL", &metrics)],
+                    rows: vec![ingest_row(n_docs, "SQL", metrics)],
                 }],
             });
         }

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -431,6 +431,30 @@ pub async fn supertable_storage_fixture() -> StorageFixture {
     }
 }
 
+/// Storage for a prepared dataset at a fixed prefix — no unique suffix, no
+/// cleanup, so the data persists across runs. `subdir` namespaces the modality
+/// under the base prefix from `INFINO_BENCH_DATASET_PREFIX`. Real backend only,
+/// same as [`supertable_storage_fixture`].
+pub async fn dataset_storage_fixture(subdir: &str) -> StorageFixture {
+    let backend = match Backend::from_env().unwrap_or_else(|e| panic!("{e}")) {
+        Backend::S3sFs => panic!("{SUPERTABLE_REQUIRES_REAL_OBJECT_STORE}"),
+        backend => backend,
+    };
+    let base = crate::dataset::dataset_prefix()
+        .expect("dataset_storage_fixture requires INFINO_BENCH_DATASET_PREFIX");
+    let prefix = format!("{}/{subdir}", base.trim_matches('/'));
+    let label = backend.label();
+    let storage = backend.provider(&prefix).expect("dataset provider");
+    eprintln!("[tiers] dataset {label} prefix={prefix}");
+    StorageFixture {
+        storage,
+        storage_label: label,
+        remote: true,
+        cleanup: None,
+        _keepalive: StorageKeepalive::Remote,
+    }
+}
+
 /// Upload one superfile blob for superfile-shaped warm/cold benches (1M).
 pub async fn commit_superfile(bytes: &Bytes) -> SuperfileCommitted {
     let fixture = backing_store(SUPERFILE_S3S_BUCKET, "infino-superfile-bench").await;


### PR DESCRIPTION
## What

Adds a "dataset mode" to the supertable benches: prepare a dataset once on
object storage, then benchmark its query/search phases repeatedly without
regenerating the corpus or re-ingesting. Gated entirely behind
`INFINO_BENCH_DATASET_PREFIX` — unset, every bench behaves exactly as before.

A new `workflow_dispatch` (`dataset-bench-azure.yml`) opens a named dataset
from Azure Blob and runs only its read phases.

## Why

Today every bench run generates 10M docs and ingests them to object storage
before it can measure anything — minutes of work repeated on every run, even
when only query latency is of interest. Ingest is the expensive part; the
corpus is fully seeded and deterministic, so a prepared dataset is reusable.
Splitting prepare from benchmark lets us pay the ingest once and iterate on
search/query numbers against frozen data.

## How

- **Knob guard** (`benches/utils/dataset.rs`): a dataset carries a `dataset.json`
  sidecar of the byte-affecting knobs (doc count, dim, n_cent, seeds, metric,
  codec, modality). On open, the bench verifies these match and refuses
  otherwise. Deliberately *not* keyed on `BUILDER_ID` (it changes every commit);
  on-disk format compatibility is the reader's existing `UnsupportedVersion`
  check.
- **Prepare** (`build_on_storage`): in dataset mode, ingest writes to a fixed,
  persistent prefix per modality (no unique suffix, no cleanup) and drops the
  sidecar via atomic-create (won't clobber an existing dataset).
- **Benchmark** (`supertable::{fts,vector,sql}` runners): read phases open the
  pre-uploaded dataset instead of ingesting. SQL reads its query sample from the
  sidecar; vector still regenerates the corpus for recall ground truth but skips
  the ingest. The build phase still ingests (that is the prepare step).
- **Workflow**: pick `dataset` + `modality` + `docs`; it pre-flights the sidecar
  before provisioning a VM, builds with the shared sccache, runs search/query,
  and reports latency. No baseline/history publish; `ci.yml` and the existing
  benchmark workflow are untouched.

## Validation

Ran end-to-end against Azure with a 1000-doc dataset:

- prepare → wrote segments + `dataset.json` to a fixed prefix (persisted)
- open → opened the dataset with no ingest
- search → `bm25_search` correct against opened data (df=1 → 1 hit)
- guard → a mismatched doc count is rejected with a clear "re-prepare" panic

## Notes

- Usage — first-class verbs (env var remains as the CI / child-process channel):
  ```sh
  cargo bench -- dataset prepare datasets/bench-10m          # ingest + sidecar
  cargo bench -- dataset bench   datasets/bench-10m vector   # read phases only
  cargo bench -- dataset run     datasets/bench-10m          # prepare if absent, then bench
  ```
  prepare fails fast if the dataset exists; bench fails fast if it doesn't;
  run is idempotent. The workflow exposes the same verbs as a `mode` input.
- Adds `serde` (derive) to the bench-utils crate only (already transitive via
  `serde_json`); no change to the shipped crate's dependencies.

