### PR TITLE
docs: install the Python package from TestPyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 **Python**
 
 ```sh
-pip install infino
+# Install from TestPyPI.
+pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ infino
 ```
 
 **Node.js**


### PR DESCRIPTION
## Why
`pip install infino` doesn't resolve — the package isn't published to the main PyPI.

## What
Point the README's Python install at TestPyPI:
```sh
pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ infino
```
`--extra-index-url` lets pip pull dependencies (`pyarrow`) from the main PyPI, which TestPyPI doesn't mirror.

## Verified
Clean venv → ran the install command verbatim (pulled `infino 0.1.0rc1` + `pyarrow`) → ran the README Quickstart example: BM25, vector kNN, and SQL filter all return the expected rows.

## Not in scope
The Node (`npm install infino`) and Rust (`cargo add infino`) install lines still assume public publishing — left unchanged here; separate decision.