### PR TITLE
nit: remove action to build py package on  macos13 from ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       # Native runner per platform — `make python-wheel` builds for the
       # host, so no cross-compilation. One abi3 wheel each (CPython >= 3.9).
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14]
     steps:
       - uses: actions/checkout@v4
       - name: Free disk space


### PR DESCRIPTION
- Remove action to build python package on macos13 from ci pipeline.