### PR TITLE
supertable: drop redundant fp32 centroids from open_blob (-72% cold open)

### DIFF
--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1202,9 +1202,16 @@ fn vector_open_ranges(bytes: &Bytes, off: u64, len: u64) -> Option<Vec<(u64, u64
         if centroids_off < SUB_HEADER_SIZE || cluster_idx_end > subsection_len {
             return None;
         }
+        // Stage only [cluster_idx .. cluster_idx_end]. The fp32 centroids that
+        // precede it are read solely by the rare fallback per-segment `nprobe`
+        // path (segments lacking a manifest cluster summary), which range-GETs
+        // them from the superfile on demand — they remain on disk. The hot
+        // cluster-probe path reads only `cluster_idx`, so keeping centroids out
+        // of the open_blob makes the manifest-inline open footprint independent
+        // of `n_cent` (centroids are ~99% of it at high `n_cent`).
         ranges.push((
-            off + subsection_off as u64 + centroids_off as u64,
-            (cluster_idx_end - centroids_off) as u64,
+            off + subsection_off as u64 + cluster_idx_off as u64,
+            (cluster_idx_end - cluster_idx_off) as u64,
         ));
         if codec_meta_size > 0 {
             let meta_end = codec_meta_off.checked_add(codec_meta_size)?;

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -2513,6 +2513,54 @@ mod tests {
         assert_eq!(total, seg.n_docs);
     }
 
+    #[test]
+    fn open_blob_omits_fp32_centroids_keeps_cluster_idx() {
+        // `dim` is chosen so the fp32 centroid block (`n_cent * dim * 4`) is
+        // far larger than any structural open range (outer header, directory,
+        // sub-header, cluster_idx), making the exclusion unambiguous.
+        let dim = 64;
+        let st = Supertable::create(options_with_vector(dim)).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_vector_batch(0, 8, dim)).expect("append");
+        w.commit().expect("commit");
+
+        let r = st.reader();
+        let seg = &r.manifest().superfiles[0];
+        let vs = seg.vector_summary.get("emb").expect("emb summary");
+        let n_cent = vs.clusters.n_cent as usize;
+        assert!(n_cent >= 1 && vs.clusters.dim as usize == dim);
+
+        let offsets = seg
+            .subsection_offsets
+            .as_ref()
+            .expect("subsection offsets captured at commit");
+        let centroids_bytes = (n_cent * dim * 4) as u64;
+        let cluster_idx_bytes =
+            (n_cent * crate::superfile::format::vec::CLUSTER_IDX_ENTRY_BYTES) as u64;
+
+        // No captured open range is centroid-sized: the fp32 centroids are not
+        // staged into the manifest open_blob (the cluster-probe hot path never
+        // reads them; the fallback nprobe path range-GETs them on demand).
+        assert!(
+            offsets
+                .vec_open_ranges
+                .iter()
+                .all(|&(_, len)| len < centroids_bytes),
+            "open_blob must not carry fp32 centroids; ranges={:?}, centroids={centroids_bytes} B",
+            offsets.vec_open_ranges,
+        );
+        // ...but it must still carry the small cluster_idx that the
+        // cluster-probe path reads zero-GET on cold open.
+        assert!(
+            offsets
+                .vec_open_ranges
+                .iter()
+                .any(|&(_, len)| len == cluster_idx_bytes),
+            "open_blob must carry cluster_idx ({cluster_idx_bytes} B); ranges={:?}",
+            offsets.vec_open_ranges,
+        );
+    }
+
     // ---- rayon-shard parallelism -------------------------------------
 
     #[test]


### PR DESCRIPTION
Implements #99. Design rationale in the decision log: infino-ai/claude-plans#34.

### Change
The per-segment vector `open_blob` (inline in the manifest part) stored the **fp32 centroids** (`n_cent × dim × 4`), fetched on every full-fanout cold open but read only by the rare fallback per-segment `nprobe` path. The hot cluster-probe path (`search_clusters_async`) reads only `cluster_idx`, and global cluster selection uses the manifest summary's **Sq8** centroids — so the fp32 copy in the open_blob is redundant (it also remains in the superfile on disk).

`vector_open_ranges` now stages only `[cluster_idx .. cluster_idx_end]`. The fallback path range-GETs centroids from the superfile on demand (`PrefetchedSource` misses fall through to a range GET).

### Result (real S3, skip-calibration cold, p=8/r=4)
| scale | cold open: before (main) | cold open: after | Δ |
|---|---|---|---|
| 1M | 1.04 s | 0.78 s | −25% |
| 10M | 2.61 s | 0.74 s | **−72% (3.5×)** |

Slim cold open is **scale-flat (~0.75 s)** — the `n_cent` dependence is gone. Cold search and recall unchanged. Secondary: manifest open-blob footprint shrinks ~7× at 10M (~117 MB → ~17 MB), lowering resident manifest RSS.

### Scope / safety
Manifest open_blob (commit-path) change — **not** a superfile on-disk format change. Centroids stay in the superfile; old manifests keep their copy and readers already tolerate overlay misses, so mixed manifests are fine.

**Fallback path.** Every normally-committed vector segment gets a cluster summary at commit, so the **cluster-probe path is always taken** — it reads only `cluster_idx`, never the centroids. The fp32-centroid read is the *defensive* fallback `nprobe` path, served by the `PrefetchedSource` fall-through range-GET (the same get-range-on-miss the bare-superfile `open_lazy` path always uses).

### Validation
- [x] `supertable query::` incl. brute-force recall oracle — green (now exercises the slim open_blob by default)
- [x] `disk_cache::` cold-open incl. warm-search zero-GET — green
- [x] `superfile::vector` IVF oracles — green (cover centroid-read via `get_range` on the lazy path)
- [x] `supertable_commit_crash_localfs` (commit-path crash safety) — green
- [x] **open_blob shape regression test** — `open_blob_omits_fp32_centroids_keeps_cluster_idx`: asserts the captured open ranges carry `cluster_idx` but no centroid-sized range (fails on pre-change, passes after)
- [x] **recall@10 ≥ 0.99 — confirmed unchanged.** 1M differential (main vs branch, full calibration): recall **identical** at every target — 0.90→0.988, 0.95→0.988, **0.99→0.996** — and recall@10 = 0.996 ≥ 0.99 on both. (10M default-config calibration is not measurable on any branch — calibration-sweep hang, see #88 — so confirmed by the 1M differential + the brute-force oracle.)

