### PR TITLE
ci: grant id-token write on dataset workflow callers

### DIFF
--- a/.github/workflows/dataset-bench.yml
+++ b/.github/workflows/dataset-bench.yml
@@ -59,6 +59,12 @@ on:
         default: "240"
         type: string
 
+# Granted at the caller so the reusable dataset-bench-vm.yml can claim the
+# Azure OIDC token it requests; a called workflow can't escalate beyond this.
+permissions:
+  id-token: write   # Azure OIDC federated login
+  contents: read    # clone the repo on the VM via the job token
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/dataset-prepare.yml
+++ b/.github/workflows/dataset-prepare.yml
@@ -48,6 +48,12 @@ on:
         default: "240"
         type: string
 
+# Granted at the caller so the reusable dataset-bench-vm.yml can claim the
+# Azure OIDC token it requests; a called workflow can't escalate beyond this.
+permissions:
+  id-token: write   # Azure OIDC federated login
+  contents: read    # clone the repo on the VM via the job token
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`dataset-prepare.yml` failed to validate:

> Error calling workflow `dataset-bench-vm.yml`. The workflow is requesting `id-token: write`, but is only allowed `id-token: none`.

The reusable `dataset-bench-vm.yml` requests `id-token: write` for Azure OIDC login. A called workflow can't escalate beyond the permissions its caller grants — and `dataset-prepare.yml` / `dataset-bench.yml` had no `permissions:` block, so the default `id-token: none` made the call invalid.

## Fix

Grant `id-token: write` + `contents: read` at both callers (`dataset-prepare.yml`, `dataset-bench.yml`).

## Notes

- `dataset-bench.yml` had the identical defect (same reusable callee) — fixed in the same PR.
- Both files validated as YAML.