### PR TITLE
refactor manifest: expose manifest::load method for reading and loading manifest from storage

### DIFF
--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 
 use crate::storage::StorageError;
 use crate::superfile::error::BuildError as SuperfileBuildError;
+use crate::supertable::ManifestLoadError;
 
 /// Errors raised when constructing or operating against a
 /// `SupertableOptions` / `SupertableWriter`.
@@ -150,6 +151,10 @@ pub enum CommitError {
     #[error("build error during commit")]
     Build(#[from] BuildError),
 
+    /// Manifest error
+    #[error("manifest load error: {0}")]
+    ManifestLoadError(#[from] ManifestLoadError),
+
     /// Failed to encode a manifest part or list to its wire
     /// format. Indicates a programmer error (e.g., a
     /// non-serializable scalar value in a manifest list), not
@@ -203,6 +208,10 @@ pub enum OpenError {
     #[error("manifest list parse failed")]
     ManifestListParse(String),
 
+    /// Manifest load error.
+    #[error("manifest load error")]
+    ManifestLoadError(#[from] ManifestLoadError),
+
     /// Manifest part load or parse failed during open or
     /// refresh.
     #[error("manifest part load failed: {part_id}")]
@@ -236,22 +245,6 @@ pub enum OpenError {
     /// path.
     #[error("commit error during open")]
     Commit(#[from] CommitError),
-
-    /// The persisted manifest list's `options_hash` doesn't
-    /// match the digest computed from the caller's
-    /// `SupertableOptions`. Either the caller built options
-    /// inconsistent with the on-disk supertable (schema /
-    /// partition strategy / id column changed) or the
-    /// manifest was written by a different supertable.
-    /// Surfaced ahead of any per-superfile decode so callers
-    /// see a typed mismatch instead of a downstream parquet
-    /// or arrow error.
-    ///
-    /// Bypass: stamping `options_hash = ContentHash([0u8; 32])`
-    /// in a manifest list (the legacy / synthetic-fixture
-    /// path) skips the check entirely.
-    #[error("options_hash mismatch: caller={expected} list={actual}")]
-    OptionsHashMismatch { expected: String, actual: String },
 }
 
 /// Errors raised by [`crate::supertable::Supertable::compact`].

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -26,6 +26,7 @@ use super::error::{BuildError, OpenError};
 use super::manifest::Manifest;
 use super::options::SupertableOptions;
 use crate::runtime_bridge::{bridge_on_runtime, bridge_sync_to_async};
+use crate::supertable::ManifestLoadError;
 
 /// Top-level handle. Cheap to clone (one `Arc::clone`); all clones
 /// share the same `SupertableInner`. Hand a clone to each thread
@@ -278,8 +279,7 @@ impl Supertable {
     /// snapshot at the pointer's `manifest_id`.
     ///
     /// Errors:
-    /// - [`OpenError::PointerUnreadable`] if the pointer
-    ///   doesn't exist (open-or-create trigger).
+    /// - [`OpenError::ManifestLoadError`] for manifest load failures.
     /// - [`OpenError::Build`] if `options.storage` is `None`
     ///   (open requires a storage backend).
     /// - [`OpenError::Storage`], [`OpenError::ManifestListParse`],
@@ -299,11 +299,6 @@ impl Supertable {
     /// sync [`Supertable::open`]; this is the I/O implementation it
     /// (and the open-time create path) drive on the ambient runtime.
     pub(crate) async fn open_async(options: SupertableOptions) -> Result<Self, OpenError> {
-        use crate::supertable::ManifestPartLoader;
-        use crate::supertable::manifest::commit::read_pointer;
-        use crate::supertable::manifest::list as list_mod;
-        use crate::supertable::manifest::{Manifest, SuperfileList};
-
         let storage = options
             .storage
             .as_ref()
@@ -315,117 +310,9 @@ impl Supertable {
                 ))
             })?
             .clone();
-
-        // 1. Read the pointer file.
-        let pointer = match read_pointer(&*storage).await? {
-            Some(p) => p,
-            None => {
-                // No pointer → no supertable at this location.
-                // Map to OpenError::PointerUnreadable so the
-                // open-or-create caller can pattern-match.
-                return Err(OpenError::PointerUnreadable(
-                    crate::storage::StorageError::NotFound {
-                        uri: "_supertable/current".into(),
-                    },
-                ));
-            }
-        };
-
-        // 2. Load + parse the manifest list.
-        let (list_bytes, _) = storage
-            .get(&pointer.manifest_list_uri)
-            .await
-            .map_err(OpenError::Storage)?;
-        let list = list_mod::decode(&list_bytes)
-            .map_err(|e| OpenError::ManifestListParse(format!("{e}")))?;
-
-        // Verify the caller's options match the
-        // manifest's stamped digest. The all-zero stored
-        // hash bypasses validation (legacy + synthetic
-        // fixtures).
-        let expected_hash = crate::supertable::manifest::options_hash::compute_options_hash(
-            &options,
-            &list.partition_strategy,
-        );
-        if let Err(mismatch) = crate::supertable::manifest::options_hash::verify_options_hash(
-            expected_hash,
-            list.options_hash,
-        ) {
-            return Err(OpenError::OptionsHashMismatch {
-                expected: mismatch.expected,
-                actual: mismatch.actual,
-            });
-        }
-
-        // 3. Build the loader. Then either eager-fetch every
-        //    part (small manifests — fast first query) or
-        //    populate empty `OnceCell`s for lazy-load (large
-        //    manifests pay no upfront cost; parts hydrate on
-        //    first `Manifest::part(id).await`).
-        let loader = Arc::new(ManifestPartLoader::new(Arc::clone(&storage), &list));
-        let n_parts = list.parts.len();
-        let threshold = options.eager_load_threshold_parts as usize;
-        let eager = n_parts <= threshold;
-
-        let parts_map = dashmap::DashMap::new();
-        let mut all_superfiles: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
-        if eager {
-            // Eager path: parallel-fetch every part + populate
-            // the flat superfile_list.superfiles view so the
-            // iteration-style query paths (`bm25_search`,
-            // `vector_search`, `query_sql`) see all superfiles
-            // without going through the hierarchical iterator.
-            let part_ids: Vec<_> = list.parts.iter().map(|p| p.part_id).collect();
-            let load_futs = part_ids
-                .iter()
-                .map(|id| {
-                    let loader = Arc::clone(&loader);
-                    let pid = *id;
-                    async move { loader.load(pid).await }
-                })
-                .collect::<Vec<_>>();
-            let loaded = futures::future::join_all(load_futs).await;
-            for (pid, result) in part_ids.iter().zip(loaded) {
-                let part = result.map_err(|e| OpenError::ManifestPartLoad {
-                    part_id: pid.0.to_string(),
-                    source: Box::new(e),
-                })?;
-                all_superfiles.extend(part.superfiles.iter().cloned());
-                let cell = tokio::sync::OnceCell::new();
-                cell.set(part).expect("fresh OnceCell");
-                parts_map.insert(*pid, Arc::new(cell));
-            }
-        } else {
-            // Lazy path: each part gets an empty
-            // `OnceCell`; first `Manifest::part(id).await`
-            // triggers a single storage GET for that part.
-            // `superfile_list.superfiles` stays empty — legacy
-            // flat-iteration queries return zero results
-            // until the hierarchical query path lands.
-            // Callers in lazy mode today drive
-            // `Manifest::part().await` directly.
-            for entry in &list.parts {
-                parts_map.insert(entry.part_id, Arc::new(tokio::sync::OnceCell::new()));
-            }
-        }
-
-        // 4. Build the in-memory hierarchical Manifest.
-        //    `manifest_id` mirrors the pointer. The flat
-        //    `superfile_list.superfiles` is populated only in
-        //    eager mode (see above); lazy mode leaves it
-        //    empty until the hierarchical query path lands.
         let options_arc = Arc::new(options);
-        let mut superfile_list = SuperfileList::empty(options_arc.clone());
-        superfile_list.manifest_id = pointer.manifest_id;
-        superfile_list.superfiles = all_superfiles;
 
-        let manifest = Manifest {
-            superfile_list,
-            list: Some(list),
-            parts: parts_map,
-            loader: Some(loader),
-        };
-
+        let manifest = Manifest::load(None, storage, Some(options_arc.clone())).await?;
         let tombstone_cache = build_tombstone_cache(&options_arc);
         // Fresh generator per open. The 64-bit ms timestamp
         // prefix advances naturally across process restarts, so
@@ -438,7 +325,7 @@ impl Supertable {
             crate::supertable::wal::state_doc::SupertableHandleId(id_generator.next_id());
         let inner = Arc::new(SupertableInner {
             options: options_arc,
-            manifest: ArcSwap::new(Arc::new(manifest)),
+            manifest: ArcSwap::new(manifest),
             writer_outstanding: AtomicBool::new(false),
             id_generator: Mutex::new(id_generator),
             query_runtime: OnceLock::new(),
@@ -483,11 +370,6 @@ impl Supertable {
     /// [`crate::supertable::options::Consistency`]. This is the
     /// mechanism that drives the pointer re-check.
     pub(crate) async fn refresh(&self) -> Result<bool, OpenError> {
-        use crate::supertable::ManifestPartLoader;
-        use crate::supertable::manifest::commit::read_pointer;
-        use crate::supertable::manifest::list as list_mod;
-        use crate::supertable::manifest::{Manifest, SuperfileList};
-
         let storage = self
             .inner
             .options
@@ -500,104 +382,14 @@ impl Supertable {
             })?
             .clone();
 
-        // 1. Read the current pointer. If it's not newer than
-        //    our in-memory manifest_id, no-op.
-        let pointer = match read_pointer(&*storage).await? {
-            Some(p) => p,
-            None => return Ok(false),
-        };
         let current = self.inner.manifest.load_full();
-        if pointer.manifest_id <= current.superfile_list.manifest_id {
-            return Ok(false);
-        }
-
-        // 2. Load + parse the new manifest list.
-        let (list_bytes, _) = storage
-            .get(&pointer.manifest_list_uri)
-            .await
-            .map_err(OpenError::Storage)?;
-        let new_list = list_mod::decode(&list_bytes)
-            .map_err(|e| OpenError::ManifestListParse(format!("{e}")))?;
-
-        // 3. Inherit unchanged parts via content-addressed
-        //    lookup. For each part in the new list whose
-        //    PartId is also in the current Manifest's
-        //    parts cache, Arc::clone the OnceCell — same
-        //    bytes, no re-fetch, no re-parse. Parts in the
-        //    new list that aren't in the current cache are
-        //    eager-fetched.
-        let new_loader = Arc::new(ManifestPartLoader::new(Arc::clone(&storage), &new_list));
-        let new_parts: dashmap::DashMap<_, _> = dashmap::DashMap::new();
-        let mut missing_part_ids = Vec::new();
-        for entry in &new_list.parts {
-            if let Some(existing) = current.parts.get(&entry.part_id) {
-                new_parts.insert(entry.part_id, existing.value().clone());
-            } else {
-                missing_part_ids.push(entry.part_id);
-            }
-        }
-
-        // Eager-fetch the missing ones in parallel — but
-        // only when the total post-refresh part count is at
-        // or under the eager-load threshold. Above
-        // it, leave missing parts as empty `OnceCell`s for
-        // lazy-load on first access, matching the lazy-open
-        // semantics. Inherited parts (Arc::clone'd above)
-        // keep whatever state they had — already-loaded
-        // stays loaded; lazy stays lazy.
-        let threshold = self.inner.options.eager_load_threshold_parts as usize;
-        let eager = new_list.parts.len() <= threshold;
-        if eager {
-            let load_futs = missing_part_ids
-                .iter()
-                .map(|id| {
-                    let loader = Arc::clone(&new_loader);
-                    let pid = *id;
-                    async move { loader.load(pid).await }
-                })
-                .collect::<Vec<_>>();
-            let loaded = futures::future::join_all(load_futs).await;
-            for (pid, result) in missing_part_ids.iter().zip(loaded) {
-                let part = result.map_err(|e| OpenError::ManifestPartLoad {
-                    part_id: pid.0.to_string(),
-                    source: Box::new(e),
-                })?;
-                let cell = tokio::sync::OnceCell::new();
-                cell.set(part).expect("fresh cell");
-                new_parts.insert(*pid, Arc::new(cell));
-            }
-        } else {
-            for pid in &missing_part_ids {
-                new_parts.insert(*pid, Arc::new(tokio::sync::OnceCell::new()));
-            }
-        }
-
-        // 4. Rebuild the flat superfile_list from all parts in
-        //    the new manifest — eager mode only. In lazy
-        //    mode the flat view stays empty until the hierarchical query path lands.
-        let mut all_superfiles: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
-        if eager {
-            for entry in &new_list.parts {
-                let cell = new_parts.get(&entry.part_id).expect("part inserted above");
-                let part = cell
-                    .value()
-                    .get()
-                    .expect("eager-fetched or inherited; must be set");
-                all_superfiles.extend(part.superfiles.iter().cloned());
-            }
-        }
-
-        // 5. Build + ArcSwap the new Manifest.
-        let mut new_superfile_list = SuperfileList::empty(self.inner.options.clone());
-        new_superfile_list.manifest_id = pointer.manifest_id;
-        new_superfile_list.superfiles = all_superfiles;
-        let new_manifest = Manifest {
-            superfile_list: new_superfile_list,
-            list: Some(new_list),
-            parts: new_parts,
-            loader: Some(new_loader),
+        let manifest = match Manifest::load(Some(current), storage, None).await {
+            Ok(manifest) => manifest,
+            Err(ManifestLoadError::PointerNotFound) => return Ok(false),
+            Err(ManifestLoadError::AlreadyLoaded) => return Ok(false),
+            Err(err) => return Err(OpenError::ManifestLoadError(err)),
         };
-        self.inner.manifest.store(Arc::new(new_manifest));
+        self.inner.manifest.store(manifest);
         Ok(true)
     }
 

--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 
 use futures::future;
 
-use crate::storage::{StorageError, StorageProvider};
+use crate::storage::{ObjectMeta, StorageError, StorageProvider};
 use crate::supertable::error::CommitError;
 use crate::supertable::manifest::list::{
     self as list_mod, ManifestList, ManifestListEntry, PartitionStrategy,
@@ -55,7 +55,7 @@ use crate::supertable::manifest::part::{
     self as part_mod, BLAKE3_DIGEST_BYTES, BLAKE3_HEX_LEN, ContentHash, ManifestPart, PartId,
 };
 use crate::supertable::manifest::partition::{assign_partition, encode_partition_key};
-use crate::supertable::{Manifest, SuperfileEntry, SupertableOptions};
+use crate::supertable::{Manifest, ManifestLoadError, SuperfileEntry, SupertableOptions};
 
 /// Pointer-file location under the supertable root. The only
 /// path that ever gets atomically renamed; everything else is
@@ -121,9 +121,9 @@ impl PointerFile {
     }
 
     /// Parse the on-disk text format.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, CommitError> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ManifestLoadError> {
         let s = std::str::from_utf8(bytes)
-            .map_err(|e| CommitError::PointerParse(format!("not utf-8: {e}")))?;
+            .map_err(|e| ManifestLoadError::PointerParse(format!("not utf-8: {e}")))?;
 
         let mut manifest_id: Option<u64> = None;
         let mut manifest_list_uri: Option<String> = None;
@@ -133,28 +133,26 @@ impl PointerFile {
             if line.is_empty() {
                 continue;
             }
-            let (key, value) = line
-                .split_once('=')
-                .ok_or_else(|| CommitError::PointerParse(format!("no '=' in line: {line:?}")))?;
+            let (key, value) = line.split_once('=').ok_or_else(|| {
+                ManifestLoadError::PointerParse(format!("no '=' in line: {line:?}"))
+            })?;
             match key {
                 "manifest_id" => {
-                    manifest_id = Some(
-                        value
-                            .parse::<u64>()
-                            .map_err(|e| CommitError::PointerParse(format!("manifest_id: {e}")))?,
-                    );
+                    manifest_id = Some(value.parse::<u64>().map_err(|e| {
+                        ManifestLoadError::PointerParse(format!("manifest_id: {e}"))
+                    })?);
                 }
                 "manifest_list_uri" => {
                     manifest_list_uri = Some(value.to_string());
                 }
                 "content_hash" => {
                     let hex = value.strip_prefix("blake3:").ok_or_else(|| {
-                        CommitError::PointerParse(format!(
+                        ManifestLoadError::PointerParse(format!(
                             "content_hash missing 'blake3:' prefix: {value}"
                         ))
                     })?;
                     if hex.len() != BLAKE3_HEX_LEN {
-                        return Err(CommitError::PointerParse(format!(
+                        return Err(ManifestLoadError::PointerParse(format!(
                             "content_hash hex must be {BLAKE3_HEX_LEN} chars; got {}",
                             hex.len()
                         )));
@@ -163,7 +161,7 @@ impl PointerFile {
                     for i in 0..BLAKE3_DIGEST_BYTES {
                         bytes[i] =
                             u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).map_err(|_| {
-                                CommitError::PointerParse(format!("content_hash hex: {hex}"))
+                                ManifestLoadError::PointerParse(format!("content_hash hex: {hex}"))
                             })?;
                     }
                     content_hash = Some(ContentHash(bytes));
@@ -177,11 +175,12 @@ impl PointerFile {
 
         Ok(Self {
             manifest_id: manifest_id
-                .ok_or_else(|| CommitError::PointerParse("missing manifest_id".into()))?,
-            manifest_list_uri: manifest_list_uri
-                .ok_or_else(|| CommitError::PointerParse("missing manifest_list_uri".into()))?,
+                .ok_or_else(|| ManifestLoadError::PointerParse("missing manifest_id".into()))?,
+            manifest_list_uri: manifest_list_uri.ok_or_else(|| {
+                ManifestLoadError::PointerParse("missing manifest_list_uri".into())
+            })?,
             content_hash: content_hash
-                .ok_or_else(|| CommitError::PointerParse("missing content_hash".into()))?,
+                .ok_or_else(|| ManifestLoadError::PointerParse("missing content_hash".into()))?,
         })
     }
 }
@@ -192,11 +191,11 @@ impl PointerFile {
 /// supertable). Returns `Err` on any other failure.
 pub async fn read_pointer(
     storage: &dyn StorageProvider,
-) -> Result<Option<PointerFile>, CommitError> {
+) -> Result<Option<(PointerFile, ObjectMeta)>, ManifestLoadError> {
     match storage.get(POINTER_PATH).await {
-        Ok((bytes, _)) => Ok(Some(PointerFile::from_bytes(&bytes)?)),
+        Ok((bytes, meta)) => Ok(Some((PointerFile::from_bytes(&bytes)?, meta))),
         Err(StorageError::NotFound { .. }) => Ok(None),
-        Err(e) => Err(e.into()),
+        Err(e) => Err(ManifestLoadError::Storage(e)),
     }
 }
 
@@ -434,13 +433,9 @@ pub async fn get_current_manifest_etag(
     storage: &Arc<dyn StorageProvider>,
     current: Arc<Manifest>,
 ) -> Result<Option<String>, CommitError> {
-    let (bytes, meta) = match storage.get(POINTER_PATH).await {
-        Ok((bytes, meta)) => (bytes, meta),
-        Err(StorageError::NotFound { .. }) => return Ok(None),
-        Err(e) => return Err(crate::supertable::CommitError::from(e)),
+    let Some((pointer_file, meta)) = read_pointer(storage.as_ref()).await? else {
+        return Ok(None);
     };
-
-    let pointer_file = PointerFile::from_bytes(&bytes)?;
     let Some(meta_list) = current.list.as_ref() else {
         // no manifest list for in-memory supertables
         return Ok(None);
@@ -805,7 +800,7 @@ mod tests {
     fn assert_parse_err(bytes: &[u8], needle: &str) {
         let err = PointerFile::from_bytes(bytes).expect_err("must error");
         match err {
-            CommitError::PointerParse(msg) => assert!(
+            ManifestLoadError::PointerParse(msg) => assert!(
                 msg.contains(needle),
                 "expected `{needle}` in error; got: {msg}"
             ),
@@ -947,10 +942,10 @@ mod tests {
         write_pointer(storage.as_ref(), &p, None)
             .await
             .expect("write");
-        let read = read_pointer(storage.as_ref())
+        let (read, _) = read_pointer(storage.as_ref())
             .await
             .expect("read")
-            .expect("present");
+            .expect("some");
         assert_eq!(read, p);
     }
 

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -38,11 +38,15 @@ use std::sync::Arc;
 use arrow::compute::kernels::aggregate as agg;
 use arrow_array::*;
 use arrow_schema::{DataType, Schema};
+use dashmap::DashMap;
 use uuid::Uuid;
 use xxhash_rust::xxh3::xxh3_64;
 
-use crate::superfile::vector::distance::{
-    COSINE_DISTANCE_BASE, L2_CROSS_TERM_COEFF, Metric, sq8_dot, u8_sum_sumsq,
+use crate::{
+    superfile::vector::distance::{
+        COSINE_DISTANCE_BASE, L2_CROSS_TERM_COEFF, Metric, sq8_dot, u8_sum_sumsq,
+    },
+    supertable::manifest::commit::read_pointer,
 };
 
 use bloom::Bloom;
@@ -182,6 +186,167 @@ impl Manifest {
         }
     }
 
+    pub(crate) async fn load(
+        current_manifest: Option<Arc<Self>>,
+        storage: Arc<dyn crate::storage::StorageProvider>,
+        options: Option<Arc<SupertableOptions>>,
+    ) -> Result<Arc<Self>, ManifestLoadError> {
+        // 1. Read the pointer file.
+        let (pointer, _) = match read_pointer(storage.as_ref()).await? {
+            Some(p) => p,
+            // No pointer yet means nobody has committed; our next
+            // attempt will write the initial pointer with
+            // expected_prev_etag = None.
+            None => return Err(ManifestLoadError::PointerNotFound),
+        };
+
+        if let Some(current_manifest) = &current_manifest
+            && current_manifest.superfile_list.manifest_id >= pointer.manifest_id
+        {
+            // Pointer hasn't advanced past our in-memory state —
+            return Err(ManifestLoadError::AlreadyLoaded);
+        }
+
+        // 2. Load + parse the manifest list.
+        let (list_bytes, _) = storage
+            .get(&pointer.manifest_list_uri)
+            .await
+            .map_err(crate::supertable::ManifestLoadError::Storage)?;
+        let list = list::decode(&list_bytes).map_err(ManifestLoadError::ListParse)?;
+
+        let options = if let Some(options) = options {
+            options
+        } else if let Some(current) = &current_manifest {
+            current.options.clone()
+        } else {
+            return Err(ManifestLoadError::ContentHashMismatch {
+                expected: "valid options".to_string(),
+                actual: "None options".to_string(),
+            });
+        };
+
+        // Verify the caller's options match the
+        // manifest's stamped digest. The all-zero stored
+        // hash bypasses validation (legacy + synthetic
+        // fixtures).
+        let expected_hash = crate::supertable::manifest::options_hash::compute_options_hash(
+            &options,
+            &list.partition_strategy,
+        );
+        if let Err(mismatch) = crate::supertable::manifest::options_hash::verify_options_hash(
+            expected_hash,
+            list.options_hash,
+        ) {
+            return Err(ManifestLoadError::ContentHashMismatch {
+                expected: mismatch.expected,
+                actual: mismatch.actual,
+            });
+        }
+
+        // 3. Build the loader, superfiles & parts
+        let loader = Arc::new(ManifestPartLoader::new(Arc::clone(&storage), &list));
+        let parts: dashmap::DashMap<_, _> = DashMap::new();
+        let mut all_superfiles: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
+        if let Some(current_manifest) = &current_manifest {
+            // If we have an existing manifest, populate `parts` with
+            // existing entries and track missing part IDs for lazy-load.
+            let mut missing_part_ids = Vec::new();
+            for entry in &list.parts {
+                if let Some(existing) = current_manifest.parts.get(&entry.part_id) {
+                    parts.insert(entry.part_id, existing.value().clone());
+                } else {
+                    missing_part_ids.push(entry.part_id);
+                }
+            }
+
+            let threshold = options.eager_load_threshold_parts as usize;
+            let eager = list.parts.len() <= threshold;
+
+            if eager {
+                let load_futs = missing_part_ids
+                    .iter()
+                    .map(|id| {
+                        let loader = Arc::clone(&loader);
+                        let pid = *id;
+                        async move { loader.load(pid).await }
+                    })
+                    .collect::<Vec<_>>();
+                let loaded = futures::future::join_all(load_futs).await;
+                for (pid, result) in missing_part_ids.iter().zip(loaded) {
+                    let part = result?;
+                    let cell = tokio::sync::OnceCell::new();
+                    cell.set(part).expect("fresh cell");
+                    parts.insert(*pid, Arc::new(cell));
+                }
+                for entry in &list.parts {
+                    let cell = parts.get(&entry.part_id).expect("part inserted above");
+                    let part = cell
+                        .value()
+                        .get()
+                        .expect("eager-fetched or inherited; must be set");
+                    all_superfiles.extend(part.superfiles.iter().cloned());
+                }
+            } else {
+                for pid in &missing_part_ids {
+                    parts.insert(*pid, Arc::new(tokio::sync::OnceCell::new()));
+                }
+            }
+        } else {
+            let n_parts = list.parts.len();
+            let threshold = options.eager_load_threshold_parts as usize;
+            let eager = n_parts <= threshold;
+            if eager {
+                // eager-fetching every part (small manifests — fast first query)
+                // parallel-fetch every part + populate
+                // the flat superfile_list.superfiles view so the
+                // iteration-style query paths (`bm25_search`,
+                // `vector_search`, `query_sql`) see all superfiles
+                // without going through the hierarchical iterator.
+                let part_ids: Vec<_> = list.parts.iter().map(|p| p.part_id).collect();
+                let load_futs = part_ids
+                    .iter()
+                    .map(|id| {
+                        let loader = Arc::clone(&loader);
+                        let pid = *id;
+                        async move { loader.load(pid).await }
+                    })
+                    .collect::<Vec<_>>();
+                let loaded = futures::future::join_all(load_futs).await;
+                for (pid, result) in part_ids.iter().zip(loaded) {
+                    let part = result?;
+                    all_superfiles.extend(part.superfiles.iter().cloned());
+                    let cell = tokio::sync::OnceCell::new();
+                    cell.set(part).expect("fresh OnceCell");
+                    parts.insert(*pid, Arc::new(cell));
+                }
+            } else {
+                // Lazy path: each part gets an empty
+                // `OnceCell`; first `Manifest::part(id).await`
+                // triggers a single storage GET for that part.
+                // `superfile_list.superfiles` stays empty — legacy
+                // flat-iteration queries return zero results
+                // until the hierarchical query path lands.
+                // Callers in lazy mode today drive
+                // `Manifest::part().await` directly.
+                for entry in &list.parts {
+                    parts.insert(entry.part_id, Arc::new(tokio::sync::OnceCell::new()));
+                }
+            }
+        }
+
+        let mut new_superfile_list = SuperfileList::empty(options.clone());
+        new_superfile_list.manifest_id = pointer.manifest_id;
+        new_superfile_list.superfiles = all_superfiles;
+        let new_manifest = Manifest {
+            superfile_list: new_superfile_list,
+            list: Some(list),
+            parts,
+            loader: Some(loader),
+        };
+
+        Ok(Arc::new(new_manifest))
+    }
+
     /// Build a successor manifest with `new_entries` appended.
     /// Preserves the persistence-side metadata (`list`, `loader`)
     /// from the predecessor; the per-part cache is fresh (an empty
@@ -291,11 +456,22 @@ impl ManifestPartLoader {
 /// testable in isolation.
 #[derive(Debug, thiserror::Error)]
 pub enum ManifestLoadError {
+    /// Pointer not found in storage.
+    #[error("pointer not found in storage")]
+    PointerNotFound,
+    #[error("already loaded")]
+    AlreadyLoaded,
+    /// Pointer parse error.
+    #[error("pointer parse error: {0}")]
+    PointerParse(String),
     /// Caller invoked `Manifest::part(...)` on an in-process-only
     /// manifest (no storage attached). The hierarchical manifest
     /// has no on-disk parts to load from.
     #[error("no storage / loader attached to this manifest")]
     NoLoaderAttached,
+
+    #[error("list parse error: {0}")]
+    ListParse(#[source] list::ListParseError),
     /// `part_id` isn't in this manifest's list. Either the caller
     /// passed a stale id (pre-refresh) or the manifest list is
     /// missing an entry.

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -69,17 +69,15 @@ use crate::superfile::format::vec::{
     dir_entry, outer_hdr, sub_hdr,
 };
 use crate::superfile::format::{footer::read_kv_metadata, kv};
-use crate::supertable::CommitError as SupertableCommitError;
+use crate::supertable::manifest::Manifest;
 use crate::supertable::manifest::ManifestPartLoader;
 use crate::supertable::manifest::commit::get_current_manifest_etag;
-use crate::supertable::manifest::commit::read_pointer;
 use crate::supertable::manifest::commit::{self as commit_mod};
-use crate::supertable::manifest::list as list_mod;
 use crate::supertable::manifest::list::{
     FORMAT_VERSION as LIST_FORMAT_VERSION, ManifestList, PartitionStrategy,
 };
 use crate::supertable::manifest::part::{self as part_mod, PartId};
-use crate::supertable::manifest::{Manifest, SuperfileList};
+use crate::supertable::{CommitError as SupertableCommitError, ManifestLoadError};
 
 use super::build::fanout_shards;
 use super::error::BuildError;
@@ -1915,85 +1913,14 @@ async fn refresh_inner_state_async(
     inner: &SupertableInner,
     storage: &Arc<dyn crate::storage::StorageProvider>,
 ) -> Result<(), crate::supertable::CommitError> {
-    let pointer = match read_pointer(storage.as_ref()).await? {
-        Some(p) => p,
-        // No pointer yet means nobody has committed; our next
-        // attempt will write the initial pointer with
-        // expected_prev_etag = None.
-        None => return Ok(()),
-    };
     let current = inner.manifest.load_full();
-    if pointer.manifest_id <= current.superfile_list.manifest_id {
-        // Pointer hasn't advanced past our in-memory state —
-        // our last CAS lost to a writer that has since been
-        // overwritten, or the lost-race writer's manifest_id
-        // is somehow ≤ ours. Either way, the next attempt's
-        // `inner.manifest.load_full()` is already correct.
-        return Ok(());
-    }
-
-    let (list_bytes, _) = storage
-        .get(&pointer.manifest_list_uri)
-        .await
-        .map_err(crate::supertable::CommitError::from)?;
-    let new_list = list_mod::decode(&list_bytes).map_err(|e| {
-        crate::supertable::CommitError::PointerParse(format!(
-            "manifest list decode during retry refresh: {e}"
-        ))
-    })?;
-
-    let new_loader = Arc::new(ManifestPartLoader::new(Arc::clone(storage), &new_list));
-    let new_parts: dashmap::DashMap<_, _> = dashmap::DashMap::new();
-    let mut missing_part_ids = Vec::new();
-    for entry in &new_list.parts {
-        if let Some(existing) = current.parts.get(&entry.part_id) {
-            new_parts.insert(entry.part_id, existing.value().clone());
-        } else {
-            missing_part_ids.push(entry.part_id);
-        }
-    }
-
-    let load_futs = missing_part_ids
-        .iter()
-        .map(|id| {
-            let loader = Arc::clone(&new_loader);
-            let pid = *id;
-            async move { loader.load(pid).await }
-        })
-        .collect::<Vec<_>>();
-    let loaded = futures::future::join_all(load_futs).await;
-    for (pid, result) in missing_part_ids.iter().zip(loaded) {
-        let part = result.map_err(|e| {
-            crate::supertable::CommitError::Encode(format!(
-                "manifest part load during retry refresh: part_id={} err={}",
-                pid.0, e
-            ))
-        })?;
-        let cell = tokio::sync::OnceCell::new();
-        cell.set(part).expect("fresh cell");
-        new_parts.insert(*pid, Arc::new(cell));
-    }
-
-    let mut all_superfiles: Vec<Arc<crate::supertable::SuperfileEntry>> = Vec::new();
-    for entry in &new_list.parts {
-        let cell = new_parts.get(&entry.part_id).expect("part inserted above");
-        let part = cell
-            .value()
-            .get()
-            .expect("eager-fetched or inherited; must be set");
-        all_superfiles.extend(part.superfiles.iter().cloned());
-    }
-
-    let mut new_superfile_list = SuperfileList::empty(inner.options.clone());
-    new_superfile_list.manifest_id = pointer.manifest_id;
-    new_superfile_list.superfiles = all_superfiles;
-    let new_manifest = Manifest {
-        superfile_list: new_superfile_list,
-        list: Some(new_list),
-        parts: new_parts,
-        loader: Some(new_loader),
+    let manifest = match Manifest::load(Some(current), storage.clone(), None).await {
+        Ok(manifest) => manifest,
+        Err(ManifestLoadError::PointerNotFound) => return Ok(()),
+        Err(ManifestLoadError::AlreadyLoaded) => return Ok(()),
+        Err(err) => return Err(crate::supertable::CommitError::ManifestLoadError(err)),
     };
-    inner.manifest.store(Arc::new(new_manifest));
+    inner.manifest.store(manifest);
     Ok(())
 }
 

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -29,7 +29,7 @@ use infino::superfile::fts::reader::BoolMode;
 use infino::superfile::fts::tokenize::Tokenizer;
 use infino::supertable::options::Consistency;
 use infino::supertable::storage::{LocalFsStorageProvider, StorageProvider};
-use infino::supertable::{OpenError, Supertable, SupertableOptions};
+use infino::supertable::{ManifestLoadError, OpenError, Supertable, SupertableOptions};
 use infino::test_helpers::{build_title_batch, default_supertable_options, default_tokenizer};
 
 /// BM25 top-k for the open/refresh consistency queries.
@@ -81,7 +81,7 @@ fn open_on_fresh_tempdir_returns_pointer_unreadable() {
     let err = Supertable::open(default_supertable_options().with_storage(storage))
         .expect_err("must reject fresh dir");
     assert!(
-        matches!(err, OpenError::PointerUnreadable(_)),
+        matches!(err, OpenError::ManifestLoadError(_)),
         "expected PointerUnreadable, got {err:?}"
     );
 }
@@ -256,7 +256,10 @@ fn open_rejects_mismatched_options_via_options_hash() {
     let err = Supertable::open(mismatched_opts)
         .expect_err("open must surface OptionsHashMismatch for a reordered schema");
     assert!(
-        matches!(err, OpenError::OptionsHashMismatch { .. }),
+        matches!(
+            err,
+            OpenError::ManifestLoadError(ManifestLoadError::ContentHashMismatch { .. })
+        ),
         "expected OptionsHashMismatch; got {err:?}"
     );
 }

--- a/tests/supertable/commit/persistence.rs
+++ b/tests/supertable/commit/persistence.rs
@@ -51,7 +51,7 @@ fn commit_persists_pointer_list_part_and_superfile() {
     drop(w);
 
     // Pointer file exists on disk, manifest_id=1 (initial was 0).
-    let pointer = futures::executor::block_on(read_pointer(&*storage))
+    let (pointer, _) = futures::executor::block_on(read_pointer(&*storage))
         .expect("read")
         .expect("pointer present");
     assert_eq!(pointer.manifest_id, 1);
@@ -115,7 +115,7 @@ fn two_successive_commits_both_publish() {
     w.commit().expect("commit2");
     drop(w);
 
-    let pointer = futures::executor::block_on(read_pointer(&*storage))
+    let (pointer, _) = futures::executor::block_on(read_pointer(&*storage))
         .expect("read")
         .expect("pointer");
     assert_eq!(
@@ -292,7 +292,7 @@ fn manifest_id_increments_only_on_non_empty_commits() {
     w.commit().expect("real commit");
     drop(w);
 
-    let pointer = futures::executor::block_on(read_pointer(&*storage))
+    let (pointer, _) = futures::executor::block_on(read_pointer(&*storage))
         .expect("read")
         .expect("pointer");
     assert_eq!(pointer.manifest_id, 1);

--- a/tests/supertable/commit/pointer_atomic.rs
+++ b/tests/supertable/commit/pointer_atomic.rs
@@ -35,7 +35,6 @@ use bytes::Bytes;
 use tokio::sync::{Barrier, Mutex};
 use uuid::Uuid;
 
-use infino::supertable::CommitError;
 use infino::supertable::manifest::commit::{
     self, MANIFEST_LISTS_DIR, MANIFEST_PARTS_DIR, POINTER_PATH, PointerFile, list_uri, part_uri,
     read_pointer, write_pointer,
@@ -47,6 +46,7 @@ use infino::supertable::manifest::part::{self as part_mod, ContentHash, Manifest
 use infino::supertable::storage::{
     LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider,
 };
+use infino::supertable::{CommitError, ManifestLoadError};
 use tempfile::TempDir;
 
 /// Manifest id used by the pointer-file round-trip fixture.
@@ -105,7 +105,7 @@ fn pointer_file_text_format_roundtrip() {
 fn pointer_file_rejects_truncated() {
     let bad = b"manifest_id=1\nmanifest_list_uri=foo\n"; // missing content_hash
     let err = PointerFile::from_bytes(bad).expect_err("must reject");
-    assert!(matches!(err, CommitError::PointerParse(_)), "{err:?}");
+    assert!(matches!(err, ManifestLoadError::PointerParse(_)), "{err:?}");
 }
 
 #[test]
@@ -188,7 +188,7 @@ async fn initial_commit_writes_list_part_pointer() {
     assert_eq!(pointer.manifest_list_uri, list_uri(0));
 
     // Pointer is readable.
-    let read = read_pointer(&storage).await.expect("read").expect("some");
+    let (read, _) = read_pointer(&storage).await.expect("read").expect("some");
     assert_eq!(read, pointer);
     // List + part are at their expected URIs.
     let (list_bytes, _) = storage.get(&list_uri(0)).await.expect("list bytes");
@@ -235,7 +235,7 @@ async fn second_commit_with_valid_prev_etag_succeeds() {
         .expect("v1");
     assert_eq!(pointer.manifest_id, 1);
 
-    let read = read_pointer(&storage).await.expect("read").expect("some");
+    let (read, _) = read_pointer(&storage).await.expect("read").expect("some");
     assert_eq!(read.manifest_id, 1);
 }
 
@@ -312,7 +312,7 @@ async fn part_reuse_writes_zero_new_part_files() {
     );
 
     // But manifest_id 1 is published.
-    let read = read_pointer(&storage).await.expect("read").expect("some");
+    let (read, _) = read_pointer(&storage).await.expect("read").expect("some");
     assert_eq!(read.manifest_id, 1);
 }
 
@@ -566,7 +566,7 @@ async fn write_pointer_initial_then_update() {
         .await
         .expect("update");
 
-    let read = read_pointer(&storage).await.expect("read").expect("some");
+    let (read, _) = read_pointer(&storage).await.expect("read").expect("some");
     assert_eq!(read, p1);
 }
 

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -284,7 +284,7 @@ fn crash_post_superfile_no_prior_commit_yields_pointer_unreadable() {
     let err = Supertable::open(default_supertable_options().with_storage(storage))
         .expect_err("must reject post-crash state with no pointer");
     assert!(
-        matches!(err, OpenError::PointerUnreadable(_)),
+        matches!(err, OpenError::ManifestLoadError(_)),
         "expected PointerUnreadable, got {err:?}"
     );
 
@@ -316,7 +316,7 @@ fn crash_post_list_no_prior_commit_yields_pointer_unreadable() {
     let err = Supertable::open(default_supertable_options().with_storage(storage))
         .expect_err("must reject post-crash state with no pointer");
     assert!(
-        matches!(err, OpenError::PointerUnreadable(_)),
+        matches!(err, OpenError::ManifestLoadError(_)),
         "expected PointerUnreadable, got {err:?}"
     );
 


### PR DESCRIPTION
### What does this PR do?
- Refactor the code for loading the manifest across the codebase into a `Manifest::load` fn

### Why do we need this change?
- Well defined api for `Manifest` instead of duplicate, complex code all around the codebase