### PR TITLE
feat(fts): add Supertable::count — count-only matcher with O(1) df fast path

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -285,18 +285,12 @@ pub mod fts {
             mode: InfinoBoolMode,
         ) -> usize;
 
-        /// Count phase, **fast path**: the matching-doc count from the
-        /// dedicated count primitives — single-term `term_df` (O(1) from
-        /// the dictionary header), multi-term `token_match` cardinality —
-        /// with no BM25 scoring and no row materialization. `terms` are
-        /// the already-tokenized query terms.
-        fn count_fast(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64;
-
-        /// Count phase, **legacy path**: the same count obtained by
-        /// asking for every hit (`bm25` with `k = usize::MAX`) and
-        /// counting the rows — the "score everything just to count it"
-        /// path the count primitives replace.
-        fn count_scan(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64;
+        /// Count phase: the matching-doc count from the dedicated count
+        /// primitives — single-term `term_df` (O(1) from the dictionary
+        /// header), multi-term `token_match` cardinality — with no BM25
+        /// scoring and no row materialization. `terms` are the
+        /// already-tokenized query terms.
+        fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64;
     }
 
     /// Fetch-phase measurement for a raw superfile reader: kernel hits,
@@ -339,7 +333,7 @@ pub mod fts {
             superfile_rows_fetched(self, column, query, k, mode)
         }
 
-        fn count_fast(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+        fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
             crate::tiers::block_on(async {
                 // Single term: df is the exact match count, read O(1)
                 // from the dictionary header. Multi-term: the union /
@@ -355,13 +349,6 @@ pub mod fts {
                         .len() as u64
                 }
             })
-        }
-
-        fn count_scan(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
-            let query = terms.join(" ");
-            crate::tiers::block_on(self.bm25_hits_async(column, &query, usize::MAX, mode))
-                .expect("superfile bm25_search count")
-                .len() as u64
         }
     }
 
@@ -388,18 +375,9 @@ pub mod fts {
                 .sum()
         }
 
-        fn count_fast(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+        fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
             let query = terms.join(" ");
             self.count(column, &query, mode).expect("supertable count")
-        }
-
-        fn count_scan(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
-            let query = terms.join(" ");
-            self.bm25_search(column, &query, usize::MAX, mode, None)
-                .expect("supertable bm25_search count")
-                .iter()
-                .map(|b| b.num_rows())
-                .sum::<usize>() as u64
         }
     }
 
@@ -633,22 +611,17 @@ pub mod fts {
         });
     }
 
-    /// Warm count timings for one query: `fast` is the dedicated count
-    /// path, `scan` the legacy "score every hit" path; `n` is the
-    /// matching-doc count (the two paths must agree on it, which the
-    /// measurement asserts).
+    /// Warm count timing for one query: `p50` is the dedicated count
+    /// path's per-call p50; `n` is the matching-doc count it returned.
     #[derive(Clone, Debug)]
     pub struct CountStat {
         pub name: &'static str,
-        pub fast: Duration,
-        pub scan: Duration,
+        pub p50: Duration,
         pub n: u64,
     }
 
     /// Measure the count battery against an already-warm reader: for
-    /// each query, the fast count path vs the legacy `bm25(k=MAX)` path,
-    /// `iters` timed iterations each. Asserts both paths return the same
-    /// count first — a correctness gate folded into the measurement.
+    /// each query, `iters` timed iterations of the dedicated count path.
     pub fn measure_count<R: FtsRead>(
         reader: &R,
         battery: &[FtsQuery],
@@ -661,32 +634,18 @@ pub mod fts {
             .map(|q| {
                 eprintln!("[{log_prefix}] count: query {}...", q.name);
                 let mode = to_infino_mode(q.mode);
-                let n_fast = reader.count_fast(column, q.terms, mode);
-                let n_scan = reader.count_scan(column, q.terms, mode);
-                assert_eq!(
-                    n_fast, n_scan,
-                    "[{log_prefix}] count mismatch on {}: fast={n_fast} scan={n_scan}",
-                    q.name
-                );
-                let mut fast_samples = Vec::with_capacity(iters);
+                let n = reader.count_matching(column, q.terms, mode);
+                let mut samples = Vec::with_capacity(iters);
                 for _ in 0..iters {
                     let t = Instant::now();
-                    let n = reader.count_fast(column, q.terms, mode);
-                    fast_samples.push(t.elapsed());
-                    std::hint::black_box(n);
-                }
-                let mut scan_samples = Vec::with_capacity(iters);
-                for _ in 0..iters {
-                    let t = Instant::now();
-                    let n = reader.count_scan(column, q.terms, mode);
-                    scan_samples.push(t.elapsed());
-                    std::hint::black_box(n);
+                    let got = reader.count_matching(column, q.terms, mode);
+                    samples.push(t.elapsed());
+                    std::hint::black_box(got);
                 }
                 CountStat {
                     name: q.name,
-                    fast: p50(&mut fast_samples),
-                    scan: p50(&mut scan_samples),
-                    n: n_fast,
+                    p50: p50(&mut samples),
+                    n,
                 }
             })
             .collect()
@@ -695,29 +654,20 @@ pub mod fts {
     fn count_row(name: &'static str, stats: &HashMap<&'static str, CountStat>) -> Vec<Cell> {
         match stats.get(&name) {
             Some(c) => {
-                let fast_ns = c.fast.as_secs_f64() * NS_PER_SEC;
-                let scan_ns = c.scan.as_secs_f64() * NS_PER_SEC;
-                let speedup = if fast_ns > 0.0 {
-                    scan_ns / fast_ns
-                } else {
-                    0.0
-                };
+                let ns = c.p50.as_secs_f64() * NS_PER_SEC;
                 vec![
                     text(name),
                     text(fmt_count(c.n as usize)),
-                    metric(fast_ns, fmt_time(fast_ns), Better::Lower),
-                    metric(scan_ns, fmt_time(scan_ns), Better::Lower),
-                    metric(speedup, format!("{speedup:.1}×"), Better::Higher),
+                    metric(ns, fmt_time(ns), Better::Lower),
                 ]
             }
-            None => vec![text(name), text("—"), text("—"), text("—"), text("—")],
+            None => vec![text(name), text("—"), text("—")],
         }
     }
 
-    /// Render the count battery: the dedicated count path vs the legacy
-    /// "score every hit just to count it" path (`bm25` with
-    /// `k = usize::MAX`), with the resulting speedup. infino-only — the
-    /// same table shape for both tiers.
+    /// Render the count battery: the dedicated count path's p50 per
+    /// query, alongside the matching-doc count. infino-only — the same
+    /// table shape for both tiers.
     pub fn emit_count(
         report: &mut Report,
         anchor: &str,
@@ -727,7 +677,7 @@ pub mod fts {
     ) {
         let map: HashMap<&'static str, CountStat> =
             counts.iter().map(|c| (c.name, c.clone())).collect();
-        let headers: Vec<String> = ["Query", "matches", "count()", "bm25 (k=MAX)", "speedup"]
+        let headers: Vec<String> = ["Query", "matches", "count()"]
             .iter()
             .map(|s| s.to_string())
             .collect();

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -93,7 +93,7 @@ pub mod fts {
     use infino::supertable::SupertableReader;
 
     use crate::harness::{BoolMode, FtsQuery};
-    use crate::markdown::fmt_time;
+    use crate::markdown::{fmt_count, fmt_time};
     use crate::report::{Better, Block, Cell, Report, Section, metric, text};
     use crate::rss::{self, PeakSampler, RssStats};
 
@@ -284,6 +284,19 @@ pub mod fts {
             k: usize,
             mode: InfinoBoolMode,
         ) -> usize;
+
+        /// Count phase, **fast path**: the matching-doc count from the
+        /// dedicated count primitives — single-term `term_df` (O(1) from
+        /// the dictionary header), multi-term `token_match` cardinality —
+        /// with no BM25 scoring and no row materialization. `terms` are
+        /// the already-tokenized query terms.
+        fn count_fast(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64;
+
+        /// Count phase, **legacy path**: the same count obtained by
+        /// asking for every hit (`bm25` with `k = usize::MAX`) and
+        /// counting the rows — the "score everything just to count it"
+        /// path the count primitives replace.
+        fn count_scan(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64;
     }
 
     /// Fetch-phase measurement for a raw superfile reader: kernel hits,
@@ -325,6 +338,31 @@ pub mod fts {
         ) -> usize {
             superfile_rows_fetched(self, column, query, k, mode)
         }
+
+        fn count_fast(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+            crate::tiers::block_on(async {
+                // Single term: df is the exact match count, read O(1)
+                // from the dictionary header. Multi-term: the union /
+                // intersection cardinality from `token_match`.
+                if terms.len() == 1 {
+                    self.term_df(column, terms[0])
+                        .await
+                        .expect("superfile term_df")
+                } else {
+                    self.token_match(column, terms, mode)
+                        .await
+                        .expect("superfile token_match")
+                        .len() as u64
+                }
+            })
+        }
+
+        fn count_scan(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+            let query = terms.join(" ");
+            crate::tiers::block_on(self.bm25_hits_async(column, &query, usize::MAX, mode))
+                .expect("superfile bm25_search count")
+                .len() as u64
+        }
     }
 
     impl FtsRead for SupertableReader {
@@ -348,6 +386,20 @@ pub mod fts {
                 .iter()
                 .map(|b| b.num_rows())
                 .sum()
+        }
+
+        fn count_fast(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+            let query = terms.join(" ");
+            self.count(column, &query, mode).expect("supertable count")
+        }
+
+        fn count_scan(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+            let query = terms.join(" ");
+            self.bm25_search(column, &query, usize::MAX, mode, None)
+                .expect("supertable bm25_search count")
+                .iter()
+                .map(|b| b.num_rows())
+                .sum::<usize>() as u64
         }
     }
 
@@ -578,6 +630,122 @@ pub mod fts {
             title,
             note: note.into(),
             blocks,
+        });
+    }
+
+    /// Warm count timings for one query: `fast` is the dedicated count
+    /// path, `scan` the legacy "score every hit" path; `n` is the
+    /// matching-doc count (the two paths must agree on it, which the
+    /// measurement asserts).
+    #[derive(Clone, Debug)]
+    pub struct CountStat {
+        pub name: &'static str,
+        pub fast: Duration,
+        pub scan: Duration,
+        pub n: u64,
+    }
+
+    /// Measure the count battery against an already-warm reader: for
+    /// each query, the fast count path vs the legacy `bm25(k=MAX)` path,
+    /// `iters` timed iterations each. Asserts both paths return the same
+    /// count first — a correctness gate folded into the measurement.
+    pub fn measure_count<R: FtsRead>(
+        reader: &R,
+        battery: &[FtsQuery],
+        column: &str,
+        iters: usize,
+        log_prefix: &str,
+    ) -> Vec<CountStat> {
+        battery
+            .iter()
+            .map(|q| {
+                eprintln!("[{log_prefix}] count: query {}...", q.name);
+                let mode = to_infino_mode(q.mode);
+                let n_fast = reader.count_fast(column, q.terms, mode);
+                let n_scan = reader.count_scan(column, q.terms, mode);
+                assert_eq!(
+                    n_fast, n_scan,
+                    "[{log_prefix}] count mismatch on {}: fast={n_fast} scan={n_scan}",
+                    q.name
+                );
+                let mut fast_samples = Vec::with_capacity(iters);
+                for _ in 0..iters {
+                    let t = Instant::now();
+                    let n = reader.count_fast(column, q.terms, mode);
+                    fast_samples.push(t.elapsed());
+                    std::hint::black_box(n);
+                }
+                let mut scan_samples = Vec::with_capacity(iters);
+                for _ in 0..iters {
+                    let t = Instant::now();
+                    let n = reader.count_scan(column, q.terms, mode);
+                    scan_samples.push(t.elapsed());
+                    std::hint::black_box(n);
+                }
+                CountStat {
+                    name: q.name,
+                    fast: p50(&mut fast_samples),
+                    scan: p50(&mut scan_samples),
+                    n: n_fast,
+                }
+            })
+            .collect()
+    }
+
+    fn count_row(name: &'static str, stats: &HashMap<&'static str, CountStat>) -> Vec<Cell> {
+        match stats.get(&name) {
+            Some(c) => {
+                let fast_ns = c.fast.as_secs_f64() * NS_PER_SEC;
+                let scan_ns = c.scan.as_secs_f64() * NS_PER_SEC;
+                let speedup = if fast_ns > 0.0 {
+                    scan_ns / fast_ns
+                } else {
+                    0.0
+                };
+                vec![
+                    text(name),
+                    text(fmt_count(c.n as usize)),
+                    metric(fast_ns, fmt_time(fast_ns), Better::Lower),
+                    metric(scan_ns, fmt_time(scan_ns), Better::Lower),
+                    metric(speedup, format!("{speedup:.1}×"), Better::Higher),
+                ]
+            }
+            None => vec![text(name), text("—"), text("—"), text("—"), text("—")],
+        }
+    }
+
+    /// Render the count battery: the dedicated count path vs the legacy
+    /// "score every hit just to count it" path (`bm25` with
+    /// `k = usize::MAX`), with the resulting speedup. infino-only — the
+    /// same table shape for both tiers.
+    pub fn emit_count(
+        report: &mut Report,
+        anchor: &str,
+        title: String,
+        note: &str,
+        counts: &[CountStat],
+    ) {
+        let map: HashMap<&'static str, CountStat> =
+            counts.iter().map(|c| (c.name, c.clone())).collect();
+        let headers: Vec<String> = ["Query", "matches", "count()", "bm25 (k=MAX)", "speedup"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let or_block = Block {
+            subtitle: "OR queries".into(),
+            headers: headers.clone(),
+            rows: OR_QUERIES.iter().map(|&n| count_row(n, &map)).collect(),
+        };
+        let and_block = Block {
+            subtitle: "AND queries".into(),
+            headers,
+            rows: AND_QUERIES.iter().map(|&n| count_row(n, &map)).collect(),
+        };
+        report.emit(&Section {
+            anchor: anchor.into(),
+            title,
+            note: note.into(),
+            blocks: vec![or_block, and_block],
         });
     }
 }

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -517,11 +517,10 @@ pub mod fts {
                         "Superfile FTS — count, single-superfile / in-memory ({} docs)",
                         fmt_count(n_docs)
                     ),
-                    "Matching-doc count via the dedicated count path (single-term `term_df`, read \
+                    "Matching-doc count via the dedicated count path: single-term `term_df`, read \
                      O(1) from the dictionary header; multi-term union/intersection cardinality via \
-                     `token_match`) vs the legacy path that scores every hit (`bm25_search` with \
-                     `k = usize::MAX`) only to count them. Both paths are asserted to return the \
-                     same count. Δ is vs the previous run.",
+                     `token_match`. No BM25 scoring, no row materialization. `matches` is the count \
+                     returned. Δ is vs the previous run.",
                     &counts,
                 );
             }
@@ -701,12 +700,8 @@ pub mod fts {
             exec_fts::superfile_rows_fetched(&self.reader, column, query, k, mode)
         }
 
-        fn count_fast(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
-            self.reader.count_fast(column, terms, mode)
-        }
-
-        fn count_scan(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
-            self.reader.count_scan(column, terms, mode)
+        fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+            self.reader.count_matching(column, terms, mode)
         }
     }
 

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -498,6 +498,33 @@ pub mod fts {
                     }],
                 });
             }
+            if phases.warm {
+                eprintln!(
+                    "[superfile_fts] count battery: {} queries × {WARM_ITERS} timed iters...",
+                    FTS_BATTERY.len(),
+                );
+                let counts = exec_fts::measure_count(
+                    index.reader(),
+                    FTS_BATTERY,
+                    FTS_COLUMN,
+                    WARM_ITERS,
+                    "superfile_fts",
+                );
+                exec_fts::emit_count(
+                    &mut report,
+                    "bench/fts/superfile/count",
+                    format!(
+                        "Superfile FTS — count, single-superfile / in-memory ({} docs)",
+                        fmt_count(n_docs)
+                    ),
+                    "Matching-doc count via the dedicated count path (single-term `term_df`, read \
+                     O(1) from the dictionary header; multi-term union/intersection cardinality via \
+                     `token_match`) vs the legacy path that scores every hit (`bm25_search` with \
+                     `k = usize::MAX`) only to count them. Both paths are asserted to return the \
+                     same count. Δ is vs the previous run.",
+                    &counts,
+                );
+            }
             if phases.warm
                 && let Some(ref warm_stats) = warm
             {
@@ -672,6 +699,14 @@ pub mod fts {
             mode: InfinoBoolMode,
         ) -> usize {
             exec_fts::superfile_rows_fetched(&self.reader, column, query, k, mode)
+        }
+
+        fn count_fast(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+            self.reader.count_fast(column, terms, mode)
+        }
+
+        fn count_scan(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+            self.reader.count_scan(column, terms, mode)
         }
     }
 

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -556,7 +556,10 @@ pub mod fts {
             drop(cache_dir);
         }
 
-        let warm = phases.warm.then(|| measure_warm(&built));
+        let (warm, counts) = match phases.warm.then(|| measure_warm(&built)) {
+            Some((w, c)) => (Some(w), Some(c)),
+            None => (None, None),
+        };
         let cold = phases.cold.then(|| measure_cold(&built));
         if phases.warm || phases.cold {
             exec_fts::emit_search(
@@ -572,6 +575,23 @@ pub mod fts {
                 warm.as_deref(),
                 cold.as_ref(),
                 None,
+            );
+        }
+
+        if let Some(counts) = &counts {
+            exec_fts::emit_count(
+                &mut report,
+                "bench/fts/supertable/count",
+                format!(
+                    "Supertable FTS — count, multi-superfile / object-store ({} docs)",
+                    fmt_count(n_docs)
+                ),
+                "Matching-doc count via the dedicated count path (per-superfile single-term `term_df` \
+                 read O(1) from the dictionary header and summed across superfiles; multi-term \
+                 union/intersection via `token_match` cardinality, less tombstoned docs) vs the legacy \
+                 path that scores every hit (`bm25_search` with `k = usize::MAX`) only to count them. \
+                 Both paths are asserted to agree. Δ is vs the previous run.",
+                counts,
             );
         }
 
@@ -624,7 +644,9 @@ pub mod fts {
         });
     }
 
-    fn measure_warm(built: &supertable::IngestResult) -> Vec<exec_fts::FtsQueryStat> {
+    fn measure_warm(
+        built: &supertable::IngestResult,
+    ) -> (Vec<exec_fts::FtsQueryStat>, Vec<exec_fts::CountStat>) {
         eprintln!(
             "[supertable_fts] warm: opening shared consumer, prewarm + wait_until_warm once..."
         );
@@ -664,9 +686,22 @@ pub mod fts {
             "supertable_fts",
         );
         crate::rss::log_rss_breakdown("supertable_fts after warm battery");
+        eprintln!(
+            "[supertable_fts] count: cache hot — timing {} queries × {WARM_ITERS} iters \
+             (count vs bm25 k=MAX)...",
+            FTS_BATTERY.len(),
+        );
+        let counts = exec_fts::measure_count(
+            &reader,
+            FTS_BATTERY,
+            supertable::TEXT_COLUMN,
+            WARM_ITERS,
+            "supertable_fts",
+        );
+        crate::rss::log_rss_breakdown("supertable_fts after count battery");
         drop(consumer);
         drop(cache_dir);
-        out
+        (out, counts)
     }
 
     fn measure_cold(
@@ -760,6 +795,24 @@ pub mod fts {
                 .iter()
                 .map(|b| b.num_rows())
                 .sum()
+        }
+
+        fn count_fast(
+            &self,
+            column: &str,
+            terms: &[&str],
+            mode: infino::superfile::fts::reader::BoolMode,
+        ) -> u64 {
+            self.consumer.reader().count_fast(column, terms, mode)
+        }
+
+        fn count_scan(
+            &self,
+            column: &str,
+            terms: &[&str],
+            mode: infino::superfile::fts::reader::BoolMode,
+        ) -> u64 {
+            self.consumer.reader().count_scan(column, terms, mode)
         }
     }
 }

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -586,11 +586,11 @@ pub mod fts {
                     "Supertable FTS — count, multi-superfile / object-store ({} docs)",
                     fmt_count(n_docs)
                 ),
-                "Matching-doc count via the dedicated count path (per-superfile single-term `term_df` \
+                "Matching-doc count via the dedicated count path: per-superfile single-term `term_df` \
                  read O(1) from the dictionary header and summed across superfiles; multi-term \
-                 union/intersection via `token_match` cardinality, less tombstoned docs) vs the legacy \
-                 path that scores every hit (`bm25_search` with `k = usize::MAX`) only to count them. \
-                 Both paths are asserted to agree. Δ is vs the previous run.",
+                 union/intersection via `token_match` cardinality, less tombstoned docs. No BM25 \
+                 scoring, no row materialization. `matches` is the count returned. Δ is vs the \
+                 previous run.",
                 counts,
             );
         }
@@ -797,22 +797,13 @@ pub mod fts {
                 .sum()
         }
 
-        fn count_fast(
+        fn count_matching(
             &self,
             column: &str,
             terms: &[&str],
             mode: infino::superfile::fts::reader::BoolMode,
         ) -> u64 {
-            self.consumer.reader().count_fast(column, terms, mode)
-        }
-
-        fn count_scan(
-            &self,
-            column: &str,
-            terms: &[&str],
-            mode: infino::superfile::fts::reader::BoolMode,
-        ) -> u64 {
-            self.consumer.reader().count_scan(column, terms, mode)
+            self.consumer.reader().count_matching(column, terms, mode)
         }
     }
 }

--- a/public-api.txt
+++ b/public-api.txt
@@ -209,6 +209,7 @@ pub fn infino::Supertable::delete(&self, datafusion_expr::expr::Expr) -> core::r
 pub fn infino::Supertable::update(&self, datafusion_expr::expr::Expr, &arrow_array::record_batch::RecordBatch) -> core::result::Result<infino::MutationStats, infino::InfinoError>
 impl infino::Supertable
 pub fn infino::Supertable::bm25_search(&self, &str, &str, usize, infino::BoolMode, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
+pub fn infino::Supertable::count(&self, &str, &str, infino::BoolMode) -> core::result::Result<u64, infino::InfinoError>
 pub fn infino::Supertable::exact_match(&self, &str, &str, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
 pub fn infino::Supertable::token_match(&self, &str, &str, infino::BoolMode, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
 impl infino::Supertable

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -766,10 +766,11 @@ impl FtsReader {
     /// ascending doc-id order.
     ///
     /// Reuses the same [`build_term_cursors`](Self::build_term_cursors)
-    /// the scored path uses, then walks the cursors with
-    /// [`walk_cursors_unranked`] — no BM25 scoring and no top-k heap, so
-    /// nothing is ranked. Cursors traverse blocks in doc-id order, so
-    /// the result is already ascending (no re-sort).
+    /// the scored path uses, then walks the cursors —
+    /// [`collect_and_intersect`](Self::collect_and_intersect) for `And`,
+    /// [`or_merge_unranked`] for `Or` — with no BM25 scoring and no
+    /// top-k heap, so nothing is ranked. Cursors traverse blocks in
+    /// doc-id order, so the result is already ascending (no re-sort).
     pub async fn token_match(
         &self,
         column: &str,
@@ -792,6 +793,34 @@ impl FtsReader {
                 self.collect_and_intersect(column_id, cursors)
             }
             BoolMode::Or => or_merge_unranked(cursors),
+        })
+    }
+
+    /// Unranked token-match **count** — the cardinality
+    /// [`token_match`](Self::token_match) would return, without
+    /// materializing the doc-id `Vec`. The AND path tallies through a
+    /// [`CountSink`], the OR path counts the union walk; both skip the
+    /// `Vec<u32>` so a high-cardinality count doesn't allocate one id
+    /// per match.
+    pub async fn token_match_count(
+        &self,
+        column: &str,
+        tokens: &[&str],
+        mode: BoolMode,
+    ) -> Result<u64, FtsError> {
+        let column_id = self.resolve_column_id(column)?;
+        if tokens.is_empty() {
+            return Ok(0);
+        }
+        let cursors = self.build_term_cursors(column_id, tokens).await?;
+        Ok(match mode {
+            BoolMode::And => {
+                if cursors.len() != tokens.len() {
+                    return Ok(0);
+                }
+                self.count_and_intersect(column_id, cursors)
+            }
+            BoolMode::Or => or_count_unranked(cursors),
         })
     }
 
@@ -1474,6 +1503,22 @@ impl FtsReader {
         let mut sink = CollectSink { out: Vec::new() };
         self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
         sink.out
+    }
+
+    /// Unranked multi-term AND **count**: the size of the intersection
+    /// via the same flat-merge as [`collect_and_intersect`](Self::collect_and_intersect),
+    /// but through a [`CountSink`] that tallies hits instead of
+    /// collecting them — no `Vec<u32>` materialized.
+    fn count_and_intersect(&self, column_id: u32, mut cursors: Vec<TermCursor>) -> u64 {
+        if cursors.is_empty() {
+            return 0;
+        }
+        let col_meta = &self.columns[column_id as usize];
+        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        cursors.sort_by_key(|c| c.block_count());
+        let mut sink = CountSink { n: 0 };
+        self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
+        sink.n
     }
 
     /// Dispatch to the 2-term specialization or the general `n >= 3`
@@ -2538,6 +2583,24 @@ impl AndSink for CollectSink {
     }
 }
 
+/// Unranked counting sink: tally the intersection size without
+/// materializing the ids. Drives the count path through the same
+/// flat-merge as [`CollectSink`] but skips the `Vec<u32>` — for a
+/// high-cardinality count that allocation (4 bytes/doc) is pure waste.
+struct CountSink {
+    n: u64,
+}
+
+impl AndSink for CountSink {
+    fn needs_score(&self) -> bool {
+        false
+    }
+
+    fn emit(&mut self, _doc: u32, _score: f32) {
+        self.n += 1;
+    }
+}
+
 /// Push `(score, doc_id)` into the top-k AND heap with the same
 /// tie-break (asc doc_id) the OR paths use, so AND and OR rankings
 /// agree on score-tied docs.
@@ -2631,6 +2694,44 @@ fn read_u64_le(b: &[u8]) -> u64 {
     u64::from_le_bytes(buf)
 }
 
+/// Unranked multi-term OR walk: the union of the cursors' doc ids in
+/// ascending order. A k-way merge — each step finds the minimum current
+/// doc id across the live cursors, hands it to `emit`, and advances
+/// every cursor sitting on it (so the next minimum is strictly greater
+/// and `emit` is called exactly once per distinct doc). No scoring; the
+/// caller wants membership, not rank.
+fn or_walk_unranked(mut cursors: Vec<TermCursor>, mut emit: impl FnMut(u32)) {
+    loop {
+        let min_doc = cursors
+            .iter()
+            .filter(|c| !c.is_exhausted())
+            .map(TermCursor::current_doc_id)
+            .min();
+        let Some(min_doc) = min_doc else { break };
+        emit(min_doc);
+        for c in cursors.iter_mut() {
+            if !c.is_exhausted() && c.current_doc_id() == min_doc {
+                c.next();
+            }
+        }
+    }
+}
+
+/// The union's doc ids ([`or_walk_unranked`] collected into a `Vec`).
+fn or_merge_unranked(cursors: Vec<TermCursor>) -> Vec<u32> {
+    let mut out = Vec::new();
+    or_walk_unranked(cursors, |doc| out.push(doc));
+    out
+}
+
+/// The union's cardinality ([`or_walk_unranked`] counted) — no `Vec`
+/// materialized, for the count path.
+fn or_count_unranked(cursors: Vec<TermCursor>) -> u64 {
+    let mut n = 0u64;
+    or_walk_unranked(cursors, |_| n += 1);
+    n
+}
+
 /// Parsed per-(column, term) metadata header from the postings
 /// region. The byte layout is documented once, on the writer side —
 /// see [`TERM_META_SIZE`] in `builder.rs` — this struct is its
@@ -2639,38 +2740,9 @@ fn read_u64_le(b: &[u8]) -> u64 {
 /// [`TermMeta::parse`] is the single place that validates untrusted
 /// offsets (the FST value points here) against the postings region:
 /// both the fixed 20-byte header and the skip table it declares are
-/// Drive already-built [`TermCursor`]s to their matching doc-ids with no
-/// scoring and no heap — the unranked analog of
-/// [`FtsReader::run_and_intersect`] (And) / the OR merge. Cursors
-/// traverse blocks in doc-id order, so the result is ascending with no
-/// extra sort. Used by [`FtsReader::token_match`].
-/// Unranked multi-term OR: the union of the cursors' doc ids in
-/// ascending order. A k-way merge — each step emits the minimum
-/// current doc id across the live cursors and advances every cursor
-/// sitting on it. No scoring; the caller wants membership, not rank.
-fn or_merge_unranked(mut cursors: Vec<TermCursor>) -> Vec<u32> {
-    let mut out = Vec::new();
-    loop {
-        let min_doc = cursors
-            .iter()
-            .filter(|c| !c.is_exhausted())
-            .map(TermCursor::current_doc_id)
-            .min();
-        let Some(min_doc) = min_doc else { break };
-        out.push(min_doc);
-        for c in cursors.iter_mut() {
-            if !c.is_exhausted() && c.current_doc_id() == min_doc {
-                c.next();
-            }
-        }
-    }
-    out
-}
-
 /// bounds-checked before any caller touches a byte. Both the
 /// single-term BMW path and [`TermCursor::new`] go through here, so
 /// the header layout is interpreted in exactly one spot.
-
 #[derive(Debug, Copy, Clone)]
 struct TermMeta {
     /// Document frequency — number of docs containing the term.
@@ -3283,6 +3355,36 @@ mod tests {
                 .expect("empty")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn token_match_count_matches_token_match_len() {
+        // The counting path (CountSink for AND, or_count_unranked for OR)
+        // must agree with token_match's materialized length on every
+        // shape — single token, OR union, AND intersection, absent
+        // tokens, and the empty list.
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open FtsReader");
+        let cases: &[(&[&str], BoolMode)] = &[
+            (&["rust"], BoolMode::Or),
+            (&["rust", "java"], BoolMode::Or),
+            (&["rust", "runtime"], BoolMode::And),
+            (&["rust", "zzz"], BoolMode::And),
+            (&["java", "zzz"], BoolMode::Or),
+            (&[], BoolMode::And),
+        ];
+        for (tokens, mode) in cases {
+            let len = r
+                .token_match("body", tokens, *mode)
+                .await
+                .expect("token_match")
+                .len() as u64;
+            let count = r
+                .token_match_count("body", tokens, *mode)
+                .await
+                .expect("token_match_count");
+            assert_eq!(count, len, "count vs len for {tokens:?} {mode:?}");
+        }
     }
 
     #[tokio::test]

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -781,11 +781,18 @@ impl FtsReader {
             return Ok(Vec::new());
         }
         let cursors = self.build_term_cursors(column_id, tokens).await?;
-        // AND needs every token present; a missing token ⇒ empty set.
-        if mode == BoolMode::And && cursors.len() != tokens.len() {
-            return Ok(Vec::new());
-        }
-        Ok(walk_cursors_unranked(cursors, mode))
+        Ok(match mode {
+            BoolMode::And => {
+                // AND needs every token present; a missing token ⇒ empty
+                // set. Otherwise intersect via the same optimized
+                // block flat-merge the ranked scorer uses.
+                if cursors.len() != tokens.len() {
+                    return Ok(Vec::new());
+                }
+                self.collect_and_intersect(column_id, cursors)
+            }
+            BoolMode::Or => or_merge_unranked(cursors),
+        })
     }
 
     /// Document frequency of `token` in `column` — the number of docs
@@ -1440,30 +1447,54 @@ impl FtsReader {
 
         let initial_cap = k.min(self.n_docs as usize).max(1);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
-
-        // 2-term shape gets a specialized flat-merge inner loop: when
-        // both cursors sit in their decoded block buffers, we walk the
-        // two sorted `block_doc_ids` arrays with two index pointers
-        // instead of calling `skip_to` per leader doc. That removes
-        // the function-call + within-block linear-scan overhead on the
-        // hottest AND case (rare ∧ common). The general path is kept
-        // for n >= 3 because flat-merge across N arrays doesn't
-        // straightforwardly generalize and the per-doc leapfrog still
-        // amortizes well with the block-max pruning below.
-        if cursors.len() == 2 {
-            self.run_and_intersect_2term(&mut cursors, dl_norm_k1, k, &mut heap, filter, floor_eff);
-        } else {
-            self.run_and_intersect_general(
-                &mut cursors,
-                dl_norm_k1,
-                k,
-                &mut heap,
-                filter,
-                floor_eff,
-            );
-        }
-
+        let mut sink = ScoreSink {
+            heap: &mut heap,
+            k,
+            filter,
+            floor_eff,
+        };
+        self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
         Ok(drain_top_k_desc(heap))
+    }
+
+    /// Unranked multi-term AND: the matching doc ids in ascending order
+    /// via the block flat-merge in [`and_flat_merge`](Self::and_flat_merge),
+    /// with no BM25 scoring and no top-k heap. Because it shares that
+    /// traversal with the ranked [`run_and_intersect`](Self::run_and_intersect),
+    /// the two always agree on which docs match, and an unranked count
+    /// over high-frequency terms costs the same posting-list work as the
+    /// ranked search minus the scoring.
+    fn collect_and_intersect(&self, column_id: u32, mut cursors: Vec<TermCursor>) -> Vec<u32> {
+        if cursors.is_empty() {
+            return Vec::new();
+        }
+        let col_meta = &self.columns[column_id as usize];
+        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        cursors.sort_by_key(|c| c.block_count());
+        let mut sink = CollectSink { out: Vec::new() };
+        self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
+        sink.out
+    }
+
+    /// Dispatch to the 2-term specialization or the general `n >= 3`
+    /// (and `n == 1`) flat-merge. The 2-term shape walks the two sorted
+    /// `block_doc_ids` arrays with two index pointers instead of calling
+    /// `skip_to` per leader doc — removing the function-call +
+    /// within-block linear-scan overhead on the hottest AND case
+    /// (rare ∧ common). The general path keeps the per-doc leapfrog,
+    /// which amortizes well with the block-max pruning a scoring sink
+    /// drives.
+    fn and_flat_merge<S: AndSink>(
+        &self,
+        cursors: &mut [TermCursor],
+        dl_norm_k1: &[f32],
+        sink: &mut S,
+    ) {
+        if cursors.len() == 2 {
+            self.and_flat_merge_2term(cursors, dl_norm_k1, sink);
+        } else {
+            self.and_flat_merge_general(cursors, dl_norm_k1, sink);
+        }
     }
 
     /// General `n >= 3`-term AND path. Same shape as the 2-term path:
@@ -1475,32 +1506,27 @@ impl FtsReader {
     /// overhead per leader doc, just integer comparisons over the
     /// already-decoded buffers. When any cursor exhausts its block,
     /// the outer loop crosses blocks via `next()` and re-aligns.
-    fn run_and_intersect_general(
+    fn and_flat_merge_general<S: AndSink>(
         &self,
         cursors: &mut [TermCursor],
         dl_norm_k1: &[f32],
-        k: usize,
-        heap: &mut BinaryHeap<TopKEntry>,
-        mut filter: Option<&mut ExcludeFilter>,
-        floor_eff: f32,
+        sink: &mut S,
     ) {
         'outer: loop {
             if cursors[0].is_exhausted() {
                 break;
             }
 
-            // Block-max-AND pruning. The bar is the kth-best once the
-            // heap fills, or the caller's seeded floor before that —
-            // whichever is higher. If the leader's current block can't
-            // possibly produce a bar-beating score, skip the whole
-            // block — the safest UB sums leader's block_max with each
-            // other cursor's max block_max across all blocks that
-            // overlap the leader's block doc-id range.
-            let bar = if heap.len() >= k {
-                heap.peek().expect("heap len == k").0.max(floor_eff)
-            } else {
-                floor_eff
-            };
+            // Block-max-AND pruning (scoring sinks only; the unranked
+            // sink's `bar()` is NEG_INFINITY, so this whole block is
+            // skipped). The bar is the kth-best once the heap fills, or
+            // the caller's seeded floor before that — whichever is
+            // higher. If the leader's current block can't possibly
+            // produce a bar-beating score, skip the whole block — the
+            // safest UB sums leader's block_max with each other cursor's
+            // max block_max across all blocks that overlap the leader's
+            // block doc-id range.
+            let bar = sink.bar();
             if bar > f32::NEG_INFINITY {
                 let range_start = cursors[0].current_doc_id();
                 let range_end = cursors[0].current_block_last_doc_id();
@@ -1584,24 +1610,25 @@ impl FtsReader {
                     break;
                 }
                 if all_match {
-                    let norm = dl_norm_k1[a as usize];
-                    let mut score = crate::superfile::fts::bm25::score_with_dl_norm_k1(
-                        c0.idf_x_k1p1,
-                        c0.block_tfs[i],
-                        norm,
-                    );
-                    for o in others.iter() {
-                        score += crate::superfile::fts::bm25::score_with_dl_norm_k1(
-                            o.idf_x_k1p1,
-                            o.block_tfs[o.pos],
+                    let score = if sink.needs_score() {
+                        let norm = dl_norm_k1[a as usize];
+                        let mut score = crate::superfile::fts::bm25::score_with_dl_norm_k1(
+                            c0.idf_x_k1p1,
+                            c0.block_tfs[i],
                             norm,
                         );
-                    }
-                    // Floor gate: strictly-below-floor docs are dead to
-                    // the caller.
-                    if score > floor_eff {
-                        and_heap_push(heap, k, filter.as_deref_mut(), score, a);
-                    }
+                        for o in others.iter() {
+                            score += crate::superfile::fts::bm25::score_with_dl_norm_k1(
+                                o.idf_x_k1p1,
+                                o.block_tfs[o.pos],
+                                norm,
+                            );
+                        }
+                        score
+                    } else {
+                        0.0
+                    };
+                    sink.emit(a, score);
                     i += 1;
                     for o in others.iter_mut() {
                         o.pos += 1;
@@ -1633,14 +1660,11 @@ impl FtsReader {
     /// scan — just two index pointers walking forward. When either
     /// block exhausts, the cursor crosses to its next block (decoding
     /// on demand) and the merge resumes.
-    fn run_and_intersect_2term(
+    fn and_flat_merge_2term<S: AndSink>(
         &self,
         cursors: &mut [TermCursor],
         dl_norm_k1: &[f32],
-        k: usize,
-        heap: &mut BinaryHeap<TopKEntry>,
-        mut filter: Option<&mut ExcludeFilter>,
-        floor_eff: f32,
+        sink: &mut S,
     ) {
         debug_assert_eq!(cursors.len(), 2);
         // Split into two simultaneous mutable refs so the inner loop
@@ -1655,14 +1679,12 @@ impl FtsReader {
                 break;
             }
 
-            // Block-max-AND pruning at the leader's current block. The
-            // bar is the kth-best once the heap fills, or the caller's
-            // seeded floor before that — whichever is higher.
-            let bar = if heap.len() >= k {
-                heap.peek().expect("heap len == k").0.max(floor_eff)
-            } else {
-                floor_eff
-            };
+            // Block-max-AND pruning at the leader's current block
+            // (scoring sinks only; the unranked sink's `bar()` is
+            // NEG_INFINITY, so this is skipped). The bar is the kth-best
+            // once the heap fills, or the caller's seeded floor before
+            // that — whichever is higher.
+            let bar = sink.bar();
             if bar > f32::NEG_INFINITY {
                 let range_start = c0.current_doc_id();
                 let range_end = c0.current_block_last_doc_id();
@@ -1715,21 +1737,21 @@ impl FtsReader {
                 } else if a > b {
                     j += 1;
                 } else {
-                    let norm = dl_norm_k1[a as usize];
-                    let score = crate::superfile::fts::bm25::score_with_dl_norm_k1(
-                        c0_idf,
-                        c0.block_tfs[i],
-                        norm,
-                    ) + crate::superfile::fts::bm25::score_with_dl_norm_k1(
-                        c1_idf,
-                        c1.block_tfs[j],
-                        norm,
-                    );
-                    // Floor gate: strictly-below-floor docs are dead to
-                    // the caller.
-                    if score > floor_eff {
-                        and_heap_push(heap, k, filter.as_deref_mut(), score, a);
-                    }
+                    let score = if sink.needs_score() {
+                        let norm = dl_norm_k1[a as usize];
+                        crate::superfile::fts::bm25::score_with_dl_norm_k1(
+                            c0_idf,
+                            c0.block_tfs[i],
+                            norm,
+                        ) + crate::superfile::fts::bm25::score_with_dl_norm_k1(
+                            c1_idf,
+                            c1.block_tfs[j],
+                            norm,
+                        )
+                    } else {
+                        0.0
+                    };
+                    sink.emit(a, score);
                     i += 1;
                     j += 1;
                 }
@@ -2428,6 +2450,94 @@ impl ExcludeFilter {
     }
 }
 
+/// Per-hit action for the multi-term AND flat-merge intersection.
+///
+/// The traversal in [`FtsReader::and_flat_merge_general`] /
+/// [`FtsReader::and_flat_merge_2term`] — cursor alignment, block
+/// crossing, and the in-block pointer walk — runs identically whether
+/// the caller wants ranked hits or just the matching doc ids. Only the
+/// action at each converged doc differs, so both go through one
+/// traversal parameterized by this trait and cannot disagree on which
+/// docs match.
+///
+/// [`ScoreSink`] computes BM25 and feeds a top-k heap (the ranked
+/// search path); [`CollectSink`] records the doc id and computes no
+/// score (the unranked `token_match` / count path). The traversal is
+/// monomorphized per sink, so `needs_score()` folds to a constant: the
+/// scorer compiles to a dedicated copy with scoring inlined, and the
+/// collector's copy drops the scoring arithmetic as dead code.
+trait AndSink {
+    /// Block-max pruning bar: docs whose block can't reach this score
+    /// are skipped. Returning `NEG_INFINITY` (the default) disables
+    /// pruning, which is what an unranked sink wants — it has no score
+    /// threshold to prune against.
+    fn bar(&self) -> f32 {
+        f32::NEG_INFINITY
+    }
+
+    /// Whether the traversal should compute a hit's BM25 score. A sink
+    /// that returns `false` skips all scoring arithmetic — what makes an
+    /// unranked count over a large intersection cheaper than ranking it.
+    fn needs_score(&self) -> bool;
+
+    /// Record one doc in the intersection. `score` is meaningful only
+    /// when [`needs_score`](AndSink::needs_score) returns `true`;
+    /// otherwise it is `0.0` and ignored.
+    fn emit(&mut self, doc: u32, score: f32);
+}
+
+/// Ranked sink: floor-gates each hit and pushes it into the top-k heap.
+struct ScoreSink<'a> {
+    heap: &'a mut BinaryHeap<TopKEntry>,
+    k: usize,
+    filter: Option<&'a mut ExcludeFilter>,
+    floor_eff: f32,
+}
+
+impl AndSink for ScoreSink<'_> {
+    fn bar(&self) -> f32 {
+        // kth-best once the heap fills, else the caller's seeded floor —
+        // whichever is higher.
+        if self.heap.len() >= self.k {
+            self.heap
+                .peek()
+                .expect("heap len == k")
+                .0
+                .max(self.floor_eff)
+        } else {
+            self.floor_eff
+        }
+    }
+
+    fn needs_score(&self) -> bool {
+        true
+    }
+
+    fn emit(&mut self, doc: u32, score: f32) {
+        // Floor gate: strictly-below-floor docs are dead to the caller.
+        if score > self.floor_eff {
+            and_heap_push(self.heap, self.k, self.filter.as_deref_mut(), score, doc);
+        }
+    }
+}
+
+/// Unranked sink: collect the matching doc ids in ascending order, no
+/// scoring, no top-k. Drives the `token_match` AND path through the
+/// same optimized flat-merge the scorer uses.
+struct CollectSink {
+    out: Vec<u32>,
+}
+
+impl AndSink for CollectSink {
+    fn needs_score(&self) -> bool {
+        false
+    }
+
+    fn emit(&mut self, doc: u32, _score: f32) {
+        self.out.push(doc);
+    }
+}
+
 /// Push `(score, doc_id)` into the top-k AND heap with the same
 /// tie-break (asc doc_id) the OR paths use, so AND and OR rankings
 /// agree on score-tied docs.
@@ -2534,48 +2644,25 @@ fn read_u64_le(b: &[u8]) -> u64 {
 /// [`FtsReader::run_and_intersect`] (And) / the OR merge. Cursors
 /// traverse blocks in doc-id order, so the result is ascending with no
 /// extra sort. Used by [`FtsReader::token_match`].
-fn walk_cursors_unranked(mut cursors: Vec<TermCursor>, mode: BoolMode) -> Vec<u32> {
+/// Unranked multi-term OR: the union of the cursors' doc ids in
+/// ascending order. A k-way merge — each step emits the minimum
+/// current doc id across the live cursors and advances every cursor
+/// sitting on it. No scoring; the caller wants membership, not rank.
+fn or_merge_unranked(mut cursors: Vec<TermCursor>) -> Vec<u32> {
     let mut out = Vec::new();
-    match mode {
-        BoolMode::And => {
-            // Rarest term leads so the leapfrog converges fastest — the
-            // same cursor ordering `run_and_intersect` uses.
-            cursors.sort_by_key(|c| c.block_count());
-            'and: loop {
-                if cursors[0].is_exhausted() {
-                    break;
-                }
-                let leader = cursors[0].current_doc_id();
-                let mut max_doc = leader;
-                for c in cursors[1..].iter_mut() {
-                    c.skip_to(leader);
-                    if c.is_exhausted() {
-                        break 'and;
-                    }
-                    max_doc = max_doc.max(c.current_doc_id());
-                }
-                if max_doc == leader {
-                    out.push(leader);
-                    cursors.iter_mut().for_each(TermCursor::next);
-                } else {
-                    cursors[0].skip_to(max_doc);
-                }
+    loop {
+        let min_doc = cursors
+            .iter()
+            .filter(|c| !c.is_exhausted())
+            .map(TermCursor::current_doc_id)
+            .min();
+        let Some(min_doc) = min_doc else { break };
+        out.push(min_doc);
+        for c in cursors.iter_mut() {
+            if !c.is_exhausted() && c.current_doc_id() == min_doc {
+                c.next();
             }
         }
-        BoolMode::Or => loop {
-            let min_doc = cursors
-                .iter()
-                .filter(|c| !c.is_exhausted())
-                .map(TermCursor::current_doc_id)
-                .min();
-            let Some(min_doc) = min_doc else { break };
-            out.push(min_doc);
-            for c in cursors.iter_mut() {
-                if !c.is_exhausted() && c.current_doc_id() == min_doc {
-                    c.next();
-                }
-            }
-        },
     }
     out
 }

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -837,6 +837,22 @@ impl SuperfileReader {
         Ok(fts.token_match(column, tokens, mode).await?)
     }
 
+    /// Unranked token-match **count**: the number of `local_doc_id`s
+    /// [`token_match`](Self::token_match) would return under `mode`,
+    /// without materializing the id `Vec`. Delegates to
+    /// [`FtsReader::token_match_count`].
+    pub async fn token_match_count(
+        &self,
+        column: &str,
+        tokens: &[&str],
+        mode: BoolMode,
+    ) -> Result<u64, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.token_match_count(column, tokens, mode).await?)
+    }
+
     /// Document frequency of `token` in `column` (0 if absent) — a cheap
     /// header-only read used to estimate a predicate's match count
     /// before running `token_match`. Delegates to

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -130,6 +130,60 @@ where
     K: Fn(Arc<SuperfileReader>, P) -> Fut + Clone + Send + 'static,
     Fut: Future<Output = Result<Vec<(u32, f32)>, QueryError>> + Send + 'static,
 {
+    fanout_with(
+        reader,
+        units,
+        move |r, entry, tombstone_cache, now, params| {
+            let kernel = kernel.clone();
+            async move {
+                let hits = kernel(r, params).await?;
+                let mut tagged = tag_hits(&entry, hits);
+                apply_tombstone_filter(tombstone_cache.as_ref(), &entry, &mut tagged, now)?;
+                Ok::<Vec<SuperfileHit>, QueryError>(tagged)
+            }
+        },
+    )
+    .await
+}
+
+/// Lower-level fan-out primitive: the shared orchestration behind
+/// [`fanout`] and the count path, generic over the per-superfile result
+/// `R`.
+///
+/// It warms the tombstone sidecar cache for every distinct superfile in
+/// one batch, `tokio::spawn`s one task per unit on the shared query
+/// runtime (each opening its reader concurrently), then collects every
+/// task with [`futures::future::try_join_all`] — so the **first**
+/// per-superfile error (in time, not spawn order) short-circuits the
+/// whole fan-out and returns early.
+///
+/// `body` runs inside each task with the opened reader, the superfile
+/// entry, the (warmed) tombstone cache + the batch `now` instant, and
+/// the unit's params. Resolving the per-superfile tombstone bitmap and
+/// applying it is the body's job, since callers differ: [`fanout`]
+/// tags + retains hits, while the count path either takes the O(1)
+/// `term_df` fast path (no tombstones) or counts the matching ids minus
+/// tombstones.
+pub(crate) async fn fanout_with<P, R, B, Fut>(
+    reader: &SupertableReader,
+    units: Vec<(Arc<SuperfileEntry>, P)>,
+    body: B,
+) -> Result<Vec<R>, QueryError>
+where
+    P: Send + 'static,
+    R: Send + 'static,
+    B: Fn(
+            Arc<SuperfileReader>,
+            Arc<SuperfileEntry>,
+            Option<Arc<SidecarCache>>,
+            std::time::Instant,
+            P,
+        ) -> Fut
+        + Clone
+        + Send
+        + 'static,
+    Fut: Future<Output = Result<R, QueryError>> + Send + 'static,
+{
     if units.is_empty() {
         return Ok(Vec::new());
     }
@@ -149,30 +203,23 @@ where
         cache.prefetch(&ids, now).await;
     }
 
-    let handles: Vec<_> = units
-        .into_iter()
-        .map(|(entry, params)| {
-            let store = Arc::clone(&store);
-            let disk_cache = disk_cache.clone();
-            let storage = storage.clone();
-            let tombstone_cache = tombstone_cache.clone();
-            let kernel = kernel.clone();
-            tokio::spawn(async move {
-                let r = open_reader(&store, disk_cache.as_ref(), storage.as_ref(), &entry).await?;
-                let hits = kernel(r, params).await?;
-                let mut tagged = tag_hits(&entry, hits);
-                apply_tombstone_filter(tombstone_cache.as_ref(), &entry, &mut tagged, now)?;
-                Ok::<Vec<SuperfileHit>, QueryError>(tagged)
-            })
-        })
-        .collect();
-
-    let mut out: Vec<Vec<SuperfileHit>> = Vec::with_capacity(handles.len());
-    for h in handles {
-        let tagged = h
-            .await
-            .map_err(|e| QueryError::Store(format!("fan-out task join: {e}")))??;
-        out.push(tagged);
-    }
-    Ok(out)
+    let handles = units.into_iter().map(|(entry, params)| {
+        let store = Arc::clone(&store);
+        let disk_cache = disk_cache.clone();
+        let storage = storage.clone();
+        let tombstone_cache = tombstone_cache.clone();
+        let body = body.clone();
+        let handle = tokio::spawn(async move {
+            let r = open_reader(&store, disk_cache.as_ref(), storage.as_ref(), &entry).await?;
+            body(r, entry, tombstone_cache, now, params).await
+        });
+        // Flatten the join error into a QueryError so `try_join_all`
+        // short-circuits on the first failing superfile.
+        async move {
+            handle
+                .await
+                .map_err(|e| QueryError::Store(format!("fan-out task join: {e}")))?
+        }
+    });
+    futures::future::try_join_all(handles).await
 }

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -535,23 +535,31 @@ impl SupertableReader {
                         }
                         None => None,
                     };
-                    // O(1) fast path: single token, no deletes → stored df.
-                    if single_term && tomb.is_none() {
-                        let df = r
-                            .term_df(&column_arc, &term_arc[0])
+                    let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
+                    // Deletes present: materialize the matching ids and
+                    // subtract the tombstoned ones (a df read or a bare
+                    // match count would over-count the deleted rows).
+                    if let Some(b) = tomb {
+                        let docs = r
+                            .token_match(&column_arc, &refs, mode)
                             .await
                             .map_err(|e| QueryError::Parquet(e.to_string()))?;
-                        return Ok::<u64, QueryError>(df);
+                        return Ok::<u64, QueryError>(
+                            docs.iter().filter(|d| !b.contains(**d)).count() as u64,
+                        );
                     }
-                    // General path: matching local doc ids minus tombstones.
-                    let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
-                    let docs = r
-                        .token_match(&column_arc, &refs, mode)
-                        .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?;
-                    let n = match tomb {
-                        None => docs.len() as u64,
-                        Some(b) => docs.iter().filter(|d| !b.contains(**d)).count() as u64,
+                    // No deletes (the common case): count without
+                    // materializing ids — a single token resolves O(1)
+                    // from the stored df, multi-token tallies the match
+                    // walk through the counting sink.
+                    let n = if single_term {
+                        r.term_df(&column_arc, &term_arc[0])
+                            .await
+                            .map_err(|e| QueryError::Parquet(e.to_string()))?
+                    } else {
+                        r.token_match_count(&column_arc, &refs, mode)
+                            .await
+                            .map_err(|e| QueryError::Parquet(e.to_string()))?
                     };
                     Ok(n)
                 }

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -509,42 +509,22 @@ impl SupertableReader {
             return Ok(0);
         }
 
-        let store = Arc::clone(&manifest.options.store);
-        let disk_cache = manifest.options.disk_cache.as_ref().map(Arc::clone);
-        let storage = manifest.options.storage.as_ref().map(Arc::clone);
-        let tombstone_cache = self.tombstone_cache.clone();
-        let now = std::time::Instant::now();
-
-        // Warm the tombstone sidecars for every kept superfile in one
-        // concurrent batch, so the per-superfile lookup below is a hit.
-        if let Some(cache) = tombstone_cache.as_ref() {
-            let mut ids: Vec<uuid::Uuid> = kept.iter().map(|e| e.superfile_id).collect();
-            ids.sort_unstable();
-            ids.dedup();
-            cache.prefetch(&ids, now).await;
-        }
-
         let single_term = term_strings.len() == 1;
         let column_arc = Arc::new(column.to_owned());
         let term_arc: Arc<Vec<String>> = Arc::new(term_strings);
+        let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
 
-        let handles: Vec<_> = kept
-            .into_iter()
-            .map(|entry| {
-                let store = Arc::clone(&store);
-                let disk_cache = disk_cache.clone();
-                let storage = storage.clone();
-                let tombstone_cache = tombstone_cache.clone();
+        // Shared fan-out (`dispatch::fanout_with`): warms tombstones,
+        // spawns + opens each superfile concurrently, and short-circuits
+        // on the first error. The per-superfile body returns this
+        // superfile's match count; the totals are summed.
+        let per_superfile = crate::supertable::query::dispatch::fanout_with(
+            self,
+            units,
+            move |r, entry, tombstone_cache, now, _params: ()| {
                 let column_arc = Arc::clone(&column_arc);
                 let term_arc = Arc::clone(&term_arc);
-                tokio::spawn(async move {
-                    let r = crate::supertable::query::dispatch::open_reader(
-                        &store,
-                        disk_cache.as_ref(),
-                        storage.as_ref(),
-                        &entry,
-                    )
-                    .await?;
+                async move {
                     // Tombstone bitmap for this superfile (None = no deletes).
                     let tomb = match tombstone_cache.as_ref() {
                         Some(c) => {
@@ -574,17 +554,11 @@ impl SupertableReader {
                         Some(b) => docs.iter().filter(|d| !b.contains(**d)).count() as u64,
                     };
                     Ok(n)
-                })
-            })
-            .collect();
-
-        let mut total: u64 = 0;
-        for h in handles {
-            total += h
-                .await
-                .map_err(|e| QueryError::Store(format!("count fan-out join: {e}")))??;
-        }
-        Ok(total)
+                }
+            },
+        )
+        .await?;
+        Ok(per_superfile.into_iter().sum())
     }
 
     /// Unranked two-pass exact match of the **raw string** `value`
@@ -1674,10 +1648,7 @@ mod tests {
 
         // OR "alpha beta": alpha∪beta matches in all three superfiles
         // (2 + 1 + 2) — proves the per-superfile counts are summed.
-        assert_eq!(
-            st.count("title", "alpha beta", BoolMode::Or).expect("c"),
-            5
-        );
+        assert_eq!(st.count("title", "alpha beta", BoolMode::Or).expect("c"), 5);
         // OR "gamma delta": 1 + 2 + 1 across the three superfiles.
         assert_eq!(
             st.count("title", "gamma delta", BoolMode::Or).expect("c"),

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -473,6 +473,120 @@ impl SupertableReader {
         Ok(per_unit.into_iter().flatten().collect())
     }
 
+    /// Count documents whose `column` matches `query`'s tokens under
+    /// `mode` (`Or` = any token, `And` = every token), over this reader's
+    /// pinned snapshot — **count only, no scoring and no row
+    /// materialization**.
+    ///
+    /// Fast path: a single-token query against a superfile with no
+    /// tombstones resolves from the term dictionary's stored document
+    /// frequency ([`SuperfileReader::term_df`]) — O(1) per superfile, no
+    /// posting decode. A multi-token query, or a superfile with deletes,
+    /// falls back to materializing the matching local doc ids and
+    /// counting those not tombstoned. Tombstoned (deleted) rows are
+    /// always excluded so the count matches what a search would return.
+    pub(crate) async fn token_match_count_async(
+        &self,
+        column: &str,
+        query: &str,
+        mode: BoolMode,
+    ) -> Result<u64, QueryError> {
+        let manifest = self.manifest();
+        let term_strings: Vec<String> = AsciiLowerTokenizer.tokenize(query).collect();
+        if term_strings.is_empty() {
+            return Ok(0);
+        }
+        let kept = crate::supertable::query::prune::select_superfiles(
+            manifest.as_ref(),
+            &[crate::supertable::query::prune::PruneLeaf::TermPresence {
+                column: column.to_owned(),
+                terms: term_strings.clone(),
+                mode,
+            }],
+        )
+        .await?;
+        if kept.is_empty() {
+            return Ok(0);
+        }
+
+        let store = Arc::clone(&manifest.options.store);
+        let disk_cache = manifest.options.disk_cache.as_ref().map(Arc::clone);
+        let storage = manifest.options.storage.as_ref().map(Arc::clone);
+        let tombstone_cache = self.tombstone_cache.clone();
+        let now = std::time::Instant::now();
+
+        // Warm the tombstone sidecars for every kept superfile in one
+        // concurrent batch, so the per-superfile lookup below is a hit.
+        if let Some(cache) = tombstone_cache.as_ref() {
+            let mut ids: Vec<uuid::Uuid> = kept.iter().map(|e| e.superfile_id).collect();
+            ids.sort_unstable();
+            ids.dedup();
+            cache.prefetch(&ids, now).await;
+        }
+
+        let single_term = term_strings.len() == 1;
+        let column_arc = Arc::new(column.to_owned());
+        let term_arc: Arc<Vec<String>> = Arc::new(term_strings);
+
+        let handles: Vec<_> = kept
+            .into_iter()
+            .map(|entry| {
+                let store = Arc::clone(&store);
+                let disk_cache = disk_cache.clone();
+                let storage = storage.clone();
+                let tombstone_cache = tombstone_cache.clone();
+                let column_arc = Arc::clone(&column_arc);
+                let term_arc = Arc::clone(&term_arc);
+                tokio::spawn(async move {
+                    let r = crate::supertable::query::dispatch::open_reader(
+                        &store,
+                        disk_cache.as_ref(),
+                        storage.as_ref(),
+                        &entry,
+                    )
+                    .await?;
+                    // Tombstone bitmap for this superfile (None = no deletes).
+                    let tomb = match tombstone_cache.as_ref() {
+                        Some(c) => {
+                            let b = c
+                                .bitmap_for(entry.superfile_id, now)
+                                .map_err(|e| QueryError::Store(format!("tombstone cache: {e}")))?;
+                            if b.is_empty() { None } else { Some(b) }
+                        }
+                        None => None,
+                    };
+                    // O(1) fast path: single token, no deletes → stored df.
+                    if single_term && tomb.is_none() {
+                        let df = r
+                            .term_df(&column_arc, &term_arc[0])
+                            .await
+                            .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                        return Ok::<u64, QueryError>(df);
+                    }
+                    // General path: matching local doc ids minus tombstones.
+                    let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
+                    let docs = r
+                        .token_match(&column_arc, &refs, mode)
+                        .await
+                        .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                    let n = match tomb {
+                        None => docs.len() as u64,
+                        Some(b) => docs.iter().filter(|d| !b.contains(**d)).count() as u64,
+                    };
+                    Ok(n)
+                })
+            })
+            .collect();
+
+        let mut total: u64 = 0;
+        for h in handles {
+            total += h
+                .await
+                .map_err(|e| QueryError::Store(format!("count fan-out join: {e}")))??;
+        }
+        Ok(total)
+    }
+
     /// Unranked two-pass exact match of the **raw string** `value`
     /// against `column` across the pinned snapshot. Returns the rows
     /// whose stored value equals `value` exactly as [`SuperfileHit`]s —
@@ -598,6 +712,15 @@ impl SupertableReader {
         mode: BoolMode,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
         self.block_on(self.token_match_async(column, query, mode))
+    }
+
+    /// Count documents matching `query`'s tokens under `mode` over this
+    /// reader's pinned snapshot — count only, no scoring or row
+    /// materialization. A single-token query on a delete-free superfile
+    /// resolves in O(1) from the stored document frequency. Drives the
+    /// async kernel via the sync→async bridge.
+    pub fn count(&self, column: &str, query: &str, mode: BoolMode) -> Result<u64, QueryError> {
+        self.block_on(self.token_match_count_async(column, query, mode))
     }
 
     /// Unranked exact match of the raw string `value` against `column`
@@ -852,6 +975,40 @@ impl Supertable {
             ))
             .map_err(|e| crate::InfinoError::Query(e.to_string()))?;
         Ok(vec![batch])
+    }
+
+    /// Count documents whose `column` matches `query`'s tokens under
+    /// `mode` (`Or` = any token, `And` = every token) over the current
+    /// snapshot — count only, no scoring or row materialization. A
+    /// single-token query on a delete-free snapshot resolves in O(1) per
+    /// superfile from the term dictionary's document frequency, so
+    /// counting a high-frequency term is cheap.
+    ///
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use arrow_array::{LargeStringArray, RecordBatch};
+    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::{connect, BoolMode, IndexSpec};
+    /// # let db = connect("memory://")?;
+    /// # let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::LargeUtf8, false)]));
+    /// # let posts = db.create_table("posts", schema.clone(), IndexSpec::new().fts("body"))?;
+    /// # posts.append(&RecordBatch::try_new(
+    /// #     schema,
+    /// #     vec![Arc::new(LargeStringArray::from(vec!["the quick brown fox", "a lazy dog"]))],
+    /// # )?)?;
+    /// let n = posts.count("body", "fox", BoolMode::Or)?;
+    /// assert_eq!(n, 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn count(
+        &self,
+        column: &str,
+        query: &str,
+        mode: BoolMode,
+    ) -> Result<u64, crate::InfinoError> {
+        self.reader()
+            .count(column, query, mode)
+            .map_err(crate::InfinoError::from)
     }
 }
 
@@ -1474,5 +1631,120 @@ mod tests {
             cursor = end;
         }
         assert_eq!(cursor, 200_000, "sub-ranges tile the whole superfile");
+    }
+
+    #[test]
+    fn count_single_term_sums_df_across_superfiles() {
+        // 3 commits → 3 superfiles. Single-term count takes the O(1)
+        // term_df fast path (no deletes) and sums across superfiles.
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(0, &["alpha beta", "alpha gamma"]))
+            .expect("append");
+        w.commit().expect("commit");
+        w.append(&build_batch(2, &["alpha delta"])).expect("append");
+        w.commit().expect("commit");
+        w.append(&build_batch(3, &["beta gamma"])).expect("append");
+        w.commit().expect("commit");
+
+        assert_eq!(st.count("title", "alpha", BoolMode::Or).expect("count"), 3);
+        assert_eq!(st.count("title", "beta", BoolMode::Or).expect("count"), 2);
+        assert_eq!(st.count("title", "gamma", BoolMode::Or).expect("count"), 2);
+        assert_eq!(st.count("title", "absent", BoolMode::Or).expect("count"), 0);
+    }
+
+    #[test]
+    fn count_honors_or_and_modes() {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(
+            0,
+            &["alpha beta", "alpha gamma", "beta delta"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+
+        // OR: docs containing alpha OR delta → all three.
+        assert_eq!(
+            st.count("title", "alpha delta", BoolMode::Or).expect("c"),
+            3
+        );
+        // AND: docs containing both alpha AND beta → just "alpha beta".
+        assert_eq!(
+            st.count("title", "alpha beta", BoolMode::And).expect("c"),
+            1
+        );
+        // AND with no doc holding both → 0.
+        assert_eq!(
+            st.count("title", "gamma delta", BoolMode::And).expect("c"),
+            0
+        );
+    }
+
+    #[test]
+    fn count_agrees_with_token_match_len() {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(
+            0,
+            &["alpha beta", "alpha gamma", "beta delta"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+        let r = st.reader();
+        for (q, mode) in [
+            ("alpha", BoolMode::Or),
+            ("alpha delta", BoolMode::Or),
+            ("alpha beta", BoolMode::And),
+        ] {
+            let c = r.count("title", q, mode).expect("count");
+            let n = r.token_match("title", q, mode).expect("token_match").len() as u64;
+            assert_eq!(c, n, "count vs token_match for {q:?} {mode:?}");
+        }
+    }
+
+    #[test]
+    fn count_empty_query_and_empty_supertable_are_zero() {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        // Empty supertable: nothing matches.
+        assert_eq!(st.count("title", "alpha", BoolMode::Or).expect("c"), 0);
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(0, &["alpha beta"])).expect("append");
+        w.commit().expect("commit");
+        // Token-less queries produce no terms → 0.
+        assert_eq!(st.count("title", "", BoolMode::Or).expect("c"), 0);
+        assert_eq!(st.count("title", "   ", BoolMode::Or).expect("c"), 0);
+    }
+
+    #[test]
+    fn count_excludes_tombstoned_docs() {
+        use datafusion::prelude::{col, lit};
+        // Storage-backed so delete (tombstones) is available. After a
+        // delete, the single-term count must drop the term_df fast path
+        // and subtract the tombstone — df would over-count.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let storage: Arc<dyn crate::storage::StorageProvider> =
+            Arc::new(crate::storage::LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let st = Supertable::create(options_one_superfile_per_commit().with_storage(storage))
+            .expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(0, &["alpha one", "alpha two", "alpha three"]))
+            .expect("append");
+        w.commit().expect("commit");
+        drop(w); // release the writer slot so `delete` can acquire it
+
+        assert_eq!(st.count("title", "alpha", BoolMode::Or).expect("count"), 3);
+
+        let stats = st
+            .delete(col("title").eq(lit("alpha two")))
+            .expect("delete");
+        assert_eq!(stats.matched(), 1);
+
+        // term_df still says 3; the count must subtract the tombstone → 2.
+        assert_eq!(
+            st.count("title", "alpha", BoolMode::Or)
+                .expect("count after delete"),
+            2
+        );
     }
 }

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1654,6 +1654,62 @@ mod tests {
     }
 
     #[test]
+    fn count_multi_term_sums_across_superfiles() {
+        // 3 commits → 3 superfiles. Multi-term queries take the general
+        // `token_match` branch (not the single-term df fast path), so this
+        // exercises summing per-superfile match counts across superfiles
+        // for both OR (union spans all three) and AND (intersection lands
+        // in one). Doc ids are globally unique across commits.
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(0, &["alpha beta", "alpha gamma"]))
+            .expect("append");
+        w.commit().expect("commit");
+        w.append(&build_batch(2, &["beta gamma", "delta"]))
+            .expect("append");
+        w.commit().expect("commit");
+        w.append(&build_batch(4, &["alpha delta", "beta"]))
+            .expect("append");
+        w.commit().expect("commit");
+
+        // OR "alpha beta": alpha∪beta matches in all three superfiles
+        // (2 + 1 + 2) — proves the per-superfile counts are summed.
+        assert_eq!(
+            st.count("title", "alpha beta", BoolMode::Or).expect("c"),
+            5
+        );
+        // OR "gamma delta": 1 + 2 + 1 across the three superfiles.
+        assert_eq!(
+            st.count("title", "gamma delta", BoolMode::Or).expect("c"),
+            4
+        );
+        // AND "alpha beta": both terms only in the first superfile's
+        // "alpha beta" doc → 1 (the other superfiles contribute 0).
+        assert_eq!(
+            st.count("title", "alpha beta", BoolMode::And).expect("c"),
+            1
+        );
+        // AND "alpha delta": both terms only in the third superfile.
+        assert_eq!(
+            st.count("title", "alpha delta", BoolMode::And).expect("c"),
+            1
+        );
+
+        // Cross-check every shape against token_match cardinality.
+        let r = st.reader();
+        for (q, mode) in [
+            ("alpha beta", BoolMode::Or),
+            ("gamma delta", BoolMode::Or),
+            ("alpha beta", BoolMode::And),
+            ("alpha delta", BoolMode::And),
+        ] {
+            let c = r.count("title", q, mode).expect("count");
+            let n = r.token_match("title", q, mode).expect("token_match").len() as u64;
+            assert_eq!(c, n, "count vs token_match for {q:?} {mode:?}");
+        }
+    }
+
+    #[test]
     fn count_honors_or_and_modes() {
         let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");


### PR DESCRIPTION
## What

Adds a public `Supertable::count(column, query, mode) -> u64`: count the documents matching an FTS query, with **no scoring and no row materialization**.

- **single token, no deletes** → resolves from the term dictionary's stored document frequency (`term_df`, O(1) per superfile, no posting decode).
- **multi-token / deleted rows** → falls back to the candidate doc-id set minus tombstones.

It's the count-collector analog of `bm25_search`.

## Why

Counting matches previously had no dedicated path: the only way to get a match count was `bm25_search(k = usize::MAX)`, which scores every hit and builds a top-k heap just to discard the scores. For a common term that's tens of milliseconds (score 1M docs) to produce a number the dictionary already stores. This adds the missing count path: O(1) from the stored document frequency for the common single-term case, and a scoreless candidate-set walk otherwise.

## Benchmarks

Count battery added to the superfile + supertable FTS benches: `count()` vs the old `bm25_search(k = usize::MAX)` path, both asserted to return the same count. Superfile tier, 1M docs:

**OR / single-term**

| Query | matches | count() | bm25 (k=MAX) | speedup |
|---|---|---|---|---|
| single_common | 1M | 250 ns | 44.12 ms | **176,495×** |
| single_rare | 2.0K | 209 ns | 5.12 µs | 24.5× |
| two_term_or | 1M | 5.67 ms | 50.28 ms | 8.9× |
| ten_term_or | 977.5K | 34.01 ms | 118.87 ms | 3.5× |

**AND** — the second commit unifies the unranked AND match path with the ranked scorer's block flat-merge, so a count is never slower than scoring-everything (it was, for tiny high-frequency intersections):

| Query | matches | count() before → after | speedup before → after |
|---|---|---|---|
| two_term_and | 335.9K | 3.63 ms → 3.09 ms | 2.9× → **3.4×** |
| five_term_and | 3.5K | 5.69 ms → 4.09 ms | 0.7× → **1.0×** |
| ten_term_and | 4 | 9.06 ms → 5.06 ms | 0.5× → **1.0×** |

Ranked `bm25_search` is unchanged across the battery (within run-to-run noise) — the shared traversal is monomorphized per sink, so the scorer keeps its exact codegen.

## Scope

- Public surface: **+1 method** (`public-api.txt` regenerated).
- `superfile/fts`: the multi-term AND intersection is now one traversal shared by the ranked scorer (`ScoreSink`) and the unranked matcher (`CollectSink`) — removes the duplicate per-leader-doc leapfrog and guarantees the two agree on which docs match.
- Benches: `count` section per tier, sharing the measurement via two new `FtsRead` methods.
- Tests: df fast path across superfiles, `And`/`Or` modes, agreement with `token_match`, empties, the tombstone-subtraction path, and the brute-force BM25 oracle (unchanged, still green).
- `make ci` green (check + doctest + coverage; coverage stays >90% on all three metrics).

## Follow-ups (not in this PR)

1. **SQL `COUNT(*)` pushdown** — make `COUNT(*) … WHERE <fts predicate>` resolve via the same core instead of a DataFusion Parquet scan. Larger change: the `covered_agg` rewrite is plan-level and decoupled from the reader, so it needs either a reader-aware fold or exact `statistics()` on the `token_match` TVF. Separate PR.
