### PR TITLE
python: expose cache and cold-fetch connect options

### DIFF
--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -182,8 +182,7 @@ db = infino.connect(
 For object-storage-backed catalogs, a local disk cache keeps hot data on
 fast local storage. `cold_fetch_mode` controls how cache misses are
 served: `"hybrid_with_prefetch"`, `"range_only"`, or
-`"lazy_foreground_with_background_fill"` (aliases `"hybrid"`, `"range"`,
-`"lazy"`).
+`"lazy_foreground_with_background_fill"`.
 
 ```python
 db = infino.connect(

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -177,6 +177,23 @@ db = infino.connect(
 )
 ```
 
+### Local disk cache
+
+For object-storage-backed catalogs, a local disk cache keeps hot data on
+fast local storage. `cold_fetch_mode` controls how cache misses are
+served: `"hybrid_with_prefetch"`, `"range_only"`, or
+`"lazy_foreground_with_background_fill"` (aliases `"hybrid"`, `"range"`,
+`"lazy"`).
+
+```python
+db = infino.connect(
+    "s3://bucket/prefix",
+    cache_dir="/mnt/nvme/infino-cache",
+    cache_budget_bytes=64 * 1024**3,
+    cold_fetch_mode="lazy_foreground_with_background_fill",
+)
+```
+
 ## Schema and type requirements
 
 - Full-text columns must be Arrow `large_utf8`.
@@ -189,7 +206,7 @@ db = infino.connect(
 
 ## API reference
 
-- `infino.connect(uri, *, endpoint=None, region=None, access_key=None, secret_key=None) -> Connection`
+- `infino.connect(uri, *, endpoint=None, region=None, access_key=None, secret_key=None, cache_dir=None, cache_budget_bytes=None, cold_fetch_mode=None) -> Connection`
 - `Connection`
   - `create_table(name, schema, index_spec) -> Table`
   - `open_table(name) -> Table`

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -105,13 +105,18 @@ fn connect(
     let inner = py.detach(|| {
         let mut opts = ConnectOptions::new();
         let mut has_options = false;
-        if let Some(endpoint) = endpoint {
+        // The S3 endpoint + credentials are all-or-nothing: any one of them
+        // means the caller wants an explicit endpoint, so require the rest
+        // rather than silently dropping a partial config back to ambient.
+        if endpoint.is_some() || region.is_some() || access_key.is_some() || secret_key.is_some() {
+            let endpoint = endpoint
+                .ok_or_else(|| PyValueError::new_err("endpoint is required with S3 credentials"))?;
             let region = region
-                .ok_or_else(|| PyValueError::new_err("region is required with endpoint"))?;
+                .ok_or_else(|| PyValueError::new_err("region is required for an S3 endpoint"))?;
             let access_key = access_key
-                .ok_or_else(|| PyValueError::new_err("access_key is required with endpoint"))?;
+                .ok_or_else(|| PyValueError::new_err("access_key is required for an S3 endpoint"))?;
             let secret_key = secret_key
-                .ok_or_else(|| PyValueError::new_err("secret_key is required with endpoint"))?;
+                .ok_or_else(|| PyValueError::new_err("secret_key is required for an S3 endpoint"))?;
             opts = opts.with_s3_endpoint(endpoint, region, access_key, secret_key);
             has_options = true;
         }

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -66,14 +66,12 @@ fn metric_from_str(s: &str) -> PyResult<Metric> {
     }
 }
 
-/// Parse a cold-fetch-mode name; short aliases also accepted.
+/// Parse a cold-fetch-mode name into its [`ColdFetchMode`].
 fn cold_fetch_from_str(s: &str) -> PyResult<ColdFetchMode> {
-    match s.to_ascii_lowercase().as_str() {
-        "hybrid_with_prefetch" | "hybrid" => Ok(ColdFetchMode::HybridWithPrefetch),
-        "range_only" | "range" => Ok(ColdFetchMode::RangeOnly),
-        "lazy_foreground_with_background_fill" | "lazy" => {
-            Ok(ColdFetchMode::LazyForegroundWithBackgroundFill)
-        }
+    match s {
+        "hybrid_with_prefetch" => Ok(ColdFetchMode::HybridWithPrefetch),
+        "range_only" => Ok(ColdFetchMode::RangeOnly),
+        "lazy_foreground_with_background_fill" => Ok(ColdFetchMode::LazyForegroundWithBackgroundFill),
         other => Err(PyValueError::new_err(format!(
             "unknown cold_fetch_mode {other:?}; use 'hybrid_with_prefetch', \
              'range_only', or 'lazy_foreground_with_background_fill'"

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -28,8 +28,8 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
 use infino::{
-    BoolMode, CompactionError, CompactionSettings, ConnectOptions, InfinoError, Metric,
-    VectorSearchOptions,
+    BoolMode, ColdFetchMode, CompactionError, CompactionSettings, ConnectOptions, InfinoError,
+    Metric, VectorSearchOptions,
 };
 
 /// Map a core [`InfinoError`] to the closest Python exception.
@@ -66,13 +66,31 @@ fn metric_from_str(s: &str) -> PyResult<Metric> {
     }
 }
 
+/// Parse a cold-fetch-mode name; short aliases also accepted.
+fn cold_fetch_from_str(s: &str) -> PyResult<ColdFetchMode> {
+    match s.to_ascii_lowercase().as_str() {
+        "hybrid_with_prefetch" | "hybrid" => Ok(ColdFetchMode::HybridWithPrefetch),
+        "range_only" | "range" => Ok(ColdFetchMode::RangeOnly),
+        "lazy_foreground_with_background_fill" | "lazy" => {
+            Ok(ColdFetchMode::LazyForegroundWithBackgroundFill)
+        }
+        other => Err(PyValueError::new_err(format!(
+            "unknown cold_fetch_mode {other:?}; use 'hybrid_with_prefetch', \
+             'range_only', or 'lazy_foreground_with_background_fill'"
+        ))),
+    }
+}
+
 /// Open (or create) a catalog rooted at `uri`. Storage config the URI
-/// can't carry is passed as keyword arguments (no separate
-/// `connect_with` in Python). Today that is the explicit S3-compatible
-/// endpoint + static credentials; omit them for local / `memory://` /
-/// ambient-credential S3.
+/// can't carry is passed as keyword arguments: explicit S3 endpoint +
+/// static credentials, and the optional local disk cache (`cache_dir`,
+/// `cache_budget_bytes`, `cold_fetch_mode`). Omit all for local /
+/// `memory://` / ambient-credential S3.
+// Flat kwargs are the intended Python API; a config struct would change it.
+#[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (uri, *, endpoint=None, region=None, access_key=None, secret_key=None))]
+#[pyo3(signature = (uri, *, endpoint=None, region=None, access_key=None, secret_key=None,
+                    cache_dir=None, cache_budget_bytes=None, cold_fetch_mode=None))]
 fn connect(
     py: Python<'_>,
     uri: &str,
@@ -80,24 +98,44 @@ fn connect(
     region: Option<String>,
     access_key: Option<String>,
     secret_key: Option<String>,
+    cache_dir: Option<String>,
+    cache_budget_bytes: Option<u64>,
+    cold_fetch_mode: Option<String>,
 ) -> PyResult<Connection> {
     // Opening a connection can touch object storage; release the GIL so
     // other Python threads run during the (blocking) I/O.
-    let inner = py
-        .detach(|| match endpoint {
-            Some(endpoint) => {
-                let region = region
-                    .ok_or_else(|| PyValueError::new_err("region is required with endpoint"))?;
-                let access_key = access_key
-                    .ok_or_else(|| PyValueError::new_err("access_key is required with endpoint"))?;
-                let secret_key = secret_key
-                    .ok_or_else(|| PyValueError::new_err("secret_key is required with endpoint"))?;
-                let opts = ConnectOptions::new()
-                    .with_s3_endpoint(endpoint, region, access_key, secret_key);
-                infino::connect_with(uri, opts).map_err(py_err)
-            }
-            None => infino::connect(uri).map_err(py_err),
-        })?;
+    let inner = py.detach(|| {
+        let mut opts = ConnectOptions::new();
+        let mut custom = false;
+        if let Some(endpoint) = endpoint {
+            let region = region
+                .ok_or_else(|| PyValueError::new_err("region is required with endpoint"))?;
+            let access_key = access_key
+                .ok_or_else(|| PyValueError::new_err("access_key is required with endpoint"))?;
+            let secret_key = secret_key
+                .ok_or_else(|| PyValueError::new_err("secret_key is required with endpoint"))?;
+            opts = opts.with_s3_endpoint(endpoint, region, access_key, secret_key);
+            custom = true;
+        }
+        if let Some(dir) = cache_dir {
+            opts = opts.with_cache_dir(dir);
+            custom = true;
+        }
+        if let Some(bytes) = cache_budget_bytes {
+            opts = opts.with_cache_budget_bytes(bytes);
+            custom = true;
+        }
+        if let Some(mode) = cold_fetch_mode {
+            opts = opts.with_cold_fetch_mode(cold_fetch_from_str(&mode)?);
+            custom = true;
+        }
+        // Keep the plain `connect(uri)` path untouched when no options are set.
+        if custom {
+            infino::connect_with(uri, opts).map_err(py_err)
+        } else {
+            infino::connect(uri).map_err(py_err)
+        }
+    })?;
     Ok(Connection { inner })
 }
 

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -68,7 +68,7 @@ fn metric_from_str(s: &str) -> PyResult<Metric> {
 
 /// Parse a cold-fetch-mode name into its [`ColdFetchMode`].
 fn cold_fetch_from_str(s: &str) -> PyResult<ColdFetchMode> {
-    match s {
+    match s.to_ascii_lowercase().as_str() {
         "hybrid_with_prefetch" => Ok(ColdFetchMode::HybridWithPrefetch),
         "range_only" => Ok(ColdFetchMode::RangeOnly),
         "lazy_foreground_with_background_fill" => Ok(ColdFetchMode::LazyForegroundWithBackgroundFill),

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -106,7 +106,7 @@ fn connect(
     // other Python threads run during the (blocking) I/O.
     let inner = py.detach(|| {
         let mut opts = ConnectOptions::new();
-        let mut custom = false;
+        let mut has_options = false;
         if let Some(endpoint) = endpoint {
             let region = region
                 .ok_or_else(|| PyValueError::new_err("region is required with endpoint"))?;
@@ -115,22 +115,22 @@ fn connect(
             let secret_key = secret_key
                 .ok_or_else(|| PyValueError::new_err("secret_key is required with endpoint"))?;
             opts = opts.with_s3_endpoint(endpoint, region, access_key, secret_key);
-            custom = true;
+            has_options = true;
         }
         if let Some(dir) = cache_dir {
             opts = opts.with_cache_dir(dir);
-            custom = true;
+            has_options = true;
         }
         if let Some(bytes) = cache_budget_bytes {
             opts = opts.with_cache_budget_bytes(bytes);
-            custom = true;
+            has_options = true;
         }
         if let Some(mode) = cold_fetch_mode {
             opts = opts.with_cold_fetch_mode(cold_fetch_from_str(&mode)?);
-            custom = true;
+            has_options = true;
         }
-        // Keep the plain `connect(uri)` path untouched when no options are set.
-        if custom {
+        // Preserve the plain `connect(uri)` path when no options are set.
+        if has_options {
             infino::connect_with(uri, opts).map_err(py_err)
         } else {
             infino::connect(uri).map_err(py_err)

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -60,6 +60,13 @@ def test_connect_rejects_invalid_cold_fetch_mode():
         infino.connect("memory://", cold_fetch_mode="nonsense")
 
 
+def test_connect_rejects_partial_s3_credentials():
+    # A credential without the rest must error, not silently fall back to
+    # ambient credentials.
+    with pytest.raises(ValueError):
+        infino.connect("s3://bucket/prefix", access_key="only-this")
+
+
 def test_query_sql_returns_pyarrow_table():
     db = infino.connect("memory://")
     table = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -42,6 +42,24 @@ def test_memory_roundtrip():
     assert db.list_tables() == []
 
 
+def test_connect_accepts_cache_options(tmp_path):
+    # Cache options are a no-op for local storage but must parse and apply.
+    db = infino.connect(
+        str(tmp_path / "catalog"),
+        cache_dir=str(tmp_path / "cache"),
+        cache_budget_bytes=64 * 1024 * 1024,
+        cold_fetch_mode="lazy",
+    )
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append([{"title": "the quick brown fox"}])
+    assert t.token_match("title", "fox").num_rows == 1
+
+
+def test_connect_rejects_invalid_cold_fetch_mode():
+    with pytest.raises(ValueError):
+        infino.connect("memory://", cold_fetch_mode="nonsense")
+
+
 def test_query_sql_returns_pyarrow_table():
     db = infino.connect("memory://")
     table = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -55,6 +55,11 @@ def test_connect_accepts_cache_options(tmp_path):
     assert t.token_match("title", "fox").num_rows == 1
 
 
+def test_connect_cold_fetch_mode_is_case_insensitive():
+    # Consistent with metric / mode parsing.
+    infino.connect("memory://", cold_fetch_mode="RANGE_ONLY")
+
+
 def test_connect_rejects_invalid_cold_fetch_mode():
     with pytest.raises(ValueError):
         infino.connect("memory://", cold_fetch_mode="nonsense")

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -48,7 +48,7 @@ def test_connect_accepts_cache_options(tmp_path):
         str(tmp_path / "catalog"),
         cache_dir=str(tmp_path / "cache"),
         cache_budget_bytes=64 * 1024 * 1024,
-        cold_fetch_mode="lazy",
+        cold_fetch_mode="lazy_foreground_with_background_fill",
     )
     t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
     t.append([{"title": "the quick brown fox"}])


### PR DESCRIPTION
Closes #156.

## What
`connect` gains three keyword arguments, mapping to the existing Rust `ConnectOptions`:
- `cache_dir` — local disk-cache directory for object-storage-backed catalogs.
- `cache_budget_bytes` — cache budget.
- `cold_fetch_mode` — one of `"hybrid_with_prefetch"` / `"range_only"` / `"lazy_foreground_with_background_fill"` (exact match; invalid values raise `ValueError`).

## Notes
- Plain `connect(uri)` is unchanged — options route through `connect_with` only when set.
- S3 endpoint + credentials are all-or-nothing: passing any one of `endpoint` / `region` / `access_key` / `secret_key` now requires the rest, instead of silently dropping a partial config to ambient credentials.
- Binding-only: no core change, `public-api.txt` untouched, query / ingest / cost paths unaffected.

## Tests
Cache options parse + apply (no-op on local storage), invalid `cold_fetch_mode` rejection, and partial-S3-credential rejection. README gains a local-disk-cache example. S3 integration left out (needs live credentials), per the issue.