### PR TITLE
ci: post PR-Agent suggestions as inline comments

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -37,6 +37,7 @@ must not name them.
 """
 
 [pr_code_suggestions]
+commitable_code_suggestions = true
 extra_instructions = """\
 Favor correctness and clarity over micro-optimizations. Enforce infino's code
 standards on the changed lines:


### PR DESCRIPTION
Switches `/improve` output from a single summary table to inline,
one-click-committable comments on each diff line.

## Change
- `.pr_agent.toml`: `commitable_code_suggestions = true`

## Notes
- Follow-up to the PR reviewer added in #136.
- Tradeoff: inline comments add more PR footprint than the table on large diffs; chosen deliberately for reviewability.