### PR TITLE
python: expose update, delete and compact

### DIFF
--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2143,6 +2143,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
+ "datafusion",
  "infino",
  "pyo3",
 ]

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -29,3 +29,8 @@ arrow-schema = "58"
 # stable ABI), so distribution needs one wheel per platform rather than
 # one per Python version.
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
+# Parse a SQL predicate string (for `update` / `delete`) into a DataFusion
+# `Expr` — the type the core `update` / `delete` take. Pinned to infino's
+# datafusion version so the `Expr` type unifies with the core signatures;
+# feature unification reuses infino's already-compiled datafusion.
+datafusion = "53"

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -1,85 +1,227 @@
-# infino — Python bindings
+# Infino
 
-PyO3 + maturin bindings over infino's catalog API. Sync; Arrow is the
-interchange.
+[![PyPI](https://img.shields.io/pypi/v/infino.svg)](https://pypi.org/project/infino/)
+[![Python](https://img.shields.io/pypi/pyversions/infino.svg)](https://pypi.org/project/infino/)
+[![License](https://img.shields.io/pypi/l/infino.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
+**SQL, full-text, and vector search over your data on object storage — one engine, no server to run.**
+
+Infino keeps your data in Apache Parquet on object storage (local disk,
+Amazon S3, or any S3-compatible store) and runs SQL, full-text (BM25),
+and vector search over it from a single system. Each file is a valid
+Parquet file with BM25 and vector indexes embedded directly inside it; a
+table composes many such files with snapshot-isolated reads, append-only
+writes, and atomic commits. It runs in your process — there is no daemon,
+no cluster, and no managed service to operate.
+
+Apache Arrow is the interchange: schemas and batches cross the boundary
+as `pyarrow` objects, and every search returns a `pyarrow.Table`.
+
+## Installation
+
+```sh
+pip install infino
+```
+
+Requires Python 3.9 or newer. `pyarrow` is installed as a dependency;
+`pandas` is optional and used only if you pass DataFrames.
+
+## Quickstart
 
 ```python
 import infino
 import pyarrow as pa
 
-db = infino.connect("memory://")            # or "./data", "s3://bucket/prefix"
+# Connect to a catalog. Use a local path or an S3 URI for durable storage;
+# "memory://" is ephemeral and handy for tests.
+db = infino.connect("./data")
+
+# Declare a schema and which columns to index. An "_id" column is added
+# automatically — you don't define it.
 schema = pa.schema([pa.field("title", pa.large_utf8(), nullable=False)])
 docs = db.create_table("docs", schema, infino.IndexSpec().fts("title"))
 
-docs.append(pa.record_batch([pa.array(["the quick brown fox"])], names=["title"]))
+# Append rows. One append is one atomic commit.
+docs.append([{"title": "the quick brown fox"}, {"title": "a lazy dog"}])
 
-rows = docs.bm25_search("title", "fox", 10)                                # pyarrow.Table (_id, title, score)
-ids = docs.bm25_search("title", "fox", 10, projection=["_id", "score"])    # no scalar decode
-table = db.query_sql("SELECT _id, score FROM bm25_search('docs', 'title', 'fox', 10)")
+# Full-text search. Returns a pyarrow.Table of (_id, score).
+hits = docs.bm25_search("title", "fox", k=10)
+print(hits.column_names)        # ['_id', 'score']
 ```
 
-### Update & delete
+## Core concepts
 
-Mutations need durable storage (a local path or object store, not
-`memory://`). The predicate is a SQL boolean expression — the same thing
-you'd put after `WHERE` — evaluated against the table's columns:
+- **Connection** — a handle to a catalog (a set of tables under one URI).
+  Open it with `infino.connect(uri)`.
+- **Table** — an append-only, snapshot-isolated collection of rows. Each
+  table carries an auto-generated `_id` column.
+- **IndexSpec** — declares which columns are full-text (BM25) and which
+  are vector indexed. Columns without an index are still stored,
+  filterable in SQL, and returnable via projection.
+- **Commits** — every `append`, `update`, and `delete` is a single atomic
+  commit. Readers see a consistent snapshot and are never torn by a
+  concurrent write.
+- **Arrow everywhere** — searches return `pyarrow.Table`; `append` and
+  `update` accept Arrow, pandas, or `list[dict]`.
+
+## Full-text search
 
 ```python
-db = infino.connect("./data")
 docs = db.create_table("docs", schema, infino.IndexSpec().fts("title"))
-docs.append([{"title": "draft post"}, {"title": "spam"}])
+docs.append([{"title": "the quick brown fox"}, {"title": "a lazy dog"}])
 
-docs.delete("title = 'spam'")                          # drop matching rows
-stats = docs.update("title = 'draft post'",            # replace matched rows 1:1
-                    [{"title": "published post"}])
-stats.matched, stats.n_tombstoned                      # -> (1, 1)
+# Ranked BM25 — higher score is a better match.
+docs.bm25_search("title", "quick fox", k=10)               # OR by default
+docs.bm25_search("title", "quick fox", k=10, mode="and")   # require all terms
 
-docs.compact()                                         # merge small superfiles
+# Unranked matching (score is 0.0): every row containing the term(s),
+# or an exact whole-value match.
+docs.token_match("title", "fox")
+docs.exact_match("title", "the quick brown fox")
 ```
 
-`update` is a 1:1 replacement: the number of rows the predicate matches
-must equal the number of rows you supply, or it raises. `new_rows` takes
-the same shapes as `append` (pyarrow, pandas, or `list[dict]`).
+## Vector search
 
-## Build & test (requires online crates.io access)
+Vector columns are `fixed_size_list<float32, dim>` with `dim` in
+`[16, 4096]`. The distance metric is fixed when you declare the index
+(`"cosine"`, `"l2sq"`, or `"negdot"`); for vector results a smaller score
+is nearer.
 
-This crate is **excluded** from the infino cargo workspace so the core
-Rust crate doesn't require Python to build. Build it standalone with
-maturin (not `cargo build -p`, which would need workspace membership):
+```python
+dim = 384
+schema = pa.schema([pa.field("emb", pa.list_(pa.float32(), dim), nullable=False)])
+spec = infino.IndexSpec().vector("emb", dim, n_cent=256, metric="cosine")
+vecs = db.create_table("vecs", schema, spec)
+
+vecs.append(pa.record_batch([pa.array(embeddings, type=pa.list_(pa.float32(), dim))],
+                            names=["emb"]))
+
+vecs.vector_search("emb", query_vector, k=10)              # query_vector: list[float]
+vecs.vector_search("emb", query_vector, k=10, nprobe=32)   # probe more partitions
+```
+
+## SQL
+
+Run SQL across the catalog's tables. Search is available inside SQL
+through table-valued functions, so you can rank and join in one query.
+
+```python
+db.query_sql("SELECT COUNT(*) AS n FROM docs")
+db.query_sql("SELECT _id, score FROM bm25_search('docs', 'title', 'fox', 10)")
+```
+
+## Projections
+
+By default a search returns just `_id` and `score` — no row data is
+decoded. Name the columns you want to materialize:
+
+```python
+docs.bm25_search("title", "fox", k=10)                          # _id + score only
+docs.bm25_search("title", "fox", k=10, projection=["_id", "title", "score"])
+```
+
+## Updates and deletes
+
+Mutations require durable storage (a local path or object store, not
+`memory://`). The predicate is a SQL boolean expression — the same thing
+you would write after `WHERE` — evaluated against the table's columns.
+
+```python
+docs.append([{"title": "draft post"}, {"title": "spam"}])
+
+# Delete every row matching the predicate.
+docs.delete("title = 'spam'")
+
+# Replace matched rows 1:1 with new rows (same input shapes as append).
+stats = docs.update("title = 'draft post'", [{"title": "published post"}])
+print(stats.matched, stats.n_tombstoned, stats.n_not_found)
+```
+
+`update` is a one-to-one replacement: the number of rows the predicate
+matches must equal the number of rows you supply, otherwise it raises.
+Both methods return a `MutationStats` with `matched`, `n_tombstoned`, and
+`n_not_found`.
+
+## Compaction
+
+Many small appends produce many small files. `compact` merges small or
+underfilled files into larger ones, which keeps reads efficient.
+
+```python
+docs.compact()                                              # engine defaults
+docs.compact(infino.CompactOptions(target_superfile_size_mb=256,
+                                   min_fill_percent=50))
+```
+
+## Storage backends
+
+`connect` selects the backend from the URI:
+
+| URI                       | Backend                                  |
+| ------------------------- | ---------------------------------------- |
+| `./data`, `/abs/path`     | Local filesystem                         |
+| `s3://bucket/prefix`      | Amazon S3 / S3-compatible object storage |
+| `memory://`               | In-process, ephemeral (testing)          |
+
+For S3-compatible stores that need an explicit endpoint and static
+credentials, pass them as keyword arguments (omit them to use ambient AWS
+credentials):
+
+```python
+db = infino.connect(
+    "s3://bucket/prefix",
+    endpoint="https://s3.example.com",
+    region="us-east-1",
+    access_key="…",
+    secret_key="…",
+)
+```
+
+## Schema and type requirements
+
+- Full-text columns must be Arrow `large_utf8`.
+- Vector columns must be `fixed_size_list<float32, dim>` with `dim` in
+  `[16, 4096]`.
+- The `_id` column is generated by the engine; do not declare it.
+- `append` and `update` accept a `pyarrow.RecordBatch` or `Table`, a
+  pandas `DataFrame`, or a `list[dict]`, coerced to Arrow against the
+  table's declared schema.
+
+## API reference
+
+- `infino.connect(uri, *, endpoint=None, region=None, access_key=None, secret_key=None) -> Connection`
+- `Connection`
+  - `create_table(name, schema, index_spec) -> Table`
+  - `open_table(name) -> Table`
+  - `drop_table(name, purge=False)` — `purge=True` also deletes the data
+  - `list_tables() -> list[str]`
+  - `query_sql(sql) -> pyarrow.Table`
+- `Table`
+  - `append(data)`
+  - `bm25_search(column, query, k, mode="or", projection=None) -> pyarrow.Table`
+  - `vector_search(column, query, k, nprobe=None, projection=None) -> pyarrow.Table`
+  - `token_match(column, query, mode="or", projection=None) -> pyarrow.Table`
+  - `exact_match(column, value, projection=None) -> pyarrow.Table`
+  - `delete(predicate) -> MutationStats`
+  - `update(predicate, new_rows) -> MutationStats`
+  - `compact(settings=None)`
+  - `schema() -> pyarrow.Schema`
+- `IndexSpec().fts(column).vector(column, dim, n_cent, metric)`
+- `CompactOptions(max_memory_mb=None, min_fill_percent=None, target_superfile_size_mb=None)`
+- `MutationStats` — returned by `delete` / `update`; read-only attributes `matched`, `n_tombstoned`, `n_not_found`
+
+## Building from source
+
+The bindings are built with [maturin](https://www.maturin.rs/). Building
+requires a Rust toolchain and access to crates.io.
 
 ```sh
-cd infino-python
 python3 -m venv .venv && source .venv/bin/activate
 pip install maturin pytest pyarrow
-maturin develop          # compile the extension + install into the venv
+maturin develop          # compile the extension and install it into the venv
 pytest tests/
 ```
 
-## Scope
+## License
 
-- `connect(uri, *, endpoint, region, access_key, secret_key)` — backend
-  from the URI scheme; S3-compatible static creds via kwargs.
-- `Connection`: `create_table(name, pyarrow.Schema, IndexSpec)`,
-  `open_table`, `drop_table`, `list_tables`, `query_sql` → pyarrow Table.
-- `Table`: `append(...)`, `schema`, and the search surface —
-  `bm25_search` / `vector_search` / `token_match` / `exact_match` all
-  return a pyarrow `Table`. `projection` names the output columns
-  (`_id`, any scalar column, or `score`); omitting it returns the
-  engine-native `_id` + `score` pair with no scalar decode —
-  materializing row data is an explicit opt-in by naming columns. The
-  unranked `token_match` / `exact_match` rows carry `score == 0.0`.
-  `append` accepts a pyarrow `RecordBatch` or `Table`, a pandas
-  `DataFrame`, or a `list[dict]` — coerced to Arrow against the table's
-  declared schema (Python sources are nullable; null-free columns are
-  re-wrapped to match). One `append` is one commit.
-- `Table` mutations — `delete(predicate)` and `update(predicate, new_rows)`
-  take a SQL predicate string (e.g. `"status = 'spam'"`); `update` replaces
-  the matched rows 1:1 with `new_rows` (same shapes as `append`). Both
-  return `MutationStats` (`matched`, `n_tombstoned`, `n_not_found`) and need
-  durable storage (not `memory://`).
-- `Table.compact(CompactOptions(...))` — merge small / underfilled
-  superfiles; omit the options for engine defaults.
-- `IndexSpec().fts(col).vector(col, dim, n_cent, metric)`.
-
-Next: richer `ConnectOptions` (disk cache); abi3 wheels + CI for
-distribution.
+Apache-2.0.

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -49,7 +49,14 @@ pytest tests/
   `DataFrame`, or a `list[dict]` — coerced to Arrow against the table's
   declared schema (Python sources are nullable; null-free columns are
   re-wrapped to match). One `append` is one commit.
+- `Table` mutations — `delete(predicate)` and `update(predicate, new_rows)`
+  take a SQL predicate string (e.g. `"status = 'spam'"`); `update` replaces
+  the matched rows 1:1 with `new_rows` (same shapes as `append`). Both
+  return `MutationStats` (`matched`, `n_tombstoned`, `n_not_found`) and need
+  durable storage (not `memory://`).
+- `Table.compact(CompactOptions(...))` — merge small / underfilled
+  superfiles; omit the options for engine defaults.
 - `IndexSpec().fts(col).vector(col, dim, n_cent, metric)`.
 
-Next: `update` / `delete`; richer `ConnectOptions` (disk cache);
-abi3 wheels + CI for distribution.
+Next: richer `ConnectOptions` (disk cache); abi3 wheels + CI for
+distribution.

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -102,12 +102,12 @@ vecs.vector_search("emb", query_vector, k=10, nprobe=32)   # probe more partitio
 
 ## SQL
 
-Run SQL across the catalog's tables. Search is available inside SQL
-through table-valued functions, so you can rank and join in one query.
+Run SQL across the catalog's tables for analytics and filtering. Results
+come back as a `pyarrow.Table`.
 
 ```python
 db.query_sql("SELECT COUNT(*) AS n FROM docs")
-db.query_sql("SELECT _id, score FROM bm25_search('docs', 'title', 'fox', 10)")
+db.query_sql("SELECT title FROM docs WHERE title = 'a lazy dog'")
 ```
 
 ## Projections
@@ -157,11 +157,11 @@ docs.compact(infino.CompactOptions(target_superfile_size_mb=256,
 
 `connect` selects the backend from the URI:
 
-| URI                       | Backend                                  |
-| ------------------------- | ---------------------------------------- |
-| `./data`, `/abs/path`     | Local filesystem                         |
-| `s3://bucket/prefix`      | Amazon S3 / S3-compatible object storage |
-| `memory://`               | In-process, ephemeral (testing)          |
+| URI                   | Backend                                  |
+| --------------------- | ---------------------------------------- |
+| `./data`, `/abs/path` | Local filesystem                         |
+| `s3://bucket/prefix`  | Amazon S3 / S3-compatible object storage |
+| `memory://`           | In-process, ephemeral (testing)          |
 
 For S3-compatible stores that need an explicit endpoint and static
 credentials, pass them as keyword arguments (omit them to use ambient AWS

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -18,6 +18,29 @@ ids = docs.bm25_search("title", "fox", 10, projection=["_id", "score"])    # no 
 table = db.query_sql("SELECT _id, score FROM bm25_search('docs', 'title', 'fox', 10)")
 ```
 
+### Update & delete
+
+Mutations need durable storage (a local path or object store, not
+`memory://`). The predicate is a SQL boolean expression — the same thing
+you'd put after `WHERE` — evaluated against the table's columns:
+
+```python
+db = infino.connect("./data")
+docs = db.create_table("docs", schema, infino.IndexSpec().fts("title"))
+docs.append([{"title": "draft post"}, {"title": "spam"}])
+
+docs.delete("title = 'spam'")                          # drop matching rows
+stats = docs.update("title = 'draft post'",            # replace matched rows 1:1
+                    [{"title": "published post"}])
+stats.matched, stats.n_tombstoned                      # -> (1, 1)
+
+docs.compact()                                         # merge small superfiles
+```
+
+`update` is a 1:1 replacement: the number of rows the predicate matches
+must equal the number of rows you supply, or it raises. `new_rows` takes
+the same shapes as `append` (pyarrow, pandas, or `list[dict]`).
+
 ## Build & test (requires online crates.io access)
 
 This crate is **excluded** from the infino cargo workspace so the core

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -398,8 +398,11 @@ impl Table {
     /// Delete rows matching a SQL predicate string, e.g. `"status = 'spam'"`.
     /// Needs durable storage — a `memory://` table raises.
     fn delete(&self, py: Python<'_>, predicate: &str) -> PyResult<MutationStats> {
-        let expr = self.parse_predicate(predicate)?;
-        let stats = py.detach(|| self.inner.delete(expr)).map_err(py_err)?;
+        // Parse and mutate both off the GIL — neither touches Python.
+        let stats = py.detach(|| {
+            let expr = self.parse_predicate(predicate)?;
+            self.inner.delete(expr).map_err(py_err)
+        })?;
         Ok(MutationStats::from_core(&stats))
     }
 
@@ -412,7 +415,6 @@ impl Table {
         predicate: &str,
         new_rows: &Bound<'_, PyAny>,
     ) -> PyResult<MutationStats> {
-        let expr = self.parse_predicate(predicate)?;
         let declared = self.inner.schema();
         let py_schema = declared.as_ref().to_pyarrow(py)?;
         // Pass an empty batch through rather than short-circuiting like
@@ -421,9 +423,11 @@ impl Table {
             Some(batch) => align_to_schema(declared, batch)?,
             None => RecordBatch::new_empty(declared),
         };
-        let stats = py
-            .detach(|| self.inner.update(expr, &aligned))
-            .map_err(py_err)?;
+        // Parse and mutate both off the GIL — neither touches Python.
+        let stats = py.detach(|| {
+            let expr = self.parse_predicate(predicate)?;
+            self.inner.update(expr, &aligned).map_err(py_err)
+        })?;
         Ok(MutationStats::from_core(&stats))
     }
 

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -20,11 +20,17 @@ use arrow::compute::concat_batches;
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
+use datafusion::common::DFSchema;
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::Expr;
 use pyo3::exceptions::{PyKeyError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
-use infino::{BoolMode, ConnectOptions, InfinoError, Metric, VectorSearchOptions};
+use infino::{
+    BoolMode, CompactionError, CompactionSettings, ConnectOptions, InfinoError, Metric,
+    VectorSearchOptions,
+};
 
 /// Map a core [`InfinoError`] to the closest Python exception.
 fn py_err(e: InfinoError) -> PyErr {
@@ -37,6 +43,16 @@ fn py_err(e: InfinoError) -> PyErr {
         InfinoError::Io(m) | InfinoError::Backend(m) => PyRuntimeError::new_err(m),
         // `InfinoError` is `#[non_exhaustive]`: future variants fall back
         // to a generic runtime error carrying the message.
+        other => PyRuntimeError::new_err(other.to_string()),
+    }
+}
+
+/// Compaction has its own error type, so it doesn't go through `py_err`.
+fn compact_err(e: CompactionError) -> PyErr {
+    match e {
+        CompactionError::NoStorage => {
+            PyValueError::new_err("compact requires durable storage (not memory://)")
+        }
         other => PyRuntimeError::new_err(other.to_string()),
     }
 }
@@ -197,6 +213,63 @@ impl Connection {
     }
 }
 
+/// Row counts returned by `update` / `delete`.
+#[pyclass(name = "MutationStats", frozen)]
+struct MutationStats {
+    #[pyo3(get)]
+    matched: usize,
+    #[pyo3(get)]
+    n_tombstoned: usize,
+    #[pyo3(get)]
+    n_not_found: usize,
+}
+
+impl MutationStats {
+    fn from_core(s: &infino::MutationStats) -> Self {
+        Self {
+            matched: s.matched(),
+            n_tombstoned: s.n_tombstoned(),
+            n_not_found: s.n_not_found(),
+        }
+    }
+}
+
+#[pymethods]
+impl MutationStats {
+    fn __repr__(&self) -> String {
+        format!(
+            "MutationStats(matched={}, n_tombstoned={}, n_not_found={})",
+            self.matched, self.n_tombstoned, self.n_not_found
+        )
+    }
+}
+
+/// Tuning for `compact`; omitted fields fall back to engine defaults.
+#[pyclass(name = "CompactOptions", skip_from_py_object)]
+#[derive(Clone, Default)]
+struct CompactOptions {
+    max_memory_mb: Option<u64>,
+    min_fill_percent: Option<u8>,
+    target_superfile_size_mb: Option<u64>,
+}
+
+#[pymethods]
+impl CompactOptions {
+    #[new]
+    #[pyo3(signature = (*, max_memory_mb=None, min_fill_percent=None, target_superfile_size_mb=None))]
+    fn new(
+        max_memory_mb: Option<u64>,
+        min_fill_percent: Option<u8>,
+        target_superfile_size_mb: Option<u64>,
+    ) -> Self {
+        Self {
+            max_memory_mb,
+            min_fill_percent,
+            target_superfile_size_mb,
+        }
+    }
+}
+
 /// A single-table handle.
 #[pyclass]
 struct Table {
@@ -214,12 +287,7 @@ impl Table {
         let py_schema = declared.as_ref().to_pyarrow(py)?;
         match coerce_to_record_batch(py, data, &py_schema)? {
             Some(batch) => {
-                // Python sources (pandas, list[dict]) are inherently
-                // nullable; re-wrap the (null-free) columns under the
-                // table's declared schema so the exact-schema append check
-                // accepts them. A genuine type or null mismatch still errors.
-                let aligned = RecordBatch::try_new(declared, batch.columns().to_vec())
-                    .map_err(|e| PyValueError::new_err(e.to_string()))?;
+                let aligned = align_to_schema(declared, batch)?;
                 // Append commits a superfile to storage — release the GIL.
                 py.detach(|| self.inner.append(&aligned)).map_err(py_err)
             }
@@ -327,9 +395,72 @@ impl Table {
         batches_to_pyarrow_table(py, batches)
     }
 
+    /// Delete rows matching a SQL predicate string, e.g. `"status = 'spam'"`.
+    /// Needs durable storage — a `memory://` table raises.
+    fn delete(&self, py: Python<'_>, predicate: &str) -> PyResult<MutationStats> {
+        let expr = self.parse_predicate(predicate)?;
+        let stats = py.detach(|| self.inner.delete(expr)).map_err(py_err)?;
+        Ok(MutationStats::from_core(&stats))
+    }
+
+    /// Replace rows matching a SQL predicate with `new_rows` (same shapes as
+    /// `append`). Replacement is 1:1 — the match count must equal the number
+    /// of rows supplied. Needs durable storage.
+    fn update(
+        &self,
+        py: Python<'_>,
+        predicate: &str,
+        new_rows: &Bound<'_, PyAny>,
+    ) -> PyResult<MutationStats> {
+        let expr = self.parse_predicate(predicate)?;
+        let declared = self.inner.schema();
+        let py_schema = declared.as_ref().to_pyarrow(py)?;
+        // Pass an empty batch through rather than short-circuiting like
+        // `append` does — we want the engine's cardinality check to run.
+        let aligned = match coerce_to_record_batch(py, new_rows, &py_schema)? {
+            Some(batch) => align_to_schema(declared, batch)?,
+            None => RecordBatch::new_empty(declared),
+        };
+        let stats = py
+            .detach(|| self.inner.update(expr, &aligned))
+            .map_err(py_err)?;
+        Ok(MutationStats::from_core(&stats))
+    }
+
+    /// Merge small / underfilled superfiles into larger ones. Omit
+    /// `settings` for engine defaults.
+    #[pyo3(signature = (settings=None))]
+    fn compact(&self, py: Python<'_>, settings: Option<&CompactOptions>) -> PyResult<()> {
+        let mut s = CompactionSettings::default();
+        if let Some(o) = settings {
+            if let Some(v) = o.max_memory_mb {
+                s.max_memory_mb = v;
+            }
+            if let Some(v) = o.min_fill_percent {
+                s.min_fill_percent = v;
+            }
+            if let Some(v) = o.target_superfile_size_mb {
+                s.target_superfile_size_mb = v;
+            }
+        }
+        py.detach(|| self.inner.compact(&s)).map_err(compact_err)
+    }
+
     /// The user-facing Arrow schema, as a pyarrow `Schema`.
     fn schema<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         self.inner.schema().as_ref().to_pyarrow(py)
+    }
+}
+
+impl Table {
+    /// Resolve a SQL predicate string into the `Expr` the core mutation
+    /// API takes. Column names resolve against the table's own schema.
+    fn parse_predicate(&self, predicate: &str) -> PyResult<Expr> {
+        let df_schema = DFSchema::try_from(self.inner.schema().as_ref().clone())
+            .map_err(|e| PyValueError::new_err(format!("schema: {e}")))?;
+        SessionContext::new()
+            .parse_sql_expr(predicate, &df_schema)
+            .map_err(|e| PyValueError::new_err(format!("invalid predicate {predicate:?}: {e}")))
     }
 }
 
@@ -363,6 +494,14 @@ fn parse_mode(mode: Option<&str>) -> PyResult<BoolMode> {
             "mode must be 'or' or 'and', got {other:?}"
         ))),
     }
+}
+
+/// Re-wrap a coerced batch under the table's declared schema. Python
+/// sources (pandas, list[dict]) are inherently nullable; this lets the
+/// exact-schema check accept them. A genuine type / null mismatch still errors.
+fn align_to_schema(declared: Arc<Schema>, batch: RecordBatch) -> PyResult<RecordBatch> {
+    RecordBatch::try_new(declared, batch.columns().to_vec())
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Coerce append input — a pyarrow `RecordBatch` / `Table`, a pandas
@@ -433,5 +572,7 @@ fn infino_ext(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Connection>()?;
     m.add_class::<Table>()?;
     m.add_class::<IndexSpec>()?;
+    m.add_class::<MutationStats>()?;
+    m.add_class::<CompactOptions>()?;
     Ok(())
 }

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -48,13 +48,10 @@ fn py_err(e: InfinoError) -> PyErr {
 }
 
 /// Compaction has its own error type, so it doesn't go through `py_err`.
+/// These are storage / build failures — surfaced as runtime errors, like
+/// the mutation paths.
 fn compact_err(e: CompactionError) -> PyErr {
-    match e {
-        CompactionError::NoStorage => {
-            PyValueError::new_err("compact requires durable storage (not memory://)")
-        }
-        other => PyRuntimeError::new_err(other.to_string()),
-    }
+    PyRuntimeError::new_err(e.to_string())
 }
 
 /// Parse a metric name (`"cosine"` / `"l2sq"` / `"negdot"`).

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -219,6 +219,19 @@ def test_compact_preserves_data(tmp_path):
     t.compact()  # defaults run cleanly too
 
 
+def test_compact_on_memory_is_noop():
+    # Compaction needs a store to write merged files, but "memory://" is a
+    # store — so this is a no-op, not the durable-storage rejection that
+    # delete / update raise. Pin that contract.
+    db = infino.connect("memory://")
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    for title in ("alpha", "beta", "gamma"):
+        t.append([{"title": title}])
+
+    assert t.compact() is None
+    assert _count(db, "docs") == 3
+
+
 def test_vector_search_end_to_end():
     db = infino.connect("memory://")
     dim = 16  # infino requires vector dim in [16, 4096]

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -146,6 +146,55 @@ def test_update_cardinality_mismatch(tmp_path):
         t.update("title = 'alpha'", [{"title": "x"}, {"title": "y"}])
 
 
+def test_delete_matching_many_and_none(tmp_path):
+    db = infino.connect(str(tmp_path / "catalog"))
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "spam"}, {"title": "spam"}, {"title": "ham"}])
+
+    deleted = t.delete("title = 'spam'")
+    assert deleted.matched == 2
+    assert _count(db, "docs") == 1
+
+    missed = t.delete("title = 'nothing-here'")
+    assert missed.matched == 0
+    assert missed.n_tombstoned == 0
+
+
+def test_update_accepts_pyarrow_record_batch(tmp_path):
+    db = infino.connect(str(tmp_path / "catalog"))
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "draft"}])
+
+    t.update("title = 'draft'", _title_batch(["published"]))
+    assert t.token_match("title", "published").num_rows == 1
+
+
+def test_invalid_predicate_raises(tmp_path):
+    db = infino.connect(str(tmp_path / "catalog"))
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "alpha"}])
+
+    with pytest.raises(ValueError):
+        t.delete("no_such_column = 'x'")
+    with pytest.raises(ValueError):
+        t.delete("this is not sql")
+
+
+def test_mutations_persist_across_reconnect(tmp_path):
+    uri = str(tmp_path / "catalog")
+    db = infino.connect(uri)
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "alpha"}, {"title": "beta"}])
+    t.delete("title = 'alpha'")
+    t.update("title = 'beta'", [{"title": "beta2"}])
+    del t
+    del db
+
+    reopened = infino.connect(uri).open_table("docs")
+    assert reopened.token_match("title", "alpha").num_rows == 0
+    assert reopened.token_match("title", "beta2").num_rows == 1
+
+
 def test_mutations_reject_memory():
     db = infino.connect("memory://")
     t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -113,6 +113,63 @@ def test_append_accepts_pandas_dataframe():
     assert _count(db, "docs") == 2
 
 
+def test_delete_by_predicate(tmp_path):
+    db = infino.connect(str(tmp_path / "catalog"))  # mutations need durable storage
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "alpha"}, {"title": "bravo"}, {"title": "charlie"}])
+
+    stats = t.delete("title = 'bravo'")
+    assert stats.matched == 1
+    assert stats.n_tombstoned == 1
+    assert t.token_match("title", "bravo").num_rows == 0
+    assert _count(db, "docs") == 2
+
+
+def test_update_by_predicate(tmp_path):
+    db = infino.connect(str(tmp_path / "catalog"))
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "draft"}, {"title": "keep"}])
+
+    stats = t.update("title = 'draft'", [{"title": "published"}])
+    assert stats.matched == 1
+    assert t.token_match("title", "draft").num_rows == 0
+    assert t.token_match("title", "published").num_rows == 1
+
+
+def test_update_cardinality_mismatch(tmp_path):
+    db = infino.connect(str(tmp_path / "catalog"))
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "alpha"}, {"title": "beta"}])
+
+    # One row matches, two replacements supplied.
+    with pytest.raises(ValueError):
+        t.update("title = 'alpha'", [{"title": "x"}, {"title": "y"}])
+
+
+def test_mutations_reject_memory():
+    db = infino.connect("memory://")
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "alpha"}])
+
+    with pytest.raises(RuntimeError):
+        t.delete("title = 'alpha'")
+    with pytest.raises(RuntimeError):
+        t.update("title = 'alpha'", [{"title": "beta"}])
+
+
+def test_compact_preserves_data(tmp_path):
+    db = infino.connect(str(tmp_path / "catalog"))
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    for title in ("alpha", "beta", "gamma"):  # three appends -> three superfiles
+        t.append([{"title": title}])
+
+    t.compact(infino.CompactOptions(target_superfile_size_mb=256, min_fill_percent=50))
+    assert _count(db, "docs") == 3
+    assert t.token_match("title", "beta").num_rows == 1
+
+    t.compact()  # defaults run cleanly too
+
+
 def test_vector_search_end_to_end():
     db = infino.connect("memory://")
     dim = 16  # infino requires vector dim in [16, 4096]


### PR DESCRIPTION
Closes #155. Adds table mutations and compaction to the Python bindings.

## What
- `Table.delete(predicate)` and `Table.update(predicate, new_rows)` — predicate is a SQL `WHERE`-style string; `update` is a 1:1 replacement and `new_rows` takes the same shapes as `append`.
- `Table.compact(settings=None)` — merge small / underfilled superfiles.
- New `MutationStats` (`matched` / `n_tombstoned` / `n_not_found`) and `CompactOptions` types.

## How
The binding parses the SQL predicate into a DataFusion `Expr` (via `SessionContext::parse_sql_expr` against the table schema) and calls the existing public `Supertable::{update,delete,compact}`. **No core code changed** — `public-api.txt` is untouched, and query / ingest / cost paths are unaffected.

## Tests
- Smoke tests: delete (single / multi / zero-match), update success + cardinality mismatch, RecordBatch input, invalid predicate, durability across reconnect, memory:// rejection, compaction. All green.
- Every README example verified end-to-end.

## Reviewer notes
- README rewritten for PyPI (this is the published project description).
- Found a **pre-existing core bug** (out of scope here): `query_sql` with a search TVF panics for sync callers on durable storage — `query_sql` drives on a `current_thread` runtime, and the TVF's `open_table` re-enters `bridge_sync_to_async` → illegal `block_in_place`. `memory://` dodges it. README uses scalar SQL; search stays on the dedicated methods. Will file separately.