### PR TITLE
python: add typed stubs, py.typed, and module metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
           workspaces: infino-python
       # Builds the extension + runs the smoke tests (self-contained venv).
       - run: make python-test
+      # Type-check the shipped stubs against a sample consumer (mypy --strict).
+      - run: make python-typecheck
 
   python-examples:
     name: Python examples (end to end)

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ lcov.info
 infino-python/target/
 infino-python/.venv/
 infino-python/dist/
+# Compiled extension dropped into the source package by `maturin develop`.
+infino-python/python/infino/*.so
 **/__pycache__/
 **/.pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
         coverage coverage-summary \
         bench bench-quick miri asan ci clean \
         public-api public-api-update \
-        python-test python-wheel python-examples-test \
+        python-test python-typecheck python-wheel python-examples-test \
         node-test node-build node-verify node-example
 
 # Import layout: group into std / external / crate blocks and merge each
@@ -116,6 +116,19 @@ python-test:
 	infino-python/.venv/bin/pip install -q maturin pytest pyarrow pandas
 	VIRTUAL_ENV=$(CURDIR)/infino-python/.venv infino-python/.venv/bin/maturin develop --locked -m infino-python/Cargo.toml
 	infino-python/.venv/bin/python -m pytest infino-python/tests/ -v
+
+# Type-check the package and a sample consumer under `mypy --strict`,
+# against the source stubs (no extension build needed). Checking
+# `__init__.py` verifies its re-exports match the `_infino` stub; checking
+# the sample fails the run if the surface drifts or a `Literal` argument
+# widens to plain `str`.
+python-typecheck:
+	python3 -m venv infino-python/.venv
+	infino-python/.venv/bin/pip install -q --upgrade pip mypy
+	MYPYPATH=infino-python/python infino-python/.venv/bin/mypy \
+		--config-file infino-python/pyproject.toml \
+		infino-python/python/infino/__init__.py \
+		infino-python/tests/typing/quickstart.py
 
 # Build a release abi3 wheel for the current platform into
 # `infino-python/dist/` (one wheel covers CPython >= 3.9).

--- a/infino-python/pyproject.toml
+++ b/infino-python/pyproject.toml
@@ -15,6 +15,22 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = ["pytest", "pyarrow>=14"]
 
+[tool.mypy]
+strict = true
+
+# pyarrow ships no type information; treat it as untyped rather than
+# failing the strict run on a third-party gap.
+[[tool.mypy.overrides]]
+module = ["pyarrow", "pyarrow.*"]
+ignore_missing_imports = true
+
 [tool.maturin]
-# The cdylib's lib name is `infino`, so the built module is `infino`.
+# Mixed layout: the compiled cdylib is the private `infino._infino`
+# extension; the hand-written `python/infino/` package re-exports it and
+# ships the typing artifacts (`py.typed`, stubs) and module metadata.
+python-source = "python"
+module-name = "infino._infino"
 features = ["pyo3/extension-module"]
+# Keep compiled bytecode out of the wheel (a local `develop` leaves it in
+# the source tree).
+exclude = ["**/__pycache__/**"]

--- a/infino-python/python/infino/__init__.py
+++ b/infino-python/python/infino/__init__.py
@@ -1,0 +1,32 @@
+"""Fast search on object storage — SQL, full-text, and vector search.
+
+The public API is a thin re-export of the compiled `infino._infino`
+extension; this package adds typing artifacts and module metadata.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+from infino._infino import (
+    Connection,
+    IndexSpec,
+    MutationStats,
+    OptimizeOptions,
+    Table,
+    connect,
+)
+
+try:
+    __version__ = version("infino")
+except PackageNotFoundError:  # source tree without installed metadata
+    __version__ = "0.0.0"
+
+__all__ = [
+    "connect",
+    "Connection",
+    "Table",
+    "IndexSpec",
+    "MutationStats",
+    "OptimizeOptions",
+]

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -1,0 +1,100 @@
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, TypeAlias
+
+from pyarrow import RecordBatch, Schema, Table as ArrowTable
+
+Metric: TypeAlias = Literal["cosine", "l2sq", "l2", "negdot", "dot"]
+BoolMode: TypeAlias = Literal["or", "and"]
+ColdFetchMode: TypeAlias = Literal[
+    "hybrid_with_prefetch",
+    "range_only",
+    "lazy_foreground_with_background_fill",
+]
+
+# Inputs `append` / `update` coerce to Arrow under the table's declared
+# schema. A pandas `DataFrame` is also accepted at runtime but is omitted
+# here deliberately: typing it would couple these stubs to pandas' optional
+# type information. For a statically-typed path, convert with
+# `pyarrow.Table.from_pandas(df)`.
+RowData: TypeAlias = RecordBatch | ArrowTable | Sequence[Mapping[str, Any]]
+
+def connect(
+    uri: str,
+    *,
+    endpoint: str | None = ...,
+    region: str | None = ...,
+    access_key: str | None = ...,
+    secret_key: str | None = ...,
+    cache_dir: str | None = ...,
+    cache_budget_bytes: int | None = ...,
+    cold_fetch_mode: ColdFetchMode | None = ...,
+) -> Connection: ...
+
+class Connection:
+    def create_table(self, name: str, schema: Schema, indexes: IndexSpec) -> Table: ...
+    def open_table(self, name: str) -> Table: ...
+    def drop_table(self, name: str, purge: bool = ...) -> None: ...
+    def list_tables(self) -> list[str]: ...
+    def query_sql(self, sql: str) -> ArrowTable: ...
+
+class IndexSpec:
+    def __init__(self) -> None: ...
+    def fts(self, column: str) -> IndexSpec: ...
+    def vector(self, column: str, dim: int, n_cent: int, metric: Metric) -> IndexSpec: ...
+
+class Table:
+    def append(self, data: RowData) -> None: ...
+    def bm25_search(
+        self,
+        column: str,
+        query: str,
+        k: int,
+        mode: BoolMode | None = ...,
+        projection: Sequence[str] | None = ...,
+    ) -> ArrowTable: ...
+    def vector_search(
+        self,
+        column: str,
+        query: Sequence[float],
+        k: int,
+        nprobe: int | None = ...,
+        filter_column: str | None = ...,
+        filter_query: str | None = ...,
+        filter_mode: BoolMode | None = ...,
+        projection: Sequence[str] | None = ...,
+    ) -> ArrowTable: ...
+    def token_match(
+        self,
+        column: str,
+        query: str,
+        mode: BoolMode | None = ...,
+        projection: Sequence[str] | None = ...,
+    ) -> ArrowTable: ...
+    def exact_match(
+        self,
+        column: str,
+        value: str,
+        projection: Sequence[str] | None = ...,
+    ) -> ArrowTable: ...
+    def delete(self, predicate: str) -> MutationStats: ...
+    def update(self, predicate: str, new_rows: RowData) -> MutationStats: ...
+    def optimize(self, settings: OptimizeOptions | None = ...) -> None: ...
+    def schema(self) -> Schema: ...
+
+class MutationStats:
+    @property
+    def matched(self) -> int: ...
+    @property
+    def n_tombstoned(self) -> int: ...
+    @property
+    def n_not_found(self) -> int: ...
+    def __repr__(self) -> str: ...
+
+class OptimizeOptions:
+    def __init__(
+        self,
+        *,
+        max_memory_mb: int | None = ...,
+        min_fill_percent: int | None = ...,
+        target_superfile_size_mb: int | None = ...,
+    ) -> None: ...

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -635,11 +635,13 @@ fn coerce_to_record_batch(
     }
 }
 
-// Named `infino_ext` (not `infino`) so the generated module item doesn't
-// shadow the `infino` crate inside this file; `#[pyo3(name = "infino")]`
-// keeps the Python module name `infino` (init symbol `PyInit_infino`).
+// The compiled extension is `infino._infino`: the `python/infino/`
+// package re-exports it and carries the typing artifacts (`py.typed`,
+// stubs, `__version__`). Naming the module item `infino_ext` keeps it
+// from shadowing the `infino` crate inside this file; the init symbol is
+// `PyInit__infino`.
 #[pymodule]
-#[pyo3(name = "infino")]
+#[pyo3(name = "_infino")]
 fn infino_ext(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(connect, m)?)?;
     m.add_class::<Connection>()?;

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -8,9 +8,31 @@ Run after `maturin develop`:
     pytest tests/
 """
 
+import pathlib
+
 import infino
 import pyarrow as pa
 import pytest
+
+
+def test_package_metadata():
+    assert isinstance(infino.__version__, str) and infino.__version__
+    assert set(infino.__all__) == {
+        "connect",
+        "Connection",
+        "Table",
+        "IndexSpec",
+        "MutationStats",
+        "OptimizeOptions",
+    }
+
+
+def test_typing_artifacts_are_packaged():
+    # The stub and marker must ship beside the module, or type checkers
+    # silently ignore the package despite the work above.
+    pkg = pathlib.Path(infino.__file__).parent
+    assert (pkg / "py.typed").is_file()
+    assert (pkg / "_infino.pyi").is_file()
 
 
 def _title_schema() -> pa.Schema:

--- a/infino-python/tests/typing/quickstart.py
+++ b/infino-python/tests/typing/quickstart.py
@@ -1,0 +1,79 @@
+"""Type-check sample for the infino stubs (checked under `mypy --strict`).
+
+Not executed — its job is to fail the type-check gate if the published
+stubs drift from the surface or lose their `Literal` constraints. The
+`type: ignore` lines double as assertions: `warn_unused_ignores` (part of
+`--strict`) fails the run if mypy stops flagging the rejected values, i.e.
+if a `Literal` silently widens to plain `str`.
+"""
+
+import pyarrow as pa
+
+import infino
+
+
+def quickstart() -> None:
+    db: infino.Connection = infino.connect("memory://")
+
+    schema = pa.schema([pa.field("title", pa.large_utf8(), nullable=False)])
+    spec = infino.IndexSpec().fts("title")
+    docs: infino.Table = db.create_table("docs", schema, spec)
+
+    docs.append([{"title": "the quick brown fox"}, {"title": "a lazy dog"}])
+
+    hits = docs.bm25_search("title", "fox", k=10, mode="and")
+    names: list[str] = hits.column_names
+
+    counts = db.query_sql("SELECT COUNT(*) AS n FROM docs")
+    tables: list[str] = db.list_tables()
+    _ = (names, counts, tables)
+
+
+def vectors() -> None:
+    db = infino.connect("memory://")
+    schema = pa.schema([pa.field("emb", pa.list_(pa.float32(), 16), nullable=False)])
+    spec = infino.IndexSpec().vector("emb", 16, 1, "cosine")
+    vecs: infino.Table = db.create_table("vecs", schema, spec)
+    vecs.vector_search("emb", [0.0] * 16, k=5, nprobe=8)
+    vecs.vector_search(
+        "emb",
+        [0.0] * 16,
+        k=5,
+        filter_column="title",
+        filter_query="fox",
+        filter_mode="and",
+    )
+
+
+def mutations() -> None:
+    db = infino.connect("./data")
+    docs = db.open_table("docs")
+    stats: infino.MutationStats = docs.delete("title = 'spam'")
+    matched: int = stats.matched
+    docs.update("title = 'draft'", [{"title": "published"}])
+    docs.optimize(infino.OptimizeOptions(min_fill_percent=50))
+    _ = matched
+
+
+def rejects_invalid_literals() -> None:
+    db = infino.connect("memory://")
+    schema = pa.schema([pa.field("emb", pa.list_(pa.float32(), 16), nullable=False)])
+    db.create_table(
+        "vecs",
+        schema,
+        infino.IndexSpec().vector("emb", 16, 1, "euclidean"),  # type: ignore[arg-type]
+    )
+    db.create_table("docs", schema, infino.IndexSpec()).bm25_search(
+        "emb", "q", k=1, mode="xor"  # type: ignore[arg-type]
+    )
+    db.create_table(
+        "vecs2", schema, infino.IndexSpec().vector("emb", 16, 1, "cosine")
+    ).vector_search(
+        "emb",
+        [0.0] * 16,
+        k=1,
+        filter_column="title",
+        filter_query="fox",
+        filter_mode="nand",  # type: ignore[arg-type]
+    )
+    infino.connect("memory://", cold_fetch_mode="warp_speed")  # type: ignore[arg-type]


### PR DESCRIPTION
## What

Adds Python typing + metadata for the v1 PyO3 surface. Closes #149.

- **Mixed maturin layout**: the compiled module becomes the private `infino._infino`; a hand-written `python/infino/` package re-exports it and carries the typing artifacts.
- `_infino.pyi` — full v1 surface (`connect`, `Connection`, `Table`, `IndexSpec`, `MutationStats`, `CompactOptions`) with `Literal` types for `mode` / `metric` / `cold_fetch_mode`.
- `py.typed` marker; `__version__` (from package metadata, single-sourced via Cargo.toml) and `__all__`.
- `mypy --strict` CI gate + a sample consumer; a smoke test asserts the stub and marker are packaged.

## Why this layout

This is the canonical PyO3 shape (pydantic-core, cryptography): a **real, type-checked** `__init__.py` over a `_infino.pyi` extension stub — not an `__init__.pyi` that shadows the package and lets re-exports drift unchecked. mypy verifies `__init__.py`'s re-exports match the stub (demonstrably catches a bogus name), and the gate runs on **source** so it needs no extension build.

## No behavior change

Per the issue non-goals: the only Rust change is the module rename (`infino` → `_infino`). No PyO3 logic touched, no wheel-matrix work (#75 tracks that).

## Verification

- 25 smoke tests pass (incl. the new packaging guard).
- `mypy --strict` clean over the package + sample; re-export drift and `Literal` widening both caught (the sample's `type: ignore` lines double as assertions via `warn_unused_ignores`).
- Wheel ships `__init__.py`, `_infino.pyi`, `py.typed`, `_infino.abi3.so` — no bytecode.
- `python -c "import infino; print(infino.__version__)"` → `0.1.0`.