### PR TITLE
python: show the README on the PyPI project page

### DIFF
--- a/infino-python/pyproject.toml
+++ b/infino-python/pyproject.toml
@@ -5,6 +5,8 @@ build-backend = "maturin"
 [project]
 name = "infino"
 description = "Fast search on object storage — SQL, full-text, and vector search."
+# Long description rendered on the PyPI project page (markdown).
+readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
 dependencies = ["pyarrow>=14"]


### PR DESCRIPTION
## Why
The TestPyPI project page (https://test.pypi.org/project/infino/) renders blank — only the one-line summary, no documentation. The package declares no `readme`, so the built wheel carries no long description.

## What
Add `readme = "README.md"` to `[project]`. maturin embeds `infino-python/README.md` as the markdown long description (`Description-Content-Type: text/markdown`), which PyPI renders on the project page.

## Verified
Rebuilt the wheel and inspected its METADATA:
- `Description-Content-Type: text/markdown; charset=UTF-8; variant=GFM`
- Long-description body = the README (`# infino — Python bindings …`).

## Notes
- Metadata is baked at build time and PyPI versions are immutable, so this takes effect on the **next** published version — `0.1.0rc1` stays blank.
- The page will render the bindings' README; any relative links in it won't resolve on PyPI (cosmetic, can absolutize later).