### PR TITLE
ci: fix and broaden the bench trend charts

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -381,9 +381,10 @@ jobs:
             echo "published: $j ($SHA)"
           done
 
-      # Plot P90 RSS over the last (≤10) main commits as Mermaid line charts in
-      # the run summary. Informational: a fetch hiccup drops a point, never fails.
-      - name: Render P90 RSS trend chart
+      # Render latency / memory / throughput trends over the last (≤10) main
+      # commits as Mermaid charts in the run summary. Best-effort: a fetch
+      # hiccup drops a point but never fails the step.
+      - name: Render trend charts
         if: ${{ inputs.update_baseline && success() }}
         env:
           ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
@@ -391,57 +392,90 @@ jobs:
           CONTAINER: ${{ secrets.INFINO_REAL_AZURE_CONTAINER }}
           VM_SIZE: ${{ inputs.vm_size }}
           DOCS: ${{ inputs.docs }}
-          TARGETS: ${{ steps.resolve.outputs.targets }}
+          # Reports this run produced — also the history-blob basenames each
+          # series reads from. A series renders only if its report is here.
+          REPORTS: ${{ steps.resolve.outputs.reports }}
         run: |
           set -uo pipefail
           SUMMARY="$GITHUB_STEP_SUMMARY"
-          jname() { case "$1" in supertable_all) echo supertable ;; *) echo "$1" ;; esac; }
 
-          # Headline series: "<bench-json>\t<P90-RSS-metric-key>\t<title>".
-          SERIES=$'sql\tbench/sql/build||1 writer|P90 RSS\tSQL 1-writer build — P90 RSS
-          sql\tbench/sql/query|Search table functions (bm25 / vector / hybrid / token / exact)|bm25_search|P90 RSS\tSQL bm25_search — P90 RSS
-          supertable\tbench/supertable/ingest||combined FTS + vector|P90 RSS\tSupertable ingest — P90 RSS'
+          # One row per chart, tab-separated:
+          #   section <TAB> report <TAB> metric-key <TAB> divisor <TAB> unit <TAB> title
+          # The divisor maps the stored raw value into the chart unit:
+          #   latency ns → ms (1000000), bytes → MiB (1048576), docs/s raw (1).
+          # Keys come from the per-modality reports the bench emits today; the
+          # retired consolidated `supertable` report is not used. Cost
+          # (queries/$) keys are excluded — they embed volatile text (heap
+          # size, probe params), so the key changes per commit and can't trend.
+          # The leading indent on each row is a YAML block-scalar artifact and
+          # is stripped once, below.
+          series=$'Latency — warm search (ms)\tsupertable_vector\tbench/vector/supertable/search||default|warm\t1000000\tms\tSupertable vector warm search
+          Latency — warm search (ms)\tsupertable_sql\tbench/sql/supertable/warm|Search table functions (bm25 / vector / hybrid / token / exact)|bm25_search|p50\t1000000\tms\tSupertable SQL bm25_search p50
+          Latency — warm search (ms)\tsupertable_sql\tbench/sql/supertable/warm|Search table functions (bm25 / vector / hybrid / token / exact)|vector_search|p50\t1000000\tms\tSupertable SQL vector_search p50
+          Latency — warm search (ms)\tsupertable_sql\tbench/sql/supertable/warm|Search table functions (bm25 / vector / hybrid / token / exact)|hybrid_search|p50\t1000000\tms\tSupertable SQL hybrid_search p50
+          Latency — warm search (ms)\tsuperfile_vector\tbench/vector/superfile/search||default|warm\t1000000\tms\tSuperfile vector warm search
+          Memory — P90 RSS (MiB)\tsupertable_fts\tbench/fts/supertable/ingest||FTS-only|P90 RSS\t1048576\tMiB\tSupertable FTS ingest
+          Memory — P90 RSS (MiB)\tsupertable_vector\tbench/vector/supertable/ingest||vector-only|P90 RSS\t1048576\tMiB\tSupertable vector ingest
+          Memory — P90 RSS (MiB)\tsql\tbench/sql/build||1 writer|P90 RSS\t1048576\tMiB\tSQL 1-writer build
+          Memory — P90 RSS (MiB)\tsql\tbench/sql/query|Search table functions (bm25 / vector / hybrid / token / exact)|bm25_search|P90 RSS\t1048576\tMiB\tSQL bm25_search
+          Throughput — ingest (docs/s)\tsupertable_fts\tbench/fts/supertable/ingest||FTS-only|Throughput\t1\tdocs/s\tSupertable FTS ingest
+          Throughput — ingest (docs/s)\tsupertable_vector\tbench/vector/supertable/ingest||vector-only|Throughput\t1\tdocs/s\tSupertable vector ingest'
+          series="$(printf '%s\n' "$series" | sed 's/^[[:space:]]*//')"
 
-          built=""; for t in $TARGETS; do built="$built $(jname "$t")"; done
-          echo "## Trend — P90 RSS (last 10 main commits)" >> "$SUMMARY"
+          printf '## Trends (last 10 main commits)\n' >> "$SUMMARY"
 
-          # Loops read on dedicated FDs (3, 4) so the az calls in the body —
-          # which read stdin — can't consume the loop input.
-          while IFS=$'\t' read -r -u 3 jb key title; do
-            jb="${jb#"${jb%%[![:space:]]*}"}"   # strip leading indent from heredoc
-            case " $built " in *" $jb "*) ;; *) continue ;; esac
+          # Guard against series/report drift: if no row matches REPORTS the
+          # section would be silently empty (the bug that hid the broken gate).
+          matched=0
+          last_section=""
 
-            rows="$(az storage blob list -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
-                      --prefix "bench/${jb}/history/${VM_SIZE}-${DOCS}-" --include m \
-                      --query "[].{n:name, ts:metadata.ts, sha:metadata.sha}" -o tsv 2>/dev/null \
-                    | sort -k2 -n | tail -10)"
+          # FDs 3/4 keep the loop input clear of the az calls' own stdin reads.
+          while IFS=$'\t' read -r -u 3 section report key divisor unit title; do
+            case " $REPORTS " in *" $report "*) ;; *) continue ;; esac
+            matched=$((matched + 1))
+            if [ "$section" != "$last_section" ]; then
+              printf '### %s\n' "$section" >> "$SUMMARY"
+              last_section="$section"
+            fi
 
-            labels=(); values=(); n=0
-            while IFS=$'\t' read -r -u 4 name ts sha; do
+            # Last ≤10 history points for this metric, ordered oldest→newest
+            # by commit time; keep only the name and short sha of each.
+            blobs="$(az storage blob list -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
+                       --prefix "bench/${report}/history/${VM_SIZE}-${DOCS}-" --include m \
+                       --query "[].{name:name, ts:metadata.ts, sha:metadata.sha}" -o tsv 2>/dev/null \
+                     | sort -k2 -n | tail -10)"
+
+            labels=(); values=(); points=0
+            while IFS=$'\t' read -r -u 4 name _ sha; do
               [ -n "$name" ] || continue
               az storage blob download -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
-                -n "$name" -f /tmp/h.json -o none 2>/dev/null || continue
-              v="$(jq -r --arg k "$key" '.[$k] // empty' /tmp/h.json)"
-              [ -n "$v" ] || continue
+                -n "$name" -f /tmp/point.json -o none 2>/dev/null || continue
+              value="$(jq -r --arg k "$key" '.[$k] // empty' /tmp/point.json)"
+              [ -n "$value" ] || continue
               labels+=("${sha:0:7}")
-              values+=("$(awk -v b="$v" 'BEGIN{printf "%.0f", b/1048576}')")
-              n=$((n+1))
-            done 4<<< "$rows"
+              values+=("$(awk -v v="$value" -v d="$divisor" 'BEGIN{printf "%g", v / d}')")
+              points=$((points + 1))
+            done 4<<< "$blobs"
 
-            if [ "$n" -lt 2 ]; then
-              echo "_${title}: ${n} data point(s) — need ≥2 to chart._" >> "$SUMMARY"
+            if [ "$points" -lt 2 ]; then
+              printf '_%s: %d data point(s) — need ≥2 to chart._\n' "$title" "$points" >> "$SUMMARY"
               continue
             fi
             {
               echo '```mermaid'
               echo 'xychart-beta'
-              echo "    title \"${title} (MiB)\""
+              echo "    title \"${title} (${unit})\""
               printf '    x-axis [%s]\n' "$(IFS=,; echo "${labels[*]}")"
-              echo '    y-axis "MiB"'
+              echo "    y-axis \"${unit}\""
               printf '    line [%s]\n' "$(IFS=,; echo "${values[*]}")"
               echo '```'
             } >> "$SUMMARY"
-          done 3<<< "$SERIES"
+          done 3<<< "$series"
+
+          if [ "$matched" -eq 0 ]; then
+            echo "::warning::no trend series matched reports [$REPORTS] — check the series table"
+            echo "_No trend series matched reports: \`$REPORTS\`._" >> "$SUMMARY"
+          fi
 
       - name: Summarize results
         if: always()


### PR DESCRIPTION
## Problem
The trend-chart step never rendered a chart, even on main. Two stacked bugs:
1. Series were gated on `steps.resolve.outputs.targets` — an output that doesn't exist (resolve only emits `args` + `reports`). So every series was skipped.
2. The lone supertable series pointed at the retired consolidated `supertable` ingest report, which the bench no longer emits — only legacy 10M blobs have it.

## Fix
- Gate series on the run's actual `reports` (the JSON basenames it publishes).
- Repoint ingest to the live per-modality reports/keys (`supertable_fts`, `supertable_vector`).
- Broaden from P90-RSS-only to **latency / memory / throughput**, grouped into sections with per-series units (ns→ms, bytes→MiB, docs/s raw).
- Warn (instead of silently emitting an empty section) when no series matches — so this class of drift can't hide again.
- Cost (`queries/$`) keys excluded on purpose: they embed volatile text (heap size, probe params), so the key changes per commit and can't trend.

## Validation
- Every series checked against real history data — 10 points each across the last 10 main commits.
- Executed the step's script verbatim against real storage: 11 charts render (8 supertable + 3 superfile).
- `actionlint` + `shellcheck` clean.