### PR TITLE
docs: lead README with value proposition + core advantages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ and as a search index through infino's own reader, so your data stays open and p
 
 **Why infino**
 
+- **Best performance per dollar** — engineered for the strongest speed-per-dollar trade-off, not just raw latency: object-storage economics plus a read path continuously benchmarked on speed *and* cost (bytes fetched, request count, memory footprint).
 - **Three modalities, one engine** — keyword (BM25), vector, and SQL over the same rows; no copying data between systems to combine them.
 - **Object-storage-native** — your data lives on S3, Azure, or local disk, with snapshot-isolated reads and append / update / delete through atomic commits. No cluster to stand up.
 - **Open, no lock-in** — superfiles are spec-compliant Parquet, so anything that reads Parquet can read your data.
-- **Fast and cost-aware** — low-latency search at scale is a first-class, continuously benchmarked goal.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # infino
 
-Infino stores data in a search-optimized lakehouse format. **One file = a valid Apache Parquet file plus embedded BM25 + vector indexes** — readable as Parquet by
-[DataFusion](https://datafusion.apache.org/) /
-[DuckDB](https://duckdb.org/) /
-[pyarrow](https://arrow.apache.org/docs/python/),
-and as a search index by infino's reader.
+**Infino is a fast retrieval engine that runs SQL, full-text search, and vector search over a single copy of your data on object storage.** Point it at a bucket on S3 (or Azure, or local disk) and query the same rows three ways from one system — no separate search cluster, vector database, and warehouse to provision and keep in sync, and no daemon or managed service to operate.
+
+The format is what makes this work: **every file is a valid Apache Parquet file with BM25 and vector indexes spliced in.** The same files read as plain Parquet through the Arrow ecosystem —
+[DataFusion](https://datafusion.apache.org/),
+[DuckDB](https://duckdb.org/),
+[pyarrow](https://arrow.apache.org/docs/python/) —
+and as a search index through infino's own reader, so your data stays open and portable while gaining low-latency search.
+
+**Why infino**
+
+- **Three modalities, one engine** — keyword (BM25), vector, and SQL over the same rows; no copying data between systems to combine them.
+- **Object-storage-native** — your data lives on S3, Azure, or local disk, with snapshot-isolated reads and append / update / delete through atomic commits. No cluster to stand up.
+- **Open, no lock-in** — superfiles are spec-compliant Parquet, so anything that reads Parquet can read your data.
+- **Fast and cost-aware** — low-latency search at scale is a first-class, continuously benchmarked goal.
 
 ## Links
 


### PR DESCRIPTION
Reworks the README opening for first-time readers (we're about to give repo access to early users), so it leads with *what infino is and why to use it* before the format details.

## Changes
- New opening: one engine for **SQL + full-text + vector search over a single copy of data on object storage** — no separate search cluster / vector DB / warehouse to keep in sync, no daemon or managed service.
- Keeps the Parquet/Arrow-compat hook (every file is a valid Apache Parquet file with BM25 + vector indexes spliced in) and the DataFusion / DuckDB / pyarrow links.
- Adds a skimmable **"Why infino"** list, led by **best performance per dollar** (strongest speed-per-dollar trade-off), then three modalities / object-storage-native / open-no-lock-in.

## Notes
- Claims are qualitative and framed as design goals; no head-to-head comparisons or benchmark numbers in the README.
- Docs-only change; no code touched.