### PR TITLE
ci: speed up Python wheel builds; drop unsupported Windows target

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -97,6 +97,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Restore the dep graph (datafusion etc.) so only infino-python rebuilds.
+      # Order matters: rust-cache keys on Cargo.lock, which the stamp step
+      # bumps — cache before stamp to keep the key stable across releases.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: infino-python
+
       # Version is dynamic (pyproject `dynamic = ["version"]`) → maturin reads
       # it from Cargo.toml. Stamp it into Cargo.toml *and* Cargo.lock so the
       # build stays --locked. python3 over sed: one script, every runner,

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -74,7 +74,8 @@ jobs:
           - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl }
           - { os: macos-14,         target: aarch64-apple-darwin }
           - { os: macos-15-intel,   target: x86_64-apple-darwin }
-          - { os: windows-latest,   target: x86_64-pc-windows-msvc }
+          # No Windows: the core crate uses Unix-only APIs (std::os::unix
+          # positional writes, memmap2 madvise) that don't compile on MSVC.
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Two changes to the Python publish workflow.

## 1. Cache Rust deps (speed)
Every wheel leg recompiled the whole dependency graph (datafusion et al.) from scratch — the build had no Rust caching, unlike the `python` jobs in `ci.yml`.

Add `Swatinem/rust-cache@v2` (`workspaces: infino-python`), placed **before** the `Stamp version` step: rust-cache keys on `Cargo.lock`, and stamping bumps `infino-python`'s version there, so caching the pristine lockfile keeps the key stable across releases. The dep graph is then restored and only `infino-python` recompiles.

First post-merge run is still cold (it populates the cache); the speed-up lands from the second run on. The 6 legs cache independently. No change to the produced wheels.

## 2. Drop the Windows wheel target
The first TestPyPI dispatch showed `x86_64-pc-windows-msvc` fails to compile the core crate — it uses Unix-only APIs (`std::os::unix` positional writes via `write_all_at`, `memmap2`'s `unchecked_advise`/madvise). Building Windows wheels requires porting the engine first, so the leg is removed rather than left perpetually red.

Coverage remains Linux (glibc + musl, x86_64 + aarch64) and macOS (arm64 + x86_64) — the mainstream install base. Windows users get a clean "no matching distribution" until the engine is ported.

## Considered, not included
- **`strip = true`**: measured ~3.5% off the compressed wheel (1.5 MB / 43 MB) at the cost of symbol-named panic backtraces — not worth it for a launching package.
- **`sccache` / dropping `free-disk-space`**: deferred until per-leg timings from a cached run show which legs dominate.