### PR TITLE
refactor manifest: allow manifest ops only through api

### DIFF
--- a/benches/utils/tombstone_overhead.rs
+++ b/benches/utils/tombstone_overhead.rs
@@ -169,7 +169,7 @@ impl WorkloadState {
 fn drive_tombstones(st: &Supertable, ws: &WalStore, fraction: f64, churn: bool) {
     let manifest = st.reader().manifest().clone();
     let mut targets: Vec<i128> = Vec::new();
-    for entry in manifest.superfile_list.superfiles.iter() {
+    for entry in manifest.get_all_superfiles().iter() {
         let n = (entry.n_docs as f64 * fraction).ceil() as i64;
         for i in 0..n {
             targets.push(entry.id_min + i as i128);

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -1736,9 +1736,8 @@ pub(crate) mod diag {
                 keys.push(infino::supertable::manifest::commit::list_uri(
                     consumer.manifest_id(),
                 ));
-                if let Some(list) = &manifest.list {
-                    keys.extend(list.parts.iter().map(|p| p.uri.clone()));
-                }
+                let list_entries = manifest.get_all_list_entries();
+                keys.extend(list_entries.iter().map(|p| p.uri.clone()));
                 keys.extend(
                     manifest
                         .superfiles

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -172,8 +172,7 @@ impl Supertable {
         // This populates both bitmap and seal information for all superfiles.
         // The cache returns empty bitmaps for superfiles without tombstones.
         let superfile_ids: Vec<Uuid> = manifest
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .iter()
             .map(|e| e.superfile_id)
             .collect();
@@ -204,8 +203,7 @@ impl Supertable {
 
         // Build SuperfileStats for every superfile in the snapshot.
         let stats: Vec<SuperfileStats> = manifest
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .iter()
             .map(|entry| {
                 let (bitmap, seal) = sidecar_map
@@ -321,8 +319,7 @@ impl Supertable {
             .iter()
             .map(|id| {
                 manifest
-                    .superfile_list
-                    .superfiles
+                    .get_all_superfiles()
                     .iter()
                     .find(|e| e.superfile_id == *id)
                     .cloned()
@@ -675,8 +672,7 @@ mod tests {
         let reader = st.reader();
         let superfiles: Vec<Arc<SuperfileEntry>> = reader
             .manifest()
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .iter()
             .take(2)
             .cloned()
@@ -719,8 +715,7 @@ mod tests {
         let reader = st.reader();
         let superfiles: Vec<Arc<SuperfileEntry>> = reader
             .manifest()
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .iter()
             .take(2)
             .cloned()
@@ -812,8 +807,7 @@ mod tests {
         let reader = st.reader();
         let superfiles: Vec<Arc<SuperfileEntry>> = reader
             .manifest()
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .iter()
             .take(3)
             .cloned()
@@ -884,8 +878,7 @@ mod tests {
         let reader = st.reader();
         let superfiles: Vec<Arc<SuperfileEntry>> = reader
             .manifest()
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .iter()
             .take(1)
             .cloned()

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -317,4 +317,7 @@ pub enum QueryError {
 
     #[error("DataFusion failed to execute the query: {0}")]
     Execute(String),
+
+    #[error("manifest load error: {0}")]
+    ManifestLoad(ManifestLoadError),
 }

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -642,7 +642,7 @@ impl Supertable {
     #[cfg(any(test, feature = "test-helpers"))]
     pub fn stats(&self) -> crate::supertable::SupertableStats {
         let manifest = self.inner.manifest.load();
-        let n_manifest_parts = manifest.list.as_ref().map(|l| l.parts.len());
+        let n_manifest_parts = manifest.get_num_parts();
         let cache = self.inner.options.disk_cache.as_ref();
         let mmap_resident_bytes = cache.map(|c| c.current_mmap_size_bytes());
         // One `cache.stats()` call covers four fields. Cache
@@ -652,10 +652,10 @@ impl Supertable {
         // adequate for observability.
         let cache_snapshot = cache.map(|c| c.stats());
         crate::supertable::SupertableStats {
-            manifest_id: manifest.superfile_list.manifest_id,
-            n_superfiles: manifest.superfile_list.superfiles.len(),
+            manifest_id: manifest.get_manifest_id(),
+            n_superfiles: manifest.get_all_superfiles().len(),
             n_manifest_parts,
-            n_manifest_parts_loaded: manifest.parts.len(),
+            n_manifest_parts_loaded: manifest.get_num_parts_loaded(),
             process_rss_bytes: crate::supertable::stats::process_rss_bytes(),
             mmap_resident_bytes,
             memory_budget_bytes: self.inner.options.memory_budget_bytes,
@@ -1175,7 +1175,7 @@ mod tests {
         assert_eq!(s.manifest_id, 1);
         assert_eq!(s.n_superfiles, 2);
         // In-memory supertable has no manifest list / disk cache.
-        assert_eq!(s.n_manifest_parts, None);
+        assert_eq!(s.n_manifest_parts, 0);
         assert_eq!(s.mmap_resident_bytes, None);
         assert_eq!(s.n_cold_fetches, None);
     }

--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -576,7 +576,7 @@ pub async fn rebalance_for_commit(
                     });
                 } else {
                     // Rewrite: load existing part and combine with new superfiles.
-                    let existing_part = old.part(entry.part_id).await.map_err(|e| {
+                    let existing_part = old.get_part_by_id(entry.part_id).await.map_err(|e| {
                         crate::supertable::CommitError::PointerParse(format!(
                             "loading existing part {} for partition rewrite: {e}",
                             entry.part_id.0
@@ -657,7 +657,7 @@ pub async fn rebalance_for_commit(
                     .collect::<Vec<_>>(),
                 Some(existing),
             )
-        } else if let Ok(existing_part) = old.part(entry.part_id).await {
+        } else if let Ok(existing_part) = old.get_part_by_id(entry.part_id).await {
             (
                 existing_part
                     .superfiles

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -32,7 +32,7 @@ pub mod part;
 pub mod partition;
 pub mod term_range;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::compute::kernels::aggregate as agg;
@@ -42,11 +42,13 @@ use dashmap::DashMap;
 use uuid::Uuid;
 use xxhash_rust::xxh3::xxh3_64;
 
+use crate::supertable::manifest::part::PartId;
+use crate::supertable::query::prune::PruneLeaf;
 use crate::{
     superfile::vector::distance::{
         COSINE_DISTANCE_BASE, L2_CROSS_TERM_COEFF, Metric, sq8_dot, u8_sum_sumsq,
     },
-    supertable::manifest::commit::read_pointer,
+    supertable::{manifest::commit::read_pointer, query::hierarchical_iter},
 };
 
 use bloom::Bloom;
@@ -142,13 +144,13 @@ impl SuperfileList {
 ///
 /// [`ManifestList`]: list::ManifestList
 pub struct Manifest {
-    pub superfile_list: SuperfileList,
-    pub list: Option<list::ManifestList>,
-    pub parts: dashmap::DashMap<
+    superfile_list: SuperfileList,
+    list: Option<list::ManifestList>,
+    parts: dashmap::DashMap<
         part::PartId,
         std::sync::Arc<tokio::sync::OnceCell<std::sync::Arc<part::ManifestPart>>>,
     >,
-    pub loader: Option<std::sync::Arc<ManifestPartLoader>>,
+    loader: Option<std::sync::Arc<ManifestPartLoader>>,
 }
 
 impl std::fmt::Debug for Manifest {
@@ -175,6 +177,38 @@ impl std::ops::Deref for Manifest {
 }
 
 impl Manifest {
+    pub fn new(
+        manifest_id: u64,
+        options: Arc<SupertableOptions>,
+        superfile_list: Vec<Arc<SuperfileEntry>>,
+        storage: Option<Arc<dyn crate::storage::StorageProvider>>,
+        list: Option<list::ManifestList>,
+    ) -> Self {
+        let superfile_list = SuperfileList {
+            manifest_id,
+            options,
+            superfiles: superfile_list,
+        };
+        if let Some(storage) = storage
+            && let Some(list) = list
+        {
+            let loader = Arc::new(ManifestPartLoader::new(Arc::clone(&storage), &list));
+            Self {
+                superfile_list,
+                list: Some(list),
+                parts: dashmap::DashMap::new(),
+                loader: Some(loader),
+            }
+        } else {
+            Self {
+                superfile_list,
+                list: None,
+                parts: dashmap::DashMap::new(),
+                loader: None,
+            }
+        }
+    }
+
     /// Empty initial manifest at `manifest_id = 0`. Used by
     /// `Supertable::create` when no storage is attached.
     pub fn empty(options: Arc<SupertableOptions>) -> Self {
@@ -184,6 +218,43 @@ impl Manifest {
             parts: dashmap::DashMap::new(),
             loader: None,
         }
+    }
+
+    pub fn get_manifest_id(&self) -> u64 {
+        self.superfile_list.manifest_id
+    }
+
+    pub fn get_partition_strategy(&self) -> list::PartitionStrategy {
+        self.list
+            .as_ref()
+            .map(|l| l.partition_strategy.clone())
+            .unwrap_or(self.superfile_list.options.effective_partition_strategy())
+    }
+
+    pub fn get_num_parts(&self) -> usize {
+        self.list.as_ref().map(|l| l.parts.len()).unwrap_or(0)
+    }
+
+    pub fn get_num_parts_loaded(&self) -> usize {
+        self.parts.len()
+    }
+
+    pub fn is_in_process_only(&self) -> bool {
+        self.list.is_none()
+    }
+
+    pub fn get_cached_part_by_id(&self, part_id: &part::PartId) -> Option<Arc<part::ManifestPart>> {
+        self.parts
+            .get(part_id)
+            .and_then(|cell| cell.value().get().cloned())
+    }
+
+    pub fn get_cached_part_by_list_idx(&self, idx: usize) -> Option<Arc<part::ManifestPart>> {
+        let Some(list) = &self.list else {
+            return None;
+        };
+        let part_id = list.parts[idx].part_id;
+        self.get_cached_part_by_id(&part_id)
     }
 
     pub(crate) async fn load(
@@ -347,6 +418,70 @@ impl Manifest {
         Ok(Arc::new(new_manifest))
     }
 
+    pub fn get_all_superfiles(&self) -> &[Arc<SuperfileEntry>] {
+        &self.superfile_list.superfiles
+    }
+
+    pub(crate) async fn get_pruned_superfiles(
+        &self,
+        leaves: &[PruneLeaf],
+    ) -> Result<Vec<Arc<SuperfileEntry>>, ManifestLoadError> {
+        match &self.list {
+            Some(list) => {
+                // Intersect each constraining leaf's kept-part set. A leaf
+                // with no part pruner (`None`) imposes no constraint.
+                let mut kept: Option<HashSet<PartId>> = None;
+                for leaf in leaves {
+                    if let Some(part_ids) = leaf.keep_parts(list) {
+                        let set: HashSet<PartId> = part_ids.into_iter().collect();
+                        kept = Some(match kept {
+                            None => set,
+                            Some(existing) => existing.intersection(&set).copied().collect(),
+                        });
+                    }
+                }
+                // Preserve manifest (time) order of the surviving parts.
+                let ordered: Vec<PartId> = match kept {
+                    Some(set) => list
+                        .parts
+                        .iter()
+                        .map(|p| p.part_id)
+                        .filter(|id| set.contains(id))
+                        .collect(),
+                    None => list.parts.iter().map(|p| p.part_id).collect(),
+                };
+                hierarchical_iter::load_and_flatten(self, &ordered).await
+            }
+            None => Ok(hierarchical_iter::fallback_to_flat_superfiles(self)),
+        }
+    }
+
+    pub(crate) async fn get_pruned_superfiles_for_vector(
+        &self,
+        column: &str,
+        query: &[f32],
+    ) -> Result<Vec<Arc<SuperfileEntry>>, ManifestLoadError> {
+        match &self.list {
+            Some(list) => {
+                let kept = crate::supertable::manifest::list_prune::prune_parts_for_vector(
+                    list,
+                    column,
+                    query,
+                    f32::INFINITY,
+                );
+                hierarchical_iter::load_and_flatten(self, &kept).await
+            }
+            None => Ok(hierarchical_iter::fallback_to_flat_superfiles(self)),
+        }
+    }
+
+    pub fn get_all_list_entries(&self) -> &[list::ManifestListEntry] {
+        match &self.list {
+            Some(list) => &list.parts,
+            None => &[],
+        }
+    }
+
     /// Build a successor manifest with `new_entries` appended.
     /// Preserves the persistence-side metadata (`list`, `loader`)
     /// from the predecessor; the per-part cache is fresh (an empty
@@ -376,7 +511,7 @@ impl Manifest {
     ///   blake3 doesn't match the manifest list's recorded hash.
     /// - `OpenError::ManifestPartParse { … }` for Avro / zstd
     ///   decode failures.
-    pub async fn part(
+    pub async fn get_part_by_id(
         &self,
         part_id: part::PartId,
     ) -> Result<std::sync::Arc<part::ManifestPart>, ManifestLoadError> {
@@ -2019,7 +2154,7 @@ mod tests {
             let manifest =
                 build_manifest_with_loader(list, Arc::clone(&storage) as Arc<dyn StorageProvider>);
 
-            let loaded = manifest.part(part.part_id).await.expect("load");
+            let loaded = manifest.get_part_by_id(part.part_id).await.expect("load");
             assert_eq!(loaded.part_id, part.part_id);
             assert_eq!(storage.get_call_count(), 1, "exactly one storage.get");
         }
@@ -2033,8 +2168,14 @@ mod tests {
             let manifest =
                 build_manifest_with_loader(list, Arc::clone(&storage) as Arc<dyn StorageProvider>);
 
-            let a = manifest.part(part.part_id).await.expect("first load");
-            let b = manifest.part(part.part_id).await.expect("second load");
+            let a = manifest
+                .get_part_by_id(part.part_id)
+                .await
+                .expect("first load");
+            let b = manifest
+                .get_part_by_id(part.part_id)
+                .await
+                .expect("second load");
             assert!(Arc::ptr_eq(&a, &b), "second touch must return cached Arc");
             assert_eq!(storage.get_call_count(), 1, "cache hit ⇒ no extra get");
         }
@@ -2055,7 +2196,7 @@ mod tests {
             for _ in 0..100 {
                 let m = Arc::clone(&manifest);
                 let pid = part.part_id;
-                handles.push(tokio::spawn(async move { m.part(pid).await }));
+                handles.push(tokio::spawn(async move { m.get_part_by_id(pid).await }));
             }
             let mut first: Option<Arc<ManifestPart>> = None;
             for h in handles {
@@ -2095,7 +2236,7 @@ mod tests {
                 build_manifest_with_loader(list, Arc::clone(&storage) as Arc<dyn StorageProvider>);
 
             let err = manifest
-                .part(part.part_id)
+                .get_part_by_id(part.part_id)
                 .await
                 .expect_err("must reject tampered bytes");
             assert!(
@@ -2109,7 +2250,7 @@ mod tests {
             // not magically succeed.
             let _pre = storage.get_call_count();
             let err2 = manifest
-                .part(part.part_id)
+                .get_part_by_id(part.part_id)
                 .await
                 .expect_err("must reject on retry too");
             assert!(matches!(
@@ -2128,7 +2269,10 @@ mod tests {
                 build_manifest_with_loader(list, Arc::clone(&storage) as Arc<dyn StorageProvider>);
 
             let stranger = PartId(Uuid::from_bytes([0xff; 16]));
-            let err = manifest.part(stranger).await.expect_err("must reject");
+            let err = manifest
+                .get_part_by_id(stranger)
+                .await
+                .expect_err("must reject");
             assert!(
                 matches!(err, ManifestLoadError::PartNotInList { .. }),
                 "expected PartNotInList, got {err:?}"
@@ -2147,7 +2291,7 @@ mod tests {
             // not panic.
             let manifest = Manifest::empty(options_for_test());
             let err = manifest
-                .part(PartId(Uuid::nil()))
+                .get_part_by_id(PartId(Uuid::nil()))
                 .await
                 .expect_err("must error");
             assert!(

--- a/src/supertable/query/covered_agg.rs
+++ b/src/supertable/query/covered_agg.rs
@@ -156,7 +156,7 @@ fn try_rewrite(plan: &LogicalPlan) -> DfResult<Option<LogicalPlan>> {
     // Hierarchical manifests keep segments in lazily-loaded parts; the
     // flat view may be partial, so classification would be unsound.
     let manifest = provider.manifest();
-    if manifest.list.is_some() {
+    if !manifest.is_in_process_only() {
         return Ok(None);
     }
     let id_column = manifest.options.id_column.as_str();

--- a/src/supertable/query/hierarchical_iter.rs
+++ b/src/supertable/query/hierarchical_iter.rs
@@ -26,7 +26,7 @@
 
 use std::sync::Arc;
 
-use crate::supertable::error::QueryError;
+use crate::supertable::ManifestLoadError;
 use crate::supertable::manifest::part::{ManifestPart, PartId};
 use crate::supertable::manifest::{Manifest, SuperfileEntry};
 
@@ -46,7 +46,7 @@ use crate::supertable::manifest::{Manifest, SuperfileEntry};
 pub async fn load_kept_parts(
     manifest: &Manifest,
     kept_part_ids: &[PartId],
-) -> Result<Vec<Arc<ManifestPart>>, QueryError> {
+) -> Result<Vec<Arc<ManifestPart>>, ManifestLoadError> {
     if kept_part_ids.is_empty() {
         return Ok(Vec::new());
     }
@@ -54,14 +54,14 @@ pub async fn load_kept_parts(
         .iter()
         .map(|id| {
             let pid = *id;
-            async move { manifest.part(pid).await }
+            async move { manifest.get_part_by_id(pid).await }
         })
         .collect();
 
     let loaded = futures::future::join_all(load_futs).await;
     let mut out = Vec::with_capacity(loaded.len());
     for r in loaded {
-        out.push(r.map_err(|e| QueryError::Store(format!("part load: {e}")))?);
+        out.push(r?);
     }
     Ok(out)
 }
@@ -84,7 +84,7 @@ pub fn flatten_superfiles(parts: &[Arc<ManifestPart>]) -> Vec<Arc<SuperfileEntry
 pub async fn load_and_flatten(
     manifest: &Manifest,
     kept_part_ids: &[PartId],
-) -> Result<Vec<Arc<SuperfileEntry>>, QueryError> {
+) -> Result<Vec<Arc<SuperfileEntry>>, ManifestLoadError> {
     let parts = load_kept_parts(manifest, kept_part_ids).await?;
     Ok(flatten_superfiles(&parts))
 }

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -549,7 +549,7 @@ impl TableProvider for SupertableProvider {
         // there, so whole-table claims would be wrong. The scan-level
         // statistics (computed from the actually-flattened survivors)
         // still apply in that mode.
-        if self.manifest.list.is_some() {
+        if !self.manifest.is_in_process_only() {
             return None;
         }
         Some(self.statistics_for(&self.manifest.superfiles))

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -26,7 +26,6 @@
 //! different shape from these static boolean tests. It keeps its own
 //! path.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use arrow::ipc::reader::StreamReader;
@@ -41,7 +40,6 @@ use crate::supertable::manifest::list_prune::{
 use crate::supertable::manifest::part::PartId;
 use crate::supertable::manifest::{Manifest, SuperfileEntry};
 
-use super::hierarchical_iter;
 use super::skip::{
     ScalarPredicate, fts_bloom_skip, fts_prefix_skip, scalar_skip, scalar_value_may_match,
 };
@@ -69,7 +67,7 @@ pub(crate) enum PruneLeaf {
 impl PruneLeaf {
     /// Part-tier keep set for this leaf, or `None` when the leaf has no
     /// part-level pruner (it imposes no part constraint → keep all).
-    fn keep_parts(&self, list: &ManifestList) -> Option<Vec<PartId>> {
+    pub(crate) fn keep_parts(&self, list: &ManifestList) -> Option<Vec<PartId>> {
         match self {
             PruneLeaf::TermPresence {
                 column,
@@ -145,34 +143,10 @@ pub(crate) async fn select_superfiles(
 ) -> Result<Vec<Arc<SuperfileEntry>>, QueryError> {
     // ---- Tier A: part-level prune (only when a hierarchical list
     // exists; otherwise the flat superfile view is the whole table).
-    let superfiles: Vec<Arc<SuperfileEntry>> = match manifest.list.as_ref() {
-        Some(list) => {
-            // Intersect each constraining leaf's kept-part set. A leaf
-            // with no part pruner (`None`) imposes no constraint.
-            let mut kept: Option<HashSet<PartId>> = None;
-            for leaf in leaves {
-                if let Some(part_ids) = leaf.keep_parts(list) {
-                    let set: HashSet<PartId> = part_ids.into_iter().collect();
-                    kept = Some(match kept {
-                        None => set,
-                        Some(existing) => existing.intersection(&set).copied().collect(),
-                    });
-                }
-            }
-            // Preserve manifest (time) order of the surviving parts.
-            let ordered: Vec<PartId> = match kept {
-                Some(set) => list
-                    .parts
-                    .iter()
-                    .map(|p| p.part_id)
-                    .filter(|id| set.contains(id))
-                    .collect(),
-                None => list.parts.iter().map(|p| p.part_id).collect(),
-            };
-            hierarchical_iter::load_and_flatten(manifest, &ordered).await?
-        }
-        None => hierarchical_iter::fallback_to_flat_superfiles(manifest),
-    };
+    let superfiles = manifest
+        .get_pruned_superfiles(leaves)
+        .await
+        .map_err(QueryError::ManifestLoad)?;
 
     if superfiles.is_empty() {
         return Ok(Vec::new());

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -112,25 +112,11 @@ impl SupertableReader {
             return Ok(Vec::new());
         }
         let manifest = self.manifest();
+        let superfiles = manifest
+            .get_pruned_superfiles_for_vector(column, query)
+            .await
+            .map_err(QueryError::ManifestLoad)?;
 
-        let superfiles: Vec<Arc<SuperfileEntry>> = match manifest.list.as_ref() {
-            Some(list) => {
-                let kept = crate::supertable::manifest::list_prune::prune_parts_for_vector(
-                    list,
-                    column,
-                    query,
-                    f32::INFINITY,
-                );
-                crate::supertable::query::hierarchical_iter::load_and_flatten(
-                    manifest.as_ref(),
-                    &kept,
-                )
-                .await?
-            }
-            None => crate::supertable::query::hierarchical_iter::fallback_to_flat_superfiles(
-                manifest.as_ref(),
-            ),
-        };
         if superfiles.is_empty() {
             return Ok(Vec::new());
         }

--- a/src/supertable/stats.rs
+++ b/src/supertable/stats.rs
@@ -46,14 +46,7 @@ pub struct SupertableStats {
 
     /// Number of manifest parts referenced in the currently
     /// pinned [`crate::supertable::manifest::list::ManifestList`].
-    ///
-    /// `None` for supertables whose current `Manifest` has no
-    /// persisted list — i.e., freshly `create`'d in-process
-    /// supertables, or supertables with `options.storage =
-    /// None`. Such supertables operate entirely through the
-    /// flat `SuperfileList`; the hierarchical part structure is
-    /// only meaningful for persisted supertables.
-    pub n_manifest_parts: Option<usize>,
+    pub n_manifest_parts: usize,
 
     /// Number of manifest parts that have been hydrated in
     /// the in-memory cache. Always ≤ `n_manifest_parts` when

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -257,8 +257,7 @@ pub async fn run_append_phase(
 /// linear scan is fine at the supertable sizes we target.
 fn manifest_contains(manifest: &crate::supertable::Manifest, superfile_id: Uuid) -> bool {
     manifest
-        .superfile_list
-        .superfiles
+        .get_all_superfiles()
         .iter()
         .any(|s| s.uri.0 == superfile_id)
 }
@@ -1057,7 +1056,7 @@ fn resolve_target_id_in_manifest(
 ) -> Result<Option<(Uuid, u32)>, TombstonePhaseError> {
     let target = target_id.0;
 
-    for entry in manifest.superfile_list.superfiles.iter() {
+    for entry in manifest.get_all_superfiles().iter() {
         if target < entry.id_min || target > entry.id_max {
             continue;
         }
@@ -1473,8 +1472,7 @@ mod tests {
         let manifest1 = st1.inner().manifest.load_full();
         let pre_uuid = wal.preallocated_superfile_id.expect("set");
         let entry1 = manifest1
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .iter()
             .find(|e| e.uri.0 == pre_uuid)
             .expect("entry");
@@ -1505,8 +1503,7 @@ mod tests {
         // Sanity: the entry's stats also agree.
         let manifest2 = st2.inner().manifest.load_full();
         let entry2 = manifest2
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .iter()
             .find(|e| e.uri.0 == pre_uuid)
             .expect("entry");

--- a/src/supertable/wal/recovery_sweep_tests.rs
+++ b/src/supertable/wal/recovery_sweep_tests.rs
@@ -96,8 +96,7 @@ async fn open_time_sweep_drives_pre_seeded_intent_walls_to_complete() {
             .expect("open");
         let manifest = st.reader().manifest().clone();
         target_id = manifest
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .first()
             .expect("superfile present")
             .id_min;
@@ -178,7 +177,7 @@ fn create_with_existing_pointer_delegates_to_open() {
     .expect("create with existing pointer");
     let manifest = st.reader().manifest().clone();
     assert!(
-        !manifest.superfile_list.superfiles.is_empty(),
+        !manifest.get_all_superfiles().is_empty(),
         "create against existing pointer must load the committed manifest"
     );
     let batches = st
@@ -228,8 +227,7 @@ async fn sweep_preempts_expired_lease_and_completes_wal() {
             .expect("open for manifest");
         let manifest = st.reader().manifest().clone();
         target_id = manifest
-            .superfile_list
-            .superfiles
+            .get_all_superfiles()
             .first()
             .expect("superfile")
             .id_min;

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -70,12 +70,9 @@ use crate::superfile::format::vec::{
 };
 use crate::superfile::format::{footer::read_kv_metadata, kv};
 use crate::supertable::manifest::Manifest;
-use crate::supertable::manifest::ManifestPartLoader;
 use crate::supertable::manifest::commit::get_current_manifest_etag;
 use crate::supertable::manifest::commit::{self as commit_mod};
-use crate::supertable::manifest::list::{
-    FORMAT_VERSION as LIST_FORMAT_VERSION, ManifestList, PartitionStrategy,
-};
+use crate::supertable::manifest::list::{FORMAT_VERSION as LIST_FORMAT_VERSION, ManifestList};
 use crate::supertable::manifest::part::{self as part_mod, PartId};
 use crate::supertable::{CommitError as SupertableCommitError, ManifestLoadError};
 
@@ -1661,8 +1658,15 @@ pub(in crate::supertable) fn persist_commit(
             // iteration) feeds into our successor's
             // `new_superfile_list`.
             let old = inner.manifest.load_full();
-            let new_superfile_list = old.superfile_list.with_appended(new_entries.clone());
+            let new_superfile_list = old
+                .get_all_superfiles()
+                .iter()
+                .chain(new_entries.iter())
+                .map(Arc::clone)
+                .collect::<Vec<_>>();
+
             let pending_writes = &mut pending_storage_writes;
+            let new_manifest_id = old.manifest_id + 1;
 
             match try_commit_attempt(
                 Arc::clone(&storage_async),
@@ -1670,13 +1674,17 @@ pub(in crate::supertable) fn persist_commit(
                 Arc::clone(&old),
                 &new_entries,
                 &[],
-                new_superfile_list.manifest_id,
+                new_manifest_id,
                 pending_writes,
             )
             .await
             {
                 Ok(new_list) => {
-                    return Ok::<_, crate::supertable::CommitError>((new_list, new_superfile_list));
+                    return Ok::<_, crate::supertable::CommitError>((
+                        new_manifest_id,
+                        new_list,
+                        new_superfile_list,
+                    ));
                 }
                 Err(crate::supertable::CommitError::WriteContentionExhausted)
                     if attempt + 1 < max_retries =>
@@ -1696,30 +1704,34 @@ pub(in crate::supertable) fn persist_commit(
         Err(last_err.unwrap_or(crate::supertable::CommitError::WriteContentionExhausted))
     };
 
-    let (new_list, new_superfile_list) = match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            // Ambient tokio runtime present — use it. Don't
-            // touch `inner.query_runtime()` so we don't risk
-            // dropping our owned runtime from within
-            // another's worker context.
-            tokio::task::block_in_place(|| handle.block_on(drive))?
-        }
-        Err(_) => {
-            // Sync caller; lazy-init the supertable's
-            // owned runtime.
-            inner.query_runtime().block_on(drive)?
-        }
-    };
+    let (new_manifest_id, new_list, new_superfile_list) =
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                // Ambient tokio runtime present — use it. Don't
+                // touch `inner.query_runtime()` so we don't risk
+                // dropping our owned runtime from within
+                // another's worker context.
+                tokio::task::block_in_place(|| handle.block_on(drive))?
+            }
+            Err(_) => {
+                // Sync caller; lazy-init the supertable's
+                // owned runtime.
+                inner.query_runtime().block_on(drive)?
+            }
+        };
 
     // Build the new in-memory Manifest with the persisted
     // list + a fresh ManifestPartLoader installed.
-    let loader = Arc::new(ManifestPartLoader::new(Arc::clone(&storage), &new_list));
-    Ok(Manifest {
-        superfile_list: new_superfile_list,
-        list: Some(new_list),
-        parts: dashmap::DashMap::new(),
-        loader: Some(loader),
-    })
+    let opts = Arc::clone(&inner.options);
+    let manifest = Manifest::new(
+        new_manifest_id,
+        opts,
+        new_superfile_list,
+        Some(storage),
+        Some(new_list),
+    );
+
+    Ok(manifest)
 }
 
 // Writes the superfile list to storage. Performs the side-effect of modifying pending_storage_writes
@@ -1832,11 +1844,7 @@ pub(crate) async fn try_commit_attempt(
     //    against this so a schema mismatch surfaces as a
     //    typed error rather than a downstream decode
     //    failure.
-    let strategy: PartitionStrategy = old
-        .list
-        .as_ref()
-        .map(|l| l.partition_strategy.clone())
-        .unwrap_or_else(|| opts.effective_partition_strategy());
+    let strategy = old.get_partition_strategy();
     let opts_hash =
         crate::supertable::manifest::options_hash::compute_options_hash(opts.as_ref(), &strategy);
     let new_list = ManifestList {

--- a/tests/supertable/commit/id_uniqueness.rs
+++ b/tests/supertable/commit/id_uniqueness.rs
@@ -194,7 +194,7 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
     )
     .expect("open");
     let reader = consumer.reader();
-    let segs = &reader.manifest().superfile_list.superfiles;
+    let segs = reader.manifest().get_all_superfiles();
     assert_eq!(
         segs.len(),
         N_HANDLES,

--- a/tests/supertable/commit/partition_assignment.rs
+++ b/tests/supertable/commit/partition_assignment.rs
@@ -85,22 +85,19 @@ fn default_strategy_is_single_bucket_hash_observationally_equivalent_to_pre_m15a
 
     let r = st.reader();
     let m = r.manifest();
-    let list = m
-        .list
-        .as_ref()
-        .expect("list exists after storage-backed commits");
+    let list_entries = m.get_all_list_entries();
     assert_eq!(
-        list.parts.len(),
+        list_entries.len(),
         1,
         "single-bucket default → one list entry; got {} entries",
-        list.parts.len()
+        list_entries.len()
     );
     assert_eq!(
-        list.parts[0].n_superfiles, 3,
+        list_entries[0].n_superfiles, 3,
         "after 3 single-superfile commits the part should hold 3 superfiles"
     );
     // partition_key is the 4-byte LE encoding of bucket 0.
-    assert_eq!(list.parts[0].partition_key, [0u8, 0, 0, 0]);
+    assert_eq!(list_entries[0].partition_key, [0u8, 0, 0, 0]);
 }
 
 #[test]
@@ -123,8 +120,8 @@ fn rewrite_path_produces_fresh_part_id_per_commit() {
         let m_id = {
             let r = st.reader();
             let m = r.manifest();
-            let list = m.list.as_ref().expect("list");
-            list.parts[0].part_id
+            let list_entries = m.get_all_list_entries();
+            list_entries[0].part_id
         };
         part_ids.push(m_id);
     }
@@ -158,19 +155,19 @@ fn target_superfiles_per_partition_triggers_part_split() {
 
     let r = st.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
+    let list_entries = m.get_all_list_entries();
     assert_eq!(
-        list.parts.len(),
+        list_entries.len(),
         2,
         "after 3 commits with target=2, the partition should split into 2 entries; \
          got {} entries",
-        list.parts.len()
+        list_entries.len()
     );
     assert_eq!(
-        list.parts[0].partition_key, list.parts[1].partition_key,
+        list_entries[0].partition_key, list_entries[1].partition_key,
         "both entries should share the same partition_key (same partition, split into 2 parts)"
     );
-    let total_superfiles: u64 = list.parts.iter().map(|p| p.n_superfiles).sum();
+    let total_superfiles: u64 = list_entries.iter().map(|p| p.n_superfiles).sum();
     assert_eq!(total_superfiles, 3);
 }
 
@@ -295,16 +292,16 @@ fn time_range_assigns_int64_superfiles_to_bucket_zero() {
     }
     let r = st.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
+    let list_entries = m.get_all_list_entries();
     assert_eq!(
-        list.parts.len(),
+        list_entries.len(),
         1,
         "single-bucket commit produces one part"
     );
     // TimeRange partition_key is 8 bytes LE bucket index.
-    assert_eq!(list.parts[0].partition_key.len(), PARTITION_KEY_BYTES);
+    assert_eq!(list_entries[0].partition_key.len(), PARTITION_KEY_BYTES);
     let bucket = u64::from_le_bytes(
-        list.parts[0]
+        list_entries[0]
             .partition_key
             .as_slice()
             .try_into()

--- a/tests/supertable/commit/stats.rs
+++ b/tests/supertable/commit/stats.rs
@@ -48,7 +48,7 @@ fn fresh_supertable_returns_empty_stats() {
     assert_eq!(s.manifest_id, 0);
     assert_eq!(s.n_superfiles, 0);
     assert_eq!(
-        s.n_manifest_parts, None,
+        s.n_manifest_parts, 0,
         "fresh in-process supertable has no ManifestList"
     );
     assert_eq!(s.n_manifest_parts_loaded, 0);
@@ -82,7 +82,7 @@ fn stats_track_commits_on_in_process_supertable() {
         s2.n_superfiles
     );
     assert_eq!(
-        s2.n_manifest_parts, None,
+        s2.n_manifest_parts, 0,
         "in-process supertable never has a ManifestList"
     );
 }
@@ -108,8 +108,7 @@ fn stats_show_manifest_parts_when_storage_attached() {
     let producer_stats = producer.stats();
     assert_eq!(producer_stats.manifest_id, 1);
     assert_eq!(
-        producer_stats.n_manifest_parts,
-        Some(1),
+        producer_stats.n_manifest_parts, 1,
         "post-commit ManifestList exists with one part"
     );
     assert_eq!(
@@ -125,7 +124,7 @@ fn stats_show_manifest_parts_when_storage_attached() {
             .expect("open");
     let consumer_stats = consumer.stats();
     assert_eq!(consumer_stats.manifest_id, 1);
-    assert_eq!(consumer_stats.n_manifest_parts, Some(1));
+    assert_eq!(consumer_stats.n_manifest_parts, 1);
     assert_eq!(
         consumer_stats.n_manifest_parts_loaded, 1,
         "open eager-fetches every part"

--- a/tests/supertable/disk_cache/end_to_end.rs
+++ b/tests/supertable/disk_cache/end_to_end.rs
@@ -328,7 +328,7 @@ fn manifest_superfiles_are_not_pinned_by_supertable_create() {
     let post = cache.current_pinned_uris();
     assert!(post.is_empty(), "expected empty pinned set; got {post:?}");
     let reader = st.reader();
-    assert_eq!(reader.manifest().superfile_list.superfiles.len(), 1);
+    assert_eq!(reader.manifest().get_all_superfiles().len(), 1);
 }
 
 #[test]
@@ -367,7 +367,7 @@ fn manifest_superfiles_are_not_pinned_by_supertable_open() {
         pinned.is_empty(),
         "expected empty pinned set; got {pinned:?}"
     );
-    let n_superfiles = consumer.reader().manifest().superfile_list.superfiles.len();
+    let n_superfiles = consumer.reader().manifest().get_all_superfiles().len();
     assert_eq!(n_superfiles, 1);
 }
 

--- a/tests/supertable/manifest/lazy_open.rs
+++ b/tests/supertable/manifest/lazy_open.rs
@@ -64,17 +64,17 @@ fn one_part_eager_fetches_under_default_threshold() {
 
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    assert_eq!(list.parts.len(), 1);
+    let list_entries = m.get_all_list_entries();
+    assert_eq!(list_entries.len(), 1);
     assert_eq!(
-        m.superfile_list.superfiles.len(),
+        m.get_all_superfiles().len(),
         1,
         "eager mode must populate superfile_list.superfiles"
     );
     // Eager-mode populates the OnceCell.
-    let cell = m.parts.get(&list.parts[0].part_id).expect("part in cache");
+    let part = m.get_cached_part_by_list_idx(0);
     assert!(
-        cell.value().get().is_some(),
+        part.is_some(),
         "eager-fetched OnceCell should be initialized"
     );
 }
@@ -107,25 +107,19 @@ fn many_parts_skip_eager_fetch() {
             .expect("open");
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    assert_eq!(list.parts.len(), 5);
+    let list_entries = m.get_all_list_entries();
+    assert_eq!(list_entries.len(), 5);
     assert!(
-        m.superfile_list.superfiles.is_empty(),
+        m.get_all_superfiles().is_empty(),
         "lazy mode leaves superfile_list.superfiles empty pending \
          the hierarchical query path; got {} superfiles",
-        m.superfile_list.superfiles.len()
+        m.get_all_superfiles().len()
     );
 
     // Every part has an empty OnceCell.
-    let n_loaded = list
-        .parts
+    let n_loaded = list_entries
         .iter()
-        .filter(|entry| {
-            m.parts
-                .get(&entry.part_id)
-                .map(|c| c.value().get().is_some())
-                .unwrap_or(false)
-        })
+        .filter(|entry| m.get_cached_part_by_id(&entry.part_id).is_some())
         .count();
     assert_eq!(
         n_loaded, 0,
@@ -160,16 +154,16 @@ async fn manifest_part_lazy_loads_on_first_access() {
             .expect("open");
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    let target_pid = list.parts[LAZY_LOAD_TARGET_PART_INDEX].part_id;
+    let list_entries = m.get_all_list_entries();
+    let target_pid = list_entries[LAZY_LOAD_TARGET_PART_INDEX].part_id;
 
     // Pre-condition: target part's OnceCell empty.
-    let cell = m.parts.get(&target_pid).expect("part in cache");
-    assert!(cell.value().get().is_none(), "target part starts cold");
-    drop(cell);
+    let part = m.get_cached_part_by_id(&target_pid);
+    assert!(part.is_none(), "target part starts cold");
+    drop(part);
 
     // First load: pulls bytes.
-    let part = m.part(target_pid).await.expect("first load");
+    let part = m.get_part_by_id(target_pid).await.expect("first load");
     assert_eq!(part.superfiles.len(), 1);
 
     // Cell is now populated.
@@ -178,24 +172,18 @@ async fn manifest_part_lazy_loads_on_first_access() {
     // on the same shard via `entry()`, which would
     // deadlock against a still-held read `Ref`.
     {
-        let cell = m.parts.get(&target_pid).expect("still in cache");
-        assert!(
-            cell.value().get().is_some(),
-            "first part().await must populate the OnceCell"
-        );
+        let _part = m
+            .get_cached_part_by_id(&target_pid)
+            .expect("still in cache");
     }
 
     // Other parts stay cold. Same shard-lock discipline:
     // each iteration's `Ref` drops at end of its closure
     // body.
-    let other_loaded = list
-        .parts
+    let other_loaded = list_entries
         .iter()
         .filter(|e| e.part_id != target_pid)
-        .filter(|entry| {
-            let c = m.parts.get(&entry.part_id);
-            c.map(|c| c.value().get().is_some()).unwrap_or(false)
-        })
+        .filter(|entry| m.get_cached_part_by_id(&entry.part_id).is_some())
         .count();
     assert_eq!(
         other_loaded, 0,
@@ -203,7 +191,7 @@ async fn manifest_part_lazy_loads_on_first_access() {
     );
 
     // Second load on the same part: OnceCell hit.
-    let part_again = m.part(target_pid).await.expect("second load");
+    let part_again = m.get_part_by_id(target_pid).await.expect("second load");
     // Both references point at the same Arc — OnceCell
     // hands out an Arc::clone on each get_or_init call.
     assert!(
@@ -238,15 +226,12 @@ fn with_eager_load_threshold_zero_forces_lazy_on_tiny_manifest() {
     .expect("open");
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    assert_eq!(list.parts.len(), 1);
+    let list_entries = m.get_all_list_entries();
+    assert_eq!(list_entries.len(), 1);
     assert!(
-        m.superfile_list.superfiles.is_empty(),
+        m.get_all_superfiles().is_empty(),
         "threshold=0 forces lazy even on 1-part manifest"
     );
-    let cell = m.parts.get(&list.parts[0].part_id).expect("in cache");
-    assert!(
-        cell.value().get().is_none(),
-        "threshold=0 must not eager-fetch"
-    );
+    let part = m.get_cached_part_by_id(&list_entries[0].part_id);
+    assert!(part.is_none(), "threshold=0 must not eager-fetch");
 }

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -133,17 +133,11 @@ fn bm25_exact_term_loads_only_the_matching_part() {
     {
         let r = consumer.reader();
         let m = r.manifest();
-        let list = m.list.as_ref().expect("list");
-        assert_eq!(list.parts.len(), HIERARCHICAL_PART_COUNT);
-        let loaded = list
-            .parts
+        let list_entries = m.get_all_list_entries();
+        assert_eq!(list_entries.len(), HIERARCHICAL_PART_COUNT);
+        let loaded = list_entries
             .iter()
-            .filter(|e| {
-                m.parts
-                    .get(&e.part_id)
-                    .and_then(|c| c.value().get().cloned())
-                    .is_some()
-            })
+            .filter(|e| m.get_cached_part_by_id(&e.part_id).is_some())
             .count();
         assert_eq!(loaded, 0, "lazy-open should not have eager-fetched");
     }
@@ -164,16 +158,10 @@ fn bm25_exact_term_loads_only_the_matching_part() {
     // Post-condition: exactly one OnceCell populated.
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    let n_loaded = list
-        .parts
+    let list_entries = m.get_all_list_entries();
+    let n_loaded = list_entries
         .iter()
-        .filter(|e| {
-            m.parts
-                .get(&e.part_id)
-                .and_then(|c| c.value().get().cloned())
-                .is_some()
-        })
+        .filter(|e| m.get_cached_part_by_id(&e.part_id).is_some())
         .count();
     assert_eq!(
         n_loaded, 1,
@@ -214,16 +202,10 @@ fn bm25_term_in_no_part_loads_nothing() {
     // part was ever loaded.
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    let n_loaded = list
-        .parts
+    let list_entries = m.get_all_list_entries();
+    let n_loaded = list_entries
         .iter()
-        .filter(|e| {
-            m.parts
-                .get(&e.part_id)
-                .and_then(|c| c.value().get().cloned())
-                .is_some()
-        })
+        .filter(|e| m.get_cached_part_by_id(&e.part_id).is_some())
         .count();
     // Allow some flexibility for bloom false-positives —
     // in degenerate cases the bloom can spuriously claim
@@ -266,16 +248,10 @@ fn bm25_prefix_with_narrow_prefix_loads_one_part() {
 
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    let n_loaded = list
-        .parts
+    let list_entries = m.get_all_list_entries();
+    let n_loaded = list_entries
         .iter()
-        .filter(|e| {
-            m.parts
-                .get(&e.part_id)
-                .and_then(|c| c.value().get().cloned())
-                .is_some()
-        })
+        .filter(|e| m.get_cached_part_by_id(&e.part_id).is_some())
         .count();
     // Term-range prune is range-based — a part survives
     // iff [prefix, prefix_upper_bound) overlaps the
@@ -328,16 +304,10 @@ fn sql_loads_all_parts_returns_correct_count() {
     // Post: all 5 parts loaded (SQL doesn't list-prune).
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    let n_loaded = list
-        .parts
+    let list_entries = m.get_all_list_entries();
+    let n_loaded = list_entries
         .iter()
-        .filter(|e| {
-            m.parts
-                .get(&e.part_id)
-                .and_then(|c| c.value().get().cloned())
-                .is_some()
-        })
+        .filter(|e| m.get_cached_part_by_id(&e.part_id).is_some())
         .count();
     assert_eq!(
         n_loaded, HIERARCHICAL_PART_COUNT,
@@ -376,13 +346,10 @@ fn eager_mode_query_paths_observationally_unchanged() {
     // Eager: 1 part loaded at open.
     let r = consumer.reader();
     let m = r.manifest();
-    let list = m.list.as_ref().expect("list");
-    assert_eq!(list.parts.len(), 1);
+    let list_entries = m.get_all_list_entries();
+    assert_eq!(list_entries.len(), 1);
     assert!(
-        m.parts
-            .get(&list.parts[0].part_id)
-            .and_then(|c| c.value().get().cloned())
-            .is_some(),
+        m.get_cached_part_by_id(&list_entries[0].part_id).is_some(),
         "eager mode pre-loads the part at open"
     );
     drop(r);

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -93,8 +93,7 @@ async fn fts_query_excludes_tombstoned_row() {
     // contiguously starting at `id_min`, so middle = id_min + 1.
     let manifest = st.reader().manifest().clone();
     let entry = manifest
-        .superfile_list
-        .superfiles
+        .get_all_superfiles()
         .first()
         .expect("at least one superfile");
     let target = entry.id_min + 1;
@@ -139,8 +138,7 @@ async fn sql_query_excludes_tombstoned_row() {
 
     let manifest = st.reader().manifest().clone();
     let entry = manifest
-        .superfile_list
-        .superfiles
+        .get_all_superfiles()
         .first()
         .expect("at least one superfile");
     // Tombstone two of the four rows: id_min and id_min+2.
@@ -300,8 +298,7 @@ async fn vector_query_excludes_tombstoned_row() {
 
     let manifest = st.reader().manifest().clone();
     let entry = manifest
-        .superfile_list
-        .superfiles
+        .get_all_superfiles()
         .first()
         .expect("at least one superfile");
     let target = entry.id_min; // row 0

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -464,15 +464,12 @@ async fn supertable_real_azure_round_trip() {
 
         let reader = consumer.reader();
         let manifest = reader.manifest();
-        let list = manifest
-            .list
-            .as_ref()
-            .ok_or_else(|| "real Azure open did not recover persisted manifest list".to_string())?;
         let mut cleanup_keys = vec![
             "_supertable/current".to_string(),
             infino::supertable::manifest::commit::list_uri(consumer.manifest_id()),
         ];
-        cleanup_keys.extend(list.parts.iter().map(|p| p.uri.clone()));
+        let list_entries = manifest.get_all_list_entries();
+        cleanup_keys.extend(list_entries.iter().map(|p| p.uri.clone()));
         cleanup_keys.extend(
             manifest
                 .superfiles

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -501,15 +501,12 @@ async fn supertable_real_s3_lazy_vector_and_fts_round_trip() {
 
         let reader = consumer.reader();
         let manifest = reader.manifest();
-        let list = manifest
-            .list
-            .as_ref()
-            .ok_or_else(|| "real S3 open did not recover persisted manifest list".to_string())?;
         let mut cleanup_keys = vec![
             "_supertable/current".to_string(),
             infino::supertable::manifest::commit::list_uri(consumer.manifest_id()),
         ];
-        cleanup_keys.extend(list.parts.iter().map(|p| p.uri.clone()));
+        let list_entries = manifest.get_all_list_entries();
+        cleanup_keys.extend(list_entries.iter().map(|p| p.uri.clone()));
         cleanup_keys.extend(
             manifest
                 .superfiles

--- a/tests/supertable/update_crash_property.rs
+++ b/tests/supertable/update_crash_property.rs
@@ -91,8 +91,7 @@ async fn seed_partial_state(
         .expect("open for ids");
     let manifest = st.reader().manifest().clone();
     let id_min = manifest
-        .superfile_list
-        .superfiles
+        .get_all_superfiles()
         .first()
         .expect("superfile")
         .id_min;
@@ -116,8 +115,7 @@ async fn seed_partial_state(
                 tombstoned_in_superfile: if outcome == TombstoneOutcome::Tombstoned {
                     Some(
                         manifest
-                            .superfile_list
-                            .superfiles
+                            .get_all_superfiles()
                             .first()
                             .expect("superfile")
                             .superfile_id,

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -291,8 +291,7 @@ async fn update_emitted_superfile_carries_subsection_offsets() {
     let reader = st.reader();
     let manifest = reader.manifest();
     let emitted = manifest
-        .superfile_list
-        .superfiles
+        .get_all_superfiles()
         .iter()
         .find(|e| e.n_docs == 1)
         .expect("update-emitted single-row superfile present");

--- a/tests/supertable_concurrent_processes.rs
+++ b/tests/supertable_concurrent_processes.rs
@@ -171,7 +171,7 @@ async fn three_handles_concurrent_commits_all_succeed() {
     // assert specific id values across writer processes (each
     // gets its own random worker_id).
     let reader = consumer.reader();
-    let segs = &reader.manifest().superfile_list.superfiles;
+    let segs = reader.manifest().get_all_superfiles();
     let uris: std::collections::HashSet<_> = segs.iter().map(|s| s.uri.0).collect();
     assert_eq!(
         uris.len(),


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Encapsulate manifest internals behind APIs
  - Add manifest getters and constructor
  - Rename part loading accessor

- Centralize hierarchical manifest pruning/loading
  - Move query pruning into `Manifest`
  - Reuse vector and query selection paths

- Propagate typed manifest load errors
  - Add `QueryError::ManifestLoad`
  - Return load errors directly

- Update stats semantics and tests
  - `n_manifest_parts` now returns `0`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manifest internals made private"] -->|"exposed via getters"| B["Call sites use Manifest API"]
  B -->|"used by"| C["Compaction, WAL, writer, benches, tests"]
  A -->|"adds"| D["Centralized prune/load helpers"]
  D -->|"powers"| E["Query and vector selection"]
  D -->|"errors mapped to"| F["QueryError::ManifestLoad"]
  B -->|"simplifies"| G["Stats and persisted manifest construction"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>tombstone_overhead.rs</strong><dd><code>Use manifest accessor for superfiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-b1e3b8115a9676bee7173bb887f8ef7de762d50e7d4c31ead09162bd249cfa31">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unified_object_store.rs</strong><dd><code>Replace direct list access with API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-87219fd9f2f00ec3878074602dac115f4f5eccc9ff1eb6f6764a0b7eadba3e32">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Switch compaction paths to manifest getters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-c2242dece5bb2da5c7518ff92307a036b8c84ffa87e7d0b4ebe34fc42a6662e7">+7/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handle.rs</strong><dd><code>Update stats to use manifest APIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-42034392b5abe1c07aecb6b256f23c61844ad0368ae146144a6ecfbf9c411a98">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commit.rs</strong><dd><code>Rename manifest part loading calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-b389e45f1583fa07cf804f464afdcd4c30702bd13a04b2adb98cfc53f529bf18">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Privatize manifest fields and add accessors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-22a52bc288eb46617575789dec35e81fd229c12e32c4a83fd3b847ee6e1bcc47">+159/-15</a></td>

</tr>

<tr>
  <td><strong>covered_agg.rs</strong><dd><code>Use manifest mode helper in rewrite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-8e974709809de61df63b3b4abda8e016d31faa894094692e19817bf909d8f25e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>provider.rs</strong><dd><code>Gate statistics with manifest helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-a975c660e62323b2ebefc8a7b50fe7e21f86358b498c147470919308c7107f2e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prune.rs</strong><dd><code>Delegate superfile pruning to manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-5f9955e0d1167438cdc0225e3fe62a7084edf945cc36551ec3ecde56b63179d0">+5/-31</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vector.rs</strong><dd><code>Centralize vector pruning through manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-d6356999b80c383c27afc9983428a018c4eab3377e44964e68a8d4e82bb68a0a">+4/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pipeline.rs</strong><dd><code>Replace direct superfile list reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-32ff378a675c9013f21b13f5320a276d887cd39eba945727555b366c953f5c2b">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>writer.rs</strong><dd><code>Build persisted manifests via constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-f32a4b39d1d1863493dbd4328546e1f4e7b44126d846fa16cf31fcd062b11c88">+41/-33</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>error.rs</strong><dd><code>Add typed query manifest load error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-d1a0aa15856bf7ed6530701dcd1c8d3422e3395a3dce2aa13b178485ccb0e9b8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hierarchical_iter.rs</strong><dd><code>Return manifest load errors directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-cfa29154dc6aa1135e635297b20292af240514edd383d58609d19aa99b5d2573">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>stats.rs</strong><dd><code>Make manifest part count always numeric</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-ca554dbd8e592e5088d7072ba0f4ad9d62ae04e2e542f9944a80ad0738fce769">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>recovery_sweep_tests.rs</strong><dd><code>Update WAL recovery tests for APIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-8a2d359905cd2675b8017c202bce157e4ce96574bc275bc0f2ec79f293fdb31d">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>id_uniqueness.rs</strong><dd><code>Use manifest getter in commit test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-217d5992f9be9292b393e2f1939830297481cc2dd0c68836a2d9fc292aac1236">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>partition_assignment.rs</strong><dd><code>Replace list field access in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-14703a4b236bc111d82e42c3b67168fd8efc6dac11d0eae487f7312a97d76c70">+16/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>stats.rs</strong><dd><code>Adjust stats expectations to zero parts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-294aa4d69510d53d00a27f61beec1e9e83cfa0b777b018725c2515c65be201dc">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>end_to_end.rs</strong><dd><code>Use manifest accessor in cache tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-f04e02f4c2245c6493a612686707b8e0eb01207a9212bb5a44742cb81aec4ed8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>lazy_open.rs</strong></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-e4d33b79a32711c79586b3db390a92b42a6764cf553a62021b81b3abcf744b9c">+28/-43</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>hierarchical.rs</strong></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-409ea82c7d138435db51c9ab92a34f0c1cd9a8b69a537fb61763618118574b4b">+19/-52</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tombstone_filter.rs</strong></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-8b2a5eb80819dd3fa5e9b6a440ec92ada301bbd611d07035f86509d0b047c17b">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>smoke_azure.rs</strong></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-eea0a0fa9643ea0a772f10f6ebd8cb80b68771fb9ec98f430eeae2ae53b017eb">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>smoke_s3.rs</strong></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-29118d4fb5f9bb1f2cb2249e0ca2eea3c374c766968557166b26da9373ab9087">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update_crash_property.rs</strong></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-68ecc2ee8135e5f685a8f5731de87cf497e2ab37ea9dbec85f7a07f24df5e5a1">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>writer_mutations.rs</strong></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-8e0162119a79457be0897eac809a6c248498fbf74ad6ebe01999f849875ccf52">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>supertable_concurrent_processes.rs</strong></td>
  <td><a href="https://github.com/infino-ai/infino/pull/159/files#diff-971747e3e80e1b59ede50dfbc40f5566eb11b383f5a2855125cd185861e15435">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

