### PR TITLE
chore: allow one compaction at any given point in one process

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -41,6 +41,7 @@ impl core::marker::UnsafeUnpin for infino::ColdFetchMode
 impl core::panic::unwind_safe::RefUnwindSafe for infino::ColdFetchMode
 impl core::panic::unwind_safe::UnwindSafe for infino::ColdFetchMode
 pub enum infino::CompactionError
+pub infino::CompactionError::AlreadyCompacting
 pub infino::CompactionError::Build(alloc::string::String)
 pub infino::CompactionError::Commit(alloc::string::String)
 pub infino::CompactionError::EmptyMergedSuperfile

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -24,8 +24,16 @@ use crate::{
     },
 };
 use bytes::Bytes;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, sync::atomic::Ordering};
 use uuid::Uuid;
+
+struct CompactionSlot<'a>(&'a std::sync::atomic::AtomicBool);
+
+impl Drop for CompactionSlot<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
 
 const MIB: u64 = 1024 * 1024;
 
@@ -166,6 +174,18 @@ impl Supertable {
         cfg: &CompactionSettings,
     ) -> Result<(), CompactionError> {
         let inner = self.inner();
+
+        match inner.compaction_outstanding.compare_exchange(
+            false,
+            true,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => {}
+            Err(_) => return Err(CompactionError::AlreadyCompacting),
+        }
+        let _slot = CompactionSlot(&inner.compaction_outstanding);
+
         let manifest = inner.manifest.load_full();
 
         // Prefetch sidecars using the cache to batch storage GETs.
@@ -405,6 +425,7 @@ mod tests {
     use super::*;
     use crate::BoolMode;
     use crate::Supertable;
+    use crate::supertable::error::CompactionError;
     use crate::supertable::storage::LocalFsStorageProvider;
     use crate::test_helpers::{build_title_batch, default_supertable_options};
     use std::collections::HashSet;
@@ -972,6 +993,49 @@ mod tests {
         let mut w = st.writer().expect("writer");
         w.append(&build_title_batch(titles)).expect("append");
         w.commit().expect("commit");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_rejects_concurrent_call_while_slot_held() {
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+
+        // Manually set the slot as if a compaction is running.
+        st.inner()
+            .compaction_outstanding
+            .store(true, Ordering::Release);
+
+        let err = st
+            .compact_async(&small_compact_cfg())
+            .await
+            .expect_err("must reject while slot held");
+
+        assert!(
+            matches!(err, CompactionError::AlreadyCompacting),
+            "expected AlreadyCompacting, got {err:?}"
+        );
+
+        // Release so the supertable is clean for drop.
+        st.inner()
+            .compaction_outstanding
+            .store(false, Ordering::Release);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_slot_released_after_completion() {
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+
+        commit_titles(&st, &["alpha first", "alpha second"]);
+
+        st.compact_async(&small_compact_cfg())
+            .await
+            .expect("first compact");
+
+        // Slot must be released so a second call succeeds.
+        st.compact_async(&small_compact_cfg())
+            .await
+            .expect("second compact after slot release");
     }
 
     // ─── End-to-end compact() tests ────────────────────────────────────────

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -292,6 +292,10 @@ pub enum CompactionError {
     /// Refreshing the in-memory manifest after a successful commit failed.
     #[error("post-commit manifest refresh failed: {0}")]
     Refresh(String),
+
+    /// Another compaction is already running on this supertable handle.
+    #[error("compaction already in progress on this supertable handle")]
+    AlreadyCompacting,
 }
 
 /// Errors raised by query-time methods on [`crate::supertable::Supertable`]

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -60,6 +60,12 @@ pub(super) struct SupertableInner {
     /// concurrent `Supertable::writer()` call until the first
     /// writer is dropped.
     pub(super) writer_outstanding: AtomicBool,
+    /// Single-compaction slot. Same acquire/release pattern as
+    /// `writer_outstanding`. Prevents concurrent `compact()` calls
+    /// within the same process from racing on seals and manifest
+    /// writes. Cross-process coordination happens at the sidecar-seal
+    /// level.
+    pub(super) compaction_outstanding: AtomicBool,
     /// Generator for the supertable-injected `_id` column.
     /// Each `append()` locks the mutex once, mints
     /// `batch.num_rows()` ids, and unlocks. The
@@ -240,6 +246,7 @@ impl Supertable {
             options,
             manifest: ArcSwap::new(Arc::new(initial)),
             writer_outstanding: AtomicBool::new(false),
+            compaction_outstanding: AtomicBool::new(false),
             id_generator: Mutex::new(id_generator),
             query_runtime: OnceLock::new(),
             sql_session_cache: Mutex::new(None),
@@ -327,6 +334,7 @@ impl Supertable {
             options: options_arc,
             manifest: ArcSwap::new(manifest),
             writer_outstanding: AtomicBool::new(false),
+            compaction_outstanding: AtomicBool::new(false),
             id_generator: Mutex::new(id_generator),
             query_runtime: OnceLock::new(),
             sql_session_cache: Mutex::new(None),


### PR DESCRIPTION
### What is the change

in compaction v1, only allow one compaction job to run at any given time. This logic will change in future and we wil also remove the compaction outstanding atomic bool from supertableinnter to persist or metadata store