### PR TITLE
rename: 'segment' terminology to 'superfile' across the codebase

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -307,7 +307,7 @@ jobs:
           cd "$HOME/infino-src"
           export INFINO_BENCH_STORE=azure
           [ "$KEEP" = "true" ] && export INFINO_BENCH_KEEP_TABLE=1
-          # The multi-commit build holds many segment files + object-store
+          # The multi-commit build holds many superfile files + object-store
           # connections open at once; raise the fd soft limit to the hard
           # max so commits don't hit EMFILE ("too many open files").
           ulimit -n "$(ulimit -Hn)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ cargo bench --bench bench -- tombstone
   was A/B-tested (all-tokio, all-rayon, and the hybrid; the hybrid won —
   rayon saturates cores better, tokio drives I/O better) and is the
   standing concurrency contract for the query and build paths:
-  - **tokio owns the I/O waves**: segment opens, object-store range
+  - **tokio owns the I/O waves**: superfile opens, object-store range
     GETs, sidecar prefetches — `tokio::spawn` / `try_join_all` on the
     shared multi-thread query runtime so connections pool and fetches
     overlap. Never build a throwaway per-call runtime on a worker
@@ -97,8 +97,8 @@ Performance *and* cost are first-class acceptance criteria for every change. A P
 
 One bench target (`[[bench]] name = "bench"`, `harness = false`, custom `main`) drives the whole suite; all measurement logic lives in the `infino-bench-utils` crate under `benches/utils/`. Selection is positional: `cargo bench --bench bench -- [tier] [modality] [phase ...]` with tier `superfile` | `supertable`, modality `fts` | `vector` | `sql`, phase `build` | `warm` | `cold` (omitted ⇒ all). A bare `cargo bench` runs every tier × modality. See `benches/README.md` for the full invocation guide and recorded result tables.
 
-- **`superfile` tier** — single-segment, in-memory scale (default 1M docs): BM25, IVF + RaBitQ vector, and SQL over one superfile.
-- **`supertable` tier** — multi-segment table over object storage (default 10M docs; backend chosen by `INFINO_BENCH_STORE`, in-process `s3s-fs` emulator by default): the warm/cold table paths for FTS, vector, and SQL.
+- **`superfile` tier** — single-superfile, in-memory scale (default 1M docs): BM25, IVF + RaBitQ vector, and SQL over one superfile.
+- **`supertable` tier** — multi-superfile table over object storage (default 10M docs; backend chosen by `INFINO_BENCH_STORE`, in-process `s3s-fs` emulator by default): the warm/cold table paths for FTS, vector, and SQL.
 
 Diagnostics are standalone programs sharing the same binary (tokens, not separate targets): `scale` (release-profile recall gates), `tombstone`, `update`, `sql-diag`, `object-store`. Scale knobs: `INFINO_BENCH_SUPERFILE_DOCS` / `INFINO_BENCH_SUPERTABLE_DOCS` (plain integers, per tier) and `INFINO_BENCH_WRITERS`.
 
@@ -112,7 +112,7 @@ Recorded numbers live in `benches/README.md`; the structured source of truth is 
 
 ## Security considerations
 
-- **Crash safety contract.** Committed superfiles must survive `SIGABRT` mid-flight. Verified by tests in `tests/supertable_commit_crash_localfs.rs` (parent spawns aborting child; assertions check segments persist). Don't break this contract; if your change touches the commit path, run that test specifically.
+- **Crash safety contract.** Committed superfiles must survive `SIGABRT` mid-flight. Verified by tests in `tests/supertable_commit_crash_localfs.rs` (parent spawns aborting child; assertions check superfiles persist). Don't break this contract; if your change touches the commit path, run that test specifically.
 - **Don't add new dependencies casually.** Supply-chain surface is part of the public crate's risk profile. New deps require justification in the PR body — what they enable, why no existing dep covers it, and the maintainer / license picture.
 - **No secrets in commits.** Agents have committed `.env` files before; the rule applies to them too.
 - **Object-store credentials** in tests use mock servers (`s3s` + `s3s-fs`); don't introduce tests that require live cloud credentials.
@@ -146,7 +146,7 @@ src/
 ├── catalog/               ← public entry point (connect → Connection → tables, search TVFs)
 ├── error.rs               ← the single public InfinoError (coarse, #[non_exhaustive])
 ├── storage/               ← byte-level I/O (StorageProvider trait, LocalFs, S3, Azure)
-├── superfile/             ← single-file format (immutable segments)
+├── superfile/             ← single-file format (immutable superfiles)
 │   ├── builder.rs         ← write path
 │   ├── reader.rs          ← read path
 │   ├── format/            ← binary layout (footer, CRC)
@@ -156,11 +156,11 @@ src/
 ├── supertable/            ← table layer (composes many superfiles)
 │   ├── handle.rs          ← Supertable, ArcSwap<Manifest>, single-writer slot
 │   ├── writer.rs          ← append + commit
-│   ├── manifest/          ← segment list + Bloom + min/max + partition strategies
-│   ├── query/             ← cross-segment fanout (fts, vector, sql)
+│   ├── manifest/          ← superfile list + Bloom + min/max + partition strategies
+│   ├── query/             ← cross-superfile fanout (fts, vector, sql)
 │   ├── tombstones/        ← runtime tombstone cache (filtering deleted rows)
 │   ├── wal/               ← write-ahead log for update/delete pipeline
-│   └── reader_cache/      ← per-process segment cache
+│   └── reader_cache/      ← per-process superfile cache
 ├── config/                ← runtime tuning knobs (StorageSettings + defaults)
 ├── runtime_bridge.rs      ← sync ↔ async runtime glue
 └── test_helpers/          ← shared test fixtures (pub for integration tests)
@@ -220,7 +220,7 @@ Rule of thumb for landing a change in the right place:
 - **Non-Parquet file format** (e.g. a proprietary columnar layout like Lance). Search-on-Parquet is the thesis; ecosystem reuse outweighs a 30-50% storage win.
 - **WAL-based ingest** (per-row durability before commit). Rejected as a different architectural model; commit-as-durability-boundary is deliberate. Note: a WAL *does* exist in `src/supertable/wal/` for the **updates/deletes** pipeline — that's orchestration state, not ingest durability. Don't conflate.
 - **HNSW graph inside each IVF partition.** Memory cost is 80 MB / 1M docs for an 18% warm-search win; not worth it given our high-`n_cent` + 1-bit-code shape.
-- **SPFresh-style in-place IVF rebalance.** Segments are immutable by design. Updates = delete + insert via tombstones.
+- **SPFresh-style in-place IVF rebalance.** Superfiles are immutable by design. Updates = delete + insert via tombstones.
 - **Multi-vector / ColBERT-style per-token vectors.** Niche; better as a sidecar pattern than a format primitive.
 - `**range_concurrent(&[Range])` storage API.** `LazyByteSource::range` is already `async fn`; callers parallelize with `try_join_all` or `FuturesUnordered`.
 
@@ -235,7 +235,7 @@ storage/superfile/supertable layers, which are themselves internal.
 
 - **Entry points** — `connect(uri)` and `connect_with(uri, ConnectOptions)`, returning a `Connection`.
 - `**Connection`** — `create_table`, `open_table`, `drop_table` (logical by default; `purge = true` also deletes the table's storage subtree), `list_tables`, `query_sql`.
-- `**Supertable**` (the table handle) — `append`, `update`, `delete`, `schema`, plus the sync search surface. All four search methods (`bm25_search`, `vector_search`, and the unranked `token_match` / `exact_match`) return Arrow rows (`Vec<RecordBatch>`) and take a `projection: Option<&[&str]>` naming the output columns (`_id`, any visible scalar column, or the trailing `score`); `None` returns the whole row, and only the projected scalar columns are decoded — `Some(&["_id", "score"])` is the no-scalar-decode path. The async kernels and the segment-local hit representation stay on the internal `SupertableReader`; the public methods resolve to the stable `_id` before returning.
+- `**Supertable**` (the table handle) — `append`, `update`, `delete`, `schema`, plus the sync search surface. All four search methods (`bm25_search`, `vector_search`, and the unranked `token_match` / `exact_match`) return Arrow rows (`Vec<RecordBatch>`) and take a `projection: Option<&[&str]>` naming the output columns (`_id`, any visible scalar column, or the trailing `score`); `None` returns the whole row, and only the projected scalar columns are decoded — `Some(&["_id", "score"])` is the no-scalar-decode path. The async kernels and the superfile-local hit representation stay on the internal `SupertableReader`; the public methods resolve to the stable `_id` before returning.
 - **Supporting types** — `ConnectOptions`, `ColdFetchMode`, `IndexSpec`, `Metric`, `BoolMode`, `VectorSearchOptions`, `MutationStats`, the `InfinoError` enum, and `BUILDER_ID`.
 
 Everything else — `SupertableReader`/`SupertableWriter`, the manifest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,4 +107,4 @@ references in [`docs/architecture/`](docs/architecture/) —
 [`superfile.md`](docs/architecture/superfile.md) (the on-disk format
 and single-file reader/builder) and
 [`supertable.md`](docs/architecture/supertable.md) (the in-memory
-cross-segment query and manifest layer).
+cross-superfile query and manifest layer).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,9 @@ bytes = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-# Supertable: lock-free manifest swap + segment ids + FTS bloom hash.
+# Supertable: lock-free manifest swap + superfile ids + FTS bloom hash.
 # Manifest is held in ArcSwap<Manifest> for reader-writer isolation;
-# SegmentEntry.segment_id is a v4 UUID; the FTS term-presence bloom
+# SuperfileEntry.superfile_id is a v4 UUID; the FTS term-presence bloom
 # uses XXH3-64 — terms come from a closed corpus (no HashDoS risk),
 # and XXH3 is significantly faster than SipHash on the miss path
 # where hash cost dominates.
@@ -140,7 +140,7 @@ object_store = { version = "0.13", features = ["aws", "azure"] }
 # requires boxed futures.
 async-trait = "0.1"
 
-# Manifest-part serde. Avro for the dense per-segment
+# Manifest-part serde. Avro for the dense per-superfile
 # tier (matches Iceberg's manifest-file choice at scale); zstd
 # for compression; blake3 for content-addressing.
 #

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ and as a search index by infino's reader.
 ## Links
 
 - **[Superfile architecture →](docs/architecture/superfile.md)** —
-  the single-file segment format: a valid Parquet file with embedded
+  the single-file superfile format: a valid Parquet file with embedded
   full-text and vector indexes. Covers the layout, Parquet
   compatibility, and the full-text and vector index design.
 - **[Supertable architecture →](docs/architecture/supertable.md)** —
-  the table layer over superfile segments: manifest snapshots, the
+  the table layer over superfile superfiles: manifest snapshots, the
   commit/publish path, pluggable storage, query fan-out with
   manifest-only skip pruning, and reader/writer concurrency.
 
@@ -54,7 +54,7 @@ let db = connect("memory://")?; // or "./data", "s3://bucket/prefix"
 let schema = Arc::new(Schema::new(vec![Field::new("title", DataType::LargeUtf8, false)]));
 let docs = db.create_table("docs", schema.clone(), IndexSpec::new().fts("title"))?;
 
-// One `append` == one commit == one sealed, immutable segment.
+// One `append` == one commit == one sealed, immutable superfile.
 let batch = RecordBatch::try_new(
     schema,
     vec![Arc::new(LargeStringArray::from(vec!["the quick brown fox"]))],
@@ -68,7 +68,7 @@ docs.append(&batch)?;
 let batches = docs.bm25_search("title", "fox", 10, BoolMode::Or, Some(&["_id", "title", "score"]))?;
 assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
 
-// SQL across the catalog — every segment is also a valid Parquet file.
+// SQL across the catalog — every superfile is also a valid Parquet file.
 let rows = db.query_sql("SELECT _id, title FROM docs")?;
 assert_eq!(rows.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -152,7 +152,7 @@ GROUP BY category;
 
 Equality, `IN`, and boolean combinations on an indexed text column
 resolve through the index to an exact candidate row set before any
-column data is read. Segments that can't match are never opened at all:
+column data is read. Superfiles that can't match are never opened at all:
 term blooms, value ranges, and vector centroids live side by side in the
 manifest, so scalar, keyword, and vector signals prune through one
 shared layer.

--- a/benches/README.md
+++ b/benches/README.md
@@ -150,10 +150,10 @@ existed yet.
 Current numbers: 1M docs per tier, real AWS S3 (us-east-1), recorded
 2026-06-09. Supertable tables are 256 superfiles across 16 commits.
 
-### FTS — superfile (single-segment, 1M docs)
+### FTS — superfile (single-superfile, 1M docs)
 
 <!-- BEGIN: bench/fts/superfile/ingest -->
-### Superfile FTS — ingest, single-segment / in-memory (1M docs, Zipfian, 200 tokens/doc, 10K vocab)
+### Superfile FTS — ingest, single-superfile / in-memory (1M docs, Zipfian, 200 tokens/doc, 10K vocab)
 
 _Host: unknown CPU · 10C/10T · macos/aarch64_
 
@@ -166,7 +166,7 @@ Build path: `SuperfileBuilder` → unified `.parquet` (same as production supert
 <!-- END: bench/fts/superfile/ingest -->
 
 <!-- BEGIN: bench/fts/superfile/search -->
-### Superfile FTS — search, single-segment / in-memory (1M docs)
+### Superfile FTS — search, single-superfile / in-memory (1M docs)
 
 _Host: unknown CPU · 10C/10T · macos/aarch64_
 
@@ -222,10 +222,10 @@ Through the string `bm25_hits_async` path (parses the `-` sigil); a correctness 
 | two_mid_and_common_neg | 5.15 ms (+3.2% worse) |
 <!-- END: bench/fts/superfile/negation -->
 
-### FTS — supertable (multi-segment, 1M docs, real S3)
+### FTS — supertable (multi-superfile, 1M docs, real S3)
 
 <!-- BEGIN: bench/fts/supertable/ingest -->
-### Supertable FTS — ingest, multi-segment / object-store (1M docs, 16 commits)
+### Supertable FTS — ingest, multi-superfile / object-store (1M docs, 16 commits)
 
 _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 
@@ -235,7 +235,7 @@ _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 <!-- END: bench/fts/supertable/ingest -->
 
 <!-- BEGIN: bench/fts/supertable/search -->
-### Supertable FTS — search, multi-segment / object-store (1M docs)
+### Supertable FTS — search, multi-superfile / object-store (1M docs)
 
 _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 
@@ -263,10 +263,10 @@ _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 | ten_term_and | 34.90 ms (new) | 8.67 GiB (new) | 8.67 GiB (new) | 8.67 GiB (new) | 544.50 ms (new) |
 <!-- END: bench/fts/supertable/search -->
 
-### Vector — superfile (single-segment, 1M × 384)
+### Vector — superfile (single-superfile, 1M × 384)
 
 <!-- BEGIN: bench/vector/superfile/ingest -->
-### Superfile vector — ingest, single-segment / in-memory (1M docs × dim=384)
+### Superfile vector — ingest, single-superfile / in-memory (1M docs × dim=384)
 
 _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 
@@ -277,7 +277,7 @@ _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 <!-- END: bench/vector/superfile/ingest -->
 
 <!-- BEGIN: bench/vector/superfile/search -->
-### Superfile vector — search, single-segment / in-memory (1M docs × dim=384)
+### Superfile vector — search, single-superfile / in-memory (1M docs × dim=384)
 
 _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 
@@ -289,10 +289,10 @@ _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 | default | p=8, r=20 | — | 853.92 µs (new) | 4.30 GiB (new) | 4.30 GiB (new) | 4.30 GiB (new) | 593.77 ms (new) |
 <!-- END: bench/vector/superfile/search -->
 
-### Vector — supertable (multi-segment, 1M × 384, real S3)
+### Vector — supertable (multi-superfile, 1M × 384, real S3)
 
 <!-- BEGIN: bench/vector/supertable/ingest -->
-### Supertable vector — ingest, multi-segment / object-store (1M docs × dim=384, 16 commits)
+### Supertable vector — ingest, multi-superfile / object-store (1M docs × dim=384, 16 commits)
 
 _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 
@@ -302,7 +302,7 @@ _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 <!-- END: bench/vector/supertable/ingest -->
 
 <!-- BEGIN: bench/vector/supertable/search -->
-### Supertable vector — search, multi-segment / object-store (1M docs × dim=384)
+### Supertable vector — search, multi-superfile / object-store (1M docs × dim=384)
 
 _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 
@@ -319,7 +319,7 @@ Correctness gate: recall@10 = 0.995 (nprobe=64, rerank=256, 20 queries).
 ### Supertable — ingest summary (all shapes, real S3)
 
 <!-- BEGIN: bench/supertable/ingest -->
-### Supertable — ingest, multi-segment / object-store (1M docs, 16 commits)
+### Supertable — ingest, multi-superfile / object-store (1M docs, 16 commits)
 
 _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 
@@ -424,10 +424,10 @@ _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 | group_by_category | 203.36 ms (new) |
 <!-- END: bench/sql/superfile/cold -->
 
-### SQL — supertable (multi-segment, 1M rows, real S3)
+### SQL — supertable (multi-superfile, 1M rows, real S3)
 
 <!-- BEGIN: bench/sql/supertable/ingest -->
-### Supertable SQL — ingest, multi-segment / object-store (1M rows, 16 commits)
+### Supertable SQL — ingest, multi-superfile / object-store (1M rows, 16 commits)
 
 _Host: Intel(R) Xeon(R) Platinum 8488C · 8C/16T · 31 GiB RAM · linux/x86_64_
 

--- a/benches/utils/Cargo.toml
+++ b/benches/utils/Cargo.toml
@@ -10,8 +10,8 @@ path = "mod.rs"
 bench = false
 
 [[bin]]
-name = "profile_segment"
-path = "bin/profile_segment.rs"
+name = "profile_superfile"
+path = "bin/profile_superfile.rs"
 bench = false
 
 

--- a/benches/utils/bench/supertable/query.rs
+++ b/benches/utils/bench/supertable/query.rs
@@ -31,7 +31,7 @@ pub fn vector_topk_global(
             let seg_idx = manifest
                 .superfiles
                 .iter()
-                .position(|e| e.uri == h.segment)
+                .position(|e| e.uri == h.superfile)
                 .expect("superfile in manifest");
             offsets[seg_idx] + h.local_doc_id
         })

--- a/benches/utils/bin/profile_superfile.rs
+++ b/benches/utils/bin/profile_superfile.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Standalone profiling harness for the per-segment vector query path.
+//! Standalone profiling harness for the per-superfile vector query path.
 //!
-//! Builds ONE supertable-segment-sized superfile (default 2.5M docs,
+//! Builds ONE supertable-superfile-sized superfile (default 2.5M docs,
 //! `n_cent = 1024`, dim 384, Sq8 / Cosine — i.e. one of the four
-//! 10M-supertable segments) and times the warm in-memory
+//! 10M-supertable superfiles) and times the warm in-memory
 //! `SuperfileReader::search` across an `(nprobe, rerank_mult)` grid,
 //! reporting per-config latency and recall@10.
 //!
@@ -17,16 +17,16 @@
 //!   * sweep `nprobe` at small `rerank_mult` -> coarse 1-bit scan cost
 //!   * sweep `rerank_mult` at fixed `nprobe` -> Sq8 rerank cost
 //!
-//! and the recall column shows whether per-segment recall keeps
+//! and the recall column shows whether per-superfile recall keeps
 //! climbing past the old 16-probe cap (the ceiling question).
 //!
-//! To A/B the within-segment rayon parallelism, flip
+//! To A/B the within-superfile rayon parallelism, flip
 //! `PARALLEL_SCAN_MIN` in `src/superfile/vector/reader.rs`
 //! (`usize::MAX` forces serial, `0` forces parallel) and rerun.
 //!
 //! Run:
-//!   cargo run --release -p infino-bench-utils --bin profile_segment
-//!   cargo run --release -p infino-bench-utils --bin profile_segment -- 625000 256
+//!   cargo run --release -p infino-bench-utils --bin profile_superfile
+//!   cargo run --release -p infino-bench-utils --bin profile_superfile -- 625000 256
 
 use std::collections::HashSet;
 use std::time::Instant;
@@ -40,9 +40,9 @@ const N_QUERIES: usize = 30;
 const TOP_K: usize = 10;
 const SIGMA: f32 = 0.1;
 
-/// Default segment doc count (one 10M-shard slice) when no CLI arg.
+/// Default superfile doc count (one 10M-shard slice) when no CLI arg.
 const DEFAULT_N_DOCS: usize = 2_500_000;
-/// Default IVF centroid count when no CLI arg (matches a supertable segment).
+/// Default IVF centroid count when no CLI arg (matches a supertable superfile).
 const DEFAULT_N_CENT: usize = 1024;
 /// XOR mask decorrelating the query seed from the corpus seed.
 const QUERY_SEED_XOR: u64 = 0x9e37;
@@ -66,7 +66,7 @@ fn main() {
         .unwrap_or(DEFAULT_N_CENT);
 
     eprintln!(
-        "[profile] building 1 segment: {n_docs} docs, n_cent={n_cent}, dim={DIM}, Sq8/Cosine"
+        "[profile] building 1 superfile: {n_docs} docs, n_cent={n_cent}, dim={DIM}, Sq8/Cosine"
     );
     let t = Instant::now();
     let vectors = corpus::generate_vector_corpus(n_docs, n_cent, SEED, true);

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -14,7 +14,7 @@
 //! ## Scale policy
 //!
 //! Scale is fixed by *shape*, not by an environment variable:
-//! superfile-shape benches use [`SUPERFILE_DOCS`] (1M, one-segment
+//! superfile-shape benches use [`SUPERFILE_DOCS`] (1M, one-superfile
 //! scale), supertable-shape benches use [`SUPERTABLE_DOCS`] (10M,
 //! sharding scale). Vector at 10M × 384 (f32) = 14.6 GB resident —
 //! needs a 32 GB+ machine. There is deliberately no `INFINO_BENCH_FULL`
@@ -90,7 +90,7 @@ pub const DIM: usize = 384;
 /// returns. Re-exported here so recall helpers stay engine-agnostic.
 pub type Hit = (u32, f32);
 
-/// Doc count for superfile-shape benches (one-segment scale). 1M ×
+/// Doc count for superfile-shape benches (one-superfile scale). 1M ×
 /// 384 (f32) ≈ 1.5 GB — fits comfortably in RAM for the warm tier and
 /// is the single-superfile cold-open unit for the warm/cold tiers.
 pub const SUPERFILE_DOCS: usize = 1_000_000;
@@ -101,7 +101,7 @@ pub const SUPERFILE_DOCS: usize = 1_000_000;
 /// over the object store.
 pub const SUPERTABLE_DOCS: usize = 10_000_000;
 
-/// Document count for the **superfile** test — a single-segment index
+/// Document count for the **superfile** test — a single-superfile index
 /// built and queried entirely **in memory**. Defaults to
 /// [`SUPERFILE_DOCS`] (1M); override with `INFINO_BENCH_SUPERFILE_DOCS`
 /// for a quicker local loop or a larger stress run.
@@ -109,7 +109,7 @@ pub fn superfile_docs() -> usize {
     docs_from_env("INFINO_BENCH_SUPERFILE_DOCS", SUPERFILE_DOCS)
 }
 
-/// Document count for the **supertable** test — a multi-segment table
+/// Document count for the **supertable** test — a multi-superfile table
 /// committed to and queried from **object storage**. Defaults to
 /// [`SUPERTABLE_DOCS`] (10M); override with
 /// `INFINO_BENCH_SUPERTABLE_DOCS`.
@@ -799,7 +799,7 @@ pub fn build_fts_index(docs: &[String]) -> FtsBuilder {
 /// Build a stand-alone vector index. `vectors` is flat `n_docs * DIM`.
 ///
 /// Bench harness picks `Sq8` by default to match the on-disk
-/// default for production segments. Per-cluster scale/offset
+/// default for production superfiles. Per-cluster scale/offset
 /// quantizer is the active codec (drop ≤ 0.04 on the
 /// pathological planted-cluster synthetic; expected near-zero on
 /// real embeddings). Callers measuring the Fp32 baseline (recall

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -5,7 +5,7 @@
 //!
 //! One implementation of each benchmark's query battery, query
 //! execution, warm/cold measurement, and report rendering. Both the
-//! superfile (single-segment, in-memory) and supertable (multi-segment,
+//! superfile (single-superfile, in-memory) and supertable (multi-superfile,
 //! object-store) runners call these functions; the only thing each tier
 //! supplies is a *reader* (and, for cold, a way to open a fresh one).
 //! The reader type is an implementation detail hidden behind the
@@ -26,7 +26,7 @@ pub fn p50(samples: &mut [Duration]) -> Duration {
 
 /// Cold timings for one query, split at the open/search boundary:
 /// `open` is the fresh-consumer open (consumer + manifest + every
-/// segment reader), `search` is the first query over the opened but
+/// superfile reader), `search` is the first query over the opened but
 /// data-cold table. Timed separately so cold search latency never
 /// bills the one-time open bookkeeping — the same cold-open vs
 /// cold-first-search split the quick-iter object-store harness uses.
@@ -36,12 +36,12 @@ pub struct ColdTiming {
     pub search: Duration,
 }
 
-/// Force-open every segment reader on the consumer's pinned snapshot —
-/// the "cold open" phase of a cold iteration. Runs the same per-segment
+/// Force-open every superfile reader on the consumer's pinned snapshot —
+/// the "cold open" phase of a cold iteration. Runs the same per-superfile
 /// open the query fan-out would lazily trigger (in-memory tier → disk
 /// cache admit → lazy range-GET fallback), concurrently like the query
 /// path, so the subsequent timed search pays only the search work.
-pub fn open_all_segments(consumer: &infino::supertable::Supertable) {
+pub fn open_all_superfiles(consumer: &infino::supertable::Supertable) {
     let reader = consumer.reader();
     let manifest = reader.manifest();
     let store = &manifest.options.store;
@@ -58,7 +58,7 @@ pub fn open_all_segments(consumer: &infino::supertable::Supertable) {
             )
         }))
         .await
-        .expect("cold open: open segment readers");
+        .expect("cold open: open superfile readers");
     });
 }
 
@@ -305,7 +305,7 @@ pub mod fts {
     /// [`ColdTiming`]). `open_fresh` returns a guard that both
     /// implements [`FtsRead`] and owns the cache/consumer resources it
     /// must drop after the timed read; the guard's constructor performs
-    /// the full open (consumer + segment readers).
+    /// the full open (consumer + superfile readers).
     pub fn measure_cold<G: FtsRead>(
         open_fresh: impl Fn() -> G,
         battery: &[FtsQuery],
@@ -514,7 +514,7 @@ pub mod vector {
 
     /// A reader the vector executor runs kNN against, returning **global**
     /// `(doc_id, score)` hits so recall can be graded against brute-force
-    /// ground truth regardless of how many segments back the reader.
+    /// ground truth regardless of how many superfiles back the reader.
     pub trait VectorRead {
         fn topk_global(
             &self,
@@ -535,7 +535,7 @@ pub mod vector {
             nprobe: usize,
             rerank: usize,
         ) -> Vec<(u32, f32)> {
-            // Single segment: local_doc_id == global id.
+            // Single superfile: local_doc_id == global id.
             crate::tiers::block_on(self.vector_hits_async(
                 column,
                 query,
@@ -560,7 +560,7 @@ pub mod vector {
                 .vector_hits(column, query, k, search_opts(nprobe, rerank))
                 .expect("supertable vector_hits");
             let manifest = reader.manifest();
-            // Per-segment global-id base offsets in manifest order.
+            // Per-superfile global-id base offsets in manifest order.
             let mut offsets: Vec<u32> = Vec::with_capacity(manifest.superfiles.len());
             let mut acc: u32 = 0;
             for entry in manifest.superfiles.iter() {
@@ -572,8 +572,8 @@ pub mod vector {
                     let seg_idx = manifest
                         .superfiles
                         .iter()
-                        .position(|e| e.uri == h.segment)
-                        .expect("hit segment present in manifest");
+                        .position(|e| e.uri == h.superfile)
+                        .expect("hit superfile present in manifest");
                     (offsets[seg_idx] + h.local_doc_id, h.score)
                 })
                 .collect()

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -39,7 +39,7 @@ const CORPUS_TEXT_SEED: u64 = 1;
 
 /// Random-rotation RNG seed for the bench vector index.
 const ROT_SEED: u64 = 7;
-/// Writer auto-flush threshold (MiB) per segment roll.
+/// Writer auto-flush threshold (MiB) per superfile roll.
 const COMMIT_THRESHOLD_SIZE_MB: u64 = 1024;
 /// Producer memory budget (8 GiB) capping resident RSS during ingest.
 const WRITER_MEMORY_BUDGET_BYTES: u64 = 8 * (1u64 << 30);
@@ -143,7 +143,7 @@ pub fn options_for(
         return opts;
     }
     let n_cent_total = corpus::n_cent(n_docs());
-    let n_cent_per_segment = (n_cent_total / N_COMMIT_CHUNKS).max(1);
+    let n_cent_per_superfile = (n_cent_total / N_COMMIT_CHUNKS).max(1);
     let pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(num_cpus::get().max(1))
@@ -162,7 +162,7 @@ pub fn options_for(
         vec![VectorConfig {
             column: VEC_COLUMN.into(),
             dim: DIM,
-            n_cent: n_cent_per_segment,
+            n_cent: n_cent_per_superfile,
             rot_seed: ROT_SEED,
             metric: Metric::Cosine,
             rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
@@ -244,7 +244,7 @@ pub fn build_on_storage(modality: Modality, corpus: &PreparedCorpus) -> IngestRe
     );
     let storage_backend = tiers::block_on(tiers::supertable_storage_fixture());
     let cleanup = storage_backend.cleanup.clone();
-    // Disk cache attached only to keep segment bytes out of the unbounded
+    // Disk cache attached only to keep superfile bytes out of the unbounded
     // in-memory store; this producer is dropped right after ingest, so skip
     // the post-commit warm-fill (pure waste + "budget exceeded" log spam).
     let (cache_dir, cache) = tiers::fresh_disk_cache(Arc::clone(&storage_backend.storage));

--- a/benches/utils/sql_diag.rs
+++ b/benches/utils/sql_diag.rs
@@ -12,13 +12,13 @@
 //! over the **same** data, so the cost can be attributed to a layer:
 //!
 //!   * `infino query_sql`        — the full path we want to speed up
-//!     (segment prune → in-memory object store → DataFusion
+//!     (superfile prune → in-memory object store → DataFusion
 //!     `ParquetSource` → `FilterExec` → collect).
 //!   * `  ├ parse+plan`          — `ctx.sql(...)` on the cached
 //!     `SessionContext` (planning only, no execution).
 //!   * `  └ execute`             — `DataFrame::collect()` (the scan).
 //!   * `DataFusion / parquet`    — vanilla DataFusion reading the same
-//!     segment Parquet files from a temp dir via `register_parquet`.
+//!     superfile Parquet files from a temp dir via `register_parquet`.
 //!     Isolates infino's provider/object-store wrapper: if this
 //!     matches `query_sql`, the wrapper is free and the cost is
 //!     DataFusion's Parquet scan itself.
@@ -27,7 +27,7 @@
 //!     floor for DataFusion's executor + output materialization.
 //!   * `raw parquet-rs decode`   — `ParquetRecordBatchReaderBuilder`
 //!     decoding only the projected column(s) straight from the
-//!     segment bytes, predicate applied by hand. The floor a custom
+//!     superfile bytes, predicate applied by hand. The floor a custom
 //!     `ExecutionPlan` that decodes our layout directly would
 //!     approach.
 //!
@@ -68,7 +68,7 @@ use crate::corpus::{self, MmapTextCorpus};
 use crate::markdown::fmt_count;
 
 /// Rows per commit — mirrors `InfinoSqlEngine`'s `WRITE_CHUNK`, so the
-/// segment count matches the headline SQL bench.
+/// superfile count matches the headline SQL bench.
 const WRITE_CHUNK: usize = 65_536;
 
 /// Round-robin category labels (matches `superfile::sql::CATEGORIES`).
@@ -196,14 +196,14 @@ fn time_path(iters: usize, mut f: impl FnMut() -> usize) -> (Duration, Duration,
     (percentile(&mut samples, 50), mean, rows)
 }
 
-/// Raw parquet-rs decode of `cols` from every segment, applying `keep`
+/// Raw parquet-rs decode of `cols` from every superfile, applying `keep`
 /// to each row by hand and counting survivors — the direct-decode
 /// floor a custom `ExecutionPlan` would approach. When only `title`
 /// is projected (no filter columns) the per-row predicate is skipped
 /// entirely, matching a filterless scan.
-fn raw_decode(segments: &[Bytes], cols: &[usize], keep: fn(&str, i64) -> bool) -> usize {
+fn raw_decode(superfiles: &[Bytes], cols: &[usize], keep: fn(&str, i64) -> bool) -> usize {
     let mut kept = 0usize;
-    for bytes in segments {
+    for bytes in superfiles {
         let builder =
             ParquetRecordBatchReaderBuilder::try_new(bytes.clone()).expect("parquet builder");
         let mask = ProjectionMask::roots(builder.parquet_schema(), cols.iter().copied());
@@ -267,16 +267,16 @@ pub fn run() {
         fmt_count(n)
     );
 
-    // ── Shared corpus + per-chunk batches (the "segments"). ──────────
+    // ── Shared corpus + per-chunk batches (the "superfiles"). ──────────
     eprintln!("[sql-diag] generating {}-row corpus...", fmt_count(n));
     let corpus = MmapTextCorpus::generate(n, 1);
     let corpus_rows = corpus.rows();
     let batches: Vec<RecordBatch> = corpus_rows.chunks(WRITE_CHUNK).map(chunk_batch).collect();
-    let segments: Vec<Bytes> = batches.iter().map(batch_to_parquet).collect();
+    let superfiles: Vec<Bytes> = batches.iter().map(batch_to_parquet).collect();
     eprintln!(
-        "[sql-diag] {} segment(s), {:.1} MiB parquet total",
+        "[sql-diag] {} superfile(s), {:.1} MiB parquet total",
         batches.len(),
-        segments.iter().map(|b| b.len()).sum::<usize>() as f64 / (1024.0 * 1024.0)
+        superfiles.iter().map(|b| b.len()).sum::<usize>() as f64 / (1024.0 * 1024.0)
     );
 
     // ── infino Supertable (scalar + FTS), committed per chunk. ───────
@@ -295,11 +295,11 @@ pub fn run() {
         build_t0.elapsed().as_secs_f64()
     );
 
-    // Spill segments to a temp dir for the vanilla-DataFusion baseline.
+    // Spill superfiles to a temp dir for the vanilla-DataFusion baseline.
     let dir = tempfile::TempDir::new().expect("tempdir");
-    for (i, bytes) in segments.iter().enumerate() {
+    for (i, bytes) in superfiles.iter().enumerate() {
         let path = dir.path().join(format!("seg_{i:05}.parquet"));
-        std::fs::write(&path, bytes).expect("write segment parquet");
+        std::fs::write(&path, bytes).expect("write superfile parquet");
     }
 
     let rt = Runtime::new().expect("tokio runtime");
@@ -421,8 +421,9 @@ pub fn run() {
         };
 
         // 4. raw parquet-rs decode floor.
-        let (raw_p50, raw_mean, raw_rows) =
-            time_path(iters, || raw_decode(&segments, shape.raw_cols, shape.keep));
+        let (raw_p50, raw_mean, raw_rows) = time_path(iters, || {
+            raw_decode(&superfiles, shape.raw_cols, shape.keep)
+        });
 
         // Sanity: every path must agree on the result-set size.
         assert_eq!(

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -375,7 +375,7 @@ pub mod fts {
                 &mut report,
                 "bench/fts/superfile/search",
                 format!(
-                    "Superfile FTS — search, single-segment / in-memory ({} docs)",
+                    "Superfile FTS — search, single-superfile / in-memory ({} docs)",
                     fmt_count(n_docs)
                 ),
                 "Warm = `SuperfileReader::open` in memory (per-query p50); cold = same `.parquet` on \
@@ -627,7 +627,7 @@ pub mod fts {
         report.emit(&Section {
             anchor: "bench/fts/superfile/ingest".into(),
             title: format!(
-                "Superfile FTS — ingest, single-segment / in-memory ({} docs, Zipfian, 200 tokens/doc, 10K vocab)",
+                "Superfile FTS — ingest, single-superfile / in-memory ({} docs, Zipfian, 200 tokens/doc, 10K vocab)",
                 fmt_count(n_docs)
             ),
             note: "Build path: `SuperfileBuilder` → unified `.parquet` (same as production supertable \
@@ -846,7 +846,7 @@ pub mod vector {
                 "superfile_vec",
                 "bench/vector/superfile/search",
                 format!(
-                    "Superfile vector — search, single-segment / in-memory ({} docs × dim={DIM})",
+                    "Superfile vector — search, single-superfile / in-memory ({} docs × dim={DIM})",
                     fmt_count(n_docs)
                 ),
                 "Correctness, warm search, and cold upload reuse the measured 1-writer artifact. Recall rows use the lowest-p50 calibrated point meeting each target; `default` is the user-facing option baseline. Δ is vs the previous run.",
@@ -949,7 +949,7 @@ pub mod vector {
         report.emit(&Section {
             anchor: "bench/vector/superfile/ingest".into(),
             title: format!(
-                "Superfile vector — ingest, single-segment / in-memory ({} docs × dim={DIM})",
+                "Superfile vector — ingest, single-superfile / in-memory ({} docs × dim={DIM})",
                 fmt_count(n_docs)
             ),
             note: "Build path: `SuperfileBuilder` → unified `.parquet`, through `VectorEngine`. Rows are by writer count; `1 writer` is the canonical artifact used by correctness/search/cold upload. Δ is vs the previous run.".into(),
@@ -1190,7 +1190,7 @@ pub mod sql {
         let cold = exec_sql::measure_cold(
             || {
                 let (cache_dir, table) = open_cold_consumer(&artifact);
-                crate::executors::open_all_segments(&table);
+                crate::executors::open_all_superfiles(&table);
                 SqlColdGuard {
                     _cache_dir: cache_dir,
                     table,

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -3,7 +3,7 @@
 
 //! Supertable object-store bench (infino-only entry point).
 //!
-//! Multi-segment ingest to object storage at the supertable scale
+//! Multi-superfile ingest to object storage at the supertable scale
 //! (`INFINO_BENCH_SUPERTABLE_DOCS`, default 10M), built through the
 //! production `SupertableWriter::append` + `commit` path. Three index
 //! shapes are measured for apples-to-apples comparison against
@@ -297,7 +297,7 @@ pub fn run() {
     report.emit(&Section {
         anchor: "bench/supertable/ingest".into(),
         title: format!(
-            "Supertable — ingest, multi-segment / object-store ({} docs × dim={}, {} commits)",
+            "Supertable — ingest, multi-superfile / object-store ({} docs × dim={}, {} commits)",
             fmt_count(n_docs),
             crate::corpus::DIM,
             supertable::N_COMMIT_CHUNKS
@@ -306,7 +306,7 @@ pub fn run() {
                Each shape is built in its own subprocess, so Peak/Median/P90 RSS are measured from a \
                clean address space and are comparable across shapes. Rows are the three index shapes \
                built from the same seeded corpus, so each is directly comparable to its single-modality \
-               peer. Throughput is rows/s; `Superfiles` is the committed segment count. Δ is vs the \
+               peer. Throughput is rows/s; `Superfiles` is the committed superfile count. Δ is vs the \
                previous run."
             .into(),
         blocks: vec![Block {
@@ -441,7 +441,7 @@ pub mod fts {
                 &mut report,
                 "bench/fts/supertable/search",
                 format!(
-                    "Supertable FTS — search, multi-segment / object-store ({} docs)",
+                    "Supertable FTS — search, multi-superfile / object-store ({} docs)",
                     fmt_count(n_docs)
                 ),
                 "Warm = shared consumer + disk cache (untimed prewarm + wait_until_warm, then per-query \
@@ -465,11 +465,11 @@ pub mod fts {
         report.emit(&Section {
             anchor: "bench/fts/supertable/ingest".into(),
             title: format!(
-                "Supertable FTS — ingest, multi-segment / object-store ({} docs, {} commits)",
+                "Supertable FTS — ingest, multi-superfile / object-store ({} docs, {} commits)",
                 fmt_count(n_docs),
                 supertable::N_COMMIT_CHUNKS
             ),
-            note: "Build path: `SupertableWriter::append` + `commit` to object storage (production path). Throughput is rows/s; `Superfiles` is the committed segment count. Δ is vs the previous run.".into(),
+            note: "Build path: `SupertableWriter::append` + `commit` to object storage (production path). Throughput is rows/s; `Superfiles` is the committed superfile count. Δ is vs the previous run.".into(),
             blocks: vec![Block {
                 subtitle: String::new(),
                 headers: vec![
@@ -538,7 +538,7 @@ pub mod fts {
 
     /// Cold-tier guard: a fresh disk cache + consumer per open. The
     /// constructor performs the full cold open (consumer + manifest +
-    /// every segment reader), so the timed `bm25_rows` pays only the
+    /// every superfile reader), so the timed `bm25_rows` pays only the
     /// cold search work — open and search are reported separately.
     struct SupertableColdGuard {
         _cache_dir: TempDir,
@@ -548,7 +548,7 @@ pub mod fts {
     impl SupertableColdGuard {
         fn open(built: &supertable::IngestResult) -> Self {
             let (cache_dir, consumer) = open_consumer(Modality::Fts, built);
-            crate::executors::open_all_segments(&consumer);
+            crate::executors::open_all_superfiles(&consumer);
             Self {
                 _cache_dir: cache_dir,
                 consumer,
@@ -594,7 +594,7 @@ pub mod vector {
     /// Build a vector-only supertable, then measure warm + cold kNN search
     /// at calibrated recall targets (and a default config), with a
     /// correctness recall gate — the same measurement the superfile vector
-    /// runner produces, over the multi-segment object-store consumer.
+    /// runner produces, over the multi-superfile object-store consumer.
     pub fn run(phases: Phases) {
         if let Err(reason) = tiers::supertable_backend_check() {
             eprintln!("[supertable_vector] skipped: {reason}");
@@ -635,12 +635,12 @@ pub mod vector {
             report.emit(&Section {
                 anchor: "bench/vector/supertable/ingest".into(),
                 title: format!(
-                    "Supertable vector — ingest, multi-segment / object-store ({} docs × dim={}, {} commits)",
+                    "Supertable vector — ingest, multi-superfile / object-store ({} docs × dim={}, {} commits)",
                     fmt_count(n_docs),
                     DIM,
                     supertable::N_COMMIT_CHUNKS
                 ),
-                note: "Build path: `SupertableWriter::append` + `commit` to object storage (production path). Throughput is rows/s; `Superfiles` is the committed segment count. Δ is vs the previous run.".into(),
+                note: "Build path: `SupertableWriter::append` + `commit` to object storage (production path). Throughput is rows/s; `Superfiles` is the committed superfile count. Δ is vs the previous run.".into(),
                 blocks: vec![Block {
                     subtitle: String::new(),
                     headers: vec![
@@ -690,7 +690,7 @@ pub mod vector {
             // One consumer drives correctness + calibration. Full cache
             // promotion (prewarm + wait_until_warm) only matters for the
             // warm timing rows — a cold-only run skips it (fts/sql gate
-            // the same way) so it doesn't pull every segment into the
+            // the same way) so it doesn't pull every superfile into the
             // cache just to throw it away.
             let (cache_dir, consumer) = open_consumer(Modality::Vector, &built);
             if phases.warm {
@@ -713,7 +713,7 @@ pub mod vector {
             }
 
             let title = format!(
-                "Supertable vector — search, multi-segment / object-store ({} docs × dim={})",
+                "Supertable vector — search, multi-superfile / object-store ({} docs × dim={})",
                 fmt_count(n_docs),
                 DIM
             );
@@ -757,7 +757,7 @@ pub mod vector {
     impl SupertableVecColdGuard {
         fn open(built: &supertable::IngestResult) -> Self {
             let (cache_dir, consumer) = open_consumer(Modality::Vector, built);
-            crate::executors::open_all_segments(&consumer);
+            crate::executors::open_all_superfiles(&consumer);
             Self {
                 _cache_dir: cache_dir,
                 consumer,
@@ -825,11 +825,11 @@ pub mod sql {
             report.emit(&Section {
                 anchor: "bench/sql/supertable/ingest".into(),
                 title: format!(
-                    "Supertable SQL — ingest, multi-segment / object-store ({} rows, {} commits)",
+                    "Supertable SQL — ingest, multi-superfile / object-store ({} rows, {} commits)",
                     fmt_count(n_docs),
                     supertable::N_COMMIT_CHUNKS
                 ),
-                note: "Build path: `SupertableWriter::append` + `commit` to object storage (production path). Throughput is rows/s; `Superfiles` is the committed segment count. Δ is vs the previous run.".into(),
+                note: "Build path: `SupertableWriter::append` + `commit` to object storage (production path). Throughput is rows/s; `Superfiles` is the committed superfile count. Δ is vs the previous run.".into(),
                 blocks: vec![Block {
                     subtitle: String::new(),
                     headers: vec![
@@ -926,7 +926,7 @@ pub mod sql {
     impl SupertableSqlColdGuard {
         fn open(built: &supertable::IngestResult) -> Self {
             let (cache_dir, consumer) = open_consumer(Modality::Sql, built);
-            crate::executors::open_all_segments(&consumer);
+            crate::executors::open_all_superfiles(&consumer);
             Self {
                 _cache_dir: cache_dir,
                 consumer,

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -96,7 +96,7 @@ enum StorageKeepalive {
 
 /// A real-backend prefix a bench run created and must delete on exit so it
 /// accrues no storage cost. The supertable build writes many objects
-/// (segments, manifests, the pointer) under one unique prefix; cleanup lists
+/// (superfiles, manifests, the pointer) under one unique prefix; cleanup lists
 /// every key beneath it and deletes them. `root` is an *un*-prefixed provider
 /// (bucket/container root): `list_with_prefix` takes an absolute key prefix
 /// and `delete` targets the absolute keys it returns verbatim, so both sides
@@ -415,7 +415,7 @@ emulator is not usable here: it does not implement conditional If-Match PUTs, \
 which the supertable's multi-commit OCC requires, so every commit after the \
 first would lose the CAS.";
 
-/// Supertable-shaped backing store (multi-segment, multi-commit benches).
+/// Supertable-shaped backing store (multi-superfile, multi-commit benches).
 ///
 /// **Real object store only** (S3 or Azure). The supertable build commits
 /// many times, so its OCC pointer update rides on the conditional `If-Match`
@@ -483,7 +483,7 @@ fn supertable_search_cache_gib() -> Option<u64> {
 
 /// Fresh disk cache for ingest producers (8 GiB budget).
 ///
-/// Ingest attaches this cache only to keep segment bytes out of the
+/// Ingest attaches this cache only to keep superfile bytes out of the
 /// unbounded in-memory tier; commit-time cache prepopulation is disabled,
 /// so this budget is not meant to hold the searchable working set.
 pub fn fresh_disk_cache(storage: Arc<dyn StorageProvider>) -> (TempDir, Arc<DiskCacheStore>) {

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -33,11 +33,11 @@
 //!    serves both the vector and FTS readers.
 //! 2. **Cold first vector search after S3 open** — `vec.search`
 //!    at the default `(nprobe, rerank_mult)` against a freshly
-//!    opened reader and empty segment-data cache; pays the
+//!    opened reader and empty superfile-data cache; pays the
 //!    cold-search budget (~nprobe + 1 cluster GETs), excluding
 //!    file open.
 //! 3. **Cold first BM25 search after S3 open** — `bm25_search`
-//!    against a freshly opened reader and empty segment-data cache;
+//!    against a freshly opened reader and empty superfile-data cache;
 //!    pays the FTS lazy open-time fetch (header + doc-lengths) plus
 //!    per-term dict/postings range GETs (`FtsReader::open_lazy`
 //!    mirroring the vector path), excluding file open.
@@ -2218,7 +2218,7 @@ pub(crate) mod diag {
             format!("SELECT _id FROM bm25_search('{FTS_COLUMN}', '{FTS_QUERY_TERM}', {TOP_K})");
         let vec_sql = format!("SELECT _id FROM vector_search('{VEC_COLUMN}', '{q_csv}', {TOP_K})");
         // Score-only projection skips `resolve_hits` -> `resolve_columns`
-        // (no scalar decode, no per-segment superfile_reader open).
+        // (no scalar decode, no per-superfile superfile_reader open).
         // Difference vs `_id` projection isolates resolve_hits cost.
         let bm25_score_sql =
             format!("SELECT score FROM bm25_search('{FTS_COLUMN}', '{FTS_QUERY_TERM}', {TOP_K})");

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 A plain-language tour of what Infino is, how it's built, and how it
 differs from the database, search engine, and vector database alternatives. 
-For more technical detail, see [superfile](./superfile.md) (the segment format) and
+For more technical detail, see [superfile](./superfile.md) (the superfile format) and
 [supertable](./supertable.md) (the table layer).
 
 ## What is Infino?
@@ -92,7 +92,7 @@ To minimize latency and cost, infino tries to optimize data layout and data acce
    the catalog, never file contents. The same summaries back every
    modality through one shared pruning layer, so a hybrid query prunes
    on scalar, keyword, *and* vector signals together before touching a
-   single byte of a segment.
+   single byte of a superfile.
 3. **Fetches only what it needs** — for surviving files it pulls just
   the relevant byte ranges from object storage (a posting list, a
    handful of vector clusters), not the whole file. This holds for SQL
@@ -203,16 +203,16 @@ bill each independently; spin compute down without losing data.
 
 Where **Infino is distinctive even within this camp**:
 
-- **The segment is a valid Parquet file.** Data isn't trapped in a
+- **The superfile is a valid Parquet file.** Data isn't trapped in a
 proprietary index format — the *same bytes* are readable by the open
 analytics ecosystem (DuckDB, DataFusion, pyarrow) with no export step,
 while infino uses embedded index regions for search. Lower lock-in,
 easy interop with existing data tooling.
-- **Scalar + full-text + vector together in one immutable segment** —
+- **Scalar + full-text + vector together in one immutable superfile** —
 SQL, BM25, and IVF + RaBitQ vectors share one copy of the data and
 one consistency model, instead of syncing a DB + a search engine + a
 vector DB.
-- **Hybrid search is a first-class citizen — and an access path, not just an API.** In most systems, hybrid search ends at top-k: two retrievals (BM25, ANN) plus rank fusion. Here every modality shares one copy and one query path, so you fuse keyword and vector relevance — with SQL filters — in a single query against a single snapshot, with no second system to keep in sync and no client-side result stitching. And because the retrievers are *relations* (table functions) and indexed text predicates resolve to candidate row sets inside the engine, search can be the first stage of a larger SQL plan — feeding joins, filters, and aggregates — rather than its result. The same index machinery prunes segments across SQL, full-text, and vector together, so the hybrid query is also the well-pruned, cheap one.
+- **Hybrid search is a first-class citizen — and an access path, not just an API.** In most systems, hybrid search ends at top-k: two retrievals (BM25, ANN) plus rank fusion. Here every modality shares one copy and one query path, so you fuse keyword and vector relevance — with SQL filters — in a single query against a single snapshot, with no second system to keep in sync and no client-side result stitching. And because the retrievers are *relations* (table functions) and indexed text predicates resolve to candidate row sets inside the engine, search can be the first stage of a larger SQL plan — feeding joins, filters, and aggregates — rather than its result. The same index machinery prunes superfiles across SQL, full-text, and vector together, so the hybrid query is also the well-pruned, cheap one.
 
 ### At a glance
 
@@ -243,7 +243,7 @@ transition automatically.
 - **Operational simplicity.** Immutable files + an atomic manifest swap
 give clean snapshots, safe concurrent writers, and stateless,
 disposable compute.
-- **Openness / no lock-in.** Segments are Parquet; data stays usable by
+- **Openness / no lock-in.** Superfiles are Parquet; data stays usable by
 the broader ecosystem.
 
 ## Where it fits best
@@ -278,7 +278,7 @@ run one system that comfortably handles your scale and modalities, then where In
 opened with `connect(uri)`. Create / open / list / drop tables and run
 SQL across them. (The table catalog; not to be confused with a single
 table's manifest.)
-- **Superfile** — one immutable segment file (columns + keyword index +
+- **Superfile** — one immutable superfile file (columns + keyword index +
 vector index), also a valid Parquet file.
 - **Supertable** — the table: a manifest over many superfiles,
 presenting them as one queryable table. Obtained from a `Connection`.

--- a/docs/architecture/superfile.md
+++ b/docs/architecture/superfile.md
@@ -1,10 +1,10 @@
 # Superfile
 
-A superfile is infino's segment format. Each superfile is a single,
+A superfile is infino's superfile format. Each superfile is a single,
 self-contained file that is also a valid
 [Apache Parquet](https://parquet.apache.org/docs/) file. Standard
 Parquet tools read it as an ordinary columnar table; infino reads the
-same file as a search segment, with full-text and vector indexes
+same file as a search superfile, with full-text and vector indexes
 available alongside the columnar data.
 
 This document describes the format and its guarantees. The table layer
@@ -13,7 +13,7 @@ that composes many superfiles into one queryable table is described in
 
 ## Design
 
-- **Single file.** One superfile is one segment: the columnar data and
+- **Single file.** One superfile is one superfile: the columnar data and
   its search indexes live in the same file, with no sidecars to keep
   in sync.
 - **Parquet-compatible.** A superfile is a standards-compliant Parquet
@@ -22,7 +22,7 @@ that composes many superfiles into one queryable table is described in
 - **Immutable.** A superfile is written once and never modified in
   place. Changes are expressed by writing new superfiles.
 - **Search-native.** Full-text and vector search indexes are part of
-  the segment, not a separate system layered on top of it.
+  the superfile, not a separate system layered on top of it.
 
 ## Layout
 
@@ -164,13 +164,13 @@ ranged reads. It offers a zero-copy fast path for ranges already
 resident in memory and an asynchronous fetch for ranges that are not,
 can present a sub-region of a larger object as its own source, and can
 overlay a handful of pre-fetched ranges so that the several small
-reads issued while opening a segment are satisfied from one fetch
+reads issued while opening a superfile are satisfied from one fetch
 rather than many round-trips.
 
 Opening this way reads only the metadata ranges the reader needs, not
-the whole segment: the Parquet footer, then the full-text and vector
+the whole superfile: the Parquet footer, then the full-text and vector
 section headers and directories. The reader does not retain the full
-segment bytes — a source-opened reader cannot hand back the original
+superfile bytes — a source-opened reader cannot hand back the original
 Parquet file for a pass-through tool, and a caller that needs that uses
 the eager open path instead.
 
@@ -178,13 +178,13 @@ Queries then fetch only the regions they touch. A full-text query
 resolves its terms through the dictionary and fetches each term's
 posting list on demand; the postings region is never read in full. A
 vector query fetches the centroids and then only the blocks of the
-clusters it probes. So a segment on object storage answers a query by
+clusters it probes. So a superfile on object storage answers a query by
 pulling a bounded set of ranges rather than downloading the file
 first.
 
 ## Scope
 
-- A superfile is a single segment. Querying across many segments is the
+- A superfile is a single superfile. Querying across many superfiles is the
   table layer's responsibility (see [supertable](./supertable.md)).
 - A superfile is immutable and is queryable only once it is fully
   written.

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -1,25 +1,25 @@
 # Supertable
 
 A supertable is infino's table layer over [superfile](./superfile.md)
-segments. It presents many immutable superfiles as a single table that
+superfiles. It presents many immutable superfiles as a single table that
 supports SQL, full-text, and vector search, while keeping readers
 consistent under concurrent writes.
 
-This document describes the table model and its guarantees. The segment
+This document describes the table model and its guarantees. The superfile
 format is described in [superfile](./superfile.md).
 
 ## Design
 
-- **Table over segments.** A supertable is a set of immutable superfile
-segments plus a manifest that defines the current contents of the
+- **Table over superfiles.** A supertable is a set of immutable superfile
+superfiles plus a manifest that defines the current contents of the
 table.
 - **Snapshot reads.** A reader observes a single, consistent snapshot
 of the table for its entire lifetime, regardless of writes that land
 afterward.
 - **Append by commit.** Writes are staged and published as a commit. A
-commit produces new segments and a new manifest; it never mutates
-existing segments.
-- **Pluggable storage.** Segment bytes live behind a storage backend,
+commit produces new superfiles and a new manifest; it never mutates
+existing superfiles.
+- **Pluggable storage.** Superfile bytes live behind a storage backend,
 and the table layer behaves the same way over in-memory, local-disk,
 and object storage.
 
@@ -36,7 +36,7 @@ the unranked `token_match` / `exact_match`), and `schema`.
 Internally those methods drive a **reader** (a pinned, consistent
 snapshot) for queries and a single **writer** (staged changes published
 by commit) for mutations, with a **stats** view for introspection. The
-reader / writer / stats accessors, the manifest, and the segment
+reader / writer / stats accessors, the manifest, and the superfile
 internals behind them are implementation details, never part of the
 public surface.
 
@@ -49,13 +49,13 @@ taken, so a sequence of queries observes one consistent view of the
 table regardless of concurrent writes.
 
 Every read returns the same shape internally: a list of hits. A hit
-references a single row by its segment and the row's offset within that
-segment, plus a score when the query ranks results. BM25 fills the score
+references a single row by its superfile and the row's offset within that
+superfile, plus a score when the query ranks results. BM25 fills the score
 with relevance (higher is better); vector search fills it with distance
 under the column's metric (smaller is closer); a SQL filter leaves it
 unset.
 
-Those segment-local hits are the reader's internal representation. The
+Those superfile-local hits are the reader's internal representation. The
 public `Supertable` search methods resolve each hit to the table's
 stable `_id` and return Arrow `RecordBatch` rows. All four (`bm25_search`,
 `vector_search`, and the unranked `token_match` / `exact_match`) take a
@@ -104,12 +104,12 @@ and order search results alongside scalar columns:
   a single function.
   Each function runs against the reader's pinned snapshot and yields
   the table's `_id`, the projected scalar columns, and a `score`. Vector
-  columns are never scanned as SQL columns — they live in the segment's
+  columns are never scanned as SQL columns — they live in the superfile's
   embedded blob — so they are reached only through `vector_search` (or
   `hybrid_search`, which calls it).
 
-The reader also answers cheap snapshot questions — segment count,
-document count, manifest identity — without touching segment bytes. A
+The reader also answers cheap snapshot questions — superfile count,
+document count, manifest identity — without touching superfile bytes. A
 separate **stats** view adds process-level observability (cache
 residency, resident memory) for the whole table.
 
@@ -139,16 +139,16 @@ never refresh by hand.
 
 ## Manifest
 
-The manifest is the source of truth for which segments make up the
+The manifest is the source of truth for which superfiles make up the
 table at a point in time. It holds table-level configuration (schema,
-indexed columns, tokenizer) and an ordered list of segment entries.
+indexed columns, tokenizer) and an ordered list of superfile entries.
 
 ```mermaid
 flowchart TD
     reader["Reader<br/>(pinned snapshot)"] --> manifest["Manifest<br/>(immutable snapshot)"]
-    manifest --> e1["Segment entry (summary)"]
-    manifest --> e2["Segment entry (summary)"]
-    manifest --> e3["Segment entry (summary)"]
+    manifest --> e1["Superfile entry (summary)"]
+    manifest --> e2["Superfile entry (summary)"]
+    manifest --> e3["Superfile entry (summary)"]
     e1 --> s1["Superfile bytes"]
     e2 --> s2["Superfile bytes"]
     e3 --> s3["Superfile bytes"]
@@ -162,41 +162,41 @@ flowchart TD
 The manifest is immutable. Each commit builds a successor manifest and
 publishes it atomically; a reader pins the manifest current at the time
 it was created and never observes a partially applied commit.
-Successor manifests share the segment entries they carry forward, so
+Successor manifests share the superfile entries they carry forward, so
 publishing a commit allocates only the new entries rather than copying
 the whole list.
 
-Each segment entry is a summary of one superfile, holding the
+Each superfile entry is a summary of one superfile, holding the
 information the table layer needs to route and prune queries without
-reading the segment bytes:
+reading the superfile bytes:
 
-- **Location.** A storage-backend identifier for the segment's bytes.
-- **Row range.** The segment's document count and the range of primary
+- **Location.** A storage-backend identifier for the superfile's bytes.
+- **Row range.** The superfile's document count and the range of primary
 identifiers it covers.
 - **Scalar statistics.** Per-column minimum and maximum values for the
-scalar columns, used to skip segments for predicate queries.
+scalar columns, used to skip superfiles for predicate queries.
 - **Full-text summary.** Per text column, a term presence filter (a
-bloom filter over the segment's terms) and the lexicographic range of
-its terms, used to skip segments for term and prefix queries.
+bloom filter over the superfile's terms) and the lexicographic range of
+its terms, used to skip superfiles for term and prefix queries.
 - **Vector summary.** Per vector column, a representative centroid and
 radius, used to order and route vector queries.
 
-The segment bytes themselves are held by the storage backend, not the
+The superfile bytes themselves are held by the storage backend, not the
 manifest, so a manifest stays small and cheap to share across many
 concurrent readers.
 
 ### Partitioned, hierarchical manifest
 
-At scale the entry list is not a single flat array. Segments are
+At scale the entry list is not a single flat array. Superfiles are
 assigned to partitions by a partition strategy that is chosen when the
 table is created and is immutable thereafter. Within a partition,
-entries are grouped into manifest *parts*; a new commit's segments
+entries are grouped into manifest *parts*; a new commit's superfiles
 append to a partition's current part until that part crosses a soft
 cap on either entry count or compressed size, at which point the next
 commit starts a fresh part rather than rewriting the existing one. A
 top-level manifest list names the parts and carries the per-part
 aggregate summaries used for pruning, so a query can discard whole
-parts before touching any per-segment entry.
+parts before touching any per-superfile entry.
 
 Parts load on one of two paths, selected by a threshold on part count:
 
@@ -210,33 +210,33 @@ part share a single fetch.
 
 ## Commit pipeline
 
-A commit turns staged record batches into new segments and a new
+A commit turns staged record batches into new superfiles and a new
 manifest. It runs in the following stages:
 
 - **Stage.** Appended record batches accumulate in a write buffer. A
 commit consumes the current buffer; a size threshold can also trigger
 a commit automatically to bound the buffer's footprint.
 - **Shard.** The buffered rows are partitioned into balanced shards so
-that segment builds run in parallel, independent of how the caller
+that superfile builds run in parallel, independent of how the caller
 batched its appends.
 - **Build.** Each shard is built into one superfile, including its
 full-text and vector indexes, on a worker pool.
-- **Summarize.** Each new segment's manifest entry is derived — row
+- **Summarize.** Each new superfile's manifest entry is derived — row
 range, scalar statistics, and the full-text and vector summaries.
-- **Publish.** The segment bytes are written to the storage backend and
+- **Publish.** The superfile bytes are written to the storage backend and
 a successor manifest containing the existing and new entries is
 published atomically.
 
 ## Storage
 
-Segment files are stored as ordinary Parquet files. The manifest is a
-catalog over those files; it does not change the segment format. Any
-Parquet reader can open an individual segment file and read its
+Superfile files are stored as ordinary Parquet files. The manifest is a
+catalog over those files; it does not change the superfile format. Any
+Parquet reader can open an individual superfile file and read its
 columnar data directly, ignoring the embedded indexes.
 
 For persistent tables, the storage backend holds three things: the
-segment files, the manifest, and a pointer to the current manifest.
-Publishing a commit writes the new segments and manifest first, then
+superfile files, the manifest, and a pointer to the current manifest.
+Publishing a commit writes the new superfiles and manifest first, then
 swings the pointer in a single atomic step, so a reader resolving the
 pointer always lands on a complete manifest. When multiple processes
 write the same table, the pointer update is guarded so that a writer
@@ -246,8 +246,8 @@ refreshing from the current manifest and rebuilding on top, up to a
 bounded number of attempts before the commit surfaces a contention
 error.
 
-Segment uploads adapt to size. Below a configurable threshold a
-segment is written in a single put; at or above it the upload is split
+Superfile uploads adapt to size. Below a configurable threshold a
+superfile is written in a single put; at or above it the upload is split
 into fixed-size chunks driven in parallel, which lowers peak memory
 during the write and limits the cost of a transient backend failure
 mid-upload.
@@ -257,7 +257,7 @@ that many bytes or a typed error — a reader never sees a silently short
 buffer. Recovering from transient backend truncation or connection
 flakiness sits beneath this contract, in the storage layer.
 
-Readers may verify the segment's embedded checksums when opening it.
+Readers may verify the superfile's embedded checksums when opening it.
 This is on by default and can be turned off when the underlying
 storage already guarantees integrity (a content-addressed object
 store, a checksumming filesystem), trading that guarantee for faster
@@ -266,11 +266,11 @@ cold opens.
 ## Disk cache
 
 When a table is backed by remote storage, an optional disk cache keeps
-hot segments local. A cold query is served from remote byte ranges
-while the full segment is fetched in the background; once a segment is
+hot superfiles local. A cold query is served from remote byte ranges
+while the full superfile is fetched in the background; once a superfile is
 resident it is served from a local memory-mapped file. The cache tracks
-residency per segment and is bounded by a configurable budget, evicting
-cold segments when the budget is reached.
+residency per superfile and is bounded by a configurable budget, evicting
+cold superfiles when the budget is reached.
 
 The cache distinguishes on-disk residency from memory residency. An
 optional memory budget bounds the mapped working set rather than the
@@ -286,38 +286,38 @@ correctly and eviction is only ever a reclaim-and-refetch cost.
 SQL, full-text, and vector search share the same fan-out shape:
 
 1. Start from the reader's pinned manifest.
-2. Use the manifest summaries to skip segments that cannot match the
+2. Use the manifest summaries to skip superfiles that cannot match the
   query.
-3. Run the per-segment query against each remaining segment in
+3. Run the per-superfile query against each remaining superfile in
   parallel.
-4. Merge the per-segment results into a single ranked result for the
+4. Merge the per-superfile results into a single ranked result for the
   table.
 
-Skip pruning reads only the manifest summaries, never the segment
+Skip pruning reads only the manifest summaries, never the superfile
 bytes, and is always conservative: when the manifest cannot prove a
-segment is irrelevant, the segment is kept. The pruning inputs are:
+superfile is irrelevant, the superfile is kept. The pruning inputs are:
 
-- **Term queries** use each segment's term presence filter.
-- **Prefix queries** use each segment's lexicographic term range.
+- **Term queries** use each superfile's term presence filter.
+- **Prefix queries** use each superfile's lexicographic term range.
 - **Predicate (SQL) queries** use the per-column scalar statistics.
 - **Vector queries** use the per-column vector summary to order and
 route work.
 
-Pruning can remove work but never a correct result; a kept segment that
-turns out not to match only costs a per-segment query, while a segment
+Pruning can remove work but never a correct result; a kept superfile that
+turns out not to match only costs a per-superfile query, while a superfile
 is never wrongly dropped.
 
-Full-text and vector search delegate to each segment's index (the same
-search the single-segment reader runs) and merge globally. SQL is
+Full-text and vector search delegate to each superfile's index (the same
+search the single-superfile reader runs) and merge globally. SQL is
 executed over the columnar (Parquet) data and does not require the
 search indexes — but it can still reach them through the search
 table-valued functions (`vector_search`, `bm25_search`,
 `bm25_search_prefix`, `token_match`, `exact_match`), which run the same
-per-segment index fan-out and hand their results back into the SQL plan
+per-superfile index fan-out and hand their results back into the SQL plan
 as a relation.
 
 A SQL `WHERE` predicate on a full-text column also uses the index
-directly, as the **row-level** companion to the segment-level term
+directly, as the **row-level** companion to the superfile-level term
 skip: an equality (and its `AND`/`OR`/`IN` combinations) is resolved
 through the term postings to a candidate set of rows, so only those
 rows are decoded and the engine re-checks the exact predicate over
@@ -337,17 +337,17 @@ SQL-level fusion, not a separate engine kernel.
 
 - **Reader/writer isolation.** Reads and writes do not block each
 other. A reader holds an immutable manifest snapshot; a writer builds
-new segments and a new manifest independently.
+new superfiles and a new manifest independently.
 - **Atomic publication.** A reader sees either the manifest before a
 commit or the manifest after it, never an intermediate state.
 - **Single writer.** One writer is active per table at a time.
-- **Separate pools.** Query fan-out and segment builds use separate
+- **Separate pools.** Query fan-out and superfile builds use separate
 worker pools, so background writes do not starve foreground reads.
 
 ## Scope
 
-- Segments are immutable; updates are expressed by publishing a new
-manifest over different segments.
+- Superfiles are immutable; updates are expressed by publishing a new
+manifest over different superfiles.
 - One writer is active per table at a time.
 - Full-text and vector search are distinct query paths; combined
 relevance scoring is left to the caller.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,8 +7,8 @@
 //!      against the indexes embedded in the same bytes.
 //!   B. open-format — those same bytes are a valid Parquet file;
 //!      vanilla DataFusion reads them as a plain table.
-//!   C. supertable — the cross-segment layer that auto-injects a
-//!      real `_id`, queried across two committed segments.
+//!   C. supertable — the cross-superfile layer that auto-injects a
+//!      real `_id`, queried across two committed superfiles.
 //!
 //! Run with:
 //! ```text
@@ -42,7 +42,7 @@ const EMB_DIM: usize = 16;
 const DOC_ID_DECIMAL_PRECISION: u8 = 38;
 /// Decimal128 scale for `doc_id` — integer ids, no fractional part.
 const DOC_ID_DECIMAL_SCALE: i8 = 0;
-/// IVF centroids for a one-document superfile segment (one cluster).
+/// IVF centroids for a one-document superfile superfile (one cluster).
 const DEMO_N_CENT: usize = 1;
 /// Rotation-matrix RNG seed (matches the test/bench convention).
 const DEMO_ROT_SEED: u64 = 7;
@@ -114,7 +114,7 @@ fn demo_superfile() -> Bytes {
 
     let reader = SuperfileReader::open(bytes.clone()).expect("open SuperfileReader");
 
-    // The per-segment `SuperfileReader` query kernels are async; drive
+    // The per-superfile `SuperfileReader` query kernels are async; drive
     // them on a throwaway runtime here (the supertable layer below
     // exposes the sync public API instead).
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
@@ -176,17 +176,17 @@ fn demo_datafusion(bytes: &Bytes) {
 
 /// C — the supertable layer. It auto-injects a snowflake `_id`, so
 /// the user schema carries only payload columns. Two commits produce
-/// two segments; BM25 fans out across both, and SQL surfaces the
+/// two superfiles; BM25 fans out across both, and SQL surfaces the
 /// real `_id` values.
 fn demo_supertable() {
-    println!("== C. supertable: cross-segment, auto-injected _id ==");
+    println!("== C. supertable: cross-superfile, auto-injected _id ==");
 
     // default_supertable_options(): schema is `title: LargeUtf8`,
     // FTS on title, no vectors, in-memory store. The `_id` column is
     // added by the supertable, not declared here.
     let st = Supertable::create(default_supertable_options()).expect("create supertable");
 
-    // Each commit seals one segment. The writer holds an exclusive
+    // Each commit seals one superfile. The writer holds an exclusive
     // slot on the supertable, so we scope it so it drops before the
     // next one is taken.
     for title in [DOCSTRING_1, DOCSTRING_2] {
@@ -195,14 +195,14 @@ fn demo_supertable() {
         w.commit().expect("commit");
     }
 
-    // BM25 across both segments. The low-level reader `bm25_hits` returns
-    // `SuperfileHit`s carrying the source segment + local_doc_id + score;
+    // BM25 across both superfiles. The low-level reader `bm25_hits` returns
+    // `SuperfileHit`s carrying the source superfile + local_doc_id + score;
     // the public, row-returning path is `Supertable::bm25_search`.
     let hits = st
         .reader()
         .bm25_hits("title", "fox", SEARCH_TOP_K, BoolMode::Or)
         .expect("bm25 fan-out");
-    println!("  bm25 \"fox\" across segments -> {} hit(s)", hits.len());
+    println!("  bm25 \"fox\" across superfiles -> {} hit(s)", hits.len());
     for h in &hits {
         println!("    local_doc_id={} score={:.4}", h.local_doc_id, h.score);
     }

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -208,7 +208,7 @@ impl Table {
     /// Append data. Accepts a pyarrow `RecordBatch` or `Table`, a pandas
     /// `DataFrame`, or a `list[dict]` (coerced to Arrow with the table's
     /// declared schema). Durable when this returns — one `append` == one
-    /// commit == one sealed segment, so batch rows per call.
+    /// commit == one sealed superfile, so batch rows per call.
     fn append(&self, py: Python<'_>, data: &Bound<'_, PyAny>) -> PyResult<()> {
         let declared = self.inner.schema();
         let py_schema = declared.as_ref().to_pyarrow(py)?;
@@ -220,7 +220,7 @@ impl Table {
                 // accepts them. A genuine type or null mismatch still errors.
                 let aligned = RecordBatch::try_new(declared, batch.columns().to_vec())
                     .map_err(|e| PyValueError::new_err(e.to_string()))?;
-                // Append commits a segment to storage — release the GIL.
+                // Append commits a superfile to storage — release the GIL.
                 py.detach(|| self.inner.append(&aligned)).map_err(py_err)
             }
             // Empty input — nothing to append (no empty commit).
@@ -400,7 +400,7 @@ fn coerce_to_record_batch(
     };
 
     // Collapse the Table's chunks into a single RecordBatch — one append
-    // is one commit / one sealed segment.
+    // is one commit / one sealed superfile.
     let batches = table
         .call_method0("combine_chunks")?
         .call_method0("to_batches")?;

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -188,7 +188,7 @@ impl Connection {
                         .expect("non-memory backend yields a storage provider");
                 // Disk cache is keyed on the stable name (not the unique
                 // location) so the producer and a later reopener share one
-                // cache directory; segment keys carry the location, so a
+                // cache directory; superfile keys carry the location, so a
                 // re-created table never reads a dropped generation's bytes.
                 let disk_cache = build_disk_cache(&self.inner.options, &table_storage, name)?;
                 let mut opts =

--- a/src/catalog/options.rs
+++ b/src/catalog/options.rs
@@ -21,7 +21,7 @@ pub(crate) struct S3Config {
     pub(crate) secret_key: String,
 }
 
-/// How a disk-cache miss is serviced when reading cold segments from
+/// How a disk-cache miss is serviced when reading cold superfiles from
 /// object storage. Only meaningful when a disk cache is configured
 /// ([`ConnectOptions::with_cache_dir`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -33,7 +33,7 @@ pub enum ColdFetchMode {
     /// query-once / stateless callers.
     RangeOnly,
     /// A lazy reader serves the query immediately (a few range-GETs);
-    /// the full segment is downloaded to the cache in the background.
+    /// the full superfile is downloaded to the cache in the background.
     /// Lowest cold-query latency — the default.
     #[default]
     LazyForegroundWithBackgroundFill,
@@ -81,7 +81,7 @@ impl ConnectOptions {
     }
 
     /// Enable a local disk cache rooted at `dir` (off by default). Cold
-    /// segment reads are cached to NVMe; per table, under
+    /// superfile reads are cached to NVMe; per table, under
     /// `<dir>/<table>`. No effect on `memory://` catalogs.
     pub fn with_cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.cache_dir = Some(dir.into());

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -16,7 +16,7 @@
 # Nested keys are addressed with `__` (double underscore) in env vars.
 # Examples below.
 
-# Supertable runtime knobs. Reader fan-out (skip + per-segment
+# Supertable runtime knobs. Reader fan-out (skip + per-superfile
 # search + top-k merge) and writer commit-time rayon-shard run on
 # separate pools so a long-running commit can't spike reader p99 or
 # vice versa.
@@ -49,10 +49,10 @@ supertable:
 
   # Threshold above which the supertable's writer triggers an
   # internal commit() to flush the in-memory buffer to disk-
-  # equivalent (one segment per writer-pool thread). Specified
+  # equivalent (one superfile per writer-pool thread). Specified
   # in mebibytes (1 MiB = 1024 × 1024 bytes). Set 0 to disable
   # auto-flush — only caller-driven commit() will produce
-  # segments.
+  # superfiles.
   commit_threshold_size_mb: 1024
 
   # Verify the trailing whole-blob CRC and per-subsection CRCs
@@ -83,8 +83,8 @@ storage:
   # When set, storage-backed reads use DiskCacheStore. For S3,
   # lazy_foreground_with_background_fill is the object-store-native
   # cold path: foreground opens/searches with exact range GETs (or zero
-  # segment GETs at open when manifest open-batch bytes are present)
-  # while background fill promotes the full segment to mmap.
+  # superfile GETs at open when manifest open-batch bytes are present)
+  # while background fill promotes the full superfile to mmap.
   disk_cache_root:
   disk_budget_bytes: 10737418240
   cold_fetch_mode: lazy_foreground_with_background_fill
@@ -93,21 +93,21 @@ storage:
   mmap_cold_threshold_secs: 300
   mmap_sweep_interval_secs: 75
 
-# Compaction merges the small segments produced by individual
-# commits into one target-sized segment, cutting query fan-out.
+# Compaction merges the small superfiles produced by individual
+# commits into one target-sized superfile, cutting query fan-out.
 # Sizes are in mb (1 MiB = 1024 × 1024 bytes).
 #
 # Env overrides (note the double underscore for nesting):
-#   INFINO_COMPACTION__TARGET_SEGMENT_SIZE_MB=2048
+#   INFINO_COMPACTION__TARGET_SUPERFILE_SIZE_MB=2048
 #   INFINO_COMPACTION__MIN_FILL_PERCENT=80
 #   INFINO_COMPACTION__MAX_MEMORY_MB=3072
 compaction:
   # Size a compacted output aims for.
-  target_segment_size_mb: 1024
+  target_superfile_size_mb: 1024
 
   # Minimum estimated live bytes to trigger a merge,
-  # as a percentage of `target_segment_size_mb`.
-  # E.g. at 80% with a 1 GiB target, two 200 MiB segments (400 MiB) do not compact.
+  # as a percentage of `target_superfile_size_mb`.
+  # E.g. at 80% with a 1 GiB target, two 200 MiB superfiles (400 MiB) do not compact.
   min_fill_percent: 80
 
   # Maximum memory budget for materializing inputs during a single merge, in MiB.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -102,7 +102,7 @@ pub struct SupertableSettings {
     /// an internal `commit()` to flush the in-memory buffer.
     /// In mebibytes (1 MiB == 1024 × 1024 bytes). `0`
     /// disables auto-flush — only caller-driven `commit()`
-    /// produces segments.
+    /// produces superfiles.
     pub commit_threshold_size_mb: u64,
     /// Verify the trailing whole-blob CRC and per-subsection
     /// CRCs on every `SuperfileReader::open`. Defaults to
@@ -130,18 +130,18 @@ const DEFAULT_COMMIT_THRESHOLD_SIZE_MB: u64 = 1024;
 const DEFAULT_VERIFY_CRC_ON_OPEN: bool = true;
 
 // Compaction defaults
-const DEFAULT_COMPACTION_TARGET_SEGMENT_SIZE_MB: u64 = 1024;
+const DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB: u64 = 1024;
 const DEFAULT_COMPACTION_MIN_FILL_PERCENT: u8 = 80;
-const DEFAULT_COMPACTION_MAX_MEMORY_MB: u64 = DEFAULT_COMPACTION_TARGET_SEGMENT_SIZE_MB + 2048;
+const DEFAULT_COMPACTION_MAX_MEMORY_MB: u64 = DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB + 2048;
 
 /// Compaction subsection of [`Config`].
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct CompactionSettings {
-    /// Target size of a compacted segment, in MiB.
-    pub target_segment_size_mb: u64,
+    /// Target size of a compacted superfile, in MiB.
+    pub target_superfile_size_mb: u64,
     /// Minimum estimated live bytes to trigger a merge,
-    /// as a percentage of `target_segment_size_mb`.
+    /// as a percentage of `target_superfile_size_mb`.
     pub min_fill_percent: u8,
     /// Maximum memory budget for materializing inputs during a single merge, in MiB.
     pub max_memory_mb: u64,
@@ -150,7 +150,7 @@ pub struct CompactionSettings {
 impl Default for CompactionSettings {
     fn default() -> Self {
         Self {
-            target_segment_size_mb: DEFAULT_COMPACTION_TARGET_SEGMENT_SIZE_MB,
+            target_superfile_size_mb: DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB,
             min_fill_percent: DEFAULT_COMPACTION_MIN_FILL_PERCENT,
             max_memory_mb: DEFAULT_COMPACTION_MAX_MEMORY_MB,
         }
@@ -185,14 +185,14 @@ pub enum StorageColdFetchMode {
     /// Parallel range GETs serve both the foreground reader and the
     /// disk-cache fill. Foreground returns after the range fetches;
     /// pwrite, mmap, and cache registration finish in the background.
-    /// Uses one copy of segment bandwidth per cold miss.
+    /// Uses one copy of superfile bandwidth per cold miss.
     HybridWithPrefetch,
     /// Single-range sequential fetches (no background fill). Useful
     /// for constrained environments where parallelism is undesirable.
     RangeOnly,
     /// Foreground returns a lazy reader and a background task fills
     /// the disk cache asynchronously. With manifest open-batch bytes
-    /// present, open issues zero segment-object GETs; otherwise it
+    /// present, open issues zero superfile-object GETs; otherwise it
     /// fetches the parquet tail plus vector/FTS open ranges. First
     /// query pays per-cluster range GETs; subsequent queries resolve
     /// from mmap once the fill completes.
@@ -213,8 +213,8 @@ pub struct StorageSettings {
     /// Object-store bucket name (used by the `s3` backend).
     pub bucket: Option<String>,
     /// Logical key prefix inside the bucket. All manifest and
-    /// segment objects are written under
-    /// `<bucket>/<prefix>/<manifest|segments>/…`. Empty means the
+    /// superfile objects are written under
+    /// `<bucket>/<prefix>/<manifest|superfiles>/…`. Empty means the
     /// bucket root. Not used by the `local_fs` backend (use
     /// `local_root` instead).
     pub prefix: String,
@@ -226,16 +226,16 @@ pub struct StorageSettings {
     pub cold_fetch_mode: StorageColdFetchMode,
     pub cold_fetch_streams: usize,
     pub cold_fetch_chunk_bytes: u64,
-    /// Global cap on concurrent background segment fills. See
+    /// Global cap on concurrent background superfile fills. See
     /// [`crate::supertable::reader_cache::DiskCacheConfig::prefetch_concurrency`].
     pub prefetch_concurrency: usize,
-    /// Minimum age (seconds) before an mmap'd segment is
+    /// Minimum age (seconds) before an mmap'd superfile is
     /// considered cold and eligible for eviction by the sweep.
-    /// Default: 300 s (5 min). Prevents thrashing on segments
+    /// Default: 300 s (5 min). Prevents thrashing on superfiles
     /// that just finished their background fill.
     pub mmap_cold_threshold_secs: u64,
     /// Interval (seconds) between mmap eviction sweeps. The sweep
-    /// drops pages for segments older than
+    /// drops pages for superfiles older than
     /// `mmap_cold_threshold_secs` and not accessed since the
     /// previous sweep. Default: 75 s.
     pub mmap_sweep_interval_secs: u64,
@@ -266,7 +266,7 @@ const DEFAULT_DISK_BUDGET_BYTES: u64 = 10 * (1 << 30);
 const DEFAULT_COLD_FETCH_STREAMS: usize = 8;
 /// Default cold-fetch range chunk size (4 MiB).
 const DEFAULT_COLD_FETCH_CHUNK_BYTES: u64 = 4 * (1 << 20);
-/// Default concurrent background full-segment fills.
+/// Default concurrent background full-superfile fills.
 const DEFAULT_PREFETCH_CONCURRENCY: usize = 8;
 /// Default idle age (seconds) before an mmap is swept.
 const DEFAULT_MMAP_COLD_THRESHOLD_SECS: u64 = 300;
@@ -693,8 +693,8 @@ supertable:
         let cfg = Config::defaults().expect("embedded default must parse");
         let c = &cfg.compaction;
         assert_eq!(
-            c.target_segment_size_mb,
-            DEFAULT_COMPACTION_TARGET_SEGMENT_SIZE_MB
+            c.target_superfile_size_mb,
+            DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB
         );
         assert_eq!(c.min_fill_percent, DEFAULT_COMPACTION_MIN_FILL_PERCENT);
         assert_eq!(
@@ -714,14 +714,14 @@ supertable:
     fn compaction_yaml_layer_overrides_defaults() {
         let yaml = r#"
                compaction:
-                    target_segment_size_mb: 2048
+                    target_superfile_size_mb: 2048
                     min_fill_percent: 50
            "#;
         let fig = Figment::new()
             .merge(Yaml::string(EMBEDDED_DEFAULT))
             .merge(Yaml::string(yaml));
         let cfg = Config::from_figment(fig).expect("layered yaml");
-        assert_eq!(cfg.compaction.target_segment_size_mb, 2048);
+        assert_eq!(cfg.compaction.target_superfile_size_mb, 2048);
         assert_eq!(cfg.compaction.min_fill_percent, 50);
         assert_eq!(cfg.compaction.max_memory_mb, 3072);
     }
@@ -730,14 +730,14 @@ supertable:
     fn compaction_nested_env_var_overrides_field() {
         let _g = ENV_LOCK.lock().expect("acquire lock");
         unsafe {
-            std::env::set_var("INFINO_COMPACTION__TARGET_SEGMENT_SIZE_MB", "4096");
+            std::env::set_var("INFINO_COMPACTION__TARGET_SUPERFILE_SIZE_MB", "4096");
             std::env::set_var("INFINO_COMPACTION__MIN_FILL_PERCENT", "60");
         }
         let cfg = Config::load().expect("load with compaction env override");
-        assert_eq!(cfg.compaction.target_segment_size_mb, 4096);
+        assert_eq!(cfg.compaction.target_superfile_size_mb, 4096);
         assert_eq!(cfg.compaction.min_fill_percent, 60);
         unsafe {
-            std::env::remove_var("INFINO_COMPACTION__TARGET_SEGMENT_SIZE_MB");
+            std::env::remove_var("INFINO_COMPACTION__TARGET_SUPERFILE_SIZE_MB");
             std::env::remove_var("INFINO_COMPACTION__MIN_FILL_PERCENT");
         }
     }
@@ -747,12 +747,12 @@ supertable:
         let fig = Figment::new()
             .merge(Yaml::string(EMBEDDED_DEFAULT))
             .merge(Yaml::string(
-                "compaction:\n  target_segment_size_mb: \"not-a-number\"\n",
+                "compaction:\n  target_superfile_size_mb: \"not-a-number\"\n",
             ));
         let err = Config::from_figment(fig).expect_err("expected error");
         let msg = err.to_string();
         assert!(
-            msg.contains("target_segment_size_mb")
+            msg.contains("target_superfile_size_mb")
                 || msg.contains("invalid type")
                 || msg.contains("expected"),
             "expected a typed-error message; got {msg:?}"

--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -143,7 +143,7 @@ const AZURE_POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_s
 const AZURE_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Whole-request timeout (incl. body). The 30s default is too tight for
-/// a multi-MB segment PUT on a modest uplink — it aborts mid-upload.
+/// a multi-MB superfile PUT on a modest uplink — it aborts mid-upload.
 const AZURE_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
 /// HTTP client options: deep warm idle pool + bounded connect/request.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -195,11 +195,11 @@ pub trait StorageProvider: Send + Sync + std::fmt::Debug {
         expected_etag: Option<&str>,
     ) -> Result<Option<String>, StorageError>;
 
-    /// Streaming multipart upload — for segments larger than
+    /// Streaming multipart upload — for superfiles larger than
     /// `SupertableOptions::put_multipart_threshold_bytes`
     /// (default 100 MB), the writer routes through this path
     /// instead of `put_atomic` to avoid buffering the whole
-    /// segment in RAM during commit.
+    /// superfile in RAM during commit.
     ///
     /// Returns the underlying `object_store::MultipartUpload`
     /// handle; callers drive it via its own `put_part` /
@@ -239,7 +239,7 @@ pub trait StorageProvider: Send + Sync + std::fmt::Debug {
     /// Used by the SQL scan and search-hit row resolution to hand
     /// DataFusion's `ParquetSource` the real object store so it issues
     /// async footer / row-group / page range GETs against object
-    /// storage, instead of buffering whole segments into memory.
+    /// storage, instead of buffering whole superfiles into memory.
     ///
     /// `None` for providers without a native `object_store` handle
     /// (mocks / in-memory test doubles); those callers fall back to the

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -227,8 +227,8 @@ const S3_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5
 /// Tuned HTTP client options for the object-store-native fan-out.
 ///
 /// The supertable vector/FTS query path fans out one cold-open +
-/// cold-search batch per segment concurrently. With the default
-/// idle-connection pool, a wide fan-out (hundreds of segments ×
+/// cold-search batch per superfile concurrently. With the default
+/// idle-connection pool, a wide fan-out (hundreds of superfiles ×
 /// several range GETs each) churns TCP/TLS connections — each new
 /// connection pays a TLS handshake RTT on top of the request RTT,
 /// inflating the p99 tail under load. Keeping a large warm idle

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -712,7 +712,7 @@ impl SuperfileBuilder {
             ));
         }
 
-        // A segment has three independent build outputs: the scalar /
+        // A superfile has three independent build outputs: the scalar /
         // relational Parquet body (the SQL-queryable columns), the FTS
         // blob, and the vector blob. None reads another's bytes — blobs
         // are appended after the last row group, and FTS/vector

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -141,7 +141,7 @@ pub enum ReadError {
     #[error("column {0:?} not found in superfile schema")]
     UnknownColumn(String),
 
-    #[error("local_doc_id {doc_id} out of range (segment has {n_docs} docs)")]
+    #[error("local_doc_id {doc_id} out of range (superfile has {n_docs} docs)")]
     DocIdOutOfRange { doc_id: u32, n_docs: u64 },
 
     #[error("take-by-doc-id requires eager bytes; reader was opened via open_lazy")]

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -185,7 +185,7 @@ pub mod vec {
     ///   `per_cluster_blocks_off + doc_off[c] * (code_bytes + 4)`,
     ///   block size `count[c] * (code_bytes + 4)`.
     ///
-    /// Only this version is accepted on read; a segment stamped
+    /// Only this version is accepted on read; a superfile stamped
     /// with any other value at this slot is rejected as malformed
     /// rather than carrying an alternate parse path.
     pub const SUBSECTION_VERSION: u32 = 2;
@@ -285,7 +285,7 @@ pub mod kv {
     /// Required: name of the schema column serving the `id` role.
     pub const ID_COLUMN: &str = "inf.id_column";
 
-    /// Required: total document count in this segment (string-encoded u64).
+    /// Required: total document count in this superfile (string-encoded u64).
     pub const N_DOCS: &str = "inf.n_docs";
 
     /// Required: writer library + version + git commit (auto-populated at
@@ -373,7 +373,7 @@ impl Version {
         })
     }
 
-    /// Reader policy: accept this segment if its format-version's major
+    /// Reader policy: accept this superfile if its format-version's major
     /// matches our `FORMAT_VERSION`'s major. Minor/patch differences are
     /// forward-compatible by design (unknown KV keys ignored, unknown JSON
     /// fields ignored).

--- a/src/superfile/fts/bm25.rs
+++ b/src/superfile/fts/bm25.rs
@@ -62,12 +62,12 @@ pub fn idf(n_docs: u64, df: u64) -> f32 {
 ///
 /// `tf`    — term frequency in this document, this column.
 /// `dl`    — this document's length in this column (in tokens).
-/// `avgdl` — average document length across the segment, this column.
+/// `avgdl` — average document length across the superfile, this column.
 #[inline(always)]
 pub fn score(idf_t: f32, tf: u32, dl: u32, avgdl: f32) -> f32 {
     let tf = tf as f32;
     // avgdl is precomputed at build time and stored in the doc-lengths
-    // directory; if a segment has zero docs we wouldn't be calling this
+    // directory; if a superfile has zero docs we wouldn't be calling this
     // function, but guard anyway against a divide-by-zero on degenerate
     // input.
     let norm = if avgdl > 0.0 {

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -171,13 +171,13 @@ impl FinishProfile {
 /// start of this struct.
 ///
 /// Layout:
-///   off  0 ..  4 : df (u32) — bounded by n_docs per segment
+///   off  0 ..  4 : df (u32) — bounded by n_docs per superfile
 ///   off  4 .. 12 : postings_offset (u64) — equals the term's metadata_offset;
-///                  self-describing. u64 supports segments past 4 GiB
+///                  self-describing. u64 supports superfiles past 4 GiB
 ///                  (e.g. the 16 GB target).
 ///   off 12 .. 16 : postings_length (u32) — single term's bytes, well under
 ///                  4 G even at high df (≤ ~1 MB for the most common term in
-///                  a 16 GB segment).
+///                  a 16 GB superfile).
 ///   off 16 .. 20 : num_blocks (u32)
 ///
 /// `df`, `postings_length`, and `num_blocks` stay u32; only the absolute
@@ -192,7 +192,7 @@ pub(crate) const SKIP_ENTRY_SIZE: usize = 16;
 /// Layout:
 ///   off  0 ..  4 : column_id (u32)
 ///   off  4 .. 12 : doc_lengths_offset (u64) — absolute offset of this column's
-///                  doc-lengths array in the FTS blob. u64 supports segments
+///                  doc-lengths array in the FTS blob. u64 supports superfiles
 ///                  past 4 GiB.
 ///   off 12 .. 16 : avgdl_x1000 (u32) — avgdl × 1000, as an integer
 ///

--- a/src/superfile/fts/dict.rs
+++ b/src/superfile/fts/dict.rs
@@ -516,7 +516,7 @@ mod tests {
     fn serialization_is_deterministic() {
         // Same inputs (regardless of insertion order) produce
         // byte-identical FST output. Important for reproducible builds
-        // and for content-addressed segment hashing.
+        // and for content-addressed superfile hashing.
         let mut b1 = DictBuilder::new();
         b1.insert(&make_key("a", "x"), 1);
         b1.insert(&make_key("b", "y"), 2);

--- a/src/superfile/fts/fst_value.rs
+++ b/src/superfile/fts/fst_value.rs
@@ -24,7 +24,7 @@
 //! Why low-bit flag (not high-bit): the `fst` crate VLQ-encodes
 //! values, so encoded length grows with magnitude. Putting the flag
 //! in the low bit keeps PFOR-form values small (~5–6 bytes VLQ at
-//! 16 GB segment scale); only inline values pay the larger encoding
+//! 16 GB superfile scale); only inline values pay the larger encoding
 //! (~7–8 bytes VLQ for the composite). High-bit flag would force
 //! *every* value to a full ~9-byte encoding.
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -561,7 +561,7 @@ impl FtsReader {
 
     /// Resolve a column name to its dense column_id, or
     /// `FtsError::UnknownColumn` if the column isn't FTS-indexed in
-    /// this segment. Shared by every public search entry point.
+    /// this superfile. Shared by every public search entry point.
     fn resolve_column_id(&self, column: &str) -> Result<u32, FtsError> {
         self.column_id_by_name
             .get(column)
@@ -570,13 +570,13 @@ impl FtsReader {
     }
 
     /// Walk the FST and collect every term registered under
-    /// `column`, in lex order. Used to populate per-segment FTS
+    /// `column`, in lex order. Used to populate per-superfile FTS
     /// skip-pruning summaries (term-presence bloom + lex term
     /// range) at commit time.
     ///
     /// Returns an empty `Vec` if `column` is not registered as
-    /// an FTS column in this segment. Cost is O(terms in column)
-    /// FST decodes; intended to be called once per (segment,
+    /// an FTS column in this superfile. Cost is O(terms in column)
+    /// FST decodes; intended to be called once per (superfile,
     /// column) at commit time, not on the query hot path.
     pub fn iter_column_terms(&self, column: &str) -> Result<Vec<Vec<u8>>, FtsError> {
         self.iter_terms_with_prefix(column, b"")
@@ -751,7 +751,7 @@ impl FtsReader {
     /// metadata header. Returns `0` if the token isn't in the column's
     /// dictionary. Used by the candidate planner to estimate a `WHERE`
     /// predicate's match count *ahead of* running `token_match`, so a
-    /// predicate that would match a large fraction of the segment can
+    /// predicate that would match a large fraction of the superfile can
     /// fall back to a plain scan instead of a (losing) index pushdown.
     pub async fn term_df(&self, column: &str, token: &str) -> Result<u64, FtsError> {
         let column_id = self.resolve_column_id(column)?;
@@ -787,8 +787,8 @@ impl FtsReader {
     /// Same scoring semantics as [`Self::search`] in `BoolMode::Or`
     /// for the multi-term case, but only docs whose id falls within
     /// `[doc_id_start, doc_id_end)` are eligible. Used by the
-    /// supertable's intra-segment parallel fan-out: when the reader
-    /// pool has more threads than segments, each segment is sliced
+    /// supertable's intra-superfile parallel fan-out: when the reader
+    /// pool has more threads than superfiles, each superfile is sliced
     /// into N equal-width doc-id sub-ranges and one task per
     /// sub-range runs here in parallel; the caller merges the
     /// per-sub-range top-K heaps.
@@ -1632,8 +1632,8 @@ impl FtsReader {
 
     /// MaxScore+BMM constrained to the doc_id half-open range
     /// `[doc_id_start, doc_id_end)`. Used by the supertable layer's
-    /// intra-segment parallel fan-out: when the reader pool has more
-    /// threads than segments, each segment is split into N sub-ranges
+    /// intra-superfile parallel fan-out: when the reader pool has more
+    /// threads than superfiles, each superfile is split into N sub-ranges
     /// and the per-sub-range searches run in parallel, each producing
     /// its own top-K heap that the caller merges.
     ///
@@ -2009,12 +2009,12 @@ impl FtsReader {
     /// it narrowly wins, and we want the option available for future
     /// re-routing work without re-implementing it.
     ///
-    /// **When this can beat BMM (measured at 10M × 8 segments)**:
+    /// **When this can beat BMM (measured at 10M × 8 superfiles)**:
     /// - **Prefix expansions over very-rare terms, in parallel mode.**
     ///   E.g., `term0009*` expanding to 10 terms at Zipfian rank
     ///   90–99 (df ≈ 0.1% each). On the supertable parallel bench,
     ///   exhaustive ran at 40.2 ms vs BMM's 54.0 ms — a 26% win. The
-    ///   per-segment work is tiny (∼12 K matching docs across 10
+    ///   per-superfile work is tiny (∼12 K matching docs across 10
     ///   short cursors) so BMM's per-block bookkeeping
     ///   (`f_essential` recomputation, `shallow_advance_block_to`,
     ///   `inspect_block_max_bm25`) dominates over actual scoring

--- a/src/superfile/lazy_source.rs
+++ b/src/superfile/lazy_source.rs
@@ -4,7 +4,7 @@
 //! [`LazyByteSource`] — pulls byte ranges from an arbitrary
 //! backing (mmap, network range-fetch, broadcast subscription)
 //! so [`SuperfileReader::open_lazy`] can construct a reader
-//! without materializing the full segment up-front.
+//! without materializing the full superfile up-front.
 //!
 //! The trait lives next to the `superfile` reader; concrete
 //! impls live wherever the backing does. Errors propagate
@@ -16,13 +16,13 @@
 //!
 //! [`SuperfileReader::open_lazy`] accepts a source instead
 //! of bytes-in-hand. The caller no longer materializes the
-//! segment before calling; the source decides where the
+//! superfile before calling; the source decides where the
 //! bytes come from (mmap of a local file, range-fetched
 //! object store, a coalescing broadcaster that fans one
 //! fetch out to many subscribers).
 //!
 //! Opening reads only the metadata ranges the reader needs,
-//! not the whole segment: the Parquet footer, then the FTS
+//! not the whole superfile: the Parquet footer, then the FTS
 //! and vector section headers and directories. The inner
 //! readers thread the source through their own lookups, so
 //! queries fetch only the bytes they touch — `FtsReader`
@@ -30,7 +30,7 @@
 //! postings region is never read in full), and `VectorReader`
 //! fetches centroids and then only the probed clusters'
 //! blocks. A source-opened [`SuperfileReader`] therefore does
-//! not retain the full segment; `parquet_bytes()` returns
+//! not retain the full superfile; `parquet_bytes()` returns
 //! `None`, and pass-through Parquet callers use the eager
 //! `open` path instead.
 //!
@@ -363,7 +363,7 @@ impl Source {
 }
 
 /// In-memory `LazyByteSource` adapter — useful for tests and
-/// for callers that already have the full segment bytes.
+/// for callers that already have the full superfile bytes.
 #[derive(Debug, Clone)]
 pub struct BytesLazyByteSource {
     bytes: Bytes,
@@ -500,7 +500,7 @@ pub(crate) struct PrefetchedSource {
     inner: Arc<dyn LazyByteSource>,
     /// (absolute_start, bytes). One entry per pre-fetched
     /// range. Lookup walks the vec linearly — the open-time
-    /// path installs ≤ 3 ranges per segment so the linear
+    /// path installs ≤ 3 ranges per superfile so the linear
     /// scan is faster than a tree-keyed structure (cache-line
     /// hot, no allocation).
     prefetched: Vec<(u64, Bytes)>,

--- a/src/superfile/mod.rs
+++ b/src/superfile/mod.rs
@@ -10,10 +10,10 @@
 //!
 //! The only in-tree caller of `SuperfileBuilder` /
 //! `SuperfileReader` is the `supertable` layer. The
-//! supertable owns the multi-segment + manifest + storage
+//! supertable owns the multi-superfile + manifest + storage
 //! policy; each rayon shard worker uses `SuperfileBuilder`
 //! one-shot (one `add_batch` loop → one `finish()`), and
-//! each cached / opened segment runs through
+//! each cached / opened superfile runs through
 //! `SuperfileReader::open` once per cache hydration. The
 //! builder is consume-on-`finish()`; a session that wants N
 //! superfiles instantiates N builders.

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -17,7 +17,7 @@
 //! Eager at the blob level (both blobs sliced once at `open()`), lazy
 //! within each blob (per-(column,term) postings + per-cluster vector
 //! codes are read on-demand by the underlying readers). The
-//! single-segment SuperfileReader does no I/O after `open()`; a
+//! single-superfile SuperfileReader does no I/O after `open()`; a
 //! storage layer can layer cold-fetch heuristics on top.
 
 use std::sync::Arc;
@@ -74,7 +74,7 @@ impl Default for OpenOptions {
 pub struct SuperfileReader {
     /// Full Parquet bytes, `Some` only for the eager [`open`]
     /// path. The lazy [`open_lazy`] path drops the
-    /// whole-segment hold — pass-through SQL / external-Parquet
+    /// whole-superfile hold — pass-through SQL / external-Parquet
     /// callers (`parquet_bytes`) see `None` and must take a
     /// different path. Vector + FTS queries work on either,
     /// since each carries its own source under the inner readers.
@@ -89,7 +89,7 @@ pub struct SuperfileReader {
     /// on the [`open_lazy`] path. `None` on the eager [`open`] path
     /// (resident bytes already cover every range). Lets
     /// [`byte_source`](Self::byte_source) hand callers one uniform
-    /// whole-segment byte source regardless of how the reader opened.
+    /// whole-superfile byte source regardless of how the reader opened.
     ///
     /// [`open_lazy`]: SuperfileReader::open_lazy
     /// [`open`]: SuperfileReader::open
@@ -141,7 +141,7 @@ impl SuperfileReader {
     /// fetch centroids, cluster indexes, and per-cluster blocks on
     /// demand via the source.
     ///
-    /// The returned reader does **not** hold the full segment;
+    /// The returned reader does **not** hold the full superfile;
     /// `parquet_bytes()` returns `None`. Callers that need the
     /// full Parquet bytes (DataFusion register, DuckDB,
     /// pyarrow) must use the eager [`open`] path.
@@ -155,12 +155,12 @@ impl SuperfileReader {
 
     /// Like [`open_lazy`] but with explicit [`OpenOptions`].
     ///
-    /// Lazy opens do not run whole-segment CRC scans. Forcing CRC
-    /// verification here would require reading the full segment through
+    /// Lazy opens do not run whole-superfile CRC scans. Forcing CRC
+    /// verification here would require reading the full superfile through
     /// range GETs, which is exactly what the lazy path is meant to avoid;
     /// the embedded vector/FTS lazy readers therefore use their
     /// object-store options (`verify_crc = false`) while eager cache
-    /// promotion can verify after the full segment is materialized.
+    /// promotion can verify after the full superfile is materialized.
     ///
     /// [`open_lazy`]: SuperfileReader::open_lazy
     pub async fn open_lazy_with(
@@ -445,7 +445,7 @@ impl SuperfileReader {
     /// Parquet reader (DataFusion, DuckDB, pyarrow, …).
     ///
     /// Returns `None` for readers opened via [`open_lazy`] — the
-    /// lazy path does not materialize the full segment,
+    /// lazy path does not materialize the full superfile,
     /// so external-Parquet pass-throughs need either the eager
     /// [`open`] path or an explicit `LazyByteSource::range(0, size)`
     /// against the source.
@@ -502,7 +502,7 @@ impl SuperfileReader {
         Ok(record_batch)
     }
 
-    /// A [`LazyByteSource`] over the **entire** segment, regardless of
+    /// A [`LazyByteSource`] over the **entire** superfile, regardless of
     /// how the reader was opened. The single byte-access handle the
     /// SQL/DataFusion path reads through -- callers never branch on
     /// storage mode:
@@ -527,19 +527,19 @@ impl SuperfileReader {
         }
     }
 
-    /// Resolve in-segment row offsets to their durable identity.
+    /// Resolve in-superfile row offsets to their durable identity.
     ///
-    /// Given a slice of `local_doc_id`s — the per-segment row
+    /// Given a slice of `local_doc_id`s — the per-superfile row
     /// offsets produced by [`bm25_search`](Self::bm25_search) /
     /// [`vector_search`](Self::vector_search) and carried in a
     /// `SuperfileHit` — return a [`RecordBatch`] of the requested
     /// `projection` columns at exactly those rows, in the same
     /// order as `local_doc_ids`. This is the bridge from a hit's
-    /// `(segment, local_doc_id)` to the supertable's durable `_id`
+    /// `(superfile, local_doc_id)` to the supertable's durable `_id`
     /// plus any projected scalar columns: pass
     /// [`id_column`](Self::id_column) in `projection` to recover the
     /// primary key, and zip the result rows back to the per-hit
-    /// scores positionally (row `i` is the segment row at
+    /// scores positionally (row `i` is the superfile row at
     /// `local_doc_ids[i]`).
     ///
     /// Output columns are `projection` in the given order (not file
@@ -617,7 +617,7 @@ impl SuperfileReader {
         // only pays the projected-column page decode. The page index
         // (when present) lets `RowSelection` seek to the relevant
         // pages. CPU-bound over in-memory bytes — callers fan these
-        // across `options.reader_pool` for cross-segment parallelism.
+        // across `options.reader_pool` for cross-superfile parallelism.
         let builder = ParquetRecordBatchReaderBuilder::new_with_metadata(bytes, arrow_meta);
         let mask = ProjectionMask::roots(builder.parquet_schema(), col_indices.iter().copied());
         let reader = builder
@@ -677,7 +677,7 @@ impl SuperfileReader {
         let bytes = self.bytes.clone().ok_or_else(|| {
             ReadError::Io(std::io::Error::other(
                 "id_lookup requires an eager-opened superfile; this reader was opened via \
-                 the lazy path and does not hold the full segment bytes",
+                 the lazy path and does not hold the full superfile bytes",
             ))
         })?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
@@ -760,11 +760,11 @@ impl SuperfileReader {
     /// supplies the already-tokenized term slice and we skip the
     /// `AsciiLowerTokenizer` pass.
     ///
-    /// Used by the supertable layer's fan-out: the cross-segment
+    /// Used by the supertable layer's fan-out: the cross-superfile
     /// search tokenizes the query once at the orchestrator (to
     /// compute the bloom-skip mask) and then passes the same
-    /// `terms` slice to every per-segment search, avoiding
-    /// `(N+1)·T` redundant tokenizations across N segments and
+    /// `terms` slice to every per-superfile search, avoiding
+    /// `(N+1)·T` redundant tokenizations across N superfiles and
     /// a T-token query.
     ///
     /// Terms must be already lower-cased ASCII alphanumeric tokens
@@ -870,7 +870,7 @@ impl SuperfileReader {
     /// Pre-tokenized BM25 search with negated terms excluded — the
     /// negation sibling of [`Self::bm25_search_pretokenized`]. The
     /// supertable fan-out parses the `-` sigil once at the orchestrator
-    /// and hands every segment the split lists through here.
+    /// and hands every superfile the split lists through here.
     pub(crate) async fn bm25_search_pretokenized_excluding(
         &self,
         column: &str,
@@ -931,8 +931,8 @@ impl SuperfileReader {
     ///
     /// Mirrors [`Self::bm25_search_pretokenized`] in `BoolMode::Or`
     /// shape but only scores docs in `[doc_id_start, doc_id_end)`.
-    /// Used by the supertable layer's intra-segment parallel
-    /// fan-out: the supertable splits each segment into N
+    /// Used by the supertable layer's intra-superfile parallel
+    /// fan-out: the supertable splits each superfile into N
     /// equal-width sub-ranges, runs one call per sub-range in
     /// parallel on the reader pool, then merges the per-sub-range
     /// top-K heaps.
@@ -963,7 +963,7 @@ impl SuperfileReader {
     /// AsciiLower the prefix, walk the FST for matching terms, run
     /// BM25 OR over the term set — but only docs in
     /// `[doc_id_start, doc_id_end)` are eligible. Used by the
-    /// supertable layer's intra-segment parallel fan-out on prefix
+    /// supertable layer's intra-superfile parallel fan-out on prefix
     /// queries; the per-sub-range expansion is identical (same FST,
     /// same column) so each sub-range expands locally rather than
     /// passing pre-expanded terms across the task boundary.
@@ -1019,7 +1019,7 @@ impl SuperfileReader {
     ///
     /// Async — consistent with [`Self::bm25_search`]: the reader's
     /// search surfaces are `async` so the supertable fan-out can drive
-    /// every segment concurrently on the shared query runtime. The
+    /// every superfile concurrently on the shared query runtime. The
     /// public `Supertable` API remains strictly sync; it wraps these
     /// kernels in `block_on_query`. Per-range byte access
     /// routes through
@@ -1048,8 +1048,8 @@ impl SuperfileReader {
     }
 
     /// As [`Self::vector_search`], but probes an **externally chosen**
-    /// set of IVF cluster ids — selected globally across segments from
-    /// the manifest's per-cluster centroids — instead of this segment's
+    /// set of IVF cluster ids — selected globally across superfiles from
+    /// the manifest's per-cluster centroids — instead of this superfile's
     /// own `nprobe` centroid scoring. `rerank_mult` is still derived from
     /// `options`; `options.nprobe` is unused on this path.
     pub async fn vector_search_clusters(

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -479,7 +479,7 @@ impl VectorBuilder {
     /// push the floor lower still.
     ///
     /// Object-storage callers can pass a multipart upload
-    /// writer here so segment build never owns the full blob in
+    /// writer here so superfile build never owns the full blob in
     /// RAM.
     pub fn finish_to<W: Write>(self, mut w: W) -> Result<(), BuildError> {
         let VectorBuilder {
@@ -490,7 +490,7 @@ impl VectorBuilder {
 
         let n_columns = columns.len() as u32;
         // n_docs in the outer header is the max across columns
-        // (per-segment doc count; spec: same across all columns).
+        // (per-superfile doc count; spec: same across all columns).
         let n_docs: u64 = columns.iter().map(|c| c.n_docs as u64).max().unwrap_or(0);
 
         // Snapshot config + n_docs first so the directory loop
@@ -1309,7 +1309,7 @@ fn run_pass2(
         //
         // for `RerankCodec::RabitqOnly` we skip the per-row
         // fp32 vector write entirely — pass 3 doesn't materialise
-        // `full_layout` for that codec, and the on-disk segment
+        // `full_layout` for that codec, and the on-disk superfile
         // has no `full[]` region, so spilling the vectors to a
         // bucket file would be pure wasted I/O. At dim=384 this
         // drops the per-row bucket write from 1 588 B to 52 B

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -76,7 +76,7 @@ pub fn distance(metric: Metric, a: &[f32], b: &[f32]) -> f32 {
 /// f32 dot product. Dispatches to the AVX-512 16-lane FMA kernel when
 /// the runtime CPUID gate passes; otherwise the `wide::f32x8` AVX2 /
 /// NEON / scalar kernel (which has been the universal kernel since the
-/// segment-builder existed). Both kernels handle non-multiple-of-lane
+/// superfile-builder existed). Both kernels handle non-multiple-of-lane
 /// inputs via a scalar tail.
 #[inline]
 pub fn dot(a: &[f32], b: &[f32]) -> f32 {

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -934,7 +934,7 @@ impl VectorReader {
                 let off = cluster_idx_off + cluster_idx_size;
                 // codec_meta must immediately precede the
                 // per-cluster blocks region by exactly its
-                // declared size. Any gap is a malformed segment.
+                // declared size. Any gap is a malformed superfile.
                 if off + codec_meta_size != per_cluster_blocks_off {
                     return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                         "column '{}' codec_meta region [{off}..{}) does not abut \
@@ -1090,7 +1090,7 @@ impl VectorReader {
     }
 
     /// Per-column summary centroid + radius, used by the storage plan
-    /// for cross-segment skip pruning.
+    /// for cross-superfile skip pruning.
     pub fn summary(&self, column: &str) -> Option<(Vec<f32>, f32)> {
         let cid = *self.column_id_by_name.get(column)?;
         let col = &self.columns[cid as usize];
@@ -1113,7 +1113,7 @@ impl VectorReader {
     /// The column's per-cluster IVF centroids (fp32, cluster-major,
     /// `n_cent * dim`) plus each cluster's indexed doc count. Returns
     /// `(n_cent, dim, centroids, counts)`. Used by the writer to stage
-    /// quantized cluster centroids into the manifest for cross-segment
+    /// quantized cluster centroids into the manifest for cross-superfile
     /// global cluster selection. `None` if the column is unknown or the
     /// centroid/cluster_idx bytes aren't resident.
     pub fn cluster_centroids(&self, column: &str) -> Option<(u32, u32, Vec<f32>, Vec<u32>)> {
@@ -1167,7 +1167,7 @@ impl VectorReader {
     /// sync and bridges to the underlying async
     /// `LazyByteSource::range` only on a cold `Source::Lazy`
     /// miss (via `block_in_place + Handle::block_on`, same
-    /// pattern as `supertable::query::segment_reader`). On
+    /// pattern as `supertable::query::superfile_reader`). On
     /// `Source::InMemory` and on `Source::Lazy` warm caches
     /// (`BytesLazyByteSource`, mmap-backed) every fetch resolves
     /// zero-copy on the sync fast path.
@@ -1275,11 +1275,11 @@ impl VectorReader {
         // pull the full rerank vectors ONLY for the survivors:
         //   * warm — the prefix is already resident (the sync probe
         //     above hits), and survivor rows are sliced from the
-        //     resident segment; zero GETs either wave.
+        //     resident superfile; zero GETs either wave.
         //   * cold — fetch the prefixes over the wire in one coalesced
         //     RTT batch, score, then fetch the survivor rows in a
         //     second small batch. The dominant per-candidate `full[]`
-        //     bytes (~3.4 MiB/segment — the volume that saturates S3
+        //     bytes (~3.4 MiB/superfile — the volume that saturates S3
         //     read throughput on a 256-way cold fan-out) are never
         //     moved for non-survivors.
         // The scoring math is identical to the old full-block path —
@@ -1370,7 +1370,7 @@ impl VectorReader {
     /// region, per-cluster code prefixes + Sq8 meta, survivor rerank
     /// rows) are `await`ed on the caller's runtime instead of bridged
     /// through a per-call throwaway runtime. This is what lets the
-    /// supertable vector fan-out drive every segment concurrently on
+    /// supertable vector fan-out drive every superfile concurrently on
     /// the shared query runtime — mirroring the FTS
     /// `bm25_search_pretokenized` path — rather than serializing cold
     /// object-store GETs. The CPU steps (centroid/code scoring,
@@ -1424,8 +1424,8 @@ impl VectorReader {
     }
 
     /// Async IVF probe over an **externally chosen** set of cluster ids.
-    /// The cross-segment global selector picks these from the manifest's
-    /// per-cluster centroids, so this skips the segment's own centroid
+    /// The cross-superfile global selector picks these from the manifest's
+    /// per-cluster centroids, so this skips the superfile's own centroid
     /// scoring entirely — it fetches just the cluster index, then probes
     /// exactly `clusters` (ids ≥ `n_cent` and empty clusters are
     /// ignored). The shortlist + rerank are byte-for-byte the same as
@@ -1460,9 +1460,9 @@ impl VectorReader {
     /// Shared async tail of the IVF probe: given a chosen set of cluster
     /// ids plus the already-fetched cluster index, fetch each non-empty
     /// cluster's block, build the 1-bit shortlist, and rerank to top-k.
-    /// Used by [`Self::search_async`] (clusters from this segment's
+    /// Used by [`Self::search_async`] (clusters from this superfile's
     /// centroid scoring) and [`Self::search_clusters_async`] (clusters
-    /// from the global cross-segment selector).
+    /// from the global cross-superfile selector).
     async fn probe_clusters_async(
         &self,
         col: &ColumnReader,
@@ -1922,7 +1922,7 @@ fn score_centroids(
 /// scan. Below this the fixed rayon dispatch cost outweighs the
 /// multicore speedup, so small queries — notably the 1M single-
 /// superfile nprobe=1 hot path — stay serial, while the 10M
-/// supertable's `nprobe × segments` fan-out goes parallel.
+/// supertable's `nprobe × superfiles` fan-out goes parallel.
 const PARALLEL_SCAN_MIN: usize = 2048;
 
 #[inline]
@@ -2910,7 +2910,7 @@ mod tests {
         // orders.)
         use std::collections::HashSet;
         let (blob, json, all) =
-            build_small_segment(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
         let r = VectorReader::open(blob, &json).expect("open");
         let q = &all[0];
         let (k, rerank, n_cent) = (5usize, 5usize, 4u32);
@@ -3047,9 +3047,9 @@ mod tests {
     // The codec discriminator rides as byte 52 of the per-column
     // directory entry; the codec_meta region offset rides as bytes
     // 12..16 of the sub-header. Both are zero on older fp32
-    // segments. `Fp32` / `Sq8` / `RabitqOnly` are wired end-to-end;
+    // superfiles. `Fp32` / `Sq8` / `RabitqOnly` are wired end-to-end;
     // must still round-trip as a typed `MalformedVersion` at open
-    // time so a future segment built by a newer binary fails loud
+    // time so a future superfile built by a newer binary fails loud
     // against an older binary rather than mis-decoding.
 
     use crate::superfile::format::checksum::crc32c;
@@ -3071,7 +3071,7 @@ mod tests {
         );
         assert_eq!(
             r.columns[0].codec_meta_off, 0,
-            "Fp32 segments must write codec_meta_off = 0 (zero-size region)"
+            "Fp32 superfiles must write codec_meta_off = 0 (zero-size region)"
         );
     }
 
@@ -3585,13 +3585,13 @@ mod tests {
     //
     // The `None` codec drops the `full[]` region entirely. The
     // 1-bit shortlist *is* the final ranking; the on-disk
-    // segment shrinks by ~30× at 1M × 384. Distance values
+    // superfile shrinks by ~30× at 1M × 384. Distance values
     // returned from `search()` are `-estimate` (1-bit dot
     // estimate, sign-flipped so smaller = closer holds) — not a
     // true metric distance.
 
     /// building with `RerankCodec::RabitqOnly` succeeds
-    /// and the on-disk segment carries a zero-length `full[]`
+    /// and the on-disk superfile carries a zero-length `full[]`
     /// region. Also pins the directory-entry discriminator
     /// (`codec_id = 3`) and the zero-byte codec_meta invariant
     /// (`codec_meta_off = 0`).
@@ -3628,9 +3628,9 @@ mod tests {
         );
         assert_eq!(
             col.codec_meta_off, 0,
-            "None segments must write codec_meta_off = 0 (zero-byte meta region)"
+            "None superfiles must write codec_meta_off = 0 (zero-byte meta region)"
         );
-        // `None` segments have zero-length full[] (per_vec_bytes
+        // `None` superfiles have zero-length full[] (per_vec_bytes
         // = 0), so each per-cluster block is just
         // `[codes][doc_ids]` — the blocks region is exactly
         // `n_docs × (code_bytes + 4)` with no full bytes.
@@ -3639,7 +3639,7 @@ mod tests {
         assert_eq!(
             region_size,
             (n_docs as usize) * (cb + 4),
-            "None segments interleave no full[] bytes — blocks region is \
+            "None superfiles interleave no full[] bytes — blocks region is \
              exactly n_docs × (code_bytes + 4)"
         );
         assert_eq!(col.n_docs, n_docs);
@@ -3817,11 +3817,11 @@ mod tests {
 
     /// a directory entry carrying an unknown codec id
     /// (anything outside `0..=3` — e.g. `255` from a corrupted /
-    /// future-format segment) errors as `MalformedVersion`. The
+    /// future-format superfile) errors as `MalformedVersion`. The
     /// safety net catches both forward-compat reads (future codec
     /// ids land in the gap) and on-disk corruption.
     #[test]
-    fn open_rejects_segment_with_unknown_codec_id() {
+    fn open_rejects_superfile_with_unknown_codec_id() {
         let (blob, json) = build_blob(64, 16, 4, Metric::L2Sq);
         let mut bytes = blob.to_vec();
 
@@ -3974,7 +3974,7 @@ mod tests {
             (255.0 * mean_intra / mean_g_range).round() as i32
         );
 
-        // 3. Build Fp32 + Sq8 segments from the same corpus.
+        // 3. Build Fp32 + Sq8 superfiles from the same corpus.
         let build = |codec: RerankCodec| -> Bytes {
             let mut b = VectorBuilder::new();
             b.register_column(VectorConfig {
@@ -3994,7 +3994,7 @@ mod tests {
         let fp32_blob = build(RerankCodec::Fp32);
         let sq8_blob = build(RerankCodec::Sq8Residual);
         eprintln!(
-            "--- segment sizes ---\n\
+            "--- superfile sizes ---\n\
              fp32: {:.2} MiB (1.00x)\n\
              sq8:  {:.2} MiB ({:.2}x)",
             fp32_blob.len() as f64 / 1024.0 / 1024.0,
@@ -4161,7 +4161,7 @@ mod tests {
     // bridges to the source's async `range()` via
     // `block_in_place + Handle::block_on` / one-shot
     // `current_thread` `Runtime`, the same pattern
-    // `supertable::query::segment_reader` uses for the disk-cache
+    // `supertable::query::superfile_reader` uses for the disk-cache
     // fetch path. No `search_async` is exposed at the public
     // surface; the cold-path async bridging is hidden inside
     // `Source::get_range`.
@@ -4504,7 +4504,7 @@ mod tests {
     // -----------------------------------------------------------------
     //
     // The headline guarantee is "resident set per open
-    // vector segment is bounded by O(n_cent × dim × 4 + small)",
+    // vector superfile is bounded by O(n_cent × dim × 4 + small)",
     // independent of `n_docs`. Acceptance criterion #2 spells it
     // out: opening a `Source::Lazy` over a mmap-backed
     // `BytesLazyByteSource` at 1M × 384 with
@@ -4738,21 +4738,21 @@ mod tests {
     // — supertable-scale memory ceiling
     // -----------------------------------------------------------------
     //
-    // The single-segment `mem_ceiling_lazy_open_*` tests above pin the
-    // per-reader bound. These multi-segment variants pin the
-    // *supertable-shaped* bound: open N segments concurrently — same
-    // shape `Supertable::commit` produces (N = N_SEGMENTS_BENCH × num_cpus
+    // The single-superfile `mem_ceiling_lazy_open_*` tests above pin the
+    // per-reader bound. These multi-superfile variants pin the
+    // *supertable-shaped* bound: open N superfiles concurrently — same
+    // shape `Supertable::commit` produces (N = N_SUPERFILES_BENCH × num_cpus
     // because `split_buffer_into_row_shards` shards each commit's
-    // buffer into one segment per writer-pool thread) — and assert the
+    // buffer into one superfile per writer-pool thread) — and assert the
     // total anon RSS delta scales as `N × O(centroids + rotation +
     // small)`, not as `N × subsection_size`.
     //
     // What this proves (and what it doesn't):
     //
     // - PROVES: a supertable opened with the production disk-cache
-    //   path (`Source::InMemory(Bytes::from_owner(mmap))` per segment —
+    //   path (`Source::InMemory(Bytes::from_owner(mmap))` per superfile —
     //   see `supertable::reader_cache::disk::insert`) keeps anon
-    //   RSS bounded across an arbitrary number of segments, with no
+    //   RSS bounded across an arbitrary number of superfiles, with no
     //   per-doc anon term. Equivalent here because
     //   `Bytes::from_owner` is zero-copy over the mmap, and the
     //   lazy-open path doesn't touch `doc_ids[]` / `full[]` at
@@ -4760,9 +4760,9 @@ mod tests {
     //   open ever touched `doc_ids[]`).
     //
     // - DOES NOT PROVE: the in-process `InMemoryReaderCache` path
-    //   (`Bytes::from(Vec)` per segment — see
+    //   (`Bytes::from(Vec)` per superfile — see
     //   `supertable::reader_cache::in_memory::insert`) has the same
-    //   bound. That path holds each segment's bytes in anon by
+    //   bound. That path holds each superfile's bytes in anon by
     //   construction (no mmap involved). The in-memory cache is the
     //   test/bench path; production attaches a `StorageProvider` and
     //   routes through the disk cache. A separate test for the
@@ -4771,29 +4771,29 @@ mod tests {
     //
     // The bench's 10M × 4-commit × num_cpus-thread shape produces
     // exactly the topology these tests exercise. The smoke variant
-    // mirrors the bench's *layout* at a tiny corpus size (4 segments
+    // mirrors the bench's *layout* at a tiny corpus size (4 superfiles
     // × 50 k docs × 64 dim) so every PR catches regressions
     // (~5 s build). The `#[ignore]`'d plan-spec variant uses the
-    // bench's actual per-segment shape (16 segments × 625 k docs ×
-    // 384 dim × n_cent_per_segment matching the bench's
+    // bench's actual per-superfile shape (16 superfiles × 625 k docs ×
+    // 384 dim × n_cent_per_superfile matching the bench's
     // `n_cent_total / 4`) and runs only when called out.
 
-    /// Open `N` segment files (built by `build_corpus_to_file`) via
+    /// Open `N` superfile files (built by `build_corpus_to_file`) via
     /// `Source::Lazy(BytesLazyByteSource over Arc<Mmap>)` and return
     /// the total RSS delta attributable to those opens. Anchors
     /// `(readers, mmaps)` past the after-RSS read.
-    fn measure_lazy_multi_segment_open_rss_delta(
+    fn measure_lazy_multi_superfile_open_rss_delta(
         corpus_paths: &[std::path::PathBuf],
         jsons: &[String],
     ) -> (usize, usize, usize) {
         assert_eq!(corpus_paths.len(), jsons.len(), "paths/jsons must align");
-        let n_segments = corpus_paths.len();
+        let n_superfiles = corpus_paths.len();
 
         // Pre-build (mmap, lazy source) pairs *before* the `before`
         // snapshot so the syscalls don't contaminate the delta — we
         // only want the open path's allocations in the measurement.
         let mut lazies: Vec<(StdArc<memmap2::Mmap>, StdArc<dyn LazyByteSource>)> =
-            Vec::with_capacity(n_segments);
+            Vec::with_capacity(n_superfiles);
         for path in corpus_paths {
             let file = std::fs::File::open(path).expect("reopen corpus readonly");
             let mmap = unsafe { memmap2::Mmap::map(&file) }.expect("mmap corpus");
@@ -4807,7 +4807,7 @@ mod tests {
             .expect("memory_stats supported")
             .physical_mem;
 
-        let mut readers: Vec<VectorReader> = Vec::with_capacity(n_segments);
+        let mut readers: Vec<VectorReader> = Vec::with_capacity(n_superfiles);
         let mut n_cols_total = 0usize;
         for ((_, lazy), json) in lazies.iter().zip(jsons.iter()) {
             let reader = VectorReader::open_with_source(
@@ -4833,35 +4833,35 @@ mod tests {
         drop(readers);
         drop(lazies);
 
-        (delta, n_cols_total, n_segments)
+        (delta, n_cols_total, n_superfiles)
     }
 
     /// **supertable-scale memory ceiling (smoke).**
     ///
     /// Mirrors the bench's 4-commit × num_cpus-thread shape at a
-    /// tiny corpus size. Builds 4 segment files (each 50 k × 64
+    /// tiny corpus size. Builds 4 superfile files (each 50 k × 64
     /// dim × n_cent=64 — same shape as
     /// `mem_ceiling_lazy_open_smoke`), opens all 4 lazy, and
     /// asserts the total anon RSS delta is ≤ 10 MiB. With
-    /// per-segment ceiling of 10 MiB / column from the single-
-    /// segment smoke and a 4× multiplier in the worst case
-    /// (centroids + rotation matrix per segment), 10 MiB total
+    /// per-superfile ceiling of 10 MiB / column from the single-
+    /// superfile smoke and a 4× multiplier in the worst case
+    /// (centroids + rotation matrix per superfile), 10 MiB total
     /// gives plenty of headroom while still failing loud if a
-    /// regression makes per-segment opens allocate per-doc.
+    /// regression makes per-superfile opens allocate per-doc.
     ///
     /// Runs in the default `cargo test --lib` suite (~3–5 s
     /// total) so every PR validates the supertable-shape bound.
     #[test]
-    fn mem_ceiling_lazy_multi_segment_open_smoke() {
-        const N_SEGMENTS: usize = 4;
+    fn mem_ceiling_lazy_multi_superfile_open_smoke() {
+        const N_SUPERFILES: usize = 4;
         const N_DOCS_PER_SEG: u32 = 50_000;
         const DIM: usize = 64;
         const N_CENT: usize = 64;
 
-        let mut tmps: Vec<tempfile::NamedTempFile> = Vec::with_capacity(N_SEGMENTS);
-        let mut paths: Vec<std::path::PathBuf> = Vec::with_capacity(N_SEGMENTS);
-        let mut jsons: Vec<String> = Vec::with_capacity(N_SEGMENTS);
-        for _ in 0..N_SEGMENTS {
+        let mut tmps: Vec<tempfile::NamedTempFile> = Vec::with_capacity(N_SUPERFILES);
+        let mut paths: Vec<std::path::PathBuf> = Vec::with_capacity(N_SUPERFILES);
+        let mut jsons: Vec<String> = Vec::with_capacity(N_SUPERFILES);
+        for _ in 0..N_SUPERFILES {
             let tmp = tempfile::NamedTempFile::new().expect("tempfile");
             let json = build_corpus_to_file(tmp.path(), N_DOCS_PER_SEG, DIM, N_CENT);
             paths.push(tmp.path().to_path_buf());
@@ -4869,21 +4869,21 @@ mod tests {
             tmps.push(tmp); // keep the tempfile alive until end
         }
 
-        let (delta_bytes, n_cols_total, n_segments) =
-            measure_lazy_multi_segment_open_rss_delta(&paths, &jsons);
+        let (delta_bytes, n_cols_total, n_superfiles) =
+            measure_lazy_multi_superfile_open_rss_delta(&paths, &jsons);
         let delta_mib = delta_bytes as f64 / (1024.0 * 1024.0);
-        let per_seg_mib = delta_mib / n_segments as f64;
+        let per_seg_mib = delta_mib / n_superfiles as f64;
 
         eprintln!(
-            "mem_ceiling_lazy_multi_segment_open_smoke ({N_SEGMENTS} × {N_DOCS_PER_SEG} × \
-             {DIM}, n_cent={N_CENT}): RSS delta = {delta_mib:.3} MiB over {n_segments} \
-             segment(s) ({n_cols_total} column(s) total) = {per_seg_mib:.3} MiB/segment"
+            "mem_ceiling_lazy_multi_superfile_open_smoke ({N_SUPERFILES} × {N_DOCS_PER_SEG} × \
+             {DIM}, n_cent={N_CENT}): RSS delta = {delta_mib:.3} MiB over {n_superfiles} \
+             superfile(s) ({n_cols_total} column(s) total) = {per_seg_mib:.3} MiB/superfile"
         );
 
         assert!(
             delta_mib <= 10.0,
             "supertable-shape lazy open RSS delta {delta_mib:.3} MiB exceeds 10 MiB ceiling \
-             at {N_SEGMENTS} × {N_DOCS_PER_SEG} × {DIM} — regression hint: each segment may \
+             at {N_SUPERFILES} × {N_DOCS_PER_SEG} × {DIM} — regression hint: each superfile may \
              be touching its doc_ids/full[]/codes region at open"
         );
 
@@ -4893,10 +4893,10 @@ mod tests {
     /// **supertable-scale memory ceiling (plan-spec).**
     ///
     /// Mirrors the bench's actual 10M × 4-commit ×
-    /// 4-thread-writer-pool topology: 16 segments × 625 k docs ×
-    /// 384 dim × `n_cent_per_segment = n_cent(10M) / 4` (the
+    /// 4-thread-writer-pool topology: 16 superfiles × 625 k docs ×
+    /// 384 dim × `n_cent_per_superfile = n_cent(10M) / 4` (the
     /// bench's `corpus::n_cent(10M)` returns 1024, so this is
-    /// 256). Each segment file is ~960 MiB on disk; the test
+    /// 256). Each superfile file is ~960 MiB on disk; the test
     /// writes ~15 GiB total to the tempdir. Build time is
     /// dominated by the 16 sequential streaming builds at
     /// ~10 s each in release ≈ 3 min total.
@@ -4908,15 +4908,15 @@ mod tests {
     ///     mem_ceiling_lazy_supertable_scale_under_50mib -- --ignored --nocapture
     /// ```
     ///
-    /// Bound: 50 MiB total anon over the 16 segments. The
-    /// per-segment open materialises:
+    /// Bound: 50 MiB total anon over the 16 superfiles. The
+    /// per-superfile open materialises:
     /// - rotation matrix: `dim² × 4 = 576 KiB` at dim=384
     /// - centroids buffer (in lazy source page cache, not anon):
     ///   `n_cent × dim × 4 = 384 KiB` at the smoke shape
     /// - per-column header / cluster_idx slices (KiB-range)
     ///
     /// Add a 2× safety margin for allocator overhead +
-    /// reader-struct fields, multiply by 16 segments → ~20 MiB
+    /// reader-struct fields, multiply by 16 superfiles → ~20 MiB
     /// theoretical, 50 MiB ceiling for headroom. A regression
     /// that re-introduces eager subsection materialisation
     /// would blow this to ~15 GiB (the full corpus) and fail
@@ -4924,18 +4924,18 @@ mod tests {
     #[test]
     #[ignore]
     fn mem_ceiling_lazy_supertable_scale_under_50mib() {
-        const N_SEGMENTS: usize = 16;
+        const N_SUPERFILES: usize = 16;
         const N_DOCS_PER_SEG: u32 = 625_000;
         const DIM: usize = 384;
         const N_CENT_PER_SEG: usize = 256;
 
-        let mut tmps: Vec<tempfile::NamedTempFile> = Vec::with_capacity(N_SEGMENTS);
-        let mut paths: Vec<std::path::PathBuf> = Vec::with_capacity(N_SEGMENTS);
-        let mut jsons: Vec<String> = Vec::with_capacity(N_SEGMENTS);
-        for i in 0..N_SEGMENTS {
+        let mut tmps: Vec<tempfile::NamedTempFile> = Vec::with_capacity(N_SUPERFILES);
+        let mut paths: Vec<std::path::PathBuf> = Vec::with_capacity(N_SUPERFILES);
+        let mut jsons: Vec<String> = Vec::with_capacity(N_SUPERFILES);
+        for i in 0..N_SUPERFILES {
             let tmp = tempfile::NamedTempFile::new().expect("tempfile");
             eprintln!(
-                "  building segment {i:2}/{N_SEGMENTS} \
+                "  building superfile {i:2}/{N_SUPERFILES} \
                  ({N_DOCS_PER_SEG} × {DIM}, n_cent={N_CENT_PER_SEG})…"
             );
             let json = build_corpus_to_file(tmp.path(), N_DOCS_PER_SEG, DIM, N_CENT_PER_SEG);
@@ -4944,58 +4944,58 @@ mod tests {
             tmps.push(tmp);
         }
 
-        let (delta_bytes, n_cols_total, n_segments) =
-            measure_lazy_multi_segment_open_rss_delta(&paths, &jsons);
+        let (delta_bytes, n_cols_total, n_superfiles) =
+            measure_lazy_multi_superfile_open_rss_delta(&paths, &jsons);
         let delta_mib = delta_bytes as f64 / (1024.0 * 1024.0);
-        let per_seg_mib = delta_mib / n_segments as f64;
+        let per_seg_mib = delta_mib / n_superfiles as f64;
 
         eprintln!(
-            "mem_ceiling_lazy_supertable_scale_under_50mib ({N_SEGMENTS} × {N_DOCS_PER_SEG} × \
+            "mem_ceiling_lazy_supertable_scale_under_50mib ({N_SUPERFILES} × {N_DOCS_PER_SEG} × \
              {DIM}, n_cent={N_CENT_PER_SEG}): RSS delta = {delta_mib:.3} MiB over \
-             {n_segments} segment(s) ({n_cols_total} column(s) total) = \
-             {per_seg_mib:.3} MiB/segment"
+             {n_superfiles} superfile(s) ({n_cols_total} column(s) total) = \
+             {per_seg_mib:.3} MiB/superfile"
         );
 
         assert!(
             delta_mib <= 50.0,
             "supertable-scale (10M-bench shape) lazy open RSS delta {delta_mib:.3} MiB \
-             exceeds 50 MiB ceiling at {N_SEGMENTS} × {N_DOCS_PER_SEG} × {DIM}. \
+             exceeds 50 MiB ceiling at {N_SUPERFILES} × {N_DOCS_PER_SEG} × {DIM}. \
              Eager re-introduction would push this past 15 GiB."
         );
 
         drop(tmps);
     }
 
-    /// **many-segments stress test (100M
+    /// **many-superfiles stress test (100M
     /// aspiration shape).**
     ///
     /// The honest scale test for "100M docs across a supertable"
-    /// can't materialise 100M production-shape segments on a
-    /// developer box (the per-segment 625k × 384 shape used in
-    /// the bench produces ~960 MiB on disk × 160 segments = 150
+    /// can't materialise 100M production-shape superfiles on a
+    /// developer box (the per-superfile 625k × 384 shape used in
+    /// the bench produces ~960 MiB on disk × 160 superfiles = 150
     /// GiB of corpus). Instead, this test pins the *structural*
-    /// memory bound by varying the high-cardinality axis (segment
-    /// count) at a thin per-segment shape: **100 segments × 50 k
+    /// memory bound by varying the high-cardinality axis (superfile
+    /// count) at a thin per-superfile shape: **100 superfiles × 50 k
     /// docs × 128 dim × 128 n_cent**.
     ///
     /// What this proves:
     ///
-    /// - Per-segment open allocation is `O(n_cent × dim × 4 +
+    /// - Per-superfile open allocation is `O(n_cent × dim × 4 +
     ///   rotation + small)` — no `n_docs` term. At this shape:
     ///   centroids 64 KiB + rotation matrix 64 KiB + column
-    ///   metadata ≪ 1 MiB per segment. Total expected RSS delta
-    ///   ≪ 200 MiB across 100 segments; 400 MiB ceiling for
+    ///   metadata ≪ 1 MiB per superfile. Total expected RSS delta
+    ///   ≪ 200 MiB across 100 superfiles; 400 MiB ceiling for
     ///   allocator overhead + reader-struct fields.
     ///
-    /// - The deletion of `doc_to_pos` made segment-count
+    /// - The deletion of `doc_to_pos` made superfile-count
     ///   the only scaling dimension. A regression that reintroduced
     ///   any per-doc resident state — e.g. a returning lookup
     ///   table at `n_docs × 4` bytes per column — would here
     ///   allocate 100 × 50 k × 4 = 20 MiB anon just for tables
-    ///   (small but growing); at the bench's 100 segments × 625 k
+    ///   (small but growing); at the bench's 100 superfiles × 625 k
     ///   the same regression is 250 MiB.
     ///
-    /// Each segment file is ~25 MiB on disk; the test writes
+    /// Each superfile file is ~25 MiB on disk; the test writes
     /// ~2.5 GiB total to the tempdir. Build time is dominated by
     /// the 100 sequential streaming builds (~1.5 s each in
     /// release ≈ 2.5 min total).
@@ -5004,24 +5004,24 @@ mod tests {
     ///
     /// ```bash
     /// cargo test --release -p infino --lib \
-    ///     mem_ceiling_lazy_many_segments_under_400mib -- --ignored --nocapture
+    ///     mem_ceiling_lazy_many_superfiles_under_400mib -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore]
-    fn mem_ceiling_lazy_many_segments_under_400mib() {
-        const N_SEGMENTS: usize = 100;
+    fn mem_ceiling_lazy_many_superfiles_under_400mib() {
+        const N_SUPERFILES: usize = 100;
         const N_DOCS_PER_SEG: u32 = 50_000;
         const DIM: usize = 128;
         const N_CENT_PER_SEG: usize = 128;
 
-        let mut tmps: Vec<tempfile::NamedTempFile> = Vec::with_capacity(N_SEGMENTS);
-        let mut paths: Vec<std::path::PathBuf> = Vec::with_capacity(N_SEGMENTS);
-        let mut jsons: Vec<String> = Vec::with_capacity(N_SEGMENTS);
-        for i in 0..N_SEGMENTS {
+        let mut tmps: Vec<tempfile::NamedTempFile> = Vec::with_capacity(N_SUPERFILES);
+        let mut paths: Vec<std::path::PathBuf> = Vec::with_capacity(N_SUPERFILES);
+        let mut jsons: Vec<String> = Vec::with_capacity(N_SUPERFILES);
+        for i in 0..N_SUPERFILES {
             let tmp = tempfile::NamedTempFile::new().expect("tempfile");
             if i % 10 == 0 {
                 eprintln!(
-                    "  building segment {i:3}/{N_SEGMENTS} \
+                    "  building superfile {i:3}/{N_SUPERFILES} \
                      ({N_DOCS_PER_SEG} × {DIM}, n_cent={N_CENT_PER_SEG})…"
                 );
             }
@@ -5031,22 +5031,22 @@ mod tests {
             tmps.push(tmp);
         }
 
-        let (delta_bytes, n_cols_total, n_segments) =
-            measure_lazy_multi_segment_open_rss_delta(&paths, &jsons);
+        let (delta_bytes, n_cols_total, n_superfiles) =
+            measure_lazy_multi_superfile_open_rss_delta(&paths, &jsons);
         let delta_mib = delta_bytes as f64 / (1024.0 * 1024.0);
-        let per_seg_mib = delta_mib / n_segments as f64;
+        let per_seg_mib = delta_mib / n_superfiles as f64;
 
         eprintln!(
-            "mem_ceiling_lazy_many_segments_under_400mib ({N_SEGMENTS} × {N_DOCS_PER_SEG} × \
+            "mem_ceiling_lazy_many_superfiles_under_400mib ({N_SUPERFILES} × {N_DOCS_PER_SEG} × \
              {DIM}, n_cent={N_CENT_PER_SEG}): RSS delta = {delta_mib:.3} MiB over \
-             {n_segments} segment(s) ({n_cols_total} column(s) total) = \
-             {per_seg_mib:.3} MiB/segment"
+             {n_superfiles} superfile(s) ({n_cols_total} column(s) total) = \
+             {per_seg_mib:.3} MiB/superfile"
         );
 
         assert!(
             delta_mib <= 400.0,
-            "many-segments lazy open RSS delta {delta_mib:.3} MiB exceeds 400 MiB ceiling \
-             at {N_SEGMENTS} × {N_DOCS_PER_SEG} × {DIM}. A regression that reintroduced \
+            "many-superfiles lazy open RSS delta {delta_mib:.3} MiB exceeds 400 MiB ceiling \
+             at {N_SUPERFILES} × {N_DOCS_PER_SEG} × {DIM}. A regression that reintroduced \
              any per-doc resident state would push this much higher; the deletion of \
              doc_to_pos is what keeps the bound structural."
         );
@@ -5062,7 +5062,7 @@ mod tests {
     // per-cluster blocks; those are search-time data.
     // -----------------------------------------------------------------
 
-    fn build_small_segment(
+    fn build_small_superfile(
         dim: usize,
         n_cent: usize,
         n_docs: u32,
@@ -5098,9 +5098,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn open_lazy_small_sq8_segment_fetches_exact_metadata_ranges() {
+    async fn open_lazy_small_sq8_superfile_fetches_exact_metadata_ranges() {
         let (blob, json, _) =
-            build_small_segment(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
         let counting = StdArc::new(CountingLazyByteSource::new(blob));
         let async_counter = counting.async_counter();
 
@@ -5122,9 +5122,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn open_lazy_small_segment_fetches_no_codec_meta_for_non_sq8() {
+    async fn open_lazy_small_superfile_fetches_no_codec_meta_for_non_sq8() {
         for codec in [RerankCodec::Fp32, RerankCodec::RabitqOnly] {
-            let (blob, json, _) = build_small_segment(32, 4, 64, codec, Metric::L2Sq);
+            let (blob, json, _) = build_small_superfile(32, 4, 64, codec, Metric::L2Sq);
             let counting = StdArc::new(CountingLazyByteSource::new(blob));
             let async_counter = counting.async_counter();
 
@@ -5158,7 +5158,7 @@ mod tests {
             RerankCodec::Sq8Residual,
             RerankCodec::RabitqOnly,
         ] {
-            let (blob, json, all) = build_small_segment(32, 4, 64, codec, Metric::L2Sq);
+            let (blob, json, all) = build_small_superfile(32, 4, 64, codec, Metric::L2Sq);
             let r_eager = VectorReader::open(blob.clone(), &json)
                 .unwrap_or_else(|e| panic!("eager open {codec:?}: {e:?}"));
             let counting = StdArc::new(CountingLazyByteSource::new(blob));
@@ -5194,7 +5194,7 @@ mod tests {
     ///
     /// Headline budget for the cold first-search phase
     /// (≤ 12 ranges, ≤ 5 MB at 1M × 384 sq8, nprobe = 8). The
-    /// small-segment test here pins the structural shape; the
+    /// small-superfile test here pins the structural shape; the
     /// s3s-fs bench measures the real wall-clock against AWS-
     /// shape RTTs.
     ///
@@ -5204,7 +5204,7 @@ mod tests {
     #[tokio::test]
     async fn cold_first_search_after_open_lazy_within_nprobe_plus_one_ranges() {
         let (blob, json, all) =
-            build_small_segment(32, 8, 128, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_small_superfile(32, 8, 128, RerankCodec::Sq8Residual, Metric::L2Sq);
 
         let counting = StdArc::new(CountingLazyByteSource::new(blob));
         let async_counter = counting.async_counter();
@@ -5272,7 +5272,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cold_first_search_dispatches_cluster_gets_concurrently() {
         let (blob, json, all) =
-            build_small_segment(32, 8, 256, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_small_superfile(32, 8, 256, RerankCodec::Sq8Residual, Metric::L2Sq);
 
         let counting = StdArc::new(CountingLazyByteSource::new(blob));
         let async_counter = counting.async_counter();
@@ -5336,7 +5336,7 @@ mod tests {
             RerankCodec::Sq8Residual,
             RerankCodec::RabitqOnly,
         ] {
-            let (blob, json, all) = build_small_segment(32, 4, 64, codec, Metric::L2Sq);
+            let (blob, json, all) = build_small_superfile(32, 4, 64, codec, Metric::L2Sq);
             let r_eager = VectorReader::open(blob.clone(), &json)
                 .unwrap_or_else(|e| panic!("eager open {codec:?}: {e:?}"));
             let counting = StdArc::new(CountingLazyByteSource::new(blob));
@@ -5375,7 +5375,7 @@ mod tests {
     #[test]
     fn cluster_block_range_matches_v1_layout_invariant() {
         let (blob, json, _) =
-            build_small_segment(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
         let r = VectorReader::open(blob, &json).expect("open");
         let col = &r.columns[0];
         let cb = col.quant.code_bytes();
@@ -5446,7 +5446,7 @@ mod tests {
     #[tokio::test]
     async fn open_lazy_column_metadata_matches_eager_open() {
         let (blob, json, _) =
-            build_small_segment(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
         let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
         let counting = StdArc::new(CountingLazyByteSource::new(blob));
         // Simulate the object-store path: with no zero-copy sync read

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -14,7 +14,7 @@
 //!   correction is applied only to that set. Default codec.
 //! - [`RerankCodec::RabitqOnly`]: no rerank column at all. The
 //!   1-bit RaBitQ shortlist is the final ranking — opt-in,
-//!   recall-degraded, shrinks the segment by ~30× at 1M × 384.
+//!   recall-degraded, shrinks the superfile by ~30× at 1M × 384.
 //!   Named `RabitqOnly` rather than `None` to (a) avoid shadowing
 //!   `Option::None` at every call site and (b) describe the search
 //!   behaviour rather than the absence of a codec.
@@ -24,7 +24,7 @@
 //! The codec choice rides as a single byte in the per-column
 //! subsection-directory entry at offset 52 (bytes 53..55 stay
 //! reserved). A zero byte at slot 52 deserializes to
-//! [`RerankCodec::Fp32`], so fp32-only segments that left the
+//! [`RerankCodec::Fp32`], so fp32-only superfiles that left the
 //! slot zero round-trip identically.
 //!
 //! ## `codec_meta` region
@@ -34,7 +34,7 @@
 //! `codec_meta` region between the `codes` region and the
 //! `full[]` region. The region's relative offset within the
 //! subsection is recorded in sub-header bytes 12..16 as
-//! `codec_meta_off: u32`. `Fp32` / `RabitqOnly` segments
+//! `codec_meta_off: u32`. `Fp32` / `RabitqOnly` superfiles
 //! write `codec_meta_off = 0`.
 
 use serde::{Deserialize, Serialize};
@@ -92,7 +92,7 @@ pub enum RerankCodec {
     /// No rerank column at all. The 1-bit RaBitQ shortlist is
     /// the final ranking. Opt-in — recall drops 0.05–0.15 on
     /// typical normalized-Gaussian / image-embedding corpora;
-    /// trade-off is a ~30× segment-size shrink at 1M × 384.
+    /// trade-off is a ~30× superfile-size shrink at 1M × 384.
     ///
     /// Spelled `RabitqOnly` rather than `None` so call sites
     /// don't collide with `Option::None` and the variant name
@@ -115,7 +115,7 @@ impl Default for RerankCodec {
 impl RerankCodec {
     /// On-disk discriminator byte. Lives at offset 52 inside the
     /// 64-byte per-column directory entry. `0` is reserved for
-    /// [`Self::Fp32`] so fp32-only segments that left the slot
+    /// [`Self::Fp32`] so fp32-only superfiles that left the slot
     /// zero round-trip identically.
     #[inline]
     pub const fn codec_id(self) -> u8 {
@@ -128,7 +128,7 @@ impl RerankCodec {
 
     /// Inverse of [`Self::codec_id`]. Returns `None` for unknown
     /// discriminator bytes — the reader treats that as a
-    /// `MalformedVersion` failure so a corrupted / future segment
+    /// `MalformedVersion` failure so a corrupted / future superfile
     /// fails loud rather than mis-decoding.
     #[inline]
     pub const fn from_codec_id(id: u8) -> Option<Self> {
@@ -285,7 +285,7 @@ mod tests {
         assert_eq!(RerankCodec::default(), RerankCodec::Sq8Residual);
     }
 
-    /// `Fp32`'s codec_id is zero. Older segments have all-zero
+    /// `Fp32`'s codec_id is zero. Older superfiles have all-zero
     /// reserved bytes in the directory-entry slot we squat on
     /// for the codec discriminator; the zero match keeps them
     /// readable as `Fp32` without a format bump.

--- a/src/supertable/build.rs
+++ b/src/supertable/build.rs
@@ -3,16 +3,16 @@
 
 //! Shared build-side dispatch for supertable commit fan-out.
 //!
-//! Query paths use `query::dispatch` so FTS, vector, and SQL segment
+//! Query paths use `query::dispatch` so FTS, vector, and SQL superfile
 //! work share one runtime and one fan-out primitive. Builds have the
 //! same outer shape at the supertable layer: a commit partitions
-//! buffered rows into segment shards, then builds one superfile per
+//! buffered rows into superfile shards, then builds one superfile per
 //! shard. This module owns that fan-out so FTS-only, vector-only, and
 //! combined commits all go through the same scheduler — no per-modality
 //! branching.
 //!
 //! The work function decides what a shard means; for the current writer
-//! it is one `SuperfileBuilder` producing one immutable segment. The
+//! it is one `SuperfileBuilder` producing one immutable superfile. The
 //! fan-out is a single rayon level: every shard is dispatched onto
 //! `pool` at once via `par_iter`. Each shard's kernel is free to expose
 //! its own intra-shard rayon work (e.g. the vector builder's row-parallel

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! no I/O. `supertable::compact` gathers the
 //! stats, calls [`select`], then merges each [`CompactionJob`].
-//! Compaction is single-level — a target-sized segment is never
+//! Compaction is single-level — a target-sized superfile is never
 //! re-compacted.
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
     supertable::{
         BuildError, SuperfileEntry,
         query::dispatch::open_reader,
-        writer::{PreparedSegment, ShardOutput, prepare_segment},
+        writer::{PreparedSuperfile, ShardOutput, prepare_superfile},
     },
 };
 use bytes::Bytes;
@@ -26,7 +26,7 @@ const MIB: u64 = 1024 * 1024;
 
 /// Stats for one superfile. The caller fills these in.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SegmentStats {
+pub struct SuperfileStats {
     pub superfile_id: Uuid,
     /// Partition it belongs to.
     /// never merge across partitions.
@@ -38,7 +38,7 @@ pub struct SegmentStats {
     pub sealed_by_other: bool,
 }
 
-impl SegmentStats {
+impl SuperfileStats {
     fn live_docs(&self) -> u64 {
         self.n_docs.saturating_sub(self.tombstoned_docs)
     }
@@ -61,16 +61,16 @@ pub struct CompactionJob {
     pub estimated_output_bytes: u64,
 }
 
-/// Plan compaction: pack each partition's small segments into
+/// Plan compaction: pack each partition's small superfiles into
 /// as many target-sized jobs as they fill. Leftovers that can't
 /// reach the floor are left for next time.
-pub fn select(segments: &[SegmentStats], cfg: &CompactionSettings) -> Vec<CompactionJob> {
-    let target_bytes = cfg.target_segment_size_mb.saturating_mul(MIB);
+pub fn select(superfiles: &[SuperfileStats], cfg: &CompactionSettings) -> Vec<CompactionJob> {
+    let target_bytes = cfg.target_superfile_size_mb.saturating_mul(MIB);
     let min_output_bytes =
         (target_bytes as u128 * cfg.min_fill_percent.clamp(1, 100) as u128 / 100) as u64;
 
-    let mut by_partition: BTreeMap<&[u8], Vec<&SegmentStats>> = BTreeMap::new();
-    for s in segments {
+    let mut by_partition: BTreeMap<&[u8], Vec<&SuperfileStats>> = BTreeMap::new();
+    for s in superfiles {
         by_partition.entry(&s.partition_key).or_default().push(s);
     }
 
@@ -83,14 +83,14 @@ pub fn select(segments: &[SegmentStats], cfg: &CompactionSettings) -> Vec<Compac
 
 fn pack_partition(
     key: &[u8],
-    segs: Vec<&SegmentStats>,
+    segs: Vec<&SuperfileStats>,
     target_bytes: u64,
     min_output_bytes: u64,
     jobs: &mut Vec<CompactionJob>,
 ) {
-    // Exclude segments already at target size — they are done and
+    // Exclude superfiles already at target size — they are done and
     // re-compacting them gains nothing.
-    let mut candidates: Vec<&SegmentStats> = segs
+    let mut candidates: Vec<&SuperfileStats> = segs
         .into_iter()
         .filter(|s| !s.sealed_by_other && s.size_bytes < min_output_bytes)
         .collect();
@@ -121,11 +121,11 @@ struct PendingJob {
 }
 
 impl PendingJob {
-    fn fits(&self, s: &SegmentStats, target_bytes: u64) -> bool {
+    fn fits(&self, s: &SuperfileStats, target_bytes: u64) -> bool {
         self.live_bytes + s.live_bytes() <= target_bytes
     }
 
-    fn push(&mut self, s: &SegmentStats) {
+    fn push(&mut self, s: &SuperfileStats) {
         self.inputs.push(s.superfile_id);
         self.live_bytes += s.live_bytes();
     }
@@ -148,7 +148,7 @@ impl Supertable {
     pub(crate) async fn merge_superfiles(
         &self,
         superfiles: &[Arc<SuperfileEntry>],
-    ) -> Result<PreparedSegment, BuildError> {
+    ) -> Result<PreparedSuperfile, BuildError> {
         let manifest = { self.inner().manifest.load().clone() };
         let store = manifest.options.store.clone();
         let disk_cache = manifest.options.disk_cache.clone();
@@ -199,9 +199,9 @@ impl Supertable {
             superfile_stats.scalar_stats,
         );
 
-        let prepared_segment = prepare_segment(self.inner().as_ref(), shard)?;
+        let prepared_superfile = prepare_superfile(self.inner().as_ref(), shard)?;
 
-        prepared_segment.ok_or(BuildError::NoDocsToBuild)
+        prepared_superfile.ok_or(BuildError::NoDocsToBuild)
     }
 }
 
@@ -218,8 +218,8 @@ mod tests {
         n * MIB
     }
 
-    fn seg(id: u128, size_mib: u64, n_docs: u64, tombstoned: u64) -> SegmentStats {
-        SegmentStats {
+    fn seg(id: u128, size_mib: u64, n_docs: u64, tombstoned: u64) -> SuperfileStats {
+        SuperfileStats {
             superfile_id: Uuid::from_u128(id),
             partition_key: Vec::new(),
             size_bytes: mib(size_mib),
@@ -256,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn splits_many_segments_into_multiple_jobs() {
+    fn splits_many_superfiles_into_multiple_jobs() {
         // 12 × 200 MiB: two jobs of 5, last 2 left over.
         let segs: Vec<_> = (0..12).map(|i| seg(i, 200, 1000, 0)).collect();
         let jobs = select(&segs, &default_cfg());
@@ -265,7 +265,7 @@ mod tests {
     }
 
     #[test]
-    fn already_target_sized_segment_is_never_re_compacted() {
+    fn already_target_sized_superfile_is_never_re_compacted() {
         let big = seg(99, 1024, 1_000_000, 0);
         let mut segs = vec![big.clone()];
         segs.extend((0..5).map(|i| seg(i, 200, 1000, 0)));
@@ -370,7 +370,7 @@ mod tests {
         assert_eq!(superfiles.len(), 2, "should have 2 superfiles");
 
         // Merge the superfiles - should succeed
-        let _merged_segment = st
+        let _merged_superfile = st
             .merge_superfiles(&superfiles)
             .await
             .expect("merge_superfiles should succeed");
@@ -425,27 +425,27 @@ mod tests {
             .unwrap_or(i128::MIN);
 
         // Merge should succeed and preserve scalar stats
-        let merged_segment = st
+        let merged_superfile = st
             .merge_superfiles(&superfiles)
             .await
             .expect("merge_superfiles should succeed");
 
-        // Verify merged segment stats match expected values
+        // Verify merged superfile stats match expected values
         assert_eq!(
-            merged_segment.entry.n_docs, expected_n_docs,
+            merged_superfile.entry.n_docs, expected_n_docs,
             "n_docs should be sum of input superfiles"
         );
         assert_eq!(
-            merged_segment.entry.id_min, expected_id_min,
+            merged_superfile.entry.id_min, expected_id_min,
             "id_min should be minimum across all superfiles"
         );
         assert_eq!(
-            merged_segment.entry.id_max, expected_id_max,
+            merged_superfile.entry.id_max, expected_id_max,
             "id_max should be maximum across all superfiles"
         );
 
         // Verify scalar stats for title column (lexicographic ordering: apple < banana < cherry < date)
-        let title_stats = merged_segment
+        let title_stats = merged_superfile
             .entry
             .scalar_stats
             .cols
@@ -507,15 +507,15 @@ mod tests {
         assert_eq!(superfiles.len(), 3, "should have 3 superfiles");
 
         // Merging 3 superfiles should succeed
-        let merged_segment = st
+        let merged_superfile = st
             .merge_superfiles(&superfiles)
             .await
             .expect("merge_superfiles should succeed");
 
-        // Verify merged segment stats
+        // Verify merged superfile stats
         assert_eq!(
-            merged_segment.entry.n_docs, 6,
-            "merged segment should have 6 documents (3 files × 2 docs each)"
+            merged_superfile.entry.n_docs, 6,
+            "merged superfile should have 6 documents (3 files × 2 docs each)"
         );
 
         let source_id_min = superfiles
@@ -528,14 +528,14 @@ mod tests {
             .map(|sf| sf.id_max)
             .max()
             .unwrap_or(i128::MIN);
-        assert_eq!(merged_segment.entry.id_min, source_id_min);
-        assert_eq!(merged_segment.entry.id_max, source_id_max);
+        assert_eq!(merged_superfile.entry.id_min, source_id_min);
+        assert_eq!(merged_superfile.entry.id_max, source_id_max);
 
         // Verify no data loss by querying the merged reader
-        let merged_reader = merged_segment
+        let merged_reader = merged_superfile
             .open_reader()
-            .expect("merged segment should have bytes")
-            .expect("open reader on merged segment");
+            .expect("merged superfile should have bytes")
+            .expect("open reader on merged superfile");
 
         assert_eq!(merged_reader.n_docs(), 6, "reader should report 6 docs");
 
@@ -579,15 +579,15 @@ mod tests {
         assert_eq!(superfiles.len(), 1, "should have 1 superfile");
 
         // Merging a single superfile should succeed
-        let merged_segment = st
+        let merged_superfile = st
             .merge_superfiles(&superfiles)
             .await
             .expect("merge_superfiles should succeed");
 
-        // Verify merged segment stats
+        // Verify merged superfile stats
         assert_eq!(
-            merged_segment.entry.n_docs, 2,
-            "merged segment should have 2 documents"
+            merged_superfile.entry.n_docs, 2,
+            "merged superfile should have 2 documents"
         );
 
         let source_id_min = superfiles
@@ -600,14 +600,14 @@ mod tests {
             .map(|sf| sf.id_max)
             .max()
             .unwrap_or(i128::MIN);
-        assert_eq!(merged_segment.entry.id_min, source_id_min);
-        assert_eq!(merged_segment.entry.id_max, source_id_max);
+        assert_eq!(merged_superfile.entry.id_min, source_id_min);
+        assert_eq!(merged_superfile.entry.id_max, source_id_max);
 
         // Verify no data loss by querying the merged reader
-        let merged_reader = merged_segment
+        let merged_reader = merged_superfile
             .open_reader()
-            .expect("merged segment should have bytes")
-            .expect("open reader on merged segment");
+            .expect("merged superfile should have bytes")
+            .expect("open reader on merged superfile");
 
         assert_eq!(merged_reader.n_docs(), 2, "reader should report 2 docs");
 

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -103,7 +103,7 @@ pub enum BuildError {
     )]
     SupertableInUse,
 
-    #[error("segment store: {0}")]
+    #[error("superfile store: {0}")]
     Store(String),
 
     #[error("rayon thread pool creation failed: {0}")]
@@ -169,17 +169,17 @@ pub enum CommitError {
     #[error("write contention exhausted retries")]
     WriteContentionExhausted,
 
-    /// A segment's column range spans multiple
+    /// A superfile's column range spans multiple
     /// partitions under the configured `PartitionStrategy`.
-    /// For `TimeRange` / `ColumnRange`, the segment's
+    /// For `TimeRange` / `ColumnRange`, the superfile's
     /// `(min, max)` straddles a bucket boundary. For `Hash`,
-    /// the segment's `partition_hint` is unset — the writer
+    /// the superfile's `partition_hint` is unset — the writer
     /// didn't pre-shard.
     ///
     /// Single-bucket Hash strategies (`n_buckets == 1`) are
     /// special-cased to bypass this check, since every
     /// possible value hashes to bucket 0.
-    #[error("segment spans partition boundary: {detail}")]
+    #[error("superfile spans partition boundary: {detail}")]
     SuperfileSpansPartition { detail: String },
 }
 
@@ -243,7 +243,7 @@ pub enum OpenError {
     /// inconsistent with the on-disk supertable (schema /
     /// partition strategy / id column changed) or the
     /// manifest was written by a different supertable.
-    /// Surfaced ahead of any per-segment decode so callers
+    /// Surfaced ahead of any per-superfile decode so callers
     /// see a typed mismatch instead of a downstream parquet
     /// or arrow error.
     ///
@@ -266,7 +266,7 @@ pub enum OpenError {
 /// failed mid-scan".
 #[derive(Debug, Error)]
 pub enum QueryError {
-    #[error("segment store error during query: {0}")]
+    #[error("superfile store error during query: {0}")]
     Store(String),
 
     #[error("error reading parquet bytes during scan: {0}")]

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -42,7 +42,7 @@ pub struct Supertable {
 /// single-writer slot enforcement.
 pub(super) struct SupertableInner {
     /// Schema, FTS columns, vector columns, tokenizer, thread
-    /// pools, segment store, commit threshold. Immutable for
+    /// pools, superfile store, commit threshold. Immutable for
     /// the supertable's lifetime; shared via Arc so readers,
     /// the writer, and rayon shard workers all see the same
     /// instances without copying.
@@ -368,7 +368,7 @@ impl Supertable {
         let eager = n_parts <= threshold;
 
         let parts_map = dashmap::DashMap::new();
-        let mut all_segments: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
+        let mut all_superfiles: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
         if eager {
             // Eager path: parallel-fetch every part + populate
             // the flat superfile_list.superfiles view so the
@@ -390,7 +390,7 @@ impl Supertable {
                     part_id: pid.0.to_string(),
                     source: Box::new(e),
                 })?;
-                all_segments.extend(part.superfiles.iter().cloned());
+                all_superfiles.extend(part.superfiles.iter().cloned());
                 let cell = tokio::sync::OnceCell::new();
                 cell.set(part).expect("fresh OnceCell");
                 parts_map.insert(*pid, Arc::new(cell));
@@ -417,7 +417,7 @@ impl Supertable {
         let options_arc = Arc::new(options);
         let mut superfile_list = SuperfileList::empty(options_arc.clone());
         superfile_list.manifest_id = pointer.manifest_id;
-        superfile_list.superfiles = all_segments;
+        superfile_list.superfiles = all_superfiles;
 
         let manifest = Manifest {
             superfile_list,
@@ -575,7 +575,7 @@ impl Supertable {
         // 4. Rebuild the flat superfile_list from all parts in
         //    the new manifest — eager mode only. In lazy
         //    mode the flat view stays empty until the hierarchical query path lands.
-        let mut all_segments: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
+        let mut all_superfiles: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
         if eager {
             for entry in &new_list.parts {
                 let cell = new_parts.get(&entry.part_id).expect("part inserted above");
@@ -583,16 +583,16 @@ impl Supertable {
                     .value()
                     .get()
                     .expect("eager-fetched or inherited; must be set");
-                all_segments.extend(part.superfiles.iter().cloned());
+                all_superfiles.extend(part.superfiles.iter().cloned());
             }
         }
 
         // 5. Build + ArcSwap the new Manifest.
-        let mut new_segment_list = SuperfileList::empty(self.inner.options.clone());
-        new_segment_list.manifest_id = pointer.manifest_id;
-        new_segment_list.superfiles = all_segments;
+        let mut new_superfile_list = SuperfileList::empty(self.inner.options.clone());
+        new_superfile_list.manifest_id = pointer.manifest_id;
+        new_superfile_list.superfiles = all_superfiles;
         let new_manifest = Manifest {
-            superfile_list: new_segment_list,
+            superfile_list: new_superfile_list,
             list: Some(new_list),
             parts: new_parts,
             loader: Some(new_loader),
@@ -712,7 +712,7 @@ impl Supertable {
         bridge_on_runtime(fut, &self.query_runtime())
     }
 
-    /// Block until the on-disk cache has fully promoted every segment
+    /// Block until the on-disk cache has fully promoted every superfile
     /// in the current manifest to an mmap-backed reader, or `timeout`
     /// elapses for one of them. This is the public "warm-readiness"
     /// primitive: once it returns `Ok(())`, subsequent searches read
@@ -730,10 +730,10 @@ impl Supertable {
     ///
     /// Crucially, requesting promotion here is also what *drives* it to
     /// completion: registering a promotion waiter releases the
-    /// background full-segment fill that otherwise idles behind
+    /// background full-superfile fill that otherwise idles behind
     /// foreground lazy readers under steady query load. Warming purely
     /// by replaying queries does not register that waiter, so the
-    /// segments can stay lazy/S3-backed indefinitely.
+    /// superfiles can stay lazy/S3-backed indefinitely.
     #[cfg(any(test, feature = "test-helpers"))]
     pub fn wait_until_warm(
         &self,
@@ -926,7 +926,7 @@ impl Supertable {
 /// concurrent user.
 ///
 /// Policy: **pin nothing.** The cache is a bounded LRU and must
-/// be free to evict any segment to stay under its budget — an
+/// be free to evict any superfile to stay under its budget — an
 /// index larger than the cache budget has to be able to
 /// stream/evict through it. (Previously this pinned the entire
 /// live manifest, which made the index *required* to fit inside
@@ -1033,7 +1033,7 @@ impl SupertableReader {
     }
 
     /// Pinned manifest. Exposed for query-side machinery
-    /// (skip helpers, fan-out, etc.) to read the segment list
+    /// (skip helpers, fan-out, etc.) to read the superfile list
     /// + summaries directly.
     pub fn manifest(&self) -> &Arc<Manifest> {
         &self.manifest
@@ -1201,7 +1201,7 @@ mod tests {
         assert_eq!(r2.manifest_id(), 2);
         assert_eq!(r3.manifest_id(), 3);
 
-        // Segment counts are monotonic across capture times.
+        // Superfile counts are monotonic across capture times.
         assert_eq!(r0.n_superfiles(), 0);
         assert_eq!(r1.n_superfiles(), 1);
         assert_eq!(r2.n_superfiles(), 2);

--- a/src/supertable/lazy_source.rs
+++ b/src/supertable/lazy_source.rs
@@ -12,7 +12,7 @@
 //!   `SuperfileReader::open_lazy` against any storage
 //!   backend. This is the `ColdFetchMode::RangeOnly` path —
 //!   stateless callers that don't want to materialize the
-//!   segment in the disk cache.
+//!   superfile in the disk cache.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/supertable/manifest/aggregates.rs
+++ b/src/supertable/manifest/aggregates.rs
@@ -14,19 +14,19 @@
 //!   bytes (same encoding `ManifestListEntry` uses).
 //! - `fts_summary_agg.term_range_union`: per FTS column,
 //!   `(min(min_term), max(max_term))` across superfiles with
-//!   non-empty FSTs. Absent (`None`) if every segment's FST
+//!   non-empty FSTs. Absent (`None`) if every superfile's FST
 //!   for that column is empty.
 //! - `vector_summary_agg`: per vector column, mean-of-
-//!   centroids + max(distance + segment_radius). Bounds every
-//!   segment's vector ball with one outer ball, so the
+//!   centroids + max(distance + superfile_radius). Bounds every
+//!   superfile's vector ball with one outer ball, so the
 //!   list-level vector skip is correct by construction (no
 //!   false negatives).
 //!
 //! `fts_summary_agg.term_bloom_union` is currently emitted
 //! empty (interpreted as "always-keep" by the list-level
 //! pruner) and `n_terms_distinct` as 0; HLL-sized blooms over
-//! the union of per-segment FSTs would require a per-commit
-//! cardinality estimate over each segment's terms.
+//! the union of per-superfile FSTs would require a per-commit
+//! cardinality estimate over each superfile's terms.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -49,7 +49,7 @@ pub struct AggregateSet {
 }
 
 /// Build the aggregate set for one manifest part from its
-/// segment list.
+/// superfile list.
 ///
 /// Empty `superfiles` → all-default `AggregateSet` (id_range
 /// `(0, 0)`, empty maps). The list-level pruner treats empty
@@ -76,7 +76,7 @@ pub fn compute(superfiles: &[Arc<SuperfileEntry>]) -> AggregateSet {
 // ---------------------------------------------------------
 
 fn scalar_stats_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, ScalarStatsAgg> {
-    // Gather, per column, all per-segment (min, max) ArrayRefs.
+    // Gather, per column, all per-superfile (min, max) ArrayRefs.
     let mut per_column: HashMap<String, (Vec<ArrayRef>, Vec<ArrayRef>)> = HashMap::new();
     for seg in superfiles {
         for (col, (mn, mx)) in &seg.scalar_stats.cols {
@@ -227,10 +227,10 @@ fn ipc_encode_length1(col_name: &str, arr: &ArrayRef) -> Vec<u8> {
 // FTS summary aggregate: term_range_union + term_bloom_union.
 // ---------------------------------------------------------
 //
-// Bloom union is the bit-OR of each segment's bloom for the
+// Bloom union is the bit-OR of each superfile's bloom for the
 // column. Same bloom-shape across all superfiles (the writer
 // builds with `BloomBuilder::new()` — fixed `DEFAULT_N_BLOCKS`
-// + xxh3_64), so bit-OR preserves "any segment contained
+// + xxh3_64), so bit-OR preserves "any superfile contained
 // this term" with the same FPR. The block-and-mask scheme
 // `Bloom::contains` uses is positional, not arithmetic,
 // so bit-OR is exact for the union semantic. The
@@ -243,7 +243,7 @@ type FtsColumnAccumulator = (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>, 
 fn fts_summary_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, FtsSummaryAgg> {
     // Per-column accumulators: (min, max, union-bloom-bytes,
     // n_blocks). The union bloom starts at zero-init the
-    // first time we see a segment with a populated bloom for
+    // first time we see a superfile with a populated bloom for
     // that column; subsequent superfiles bit-OR into it.
     let mut per_column: HashMap<String, FtsColumnAccumulator> = HashMap::new();
     for seg in superfiles {
@@ -262,7 +262,7 @@ fn fts_summary_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, FtsSu
                     _ => entry.1 = Some(summary.term_range.1.clone()),
                 }
             }
-            // Union the segment's bloom into the part-level
+            // Union the superfile's bloom into the part-level
             // bloom. Skip zero-length blooms (superfiles with
             // no FST entries for this column).
             let seg_bytes = summary.term_bloom.to_bytes();
@@ -445,7 +445,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_stats_agg_unions_utf8_min_max_across_segments() {
+    fn scalar_stats_agg_unions_utf8_min_max_across_superfiles() {
         let segs = vec![
             seg_with_string_minmax("title", "alpha", "delta", false),
             seg_with_string_minmax("title", "bravo", "echo", false),
@@ -457,7 +457,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_stats_agg_unions_large_utf8_min_max_across_segments() {
+    fn scalar_stats_agg_unions_large_utf8_min_max_across_superfiles() {
         let segs = vec![
             seg_with_string_minmax("body", "mango", "papaya", true),
             seg_with_string_minmax("body", "apple", "orange", true),

--- a/src/supertable/manifest/bloom.rs
+++ b/src/supertable/manifest/bloom.rs
@@ -3,13 +3,13 @@
 
 //! FTS term-presence bloom filter.
 //!
-//! One bloom per (segment, FTS column). Built once at commit time
-//! by feeding the segment's FST term iterator through a
+//! One bloom per (superfile, FTS column). Built once at commit time
+//! by feeding the superfile's FST term iterator through a
 //! [`BloomBuilder`]; queried at skip-prune time via
-//! [`Bloom::contains`] to decide whether a segment could contain
+//! [`Bloom::contains`] to decide whether a superfile could contain
 //! at least one of a query's terms. Returns `false` definitively
-//! (skip the segment) or `true` with the bloom's false-positive
-//! rate (scan the segment).
+//! (skip the superfile) or `true` with the bloom's false-positive
+//! rate (scan the superfile).
 //!
 //! # Algorithm: block bloom + XXH3-64 + portable SIMD bit-test
 //!
@@ -42,7 +42,7 @@
 //! - 64 KiB total → 1024 blocks of 64 B each (`n_blocks` is always
 //!   a power of two so the modulo is a bit-AND).
 //! - K = 4 hash functions per block.
-//! - At ~100 K distinct terms (a typical Zipfian 1 M-doc segment),
+//! - At ~100 K distinct terms (a typical Zipfian 1 M-doc superfile),
 //!   that's ~100 items / block, ~7% FPR — meaningful skip without
 //!   blowing manifest RAM.
 //!
@@ -71,7 +71,7 @@ const BLOCK_WORDS: usize = BLOCK_BYTES / 8; // 8
 pub const K: usize = 4;
 
 /// Default bloom size: 64 KiB / 1024 blocks. Sized so a typical
-/// Zipfian 1 M-doc segment with ~100 K distinct terms hits ~7%
+/// Zipfian 1 M-doc superfile with ~100 K distinct terms hits ~7%
 /// FPR.
 pub const DEFAULT_N_BLOCKS: usize = 1024;
 /// Default bloom byte size (64 KiB).
@@ -83,7 +83,7 @@ pub const DEFAULT_BLOOM_BYTES: usize = DEFAULT_N_BLOCKS * BLOCK_BYTES;
 const GOLDEN_RATIO_U64: u64 = 0x9E37_79B9_7F4A_7C15;
 
 /// Term-presence bloom filter for a single FTS column in a single
-/// segment.
+/// superfile.
 ///
 /// Cheap to clone (`Arc::clone` on the underlying word buffer); a
 /// `FtsSummary` clone shares this Arc with all manifest copies in
@@ -134,7 +134,7 @@ impl Bloom {
     }
 
     /// Test whether `key` may have been inserted. `false` is
-    /// definitive (the segment doesn't contain `key`); `true` may
+    /// definitive (the superfile doesn't contain `key`); `true` may
     /// be a false positive at the bloom's configured FPR.
     #[inline]
     pub fn contains(&self, key: &[u8]) -> bool {
@@ -168,7 +168,7 @@ impl Bloom {
 /// fed with [`BloomBuilder::insert`]; finalized with
 /// [`BloomBuilder::finish`].
 ///
-/// One builder per (segment, FTS column) at commit time.
+/// One builder per (superfile, FTS column) at commit time.
 pub struct BloomBuilder {
     words: Vec<u64>,
     n_blocks_mask: u32,
@@ -200,7 +200,7 @@ impl BloomBuilder {
         let (block_idx, mask) = block_and_mask(h, self.n_blocks_mask);
         let block_offset = block_idx * BLOCK_WORDS;
         // OR each mask word into the corresponding block word.
-        // Insert is uncommon enough (per-segment-build, not per-
+        // Insert is uncommon enough (per-superfile-build, not per-
         // query) that we don't bother SIMDing this path.
         let block = &mut self.words[block_offset..block_offset + BLOCK_WORDS];
         for (b, m) in block.iter_mut().zip(mask.iter()) {

--- a/src/supertable/manifest/encoding.rs
+++ b/src/supertable/manifest/encoding.rs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Binary encodings for the per-segment skip-summary types
+//! Binary encodings for the per-superfile skip-summary types
 //! that ride inside the manifest-part Avro schema as opaque
 //! `bytes` fields.
 //!
 //! The Avro layer doesn't need to introspect these — the
 //! aggregate skip pruning at the manifest-list level uses
-//! the parent-level aggregates, not the per-segment bytes;
-//! the per-segment summaries are loaded into memory by the
-//! manifest-part decoder and consumed by the segment-level
+//! the parent-level aggregates, not the per-superfile bytes;
+//! the per-superfile summaries are loaded into memory by the
+//! manifest-part decoder and consumed by the superfile-level
 //! prune path.
 //!
 //! Three encodings, all little-endian, all designed for
@@ -253,7 +253,7 @@ pub fn encode_vector_summary(s: &VectorSummary) -> Vec<u8> {
     }
     out.extend_from_slice(&s.radius.to_le_bytes());
     // Per-cluster centroid block: n_cent, dim, then counts / mins /
-    // scales / Sq8 codes. `n_cent == 0` encodes a segment with no
+    // scales / Sq8 codes. `n_cent == 0` encodes a superfile with no
     // vector index for the column (empty trailer).
     out.extend_from_slice(&cl.n_cent.to_le_bytes());
     out.extend_from_slice(&cl.dim.to_le_bytes());
@@ -291,7 +291,7 @@ pub fn decode_vector_summary(bytes: &[u8]) -> Result<VectorSummary, DecodeError>
     let radius = f32::from_le_bytes([rb[0], rb[1], rb[2], rb[3]]);
 
     // Per-cluster centroid block (new-engine format). `n_cent == 0` is
-    // a segment with no vector index for the column.
+    // a superfile with no vector index for the column.
     let n_cent = read_u32(&mut c, "cluster_n_cent")? as usize;
     let cdim = read_u32(&mut c, "cluster_dim")? as usize;
 

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -177,13 +177,13 @@ pub struct FtsSummaryAgg {
     /// part's superfiles. `0` for the `Default` shape.
     pub n_terms_distinct: u64,
     /// `(min, max)` term range across the part. `None` if
-    /// every segment's FST was empty for this column.
+    /// every superfile's FST was empty for this column.
     pub term_range_union: Option<(Vec<u8>, Vec<u8>)>,
 }
 
 /// Aggregate vector summary across a part's superfiles —
-/// mean-of-centroids + max-distance-with-segment-radius (one
-/// outer ball bounding every segment's vector ball). The
+/// mean-of-centroids + max-distance-with-superfile-radius (one
+/// outer ball bounding every superfile's vector ball). The
 /// `Default` shape is treated as "always-keep" by the list-
 /// level pruner.
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/src/supertable/manifest/list_prune.rs
+++ b/src/supertable/manifest/list_prune.rs
@@ -7,7 +7,7 @@
 //! aggregate skip tests in [`ManifestListEntry`] to identify
 //! candidate parts for a given query shape. Survivors are
 //! the parts the query layer should load (via
-//! [`Manifest::part`]) for per-segment pruning.
+//! [`Manifest::part`]) for per-superfile pruning.
 //!
 //! These functions are standalone — they don't depend on
 //! the in-memory `Manifest` or its `ManifestPartLoader`.
@@ -16,11 +16,11 @@
 //!
 //! ## Correctness invariants
 //!
-//! - **Monotonic**: every part the flat (segment-level) prune
+//! - **Monotonic**: every part the flat (superfile-level) prune
 //!   would visit is also a survivor here. Aggregate
 //!   summaries are constructed to over-approximate the union
-//!   of segment-level skip data, so a query that matches any
-//!   segment in a part necessarily matches the part's
+//!   of superfile-level skip data, so a query that matches any
+//!   superfile in a part necessarily matches the part's
 //!   aggregate.
 //! - **"Always-keep" defaults**: parts with empty `*_agg`
 //!   entries for the queried column trivially survive (e.g.
@@ -68,7 +68,7 @@ fn part_overlaps_prefix(
         return true;
     };
     let Some((min_term, max_term)) = agg.term_range_union.as_ref() else {
-        // Every segment had an empty FST for this column;
+        // Every superfile had an empty FST for this column;
         // nothing to match. Skip.
         return false;
     };
@@ -104,7 +104,7 @@ fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
 /// Filter the list's parts to those whose
 /// `term_bloom_union[column]` allows at least one query
 /// term (mode = Or) or all of them (mode = And) — i.e. the
-/// list-level analogue of segment-level `fts_bloom_skip`.
+/// list-level analogue of superfile-level `fts_bloom_skip`.
 ///
 /// Parts without a bloom union entry for this column (e.g.,
 /// pre-aggregate manifests or aggregates that fell back
@@ -116,7 +116,7 @@ fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
 /// Used by `bm25_search` (exact-term) to prune entire parts
 /// before lazy-loading. Complements
 /// `prune_parts_for_fts_prefix` (which uses term-range
-/// overlap on prefix queries) and segment-level
+/// overlap on prefix queries) and superfile-level
 /// `fts_bloom_skip` (applied after a part is loaded).
 pub fn prune_parts_for_fts_terms(
     list: &ManifestList,
@@ -199,7 +199,7 @@ pub fn prune_parts_for_id_range(
 ///
 /// Distance is L2; for cosine workloads, the query vector + centroids
 /// should be normalized at the caller layer (matching the convention the
-/// segment-level vector skip already uses).
+/// superfile-level vector skip already uses).
 pub fn prune_parts_for_vector(
     list: &ManifestList,
     column: &str,
@@ -218,7 +218,7 @@ pub fn prune_parts_for_vector(
             }
             let envelope = decode_centroid_envelope(&agg.centroid_envelope);
             if envelope.len() != query.len() {
-                // Dim mismatch — keep (the per-segment prune
+                // Dim mismatch — keep (the per-superfile prune
                 // will reject correctly).
                 return Some(entry.part_id);
             }
@@ -343,7 +343,7 @@ mod tests {
         })
     }
 
-    fn entry_from_segments(superfiles: &[Arc<SuperfileEntry>], seed: u8) -> ManifestListEntry {
+    fn entry_from_superfiles(superfiles: &[Arc<SuperfileEntry>], seed: u8) -> ManifestListEntry {
         let aggs = aggregates::compute(superfiles);
         ManifestListEntry {
             part_id: PartId(Uuid::from_bytes([seed; 16])),
@@ -389,7 +389,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregates_compute_id_range_is_min_max_across_segments() {
+    fn aggregates_compute_id_range_is_min_max_across_superfiles() {
         let s_a = seg(100, 199, &["alpha"], None, 0.0);
         let s_b = seg(0, 99, &["beta"], None, 0.0);
         let s_c = seg(500, 599, &["gamma"], None, 0.0);
@@ -475,13 +475,13 @@ mod tests {
     }
 
     #[test]
-    fn aggregates_compute_vector_envelope_bounds_all_segment_balls() {
+    fn aggregates_compute_vector_envelope_bounds_all_superfile_balls() {
         let s_a = seg(0, 10, &[], Some(vec![1.0, 0.0, 0.0]), 0.5);
         let s_b = seg(11, 20, &[], Some(vec![0.0, 1.0, 0.0]), 0.5);
         let aggs = aggregates::compute(&[s_a.clone(), s_b.clone()]);
         let v = aggs.vector_summary_agg.get("emb").expect("vec agg");
         let mean = [0.5, 0.5, 0.0];
-        // Each segment's centroid is ~0.707 from the mean; +
+        // Each superfile's centroid is ~0.707 from the mean; +
         // radius 0.5 → envelope_radius >= 1.207.
         assert!(
             v.envelope_radius >= 1.207 - 0.01,
@@ -584,10 +584,10 @@ mod tests {
 
     #[test]
     fn prune_parts_for_id_range_filters_non_overlapping_parts() {
-        let part0 = entry_from_segments(&[seg(0, 99, &[], None, 0.0)], 0);
-        let part1 = entry_from_segments(&[seg(100, 199, &[], None, 0.0)], 1);
-        let part2 = entry_from_segments(&[seg(200, 299, &[], None, 0.0)], 2);
-        let part3 = entry_from_segments(&[seg(300, 399, &[], None, 0.0)], 3);
+        let part0 = entry_from_superfiles(&[seg(0, 99, &[], None, 0.0)], 0);
+        let part1 = entry_from_superfiles(&[seg(100, 199, &[], None, 0.0)], 1);
+        let part2 = entry_from_superfiles(&[seg(200, 299, &[], None, 0.0)], 2);
+        let part3 = entry_from_superfiles(&[seg(300, 399, &[], None, 0.0)], 3);
         let list = list_with(vec![part0, part1.clone(), part2.clone(), part3]);
 
         let survivors = prune_parts_for_id_range(&list, 150, 250);
@@ -600,10 +600,10 @@ mod tests {
     #[test]
     fn prune_parts_for_fts_prefix_filters_disjoint_term_ranges() {
         let part0 =
-            entry_from_segments(&[seg(0, 10, &["alpha", "bravo", "charlie"], None, 0.0)], 0);
+            entry_from_superfiles(&[seg(0, 10, &["alpha", "bravo", "charlie"], None, 0.0)], 0);
         let part1 =
-            entry_from_segments(&[seg(11, 20, &["delta", "echo", "foxtrot"], None, 0.0)], 1);
-        let part2 = entry_from_segments(&[seg(21, 30, &["hotel", "kilo", "lima"], None, 0.0)], 2);
+            entry_from_superfiles(&[seg(11, 20, &["delta", "echo", "foxtrot"], None, 0.0)], 1);
+        let part2 = entry_from_superfiles(&[seg(21, 30, &["hotel", "kilo", "lima"], None, 0.0)], 2);
         let list = list_with(vec![part0, part1.clone(), part2]);
 
         let survivors = prune_parts_for_fts_prefix(&list, "title", b"echo");
@@ -615,7 +615,7 @@ mod tests {
     fn prune_parts_for_fts_prefix_keeps_part_with_no_aggregate() {
         // Part has no FTS aggregate for the queried column —
         // always-keep.
-        let part = entry_from_segments(&[seg(0, 10, &[], None, 0.0)], 0);
+        let part = entry_from_superfiles(&[seg(0, 10, &[], None, 0.0)], 0);
         let list = list_with(vec![part.clone()]);
         let survivors = prune_parts_for_fts_prefix(&list, "missing", b"any");
         assert_eq!(survivors, vec![part.part_id]);
@@ -623,8 +623,9 @@ mod tests {
 
     #[test]
     fn prune_parts_for_vector_filters_far_parts() {
-        let part_a = entry_from_segments(&[seg(0, 10, &[], Some(vec![10.0, 0.0, 0.0]), 0.5)], 0);
-        let part_b = entry_from_segments(&[seg(11, 20, &[], Some(vec![-10.0, 0.0, 0.0]), 0.5)], 1);
+        let part_a = entry_from_superfiles(&[seg(0, 10, &[], Some(vec![10.0, 0.0, 0.0]), 0.5)], 0);
+        let part_b =
+            entry_from_superfiles(&[seg(11, 20, &[], Some(vec![-10.0, 0.0, 0.0]), 0.5)], 1);
         let list = list_with(vec![part_a.clone(), part_b]);
         let survivors = prune_parts_for_vector(&list, "emb", &[10.0, 0.0, 0.0], 1.0);
         assert_eq!(survivors.len(), 1);
@@ -633,8 +634,8 @@ mod tests {
 
     #[test]
     fn prune_parts_for_vector_keeps_overlapping_envelope() {
-        let part_a = entry_from_segments(&[seg(0, 10, &[], Some(vec![1.0, 0.0, 0.0]), 1.0)], 0);
-        let part_b = entry_from_segments(&[seg(11, 20, &[], Some(vec![-1.0, 0.0, 0.0]), 1.0)], 1);
+        let part_a = entry_from_superfiles(&[seg(0, 10, &[], Some(vec![1.0, 0.0, 0.0]), 1.0)], 0);
+        let part_b = entry_from_superfiles(&[seg(11, 20, &[], Some(vec![-1.0, 0.0, 0.0]), 1.0)], 1);
         let list = list_with(vec![part_a, part_b]);
         let survivors = prune_parts_for_vector(&list, "emb", &[0.0, 0.0, 0.0], 1.0);
         assert_eq!(
@@ -646,10 +647,10 @@ mod tests {
 
     #[test]
     fn pruning_is_monotonic_no_false_negatives() {
-        // Property: any segment the flat (segment-level)
+        // Property: any superfile the flat (superfile-level)
         // pruner would visit is necessarily in a part the
         // list-level pruner keeps. Aggregates over-
-        // approximate the segment-level skip data.
+        // approximate the superfile-level skip data.
         let segs_part0 = vec![
             seg(0, 10, &["apple"], None, 0.0),
             seg(11, 20, &["banana", "cherry"], None, 0.0),
@@ -658,8 +659,8 @@ mod tests {
             seg(21, 30, &["alpha"], None, 0.0),
             seg(31, 40, &["echo", "foxtrot"], None, 0.0),
         ];
-        let part0 = entry_from_segments(&segs_part0, 0);
-        let part1 = entry_from_segments(&segs_part1, 1);
+        let part0 = entry_from_superfiles(&segs_part0, 0);
+        let part1 = entry_from_superfiles(&segs_part1, 1);
         let list = list_with(vec![part0.clone(), part1.clone()]);
 
         let survivors = prune_parts_for_fts_prefix(&list, "title", b"ban");

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -44,7 +44,7 @@ use super::options::SupertableOptions;
 
 /// One immutable point-in-time view of the supertable.
 ///
-/// **Construction is copy-on-write.** Adding a segment via
+/// **Construction is copy-on-write.** Adding a superfile via
 /// [`Manifest::with_appended`] returns a new `Manifest` whose
 /// `superfiles` is `Vec::clone()` + new entries appended; the original
 /// `Manifest`'s `superfiles` is unchanged. `Arc<SuperfileEntry>` shares
@@ -74,7 +74,7 @@ pub struct SuperfileList {
     /// Pointer back to the immutable per-supertable configuration.
     /// Same Arc across all manifests of one supertable.
     pub options: Arc<SupertableOptions>,
-    /// Append-only list of segment entries. Each entry's `Arc`-share
+    /// Append-only list of superfile entries. Each entry's `Arc`-share
     /// is what makes the copy-on-write per-commit construction
     /// cheap.
     pub superfiles: Vec<Arc<SuperfileEntry>>,
@@ -309,8 +309,8 @@ pub enum ManifestLoadError {
     Parse(#[from] part::PartParseError),
 }
 
-/// One segment's metadata + skip-pruning summaries. The bytes that
-/// back the segment live in the segment store keyed by `uri` —
+/// One superfile's metadata + skip-pruning summaries. The bytes that
+/// back the superfile live in the superfile store keyed by `uri` —
 /// `superfile_id` is for debugging / observability, `uri` is for
 /// store routing.
 #[derive(Debug)]
@@ -351,7 +351,7 @@ pub struct SuperfileEntry {
     /// from the configured strategy at commit time.
     pub partition_key: Vec<u8>,
     /// Hash partitioning operates per-row, but at commit time we
-    /// only have per-segment summaries. Hash strategy requires
+    /// only have per-superfile summaries. Hash strategy requires
     /// superfiles to be pre-sharded — each builder-shard stamps the
     /// resulting bucket here on ingest. `None` under non-hash
     /// strategies and under the single-bucket Hash default.
@@ -367,7 +367,7 @@ pub struct SuperfileEntry {
     /// the values are by construction consistent with what the
     /// parquet KV metadata would later say).
     ///
-    /// `None` on segments produced by older writers that did not
+    /// `None` on superfiles produced by older writers that did not
     /// stamp this field; the cold open path falls back to the
     /// 2-RTT shape (parquet tail
     /// then vec/fts in parallel) — see
@@ -394,10 +394,10 @@ pub struct SubsectionOffsets {
     /// but available without any I/O.
     pub total_size: u64,
     /// Absolute `(offset, length)` of the vector subsection. `None`
-    /// when the segment carries no vector subsection.
+    /// when the superfile carries no vector subsection.
     pub vec: Option<(u64, u64)>,
     /// Absolute `(offset, length)` of the FTS subsection. `None`
-    /// when the segment carries no FTS subsection.
+    /// when the superfile carries no FTS subsection.
     pub fts: Option<(u64, u64)>,
     /// Absolute ranges that fully cover vector open-time metadata.
     /// The hinted cache path prefetches these in the first network
@@ -408,20 +408,20 @@ pub struct SubsectionOffsets {
     /// header+dictionary and doc-length tables. Query-time postings
     /// stay lazy.
     pub fts_open_ranges: Vec<(u64, u64)>,
-    /// the actual bytes covering the segment's
+    /// the actual bytes covering the superfile's
     /// open-time batch (parquet footer tail + the
     /// `vec_open_ranges` + the `fts_open_ranges`), carried inline
     /// in the manifest part.
     ///
     /// When non-empty, the cold-fetch path installs these directly
     /// into the reader's prefetch overlay and issues **zero**
-    /// open-time GETs against the segment object — the bytes
+    /// open-time GETs against the superfile object — the bytes
     /// already arrived in the single part GET that `cold_open`
-    /// performs. The genuine first-touch per-segment cost then
+    /// performs. The genuine first-touch per-superfile cost then
     /// collapses from 2 RTT-batches (open metadata + cluster
     /// postings) to 1 (postings only).
     ///
-    /// Each tuple is `(absolute_offset, bytes)`. Empty on segments
+    /// Each tuple is `(absolute_offset, bytes)`. Empty on superfiles
     /// produced by older writers that did not capture it, or when
     /// blob capture is disabled
     /// — the path then falls back to fetching `vec_open_ranges` /
@@ -429,7 +429,7 @@ pub struct SubsectionOffsets {
     pub open_blob: Vec<(u64, Vec<u8>)>,
 }
 
-/// Opaque store key — wraps a UUID v4. The segment store treats
+/// Opaque store key — wraps a UUID v4. The superfile store treats
 /// this as a hash-eq token and doesn't peek inside. An
 /// object-store-backed variant could swap to a path-shaped URI
 /// without changing any caller, since the trait shape stays the
@@ -439,21 +439,21 @@ pub struct SuperfileUri(pub Uuid);
 
 impl SuperfileUri {
     /// Generate a fresh URI. Called by the writer at commit time
-    /// when assigning a key for a new segment's bytes.
+    /// when assigning a key for a new superfile's bytes.
     pub fn new_v4() -> Self {
         Self(Uuid::new_v4())
     }
 
-    /// Object-store / LocalFS path for committed segment bytes.
+    /// Object-store / LocalFS path for committed superfile bytes.
     /// `.sf.parquet` double suffix — on disk this is still valid
     /// Parquet (row groups + optional embedded FTS/vector blobs +
     /// footer), while the `.sf` marker flags it as a Superfile
-    /// segment without making the file look non-standard.
+    /// superfile without making the file look non-standard.
     pub fn storage_path(self) -> String {
         format!("data/seg-{}.sf.parquet", self.0)
     }
 
-    /// Disk-cache filename for a promoted segment.
+    /// Disk-cache filename for a promoted superfile.
     pub fn cache_filename(self) -> String {
         format!("seg-{}.sf.parquet", self.0)
     }
@@ -464,7 +464,7 @@ impl SuperfileUri {
     }
 }
 
-/// Per-scalar-column min/max for a segment, used by scalar skip
+/// Per-scalar-column min/max for a superfile, used by scalar skip
 /// pruning. Each column's min/max is a length-1 `ArrayRef` of the
 /// column's data type — the most general shape that doesn't
 /// require pulling DataFusion into this layer. The skip helper
@@ -488,7 +488,7 @@ impl ScalarStatsTable {
     /// integer / float / boolean / utf8).
     ///
     /// Used by [`crate::supertable::writer::SupertableWriter`] at
-    /// commit time to populate per-segment scalar skip stats. The
+    /// commit time to populate per-superfile scalar skip stats. The
     /// resulting table maps `column_name → (min_arr, max_arr)`,
     /// where each entry is a length-1 [`ArrayRef`] of the column's
     /// type — zero-pad isn't needed since the skip planner reads
@@ -784,13 +784,13 @@ fn column_min_max(col: &arrow_array::ArrayRef) -> Option<(ArrayRef, ArrayRef)> {
 #[derive(Debug, Clone)]
 pub struct FtsSummary {
     /// Term-presence bloom filter — sized to ~7% FPR at typical
-    /// per-column term cardinalities (64 KiB / column / segment
+    /// per-column term cardinalities (64 KiB / column / superfile
     /// is the default).
     pub term_bloom: Bloom,
     /// Number of distinct terms seen at build time. Useful for
     /// validating the bloom's sizing in tests + for observability.
     pub n_terms_distinct: u32,
-    /// Lex-smallest and lex-largest term in this segment's FST for
+    /// Lex-smallest and lex-largest term in this superfile's FST for
     /// this column. Prefix skip checks
     /// `[prefix, prefix_upper_bound)` overlap with this range.
     pub term_range: (Vec<u8>, Vec<u8>),
@@ -808,11 +808,11 @@ pub struct VectorSummary {
     /// Cluster centroid; length matches the vector column's `dim`
     /// declared in `SupertableOptions::vector_columns`.
     pub centroid: Vec<f32>,
-    /// Maximum distance from any indexed vector in this segment to
+    /// Maximum distance from any indexed vector in this superfile to
     /// `centroid`, in the same metric the column was built with.
     pub radius: f32,
     /// Per-cluster IVF centroids (Sq8, per-cluster calibration) for
-    /// cross-segment global cluster selection. Empty when the segment
+    /// cross-superfile global cluster selection. Empty when the superfile
     /// has no vector index for this column.
     pub clusters: ClusterCentroids,
 }
@@ -824,9 +824,9 @@ const SQ8_CODE_MAX: f32 = 255.0;
 
 /// Per-cluster IVF centroids for one vector column, Sq8-quantized with
 /// per-cluster calibration. Carried in the manifest so a query can rank
-/// every segment's clusters globally — without opening the segment —
+/// every superfile's clusters globally — without opening the superfile —
 /// and probe only the globally-closest clusters. The 1-bit shortlist +
-/// rerank still run on the segment's on-disk compressed vectors; these
+/// rerank still run on the superfile's on-disk compressed vectors; these
 /// drive cluster *selection* only.
 ///
 /// Quantization is value-only (no metric); the selector applies the
@@ -847,7 +847,7 @@ pub struct ClusterCentroids {
 }
 
 impl ClusterCentroids {
-    /// The "no cluster centroids" value — a segment without a vector
+    /// The "no cluster centroids" value — a superfile without a vector
     /// index for the column.
     pub fn empty() -> Self {
         Self::default()
@@ -977,7 +977,7 @@ mod tests {
     }
 
     #[test]
-    fn with_appended_increments_manifest_id_and_extends_segments() {
+    fn with_appended_increments_manifest_id_and_extends_superfiles() {
         let m0 = Manifest::empty(opts());
         let entry = seg_entry(Uuid::new_v4(), 100);
         let m1 = m0.with_appended(vec![entry.clone()]);
@@ -1005,10 +1005,10 @@ mod tests {
     }
 
     #[test]
-    fn with_appended_shares_old_segments_via_arc() {
+    fn with_appended_shares_old_superfiles_via_arc() {
         // The new manifest's superfiles[0] should be the SAME Arc as
         // the original's superfiles[0] — copy-on-write doesn't
-        // re-allocate per-segment. (Verified by Arc::ptr_eq.)
+        // re-allocate per-superfile. (Verified by Arc::ptr_eq.)
         let entry = seg_entry(Uuid::new_v4(), 1);
         let m0 = Manifest::empty(opts()).with_appended(vec![entry.clone()]);
         let m1 = m0.with_appended(vec![seg_entry(Uuid::new_v4(), 2)]);
@@ -1029,7 +1029,7 @@ mod tests {
     }
 
     #[test]
-    fn segment_uri_is_distinct_per_call() {
+    fn superfile_uri_is_distinct_per_call() {
         let a = SuperfileUri::new_v4();
         let b = SuperfileUri::new_v4();
         assert_ne!(a, b);

--- a/src/supertable/manifest/part.rs
+++ b/src/supertable/manifest/part.rs
@@ -8,7 +8,7 @@
 //! the blake3 hash of the compressed bytes. The blake3 hash
 //! is the part's URI (modulo backend prefix); content
 //! addressing means commits that don't change a part's
-//! segment set reuse it across manifest versions without a
+//! superfile set reuse it across manifest versions without a
 //! re-PUT.
 
 use std::collections::HashMap;
@@ -245,7 +245,7 @@ pub fn encode(part: &ManifestPart, zstd_level: i32) -> Vec<u8> {
     // part twice would produce different bytes → different
     // blake3 → different URI. Iceberg manifest files take the
     // same approach for the same reason.
-    let segment_records: Vec<AvroValue> = part
+    let superfile_records: Vec<AvroValue> = part
         .superfiles
         .iter()
         .map(|seg| {
@@ -308,7 +308,7 @@ pub fn encode(part: &ManifestPart, zstd_level: i32) -> Vec<u8> {
             "part_id".into(),
             AvroValue::String(part.part_id.0.to_string()),
         ),
-        ("superfiles".into(), AvroValue::Array(segment_records)),
+        ("superfiles".into(), AvroValue::Array(superfile_records)),
     ]);
 
     let avro_bytes = to_avro_datum(schema(), record).expect("avro datum encode");
@@ -349,16 +349,16 @@ pub fn decode(bytes: &[u8]) -> Result<ManifestPart, PartParseError> {
         Uuid::parse_str(&part_id_str).map_err(|e| PartParseError::BadSuperfileId(e.to_string()))?,
     );
 
-    let segments_val = map
+    let superfiles_val = map
         .remove("superfiles")
         .ok_or(PartParseError::MissingField("superfiles"))?;
-    let segs = match segments_val {
+    let segs = match superfiles_val {
         AvroValue::Array(a) => a,
         _ => return Err(PartParseError::WrongFieldType("superfiles")),
     };
     let mut superfiles = Vec::with_capacity(segs.len());
     for seg_val in segs {
-        superfiles.push(Arc::new(decode_segment(seg_val)?));
+        superfiles.push(Arc::new(decode_superfile(seg_val)?));
     }
 
     Ok(ManifestPart {
@@ -368,12 +368,12 @@ pub fn decode(bytes: &[u8]) -> Result<ManifestPart, PartParseError> {
     })
 }
 
-fn decode_segment(v: AvroValue) -> Result<SuperfileEntry, PartParseError> {
+fn decode_superfile(v: AvroValue) -> Result<SuperfileEntry, PartParseError> {
     let fields = match v {
         AvroValue::Record(r) => r,
         _ => {
             return Err(PartParseError::SchemaMismatch(
-                "segment not a record".into(),
+                "superfile not a record".into(),
             ));
         }
     };
@@ -700,8 +700,8 @@ fn _encoding_used() {
 mod tests {
     //! Avro+zstd round-trip tests for `ManifestPart`.
     //!
-    //! Covers: empty / single / multi-segment round-trip;
-    //! every per-segment summary type (scalar stats, fts
+    //! Covers: empty / single / multi-superfile round-trip;
+    //! every per-superfile summary type (scalar stats, fts
     //! summary, vector summary) survives bit-exactly through
     //! encode → decode; centroid f32 values are bit-identical
     //! (no decimal-string round-trip); content_hash covers
@@ -720,7 +720,7 @@ mod tests {
     use std::sync::Arc;
     use uuid::Uuid;
 
-    fn fresh_segment(n_docs: u64) -> Arc<SuperfileEntry> {
+    fn fresh_superfile(n_docs: u64) -> Arc<SuperfileEntry> {
         let id = Uuid::new_v4();
         Arc::new(SuperfileEntry {
             superfile_id: id,
@@ -802,7 +802,7 @@ mod tests {
         ScalarStatsTable { cols }
     }
 
-    fn make_rich_segment() -> Arc<SuperfileEntry> {
+    fn make_rich_superfile() -> Arc<SuperfileEntry> {
         let id = Uuid::new_v4();
         let mut fts = HashMap::new();
         fts.insert(
@@ -840,7 +840,7 @@ mod tests {
         })
     }
 
-    fn assert_segments_equal(a: &SuperfileEntry, b: &SuperfileEntry) {
+    fn assert_superfiles_equal(a: &SuperfileEntry, b: &SuperfileEntry) {
         assert_eq!(a.superfile_id, b.superfile_id, "superfile_id");
         assert_eq!(a.uri, b.uri, "uri");
         assert_eq!(a.n_docs, b.n_docs, "n_docs");
@@ -919,29 +919,29 @@ mod tests {
     }
 
     #[test]
-    fn single_minimal_segment_roundtrip() {
-        let part = fresh_part(vec![fresh_segment(100)]);
+    fn single_minimal_superfile_roundtrip() {
+        let part = fresh_part(vec![fresh_superfile(100)]);
         let bytes = encode(&part, 3);
         let decoded = decode(&bytes).expect("decode minimal");
         assert_eq!(decoded.superfiles.len(), 1);
-        assert_segments_equal(&decoded.superfiles[0], &part.superfiles[0]);
+        assert_superfiles_equal(&decoded.superfiles[0], &part.superfiles[0]);
     }
 
     #[test]
-    fn multi_segment_with_full_summaries_roundtrip() {
-        let superfiles: Vec<Arc<SuperfileEntry>> = (0..5).map(|_| make_rich_segment()).collect();
+    fn multi_superfile_with_full_summaries_roundtrip() {
+        let superfiles: Vec<Arc<SuperfileEntry>> = (0..5).map(|_| make_rich_superfile()).collect();
         let part = fresh_part(superfiles);
         let bytes = encode(&part, 3);
         let decoded = decode(&bytes).expect("decode rich");
         assert_eq!(decoded.superfiles.len(), 5);
         for (a, b) in decoded.superfiles.iter().zip(part.superfiles.iter()) {
-            assert_segments_equal(a, b);
+            assert_superfiles_equal(a, b);
         }
     }
 
     #[test]
     fn content_hash_covers_all_bytes() {
-        let part = fresh_part(vec![make_rich_segment()]);
+        let part = fresh_part(vec![make_rich_superfile()]);
         let bytes = encode(&part, 3);
         let hash = ContentHash::of(&bytes);
 
@@ -960,7 +960,7 @@ mod tests {
         // Same superfiles + same part_id ⇒ bit-identical Avro
         // output, bit-identical zstd output, same blake3 —
         // the property cross-version part-reuse rides on.
-        let superfiles = vec![make_rich_segment(), make_rich_segment()];
+        let superfiles = vec![make_rich_superfile(), make_rich_superfile()];
         let part_a = ManifestPart {
             format_version: FORMAT_VERSION.into(),
             part_id: PartId(Uuid::nil()),
@@ -1024,7 +1024,7 @@ mod tests {
 
     #[test]
     fn incompatible_major_version_rejected() {
-        let mut part = fresh_part(vec![fresh_segment(1)]);
+        let mut part = fresh_part(vec![fresh_superfile(1)]);
         part.format_version = "2.0".into();
         let bytes = encode(&part, 3);
         let err = decode(&bytes).expect_err("major 2 must reject");
@@ -1036,7 +1036,7 @@ mod tests {
 
     #[test]
     fn minor_version_compatible() {
-        let mut part = fresh_part(vec![fresh_segment(7)]);
+        let mut part = fresh_part(vec![fresh_superfile(7)]);
         part.format_version = "1.99".into();
         let bytes = encode(&part, 3);
         let decoded = decode(&bytes).expect("minor 99 must accept");
@@ -1046,7 +1046,7 @@ mod tests {
 
     #[test]
     fn zstd_corruption_surfaces_typed_error() {
-        let part = fresh_part(vec![fresh_segment(1)]);
+        let part = fresh_part(vec![fresh_superfile(1)]);
         let mut bytes = encode(&part, 3);
         bytes[0] ^= 0xff;
         bytes[1] ^= 0xff;
@@ -1061,7 +1061,7 @@ mod tests {
     fn bytes_payload_is_well_formed_use_via_bytes_type() {
         // Sanity: wire shape is acceptable to bytes::Bytes
         // for the storage layer downstream.
-        let part = fresh_part(vec![make_rich_segment()]);
+        let part = fresh_part(vec![make_rich_superfile()]);
         let raw = encode(&part, 3);
         let wrapped = Bytes::from(raw.clone());
         let decoded = decode(&wrapped).expect("decode from Bytes");

--- a/src/supertable/manifest/partition.rs
+++ b/src/supertable/manifest/partition.rs
@@ -5,7 +5,7 @@
 //!
 //! Given a `SuperfileEntry`'s per-column min/max summaries +
 //! the supertable's configured `PartitionStrategy`, decide
-//! which partition the segment belongs to. Drives the
+//! which partition the superfile belongs to. Drives the
 //! writer's "rewrite latest part" policy: superfiles in the
 //! same partition share a `ManifestPart`; superfiles in
 //! different partitions go into separate parts so a
@@ -88,7 +88,7 @@ pub fn decode_partition_key(
 
 /// Decide which partition `seg` belongs to under `strategy`.
 ///
-/// - **TimeRange**: segment's `(min, max)` on the partition
+/// - **TimeRange**: superfile's `(min, max)` on the partition
 ///   column must fall within a single bucket
 ///   (`min / granularity_secs == max / granularity_secs`).
 ///   Spans → `SuperfileSpansPartition`.
@@ -98,7 +98,7 @@ pub fn decode_partition_key(
 ///   bucket 0; pre-shard is trivial). Without the hint,
 ///   surfaces `SuperfileSpansPartition` with a "hash strategy
 ///   requires pre-sharded superfiles" message.
-/// - **ColumnRange**: segment's `(min, max)` must fall within
+/// - **ColumnRange**: superfile's `(min, max)` must fall within
 ///   one boundary interval. Spans → `SuperfileSpansPartition`.
 ///
 /// The `n_buckets == 1` Hash short-circuit is critical for
@@ -132,7 +132,7 @@ pub fn assign_partition(
             if min_bucket != max_bucket {
                 return Err(CommitError::SuperfileSpansPartition {
                     detail: format!(
-                        "segment {} column {column:?} [{min}, {max}] spans buckets \
+                        "superfile {} column {column:?} [{min}, {max}] spans buckets \
                          {min_bucket}..={max_bucket}; reduce commit_threshold_size_mb \
                          or flush at granularity boundaries",
                         seg.uri.0
@@ -159,7 +159,7 @@ pub fn assign_partition(
                         detail: format!(
                             "Hash{{n_buckets:{n_buckets}}} strategy requires pre-sharded \
                          superfiles; SuperfileEntry.partition_hint must be Some(bucket) \
-                         (segment {})",
+                         (superfile {})",
                             seg.uri.0
                         ),
                     })?;
@@ -185,7 +185,7 @@ pub fn assign_partition(
     }
 }
 
-/// Extract the segment's `(min, max)` for `column` as `i64`.
+/// Extract the superfile's `(min, max)` for `column` as `i64`.
 /// `ScalarStatsTable.cols[column]` carries Arrow length-1
 /// `ArrayRef`s; this helper downcasts against the column's
 /// actual Arrow type and returns the value at index 0.
@@ -207,7 +207,7 @@ fn scalar_i64_minmax(seg: &SuperfileEntry, column: &str) -> Result<(i64, i64), C
             .get(column)
             .ok_or_else(|| CommitError::SuperfileSpansPartition {
                 detail: format!(
-                    "TimeRange strategy: segment {} has no scalar_stats \
+                    "TimeRange strategy: superfile {} has no scalar_stats \
                      for column {column:?}",
                     seg.uri.0
                 ),
@@ -227,7 +227,7 @@ fn downcast_i64(
     if arr.is_empty() || arr.is_null(0) {
         return Err(CommitError::SuperfileSpansPartition {
             detail: format!(
-                "TimeRange strategy: segment {} column {column:?} stats array \
+                "TimeRange strategy: superfile {} column {column:?} stats array \
                  is empty or null at index 0",
                 seg.uri.0
             ),
@@ -257,7 +257,7 @@ fn downcast_i64(
         other => {
             return Err(CommitError::SuperfileSpansPartition {
                 detail: format!(
-                    "TimeRange strategy: segment {} column {column:?} has \
+                    "TimeRange strategy: superfile {} column {column:?} has \
                      unsupported type {other:?}; expected Int64 or Timestamp*",
                     seg.uri.0
                 ),
@@ -266,7 +266,7 @@ fn downcast_i64(
     };
     v.ok_or_else(|| CommitError::SuperfileSpansPartition {
         detail: format!(
-            "TimeRange strategy: segment {} column {column:?} downcast failed",
+            "TimeRange strategy: superfile {} column {column:?} downcast failed",
             seg.uri.0
         ),
     })
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn assign_partition_time_range_rejects_segment_spanning_buckets() {
+    fn assign_partition_time_range_rejects_superfile_spanning_buckets() {
         // min in bucket 0, max in bucket 1 → SuperfileSpansPartition.
         let strategy = PartitionStrategy::TimeRange {
             column: "ts".into(),

--- a/src/supertable/manifest/term_range.rs
+++ b/src/supertable/manifest/term_range.rs
@@ -3,25 +3,25 @@
 
 //! Lex term range — the second skip-pruning summary per FTS column.
 //!
-//! Where the bloom drives **exact-term** skip ("does this segment
+//! Where the bloom drives **exact-term** skip ("does this superfile
 //! contain term X?"), the term range drives **prefix-query** skip
-//! ("could this segment contain any term starting with prefix P?").
+//! ("could this superfile contain any term starting with prefix P?").
 //! Stored on `FtsSummary` as `(min_term, max_term)` — the
-//! lex-smallest and lex-largest terms in the segment's FST for
+//! lex-smallest and lex-largest terms in the superfile's FST for
 //! that column.
 //!
-//! A prefix `p` matches some term in the segment iff the half-open
+//! A prefix `p` matches some term in the superfile iff the half-open
 //! lex interval `[p, prefix_upper_bound(p))` overlaps the
-//! segment's `[min_term, max_term]`. The two helpers below — one
+//! superfile's `[min_term, max_term]`. The two helpers below — one
 //! to compute `prefix_upper_bound` and one to check overlap — are
-//! the entire skip operation; the manifest's segment list scan
-//! does this comparison once per segment, before any byte of
+//! the entire skip operation; the manifest's superfile list scan
+//! does this comparison once per superfile, before any byte of
 //! payload is touched.
 //!
 //! # Edge cases
 //!
 //! - **Empty prefix** matches every term, so there's no upper
-//!   bound and the range overlaps every non-empty segment.
+//!   bound and the range overlaps every non-empty superfile.
 //! - **All-`0xFF` prefix** has no successor in the byte ordering
 //!   (you can't increment past `0xFF`); only terms that are
 //!   exactly `prefix` or are lex-greater starting with all-`0xFF`
@@ -72,11 +72,11 @@ pub fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
 /// `prefix`.
 ///
 /// Concretely: the half-open interval `[prefix,
-/// prefix_upper_bound(prefix))` overlaps the segment's closed
+/// prefix_upper_bound(prefix))` overlaps the superfile's closed
 /// interval `[min_term, max_term]`.
 ///
 /// Used by the prefix-query skip helper to decide whether to fan
-/// out into a segment. False positives over-fetch (segment is
+/// out into a superfile. False positives over-fetch (superfile is
 /// scanned but no term matches) — acceptable. False negatives
 /// under-fetch — never allowed; would silently drop matching
 /// terms.
@@ -85,7 +85,7 @@ pub fn prefix_overlaps_range(prefix: &[u8], min_term: &[u8], max_term: &[u8]) ->
     if prefix.is_empty() {
         return true;
     }
-    // The segment's max term must be ≥ the prefix itself, OR
+    // The superfile's max term must be ≥ the prefix itself, OR
     // start with the prefix. Equivalently: max_term must be ≥ prefix
     // when compared lex.
     if max_term < prefix {
@@ -221,23 +221,23 @@ mod tests {
 
     #[test]
     fn prefix_inside_range_overlaps() {
-        // segment's terms are in [b"checkin", b"checkout"], prefix
+        // superfile's terms are in [b"checkin", b"checkout"], prefix
         // "check" should overlap.
         assert!(prefix_overlaps_range(b"check", b"checkin", b"checkout"));
-        // Single-term segment matching the prefix.
+        // Single-term superfile matching the prefix.
         assert!(prefix_overlaps_range(b"err", b"errand", b"errand"));
     }
 
     #[test]
     fn prefix_above_max_term_does_not_overlap() {
-        // segment terms ≤ "alpha", prefix "beta" can't appear.
+        // superfile terms ≤ "alpha", prefix "beta" can't appear.
         assert!(!prefix_overlaps_range(b"beta", b"a", b"alpha"));
         assert!(!prefix_overlaps_range(b"zzz", b"a", b"y"));
     }
 
     #[test]
     fn prefix_below_min_term_does_not_overlap() {
-        // segment terms ≥ "g", prefix "a" can't appear (since
+        // superfile terms ≥ "g", prefix "a" can't appear (since
         // every "a..." is < "g").
         assert!(!prefix_overlaps_range(b"a", b"g", b"z"));
         assert!(!prefix_overlaps_range(b"abc", b"def", b"xyz"));
@@ -245,13 +245,13 @@ mod tests {
 
     #[test]
     fn prefix_equals_min_term_overlaps() {
-        // Segment min is exactly the prefix.
+        // Superfile min is exactly the prefix.
         assert!(prefix_overlaps_range(b"err", b"err", b"erz"));
     }
 
     #[test]
     fn prefix_equals_max_term_overlaps() {
-        // Segment max is exactly the prefix.
+        // Superfile max is exactly the prefix.
         assert!(prefix_overlaps_range(b"err", b"a", b"err"));
     }
 
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn prefix_overlap_property_no_false_negatives() {
-        // For any segment range and any prefix, if `prefix` is a
+        // For any superfile range and any prefix, if `prefix` is a
         // strict prefix of any term in [min, max], the helper must
         // return true (false negatives would silently drop matching
         // terms — unsound).
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn prefix_overlap_handles_trailing_ff_in_prefix() {
-        // prefix [0xFE, 0xFF, 0xFF] → upper [0xFF]. Segments whose
+        // prefix [0xFE, 0xFF, 0xFF] → upper [0xFF]. Superfiles whose
         // min is < [0xFF] and max ≥ [0xFE, 0xFF, 0xFF] overlap.
         let p = &[0xFE, 0xFF, 0xFF];
         assert!(prefix_overlaps_range(

--- a/src/supertable/mod.rs
+++ b/src/supertable/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Supertable layer — the in-memory cross-segment query + manifest
+//! Supertable layer — the in-memory cross-superfile query + manifest
 //! layer over [`SuperfileBuilder`] / [`SuperfileReader`].
 //!
 //! A supertable is to superfile what an Iceberg / Delta table is

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -128,7 +128,7 @@ const DEFAULT_PUT_MULTIPART_THRESHOLD_BYTES: u64 = 100 * (1 << 20);
 /// observationally "no partitioning".
 const DEFAULT_PARTITION_N_BUCKETS: u32 = 1;
 
-/// Read-path freshness policy — how an open handle picks up segments
+/// Read-path freshness policy — how an open handle picks up superfiles
 /// committed (by this or another process) after it opened.
 ///
 /// Modeled on the same knob every object-store-native engine exposes
@@ -170,7 +170,7 @@ impl Default for Consistency {
 ///
 /// Holds both the immutable per-supertable configuration (schema,
 /// FTS / vector columns, tokenizer) and the runtime resources the
-/// writer / reader paths use (thread pools, segment store,
+/// writer / reader paths use (thread pools, superfile store,
 /// commit-flush threshold). Held by `SupertableInner` as
 /// `Arc<SupertableOptions>` so readers, the writer, and rayon
 /// shard workers all see the same instances without copying.
@@ -196,7 +196,7 @@ pub struct SupertableOptions {
     /// Shared tokenizer for all FTS columns. Required iff
     /// `fts_columns` is non-empty.
     pub tokenizer: Option<Arc<dyn Tokenizer>>,
-    /// Pool used by reader fan-out (skip + per-segment fan-out +
+    /// Pool used by reader fan-out (skip + per-superfile fan-out +
     /// top-k merge). Default: every logical core.
     pub reader_pool: Arc<ThreadPool>,
     /// Pool used by writer commit-time rayon-shard. Default:
@@ -214,13 +214,13 @@ pub struct SupertableOptions {
     /// `SuperfileReaderCache`) unless a `disk_cache` is attached,
     /// in which case the reader path routes through the cache.
     pub storage: Option<Arc<dyn crate::storage::StorageProvider>>,
-    /// Disk cache for storage-backed segment reads.
+    /// Disk cache for storage-backed superfile reads.
     /// When attached together with `storage`, the supertable's
-    /// reader path routes segment-bytes lookups through this
+    /// reader path routes superfile-bytes lookups through this
     /// cache instead of relying solely on the in-memory `store`
     /// — the load-bearing change that lets a cross-process
     /// `Supertable::open` answer queries on a 100GB index
-    /// without pulling every segment into RAM.
+    /// without pulling every superfile into RAM.
     ///
     /// Construction stays user-managed (`Arc<DiskCacheStore>`)
     /// so callers retain full control over cache root, budget,
@@ -259,12 +259,12 @@ pub struct SupertableOptions {
     /// but does NOT proactively bound the RSS.
     pub memory_budget_bytes: Option<u64>,
     /// When `true` (default), each commit pre-populates the
-    /// attached `disk_cache` with the segment bytes it just
+    /// attached `disk_cache` with the superfile bytes it just
     /// wrote (so the producer's own next query skips the
     /// cold-fetch round-trip). Set `false` for a write-only
     /// producer that drops the cache right after ingest: the
     /// pre-population is then pure wasted work (and, when the
-    /// segment set exceeds the cache budget, floods the log
+    /// superfile set exceeds the cache budget, floods the log
     /// with "budget exceeded" warnings). No effect without
     /// `disk_cache` attached.
     pub prepopulate_cache_on_commit: bool,
@@ -275,7 +275,7 @@ pub struct SupertableOptions {
     /// When `None` at [`Supertable::create`] time, resolved
     /// to `Hash { column: id_column, n_buckets: 1 }` — a
     /// single-bucket strategy that's observationally
-    /// equivalent to "no partitioning" (every segment lands
+    /// equivalent to "no partitioning" (every superfile lands
     /// in the one bucket → one `ManifestPart` per commit).
     /// Callers wanting real partitioning set this via
     /// [`Self::with_partition_strategy`].
@@ -334,11 +334,11 @@ pub struct SupertableOptions {
     /// caller-driven `commit()` produces superfiles.
     /// Default: 1024 (1 GiB).
     pub commit_threshold_size_mb: u64,
-    /// Segment size (in bytes) at or above which the writer
+    /// Superfile size (in bytes) at or above which the writer
     /// routes the storage write through
     /// [`StorageProvider::put_multipart`] instead of
     /// [`StorageProvider::put_atomic`]. The single-PUT path
-    /// pins the whole segment in `Bytes` at issue time and
+    /// pins the whole superfile in `Bytes` at issue time and
     /// re-uploads everything on retry; the multipart path
     /// splits the upload into 8-MiB chunks driven in
     /// parallel, lowering both peak RSS during the put and
@@ -348,7 +348,7 @@ pub struct SupertableOptions {
     /// standard S3 SDK multipart threshold. Set to
     /// `u64::MAX` to disable multipart routing entirely;
     /// set to a tiny value (e.g. `1`) to force every
-    /// segment through the multipart path (useful for tests).
+    /// superfile through the multipart path (useful for tests).
     pub put_multipart_threshold_bytes: u64,
     /// Whether the supertable's read-side opens of
     /// `SuperfileReader` should verify the trailing whole-
@@ -601,7 +601,7 @@ impl SupertableOptions {
         self
     }
 
-    /// Override the segment store. Default is
+    /// Override the superfile store. Default is
     /// [`InMemoryReaderCache`]; tests + production deployments
     /// with persistence swap this for an mmap- or object-store-
     /// backed implementation.
@@ -612,7 +612,7 @@ impl SupertableOptions {
 
     /// Attach an object-store backend. Engages the
     /// write-through path: each successful commit persists
-    /// segment bytes + the new manifest (parts + list +
+    /// superfile bytes + the new manifest (parts + list +
     /// pointer) to storage via the `commit_manifest`
     /// primitive.
     ///
@@ -632,13 +632,13 @@ impl SupertableOptions {
     ///
     /// When attached:
     ///   - The writer's commit path **skips** the in-memory
-    ///     `store.put` — segment bytes go to object storage
+    ///     `store.put` — superfile bytes go to object storage
     ///     only, and the cache hydrates lazily on first query.
     ///     This removes the OOM trap at 100GB scale (the
     ///     in-memory `SuperfileReaderCache` doesn't evict, so a
     ///     long-running writer would otherwise accumulate every
-    ///     segment's bytes in RAM forever).
-    ///   - Reader paths route segment-byte lookups through the
+    ///     superfile's bytes in RAM forever).
+    ///   - Reader paths route superfile-byte lookups through the
     ///     cache (in-memory tier checked first for hot writes
     ///     made in this process, then disk cache, then
     ///     cold-fetch from object storage).
@@ -727,7 +727,7 @@ impl SupertableOptions {
         self
     }
 
-    /// Override the segment-size threshold (bytes) at which
+    /// Override the superfile-size threshold (bytes) at which
     /// the writer routes through `put_multipart` instead of
     /// `put_atomic`. See [`Self::put_multipart_threshold_bytes`].
     /// Default `100 MiB`.
@@ -764,7 +764,7 @@ impl SupertableOptions {
     /// as-is (clamped to ≥ 1).
     ///
     /// The schema, FTS / vector configuration, tokenizer, and
-    /// in-memory segment store are preserved. If
+    /// in-memory superfile store are preserved. If
     /// `cfg.storage.backend` is not `none`, this method attaches
     /// the requested storage provider; if
     /// `cfg.storage.disk_cache_root` is set, it also attaches a

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -8,16 +8,16 @@
 //! non-matching rows. The inverted index already knows which rows
 //! contain a term, so we resolve a small **candidate row set** from the
 //! postings and decode only those rows — the row-level analog of the
-//! term-bloom *segment* prune.
+//! term-bloom *superfile* prune.
 //!
 //! ## How (two passes)
 //!
 //!   1. **Candidate generation (this module).** The `WHERE` `Expr` tree
 //!      is lowered to a [`CandidatePlan`] — a boolean tree whose leaves
 //!      retrieve rows via [`SuperfileReader::token_match`]. Evaluated
-//!      against one segment it yields a `RoaringBitmap` of candidate
+//!      against one superfile it yields a `RoaringBitmap` of candidate
 //!      `local_doc_id`s, or `None` ("no usable bound — scan the
-//!      segment").
+//!      superfile").
 //!   2. **Verification (DataFusion).** The provider turns the candidate
 //!      set into a Parquet row selection so only those rows decode, and
 //!      DataFusion's `FilterExec` (filters are reported `Inexact`)
@@ -49,16 +49,16 @@ use crate::superfile::SuperfileReader;
 use crate::superfile::fts::reader::BoolMode;
 use crate::superfile::fts::tokenize::Tokenizer;
 
-/// A segment-independent boolean plan over FTS term retrievals, lowered
+/// A superfile-independent boolean plan over FTS term retrievals, lowered
 /// once from a SQL `WHERE` clause and [`evaluate`](CandidatePlan::evaluate)d
-/// per segment to a superset of the rows satisfying the FTS-resolvable
+/// per superfile to a superset of the rows satisfying the FTS-resolvable
 /// part of the predicate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CandidatePlan {
     /// Rows whose `column` contains every one of `tokens` (term-AND).
     /// The candidate superset of `column = '<text tokenizing to tokens>'`;
     /// the exact predicate is re-verified by the `FilterExec` above the
-    /// scan (filters are reported `Inexact`). Resolved per segment by a
+    /// scan (filters are reported `Inexact`). Resolved per superfile by a
     /// single `token_match(.., And)` — postings only, no column decode —
     /// so verification + projection happen together in DataFusion's one
     /// scan pass. (An `exact_match`-per-leaf alternative was measured and
@@ -69,7 +69,7 @@ pub(crate) enum CandidatePlan {
     And(Vec<CandidatePlan>),
     /// Union of children (logical `OR`).
     Or(Vec<CandidatePlan>),
-    /// No usable bound: scan the segment and let `FilterExec` verify.
+    /// No usable bound: scan the superfile and let `FilterExec` verify.
     Unbounded,
 }
 
@@ -97,7 +97,7 @@ impl CandidatePlan {
         )
     }
 
-    /// Evaluate against one segment's reader. `Ok(None)` means "no bound
+    /// Evaluate against one superfile's reader. `Ok(None)` means "no bound
     /// — scan all rows"; `Ok(Some(bitmap))` is the candidate
     /// `local_doc_id` superset (possibly empty). `TermsAll` is one
     /// `token_match(.., And)`; `And`/`Or` intersect/union children.
@@ -147,13 +147,13 @@ impl CandidatePlan {
 
 impl CandidatePlan {
     /// Cheap upper-bound estimate of how many rows this plan would match
-    /// in `reader`'s segment, computed from per-term `df` only (no
+    /// in `reader`'s superfile, computed from per-term `df` only (no
     /// `token_match`, no posting decode). The bound follows the boolean
     /// tree: a term-`AND` can't exceed the **smallest** term's `df`
     /// (`min`); an `OR`/`IN` union can't exceed the **sum** of branch
     /// estimates (capped at `n_docs`); `Unbounded` is `n_docs` (no
     /// bound). The provider uses this to skip the index pushdown when a
-    /// predicate would match a large fraction of the segment — there the
+    /// predicate would match a large fraction of the superfile — there the
     /// matches saturate the data pages so an index `RowSelection` can't
     /// skip any, and a plain scan is cheaper.
     pub(crate) fn estimate<'a>(

--- a/src/supertable/query/df_object_store.rs
+++ b/src/supertable/query/df_object_store.rs
@@ -7,17 +7,17 @@
 //! DataFusion's `ParquetSource` reads its input through an
 //! [`object_store::ObjectStore`]. This is that store — and *only* that.
 //! It owns no storage policy: it serves byte ranges straight out of the
-//! [`LazyByteSource`] each segment's [`SuperfileReader::byte_source`]
+//! [`LazyByteSource`] each superfile's [`SuperfileReader::byte_source`]
 //! already exposes. The provider calls `superfile_reader(...)`, takes
 //! the byte source, registers it here, and DataFusion reads.
 //!
 //! There is exactly one read path and no branch on storage mode:
 //!
-//! - warm / mmap-backed segments resolve every range as a zero-copy
+//! - warm / mmap-backed superfiles resolve every range as a zero-copy
 //!   `Bytes::slice` (the resident-bytes [`LazyByteSource`]); nothing is
 //!   copied into a DataFusion `InMemory` store, so warm SQL is as cheap
 //!   as the FTS/vector resolve path (slice = refcount bump).
-//! - cold / lazy segments range-fetch straight from object storage
+//! - cold / lazy superfiles range-fetch straight from object storage
 //!   through the same source.
 //!
 //! Only the read methods are real; this store is never written to,
@@ -44,41 +44,41 @@ use object_store::{
 
 use crate::superfile::LazyByteSource;
 
-/// Fixed `last_modified` reported for every registered segment.
+/// Fixed `last_modified` reported for every registered superfile.
 /// Superfiles are immutable once committed, so a wall-clock timestamp
 /// carries no signal here — and a value that changed on every call
 /// would defeat any downstream cache keyed on `(path, last_modified)`
 /// and make responses non-deterministic.
-const SEGMENT_LAST_MODIFIED: chrono::DateTime<chrono::Utc> = chrono::DateTime::UNIX_EPOCH;
+const SUPERFILE_LAST_MODIFIED: chrono::DateTime<chrono::Utc> = chrono::DateTime::UNIX_EPOCH;
 
-/// Read-only [`ObjectStore`] backed by per-segment [`LazyByteSource`]s.
+/// Read-only [`ObjectStore`] backed by per-superfile [`LazyByteSource`]s.
 ///
 /// Construct via [`from_sources`](Self::from_sources) with the byte
 /// sources the provider pulled from `superfile_reader`, register it on
 /// the DataFusion session, and point each `PartitionedFile` at the
 /// matching path. See the module docs.
 pub(crate) struct SuperfileObjectStore {
-    /// One byte source per surviving segment, keyed by the same path
-    /// used to build the segment's `PartitionedFile`.
+    /// One byte source per surviving superfile, keyed by the same path
+    /// used to build the superfile's `PartitionedFile`.
     sources: HashMap<ObjPath, Arc<dyn LazyByteSource>>,
 }
 
 impl fmt::Debug for SuperfileObjectStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SuperfileObjectStore")
-            .field("n_segments", &self.sources.len())
+            .field("n_superfiles", &self.sources.len())
             .finish()
     }
 }
 
 impl fmt::Display for SuperfileObjectStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SuperfileObjectStore({} segments)", self.sources.len())
+        write!(f, "SuperfileObjectStore({} superfiles)", self.sources.len())
     }
 }
 
 impl SuperfileObjectStore {
-    /// Build the store from the segment byte sources gathered during a
+    /// Build the store from the superfile byte sources gathered during a
     /// scan. Each key is the path the matching `PartitionedFile` is
     /// created with.
     pub(crate) fn from_sources(sources: HashMap<ObjPath, Arc<dyn LazyByteSource>>) -> Self {
@@ -88,7 +88,7 @@ impl SuperfileObjectStore {
     fn source(&self, location: &ObjPath) -> OsResult<&Arc<dyn LazyByteSource>> {
         self.sources.get(location).ok_or_else(|| OsError::NotFound {
             path: location.to_string(),
-            source: format!("segment {location} not registered in SuperfileObjectStore").into(),
+            source: format!("superfile {location} not registered in SuperfileObjectStore").into(),
         })
     }
 }
@@ -118,7 +118,7 @@ impl ObjectStore for SuperfileObjectStore {
         let size = source.size();
         let meta = ObjectMeta {
             location: location.clone(),
-            last_modified: SEGMENT_LAST_MODIFIED,
+            last_modified: SUPERFILE_LAST_MODIFIED,
             size,
             e_tag: None,
             version: None,

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -1,31 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Shared fan-out/dispatch for the segment-parallel query paths.
+//! Shared fan-out/dispatch for the superfile-parallel query paths.
 //!
 //! Vector kNN and BM25/prefix FTS both face the identical shape: a
-//! pinned manifest snapshot, a kept set of segments (after manifest
-//! pruning), and a per-segment search kernel whose result is a list of
+//! pinned manifest snapshot, a kept set of superfiles (after manifest
+//! pruning), and a per-superfile search kernel whose result is a list of
 //! `(local_doc_id, score)` pairs. The plumbing around that kernel —
-//! open every segment reader concurrently, warm the tombstone sidecar
-//! cache in one batch, run each segment's kernel, tag the hits with
-//! their segment URI, and drop tombstoned rows — is the same for both.
+//! open every superfile reader concurrently, warm the tombstone sidecar
+//! cache in one batch, run each superfile's kernel, tag the hits with
+//! their superfile URI, and drop tombstoned rows — is the same for both.
 //!
 //! This module owns that plumbing so the two query paths share one
 //! orchestrator instead of each re-implementing the fan-out. The
 //! division of labor is the project-wide model:
 //!
-//!   * **tokio owns the I/O waves.** Segment opens and the kernel's
+//!   * **tokio owns the I/O waves.** Superfile opens and the kernel's
 //!     cold object-store range GETs are `await`ed on the shared
 //!     multi-thread query runtime, so reqwest connections pool and
-//!     hundreds of segments' fetches are in flight at once.
-//!   * **rayon owns the CPU waves.** The per-segment compute (centroid
+//!     hundreds of superfiles' fetches are in flight at once.
+//!   * **rayon owns the CPU waves.** The per-superfile compute (centroid
 //!     / 1-bit-code scoring + rerank for vector; BMW/MaxScore scoring
 //!     for FTS) runs on the global rayon pool via the kernel's internal
 //!     `par_iter` — never on the tokio workers that must stay free to
 //!     drive the I/O.
 //!
-//! The per-segment merge (top-k ascending for vector distance,
+//! The per-superfile merge (top-k ascending for vector distance,
 //! descending for BM25 relevance) stays with each caller; this layer
 //! returns the per-unit tagged+filtered hit lists.
 
@@ -42,9 +42,9 @@ use crate::supertable::tombstones::SidecarCache;
 
 use super::SuperfileHit;
 
-/// Open one segment's `SuperfileReader` through the reader cache.
+/// Open one superfile's `SuperfileReader` through the reader cache.
 /// Warm opens are in-memory cache hits (microseconds); cold opens
-/// fetch the segment header/footer from object storage. Always
+/// fetch the superfile header/footer from object storage. Always
 /// `await`ed so the open I/O overlaps across the fan-out.
 pub(crate) async fn open_reader(
     store: &Arc<dyn SuperfileReaderCache>,
@@ -64,18 +64,18 @@ pub(crate) async fn open_reader(
 }
 
 /// Tag a kernel's `(local_doc_id, score)` results with their source
-/// segment URI.
+/// superfile URI.
 pub(crate) fn tag_hits(entry: &SuperfileEntry, hits: Vec<(u32, f32)>) -> Vec<SuperfileHit> {
     hits.into_iter()
         .map(|(local_doc_id, score)| SuperfileHit {
-            segment: entry.uri,
+            superfile: entry.uri,
             local_doc_id,
             score,
         })
         .collect()
 }
 
-/// Drop tombstoned `local_doc_id`s from one segment's hits. After the
+/// Drop tombstoned `local_doc_id`s from one superfile's hits. After the
 /// orchestrator's batched [`SidecarCache::prefetch`] every lookup here
 /// is an in-memory cache hit, so this is a cheap retain pass.
 pub(crate) fn apply_tombstone_filter(
@@ -97,14 +97,14 @@ pub(crate) fn apply_tombstone_filter(
     Ok(())
 }
 
-/// Fan a per-segment async kernel out across `units`, returning each
+/// Fan a per-superfile async kernel out across `units`, returning each
 /// unit's tagged + tombstone-filtered hits in input order.
 ///
-/// Each unit is `(segment_entry, params)`; `params` carries any
+/// Each unit is `(superfile_entry, params)`; `params` carries any
 /// per-unit kernel input (e.g. an FTS doc-id sub-range — `()` for
 /// vector). The orchestrator:
 ///
-///   1. Warms the tombstone sidecar cache for every distinct segment
+///   1. Warms the tombstone sidecar cache for every distinct superfile
 ///      in one concurrent batch (so the post-search filter is all
 ///      cache hits).
 ///   2. `tokio::spawn`s one task per unit on the shared query runtime;
@@ -136,8 +136,8 @@ where
     let tombstone_cache = reader.tombstone_cache.clone();
     let now = std::time::Instant::now();
 
-    // Warm the tombstone sidecars for every distinct segment in one
-    // concurrent batch before the per-segment fan-out.
+    // Warm the tombstone sidecars for every distinct superfile in one
+    // concurrent batch before the per-superfile fan-out.
     if let Some(cache) = tombstone_cache.as_ref() {
         let mut ids: Vec<uuid::Uuid> = units.iter().map(|(e, _)| e.superfile_id).collect();
         ids.sort_unstable();

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -7,7 +7,7 @@
 //! `bm25_search_prefix`, ...) produce a `Vec<SuperfileHit>` from a
 //! kernel and then face the same two jobs:
 //!
-//!   1. **Resolve** each `(segment, local_doc_id)` hit to the
+//!   1. **Resolve** each `(superfile, local_doc_id)` hit to the
 //!      supertable's `_id` + projected scalar columns via
 //!      [`SuperfileReader::take_by_local_doc_ids`], preserving the
 //!      kernel's rank order, and append a `score` column.
@@ -96,11 +96,11 @@ pub(crate) fn output_schema_with_score(scalar_schema: &SchemaRef) -> SchemaRef {
 /// column ([`output_schema_with_score`]); `projection` indexes into
 /// it, exactly as DataFusion hands to `scan`. **Only the scalar
 /// columns the projection actually selects are decoded** — a query
-/// that selects just `score` opens no segment readers and touches no
+/// that selects just `score` opens no superfile readers and touches no
 /// scalar bytes (cost-first: never decode a column the query did not
 /// select). The `score` column is synthesized from the hits.
 ///
-/// Selected scalar columns are read per segment (each
+/// Selected scalar columns are read per superfile (each
 /// `take_by_local_doc_ids` is a column-projected read), concatenated,
 /// then a single `take` reorders rows back into the global rank order
 /// so row `i` is the `i`-th hit.
@@ -180,11 +180,11 @@ pub(crate) async fn resolve_hits(
     .map_err(|e| DataFusionError::Execution(e.to_string()))
 }
 
-/// Read `names` (scalar columns) at the `hits`' `(segment,
+/// Read `names` (scalar columns) at the `hits`' `(superfile,
 /// local_doc_id)` rows and return them in global rank order.
 ///
-/// Hits are grouped by segment for one column-projected
-/// [`take_by_local_doc_ids`] per segment; the per-segment batches are
+/// Hits are grouped by superfile for one column-projected
+/// [`take_by_local_doc_ids`] per superfile; the per-superfile batches are
 /// concatenated and a single `take` restores rank order. Caller
 /// guarantees `hits` and `names` are both non-empty.
 ///
@@ -194,16 +194,16 @@ async fn resolve_columns(
     hits: &[SuperfileHit],
     names: &[&str],
 ) -> DfResult<RecordBatch> {
-    // Group local_doc_ids by segment, preserving first-seen segment
+    // Group local_doc_ids by superfile, preserving first-seen superfile
     // order and recording where each global hit lands.
     let mut seg_order: Vec<SuperfileUri> = Vec::new();
     let mut seg_locals: Vec<Vec<u32>> = Vec::new();
     let mut placement: Vec<(usize, usize)> = Vec::with_capacity(hits.len());
     for hit in hits {
-        let seg_idx = match seg_order.iter().position(|s| *s == hit.segment) {
+        let seg_idx = match seg_order.iter().position(|s| *s == hit.superfile) {
             Some(i) => i,
             None => {
-                seg_order.push(hit.segment);
+                seg_order.push(hit.superfile);
                 seg_locals.push(Vec::new());
                 seg_order.len() - 1
             }
@@ -213,7 +213,7 @@ async fn resolve_columns(
         placement.push((seg_idx, row));
     }
 
-    // Open every distinct segment reader concurrently on the tokio
+    // Open every distinct superfile reader concurrently on the tokio
     // runtime — these are async I/O (in-memory cache lookups /
     // disk-cache cold fetches), so overlapping them is the right
     // model and they cost ~microseconds when warm.
@@ -230,7 +230,7 @@ async fn resolve_columns(
     .await
     .map_err(|e| DataFusionError::Execution(e.to_string()))?;
 
-    // Materialize each segment's projected hit rows, split by tier:
+    // Materialize each superfile's projected hit rows, split by tier:
     //
     //   - **Resident readers** (in-memory tier / freshly written):
     //     `take_by_local_doc_ids` is a CPU-bound Parquet page decode
@@ -241,11 +241,11 @@ async fn resolve_columns(
     //   - **Lazy readers** stream ONLY the projected hit rows through
     //     parquet's async `ParquetObjectReader` (footer + projected
     //     column pages via range GETs) — async I/O that belongs on the
-    //     query runtime; a cold read never materializes the segment.
+    //     query runtime; a cold read never materializes the superfile.
     //
     // Both waves run concurrently and stitch back in `seg_order`
-    // order. Segment count here is bounded by the global top-k (one
-    // entry per distinct hit-bearing segment), so the fan-out is small.
+    // order. Superfile count here is bounded by the global top-k (one
+    // entry per distinct hit-bearing superfile), so the fan-out is small.
     let mut warm_inputs: Vec<(usize, Arc<SuperfileReader>, Vec<u32>)> = Vec::new();
     let mut cold_units: Vec<(usize, &SuperfileUri, &Arc<SuperfileReader>, &[u32])> = Vec::new();
     for (i, ((uri, rd), locals)) in seg_order
@@ -329,18 +329,18 @@ async fn resolve_columns(
     for (i, batch) in warm_done?.into_iter().chain(cold_done?) {
         slots[i] = Some(batch);
     }
-    let per_segment: Vec<RecordBatch> = slots
+    let per_superfile: Vec<RecordBatch> = slots
         .into_iter()
-        .map(|s| s.expect("invariant: every segment resolved by exactly one wave"))
+        .map(|s| s.expect("invariant: every superfile resolved by exactly one wave"))
         .collect();
     // Concatenate, then reorder rows into global rank order.
-    let cat_schema = per_segment[0].schema();
-    let combined = concat_batches(&cat_schema, &per_segment)
+    let cat_schema = per_superfile[0].schema();
+    let combined = concat_batches(&cat_schema, &per_superfile)
         .map_err(|e| DataFusionError::Execution(e.to_string()))?;
 
-    let mut offsets: Vec<u32> = Vec::with_capacity(per_segment.len());
+    let mut offsets: Vec<u32> = Vec::with_capacity(per_superfile.len());
     let mut acc: u32 = 0;
-    for batch in &per_segment {
+    for batch in &per_superfile {
         offsets.push(acc);
         acc += batch.num_rows() as u32;
     }
@@ -358,10 +358,10 @@ async fn resolve_columns(
 }
 
 /// Stream the projected `names` columns at `local_doc_ids` from a lazy
-/// object-store segment via parquet's async `ParquetObjectReader`
+/// object-store superfile via parquet's async `ParquetObjectReader`
 /// (footer + projected column pages fetched as range GETs). Mirrors
 /// [`SuperfileReader::take_by_local_doc_ids`]'s row-selection + rank-back,
-/// but never materializes the whole segment — this is the cold/object-
+/// but never materializes the whole superfile — this is the cold/object-
 /// store row-resolution path.
 ///
 /// [`SuperfileReader::take_by_local_doc_ids`]: crate::superfile::SuperfileReader::take_by_local_doc_ids

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -40,7 +40,7 @@
 //! contributions from the two lists are summed. The emitted `score`
 //! column is the fused RRF score — **higher is better**, so `ORDER BY
 //! score DESC` lists the best blended matches first. Identity is
-//! `(segment, local_doc_id)`, so a document surfaced by *both*
+//! `(superfile, local_doc_id)`, so a document surfaced by *both*
 //! retrievers is boosted above one surfaced by a single retriever.
 
 use std::any::Any;
@@ -434,9 +434,9 @@ impl ExecutionPlan for HybridSearchExec {
 /// fusion.
 ///
 /// Each list is assumed best-first. A hit at 0-based position `r`
-/// contributes `1 / (RRF_K + r + 1)` to its `(segment, local_doc_id)`
+/// contributes `1 / (RRF_K + r + 1)` to its `(superfile, local_doc_id)`
 /// identity; contributions from the two lists are summed. The result
-/// is sorted by fused score descending — `(segment, local_doc_id)` as
+/// is sorted by fused score descending — `(superfile, local_doc_id)` as
 /// a total tie-break so the order is deterministic regardless of the
 /// `HashMap`'s iteration order — and truncated to `k`. The returned
 /// hits carry the fused RRF score (higher is better).
@@ -446,14 +446,14 @@ fn rrf_fuse(bm25: &[SuperfileHit], vector: &[SuperfileHit], k: usize) -> Vec<Sup
     for list in [bm25, vector] {
         for (rank, hit) in list.iter().enumerate() {
             let contribution = 1.0 / (RRF_K + rank as f32 + 1.0);
-            *acc.entry((hit.segment, hit.local_doc_id)).or_insert(0.0) += contribution;
+            *acc.entry((hit.superfile, hit.local_doc_id)).or_insert(0.0) += contribution;
         }
     }
 
     let mut fused: Vec<SuperfileHit> = acc
         .into_iter()
-        .map(|((segment, local_doc_id), score)| SuperfileHit {
-            segment,
+        .map(|((superfile, local_doc_id), score)| SuperfileHit {
+            superfile,
             local_doc_id,
             score,
         })
@@ -462,7 +462,7 @@ fn rrf_fuse(bm25: &[SuperfileHit], vector: &[SuperfileHit], k: usize) -> Vec<Sup
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.segment.cmp(&b.segment))
+            .then_with(|| a.superfile.cmp(&b.superfile))
             .then_with(|| a.local_doc_id.cmp(&b.local_doc_id))
     });
     fused.truncate(k);
@@ -546,7 +546,7 @@ mod tests {
         RecordBatch::try_new(schema, vec![Arc::new(title_arr), Arc::new(fsl)]).expect("batch")
     }
 
-    /// Demo corpus (single segment). `async` is unique to doc 0;
+    /// Demo corpus (single superfile). `async` is unique to doc 0;
     /// `rust` is in docs 0 + 4. Doc `i`'s vector is one-hot at dim `i`.
     fn demo(dim: usize) -> Supertable {
         let st = Supertable::create(options_title_emb(dim)).expect("create");
@@ -629,7 +629,7 @@ mod tests {
     fn rrf_fuse_boosts_shared_hits_and_orders_by_fused_score() {
         let seg = SuperfileUri::new_v4();
         let h = |doc: u32, score: f32| SuperfileHit {
-            segment: seg,
+            superfile: seg,
             local_doc_id: doc,
             score,
         };
@@ -653,7 +653,7 @@ mod tests {
     fn rrf_fuse_truncates_to_k() {
         let seg = SuperfileUri::new_v4();
         let h = |doc: u32| SuperfileHit {
-            segment: seg,
+            superfile: seg,
             local_doc_id: doc,
             score: 0.0,
         };
@@ -664,23 +664,23 @@ mod tests {
     }
 
     #[test]
-    fn rrf_fuse_distinguishes_same_doc_id_across_segments() {
+    fn rrf_fuse_distinguishes_same_doc_id_across_superfiles() {
         // local_doc_id alone is not a global identity: the same
-        // doc id in two segments are *different* hits.
+        // doc id in two superfiles are *different* hits.
         let seg_a = SuperfileUri::new_v4();
         let seg_b = SuperfileUri::new_v4();
         let bm25 = vec![SuperfileHit {
-            segment: seg_a,
+            superfile: seg_a,
             local_doc_id: 0,
             score: 1.0,
         }];
         let vector = vec![SuperfileHit {
-            segment: seg_b,
+            superfile: seg_b,
             local_doc_id: 0,
             score: 0.1,
         }];
         let fused = rrf_fuse(&bm25, &vector, 10);
-        assert_eq!(fused.len(), 2, "distinct segments → distinct hits");
+        assert_eq!(fused.len(), 2, "distinct superfiles → distinct hits");
     }
 
     // ---- end-to-end through query_sql ----
@@ -825,7 +825,7 @@ mod tests {
     // but nothing else covered: a single SQL statement that JOINs an
     // FTS retriever (`bm25_search`) and a vector retriever
     // (`vector_search`) on the durable `_id` and post-filters with a
-    // scalar `WHERE` — across two segments.
+    // scalar `WHERE` — across two superfiles.
 
     /// Schema `[category (scalar), title (FTS), emb (vector)]`. Unlike
     /// `options_title_emb`, `category` is a plain scalar column (not in
@@ -894,7 +894,7 @@ mod tests {
         .expect("batch")
     }
 
-    /// Two-segment corpus (docs 0–3, then 4–7) engineered so the three
+    /// Two-superfile corpus (docs 0–3, then 4–7) engineered so the three
     /// retrievers each drop a *different* doc. With dim = 8 and a graded
     /// query vector `[8,7,…,1]`, the cosine distance to one-hot doc `i`
     /// is strictly increasing in `i`, so `vector_search(k=5)` is exactly
@@ -905,7 +905,7 @@ mod tests {
     ///   - three-way intersection    = {0,3}
     /// Sole-reason witnesses: doc1 dropped only by FTS, doc2 only by the
     /// scalar filter, doc5 only by the vector cutoff.
-    fn demo_cat_two_segments(dim: usize) -> Supertable {
+    fn demo_cat_two_superfiles(dim: usize) -> Supertable {
         let st = Supertable::create(options_cat_title_emb(dim)).expect("create");
         let schema = st.options().schema.clone();
         // Each writer holds the single-writer lock until dropped, so
@@ -940,7 +940,7 @@ mod tests {
     #[test]
     fn sql_join_of_bm25_and_vector_with_scalar_filter_matches_three_way_intersection() {
         let dim = 16;
-        let st = demo_cat_two_segments(dim);
+        let st = demo_cat_two_superfiles(dim);
         // Graded query vector [dim, dim-1, …, 1] → cosine distance to
         // one-hot doc `i` is strictly increasing in `i`, so the vector
         // distance rank equals the doc id (no ties among the 8 docs).
@@ -973,7 +973,7 @@ mod tests {
 
         // THE query under test: FTS ⋈ vector on the durable _id, then a
         // scalar SQL predicate — sql + vector + fts in one statement,
-        // spanning two segments.
+        // spanning two superfiles.
         let combined_batches = st
             .reader()
             .query_sql(&format!(

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -459,7 +459,7 @@ mod tests {
         )
     }
 
-    fn options_one_segment_per_commit(dim: usize) -> SupertableOptions {
+    fn options_one_superfile_per_commit(dim: usize) -> SupertableOptions {
         let pool = Arc::new(
             rayon::ThreadPoolBuilder::new()
                 .num_threads(1)
@@ -509,9 +509,9 @@ mod tests {
         RecordBatch::try_new(schema, vec![Arc::new(titles), Arc::new(fsl)]).expect("batch")
     }
 
-    /// Single-segment supertable with `n` one-hot docs.
-    fn supertable_one_segment(dim: usize, n: usize) -> Supertable {
-        let st = Supertable::create(options_one_segment_per_commit(dim)).expect("create");
+    /// Single-superfile supertable with `n` one-hot docs.
+    fn supertable_one_superfile(dim: usize, n: usize) -> Supertable {
+        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
         w.append(&build_vector_batch(0, n, dim, schema))
@@ -574,14 +574,14 @@ mod tests {
     #[test]
     fn vector_search_tvf_emits_id_and_score_in_distance_order() {
         let dim = 16;
-        let st = supertable_one_segment(dim, 8);
+        let st = supertable_one_superfile(dim, 8);
         let sql = format!(
             "SELECT _id, title, score FROM vector_search('emb', '{}', 8)",
             csv_one_hot(dim, 0)
         );
         let batches = st.reader().query_sql(&sql).expect("query_sql");
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
-        assert_eq!(total, 8, "single segment, k=8 → all 8 docs resolved");
+        assert_eq!(total, 8, "single superfile, k=8 → all 8 docs resolved");
 
         let b = &batches[0];
         assert_eq!(b.num_columns(), 3);
@@ -609,7 +609,7 @@ mod tests {
     #[test]
     fn vector_search_tvf_star_projection_appends_score_column() {
         let dim = 16;
-        let st = supertable_one_segment(dim, 8);
+        let st = supertable_one_superfile(dim, 8);
         let sql = format!(
             "SELECT * FROM vector_search('emb', '{}', 3)",
             csv_one_hot(dim, 0)
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn vector_search_tvf_score_only_projection() {
         let dim = 16;
-        let st = supertable_one_segment(dim, 8);
+        let st = supertable_one_superfile(dim, 8);
         let sql = format!(
             "SELECT score FROM vector_search('emb', '{}', 2)",
             csv_one_hot(dim, 0)
@@ -642,10 +642,10 @@ mod tests {
     #[test]
     fn vector_search_tvf_score_only_matches_full_projection_scores() {
         // The `score`-only projection decodes no scalar columns (opens
-        // no segment readers); it must still produce the exact scores
+        // no superfile readers); it must still produce the exact scores
         // and row count of the fully-resolved projection.
         let dim = 16;
-        let st = supertable_one_segment(dim, 8);
+        let st = supertable_one_superfile(dim, 8);
         let q = csv_one_hot(dim, 0);
         let full = st
             .reader()
@@ -678,7 +678,7 @@ mod tests {
     #[test]
     fn vector_search_tvf_accepts_sql_array_literal() {
         let dim = 16;
-        let st = supertable_one_segment(dim, 8);
+        let st = supertable_one_superfile(dim, 8);
         let arr = (0..dim)
             .map(|d| if d == 0 { "1.0" } else { "0.0" })
             .collect::<Vec<_>>()
@@ -693,7 +693,7 @@ mod tests {
     #[test]
     fn vector_search_tvf_empty_supertable_returns_no_rows() {
         let dim = 16;
-        let st = Supertable::create(options_one_segment_per_commit(dim)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
         let sql = format!(
             "SELECT _id, score FROM vector_search('emb', '{}', 5)",
             csv_one_hot(dim, 0)

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -24,7 +24,7 @@
 //!
 //! Internally these drive the async kernel on the snapshot-pinned
 //! [`SupertableReader`], whose `bm25_search` (rows) / `bm25_hits`
-//! ([`SuperfileHit`], segment-local) / `bm25_search_prefix` methods are
+//! ([`SuperfileHit`], superfile-local) / `bm25_search_prefix` methods are
 //! the engine-facing surface. Ranked results are sorted by score
 //! *descending* — higher BM25 score is more relevant.
 //!
@@ -32,38 +32,38 @@
 //!
 //! Internally pins a snapshot reader and drives the async
 //! kernel to completion via the sync→async bridge. The reader
-//! holds a pinned `Arc<Manifest>`; for each visible segment we:
+//! holds a pinned `Arc<Manifest>`; for each visible superfile we:
 //!
-//!   1. Fetch the segment's `SuperfileReader` from the store.
+//!   1. Fetch the superfile's `SuperfileReader` from the store.
 //!   2. Delegate to `SuperfileReader::bm25_search` /
 //!      `bm25_search_prefix` (already implemented at the superfile
-//!      layer; per-segment top-k with BlockMaxWAND skip).
-//!   3. Tag each `(local_doc_id, score)` with the segment URI.
+//!      layer; per-superfile top-k with BlockMaxWAND skip).
+//!   3. Tag each `(local_doc_id, score)` with the superfile URI.
 //!   4. Concatenate across superfiles and global-top-k by score.
 //!
-//! Rayon fan-out runs on `options.reader_pool`. For an N-segment
-//! supertable we issue N parallel per-segment searches; the pool
+//! Rayon fan-out runs on `options.reader_pool`. For an N-superfile
+//! supertable we issue N parallel per-superfile searches; the pool
 //! caps concurrency at the configured reader thread count.
 //!
 //! ## Score comparability across superfiles
 //!
-//! BM25's IDF is computed from per-segment `n_docs` and `df`,
-//! so a rare term in a small segment can score higher than the
-//! same term in a larger segment. This is the classical sharded-
+//! BM25's IDF is computed from per-superfile `n_docs` and `df`,
+//! so a rare term in a small superfile can score higher than the
+//! same term in a larger superfile. This is the classical sharded-
 //! BM25 problem:
-//! treating per-segment scores as comparable is a documented
+//! treating per-superfile scores as comparable is a documented
 //! approximation, accepted in v1 because (a) global IDF would
 //! require either a manifest-wide df table or a two-pass query
 //! (df gather + score), both with non-trivial memory/latency
 //! cost; (b) for k ≥ 10 and reasonably balanced superfiles the top-k
 //! *set* converges to the global answer even if score *order*
 //! within the set wiggles. Oracle tests assert set membership at
-//! `k = 10` against a single-segment ground truth.
+//! `k = 10` against a single-superfile ground truth.
 //!
 //! Manifest-level skip pruning is wired in: each call computes a
-//! per-segment keep/prune mask from the FTS bloom (exact-term
+//! per-superfile keep/prune mask from the FTS bloom (exact-term
 //! mode) or the lex term range (prefix mode) before issuing
-//! per-segment work, so pruned superfiles never trigger a
+//! per-superfile work, so pruned superfiles never trigger a
 //! `SuperfileReaderCache::reader` call. Vector + SQL skip remain
 //! deferred (see those modules' headers).
 
@@ -81,7 +81,7 @@ use crate::supertable::handle::{Supertable, SupertableReader};
 use crate::supertable::manifest::{Manifest, SuperfileEntry};
 use crate::supertable::query::SuperfileHit;
 use crate::supertable::query::exec::common::resolve_hits_named;
-use crate::supertable::query::prune::{PruneLeaf, select_segments};
+use crate::supertable::query::prune::{PruneLeaf, select_superfiles};
 
 impl SupertableReader {
     /// Single-column BM25 search across the pinned manifest's
@@ -90,9 +90,9 @@ impl SupertableReader {
     ///
     /// `query` is tokenized by the v1 [`AsciiLowerTokenizer`] —
     /// the same tokenizer used at index time. Returns
-    /// [`QueryError::Store`] if any segment is unreachable, or
-    /// [`QueryError::Parquet`] if a segment's bytes can't be
-    /// queried (column missing from the segment's FTS index, etc.).
+    /// [`QueryError::Store`] if any superfile is unreachable, or
+    /// [`QueryError::Parquet`] if a superfile's bytes can't be
+    /// queried (column missing from the superfile's FTS index, etc.).
     ///
     /// Empty supertable (no superfiles) returns an empty `Vec`
     /// without consulting the store.
@@ -116,19 +116,19 @@ impl SupertableReader {
         let pool_threads = manifest.options.reader_pool.current_num_threads();
         let column_owned = column.to_owned();
 
-        // Parse the query once here, not per segment. The fan-out
+        // Parse the query once here, not per superfile. The fan-out
         // closures below need owned ('static) data for tokio::spawn,
         // so this is the one place the tokens are copied — the prune
-        // and every per-segment search reuse them.
+        // and every per-superfile search reuse them.
         let parsed = AsciiLowerTokenizer.parse(query);
         let positives: Vec<String> = parsed.positives.into_iter().map(Cow::into_owned).collect();
         let negatives: Vec<String> = parsed.negatives.into_iter().map(Cow::into_owned).collect();
 
-        // Pick the segments to search, via the shared two-tier bloom
+        // Pick the superfiles to search, via the shared two-tier bloom
         // prune. Only positive terms prune — a negated term must never
-        // drop a segment: a segment without it is the best case (none
+        // drop a superfile: a superfile without it is the best case (none
         // of its docs can be excluded), and under `And` it would even
-        // prune every segment that lacks the negated term.
+        // prune every superfile that lacks the negated term.
         // The leaf takes `positives` by value to avoid cloning the
         // list; we take it back right after the call.
         let prune_leaf = PruneLeaf::TermPresence {
@@ -136,7 +136,7 @@ impl SupertableReader {
             terms: positives,
             mode,
         };
-        let kept = select_segments(manifest.as_ref(), slice::from_ref(&prune_leaf)).await?;
+        let kept = select_superfiles(manifest.as_ref(), slice::from_ref(&prune_leaf)).await?;
         let PruneLeaf::TermPresence {
             terms: positives, ..
         } = prune_leaf
@@ -149,7 +149,7 @@ impl SupertableReader {
 
         // Build the work-unit list. When the reader pool has more
         // threads than there are kept superfiles AND we're on the
-        // multi-term OR hot path, slice each segment into doc_id
+        // multi-term OR hot path, slice each superfile into doc_id
         // sub-ranges so the fan-out can saturate every pool thread.
         // Single-term OR and AND stay on the un-ranged call.
         let kept_refs: Vec<&Arc<SuperfileEntry>> = kept.iter().collect();
@@ -164,11 +164,11 @@ impl SupertableReader {
 
         // One shared fan-out (`query::dispatch::fanout`) — the same
         // orchestrator the vector path uses. It warms the tombstone
-        // sidecars in one batch, opens each segment reader and runs the
+        // sidecars in one batch, opens each superfile reader and runs the
         // kernel under `tokio::spawn` so cold GETs overlap, then tags +
         // tombstone-filters each unit's hits. The per-unit `params` is
         // the optional doc-id sub-range; `None` searches the whole
-        // segment.
+        // superfile.
         let kernel = move |r: Arc<SuperfileReader>, range: Option<(u32, u32)>| {
             let column_arc = Arc::clone(&column_arc);
             let term_arc = Arc::clone(&term_arc);
@@ -208,7 +208,7 @@ impl SupertableReader {
 
     /// Prefix-expanded BM25 search across the pinned manifest's
     /// superfiles. The prefix is ASCII-lowercased before expansion
-    /// (matching the v1 tokenizer) and expanded per-segment to the
+    /// (matching the v1 tokenizer) and expanded per-superfile to the
     /// concrete term list before `BoolMode::Or` BM25 scoring.
     ///
     /// Returns up to `k` highest-scoring hits, sorted descending
@@ -240,10 +240,10 @@ impl SupertableReader {
         // tokenizer's interpretation of the prefix.
         let prefix_lower = prefix_owned.to_ascii_lowercase();
 
-        // Segment selection via the shared two-tier prune — the
+        // Superfile selection via the shared two-tier prune — the
         // single-`Prefix`-leaf case (part-level term-range skip →
-        // lazy-load surviving parts → per-segment term-range skip).
-        let kept = crate::supertable::query::prune::select_segments(
+        // lazy-load surviving parts → per-superfile term-range skip).
+        let kept = crate::supertable::query::prune::select_superfiles(
             manifest.as_ref(),
             &[crate::supertable::query::prune::PruneLeaf::Prefix {
                 column: column_owned.clone(),
@@ -291,7 +291,7 @@ impl SupertableReader {
     /// Unranked token match across the pinned snapshot. Returns
     /// every row matching `query`'s tokens under `mode` (`Or` = any
     /// token, `And` = every token) as [`SuperfileHit`]s — **no scoring**
-    /// (`score` is left `0.0`; these results are unordered). Segment
+    /// (`score` is left `0.0`; these results are unordered). Superfile
     /// skip uses the same term-bloom prune as BM25.
     ///
     /// `pub(crate)` async kernel; the public surface is the sync
@@ -307,7 +307,7 @@ impl SupertableReader {
         if term_strings.is_empty() {
             return Ok(Vec::new());
         }
-        let kept = crate::supertable::query::prune::select_segments(
+        let kept = crate::supertable::query::prune::select_superfiles(
             manifest.as_ref(),
             &[crate::supertable::query::prune::PruneLeaf::TermPresence {
                 column: column.to_owned(),
@@ -342,7 +342,7 @@ impl SupertableReader {
     /// against `column` across the pinned snapshot. Returns the rows
     /// whose stored value equals `value` exactly as [`SuperfileHit`]s —
     /// **no scoring**. See [`crate::superfile::SuperfileReader::exact_match`]
-    /// for the per-segment two-pass (token-AND prune + raw verify).
+    /// for the per-superfile two-pass (token-AND prune + raw verify).
     ///
     /// `pub(crate)` async kernel; the public surface is the sync
     /// [`SupertableReader::exact_match`].
@@ -353,7 +353,7 @@ impl SupertableReader {
     ) -> Result<Vec<SuperfileHit>, QueryError> {
         let manifest = self.manifest();
         let term_strings: Vec<String> = AsciiLowerTokenizer.tokenize(value).collect();
-        // Tokens prune segments via the term bloom (AND); a token-less
+        // Tokens prune superfiles via the term bloom (AND); a token-less
         // value (e.g. punctuation only) can't prune, so keep all.
         let leaves = if term_strings.is_empty() {
             Vec::new()
@@ -365,7 +365,7 @@ impl SupertableReader {
             }]
         };
         let kept =
-            crate::supertable::query::prune::select_segments(manifest.as_ref(), &leaves).await?;
+            crate::supertable::query::prune::select_superfiles(manifest.as_ref(), &leaves).await?;
         if kept.is_empty() {
             return Ok(Vec::new());
         }
@@ -476,8 +476,8 @@ impl SupertableReader {
     }
 }
 
-/// One unit of per-segment search work scheduled into the reader
-/// pool's `par_iter`. `range == None` means "the whole segment" and
+/// One unit of per-superfile search work scheduled into the reader
+/// pool's `par_iter`. `range == None` means "the whole superfile" and
 /// dispatches to the un-ranged BM25 API; `range == Some((start,
 /// end))` means "only doc_ids in [start, end)" and dispatches to
 /// the range-aware OR path.
@@ -490,47 +490,47 @@ struct WorkUnit {
 /// more pool-scheduling + per-shard top-K-merge overhead than it
 /// saves in scoring work. Tuned to be coarse — the heuristic only
 /// needs to avoid splitting toy superfiles; production superfiles at
-/// the scales we benchmark (1.25M docs/segment after 10M × cpus/2
+/// the scales we benchmark (1.25M docs/superfile after 10M × cpus/2
 /// row-shard) are well above this floor.
 const SUBRANGE_MIN_DOCS: u32 = 50_000;
 
 /// Minimum query term count that makes OR sub-range fan-out eligible.
 /// The range-aware Block-Max MaxScore path is only wired up for
-/// multi-term OR, so single-term queries stay whole-segment.
+/// multi-term OR, so single-term queries stay whole-superfile.
 const OR_FANOUT_MIN_TERMS: usize = 2;
 
-/// How a query fans out over the kept segments.
+/// How a query fans out over the kept superfiles.
 enum FanOut {
-    /// One un-ranged unit per segment.
-    PerSegment,
-    /// Additionally slice big segments into doc-id sub-ranges when the
+    /// One un-ranged unit per superfile.
+    PerSuperfile,
+    /// Additionally slice big superfiles into doc-id sub-ranges when the
     /// reader pool has spare threads.
     SubRanges,
 }
 
 /// Pick the fan-out for a term query: only multi-term OR has a
 /// range-aware kernel, and negation has no ranged kernel (v1), so
-/// everything else stays one un-ranged unit per segment.
+/// everything else stays one un-ranged unit per superfile.
 fn fanout_for(mode: BoolMode, n_positives: usize, has_negatives: bool) -> FanOut {
     if mode == BoolMode::Or && n_positives >= OR_FANOUT_MIN_TERMS && !has_negatives {
         FanOut::SubRanges
     } else {
-        FanOut::PerSegment
+        FanOut::PerSuperfile
     }
 }
 
 /// Slice the kept superfiles into parallel work units — one
-/// [`WorkUnit`] per (segment, doc_id sub-range) tuple.
+/// [`WorkUnit`] per (superfile, doc_id sub-range) tuple.
 ///
 /// `FanOut::SubRanges` slices only when:
 ///   1. The reader pool has more threads than kept superfiles —
-///      otherwise every thread is already saturated by one segment
+///      otherwise every thread is already saturated by one superfile
 ///      and splitting just adds overhead.
 ///   2. The candidate sub-range width is at least
 ///      `SUBRANGE_MIN_DOCS` — below that, BMM bookkeeping +
 ///      cross-sub-range top-K merge dominate the parallel win.
 ///
-/// Otherwise each kept segment becomes a single un-ranged work unit
+/// Otherwise each kept superfile becomes a single un-ranged work unit
 /// — identical to the original `par_iter` over superfiles shape.
 fn build_work_units(
     kept: &[&Arc<SuperfileEntry>],
@@ -538,7 +538,7 @@ fn build_work_units(
     pool_threads: usize,
 ) -> Vec<WorkUnit> {
     let want_subranges = pool_threads.div_ceil(kept.len().max(1)).max(1);
-    if matches!(fanout, FanOut::PerSegment) || want_subranges <= 1 {
+    if matches!(fanout, FanOut::PerSuperfile) || want_subranges <= 1 {
         return kept
             .iter()
             .map(|e| WorkUnit {
@@ -556,10 +556,10 @@ fn build_work_units(
         }
         // Round the sub-range count down to avoid producing
         // narrower-than-floor slices. With `want_subranges = 2` on
-        // a 1.25M-doc segment, stride = 625K (well above floor) so
-        // both sub-ranges fire. With a tiny segment (e.g., 10K
+        // a 1.25M-doc superfile, stride = 625K (well above floor) so
+        // both sub-ranges fire. With a tiny superfile (e.g., 10K
         // docs, well below `SUBRANGE_MIN_DOCS`), the division
-        // collapses to 1 sub-range = full segment.
+        // collapses to 1 sub-range = full superfile.
         let cap_by_floor = (n_docs / SUBRANGE_MIN_DOCS).max(1) as usize;
         let n_sub = want_subranges.min(cap_by_floor);
         if n_sub <= 1 {
@@ -583,10 +583,10 @@ fn build_work_units(
     units
 }
 
-/// Merge per-segment hits and return the top-k by *descending*
+/// Merge per-superfile hits and return the top-k by *descending*
 /// score (highest BM25 = most relevant). Uses a min-heap of size k
 /// so we never sort more than k elements.
-fn top_k_descending(per_segment: Vec<Vec<SuperfileHit>>, k: usize) -> Vec<SuperfileHit> {
+fn top_k_descending(per_superfile: Vec<Vec<SuperfileHit>>, k: usize) -> Vec<SuperfileHit> {
     use std::cmp::Ordering;
     use std::collections::BinaryHeap;
 
@@ -609,7 +609,7 @@ fn top_k_descending(per_segment: Vec<Vec<SuperfileHit>>, k: usize) -> Vec<Superf
     }
 
     let mut heap = BinaryHeap::with_capacity(k + 1);
-    for hit in per_segment.into_iter().flatten() {
+    for hit in per_superfile.into_iter().flatten() {
         if heap.len() < k {
             heap.push(MinByScore(hit));
         } else if let Some(worst) = heap.peek()
@@ -748,7 +748,7 @@ mod tests {
     use crate::test_helpers::default_tokenizer as tok;
 
     /// Drive an async future to completion on a throwaway current-thread
-    /// runtime. Used only for the single-segment `SuperfileReader`
+    /// runtime. Used only for the single-superfile `SuperfileReader`
     /// oracle, whose search surface is async-only; the supertable
     /// reader's own search methods are sync and need no runtime here.
     fn block_on<F: std::future::Future>(fut: F) -> F::Output {
@@ -767,7 +767,7 @@ mod tests {
         )]))
     }
 
-    fn options_one_segment_per_commit() -> SupertableOptions {
+    fn options_one_superfile_per_commit() -> SupertableOptions {
         let pool = Arc::new(
             rayon::ThreadPoolBuilder::new()
                 .num_threads(1)
@@ -793,7 +793,7 @@ mod tests {
 
     /// Build a single SuperfileBuilder containing the same docs as
     /// the supertable across all superfiles. Used as the oracle for
-    /// per-segment-vs-global BM25 set-membership tests.
+    /// per-superfile-vs-global BM25 set-membership tests.
     fn build_oracle_superfile(titles: &[&str]) -> Arc<crate::superfile::SuperfileReader> {
         // The oracle path goes directly through SuperfileBuilder
         // (not through Supertable::append's auto-injection), so
@@ -836,10 +836,10 @@ mod tests {
     }
 
     #[test]
-    fn negation_excludes_across_segments() {
-        // 3 commits → 3 segments. "alpha -beta" must drop the one doc
+    fn negation_excludes_across_superfiles() {
+        // 3 commits → 3 superfiles. "alpha -beta" must drop the one doc
         // containing beta and keep the other two alpha docs.
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["alpha beta", "alpha gamma"]))
             .expect("append");
@@ -863,12 +863,12 @@ mod tests {
     }
 
     #[test]
-    fn negated_term_does_not_prune_segments() {
-        // "delta" exists only in segment 2. Under And, if the negated
-        // term leaked into the bloom prune, segments 1 and 3 (no delta)
+    fn negated_term_does_not_prune_superfiles() {
+        // "delta" exists only in superfile 2. Under And, if the negated
+        // term leaked into the bloom prune, superfiles 1 and 3 (no delta)
         // would be wrongly dropped and the result would be empty; the
-        // correct answer is segment 1's two alpha docs.
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        // correct answer is superfile 1's two alpha docs.
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["alpha one", "alpha two"]))
             .expect("append");
@@ -887,7 +887,7 @@ mod tests {
 
     #[test]
     fn negation_only_query_errors() {
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["alpha beta"])).expect("append");
         w.commit().expect("commit");
@@ -899,7 +899,7 @@ mod tests {
 
     #[test]
     fn bm25_search_empty_supertable_returns_empty_without_store_calls() {
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let r = st.reader();
         let hits = r
             .bm25_hits("title", "rust", 5, BoolMode::Or)
@@ -909,7 +909,7 @@ mod tests {
 
     #[test]
     fn bm25_search_k_zero_short_circuits() {
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["rust async"])).expect("append");
         w.commit().expect("commit");
@@ -922,7 +922,7 @@ mod tests {
 
     #[test]
     fn bm25_search_returns_descending_score_order() {
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(
             0,
@@ -948,8 +948,8 @@ mod tests {
     }
 
     #[test]
-    fn bm25_search_carries_segment_uri_for_each_hit() {
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+    fn bm25_search_carries_superfile_uri_for_each_hit() {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["rust rust async"])).expect("a1");
         w.commit().expect("c1");
@@ -962,8 +962,8 @@ mod tests {
             .bm25_hits("title", "rust", 5, BoolMode::Or)
             .expect("query");
         assert_eq!(hits.len(), 2);
-        // Both segment URIs should appear.
-        let mut uris: Vec<_> = hits.iter().map(|h| h.segment).collect();
+        // Both superfile URIs should appear.
+        let mut uris: Vec<_> = hits.iter().map(|h| h.superfile).collect();
         uris.sort();
         let expected: Vec<_> = {
             let mut v: Vec<_> = r.manifest().superfiles.iter().map(|e| e.uri).collect();
@@ -976,13 +976,13 @@ mod tests {
     #[test]
     fn bm25_search_oracle_top_k_set_matches_single_superfile() {
         // Plant a corpus where the top-k under BM25 is unambiguous
-        // regardless of per-segment-vs-global IDF variation: 3 docs
+        // regardless of per-superfile-vs-global IDF variation: 3 docs
         // contain the rare term `nimblefox`, distributed across 3
         // superfiles; the other 9 docs share only generic terms with
         // each other and with the query, so they score zero against
         // `nimblefox`. The set membership check survives even
-        // though per-segment IDF for `nimblefox` differs from
-        // global IDF (it's `df=1` in each segment vs `df=3` global).
+        // though per-superfile IDF for `nimblefox` differs from
+        // global IDF (it's `df=1` in each superfile vs `df=3` global).
         let titles = vec![
             "lookup nimblefox special token",   // 0  — match
             "ordinary common everyday text",    // 1
@@ -992,13 +992,13 @@ mod tests {
             "generic page that adds nothing",   // 5
             "another stuffer no rare terms",    // 6
             "more padding here for filler",     // 7
-            "tail nimblefox final segment",     // 8  — match
+            "tail nimblefox final superfile",   // 8  — match
             "another tail row",                 // 9
             "yet another normal title",         // 10
             "wrapping up the corpus today",     // 11
         ];
 
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         for chunk_start in (0..titles.len()).step_by(4) {
             let end = (chunk_start + 4).min(titles.len());
@@ -1010,7 +1010,7 @@ mod tests {
         assert_eq!(st.reader().n_superfiles(), 3);
 
         let oracle = build_oracle_superfile(&titles);
-        // Single-segment `SuperfileReader` oracle: async-only search,
+        // Single-superfile `SuperfileReader` oracle: async-only search,
         // driven on a throwaway runtime. The supertable reader below
         // uses its sync public API.
         let oracle_hits = block_on(oracle.bm25_hits_async("title", "nimblefox", 5, BoolMode::Or))
@@ -1026,7 +1026,7 @@ mod tests {
             .bm25_hits("title", "nimblefox", 5, BoolMode::Or)
             .expect("supertable query");
         assert_eq!(st_hits.len(), 3);
-        // Resolve supertable hits to global doc-ids via segment
+        // Resolve supertable hits to global doc-ids via superfile
         // ordering (superfiles appear in append order; chunk size = 4).
         let manifest = st_reader.manifest();
         let st_globals: std::collections::HashSet<u32> = st_hits
@@ -1035,8 +1035,8 @@ mod tests {
                 let seg_idx = manifest
                     .superfiles
                     .iter()
-                    .position(|e| e.uri == h.segment)
-                    .expect("segment in manifest");
+                    .position(|e| e.uri == h.superfile)
+                    .expect("superfile in manifest");
                 (seg_idx as u32) * 4 + h.local_doc_id
             })
             .collect();
@@ -1055,7 +1055,7 @@ mod tests {
             "rusty pipe rebuild",
             "go concurrency model",
         ];
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         for chunk_start in (0..titles.len()).step_by(2) {
             let end = (chunk_start + 2).min(titles.len());
@@ -1081,8 +1081,8 @@ mod tests {
                 let seg_idx = manifest
                     .superfiles
                     .iter()
-                    .position(|e| e.uri == h.segment)
-                    .expect("segment in manifest");
+                    .position(|e| e.uri == h.superfile)
+                    .expect("superfile in manifest");
                 (seg_idx as u32) * 2 + h.local_doc_id
             })
             .collect();
@@ -1095,7 +1095,7 @@ mod tests {
 
     #[test]
     fn bm25_search_prefix_unmatched_prefix_returns_empty() {
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["rust async"])).expect("append");
         w.commit().expect("commit");
@@ -1110,7 +1110,7 @@ mod tests {
         // Index stores tokenized terms (lowercased); user provides
         // mixed-case prefix; we lowercase before expansion so the
         // FST walk finds the matching subtree.
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["Rust async runtime"]))
             .expect("append");
@@ -1123,7 +1123,7 @@ mod tests {
 
     #[test]
     fn bm25_search_unknown_column_errors() {
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["rust"])).expect("append");
         w.commit().expect("commit");
@@ -1138,7 +1138,7 @@ mod tests {
     #[test]
     fn bm25_search_results_global_top_k_caps_at_k() {
         // 4 superfiles × 1 doc each = 4 hits; ask for k=2; expect 2.
-        let st = Supertable::create(options_one_segment_per_commit()).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
         for i in 0..4 {
             w.append(&build_batch(i * 10, &["rust async runtime"]))

--- a/src/supertable/query/hierarchical_iter.rs
+++ b/src/supertable/query/hierarchical_iter.rs
@@ -5,7 +5,7 @@
 //!
 //! The bridge between the list-level prune helpers
 //! (`list_prune::prune_parts_for_*`) and the per-part
-//! segment iteration the query paths need:
+//! superfile iteration the query paths need:
 //!
 //!   1. Caller computes a `kept_part_ids: Vec<PartId>` via
 //!      the appropriate `prune_parts_for_*` for its query
@@ -14,9 +14,9 @@
 //!      `Manifest::part(id).await`, in parallel. Already-
 //!      loaded parts (eager mode, or warm OnceCells) cost
 //!      nothing.
-//!   3. [`flatten_segments`] concatenates the loaded parts'
+//!   3. [`flatten_superfiles`] concatenates the loaded parts'
 //!      superfiles into a single `Vec<Arc<SuperfileEntry>>`
-//!      that the existing segment-level skip + fan-out
+//!      that the existing superfile-level skip + fan-out
 //!      code consumes.
 //!
 //! `async` end-to-end: the query paths that call these helpers
@@ -67,10 +67,10 @@ pub async fn load_kept_parts(
 }
 
 /// Concatenate the loaded parts' superfiles into a flat
-/// `Vec<Arc<SuperfileEntry>>` for downstream segment-level
+/// `Vec<Arc<SuperfileEntry>>` for downstream superfile-level
 /// skip + fan-out. Cheap: every entry is `Arc::clone` of an
 /// already-allocated `SuperfileEntry`.
-pub fn flatten_segments(parts: &[Arc<ManifestPart>]) -> Vec<Arc<SuperfileEntry>> {
+pub fn flatten_superfiles(parts: &[Arc<ManifestPart>]) -> Vec<Arc<SuperfileEntry>> {
     let total: usize = parts.iter().map(|p| p.superfiles.len()).sum();
     let mut out = Vec::with_capacity(total);
     for p in parts {
@@ -86,7 +86,7 @@ pub async fn load_and_flatten(
     kept_part_ids: &[PartId],
 ) -> Result<Vec<Arc<SuperfileEntry>>, QueryError> {
     let parts = load_kept_parts(manifest, kept_part_ids).await?;
-    Ok(flatten_segments(&parts))
+    Ok(flatten_superfiles(&parts))
 }
 
 /// **Fallback shape** for query callers operating on
@@ -95,6 +95,6 @@ pub async fn load_and_flatten(
 /// the flat `manifest.superfiles`. The eager-mode + lazy-mode hierarchical
 /// path through `load_and_flatten` requires a `ManifestList`; this branch
 /// covers the no-list case so the query paths remain uniformly callable.
-pub fn fallback_to_flat_segments(manifest: &Manifest) -> Vec<Arc<SuperfileEntry>> {
+pub fn fallback_to_flat_superfiles(manifest: &Manifest) -> Vec<Arc<SuperfileEntry>> {
     manifest.superfiles.to_vec()
 }

--- a/src/supertable/query/mod.rs
+++ b/src/supertable/query/mod.rs
@@ -11,8 +11,8 @@
 //! - [`vector`] — cluster-aware kNN fan-out method on
 //!   [`super::SupertableReader`].
 //!
-//! All non-SQL paths return [`SuperfileHit`] tuples — `(segment_uri,
-//! local_doc_id, score)`. Doc-id space is local to a segment in
+//! All non-SQL paths return [`SuperfileHit`] tuples — `(superfile_uri,
+//! local_doc_id, score)`. Doc-id space is local to a superfile in
 //! v1, so global identity resolution is the caller's
 //! responsibility.
 //!
@@ -38,20 +38,20 @@ use super::manifest::SuperfileUri;
 
 /// One scored result from a fan-out query (BM25 or vector).
 ///
-/// `local_doc_id` is the row offset *within* `segment`; doc-id
-/// space is local to a segment in v1. Resolving to a global
+/// `local_doc_id` is the row offset *within* `superfile`; doc-id
+/// space is local to a superfile in v1. Resolving to a global
 /// identity goes through the caller's primary-key column —
 /// typically a
 /// `Supertable::query_sql("SELECT pk FROM supertable WHERE
-/// segment = ? AND doc_id = ?")` follow-up, or by carrying the
+/// superfile = ? AND doc_id = ?")` follow-up, or by carrying the
 /// caller's own surrogate key as a scalar column.
 ///
 /// Cheap to copy: 16 bytes for `SuperfileUri` (Uuid) + 4 + 4 = 24 B.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SuperfileHit {
-    /// Source segment.
-    pub segment: SuperfileUri,
-    /// Row offset within `segment`.
+    /// Source superfile.
+    pub superfile: SuperfileUri,
+    /// Row offset within `superfile`.
     pub local_doc_id: u32,
     /// Score. Direction is method-dependent — see the originating
     /// method's docs:

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -2,25 +2,25 @@
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
 //! `SupertableProvider` — a DataFusion [`TableProvider`] that owns
-//! segment selection and hands the rest to DataFusion.
+//! superfile selection and hands the rest to DataFusion.
 //!
 //! ## Two-tier pruning
 //!
 //! This is the SQL counterpart to the dedicated BM25 / vector
-//! entry points: **infino decides which segments are relevant;
+//! entry points: **infino decides which superfiles are relevant;
 //! DataFusion executes over them.** Concretely, [`scan`] performs
 //! two tiers of skipping:
 //!
-//!   1. **Segment skip (infino).** The `WHERE` clause's simple
+//!   1. **Superfile skip (infino).** The `WHERE` clause's simple
 //!      `column <op> literal` conjuncts are lowered to
 //!      [`ScalarPredicate`]s and run through
-//!      [`scalar_skip`] against each segment's persisted
-//!      `ScalarStatsTable` min/max. Definitely-irrelevant segments
+//!      [`scalar_skip`] against each superfile's persisted
+//!      `ScalarStatsTable` min/max. Definitely-irrelevant superfiles
 //!      are dropped before any bytes are decoded. This is the same
 //!      manifest-level skip philosophy as `fts_bloom_skip` /
 //!      `vector_centroid_skip`.
 //!   2. **Row-group / page skip (DataFusion).** The surviving
-//!      segments' Parquet bytes are exposed to a DataFusion
+//!      superfiles' Parquet bytes are exposed to a DataFusion
 //!      `ParquetSource` via an in-memory object store. The same
 //!      predicate is handed to DataFusion as a physical expression
 //!      so `PruningPredicate` prunes row groups and pages, then
@@ -32,11 +32,11 @@
 //! DataFusion always re-applies the full predicate in a
 //! `FilterExec` above the scan. Both skip tiers are pure
 //! *conservative* optimizations — they may keep a non-matching
-//! segment/row group, never drop a matching one.
+//! superfile/row group, never drop a matching one.
 //!
 //! ## Why an in-memory object store
 //!
-//! The reader cache already holds warm segments as resident Parquet bytes
+//! The reader cache already holds warm superfiles as resident Parquet bytes
 //! (`SuperfileReader::parquet_bytes`, an `Arc`-backed `Bytes` — cloning is
 //! a refcount bump, not a copy). Registering those bytes into a DataFusion
 //! [`InMemory`] object store lets us reuse DataFusion's full `ParquetSource`
@@ -85,12 +85,12 @@ use datafusion::scalar::ScalarValue;
 /// resolving filter columns to a physical pruning predicate.
 pub(crate) const TABLE_NAME: &str = "supertable";
 
-/// Object-store URL *prefix* the surviving segments are registered under
+/// Object-store URL *prefix* the surviving superfiles are registered under
 /// for a scan. The authority is arbitrary — only a key into the session's
 /// object-store registry — but it must be **unique per provider**: a
 /// multi-table catalog query (`Connection::query_sql`) registers several
 /// providers into one DataFusion session, and a shared key would let one
-/// table's store overwrite another's, so the shadowed table's segments
+/// table's store overwrite another's, so the shadowed table's superfiles
 /// would read "not found". A process-global counter makes each provider's
 /// URL distinct while staying stable across that provider's own scans (so
 /// the cached single-table session re-registers the same key, no growth).
@@ -101,12 +101,12 @@ static STORE_URL_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU6
 
 /// Selectivity gate for the FTS `WHERE` pushdown: only push an index
 /// candidate set into the scan when the estimated match count is at
-/// most this fraction of the segment's rows. Above it, matches saturate
+/// most this fraction of the superfile's rows. Above it, matches saturate
 /// the Parquet data pages so an index `RowSelection` can't skip any —
 /// a plain scan is cheaper than the posting walk + selection overhead.
 const PUSHDOWN_MAX_FRACTION: f64 = 0.01;
 
-/// Floor for the gate so the pushdown stays active on small segments
+/// Floor for the gate so the pushdown stays active on small superfiles
 /// (where `n_docs * fraction` rounds to ~0 but there's no page-skip
 /// tradeoff to lose anyway).
 const PUSHDOWN_MIN_ROWS: u64 = 4096;
@@ -118,18 +118,18 @@ const PUSHDOWN_MIN_ROWS: u64 = 4096;
 /// plan. See the module docs for the two-tier pruning model.
 pub(crate) struct SupertableProvider {
     /// User-visible scalar schema (`_id` + scalar + FTS columns).
-    /// Matches the Parquet body each segment was written with.
+    /// Matches the Parquet body each superfile was written with.
     schema: SchemaRef,
     /// Pinned manifest snapshot for this query.
     manifest: Arc<Manifest>,
-    /// In-memory segment-bytes tier.
+    /// In-memory superfile-bytes tier.
     store: Arc<dyn SuperfileReaderCache>,
     /// Optional disk cache (storage-backed supertables).
     disk_cache: Option<Arc<DiskCacheStore>>,
     /// Per-superfile soft-delete (tombstone) overlay. `None` for
     /// in-memory tables with no WAL/mutation surface. When present,
     /// [`scan`](TableProvider::scan) pushes the tombstoned rows into
-    /// each segment's Parquet read as a [`ParquetAccessPlan`] row
+    /// each superfile's Parquet read as a [`ParquetAccessPlan`] row
     /// selection — the *lazy* delete path: deleted rows are skipped
     /// during decode rather than materialized then dropped. This
     /// keeps the analytical SELECT path's projection/limit/row-group
@@ -180,11 +180,11 @@ impl SupertableProvider {
 
     /// Lower scalar predicates to prune leaves. Each predicate yields a
     /// `Scalar` leaf; additionally, an equality on an FTS-indexed text
-    /// column also yields a `TermPresence` leaf so the segment's term
+    /// column also yields a `TermPresence` leaf so the superfile's term
     /// bloom prunes it. Sound: a row matching `col = 'a b'` has a value
     /// whose tokens include every token of the literal, so requiring all
     /// of them possibly-present (`BoolMode::And`) never drops a match —
-    /// bloom false positives can only keep a segment, never drop one.
+    /// bloom false positives can only keep a superfile, never drop one.
     fn predicates_to_prune_leaves(
         &self,
         predicates: Vec<ScalarPredicate>,
@@ -212,13 +212,13 @@ impl SupertableProvider {
         leaves
     }
 
-    /// Lower `filters` to prune leaves and return the segments that
+    /// Lower `filters` to prune leaves and return the superfiles that
     /// survive the two-tier prune — exactly the inputs the scan hands to
     /// DataFusion.
     async fn select_survivors(&self, filters: &[Expr]) -> DfResult<Vec<Arc<SuperfileEntry>>> {
         let predicates = exprs_to_scalar_predicates(filters, &self.schema);
         let leaves = self.predicates_to_prune_leaves(predicates);
-        crate::supertable::query::prune::select_segments(self.manifest.as_ref(), &leaves)
+        crate::supertable::query::prune::select_superfiles(self.manifest.as_ref(), &leaves)
             .await
             .map_err(|e| DataFusionError::Execution(e.to_string()))
     }
@@ -235,10 +235,10 @@ impl SupertableProvider {
             .collect()
     }
 
-    /// Test hook: how many segments survive pruning for `filters` — the
+    /// Test hook: how many superfiles survive pruning for `filters` — the
     /// observable behind "did the index prune more than min/max?".
     #[cfg(test)]
-    pub(crate) async fn surviving_segment_count(&self, filters: &[Expr]) -> usize {
+    pub(crate) async fn surviving_superfile_count(&self, filters: &[Expr]) -> usize {
         self.select_survivors(filters)
             .await
             .expect("select survivors")
@@ -277,7 +277,7 @@ impl TableProvider for SupertableProvider {
     /// projection (one decode), which a self-verifying `exact_match`
     /// candidate would split into an extra pass — measured slower.
     /// Returning `Unsupported` (the default) would withhold the filters
-    /// from [`scan`] entirely, disabling segment + row-group skip.
+    /// from [`scan`] entirely, disabling superfile + row-group skip.
     fn supports_filters_pushdown(
         &self,
         filters: &[&Expr],
@@ -292,13 +292,13 @@ impl TableProvider for SupertableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DfResult<Arc<dyn ExecutionPlan>> {
-        // Segment selection via the shared two-tier prune (the same
+        // Superfile selection via the shared two-tier prune (the same
         // path FTS search uses); see `select_survivors`. Survivors go to
         // DataFusion.
         let survivor_entries = self.select_survivors(filters).await?;
         let survivors: Vec<&Arc<SuperfileEntry>> = survivor_entries.iter().collect();
 
-        // Nothing survived (empty table, or every segment pruned):
+        // Nothing survived (empty table, or every superfile pruned):
         // a schema-correct empty scan. EmptyExec yields one
         // partition / zero rows, so `COUNT(*)` is 0 and `SELECT *`
         // returns the right empty shape. The projection must be
@@ -313,13 +313,13 @@ impl TableProvider for SupertableProvider {
             return Ok(Arc::new(EmptyExec::new(projected)));
         }
 
-        // One `Instant::now()` for the whole scan so every per-segment
+        // One `Instant::now()` for the whole scan so every per-superfile
         // tombstone lookup shares the same `SidecarCache` TTL
         // reference.
         let now = std::time::Instant::now();
 
-        // Warm every surviving segment's tombstone bitmap in one
-        // batched fetch before the per-segment sweep below, mirroring
+        // Warm every surviving superfile's tombstone bitmap in one
+        // batched fetch before the per-superfile sweep below, mirroring
         // the bm25 / vector fan-out (see `SidecarCache::prefetch`);
         // each `bitmap_for` in the loop then resolves from cache.
         if let Some(cache) = self.tombstone_cache.as_ref() {
@@ -329,34 +329,34 @@ impl TableProvider for SupertableProvider {
 
         // Pass 1 — build the index candidate plan once for this scan. It
         // lowers the FTS-resolvable part of the `WHERE` clause to a
-        // boolean tree over `token_match`; evaluated per segment below
+        // boolean tree over `token_match`; evaluated per superfile below
         // it yields a candidate row-id superset (or `Unbounded` = scan
-        // the segment). See `crate::supertable::query::candidate`.
+        // the superfile). See `crate::supertable::query::candidate`.
         let candidate_plan = crate::supertable::query::candidate::CandidatePlan::from_filters(
             filters,
             &self.fts_cols_set(),
             self.manifest.options.tokenizer.as_ref(),
         );
 
-        // Every surviving segment is read through the one byte path the
+        // Every surviving superfile is read through the one byte path the
         // FTS/vector resolve path uses: `superfile_reader(...)` ->
-        // `SuperfileReader::byte_source()`. Warm / mmap segments slice
-        // their resident bytes zero-copy; cold segments range-fetch from
+        // `SuperfileReader::byte_source()`. Warm / mmap superfiles slice
+        // their resident bytes zero-copy; cold superfiles range-fetch from
         // object storage through the same source. The provider never
         // branches on which — that distinction lives entirely inside the
         // byte source.
         let mut sources: HashMap<ObjPath, Arc<dyn LazyByteSource>> = HashMap::new();
 
-        // Per-segment scan inputs, resolved into PartitionedFiles once the
-        // store is built (row-group counts are read from each segment's
+        // Per-superfile scan inputs, resolved into PartitionedFiles once the
+        // store is built (row-group counts are read from each superfile's
         // footer through the same byte source).
-        struct SegmentScan {
+        struct SuperfileScan {
             path: ObjPath,
             size: u64,
             candidates: Option<RoaringBitmap>,
             tombstones: Arc<RoaringBitmap>,
         }
-        let mut segments: Vec<SegmentScan> = Vec::with_capacity(survivors.len());
+        let mut superfiles: Vec<SuperfileScan> = Vec::with_capacity(survivors.len());
 
         for entry in &survivors {
             let reader = crate::supertable::query::superfile_reader::superfile_reader(
@@ -369,17 +369,17 @@ impl TableProvider for SupertableProvider {
             .await
             .map_err(|e| DataFusionError::Execution(e.to_string()))?;
 
-            // Pass 1 (per segment): resolve candidate rows from the
-            // index. `None` => no usable bound, scan the segment.
+            // Pass 1 (per superfile): resolve candidate rows from the
+            // index. `None` => no usable bound, scan the superfile.
             //
             // Selectivity gate: estimate the match count from per-term
             // `df` first (cheap, header-only). If a predicate would match
-            // more than `PUSHDOWN_MAX_FRACTION` of this segment, skip the
+            // more than `PUSHDOWN_MAX_FRACTION` of this superfile, skip the
             // index path and let DataFusion scan: at that match density
             // the rows saturate the data pages, so an index `RowSelection`
             // can't skip any page and only adds posting-walk + selection
             // overhead. The floor keeps the pushdown active on small
-            // segments.
+            // superfiles.
             let est = candidate_plan
                 .estimate(reader.as_ref())
                 .await
@@ -395,7 +395,7 @@ impl TableProvider for SupertableProvider {
                     .map_err(|e| DataFusionError::Execution(e.to_string()))?
             };
 
-            // This segment's tombstoned rows (empty when no overlay).
+            // This superfile's tombstoned rows (empty when no overlay).
             let tombstones = match self.tombstone_cache.as_ref() {
                 Some(cache) => cache
                     .bitmap_for(entry.superfile_id, now)
@@ -407,7 +407,7 @@ impl TableProvider for SupertableProvider {
             let size = source.size();
             let path = ObjPath::from(entry.uri.storage_path());
             sources.insert(path.clone(), source);
-            segments.push(SegmentScan {
+            superfiles.push(SuperfileScan {
                 path,
                 size,
                 candidates,
@@ -418,12 +418,12 @@ impl TableProvider for SupertableProvider {
         // The single object store DataFusion reads every survivor through.
         let store: Arc<dyn OsObjectStore> = Arc::new(SuperfileObjectStore::from_sources(sources));
 
-        // Build each segment's PartitionedFile + access plan. Row-group
+        // Build each superfile's PartitionedFile + access plan. Row-group
         // counts come from the footer read through the same store: a
-        // zero-copy footer slice on warm/mmap segments, a small range GET
+        // zero-copy footer slice on warm/mmap superfiles, a small range GET
         // on cold ones.
-        let mut files: Vec<PartitionedFile> = Vec::with_capacity(segments.len());
-        for seg in &segments {
+        let mut files: Vec<PartitionedFile> = Vec::with_capacity(superfiles.len());
+        for seg in &superfiles {
             let row_counts =
                 row_group_rows_object_store(Arc::clone(&store), seg.path.clone(), Some(seg.size))
                     .await?;
@@ -442,7 +442,7 @@ impl TableProvider for SupertableProvider {
         // so the predicate columns are decoded first and only surviving
         // rows materialize.
         //
-        // When the index *did* bound the rows, the per-segment access plan
+        // When the index *did* bound the rows, the per-superfile access plan
         // already selects exactly the candidate rows and the `FilterExec`
         // above (filters are `Inexact`) verifies the exact predicate over
         // that tiny set. So we attach the pushdown predicate only on the
@@ -487,13 +487,13 @@ impl TableProvider for SupertableProvider {
     }
 }
 
-/// Build a [`ParquetAccessPlan`] that skips this segment's
+/// Build a [`ParquetAccessPlan`] that skips this superfile's
 /// tombstoned rows during decode, or `None` if none of the deleted
 /// `local_doc_id`s fall inside the file (so a plain full scan is
 /// correct and cheaper than attaching an all-`Scan` plan).
 ///
 /// `bitmap` holds the tombstoned `local_doc_id`s, where a row's
-/// `local_doc_id` is its 0-based global position within the segment's
+/// `local_doc_id` is its 0-based global position within the superfile's
 /// Parquet body (row groups are laid out in append order, so global
 /// position partitions contiguously across them). For each row group
 /// we translate the deleted positions into a [`RowSelection`] of
@@ -502,7 +502,7 @@ impl TableProvider for SupertableProvider {
 ///
 /// Parsing the footer via [`ParquetRecordBatchReaderBuilder`] only
 /// touches metadata, not column data, and only happens when the
-/// segment actually has tombstones — clean tables pay nothing.
+/// superfile actually has tombstones — clean tables pay nothing.
 /// Byte-sourced wrapper over [`tombstone_access_plan_from_counts`]. The
 /// scan paths call the counts core directly via [`build_access_plan`];
 /// this wrapper serves callers that hold the raw Parquet bytes — the
@@ -521,7 +521,7 @@ pub(crate) fn tombstone_access_plan(
 
 /// Counts-based core of [`tombstone_access_plan`]: `row_counts[i]` is the
 /// row count of row group `i`. Lets the object-store scan path build the
-/// plan from a lazily-fetched footer (no whole-segment bytes).
+/// plan from a lazily-fetched footer (no whole-superfile bytes).
 fn tombstone_access_plan_from_counts(
     row_counts: &[u32],
     bitmap: &RoaringBitmap,
@@ -606,7 +606,7 @@ async fn row_group_rows_object_store(
 
     let mut object_reader = ParquetObjectReader::new(store, path);
     if let Some(size) = file_size.filter(|&s| s > 0) {
-        // Skip an extra HEAD when the manifest already knows segment size.
+        // Skip an extra HEAD when the manifest already knows superfile size.
         object_reader = object_reader.with_file_size(size);
     }
     let builder = ParquetRecordBatchStreamBuilder::new(object_reader)
@@ -620,7 +620,7 @@ async fn row_group_rows_object_store(
         .collect())
 }
 
-/// Assemble the per-segment [`ParquetAccessPlan`] from row-group counts:
+/// Assemble the per-superfile [`ParquetAccessPlan`] from row-group counts:
 /// index candidates (minus tombstones) drive a selection plan; otherwise
 /// tombstones alone drive a delete-skip plan; a clean full scan is `None`.
 fn build_access_plan(
@@ -649,14 +649,14 @@ fn build_access_plan(
 /// plan. Used for index-driven row selection: the candidate planner
 /// yields a small set of `local_doc_id`s (already minus tombstones),
 /// and we want the Parquet reader to materialize the payload columns
-/// for just those rows rather than scanning the segment.
+/// for just those rows rather than scanning the superfile.
 ///
 /// `keep`'s ids are `local_doc_id`s - global row positions in the
 /// Parquet body - which partition contiguously across row groups laid
 /// out in append order. An empty `keep` produces an all-skip plan (zero
-/// rows decoded), the correct result for a segment with no candidate.
+/// rows decoded), the correct result for a superfile with no candidate.
 /// `row_counts[i]` is the row count of row group `i`, read from the
-/// segment footer through the unified store via [`build_access_plan`].
+/// superfile footer through the unified store via [`build_access_plan`].
 fn selection_access_plan_from_counts(
     row_counts: &[u32],
     keep: &RoaringBitmap,
@@ -713,7 +713,7 @@ fn selection_access_plan_from_counts(
 }
 
 /// Lower a conjunction of DataFusion filter `Expr`s into infino's
-/// [`ScalarPredicate`]s for segment skip.
+/// [`ScalarPredicate`]s for superfile skip.
 ///
 /// Each top-level filter is treated as a conjunct; nested `AND`s
 /// are flattened. Only `column <op> literal` (and the mirrored
@@ -1003,10 +1003,10 @@ mod tests {
         assert!(preds.is_empty());
     }
 
-    // ---- Segment-prune contrast: index helps vs. doesn't ----------
+    // ---- Superfile-prune contrast: index helps vs. doesn't ----------
     //
-    // End-to-end through a real multi-segment supertable: count how many
-    // segments survive the scan's prune for different predicates. This
+    // End-to-end through a real multi-superfile supertable: count how many
+    // superfiles survive the scan's prune for different predicates. This
     // is the observable proof that the embedded FTS index prunes more
     // than the scalar min/max a plain Parquet scan relies on — and,
     // honestly, where it doesn't (full scans, non-FTS predicates).
@@ -1019,8 +1019,8 @@ mod tests {
     }
 
     fn cat_title_opts() -> SupertableOptions {
-        // One writer thread → one segment per commit (deterministic
-        // segment counts).
+        // One writer thread → one superfile per commit (deterministic
+        // superfile counts).
         let pool = Arc::new(
             rayon::ThreadPoolBuilder::new()
                 .num_threads(1)
@@ -1051,12 +1051,12 @@ mod tests {
     }
 
     #[test]
-    fn segment_prune_index_helps_vs_does_not() {
+    fn superfile_prune_index_helps_vs_does_not() {
         let st = Supertable::create(cat_title_opts()).expect("create");
         let mut w = st.writer().expect("writer");
-        // Three segments. Every segment's `title` lexicographic range
+        // Three superfiles. Every superfile's `title` lexicographic range
         // spans "mango", so scalar min/max can prune none of them — but
-        // only the middle segment actually holds the token.
+        // only the middle superfile actually holds the token.
         w.append(&cat_title_batch(&["lang", "lang"], &["aardvark", "zebra"]))
             .expect("a1");
         w.commit().expect("c1");
@@ -1081,28 +1081,28 @@ mod tests {
             .build()
             .expect("rt");
 
-        // Index HELPS: the term bloom prunes the two wide-range segments
+        // Index HELPS: the term bloom prunes the two wide-range superfiles
         // that min/max could not, leaving only the real holder.
         assert_eq!(
-            rt.block_on(provider.surviving_segment_count(&[col("title").eq(lit("mango"))])),
+            rt.block_on(provider.surviving_superfile_count(&[col("title").eq(lit("mango"))])),
             1,
             "FTS bloom prunes to the single token holder"
         );
 
-        // Index can't help a full scan — every segment is read.
+        // Index can't help a full scan — every superfile is read.
         assert_eq!(
-            rt.block_on(provider.surviving_segment_count(&[])),
+            rt.block_on(provider.surviving_superfile_count(&[])),
             3,
             "no predicate → full scan, nothing pruned"
         );
 
-        // Non-FTS predicate present in every segment: no bloom to use,
+        // Non-FTS predicate present in every superfile: no bloom to use,
         // and min/max can't prune (all categories equal) → nothing
         // pruned. This is the honest "index doesn't help" case.
         assert_eq!(
-            rt.block_on(provider.surviving_segment_count(&[col("category").eq(lit("lang"))])),
+            rt.block_on(provider.surviving_superfile_count(&[col("category").eq(lit("lang"))])),
             3,
-            "non-FTS predicate matching all segments prunes nothing"
+            "non-FTS predicate matching all superfiles prunes nothing"
         );
     }
 }

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Unified segment-selection (pruning) for the boolean-predicate
+//! Unified superfile-selection (pruning) for the boolean-predicate
 //! query paths.
 //!
 //! FTS (exact + prefix) and SQL scalar filtering ask the *same*
-//! question before they touch any segment bytes: "which segments could
+//! question before they touch any superfile bytes: "which superfiles could
 //! possibly contain a row this predicate matches?" Each answers it by
 //! conservatively evaluating a per-column test against the manifest's
 //! summaries — term bloom, term range, scalar min/max — first over the
-//! list's part-level aggregates, then over the surviving segments'
-//! per-segment summaries.
+//! list's part-level aggregates, then over the surviving superfiles'
+//! per-superfile summaries.
 //!
 //! This module owns that two-tier walk so the three call sites
 //! (`bm25_search`, `bm25_search_prefix`, the SQL `SupertableProvider`)
 //! share one selection path instead of each re-deriving it. The
 //! per-leaf math is **not** reimplemented here: each [`PruneLeaf`]
-//! delegates to the existing helpers in [`super::skip`] (segment tier)
+//! delegates to the existing helpers in [`super::skip`] (superfile tier)
 //! and [`crate::supertable::manifest::list_prune`] (part tier), so edge
 //! behavior — empty-term handling, missing-column "always keep",
 //! conservatism — is inherited verbatim.
@@ -48,10 +48,10 @@ use super::skip::{
 
 /// One conjunct of a prune predicate: a per-column test backed by a
 /// manifest summary. The full predicate is the **conjunction** of its
-/// leaves — a segment survives only if every leaf keeps it. (A
+/// leaves — a superfile survives only if every leaf keeps it. (A
 /// `TermPresence` leaf carries its own intra-leaf OR/AND over terms via
 /// [`BoolMode`]; cross-column OR isn't expressible yet and isn't needed
-/// — an unprunable predicate simply contributes no leaf and the segment
+/// — an unprunable predicate simply contributes no leaf and the superfile
 /// is kept.)
 pub(crate) enum PruneLeaf {
     /// Exact-term presence on an FTS column → term bloom.
@@ -93,7 +93,7 @@ impl PruneLeaf {
 ///
 /// The aggregate min/max live as length-1 Arrow IPC batches
 /// (`ScalarStatsAgg.{min,max}`); we decode them and reuse the same
-/// comparison core the segment tier uses ([`scalar_value_may_match`]).
+/// comparison core the superfile tier uses ([`scalar_value_may_match`]).
 fn scalar_keep_parts(list: &ManifestList, pred: &ScalarPredicate) -> Vec<PartId> {
     list.parts
         .iter()
@@ -132,19 +132,19 @@ fn decode_length1_scalar(bytes: &[u8]) -> Option<ScalarValue> {
     None
 }
 
-/// Select the segments a predicate could match, newest-first in
+/// Select the superfiles a predicate could match, newest-first in
 /// manifest order, applying the two prune tiers (part aggregates →
-/// per-segment summaries). Returns the surviving segment entries; the
+/// per-superfile summaries). Returns the surviving superfile entries; the
 /// caller drives execution over them (search fan-out or DataFusion
 /// scan).
 ///
-/// An empty `leaves` slice keeps every segment (the no-`WHERE` scan).
-pub(crate) async fn select_segments(
+/// An empty `leaves` slice keeps every superfile (the no-`WHERE` scan).
+pub(crate) async fn select_superfiles(
     manifest: &Manifest,
     leaves: &[PruneLeaf],
 ) -> Result<Vec<Arc<SuperfileEntry>>, QueryError> {
     // ---- Tier A: part-level prune (only when a hierarchical list
-    // exists; otherwise the flat segment view is the whole table).
+    // exists; otherwise the flat superfile view is the whole table).
     let superfiles: Vec<Arc<SuperfileEntry>> = match manifest.list.as_ref() {
         Some(list) => {
             // Intersect each constraining leaf's kept-part set. A leaf
@@ -171,14 +171,14 @@ pub(crate) async fn select_segments(
             };
             hierarchical_iter::load_and_flatten(manifest, &ordered).await?
         }
-        None => hierarchical_iter::fallback_to_flat_segments(manifest),
+        None => hierarchical_iter::fallback_to_flat_superfiles(manifest),
     };
 
     if superfiles.is_empty() {
         return Ok(Vec::new());
     }
 
-    // ---- Tier B: per-segment prune. Start all-keep, AND each leaf's
+    // ---- Tier B: per-superfile prune. Start all-keep, AND each leaf's
     // mask. Scalar leaves are evaluated together (one `scalar_skip`
     // conjunction call) to match the pre-unification semantics.
     let mut mask = vec![true; superfiles.len()];
@@ -223,7 +223,7 @@ pub(crate) async fn select_segments(
 }
 
 /// Element-wise `dst &= src`. Both slices are one bool per surviving
-/// segment, in the same order, so the index alignment holds.
+/// superfile, in the same order, so the index alignment holds.
 fn and_into(dst: &mut [bool], src: &[bool]) {
     debug_assert_eq!(dst.len(), src.len());
     for (d, s) in dst.iter_mut().zip(src.iter()) {
@@ -373,7 +373,7 @@ mod tests {
         )
     }
 
-    /// A single segment whose `title` column carries both the scalar
+    /// A single superfile whose `title` column carries both the scalar
     /// min/max (what a plain Parquet reader exposes) and an FTS term
     /// bloom + range (what infino adds). Each title is treated as one
     /// token, so the bloom is exact membership over the title values.
@@ -422,16 +422,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fts_bloom_prunes_segment_that_scalar_minmax_cannot() {
-        // Pathology: a segment whose title values straddle the queried
+    async fn fts_bloom_prunes_superfile_that_scalar_minmax_cannot() {
+        // Pathology: a superfile whose title values straddle the queried
         // value lexicographically, so the scalar [min,max] (the only
         // signal a plain Parquet+DataFusion scan has) can't rule it out
-        // — yet the segment provably does not contain the value.
+        // — yet the superfile provably does not contain the value.
         //
-        // Segment A: {apple, zebra} → range ["apple","zebra"] spans
+        // Superfile A: {apple, zebra} → range ["apple","zebra"] spans
         //   "mango", so scalar min/max keeps it; its term bloom lacks
         //   "mango".
-        // Segment B: {kiwi, mango} → actually contains "mango".
+        // Superfile B: {kiwi, mango} → actually contains "mango".
         let a = seg_title(&["apple", "zebra"]);
         let b = seg_title(&["kiwi", "mango"]);
         let manifest = Manifest::empty(opts_title_fts()).with_appended(vec![a.clone(), b.clone()]);
@@ -448,37 +448,37 @@ mod tests {
         };
 
         // DataFusion-equivalent: scalar min/max only. "mango" is within
-        // both segments' lexicographic ranges, so neither is pruned.
-        let scalar_only = select_segments(&manifest, std::slice::from_ref(&scalar_leaf))
+        // both superfiles' lexicographic ranges, so neither is pruned.
+        let scalar_only = select_superfiles(&manifest, std::slice::from_ref(&scalar_leaf))
             .await
             .expect("select");
         assert_eq!(
             scalar_only.len(),
             2,
-            "scalar min/max alone cannot prune either segment"
+            "scalar min/max alone cannot prune either superfile"
         );
 
-        // infino's term bloom proves "mango" absent from segment A and
-        // prunes it; only the segment that can actually match remains.
-        let with_fts = select_segments(&manifest, &[scalar_leaf, term_leaf])
+        // infino's term bloom proves "mango" absent from superfile A and
+        // prunes it; only the superfile that can actually match remains.
+        let with_fts = select_superfiles(&manifest, &[scalar_leaf, term_leaf])
             .await
             .expect("select");
         let kept: Vec<_> = with_fts.iter().map(|e| e.superfile_id).collect();
         assert_eq!(
             kept,
             vec![b.superfile_id],
-            "FTS bloom prunes the segment plain min/max could not, keeping only the real match"
+            "FTS bloom prunes the superfile plain min/max could not, keeping only the real match"
         );
     }
 
     // ---- Unified-substrate coverage across leaf modes -------------
     //
-    // These drive `select_segments` (the path SQL + FTS share) on a
-    // flat (no-list) manifest, so they exercise the segment tier + the
+    // These drive `select_superfiles` (the path SQL + FTS share) on a
+    // flat (no-list) manifest, so they exercise the superfile tier + the
     // AND-combination of leaves. Part-tier behavior is covered directly
     // by the `scalar_keep_parts` tests above and the `list_prune` suite.
 
-    /// Segment carrying both a scalar min/max (what a plain Parquet
+    /// Superfile carrying both a scalar min/max (what a plain Parquet
     /// reader exposes) and an FTS term bloom + range (what infino adds)
     /// for the `title` column. `bloom_tokens` are inserted as exact
     /// terms; the term range is their lex span.
@@ -535,7 +535,7 @@ mod tests {
     }
 
     async fn ids(m: &Manifest, leaves: &[PruneLeaf]) -> Vec<Uuid> {
-        select_segments(m, leaves)
+        select_superfiles(m, leaves)
             .await
             .expect("select")
             .iter()
@@ -573,7 +573,7 @@ mod tests {
     #[tokio::test]
     async fn multi_token_equality_prunes_when_any_token_absent() {
         // `title = 'rust async'`: the literal tokenizes to {rust,async}.
-        // Segment has 'rust' but not 'async', and its lex range spans
+        // Superfile has 'rust' but not 'async', and its lex range spans
         // the literal — so min/max keeps it, the AND-bloom prunes it.
         let a = seg("a", "z", &["rust", "tokio"]);
         let m = manifest(vec![a.clone()]);
@@ -591,14 +591,14 @@ mod tests {
             )
             .await
             .is_empty(),
-            "AND-bloom prunes a segment missing one of the literal's tokens"
+            "AND-bloom prunes a superfile missing one of the literal's tokens"
         );
     }
 
     #[tokio::test]
-    async fn bloom_keeps_only_the_token_holder_across_many_wide_segments() {
-        // Four segments whose scalar ranges all span "mango", plus the
-        // one segment that holds it. Plain min/max prunes none; the
+    async fn bloom_keeps_only_the_token_holder_across_many_wide_superfiles() {
+        // Four superfiles whose scalar ranges all span "mango", plus the
+        // one superfile that holds it. Plain min/max prunes none; the
         // bloom isolates the single holder.
         let s1 = seg("a", "z", &["alpha", "omega"]);
         let s2 = seg("a", "z", &["beta", "gamma"]);
@@ -608,7 +608,7 @@ mod tests {
         assert_eq!(
             ids(&m, &[eq("title", "mango")]).await.len(),
             4,
-            "min/max cannot prune any wide-range segment"
+            "min/max cannot prune any wide-range superfile"
         );
         assert_eq!(
             ids(
@@ -620,7 +620,7 @@ mod tests {
             )
             .await,
             vec![hit.superfile_id],
-            "bloom keeps exactly the segment that holds the token"
+            "bloom keeps exactly the superfile that holds the token"
         );
     }
 
@@ -647,7 +647,7 @@ mod tests {
         assert_eq!(
             ids(&m, &[term("title", &["alpha", "missing"], BoolMode::Or)]).await,
             vec![a.superfile_id],
-            "OR keeps a segment with any matching term, prunes one with none"
+            "OR keeps a superfile with any matching term, prunes one with none"
         );
     }
 
@@ -673,7 +673,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_predicate_keeps_all_segments() {
+    async fn empty_predicate_keeps_all_superfiles() {
         let m = manifest(vec![seg("a", "b", &[]), seg("c", "d", &[])]);
         assert_eq!(ids(&m, &[]).await.len(), 2, "no leaves → full scan");
     }
@@ -687,17 +687,17 @@ mod tests {
         assert_eq!(
             ids(&m, &[eq("missing", "v")]).await,
             vec![a.superfile_id],
-            "scalar on a column with no stats keeps the segment"
+            "scalar on a column with no stats keeps the superfile"
         );
         assert_eq!(
             ids(&m, &[term("missing", &["v"], BoolMode::And)]).await,
             vec![a.superfile_id],
-            "term presence on a column with no FTS summary keeps the segment"
+            "term presence on a column with no FTS summary keeps the superfile"
         );
     }
 
     #[tokio::test]
-    async fn segment_holding_all_tokens_is_never_dropped() {
+    async fn superfile_holding_all_tokens_is_never_dropped() {
         let a = seg("a", "z", &["rust", "async", "tokio"]);
         let m = manifest(vec![a.clone()]);
         assert_eq!(
@@ -710,7 +710,7 @@ mod tests {
             )
             .await,
             vec![a.superfile_id],
-            "a segment whose terms cover the literal is always kept"
+            "a superfile whose terms cover the literal is always kept"
         );
     }
 }

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -4,13 +4,13 @@
 //! Manifest-level skip pruning helpers.
 //!
 //! Each helper takes a pinned [`Manifest`] snapshot plus a query
-//! shape and returns a `Vec<bool>` mask — one slot per segment, in
+//! shape and returns a `Vec<bool>` mask — one slot per superfile, in
 //! manifest order — where `true` means "keep" and `false` means
 //! "prune".  The masks are pure functions of manifest metadata
 //! ([`SuperfileEntry::scalar_stats`], [`SuperfileEntry::fts_summary`],
 //! [`SuperfileEntry::vector_summary`]) — **no store calls**.
 //! Pruned superfiles are dropped before the query layer issues any
-//! per-segment work, so an irrelevant segment never causes a
+//! per-superfile work, so an irrelevant superfile never causes a
 //! `SuperfileReaderCache::reader` call (the load-bearing perf claim of
 //! the skip layer).
 //!
@@ -21,15 +21,15 @@
 //!
 //! ## Conservatism
 //!
-//! All helpers err on the side of keeping a segment when in
+//! All helpers err on the side of keeping a superfile when in
 //! doubt:
 //!
-//! - Unknown column → keep all (per-segment search will surface
+//! - Unknown column → keep all (per-superfile search will surface
 //!   the column-missing error to the caller).
 //! - All-zero or absent summary → keep (treat as "may match").
 //! - Empty query (no terms / `prefix == ""`) → keep all.
 //!
-//! False-positive keeps cost a per-segment search call but never
+//! False-positive keeps cost a per-superfile search call but never
 //! a wrong answer. False-negative prunes would silently drop
 //! relevant docs and are forbidden.
 //!
@@ -37,7 +37,7 @@
 //!
 //! Conservative pre-cutoff pruning is hard for IVF vectors
 //! because we don't know the global top-k cutoff distance until
-//! at least one segment has been searched. v1
+//! at least one superfile has been searched. v1
 //! [`vector_centroid_skip`] returns all-keep and exposes
 //! [`superfiles_sorted_by_centroid_distance`] so a future
 //! incremental top-k pruning layer has the ordering it needs
@@ -56,14 +56,14 @@ use crate::supertable::manifest::{Manifest, SuperfileEntry, term_range::prefix_o
 
 /// Bloom-skip mask for an exact-term BM25 search.
 ///
-/// For each segment, look up every tokenized query term in the
-/// segment's per-column term-presence bloom:
+/// For each superfile, look up every tokenized query term in the
+/// superfile's per-column term-presence bloom:
 ///
 /// - `BoolMode::Or`  — keep if **any** term is possibly-present
 ///   (a doc containing any term contributes a positive score).
 /// - `BoolMode::And` — keep if **all** terms are possibly-present
 ///   (a relevant doc must contain every term, so a single
-///   definitely-absent term prunes the whole segment).
+///   definitely-absent term prunes the whole superfile).
 ///
 /// `query_terms` are the terms after the same tokenizer used at
 /// index time. Per the v1 tokenizer (`AsciiLowerTokenizer`) that
@@ -100,10 +100,10 @@ pub fn fts_bloom_skip(
 
 /// Term-range skip mask for a prefix BM25 search.
 ///
-/// For each segment, check whether `[prefix, prefix_upper_bound)`
-/// overlaps the segment's lex term range
+/// For each superfile, check whether `[prefix, prefix_upper_bound)`
+/// overlaps the superfile's lex term range
 /// `[fts_summary.term_range.0, fts_summary.term_range.1]`. A
-/// non-overlapping segment cannot contain any term beginning with
+/// non-overlapping superfile cannot contain any term beginning with
 /// `prefix` and is pruned.
 ///
 /// `prefix` is the same lowercased byte sequence the prefix
@@ -127,7 +127,7 @@ pub fn fts_prefix_skip(
             Some(summary) => {
                 let (min_term, max_term) = &summary.term_range;
                 if min_term.is_empty() && max_term.is_empty() {
-                    // 0-term segment — bloom build also flags
+                    // 0-term superfile — bloom build also flags
                     // this; nothing matches. Prune.
                     return false;
                 }
@@ -156,9 +156,9 @@ pub fn vector_centroid_skip(manifest: &Manifest, _column: &str, _query: &[f32]) 
 }
 
 /// Indices into `manifest.superfiles` sorted ascending by the
-/// per-segment centroid's distance to `query` under `metric`.
+/// per-superfile centroid's distance to `query` under `metric`.
 ///
-/// Segments without a vector summary for `column` are sorted to
+/// Superfiles without a vector summary for `column` are sorted to
 /// the end (treated as worst-case). Used as a fan-out hint for
 /// vector search: searching closer-centroid superfiles first means
 /// later superfiles are likelier to be skippable once the running
@@ -184,8 +184,8 @@ pub fn superfiles_sorted_by_centroid_distance(
             _ => (i, f32::INFINITY),
         })
         .collect();
-    // pdqsort: per-query segment skip ordering. (segment_idx, dist)
-    // tuples are unique by segment_idx, so any tie-break is fine.
+    // pdqsort: per-query superfile skip ordering. (superfile_idx, dist)
+    // tuples are unique by superfile_idx, so any tie-break is fine.
     scored.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.into_iter().map(|(i, _)| i).collect()
 }
@@ -195,7 +195,7 @@ pub fn superfiles_sorted_by_centroid_distance(
 /// These mirror the SQL comparison operators the
 /// `SupertableProvider` lowers from a DataFusion `Expr` into
 /// infino's own predicate form. Any operator we can't normalize is
-/// simply never handed to [`scalar_skip`] — the segment is kept and
+/// simply never handed to [`scalar_skip`] — the superfile is kept and
 /// DataFusion's `FilterExec` still applies the predicate to rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScalarOp {
@@ -225,13 +225,13 @@ pub struct ScalarPredicate {
 /// Scalar-skip mask for a conjunction of `column <op> literal`
 /// predicates (a SQL `WHERE` of `AND`-ed simple comparisons).
 ///
-/// For each segment, consult the per-column min/max persisted in
-/// [`SuperfileEntry::scalar_stats`] and keep the segment unless
-/// some predicate *proves* no row in the segment can satisfy it.
+/// For each superfile, consult the per-column min/max persisted in
+/// [`SuperfileEntry::scalar_stats`] and keep the superfile unless
+/// some predicate *proves* no row in the superfile can satisfy it.
 /// Because the predicates are conjunctive, a single
-/// definitely-false predicate prunes the whole segment.
+/// definitely-false predicate prunes the whole superfile.
 ///
-/// Conservatism (never a false prune): a segment is kept when
+/// Conservatism (never a false prune): a superfile is kept when
 ///
 /// - the column has no persisted stats (the writer skips types
 ///   whose ordering isn't well-defined, and all-null columns),
@@ -239,12 +239,12 @@ pub struct ScalarPredicate {
 /// - the literal can't be coerced to the column's stat type, or
 /// - the values are otherwise incomparable.
 ///
-/// An empty predicate slice keeps every segment.
+/// An empty predicate slice keeps every superfile.
 ///
 /// This is the SQL-side sibling of [`fts_bloom_skip`] /
-/// [`fts_prefix_skip`]: **infino owns segment selection.**
-/// DataFusion only executes over the surviving segments (and does
-/// its own row-group/page pruning inside each Parquet segment).
+/// [`fts_prefix_skip`]: **infino owns superfile selection.**
+/// DataFusion only executes over the surviving superfiles (and does
+/// its own row-group/page pruning inside each Parquet superfile).
 pub fn scalar_skip(
     superfiles: &[Arc<SuperfileEntry>],
     predicates: &[ScalarPredicate],
@@ -254,14 +254,14 @@ pub fn scalar_skip(
     }
     superfiles
         .iter()
-        .map(|entry| predicates.iter().all(|p| segment_may_match(entry, p)))
+        .map(|entry| predicates.iter().all(|p| superfile_may_match(entry, p)))
         .collect()
 }
 
 /// Whether `entry` *could* contain a row satisfying `pred`, judged
-/// only from the segment's persisted min/max. Conservative: any
+/// only from the superfile's persisted min/max. Conservative: any
 /// uncertainty returns `true` (keep).
-fn segment_may_match(entry: &SuperfileEntry, pred: &ScalarPredicate) -> bool {
+fn superfile_may_match(entry: &SuperfileEntry, pred: &ScalarPredicate) -> bool {
     let Some((min_arr, max_arr)) = entry.scalar_stats.cols.get(&pred.column) else {
         // No stats for this column — can't prove irrelevance.
         return true;
@@ -276,7 +276,7 @@ fn segment_may_match(entry: &SuperfileEntry, pred: &ScalarPredicate) -> bool {
 }
 
 /// Conservative `min`/`max`-vs-`value` comparison core, shared by the
-/// segment tier ([`segment_may_match`]) and the part tier (the scalar
+/// superfile tier ([`superfile_may_match`]) and the part tier (the scalar
 /// part prune in [`crate::supertable::query::prune`]). Returns `true`
 /// (keep) on any uncertainty: null bounds, an un-coercible literal, or
 /// otherwise-incomparable values. Never a false prune.
@@ -305,7 +305,7 @@ pub(crate) fn scalar_value_may_match(
             (Some(lo), Some(hi)) => lo != Ordering::Less && hi != Ordering::Greater,
             _ => true,
         },
-        // prune only when the segment is a single constant == v
+        // prune only when the superfile is a single constant == v
         ScalarOp::NotEq => {
             let constant = min.partial_cmp(max) == Some(Ordering::Equal);
             let equals_v = cmp_v_min == Some(Ordering::Equal);
@@ -393,7 +393,7 @@ mod tests {
         )
     }
 
-    fn empty_segment() -> SuperfileEntry {
+    fn empty_superfile() -> SuperfileEntry {
         let uri = SuperfileUri::new_v4();
         SuperfileEntry {
             superfile_id: Uuid::new_v4(),
@@ -428,15 +428,19 @@ mod tests {
         (column.to_string(), summary)
     }
 
-    fn segment_with_terms(column: &str, terms: &[&str]) -> Arc<SuperfileEntry> {
-        let mut e = empty_segment();
+    fn superfile_with_terms(column: &str, terms: &[&str]) -> Arc<SuperfileEntry> {
+        let mut e = empty_superfile();
         let (k, v) = fts_summary_with(column, terms);
         e.fts_summary.insert(k, v);
         Arc::new(e)
     }
 
-    fn segment_with_centroid(column: &str, centroid: Vec<f32>, radius: f32) -> Arc<SuperfileEntry> {
-        let mut e = empty_segment();
+    fn superfile_with_centroid(
+        column: &str,
+        centroid: Vec<f32>,
+        radius: f32,
+    ) -> Arc<SuperfileEntry> {
+        let mut e = empty_superfile();
         e.vector_summary.insert(
             column.to_string(),
             VectorSummary {
@@ -462,28 +466,28 @@ mod tests {
     // ---- fts_bloom_skip ----------------------------------------------
 
     #[test]
-    fn bloom_skip_keeps_segments_with_any_query_term_in_or_mode() {
-        let s_a = segment_with_terms("title", &["alpha", "beta"]);
-        let s_b = segment_with_terms("title", &["gamma", "delta"]);
+    fn bloom_skip_keeps_superfiles_with_any_query_term_in_or_mode() {
+        let s_a = superfile_with_terms("title", &["alpha", "beta"]);
+        let s_b = superfile_with_terms("title", &["gamma", "delta"]);
         let m = manifest_with(opts_simple(), vec![s_a, s_b]);
         let mask = fts_bloom_skip(&m.superfiles, "title", &["alpha", "missing"], BoolMode::Or);
-        // Segment A has alpha → keep. Segment B has neither → prune.
+        // Superfile A has alpha → keep. Superfile B has neither → prune.
         assert_eq!(mask, vec![true, false]);
     }
 
     #[test]
     fn bloom_skip_requires_all_terms_present_in_and_mode() {
-        let s_a = segment_with_terms("title", &["alpha", "beta"]);
-        let s_b = segment_with_terms("title", &["alpha", "gamma"]);
+        let s_a = superfile_with_terms("title", &["alpha", "beta"]);
+        let s_b = superfile_with_terms("title", &["alpha", "gamma"]);
         let m = manifest_with(opts_simple(), vec![s_a, s_b]);
         let mask = fts_bloom_skip(&m.superfiles, "title", &["alpha", "beta"], BoolMode::And);
-        // Segment A has both. Segment B is missing 'beta' → prune.
+        // Superfile A has both. Superfile B is missing 'beta' → prune.
         assert_eq!(mask, vec![true, false]);
     }
 
     #[test]
     fn bloom_skip_unknown_column_keeps_all() {
-        let s = segment_with_terms("title", &["alpha"]);
+        let s = superfile_with_terms("title", &["alpha"]);
         let m = manifest_with(opts_simple(), vec![s]);
         let mask = fts_bloom_skip(&m.superfiles, "no_such_column", &["alpha"], BoolMode::Or);
         assert_eq!(mask, vec![true]);
@@ -491,14 +495,14 @@ mod tests {
 
     #[test]
     fn bloom_skip_empty_terms_keeps_all() {
-        let s = segment_with_terms("title", &["alpha"]);
+        let s = superfile_with_terms("title", &["alpha"]);
         let m = manifest_with(opts_simple(), vec![s]);
         let mask = fts_bloom_skip(&m.superfiles, "title", &[], BoolMode::Or);
         assert_eq!(mask, vec![true]);
     }
 
     #[test]
-    fn bloom_skip_with_no_segments_returns_empty_vec() {
+    fn bloom_skip_with_no_superfiles_returns_empty_vec() {
         let m = manifest_with(opts_simple(), vec![]);
         let mask = fts_bloom_skip(&m.superfiles, "title", &["alpha"], BoolMode::Or);
         assert!(mask.is_empty());
@@ -507,22 +511,22 @@ mod tests {
     // ---- fts_prefix_skip ---------------------------------------------
 
     #[test]
-    fn prefix_skip_prunes_segments_outside_prefix_range() {
-        // Segment A: terms in ['apple', 'banana'] → prefix "rust"
+    fn prefix_skip_prunes_superfiles_outside_prefix_range() {
+        // Superfile A: terms in ['apple', 'banana'] → prefix "rust"
         //            doesn't overlap.
-        // Segment B: terms in ['python', 'rust']  → prefix "rust"
+        // Superfile B: terms in ['python', 'rust']  → prefix "rust"
         //            overlaps the upper end.
-        let s_a = segment_with_terms("title", &["apple", "banana"]);
-        let s_b = segment_with_terms("title", &["python", "rust"]);
+        let s_a = superfile_with_terms("title", &["apple", "banana"]);
+        let s_b = superfile_with_terms("title", &["python", "rust"]);
         let m = manifest_with(opts_simple(), vec![s_a, s_b]);
         let mask = fts_prefix_skip(&m.superfiles, "title", b"rust");
         assert_eq!(mask, vec![false, true]);
     }
 
     #[test]
-    fn prefix_skip_keeps_segments_with_matching_prefix_inside_range() {
+    fn prefix_skip_keeps_superfiles_with_matching_prefix_inside_range() {
         // Terms ['rusting', 'rusty'] → prefix "rust" overlaps.
-        let s = segment_with_terms("title", &["rusting", "rusty"]);
+        let s = superfile_with_terms("title", &["rusting", "rusty"]);
         let m = manifest_with(opts_simple(), vec![s]);
         let mask = fts_prefix_skip(&m.superfiles, "title", b"rust");
         assert_eq!(mask, vec![true]);
@@ -530,7 +534,7 @@ mod tests {
 
     #[test]
     fn prefix_skip_empty_prefix_keeps_all() {
-        let s = segment_with_terms("title", &["alpha"]);
+        let s = superfile_with_terms("title", &["alpha"]);
         let m = manifest_with(opts_simple(), vec![s]);
         let mask = fts_prefix_skip(&m.superfiles, "title", b"");
         assert_eq!(mask, vec![true]);
@@ -538,19 +542,19 @@ mod tests {
 
     #[test]
     fn prefix_skip_unknown_column_keeps_all() {
-        let s = segment_with_terms("title", &["alpha"]);
+        let s = superfile_with_terms("title", &["alpha"]);
         let m = manifest_with(opts_simple(), vec![s]);
         let mask = fts_prefix_skip(&m.superfiles, "no_such_column", b"alp");
         assert_eq!(mask, vec![true]);
     }
 
     #[test]
-    fn prefix_skip_zero_term_segment_pruned() {
+    fn prefix_skip_zero_term_superfile_pruned() {
         // Empty term_range = no terms indexed. Prefix can't match.
-        let s = Arc::new(empty_segment());
+        let s = Arc::new(empty_superfile());
         let m = manifest_with(opts_simple(), vec![s]);
         let mask = fts_prefix_skip(&m.superfiles, "title", b"rust");
-        // No FTS summary on the segment → keep (column-missing
+        // No FTS summary on the superfile → keep (column-missing
         // path). Sanity: this is the "unknown column" path, not
         // the "0-term FTS column" path.
         assert_eq!(mask, vec![true]);
@@ -559,9 +563,9 @@ mod tests {
     // ---- vector_centroid_skip + ordering ------------------------------
 
     #[test]
-    fn vector_centroid_skip_v1_keeps_all_segments() {
-        let s_a = segment_with_centroid("emb", vec![0.0; 16], 0.5);
-        let s_b = segment_with_centroid("emb", vec![10.0; 16], 0.5);
+    fn vector_centroid_skip_v1_keeps_all_superfiles() {
+        let s_a = superfile_with_centroid("emb", vec![0.0; 16], 0.5);
+        let s_b = superfile_with_centroid("emb", vec![10.0; 16], 0.5);
         let m = manifest_with(opts_with_vector(), vec![s_a, s_b]);
         let q = vec![0.0f32; 16];
         let mask = vector_centroid_skip(&m, "emb", &q);
@@ -572,7 +576,7 @@ mod tests {
     fn superfiles_sorted_by_centroid_distance_orders_by_metric() {
         // L2-sq metric on simple 1-hot centroids.
         let opts = opts_with_vector();
-        let near = segment_with_centroid(
+        let near = superfile_with_centroid(
             "emb",
             {
                 let mut v = vec![0.0f32; 16];
@@ -581,7 +585,7 @@ mod tests {
             },
             0.0,
         );
-        let far = segment_with_centroid(
+        let far = superfile_with_centroid(
             "emb",
             {
                 let mut v = vec![0.0f32; 16];
@@ -603,8 +607,8 @@ mod tests {
 
     #[test]
     fn superfiles_sorted_by_centroid_distance_pushes_missing_summary_to_end() {
-        let with_v = segment_with_centroid("emb", vec![1.0f32; 16], 0.0);
-        let without_v = Arc::new(empty_segment());
+        let with_v = superfile_with_centroid("emb", vec![1.0f32; 16], 0.0);
+        let without_v = Arc::new(empty_superfile());
         let m = manifest_with(opts_with_vector(), vec![without_v, with_v]);
         let q = vec![1.0f32; 16];
         let order = superfiles_sorted_by_centroid_distance(&m, "emb", &q, Metric::L2Sq);
@@ -615,7 +619,7 @@ mod tests {
     // ---- scalar_skip -------------------------------------------------
 
     fn seg_with_int_stats(col: &str, min: i64, max: i64) -> Arc<SuperfileEntry> {
-        let mut e = empty_segment();
+        let mut e = empty_superfile();
         let mn: ArrayRef = Arc::new(Int64Array::from(vec![min]));
         let mx: ArrayRef = Arc::new(Int64Array::from(vec![max]));
         e.scalar_stats.cols.insert(col.to_string(), (mn, mx));
@@ -623,7 +627,7 @@ mod tests {
     }
 
     fn seg_with_str_stats(col: &str, min: &str, max: &str) -> Arc<SuperfileEntry> {
-        let mut e = empty_segment();
+        let mut e = empty_superfile();
         let mn: ArrayRef = Arc::new(LargeStringArray::from(vec![min]));
         let mx: ArrayRef = Arc::new(LargeStringArray::from(vec![max]));
         e.scalar_stats.cols.insert(col.to_string(), (mn, mx));
@@ -648,7 +652,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_skip_eq_prunes_segments_whose_range_excludes_value() {
+    fn scalar_skip_eq_prunes_superfiles_whose_range_excludes_value() {
         let segs = vec![
             seg_with_int_stats("x", 0, 10),
             seg_with_int_stats("x", 100, 110),
@@ -755,8 +759,8 @@ mod tests {
     }
 
     #[test]
-    fn scalar_skip_null_stats_keeps_segment() {
-        let mut e = empty_segment();
+    fn scalar_skip_null_stats_keeps_superfile() {
+        let mut e = empty_superfile();
         let mn: ArrayRef = Arc::new(Int64Array::from(vec![None::<i64>]));
         let mx: ArrayRef = Arc::new(Int64Array::from(vec![None::<i64>]));
         e.scalar_stats.cols.insert("x".to_string(), (mn, mx));
@@ -769,10 +773,10 @@ mod tests {
     }
 
     #[test]
-    fn scalar_skip_not_eq_prunes_only_constant_segment() {
+    fn scalar_skip_not_eq_prunes_only_constant_superfile() {
         let segs = vec![seg_with_int_stats("x", 5, 5), seg_with_int_stats("x", 5, 9)];
-        // x != 5 → constant all-5 segment matches nothing → prune;
-        // the ranged segment is kept.
+        // x != 5 → constant all-5 superfile matches nothing → prune;
+        // the ranged superfile is kept.
         let mask = scalar_skip(
             &segs,
             &[pred("x", ScalarOp::NotEq, ScalarValue::Int64(Some(5)))],

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -27,12 +27,12 @@
 //! The provider's `scan` does the real work — see
 //! [`crate::supertable::query::provider`]. In short, it applies
 //! **two tiers of pruning**: infino's [`scalar_skip`] drops
-//! definitely-irrelevant *segments* from the pushed-down `WHERE`
+//! definitely-irrelevant *superfiles* from the pushed-down `WHERE`
 //! predicates, then DataFusion's `ParquetSource` prunes *row
 //! groups / pages* and pushes projection + limit into the Parquet
-//! reader over the surviving segments. This replaces the v1
+//! reader over the surviving superfiles. This replaces the v1
 //! `MemTable` path, which eagerly decoded every row group of every
-//! segment regardless of the query.
+//! superfile regardless of the query.
 //!
 //! [`scalar_skip`]: crate::supertable::query::skip::scalar_skip
 //! [`SupertableProvider`]: crate::supertable::query::provider::SupertableProvider
@@ -43,7 +43,7 @@
 //! contains id + scalar columns + FTS columns; vector columns are
 //! stored in the embedded vector blob and never exposed via SQL
 //! (callers reach them through `vector_search`). The parquet body
-//! of each segment was written with this same scalar schema, so
+//! of each superfile was written with this same scalar schema, so
 //! round-trip shape matches without projection or rewrite.
 
 use std::sync::Arc;
@@ -113,7 +113,7 @@ impl SupertableReader {
     /// `register_*` setup. Shared by [`query_sql`](Self::query_sql)
     /// (SQL string) and [`scan_ids_matching`](Self::scan_ids_matching)
     /// (programmatic `Expr`), so mutation id-capture gets the same
-    /// segment-skip + row-group/page pruning + lazy tombstone
+    /// superfile-skip + row-group/page pruning + lazy tombstone
     /// filtering the read path uses.
     ///
     /// Freshness policy is applied when the reader is created by
@@ -183,10 +183,10 @@ impl SupertableReader {
     /// Runs through the same pushdown-aware [`SupertableProvider`]
     /// as `query_sql` (via [`sql_session_context`](Self::sql_session_context)):
     /// `expr` is applied as a `DataFrame::filter` and the result
-    /// projected to just `_id`. Segment skip, row-group / page
+    /// projected to just `_id`. Superfile skip, row-group / page
     /// pruning, and lazy tombstone filtering all apply, so a
     /// large-table delete/update predicate never materializes every
-    /// segment into memory.
+    /// superfile into memory.
     ///
     /// Note: the resolution is against the **current** manifest
     /// snapshot, exactly like a contemporaneous `query_sql` would
@@ -312,7 +312,7 @@ mod tests {
 
     fn options_id_cat_title() -> SupertableOptions {
         // Single-threaded writer pool so each commit produces
-        // exactly one segment — keeps assertions on per-segment
+        // exactly one superfile — keeps assertions on per-superfile
         // counts deterministic.
         let pool = Arc::new(
             rayon::ThreadPoolBuilder::new()
@@ -459,7 +459,7 @@ mod tests {
     }
 
     #[test]
-    fn query_sql_scans_across_multiple_segments() {
+    fn query_sql_scans_across_multiple_superfiles() {
         // Three commits → three superfiles. SQL must aggregate across
         // all of them.
         let st = Supertable::create(options_id_cat_title()).expect("create");
@@ -487,10 +487,10 @@ mod tests {
     }
 
     #[test]
-    fn query_sql_equality_on_fts_column_across_segments_is_correct() {
+    fn query_sql_equality_on_fts_column_across_superfiles_is_correct() {
         // Equality on the FTS-indexed `title` column drives the new
         // term-bloom prune leaf (plus the scalar min/max leaf). The two
-        // segments whose bloom lacks "bravo" may be pruned, but the
+        // superfiles whose bloom lacks "bravo" may be pruned, but the
         // result must still be exactly the one matching row — proving
         // the bloom prune never drops a match.
         let st = Supertable::create(options_id_cat_title()).expect("create");
@@ -522,7 +522,7 @@ mod tests {
     #[test]
     fn query_sql_multiword_equality_on_fts_column_is_correct() {
         // Multi-word literal: the equality lowers to a `TermPresence`
-        // leaf over {rust, async, runtime} (AND). The second segment's
+        // leaf over {rust, async, runtime} (AND). The second superfile's
         // bloom lacks those tokens and is pruned, yet results are exact
         // — DataFusion's FilterExec re-applies the full string equality.
         let st = Supertable::create(options_id_cat_title()).expect("create");
@@ -542,7 +542,7 @@ mod tests {
             ),
             1
         );
-        // Tokens present in segment 1, but no row equals this exact
+        // Tokens present in superfile 1, but no row equals this exact
         // string — the prune is an optimization, correctness holds.
         assert_eq!(
             run_count(
@@ -557,7 +557,7 @@ mod tests {
     fn query_sql_fts_equality_superset_is_narrowed_to_exact_match() {
         // Index-driven row selection: the candidate plan resolves
         // `WHERE title = 'rust async'` to the term-AND posting set, which
-        // within one segment is a *superset* — both rows below contain
+        // within one superfile is a *superset* — both rows below contain
         // {rust, async}. The FilterExec above the scan must narrow that
         // candidate superset to the single exact-equality row, proving
         // the row-level prune never over-returns.
@@ -714,7 +714,7 @@ mod tests {
     }
 
     #[test]
-    fn query_sql_select_orders_ids_across_segments() {
+    fn query_sql_select_orders_ids_across_superfiles() {
         // Verifies row identity round-trips through MemTable +
         // DataFusion: rows planted across two superfiles come back
         // in monotonic _id order under ORDER BY. The _id values

--- a/src/supertable/query/superfile_reader.rs
+++ b/src/supertable/query/superfile_reader.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Tiered segment-bytes lookup.
+//! Tiered superfile-bytes lookup.
 //!
 //! [`superfile_reader`] is the single accessor the query paths
 //! (`bm25_search`, `vector_search`, `query_sql`) use to turn a
@@ -9,7 +9,7 @@
 //!
 //!   1. **In-memory tier first.** If `store.reader(uri)`
 //!      succeeds — i.e., this process's writer recently
-//!      published the segment and the bytes are still in
+//!      published the superfile and the bytes are still in
 //!      `InMemoryReaderCache` — return that reader. Fast
 //!      path; no syscalls.
 //!   2. **Disk cache fallback.** Miss in the in-memory tier
@@ -72,7 +72,7 @@ pub async fn superfile_reader(
     if let Some(cache) = disk_cache {
         match cache.reader_with_hints(uri, offsets).await {
             Ok(reader) => return Ok(reader),
-            // Cache can't admit this segment (e.g. it's larger than the
+            // Cache can't admit this superfile (e.g. it's larger than the
             // whole budget). Stream it directly via range GETs instead
             // of failing the query.
             Err(DiskCacheError::BudgetExceeded) => {

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -19,7 +19,7 @@
 //!
 //! Internally these drive the async kernel on the snapshot-pinned
 //! [`SupertableReader`], whose `vector_search` (rows) / `vector_hits`
-//! ([`SuperfileHit`], segment-local) methods are the engine-facing
+//! ([`SuperfileHit`], superfile-local) methods are the engine-facing
 //! surface. Results are sorted by distance *ascending* — smaller is
 //! closer (cosine: `1 - dot`, L2-sq: squared distance).
 //!
@@ -27,36 +27,36 @@
 //!
 //! Internally pins a snapshot reader and drives the async
 //! kernel to completion via the sync→async bridge. The reader
-//! holds a pinned `Arc<Manifest>`; for each visible segment we:
+//! holds a pinned `Arc<Manifest>`; for each visible superfile we:
 //!
-//!   1. Fetch the segment's `SuperfileReader` from the store.
+//!   1. Fetch the superfile's `SuperfileReader` from the store.
 //!   2. Delegate to `SuperfileReader::vector_search`
 //!      (cluster-aware IVF + 1-bit RaBitQ shortlist + full-precision
-//!      rerank, all inside one segment).
-//!   3. Tag each `(local_doc_id, distance)` with the segment URI.
+//!      rerank, all inside one superfile).
+//!   3. Tag each `(local_doc_id, distance)` with the superfile URI.
 //!   4. Concatenate across superfiles and global-top-k by distance.
 //!
 //! Unlike BM25, vector distances are inherently comparable across
 //! superfiles — both cosine and L2-sq are functions of the query
-//! and the per-doc vector only, not of segment-scoped statistics.
-//! So the per-segment top-k → concatenate → global top-k pattern
-//! recovers exact recall (modulo each per-segment IVF's nprobe-
+//! and the per-doc vector only, not of superfile-scoped statistics.
+//! So the per-superfile top-k → concatenate → global top-k pattern
+//! recovers exact recall (modulo each per-superfile IVF's nprobe-
 //! driven recall tradeoff, which is identical to the single-
 //! superfile case).
 //!
 //! Fan-out uses centroid pruning:
 //!
 //!   1. **Score & sort** — compute `distance(query, centroid)`
-//!      for each segment (SIMD-accelerated: AVX-512 / AVX2 /
-//!      NEON). Derive a lower bound per segment:
+//!      for each superfile (SIMD-accelerated: AVX-512 / AVX2 /
+//!      NEON). Derive a lower bound per superfile:
 //!      `max(0, centroid_dist − radius)`. Sort ascending.
 //!      This is free — centroids are manifest metadata, no
 //!      S3 GETs.
 //!   2. **Search closest** — search the top `k*2` (min 3)
-//!      segments in parallel (`tokio::spawn` per segment).
+//!      superfiles in parallel (`tokio::spawn` per superfile).
 //!      Merge results via bounded heap.
 //!
-//! Every skipped segment is a batch of GET requests the
+//! Every skipped superfile is a batch of GET requests the
 //! object-store-native engine never issues. For cold queries
 //! this is the difference between seconds and milliseconds.
 
@@ -75,9 +75,9 @@ use arrow::record_batch::RecordBatch;
 use super::SuperfileHit;
 use super::exec::common::resolve_hits_named;
 
-/// How to probe one segment in the vector fan-out: the globally-selected
-/// cluster ids for that segment, or — for a segment whose manifest
-/// summary carries no per-cluster centroids — a normal per-segment
+/// How to probe one superfile in the vector fan-out: the globally-selected
+/// cluster ids for that superfile, or — for a superfile whose manifest
+/// summary carries no per-cluster centroids — a normal per-superfile
 /// `nprobe` probe (fallback, never silently dropped).
 enum Probe {
     Clusters(Vec<u32>),
@@ -92,7 +92,7 @@ impl SupertableReader {
     /// `query` must match the column's declared `dim`.
     ///
     /// `options` (see [`VectorSearchOptions`]) controls per-
-    /// segment recall-vs-latency knobs (`nprobe`, `rerank_mult`).
+    /// superfile recall-vs-latency knobs (`nprobe`, `rerank_mult`).
     /// Defaults recover ≥0.9 recall@10 on typical IVF setups.
     ///
     /// Empty supertable (no superfiles) and `k == 0` short-circuit
@@ -127,7 +127,7 @@ impl SupertableReader {
                 )
                 .await?
             }
-            None => crate::supertable::query::hierarchical_iter::fallback_to_flat_segments(
+            None => crate::supertable::query::hierarchical_iter::fallback_to_flat_superfiles(
                 manifest.as_ref(),
             ),
         };
@@ -135,18 +135,18 @@ impl SupertableReader {
             return Ok(Vec::new());
         }
 
-        // ---- Global cross-segment cluster selection.
+        // ---- Global cross-superfile cluster selection.
         //
-        // Each kept segment's manifest summary carries its per-cluster
-        // (Sq8) centroids. Rank every (segment, cluster) by centroid
+        // Each kept superfile's manifest summary carries its per-cluster
+        // (Sq8) centroids. Rank every (superfile, cluster) by centroid
         // distance to the query and probe only the globally-closest
-        // clusters — so a query touches just the segments that own a
-        // near cluster, instead of running `nprobe` in every segment.
-        // (A single per-segment centroid can't do this: a time-ordered
-        // segment is a broad mix, so its mean sits near the global
+        // clusters — so a query touches just the superfiles that own a
+        // near cluster, instead of running `nprobe` in every superfile.
+        // (A single per-superfile centroid can't do this: a time-ordered
+        // superfile is a broad mix, so its mean sits near the global
         // centroid. Per-cluster centroids are fine-grained enough to
-        // rank.) A segment whose summary has no cluster centroids falls
-        // back to a normal per-segment `nprobe` probe — never dropped.
+        // rank.) A superfile whose summary has no cluster centroids falls
+        // back to a normal per-superfile `nprobe` probe — never dropped.
         let metric = manifest
             .options
             .vector_columns
@@ -174,10 +174,10 @@ impl SupertableReader {
             }
         }
 
-        // Global probe budget: the closest `nprobe × (eligible segments)`
-        // clusters — the same total probe count as the old per-segment
-        // `nprobe`, but selected globally, so near segments get more
-        // probes and far segments are skipped entirely. (Stage-4 recall
+        // Global probe budget: the closest `nprobe × (eligible superfiles)`
+        // clusters — the same total probe count as the old per-superfile
+        // `nprobe`, but selected globally, so near superfiles get more
+        // probes and far superfiles are skipped entirely. (Stage-4 recall
         // tuning may lower this.)
         let n_eligible = superfiles.len().saturating_sub(fallback.len());
         let budget = options
@@ -195,10 +195,10 @@ impl SupertableReader {
             per_seg.entry(si).or_default().push(c);
         }
 
-        // Build fan-out units: selected segments probe their chosen
-        // clusters; fallback segments probe `nprobe` normally; segments
+        // Build fan-out units: selected superfiles probe their chosen
+        // clusters; fallback superfiles probe `nprobe` normally; superfiles
         // with centroids but no globally-selected cluster are skipped
-        // (the cross-segment win).
+        // (the cross-superfile win).
         let fallback: std::collections::HashSet<usize> = fallback.into_iter().collect();
         let mut units: Vec<(Arc<SuperfileEntry>, Probe)> = Vec::new();
         for (si, entry) in superfiles.iter().enumerate() {
@@ -213,10 +213,10 @@ impl SupertableReader {
         }
 
         // Fan out through the shared [`query::dispatch::fanout`] (also
-        // used by FTS): one tokio task per probed segment opens the
-        // reader and runs the kNN kernel — cold GETs across segments are
+        // used by FTS): one tokio task per probed superfile opens the
+        // reader and runs the kNN kernel — cold GETs across superfiles are
         // concurrent (tokio owns I/O), shortlist + rerank stay on rayon.
-        // Skipped segments issue zero GETs.
+        // Skipped superfiles issue zero GETs.
         let column_arc = Arc::new(column.to_owned());
         let query_arc = Arc::new(query.to_vec());
         let kernel = move |reader: Arc<SuperfileReader>, probe: Probe| {
@@ -234,9 +234,9 @@ impl SupertableReader {
                 res.map_err(|e| QueryError::Parquet(e.to_string()))
             }
         };
-        let per_segment = crate::supertable::query::dispatch::fanout(self, units, kernel).await?;
+        let per_superfile = crate::supertable::query::dispatch::fanout(self, units, kernel).await?;
 
-        Ok(top_k_ascending(per_segment, k))
+        Ok(top_k_ascending(per_superfile, k))
     }
 }
 
@@ -286,11 +286,11 @@ impl SupertableReader {
     }
 }
 
-/// Merge per-segment hits and return the top-k by *ascending*
+/// Merge per-superfile hits and return the top-k by *ascending*
 /// distance (smallest = closest). Uses a max-heap of size k so
 /// we never sort more than k elements — O(S·k·log k) instead of
 /// O(S·k·log(S·k)) for the full-sort approach.
-fn top_k_ascending(per_segment: Vec<Vec<SuperfileHit>>, k: usize) -> Vec<SuperfileHit> {
+fn top_k_ascending(per_superfile: Vec<Vec<SuperfileHit>>, k: usize) -> Vec<SuperfileHit> {
     use std::cmp::Ordering;
     use std::collections::BinaryHeap;
 
@@ -312,7 +312,7 @@ fn top_k_ascending(per_segment: Vec<Vec<SuperfileHit>>, k: usize) -> Vec<Superfi
     }
 
     let mut heap = BinaryHeap::with_capacity(k + 1);
-    for hit in per_segment.into_iter().flatten() {
+    for hit in per_superfile.into_iter().flatten() {
         if heap.len() < k {
             heap.push(MaxByScore(hit));
         } else if let Some(worst) = heap.peek()
@@ -401,7 +401,7 @@ mod tests {
     use crate::test_helpers::default_tokenizer as tok;
 
     /// Drive an async future to completion on a throwaway current-thread
-    /// runtime. Used only for the single-segment `SuperfileReader`
+    /// runtime. Used only for the single-superfile `SuperfileReader`
     /// oracle, whose search surface is async-only; the supertable
     /// reader's own search methods are sync and need no runtime here.
     fn block_on<F: std::future::Future>(fut: F) -> F::Output {
@@ -429,7 +429,7 @@ mod tests {
         ]))
     }
 
-    fn options_one_segment_per_commit(dim: usize) -> SupertableOptions {
+    fn options_one_superfile_per_commit(dim: usize) -> SupertableOptions {
         let pool = Arc::new(
             rayon::ThreadPoolBuilder::new()
                 .num_threads(1)
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn vector_search_empty_supertable_returns_empty() {
-        let st = Supertable::create(options_one_segment_per_commit(16)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(16)).expect("create");
         let r = st.reader();
         let q = vec![0.1f32; 16];
         let hits = r
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn vector_search_k_zero_short_circuits() {
-        let st = Supertable::create(options_one_segment_per_commit(16)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(16)).expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
         w.append(&build_vector_batch(0, 8, 16, schema)).expect("a");
@@ -575,7 +575,7 @@ mod tests {
     #[test]
     fn vector_search_returns_ascending_distance_order() {
         let dim = 16;
-        let st = Supertable::create(options_one_segment_per_commit(dim)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
         w.append(&build_vector_batch(0, 8, dim, schema)).expect("a");
@@ -603,7 +603,7 @@ mod tests {
     #[test]
     fn vector_search_top_k_caps_at_k() {
         let dim = 16;
-        let st = Supertable::create(options_one_segment_per_commit(dim)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
         // Three commits → three superfiles × 8 docs = 24 docs.
@@ -622,15 +622,15 @@ mod tests {
 
     #[test]
     fn vector_search_global_selection_recovers_neighbors_under_low_budget() {
-        // 10 segments × 16 one-hot docs. Query e_0's true neighbors are
-        // the 10 docs with id % dim == 0 (one per segment) at cosine
+        // 10 superfiles × 16 one-hot docs. Query e_0's true neighbors are
+        // the 10 docs with id % dim == 0 (one per superfile) at cosine
         // distance 0; every other doc is orthogonal (distance 1). With
         // nprobe = 1 the global budget is only 10 clusters across all 10
-        // segments — so this exercises real cross-segment cluster
+        // superfiles — so this exercises real cross-superfile cluster
         // pruning (most of the 10 × n_cent clusters are skipped), and
         // recall@10 must still recover the concentrated neighbors.
         let dim = 16;
-        let st = Supertable::create(options_one_segment_per_commit(dim)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
         let n_seg = 10u64;
@@ -655,9 +655,9 @@ mod tests {
     }
 
     #[test]
-    fn vector_search_carries_segment_uris_for_multi_segment_results() {
+    fn vector_search_carries_superfile_uris_for_multi_superfile_results() {
         let dim = 16;
-        let st = Supertable::create(options_one_segment_per_commit(dim)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
         for chunk in 0..3u64 {
@@ -670,21 +670,22 @@ mod tests {
         let hits = r
             .vector_hits("emb", &q, 24, VectorSearchOptions::new())
             .expect("query");
-        let segment_uris: std::collections::HashSet<_> = hits.iter().map(|h| h.segment).collect();
+        let superfile_uris: std::collections::HashSet<_> =
+            hits.iter().map(|h| h.superfile).collect();
         // All three superfiles should contribute (high k pulls from
         // each).
-        assert_eq!(segment_uris.len(), 3);
+        assert_eq!(superfile_uris.len(), 3);
     }
 
     #[test]
     fn vector_search_oracle_top_k_set_matches_single_superfile() {
-        // Vector distances are segment-independent — cosine /
+        // Vector distances are superfile-independent — cosine /
         // L2-sq are functions of the query + per-doc vector only.
-        // So the per-segment-top-k → global-top-k pattern recovers
+        // So the per-superfile-top-k → global-top-k pattern recovers
         // the same set as a single-superfile search, modulo each
         // IVF's nprobe-driven recall (we use a high-recall config).
         let dim = 16;
-        let st = Supertable::create(options_one_segment_per_commit(dim)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
         // 24 docs across 3 superfiles.
@@ -705,7 +706,7 @@ mod tests {
         let mut q = vec![0.0f32; dim];
         q[0] = 1.0;
 
-        // The oracle is a single-segment `SuperfileReader` whose search
+        // The oracle is a single-superfile `SuperfileReader` whose search
         // is async-only; drive it on a throwaway runtime. The supertable
         // reader below uses its sync public API.
         let oracle_hits =
@@ -725,8 +726,8 @@ mod tests {
                 let seg_idx = manifest
                     .superfiles
                     .iter()
-                    .position(|e| e.uri == h.segment)
-                    .expect("segment in manifest");
+                    .position(|e| e.uri == h.superfile)
+                    .expect("superfile in manifest");
                 (seg_idx as u32) * 8 + h.local_doc_id
             })
             .collect();
@@ -737,7 +738,7 @@ mod tests {
     #[test]
     fn vector_search_unknown_column_errors() {
         let dim = 16;
-        let st = Supertable::create(options_one_segment_per_commit(dim)).expect("create");
+        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
         w.append(&build_vector_batch(0, 8, dim, schema)).expect("a");
@@ -810,7 +811,7 @@ mod tests {
         let entry = synthetic_entry(sf_id);
         let mut hits: Vec<SuperfileHit> = (0..8u32)
             .map(|d| SuperfileHit {
-                segment: entry.uri,
+                superfile: entry.uri,
                 local_doc_id: d,
                 score: d as f32,
             })
@@ -833,7 +834,7 @@ mod tests {
         let entry = synthetic_entry(Uuid::from_u128(0xABCD));
         let mut hits: Vec<SuperfileHit> = (0..4u32)
             .map(|d| SuperfileHit {
-                segment: entry.uri,
+                superfile: entry.uri,
                 local_doc_id: d,
                 score: 0.0,
             })
@@ -863,7 +864,7 @@ mod tests {
         let entry = synthetic_entry(Uuid::from_u128(0x1111));
         let mut hits: Vec<SuperfileHit> = (0..4u32)
             .map(|d| SuperfileHit {
-                segment: entry.uri,
+                superfile: entry.uri,
                 local_doc_id: d,
                 score: 0.0,
             })

--- a/src/supertable/reader_cache/config.rs
+++ b/src/supertable/reader_cache/config.rs
@@ -17,7 +17,7 @@ use crate::supertable::manifest::SuperfileUri;
 /// [`ColdFetchMode::HybridWithPrefetch`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ColdFetchMode {
-    /// Parallel range-GETs fan out over the segment; each
+    /// Parallel range-GETs fan out over the superfile; each
     /// response is Arc-cloned and tee'd to (a) the foreground
     /// caller (in-memory `SuperfileReader`) and (b) a
     /// fire-and-forget pwrite into the cache file. Foreground
@@ -40,8 +40,8 @@ pub enum ColdFetchMode {
     /// [`SuperfileReader::open_lazy`]-built reader over a
     /// [`StorageRangeSource`]; pays only the cold-open
     /// + cold-search byte budget against object storage
-    /// (~6 GETs / ~2-3 MiB on a typical 1.5 GiB segment).
-    /// A background task downloads the full segment to NVMe
+    /// (~6 GETs / ~2-3 MiB on a typical 1.5 GiB superfile).
+    /// A background task downloads the full superfile to NVMe
     /// after foreground lazy readers release, then mmaps it
     /// + replaces the cache entry;
     /// any subsequent `reader(uri)` call returns the
@@ -49,11 +49,11 @@ pub enum ColdFetchMode {
     /// **zero** S3 GETs.
     ///
     /// **Up to 2× bandwidth per cold miss** — foreground
-    /// per-query ranges and the eventual full-segment cache
+    /// per-query ranges and the eventual full-superfile cache
     /// fill both read from object storage, but the fill is
     /// deferred until the latency-critical foreground reader
     /// is dropped. The tradeoff: minimal cold-query latency
-    /// (one-segment hot working set fits in a few range-GETs)
+    /// (one-superfile hot working set fits in a few range-GETs)
     /// at the cost of extra cold-fetch bandwidth vs.
     /// `HybridWithPrefetch`.
     /// Pick this mode for object-storage-native deployments
@@ -71,7 +71,7 @@ pub enum ColdFetchMode {
 /// `DiskCacheSettings` from `Config`; one converts to the
 /// other at supertable construction).
 pub struct DiskCacheConfig {
-    /// Filesystem root for cached segment files. Created
+    /// Filesystem root for cached superfile files. Created
     /// (recursively) at `DiskCacheStore::new`.
     pub cache_root: PathBuf,
     /// Tier 1 size cap. Soft cap — exceeded transiently
@@ -88,11 +88,11 @@ pub struct DiskCacheConfig {
     /// product `cold_fetch_streams × cold_fetch_chunk_bytes`
     /// bounds peak in-flight memory per cold miss — the
     /// chunk size is fixed at this value regardless of
-    /// segment size, so a large segment fans out into more
+    /// superfile size, so a large superfile fans out into more
     /// chunks rather than inflating per-chunk memory.
     pub cold_fetch_chunk_bytes: u64,
-    /// Global cap on concurrent **background** segment fills
-    /// (the `LazyForegroundWithBackgroundFill` full-segment
+    /// Global cap on concurrent **background** superfile fills
+    /// (the `LazyForegroundWithBackgroundFill` full-superfile
     /// download). Each in-flight fill is itself bounded to
     /// `cold_fetch_streams × cold_fetch_chunk_bytes`, so the
     /// process-wide background-fill memory ceiling is
@@ -130,7 +130,7 @@ const DEFAULT_COLD_FETCH_STREAMS: usize = 16;
 /// Default range-GET chunk size (16 MiB); peak in-flight bytes is
 /// `streams × chunk`.
 const DEFAULT_COLD_FETCH_CHUNK_BYTES: u64 = 16 * (1 << 20);
-/// Default number of concurrent background full-segment fills.
+/// Default number of concurrent background full-superfile fills.
 const DEFAULT_PREFETCH_CONCURRENCY: usize = 8;
 /// Default idle age (seconds) before an mmap is `MADV_DONTNEED`-swept.
 const DEFAULT_MMAP_COLD_THRESHOLD_SECS: u64 = 300;

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -42,14 +42,14 @@ const VECTOR_OPEN_HEADER_FALLBACK_BYTES: u64 = 32;
 const FTS_OPEN_HEADER_FALLBACK_BYTES: u64 = 48;
 
 /// Poll cadence while waiting for another task to mmap-promote a
-/// segment. Short so the waiter picks up the promotion promptly
+/// superfile. Short so the waiter picks up the promotion promptly
 /// without busy-spinning.
 const MMAP_PROMOTION_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Yield cadence in the background-fill upgrade loop. Gives a
 /// short-lived caller (e.g. a cold benchmark with a fresh cache per
 /// iteration) a scheduling turn to drop the cache before a
-/// full-segment fill starts.
+/// full-superfile fill starts.
 const STORE_UPGRADE_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Errors surfaced by [`DiskCacheStore::reader`].
@@ -69,7 +69,7 @@ pub enum DiskCacheError {
     SuperfileOpenRead(#[from] crate::superfile::ReadError),
     /// Eviction couldn't free enough space because every
     /// cached entry was pinned (or there were no cached
-    /// entries and the incoming segment alone exceeds the
+    /// entries and the incoming superfile alone exceeds the
     /// disk budget). The query layer can fall back to a
     /// `RangeOnly` path on this error; the cache itself just
     /// surfaces it as a typed error.
@@ -130,7 +130,7 @@ pub struct CacheStats {
     pub n_madvise_calls: u64,
 }
 
-/// Pulls segment bytes through a [`StorageProvider`] and
+/// Pulls superfile bytes through a [`StorageProvider`] and
 /// caches them locally as mmap-backed `SuperfileReader`s.
 ///
 /// Construction is sync; `reader()` is async (cold fetches
@@ -166,7 +166,7 @@ pub struct DiskCacheStore {
     /// mutex and invoke it lock-free, so the mutex is held
     /// only for the Arc bump.
     pinned_fn: std::sync::Mutex<Arc<dyn Fn() -> HashSet<SuperfileUri> + Send + Sync>>,
-    /// Global cap on concurrent background segment fills. Each
+    /// Global cap on concurrent background superfile fills. Each
     /// background fill acquires one permit for its whole
     /// duration; foreground per-query range reads don't. Sized
     /// `config.prefetch_concurrency` at construction.
@@ -387,7 +387,7 @@ impl DiskCacheStore {
     /// `cached`.
     ///
     /// Used as the [`DiskCacheError::BudgetExceeded`] fallback —
-    /// e.g. a single segment larger than the whole cache budget.
+    /// e.g. a single superfile larger than the whole cache budget.
     /// The query still succeeds by issuing range GETs for only the
     /// bytes the reader touches; nothing is admitted, so there's
     /// nothing to evict.
@@ -412,7 +412,7 @@ impl DiskCacheStore {
         };
         // Range-only is also a lazy reader over object storage. A full CRC
         // scan here would turn a fallback path meant to issue targeted
-        // ranges into a whole-segment read.
+        // ranges into a whole-superfile read.
         let reader =
             SuperfileReader::open_lazy_with(range_src, OpenOptions { verify_crc: false }).await?;
         Ok(Arc::new(reader))
@@ -522,7 +522,7 @@ impl DiskCacheStore {
             tokio::time::sleep(MMAP_PROMOTION_POLL_INTERVAL).await;
         }
         Err(DiskCacheError::SuperfileOpen(format!(
-            "segment {uri:?} not mmap-promoted within {timeout:?}"
+            "superfile {uri:?} not mmap-promoted within {timeout:?}"
         )))
     }
 
@@ -660,7 +660,7 @@ impl DiskCacheStore {
     /// pre-populate the cache with the superfiles it just
     /// published, so the producer's next query on its own
     /// superfiles skips the cold-fetch wall-time hit (parallel
-    /// range-fetch + pwrite + mmap, ~50-150 ms per segment on
+    /// range-fetch + pwrite + mmap, ~50-150 ms per superfile on
     /// the laptop bench).
     ///
     /// Idempotent: if `uri` is already in the cache,
@@ -686,7 +686,7 @@ impl DiskCacheStore {
         // Idempotent: already-cached URIs are a no-op. The
         // writer may call this for superfiles a prior commit
         // already published (e.g., an OCC retry where the
-        // same UUID segment got re-inserted into the cache).
+        // same UUID superfile got re-inserted into the cache).
         if self.cached.contains_key(uri) {
             return Ok(());
         }
@@ -793,7 +793,7 @@ impl DiskCacheStore {
         self.config.cache_root.join(uri.cache_tmp_filename())
     }
 
-    /// The storage-side URI for a segment, mirroring the
+    /// The storage-side URI for a superfile, mirroring the
     /// writer's persist layout.
     fn storage_path(uri: &SuperfileUri) -> String {
         uri.storage_path()
@@ -963,7 +963,7 @@ impl DiskCacheStore {
     /// [`SuperfileReader::open_lazy`]-built reader over a
     /// [`crate::supertable::StorageRangeSource`]; spawns a
     /// background task that waits for foreground lazy readers
-    /// to release before fetching the full segment, mmap'ing
+    /// to release before fetching the full superfile, mmap'ing
     /// it, and replacing the cached entry. Subsequent
     /// `reader(uri)` calls return the mmap-backed reader (zero
     /// S3 GETs for any subsequent search).
@@ -1006,12 +1006,12 @@ impl DiskCacheStore {
     /// Lazy cold-fetch path. Foreground builds a reader via
     /// `SuperfileReader::open_lazy_with(StorageRangeSource)`;
     /// background task waits for foreground lazy readers to release,
-    /// then downloads the full segment to NVMe, mmaps it, and replaces
+    /// then downloads the full superfile to NVMe, mmaps it, and replaces
     /// the cache entry.
     ///
     /// If `offsets` is present, the lazy source starts with a known
-    /// segment size and an optional open-batch overlay:
-    ///   - with `open_blob`: zero segment-object GETs at open time,
+    /// superfile size and an optional open-batch overlay:
+    ///   - with `open_blob`: zero superfile-object GETs at open time,
     ///     because manifest-part fetch already carried the bytes.
     ///   - without `open_blob`: parquet tail + vector + FTS open ranges
     ///     are fetched in one parallel batch.
@@ -1073,7 +1073,7 @@ impl DiskCacheStore {
                 // The open-batch bytes (parquet tail + vector + FTS open
                 // ranges) already rode in with the manifest part GET that
                 // `cold_open` performed. Install them straight into the
-                // overlay: ZERO open-time GETs against the segment object.
+                // overlay: ZERO open-time GETs against the superfile object.
                 for (off, bytes) in &offsets.open_blob {
                     overlay.install(*off, Bytes::copy_from_slice(bytes));
                 }
@@ -1121,9 +1121,9 @@ impl DiskCacheStore {
             // vec subsection head, fts subsection) hits the overlay sync
             // when the open batch is present. Lazy opens intentionally
             // skip full CRC scans: verifying every subsection would force
-            // whole-segment range reads, defeating the lazy/open-batch
+            // whole-superfile range reads, defeating the lazy/open-batch
             // path. Eager cache promotion can still verify when it
-            // materializes the full segment.
+            // materializes the full superfile.
             let lazy_reader = SuperfileReader::open_lazy_with(
                 Arc::clone(&source),
                 OpenOptions { verify_crc: false },
@@ -1163,7 +1163,7 @@ impl DiskCacheStore {
         self.cached.insert(*uri, Arc::clone(&entry));
 
         // Background promotion waits until foreground lazy readers
-        // release before starting full-segment fetch, so cache fill
+        // release before starting full-superfile fetch, so cache fill
         // does not compete with query-critical range GETs.
         if !skip_background_fill() {
             let store = Arc::downgrade(self);
@@ -1345,7 +1345,7 @@ impl DiskCacheStore {
         let n_streams = self.config.cold_fetch_streams.max(1);
         // Fixed chunk size — do NOT scale with `size`. Peak
         // in-flight memory is `n_streams × chunk_size`
-        // regardless of segment size, because the per-fill
+        // regardless of superfile size, because the per-fill
         // semaphore below caps concurrent chunks at `n_streams`.
         let chunk_size = self.config.cold_fetch_chunk_bytes.max(1);
 
@@ -1573,7 +1573,7 @@ async fn wait_for_lazy_foreground_release(
         if reader.strong_count() <= 1 {
             // Give short-lived callers (notably cold benchmarks with a
             // fresh cache per iteration) a scheduling turn to drop the
-            // cache before we start a full-segment background fill.
+            // cache before we start a full-superfile background fill.
             tokio::time::sleep(STORE_UPGRADE_RETRY_INTERVAL).await;
             return store.upgrade();
         }
@@ -1607,8 +1607,8 @@ async fn cold_fetch_to_disk_cancelable(
     let mut next_chunk = 0u64;
     let mut in_flight = FuturesUnordered::new();
 
-    // Fetch the full segment in bounded chunks instead of a whole-object
-    // `get()`: large segments can be hundreds of MiB to many GiB, and
+    // Fetch the full superfile in bounded chunks instead of a whole-object
+    // `get()`: large superfiles can be hundreds of MiB to many GiB, and
     // materializing them as one `Bytes` would reintroduce the RSS spike
     // this disk-cache path is meant to avoid.
     loop {
@@ -1671,18 +1671,18 @@ fn rollback_lazy_background_fill(
 /// background promotion path for the
 /// `LazyForegroundWithBackgroundFill` cold-fetch mode.
 /// Waits for foreground lazy readers to release, downloads the
-/// full segment via cancelable parallel range-GETs to NVMe,
+/// full superfile via cancelable parallel range-GETs to NVMe,
 /// mmaps the resulting file, and atomically replaces the lazy
 /// cache entry with a mmap-backed reader. Subsequent
 /// `reader(uri)` calls hit the promoted entry — every query
 /// resolves from mmap (zero S3 GETs).
 /// Diagnostic gate for the `LazyForegroundWithBackgroundFill`
-/// full-segment promotion. When `INFINO_DISABLE_BG_FILL=1` (or
+/// full-superfile promotion. When `INFINO_DISABLE_BG_FILL=1` (or
 /// `true`), the cold-fetch path installs the open-blob overlay
 /// and serves the foreground query over range GETs, but never
-/// spawns the full-segment background download. Lets us measure
+/// spawns the full-superfile background download. Lets us measure
 /// the cold fan-out cost in isolation from the competing
-/// full-segment fills.
+/// full-superfile fills.
 pub(crate) fn skip_background_fill() -> bool {
     static SKIP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *SKIP.get_or_init(|| {

--- a/src/supertable/reader_cache/in_memory.rs
+++ b/src/supertable/reader_cache/in_memory.rs
@@ -3,9 +3,9 @@
 
 //! In-memory reader cache.
 //!
-//! Holds every inserted segment's bytes in RAM for the
+//! Holds every inserted superfile's bytes in RAM for the
 //! supertable's lifetime. No eviction — total RAM is the sum of
-//! every published segment's bytes. Suitable for the in-memory
+//! every published superfile's bytes. Suitable for the in-memory
 //! supertable shape; not for corpora that exceed the host's RAM
 //! budget.
 //!
@@ -45,7 +45,7 @@ struct Entry {
     reader: Arc<SuperfileReader>,
 }
 
-/// `RwLock<HashMap<SuperfileUri, Entry>>`-backed segment store.
+/// `RwLock<HashMap<SuperfileUri, Entry>>`-backed superfile store.
 ///
 /// Cheap to clone *as `Arc<dyn SuperfileReaderCache>`* — but `Clone` is
 /// not implemented directly because cloning the inner map (vs the
@@ -236,7 +236,7 @@ mod tests {
         store.insert(uri, bytes.clone()).expect("idempotent insert");
         let r2 = store.reader(&uri).expect("second reader");
 
-        assert_eq!(store.n_superfiles(), 1, "still one segment");
+        assert_eq!(store.n_superfiles(), 1, "still one superfile");
         assert_eq!(
             store.resident_bytes(),
             bytes_after_first,
@@ -247,10 +247,10 @@ mod tests {
         assert!(Arc::ptr_eq(&r1, &r2));
     }
 
-    // ---- multi-segment accounting --------------------------------------
+    // ---- multi-superfile accounting --------------------------------------
 
     #[test]
-    fn resident_bytes_sums_across_segments() {
+    fn resident_bytes_sums_across_superfiles() {
         let store = InMemoryReaderCache::new();
         let bytes_a = minimal_superfile_bytes();
         let bytes_b = minimal_superfile_bytes();
@@ -360,7 +360,7 @@ mod tests {
         // proportionally.
         let resident = store.resident_bytes();
         assert!(resident > 0);
-        // Each segment is the same size (minimal_superfile_bytes
+        // Each superfile is the same size (minimal_superfile_bytes
         // is deterministic).
         let expected_per_seg = minimal_superfile_bytes().len();
         assert_eq!(resident, expected_per_seg * n);
@@ -389,7 +389,7 @@ mod tests {
             h.join().expect("thread panicked");
         }
 
-        // Exactly one segment in the store.
+        // Exactly one superfile in the store.
         assert_eq!(store.resident_bytes(), minimal_superfile_bytes().len());
         // All reads return the same Arc.
         let r1 = store.reader(&uri).expect("r1");

--- a/src/supertable/reader_cache/mod.rs
+++ b/src/supertable/reader_cache/mod.rs
@@ -4,13 +4,13 @@
 //! In-process cache of parsed `SuperfileReader`s keyed by
 //! [`SuperfileUri`].
 //!
-//! The supertable's manifest carries metadata only — segment id,
+//! The supertable's manifest carries metadata only — superfile id,
 //! summary stats, FTS bloom, etc. The actual parsed superfile
 //! readers live here, behind the [`SuperfileReaderCache`] trait,
 //! owned by the supertable inner state and shared across reader
 //! threads via `Arc<dyn SuperfileReaderCache>`. This split keeps
 //! manifest snapshots cheap (a few KB each) while letting hot
-//! queries reuse one parsed reader per segment across threads.
+//! queries reuse one parsed reader per superfile across threads.
 //!
 //! ## Implementations
 //!
@@ -69,8 +69,8 @@ pub trait SuperfileReaderCache: Send + Sync {
     /// never registered with [`SuperfileReaderCache::insert`].
     fn reader(&self, uri: &SuperfileUri) -> Result<Arc<SuperfileReader>, ReaderCacheError>;
 
-    /// Insert a new segment's bytes under `uri`. Called once per
-    /// segment by the writer, at commit time.
+    /// Insert a new superfile's bytes under `uri`. Called once per
+    /// superfile by the writer, at commit time.
     ///
     /// Idempotent: re-inserting the same `uri` is a no-op (the
     /// caller's contract is that a `SuperfileUri` always names the
@@ -82,7 +82,7 @@ pub trait SuperfileReaderCache: Send + Sync {
     fn insert(&self, uri: SuperfileUri, bytes: Bytes) -> Result<(), ReaderCacheError>;
 
     /// Approximate resident byte count, summed across every
-    /// cached segment. Used by tests + observability that need to
+    /// cached superfile. Used by tests + observability that need to
     /// confirm RAM bounds match expectations.
     fn resident_bytes(&self) -> usize;
 }
@@ -90,7 +90,7 @@ pub trait SuperfileReaderCache: Send + Sync {
 /// Error type for [`SuperfileReaderCache`] operations.
 #[derive(Debug, Error)]
 pub enum ReaderCacheError {
-    #[error("segment uri {uri:?} not found in cache")]
+    #[error("superfile uri {uri:?} not found in cache")]
     NotFound { uri: SuperfileUri },
 
     #[error("failed to open superfile bytes: {source}")]

--- a/src/supertable/stats.rs
+++ b/src/supertable/stats.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Scope
 //!
-//! - Manifest-side counters: pinned version, live segment
+//! - Manifest-side counters: pinned version, live superfile
 //!   count, manifest-part counts (referenced + hydrated).
 //! - Process-level memory: OS-reported RSS.
 //! - Disk-cache aggregates (when a cache is attached): mmap

--- a/src/supertable/tombstones/cache.rs
+++ b/src/supertable/tombstones/cache.rs
@@ -52,22 +52,22 @@ use crate::supertable::wal::WalStore;
 /// extra storage GET across enough queries that the steady-
 /// state per-query cost stays inside the hot-path budget.
 ///
-/// Applies only to *present* sidecars (a segment that actually
+/// Applies only to *present* sidecars (a superfile that actually
 /// has tombstones); absent/empty sidecars use
 /// [`DEFAULT_NEGATIVE_TTL`].
 pub const DEFAULT_REFRESH_TTL: Duration = Duration::from_secs(1);
 
 /// Negative/empty-view refresh interval — much longer than the
-/// positive TTL. The overwhelmingly common case is a segment
+/// positive TTL. The overwhelmingly common case is a superfile
 /// with **no** tombstones at all (no sidecar on storage → a 404,
 /// cached as an empty bitmap). Re-GETting that 404 on the 1 s
 /// positive TTL turns every steady-state query into one
-/// object-store round trip *per segment*, which at high segment
+/// object-store round trip *per superfile*, which at high superfile
 /// counts (a wide supertable fan-out) dominates the hot path —
 /// the serial post-search tombstone sweep becomes seconds.
 ///
 /// A sidecar only appears when some process deletes a row in that
-/// segment. This process invalidates its own deletes synchronously
+/// superfile. This process invalidates its own deletes synchronously
 /// (see [`SidecarCache::invalidate`]), so the only staleness this
 /// TTL governs is a *cross-process* delete — already an
 /// eventual-consistency concern, not a correctness one. Holding
@@ -156,11 +156,11 @@ impl SidecarCache {
     }
 
     /// Concurrently refresh every id whose cached view is missing or
-    /// stale, so a subsequent per-segment [`Self::bitmap_for`] sweep
+    /// stale, so a subsequent per-superfile [`Self::bitmap_for`] sweep
     /// is all cache hits.
     ///
     /// This is the hot-path entry point for a wide fan-out: it
-    /// replaces N *serial* blocking storage GETs (one per segment,
+    /// replaces N *serial* blocking storage GETs (one per superfile,
     /// each a sync→async bridge) with a single *concurrent* batch
     /// whose wall cost is ≈ one round trip rather than N. Ids that
     /// are already fresh are skipped, so in the no-deletes steady

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -382,7 +382,7 @@ async fn do_apply(
     //
     // FTS + vector summaries are derived from a fresh
     // `SuperfileReader` on the just-built bytes — same shape the
-    // writer's `prepare_segment` uses. Scalar stats come from
+    // writer's `prepare_superfile` uses. Scalar stats come from
     // the in-memory `RecordBatch` directly; nothing needs to
     // round-trip through Parquet.
     let reader = SuperfileReader::open_with(bytes.clone(), inner.options.superfile_open_options())
@@ -542,7 +542,7 @@ fn prepend_id_column(
 
 /// Per-FTS-column bloom + range summary derived from the
 /// just-built superfile's `SuperfileReader`. Mirrors the shape
-/// the writer's `prepare_segment` builds so summaries match
+/// the writer's `prepare_superfile` builds so summaries match
 /// regardless of which code path produced the superfile.
 fn build_fts_summary(
     reader: &SuperfileReader,
@@ -555,7 +555,7 @@ fn build_fts_summary(
     for fc in &options.fts_columns {
         let terms = fts_reader
             .iter_column_terms(&fc.column)
-            .expect("FST bytes valid: segment just built");
+            .expect("FST bytes valid: superfile just built");
         let n_terms_distinct = terms.len() as u32;
         let (min_term, max_term) = match (terms.first(), terms.last()) {
             (Some(min), Some(max)) => (min.clone(), max.clone()),
@@ -1101,7 +1101,7 @@ fn resolve_target_id_in_manifest(
             }
         };
 
-        // id_lookup requires the full segment bytes (eager open).
+        // id_lookup requires the full superfile bytes (eager open).
         // A lazy-opened reader from the cache path will return an Io
         // error here; fall back to a direct storage fetch in that case.
         let lookup_result = match reader.id_lookup(target) {

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -190,7 +190,7 @@ struct BufferedBatch {
 ///
 /// Trailing empty shards (only possible when `total_rows < n_shards`)
 /// are dropped before return; callers see exactly the shards that
-/// will produce a non-empty segment.
+/// will produce a non-empty superfile.
 fn split_buffer_into_row_shards(
     buffer: Vec<BufferedBatch>,
     n_shards: usize,
@@ -256,7 +256,7 @@ impl Supertable {
     /// Append one batch of rows and commit — durable when this returns.
     ///
     /// Folds the buffered writer + commit into a single call: one
-    /// `append` == one commit == one sealed segment, so callers batch
+    /// `append` == one commit == one sealed superfile, so callers batch
     /// rows per call rather than calling once per row.
     ///
     /// ```
@@ -1021,7 +1021,7 @@ impl ShardOutput {
     }
 }
 
-/// Build one segment from one slice of buffered batches. Runs on
+/// Build one superfile from one slice of buffered batches. Runs on
 /// a rayon worker thread inside the writer pool's `install`.
 fn build_one_shard(
     slice: &[BufferedBatch],
@@ -1118,8 +1118,8 @@ pub(crate) fn build_subsection_offsets(bytes: &Bytes) -> Option<SubsectionOffset
 
     // capture the open-time batch bytes (parquet
     // footer tail + vector open ranges + FTS open ranges) so the
-    // reader can resolve a segment's open metadata straight from
-    // the manifest part, issuing zero per-segment open GETs.
+    // reader can resolve a superfile's open metadata straight from
+    // the manifest part, issuing zero per-superfile open GETs.
     let open_blob = build_open_blob(bytes, total_size, &vec_open_ranges, &fts_open_ranges);
 
     Some(SubsectionOffsets {
@@ -1132,14 +1132,14 @@ pub(crate) fn build_subsection_offsets(bytes: &Bytes) -> Option<SubsectionOffset
     })
 }
 
-/// Slice the bytes for the segment's open-time batch out of the
+/// Slice the bytes for the superfile's open-time batch out of the
 /// freshly-written superfile so the manifest can carry them
 /// inline. Mirrors the cold-fetch open batch in
 /// `DiskCacheStore::cold_fetch_lazy_with_hints`: the parquet
 /// footer tail (matching the 64 KiB speculation length) plus each
 /// vector / FTS open range. Returns `(absolute_offset, bytes)`
 /// tuples; an empty `Vec` disables the inline-open fast path for
-/// this segment.
+/// this superfile.
 fn build_open_blob(
     bytes: &Bytes,
     total_size: u64,
@@ -1309,9 +1309,9 @@ fn read_u64_le(bytes: &[u8]) -> u64 {
 
 /// Per-shard publish artifacts produced in parallel before the
 /// serial manifest swap. One entry per non-empty shard.
-pub(crate) struct PreparedSegment {
+pub(crate) struct PreparedSuperfile {
     pub(crate) entry: Arc<SuperfileEntry>,
-    /// Bytes destined for the in-memory segment store. `Some` on
+    /// Bytes destined for the in-memory superfile store. `Some` on
     /// the in-memory-only path and the storage-without-cache
     /// path; `None` on the cache-attached path (the disk cache
     /// hydrates lazily from storage).
@@ -1320,8 +1320,8 @@ pub(crate) struct PreparedSegment {
     bytes_for_cache: Option<(SuperfileUri, Bytes)>,
 }
 
-impl PreparedSegment {
-    /// Open a `SuperfileReader` directly on this segment's bytes.
+impl PreparedSuperfile {
+    /// Open a `SuperfileReader` directly on this superfile's bytes.
     /// Returns `None` if no bytes are held (cache-attached path with
     /// no prepopulation — bytes went to storage only).
     #[cfg(test)]
@@ -1342,10 +1342,10 @@ impl PreparedSegment {
 /// on the shard bytes, derive FTS + vector summaries, and decide
 /// the bytes-disposition triplet. Pure per-shard work — no shared
 /// mutable state, safe to run in parallel across shards.
-pub(super) fn prepare_segment(
+pub(super) fn prepare_superfile(
     inner: &SupertableInner,
     shard: ShardOutput,
-) -> Result<Option<PreparedSegment>, BuildError> {
+) -> Result<Option<PreparedSuperfile>, BuildError> {
     if shard.n_docs == 0 {
         return Ok(None);
     }
@@ -1355,7 +1355,7 @@ pub(super) fn prepare_segment(
     let bytes_for_storage = inner.options.storage.is_some().then(|| shard.bytes.clone());
     let cache_attached = inner.options.disk_cache.is_some() && inner.options.storage.is_some();
     // `bytes_for_store` (in-memory tier) is gated only on cache attachment —
-    // a cache-attached producer keeps segment bytes out of the unbounded
+    // a cache-attached producer keeps superfile bytes out of the unbounded
     // in-memory store regardless of whether we pre-populate the disk cache.
     let bytes_for_store = (!cache_attached).then(|| shard.bytes.clone());
     // Pre-populating the disk cache is opt-out: a write-only producer that
@@ -1369,19 +1369,19 @@ pub(super) fn prepare_segment(
     // straight to object storage without a RAM detour, which is
     // what removes the 100GB OOM trap (the in-memory cache doesn't
     // evict, so a long-running writer with cache + storage would
-    // otherwise accumulate every segment's bytes in RAM forever).
+    // otherwise accumulate every superfile's bytes in RAM forever).
     let reader = crate::superfile::SuperfileReader::open_with(
         shard.bytes.clone(),
         inner.options.superfile_open_options(),
     )
-    .map_err(|e| BuildError::Store(format!("opening segment for summary: {e}")))?;
+    .map_err(|e| BuildError::Store(format!("opening superfile for summary: {e}")))?;
 
     let mut fts_summary: HashMap<String, FtsSummary> = HashMap::new();
     if let Some(fts_reader) = reader.fts() {
         for fc in &inner.options.fts_columns {
             let terms = fts_reader
                 .iter_column_terms(&fc.column)
-                .expect("FST bytes valid: segment just built");
+                .expect("FST bytes valid: superfile just built");
             let n_terms_distinct = terms.len() as u32;
             let (min_term, max_term) = match (terms.first(), terms.last()) {
                 (Some(min), Some(max)) => (min.clone(), max.clone()),
@@ -1407,8 +1407,8 @@ pub(super) fn prepare_segment(
         for vc in &inner.options.vector_columns {
             if let Some((centroid, radius)) = vec_reader.summary(&vc.column) {
                 // Stage the per-cluster centroids (Sq8) into the
-                // manifest so a query can rank this segment's clusters
-                // globally without opening the segment.
+                // manifest so a query can rank this superfile's clusters
+                // globally without opening the superfile.
                 let clusters = vec_reader
                     .cluster_centroids(&vc.column)
                     .map(|(n_cent, dim, fp32, counts)| {
@@ -1453,7 +1453,7 @@ pub(super) fn prepare_segment(
         subsection_offsets,
     });
 
-    Ok(Some(PreparedSegment {
+    Ok(Some(PreparedSuperfile {
         entry,
         bytes_for_store: bytes_for_store.map(|b| (uri, b)),
         bytes_for_storage: bytes_for_storage.map(|b| (uri, b)),
@@ -1461,8 +1461,8 @@ pub(super) fn prepare_segment(
     }))
 }
 
-/// Insert each shard's bytes into the segment store, derive
-/// per-segment summaries from the stored `SuperfileReader`, and
+/// Insert each shard's bytes into the superfile store, derive
+/// per-superfile summaries from the stored `SuperfileReader`, and
 /// publish all entries in one `ArcSwap` of the manifest.
 ///
 /// Per-shard work (reader open, FTS bloom build, vector summary,
@@ -1475,10 +1475,10 @@ fn publish_superfiles(
     inner: &SupertableInner,
     outputs: Vec<ShardOutput>,
 ) -> Result<(), BuildError> {
-    let prepared: Vec<PreparedSegment> = inner.options.writer_pool.install(|| {
+    let prepared: Vec<PreparedSuperfile> = inner.options.writer_pool.install(|| {
         outputs
             .into_par_iter()
-            .filter_map(|shard| prepare_segment(inner, shard).transpose())
+            .filter_map(|shard| prepare_superfile(inner, shard).transpose())
             .collect::<Result<Vec<_>, _>>()
     })?;
 
@@ -1510,7 +1510,7 @@ fn publish_superfiles(
     let old = inner.manifest.load();
 
     // Storage write-through: when storage is attached, persist
-    // each segment's bytes + the new manifest (parts + list +
+    // each superfile's bytes + the new manifest (parts + list +
     // pointer) before swapping the in-memory state. If any
     // storage operation fails the commit fails as a whole —
     // the in-memory manifest is **not** updated, so callers
@@ -1527,12 +1527,12 @@ fn publish_superfiles(
 
         // Warm the cache with the superfiles we just persisted.
         // Skips the cold-fetch round-trip on the producer's
-        // next query against its own superfiles (each segment
+        // next query against its own superfiles (each superfile
         // otherwise costs one storage HEAD + parallel
         // range-GETs to refetch what we already have in
         // hand). Best-effort: a cache insert failure (e.g.,
         // budget exhausted) is logged via the error path but
-        // doesn't fail the commit — the segment is durably
+        // doesn't fail the commit — the superfile is durably
         // in storage, and a subsequent query will cold-fetch
         // it as if pre-population hadn't been attempted.
         if !pending_cache_inserts.is_empty()
@@ -1608,7 +1608,7 @@ fn backoff_delay(attempt: u32) -> std::time::Duration {
 /// **OCC retry semantics.** On each iteration:
 ///  1. Reload `inner.manifest` to incorporate any commit a
 ///     racing writer published since our last attempt.
-///  2. Derive `new_segment_list = old.superfile_list.with_appended(new_entries.clone())`.
+///  2. Derive `new_superfile_list = old.superfile_list.with_appended(new_entries.clone())`.
 ///  3. Try `try_commit_attempt` (write superfiles → write part +
 ///     list → conditional pointer PUT).
 ///  4. On `WriteContentionExhausted` with retries left: refresh
@@ -1618,9 +1618,9 @@ fn backoff_delay(attempt: u32) -> std::time::Duration {
 ///  5. After `opts.max_commit_retries` exhausted: surface
 ///     `CommitError::WriteContentionExhausted` to the caller.
 ///
-/// **Idempotency across retries.** Segment URIs are UUID v4 —
+/// **Idempotency across retries.** Superfile URIs are UUID v4 —
 /// statically random, so a retry uses the same URIs as the
-/// prior attempt. The segment-bytes PUT swallows
+/// prior attempt. The superfile-bytes PUT swallows
 /// `PreconditionFailed` (URI already exists with bit-identical
 /// content from our prior attempt). Manifest parts are
 /// content-addressed; identical content yields identical URIs
@@ -1662,9 +1662,9 @@ pub(in crate::supertable) fn persist_commit(
             // racing writer's commit (visible via
             // `refresh_inner_state_async` below from a prior
             // iteration) feeds into our successor's
-            // `new_segment_list`.
+            // `new_superfile_list`.
             let old = inner.manifest.load_full();
-            let new_segment_list = old.superfile_list.with_appended(new_entries.clone());
+            let new_superfile_list = old.superfile_list.with_appended(new_entries.clone());
             let pending_writes = &mut pending_storage_writes;
 
             match try_commit_attempt(
@@ -1672,13 +1672,13 @@ pub(in crate::supertable) fn persist_commit(
                 Arc::clone(&opts),
                 Arc::clone(&old),
                 &new_entries,
-                new_segment_list.manifest_id,
+                new_superfile_list.manifest_id,
                 pending_writes,
             )
             .await
             {
                 Ok(new_list) => {
-                    return Ok::<_, crate::supertable::CommitError>((new_list, new_segment_list));
+                    return Ok::<_, crate::supertable::CommitError>((new_list, new_superfile_list));
                 }
                 Err(crate::supertable::CommitError::WriteContentionExhausted)
                     if attempt + 1 < max_retries =>
@@ -1698,7 +1698,7 @@ pub(in crate::supertable) fn persist_commit(
         Err(last_err.unwrap_or(crate::supertable::CommitError::WriteContentionExhausted))
     };
 
-    let (new_list, new_segment_list) = match tokio::runtime::Handle::try_current() {
+    let (new_list, new_superfile_list) = match tokio::runtime::Handle::try_current() {
         Ok(handle) => {
             // Ambient tokio runtime present — use it. Don't
             // touch `inner.query_runtime()` so we don't risk
@@ -1717,7 +1717,7 @@ pub(in crate::supertable) fn persist_commit(
     // list + a fresh ManifestPartLoader installed.
     let loader = Arc::new(ManifestPartLoader::new(Arc::clone(&storage), &new_list));
     Ok(Manifest {
-        superfile_list: new_segment_list,
+        superfile_list: new_superfile_list,
         list: Some(new_list),
         parts: dashmap::DashMap::new(),
         loader: Some(loader),
@@ -1728,7 +1728,7 @@ pub(in crate::supertable) fn persist_commit(
 // to remove successfully written entries.
 // Swallow `PreconditionFailed` per-PUT: on a retry after a
 // lost pointer-CAS, the same URI was already written by
-// our prior attempt with bit-identical bytes (segment URIs
+// our prior attempt with bit-identical bytes (superfile URIs
 // are UUID v4 — collision rate 2^-122). A "URI exists"
 // hit here means our own prior attempt; treat as success
 // so the retry path is fully idempotent.
@@ -1754,11 +1754,11 @@ pub async fn write_superfile_list(
         .map(|(i, (uri, bytes))| {
             let storage = Arc::clone(storage);
             async move {
-                let path = segment_storage_path(uri);
+                let path = superfile_storage_path(uri);
                 let result = if (bytes.len() as u64) >= multipart_threshold {
-                    put_segment_multipart(storage.as_ref(), &path, bytes.clone()).await
+                    put_superfile_multipart(storage.as_ref(), &path, bytes.clone()).await
                 } else {
-                    // Segment writes don't chain CAS, so the
+                    // Superfile writes don't chain CAS, so the
                     // returned etag isn't needed here.
                     storage.put_atomic(&path, bytes.clone()).await.map(|_| ())
                 };
@@ -1791,7 +1791,7 @@ pub async fn write_superfile_list(
     Ok(())
 }
 
-/// One attempt at the commit sequence: write segment bytes
+/// One attempt at the commit sequence: write superfile bytes
 /// → group new entries by partition → rewrite the latest part
 /// per touched partition (preserving untouched parts' URIs)
 /// → conditional pointer PUT. The retry loop in
@@ -1819,7 +1819,7 @@ async fn try_commit_attempt(
     new_manifest_id: u64,
     pending_storage_writes: &mut Vec<(SuperfileUri, Bytes)>,
 ) -> Result<ManifestList, SupertableCommitError> {
-    // 1. Write each new segment's bytes to storage in parallel.
+    // 1. Write each new superfile's bytes to storage in parallel.
     write_superfile_list(&storage, &opts, pending_storage_writes).await?;
 
     // 2. Resolve the effective partition strategy. Locked at
@@ -1886,7 +1886,7 @@ async fn try_commit_attempt(
                     ))
                 })?;
                 let combined_n = existing_part.superfiles.len() + new_for_pk.len();
-                let combined_segments: Vec<Arc<SuperfileEntry>> = existing_part
+                let combined_superfiles: Vec<Arc<SuperfileEntry>> = existing_part
                     .superfiles
                     .iter()
                     .cloned()
@@ -1900,7 +1900,7 @@ async fn try_commit_attempt(
                     // superfiles for this partition.
                     out_list_entries.push(entry.clone());
                     let new_segs: Vec<Arc<SuperfileEntry>> =
-                        combined_segments[existing_part.superfiles.len()..].to_vec();
+                        combined_superfiles[existing_part.superfiles.len()..].to_vec();
                     let (fresh_entry, fresh_part) =
                         build_part_and_entry(&opts, new_segs, entry.partition_key.clone())?;
                     out_list_entries.push(fresh_entry);
@@ -1910,7 +1910,7 @@ async fn try_commit_attempt(
                     // combined-superfiles part.
                     let (rebuilt_entry, rebuilt_part) = build_part_and_entry(
                         &opts,
-                        combined_segments,
+                        combined_superfiles,
                         entry.partition_key.clone(),
                     )?;
                     out_list_entries.push(rebuilt_entry);
@@ -2124,21 +2124,21 @@ async fn refresh_inner_state_async(
         new_parts.insert(*pid, Arc::new(cell));
     }
 
-    let mut all_segments: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
+    let mut all_superfiles: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
     for entry in &new_list.parts {
         let cell = new_parts.get(&entry.part_id).expect("part inserted above");
         let part = cell
             .value()
             .get()
             .expect("eager-fetched or inherited; must be set");
-        all_segments.extend(part.superfiles.iter().cloned());
+        all_superfiles.extend(part.superfiles.iter().cloned());
     }
 
-    let mut new_segment_list = SuperfileList::empty(inner.options.clone());
-    new_segment_list.manifest_id = pointer.manifest_id;
-    new_segment_list.superfiles = all_segments;
+    let mut new_superfile_list = SuperfileList::empty(inner.options.clone());
+    new_superfile_list.manifest_id = pointer.manifest_id;
+    new_superfile_list.superfiles = all_superfiles;
     let new_manifest = Manifest {
-        superfile_list: new_segment_list,
+        superfile_list: new_superfile_list,
         list: Some(new_list),
         parts: new_parts,
         loader: Some(new_loader),
@@ -2147,7 +2147,7 @@ async fn refresh_inner_state_async(
     Ok(())
 }
 
-/// Storage path for a segment's bytes. Lives under `data/`
+/// Storage path for a superfile's bytes. Lives under `data/`
 /// alongside the `_supertable/` manifest hierarchy.
 /// IPC-encode a `RecordBatch` to a byte buffer. Mirrors the
 /// shape the WAL's arrow sidecar carries: an
@@ -2165,16 +2165,16 @@ fn encode_record_batch_ipc(batch: &arrow_array::RecordBatch) -> Result<Bytes, St
     Ok(Bytes::from(out))
 }
 
-fn segment_storage_path(uri: &SuperfileUri) -> String {
+fn superfile_storage_path(uri: &SuperfileUri) -> String {
     uri.storage_path()
 }
 
-/// Multipart-upload variant of the writer's per-segment put.
+/// Multipart-upload variant of the writer's per-superfile put.
 /// Routes through [`crate::storage::StorageProvider::put_multipart`]
 /// for superfiles large enough that a single PUT is wasteful
 /// (slow on a backend stall, high RSS during the put).
 ///
-/// Idempotency: segment URIs are UUID v4, so the only "URI
+/// Idempotency: superfile URIs are UUID v4, so the only "URI
 /// exists" hit on retry comes from our own prior attempt
 /// with bit-identical bytes. Head-first lets us short-circuit
 /// that case before re-running the multipart dance. The
@@ -2188,7 +2188,7 @@ fn segment_storage_path(uri: &SuperfileUri) -> String {
 /// 16-MiB chunk reads on the way back out. Parts are pushed
 /// in declaration order; the parts run concurrently inside
 /// `object_store` after their futures are polled.
-async fn put_segment_multipart(
+async fn put_superfile_multipart(
     storage: &dyn crate::storage::StorageProvider,
     path: &str,
     bytes: Bytes,
@@ -2237,7 +2237,7 @@ async fn put_segment_multipart(
 }
 
 /// Drive `DiskCacheStore::insert_warm` for each
-/// just-published segment via the same sync→async bridge
+/// just-published superfile via the same sync→async bridge
 /// the rest of the writer uses (`block_in_place +
 /// Handle::block_on` when an ambient runtime is present;
 /// `inner.query_runtime()` otherwise).
@@ -2258,7 +2258,7 @@ fn warm_cache_after_commit(
             if let Err(e) = cache.insert_warm(&uri, bytes).await {
                 eprintln!(
                     "supertable: warm cache pre-population failed for {}: {} \
-                     (segment is durable in storage; first query will cold-fetch)",
+                     (superfile is durable in storage; first query will cold-fetch)",
                     uri.0, e
                 );
             }
@@ -2381,7 +2381,7 @@ mod tests {
     // ---- single-writer end-to-end (serial pool) ----------------------
 
     #[test]
-    fn append_then_commit_publishes_one_segment() {
+    fn append_then_commit_publishes_one_superfile() {
         let st = Supertable::create(options_id_title_serial()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_simple_batch(0, 4)).expect("append");
@@ -2403,8 +2403,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn segment_is_queryable_via_store() {
-        // The published segment's bytes are in the store; we
+    async fn superfile_is_queryable_via_store() {
+        // The published superfile's bytes are in the store; we
         // can fetch a SuperfileReader and run bm25_search on it.
 
         let st = Supertable::create(options_id_title_serial()).expect("create");
@@ -2413,9 +2413,9 @@ mod tests {
         w.commit().expect("commit");
 
         let r = st.reader();
-        let segment = &r.manifest().superfiles[0];
+        let superfile = &r.manifest().superfiles[0];
         let store = &st.options().store;
-        let sf_reader = store.reader(&segment.uri).expect("reader");
+        let sf_reader = store.reader(&superfile.uri).expect("reader");
         let hits = sf_reader
             .bm25_hits_async("title", "alpha", 10, BoolMode::Or)
             .await
@@ -2427,7 +2427,7 @@ mod tests {
     // ---- id_min / id_max + n_docs ------------------------------------
 
     #[test]
-    fn segment_entry_records_id_range_and_n_docs() {
+    fn superfile_entry_records_id_range_and_n_docs() {
         let st = Supertable::create(options_id_title_serial()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_simple_batch(100, 3)).expect("a");
@@ -2448,7 +2448,7 @@ mod tests {
     // ---- FTS summary --------------------------------------------------
 
     #[test]
-    fn segment_entry_carries_fts_summary() {
+    fn superfile_entry_carries_fts_summary() {
         let st = Supertable::create(options_id_title_serial()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_simple_batch(0, 4)).expect("append");
@@ -2528,7 +2528,7 @@ mod tests {
     }
 
     #[test]
-    fn segment_entry_carries_vector_summary() {
+    fn superfile_entry_carries_vector_summary() {
         let dim = 16;
         let st = Supertable::create(options_with_vector(dim)).expect("create");
         let mut w = st.writer().expect("writer");
@@ -2545,7 +2545,7 @@ mod tests {
         assert_eq!(vs.centroid.len(), dim);
         assert!(vs.radius >= 0.0);
         // Per-cluster centroids are staged into the manifest for
-        // cross-segment global cluster selection.
+        // cross-superfile global cluster selection.
         assert!(
             !vs.clusters.is_empty(),
             "cluster centroids must be populated"
@@ -2557,7 +2557,7 @@ mod tests {
         assert_eq!(vs.clusters.scales.len(), vs.clusters.n_cent as usize);
         assert_eq!(vs.clusters.codes.len(), vs.clusters.n_cent as usize * dim);
         // Every indexed doc lands in exactly one cluster, so the
-        // per-cluster counts sum to the segment's doc count.
+        // per-cluster counts sum to the superfile's doc count.
         let total: u64 = vs.clusters.counts.iter().map(|&c| c as u64).sum();
         assert_eq!(total, seg.n_docs);
     }
@@ -2565,7 +2565,7 @@ mod tests {
     // ---- rayon-shard parallelism -------------------------------------
 
     #[test]
-    fn commit_produces_one_segment_per_writer_pool_thread() {
+    fn commit_produces_one_superfile_per_writer_pool_thread() {
         // With N writer-pool threads and a buffer of M >= N
         // batches, commit should emit N superfiles (one per
         // shard).
@@ -2608,7 +2608,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_config_with_fixed_writer_threads_emits_that_many_segments() {
+    fn apply_config_with_fixed_writer_threads_emits_that_many_superfiles() {
         let yaml = r#"
 commit_threshold_size_mb: 1024
 supertable:
@@ -2620,7 +2620,7 @@ supertable:
 
         // End-to-end: build options, route them through apply_config,
         // and verify the writer pool actually sized to the config's
-        // 4 threads (one segment per shard).
+        // 4 threads (one superfile per shard).
         let opts = options_id_title().apply_config(&cfg).expect("apply_config");
         let st = Supertable::create(opts).expect("create");
         let mut w = st.writer().expect("writer");
@@ -2655,7 +2655,7 @@ supertable:
         assert_eq!(st.manifest_id(), 1, "auto-flush should fire");
         assert_eq!(w.buffered_batches(), 0, "buffer drained on auto-flush");
 
-        // No further commit should land an empty segment.
+        // No further commit should land an empty superfile.
         w.commit().expect("commit-empty");
         assert_eq!(st.manifest_id(), 1);
     }
@@ -2673,7 +2673,7 @@ supertable:
     // ---- manifest copy-on-write across multiple commits -------------
 
     #[test]
-    fn each_commit_appends_to_existing_segments() {
+    fn each_commit_appends_to_existing_superfiles() {
         let st = Supertable::create(options_id_title_serial()).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&build_simple_batch(0, 2)).expect("a1");

--- a/tests/superfile/format/lazy_byte_source.rs
+++ b/tests/superfile/format/lazy_byte_source.rs
@@ -190,7 +190,7 @@ async fn storage_range_source_drives_open_lazy_against_localfs() {
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("local"));
     let bytes = build_test_bytes();
 
-    // Seed the segment at a stable URI.
+    // Seed the superfile at a stable URI.
     let uri = "data/seg-test.sf.parquet";
     local.put_atomic(uri, bytes.clone()).await.expect("seed");
 
@@ -276,7 +276,7 @@ async fn open_lazy_via_storage_matches_open_via_bytes() {
 //      `FtsReader::open_lazy` exists; the FTS sub-blob is
 //      bounded — typically << vector subsection).
 // Total cold-open budget: ≤ 6 GETs / ≲ 2-3 MiB on a typical
-// 1.5 GiB segment.
+// 1.5 GiB superfile.
 // ============================================================
 
 use infino::superfile::vector::distance::normalize;
@@ -285,7 +285,7 @@ use infino::test_helpers::default_vector_config;
 /// Build a small superfile that exercises both the vector and
 /// FTS sub-blobs so the cold-open test can observe both
 /// sub-source paths in `open_lazy`. 4 docs × 16-dim vectors
-/// keeps the segment small but representative of the actual
+/// keeps the superfile small but representative of the actual
 /// layout produced by `SuperfileBuilder`.
 fn build_vec_plus_fts_bytes() -> Bytes {
     let dim = LAZY_VEC_DIM;
@@ -382,17 +382,17 @@ async fn cold_open_lazy_within_documented_range_budget_for_vec_plus_fts() {
     // Exact lazy open:
     //   1 footer tail
     //   3 vector metadata ranges (outer header, directory+crc, subheader;
-    //     +1 more for Sq8 codec_meta on Sq8 segments)
+    //     +1 more for Sq8 codec_meta on Sq8 superfiles)
     //   3 FTS metadata ranges (header, FST directory, doc-length tail)
     //
-    // This tiny fixture uses a non-Sq8 vector segment, so the expected
+    // This tiny fixture uses a non-Sq8 vector superfile, so the expected
     // combined budget is 7. The production latency target is governed by
     // serial batches and bytes; this assertion pins that open does not
     // drift back to whole-subsection/speculative reads.
     let documented_max = LAZY_COLD_OPEN_MAX_GETS;
     assert!(
         n_get <= documented_max,
-        "cold-open issued {n_get} GETs against a {total}-byte segment; \
+        "cold-open issued {n_get} GETs against a {total}-byte superfile; \
          documented superfile cold-open budget is ≤ {documented_max} GETs",
     );
 
@@ -413,7 +413,7 @@ async fn cold_open_lazy_within_documented_range_budget_for_vec_plus_fts() {
         "BM25 must return matches for 'special'"
     );
 
-    // The lazy reader never materializes the full segment, so
+    // The lazy reader never materializes the full superfile, so
     // `parquet_bytes()` must be `None`.
     assert!(reader.parquet_bytes().is_none());
 }

--- a/tests/supertable/commit/concurrent_threads.rs
+++ b/tests/supertable/commit/concurrent_threads.rs
@@ -107,7 +107,7 @@ fn reader_pinned_before_writer_starts_never_sees_commits() {
         drop(w);
     });
 
-    // Repeatedly probe the pinned reader; manifest_id and segment
+    // Repeatedly probe the pinned reader; manifest_id and superfile
     // count must NOT advance regardless of writer progress.
     let deadline = Instant::now() + Duration::from_millis(200);
     while Instant::now() < deadline {
@@ -119,7 +119,7 @@ fn reader_pinned_before_writer_starts_never_sees_commits() {
         assert_eq!(
             pinned.n_superfiles(),
             0,
-            "pinned reader's segment count grew while writer ran",
+            "pinned reader's superfile count grew while writer ran",
         );
     }
     writer_handle.join().expect("writer thread joined");

--- a/tests/supertable/commit/id_uniqueness.rs
+++ b/tests/supertable/commit/id_uniqueness.rs
@@ -169,9 +169,9 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
     // the only assertion that actually checks the property we care
     // about (no duplicate ids) — and at 400 ids the cost is
     // microseconds.
-    // Attach a disk cache so the consumer can pull segment bytes
+    // Attach a disk cache so the consumer can pull superfile bytes
     // back from storage on demand — the consumer didn't write any
-    // of the segments, so its in-memory reader cache is empty.
+    // of the superfiles, so its in-memory reader cache is empty.
     let cache_dir = TempDir::new().expect("cache tempdir");
     let cfg = DiskCacheConfig {
         cache_root: cache_dir.path().to_path_buf(),
@@ -198,7 +198,7 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
     assert_eq!(
         segs.len(),
         N_HANDLES,
-        "expected one segment per handle; got {}",
+        "expected one superfile per handle; got {}",
         segs.len()
     );
 
@@ -226,7 +226,7 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
         all.len()
     );
 
-    // Sanity: manifest's per-segment doc count totals match the
+    // Sanity: manifest's per-superfile doc count totals match the
     // ids actually persisted, so we know we read them all.
     let total_rows: u64 = segs.iter().map(|s| s.n_docs).sum();
     assert_eq!(total_rows, N_HANDLES as u64 * ROWS_PER_HANDLE);

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -62,8 +62,8 @@ fn open_sees_writes_made_by_a_different_handle() {
     assert_eq!(consumer.reader().n_superfiles(), 1);
     // Note: full query parity post-open requires the deferred
     // query-path integration through `DiskCacheStore` —
-    // the reader sees the manifest's segment list but
-    // segment *bytes* live only in object storage and aren't
+    // the reader sees the manifest's superfile list but
+    // superfile *bytes* live only in object storage and aren't
     // yet routed through the cache. That wiring is the next
     // step. This test validates the manifest-side open here; an
     // end-to-end query test on a post-open Supertable lands

--- a/tests/supertable/commit/partition_assignment.rs
+++ b/tests/supertable/commit/partition_assignment.rs
@@ -16,7 +16,7 @@
 //!   - **Latest-part rewrite under default strategy.** After
 //!     three commits, the manifest list has exactly one
 //!     entry (one partition), and that entry's
-//!     `n_superfiles` equals the cumulative segment count.
+//!     `n_superfiles` equals the cumulative superfile count.
 //!     The `part_id` differs from commit to commit (each
 //!     rewrite produces a fresh part with a new
 //!     content-hash).
@@ -32,7 +32,7 @@
 //!     yet (deferred), so a Hash strategy with n_buckets >
 //!     1 fails the partition-assignment contract.
 //!   - **TimeRange decoder wired up.** Int64 / Timestamp*
-//!     columns drive bucket assignment from per-segment
+//!     columns drive bucket assignment from per-superfile
 //!     min/max stats; superfiles spanning a granularity
 //!     boundary surface `SuperfileSpansPartition` at commit
 //!     time. Unsupported column types (e.g. UInt64) also
@@ -97,7 +97,7 @@ fn default_strategy_is_single_bucket_hash_observationally_equivalent_to_pre_m15a
     );
     assert_eq!(
         list.parts[0].n_superfiles, 3,
-        "after 3 single-segment commits the part should hold 3 superfiles"
+        "after 3 single-superfile commits the part should hold 3 superfiles"
     );
     // partition_key is the 4-byte LE encoding of bucket 0.
     assert_eq!(list.parts[0].partition_key, [0u8, 0, 0, 0]);
@@ -137,7 +137,7 @@ fn rewrite_path_produces_fresh_part_id_per_commit() {
 #[test]
 fn target_superfiles_per_partition_triggers_part_split() {
     // With target_superfiles_per_partition = 2 and
-    // single-segment commits, the third commit pushes the
+    // single-superfile commits, the third commit pushes the
     // partition over the cap and emits a fresh part. The
     // list grows from 1 entry to 2 entries (both for the
     // same partition_key — the old entry preserved, the
@@ -170,8 +170,8 @@ fn target_superfiles_per_partition_triggers_part_split() {
         list.parts[0].partition_key, list.parts[1].partition_key,
         "both entries should share the same partition_key (same partition, split into 2 parts)"
     );
-    let total_segments: u64 = list.parts.iter().map(|p| p.n_superfiles).sum();
-    assert_eq!(total_segments, 3);
+    let total_superfiles: u64 = list.parts.iter().map(|p| p.n_superfiles).sum();
+    assert_eq!(total_superfiles, 3);
 }
 
 #[test]
@@ -237,7 +237,7 @@ fn time_range_strategy_on_unsupported_column_type_errors_cleanly() {
 }
 
 #[test]
-fn time_range_assigns_int64_segments_to_bucket_zero() {
+fn time_range_assigns_int64_superfiles_to_bucket_zero() {
     // Happy path: an Int64-keyed schema with TimeRange
     // partition_strategy, single-bucket-spanning batch →
     // commit succeeds + the manifest list's entry carries
@@ -314,7 +314,7 @@ fn time_range_assigns_int64_segments_to_bucket_zero() {
 }
 
 #[test]
-fn time_range_segment_spanning_two_buckets_errors() {
+fn time_range_superfile_spanning_two_buckets_errors() {
     // Bucket-spanning batch (ts crosses a day boundary)
     // surfaces `SuperfileSpansPartition` so the writer
     // doesn't silently group two days' rows under one

--- a/tests/supertable/commit/persistence.rs
+++ b/tests/supertable/commit/persistence.rs
@@ -7,7 +7,7 @@
 //! `SupertableOptions::with_storage(...)` is attached:
 //!
 //! - A commit on a storage-backed supertable writes:
-//!   - each new segment's bytes to `data/seg-<uuid>.sf.parquet`
+//!   - each new superfile's bytes to `data/seg-<uuid>.sf.parquet`
 //!   - one manifest part to `manifests/part-<hash>.avro.zst`
 //!   - the manifest list to `manifest-lists/list-NNNNNN.json`
 //!   - the pointer to `_supertable/current`
@@ -38,7 +38,7 @@ use infino::test_helpers::{build_title_batch, default_supertable_options};
 use tempfile::TempDir;
 
 #[test]
-fn commit_persists_pointer_list_part_and_segment() {
+fn commit_persists_pointer_list_part_and_superfile() {
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
@@ -78,7 +78,7 @@ fn commit_persists_pointer_list_part_and_segment() {
         "single-partition mode: exactly one manifest part on disk; got {parts:?}"
     );
 
-    // Segment file exists in data/.
+    // Superfile file exists in data/.
     let data_dir = dir.path().join("data");
     let superfiles: Vec<_> = std::fs::read_dir(&data_dir)
         .expect("readdir")
@@ -87,7 +87,7 @@ fn commit_persists_pointer_list_part_and_segment() {
     assert_eq!(
         superfiles.len(),
         1,
-        "one shard committed → one segment file on disk; got {superfiles:?}"
+        "one shard committed → one superfile file on disk; got {superfiles:?}"
     );
 
     // In-memory manifest reflects the commit.
@@ -152,17 +152,17 @@ fn two_successive_commits_both_publish() {
 }
 
 #[test]
-fn multipart_threshold_forces_segment_through_put_multipart() {
+fn multipart_threshold_forces_superfile_through_put_multipart() {
     // Setting `put_multipart_threshold_bytes = 1` routes
-    // every segment through `put_multipart` instead of
+    // every superfile through `put_multipart` instead of
     // `put_atomic`. Verifies the end-to-end shape:
     //   - commit succeeds (no panic, no error)
-    //   - segment file lands on disk
+    //   - superfile file lands on disk
     //   - manifest pointer + list + part written
     //   - cross-process open recovers the data
     // The actual `put_atomic` vs `put_multipart` distinction
     // is invisible to readers — the test passes through
-    // `Supertable::open` to assert the segment bytes were
+    // `Supertable::open` to assert the superfile bytes were
     // correctly assembled by the multipart path.
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
@@ -182,7 +182,7 @@ fn multipart_threshold_forces_segment_through_put_multipart() {
     }
     drop(producer);
 
-    // Segment file landed on disk.
+    // Superfile file landed on disk.
     let data_dir = dir.path().join("data");
     let superfiles: Vec<_> = std::fs::read_dir(&data_dir)
         .expect("readdir data")
@@ -191,11 +191,11 @@ fn multipart_threshold_forces_segment_through_put_multipart() {
     assert_eq!(
         superfiles.len(),
         1,
-        "one segment file should land on disk after a multipart commit"
+        "one superfile file should land on disk after a multipart commit"
     );
 
     // Cross-process open recovers correctly — proof the
-    // multipart-uploaded segment is byte-identical to what
+    // multipart-uploaded superfile is byte-identical to what
     // the writer produced.
     let consumer =
         Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
@@ -237,7 +237,7 @@ fn no_storage_attached_takes_in_memory_path() {
 #[test]
 fn committed_supertable_remains_in_memory_queryable_for_now() {
     // Storage write-through is additive — the
-    // in-memory store still holds segment bytes, so existing
+    // in-memory store still holds superfile bytes, so existing
     // in-memory query paths keep working unchanged. Verifies no
     // regression to the FTS read path.
     let dir = TempDir::new().expect("tempdir");

--- a/tests/supertable/commit/stats.rs
+++ b/tests/supertable/commit/stats.rs
@@ -15,7 +15,7 @@
 //!     path doesn't currently hydrate the part it just wrote
 //!     — `Supertable::open` is what populates the parts
 //!     cache; the writer just rebuilds the in-memory state
-//!     from `new_segment_list`).
+//!     from `new_superfile_list`).
 //!   - `Supertable::open`'s eager-fetch populates
 //!     `n_manifest_parts_loaded == n_manifest_parts`.
 //!   - `process_rss_bytes` is non-zero and falls within a
@@ -103,7 +103,7 @@ fn stats_show_manifest_parts_when_storage_attached() {
 
     // Producer's in-memory state after commit: list is set,
     // parts cache is empty (writer rebuilds state via
-    // new_segment_list, doesn't hydrate the freshly-written
+    // new_superfile_list, doesn't hydrate the freshly-written
     // part). Contract: report what's actually in memory.
     let producer_stats = producer.stats();
     assert_eq!(producer_stats.manifest_id, 1);

--- a/tests/supertable/disk_cache/basic.rs
+++ b/tests/supertable/disk_cache/basic.rs
@@ -10,7 +10,7 @@
 //! through the invariants it promises:
 //!
 //! - cold miss triggers cold-fetch (range-GETs to assemble
-//!   the segment file)
+//!   the superfile file)
 //! - warm hit issues zero `get_range` calls
 //! - 100 concurrent cold readers on the same URI coalesce to
 //!   exactly one fetch fan-out
@@ -158,7 +158,7 @@ fn build_test_superfile_bytes() -> Bytes {
     Bytes::from(b.finish().expect("finish"))
 }
 
-async fn seed_segment(storage: &dyn StorageProvider, uri: SuperfileUri, bytes: Bytes) {
+async fn seed_superfile(storage: &dyn StorageProvider, uri: SuperfileUri, bytes: Bytes) {
     let path = uri.storage_path();
     storage.put_atomic(&path, bytes).await.expect("seed put");
 }
@@ -196,7 +196,7 @@ async fn cold_miss_triggers_range_fetches_warm_hit_does_not() {
 
     let uri = SuperfileUri::new_v4();
     let bytes = build_test_superfile_bytes();
-    seed_segment(&*proxy, uri, bytes.clone()).await;
+    seed_superfile(&*proxy, uri, bytes.clone()).await;
 
     let (_cdir, cache) = fresh_cache_with_storage(
         Arc::clone(&proxy) as Arc<dyn StorageProvider>,
@@ -234,7 +234,7 @@ async fn concurrent_cold_readers_coalesce_to_one_fetch() {
 
     let uri = SuperfileUri::new_v4();
     let bytes = build_test_superfile_bytes();
-    seed_segment(&*proxy, uri, bytes).await;
+    seed_superfile(&*proxy, uri, bytes).await;
 
     let (_cdir, cache) = fresh_cache_with_storage(
         Arc::clone(&proxy) as Arc<dyn StorageProvider>,
@@ -272,7 +272,7 @@ async fn reader_returns_working_superfile_reader() {
 
     let uri = SuperfileUri::new_v4();
     let bytes = build_test_superfile_bytes();
-    seed_segment(&*local, uri, bytes).await;
+    seed_superfile(&*local, uri, bytes).await;
 
     let (_cdir, cache) = fresh_cache_with_storage(Arc::clone(&local), DISK_CACHE_BUDGET_BYTES);
     let reader = cache.reader(&uri).await.expect("reader");
@@ -290,7 +290,7 @@ async fn reader_returns_working_superfile_reader() {
 #[tokio::test]
 async fn eviction_respects_pinned_set() {
     // Two superfiles, budget tight enough that only one fits.
-    // Pin segment A; ask for B; expect A to survive
+    // Pin superfile A; ask for B; expect A to survive
     // (BudgetExceeded surfaces because the policy can't evict
     // A and B alone exceeds budget when A is held).
     let store_dir = TempDir::new().expect("storage tempdir");
@@ -301,8 +301,8 @@ async fn eviction_respects_pinned_set() {
     let uri_b = SuperfileUri::new_v4();
     let bytes = build_test_superfile_bytes();
     let size = bytes.len() as u64;
-    seed_segment(&*local, uri_a, bytes.clone()).await;
-    seed_segment(&*local, uri_b, bytes).await;
+    seed_superfile(&*local, uri_a, bytes.clone()).await;
+    seed_superfile(&*local, uri_b, bytes).await;
 
     // Pinned-fn pins exactly URI A.
     let pinned: Arc<dyn Fn() -> HashSet<SuperfileUri> + Send + Sync> = Arc::new(move || {
@@ -314,7 +314,7 @@ async fn eviction_respects_pinned_set() {
     let cache_dir = TempDir::new().expect("cache tempdir");
     let cfg = DiskCacheConfig {
         cache_root: cache_dir.path().to_path_buf(),
-        // Budget tight: fits exactly one segment, not two.
+        // Budget tight: fits exactly one superfile, not two.
         cold_fetch_mode: infino::supertable::reader_cache::ColdFetchMode::HybridWithPrefetch,
         disk_budget_bytes: size + (size / 2),
         cold_fetch_streams: COLD_FETCH_STREAMS,
@@ -356,9 +356,9 @@ async fn lru_evicts_oldest_unpinned_when_budget_pressure_hits() {
     let uri_c = SuperfileUri::new_v4();
     let bytes = build_test_superfile_bytes();
     let size = bytes.len() as u64;
-    seed_segment(&*local, uri_a, bytes.clone()).await;
-    seed_segment(&*local, uri_b, bytes.clone()).await;
-    seed_segment(&*local, uri_c, bytes).await;
+    seed_superfile(&*local, uri_a, bytes.clone()).await;
+    seed_superfile(&*local, uri_b, bytes.clone()).await;
+    seed_superfile(&*local, uri_c, bytes).await;
 
     let cache_dir = TempDir::new().expect("cache");
     let cfg = DiskCacheConfig {
@@ -407,7 +407,7 @@ async fn reservation_race_preserves_budget_invariant() {
         .map(|_| SuperfileUri::new_v4())
         .collect();
     for u in &uris {
-        seed_segment(&*local, *u, bytes.clone()).await;
+        seed_superfile(&*local, *u, bytes.clone()).await;
     }
 
     let cache_dir = TempDir::new().expect("cache");

--- a/tests/supertable/disk_cache/end_to_end.rs
+++ b/tests/supertable/disk_cache/end_to_end.rs
@@ -136,7 +136,7 @@ fn cross_process_consumer_routes_reads_through_disk_cache() {
         mid_stats.current_bytes
     );
 
-    // Second query against the same segment — warm hit.
+    // Second query against the same superfile — warm hit.
     let _batches = consumer
         .reader()
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
@@ -153,7 +153,7 @@ fn cross_process_consumer_routes_reads_through_disk_cache() {
 fn producer_with_cache_reads_through_cache_path() {
     // The producer commits with both storage AND cache
     // attached. The writer extracts
-    // summaries directly from the segment bytes (no
+    // summaries directly from the superfile bytes (no
     // round-trip through options.store.put), so the
     // in-memory tier is NOT populated. The
     // writer additionally pre-populates the cache after
@@ -177,7 +177,7 @@ fn producer_with_cache_reads_through_cache_path() {
     drop(w);
 
     // Post-commit the cache holds the warmed
-    // segment. n_cold_fetches stays 0; n_entries == 1.
+    // superfile. n_cold_fetches stays 0; n_entries == 1.
     let pre = cache.stats();
     assert_eq!(pre.n_cold_fetches, 0);
     assert_eq!(pre.n_entries, 1, "writer should have warmed the cache");
@@ -229,7 +229,7 @@ fn writer_warms_cache_on_commit_so_producer_query_skips_cold_fetch() {
     let post_commit = cache.stats();
     assert_eq!(
         post_commit.n_entries, 1,
-        "writer must have warmed the cache with the just-committed segment"
+        "writer must have warmed the cache with the just-committed superfile"
     );
     assert_eq!(
         post_commit.n_cold_fetches, 0,
@@ -237,7 +237,7 @@ fn writer_warms_cache_on_commit_so_producer_query_skips_cold_fetch() {
     );
     assert!(
         post_commit.current_bytes > 0,
-        "cache must hold the warmed segment's bytes; got current_bytes={}",
+        "cache must hold the warmed superfile's bytes; got current_bytes={}",
         post_commit.current_bytes
     );
 
@@ -290,13 +290,13 @@ fn writer_warm_cache_is_idempotent_under_writer_retry() {
 }
 
 #[test]
-fn manifest_segments_are_not_pinned_by_supertable_create() {
-    // The cache must be free to evict any segment to stay under
+fn manifest_superfiles_are_not_pinned_by_supertable_create() {
+    // The cache must be free to evict any superfile to stay under
     // budget. Pinning the live manifest makes the whole index
     // required to fit in cache: once all resident entries are pinned,
     // the next admit can fail with BudgetExceeded. Supertable::create
     // therefore installs a pin callback that does not pin manifest
-    // segments.
+    // superfiles.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");
     let storage: Arc<dyn StorageProvider> =
@@ -314,7 +314,7 @@ fn manifest_segments_are_not_pinned_by_supertable_create() {
     let pre = cache.current_pinned_uris();
     assert!(pre.is_empty(), "expected empty pinned set; got {pre:?}");
 
-    // Commit one segment.
+    // Commit one superfile.
     {
         let mut w = st.writer().expect("writer");
         w.append(&build_title_batch(&["pinned alpha"]))
@@ -322,7 +322,7 @@ fn manifest_segments_are_not_pinned_by_supertable_create() {
         w.commit().expect("commit");
     }
 
-    // Post-commit: the manifest has one segment, but the cache still
+    // Post-commit: the manifest has one superfile, but the cache still
     // pins nothing. Eviction protection is not based on the live
     // manifest set.
     let post = cache.current_pinned_uris();
@@ -332,11 +332,11 @@ fn manifest_segments_are_not_pinned_by_supertable_create() {
 }
 
 #[test]
-fn manifest_segments_are_not_pinned_by_supertable_open() {
+fn manifest_superfiles_are_not_pinned_by_supertable_open() {
     // Supertable::open follows the same cache policy as create: the
-    // live manifest does not pin segment files. A cross-process
+    // live manifest does not pin superfile files. A cross-process
     // consumer can stream an index larger than cache budget instead
-    // of making every manifest segment ineligible for eviction.
+    // of making every manifest superfile ineligible for eviction.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
@@ -367,15 +367,15 @@ fn manifest_segments_are_not_pinned_by_supertable_open() {
         pinned.is_empty(),
         "expected empty pinned set; got {pinned:?}"
     );
-    let n_segments = consumer.reader().manifest().superfile_list.superfiles.len();
-    assert_eq!(n_segments, 1);
+    let n_superfiles = consumer.reader().manifest().superfile_list.superfiles.len();
+    assert_eq!(n_superfiles, 1);
 }
 
 #[test]
 fn pinned_fn_does_not_hold_supertable_alive() {
     // Cache outliving its supertable is supported: the installed
     // callback must not keep the supertable alive. The current policy
-    // pins no manifest segments, so the observable set is empty both
+    // pins no manifest superfiles, so the observable set is empty both
     // before and after drop.
     let storage_dir = TempDir::new().expect("storage tempdir");
     let cache_dir = TempDir::new().expect("cache tempdir");

--- a/tests/supertable/disk_cache/hybrid.rs
+++ b/tests/supertable/disk_cache/hybrid.rs
@@ -13,7 +13,7 @@
 //! - The foreground returns when all range-fetches finish;
 //!   pwrites + fsync + rename + mmap + cache registration
 //!   finalize in a separate task that outlives this method.
-//! - Bandwidth per cold miss = 1× segment size (one set of
+//! - Bandwidth per cold miss = 1× superfile size (one set of
 //!   `get_range` calls serves both foreground and cache fill).
 //! - Concurrent cold readers on the same URI coalesce to a
 //!   single coordinator (single fetch fan-out).
@@ -203,7 +203,7 @@ async fn hybrid_reader_returns_working_superfile_reader() {
 }
 
 #[tokio::test]
-async fn hybrid_bandwidth_per_cold_miss_equals_segment_size() {
+async fn hybrid_bandwidth_per_cold_miss_equals_superfile_size() {
     // The plan's "1× bandwidth per cold miss" invariant —
     // the same range responses serve both foreground and
     // cache fill; no re-fetching.
@@ -211,7 +211,7 @@ async fn hybrid_bandwidth_per_cold_miss_equals_segment_size() {
     let local: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
-    let segment_size = bytes.len();
+    let superfile_size = bytes.len();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
 
@@ -232,10 +232,10 @@ async fn hybrid_bandwidth_per_cold_miss_equals_segment_size() {
 
     let bytes_fetched = proxy.bytes();
     assert_eq!(
-        bytes_fetched, segment_size,
-        "1× bandwidth invariant: total get_range bytes ({}) must equal segment size ({}); \
+        bytes_fetched, superfile_size,
+        "1× bandwidth invariant: total get_range bytes ({}) must equal superfile size ({}); \
          any excess indicates re-fetching between foreground and cache fill",
-        bytes_fetched, segment_size
+        bytes_fetched, superfile_size
     );
 }
 
@@ -276,7 +276,7 @@ async fn hybrid_concurrent_readers_coalesce_to_one_fetch_fan_out() {
     let local: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_test_bytes();
-    let segment_size = bytes.len();
+    let superfile_size = bytes.len();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
 
@@ -294,7 +294,7 @@ async fn hybrid_concurrent_readers_coalesce_to_one_fetch_fan_out() {
     for h in joins {
         let _ = h.await.expect("join").expect("reader");
     }
-    // Bandwidth still equals one segment size — coalescing
+    // Bandwidth still equals one superfile size — coalescing
     // ensured exactly one fetch fan-out served all 50.
     tokio::time::sleep(std::time::Duration::from_millis(
         BACKGROUND_FINALIZER_SLEEP_MS,
@@ -302,7 +302,7 @@ async fn hybrid_concurrent_readers_coalesce_to_one_fetch_fan_out() {
     .await;
     assert_eq!(
         proxy.bytes(),
-        segment_size,
+        superfile_size,
         "50 concurrent cold readers must trigger exactly one fan-out"
     );
     let stats = cache.stats();

--- a/tests/supertable/disk_cache/lazy_foreground.rs
+++ b/tests/supertable/disk_cache/lazy_foreground.rs
@@ -6,7 +6,7 @@
 //! immediately (paying only the cold-open byte budget
 //! against object storage), a background task waits for the
 //! foreground lazy reader to release, downloads the full
-//! segment to NVMe + mmaps it, and **any subsequent
+//! superfile to NVMe + mmaps it, and **any subsequent
 //! `reader(uri)` call returns the mmap-backed reader** — the
 //! corresponding search issues zero S3 GETs.
 //!
@@ -14,7 +14,7 @@
 //!
 //! - The cold-foreground reader is functional immediately
 //!   (FTS queries return correct results) without waiting for
-//!   the background segment fill.
+//!   the background superfile fill.
 //! - The warm-path zero-S3-GET invariant: after the
 //!   background promotion completes, a second `reader(uri)`
 //!   plus a search resolves entirely from mmap — the counting
@@ -212,7 +212,7 @@ async fn wait_for_mmap_promotion(
 /// cold reader from
 /// `LazyForegroundWithBackgroundFill` is functional
 /// immediately. The reader is FTS-queryable without waiting
-/// for the background segment fill; the warm-promotion
+/// for the background superfile fill; the warm-promotion
 /// guarantee is a separate, additive property tested below.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn lazy_foreground_cold_reader_is_queryable_immediately() {
@@ -238,7 +238,7 @@ async fn lazy_foreground_cold_reader_is_queryable_immediately() {
     assert_eq!(hits.len(), 2, "two docs contain 'special'");
 }
 
-/// The background full-segment fill must not compete with a
+/// The background full-superfile fill must not compete with a
 /// foreground lazy reader. Holding the reader across a short
 /// delay should not issue cache-fill range GETs; promotion begins
 /// only after the reader is dropped.
@@ -385,12 +385,12 @@ async fn lazy_foreground_concurrent_cold_readers_coalesce_to_one_promotion() {
 }
 
 /// the cold-path bandwidth profile is **2× per
-/// cold miss** (per-query ranges + background full-segment
+/// cold miss** (per-query ranges + background full-superfile
 /// download). This test documents that property by asserting
-/// the total `get_range` bytes are at least `segment_size`
+/// the total `get_range` bytes are at least `superfile_size`
 /// (the background fill) plus the cold foreground's per-query
 /// range — i.e., that the background fill actually runs.
-/// Counter-balances `hybrid_bandwidth_per_cold_miss_equals_segment_size`'s
+/// Counter-balances `hybrid_bandwidth_per_cold_miss_equals_superfile_size`'s
 /// 1× invariant for the hybrid mode.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn lazy_foreground_total_bandwidth_includes_background_fill() {
@@ -398,7 +398,7 @@ async fn lazy_foreground_total_bandwidth_includes_background_fill() {
     let local: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(store_dir.path()).expect("local"));
     let bytes = build_fts_only_bytes();
-    let segment_size = bytes.len();
+    let superfile_size = bytes.len();
     let uri = SuperfileUri::new_v4();
     seed(&*local, uri, bytes).await;
 
@@ -415,10 +415,10 @@ async fn lazy_foreground_total_bandwidth_includes_background_fill() {
 
     let total_bytes = proxy.bytes();
     assert!(
-        total_bytes >= segment_size,
-        "background fill must download the full segment ({} bytes); \
+        total_bytes >= superfile_size,
+        "background fill must download the full superfile ({} bytes); \
          counting proxy observed {} bytes total",
-        segment_size,
+        superfile_size,
         total_bytes,
     );
 }

--- a/tests/supertable/main.rs
+++ b/tests/supertable/main.rs
@@ -11,7 +11,7 @@
 //!   assignment, in-process concurrency, stats accessor.
 //! - **query/**: hierarchical-manifest query path, skip-
 //!   pruning end-to-end, brute-force BM25 oracle for
-//!   multi-segment search.
+//!   multi-superfile search.
 //! - **manifest/**: the eager-vs-lazy-open threshold path.
 //! - **disk_cache/**: the cold-fetch coordinator + hybrid /
 //!   sweep policies + supertable-disk-cache integration.

--- a/tests/supertable/manifest/lazy_open.rs
+++ b/tests/supertable/manifest/lazy_open.rs
@@ -81,7 +81,7 @@ fn one_part_eager_fetches_under_default_threshold() {
 
 #[test]
 fn many_parts_skip_eager_fetch() {
-    // target_superfiles_per_partition=1 + 5 single-segment
+    // target_superfiles_per_partition=1 + 5 single-superfile
     // commits → 5 list entries, all sharing the same
     // partition_key (the partition-split path). With default
     // threshold=4, 5 > 4 → lazy.

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! BM25 correctness oracle for the supertable's multi-segment
+//! BM25 correctness oracle for the supertable's multi-superfile
 //! search path.
 //!
 //! The supertable shards the corpus across N superfiles. Each
-//! superfile runs its own BM25 with its own per-segment IDF +
-//! avgdl, and the supertable merges the per-segment top-k into a
-//! global top-k. This oracle mirrors that shape with a per-segment
+//! superfile runs its own BM25 with its own per-superfile IDF +
+//! avgdl, and the supertable merges the per-superfile top-k into a
+//! global top-k. This oracle mirrors that shape with a per-superfile
 //! brute-force BM25 and a global merge, then asserts the
 //! supertable's hits match.
 //!
 //! ## What this oracle catches
 //!
-//! Per-segment brute-force catches per-segment scoring bugs (same
-//! as the single-segment oracle in
-//! `tests/superfile/fts/brute_force_oracle.rs`). The cross-segment
-//! merge catches a separate class of bugs that the single-segment
-//! oracle can't see: wrong segment partitioning, wrong tagging of
-//! per-segment hits with their segment URI, wrong score-direction
+//! Per-superfile brute-force catches per-superfile scoring bugs (same
+//! as the single-superfile oracle in
+//! `tests/superfile/fts/brute_force_oracle.rs`). The cross-superfile
+//! merge catches a separate class of bugs that the single-superfile
+//! oracle can't see: wrong superfile partitioning, wrong tagging of
+//! per-superfile hits with their superfile URI, wrong score-direction
 //! in the top-k merge.
 //!
 //! ## Tolerances
@@ -110,10 +110,10 @@ fn planted_corpus() -> Vec<(u64, &'static str)> {
     ]
 }
 
-const SEGMENTS: usize = 4;
-const N_PREFIX_TERMS: usize = SEGMENTS;
+const SUPERFILES: usize = 4;
+const N_PREFIX_TERMS: usize = SUPERFILES;
 const N_PLANTED: usize = 60;
-const CHUNK_SIZE: usize = N_PLANTED / SEGMENTS;
+const CHUNK_SIZE: usize = N_PLANTED / SUPERFILES;
 /// Standard oracle top-k (with headroom) for the comparison queries.
 const ORACLE_TOP_K: usize = 10;
 /// Smaller oracle top-k for the single-/few-match queries.
@@ -173,8 +173,8 @@ fn build_supertable(corpus: &[(u64, String)], n_superfiles: usize) -> Supertable
     st
 }
 
-/// Convert supertable hits to global doc_ids using the segment-
-/// append order (segment_index * chunk_size + local_doc_id).
+/// Convert supertable hits to global doc_ids using the superfile-
+/// append order (superfile_index * chunk_size + local_doc_id).
 fn supertable_to_global_ids(
     st: &Supertable,
     hits: Vec<SuperfileHit>,
@@ -187,8 +187,8 @@ fn supertable_to_global_ids(
             let seg_idx = manifest
                 .superfiles
                 .iter()
-                .position(|e| e.uri == h.segment)
-                .expect("segment in manifest");
+                .position(|e| e.uri == h.superfile)
+                .expect("superfile in manifest");
             (seg_idx as u64) * (chunk_size as u64) + (h.local_doc_id as u64)
         })
         .collect()
@@ -228,11 +228,11 @@ fn supertable_prefix_global(
     supertable_to_global_ids(st, hits, chunk_size)
 }
 
-// ---- Brute-force oracle (per-segment + global merge) ---------------
+// ---- Brute-force oracle (per-superfile + global merge) ---------------
 
-/// Build a per-segment BruteForceBm25 oracle list. Index i scores
-/// segment i with that segment's own IDF/avgdl, mirroring the
-/// supertable's per-segment scoring shape.
+/// Build a per-superfile BruteForceBm25 oracle list. Index i scores
+/// superfile i with that superfile's own IDF/avgdl, mirroring the
+/// supertable's per-superfile scoring shape.
 fn build_oracles(corpus: &[(u64, String)], n_superfiles: usize) -> Vec<BruteForceBm25> {
     let tok = default_tokenizer();
     let chunk_size = corpus.len().div_ceil(n_superfiles);
@@ -247,7 +247,7 @@ fn build_oracles(corpus: &[(u64, String)], n_superfiles: usize) -> Vec<BruteForc
         .collect()
 }
 
-/// Run per-segment brute-force BM25 and merge into a global top-k
+/// Run per-superfile brute-force BM25 and merge into a global top-k
 /// in the same shape the supertable's fan-out produces.
 fn brute_force_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> Vec<u64> {
     let tok = default_tokenizer();
@@ -265,9 +265,9 @@ fn brute_force_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> Vec<u
 }
 
 /// Same as [`brute_force_top_k`] but for a multi-term explicit
-/// AND query. Each segment scores its AND intersection
+/// AND query. Each superfile scores its AND intersection
 /// independently; the global merge keeps the highest-scoring docs
-/// across segments. Mirrors the supertable's AND fan-out shape.
+/// across superfiles. Mirrors the supertable's AND fan-out shape.
 fn brute_force_and_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> Vec<u64> {
     let tok = default_tokenizer();
     let mut terms: Vec<String> = Vec::new();
@@ -319,8 +319,8 @@ struct StandardFixture {
 
 static STANDARD_FIXTURE: LazyLock<StandardFixture> = LazyLock::new(|| {
     let corp = corpus_with_prefix_terms();
-    let infino = build_supertable(&corp, SEGMENTS);
-    let oracles = build_oracles(&corp, SEGMENTS);
+    let infino = build_supertable(&corp, SUPERFILES);
+    let oracles = build_oracles(&corp, SUPERFILES);
     StandardFixture { infino, oracles }
 });
 
@@ -328,7 +328,7 @@ static STANDARD_FIXTURE: LazyLock<StandardFixture> = LazyLock::new(|| {
 
 #[test]
 fn oracle_single_rare_top1_matches() {
-    // "rare-token-zzz" appears in exactly 1 doc (id=17, segment 1).
+    // "rare-token-zzz" appears in exactly 1 doc (id=17, superfile 1).
     let f = &*STANDARD_FIXTURE;
     let inf_hits =
         supertable_search_global(&f.infino, "rare-token-zzz", ORACLE_TOP_K_SMALL, CHUNK_SIZE);
@@ -422,13 +422,13 @@ fn oracle_five_term_or_top5_matches() {
     assert_eq!(ora_top, want);
 }
 
-// ---- Tests: AND-mode oracle (multi-segment intersection) ------------
+// ---- Tests: AND-mode oracle (multi-superfile intersection) ------------
 
 #[test]
 fn oracle_two_term_and_matches() {
     // "rust" + "async" co-occur in docs 0, 20, 22 — split across
-    // segments 0 (doc 0) and 1 (docs 20, 22), so this exercises
-    // multi-segment AND fan-out.
+    // superfiles 0 (doc 0) and 1 (docs 20, 22), so this exercises
+    // multi-superfile AND fan-out.
     let f = &*STANDARD_FIXTURE;
     let inf_hits = supertable_search_and_global(&f.infino, "rust async", ORACLE_TOP_K, CHUNK_SIZE);
     let ora_hits = brute_force_and_top_k(&f.oracles, "rust async", ORACLE_TOP_K);
@@ -441,7 +441,7 @@ fn oracle_two_term_and_matches() {
 
 #[test]
 fn oracle_three_term_and_singleton_match() {
-    // "rust" + "async" + "tokio" intersect only at doc 0 (segment 0).
+    // "rust" + "async" + "tokio" intersect only at doc 0 (superfile 0).
     let f = &*STANDARD_FIXTURE;
     let inf_hits =
         supertable_search_and_global(&f.infino, "rust async tokio", ORACLE_TOP_K, CHUNK_SIZE);
@@ -463,12 +463,12 @@ fn oracle_and_missing_term_returns_empty() {
 }
 
 #[test]
-fn oracle_and_segment_locally_missing_term_still_intersects_elsewhere() {
-    // "rust" + "kafka" — "rust" appears in every segment, but
-    // "kafka" only appears in doc 15 (segment 1) where "rust" does
+fn oracle_and_superfile_locally_missing_term_still_intersects_elsewhere() {
+    // "rust" + "kafka" — "rust" appears in every superfile, but
+    // "kafka" only appears in doc 15 (superfile 1) where "rust" does
     // not co-occur. The intersection is empty across the whole
-    // table, but the test confirms that segments with the missing
-    // term contribute nothing and segments without the missing term
+    // table, but the test confirms that superfiles with the missing
+    // term contribute nothing and superfiles without the missing term
     // also contribute nothing.
     let f = &*STANDARD_FIXTURE;
     let inf_hits = supertable_search_and_global(&f.infino, "rust kafka", ORACLE_TOP_K, CHUNK_SIZE);
@@ -487,8 +487,8 @@ fn oracle_and_segment_locally_missing_term_still_intersects_elsewhere() {
 
 #[test]
 fn oracle_prefix_query_matches_explicit_term_or() {
-    // The supertable expands `alphafox` via per-segment FST walk,
-    // then runs a per-segment OR over the expansion. Mirror this
+    // The supertable expands `alphafox` via per-superfile FST walk,
+    // then runs a per-superfile OR over the expansion. Mirror this
     // by running a brute-force OR over the same explicit term list.
     let f = &*STANDARD_FIXTURE;
     let prefix = "alphafox";
@@ -507,8 +507,8 @@ fn oracle_prefix_query_matches_explicit_term_or() {
 }
 
 #[test]
-fn prefix_skip_prunes_segments_without_matching_lex_range() {
-    // Plant a prefix term in only one segment; verify the prefix
+fn prefix_skip_prunes_superfiles_without_matching_lex_range() {
+    // Plant a prefix term in only one superfile; verify the prefix
     // search returns exactly that doc and skip pruning prevents
     // other superfiles from contributing.
     let mut corp: Vec<(u64, String)> = planted_corpus()
@@ -516,7 +516,7 @@ fn prefix_skip_prunes_segments_without_matching_lex_range() {
         .map(|(id, t)| (id, t.to_string()))
         .collect();
     corp[0].1.push_str(" quokka_unique");
-    let infino = build_supertable(&corp, SEGMENTS);
+    let infino = build_supertable(&corp, SUPERFILES);
     let r = infino.reader();
     let hits = r
         .bm25_search_prefix("title", "quokka", ORACLE_TOP_K_SMALL)
@@ -524,7 +524,7 @@ fn prefix_skip_prunes_segments_without_matching_lex_range() {
     assert_eq!(hits.len(), 1);
     let manifest = r.manifest();
     let target_uri = manifest.superfiles[0].uri;
-    assert_eq!(hits[0].segment, target_uri);
+    assert_eq!(hits[0].superfile, target_uri);
     assert_eq!(hits[0].local_doc_id, 0);
 }
 
@@ -583,16 +583,16 @@ fn zipfian_corpus(n_docs: usize, seed: u64) -> Vec<(u64, String)> {
 
 #[test]
 fn oracle_zipfian_corpus_query_shapes_match() {
-    // 5K docs × 4 superfiles = 1250 docs/segment. Brute-force across
-    // segments is the exact same scoring path the supertable runs
-    // (per-segment IDF + global top-k merge with identical
+    // 5K docs × 4 superfiles = 1250 docs/superfile. Brute-force across
+    // superfiles is the exact same scoring path the supertable runs
+    // (per-superfile IDF + global top-k merge with identical
     // tie-breaker), so set overlap on the top-k is expected to be
     // tight; we keep the 60 % threshold loose to absorb any future
     // BM25 dl-norm refinements without test churn.
     let n_docs = 5_000;
     let corp = zipfian_corpus(n_docs, 42);
-    let infino = build_supertable(&corp, SEGMENTS);
-    let oracles = build_oracles(&corp, SEGMENTS);
+    let infino = build_supertable(&corp, SUPERFILES);
+    let oracles = build_oracles(&corp, SUPERFILES);
     let k = ZIPFIAN_TOP_K;
 
     let queries = [
@@ -607,7 +607,7 @@ fn oracle_zipfian_corpus_query_shapes_match() {
     ];
 
     for (label, q) in queries {
-        let inf = supertable_search_global(&infino, q, k, n_docs / SEGMENTS);
+        let inf = supertable_search_global(&infino, q, k, n_docs / SUPERFILES);
         let ora = brute_force_top_k(&oracles, q, k);
         let inf_set: HashSet<u64> = inf.iter().copied().collect();
         let ora_set: HashSet<u64> = ora.iter().copied().collect();

--- a/tests/supertable/query/fanout_concurrency.rs
+++ b/tests/supertable/query/fanout_concurrency.rs
@@ -10,7 +10,7 @@
 //!
 //! Every public search call is **sync**: it `block_on`s the
 //! supertable's shared query runtime. Underneath, `fanout` spawns one
-//! tokio task per segment for the I/O wave, and each per-segment kernel
+//! tokio task per superfile for the I/O wave, and each per-superfile kernel
 //! offloads its scoring onto the global **rayon** pool. Driving that
 //! from many OS threads at once is the classic deadlock surface:
 //!
@@ -53,14 +53,14 @@ use infino::supertable::{Supertable, SupertableOptions};
 use infino::test_helpers::{default_tokenizer, default_vector_config};
 
 const DIM: usize = 16;
-const SEGMENTS: usize = 4;
-const DOCS_PER_SEGMENT: usize = 8;
+const SUPERFILES: usize = 4;
+const DOCS_PER_SUPERFILE: usize = 8;
 
 const N_THREADS: usize = 16;
 const ITERS_PER_THREAD: usize = 25;
 /// Random-rotation seed for the fanout fixture's vector index.
 const VECTOR_ROT_SEED: u64 = 7;
-/// Rayon CPU pool size used to orchestrate cross-segment fanout.
+/// Rayon CPU pool size used to orchestrate cross-superfile fanout.
 const RAYON_POOL_THREADS: usize = 4;
 /// Number of distinct query kinds cycled in the stress loop.
 const QUERY_KIND_COUNT: usize = 4;
@@ -110,15 +110,15 @@ fn options_title_emb() -> SupertableOptions {
 }
 
 /// Doc `i` within the batch gets a "rust …" title (so BM25 `rust`
-/// fans out across every segment) and a one-hot embedding at global
+/// fans out across every superfile) and a one-hot embedding at global
 /// dim `base_dim + i`.
 fn build_batch(base_dim: usize, schema: Arc<Schema>) -> RecordBatch {
-    let titles: Vec<String> = (0..DOCS_PER_SEGMENT)
+    let titles: Vec<String> = (0..DOCS_PER_SUPERFILE)
         .map(|i| format!("rust topic {} variant", base_dim + i))
         .collect();
     let title_arr = LargeStringArray::from(titles.iter().map(|s| s.as_str()).collect::<Vec<_>>());
-    let mut flat = Vec::<f32>::with_capacity(DOCS_PER_SEGMENT * DIM);
-    for i in 0..DOCS_PER_SEGMENT {
+    let mut flat = Vec::<f32>::with_capacity(DOCS_PER_SUPERFILE * DIM);
+    for i in 0..DOCS_PER_SUPERFILE {
         let active = (base_dim + i) % DIM;
         for d in 0..DIM {
             flat.push(if d == active { 1.0 } else { 0.0 });
@@ -138,8 +138,8 @@ fn build_supertable() -> Supertable {
     let st = Supertable::create(options_title_emb()).expect("create");
     let schema = st.options().schema.clone();
     let mut w = st.writer().expect("writer");
-    for seg in 0..SEGMENTS {
-        w.append(&build_batch(seg * DOCS_PER_SEGMENT, schema.clone()))
+    for seg in 0..SUPERFILES {
+        w.append(&build_batch(seg * DOCS_PER_SUPERFILE, schema.clone()))
             .expect("append");
         w.commit().expect("commit");
     }
@@ -155,13 +155,13 @@ fn csv_one_hot(active: usize) -> String {
 }
 
 /// Stable, order-independent identity for a hit list:
-/// sorted `(segment, local_doc_id)`. Segment is rendered via its
+/// sorted `(superfile, local_doc_id)`. Superfile is rendered via its
 /// `Debug` form so the test needs no extra type imports and is immune
 /// to fan-out / merge ordering.
 fn hit_key(hits: &[SuperfileHit]) -> Vec<(String, u32)> {
     let mut v: Vec<(String, u32)> = hits
         .iter()
-        .map(|h| (format!("{:?}", h.segment), h.local_doc_id))
+        .map(|h| (format!("{:?}", h.superfile), h.local_doc_id))
         .collect();
     v.sort();
     v
@@ -261,7 +261,7 @@ fn fanout_under_concurrency_is_live_and_deterministic() {
         !gold.hybrid_ids.is_empty(),
         "hybrid golden must be non-empty"
     );
-    assert_eq!(gold.count, (SEGMENTS * DOCS_PER_SEGMENT) as i64);
+    assert_eq!(gold.count, (SUPERFILES * DOCS_PER_SUPERFILE) as i64);
 
     // Run the whole stress on a coordinator thread and gate it behind a
     // watchdog so a deadlock trips the timeout instead of hanging the

--- a/tests/supertable/query/hybrid_search.rs
+++ b/tests/supertable/query/hybrid_search.rs
@@ -4,10 +4,10 @@
 //! Public-API integration coverage for the `hybrid_search` SQL TVF.
 //!
 //! `hybrid_exec.rs` carries the in-crate unit tests (RRF math, single
-//! segment). This file exercises the function the way a consumer does:
+//! superfile). This file exercises the function the way a consumer does:
 //! through the published `infino::supertable::Supertable::query_sql`
-//! surface, over a **multi-segment** corpus so the BM25 + vector
-//! retrievers fan out across segments and fuse the cross-segment
+//! surface, over a **multi-superfile** corpus so the BM25 + vector
+//! retrievers fan out across superfiles and fuse the cross-superfile
 //! results. It pins three contracts the plan promises:
 //!
 //!   1. `SELECT *` over `hybrid_search(...)` yields the scalar schema
@@ -100,11 +100,11 @@ fn build_batch(titles: &[&str], base_dim: usize, schema: Arc<Schema>) -> RecordB
     RecordBatch::try_new(schema, vec![Arc::new(title_arr), Arc::new(fsl)]).expect("batch")
 }
 
-/// Two-segment corpus (docs 0-7, then 8-15). `rust` is sprinkled
-/// across both segments; `async` is unique to doc 0. Doc `i`'s
+/// Two-superfile corpus (docs 0-7, then 8-15). `rust` is sprinkled
+/// across both superfiles; `async` is unique to doc 0. Doc `i`'s
 /// embedding is one-hot at dim `i`, so a one-hot query at dim 0 is the
 /// exact nearest neighbour of doc 0.
-fn demo_two_segments() -> Supertable {
+fn demo_two_superfiles() -> Supertable {
     let st = Supertable::create(options_title_emb()).expect("create");
     let schema = st.options().schema.clone();
     let mut w = st.writer().expect("writer");
@@ -192,7 +192,7 @@ fn scores(batches: &[RecordBatch]) -> Vec<f32> {
 
 #[test]
 fn hybrid_search_star_projection_exposes_scalar_schema_plus_score() {
-    let st = demo_two_segments();
+    let st = demo_two_superfiles();
     let batches = st
         .reader()
         .query_sql(&format!(
@@ -213,8 +213,8 @@ fn hybrid_search_star_projection_exposes_scalar_schema_plus_score() {
 }
 
 #[test]
-fn hybrid_search_identity_set_is_union_of_subsearches_across_segments() {
-    let st = demo_two_segments();
+fn hybrid_search_identity_set_is_union_of_subsearches_across_superfiles() {
+    let st = demo_two_superfiles();
     let qv = csv_one_hot(0);
     // k ≥ the total doc count (16) so RRF never truncates the fused
     // list — the union equality only holds when |bm25 ∪ vector| ≤ k.
@@ -242,9 +242,12 @@ fn hybrid_search_identity_set_is_union_of_subsearches_across_segments() {
             .expect("vector query_sql"),
     );
 
-    // Both retrievers must actually return hits from each segment for
-    // this to be a meaningful cross-segment union (guards corpus drift).
-    assert!(bm25.len() >= 4, "'rust' should match across both segments");
+    // Both retrievers must actually return hits from each superfile for
+    // this to be a meaningful cross-superfile union (guards corpus drift).
+    assert!(
+        bm25.len() >= 4,
+        "'rust' should match across both superfiles"
+    );
     assert!(!vector.is_empty(), "vector retriever returned nothing");
 
     let expected: HashSet<i128> = bm25.union(&vector).copied().collect();
@@ -256,7 +259,7 @@ fn hybrid_search_identity_set_is_union_of_subsearches_across_segments() {
 
 #[test]
 fn hybrid_search_doc_top_in_both_retrievers_ranks_first() {
-    let st = demo_two_segments();
+    let st = demo_two_superfiles();
     // `async` is unique to doc 0 (BM25 rank 1); a one-hot query at dim
     // 0 makes doc 0 the exact vector match (rank 1). Top in both →
     // highest RRF → emitted first.

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -6,14 +6,14 @@
 //! and `hybrid_search`.
 //!
 //! The in-crate unit tests (`match_exec.rs`, `hybrid_exec.rs`) cover the
-//! SQL table-valued functions and the RRF math on a single segment.
+//! SQL table-valued functions and the RRF math on a single superfile.
 //! This file exercises the published
 //! `SupertableReader::{token_match, exact_match, hybrid_search}` surface
 //! the way a Rust consumer calls it — `st.reader().token_match(..)` —
-//! over a committed **multi-segment** corpus so the per-segment work
-//! fans out and merges across segments.
+//! over a committed **multi-superfile** corpus so the per-superfile work
+//! fans out and merges across superfiles.
 //!
-//! Hits are identified by their `(segment, local_doc_id)` pair (the same
+//! Hits are identified by their `(superfile, local_doc_id)` pair (the same
 //! identity RRF fuses on); expectations are pinned by comparing against
 //! the `bm25_search` / `vector_search` sub-searches rather than by
 //! hand-mapping doc positions, so the assertions hold regardless of how
@@ -48,11 +48,11 @@ const QUERY_DIM: usize = 0;
 const TOP_K: usize = 32;
 /// Smaller top-k for the ranking-order assertions.
 const RANK_TOP_K: usize = 8;
-/// `rust` is sprinkled across both segments; this guards against corpus
-/// drift silently making the cross-segment assertions trivial.
+/// `rust` is sprinkled across both superfiles; this guards against corpus
+/// drift silently making the cross-superfile assertions trivial.
 const MIN_RUST_HITS: usize = 4;
 
-/// First segment's titles; doc `i`'s embedding is one-hot at dim `i`.
+/// First superfile's titles; doc `i`'s embedding is one-hot at dim `i`.
 const SEG1_TITLES: &[&str] = &[
     "rust async",   // 0  — `async` is unique to this doc
     "python data",  // 1
@@ -63,7 +63,7 @@ const SEG1_TITLES: &[&str] = &[
     "kotlin flow",  // 6
     "rust systems", // 7  — only doc with both `rust` and `systems`
 ];
-/// Second segment's titles; doc `i` (global) is one-hot at dim `i`.
+/// Second superfile's titles; doc `i` (global) is one-hot at dim `i`.
 const SEG2_TITLES: &[&str] = &[
     "swift ui",      // 8
     "rust web",      // 9
@@ -129,8 +129,8 @@ fn build_batch(titles: &[&str], base_dim: usize, schema: Arc<Schema>) -> RecordB
     RecordBatch::try_new(schema, vec![Arc::new(title_arr), Arc::new(fsl)]).expect("batch")
 }
 
-/// Two committed segments built from [`SEG1_TITLES`] then [`SEG2_TITLES`].
-fn demo_two_segments() -> Supertable {
+/// Two committed superfiles built from [`SEG1_TITLES`] then [`SEG2_TITLES`].
+fn demo_two_superfiles() -> Supertable {
     let st = Supertable::create(options_title_emb()).expect("create");
     let schema = st.options().schema.clone();
     let mut w = st.writer().expect("writer");
@@ -150,15 +150,15 @@ fn one_hot(active: usize) -> Vec<f32> {
         .collect()
 }
 
-/// Stable per-row identity: the `(segment, local_doc_id)` pair RRF and
+/// Stable per-row identity: the `(superfile, local_doc_id)` pair RRF and
 /// the resolve path both key on.
 fn hit_ids(hits: &[SuperfileHit]) -> HashSet<(SuperfileUri, u32)> {
-    hits.iter().map(|h| (h.segment, h.local_doc_id)).collect()
+    hits.iter().map(|h| (h.superfile, h.local_doc_id)).collect()
 }
 
 #[test]
 fn token_match_or_is_the_unranked_bm25_candidate_set() {
-    let st = demo_two_segments();
+    let st = demo_two_superfiles();
     let reader = st.reader();
     let token = reader
         .token_match("title", "rust", BoolMode::Or)
@@ -169,7 +169,7 @@ fn token_match_or_is_the_unranked_bm25_candidate_set() {
 
     assert!(
         bm25.len() >= MIN_RUST_HITS,
-        "'rust' should match across both segments"
+        "'rust' should match across both superfiles"
     );
     assert_eq!(
         hit_ids(&token),
@@ -184,7 +184,7 @@ fn token_match_or_is_the_unranked_bm25_candidate_set() {
 
 #[test]
 fn token_match_and_intersects_tokens() {
-    let st = demo_two_segments();
+    let st = demo_two_superfiles();
     let reader = st.reader();
     // Only "rust systems" carries both tokens.
     let token = reader
@@ -204,7 +204,7 @@ fn token_match_and_intersects_tokens() {
 
 #[test]
 fn exact_match_is_raw_value_equality_not_token() {
-    let st = demo_two_segments();
+    let st = demo_two_superfiles();
     let reader = st.reader();
     // The raw title "rust async" equals exactly the docs that the
     // token-AND prune leaves (only doc 0 has both `rust` and `async`).
@@ -239,7 +239,7 @@ fn exact_match_is_raw_value_equality_not_token() {
 
 #[test]
 fn hybrid_search_unions_bm25_and_vector_and_orders_by_score() {
-    let st = demo_two_segments();
+    let st = demo_two_superfiles();
     let reader = st.reader();
     let q = one_hot(QUERY_DIM);
 
@@ -263,7 +263,7 @@ fn hybrid_search_unions_bm25_and_vector_and_orders_by_score() {
 
     assert!(
         bm25.len() >= MIN_RUST_HITS,
-        "'rust' should match across both segments"
+        "'rust' should match across both superfiles"
     );
     assert!(!vector.is_empty(), "vector retriever returned nothing");
 
@@ -285,7 +285,7 @@ fn hybrid_search_unions_bm25_and_vector_and_orders_by_score() {
 
 #[test]
 fn hybrid_search_doc_top_in_both_retrievers_ranks_first() {
-    let st = demo_two_segments();
+    let st = demo_two_superfiles();
     let reader = st.reader();
     let q = one_hot(QUERY_DIM);
 
@@ -314,15 +314,15 @@ fn hybrid_search_doc_top_in_both_retrievers_ranks_first() {
         !hybrid.is_empty() && !bm25.is_empty() && !vector.is_empty(),
         "all retrievers must return hits"
     );
-    let top = (hybrid[0].segment, hybrid[0].local_doc_id);
+    let top = (hybrid[0].superfile, hybrid[0].local_doc_id);
     assert_eq!(
         top,
-        (bm25[0].segment, bm25[0].local_doc_id),
+        (bm25[0].superfile, bm25[0].local_doc_id),
         "fused #1 must be the BM25 #1"
     );
     assert_eq!(
         top,
-        (vector[0].segment, vector[0].local_doc_id),
+        (vector[0].superfile, vector[0].local_doc_id),
         "fused #1 must also be the vector #1 (top in both ⇒ first)"
     );
 }

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -4,7 +4,7 @@
 //! Manifest-level skip pruning end-to-end.
 //!
 //! These tests are the load-bearing perf claim of the skip
-//! layer: a segment that doesn't match a query must never
+//! layer: a superfile that doesn't match a query must never
 //! trigger a [`SuperfileReaderCache::reader`] call. We assert that by
 //! wrapping the in-memory store in a counting decorator and
 //! comparing per-URI reader-call counts taken before and after
@@ -14,20 +14,20 @@
 //!
 //!   1. **Exact-term BM25** — `nimblefox` is planted in exactly
 //!      one of N superfiles. After running `bm25_search`, only that
-//!      segment's reader has been opened. The N-1 pruned superfiles
+//!      superfile's reader has been opened. The N-1 pruned superfiles
 //!      stay cold.
 //!   2. **Prefix BM25** — terms beginning with `quokka` are
-//!      planted in exactly one segment (the others contain only
+//!      planted in exactly one superfile (the others contain only
 //!      `apple`/`banana`/etc. — no overlap with the lex range
 //!      `[quokka, quokka_upper_bound)`). `bm25_search_prefix`
-//!      opens only the matching segment.
+//!      opens only the matching superfile.
 //!
 //! Vector centroid skip is not asserted here — the v1
 //! `vector_centroid_skip` returns all-keep (cutoff-driven skip
-//! is deferred), so the test would just confirm "every segment
+//! is deferred), so the test would just confirm "every superfile
 //! is opened" which isn't a useful invariant. Scalar skip via
 //! SQL is similarly deferred: the SQL path uses a `MemTable`
-//! that opens every segment at registration time; a future
+//! that opens every superfile at registration time; a future
 //! custom `TableProvider` will integrate `PruningPredicate`
 //! and revisit this.
 
@@ -50,12 +50,12 @@ use infino::test_helpers::{build_title_batch, default_tokenizer, schema_id_title
 
 /// Single-thread rayon pool for deterministic skip-pruning.
 const RAYON_POOL_THREADS: usize = 1;
-/// Four-segment corpus for the exact-term skip tests.
-const EXACT_TERM_SEGMENT_COUNT: usize = 4;
+/// Four-superfile corpus for the exact-term skip tests.
+const EXACT_TERM_SUPERFILE_COUNT: usize = 4;
 /// BM25 / prefix top-k used across the skip-pruning queries.
 const BM25_TOP_K: usize = 5;
-/// Segments with no matching term (bloom-prune-all fixture).
-const NO_MATCH_SEGMENT_COUNT: u64 = 3;
+/// Superfiles with no matching term (bloom-prune-all fixture).
+const NO_MATCH_SUPERFILE_COUNT: u64 = 3;
 
 /// Decorator over an `InMemoryReaderCache` that counts
 /// per-URI `reader` calls. Wraps without behavior change.
@@ -136,11 +136,11 @@ fn options_with_counting_store(store: Arc<CountingStore>) -> SupertableOptions {
 }
 
 #[test]
-fn bm25_exact_term_skip_opens_only_matching_segment() {
+fn bm25_exact_term_skip_opens_only_matching_superfile() {
     let store = Arc::new(CountingStore::new());
     let st = Supertable::create(options_with_counting_store(Arc::clone(&store))).expect("create");
 
-    // Four superfiles. Plant the rare term `nimblefox` in segment 0
+    // Four superfiles. Plant the rare term `nimblefox` in superfile 0
     // only; the other three superfiles share generic terms only.
     let mut w = st.writer().expect("writer");
     w.append(&build_title_batch(&[
@@ -170,14 +170,14 @@ fn bm25_exact_term_skip_opens_only_matching_segment() {
     drop(w);
 
     let r = st.reader();
-    assert_eq!(r.n_superfiles(), EXACT_TERM_SEGMENT_COUNT);
+    assert_eq!(r.n_superfiles(), EXACT_TERM_SUPERFILE_COUNT);
 
-    // Identify the URI of segment 0 (the planted segment).
+    // Identify the URI of superfile 0 (the planted superfile).
     let manifest = r.manifest();
     let target_uri = manifest.superfiles[0].uri;
 
     // Snapshot reader-call counts AFTER commits (writer publishes
-    // each segment via one reader call to derive summaries). We
+    // each superfile via one reader call to derive summaries). We
     // measure the delta over the query alone.
     let before = store.snapshot();
 
@@ -190,29 +190,29 @@ fn bm25_exact_term_skip_opens_only_matching_segment() {
         )
         .expect("query");
     assert_eq!(hits.len(), 1, "exactly one doc matches `nimblefox`");
-    assert_eq!(hits[0].segment, target_uri);
+    assert_eq!(hits[0].superfile, target_uri);
 
     let delta = store.delta(&before);
     assert_eq!(
         delta.len(),
         1,
-        "skip should open exactly one segment for an exact-term query \
+        "skip should open exactly one superfile for an exact-term query \
          where 3 of 4 superfiles have the term definitively absent — got {delta:?}"
     );
     assert!(
         delta.contains_key(&target_uri),
-        "the one opened segment must be the planted one"
+        "the one opened superfile must be the planted one"
     );
 }
 
 #[test]
-fn bm25_prefix_skip_opens_only_segments_overlapping_prefix_range() {
+fn bm25_prefix_skip_opens_only_superfiles_overlapping_prefix_range() {
     let store = Arc::new(CountingStore::new());
     let st = Supertable::create(options_with_counting_store(Arc::clone(&store))).expect("create");
 
-    // Four superfiles. Segment 1 contains terms starting with
+    // Four superfiles. Superfile 1 contains terms starting with
     // `quokka`; the other three contain only terms strictly
-    // lex-less-than `quokka` so each segment's lex term range
+    // lex-less-than `quokka` so each superfile's lex term range
     // is fully below `[quokka, quokka_upper_bound)` and the
     // term-range skip prunes them.
     let mut w = st.writer().expect("writer");
@@ -234,7 +234,7 @@ fn bm25_prefix_skip_opens_only_segments_overlapping_prefix_range() {
     drop(w);
 
     let r = st.reader();
-    assert_eq!(r.n_superfiles(), EXACT_TERM_SEGMENT_COUNT);
+    assert_eq!(r.n_superfiles(), EXACT_TERM_SUPERFILE_COUNT);
 
     let manifest = r.manifest();
     let quokka_uri = manifest.superfiles[1].uri;
@@ -243,29 +243,29 @@ fn bm25_prefix_skip_opens_only_segments_overlapping_prefix_range() {
     let hits = r
         .bm25_search_prefix("title", "quokka", BM25_TOP_K)
         .expect("prefix query");
-    assert_eq!(hits.len(), 2, "two docs in segment 1 begin with `quokka`");
+    assert_eq!(hits.len(), 2, "two docs in superfile 1 begin with `quokka`");
     for h in &hits {
-        assert_eq!(h.segment, quokka_uri);
+        assert_eq!(h.superfile, quokka_uri);
     }
 
     let delta = store.delta(&before);
     assert_eq!(
         delta.len(),
         1,
-        "term-range skip should open exactly the one segment whose \
+        "term-range skip should open exactly the one superfile whose \
          lex term range overlaps [quokka, quokka_upper_bound) — got {delta:?}"
     );
     assert!(delta.contains_key(&quokka_uri));
 }
 
 #[test]
-fn bm25_search_with_no_matching_segments_opens_no_segments_at_all() {
+fn bm25_search_with_no_matching_superfiles_opens_no_superfiles_at_all() {
     let store = Arc::new(CountingStore::new());
     let st = Supertable::create(options_with_counting_store(Arc::clone(&store))).expect("create");
 
     // Three superfiles — none contains the rare query term.
     let mut w = st.writer().expect("writer");
-    for _i in 0..NO_MATCH_SEGMENT_COUNT {
+    for _i in 0..NO_MATCH_SUPERFILE_COUNT {
         w.append(&build_title_batch(&[
             "ordinary term filler",
             "another mundane title",
@@ -296,13 +296,13 @@ fn bm25_search_with_no_matching_segments_opens_no_segments_at_all() {
 }
 
 #[test]
-fn bm25_and_mode_skip_requires_all_terms_present_in_segment() {
+fn bm25_and_mode_skip_requires_all_terms_present_in_superfile() {
     let store = Arc::new(CountingStore::new());
     let st = Supertable::create(options_with_counting_store(Arc::clone(&store))).expect("create");
 
-    // Two superfiles. Segment 0 has both `alpha` and `beta`; segment
+    // Two superfiles. Superfile 0 has both `alpha` and `beta`; superfile
     // 1 has `alpha` only. AND-mode for "alpha beta" must prune
-    // segment 1 (missing `beta`) but keep segment 0.
+    // superfile 1 (missing `beta`) but keep superfile 0.
     let mut w = st.writer().expect("writer");
     w.append(&build_title_batch(&["alpha beta gamma", "doc with beta"]))
         .expect("append");
@@ -333,7 +333,7 @@ fn bm25_and_mode_skip_requires_all_terms_present_in_segment() {
     assert_eq!(
         delta.len(),
         1,
-        "AND mode should prune the segment missing one of the terms"
+        "AND mode should prune the superfile missing one of the terms"
     );
     assert!(delta.contains_key(&kept_uri));
 }

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -263,7 +263,7 @@ async fn writer_update_cardinality_mismatch_is_rejected() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn update_emitted_segment_carries_subsection_offsets() {
+async fn update_emitted_superfile_carries_subsection_offsets() {
     let dir = TempDir::new().expect("tempdir");
     let cache_dir = TempDir::new().expect("cache");
     let storage: Arc<dyn StorageProvider> =
@@ -295,10 +295,10 @@ async fn update_emitted_segment_carries_subsection_offsets() {
         .superfiles
         .iter()
         .find(|e| e.n_docs == 1)
-        .expect("update-emitted single-row segment present");
+        .expect("update-emitted single-row superfile present");
     let offsets = emitted
         .subsection_offsets
         .as_ref()
-        .expect("update-emitted segment carries subsection_offsets");
+        .expect("update-emitted superfile carries subsection_offsets");
     assert!(offsets.total_size > 0, "total_size is stamped");
 }

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -20,7 +20,7 @@
 //!   - The pointer file is missing or still references the
 //!     prior committed `manifest_id` → open returns the prior
 //!     state (or `PointerUnreadable` on a fresh supertable).
-//!     Any segment / manifest-part / manifest-list bytes
+//!     Any superfile / manifest-part / manifest-list bytes
 //!     written before the crash but never referenced by a
 //!     committed pointer are **orphans**: tolerated by
 //!     readers and GC'd by compaction.
@@ -39,9 +39,9 @@
 //!
 //! | Test fn                                                      | Crash point                                | Expected post-crash open state                    |
 //! |--------------------------------------------------------------|---------------------------------------------|----------------------------------------------------|
-//! | `crash_post_segment_no_prior_commit_yields_pointer_unreadable` | After 1st segment PUT, before list/pointer | `OpenError::PointerUnreadable`                     |
+//! | `crash_post_superfile_no_prior_commit_yields_pointer_unreadable` | After 1st superfile PUT, before list/pointer | `OpenError::PointerUnreadable`                     |
 //! | `crash_post_list_no_prior_commit_yields_pointer_unreadable`    | After 1st list PUT, before pointer         | `OpenError::PointerUnreadable`                     |
-//! | `crash_post_segment_on_second_commit_yields_v1`                | First commit succeeds; 2nd commit's segment PUT triggers | `manifest_id == 1` (v_prev), orphan v2 segment    |
+//! | `crash_post_superfile_on_second_commit_yields_v1`                | First commit succeeds; 2nd commit's superfile PUT triggers | `manifest_id == 1` (v_prev), orphan v2 superfile    |
 //! | `crash_post_list_on_second_commit_yields_v1`                   | First commit succeeds; 2nd commit's list PUT triggers   | `manifest_id == 1`, orphan v2 list + part         |
 //! | `crash_post_pointer_on_second_commit_yields_v2`                | First commit succeeds; 2nd commit's pointer PUT triggers AFTER it lands | `manifest_id == 2` (commit was durable)           |
 //!
@@ -267,17 +267,17 @@ fn dispatch_child_if_set() -> Option<()> {
 }
 
 #[test]
-fn crash_post_segment_no_prior_commit_yields_pointer_unreadable() {
+fn crash_post_superfile_no_prior_commit_yields_pointer_unreadable() {
     if dispatch_child_if_set().is_some() {
         return; // unreachable; child never returns
     }
     let dir = spawn_crash_child(
-        "crash_post_segment_no_prior_commit_yields_pointer_unreadable",
+        "crash_post_superfile_no_prior_commit_yields_pointer_unreadable",
         KP_SEG_FIRST,
     );
 
     // Parent verifies. The crash fired after the first
-    // segment PUT, before any manifest writes. No pointer
+    // superfile PUT, before any manifest writes. No pointer
     // exists yet → open must return PointerUnreadable.
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));
@@ -288,8 +288,8 @@ fn crash_post_segment_no_prior_commit_yields_pointer_unreadable() {
         "expected PointerUnreadable, got {err:?}"
     );
 
-    // The orphan segment file is present and ignored — the
-    // segment is just bytes under data/; readers don't
+    // The orphan superfile file is present and ignored — the
+    // superfile is just bytes under data/; readers don't
     // discover it without a committed manifest list.
     let data_dir = dir.join("data");
     let n_orphans = std::fs::read_dir(&data_dir)
@@ -297,7 +297,7 @@ fn crash_post_segment_no_prior_commit_yields_pointer_unreadable() {
         .unwrap_or(0);
     assert!(
         n_orphans >= 1,
-        "orphan segment must be present on disk; found {n_orphans} in {data_dir:?}"
+        "orphan superfile must be present on disk; found {n_orphans} in {data_dir:?}"
     );
 }
 
@@ -332,12 +332,12 @@ fn crash_post_list_no_prior_commit_yields_pointer_unreadable() {
 }
 
 #[test]
-fn crash_post_segment_on_second_commit_yields_v1() {
+fn crash_post_superfile_on_second_commit_yields_v1() {
     if dispatch_child_if_set().is_some() {
         return;
     }
     let dir = spawn_crash_child(
-        "crash_post_segment_on_second_commit_yields_v1",
+        "crash_post_superfile_on_second_commit_yields_v1",
         KP_SEG_SECOND,
     );
 
@@ -349,7 +349,7 @@ fn crash_post_segment_on_second_commit_yields_v1() {
     assert_eq!(
         consumer.reader().n_superfiles(),
         1,
-        "v1 has exactly the first commit's segment; v2's orphan segment is invisible"
+        "v1 has exactly the first commit's superfile; v2's orphan superfile is invisible"
     );
 }
 

--- a/tests/supertable_concurrent_processes.rs
+++ b/tests/supertable_concurrent_processes.rs
@@ -166,7 +166,7 @@ async fn three_handles_concurrent_commits_all_succeed() {
     assert_eq!(consumer.reader().n_superfiles(), 3);
 
     // Verify all three writers' superfiles are present by
-    // counting distinct segment URIs — the supertable injects
+    // counting distinct superfile URIs — the supertable injects
     // `_id` values via its monotonic generator, so we can't
     // assert specific id values across writer processes (each
     // gets its own random worker_id).
@@ -176,7 +176,7 @@ async fn three_handles_concurrent_commits_all_succeed() {
     assert_eq!(
         uris.len(),
         segs.len(),
-        "every segment carries a distinct URI"
+        "every superfile carries a distinct URI"
     );
     assert!(
         segs.len() >= 3,
@@ -193,7 +193,7 @@ async fn three_handles_concurrent_commits_all_succeed() {
 /// before the next attempt's `with_appended` chains the
 /// loser's superfiles on top.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn retry_winner_sees_loser_segments_in_final_manifest() {
+async fn retry_winner_sees_loser_superfiles_in_final_manifest() {
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
@@ -225,7 +225,7 @@ async fn retry_winner_sees_loser_segments_in_final_manifest() {
 
     // Whichever handle ended at manifest_id = 2 should also
     // see 2 superfiles — its own plus the winner's. The handle
-    // at manifest_id = 1 only sees its own segment (pre-retry
+    // at manifest_id = 1 only sees its own superfile (pre-retry
     // state, never refreshed).
     for st in [&st_a, &st_b] {
         let r = st.reader();
@@ -239,7 +239,7 @@ async fn retry_winner_sees_loser_segments_in_final_manifest() {
             assert_eq!(
                 r.n_superfiles(),
                 1,
-                "v1 handle (winner) sees only its own segment"
+                "v1 handle (winner) sees only its own superfile"
             );
         } else {
             panic!("unexpected manifest_id: {}", r.manifest_id());


### PR DESCRIPTION
**TL;DR:** Pure terminology rename, no behavior change. A superfile and a "segment" were the same thing under two names; the duplication had drifted through identifiers, comments, error messages, docs, and a config key. Standardize on **superfile** everywhere it referred to an immutable table unit.

**Public API surface is byte-identical (`public-api.txt` unchanged).** All renamed types are internal (`pub(crate)`/local/test).

### Renamed types (internal)
| Before | After | Where |
|---|---|---|
| `SegmentStats` | `SuperfileStats` | `supertable/compaction/mod.rs` |
| `PreparedSegment` | `PreparedSuperfile` | `supertable/writer.rs` |
| `SegmentScan` | `SuperfileScan` | `supertable/query/provider.rs` (local) |

### Renamed production functions
`prepare_segment`→`prepare_superfile`, `put_segment_multipart`→`put_superfile_multipart`, `segment_storage_path`→`superfile_storage_path` (writer.rs); `select_segments`→`select_superfiles` (query/prune.rs); `surviving_segment_count`→`surviving_superfile_count` (query/provider.rs); `decode_segment`→`decode_superfile` (manifest/part.rs); `segment_may_match`→`superfile_may_match` (query/skip.rs).

### Config / consts (⚠️ external-facing)
- `target_segment_size_mb` → `target_superfile_size_mb` (config.yaml + serde struct field)
- env `INFINO_COMPACTION__TARGET_SEGMENT_SIZE_MB` → `…TARGET_SUPERFILE_SIZE_MB`
- `DEFAULT_COMPACTION_TARGET_SEGMENT_SIZE_MB` → `…TARGET_SUPERFILE…`
- `n_segments` (DataFusion EXPLAIN field label) → `n_superfiles`

This is the only config-compat break; safe today since compaction isn't shipped.

### User-facing error messages
- `"segment store: …"` → `"superfile store: …"`
- `"segment store error during query: …"` → `"superfile store error during query: …"`
- `"segment spans partition boundary: …"` → `"superfile spans partition boundary: …"` (now matches the `SuperfileSpansPartition` variant)
- `"… (segment has {n_docs} docs)"` → `"… (superfile has {n_docs} docs)"`

### File rename
`benches/utils/bin/profile_segment.rs` → `profile_superfile.rs` (+ `[[bin]]` entry in `benches/utils/Cargo.toml`), tracked via `git mv`.

### Deliberately NOT renamed (genuinely not superfiles)
- `catalog/uri.rs` — URI/object-store **path** segments (`join(segment: &str)`); file skipped entirely.
- `catalog/mod.rs` doc-comments — "object-store path segments".
- `superfile/builder.rs` — "Unicode **segmenter**" (text tokenization).

### Bulk of the diff (low-risk)
~60 test-function names, comments, and docs (`AGENTS.md`, `CONTRIBUTING.md`, `README.md`, `docs/architecture/*`). No logic touched.

### Validation
`fmt` ✓ · `build --all-targets` ✓ · `clippy -D warnings` ✓ · `public-api.txt` identical ✓ · 960 lib + 139 integration tests ✓ · `infino-python` builds ✓