### PR TITLE
test: raise line/function/region coverage above 90%

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -907,6 +907,129 @@ mod tests {
     }
 
     #[test]
+    fn connect_with_default_options_yields_empty_memory_catalog() {
+        let db = connect_with("memory://", ConnectOptions::new()).expect("connect_with");
+        assert!(db.list_tables().expect("list").is_empty());
+    }
+
+    #[test]
+    fn connection_clone_shares_one_catalog() {
+        let conn = connect("memory://").expect("connect");
+        let clone = conn.clone();
+        conn.create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create on original");
+        // The clone shares the same Arc<ConnectionInner>, so the table
+        // is visible through it.
+        assert_eq!(clone.list_tables().expect("list"), vec!["docs".to_string()]);
+    }
+
+    #[test]
+    fn query_sql_table_free_select_uses_shared_bridge() {
+        // A query naming no catalog relation falls through to the shared
+        // sync->async bridge (the `handles.first()` None arm).
+        let conn = connect("memory://").expect("connect");
+        let batches = conn
+            .query_sql("SELECT 1 AS one")
+            .expect("table-free select");
+        assert_eq!(n_rows(&batches), 1);
+    }
+
+    #[test]
+    fn query_sql_invalid_sql_is_query_error() {
+        let conn = connect("memory://").expect("connect");
+        let err = conn.query_sql("NOT VALID SQL @@@");
+        assert!(matches!(err, Err(InfinoError::Query(_))), "got {err:?}");
+    }
+
+    #[test]
+    fn drop_missing_is_not_found() {
+        let conn = connect("memory://").expect("connect");
+        assert!(matches!(
+            conn.drop_table("nope", false),
+            Err(InfinoError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn empty_table_name_rejected() {
+        let conn = connect("memory://").expect("connect");
+        assert!(
+            conn.create_table("", schema_id_title(), IndexSpec::new())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn vector_index_round_trips_metric_through_storage_catalog() {
+        use crate::Metric;
+
+        // Exercises metric_to_str (create) + metric_from_str (open) plus
+        // the VectorEntry catalog encoding across a reconnect. A
+        // storage-backed catalog records the index spec and rebuilds it
+        // on open, so the table's options-hash check must pass.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let schema = std::sync::Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("title", arrow_schema::DataType::LargeUtf8, false),
+            arrow_schema::Field::new(
+                "embedding",
+                arrow_schema::DataType::FixedSizeList(
+                    std::sync::Arc::new(arrow_schema::Field::new(
+                        "item",
+                        arrow_schema::DataType::Float32,
+                        true,
+                    )),
+                    16,
+                ),
+                false,
+            ),
+        ]));
+
+        // A FixedSizeList<Float32, 16> column of one all-zero vector,
+        // committed so the physical table writes its pointer file (open
+        // requires committed state).
+        let one_vector = || -> arrow::record_batch::RecordBatch {
+            use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray};
+            let values = Float32Array::from(vec![0.0_f32; 16]);
+            let field = std::sync::Arc::new(arrow_schema::Field::new(
+                "item",
+                arrow_schema::DataType::Float32,
+                true,
+            ));
+            let list = FixedSizeListArray::new(field, 16, std::sync::Arc::new(values), None);
+            arrow::record_batch::RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    std::sync::Arc::new(LargeStringArray::from(vec!["hello"])),
+                    std::sync::Arc::new(list),
+                ],
+            )
+            .expect("vector batch")
+        };
+
+        {
+            let conn = connect(&uri).expect("connect");
+            let table = conn
+                .create_table(
+                    "vecs",
+                    schema.clone(),
+                    IndexSpec::new()
+                        .fts("title")
+                        .vector("embedding", 16, 4, Metric::L2Sq),
+                )
+                .expect("create vector table");
+            table.append(&one_vector()).expect("append vector row");
+        }
+
+        // Reopen: open_table rebuilds the spec via metric_from_str and
+        // validates the options hash — a mismatch would error here.
+        let conn = connect(&uri).expect("reconnect");
+        assert_eq!(conn.list_tables().expect("list"), vec!["vecs".to_string()]);
+        conn.open_table("vecs").expect("open vector table");
+    }
+
+    #[test]
     fn localfs_persists_across_reconnect() {
         let dir = tempfile::tempdir().expect("tempdir");
         let uri = dir.path().to_str().expect("utf8 path").to_string();

--- a/src/error.rs
+++ b/src/error.rs
@@ -137,7 +137,10 @@ mod tests {
 
     #[test]
     fn display_messages_are_prefixed() {
-        assert_eq!(InfinoError::NotFound("t".into()).to_string(), "not found: t");
+        assert_eq!(
+            InfinoError::NotFound("t".into()).to_string(),
+            "not found: t"
+        );
         assert_eq!(
             InfinoError::AlreadyExists("t".into()).to_string(),
             "already exists: t"

--- a/src/error.rs
+++ b/src/error.rs
@@ -129,3 +129,117 @@ impl From<MutationCommitError> for InfinoError {
         InfinoError::Backend(e.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::StorageError;
+
+    #[test]
+    fn display_messages_are_prefixed() {
+        assert_eq!(InfinoError::NotFound("t".into()).to_string(), "not found: t");
+        assert_eq!(
+            InfinoError::AlreadyExists("t".into()).to_string(),
+            "already exists: t"
+        );
+        assert_eq!(InfinoError::Schema("t".into()).to_string(), "schema: t");
+        assert_eq!(
+            InfinoError::Cardinality("t".into()).to_string(),
+            "cardinality: t"
+        );
+        assert_eq!(InfinoError::Io("t".into()).to_string(), "io: t");
+        assert_eq!(InfinoError::Query("t".into()).to_string(), "query: t");
+        assert_eq!(InfinoError::Backend("t".into()).to_string(), "backend: t");
+    }
+
+    #[test]
+    fn from_storage_error_maps_each_variant() {
+        assert!(matches!(
+            InfinoError::from(StorageError::NotFound { uri: "u".into() }),
+            InfinoError::NotFound(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(StorageError::PreconditionFailed { uri: "u".into() }),
+            InfinoError::AlreadyExists(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(StorageError::TransientExhausted {
+                uri: "u".into(),
+                source: "x".into()
+            }),
+            InfinoError::Io(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(StorageError::Permanent {
+                uri: "u".into(),
+                source: "x".into()
+            }),
+            InfinoError::Io(_)
+        ));
+    }
+
+    #[test]
+    fn from_query_read_and_build_errors() {
+        assert!(matches!(
+            InfinoError::from(QueryError::Plan("p".into())),
+            InfinoError::Query(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(SuperfileReadError::MissingKv("k")),
+            InfinoError::Query(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(SuperfileBuildError::MissingIdColumn("c".into())),
+            InfinoError::Schema(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(SupertableBuildError::NoDocsToBuild),
+            InfinoError::Schema(_)
+        ));
+    }
+
+    #[test]
+    fn from_commit_and_open_errors_are_backend() {
+        assert!(matches!(
+            InfinoError::from(SupertableCommitError::Encode("e".into())),
+            InfinoError::Backend(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(OpenError::ManifestListParse("m".into())),
+            InfinoError::Backend(_)
+        ));
+    }
+
+    #[test]
+    fn from_mutation_error_maps_each_arm() {
+        assert!(matches!(
+            InfinoError::from(MutationError::PredicateEval(QueryError::Plan("p".into()))),
+            InfinoError::Query(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(MutationError::Storage(StorageError::NotFound {
+                uri: "u".into()
+            })),
+            InfinoError::NotFound(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(MutationError::CardinalityMismatch {
+                matched: 1,
+                new_rows: 2
+            }),
+            InfinoError::Cardinality(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(MutationError::MatchCountExceedsCap { matched: 9, cap: 5 }),
+            InfinoError::Cardinality(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(MutationError::SchemaMismatch("s".into())),
+            InfinoError::Schema(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(MutationError::NoStorageAttached),
+            InfinoError::Backend(_)
+        ));
+    }
+}

--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -454,4 +454,59 @@ mod tests {
         let s = format!("{p:?}");
         assert!(s.contains("AzureStorageProvider"));
     }
+
+    // ---- pure helpers: prefix / key ------------------------------------
+    //
+    // The Azure round-trip paths (head / get / get_range / put_atomic /
+    // put_if_match / delete / list_with_prefix / tail) are exercised
+    // end-to-end against the Azurite emulator in the gated
+    // `supertable_smoke_via_azure_wire_protocol` integration test. Azurite
+    // is an out-of-process Docker emulator (no in-process server crate
+    // exists the way `s3s-fs` does for S3), so it cannot be stood up from
+    // a `#[cfg(test)]` unit test here; these unit tests therefore cover the
+    // pure, server-free surface (constructors, `translate`, path/key
+    // building) directly.
+
+    #[test]
+    fn normalize_prefix_trims_surrounding_slashes() {
+        assert_eq!(normalize_prefix("/tbl/"), "tbl");
+        assert_eq!(normalize_prefix("///a/b///"), "a/b");
+        assert_eq!(normalize_prefix("plain"), "plain");
+        assert_eq!(normalize_prefix(""), "");
+    }
+
+    #[test]
+    fn key_without_prefix_strips_leading_slash() {
+        let p = test_provider();
+        assert_eq!(p.prefix(), "");
+        assert_eq!(p.key("/foo/bar"), "foo/bar");
+        assert_eq!(p.key("foo/bar"), "foo/bar");
+    }
+
+    #[test]
+    fn key_with_prefix_prepends_and_strips_leading_slash() {
+        let mut p = test_provider();
+        p.prefix = "tbl".into();
+        assert_eq!(p.prefix(), "tbl");
+        assert_eq!(p.key("data/seg-1"), "tbl/data/seg-1");
+        assert_eq!(p.key("/data/seg-1"), "tbl/data/seg-1");
+    }
+
+    #[test]
+    fn path_with_prefix_parses_under_prefix() {
+        let mut p = test_provider();
+        p.prefix = "tbl".into();
+        let parsed = p.path("data/seg-1").expect("parse");
+        assert_eq!(parsed.to_string(), "tbl/data/seg-1");
+    }
+
+    #[test]
+    fn object_store_handle_returns_path_under_prefix() {
+        let mut p = test_provider();
+        p.prefix = "tbl".into();
+        let (_, path) = p
+            .object_store_handle("data/seg-1")
+            .expect("handle for valid uri");
+        assert_eq!(path.to_string(), "tbl/data/seg-1");
+    }
 }

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -570,4 +570,96 @@ mod tests {
         assert_eq!(p.root(), &root);
         assert!(root.is_dir());
     }
+
+    #[test]
+    fn translate_maps_generic_to_transient_exhausted() {
+        // `object_store` retries transient failures internally per its
+        // RetryConfig; a `Generic` reaching `translate` is post-retry,
+        // so it maps to `TransientExhausted`.
+        let boxed: Box<dyn std::error::Error + Send + Sync> = "boom".into();
+        let e = ObjError::Generic {
+            store: "test",
+            source: boxed,
+        };
+        let mapped = translate("data/x.sf.parquet", e);
+        assert!(
+            matches!(mapped, StorageError::TransientExhausted { .. }),
+            "expected TransientExhausted, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn translate_maps_unhandled_variant_to_permanent() {
+        // A variant with no dedicated arm (e.g. `NotImplemented`)
+        // falls through to the catch-all `Permanent`.
+        let e = ObjError::NotImplemented {
+            operation: "put_opts(Update)".into(),
+            implementer: "LocalFileSystem".into(),
+        };
+        let mapped = translate("data/x.sf.parquet", e);
+        match mapped {
+            StorageError::Permanent { uri, .. } => assert_eq!(uri, "data/x.sf.parquet"),
+            other => panic!("expected Permanent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_maps_already_exists_and_precondition_to_precondition_failed() {
+        let already = ObjError::AlreadyExists {
+            path: "p".into(),
+            source: "exists".into(),
+        };
+        assert!(matches!(
+            translate("uri", already),
+            StorageError::PreconditionFailed { .. }
+        ));
+        let precond = ObjError::Precondition {
+            path: "p".into(),
+            source: "stale".into(),
+        };
+        assert!(matches!(
+            translate("uri", precond),
+            StorageError::PreconditionFailed { .. }
+        ));
+    }
+
+    #[test]
+    fn translate_maps_not_found() {
+        let nf = ObjError::NotFound {
+            path: "p".into(),
+            source: "missing".into(),
+        };
+        assert!(matches!(
+            translate("uri", nf),
+            StorageError::NotFound { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_path_surfaces_permanent_error() {
+        // A NUL byte is illegal in an `object_store::path::Path`, so
+        // `Self::path` fails before any I/O — surfacing the `path()`
+        // error arm as `Permanent`.
+        let (_dir, p) = provider();
+        let bad_uri = "data/seg\0bad.sf.parquet";
+        let err = p.head(bad_uri).await.expect_err("illegal path must fail");
+        match err {
+            StorageError::Permanent { uri, .. } => assert_eq!(uri, bad_uri),
+            other => panic!("expected Permanent, got {other:?}"),
+        }
+        // The same rejection happens on the write paths.
+        let err = p
+            .put_atomic(bad_uri, Bytes::from_static(b"x"))
+            .await
+            .expect_err("illegal path must fail on put");
+        assert!(matches!(err, StorageError::Permanent { .. }));
+    }
+
+    #[tokio::test]
+    async fn object_store_handle_returns_none_for_invalid_path() {
+        // `object_store_handle` swallows the path-parse error and
+        // returns `None` (the `?`-via-`.ok()?` arm).
+        let (_dir, p) = provider();
+        assert!(p.object_store_handle("data/bad\0path").is_none());
+    }
 }

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -530,4 +530,39 @@ mod tests {
             .expect("multipart handle");
         upload.abort().await.expect("abort");
     }
+
+    #[tokio::test]
+    async fn list_with_prefix_returns_matching_keys() {
+        let (_dir, p) = provider();
+        for key in ["seg/a.parquet", "seg/b.parquet", "other/c.parquet"] {
+            p.put_atomic(key, Bytes::from_static(b"x")).await.expect("put");
+        }
+        let mut under_seg = p.list_with_prefix("seg").await.expect("list");
+        under_seg.sort();
+        assert_eq!(under_seg, vec!["seg/a.parquet", "seg/b.parquet"]);
+
+        let all = p.list_with_prefix("").await.expect("list all");
+        assert_eq!(all.len(), 3);
+
+        let none = p.list_with_prefix("does-not-exist").await.expect("list empty");
+        assert!(none.is_empty());
+    }
+
+    #[tokio::test]
+    async fn object_store_handle_exposes_store_and_key() {
+        let (_dir, p) = provider();
+        let (_store, path) = p
+            .object_store_handle("seg/x.parquet")
+            .expect("handle for valid uri");
+        assert_eq!(path.to_string(), "seg/x.parquet");
+    }
+
+    #[test]
+    fn new_records_root_and_creates_it() {
+        let dir = TempDir::new().expect("tempdir");
+        let root = dir.path().join("nested/created/here");
+        let p = LocalFsStorageProvider::new(&root).expect("provider creates root");
+        assert_eq!(p.root(), &root);
+        assert!(root.is_dir());
+    }
 }

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -535,7 +535,9 @@ mod tests {
     async fn list_with_prefix_returns_matching_keys() {
         let (_dir, p) = provider();
         for key in ["seg/a.parquet", "seg/b.parquet", "other/c.parquet"] {
-            p.put_atomic(key, Bytes::from_static(b"x")).await.expect("put");
+            p.put_atomic(key, Bytes::from_static(b"x"))
+                .await
+                .expect("put");
         }
         let mut under_seg = p.list_with_prefix("seg").await.expect("list");
         under_seg.sort();
@@ -544,7 +546,10 @@ mod tests {
         let all = p.list_with_prefix("").await.expect("list all");
         assert_eq!(all.len(), 3);
 
-        let none = p.list_with_prefix("does-not-exist").await.expect("list empty");
+        let none = p
+            .list_with_prefix("does-not-exist")
+            .await
+            .expect("list empty");
         assert!(none.is_empty());
     }
 

--- a/src/storage/retry.rs
+++ b/src/storage/retry.rs
@@ -211,7 +211,7 @@ mod tests {
             async { Ok(7u8) }
         })
         .await;
-        assert_eq!(r.unwrap(), 7);
+        assert_eq!(r.expect("test"), 7);
         assert_eq!(calls.get(), 1);
     }
 
@@ -224,7 +224,7 @@ mod tests {
             async move { if c < 2 { Err(transient()) } else { Ok(7u8) } }
         })
         .await;
-        assert_eq!(r.unwrap(), 7);
+        assert_eq!(r.expect("test"), 7);
         assert_eq!(calls.get(), 3);
     }
 
@@ -256,7 +256,7 @@ mod tests {
     async fn range_zero_length_is_empty() {
         let r = complete_range("u", 5..5, |_| async { Ok(Bytes::new()) })
             .await
-            .unwrap();
+            .expect("test");
         assert!(r.is_empty());
     }
 
@@ -264,7 +264,7 @@ mod tests {
     async fn range_single_full_chunk() {
         let r = complete_range("u", 0..3, |_| async { Ok(Bytes::from_static(b"abc")) })
             .await
-            .unwrap();
+            .expect("test");
         assert_eq!(&r[..], b"abc");
     }
 
@@ -272,7 +272,7 @@ mod tests {
     async fn range_truncates_overlong_chunk() {
         let r = complete_range("u", 0..3, |_| async { Ok(Bytes::from_static(b"abcdef")) })
             .await
-            .unwrap();
+            .expect("test");
         assert_eq!(&r[..], b"abc");
     }
 
@@ -285,7 +285,7 @@ mod tests {
             Ok(Bytes::copy_from_slice(&data[start..end]))
         })
         .await
-        .unwrap();
+        .expect("test");
         assert_eq!(&r[..], b"abcde");
     }
 
@@ -304,7 +304,7 @@ mod tests {
             }
         })
         .await
-        .unwrap();
+        .expect("test");
         assert_eq!(&r[..], b"abc");
     }
 
@@ -323,7 +323,7 @@ mod tests {
             }
         })
         .await
-        .unwrap();
+        .expect("test");
         assert_eq!(&r[..], b"abc");
     }
 

--- a/src/storage/retry.rs
+++ b/src/storage/retry.rs
@@ -191,7 +191,9 @@ mod tests {
     fn is_retryable_only_for_transient() {
         assert!(is_retryable(&transient()));
         assert!(!is_retryable(&not_found()));
-        assert!(!is_retryable(&StorageError::PreconditionFailed { uri: "u".into() }));
+        assert!(!is_retryable(&StorageError::PreconditionFailed {
+            uri: "u".into()
+        }));
     }
 
     #[test]
@@ -219,13 +221,7 @@ mod tests {
         let r: Result<u8, StorageError> = with_reissue(|| {
             let c = calls.get();
             calls.set(c + 1);
-            async move {
-                if c < 2 {
-                    Err(transient())
-                } else {
-                    Ok(7u8)
-                }
-            }
+            async move { if c < 2 { Err(transient()) } else { Ok(7u8) } }
         })
         .await;
         assert_eq!(r.unwrap(), 7);

--- a/src/storage/retry.rs
+++ b/src/storage/retry.rs
@@ -152,3 +152,194 @@ where
     }
     Ok(out.freeze())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    fn transient() -> StorageError {
+        StorageError::TransientExhausted {
+            uri: "u".into(),
+            source: "boom".into(),
+        }
+    }
+
+    fn not_found() -> StorageError {
+        StorageError::NotFound { uri: "u".into() }
+    }
+
+    #[test]
+    fn backoff_grows_then_caps_at_max_shift() {
+        assert_eq!(backoff(0), Duration::from_millis(BACKOFF_BASE_MS));
+        assert_eq!(backoff(1), Duration::from_millis(BACKOFF_BASE_MS * 2));
+        // attempt >= BACKOFF_MAX_SHIFT saturates the shift.
+        let capped = Duration::from_millis(BACKOFF_BASE_MS * (1 << BACKOFF_MAX_SHIFT));
+        assert_eq!(backoff(BACKOFF_MAX_SHIFT), capped);
+        assert_eq!(backoff(100), capped);
+    }
+
+    #[test]
+    fn config_uses_our_budget() {
+        let c = config();
+        assert_eq!(c.max_retries, MAX_RETRIES);
+        assert_eq!(c.retry_timeout, RETRY_TIMEOUT);
+    }
+
+    #[test]
+    fn is_retryable_only_for_transient() {
+        assert!(is_retryable(&transient()));
+        assert!(!is_retryable(&not_found()));
+        assert!(!is_retryable(&StorageError::PreconditionFailed { uri: "u".into() }));
+    }
+
+    #[test]
+    fn short_read_builds_permanent_error() {
+        let e = short_read("u", 0, 100, 10);
+        assert!(matches!(e, StorageError::Permanent { .. }));
+        assert!(e.to_string().contains("short read"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reissue_ok_first_try() {
+        let calls = Cell::new(0u32);
+        let r: Result<u8, StorageError> = with_reissue(|| {
+            calls.set(calls.get() + 1);
+            async { Ok(7u8) }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 7);
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reissue_retries_transient_then_succeeds() {
+        let calls = Cell::new(0u32);
+        let r: Result<u8, StorageError> = with_reissue(|| {
+            let c = calls.get();
+            calls.set(c + 1);
+            async move {
+                if c < 2 {
+                    Err(transient())
+                } else {
+                    Ok(7u8)
+                }
+            }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 7);
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reissue_exhausts_budget_then_errors() {
+        let calls = Cell::new(0u32);
+        let r: Result<u8, StorageError> = with_reissue(|| {
+            calls.set(calls.get() + 1);
+            async { Err(transient()) }
+        })
+        .await;
+        assert!(r.is_err());
+        assert_eq!(calls.get(), MAX_TRANSIENT_RETRIES + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reissue_non_retryable_returns_immediately() {
+        let calls = Cell::new(0u32);
+        let r: Result<u8, StorageError> = with_reissue(|| {
+            calls.set(calls.get() + 1);
+            async { Err(not_found()) }
+        })
+        .await;
+        assert!(matches!(r, Err(StorageError::NotFound { .. })));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn range_zero_length_is_empty() {
+        let r = complete_range("u", 5..5, |_| async { Ok(Bytes::new()) })
+            .await
+            .unwrap();
+        assert!(r.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn range_single_full_chunk() {
+        let r = complete_range("u", 0..3, |_| async { Ok(Bytes::from_static(b"abc")) })
+            .await
+            .unwrap();
+        assert_eq!(&r[..], b"abc");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn range_truncates_overlong_chunk() {
+        let r = complete_range("u", 0..3, |_| async { Ok(Bytes::from_static(b"abcdef")) })
+            .await
+            .unwrap();
+        assert_eq!(&r[..], b"abc");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn range_assembles_short_chunks() {
+        let r = complete_range("u", 0..5, |range| async move {
+            let data = b"abcde";
+            let start = range.start as usize;
+            let end = (start + 2).min(data.len());
+            Ok(Bytes::copy_from_slice(&data[start..end]))
+        })
+        .await
+        .unwrap();
+        assert_eq!(&r[..], b"abcde");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn range_retries_transient_then_completes() {
+        let calls = Cell::new(0u32);
+        let r = complete_range("u", 0..3, |_| {
+            let c = calls.get();
+            calls.set(c + 1);
+            async move {
+                if c == 0 {
+                    Err(transient())
+                } else {
+                    Ok(Bytes::from_static(b"abc"))
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(&r[..], b"abc");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn range_empty_body_then_full() {
+        let calls = Cell::new(0u32);
+        let r = complete_range("u", 0..3, |_| {
+            let c = calls.get();
+            calls.set(c + 1);
+            async move {
+                if c == 0 {
+                    Ok(Bytes::new())
+                } else {
+                    Ok(Bytes::from_static(b"abc"))
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(&r[..], b"abc");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn range_persistent_empty_body_is_short_read() {
+        let r = complete_range("u", 0..3, |_| async { Ok(Bytes::new()) }).await;
+        assert!(matches!(r, Err(StorageError::Permanent { .. })));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn range_propagates_non_retryable() {
+        let r = complete_range("u", 0..3, |_| async { Err::<Bytes, _>(not_found()) }).await;
+        assert!(matches!(r, Err(StorageError::NotFound { .. })));
+    }
+}

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -453,7 +453,95 @@ mod tests {
     //! `delete`, `get_range`) are exercised end-to-end by the
     //! `supertable_smoke_via_s3_wire_protocol` integration
     //! test against an in-process `s3s-fs` server.
+    //!
+    //! In addition, this module stands up the same in-process
+    //! `s3s-fs` server the smoke test uses (the dev-dependencies
+    //! `s3s` / `s3s-fs` / `hyper-util` are on the lib unit-test
+    //! compile graph), so the trait impls — `put_atomic`, `get`,
+    //! `get_range`, `head`, `delete`, `list_with_prefix`,
+    //! `put_if_match`, and `tail` — are exercised here over the
+    //! real S3 HTTP wire protocol without any cloud credentials
+    //! or network access.
+    use std::net::SocketAddr;
+
+    use s3s::auth::SimpleAuth;
+    use s3s::service::S3ServiceBuilder;
+    use s3s_fs::FileSystem;
+    use tempfile::TempDir;
+    use tokio::net::TcpListener;
+
     use super::*;
+
+    // ---- in-process s3s-fs harness -------------------------------------
+
+    /// Bucket the in-process server pre-creates for round-trip tests.
+    const HARNESS_BUCKET: &str = "infino-s3-unit";
+    /// Region passed to the provider; arbitrary for s3s-fs.
+    const HARNESS_REGION: &str = "us-east-1";
+    /// Fixed dummy credential pair s3s validates SigV4 against.
+    const HARNESS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+    const HARNESS_SECRET_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+    /// Spawn s3s-fs on a random loopback port. Returns the bound
+    /// address plus the tempdir guard (drop unlinks the bucket data,
+    /// so the caller must keep it alive for the test's duration).
+    async fn spawn_s3s_fs() -> (SocketAddr, TempDir) {
+        let fs_root = TempDir::new().expect("s3s-fs root tempdir");
+        // s3s-fs treats top-level dirs as buckets; pre-create the
+        // bucket dir so a put on a key inside it doesn't 404 the
+        // bucket.
+        std::fs::create_dir_all(fs_root.path().join(HARNESS_BUCKET)).expect("create bucket dir");
+
+        let fs_backend = FileSystem::new(fs_root.path()).expect("s3s-fs FileSystem");
+        let service = {
+            let mut b = S3ServiceBuilder::new(fs_backend);
+            // Without an auth provider s3s answers 501 to any signed
+            // request; object_store always signs.
+            b.set_auth(SimpleAuth::from_single(
+                HARNESS_ACCESS_KEY,
+                HARNESS_SECRET_KEY,
+            ));
+            b.build()
+        };
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+
+        tokio::spawn(async move {
+            use hyper_util::rt::{TokioExecutor, TokioIo};
+            use hyper_util::server::conn::auto::Builder as ConnBuilder;
+            let http = ConnBuilder::new(TokioExecutor::new());
+            loop {
+                let (stream, _peer) = match listener.accept().await {
+                    Ok(t) => t,
+                    Err(_) => break,
+                };
+                let service = service.clone();
+                let http = http.clone();
+                tokio::spawn(async move {
+                    let _ = http.serve_connection(TokioIo::new(stream), service).await;
+                });
+            }
+        });
+
+        (addr, fs_root)
+    }
+
+    /// Build a provider pointed at a freshly spawned in-process server.
+    /// Returns the provider plus the tempdir guard.
+    async fn harness_provider() -> (S3StorageProvider, TempDir) {
+        let (addr, guard) = spawn_s3s_fs().await;
+        let endpoint = format!("http://{addr}");
+        let provider = S3StorageProvider::new_with_endpoint(
+            endpoint,
+            HARNESS_BUCKET,
+            HARNESS_ACCESS_KEY,
+            HARNESS_SECRET_KEY,
+            HARNESS_REGION,
+        )
+        .expect("construct provider against in-process s3s-fs");
+        (provider, guard)
+    }
 
     // ---- translate -----------------------------------------------------
 
@@ -595,5 +683,235 @@ mod tests {
         let p = endpoint_provider();
         let s = format!("{p:?}");
         assert!(s.contains("S3StorageProvider"));
+    }
+
+    // ---- pure helpers: prefix / key ------------------------------------
+
+    #[test]
+    fn normalize_prefix_trims_surrounding_slashes() {
+        assert_eq!(normalize_prefix("/tbl/"), "tbl");
+        assert_eq!(normalize_prefix("///a/b///"), "a/b");
+        assert_eq!(normalize_prefix("plain"), "plain");
+        assert_eq!(normalize_prefix(""), "");
+    }
+
+    #[test]
+    fn key_without_prefix_strips_leading_slash() {
+        let p = endpoint_provider();
+        assert_eq!(p.prefix(), "");
+        assert_eq!(p.key("/foo/bar"), "foo/bar");
+        assert_eq!(p.key("foo/bar"), "foo/bar");
+    }
+
+    #[test]
+    fn key_with_prefix_prepends_and_strips_leading_slash() {
+        let mut p = endpoint_provider();
+        p.prefix = "tbl".into();
+        assert_eq!(p.prefix(), "tbl");
+        assert_eq!(p.key("data/seg-1"), "tbl/data/seg-1");
+        assert_eq!(p.key("/data/seg-1"), "tbl/data/seg-1");
+    }
+
+    #[test]
+    fn new_with_endpoint_and_prefix_normalizes_and_applies_prefix() {
+        let p = S3StorageProvider::new_with_endpoint_and_prefix(
+            "http://127.0.0.1:1",
+            "b",
+            "AKIATESTKEY",
+            "secret",
+            "us-east-1",
+            "/scoped/tbl/",
+        )
+        .expect("construct with endpoint + prefix");
+        assert_eq!(p.bucket(), "b");
+        assert_eq!(p.prefix(), "scoped/tbl");
+        assert_eq!(p.key("data/seg-1"), "scoped/tbl/data/seg-1");
+    }
+
+    #[test]
+    fn object_store_handle_returns_path_under_prefix() {
+        let mut p = endpoint_provider();
+        p.prefix = "tbl".into();
+        let (_, path) = p
+            .object_store_handle("data/seg-1")
+            .expect("handle for valid uri");
+        assert_eq!(path.to_string(), "tbl/data/seg-1");
+    }
+
+    // ---- in-process s3s-fs round-trips ---------------------------------
+    //
+    // These exercise the StorageProvider trait impls over the real S3
+    // HTTP wire protocol against the in-process s3s-fs server — no cloud
+    // credentials, no external network.
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn put_atomic_then_get_round_trips() {
+        let (p, _guard) = harness_provider().await;
+        let body = Bytes::from_static(b"hello-unit-s3");
+        p.put_atomic("k/hello.txt", body.clone())
+            .await
+            .expect("put_atomic");
+        let (got, meta) = p.get("k/hello.txt").await.expect("get");
+        assert_eq!(got, body);
+        assert_eq!(meta.size, body.len() as u64);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn put_atomic_twice_is_precondition_failed() {
+        let (p, _guard) = harness_provider().await;
+        let body = Bytes::from_static(b"first");
+        p.put_atomic("k/dup", body.clone())
+            .await
+            .expect("first put");
+        // PutMode::Create on an existing key -> 412/conflict ->
+        // PreconditionFailed.
+        let err = p
+            .put_atomic("k/dup", Bytes::from_static(b"second"))
+            .await
+            .expect_err("second create must fail");
+        assert!(
+            matches!(err, StorageError::PreconditionFailed { .. }),
+            "expected PreconditionFailed; got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_missing_is_not_found() {
+        let (p, _guard) = harness_provider().await;
+        let err = p.get("k/absent").await.expect_err("get missing must fail");
+        assert!(
+            matches!(err, StorageError::NotFound { .. }),
+            "expected NotFound; got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn head_missing_is_not_found() {
+        let (p, _guard) = harness_provider().await;
+        let err = p.head("k/absent").await.expect_err("head missing fails");
+        assert!(
+            matches!(err, StorageError::NotFound { .. }),
+            "expected NotFound; got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn head_reports_size() {
+        let (p, _guard) = harness_provider().await;
+        let body = Bytes::from_static(b"0123456789");
+        p.put_atomic("k/sized", body.clone())
+            .await
+            .expect("put_atomic");
+        let meta = p.head("k/sized").await.expect("head");
+        assert_eq!(meta.size, body.len() as u64);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_range_returns_subslice() {
+        let (p, _guard) = harness_provider().await;
+        let body: Vec<u8> = (0..=255u8).collect();
+        p.put_atomic("k/range.bin", Bytes::from(body.clone()))
+            .await
+            .expect("put_atomic");
+        let got = p.get_range("k/range.bin", 10..20).await.expect("get_range");
+        assert_eq!(&got[..], &body[10..20]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tail_returns_trailing_bytes_and_size() {
+        let (p, _guard) = harness_provider().await;
+        let body: Vec<u8> = (0..200u8).collect();
+        p.put_atomic("k/tail.bin", Bytes::from(body.clone()))
+            .await
+            .expect("put_atomic");
+        // S3 path uses a native suffix-range fetch.
+        let (tail, size) = p.tail("k/tail.bin", 32).await.expect("tail");
+        assert_eq!(size, body.len() as u64);
+        assert_eq!(&tail[..], &body[body.len() - 32..]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tail_zero_len_falls_back_to_head_for_size() {
+        let (p, _guard) = harness_provider().await;
+        let body = Bytes::from_static(b"abcdef");
+        p.put_atomic("k/tail0.bin", body.clone())
+            .await
+            .expect("put_atomic");
+        let (tail, size) = p.tail("k/tail0.bin", 0).await.expect("zero-len tail");
+        assert!(tail.is_empty());
+        assert_eq!(size, body.len() as u64);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_removes_object() {
+        let (p, _guard) = harness_provider().await;
+        p.put_atomic("k/del", Bytes::from_static(b"x"))
+            .await
+            .expect("put_atomic");
+        p.delete("k/del").await.expect("delete existing");
+        let err = p.get("k/del").await.expect_err("deleted object gone");
+        assert!(matches!(err, StorageError::NotFound { .. }));
+        // NB: the delete-absent idempotency (Err(NotFound) => Ok arm) is
+        // not asserted here — s3s-fs returns a malformed delete response
+        // for a no-op delete, which is an emulator quirk, not a code path
+        // we own. Real S3 returns 204 for an absent key.
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn list_with_prefix_returns_matching_keys() {
+        let (p, _guard) = harness_provider().await;
+        p.put_atomic("list/a.txt", Bytes::from_static(b"a"))
+            .await
+            .expect("put a");
+        p.put_atomic("list/b.txt", Bytes::from_static(b"b"))
+            .await
+            .expect("put b");
+        p.put_atomic("other/c.txt", Bytes::from_static(b"c"))
+            .await
+            .expect("put c");
+        let mut keys = p.list_with_prefix("list/").await.expect("list");
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["list/a.txt".to_string(), "list/b.txt".to_string()]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn put_if_match_none_is_create_only() {
+        let (p, _guard) = harness_provider().await;
+        // First create-if-absent succeeds.
+        p.put_if_match("k/cas", Bytes::from_static(b"v1"), None)
+            .await
+            .expect("create-if-absent");
+        // Second create-if-absent on the same key conflicts.
+        let err = p
+            .put_if_match("k/cas", Bytes::from_static(b"v2"), None)
+            .await
+            .expect_err("second create-if-absent must fail");
+        assert!(
+            matches!(err, StorageError::PreconditionFailed { .. }),
+            "expected PreconditionFailed; got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn put_if_match_etag_update_succeeds_with_matching_etag() {
+        let (p, _guard) = harness_provider().await;
+        let etag = p
+            .put_atomic("k/upd", Bytes::from_static(b"v1"))
+            .await
+            .expect("initial put")
+            .expect("s3 returns an etag on create");
+        // Conditional update carrying the current etag succeeds and the
+        // new body is visible. (s3s-fs does not enforce the etag-match on
+        // a stale conditional update, so the 412/PreconditionFailed arm is
+        // covered against real S3 by the integration smoke; here we assert
+        // the matching-etag success path, which the emulator does honor.)
+        p.put_if_match("k/upd", Bytes::from_static(b"v2"), Some(&etag))
+            .await
+            .expect("update with matching etag");
+        let (got, _) = p.get("k/upd").await.expect("get latest");
+        assert_eq!(&got[..], b"v2");
     }
 }

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -3626,4 +3626,389 @@ mod tests {
         let _ = f.admits(1);
         let _ = f.admits(0);
     }
+
+    // ── Additional coverage ───────────────────────────────────────────
+
+    #[test]
+    fn open_with_verify_crc_off_succeeds() {
+        // The trusted-storage fast path skips the four CRC scans but must
+        // still produce a fully usable reader.
+        let (blob, json) = build_blob();
+        let r = FtsReader::open_with(blob, &json, OpenOptions { verify_crc: false })
+            .expect("open with crc off");
+        assert_eq!(r.n_docs(), 3);
+        assert_eq!(r.fts_columns().collect::<Vec<_>>(), vec!["body"]);
+    }
+
+    #[test]
+    fn open_with_object_store_options_matches_crc_off() {
+        // `for_object_store` is the named constructor for the crc-off
+        // OpenOptions the lazy/object-store path uses.
+        let opts = OpenOptions::for_object_store();
+        assert!(!opts.verify_crc);
+        let (blob, json) = build_blob();
+        FtsReader::open_with(blob, &json, opts).expect("open object-store options");
+    }
+
+    #[test]
+    fn default_open_options_verifies_crc() {
+        assert!(OpenOptions::default().verify_crc);
+    }
+
+    #[test]
+    fn default_tokenizer_helper_is_ascii_lower() {
+        assert_eq!(default_tokenizer(), "ascii_lower");
+    }
+
+    #[test]
+    fn fts_column_config_missing_tokenizer_defaults() {
+        // A column JSON without the optional `tokenizer` field decodes to
+        // the ascii_lower default (round-trips an old file written before
+        // the field existed).
+        let (blob, _) = build_blob();
+        let json = r#"[{"name":"body"}]"#;
+        let r = FtsReader::open(blob, json).expect("open with terse json");
+        let cfg = r.fts_columns_config().next().expect("one column");
+        assert_eq!(cfg.name, "body");
+    }
+
+    #[test]
+    fn fts_columns_config_exposes_per_column_metadata() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let cols: Vec<&ColumnMeta> = r.fts_columns_config().collect();
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].name, "body");
+        // Three non-empty docs ⇒ a positive average doc length and a
+        // populated per-doc normalization table.
+        assert!(cols[0].avgdl > 0.0);
+        assert_eq!(cols[0].dl_norm_k1.len(), 3);
+    }
+
+    #[test]
+    fn iter_column_terms_lists_every_term_in_lex_order() {
+        // build_blob plants the union of tokens across the 3 docs.
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let terms: Vec<String> = r
+            .iter_column_terms("body")
+            .expect("iter terms")
+            .into_iter()
+            .map(|b| String::from_utf8(b).expect("utf8"))
+            .collect();
+        // FST iteration is lex-ordered.
+        let mut sorted = terms.clone();
+        sorted.sort();
+        assert_eq!(terms, sorted, "terms must be in lex order");
+        for expected in [
+            "rust", "async", "runtime", "tokio", "java", "spring", "boot",
+        ] {
+            assert!(terms.contains(&expected.to_string()), "missing {expected}");
+        }
+    }
+
+    #[test]
+    fn iter_column_terms_unknown_column_is_empty() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        assert!(r.iter_column_terms("nope").expect("ok").is_empty());
+    }
+
+    #[test]
+    fn iter_terms_with_prefix_bounds_the_walk() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        // "runtime" begins with "run"; nothing else does.
+        let terms: Vec<String> = r
+            .iter_terms_with_prefix("body", b"run")
+            .expect("prefix walk")
+            .into_iter()
+            .map(|b| String::from_utf8(b).expect("utf8"))
+            .collect();
+        assert_eq!(terms, vec!["runtime".to_string()]);
+        // A prefix that matches nothing returns empty.
+        assert!(
+            r.iter_terms_with_prefix("body", b"zzz")
+                .expect("prefix walk")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn term_df_reports_document_frequency() {
+        let (blob, json) = build_mixed_df_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        // common → df 3 (PFOR header read), rust → df 2 (PFOR),
+        // uniqzero → df 1 (inline FST value), absent → 0.
+        assert_eq!(r.term_df("body", "common").await.expect("df"), 3);
+        assert_eq!(r.term_df("body", "rust").await.expect("df"), 2);
+        assert_eq!(r.term_df("body", "uniqzero").await.expect("df"), 1);
+        assert_eq!(r.term_df("body", "missing").await.expect("df"), 0);
+    }
+
+    #[tokio::test]
+    async fn term_df_unknown_column_errors() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let err = r.term_df("nope", "rust").await.expect_err("error");
+        assert!(matches!(err, FtsError::UnknownColumn(_)));
+    }
+
+    #[tokio::test]
+    async fn search_excluding_drops_negated_docs() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        // "runtime" hits docs 0 and 1; negate "async" (only in doc 0).
+        let hits = r
+            .search_excluding("body", &["runtime"], &["async"], 10, BoolMode::Or)
+            .await
+            .expect("search excluding");
+        let ids: Vec<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert_eq!(ids, vec![1], "doc 0 excluded by negated 'async'");
+    }
+
+    #[tokio::test]
+    async fn search_excluding_negation_only_errors() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let err = r
+            .search_excluding("body", &[], &["rust"], 10, BoolMode::Or)
+            .await
+            .expect_err("negation-only");
+        assert!(matches!(err, FtsError::NegationOnly));
+    }
+
+    #[tokio::test]
+    async fn search_excluding_no_terms_at_all_is_empty() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let hits = r
+            .search_excluding("body", &[], &[], 10, BoolMode::Or)
+            .await
+            .expect("empty");
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_with_floor_prunes_below_floor() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        // An impossibly high floor prunes every doc.
+        let hits = r
+            .search_with_floor("body", &["rust"], 10, BoolMode::Or, 1e9)
+            .await
+            .expect("floored search");
+        assert!(hits.is_empty(), "floor above all scores prunes everything");
+    }
+
+    #[tokio::test]
+    async fn search_multi_weights_and_combines_columns() {
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("title".into()).expect("register");
+        b.register_column("body".into()).expect("register");
+        // doc 0: title "rust"; doc 1: body "rust"; doc 2: neither.
+        b.add_doc(0, 0, "rust").expect("add");
+        b.add_doc(1, 0, "systems").expect("add");
+        b.add_doc(0, 1, "python").expect("add");
+        b.add_doc(1, 1, "rust ml").expect("add");
+        b.add_doc(0, 2, "go").expect("add");
+        b.add_doc(1, 2, "concurrency").expect("add");
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"title","tokenizer":"ascii_lower"},{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+        let hits = r
+            .search_multi(&[("title", 1.0), ("body", 1.0)], "rust", 10, BoolMode::Or)
+            .await
+            .expect("multi");
+        let ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert!(ids.contains(&0));
+        assert!(ids.contains(&1));
+        assert!(!ids.contains(&2));
+    }
+
+    #[tokio::test]
+    async fn search_or_range_restricts_to_doc_id_window() {
+        // Larger corpus so an OR query spans several doc ids and the
+        // ranged path actually clips some out.
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into()).expect("register");
+        for i in 0..8u32 {
+            b.add_doc(0, i, "alpha beta").expect("add");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+        // Restrict to [2, 5): only docs 2,3,4 are eligible.
+        let hits = r
+            .search_or_range_pretokenized("body", &["alpha", "beta"], 100, 2, 5)
+            .await
+            .expect("ranged search");
+        let ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert_eq!(
+            ids,
+            [2u32, 3, 4].into_iter().collect(),
+            "only docs in [2,5) returned"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_or_range_degenerate_inputs_are_empty() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        // Empty terms, k == 0, and an inverted range all short-circuit.
+        assert!(
+            r.search_or_range_pretokenized("body", &[], 10, 0, 3)
+                .await
+                .expect("empty terms")
+                .is_empty()
+        );
+        assert!(
+            r.search_or_range_pretokenized("body", &["rust"], 0, 0, 3)
+                .await
+                .expect("zero k")
+                .is_empty()
+        );
+        assert!(
+            r.search_or_range_pretokenized("body", &["rust"], 10, 3, 3)
+                .await
+                .expect("empty range")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn search_or_range_with_floor_prunes() {
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into()).expect("register");
+        for i in 0..8u32 {
+            b.add_doc(0, i, "alpha beta").expect("add");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+        let hits = r
+            .search_or_range_pretokenized_with_floor("body", &["alpha", "beta"], 100, 0, 8, 1e9)
+            .await
+            .expect("floored ranged search");
+        assert!(hits.is_empty(), "floor above all scores prunes everything");
+    }
+
+    #[tokio::test]
+    async fn search_with_algo_wand_bmw_agrees_with_bmm() {
+        // The historical WAND+BMW baseline must agree with the production
+        // BMM path on the planted corpus.
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into()).expect("register");
+        let docs = [
+            "alpha beta",
+            "alpha",
+            "beta gamma",
+            "alpha beta gamma",
+            "gamma",
+            "alpha gamma",
+            "beta",
+            "alpha beta gamma",
+        ];
+        for (i, t) in docs.iter().enumerate() {
+            b.add_doc(0, i as u32, t).expect("add");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+        let terms: &[&str] = &["alpha", "beta", "gamma"];
+        let bmm = r
+            .search_with_algo_for_bench("body", terms, 5, OrAlgo::Bmm)
+            .await
+            .expect("bmm");
+        let wand = r
+            .search_with_algo_for_bench("body", terms, 5, OrAlgo::WandBmw)
+            .await
+            .expect("wand");
+        assert_eq!(bmm.len(), wand.len());
+        for ((db, sb), (dw, sw)) in bmm.iter().zip(wand.iter()) {
+            assert_eq!(db, dw, "doc_id mismatch");
+            assert!((sb - sw).abs() < 1e-4, "score mismatch {sb} vs {sw}");
+        }
+    }
+
+    #[tokio::test]
+    async fn search_with_algo_empty_and_zero_k_short_circuit() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        assert!(
+            r.search_with_algo_for_bench("body", &[], 5, OrAlgo::Bmm)
+                .await
+                .expect("empty")
+                .is_empty()
+        );
+        assert!(
+            r.search_with_algo_for_bench("body", &["rust"], 0, OrAlgo::Exhaustive)
+                .await
+                .expect("zero k")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn read_u32_le_and_u64_le_decode_little_endian() {
+        let b32 = [0x78, 0x56, 0x34, 0x12];
+        assert_eq!(read_u32_le(&b32), 0x1234_5678);
+        let b64 = [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        assert_eq!(read_u64_le(&b64), 1);
+    }
+
+    #[test]
+    fn top_k_keeps_highest_scores_with_doc_id_tiebreak() {
+        let mut scores: HashMap<u32, f32> = HashMap::new();
+        scores.insert(0, 1.0);
+        scores.insert(1, 3.0);
+        scores.insert(2, 2.0);
+        scores.insert(3, 3.0); // tie with doc 1 on score 3.0
+        let out = top_k(scores, 2);
+        // Descending score; ties broken by ascending doc_id ⇒ doc 1 before 3.
+        assert_eq!(out, vec![(1, 3.0), (3, 3.0)]);
+    }
+
+    #[test]
+    fn top_k_smaller_than_k_returns_all_sorted() {
+        let mut scores: HashMap<u32, f32> = HashMap::new();
+        scores.insert(5, 2.0);
+        scores.insert(9, 5.0);
+        let out = top_k(scores, 10);
+        assert_eq!(out, vec![(9, 5.0), (5, 2.0)]);
+    }
+
+    #[test]
+    fn drain_top_k_desc_orders_descending_with_tiebreak() {
+        let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::new();
+        heap.push(TopKEntry(1.0, 4));
+        heap.push(TopKEntry(2.0, 1));
+        heap.push(TopKEntry(2.0, 0)); // tie with doc 1
+        let out = drain_top_k_desc(heap);
+        assert_eq!(out, vec![(0, 2.0), (1, 2.0), (4, 1.0)]);
+    }
+
+    #[tokio::test]
+    async fn open_lazy_round_trips_a_search() {
+        // Wrap the eager blob in a whole-blob lazy source so the lazy
+        // open path (header + FST + doc-length tail prefetch) runs and
+        // serves a real query.
+        let (blob, json) = build_blob();
+        let src: Arc<dyn LazyByteSource> =
+            Arc::new(crate::superfile::BytesLazyByteSource::new(blob));
+        let r = FtsReader::open_lazy(src, &json, OpenOptions::for_object_store())
+            .await
+            .expect("open_lazy");
+        assert_eq!(r.n_docs(), 3);
+        let hits = r
+            .search("body", &["rust"], 10, BoolMode::Or)
+            .await
+            .expect("search over lazy reader");
+        let ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert!(ids.contains(&0) && ids.contains(&1));
+    }
 }

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1686,4 +1686,336 @@ mod tests {
         assert!(doc_ids.contains(&0));
         assert!(doc_ids.contains(&1));
     }
+
+    // ── Additional coverage ───────────────────────────────────────────
+
+    #[test]
+    fn open_with_verify_crc_off_succeeds() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open_with(bytes, OpenOptions { verify_crc: false })
+            .expect("open with crc off");
+        assert_eq!(r.n_docs(), 4);
+        assert!(r.fts().is_some());
+    }
+
+    #[test]
+    fn default_open_options_verifies_crc() {
+        assert!(OpenOptions::default().verify_crc);
+    }
+
+    #[test]
+    fn parquet_metadata_reports_row_count() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let meta = r.parquet_metadata();
+        let total: i64 = meta.row_groups().iter().map(|rg| rg.num_rows()).sum();
+        assert_eq!(total, 4);
+    }
+
+    #[test]
+    fn debug_impl_reports_index_presence() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let s = format!("{r:?}");
+        assert!(s.contains("SuperfileReader"));
+        assert!(s.contains("has_fts: true"));
+        assert!(s.contains("has_vec: false"));
+    }
+
+    #[test]
+    fn byte_source_over_eager_bytes_serves_ranges() {
+        let bytes = build_simple_fts_only_superfile();
+        let total_len = bytes.len() as u64;
+        let r = SuperfileReader::open(bytes).expect("open");
+        let src = r.byte_source();
+        assert_eq!(src.size(), total_len);
+    }
+
+    #[test]
+    fn get_record_batch_returns_all_rows() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let batch = r.get_record_batch(None).expect("get_record_batch");
+        assert_eq!(batch.num_rows(), 4);
+        assert_eq!(batch.num_columns(), 2);
+    }
+
+    #[test]
+    fn get_record_batch_honors_tombstones() {
+        use roaring::RoaringBitmap;
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let mut deleted = RoaringBitmap::new();
+        deleted.insert(0);
+        deleted.insert(2);
+        let batch = r
+            .get_record_batch(Some(Arc::new(deleted)))
+            .expect("get_record_batch with tombstones");
+        // 4 docs, 2 deleted ⇒ 2 live rows survive.
+        assert_eq!(batch.num_rows(), 2);
+    }
+
+    #[tokio::test]
+    async fn bm25_search_pretokenized_matches_hits_path() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let hits = r
+            .bm25_search_pretokenized("title", &["rust"], 5, BoolMode::Or)
+            .await
+            .expect("pretokenized search");
+        let ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert!(ids.contains(&0));
+        assert!(ids.contains(&2));
+    }
+
+    #[tokio::test]
+    async fn bm25_search_pretokenized_with_floor_prunes() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let hits = r
+            .bm25_search_pretokenized_with_floor("title", &["rust"], 5, BoolMode::Or, 1e9)
+            .await
+            .expect("floored search");
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bm25_hits_async_honors_negation() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        // doc 0 "rust async runtime", doc 2 "rust embedded system":
+        // "rust -embedded" keeps doc 0, drops doc 2.
+        let hits = r
+            .bm25_hits_async("title", "rust -embedded", 5, BoolMode::Or)
+            .await
+            .expect("negated search");
+        let ids: Vec<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert!(ids.contains(&0));
+        assert!(!ids.contains(&2));
+    }
+
+    #[tokio::test]
+    async fn token_match_intersects_and_unions() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        // "rust" in docs 0,2; "runtime" in doc 0 only.
+        let and = r
+            .token_match("title", &["rust", "runtime"], BoolMode::And)
+            .await
+            .expect("and");
+        assert_eq!(and, vec![0]);
+        let or = r
+            .token_match("title", &["rust", "runtime"], BoolMode::Or)
+            .await
+            .expect("or");
+        assert_eq!(or, vec![0, 2]);
+    }
+
+    #[tokio::test]
+    async fn term_df_counts_documents() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        assert_eq!(r.term_df("title", "rust").await.expect("df"), 2);
+        assert_eq!(r.term_df("title", "absent").await.expect("df"), 0);
+    }
+
+    #[tokio::test]
+    async fn exact_match_verifies_raw_string_equality() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        // A token subset ("rust") prunes candidates but only the exact
+        // stored string matches.
+        let hits = r
+            .exact_match("title", "rust async runtime")
+            .await
+            .expect("exact_match");
+        assert_eq!(hits, vec![0]);
+        // No row stores just "rust", so the exact comparison yields none.
+        let none = r.exact_match("title", "rust").await.expect("exact_match");
+        assert!(none.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bm25_search_prefix_expands_terms() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        // "rust" is a prefix of "rust" (docs 0,2); "ru" expands to it too.
+        let hits = r
+            .bm25_search_prefix("title", "ru", 5)
+            .await
+            .expect("prefix search");
+        let ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert!(ids.contains(&0));
+        assert!(ids.contains(&2));
+        // No indexed term begins with "zz".
+        assert!(
+            r.bm25_search_prefix("title", "zz", 5)
+                .await
+                .expect("prefix")
+                .is_empty()
+        );
+        // k == 0 short-circuits.
+        assert!(
+            r.bm25_search_prefix("title", "ru", 0)
+                .await
+                .expect("zero k")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn bm25_search_or_range_restricts_window() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        // docs 0,2 contain "rust"/"embedded"; restrict to [0,2) ⇒ doc 0 only.
+        let hits = r
+            .bm25_search_or_range_pretokenized("title", &["rust", "embedded"], 10, 0, 2)
+            .await
+            .expect("ranged search");
+        let ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert!(ids.contains(&0));
+        assert!(!ids.contains(&2));
+    }
+
+    #[tokio::test]
+    async fn bm25_search_or_range_with_floor_prunes() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let hits = r
+            .bm25_search_or_range_pretokenized_with_floor(
+                "title",
+                &["rust", "embedded"],
+                10,
+                0,
+                4,
+                1e9,
+            )
+            .await
+            .expect("floored ranged search");
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bm25_search_prefix_range_restricts_window() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        // "ru" expands to "rust" (docs 0,2); restrict to [0,2) ⇒ doc 0.
+        let hits = r
+            .bm25_search_prefix_range("title", "ru", 10, 0, 2)
+            .await
+            .expect("prefix range");
+        let ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert!(ids.contains(&0));
+        assert!(!ids.contains(&2));
+        // Degenerate range / k short-circuits.
+        assert!(
+            r.bm25_search_prefix_range("title", "ru", 0, 0, 2)
+                .await
+                .expect("zero k")
+                .is_empty()
+        );
+        assert!(
+            r.bm25_search_prefix_range("title", "ru", 10, 2, 2)
+                .await
+                .expect("empty range")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn vector_search_clusters_probes_explicit_clusters() {
+        let bytes = build_vector_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let mut q = vec![0.0f32; 16];
+        q[2] = 1.0;
+        q[5] = 0.5;
+        normalize(&mut q);
+        // Probe all 4 clusters explicitly; doc 2 (the query's own vector)
+        // must be reachable.
+        let hits = r
+            .vector_search_clusters("emb", &q, 4, &[0, 1, 2, 3], VectorSearchOptions::default())
+            .await
+            .expect("cluster search");
+        let ids: std::collections::HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
+        assert!(ids.contains(&2));
+    }
+
+    #[tokio::test]
+    async fn vector_search_errors_when_no_vector_index() {
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let err = r
+            .vector_hits_async("emb", &[0.0f32; 16], 1, VectorSearchOptions::default())
+            .await
+            .expect_err("expected error");
+        assert!(matches!(err, ReadError::MissingKv(_)));
+    }
+
+    #[tokio::test]
+    async fn open_lazy_round_trips_search_and_blocks_eager_only_paths() {
+        // Wrap the whole superfile in a lazy source so the lazy open path
+        // runs; eager-only methods must then report LazyReaderUnsupported.
+        let bytes = build_simple_fts_only_superfile();
+        let src: Arc<dyn crate::superfile::LazyByteSource> =
+            Arc::new(crate::superfile::BytesLazyByteSource::new(bytes));
+        let r = SuperfileReader::open_lazy(src).await.expect("open_lazy");
+        assert_eq!(r.n_docs(), 4);
+        // parquet_bytes is None on the lazy path.
+        assert!(r.parquet_bytes().is_none());
+        // FTS search still works (its source travels with the inner reader).
+        let hits = r
+            .bm25_hits_async("title", "rust", 5, BoolMode::Or)
+            .await
+            .expect("lazy search");
+        assert!(!hits.is_empty());
+        // Eager-only row materialization is rejected.
+        let err = r
+            .take_by_local_doc_ids(&[0], &["doc_id"])
+            .expect_err("lazy take rejected");
+        assert!(matches!(err, ReadError::LazyReaderUnsupported));
+        let err = r.get_record_batch(None).expect_err("lazy batch rejected");
+        assert!(matches!(err, ReadError::LazyReaderUnsupported));
+        // byte_source returns the underlying lazy source (non-empty).
+        assert!(r.byte_source().size() > 0);
+    }
+
+    #[test]
+    fn slice_or_err_rejects_out_of_range() {
+        let bytes = Bytes::from(vec![0u8; 32]);
+        let err = slice_or_err(&bytes, 16, 64, "vector").expect_err("out of range");
+        assert!(matches!(err, ReadError::MalformedKv(_)));
+        // In-range slice succeeds and is zero-copy length-correct.
+        let ok = slice_or_err(&bytes, 8, 8, "vector").expect("in range");
+        assert_eq!(ok.len(), 8);
+    }
+
+    #[test]
+    fn helper_present_predicates() {
+        use crate::superfile::format::footer::KvMap;
+        let mut map = KvMap::new();
+        map.insert("a".to_string(), "1".to_string());
+        assert!(all_present(&map, &["a"]));
+        assert!(!all_present(&map, &["a", "b"]));
+        assert!(any_present(&map, &["a", "b"]));
+        assert!(!any_present(&map, &["x", "y"]));
+        // parse_u64 round-trips a numeric value and errors on garbage.
+        map.insert("n".to_string(), "42".to_string());
+        assert_eq!(parse_u64(&map, "n").expect("parse"), 42);
+        map.insert("bad".to_string(), "notnum".to_string());
+        assert!(matches!(
+            parse_u64(&map, "bad").expect_err("not a u64"),
+            ReadError::MalformedKv(_)
+        ));
+        assert!(matches!(
+            parse_u64(&map, "absent").expect_err("missing"),
+            ReadError::MissingKv(_)
+        ));
+    }
+
+    #[test]
+    fn fts_bool_mode_reexport_is_bool_mode() {
+        // The crate re-exports BoolMode as FtsBoolMode for convenience.
+        let m: FtsBoolMode = FtsBoolMode::And;
+        assert_eq!(m, BoolMode::And);
+    }
 }

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -5941,7 +5941,7 @@ mod tests {
         let n_docs = 3000u32;
         let n_cent = 4usize;
         let (blob, json, all) =
-            build_large_corpus(16, n_cent, n_docs, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_large_corpus(16, n_cent, n_docs, RerankCodec::Sq8ResidualEpsilon, Metric::L2Sq);
         let r = VectorReader::open(blob, &json).expect("open");
         let hits = r
             .search("v", &all[2001], 64, n_cent, 40)
@@ -6075,7 +6075,7 @@ mod tests {
         // `Sq8ColumnMeta::Lazy` and the first search resolves the
         // scale/offset (and L2Sq norms) through the deferred-fetch arm.
         let (blob, json, all) =
-            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8ResidualEpsilon, Metric::L2Sq);
         let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
         let counting = StdArc::new(CountingLazyByteSource::new(blob));
         // Disable sync BEFORE open so the deferred codec_meta probe inside
@@ -6132,7 +6132,7 @@ mod tests {
         // so the lazy arm takes the `norms_abs_off = None` branch — no
         // norm span fetch, `norm_by_pos = None`.
         let (blob, json, all) =
-            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::NegDot);
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8ResidualEpsilon, Metric::NegDot);
         let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
         let counting = StdArc::new(CountingLazyByteSource::new(blob));
         counting.disable_sync();
@@ -6164,7 +6164,7 @@ mod tests {
         // on a cold lazy Sq8 source drives the async coalesced
         // codes/doc_ids + Sq8-meta fetch and the async survivor-row fetch.
         let (blob, json, all) =
-            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8ResidualEpsilon, Metric::L2Sq);
         let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
         let counting = StdArc::new(CountingLazyByteSource::new(blob));
         counting.disable_sync();

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -5754,4 +5754,578 @@ mod tests {
             .expect("get_vectors_fp32 should succeed");
         assert!(retrieved.is_empty());
     }
+
+    // -----------------------------------------------------------------
+    // Catalog-surface accessors: `cluster_centroids` + `vector_columns_config`.
+    // -----------------------------------------------------------------
+    //
+    // Both feed the cross-superfile manifest staging path. They were
+    // previously exercised only indirectly through the supertable
+    // integration suite; the unit tests below pin their shape against an
+    // in-memory blob so the byte-offset math (`centroids_off`,
+    // `cluster_idx_off`, the per-entry count field) stays correct.
+
+    #[test]
+    fn cluster_centroids_returns_n_cent_dim_and_counts() {
+        let dim = 16usize;
+        let n_cent = 4usize;
+        let n_docs = 64u32;
+        let (blob, json) = build_blob(n_docs, dim, n_cent, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+
+        let (got_n_cent, got_dim, centroids, counts) =
+            r.cluster_centroids("embedding").expect("cluster_centroids");
+        assert_eq!(got_n_cent, n_cent as u32);
+        assert_eq!(got_dim, dim as u32);
+        assert_eq!(
+            centroids.len(),
+            n_cent * dim,
+            "centroids are cluster-major n_cent × dim fp32"
+        );
+        assert_eq!(counts.len(), n_cent, "one count per cluster");
+        // Every doc lands in exactly one cluster, so the counts sum to
+        // n_docs — the contract the manifest staging path relies on.
+        let total: u32 = counts.iter().sum();
+        assert_eq!(total, n_docs, "per-cluster counts must sum to n_docs");
+
+        assert!(
+            r.cluster_centroids("nonexistent").is_none(),
+            "unknown column yields None"
+        );
+    }
+
+    #[test]
+    fn vector_columns_config_yields_each_column_reader() {
+        let (blob, json) = build_blob(32, 16, 4, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let cols: Vec<&ColumnReader> = r.vector_columns_config().collect();
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].name, "embedding");
+        assert_eq!(cols[0].dim, 16);
+        assert_eq!(cols[0].n_cent, 4);
+        assert_eq!(cols[0].metric, Metric::L2Sq);
+    }
+
+    // -----------------------------------------------------------------
+    // Parallel scan paths (`PARALLEL_SCAN_MIN` rayon branches).
+    // -----------------------------------------------------------------
+    //
+    // The coarse 1-bit scan in `build_shortlist`, the fp32 / Sq8 rerank
+    // scans, and the `par_map` / `parallel_chunks` / `BoundedCoarseHeap::merge`
+    // helpers all switch from a serial loop to a chunked rayon scan once
+    // the candidate pool crosses `PARALLEL_SCAN_MIN` (2048) with more
+    // than one probed cluster. The default test corpora are far below
+    // that threshold, so these tests build a deliberately large corpus
+    // (> 2048 docs across multiple clusters) to drive the parallel arms.
+    // Correctness is pinned by a self-query: the planted vector must
+    // still come back at top-1, identical to the serial path.
+
+    /// Build a corpus large enough (`n_docs` ≥ a few thousand) to push
+    /// the per-query scans over `PARALLEL_SCAN_MIN` when every cluster is
+    /// probed. Vectors are deterministic and spread across `n_cent`
+    /// clusters by a per-doc phase so more than one cluster is non-empty.
+    fn build_large_corpus(
+        dim: usize,
+        n_cent: usize,
+        n_docs: u32,
+        codec: RerankCodec,
+        metric: Metric,
+    ) -> (Bytes, String, Vec<Vec<f32>>) {
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            column: "v".into(),
+            dim,
+            n_cent,
+            rot_seed: 101,
+            metric,
+            rerank_codec: codec,
+        })
+        .expect("register column");
+        let mut all = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs {
+            // Direction varies by a per-doc phase (spreads docs across
+            // clusters); a per-doc unique component (dim 0 carries the
+            // doc id) guarantees no two vectors collide, so a self-query
+            // has a unique nearest neighbour with distance 0.
+            let phase = i % n_cent as u32;
+            let v: Vec<f32> = (0..dim)
+                .map(|j| {
+                    if j == 0 {
+                        // Unique per-doc value keeps all vectors distinct.
+                        i as f32 * 0.001
+                    } else {
+                        let base = ((i.wrapping_mul(2654435761).wrapping_add(j as u32 * 40503))
+                            % 1000) as f32
+                            * 0.01;
+                        base + phase as f32
+                    }
+                })
+                .collect();
+            b.add(0, &v).expect("add");
+            all.push(v);
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let metric_str = match metric {
+            Metric::L2Sq => "l2sq",
+            Metric::Cosine => "cosine",
+            Metric::NegDot => "negdot",
+        };
+        let json = format!(
+            r#"[{{"column":"v","dim":{dim},"n_cent":{n_cent},"rot_seed":101,"metric":"{metric_str}"}}]"#,
+        );
+        (blob, json, all)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn parallel_coarse_scan_and_fp32_rerank_recover_self_query() {
+        // n_docs comfortably over PARALLEL_SCAN_MIN; probing every
+        // cluster makes total_candidates == n_docs, driving the parallel
+        // coarse scan in `build_shortlist`. A large k·rerank_mult shortlist
+        // (>= 2048) also pushes the fp32 rerank onto the rayon `par_map`.
+        let n_docs = 3000u32;
+        let n_cent = 4usize;
+        let (blob, json, all) =
+            build_large_corpus(16, n_cent, n_docs, RerankCodec::Fp32, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        // k=64, rerank_mult=40 → coarse_limit=2560 ≥ PARALLEL_SCAN_MIN,
+        // so the fp32 rerank shortlist is large enough to parallelize.
+        let hits = r
+            .search("v", &all[1234], 64, n_cent, 40)
+            .await
+            .expect("parallel search");
+        assert_eq!(hits.len(), 64, "k hits returned");
+        for w in hits.windows(2) {
+            assert!(w[0].1 <= w[1].1, "distances ascending");
+        }
+        // With every cluster probed and an exhaustive rerank pool, the
+        // exact self vector is in the candidate set; fp32 rerank is
+        // lossless, so the self distance is exactly 0 and ranks top-1.
+        assert_eq!(
+            hits[0].0, 1234,
+            "parallel coarse + fp32 rerank must recover self at top-1"
+        );
+        assert!(hits[0].1 < 1e-4, "self distance ~0, got {}", hits[0].1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn parallel_scan_matches_serial_scan_results() {
+        // The parallel and serial coarse/rerank paths must rank
+        // identically (chunked-parallel scoring is order-independent).
+        // Run the same query through a large corpus (parallel) and pin
+        // that a smaller-k path on the same reader is internally
+        // consistent — both recover the planted self vector.
+        use std::collections::HashSet;
+        let (blob, json, all) = build_large_corpus(16, 4, 2600, RerankCodec::Fp32, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        // Large shortlist → parallel.
+        let parallel = r.search("v", &all[42], 64, 4, 40).await.expect("parallel");
+        // Small shortlist → serial (coarse_limit = 50 < 2048).
+        let serial = r.search("v", &all[42], 10, 4, 5).await.expect("serial");
+        assert_eq!(parallel[0].0, 42, "parallel recovers self");
+        assert_eq!(serial[0].0, 42, "serial recovers self");
+        // The serial top-10 set must be a subset of the parallel top-64
+        // set (same scoring, parallel just keeps more).
+        let par_ids: HashSet<u32> = parallel.iter().map(|(id, _)| *id).collect();
+        for (id, _) in &serial {
+            assert!(
+                par_ids.contains(id),
+                "serial top-10 id {id} must appear in parallel top-64"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn parallel_sq8_rerank_recovers_self_query() {
+        // Drive the parallel arm of `sq8_score_and_refine`: a large
+        // shortlist (k·rerank_mult ≥ PARALLEL_SCAN_MIN) on an Sq8 column.
+        let n_docs = 3000u32;
+        let n_cent = 4usize;
+        let (blob, json, all) =
+            build_large_corpus(16, n_cent, n_docs, RerankCodec::Sq8Residual, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let hits = r
+            .search("v", &all[2001], 64, n_cent, 40)
+            .await
+            .expect("parallel Sq8 search");
+        // The parallel Sq8 first-pass scan + residual refine ran (>2048
+        // candidates over >1 cluster). Sq8 is lossy, so we pin structural
+        // correctness — k hits, ascending distance — rather than exact
+        // self-recovery (covered by the small-corpus Sq8 round-trip tests).
+        assert_eq!(hits.len(), 64, "k hits returned from parallel Sq8 path");
+        for w in hits.windows(2) {
+            assert!(w[0].1 <= w[1].1, "Sq8 rerank distances ascending");
+        }
+        // The self vector should still rank near the top under Sq8.
+        assert!(
+            hits.iter().take(8).any(|(id, _)| *id == 2001),
+            "self vector should appear in the parallel Sq8 top-8"
+        );
+    }
+
+    #[test]
+    fn parallel_chunks_is_bounded_by_item_count() {
+        // 0 items → at least 1 chunk; small item count caps the chunk
+        // count; both arms of the `.min(n_items).max(1)` clamp.
+        assert_eq!(parallel_chunks(0), 1, "zero items still yields one chunk");
+        assert_eq!(parallel_chunks(1), 1, "one item caps at one chunk");
+        let many = parallel_chunks(1_000_000);
+        assert!(many >= 1, "large item count yields >= 1 chunk");
+    }
+
+    #[tokio::test]
+    async fn par_map_serial_fallback_for_small_input() {
+        // parallel_chunks(items) <= 1 takes the serial map arm.
+        let out = par_map(vec![1u32, 2, 3], |x| x * 10).await;
+        assert_eq!(out, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn bounded_coarse_heap_merge_keeps_top_by_estimate() {
+        // Direct unit test of `BoundedCoarseHeap::merge` (otherwise only
+        // reached on the parallel reduce path). Two bounded heaps merged
+        // must retain the globally-highest `estimate` candidates up to
+        // the limit.
+        let mk = |did: u32, est: f32| CoarseCandidate {
+            did,
+            estimate: est,
+            pos: did,
+            cluster_id: 0,
+        };
+        let mut a = BoundedCoarseHeap::new(3);
+        for c in [mk(0, 1.0), mk(1, 2.0), mk(2, 3.0)] {
+            a.push(c);
+        }
+        let mut b = BoundedCoarseHeap::new(3);
+        for c in [mk(3, 0.5), mk(4, 5.0), mk(5, 4.0)] {
+            b.push(c);
+        }
+        a.merge(b);
+        let mut ests: Vec<f32> = a.into_vec().into_iter().map(|(_, est, _, _)| est).collect();
+        ests.sort_by(|x, y| y.partial_cmp(x).expect("finite estimates"));
+        // Top-3 by estimate across both heaps: 5.0, 4.0, 3.0.
+        assert_eq!(ests, vec![5.0, 4.0, 3.0]);
+    }
+
+    #[test]
+    fn coarse_candidate_ordering_and_equality_tie_breaks() {
+        // The Ord impl reverses estimate (max-heap "worst" peek) and
+        // tie-breaks on did, then pos, then cluster_id. PartialEq tests
+        // every field.
+        let base = CoarseCandidate {
+            did: 5,
+            estimate: 1.0,
+            pos: 10,
+            cluster_id: 2,
+        };
+        let same = CoarseCandidate { ..base };
+        assert_eq!(base, same, "identical fields compare equal");
+        assert_eq!(base.cmp(&same), Ordering::Equal, "identical → Equal");
+
+        // Higher estimate is "better" → reversed → Less in the heap order.
+        let higher_est = CoarseCandidate {
+            estimate: 2.0,
+            ..base
+        };
+        assert_eq!(
+            base.cmp(&higher_est),
+            Ordering::Greater,
+            "lower estimate sorts as the worse (Greater) candidate"
+        );
+        assert_ne!(base, higher_est);
+
+        // Equal estimate, differing did → did tie-break (reversed).
+        let other_did = CoarseCandidate { did: 6, ..base };
+        assert_eq!(base.cmp(&other_did), Ordering::Greater);
+        assert_ne!(base, other_did);
+
+        // Equal estimate + did, differing pos → pos tie-break.
+        let other_pos = CoarseCandidate { pos: 11, ..base };
+        assert_eq!(base.cmp(&other_pos), Ordering::Greater);
+        assert_ne!(base, other_pos);
+
+        // Equal estimate + did + pos, differing cluster_id.
+        let other_cluster = CoarseCandidate {
+            cluster_id: 3,
+            ..base
+        };
+        assert_eq!(base.cmp(&other_cluster), Ordering::Greater);
+        assert_ne!(base, other_cluster);
+    }
+
+    // -----------------------------------------------------------------
+    // Lazy Sq8 cold path: the `Sq8ColumnMeta::Lazy` rerank arm.
+    // -----------------------------------------------------------------
+    //
+    // When the Sq8 codec_meta bytes aren't resident at open time (an
+    // object-store-backed `Source::Lazy` with sync access disabled), the
+    // reader records `Sq8ColumnMeta::Lazy` offsets and defers the
+    // scale/offset/norms fetch to the first search. That fetch + the
+    // sparse `pos → norm` map + the per-cluster kernel rebuild is a large
+    // block in `rerank_candidates_from_blocks` that the in-memory tests
+    // never reach. These tests force it via `disable_sync()` and pin the
+    // results against the eager in-memory open.
+
+    #[tokio::test]
+    async fn lazy_sq8_cold_rerank_matches_eager_l2sq() {
+        // L2Sq Sq8 carries per-doc norms, so the lazy arm also exercises
+        // the sparse `norm_by_pos` span-fetch path.
+        //
+        // `open_lazy` with `for_object_store()` defers codec_meta — it is
+        // NOT prefetched into the overlay — so `sq8_meta` is recorded as
+        // `Sq8ColumnMeta::Lazy` and the first search resolves the
+        // scale/offset (and L2Sq norms) through the deferred-fetch arm.
+        let (blob, json, all) =
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
+        let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        // Disable sync BEFORE open so the deferred codec_meta probe inside
+        // `open_with_source` misses the warm cache and records the Sq8 meta
+        // as `Lazy`. `open_lazy` pre-installs the structural-decode bytes
+        // (header, directory, sub-header) into its overlay, so the open
+        // itself still succeeds with sync disabled on the underlying source.
+        counting.disable_sync();
+        let r_lazy = VectorReader::open_lazy(
+            StdArc::clone(&counting) as StdArc<dyn LazyByteSource>,
+            &json,
+            OpenOptions::for_object_store(),
+        )
+        .await
+        .expect("open_lazy");
+        // Pin that codec_meta really was deferred (the Lazy arm).
+        assert!(
+            matches!(r_lazy.columns[0].sq8_meta, Some(Sq8ColumnMeta::Lazy { .. })),
+            "open_lazy / for_object_store must defer Sq8 codec_meta as Lazy"
+        );
+
+        for &q in &[0usize, 17, 31] {
+            let hits_lazy = r_lazy
+                .search("v", &all[q], 5, 4, 20)
+                .await
+                .expect("lazy cold Sq8 search");
+            let hits_eager = r_eager
+                .search("v", &all[q], 5, 4, 20)
+                .await
+                .expect("eager Sq8 search");
+            // The deferred-meta lazy arm computes the same Sq8 + residual
+            // distances as the eager path but through its own fetch/kernel
+            // code, then returns the refined candidate set directly. Pin
+            // that it ran and surfaced good neighbours: the lazy result set
+            // overlaps the eager top-5.
+            assert!(
+                !hits_lazy.is_empty(),
+                "lazy cold Sq8 arm returns hits (query {q})"
+            );
+            let eager_ids: std::collections::HashSet<u32> =
+                hits_eager.iter().map(|(id, _)| *id).collect();
+            let lazy_ids: std::collections::HashSet<u32> =
+                hits_lazy.iter().map(|(id, _)| *id).collect();
+            assert!(
+                eager_ids.intersection(&lazy_ids).count() >= 1,
+                "lazy cold Sq8 result set must overlap the eager top-5 (query {q})"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn lazy_sq8_cold_rerank_no_norms_negdot() {
+        // NegDot Sq8 drops the per-doc norms (the `Σx²` term cancels),
+        // so the lazy arm takes the `norms_abs_off = None` branch — no
+        // norm span fetch, `norm_by_pos = None`.
+        let (blob, json, all) =
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::NegDot);
+        let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        counting.disable_sync();
+        let r_lazy = VectorReader::open_lazy(
+            StdArc::clone(&counting) as StdArc<dyn LazyByteSource>,
+            &json,
+            OpenOptions::for_object_store(),
+        )
+        .await
+        .expect("open_lazy");
+
+        let hits_lazy = r_lazy
+            .search("v", &all[7], 5, 4, 20)
+            .await
+            .expect("lazy cold Sq8 negdot search");
+        let hits_eager = r_eager
+            .search("v", &all[7], 5, 4, 20)
+            .await
+            .expect("eager Sq8 negdot search");
+        assert_eq!(
+            hits_lazy[0].0, hits_eager[0].0,
+            "lazy cold Sq8 negdot rerank top-1 must match eager"
+        );
+    }
+
+    #[tokio::test]
+    async fn lazy_sq8_cold_search_async_matches_eager() {
+        // The async search path (`search_async` → `probe_clusters_async`)
+        // on a cold lazy Sq8 source drives the async coalesced
+        // codes/doc_ids + Sq8-meta fetch and the async survivor-row fetch.
+        let (blob, json, all) =
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8Residual, Metric::L2Sq);
+        let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        counting.disable_sync();
+        let r_lazy = VectorReader::open_lazy(
+            StdArc::clone(&counting) as StdArc<dyn LazyByteSource>,
+            &json,
+            OpenOptions::for_object_store(),
+        )
+        .await
+        .expect("open_lazy");
+
+        let hits_lazy = r_lazy
+            .search_async("v", &all[17], 5, 4, 20)
+            .await
+            .expect("lazy cold Sq8 search_async");
+        let hits_eager = r_eager
+            .search_async("v", &all[17], 5, 4, 20)
+            .await
+            .expect("eager Sq8 search_async");
+        // As in the sync lazy-Sq8 test, pin set overlap rather than exact
+        // ordering: the deferred-meta arm returns its refined candidate set
+        // through a distinct code path.
+        assert!(!hits_lazy.is_empty(), "lazy async arm returns hits");
+        let eager_ids: std::collections::HashSet<u32> =
+            hits_eager.iter().map(|(id, _)| *id).collect();
+        let lazy_ids: std::collections::HashSet<u32> =
+            hits_lazy.iter().map(|(id, _)| *id).collect();
+        assert!(
+            eager_ids.intersection(&lazy_ids).count() >= 1,
+            "lazy cold Sq8 search_async result set must overlap the eager top-5"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_clusters_async_cold_lazy_fp32_matches_eager() {
+        // Externally-selected cluster probe over a cold lazy fp32 source:
+        // drives `search_clusters_async` → `probe_clusters_async` through
+        // the async cold coalesced fetch (no Sq8 meta extra).
+        let (blob, json, all) = build_search_corpus();
+        let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        let r_lazy = VectorReader::open_with_source(
+            Source::Lazy(StdArc::clone(&counting) as StdArc<dyn LazyByteSource>),
+            &json,
+            OpenOptions::default(),
+        )
+        .expect("lazy open");
+        counting.disable_sync();
+
+        let clusters: Vec<u32> = (0..4).collect();
+        let hits_lazy = r_lazy
+            .search_clusters_async("embedding", &all[19], 5, &clusters, 5)
+            .await
+            .expect("lazy cold search_clusters_async");
+        let hits_eager = r_eager
+            .search_clusters_async("embedding", &all[19], 5, &clusters, 5)
+            .await
+            .expect("eager search_clusters_async");
+        assert_eq!(
+            hits_lazy[0].0, hits_eager[0].0,
+            "lazy cold search_clusters_async top-1 must match eager"
+        );
+        // Out-of-range cluster ids are ignored; an empty selection yields
+        // no hits.
+        let none = r_lazy
+            .search_clusters_async("embedding", &all[19], 5, &[999u32], 5)
+            .await
+            .expect("out-of-range clusters");
+        assert!(none.is_empty(), "ids >= n_cent are ignored");
+    }
+
+    #[tokio::test]
+    async fn search_async_unknown_column_and_dim_mismatch_error() {
+        // resolve_column error arms reached through the async entry point.
+        let (blob, json) = build_blob(32, 16, 4, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let unknown = r.search_async("nope", &[0.0; 16], 5, 4, 5).await;
+        assert!(matches!(unknown, Err(VectorError::UnknownColumn(_))));
+        let dim = r.search_async("embedding", &[0.0; 8], 5, 4, 5).await;
+        assert!(matches!(dim, Err(VectorError::DimensionMismatch { .. })));
+        // k == 0 short-circuits to an empty result.
+        let empty = r
+            .search_async("embedding", &[0.0; 16], 0, 4, 5)
+            .await
+            .expect("k=0 empty");
+        assert!(empty.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_vectors_fp32_round_trips_through_lazy_cold_source() {
+        // Drive `get_vectors_fp32` against a cold lazy source so its
+        // `get_range` / `get_ranges_parallel` fetch path runs through the
+        // async bridge rather than the in-memory zero-copy slice.
+        let dim = 16usize;
+        let n_docs = 48u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            column: "embedding".into(),
+            dim,
+            n_cent: 4,
+            rot_seed: 7,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Fp32,
+        })
+        .expect("register column");
+        let mut planted = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs {
+            let v: Vec<f32> = (0..dim).map(|j| (i + j as u32) as f32 * 0.25).collect();
+            b.add(0, &v).expect("add");
+            planted.push(v);
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"column":"embedding","dim":16,"n_cent":4,"rot_seed":7,"metric":"l2sq"}]"#
+            .to_string();
+
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        let r = VectorReader::open_with_source(
+            Source::Lazy(StdArc::clone(&counting) as StdArc<dyn LazyByteSource>),
+            &json,
+            OpenOptions::default(),
+        )
+        .expect("lazy open");
+        counting.disable_sync();
+
+        let got = r.get_vectors_fp32("embedding").expect("get_vectors_fp32");
+        assert_eq!(got.len(), n_docs as usize);
+        // Insertion order is preserved; reconstructed vectors equal the
+        // planted fp32 originals exactly (fp32 codec is lossless).
+        for (i, v) in planted.iter().enumerate() {
+            assert_eq!(&got[i], v, "doc {i} round-trips exactly through fp32");
+        }
+    }
+
+    #[test]
+    fn summary_returns_none_for_unknown_column() {
+        let (blob, json) = build_blob(16, 16, 2, Metric::Cosine);
+        let r = VectorReader::open(blob, &json).expect("open");
+        assert!(r.summary("missing").is_none());
+        // Sanity on the present column too.
+        let (centroid, radius) = r.summary("embedding").expect("present");
+        assert_eq!(centroid.len(), 16);
+        assert!(radius >= 0.0);
+    }
+
+    #[tokio::test]
+    async fn search_negdot_metric_returns_sorted_hits() {
+        // Exercise the NegDot branch of centroid scoring + fp32 rerank
+        // end to end (the other metrics are covered above). NegDot ranks
+        // by negative dot product, so the nearest vector is the one with
+        // the largest dot against the query — not necessarily the query
+        // itself — hence we pin structural correctness (k sorted hits),
+        // not self-recovery.
+        let (blob, json, all) = build_small_superfile(16, 4, 64, RerankCodec::Fp32, Metric::NegDot);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let hits = r
+            .search("v", &all[23], 5, 4, 10)
+            .await
+            .expect("negdot search");
+        assert_eq!(hits.len(), 5, "k hits returned");
+        for w in hits.windows(2) {
+            assert!(w[0].1 <= w[1].1, "negdot distances ascending");
+        }
+    }
 }

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -5940,8 +5940,13 @@ mod tests {
         // shortlist (k·rerank_mult ≥ PARALLEL_SCAN_MIN) on an Sq8 column.
         let n_docs = 3000u32;
         let n_cent = 4usize;
-        let (blob, json, all) =
-            build_large_corpus(16, n_cent, n_docs, RerankCodec::Sq8ResidualEpsilon, Metric::L2Sq);
+        let (blob, json, all) = build_large_corpus(
+            16,
+            n_cent,
+            n_docs,
+            RerankCodec::Sq8ResidualEpsilon,
+            Metric::L2Sq,
+        );
         let r = VectorReader::open(blob, &json).expect("open");
         let hits = r
             .search("v", &all[2001], 64, n_cent, 40)

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -6328,4 +6328,386 @@ mod tests {
             assert!(w[0].1 <= w[1].1, "negdot distances ascending");
         }
     }
+
+    // -----------------------------------------------------------------
+    // Accessor / summary surface
+    // -----------------------------------------------------------------
+
+    /// `cluster_centroids` returns `(n_cent, dim, centroids, counts)`
+    /// with the documented shapes: `centroids.len() == n_cent · dim`,
+    /// one count per cluster, and the counts summing to `n_docs` (every
+    /// doc lands in exactly one cluster).
+    #[test]
+    fn cluster_centroids_returns_well_shaped_centroids_and_counts() {
+        let dim = 16usize;
+        let n_cent = 4u32;
+        let n_docs = 64u32;
+        let (blob, json) = build_blob(n_docs, dim, n_cent as usize, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let (got_n_cent, got_dim, centroids, counts) =
+            r.cluster_centroids("embedding").expect("present column");
+        assert_eq!(got_n_cent, n_cent);
+        assert_eq!(got_dim, dim as u32);
+        assert_eq!(centroids.len(), (n_cent as usize) * dim);
+        assert_eq!(counts.len(), n_cent as usize);
+        assert!(centroids.iter().all(|c| c.is_finite()));
+        let total: u32 = counts.iter().sum();
+        assert_eq!(
+            total, n_docs,
+            "every doc lands in exactly one cluster, so counts sum to n_docs"
+        );
+    }
+
+    /// `cluster_centroids` returns `None` for an unknown column —
+    /// the early `column_id_by_name.get` miss arm.
+    #[test]
+    fn cluster_centroids_unknown_column_returns_none() {
+        let (blob, json) = build_blob(32, 16, 4, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        assert!(r.cluster_centroids("nope").is_none());
+    }
+
+    /// `vector_columns_config` yields one `ColumnReader` per column,
+    /// exposing the public accessor fields (name, dim, metric, codec).
+    #[test]
+    fn vector_columns_config_exposes_reader_fields() {
+        let (blob, json) = build_blob(32, 16, 4, Metric::Cosine);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let cfgs: Vec<&ColumnReader> = r.vector_columns_config().collect();
+        assert_eq!(cfgs.len(), 1);
+        assert_eq!(cfgs[0].name, "embedding");
+        assert_eq!(cfgs[0].dim, 16);
+        assert_eq!(cfgs[0].metric, Metric::Cosine);
+        assert_eq!(cfgs[0].rerank_codec, RerankCodec::Fp32);
+    }
+
+    // -----------------------------------------------------------------
+    // ColumnReader range accessors
+    // -----------------------------------------------------------------
+    //
+    // These three range helpers all address the per-cluster blocks
+    // region from the same `(doc_off, count)` cluster entry. The block
+    // is `[codes][doc_ids][full]` at a fixed per-doc stride; the helpers
+    // must agree on the prefix/stride arithmetic or rerank reads the
+    // wrong bytes. Pin the relationships structurally off an Fp32 build.
+
+    #[test]
+    fn column_reader_range_accessors_agree_on_block_layout() {
+        let dim = 16usize;
+        let (blob, json) = build_blob(32, dim, 4, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let col = &r.columns[0];
+
+        let cb = col.quant.code_bytes();
+        let per_vec = col.rerank_codec.per_vector_bytes(dim);
+        let stride = cb + format::vec::DOC_ID_BYTES + per_vec;
+        assert_eq!(col.per_cluster_doc_stride(), stride);
+
+        // Whole-block range covers `count` docs at the full stride.
+        let (off, cnt) = (3u32, 5u32);
+        let block = col.cluster_block_range(off, cnt);
+        assert_eq!(block.len(), (cnt as usize) * stride);
+
+        // The codes+doc_ids prefix shares the block's start and covers
+        // exactly the leading `count · (code_bytes + 4)` bytes.
+        let prefix = col.cluster_codes_doc_ids_range(off, cnt);
+        assert_eq!(prefix.start, block.start);
+        assert_eq!(
+            prefix.len(),
+            (cnt as usize) * (cb + format::vec::DOC_ID_BYTES)
+        );
+
+        // Each rerank row sits after the prefix at `local_idx · per_vec`
+        // and is exactly one per-vector body wide. The last row's end
+        // must coincide with the whole-block end.
+        let row0 = col.cluster_rerank_row_range(off, cnt, 0);
+        assert_eq!(row0.start, block.start + prefix.len());
+        assert_eq!(row0.len(), per_vec);
+        let row_last = col.cluster_rerank_row_range(off, cnt, (cnt as usize) - 1);
+        assert_eq!(row_last.end, block.end);
+    }
+
+    // -----------------------------------------------------------------
+    // score_centroids
+    // -----------------------------------------------------------------
+
+    /// `score_centroids` returns at most `nprobe` clusters, sorted
+    /// ascending by distance, with in-range cluster ids. Querying with
+    /// a centroid's own bytes makes that cluster score ~0 and rank
+    /// first.
+    #[test]
+    fn score_centroids_truncates_and_sorts() {
+        let dim = 16usize;
+        let n_cent = 4u32;
+        let (blob, json) = build_blob(64, dim, n_cent as usize, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let col = &r.columns[0];
+        let (_, _, centroids, _) = r.cluster_centroids("embedding").expect("centroids");
+
+        // Query equal to centroid 0 → cluster 0 is the nearest.
+        let q0: Vec<f32> = centroids[0..dim].to_vec();
+        let sub = r
+            .source
+            .try_get_range_sync(col.subsection_range.clone())
+            .expect("subsection bytes");
+        let centroids_bytes =
+            &sub[col.centroids_off..col.centroids_off + (n_cent as usize) * dim * 4];
+
+        let nprobe = 2usize;
+        let scored = score_centroids(centroids_bytes, col, &q0, nprobe);
+        assert_eq!(scored.len(), nprobe, "truncated to nprobe");
+        assert_eq!(scored[0].0, 0, "self centroid is nearest");
+        for w in scored.windows(2) {
+            assert!(w[0].1 <= w[1].1, "scores ascending by distance");
+        }
+        assert!(scored.iter().all(|(c, _)| (*c as u32) < n_cent));
+
+        // nprobe ≥ n_cent returns every cluster (no truncation).
+        let all = score_centroids(centroids_bytes, col, &q0, n_cent as usize + 5);
+        assert_eq!(all.len(), n_cent as usize);
+    }
+
+    // -----------------------------------------------------------------
+    // parallel_chunks
+    // -----------------------------------------------------------------
+
+    /// `parallel_chunks` is clamped to `[1, available_parallelism]` and
+    /// never exceeds the item count.
+    #[test]
+    fn parallel_chunks_clamped_to_item_count_and_parallelism() {
+        let par = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(1);
+        assert_eq!(parallel_chunks(0), 1, "never returns zero chunks");
+        assert_eq!(parallel_chunks(1), 1);
+        // For a huge item count the chunk count saturates at parallelism.
+        assert_eq!(parallel_chunks(1_000_000), par);
+        // For a tiny item count it never exceeds the items.
+        assert!(parallel_chunks(2) <= 2);
+    }
+
+    // -----------------------------------------------------------------
+    // little-endian byte readers
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn read_u32_le_decodes_little_endian() {
+        let b = [0x78u8, 0x56, 0x34, 0x12, 0xFF];
+        assert_eq!(read_u32_le(&b), 0x1234_5678);
+        assert_eq!(read_u32_le(&[0, 0, 0, 0]), 0);
+        assert_eq!(read_u32_le(&[0xFF, 0xFF, 0xFF, 0xFF]), u32::MAX);
+    }
+
+    #[test]
+    fn read_u64_le_decodes_little_endian() {
+        let b = [0x01u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80];
+        assert_eq!(read_u64_le(&b), 0x8000_0000_0000_0001);
+        assert_eq!(read_u64_le(&[0u8; 8]), 0);
+    }
+
+    #[test]
+    fn parse_f32_le_vec_round_trips_floats() {
+        let vals = [1.5f32, -2.25, 0.0, 1234.5];
+        let mut bytes = Vec::new();
+        for v in &vals {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        let got = parse_f32_le_vec(&bytes);
+        assert_eq!(got, vals);
+        assert!(parse_f32_le_vec(&[]).is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // fetch_sync error arm
+    // -----------------------------------------------------------------
+
+    /// `fetch_sync` surfaces a `MalformedVersion` whose message names
+    /// the out-of-bounds range when the requested span runs past the
+    /// blob.
+    #[test]
+    fn fetch_sync_out_of_bounds_errors_with_range_in_message() {
+        let src = Source::InMemory(Bytes::from(vec![0u8; 8]));
+        let ok = fetch_sync(&src, 0..4, "header").expect("in-bounds succeeds");
+        assert_eq!(ok.len(), 4);
+        let err = fetch_sync(&src, 4..100, "directory").expect_err("oob fails");
+        let msg = err.to_string();
+        assert!(matches!(
+            err,
+            VectorError::Read(ReadError::MalformedVersion(_))
+        ));
+        assert!(
+            msg.contains("directory") && msg.contains("4..100"),
+            "message names the region and range, got: {msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // OpenOptions::for_object_store
+    // -----------------------------------------------------------------
+
+    /// `for_object_store` disables CRC verification (the cold-open
+    /// byte-budget default), unlike the CRC-on `Default`.
+    #[test]
+    fn open_options_for_object_store_disables_crc() {
+        assert!(!OpenOptions::for_object_store().verify_crc);
+        assert!(OpenOptions::default().verify_crc);
+        // Debug + Clone + Copy are derived; exercise them so the impls
+        // are covered and a clone is independent.
+        let opts = OpenOptions::for_object_store();
+        let copy = opts;
+        assert_eq!(format!("{copy:?}"), format!("{opts:?}"));
+    }
+
+    // -----------------------------------------------------------------
+    // CoarseCandidate ordering + BoundedCoarseHeap
+    // -----------------------------------------------------------------
+
+    fn coarse(did: u32, estimate: f32) -> CoarseCandidate {
+        CoarseCandidate {
+            did,
+            estimate,
+            pos: did,
+            cluster_id: 0,
+        }
+    }
+
+    /// `CoarseCandidate` is reverse-ordered on `estimate` so a max-heap
+    /// `peek()` yields the *worst* (lowest-estimate) retained candidate.
+    /// Also exercises `PartialEq`/`Eq` (identical fields compare equal,
+    /// differing fields do not).
+    #[test]
+    fn coarse_candidate_reverse_orders_on_estimate() {
+        let lo = coarse(1, 0.1);
+        let hi = coarse(2, 0.9);
+        // Higher estimate is "better" → compares as Less under the
+        // reversed Ord (so it sinks to the bottom of a max-heap's worst).
+        assert_eq!(hi.cmp(&lo), Ordering::Less);
+        assert_eq!(lo.cmp(&hi), Ordering::Greater);
+        assert_eq!(lo.partial_cmp(&hi), Some(Ordering::Greater));
+
+        // PartialEq / Eq.
+        assert_eq!(coarse(5, 0.5), coarse(5, 0.5));
+        assert_ne!(coarse(5, 0.5), coarse(6, 0.5));
+        assert_ne!(coarse(5, 0.5), coarse(5, 0.6));
+
+        // The max-heap's peek is the worst (lowest-estimate) candidate.
+        let mut heap = BinaryHeap::new();
+        heap.push(coarse(1, 0.1));
+        heap.push(coarse(2, 0.9));
+        heap.push(coarse(3, 0.5));
+        assert_eq!(heap.peek().expect("non-empty").estimate, 0.1);
+    }
+
+    /// `BoundedCoarseHeap` retains the `limit` highest-estimate
+    /// candidates; pushes beyond the limit evict the current worst.
+    #[test]
+    fn bounded_coarse_heap_retains_top_by_estimate() {
+        let mut h = BoundedCoarseHeap::new(3);
+        for (did, est) in [(0u32, 0.1f32), (1, 0.9), (2, 0.5), (3, 0.7), (4, 0.2)] {
+            h.push(coarse(did, est));
+        }
+        let mut kept: Vec<u32> = h.into_vec().into_iter().map(|(did, ..)| did).collect();
+        kept.sort_unstable();
+        // The three highest estimates are 0.9 (did 1), 0.7 (did 3),
+        // 0.5 (did 2).
+        assert_eq!(kept, vec![1, 2, 3]);
+    }
+
+    /// A zero-limit `BoundedCoarseHeap` drops every push and yields an
+    /// empty result.
+    #[test]
+    fn bounded_coarse_heap_zero_limit_keeps_nothing() {
+        let mut h = BoundedCoarseHeap::new(0);
+        h.push(coarse(0, 0.5));
+        h.push(coarse(1, 0.9));
+        assert!(h.into_vec().is_empty());
+    }
+
+    /// `merge` folds another heap's candidates in under the receiver's
+    /// limit, preserving the global top-by-estimate set.
+    #[test]
+    fn bounded_coarse_heap_merge_preserves_global_top() {
+        let mut a = BoundedCoarseHeap::new(2);
+        a.push(coarse(0, 0.1));
+        a.push(coarse(1, 0.4));
+        let mut b = BoundedCoarseHeap::new(2);
+        b.push(coarse(2, 0.9));
+        b.push(coarse(3, 0.2));
+        a.merge(b);
+        let mut kept: Vec<u32> = a.into_vec().into_iter().map(|(did, ..)| did).collect();
+        kept.sort_unstable();
+        // Across both heaps the two best estimates are 0.9 (did 2) and
+        // 0.4 (did 1).
+        assert_eq!(kept, vec![1, 2]);
+    }
+
+    // -----------------------------------------------------------------
+    // plan_cluster_coalesce / apply_coalesce
+    // -----------------------------------------------------------------
+
+    /// Far-apart ranges (gap beyond the coalesce window) stay as
+    /// separate fetches; `apply_coalesce` slices each requested range
+    /// back out byte-for-byte and preserves input order.
+    #[test]
+    fn plan_cluster_coalesce_keeps_distant_ranges_separate() {
+        let ranges = vec![0..4, 1_000_000..1_000_008];
+        let plan = plan_cluster_coalesce(&ranges);
+        assert_eq!(
+            plan.fetch_ranges.len(),
+            2,
+            "ranges past the coalesce gap are not merged"
+        );
+
+        // Build a synthetic blob and confirm apply_coalesce recovers the
+        // exact requested bytes in input order.
+        let mut blob = vec![0u8; 1_000_016];
+        for (i, byte) in blob.iter_mut().enumerate() {
+            *byte = (i % 251) as u8;
+        }
+        let bytes = Bytes::from(blob);
+        let fetched: Vec<Bytes> = plan
+            .fetch_ranges
+            .iter()
+            .map(|r| bytes.slice(r.clone()))
+            .collect();
+        let out = apply_coalesce(&plan, &fetched);
+        assert_eq!(out.len(), ranges.len());
+        for (o, r) in out.iter().zip(ranges.iter()) {
+            assert_eq!(o.as_ref(), &bytes[r.clone()]);
+        }
+    }
+
+    /// Adjacent / near-adjacent ranges fuse into one fetch span, and
+    /// `apply_coalesce` still slices each original range out correctly —
+    /// including when the input order is not sorted by start offset.
+    #[test]
+    fn plan_cluster_coalesce_merges_adjacent_and_slices_back() {
+        // Two adjacent ranges plus one within the gap window → all fused.
+        let ranges = vec![100..120, 80..100, 130..150];
+        let plan = plan_cluster_coalesce(&ranges);
+        assert_eq!(
+            plan.fetch_ranges.len(),
+            1,
+            "near-adjacent ranges fuse into a single fetch"
+        );
+        let merged = &plan.fetch_ranges[0];
+        assert_eq!(merged.start, 80);
+        assert_eq!(merged.end, 150);
+
+        let mut blob = vec![0u8; 256];
+        for (i, byte) in blob.iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(3);
+        }
+        let bytes = Bytes::from(blob);
+        let fetched: Vec<Bytes> = plan
+            .fetch_ranges
+            .iter()
+            .map(|r| bytes.slice(r.clone()))
+            .collect();
+        let out = apply_coalesce(&plan, &fetched);
+        // Output order matches input order, not sorted order.
+        assert_eq!(out[0].as_ref(), &bytes[100..120]);
+        assert_eq!(out[1].as_ref(), &bytes[80..100]);
+        assert_eq!(out[2].as_ref(), &bytes[130..150]);
+    }
 }

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -505,6 +505,124 @@ mod tests {
         assert!(select(&[seg(1, 200, 1000, 0)], &default_cfg()).is_empty());
     }
 
+    // ---- SuperfileStats live_docs / live_bytes -----------------------
+
+    #[test]
+    fn live_docs_subtracts_tombstones_and_saturates() {
+        let s = seg(1, 100, 1000, 250);
+        assert_eq!(s.live_docs(), 750);
+        // More tombstones than docs saturates to zero rather than
+        // underflowing.
+        let over = seg(2, 100, 100, 200);
+        assert_eq!(over.live_docs(), 0);
+    }
+
+    #[test]
+    fn live_bytes_scales_by_live_fraction() {
+        // 100 MiB, half the docs tombstoned → ~50 MiB live.
+        let s = seg(1, 100, 1000, 500);
+        assert_eq!(s.live_bytes(), mib(100) / 2);
+    }
+
+    #[test]
+    fn live_bytes_zero_docs_is_zero() {
+        // A 0-doc superfile must report 0 live bytes (guards the
+        // division-by-zero branch).
+        let s = seg(1, 100, 0, 0);
+        assert_eq!(s.live_bytes(), 0);
+    }
+
+    // ---- PendingJob fits / push -------------------------------------
+
+    #[test]
+    fn pending_job_fits_until_target_exceeded() {
+        let target = mib(100);
+        let mut p = PendingJob::default();
+        let a = seg(1, 60, 1000, 0); // 60 MiB live
+        assert!(p.fits(&a, target));
+        p.push(&a);
+        assert_eq!(p.live_bytes, mib(60));
+        assert_eq!(p.inputs.len(), 1);
+        // A second 60 MiB superfile would overflow the 100 MiB target.
+        let b = seg(2, 60, 1000, 0);
+        assert!(!p.fits(&b, target));
+        // A 40 MiB superfile fits exactly to the boundary.
+        let c = seg(3, 40, 1000, 0);
+        assert!(p.fits(&c, target));
+    }
+
+    #[test]
+    fn pending_job_emit_requires_two_inputs() {
+        // A single-input pending job never emits even if it reaches
+        // the fill floor.
+        let mut jobs = Vec::new();
+        let mut p = PendingJob::default();
+        p.push(&seg(1, 200, 1000, 0));
+        p.emit(&[], 0, &mut jobs);
+        assert!(jobs.is_empty(), "single-input job must not emit");
+        // Reset to default after emit attempt.
+        assert_eq!(p.inputs.len(), 0);
+        assert_eq!(p.live_bytes, 0);
+    }
+
+    // ---- run_compaction_job error arms ------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_compaction_job_unknown_input_surfaces_not_found() {
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+        commit_titles(&st, &["alpha first", "alpha second"]);
+        // A job referencing a superfile id that isn't in the manifest
+        // must surface SuperfileNotFound.
+        let bogus = Uuid::from_u128(0xDEAD_BEEF);
+        let job = CompactionJob {
+            partition_key: Vec::new(),
+            inputs: vec![bogus],
+            estimated_output_bytes: 0,
+        };
+        let err = st
+            .run_compaction_job(job)
+            .await
+            .expect_err("must error on unknown input");
+        assert!(
+            matches!(err, crate::supertable::error::CompactionError::SuperfileNotFound(id) if id == bogus),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_sync_wrapper_runs_jobs() {
+        // Exercise the sync `compact()` entry point (the
+        // runtime-bridge wrapper around `compact_async`). Use
+        // spawn_blocking so we're not inside a tokio runtime when
+        // the bridge tries to block.
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+        for titles in [
+            ["alpha first", "alpha second"],
+            ["bravo first", "bravo second"],
+            ["charlie first", "charlie second"],
+            ["delta first", "delta second"],
+            ["echo first", "echo second"],
+            ["foxtrot first", "foxtrot second"],
+            ["golf first", "golf second"],
+            ["hotel first", "hotel second"],
+            ["india first", "india second"],
+            ["juliet first", "juliet second"],
+        ] {
+            commit_titles(&st, &titles);
+        }
+        let before = st.manifest_id();
+        let cfg = small_compact_cfg();
+        tokio::task::spawn_blocking(move || st.compact(&cfg).map(|_| st.manifest_id()))
+            .await
+            .expect("join")
+            .map(|after| {
+                assert!(after > before, "sync compact must have run a job");
+            })
+            .expect("compact");
+    }
+
     #[test]
     fn partitions_packed_independently() {
         let mut segs = Vec::new();

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1327,4 +1327,124 @@ mod tests {
         let s = format!("{:?}", r);
         assert!(s.contains("SupertableReader"));
     }
+
+    #[test]
+    fn schema_returns_user_schema_without_injected_id() {
+        let st = Supertable::create(opts()).expect("create");
+        let sch = st.schema();
+        // The user-facing schema is exactly the column the test fixture
+        // declared — the auto-injected `_id` is not part of it.
+        assert_eq!(sch.fields().len(), 1);
+        assert_eq!(sch.field(0).name(), "title");
+    }
+
+    #[test]
+    fn manifest_accessor_matches_reader_manifest_id() {
+        let st = Supertable::create(opts()).expect("create");
+        assert_eq!(st.manifest_id(), 0);
+        publish_appended(&st, vec![entry(3)]);
+        // The handle-level `manifest_id` advances with the swap, and a
+        // fresh reader pins the same value.
+        assert_eq!(st.manifest_id(), 1);
+        assert_eq!(st.reader().manifest_id(), 1);
+    }
+
+    #[test]
+    fn handle_id_is_stable_for_a_handle_and_distinct_across_handles() {
+        let st1 = Supertable::create(opts()).expect("create");
+        let st2 = Supertable::create(opts()).expect("create");
+        // Stable within one handle (and its clones).
+        assert_eq!(st1.handle_id(), st1.clone().handle_id());
+        // Distinct across independently-created handles.
+        assert_ne!(st1.handle_id(), st2.handle_id());
+    }
+
+    #[test]
+    fn query_runtime_is_lazily_built_and_cached() {
+        let st = Supertable::create(opts()).expect("create");
+        let rt1 = st.query_runtime();
+        let rt2 = st.query_runtime();
+        // Second call returns the same cached runtime, not a fresh one.
+        assert!(Arc::ptr_eq(&rt1, &rt2));
+    }
+
+    #[test]
+    fn block_on_query_drives_a_future_to_completion() {
+        let st = Supertable::create(opts()).expect("create");
+        let out = st.block_on_query(async { 7_u32 + 35 });
+        assert_eq!(out, 42);
+    }
+
+    #[test]
+    fn stats_reports_in_memory_snapshot() {
+        let st = Supertable::create(opts()).expect("create");
+        publish_appended(&st, vec![entry(10), entry(20)]);
+        let s = st.stats();
+        assert_eq!(s.manifest_id, 1);
+        assert_eq!(s.n_superfiles, 2);
+        // In-memory supertable has no manifest list / disk cache.
+        assert_eq!(s.n_manifest_parts, None);
+        assert_eq!(s.mmap_resident_bytes, None);
+        assert_eq!(s.n_cold_fetches, None);
+    }
+
+    #[test]
+    fn wait_until_warm_is_noop_without_disk_cache() {
+        let st = Supertable::create(opts()).expect("create");
+        // No disk cache attached → returns Ok immediately.
+        st.wait_until_warm(std::time::Duration::from_millis(1))
+            .expect("warm no-op");
+    }
+
+    #[test]
+    fn debug_cached_session_populates_the_session_cache() {
+        let st = Supertable::create(opts()).expect("create");
+        // Building the diagnostic session forces a SessionContext to be
+        // built and cached on the inner.
+        let _ctx = st.__debug_cached_session();
+        let guard = st
+            .sql_session_cache()
+            .lock()
+            .expect("sql_session_cache mutex");
+        assert!(guard.is_some(), "session cache populated after warm-up");
+    }
+
+    #[test]
+    fn weak_reader_round_trips_and_debug() {
+        let st = Supertable::create(opts()).expect("create");
+        publish_appended(&st, vec![entry(4)]);
+        let reader = st.reader();
+        let weak = WeakReader::from_reader(&reader);
+        // Debug is non-exhaustive but must not explode.
+        assert!(format!("{weak:?}").contains("WeakReader"));
+        // While the parent + reader are alive, upgrade succeeds and
+        // observes the same pinned snapshot.
+        let upgraded = weak.upgrade().expect("upgrade while inner alive");
+        assert_eq!(upgraded.manifest_id(), reader.manifest_id());
+        assert_eq!(upgraded.n_superfiles(), 1);
+    }
+
+    #[test]
+    fn weak_reader_upgrade_fails_after_inner_dropped() {
+        let weak = {
+            let st = Supertable::create(opts()).expect("create");
+            let reader = st.reader();
+            let weak = WeakReader::from_reader(&reader);
+            drop(reader);
+            drop(st);
+            weak
+        };
+        // The owning inner is gone, so upgrade yields None.
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn reader_options_match_handle_options() {
+        let st = Supertable::create(opts()).expect("create");
+        let r = st.reader();
+        // The reader's options accessor reaches the same validated
+        // options the handle exposes.
+        assert_eq!(r.options().id_column, st.options().id_column);
+        assert_eq!(r.options().fts_columns.len(), 1);
+    }
 }

--- a/src/supertable/lazy_source.rs
+++ b/src/supertable/lazy_source.rs
@@ -425,4 +425,92 @@ mod tests {
         assert!(got.is_empty());
         assert_eq!(storage.call_count(), 0);
     }
+
+    /// `new` issues one HEAD up-front and caches the discovered size,
+    /// so `size()` is non-zero before any `range`/`tail` I/O.
+    #[tokio::test]
+    async fn new_heads_and_caches_size() {
+        let blob = Bytes::from(vec![3u8; 512]);
+        let storage = Arc::new(ChunkedStorage::new(blob.clone(), 512, blob.len()));
+        let src = StorageRangeSource::new(
+            Arc::clone(&storage) as Arc<dyn StorageProvider>,
+            "seg.sf.parquet",
+        )
+        .await
+        .expect("new heads ok");
+        assert_eq!(src.size(), blob.len() as u64);
+        assert_eq!(src.uri(), "seg.sf.parquet");
+    }
+
+    /// `with_unknown_size` leaves `size()` at 0 (no up-front I/O); the
+    /// first `tail()` discovers the total and patches the atomic so a
+    /// subsequent `range()` bounds-checks like a known-size source.
+    #[tokio::test]
+    async fn unknown_size_tail_discovers_and_patches_size() {
+        let blob = Bytes::from((0u8..=255).cycle().take(1024).collect::<Vec<u8>>());
+        let storage = Arc::new(ChunkedStorage::new(blob.clone(), 4096, blob.len()));
+        let src = StorageRangeSource::with_unknown_size(
+            Arc::clone(&storage) as Arc<dyn StorageProvider>,
+            "seg.sf.parquet",
+        );
+        // Before any I/O the size is unknown.
+        assert_eq!(src.size(), 0);
+
+        // `tail` routes through the default `StorageProvider::tail`
+        // (head + get_range) and returns (bytes, total).
+        let (tail_bytes, total) = src.tail(64).await.expect("tail");
+        assert_eq!(total, blob.len() as u64);
+        assert_eq!(tail_bytes.as_ref(), &blob[blob.len() - 64..]);
+        // The atomic is now patched.
+        assert_eq!(src.size(), blob.len() as u64);
+
+        // A subsequent out-of-bounds range is now caught by the
+        // bounds check rather than reaching storage.
+        let err = src
+            .range(blob.len() as u64, 8)
+            .await
+            .expect_err("past-end range must be OutOfBounds");
+        match err {
+            LazyByteSourceError::OutOfBounds { start, len, size } => {
+                assert_eq!(start, blob.len() as u64);
+                assert_eq!(len, 8);
+                assert_eq!(size, blob.len() as u64);
+            }
+            other => panic!("expected OutOfBounds, got {other:?}"),
+        }
+    }
+
+    /// A known-size source rejects a range past the end with a typed
+    /// `OutOfBounds` (the `known > 0 && start+len > known` arm) without
+    /// touching storage.
+    #[tokio::test]
+    async fn range_out_of_bounds_when_size_known() {
+        let storage = Arc::new(ChunkedStorage::new(Bytes::from(vec![0u8; 100]), 100, 100));
+        let src = StorageRangeSource::with_known_size(
+            Arc::clone(&storage) as Arc<dyn StorageProvider>,
+            "seg.sf.parquet",
+            100,
+        );
+        let err = src.range(90, 20).await.expect_err("90+20 > 100");
+        assert!(
+            matches!(err, LazyByteSourceError::OutOfBounds { .. }),
+            "expected OutOfBounds, got {err:?}"
+        );
+        assert_eq!(storage.call_count(), 0);
+    }
+
+    /// `Debug` on `StorageRangeSource` renders the struct name (the
+    /// derived `#[derive(Debug)]` impl) and includes the uri.
+    #[tokio::test]
+    async fn debug_renders_struct_name_and_uri() {
+        let storage = Arc::new(ChunkedStorage::new(Bytes::from(vec![0u8; 8]), 8, 8));
+        let src = StorageRangeSource::with_known_size(
+            Arc::clone(&storage) as Arc<dyn StorageProvider>,
+            "seg-debug.sf.parquet",
+            8,
+        );
+        let dbg = format!("{src:?}");
+        assert!(dbg.contains("StorageRangeSource"), "got {dbg}");
+        assert!(dbg.contains("seg-debug.sf.parquet"), "got {dbg}");
+    }
 }

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -2008,6 +2008,50 @@ mod tests {
     }
 
     #[test]
+    fn manifest_debug_with_list_reports_part_count() {
+        // A Manifest carrying a `list` exercises the Some-arm of the
+        // `n_parts` closure in Debug (the empty-Manifest test above
+        // only hits the `unwrap_or(0)` None-arm).
+        use list::{ManifestList, PartitionStrategy};
+        let entry = part::PartId::new_v4();
+        let list = ManifestList {
+            format_version: list::FORMAT_VERSION.into(),
+            manifest_id: 1,
+            options_hash: part::ContentHash([0u8; 32]),
+            schema: Vec::new(),
+            id_column: "_id".into(),
+            fts_columns: vec![],
+            vector_columns: vec![],
+            partition_strategy: PartitionStrategy::Hash {
+                column: "_id".into(),
+                n_buckets: 1,
+            },
+            parts: vec![list::ManifestListEntry {
+                part_id: entry,
+                uri: "manifests/part-x".into(),
+                n_superfiles: 0,
+                size_bytes_compressed: 0,
+                size_bytes_uncompressed: 0,
+                content_hash: part::ContentHash([0u8; 32]),
+                partition_key: Vec::new(),
+                id_range: (0, 0),
+                scalar_stats_agg: Default::default(),
+                fts_summary_agg: Default::default(),
+                vector_summary_agg: Default::default(),
+            }],
+        };
+        let m = Manifest {
+            superfile_list: SuperfileList::empty(opts()),
+            list: Some(list),
+            parts: dashmap::DashMap::new(),
+            loader: None,
+        };
+        let dbg = format!("{m:?}");
+        assert!(dbg.contains("n_parts: 1"), "{dbg}");
+        assert!(dbg.contains("has_list: true"), "{dbg}");
+    }
+
+    #[test]
     fn cluster_centroids_empty_is_empty_and_default_matches() {
         let cc = ClusterCentroids::empty();
         assert!(cc.is_empty());

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -2259,11 +2259,17 @@ mod tests {
         // min/max present for both orderable columns.
         let (mn, mx) = stats.cols.get("ints").expect("ints min/max");
         assert_eq!(
-            mn.as_any().downcast_ref::<Int64Array>().unwrap().value(0),
+            mn.as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("test")
+                .value(0),
             1
         );
         assert_eq!(
-            mx.as_any().downcast_ref::<Int64Array>().unwrap().value(0),
+            mx.as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("test")
+                .value(0),
             5
         );
         // null count tracked (one null in `ints`).
@@ -2271,9 +2277,23 @@ mod tests {
         assert_eq!(*stats.null_counts.get("floats").expect("null count"), 0);
         // exact sum: ints = 3+1+5 = 9 (Int64), floats = 10.0 (Float64).
         let s = stats.sums.get("ints").expect("int sum");
-        assert_eq!(s.as_any().downcast_ref::<Int64Array>().unwrap().value(0), 9);
+        assert_eq!(
+            s.as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("test")
+                .value(0),
+            9
+        );
         let s = stats.sums.get("floats").expect("float sum");
-        assert!((s.as_any().downcast_ref::<Float64Array>().unwrap().value(0) - 10.0).abs() < 1e-9);
+        assert!(
+            (s.as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("test")
+                .value(0)
+                - 10.0)
+                .abs()
+                < 1e-9
+        );
         // HLL sketch recorded for both columns.
         assert!(stats.hll.contains_key("ints"));
         assert!(stats.hll.contains_key("floats"));
@@ -2288,17 +2308,26 @@ mod tests {
         let stats = ScalarStatsTable::from_batches(&schema, &[&b1, &b2]);
         let (mn, mx) = stats.cols.get("v").expect("min/max");
         assert_eq!(
-            mn.as_any().downcast_ref::<Int32Array>().unwrap().value(0),
+            mn.as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("test")
+                .value(0),
             5
         );
         assert_eq!(
-            mx.as_any().downcast_ref::<Int32Array>().unwrap().value(0),
+            mx.as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("test")
+                .value(0),
             30
         );
         // sum across both batches = 10+20+5+30 = 65.
         let s = stats.sums.get("v").expect("sum");
         assert_eq!(
-            s.as_any().downcast_ref::<Int64Array>().unwrap().value(0),
+            s.as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("test")
+                .value(0),
             65
         );
     }
@@ -2371,7 +2400,10 @@ mod tests {
         // sums add: 100 + 50 = 150.
         let s = a.sums.get("n").expect("merged sum");
         assert_eq!(
-            s.as_any().downcast_ref::<Int64Array>().unwrap().value(0),
+            s.as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("test")
+                .value(0),
             150
         );
         // The one-sided "solo" entry is gone.
@@ -2387,7 +2419,13 @@ mod tests {
             &(Arc::new(Int64Array::from(vec![4])) as ArrayRef),
         )
         .expect("int sum");
-        assert_eq!(r.as_any().downcast_ref::<Int64Array>().unwrap().value(0), 7);
+        assert_eq!(
+            r.as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("test")
+                .value(0),
+            7
+        );
         // UInt64 + UInt64.
         let r = add_sum_arrays(
             &(Arc::new(UInt64Array::from(vec![3u64])) as ArrayRef),
@@ -2395,7 +2433,10 @@ mod tests {
         )
         .expect("uint sum");
         assert_eq!(
-            r.as_any().downcast_ref::<UInt64Array>().unwrap().value(0),
+            r.as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("test")
+                .value(0),
             7
         );
         // Float64 + Float64.
@@ -2404,7 +2445,15 @@ mod tests {
             &(Arc::new(Float64Array::from(vec![2.5])) as ArrayRef),
         )
         .expect("float sum");
-        assert!((r.as_any().downcast_ref::<Float64Array>().unwrap().value(0) - 4.0).abs() < 1e-9);
+        assert!(
+            (r.as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("test")
+                .value(0)
+                - 4.0)
+                .abs()
+                < 1e-9
+        );
         // Overflow → None.
         let r = add_sum_arrays(
             &(Arc::new(Int64Array::from(vec![i64::MAX])) as ArrayRef),
@@ -2439,14 +2488,14 @@ mod tests {
         assert_eq!(
             mn.as_any()
                 .downcast_ref::<Decimal128Array>()
-                .unwrap()
+                .expect("test")
                 .value(0),
             5
         );
         assert_eq!(
             mx.as_any()
                 .downcast_ref::<Decimal128Array>()
-                .unwrap()
+                .expect("test")
                 .value(0),
             50
         );
@@ -2470,7 +2519,17 @@ mod tests {
         );
         a.merge(&b);
         let (mn, mx) = a.cols.get("flag").expect("bool col");
-        assert!(!mn.as_any().downcast_ref::<BooleanArray>().unwrap().value(0));
-        assert!(mx.as_any().downcast_ref::<BooleanArray>().unwrap().value(0));
+        assert!(
+            !mn.as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("test")
+                .value(0)
+        );
+        assert!(
+            mx.as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("test")
+                .value(0)
+        );
     }
 }

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -1980,4 +1980,277 @@ mod tests {
             );
         }
     }
+
+    // ============================================================
+    // SuperfileUri path helpers, Debug formatters, and the
+    // ScalarStatsTable build/aggregate helpers (from_batch[es],
+    // column_sum / column_hll / column_min_max, additive merge).
+    // ============================================================
+
+    #[test]
+    fn superfile_uri_path_helpers_share_the_same_uuid() {
+        let uri = SuperfileUri(Uuid::from_u128(0x1234_5678));
+        let id = uri.0;
+        assert_eq!(uri.storage_path(), format!("data/seg-{id}.sf.parquet"));
+        assert_eq!(uri.cache_filename(), format!("seg-{id}.sf.parquet"));
+        assert_eq!(uri.cache_tmp_filename(), format!("seg-{id}.sf.parquet.tmp"));
+    }
+
+    #[test]
+    fn manifest_debug_reports_counts() {
+        let m = Manifest::empty(opts()).with_appended(vec![seg_entry(Uuid::new_v4(), 3)]);
+        let dbg = format!("{m:?}");
+        assert!(dbg.contains("Manifest"));
+        assert!(dbg.contains("manifest_id"));
+        assert!(dbg.contains("n_superfiles"));
+        // No storage attached ⇒ has_loader false, has_list false.
+        assert!(dbg.contains("has_loader"));
+    }
+
+    #[test]
+    fn cluster_centroids_empty_is_empty_and_default_matches() {
+        let cc = ClusterCentroids::empty();
+        assert!(cc.is_empty());
+        assert_eq!(cc.n_cent, 0);
+        // A populated one is not empty.
+        let cc = ClusterCentroids::from_fp32(2, 4, &[0.0; 8], vec![1, 1]);
+        assert!(!cc.is_empty());
+        assert_eq!(cc.n_cent, 2);
+        assert_eq!(cc.dim, 4);
+    }
+
+    fn batch_with_columns(schema: &Arc<Schema>, cols: Vec<ArrayRef>) -> RecordBatch {
+        RecordBatch::try_new(Arc::clone(schema), cols).expect("batch")
+    }
+
+    #[test]
+    fn scalar_stats_from_batch_computes_min_max_null_sum_hll() {
+        use arrow_array::{Float64Array, Int64Array};
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("ints", DataType::Int64, true),
+            Field::new("floats", DataType::Float64, false),
+        ]));
+        let ints: ArrayRef = Arc::new(Int64Array::from(vec![Some(3), None, Some(1), Some(5)]));
+        let floats: ArrayRef = Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0, 4.0]));
+        let batch = batch_with_columns(&schema, vec![ints, floats]);
+
+        let stats = ScalarStatsTable::from_batch(&schema, &batch);
+
+        // min/max present for both orderable columns.
+        let (mn, mx) = stats.cols.get("ints").expect("ints min/max");
+        assert_eq!(
+            mn.as_any().downcast_ref::<Int64Array>().unwrap().value(0),
+            1
+        );
+        assert_eq!(
+            mx.as_any().downcast_ref::<Int64Array>().unwrap().value(0),
+            5
+        );
+        // null count tracked (one null in `ints`).
+        assert_eq!(*stats.null_counts.get("ints").expect("null count"), 1);
+        assert_eq!(*stats.null_counts.get("floats").expect("null count"), 0);
+        // exact sum: ints = 3+1+5 = 9 (Int64), floats = 10.0 (Float64).
+        let s = stats.sums.get("ints").expect("int sum");
+        assert_eq!(s.as_any().downcast_ref::<Int64Array>().unwrap().value(0), 9);
+        let s = stats.sums.get("floats").expect("float sum");
+        assert!((s.as_any().downcast_ref::<Float64Array>().unwrap().value(0) - 10.0).abs() < 1e-9);
+        // HLL sketch recorded for both columns.
+        assert!(stats.hll.contains_key("ints"));
+        assert!(stats.hll.contains_key("floats"));
+    }
+
+    #[test]
+    fn scalar_stats_from_batches_concats_across_batches() {
+        use arrow_array::Int32Array;
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let b1 = batch_with_columns(&schema, vec![Arc::new(Int32Array::from(vec![10, 20]))]);
+        let b2 = batch_with_columns(&schema, vec![Arc::new(Int32Array::from(vec![5, 30]))]);
+        let stats = ScalarStatsTable::from_batches(&schema, &[&b1, &b2]);
+        let (mn, mx) = stats.cols.get("v").expect("min/max");
+        assert_eq!(
+            mn.as_any().downcast_ref::<Int32Array>().unwrap().value(0),
+            5
+        );
+        assert_eq!(
+            mx.as_any().downcast_ref::<Int32Array>().unwrap().value(0),
+            30
+        );
+        // sum across both batches = 10+20+5+30 = 65.
+        let s = stats.sums.get("v").expect("sum");
+        assert_eq!(
+            s.as_any().downcast_ref::<Int64Array>().unwrap().value(0),
+            65
+        );
+    }
+
+    #[test]
+    fn scalar_stats_from_batches_empty_is_empty() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let stats = ScalarStatsTable::from_batches(&schema, &[]);
+        assert!(stats.cols.is_empty());
+    }
+
+    #[test]
+    fn scalar_stats_skips_unorderable_column_types() {
+        // A List column has no well-defined min/max here, so it's
+        // silently skipped (the skip planner treats missing as
+        // "can't prune").
+        let inner = Arc::new(Field::new("item", DataType::Int32, true));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(inner),
+            true,
+        )]));
+        use arrow_array::builder::{Int32Builder, ListBuilder};
+        let mut lb = ListBuilder::new(Int32Builder::new());
+        lb.values().append_value(1);
+        lb.append(true);
+        let arr: ArrayRef = Arc::new(lb.finish());
+        let batch = batch_with_columns(&schema, vec![arr]);
+        let stats = ScalarStatsTable::from_batch(&schema, &batch);
+        assert!(stats.cols.is_empty(), "list type should be skipped");
+    }
+
+    #[test]
+    fn merge_additive_stats_intersect_on_both_sides() {
+        use arrow_array::Int64Array;
+        // Two tables: only the shared column's null_count / sum
+        // survives the merge; a one-sided column's additive stats
+        // are dropped.
+        let mut a = ScalarStatsTable::new();
+        a.cols.insert(
+            "n".into(),
+            (
+                Arc::new(Int64Array::from(vec![0])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![10])) as ArrayRef,
+            ),
+        );
+        a.null_counts.insert("n".into(), 2);
+        a.sums.insert(
+            "n".into(),
+            Arc::new(Int64Array::from(vec![100])) as ArrayRef,
+        );
+
+        let mut b = ScalarStatsTable::new();
+        b.cols.insert(
+            "n".into(),
+            (
+                Arc::new(Int64Array::from(vec![1])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![20])) as ArrayRef,
+            ),
+        );
+        b.null_counts.insert("n".into(), 3);
+        b.sums
+            .insert("n".into(), Arc::new(Int64Array::from(vec![50])) as ArrayRef);
+        // One-sided additive entry that must be dropped.
+        b.null_counts.insert("solo".into(), 9);
+
+        a.merge(&b);
+        // null counts add: 2 + 3 = 5.
+        assert_eq!(*a.null_counts.get("n").expect("merged null"), 5);
+        // sums add: 100 + 50 = 150.
+        let s = a.sums.get("n").expect("merged sum");
+        assert_eq!(
+            s.as_any().downcast_ref::<Int64Array>().unwrap().value(0),
+            150
+        );
+        // The one-sided "solo" entry is gone.
+        assert!(!a.null_counts.contains_key("solo"));
+    }
+
+    #[test]
+    fn add_sum_arrays_handles_each_type_and_overflow() {
+        use arrow_array::{Float64Array, Int64Array, UInt64Array};
+        // Int64 + Int64.
+        let r = add_sum_arrays(
+            &(Arc::new(Int64Array::from(vec![3])) as ArrayRef),
+            &(Arc::new(Int64Array::from(vec![4])) as ArrayRef),
+        )
+        .expect("int sum");
+        assert_eq!(r.as_any().downcast_ref::<Int64Array>().unwrap().value(0), 7);
+        // UInt64 + UInt64.
+        let r = add_sum_arrays(
+            &(Arc::new(UInt64Array::from(vec![3u64])) as ArrayRef),
+            &(Arc::new(UInt64Array::from(vec![4u64])) as ArrayRef),
+        )
+        .expect("uint sum");
+        assert_eq!(
+            r.as_any().downcast_ref::<UInt64Array>().unwrap().value(0),
+            7
+        );
+        // Float64 + Float64.
+        let r = add_sum_arrays(
+            &(Arc::new(Float64Array::from(vec![1.5])) as ArrayRef),
+            &(Arc::new(Float64Array::from(vec![2.5])) as ArrayRef),
+        )
+        .expect("float sum");
+        assert!((r.as_any().downcast_ref::<Float64Array>().unwrap().value(0) - 4.0).abs() < 1e-9);
+        // Overflow → None.
+        let r = add_sum_arrays(
+            &(Arc::new(Int64Array::from(vec![i64::MAX])) as ArrayRef),
+            &(Arc::new(Int64Array::from(vec![1])) as ArrayRef),
+        );
+        assert!(r.is_none(), "i64 overflow drops the stat");
+        // Type mismatch → None.
+        let r = add_sum_arrays(
+            &(Arc::new(Int64Array::from(vec![1])) as ArrayRef),
+            &(Arc::new(UInt64Array::from(vec![1u64])) as ArrayRef),
+        );
+        assert!(r.is_none(), "type mismatch drops the stat");
+    }
+
+    #[test]
+    fn merge_decimal128_and_boolean_min_max() {
+        use arrow_array::{BooleanArray, Decimal128Array};
+        // Decimal128 merge keeps numeric min/max.
+        let dec = |v: i128| -> ArrayRef {
+            Arc::new(
+                Decimal128Array::from(vec![v])
+                    .with_precision_and_scale(38, 0)
+                    .expect("decimal"),
+            )
+        };
+        let mut a = ScalarStatsTable::new();
+        a.cols.insert("d".into(), (dec(10), dec(20)));
+        let mut b = ScalarStatsTable::new();
+        b.cols.insert("d".into(), (dec(5), dec(50)));
+        a.merge(&b);
+        let (mn, mx) = a.cols.get("d").expect("decimal col");
+        assert_eq!(
+            mn.as_any()
+                .downcast_ref::<Decimal128Array>()
+                .unwrap()
+                .value(0),
+            5
+        );
+        assert_eq!(
+            mx.as_any()
+                .downcast_ref::<Decimal128Array>()
+                .unwrap()
+                .value(0),
+            50
+        );
+
+        // Boolean merge: min = AND, max = OR.
+        let mut a = ScalarStatsTable::new();
+        a.cols.insert(
+            "flag".into(),
+            (
+                Arc::new(BooleanArray::from(vec![true])) as ArrayRef,
+                Arc::new(BooleanArray::from(vec![false])) as ArrayRef,
+            ),
+        );
+        let mut b = ScalarStatsTable::new();
+        b.cols.insert(
+            "flag".into(),
+            (
+                Arc::new(BooleanArray::from(vec![false])) as ArrayRef,
+                Arc::new(BooleanArray::from(vec![true])) as ArrayRef,
+            ),
+        );
+        a.merge(&b);
+        let (mn, mx) = a.cols.get("flag").expect("bool col");
+        assert!(!mn.as_any().downcast_ref::<BooleanArray>().unwrap().value(0));
+        assert!(mx.as_any().downcast_ref::<BooleanArray>().unwrap().value(0));
+    }
 }

--- a/src/supertable/manifest/part.rs
+++ b/src/supertable/manifest/part.rs
@@ -1376,6 +1376,55 @@ mod tests {
     }
 
     #[test]
+    fn decode_superfile_rejects_non_record_value() {
+        // A non-record Avro value where a SuperfileEntry record is
+        // expected → SchemaMismatch.
+        let err = decode_superfile(AvroValue::Long(7)).expect_err("non-record");
+        assert!(
+            matches!(err, PartParseError::SchemaMismatch(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_superfile_rejects_malformed_superfile_id_uuid() {
+        // A record whose superfile_id isn't a valid UUID → BadSuperfileId
+        // from the first Uuid::parse_str in decode_superfile.
+        let rec = AvroValue::Record(vec![(
+            "superfile_id".into(),
+            AvroValue::String("not-a-uuid".into()),
+        )]);
+        let err = decode_superfile(rec).expect_err("bad uuid");
+        assert!(
+            matches!(err, PartParseError::BadSuperfileId(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_open_blob_rejects_truncated_entry() {
+        // A version-3 blob whose open_blob entry claims a length longer
+        // than the remaining bytes → SchemaMismatch (truncated) from the
+        // final `take` inside decode_open_blob.
+        let mut bytes = encode_subsection_offsets(&SubsectionOffsets {
+            total_size: 1,
+            vec: None,
+            fts: None,
+            vec_open_ranges: vec![],
+            fts_open_ranges: vec![],
+            open_blob: vec![(10, vec![0xAA, 0xBB, 0xCC])],
+        });
+        // Drop the trailing payload bytes so the declared length runs
+        // past the end of the buffer.
+        bytes.truncate(bytes.len() - 2);
+        let err = decode_subsection_offsets(&bytes).expect_err("truncated open_blob");
+        assert!(
+            matches!(err, PartParseError::SchemaMismatch(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
     fn take_i128_be_roundtrips_a_full_width_value() {
         // 16-byte big-endian fixed → i128, including a negative.
         let v: i128 = -123_456_789_012_345;

--- a/src/supertable/manifest/part.rs
+++ b/src/supertable/manifest/part.rs
@@ -1057,4 +1057,333 @@ mod tests {
         let decoded = decode(&wrapped).expect("decode from Bytes");
         assert_eq!(decoded.superfiles.len(), 1);
     }
+
+    #[test]
+    fn content_hash_of_is_deterministic_and_to_hex_is_64_chars() {
+        let h = ContentHash::of(b"the quick brown fox");
+        let h2 = ContentHash::of(b"the quick brown fox");
+        assert_eq!(h, h2, "blake3 is deterministic");
+        let hex = h.to_hex();
+        assert_eq!(hex.len(), BLAKE3_HEX_LEN);
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "to_hex emits lowercase hex"
+        );
+        // Different input ⇒ different hash.
+        assert_ne!(h, ContentHash::of(b"the quick brown foy"));
+    }
+
+    #[test]
+    fn content_hash_debug_is_truncated_display_is_full() {
+        let h = ContentHash::of(b"payload");
+        let dbg = format!("{h:?}");
+        let disp = format!("{h}");
+        // Debug shows a `blake3:<8hex>…` prefix.
+        assert!(dbg.starts_with("blake3:"), "got {dbg}");
+        assert!(dbg.ends_with('…'), "got {dbg}");
+        // 8 hex chars between prefix and ellipsis.
+        let body = dbg.trim_start_matches("blake3:").trim_end_matches('…');
+        assert_eq!(body.len(), CONTENT_HASH_DEBUG_HEX_PREFIX_LEN);
+        // Display shows the full hash.
+        assert_eq!(disp, format!("blake3:{}", h.to_hex()));
+        assert!(disp.starts_with(&dbg[..dbg.len() - '…'.len_utf8()]));
+    }
+
+    #[test]
+    fn part_id_new_v4_is_unique_and_display_matches_uuid() {
+        let a = PartId::new_v4();
+        let b = PartId::new_v4();
+        assert_ne!(a, b);
+        // Display delegates to the inner UUID.
+        assert_eq!(format!("{a}"), a.0.to_string());
+    }
+
+    #[test]
+    fn subsection_offsets_present_roundtrip_through_part() {
+        // Drive encode/decode of a SuperfileEntry carrying fully-
+        // populated subsection_offsets (version 3 / open_blob path).
+        let id = Uuid::new_v4();
+        let off = SubsectionOffsets {
+            total_size: 9_000,
+            vec: Some((100, 200)),
+            fts: Some((400, 500)),
+            vec_open_ranges: vec![(100, 64), (1000, 128)],
+            fts_open_ranges: vec![(400, 32)],
+            open_blob: vec![(50, vec![1, 2, 3, 4]), (9000, vec![9, 9])],
+        };
+        let seg = Arc::new(SuperfileEntry {
+            superfile_id: id,
+            uri: SuperfileUri(id),
+            n_docs: 3,
+            id_min: -5,
+            id_max: 7,
+            scalar_stats: ScalarStatsTable::new(),
+            fts_summary: HashMap::new(),
+            vector_summary: HashMap::new(),
+            partition_key: Vec::new(),
+            partition_hint: None,
+            subsection_offsets: Some(off.clone()),
+        });
+        let part = fresh_part(vec![seg]);
+        let decoded = decode(&encode(&part, 3)).expect("decode");
+        let got = decoded.superfiles[0]
+            .subsection_offsets
+            .as_ref()
+            .expect("offsets present");
+        assert_eq!(*got, off);
+        // Signed id range survives big-endian fixed encoding.
+        assert_eq!(decoded.superfiles[0].id_min, -5);
+        assert_eq!(decoded.superfiles[0].id_max, 7);
+    }
+
+    #[test]
+    fn subsection_offsets_absent_subsections_roundtrip() {
+        // vec / fts None, empty range lists, empty open_blob — hits
+        // the SUBSECTION_FLAG_ABSENT branches and empty-list decode.
+        let id = Uuid::new_v4();
+        let off = SubsectionOffsets {
+            total_size: 1,
+            vec: None,
+            fts: None,
+            vec_open_ranges: vec![],
+            fts_open_ranges: vec![],
+            open_blob: vec![],
+        };
+        let seg = Arc::new(SuperfileEntry {
+            superfile_id: id,
+            uri: SuperfileUri(id),
+            n_docs: 0,
+            id_min: 0,
+            id_max: 0,
+            scalar_stats: ScalarStatsTable::new(),
+            fts_summary: HashMap::new(),
+            vector_summary: HashMap::new(),
+            partition_key: Vec::new(),
+            partition_hint: None,
+            subsection_offsets: Some(off.clone()),
+        });
+        let part = fresh_part(vec![seg]);
+        let decoded = decode(&encode(&part, 3)).expect("decode");
+        assert_eq!(
+            *decoded.superfiles[0]
+                .subsection_offsets
+                .as_ref()
+                .expect("offsets"),
+            off
+        );
+    }
+
+    #[test]
+    fn encode_decode_subsection_offsets_helpers_directly() {
+        // Exercise the free encode/decode helpers without going
+        // through the whole part, covering the current-version path.
+        let off = SubsectionOffsets {
+            total_size: 123,
+            vec: Some((1, 2)),
+            fts: None,
+            vec_open_ranges: vec![(1, 2), (3, 4)],
+            fts_open_ranges: vec![],
+            open_blob: vec![(7, vec![0xde, 0xad])],
+        };
+        let bytes = encode_subsection_offsets(&off);
+        // First byte is the current version tag.
+        assert_eq!(bytes[0], SUBSECTION_OFFSETS_VERSION_CURRENT);
+        let decoded = decode_subsection_offsets(&bytes).expect("decode helper");
+        assert_eq!(decoded, off);
+    }
+
+    #[test]
+    fn decode_subsection_offsets_rejects_unknown_version() {
+        let mut bytes = encode_subsection_offsets(&SubsectionOffsets {
+            total_size: 0,
+            vec: None,
+            fts: None,
+            vec_open_ranges: vec![],
+            fts_open_ranges: vec![],
+            open_blob: vec![],
+        });
+        bytes[0] = 99; // not LEGACY (2) nor CURRENT (3)
+        let err = decode_subsection_offsets(&bytes).expect_err("unknown version");
+        assert!(matches!(err, PartParseError::SchemaMismatch(_)));
+    }
+
+    #[test]
+    fn decode_subsection_offsets_rejects_truncated_buffer() {
+        let bytes = encode_subsection_offsets(&SubsectionOffsets {
+            total_size: 42,
+            vec: Some((1, 2)),
+            fts: None,
+            vec_open_ranges: vec![],
+            fts_open_ranges: vec![],
+            open_blob: vec![],
+        });
+        // Lop off the tail so a length-prefixed read runs past the end.
+        let err = decode_subsection_offsets(&bytes[..3]).expect_err("truncated");
+        assert!(matches!(err, PartParseError::SchemaMismatch(_)));
+    }
+
+    #[test]
+    fn decode_subsection_offsets_rejects_trailing_bytes() {
+        let mut bytes = encode_subsection_offsets(&SubsectionOffsets {
+            total_size: 5,
+            vec: None,
+            fts: None,
+            vec_open_ranges: vec![],
+            fts_open_ranges: vec![],
+            open_blob: vec![],
+        });
+        bytes.push(0xaa); // extra byte after a complete encoding
+        let err = decode_subsection_offsets(&bytes).expect_err("trailing");
+        assert!(matches!(err, PartParseError::SchemaMismatch(_)));
+    }
+
+    #[test]
+    fn legacy_version_two_offsets_decode_without_open_blob() {
+        // Hand-build a version-2 blob (no open-batch blob suffix):
+        // ver, total_size(u64), vec absent, fts absent, two empty
+        // range lists. The decoder must accept it and default
+        // open_blob to empty.
+        let mut bytes = Vec::new();
+        bytes.push(SUBSECTION_OFFSETS_VERSION_LEGACY);
+        bytes.extend_from_slice(&777u64.to_le_bytes());
+        bytes.push(SUBSECTION_FLAG_ABSENT);
+        bytes.push(SUBSECTION_FLAG_ABSENT);
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // vec_open_ranges count
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // fts_open_ranges count
+        let decoded = decode_subsection_offsets(&bytes).expect("legacy decode");
+        assert_eq!(decoded.total_size, 777);
+        assert!(decoded.open_blob.is_empty());
+        assert!(decoded.vec.is_none());
+        assert!(decoded.fts.is_none());
+    }
+
+    #[test]
+    fn check_major_accepts_one_and_rejects_other_majors() {
+        assert!(check_major("1.0").is_ok());
+        assert!(check_major("1.42").is_ok());
+        assert!(matches!(
+            check_major("2.0"),
+            Err(PartParseError::IncompatibleMajorVersion { .. })
+        ));
+        assert!(matches!(
+            check_major("0.9"),
+            Err(PartParseError::IncompatibleMajorVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn take_optional_int_handles_raw_and_union_and_null() {
+        // Raw Int (non-union) → Some.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("x".into(), AvroValue::Int(5));
+        assert_eq!(take_optional_int(&mut m, "x").expect("ok"), Some(5));
+        // Raw Null → None.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("x".into(), AvroValue::Null);
+        assert_eq!(take_optional_int(&mut m, "x").expect("ok"), None);
+        // Union(value) → Some.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert(
+            "x".into(),
+            AvroValue::Union(AVRO_UNION_VALUE_INDEX, Box::new(AvroValue::Int(9))),
+        );
+        assert_eq!(take_optional_int(&mut m, "x").expect("ok"), Some(9));
+        // Union(null) → None.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert(
+            "x".into(),
+            AvroValue::Union(AVRO_UNION_NULL_INDEX, Box::new(AvroValue::Null)),
+        );
+        assert_eq!(take_optional_int(&mut m, "x").expect("ok"), None);
+        // Wrong type → error.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("x".into(), AvroValue::String("nope".into()));
+        assert!(matches!(
+            take_optional_int(&mut m, "x"),
+            Err(PartParseError::WrongFieldType(_))
+        ));
+        // Missing key → error.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        assert!(matches!(
+            take_optional_int(&mut m, "x"),
+            Err(PartParseError::MissingField(_))
+        ));
+    }
+
+    #[test]
+    fn take_optional_bytes_missing_key_defaults_to_none() {
+        // Missing key is backward-compatible None (not an error).
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        assert_eq!(take_optional_bytes(&mut m, "x").expect("ok"), None);
+        // Raw bytes → Some.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("x".into(), AvroValue::Bytes(vec![1, 2, 3]));
+        assert_eq!(
+            take_optional_bytes(&mut m, "x").expect("ok"),
+            Some(vec![1, 2, 3])
+        );
+        // Wrong inner type → error.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("x".into(), AvroValue::Int(1));
+        assert!(matches!(
+            take_optional_bytes(&mut m, "x"),
+            Err(PartParseError::WrongFieldType(_))
+        ));
+    }
+
+    #[test]
+    fn take_helpers_surface_typed_errors_on_wrong_or_missing_fields() {
+        // take_string: wrong type + missing.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("s".into(), AvroValue::Long(1));
+        assert!(matches!(
+            take_string(&mut m, "s"),
+            Err(PartParseError::WrongFieldType(_))
+        ));
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        assert!(matches!(
+            take_string(&mut m, "s"),
+            Err(PartParseError::MissingField(_))
+        ));
+        // take_long: wrong type.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("n".into(), AvroValue::String("x".into()));
+        assert!(matches!(
+            take_long(&mut m, "n"),
+            Err(PartParseError::WrongFieldType(_))
+        ));
+        // take_bytes: wrong type.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("b".into(), AvroValue::Long(1));
+        assert!(matches!(
+            take_bytes(&mut m, "b"),
+            Err(PartParseError::WrongFieldType(_))
+        ));
+        // take_i128_be: wrong type + wrong fixed width.
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("id".into(), AvroValue::Long(1));
+        assert!(matches!(
+            take_i128_be(&mut m, "id"),
+            Err(PartParseError::WrongFieldType(_))
+        ));
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert("id".into(), AvroValue::Fixed(8, vec![0u8; 8]));
+        assert!(matches!(
+            take_i128_be(&mut m, "id"),
+            Err(PartParseError::WrongFieldType(_))
+        ));
+    }
+
+    #[test]
+    fn take_i128_be_roundtrips_a_full_width_value() {
+        // 16-byte big-endian fixed → i128, including a negative.
+        let v: i128 = -123_456_789_012_345;
+        let mut m: HashMap<String, AvroValue> = HashMap::new();
+        m.insert(
+            "id".into(),
+            AvroValue::Fixed(ID_COLUMN_FIXED_BYTES, v.to_be_bytes().to_vec()),
+        );
+        assert_eq!(take_i128_be(&mut m, "id").expect("ok"), v);
+    }
 }

--- a/src/supertable/manifest/part.rs
+++ b/src/supertable/manifest/part.rs
@@ -1435,4 +1435,127 @@ mod tests {
         );
         assert_eq!(take_i128_be(&mut m, "id").expect("ok"), v);
     }
+
+    #[test]
+    fn part_parse_error_display_covers_each_arm() {
+        // Each `#[error(...)]` arm's `Display` formatting.
+        let zstd = PartParseError::Zstd("frame corrupt".into());
+        assert!(format!("{zstd}").contains("zstd decompress failed"));
+
+        let avro = PartParseError::Avro("bad datum".into());
+        assert!(format!("{avro}").contains("avro decode failed"));
+
+        let mismatch = PartParseError::SchemaMismatch("top-level not a record".into());
+        assert!(format!("{mismatch}").contains("schema mismatch"));
+
+        let bad_id = PartParseError::BadSuperfileId("not-a-uuid".into());
+        assert!(format!("{bad_id}").contains("malformed superfile_id uuid"));
+
+        let incompat = PartParseError::IncompatibleMajorVersion {
+            got: "2.0".into(),
+            supported: FORMAT_VERSION.into(),
+        };
+        let s = format!("{incompat}");
+        assert!(s.contains("incompatible major version") && s.contains("2.0"));
+
+        let missing = PartParseError::MissingField("superfiles");
+        assert!(format!("{missing}").contains("missing field: superfiles"));
+
+        let wrong = PartParseError::WrongFieldType("n_docs");
+        assert!(format!("{wrong}").contains("wrong avro field type for n_docs"));
+
+        // Debug is derived; just ensure it renders without panicking.
+        assert!(!format!("{wrong:?}").is_empty());
+    }
+
+    #[test]
+    fn summary_decode_error_converts_via_from() {
+        // The `#[from] DecodeError` arm: a `DecodeError` lifts into
+        // `PartParseError::SummaryDecode` through `?`/`From`.
+        let de = DecodeError::Truncated {
+            needed: 8,
+            had: 2,
+            what: "scalar stats",
+        };
+        let lifted: PartParseError = de.into();
+        assert!(
+            matches!(lifted, PartParseError::SummaryDecode(_)),
+            "expected SummaryDecode, got {lifted:?}"
+        );
+        assert!(format!("{lifted}").contains("per-summary decode failed"));
+    }
+
+    #[test]
+    fn decode_superfile_rejects_malformed_uri_uuid() {
+        // A record with a valid superfile_id but a non-UUID `uri`
+        // exercises the second `Uuid::parse_str` (the `uri` arm) in
+        // `decode_superfile`.
+        let rec = AvroValue::Record(vec![
+            (
+                "superfile_id".into(),
+                AvroValue::String(Uuid::new_v4().to_string()),
+            ),
+            ("uri".into(), AvroValue::String("not-a-uuid".into())),
+        ]);
+        let err = decode_superfile(rec).expect_err("bad uri uuid");
+        assert!(
+            matches!(err, PartParseError::BadSuperfileId(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_malformed_part_id_uuid() {
+        // Build a valid empty part, then re-encode with a part_id that
+        // isn't a UUID by going through the Avro layer directly so the
+        // `Uuid::parse_str(part_id)` arm in `decode` surfaces
+        // `BadSuperfileId`.
+        let record = AvroValue::Record(vec![
+            (
+                "format_version".into(),
+                AvroValue::String(FORMAT_VERSION.into()),
+            ),
+            ("part_id".into(), AvroValue::String("not-a-uuid".into())),
+            ("superfiles".into(), AvroValue::Array(vec![])),
+        ]);
+        let avro_bytes = to_avro_datum(schema(), record).expect("avro encode");
+        let bytes = zstd::stream::encode_all(avro_bytes.as_slice(), 3).expect("zstd");
+        let err = decode(&bytes).expect_err("bad part_id");
+        assert!(
+            matches!(err, PartParseError::BadSuperfileId(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_range_list_rejects_truncated_count_prefix() {
+        // A version-3 blob truncated mid vec_open_ranges count prefix
+        // surfaces SchemaMismatch from `decode_range_list`'s `take`.
+        let bytes = encode_subsection_offsets(&SubsectionOffsets {
+            total_size: 1,
+            vec: None,
+            fts: None,
+            vec_open_ranges: vec![(1, 2)],
+            fts_open_ranges: vec![],
+            open_blob: vec![],
+        });
+        // Header is: ver(1) + total(8) + vec flag(1) + fts flag(1) = 11
+        // bytes, then the vec_open_ranges u32 count. Cut into the count.
+        let err = decode_subsection_offsets(&bytes[..12]).expect_err("truncated range count");
+        assert!(
+            matches!(err, PartParseError::SchemaMismatch(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn content_hash_of_matches_to_hex_for_known_input() {
+        // Confirm `ContentHash::of` returns the same 32-byte digest the
+        // hex form reflects, and equality holds across constructions.
+        let h = ContentHash::of(b"abc");
+        // Reconstruct from the raw bytes and compare.
+        let same = ContentHash(h.0);
+        assert_eq!(h, same);
+        assert_eq!(h.to_hex().len(), BLAKE3_HEX_LEN);
+    }
 }

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -1340,4 +1340,227 @@ supertable:
         assert!(s.contains("SupertableOptions"));
         assert!(s.contains("_id"));
     }
+
+    /// Helper: a minimal valid options instance (no FTS / vector) for
+    /// exercising the builder methods that don't touch the schema.
+    fn plain_opts() -> SupertableOptions {
+        let s = Arc::new(Schema::new(vec![Field::new(
+            "category",
+            DataType::Utf8,
+            false,
+        )]));
+        SupertableOptions::new(s, vec![], vec![], None).expect("valid options")
+    }
+
+    #[test]
+    fn consistency_default_is_bounded_staleness_one_sec() {
+        assert_eq!(
+            Consistency::default(),
+            Consistency::BoundedStaleness(std::time::Duration::from_secs(
+                DEFAULT_READ_STALENESS_SECS
+            ))
+        );
+    }
+
+    #[test]
+    fn new_sets_documented_defaults() {
+        let opts = plain_opts();
+        assert!(opts.prepopulate_cache_on_commit);
+        assert!(opts.verify_crc_on_open);
+        assert!(opts.storage.is_none());
+        assert!(opts.disk_cache.is_none());
+        assert!(opts.memory_budget_bytes.is_none());
+        assert!(opts.partition_strategy.is_none());
+        assert_eq!(
+            opts.target_superfiles_per_partition,
+            DEFAULT_TARGET_SUPERFILES_PER_PARTITION
+        );
+        assert_eq!(
+            opts.part_size_threshold_bytes,
+            DEFAULT_PART_SIZE_THRESHOLD_BYTES
+        );
+        assert_eq!(
+            opts.eager_load_threshold_parts,
+            DEFAULT_EAGER_LOAD_THRESHOLD_PARTS
+        );
+        assert_eq!(opts.max_commit_retries, DEFAULT_MAX_COMMIT_RETRIES);
+        assert_eq!(
+            opts.commit_threshold_size_mb,
+            DEFAULT_COMMIT_THRESHOLD_SIZE_MB
+        );
+        assert_eq!(
+            opts.put_multipart_threshold_bytes,
+            DEFAULT_PUT_MULTIPART_THRESHOLD_BYTES
+        );
+        assert_eq!(opts.read_consistency, Consistency::default());
+    }
+
+    #[test]
+    fn effective_partition_strategy_defaults_to_single_bucket_hash() {
+        use crate::supertable::manifest::list::PartitionStrategy;
+        let opts = plain_opts();
+        match opts.effective_partition_strategy() {
+            PartitionStrategy::Hash { column, n_buckets } => {
+                assert_eq!(column, "_id");
+                assert_eq!(n_buckets, DEFAULT_PARTITION_N_BUCKETS);
+            }
+            other => panic!("expected single-bucket Hash, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn effective_partition_strategy_returns_configured_strategy() {
+        use crate::supertable::manifest::list::PartitionStrategy;
+        let strat = PartitionStrategy::Hash {
+            column: "category".into(),
+            n_buckets: 64,
+        };
+        let opts = plain_opts().with_partition_strategy(strat.clone());
+        assert_eq!(opts.effective_partition_strategy(), strat);
+    }
+
+    #[test]
+    fn scalar_threshold_builders_set_their_fields() {
+        let opts = plain_opts()
+            .with_target_superfiles_per_partition(42)
+            .with_part_size_threshold_bytes(4096)
+            .with_eager_load_threshold(0)
+            .with_max_commit_retries(99)
+            .with_commit_threshold_size_mb(7)
+            .with_put_multipart_threshold_bytes(1)
+            .with_memory_budget(1 << 30)
+            .with_cache_prepopulation(false)
+            .with_verify_crc_on_open(false);
+        assert_eq!(opts.target_superfiles_per_partition, 42);
+        assert_eq!(opts.part_size_threshold_bytes, 4096);
+        assert_eq!(opts.eager_load_threshold_parts, 0);
+        assert_eq!(opts.max_commit_retries, 99);
+        assert_eq!(opts.commit_threshold_size_mb, 7);
+        assert_eq!(opts.put_multipart_threshold_bytes, 1);
+        assert_eq!(opts.memory_budget_bytes, Some(1 << 30));
+        assert!(!opts.prepopulate_cache_on_commit);
+        assert!(!opts.verify_crc_on_open);
+    }
+
+    #[test]
+    fn with_read_consistency_overrides_default() {
+        let opts = plain_opts().with_read_consistency(Consistency::Strong);
+        assert_eq!(opts.read_consistency, Consistency::Strong);
+        let opts = opts.with_read_consistency(Consistency::Snapshot);
+        assert_eq!(opts.read_consistency, Consistency::Snapshot);
+    }
+
+    #[test]
+    fn with_reader_and_writer_pool_override_pools() {
+        let reader = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(2)
+                .build()
+                .expect("reader pool"),
+        );
+        let writer = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(3)
+                .build()
+                .expect("writer pool"),
+        );
+        let opts = plain_opts()
+            .with_reader_pool(Arc::clone(&reader))
+            .with_writer_pool(Arc::clone(&writer));
+        assert_eq!(opts.reader_pool.current_num_threads(), 2);
+        assert_eq!(opts.writer_pool.current_num_threads(), 3);
+        assert!(Arc::ptr_eq(&opts.reader_pool, &reader));
+        assert!(Arc::ptr_eq(&opts.writer_pool, &writer));
+    }
+
+    #[test]
+    fn with_store_replaces_default_store() {
+        let store: Arc<dyn SuperfileReaderCache> = Arc::new(InMemoryReaderCache::new());
+        let opts = plain_opts().with_store(Arc::clone(&store));
+        // The Arc held by opts is the one we passed in.
+        let opts_store: Arc<dyn SuperfileReaderCache> = Arc::clone(&opts.store);
+        assert!(Arc::ptr_eq(&opts_store, &store));
+    }
+
+    #[test]
+    fn with_storage_attaches_provider() {
+        let dir = std::env::temp_dir().join(format!("infino-opts-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));
+        let opts = plain_opts().with_storage(storage);
+        assert!(opts.storage.is_some());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn superfile_open_options_track_verify_crc_flag() {
+        let opts = plain_opts();
+        assert!(opts.superfile_open_options().verify_crc);
+        let opts = opts.with_verify_crc_on_open(false);
+        assert!(!opts.superfile_open_options().verify_crc);
+    }
+
+    #[test]
+    fn builder_options_use_scalar_schema_and_id_column() {
+        let s = schema_with_vector(16);
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+            .expect("valid options");
+        let bo = opts.builder_options();
+        // builder_options carries the scalar-only schema (vectors
+        // dropped, id prepended) and the same id column + role configs.
+        let names: Vec<_> = bo
+            .schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(names, vec!["_id", "title"]);
+        assert_eq!(bo.id_column, "_id");
+        assert_eq!(bo.fts_columns.len(), 1);
+        assert_eq!(bo.vector_columns.len(), 1);
+    }
+
+    #[test]
+    fn apply_config_overrides_id_column_when_no_collision() {
+        use figment::Figment;
+        use figment::providers::{Format, Yaml};
+
+        let yaml = r#"
+supertable:
+  id_column: row_pk
+"#;
+        let cfg = crate::config::Config::from_figment(Figment::new().merge(Yaml::string(yaml)))
+            .expect("parse config");
+        let opts = plain_opts().apply_config(&cfg).expect("apply_config");
+        assert_eq!(opts.id_column, "row_pk");
+    }
+
+    #[test]
+    fn apply_config_rejects_id_column_that_collides_with_schema() {
+        use figment::Figment;
+        use figment::providers::{Format, Yaml};
+
+        // Config id column collides with the user-schema field
+        // `category`.
+        let yaml = r#"
+supertable:
+  id_column: category
+"#;
+        let cfg = crate::config::Config::from_figment(Figment::new().merge(Yaml::string(yaml)))
+            .expect("parse config");
+        let err = plain_opts().apply_config(&cfg).expect_err("collision");
+        assert!(matches!(err, BuildError::IdColumnReserved(c) if c == "category"));
+    }
+
+    #[test]
+    fn apply_config_with_none_backend_leaves_storage_unattached() {
+        // Default config has storage.backend = none → no storage /
+        // disk cache attached, exercising the early-return arm of
+        // apply_storage_config.
+        let cfg = crate::config::Config::defaults().expect("defaults");
+        let opts = plain_opts().apply_config(&cfg).expect("apply_config");
+        assert!(opts.storage.is_none());
+        assert!(opts.disk_cache.is_none());
+    }
 }

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -1563,4 +1563,98 @@ supertable:
         assert!(opts.storage.is_none());
         assert!(opts.disk_cache.is_none());
     }
+
+    #[test]
+    fn with_disk_cache_attaches_cache() {
+        use crate::supertable::reader_cache::{DiskCacheConfig, DiskCacheStore, LruPolicy};
+
+        let dir = std::env::temp_dir().join(format!("infino-opts-dc-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));
+        let cache = DiskCacheStore::new_unpinned(
+            Arc::clone(&storage),
+            DiskCacheConfig {
+                cache_root: dir.join("cache"),
+                mmap_cold_threshold_secs: 0,
+                eviction: Box::new(LruPolicy::new()),
+                ..Default::default()
+            },
+        )
+        .expect("disk cache");
+
+        let opts = plain_opts().with_storage(storage).with_disk_cache(cache);
+        assert!(opts.disk_cache.is_some());
+        assert!(opts.storage.is_some());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn apply_config_attaches_local_fs_storage() {
+        use figment::Figment;
+        use figment::providers::{Format, Yaml};
+
+        // `storage.backend = local_fs` with a local_root exercises
+        // the LocalFs arm of apply_storage_config; no disk_cache_root
+        // means the cache stays unattached.
+        let dir =
+            std::env::temp_dir().join(format!("infino-opts-localfs-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let yaml = format!(
+            "storage:\n  backend: local_fs\n  local_root: {}\n",
+            dir.display()
+        );
+        let cfg = crate::config::Config::from_figment(Figment::new().merge(Yaml::string(&yaml)))
+            .expect("parse config");
+        let opts = plain_opts().apply_config(&cfg).expect("apply_config");
+        assert!(opts.storage.is_some(), "local_fs backend attaches storage");
+        assert!(
+            opts.disk_cache.is_none(),
+            "no disk_cache_root ⇒ no cache attached"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn apply_config_local_fs_with_disk_cache_root_attaches_both() {
+        use figment::Figment;
+        use figment::providers::{Format, Yaml};
+
+        // local_fs backend + a disk_cache_root drives the disk-cache
+        // construction branch of apply_storage_config (cold-fetch
+        // mode mapping, DiskCacheConfig build, new_unpinned).
+        let dir = std::env::temp_dir().join(format!("infino-opts-dcroot-{}", uuid::Uuid::new_v4()));
+        let cache_root = dir.join("cache");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let yaml = format!(
+            "storage:\n  backend: local_fs\n  local_root: {}\n  disk_cache_root: {}\n",
+            dir.display(),
+            cache_root.display()
+        );
+        let cfg = crate::config::Config::from_figment(Figment::new().merge(Yaml::string(&yaml)))
+            .expect("parse config");
+        let opts = plain_opts().apply_config(&cfg).expect("apply_config");
+        assert!(opts.storage.is_some());
+        assert!(
+            opts.disk_cache.is_some(),
+            "disk_cache_root ⇒ cache attached"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn apply_config_local_fs_without_root_is_rejected() {
+        use figment::Figment;
+        use figment::providers::{Format, Yaml};
+
+        // local_fs backend but no local_root → the typed Store error
+        // arm of apply_storage_config.
+        let yaml = "storage:\n  backend: local_fs\n";
+        let cfg = crate::config::Config::from_figment(Figment::new().merge(Yaml::string(yaml)))
+            .expect("parse config");
+        let err = plain_opts()
+            .apply_config(&cfg)
+            .expect_err("missing local_root");
+        assert!(matches!(err, BuildError::Store(_)), "{err:?}");
+    }
 }

--- a/src/supertable/query/df_object_store.rs
+++ b/src/supertable/query/df_object_store.rs
@@ -292,4 +292,99 @@ mod tests {
             .expect_err("writes to the read-only store must fail");
         assert!(matches!(err, OsError::NotImplemented { .. }), "{err}");
     }
+
+    #[tokio::test]
+    async fn head_only_request_returns_metadata_without_bytes() {
+        // `options.head = true` short-circuits before any range read:
+        // empty payload, the fixed UNIX-epoch last_modified, and a
+        // 0..0 range, but a correct `size`.
+        let (store, p) = store_with("seg-a.parquet", b"0123456789");
+        let res = store
+            .get_opts(
+                &p,
+                GetOptions {
+                    head: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("head get_opts");
+        assert_eq!(res.meta.size, 10);
+        assert_eq!(res.meta.last_modified, super::SUPERFILE_LAST_MODIFIED);
+        assert_eq!(res.range, 0..0);
+        let bytes = res.bytes().await.expect("bytes");
+        assert!(bytes.is_empty(), "HEAD payload carries no bytes");
+    }
+
+    #[tokio::test]
+    async fn put_multipart_and_copy_are_not_implemented() {
+        let (store, p) = store_with("seg-a.parquet", b"abc");
+        let mp_err = store
+            .put_multipart(&p)
+            .await
+            .expect_err("multipart upload must fail on the read-only store");
+        assert!(matches!(mp_err, OsError::NotImplemented { .. }), "{mp_err}");
+
+        let copy_err = store
+            .copy(&p, &ObjPath::from("dst.parquet"))
+            .await
+            .expect_err("copy must fail on the read-only store");
+        assert!(
+            matches!(copy_err, OsError::NotImplemented { .. }),
+            "{copy_err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_stream_yields_not_implemented_per_location() {
+        let (store, p) = store_with("seg-a.parquet", b"abc");
+        let locations = stream::iter(vec![Ok(p.clone()), Ok(ObjPath::from("seg-b.parquet"))]);
+        let results: Vec<OsResult<ObjPath>> =
+            store.delete_stream(locations.boxed()).collect().await;
+        assert_eq!(results.len(), 2);
+        for r in results {
+            let err = r.expect_err("delete must fail on the read-only store");
+            assert!(matches!(err, OsError::NotImplemented { .. }), "{err}");
+        }
+    }
+
+    #[tokio::test]
+    async fn list_is_empty_and_list_with_delimiter_returns_no_entries() {
+        // The store never advertises its contents during a scan;
+        // DataFusion reaches each superfile by its registered path.
+        let (store, _p) = store_with("seg-a.parquet", b"abc");
+        let listed: Vec<OsResult<ObjectMeta>> = store.list(None).collect().await;
+        assert!(listed.is_empty(), "list yields nothing");
+
+        let res = store
+            .list_with_delimiter(Some(&ObjPath::from("data")))
+            .await
+            .expect("list_with_delimiter");
+        assert!(res.objects.is_empty());
+        assert!(res.common_prefixes.is_empty());
+    }
+
+    #[test]
+    fn debug_and_display_report_superfile_count() {
+        let (store, _p) = store_with("seg-a.parquet", b"abc");
+        let dbg = format!("{store:?}");
+        assert!(dbg.contains("SuperfileObjectStore"), "{dbg}");
+        assert!(dbg.contains("n_superfiles"), "{dbg}");
+        let disp = format!("{store}");
+        assert_eq!(disp, "SuperfileObjectStore(1 superfiles)");
+    }
+
+    #[test]
+    fn resolve_range_clamps_every_variant() {
+        // Drive the pure range resolver across all four arms,
+        // including the past-the-end / oversized clamps.
+        assert_eq!(resolve_range(None, 10), 0..10);
+        assert_eq!(resolve_range(Some(GetRange::Bounded(2..5)), 10), 2..5);
+        // Bounded past the end clamps both ends to `size`.
+        assert_eq!(resolve_range(Some(GetRange::Bounded(8..20)), 10), 8..10);
+        assert_eq!(resolve_range(Some(GetRange::Offset(7)), 10), 7..10);
+        assert_eq!(resolve_range(Some(GetRange::Offset(99)), 10), 10..10);
+        assert_eq!(resolve_range(Some(GetRange::Suffix(4)), 10), 6..10);
+        assert_eq!(resolve_range(Some(GetRange::Suffix(99)), 10), 0..10);
+    }
 }

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -558,6 +558,16 @@ mod tests {
     use super::*;
     use datafusion::prelude::lit;
 
+    use arrow_array::{Array, FixedSizeListArray, LargeStringArray};
+    use arrow_schema::Field;
+
+    use crate::superfile::builder::{FtsConfig, VectorConfig};
+    use crate::superfile::fts::reader::BoolMode;
+    use crate::superfile::vector::distance::Metric;
+    use crate::superfile::vector::rerank_codec::RerankCodec;
+    use crate::supertable::{Supertable, SupertableOptions};
+    use crate::test_helpers::default_tokenizer as tok;
+
     #[test]
     fn arg_to_string_accepts_utf8_literal_rejects_int() {
         assert_eq!(
@@ -568,10 +578,28 @@ mod tests {
     }
 
     #[test]
+    fn arg_to_string_accepts_large_utf8_and_utf8_view() {
+        let large = Expr::Literal(ScalarValue::LargeUtf8(Some("body".into())), None);
+        assert_eq!(arg_to_string(&large, "column").expect("large utf8"), "body");
+        let view = Expr::Literal(ScalarValue::Utf8View(Some("title".into())), None);
+        assert_eq!(arg_to_string(&view, "column").expect("utf8 view"), "title");
+    }
+
+    #[test]
     fn arg_to_usize_accepts_int_rejects_negative_and_nonint() {
         assert_eq!(arg_to_usize(&lit(10_i64), "k").expect("int literal"), 10);
         assert!(arg_to_usize(&lit(-1_i64), "k").is_err());
         assert!(arg_to_usize(&lit("nope"), "k").is_err());
+    }
+
+    #[test]
+    fn arg_to_usize_accepts_all_integer_widths() {
+        let i32e = Expr::Literal(ScalarValue::Int32(Some(7)), None);
+        let u64e = Expr::Literal(ScalarValue::UInt64(Some(8)), None);
+        let u32e = Expr::Literal(ScalarValue::UInt32(Some(9)), None);
+        assert_eq!(arg_to_usize(&i32e, "k").expect("i32"), 7);
+        assert_eq!(arg_to_usize(&u64e, "k").expect("u64"), 8);
+        assert_eq!(arg_to_usize(&u32e, "k").expect("u32"), 9);
     }
 
     #[test]
@@ -581,5 +609,155 @@ mod tests {
         assert_eq!(out.fields().len(), 2);
         assert_eq!(out.field(1).name(), "score");
         assert_eq!(out.field(1).data_type(), &DataType::Float32);
+    }
+
+    // ---- harness exercising resolve_hits_named / resolve_ids_arithmetic /
+    //      resolve_columns through the public search methods ----
+
+    fn fixed_list_f32(dim: usize) -> DataType {
+        DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim as i32,
+        )
+    }
+
+    fn options_title_emb(dim: usize) -> SupertableOptions {
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("emb", fixed_list_f32(dim), false),
+        ]));
+        SupertableOptions::new(
+            schema,
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![VectorConfig {
+                column: "emb".into(),
+                dim,
+                n_cent: 4,
+                rot_seed: 7,
+                metric: Metric::Cosine,
+                rerank_codec: RerankCodec::Fp32,
+            }],
+            Some(tok()),
+        )
+        .expect("valid options")
+        .with_writer_pool(pool)
+    }
+
+    fn build_batch(titles: &[&str], dim: usize, schema: Arc<Schema>) -> RecordBatch {
+        let n = titles.len();
+        let title_arr = LargeStringArray::from(titles.to_vec());
+        let mut flat = Vec::<f32>::with_capacity(n * dim);
+        for i in 0..n {
+            for d in 0..dim {
+                flat.push(if d == i % dim { 1.0 } else { 0.0 });
+            }
+        }
+        let fsl = FixedSizeListArray::try_new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim as i32,
+            Arc::new(Float32Array::from(flat)) as ArrayRef,
+            None,
+        )
+        .expect("FSL");
+        RecordBatch::try_new(schema, vec![Arc::new(title_arr), Arc::new(fsl)]).expect("batch")
+    }
+
+    fn demo(dim: usize) -> Supertable {
+        let st = Supertable::create(options_title_emb(dim)).expect("create");
+        let mut w = st.writer().expect("writer");
+        let schema = st.options().schema.clone();
+        w.append(&build_batch(
+            &["rust async", "python data", "rust systems", "go routines"],
+            dim,
+            schema,
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+        st
+    }
+
+    #[test]
+    fn resolve_hits_named_id_only_takes_arithmetic_fast_path() {
+        // `_id`-only projection drives resolve_hits_named → the
+        // resolve_ids_arithmetic no-I/O fast path (single contiguous
+        // span: id_max - id_min + 1 == n_docs).
+        let st = demo(16);
+        let batches = st
+            .reader()
+            .bm25_search("title", "rust", 10, BoolMode::Or, Some(&["_id"]))
+            .expect("bm25_search _id");
+        let b = &batches[0];
+        assert_eq!(b.num_columns(), 1);
+        assert_eq!(b.schema().field(0).name(), "_id");
+        assert_eq!(b.num_rows(), 2, "two docs contain 'rust'");
+    }
+
+    #[test]
+    fn resolve_hits_named_default_is_id_and_score() {
+        // `None` projection is the engine-native `_id` + `score` pair.
+        let st = demo(16);
+        let batches = st
+            .reader()
+            .bm25_search("title", "rust", 10, BoolMode::Or, None)
+            .expect("bm25_search default");
+        let b = &batches[0];
+        assert_eq!(b.num_columns(), 2);
+        assert_eq!(b.schema().field(0).name(), "_id");
+        assert_eq!(b.schema().field(1).name(), "score");
+    }
+
+    #[test]
+    fn resolve_hits_named_scalar_column_decodes_via_resolve_columns() {
+        // Naming a scalar column (`title`) forces resolve_columns to
+        // decode the column bytes; `score` synthesized alongside.
+        let st = demo(16);
+        let batches = st
+            .reader()
+            .bm25_search(
+                "title",
+                "rust",
+                10,
+                BoolMode::Or,
+                Some(&["_id", "title", "score"]),
+            )
+            .expect("bm25_search title");
+        let b = &batches[0];
+        assert_eq!(b.num_columns(), 3);
+        let titles = b
+            .column(1)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("title col");
+        for i in 0..titles.len() {
+            assert!(titles.value(i).contains("rust"));
+        }
+    }
+
+    #[test]
+    fn resolve_hits_named_unknown_column_errors() {
+        let st = demo(16);
+        let res = st
+            .reader()
+            .bm25_search("title", "rust", 10, BoolMode::Or, Some(&["nope"]));
+        assert!(res.is_err(), "unknown projected column must error");
+    }
+
+    #[test]
+    fn resolve_hits_named_empty_hits_returns_empty_batch() {
+        let st = demo(16);
+        let batches = st
+            .reader()
+            .bm25_search("title", "nonexistentterm", 10, BoolMode::Or, Some(&["_id"]))
+            .expect("bm25_search empty");
+        let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total, 0);
     }
 }

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -618,4 +618,78 @@ mod tests {
                 .is_err()
         );
     }
+
+    #[test]
+    fn bm25_search_prefix_tvf_arity_error() {
+        let st = demo_corpus();
+        // prefix wants exactly 3 args; 2 → planning error.
+        assert!(
+            st.reader()
+                .query_sql("SELECT title FROM bm25_search_prefix('title', 'rus')")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn bm25_search_tvf_bad_arg_types_error() {
+        let st = demo_corpus();
+        // Non-integer k.
+        assert!(
+            st.reader()
+                .query_sql("SELECT title FROM bm25_search('title', 'rust', 'ten')")
+                .is_err(),
+            "non-integer k must error"
+        );
+        // Invalid mode literal.
+        assert!(
+            st.reader()
+                .query_sql("SELECT title FROM bm25_search('title', 'rust', 10, 'nand')")
+                .is_err(),
+            "invalid mode must error"
+        );
+    }
+
+    /// Flatten an `EXPLAIN` result into one searchable string — exercises
+    /// `Bm25Exec`'s `DisplayAs`/`describe`.
+    fn explain(st: &Supertable, sql: &str) -> String {
+        let batches = st
+            .reader()
+            .query_sql(&format!("EXPLAIN {sql}"))
+            .expect("explain");
+        let mut out = String::new();
+        for batch in &batches {
+            for column in batch.columns() {
+                if let Some(strings) = column.as_any().downcast_ref::<arrow_array::StringArray>() {
+                    for i in 0..strings.len() {
+                        if !strings.is_null(i) {
+                            out.push_str(strings.value(i));
+                            out.push('\n');
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn bm25_exec_display_describes_search_and_prefix_branches() {
+        let st = demo_corpus();
+        let terms = explain(
+            &st,
+            "SELECT _id FROM bm25_search('title', 'rust', 10, 'and')",
+        );
+        assert!(
+            terms.contains("Bm25Exec") && terms.contains("kind=search") && terms.contains("And"),
+            "search describe missing: {terms}"
+        );
+        let prefix = explain(
+            &st,
+            "SELECT _id FROM bm25_search_prefix('title', 'rus', 10)",
+        );
+        assert!(
+            prefix.contains("Bm25Exec") && prefix.contains("kind=prefix"),
+            "prefix describe missing: {prefix}"
+        );
+    }
 }

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -823,6 +823,96 @@ mod tests {
         );
     }
 
+    #[test]
+    fn hybrid_search_bad_arg_types_error() {
+        let dim = 16;
+        let st = demo(dim);
+        // Non-integer k (5th arg).
+        assert!(
+            st.reader()
+                .query_sql("SELECT _id FROM hybrid_search('title', 'rust', 'emb', '1,0', 'five')")
+                .is_err(),
+            "non-integer k must error"
+        );
+        // Unparseable query vector (4th arg).
+        assert!(
+            st.reader()
+                .query_sql("SELECT _id FROM hybrid_search('title', 'rust', 'emb', 'a,b', 3)")
+                .is_err(),
+            "bad query vector must error"
+        );
+    }
+
+    #[test]
+    fn hybrid_search_sync_method_fuses_both_retrievers() {
+        // Exercises the public sync `hybrid_search` wrapper (and through
+        // it `hybrid_search_async` + `rrf_fuse`).
+        let dim = 16;
+        let st = demo(dim);
+        let mut qv = vec![0.0_f32; dim];
+        qv[0] = 1.0; // one-hot at dim 0 → doc 0 exact vector match.
+        let hits = st
+            .reader()
+            .hybrid_search(
+                "title",
+                "async",
+                BoolMode::Or,
+                "emb",
+                &qv,
+                VectorSearchOptions::new(),
+                8,
+            )
+            .expect("hybrid_search");
+        assert!(!hits.is_empty(), "fused hits non-empty");
+        // RRF score is higher-is-better → emitted descending.
+        for w in hits.windows(2) {
+            assert!(w[0].score >= w[1].score, "fused scores descending");
+        }
+    }
+
+    /// Flatten an `EXPLAIN` result into one searchable string — exercises
+    /// `HybridSearchExec`'s `DisplayAs`/`describe`.
+    fn explain(st: &Supertable, sql: &str) -> String {
+        let batches = st
+            .reader()
+            .query_sql(&format!("EXPLAIN {sql}"))
+            .expect("explain");
+        let mut out = String::new();
+        for batch in &batches {
+            for column in batch.columns() {
+                if let Some(strings) = column.as_any().downcast_ref::<arrow_array::StringArray>() {
+                    for i in 0..strings.len() {
+                        if !strings.is_null(i) {
+                            out.push_str(strings.value(i));
+                            out.push('\n');
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn hybrid_exec_display_describes_invocation() {
+        let dim = 16;
+        let st = demo(dim);
+        let text = explain(
+            &st,
+            &format!(
+                "SELECT _id FROM hybrid_search('title', 'rust', 'emb', '{}', 5)",
+                csv_one_hot(dim, 0)
+            ),
+        );
+        assert!(
+            text.contains("HybridSearchExec")
+                && text.contains("text_col=title")
+                && text.contains("vec_col=emb")
+                && text.contains("k=5"),
+            "hybrid describe missing: {text}"
+        );
+    }
+
     // ---- sql × vector × fts composed in ONE query ----
     //
     // The TVFs above each test one retriever in isolation. This block

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -380,8 +380,14 @@ mod tests {
 
     use arrow_array::{Array, LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
+    use datafusion::execution::TaskContext;
+    use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
 
+    use super::{ExactMatchFunc, MatchExec, MatchQuery, TokenMatchFunc};
     use crate::superfile::builder::FtsConfig;
+    use crate::superfile::fts::reader::BoolMode;
+    use crate::supertable::handle::SupertableReader;
+    use crate::supertable::query::exec::common::output_schema_with_score;
     use crate::supertable::{Supertable, SupertableOptions};
     use crate::test_helpers::default_tokenizer as tok;
 
@@ -563,6 +569,145 @@ mod tests {
             exact.contains("MatchExec") && exact.contains("kind=exact"),
             "exact describe missing: {exact}"
         );
+    }
+
+    /// Build an `Arc<SupertableReader>` plus the scalar + output
+    /// schemas a `MatchExec` needs, from a committed demo table.
+    fn reader_and_schemas() -> (Arc<SupertableReader>, Arc<Schema>, Arc<Schema>) {
+        let st = demo();
+        let reader = Arc::new(st.reader());
+        let scalar_schema = reader.options().scalar_schema();
+        let output_schema = output_schema_with_score(&scalar_schema);
+        (reader, scalar_schema, output_schema)
+    }
+
+    #[test]
+    fn match_exec_try_new_rejects_out_of_range_projection() {
+        // An index past the end of the output schema fails the
+        // `output_schema.project(indices)` call inside `try_new`.
+        let (reader, scalar_schema, output_schema) = reader_and_schemas();
+        let n_cols = output_schema.fields().len();
+        let err = MatchExec::try_new(
+            reader,
+            "title".into(),
+            MatchQuery::Exact {
+                value: "rust".into(),
+            },
+            scalar_schema,
+            output_schema,
+            Some(vec![n_cols + 5]),
+        )
+        .expect_err("out-of-range projection must fail");
+        assert!(
+            matches!(err, datafusion::error::DataFusionError::Execution(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn match_exec_plan_metadata_and_children() {
+        let (reader, scalar_schema, output_schema) = reader_and_schemas();
+        let exec = MatchExec::try_new(
+            reader,
+            "title".into(),
+            MatchQuery::Token {
+                query: "rust".into(),
+                mode: BoolMode::Or,
+            },
+            scalar_schema,
+            output_schema,
+            None,
+        )
+        .expect("try_new");
+
+        assert_eq!(exec.name(), "MatchExec");
+        // Single leaf node — no children.
+        assert!(exec.children().is_empty());
+        // PlanProperties is exposed; single partition.
+        let _ = exec.properties();
+        // `as_any` downcasts back to the concrete type.
+        let arc: Arc<dyn ExecutionPlan> = Arc::new(exec);
+        assert!(arc.as_any().downcast_ref::<MatchExec>().is_some());
+
+        // `with_new_children` returns the same node (it has none).
+        let same = Arc::clone(&arc)
+            .with_new_children(vec![])
+            .expect("with_new_children");
+        assert_eq!(same.name(), "MatchExec");
+    }
+
+    #[test]
+    fn match_exec_execute_rejects_nonzero_partition() {
+        let (reader, scalar_schema, output_schema) = reader_and_schemas();
+        let exec = MatchExec::try_new(
+            reader,
+            "title".into(),
+            MatchQuery::Exact {
+                value: "rust".into(),
+            },
+            scalar_schema,
+            output_schema,
+            None,
+        )
+        .expect("try_new");
+        let ctx = Arc::new(TaskContext::default());
+        match exec.execute(1, ctx) {
+            Err(datafusion::error::DataFusionError::Internal(_)) => {}
+            Err(other) => panic!("expected Internal error, got {other:?}"),
+            Ok(_) => panic!("nonzero partition must error"),
+        }
+    }
+
+    #[test]
+    fn match_exec_debug_and_display_render_describe() {
+        let (reader, scalar_schema, output_schema) = reader_and_schemas();
+        let exec = MatchExec::try_new(
+            reader,
+            "title".into(),
+            MatchQuery::Token {
+                query: "rust".into(),
+                mode: BoolMode::And,
+            },
+            scalar_schema,
+            output_schema,
+            None,
+        )
+        .expect("try_new");
+        // `Debug` routes through `describe`.
+        let dbg = format!("{exec:?}");
+        assert!(
+            dbg.contains("MatchExec") && dbg.contains("kind=token") && dbg.contains("And"),
+            "got {dbg}"
+        );
+        // `DisplayAs::fmt_as` also routes through `describe`. Drive it
+        // directly via a tiny `Display` adapter.
+        struct D<'a>(&'a MatchExec);
+        impl std::fmt::Display for D<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                use datafusion::physical_plan::DisplayAs;
+                self.0.fmt_as(DisplayFormatType::Default, f)
+            }
+        }
+        let shown = format!("{}", D(&exec));
+        assert!(
+            shown.contains("MatchExec") && shown.contains("kind=token"),
+            "got {shown}"
+        );
+    }
+
+    #[test]
+    fn token_and_exact_func_call_reject_bad_arity() {
+        // Direct `TableFunctionImpl::call` arity checks, without the
+        // SQL layer. A live reader keeps the WeakReader upgrade-able.
+        use datafusion::catalog::TableFunctionImpl;
+        let st = demo();
+        let reader = Arc::new(st.reader());
+        let scalar_schema = reader.options().scalar_schema();
+        let tf = TokenMatchFunc::new(Arc::clone(&reader), Arc::clone(&scalar_schema));
+        // 1 arg → error; 2 args → ok.
+        assert!(tf.call(&[]).is_err(), "0 args must fail");
+        let ef = ExactMatchFunc::new(reader, scalar_schema);
+        assert!(ef.call(&[]).is_err(), "0 args must fail");
     }
 
     #[test]

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -378,7 +378,7 @@ impl ExecutionPlan for MatchExec {
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{LargeStringArray, RecordBatch};
+    use arrow_array::{Array, LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
 
     use crate::superfile::builder::FtsConfig;
@@ -522,5 +522,65 @@ mod tests {
             .exact_match("title", "go routines")
             .expect("exact_match");
         assert_eq!(exact.len(), 1);
+    }
+
+    /// Flatten an `EXPLAIN` result into one searchable string — exercises
+    /// `MatchExec`'s `DisplayAs`/`describe`.
+    fn explain(st: &Supertable, sql: &str) -> String {
+        let batches = st
+            .reader()
+            .query_sql(&format!("EXPLAIN {sql}"))
+            .expect("explain");
+        let mut out = String::new();
+        for batch in &batches {
+            for column in batch.columns() {
+                if let Some(strings) = column.as_any().downcast_ref::<arrow_array::StringArray>() {
+                    for i in 0..strings.len() {
+                        if !strings.is_null(i) {
+                            out.push_str(strings.value(i));
+                            out.push('\n');
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn match_exec_display_describes_token_and_exact_branches() {
+        let st = demo();
+        let token = explain(&st, "SELECT _id FROM token_match('title', 'rust', 'and')");
+        assert!(
+            token.contains("MatchExec") && token.contains("kind=token") && token.contains("And"),
+            "token describe missing: {token}"
+        );
+        let exact = explain(
+            &st,
+            "SELECT _id FROM exact_match('title', 'rust async runtime')",
+        );
+        assert!(
+            exact.contains("MatchExec") && exact.contains("kind=exact"),
+            "exact describe missing: {exact}"
+        );
+    }
+
+    #[test]
+    fn match_tvf_bad_arg_types_error() {
+        let st = demo();
+        // Non-string column literal.
+        assert!(
+            st.reader()
+                .query_sql("SELECT _id FROM token_match(5, 'rust')")
+                .is_err(),
+            "non-string column must error"
+        );
+        // Bad mode value (third arg).
+        assert!(
+            st.reader()
+                .query_sql("SELECT _id FROM token_match('title', 'rust', 'xor')")
+                .is_err(),
+            "invalid bool mode must error"
+        );
     }
 }

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -713,24 +713,36 @@ mod tests {
     #[test]
     fn scalar_to_f32_accepts_every_numeric_variant_rejects_other() {
         assert_eq!(
-            scalar_to_f32(&ScalarValue::Float32(Some(1.5))).unwrap(),
+            scalar_to_f32(&ScalarValue::Float32(Some(1.5))).expect("test"),
             1.5
         );
         assert_eq!(
-            scalar_to_f32(&ScalarValue::Float64(Some(2.5))).unwrap(),
+            scalar_to_f32(&ScalarValue::Float64(Some(2.5))).expect("test"),
             2.5
         );
-        assert_eq!(scalar_to_f32(&ScalarValue::Int64(Some(3))).unwrap(), 3.0);
-        assert_eq!(scalar_to_f32(&ScalarValue::Int32(Some(4))).unwrap(), 4.0);
-        assert_eq!(scalar_to_f32(&ScalarValue::UInt64(Some(5))).unwrap(), 5.0);
-        assert_eq!(scalar_to_f32(&ScalarValue::UInt32(Some(6))).unwrap(), 6.0);
+        assert_eq!(
+            scalar_to_f32(&ScalarValue::Int64(Some(3))).expect("test"),
+            3.0
+        );
+        assert_eq!(
+            scalar_to_f32(&ScalarValue::Int32(Some(4))).expect("test"),
+            4.0
+        );
+        assert_eq!(
+            scalar_to_f32(&ScalarValue::UInt64(Some(5))).expect("test"),
+            5.0
+        );
+        assert_eq!(
+            scalar_to_f32(&ScalarValue::UInt32(Some(6))).expect("test"),
+            6.0
+        );
         assert!(scalar_to_f32(&ScalarValue::Utf8(Some("x".into()))).is_err());
     }
 
     #[test]
     fn scalar_expr_to_f32_rejects_non_literal() {
         // A literal flows through to scalar_to_f32.
-        assert_eq!(scalar_expr_to_f32(&lit(2.0_f32)).unwrap(), 2.0);
+        assert_eq!(scalar_expr_to_f32(&lit(2.0_f32)).expect("test"), 2.0);
         // A column reference is not a literal → error.
         let col = datafusion::prelude::col("x");
         assert!(scalar_expr_to_f32(&col).is_err());
@@ -739,7 +751,7 @@ mod tests {
     #[test]
     fn array_to_f32_casts_and_rejects_nulls() {
         let ok: ArrayRef = Arc::new(arrow_array::Int32Array::from(vec![1, 2, 3]));
-        assert_eq!(array_to_f32(&ok).unwrap(), vec![1.0, 2.0, 3.0]);
+        assert_eq!(array_to_f32(&ok).expect("test"), vec![1.0, 2.0, 3.0]);
         let with_null: ArrayRef = Arc::new(Float32Array::from(vec![Some(1.0), None]));
         assert!(
             array_to_f32(&with_null).is_err(),
@@ -754,7 +766,7 @@ mod tests {
             ListArray::from_iter_primitive::<arrow_array::types::Int32Type, _, _>(vec![Some(
                 vec![Some(1), Some(2)],
             )]);
-        assert_eq!(list_literal_to_f32(&single).unwrap(), vec![1.0, 2.0]);
+        assert_eq!(list_literal_to_f32(&single).expect("test"), vec![1.0, 2.0]);
         // Two-row list → error.
         let two = ListArray::from_iter_primitive::<arrow_array::types::Int32Type, _, _>(vec![
             Some(vec![Some(1)]),
@@ -774,7 +786,10 @@ mod tests {
                 vec![Some(0.1_f32), Some(0.2), Some(0.3)],
             )]);
         let expr = Expr::Literal(ScalarValue::List(Arc::new(list)), None);
-        assert_eq!(arg_to_query_vector(&expr).unwrap(), vec![0.1_f32, 0.2, 0.3]);
+        assert_eq!(
+            arg_to_query_vector(&expr).expect("test"),
+            vec![0.1_f32, 0.2, 0.3]
+        );
     }
 
     #[test]

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -707,4 +707,128 @@ mod tests {
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 0);
     }
+
+    // ---- arg-parsing helper unit coverage ----
+
+    #[test]
+    fn scalar_to_f32_accepts_every_numeric_variant_rejects_other() {
+        assert_eq!(
+            scalar_to_f32(&ScalarValue::Float32(Some(1.5))).unwrap(),
+            1.5
+        );
+        assert_eq!(
+            scalar_to_f32(&ScalarValue::Float64(Some(2.5))).unwrap(),
+            2.5
+        );
+        assert_eq!(scalar_to_f32(&ScalarValue::Int64(Some(3))).unwrap(), 3.0);
+        assert_eq!(scalar_to_f32(&ScalarValue::Int32(Some(4))).unwrap(), 4.0);
+        assert_eq!(scalar_to_f32(&ScalarValue::UInt64(Some(5))).unwrap(), 5.0);
+        assert_eq!(scalar_to_f32(&ScalarValue::UInt32(Some(6))).unwrap(), 6.0);
+        assert!(scalar_to_f32(&ScalarValue::Utf8(Some("x".into()))).is_err());
+    }
+
+    #[test]
+    fn scalar_expr_to_f32_rejects_non_literal() {
+        // A literal flows through to scalar_to_f32.
+        assert_eq!(scalar_expr_to_f32(&lit(2.0_f32)).unwrap(), 2.0);
+        // A column reference is not a literal → error.
+        let col = datafusion::prelude::col("x");
+        assert!(scalar_expr_to_f32(&col).is_err());
+    }
+
+    #[test]
+    fn array_to_f32_casts_and_rejects_nulls() {
+        let ok: ArrayRef = Arc::new(arrow_array::Int32Array::from(vec![1, 2, 3]));
+        assert_eq!(array_to_f32(&ok).unwrap(), vec![1.0, 2.0, 3.0]);
+        let with_null: ArrayRef = Arc::new(Float32Array::from(vec![Some(1.0), None]));
+        assert!(
+            array_to_f32(&with_null).is_err(),
+            "null query-vector element must error"
+        );
+    }
+
+    #[test]
+    fn list_literal_to_f32_requires_single_row() {
+        // Single-row list `[1, 2]` → ok.
+        let single =
+            ListArray::from_iter_primitive::<arrow_array::types::Int32Type, _, _>(vec![Some(
+                vec![Some(1), Some(2)],
+            )]);
+        assert_eq!(list_literal_to_f32(&single).unwrap(), vec![1.0, 2.0]);
+        // Two-row list → error.
+        let two = ListArray::from_iter_primitive::<arrow_array::types::Int32Type, _, _>(vec![
+            Some(vec![Some(1)]),
+            Some(vec![Some(2)]),
+        ]);
+        assert!(
+            list_literal_to_f32(&two).is_err(),
+            "multi-row list must error"
+        );
+    }
+
+    #[test]
+    fn arg_to_query_vector_parses_list_scalar_literal() {
+        // `ScalarValue::List` branch (a const-folded SQL array literal).
+        let list =
+            ListArray::from_iter_primitive::<arrow_array::types::Float32Type, _, _>(vec![Some(
+                vec![Some(0.1_f32), Some(0.2), Some(0.3)],
+            )]);
+        let expr = Expr::Literal(ScalarValue::List(Arc::new(list)), None);
+        assert_eq!(arg_to_query_vector(&expr).unwrap(), vec![0.1_f32, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn arg_to_query_vector_rejects_unsupported_expr() {
+        // A bare column reference is neither string, list, nor make_array.
+        let col = datafusion::prelude::col("x");
+        assert!(arg_to_query_vector(&col).is_err());
+    }
+
+    #[test]
+    fn vector_search_tvf_arity_error() {
+        let dim = 16;
+        let st = supertable_one_superfile(dim, 8);
+        // 2 args (missing k) → planning error.
+        assert!(
+            st.reader()
+                .query_sql(&format!(
+                    "SELECT _id FROM vector_search('emb', '{}')",
+                    csv_one_hot(dim, 0)
+                ))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn vector_search_exec_display_describes_invocation() {
+        let dim = 16;
+        let st = supertable_one_superfile(dim, 8);
+        let batches = st
+            .reader()
+            .query_sql(&format!(
+                "EXPLAIN SELECT _id FROM vector_search('emb', '{}', 5)",
+                csv_one_hot(dim, 0)
+            ))
+            .expect("explain");
+        let mut text = String::new();
+        for b in &batches {
+            for c in b.columns() {
+                if let Some(s) = c.as_any().downcast_ref::<arrow_array::StringArray>() {
+                    for i in 0..s.len() {
+                        if !s.is_null(i) {
+                            text.push_str(s.value(i));
+                            text.push('\n');
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            text.contains("VectorSearchExec")
+                && text.contains("column=emb")
+                && text.contains("k=5")
+                && text.contains(&format!("dim={dim}")),
+            "vector describe missing: {text}"
+        );
+    }
 }

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1275,4 +1275,204 @@ mod tests {
             .expect("query");
         assert_eq!(hits.len(), 2);
     }
+
+    fn seeded_three_doc_supertable() -> Supertable {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(
+            0,
+            &["the quick brown fox", "a lazy dog", "quick thinking"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+        st
+    }
+
+    #[test]
+    fn supertable_bm25_search_rows_default_and_projected() {
+        let st = seeded_three_doc_supertable();
+
+        // Bare call → `_id` + `score` only (no scalar decode).
+        let bare = st
+            .bm25_search("title", "fox", 10, BoolMode::Or, None)
+            .expect("bm25 rows");
+        assert_eq!(bare.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+        assert_eq!(bare[0].num_columns(), 2, "_id + score");
+
+        // Named projection materializes the requested columns.
+        let rows = st
+            .bm25_search(
+                "title",
+                "fox",
+                10,
+                BoolMode::Or,
+                Some(&["_id", "title", "score"]),
+            )
+            .expect("bm25 projected rows");
+        assert_eq!(rows[0].num_columns(), 3);
+    }
+
+    #[test]
+    fn supertable_token_match_and_exact_match_rows() {
+        let st = seeded_three_doc_supertable();
+
+        // token_match: any row containing "quick" (Or over one token).
+        let tm = st
+            .token_match("title", "quick", BoolMode::Or, None)
+            .expect("token_match");
+        assert_eq!(tm.iter().map(|b| b.num_rows()).sum::<usize>(), 2);
+
+        // exact_match: only the row equal to the raw string.
+        let em = st
+            .exact_match("title", "a lazy dog", Some(&["_id", "title"]))
+            .expect("exact_match");
+        assert_eq!(em.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+        assert_eq!(em[0].num_columns(), 2);
+    }
+
+    #[test]
+    fn reader_token_match_and_exact_match_hits() {
+        let st = seeded_three_doc_supertable();
+        let r = st.reader();
+
+        // token_match And requires every token to be present.
+        let any = r.token_match("title", "quick", BoolMode::And).expect("tm");
+        assert_eq!(any.len(), 2);
+
+        // Token-less value (punctuation only) prunes nothing and matches
+        // no stored row exactly.
+        let none = r.exact_match("title", "!!!").expect("em punctuation");
+        assert!(none.is_empty());
+
+        // Exact verify against a real row.
+        let one = r.exact_match("title", "quick thinking").expect("em");
+        assert_eq!(one.len(), 1);
+    }
+
+    #[test]
+    fn token_match_empty_query_short_circuits() {
+        let st = seeded_three_doc_supertable();
+        let r = st.reader();
+        // A query that tokenizes to nothing returns empty without
+        // touching the store.
+        let hits = r
+            .token_match("title", "   ", BoolMode::Or)
+            .expect("tm empty");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn token_match_no_match_returns_empty() {
+        let st = seeded_three_doc_supertable();
+        let r = st.reader();
+        let hits = r
+            .token_match("title", "nonexistentterm", BoolMode::Or)
+            .expect("tm");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn fanout_for_only_multi_term_or_without_negation_subranges() {
+        // Multi-term OR, no negation → sub-range eligible.
+        assert!(matches!(
+            super::fanout_for(BoolMode::Or, 2, false),
+            super::FanOut::SubRanges
+        ));
+        // Single-term OR stays per-superfile.
+        assert!(matches!(
+            super::fanout_for(BoolMode::Or, 1, false),
+            super::FanOut::PerSuperfile
+        ));
+        // Negation disables sub-ranges.
+        assert!(matches!(
+            super::fanout_for(BoolMode::Or, 2, true),
+            super::FanOut::PerSuperfile
+        ));
+        // And mode stays per-superfile.
+        assert!(matches!(
+            super::fanout_for(BoolMode::And, 2, false),
+            super::FanOut::PerSuperfile
+        ));
+    }
+
+    #[test]
+    fn build_work_units_per_superfile_is_one_unranged_unit_each() {
+        use crate::supertable::manifest::{ScalarStatsTable, SuperfileEntry, SuperfileUri};
+        use std::collections::HashMap;
+        use uuid::Uuid;
+
+        fn entry(n_docs: u64) -> Arc<SuperfileEntry> {
+            let id = Uuid::new_v4();
+            Arc::new(SuperfileEntry {
+                superfile_id: id,
+                uri: SuperfileUri(id),
+                n_docs,
+                id_min: 0,
+                id_max: n_docs.saturating_sub(1) as i128,
+                scalar_stats: ScalarStatsTable::new(),
+                fts_summary: HashMap::new(),
+                vector_summary: HashMap::new(),
+                partition_key: Vec::new(),
+                partition_hint: None,
+                subsection_offsets: None,
+            })
+        }
+
+        let e0 = entry(100);
+        let e1 = entry(200);
+        let kept = vec![&e0, &e1];
+
+        // PerSuperfile always yields exactly one un-ranged unit per kept
+        // superfile regardless of pool width.
+        let units = super::build_work_units(&kept, super::FanOut::PerSuperfile, 8);
+        assert_eq!(units.len(), 2);
+        assert!(units.iter().all(|u| u.range.is_none()));
+
+        // SubRanges with one pool thread collapses to per-superfile too
+        // (no spare threads to slice across).
+        let units = super::build_work_units(&kept, super::FanOut::SubRanges, 1);
+        assert_eq!(units.len(), 2);
+        assert!(units.iter().all(|u| u.range.is_none()));
+
+        // Tiny superfiles below SUBRANGE_MIN_DOCS never slice even with
+        // spare threads.
+        let units = super::build_work_units(&kept, super::FanOut::SubRanges, 16);
+        assert_eq!(units.len(), 2);
+        assert!(units.iter().all(|u| u.range.is_none()));
+    }
+
+    #[test]
+    fn build_work_units_slices_large_superfiles_when_threads_spare() {
+        use crate::supertable::manifest::{ScalarStatsTable, SuperfileEntry, SuperfileUri};
+        use std::collections::HashMap;
+        use uuid::Uuid;
+
+        let id = Uuid::new_v4();
+        // One large superfile, well above SUBRANGE_MIN_DOCS (50k).
+        let big = Arc::new(SuperfileEntry {
+            superfile_id: id,
+            uri: SuperfileUri(id),
+            n_docs: 200_000,
+            id_min: 0,
+            id_max: 199_999,
+            scalar_stats: ScalarStatsTable::new(),
+            fts_summary: HashMap::new(),
+            vector_summary: HashMap::new(),
+            partition_key: Vec::new(),
+            partition_hint: None,
+            subsection_offsets: None,
+        });
+        let kept = vec![&big];
+        // 4 spare threads, 1 superfile → slice into multiple ranged units
+        // that tile [0, n_docs) without gaps.
+        let units = super::build_work_units(&kept, super::FanOut::SubRanges, 4);
+        assert!(units.len() > 1, "large superfile sliced into sub-ranges");
+        let mut cursor = 0u32;
+        for u in &units {
+            let (start, end) = u.range.expect("ranged unit");
+            assert_eq!(start, cursor);
+            cursor = end;
+        }
+        assert_eq!(cursor, 200_000, "sub-ranges tile the whole superfile");
+    }
 }

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -1473,4 +1473,194 @@ mod tests {
             "non-FTS predicate matching all superfiles prunes nothing"
         );
     }
+
+    /// Build a provider over a freshly-committed two-superfile table
+    /// (the `cat_title` schema), returning the provider and a runtime to
+    /// drive its async surface.
+    fn provider_over_two_superfiles() -> (SupertableProvider, tokio::runtime::Runtime) {
+        let st = Supertable::create(cat_title_opts()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&cat_title_batch(&["a", "a"], &["alpha beta", "gamma"]))
+            .expect("a1");
+        w.commit().expect("c1");
+        w.append(&cat_title_batch(&["b"], &["delta"])).expect("a2");
+        w.commit().expect("c2");
+
+        let reader = st.reader();
+        let provider = SupertableProvider::new(
+            st.options().scalar_schema(),
+            reader.manifest().clone(),
+            st.options().store.clone(),
+            st.options().disk_cache.clone(),
+            reader.tombstone_cache.clone(),
+        );
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        (provider, rt)
+    }
+
+    #[test]
+    fn trait_accessors_and_debug() {
+        let (provider, _rt) = provider_over_two_superfiles();
+
+        // as_any downcasts back to the concrete provider.
+        assert!(
+            provider
+                .as_any()
+                .downcast_ref::<SupertableProvider>()
+                .is_some()
+        );
+        // table_type is a base table.
+        assert!(matches!(provider.table_type(), TableType::Base));
+        // schema() returns the scalar schema (category + title + _id).
+        let sch = provider.schema();
+        assert!(sch.field_with_name("category").is_ok());
+        assert!(sch.field_with_name("title").is_ok());
+
+        // Debug renders a structural summary, not the trait-object fields.
+        let dbg = format!("{provider:?}");
+        assert!(dbg.contains("SupertableProvider"));
+        assert!(dbg.contains("n_superfiles"));
+    }
+
+    #[test]
+    fn supports_filters_pushdown_is_always_inexact() {
+        let (provider, _rt) = provider_over_two_superfiles();
+        let f1 = col("category").eq(lit("a"));
+        let f2 = col("title").eq(lit("alpha"));
+        let filters = [&f1, &f2];
+        let pushdown = provider
+            .supports_filters_pushdown(&filters)
+            .expect("pushdown");
+        assert_eq!(pushdown.len(), 2);
+        assert!(
+            pushdown
+                .iter()
+                .all(|p| matches!(p, TableProviderFilterPushDown::Inexact))
+        );
+    }
+
+    #[test]
+    fn statistics_exact_on_clean_in_memory_flat_manifest() {
+        let (provider, _rt) = provider_over_two_superfiles();
+        // In-memory (no manifest list) flat manifest → whole-table
+        // statistics are available and the row count is Exact (3 docs,
+        // no tombstones).
+        let stats = provider.statistics().expect("flat-manifest statistics");
+        assert!(matches!(stats.num_rows, Precision::Exact(3)));
+        // One ColumnStatistics per scalar-schema field.
+        assert_eq!(
+            stats.column_statistics.len(),
+            provider.schema().fields().len()
+        );
+    }
+
+    #[test]
+    fn manifest_accessor_and_restricted_to_idempotency_guard() {
+        let (provider, _rt) = provider_over_two_superfiles();
+        // Unrestricted provider is not a residual scan.
+        assert!(!provider.is_segment_restricted());
+
+        // manifest() exposes the pinned snapshot.
+        let ids: Vec<uuid::Uuid> = provider
+            .manifest()
+            .superfiles
+            .iter()
+            .map(|e| e.superfile_id)
+            .collect();
+        assert_eq!(ids.len(), 2);
+
+        // restricted_to keeps only the named segment and flips the guard.
+        let only_first: std::collections::HashSet<uuid::Uuid> = [ids[0]].into_iter().collect();
+        let restricted = provider.restricted_to(only_first);
+        assert!(restricted.is_segment_restricted());
+        // Both providers see the same pinned manifest (Arc::clone).
+        assert!(Arc::ptr_eq(restricted.manifest(), provider.manifest()));
+    }
+
+    #[test]
+    fn entry_is_clean_true_without_tombstone_overlay() {
+        let (provider, _rt) = provider_over_two_superfiles();
+        // In-memory tables carry no tombstone overlay, so every entry is
+        // trivially clean.
+        for entry in provider.manifest().superfiles.iter() {
+            assert!(provider.entry_is_clean(entry));
+        }
+    }
+
+    #[test]
+    fn restricted_provider_scans_only_its_segment() {
+        let (provider, rt) = provider_over_two_superfiles();
+        let first = provider.manifest().superfiles[0].superfile_id;
+        let only_first: std::collections::HashSet<uuid::Uuid> = [first].into_iter().collect();
+        let restricted = provider.restricted_to(only_first);
+        // With no filters, the unrestricted provider keeps both
+        // superfiles; the restricted one keeps only the allowed segment.
+        assert_eq!(rt.block_on(provider.surviving_superfile_count(&[])), 2);
+        assert_eq!(rt.block_on(restricted.surviving_superfile_count(&[])), 1);
+    }
+
+    // ---- Scalar aggregate helpers over a numeric column -------------
+
+    fn num_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("n", DataType::Int64, true)]))
+    }
+
+    fn num_opts() -> SupertableOptions {
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        // No FTS column — this fixture exercises the scalar-stats path
+        // (min/max/sum/null/distinct), not the term bloom.
+        SupertableOptions::new(num_schema(), vec![], vec![], None)
+            .expect("opts")
+            .with_writer_pool(pool)
+    }
+
+    fn num_batch(vals: &[Option<i64>]) -> RecordBatch {
+        RecordBatch::try_new(
+            num_schema(),
+            vec![Arc::new(Int64Array::from(vals.to_vec()))],
+        )
+        .expect("batch")
+    }
+
+    #[test]
+    fn statistics_for_aggregates_scalar_stats_across_superfiles() {
+        let st = Supertable::create(num_opts()).expect("create");
+        let mut w = st.writer().expect("writer");
+        // Superfile 1: 1,2,3 (one null). Superfile 2: 10, 20.
+        w.append(&num_batch(&[Some(1), Some(2), Some(3), None]))
+            .expect("a1");
+        w.commit().expect("c1");
+        w.append(&num_batch(&[Some(10), Some(20)])).expect("a2");
+        w.commit().expect("c2");
+
+        let reader = st.reader();
+        let provider = SupertableProvider::new(
+            st.options().scalar_schema(),
+            reader.manifest().clone(),
+            st.options().store.clone(),
+            st.options().disk_cache.clone(),
+            reader.tombstone_cache.clone(),
+        );
+
+        let stats = provider.statistics().expect("statistics");
+        // 6 rows total across both superfiles, clean view → Exact.
+        assert!(matches!(stats.num_rows, Precision::Exact(6)));
+
+        // Find the `n` column's statistics and assert aggregated min/max.
+        let sch = provider.schema();
+        let n_idx = sch.index_of("n").expect("n column");
+        let cs = &stats.column_statistics[n_idx];
+        assert_eq!(cs.min_value, Precision::Exact(ScalarValue::Int64(Some(1))));
+        assert_eq!(cs.max_value, Precision::Exact(ScalarValue::Int64(Some(20))));
+        // One null planted in superfile 1.
+        assert_eq!(cs.null_count, Precision::Exact(1));
+    }
 }

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -1838,8 +1838,14 @@ mod tests {
     /// > 1 distinguishes "kept waiting" from "barreled ahead".
     const HELD_POLL_TURNS: u32 = 5;
 
-    /// Minimal eager superfile reader (one scalar batch, no indexes).
-    fn tiny_reader() -> Arc<SuperfileReader> {
+    /// Generous timeout for [`DiskCacheStore::wait_until_mmap_promoted`]
+    /// in tests — the background fill is local-fs only, so promotion
+    /// lands in well under a second; this just bounds a hang.
+    const PROMOTE_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Build the raw bytes of a minimal superfile (one scalar batch,
+    /// no indexes).
+    fn tiny_superfile_bytes() -> Bytes {
         let schema = Arc::new(Schema::new(vec![
             decimal128_id_field("doc_id"),
             Field::new("title", DataType::LargeUtf8, false),
@@ -1851,20 +1857,48 @@ mod tests {
         let batch =
             RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
         b.add_batch(&batch, &[]).expect("add_batch");
-        let bytes = Bytes::from(b.finish().expect("finish"));
-        Arc::new(SuperfileReader::open(bytes).expect("open"))
+        Bytes::from(b.finish().expect("finish"))
+    }
+
+    /// Minimal eager superfile reader (one scalar batch, no indexes).
+    fn tiny_reader() -> Arc<SuperfileReader> {
+        Arc::new(SuperfileReader::open(tiny_superfile_bytes()).expect("open"))
     }
 
     fn test_store() -> (TempDir, Arc<DiskCacheStore>) {
+        test_store_with(|cfg| {
+            cfg.mmap_cold_threshold_secs = 0;
+        })
+    }
+
+    /// Build a store, applying `mutate` to the default config first.
+    /// The storage root is the tempdir; cache files live under
+    /// `<tempdir>/cache`. The sweep thread is left disabled by
+    /// default (callers that want it enable it through `mutate`).
+    fn test_store_with(
+        mutate: impl FnOnce(&mut DiskCacheConfig),
+    ) -> (TempDir, Arc<DiskCacheStore>) {
         let dir = TempDir::new().expect("tempdir");
         let storage: Arc<dyn StorageProvider> =
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("localfs"));
-        let cfg = DiskCacheConfig {
+        let mut cfg = DiskCacheConfig {
             cache_root: dir.path().join("cache"),
+            mmap_cold_threshold_secs: 0,
             ..Default::default()
         };
+        mutate(&mut cfg);
         let store = DiskCacheStore::new_unpinned(storage, cfg).expect("store");
         (dir, store)
+    }
+
+    /// Put `bytes` at the storage location `store.reader(&uri)` will
+    /// cold-fetch from, so the cold path has something to read.
+    async fn put_superfile(store: &Arc<DiskCacheStore>, uri: &SuperfileUri, bytes: Bytes) {
+        store
+            .storage
+            .put_atomic(&uri.storage_path(), bytes)
+            .await
+            .expect("put superfile");
     }
 
     /// Regression: `strong_count == 1` is also what *acquisition*
@@ -1913,5 +1947,487 @@ mod tests {
             "wait must yield the store once the foreground hold releases"
         );
         drop(reader);
+    }
+
+    // ----- construction / config -----
+
+    #[tokio::test]
+    async fn new_creates_cache_root() {
+        let (dir, store) = test_store();
+        assert!(dir.path().join("cache").is_dir(), "cache_root created");
+        // Debug impl exercises the custom formatter.
+        let dbg = format!("{store:?}");
+        assert!(dbg.contains("DiskCacheStore"));
+        assert!(dbg.contains("n_cold_fetches"));
+    }
+
+    #[tokio::test]
+    async fn new_with_sweep_thread_enabled_spawns_and_drops_cleanly() {
+        // threshold > 0 takes the std::thread::spawn branch; interval
+        // is clamped to >= 1. The Weak<Self> lets the thread exit when
+        // we drop the last Arc.
+        let (_dir, store) = test_store_with(|cfg| {
+            cfg.mmap_cold_threshold_secs = 1;
+            cfg.mmap_sweep_interval_secs = 0; // exercises `.max(1)` clamp
+        });
+        drop(store); // thread observes the failed Weak upgrade and exits
+    }
+
+    #[tokio::test]
+    async fn new_unpinned_installs_empty_pinned_set() {
+        let (_dir, store) = test_store();
+        assert!(store.current_pinned_uris().is_empty());
+    }
+
+    // ----- stats / accessors -----
+
+    #[tokio::test]
+    async fn stats_reflect_config_and_counters() {
+        let (_dir, store) = test_store_with(|cfg| {
+            cfg.disk_budget_bytes = 12345;
+        });
+        let s = store.stats();
+        assert_eq!(s.budget_bytes, 12345);
+        assert_eq!(s.n_entries, 0);
+        assert_eq!(s.current_bytes, 0);
+        assert_eq!(s.n_cold_fetches, 0);
+        assert_eq!(s.n_evictions, 0);
+        assert_eq!(s.n_madvise_calls, 0);
+        // CacheStats is Clone + Debug + Default.
+        let _ = format!("{:?}", s.clone());
+        assert_eq!(CacheStats::default().n_entries, 0);
+    }
+
+    #[tokio::test]
+    async fn set_and_read_pinned_fn() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        store.set_pinned_fn(Arc::new(move || {
+            let mut s = HashSet::new();
+            s.insert(uri);
+            s
+        }));
+        let pinned = store.current_pinned_uris();
+        assert!(pinned.contains(&uri));
+        assert_eq!(pinned.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn is_mmap_promoted_false_for_unknown_uri() {
+        let (_dir, store) = test_store();
+        assert!(!store.is_mmap_promoted(&SuperfileUri::new_v4()));
+    }
+
+    // ----- warm insert path (insert_warm + cold-free path) -----
+
+    #[tokio::test]
+    async fn insert_warm_caches_and_serves_reader() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let bytes = tiny_superfile_bytes();
+        let size = bytes.len() as u64;
+        store.insert_warm(&uri, bytes).await.expect("insert_warm");
+
+        // Entry is mmap-backed, counted, and warm inserts don't bump
+        // the cold-fetch counter.
+        assert!(store.is_mmap_promoted(&uri));
+        let s = store.stats();
+        assert_eq!(s.n_entries, 1);
+        assert_eq!(s.current_bytes, size);
+        assert_eq!(s.n_cold_fetches, 0);
+        assert_eq!(store.current_mmap_size_bytes(), size);
+
+        // The cache file landed on disk.
+        assert!(store.cache_path(&uri).is_file());
+
+        // reader() hits the cache (still no cold fetch).
+        let _r = store.reader(&uri).await.expect("reader");
+        assert_eq!(store.stats().n_cold_fetches, 0);
+    }
+
+    #[tokio::test]
+    async fn insert_warm_is_idempotent() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("first");
+        let before = store.stats().current_bytes;
+        // Second insert with the same URI is a no-op.
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("second");
+        assert_eq!(store.stats().current_bytes, before);
+        assert_eq!(store.stats().n_entries, 1);
+    }
+
+    #[tokio::test]
+    async fn insert_warm_rejects_unparseable_bytes() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let err = store
+            .insert_warm(&uri, Bytes::from_static(b"not a superfile"))
+            .await
+            .expect_err("garbage must fail to open");
+        // Reservation rolled back on the error path.
+        assert_eq!(store.stats().current_bytes, 0);
+        assert_eq!(store.stats().n_entries, 0);
+        // Surfaced as a typed open/read error.
+        let _ = format!("{err}");
+        let _ = format!("{err:?}");
+    }
+
+    #[tokio::test]
+    async fn insert_warm_budget_exceeded_when_too_big() {
+        let (_dir, store) = test_store_with(|cfg| {
+            cfg.disk_budget_bytes = 4; // smaller than any real superfile
+        });
+        let uri = SuperfileUri::new_v4();
+        let err = store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect_err("must exceed budget");
+        assert!(matches!(err, DiskCacheError::BudgetExceeded));
+        assert_eq!(store.stats().current_bytes, 0);
+    }
+
+    // ----- cold fetch: synchronous path -----
+
+    #[tokio::test]
+    async fn reader_synchronous_cold_then_warm_hit() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let bytes = tiny_superfile_bytes();
+        let size = bytes.len() as u64;
+        put_superfile(&store, &uri, bytes).await;
+
+        let _r = store.reader_synchronous(&uri).await.expect("cold");
+        let s = store.stats();
+        assert_eq!(s.n_cold_fetches, 1);
+        assert_eq!(s.n_entries, 1);
+        assert_eq!(s.current_bytes, size);
+        // mmap-backed after the synchronous fetch.
+        assert!(store.is_mmap_promoted(&uri));
+
+        // Second call is a warm cache hit (no new cold fetch).
+        let _r2 = store.reader_synchronous(&uri).await.expect("warm");
+        assert_eq!(store.stats().n_cold_fetches, 1);
+    }
+
+    #[tokio::test]
+    async fn reader_synchronous_missing_object_errors() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        // Nothing put at the storage path → head() fails.
+        let err = store.reader_synchronous(&uri).await.expect_err("no object");
+        let _ = format!("{err}");
+        // Coordinator removed so a later (successful) put can proceed.
+        assert!(store.coordinators.is_empty());
+    }
+
+    // ----- cold fetch: hybrid path (default mode) -----
+
+    #[tokio::test]
+    async fn reader_hybrid_cold_then_promotes_to_mmap() {
+        let (_dir, store) = test_store(); // default = HybridWithPrefetch
+        let uri = SuperfileUri::new_v4();
+        put_superfile(&store, &uri, tiny_superfile_bytes()).await;
+
+        // reader() dispatches to reader_hybrid.
+        let r = store.reader(&uri).await.expect("cold hybrid");
+        assert_eq!(r.n_docs(), 1);
+        assert_eq!(store.stats().n_cold_fetches, 1);
+        assert_eq!(store.stats().n_entries, 1);
+
+        // Background finalizer eventually swaps in the mmap entry.
+        store
+            .wait_until_mmap_promoted(&uri, PROMOTE_TIMEOUT)
+            .await
+            .expect("promotion");
+        assert!(store.is_mmap_promoted(&uri));
+
+        // Warm hit after promotion.
+        let _r2 = store.reader(&uri).await.expect("warm");
+        assert_eq!(store.stats().n_cold_fetches, 1);
+    }
+
+    #[tokio::test]
+    async fn reader_hybrid_empty_object_zero_chunks() {
+        // size == 0 takes the n_chunks == 0 branch in cold_fetch_hybrid;
+        // the empty buffer fails to parse as a superfile, surfacing an
+        // open error rather than a cache entry.
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        put_superfile(&store, &uri, Bytes::new()).await;
+        let err = store.reader(&uri).await.expect_err("empty not a superfile");
+        let _ = format!("{err}");
+    }
+
+    // ----- RangeOnly mode rejects + open_range_only bypass -----
+
+    #[tokio::test]
+    async fn reader_range_only_mode_is_rejected() {
+        let (_dir, store) = test_store_with(|cfg| {
+            cfg.cold_fetch_mode = ColdFetchMode::RangeOnly;
+        });
+        let uri = SuperfileUri::new_v4();
+        put_superfile(&store, &uri, tiny_superfile_bytes()).await;
+        let err = store.reader(&uri).await.expect_err("RangeOnly rejected");
+        assert!(matches!(err, DiskCacheError::SuperfileOpen(_)));
+    }
+
+    #[tokio::test]
+    async fn open_range_only_unknown_size_reads_directly() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        put_superfile(&store, &uri, tiny_superfile_bytes()).await;
+        // offsets = None → unknown-size StorageRangeSource.
+        let r = store.open_range_only(&uri, None).await.expect("range open");
+        assert_eq!(r.n_docs(), 1);
+        // Bypasses the cache entirely — nothing admitted.
+        assert_eq!(store.stats().n_entries, 0);
+        assert_eq!(store.stats().current_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn open_range_only_known_size_reads_directly() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let bytes = tiny_superfile_bytes();
+        let total = bytes.len() as u64;
+        put_superfile(&store, &uri, bytes).await;
+        let offsets = SubsectionOffsets {
+            total_size: total,
+            vec: None,
+            fts: None,
+            vec_open_ranges: Vec::new(),
+            fts_open_ranges: Vec::new(),
+            open_blob: Vec::new(),
+        };
+        let r = store
+            .open_range_only(&uri, Some(&offsets))
+            .await
+            .expect("known-size range open");
+        assert_eq!(r.n_docs(), 1);
+    }
+
+    // ----- lazy-foreground-with-background-fill mode -----
+
+    #[tokio::test]
+    async fn reader_lazy_unknown_size_cold_then_promotes() {
+        let (_dir, store) = test_store_with(|cfg| {
+            cfg.cold_fetch_mode = ColdFetchMode::LazyForegroundWithBackgroundFill;
+        });
+        let uri = SuperfileUri::new_v4();
+        put_superfile(&store, &uri, tiny_superfile_bytes()).await;
+
+        // reader_with_hints(None) → unknown-size lazy cold fetch.
+        let r = store.reader(&uri).await.expect("lazy cold");
+        assert_eq!(r.n_docs(), 1);
+        assert_eq!(store.stats().n_cold_fetches, 1);
+
+        // Drop the foreground reader so the background fill can start.
+        drop(r);
+        store
+            .wait_until_mmap_promoted(&uri, PROMOTE_TIMEOUT)
+            .await
+            .expect("lazy promotion");
+        assert!(store.is_mmap_promoted(&uri));
+    }
+
+    #[tokio::test]
+    async fn reader_lazy_with_hints_known_size_promotes() {
+        let (_dir, store) = test_store_with(|cfg| {
+            cfg.cold_fetch_mode = ColdFetchMode::LazyForegroundWithBackgroundFill;
+        });
+        let uri = SuperfileUri::new_v4();
+        let bytes = tiny_superfile_bytes();
+        let total = bytes.len() as u64;
+        put_superfile(&store, &uri, bytes).await;
+
+        // Known size, no open_blob → fetches the open batch over the
+        // wire (parquet tail + vec + fts ranges) using the fallback
+        // header lengths derived from `vec`/`fts` hints.
+        let offsets = SubsectionOffsets {
+            total_size: total,
+            vec: None,
+            fts: None,
+            vec_open_ranges: Vec::new(),
+            fts_open_ranges: Vec::new(),
+            open_blob: Vec::new(),
+        };
+        let r = store
+            .reader_with_hints(&uri, Some(&offsets))
+            .await
+            .expect("lazy hinted cold");
+        assert_eq!(r.n_docs(), 1);
+        assert_eq!(store.stats().n_cold_fetches, 1);
+        drop(r);
+        store
+            .wait_until_mmap_promoted(&uri, PROMOTE_TIMEOUT)
+            .await
+            .expect("lazy hinted promotion");
+        assert!(store.is_mmap_promoted(&uri));
+    }
+
+    // ----- wait_until_mmap_promoted timeout path -----
+
+    #[tokio::test]
+    async fn wait_until_mmap_promoted_times_out_for_unpromoted() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        // Never fetched → never promoted → times out.
+        let err = store
+            .wait_until_mmap_promoted(&uri, Duration::from_millis(30))
+            .await
+            .expect_err("must time out");
+        assert!(matches!(err, DiskCacheError::SuperfileOpen(_)));
+        // Guard restored the waiter counter.
+        assert_eq!(store.n_promotion_waiters.load(Ordering::Acquire), 0);
+    }
+
+    // ----- eviction + budget -----
+
+    #[tokio::test]
+    async fn cold_fetch_evicts_lru_when_over_budget() {
+        // Budget fits ~1.5 entries, forcing eviction of the older one
+        // when the second cold fetch reserves.
+        let one = tiny_superfile_bytes();
+        let entry_size = one.len() as u64;
+        let (_dir, store) = test_store_with(move |cfg| {
+            cfg.disk_budget_bytes = entry_size + entry_size / 2;
+        });
+
+        let uri_a = SuperfileUri::new_v4();
+        let uri_b = SuperfileUri::new_v4();
+        put_superfile(&store, &uri_a, tiny_superfile_bytes()).await;
+        put_superfile(&store, &uri_b, tiny_superfile_bytes()).await;
+
+        store.reader_synchronous(&uri_a).await.expect("a");
+        store.reader_synchronous(&uri_b).await.expect("b");
+
+        // a was the LRU victim; b is resident.
+        assert_eq!(store.stats().n_evictions, 1);
+        assert!(store.cached.contains_key(&uri_b));
+        assert!(!store.cached.contains_key(&uri_a));
+        // a's cache file was unlinked.
+        assert!(!store.cache_path(&uri_a).exists());
+        assert_eq!(store.stats().current_bytes, entry_size);
+    }
+
+    #[tokio::test]
+    async fn cold_fetch_budget_exceeded_with_all_pinned() {
+        let one = tiny_superfile_bytes();
+        let entry_size = one.len() as u64;
+        let (_dir, store) = test_store_with(move |cfg| {
+            cfg.disk_budget_bytes = entry_size + entry_size / 2;
+        });
+
+        let uri_a = SuperfileUri::new_v4();
+        let uri_b = SuperfileUri::new_v4();
+        put_superfile(&store, &uri_a, tiny_superfile_bytes()).await;
+        put_superfile(&store, &uri_b, tiny_superfile_bytes()).await;
+
+        // First fetch lands.
+        store.reader_synchronous(&uri_a).await.expect("a");
+        // Pin everything so eviction finds no victims.
+        store.set_pinned_fn(Arc::new(move || {
+            let mut s = HashSet::new();
+            s.insert(uri_a);
+            s
+        }));
+        let err = store
+            .reader_synchronous(&uri_b)
+            .await
+            .expect_err("no eligible victims");
+        assert!(matches!(err, DiskCacheError::BudgetExceeded));
+        // a stays put; budget unchanged.
+        assert!(store.cached.contains_key(&uri_a));
+    }
+
+    // ----- sweep_once / sweep_for_budget / madvise counters -----
+
+    #[tokio::test]
+    async fn sweep_once_advises_idle_mmap_entries() {
+        // threshold 0 means every entry is immediately "idle".
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("warm");
+        let advised = store.sweep_once();
+        assert_eq!(advised, 1);
+        assert_eq!(store.stats().n_madvise_calls, 1);
+        // A second sweep advises again (counter accumulates).
+        assert_eq!(store.sweep_once(), 1);
+        assert_eq!(store.stats().n_madvise_calls, 2);
+    }
+
+    #[tokio::test]
+    async fn sweep_once_skips_when_threshold_not_reached() {
+        // Large threshold → nothing is idle, so no madvise.
+        let (_dir, store) = test_store_with(|cfg| {
+            cfg.mmap_cold_threshold_secs = 1_000_000;
+        });
+        let uri = SuperfileUri::new_v4();
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("warm");
+        assert_eq!(store.sweep_once(), 0);
+        assert_eq!(store.stats().n_madvise_calls, 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_for_budget_noop_under_budget() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("warm");
+        // budget far above resident size → no madvise.
+        assert_eq!(store.sweep_for_budget(u64::MAX), 0);
+        assert_eq!(store.stats().n_madvise_calls, 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_for_budget_reclaims_oldest_first() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("warm");
+        let resident = store.current_mmap_size_bytes();
+        assert!(resident > 0);
+        // budget 0 forces every entry to be advised.
+        let advised = store.sweep_for_budget(0);
+        assert_eq!(advised, 1);
+        assert_eq!(store.stats().n_madvise_calls, 1);
+    }
+
+    #[tokio::test]
+    async fn current_mmap_size_bytes_zero_when_empty() {
+        let (_dir, store) = test_store();
+        assert_eq!(store.current_mmap_size_bytes(), 0);
+    }
+
+    // ----- error type conversions / Debug -----
+
+    #[tokio::test]
+    async fn disk_cache_error_displays_all_variants() {
+        let variants = [
+            DiskCacheError::SuperfileOpen("x".into()),
+            DiskCacheError::BudgetExceeded,
+            DiskCacheError::Io(std::io::Error::other("boom")),
+        ];
+        for v in variants {
+            assert!(!format!("{v}").is_empty());
+            assert!(!format!("{v:?}").is_empty());
+        }
     }
 }

--- a/src/supertable/wal/persistence.rs
+++ b/src/supertable/wal/persistence.rs
@@ -848,4 +848,124 @@ mod tests {
         // trait's idempotent-delete contract.
         ws.delete_state(state.wal_id).await.expect("second delete");
     }
+
+    // ---- delete_arrow is idempotent --------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn delete_arrow_is_idempotent_and_removes_sidecar() {
+        let (_dir, ws) = store();
+        let wal_id = WalId(43);
+        ws.put_arrow(wal_id, Bytes::from_static(b"payload"))
+            .await
+            .expect("put_arrow");
+        // First delete removes it.
+        ws.delete_arrow(wal_id).await.expect("first delete");
+        // Re-fetch now fails (object gone) — confirms the delete landed.
+        ws.get_arrow(wal_id, None)
+            .await
+            .expect_err("sidecar must be gone after delete");
+        // Second delete against the absent path is still Ok.
+        ws.delete_arrow(wal_id).await.expect("second delete");
+    }
+
+    // ---- list_wal_ids enumerates + sorts state docs ----------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn list_wal_ids_returns_only_state_docs_sorted_ascending() {
+        let (_dir, ws) = store();
+        // Create three state docs out of ascending order.
+        for id in [50i128, 10, 30] {
+            ws.create(&sample_state(id)).await.expect("create");
+        }
+        // Drop an `.arrow` sidecar under the same prefix — it must
+        // NOT appear in the list (only `.json` state docs do).
+        ws.put_arrow(WalId(99), Bytes::from_static(b"ignored"))
+            .await
+            .expect("put_arrow");
+
+        let ids = ws.list_wal_ids().await.expect("list");
+        let raw: Vec<i128> = ids.iter().map(|w| w.0).collect();
+        assert_eq!(raw, vec![10, 30, 50], "ascending oldest-first order");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn list_wal_ids_on_empty_prefix_is_empty() {
+        let (_dir, ws) = store();
+        let ids = ws.list_wal_ids().await.expect("list");
+        assert!(ids.is_empty());
+    }
+
+    // ---- list_tombstone_ids enumerates sidecars --------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn list_tombstone_ids_returns_superfiles_with_sidecars() {
+        let (_dir, ws) = store();
+        let a = uuid::Uuid::from_u128(0x1111);
+        let b = uuid::Uuid::from_u128(0x2222);
+        let empty = TombstonesSidecar {
+            seal: None,
+            bitmap: roaring::RoaringBitmap::new(),
+        };
+        ws.put_tombstones(a, None, &empty).await.expect("put a");
+        ws.put_tombstones(b, None, &empty).await.expect("put b");
+
+        let mut ids = ws.list_tombstone_ids().await.expect("list");
+        ids.sort();
+        let mut expected = vec![a, b];
+        expected.sort();
+        assert_eq!(ids, expected);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn list_tombstone_ids_on_empty_prefix_is_empty() {
+        let (_dir, ws) = store();
+        let ids = ws.list_tombstone_ids().await.expect("list");
+        assert!(ids.is_empty());
+    }
+
+    // ---- put_tombstones create-only via Some(empty etag) -----------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn put_tombstones_with_empty_expected_etag_is_create_only() {
+        // `Some(empty)` collapses to `None` (create-only) inside
+        // put_tombstones; a first write under it must land, and a
+        // second create-only write against the now-present object
+        // must lose CAS.
+        let (_dir, ws) = store();
+        let superfile_id = uuid::Uuid::from_u128(0xABCD);
+        let mut bitmap = roaring::RoaringBitmap::new();
+        bitmap.insert(1);
+        let sidecar = TombstonesSidecar { seal: None, bitmap };
+        let empty_etag: Etag = String::new();
+        ws.put_tombstones(superfile_id, Some(&empty_etag), &sidecar)
+            .await
+            .expect("first create-only put lands");
+        let err = ws
+            .put_tombstones(superfile_id, Some(&empty_etag), &sidecar)
+            .await
+            .expect_err("second create-only put must lose CAS");
+        assert!(matches!(err, WalStoreError::CasFailed { .. }), "{err:?}");
+    }
+
+    // ---- get_tombstones surfaces a decode error on garbage bytes ---------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn get_tombstones_surfaces_codec_error_on_corrupt_bytes() {
+        let (dir, ws) = store();
+        let superfile_id = uuid::Uuid::from_u128(0xDEAD);
+        // Write raw garbage directly to the sidecar path, bypassing
+        // the encoder, so the decode in `get_tombstones` fails.
+        let provider: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let path = WalStore::tombstones_path(superfile_id);
+        provider
+            .put_atomic(&path, Bytes::from_static(b"not a valid sidecar"))
+            .await
+            .expect("write garbage");
+        let err = ws
+            .get_tombstones(superfile_id)
+            .await
+            .expect_err("decode must fail");
+        assert!(matches!(err, WalStoreError::SidecarCodec { .. }), "{err:?}");
+    }
 }

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -1537,7 +1537,160 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn append_phase_without_storage_is_rejected() {
+        // A supertable with no storage attached can't commit the
+        // manifest, so `do_apply` surfaces NoStorageAttached. We use
+        // a fresh in-memory supertable + an independent WalStore
+        // (storage-backed only for the WAL artifacts) so the
+        // idempotency probe misses and we fall through to do_apply.
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        // Supertable WITHOUT storage.
+        let st = Supertable::create(default_supertable_options()).expect("create");
+        let ws = WalStore::new(Arc::clone(&storage));
+
+        let user_batch = build_title_batch(&["x"]);
+        let ipc_bytes = encode_ipc(&user_batch);
+        let content_hash = blake3::hash(&ipc_bytes).to_hex().to_string();
+        let wal_id = WalId(701);
+        ws.put_arrow(wal_id, ipc_bytes).await.expect("put_arrow");
+        let wal_doc = WalStateDoc {
+            wal_id,
+            schema_version: SCHEMA_VERSION,
+            op_kind: OpKind::Update,
+            state: WalState::Intent,
+            created_at: Utc::now(),
+            lease: None,
+            predicate_repr: "no storage".into(),
+            target_ids: vec![RowId(1)],
+            new_row_count: Some(1),
+            new_row_content_hash: Some(content_hash),
+            preallocated_superfile_id: Some(Uuid::from_u128(0x7070)),
+            minted_id_spans: vec![crate::supertable::wal::state_doc::IdSpan {
+                first: RowId(1),
+                last: RowId(1),
+            }],
+            tombstone_progress: vec![TombstoneEntry {
+                target_id: RowId(1),
+                outcome: TombstoneOutcome::Pending,
+                tombstoned_in_superfile: None,
+            }],
+        };
+        let etag = ws.create(&wal_doc).await.expect("create");
+        let err = run_append_phase(&st, &ws, &wal_doc, &etag)
+            .await
+            .expect_err("must error without storage");
+        assert!(
+            matches!(err, AppendPhaseError::NoStorageAttached),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn append_phase_missing_new_row_count_is_rejected() {
+        let (_dir, st, ws, mut wal, etag) = fixture_with_ipc_payload(&["foo"], 711, 1_000).await;
+        wal.new_row_count = None;
+        let bad_etag = ws
+            .update_with_etag(wal.wal_id, &etag, &wal)
+            .await
+            .expect("re-cas");
+        let err = run_append_phase(&st, &ws, &wal, &bad_etag)
+            .await
+            .expect_err("must error");
+        assert!(
+            matches!(
+                err,
+                AppendPhaseError::MissingField {
+                    field: "new_row_count"
+                }
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn append_phase_id_span_count_mismatch_is_rejected() {
+        // new_row_count says 1 but the minted_id_spans flatten to 2
+        // ids — the lockstep invariant is violated, surfacing a
+        // typed IdSpansLengthMismatch.
+        let (_dir, st, ws, mut wal, etag) = fixture_with_ipc_payload(&["foo"], 721, 1_000).await;
+        wal.minted_id_spans = vec![crate::supertable::wal::state_doc::IdSpan {
+            first: RowId(1),
+            last: RowId(2), // two ids, but new_row_count == 1
+        }];
+        let bad_etag = ws
+            .update_with_etag(wal.wal_id, &etag, &wal)
+            .await
+            .expect("re-cas");
+        let err = run_append_phase(&st, &ws, &wal, &bad_etag)
+            .await
+            .expect_err("must error");
+        assert!(
+            matches!(
+                err,
+                AppendPhaseError::IdSpansLengthMismatch {
+                    flat_len: 2,
+                    expected: 1,
+                    ..
+                }
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn append_phase_corrupt_ipc_surfaces_decode_error() {
+        // The recorded content hash matches the stored bytes (so the
+        // hash check passes), but the bytes aren't a valid IPC
+        // stream — decode_ipc_batch fails with IpcDecode.
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let st =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+                .expect("create");
+        let ws = WalStore::new(Arc::clone(&storage));
+        let wal_id = WalId(731);
+        let garbage = Bytes::from_static(b"this is not arrow ipc");
+        let content_hash = blake3::hash(&garbage).to_hex().to_string();
+        ws.put_arrow(wal_id, garbage).await.expect("put_arrow");
+        let wal_doc = WalStateDoc {
+            wal_id,
+            schema_version: SCHEMA_VERSION,
+            op_kind: OpKind::Update,
+            state: WalState::Intent,
+            created_at: Utc::now(),
+            lease: None,
+            predicate_repr: "corrupt ipc".into(),
+            target_ids: vec![RowId(1)],
+            new_row_count: Some(1),
+            new_row_content_hash: Some(content_hash),
+            preallocated_superfile_id: Some(Uuid::from_u128(0x7373)),
+            minted_id_spans: vec![crate::supertable::wal::state_doc::IdSpan {
+                first: RowId(1),
+                last: RowId(1),
+            }],
+            tombstone_progress: vec![TombstoneEntry {
+                target_id: RowId(1),
+                outcome: TombstoneOutcome::Pending,
+                tombstoned_in_superfile: None,
+            }],
+        };
+        let etag = ws.create(&wal_doc).await.expect("create");
+        let err = run_append_phase(&st, &ws, &wal_doc, &etag)
+            .await
+            .expect_err("must error on bad ipc");
+        assert!(matches!(err, AppendPhaseError::IpcDecode { .. }), "{err:?}");
+    }
+
     // ---- flatten_spans property ----------------------------------------
+
+    #[test]
+    fn flatten_spans_empty_is_empty() {
+        assert!(flatten_spans(&[]).is_empty());
+    }
 
     #[test]
     fn flatten_spans_concatenates_inclusive_ranges_in_order() {

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -2630,4 +2630,214 @@ supertable:
         assert_eq!(r.n_superfiles(), 3);
         assert_eq!(r.n_docs_total(), 6);
     }
+
+    // ---- merge_ranges helper -----------------------------------------
+
+    #[test]
+    fn merge_ranges_coalesces_overlapping_and_adjacent_drops_empty() {
+        // (off, len) inputs: an empty range (dropped), two
+        // overlapping ranges (coalesced), one adjacent range
+        // (coalesced, since `off <= last_end`), and one disjoint
+        // range (kept separate). Unsorted on input.
+        let input = vec![
+            (100u64, 10u64), // disjoint, far away
+            (0, 0),          // empty — dropped
+            (10, 10),        // [10,20)
+            (15, 10),        // [15,25) overlaps prior → [10,25)
+            (25, 5),         // [25,30) adjacent → [10,30)
+        ];
+        let merged = merge_ranges(input);
+        assert_eq!(merged, vec![(10, 20), (100, 10)]);
+    }
+
+    #[test]
+    fn merge_ranges_empty_input_is_empty() {
+        assert!(merge_ranges(Vec::new()).is_empty());
+    }
+
+    // ---- build_subsection_offsets on real superfile bytes ------------
+
+    #[test]
+    fn build_subsection_offsets_captures_total_size_and_fts_range() {
+        // A freshly-built FTS superfile should produce subsection
+        // offsets: total_size matches the byte length and the FTS
+        // open ranges are non-empty (there's an FTS index).
+        let st = Supertable::create(options_id_title_serial()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_simple_batch(0, 8)).expect("append");
+        w.commit().expect("commit");
+
+        let r = st.reader();
+        let seg = &r.manifest().superfiles[0];
+        let store = &st.options().store;
+        // Fetch the bytes back from the in-memory store.
+        let reader = store.reader(&seg.uri).expect("reader");
+        // Confirm the manifest already carries subsection offsets and
+        // that total_size is plausible (> 0).
+        let offsets = seg
+            .subsection_offsets
+            .as_ref()
+            .expect("offsets captured at commit");
+        assert!(offsets.total_size > 0);
+        assert!(
+            offsets.fts.is_some(),
+            "an FTS superfile must record an FTS subsection"
+        );
+        assert!(
+            !offsets.fts_open_ranges.is_empty(),
+            "FTS open ranges should be populated for the cold-open fast path"
+        );
+        // n_docs sanity via the reader, ensuring the bytes parse.
+        assert_eq!(reader.n_docs(), 8);
+    }
+
+    #[test]
+    fn build_subsection_offsets_on_garbage_returns_none() {
+        // Bytes that aren't a valid superfile (no parquet footer)
+        // must fall back to None rather than panic.
+        let garbage = Bytes::from_static(b"not a parquet file at all");
+        assert!(build_subsection_offsets(&garbage).is_none());
+    }
+
+    // ---- vector append path ------------------------------------------
+
+    #[test]
+    fn append_with_vector_column_publishes_superfile() {
+        // Drive the vector branch of `append` (the FixedSizeList
+        // downcast + Arc<Float32Array> buffering).
+        let dim = 16;
+        let st = Supertable::create(options_with_vector(dim)).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_vector_batch(0, 8, dim)).expect("append");
+        assert!(
+            w.buffered_bytes() > 0,
+            "buffered_bytes must account for the vector payload"
+        );
+        w.commit().expect("commit");
+
+        let r = st.reader();
+        assert_eq!(r.n_superfiles(), 1);
+        assert_eq!(r.n_docs_total(), 8);
+    }
+
+    // ---- end-to-end update / delete through Supertable ----------------
+
+    /// A storage-backed supertable, required for the WAL-driven
+    /// update/delete pipeline.
+    fn storage_backed_st(dir: &TempDir) -> Supertable {
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        Supertable::create(options_id_title_serial().with_storage(storage)).expect("create")
+    }
+
+    fn row(title: &str) -> RecordBatch {
+        RecordBatch::try_new(
+            schema_id_title(),
+            vec![Arc::new(LargeStringArray::from(vec![title]))],
+        )
+        .expect("row batch")
+    }
+
+    #[test]
+    fn delete_tombstones_matching_row() {
+        use datafusion::prelude::{col, lit};
+        let dir = TempDir::new().expect("tempdir");
+        let st = storage_backed_st(&dir);
+        st.append(&build_simple_batch(0, 1)).expect("append");
+        // build_simple_batch titles are "doc 0 alpha".
+        let stats = st
+            .delete(col("title").eq(lit("doc 0 alpha")))
+            .expect("delete");
+        assert_eq!(stats.matched(), 1);
+        assert_eq!(stats.n_tombstoned(), 1);
+    }
+
+    #[test]
+    fn delete_unmatched_predicate_is_noop() {
+        use datafusion::prelude::{col, lit};
+        let dir = TempDir::new().expect("tempdir");
+        let st = storage_backed_st(&dir);
+        st.append(&build_simple_batch(0, 1)).expect("append");
+        let stats = st
+            .delete(col("title").eq(lit("no such title")))
+            .expect("delete");
+        assert_eq!(stats.matched(), 0);
+        assert_eq!(stats.n_tombstoned(), 0);
+    }
+
+    #[test]
+    fn update_replaces_matching_row() {
+        use datafusion::prelude::{col, lit};
+        let dir = TempDir::new().expect("tempdir");
+        let st = storage_backed_st(&dir);
+        st.append(&row("draft")).expect("append");
+        let stats = st
+            .update(col("title").eq(lit("draft")), &row("published"))
+            .expect("update");
+        assert_eq!(stats.matched(), 1);
+        assert_eq!(stats.n_tombstoned(), 1);
+    }
+
+    #[test]
+    fn update_cardinality_mismatch_is_rejected() {
+        use datafusion::prelude::{col, lit};
+        let dir = TempDir::new().expect("tempdir");
+        let st = storage_backed_st(&dir);
+        st.append(&row("draft")).expect("append");
+        // Predicate matches one row but new_rows has two — cardinality
+        // mismatch surfaces as a typed writer error.
+        let two = RecordBatch::try_new(
+            schema_id_title(),
+            vec![Arc::new(LargeStringArray::from(vec!["a", "b"]))],
+        )
+        .expect("two-row batch");
+        let mut w = st.writer().expect("writer");
+        let err = w
+            .update(col("title").eq(lit("draft")), two)
+            .expect_err("cardinality mismatch");
+        assert!(
+            matches!(
+                err,
+                MutationError::CardinalityMismatch {
+                    matched: 1,
+                    new_rows: 2
+                }
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn update_without_storage_is_rejected() {
+        use datafusion::prelude::{col, lit};
+        // No storage attached → the update pre-flight rejects.
+        let st = Supertable::create(options_id_title_serial()).expect("create");
+        let mut w = st.writer().expect("writer");
+        let err = w
+            .update(col("title").eq(lit("x")), row("y"))
+            .expect_err("no storage");
+        assert!(matches!(err, MutationError::NoStorageAttached), "{err:?}");
+    }
+
+    #[test]
+    fn delete_without_storage_is_rejected() {
+        use datafusion::prelude::{col, lit};
+        let st = Supertable::create(options_id_title_serial()).expect("create");
+        let mut w = st.writer().expect("writer");
+        let err = w.delete(col("title").eq(lit("x"))).expect_err("no storage");
+        assert!(matches!(err, MutationError::NoStorageAttached), "{err:?}");
+    }
+
+    #[test]
+    fn buffered_bytes_grows_then_resets_on_commit() {
+        let st = Supertable::create(options_id_title_serial()).expect("create");
+        let mut w = st.writer().expect("writer");
+        assert_eq!(w.buffered_bytes(), 0);
+        w.append(&build_simple_batch(0, 4)).expect("append");
+        assert!(w.buffered_bytes() > 0, "buffer cost recorded");
+        assert_eq!(w.buffered_batches(), 1);
+        w.commit().expect("commit");
+        assert_eq!(w.buffered_bytes(), 0, "buffer drained on commit");
+        assert_eq!(w.buffered_batches(), 0);
+    }
 }


### PR DESCRIPTION
Raises unit-test coverage so the coverage gate can be re-enabled. Tests only — no production code changes.

## Coverage (cargo llvm-cov, `--features test-helpers`)

| metric | before | after |
|---|---|---|
| lines | 88.89% | **92.84%** |
| regions | 90.12% | **93.31%** |
| functions | 85.16% | **90.33%** |

All three are now > 90%.

## What's covered

~230 new unit tests across ~22 files:
- The two files that were at **0%**: `storage/retry.rs` (re-issue / range-completion helpers) and `error.rs` (the `From`/`Display` conversions).
- `reader_cache/disk.rs`, superfile/FTS/vector readers, the query-exec TVF layer (`exec/{common,match,hybrid,fts,vector}_exec.rs`), manifest + options, handle/catalog/provider, `df_object_store`, WAL/writer/compaction, and `storage/s3.rs` (driven by the in-process `s3s` emulator, no cloud creds).

## Notes

- Tests only; no production code touched.
- The Makefile/CI threshold gate is **not** in this PR — it lands separately (`ci/fail-ci-if-coverage-drops-below-90`) after this merges.
- Two areas were left to integration tests / skipped as needing disproportionate infra: Azure round-trips (Azurite is an out-of-process emulator — only its server-free surface is unit-covered) and a few corrupt-blob / fault-injection paths.
- Relates to #114.
- Merged latest `main`.