### PR TITLE
refactor manifest stats: store manifest list entry stats as arrayrefs

### DIFF
--- a/src/supertable/manifest/aggregates.rs
+++ b/src/supertable/manifest/aggregates.rs
@@ -31,9 +31,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-use arrow::ipc::writer::StreamWriter;
-use arrow_array::{ArrayRef, RecordBatch};
-use arrow_schema::{Field, Schema};
+use arrow_array::ArrayRef;
 
 use crate::supertable::manifest::SuperfileEntry;
 use crate::supertable::manifest::list::{FtsSummaryAgg, ScalarStatsAgg, VectorSummaryAgg};
@@ -43,7 +41,7 @@ use crate::supertable::manifest::list::{FtsSummaryAgg, ScalarStatsAgg, VectorSum
 #[derive(Debug, Default)]
 pub struct AggregateSet {
     pub id_range: (i128, i128),
-    pub scalar_stats_agg: BTreeMap<String, ScalarStatsAgg>,
+    pub scalar_stats_agg: HashMap<String, ScalarStatsAgg>,
     pub fts_summary_agg: BTreeMap<String, FtsSummaryAgg>,
     pub vector_summary_agg: BTreeMap<String, VectorSummaryAgg>,
 }
@@ -75,7 +73,7 @@ pub fn compute(superfiles: &[Arc<SuperfileEntry>]) -> AggregateSet {
 // Scalar stats: per column, min-of-mins / max-of-maxes.
 // ---------------------------------------------------------
 
-fn scalar_stats_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, ScalarStatsAgg> {
+fn scalar_stats_agg(superfiles: &[Arc<SuperfileEntry>]) -> HashMap<String, ScalarStatsAgg> {
     // Gather, per column, all per-superfile (min, max) ArrayRefs.
     let mut per_column: HashMap<String, (Vec<ArrayRef>, Vec<ArrayRef>)> = HashMap::new();
     for seg in superfiles {
@@ -86,7 +84,7 @@ fn scalar_stats_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, Scal
         }
     }
 
-    let mut out = BTreeMap::new();
+    let mut out = HashMap::new();
     for (col, (mins, maxes)) in per_column {
         if mins.is_empty() {
             continue;
@@ -108,8 +106,6 @@ fn scalar_stats_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, Scal
         let Some((_, agg_max)) = column_min_max(&combined_max) else {
             continue;
         };
-        let min_bytes = ipc_encode_length1(&col, &agg_min);
-        let max_bytes = ipc_encode_length1(&col, &agg_max);
 
         // Additive rollups (null count / sum / HLL) combine with
         // intersection semantics: every segment must carry the stat or
@@ -126,8 +122,7 @@ fn scalar_stats_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, Scal
                     Some(total) => crate::supertable::manifest::add_sum_arrays(&total, part)?,
                 }))
             })
-            .flatten()
-            .map(|total| ipc_encode_length1(&col, &total));
+            .flatten();
         let hll = superfiles
             .iter()
             .try_fold(
@@ -151,8 +146,8 @@ fn scalar_stats_agg(superfiles: &[Arc<SuperfileEntry>]) -> BTreeMap<String, Scal
         out.insert(
             col,
             ScalarStatsAgg {
-                min: min_bytes,
-                max: max_bytes,
+                min: agg_min,
+                max: agg_max,
                 null_count,
                 sum,
                 hll,
@@ -244,24 +239,6 @@ fn column_min_max(col: &ArrayRef) -> Option<(ArrayRef, ArrayRef)> {
         }
         _ => None,
     }
-}
-
-/// Serialize a single length-1 ArrayRef as Arrow IPC bytes —
-/// matches the `ScalarStatsAgg.{min,max}` wire shape
-/// (the per-summary encoding the manifest part carries; we
-/// mirror it at the list level so decoders are uniform).
-fn ipc_encode_length1(col_name: &str, arr: &ArrayRef) -> Vec<u8> {
-    let field = Field::new(col_name, arr.data_type().clone(), true);
-    let schema = Arc::new(Schema::new(vec![field]));
-    let batch =
-        RecordBatch::try_new(schema.clone(), vec![arr.clone()]).expect("schema/array match");
-    let mut out = Vec::new();
-    {
-        let mut writer = StreamWriter::try_new(&mut out, &schema).expect("ipc writer init");
-        writer.write(&batch).expect("ipc write");
-        writer.finish().expect("ipc finish");
-    }
-    out
 }
 
 // ---------------------------------------------------------
@@ -470,21 +447,16 @@ mod tests {
         })
     }
 
-    fn decode_ipc_string(bytes: &[u8]) -> String {
-        use arrow::ipc::reader::StreamReader;
-        let mut reader = StreamReader::try_new(bytes, None).expect("ipc reader");
-        let batch = reader.next().expect("at least one batch").expect("ok");
-        // The encoder produces a length-1 batch with the column under its name.
-        let col = batch.column(0);
-        if let Some(a) = col.as_any().downcast_ref::<StringArray>() {
+    fn string_val(arr: &ArrayRef) -> String {
+        if let Some(a) = arr.as_any().downcast_ref::<StringArray>() {
             return a.value(0).to_string();
         }
-        if let Some(a) = col.as_any().downcast_ref::<LargeStringArray>() {
+        if let Some(a) = arr.as_any().downcast_ref::<LargeStringArray>() {
             return a.value(0).to_string();
         }
         panic!(
             "expected Utf8 or LargeUtf8 column; got {:?}",
-            col.data_type()
+            arr.data_type()
         );
     }
 
@@ -496,8 +468,8 @@ mod tests {
         ];
         let aggs = scalar_stats_agg(&segs);
         let agg = aggs.get("title").expect("title agg present");
-        assert_eq!(decode_ipc_string(&agg.min), "alpha");
-        assert_eq!(decode_ipc_string(&agg.max), "echo");
+        assert_eq!(string_val(&agg.min), "alpha");
+        assert_eq!(string_val(&agg.max), "echo");
     }
 
     #[test]
@@ -508,7 +480,7 @@ mod tests {
         ];
         let aggs = scalar_stats_agg(&segs);
         let agg = aggs.get("body").expect("body agg present");
-        assert_eq!(decode_ipc_string(&agg.min), "apple");
-        assert_eq!(decode_ipc_string(&agg.max), "papaya");
+        assert_eq!(string_val(&agg.min), "apple");
+        assert_eq!(string_val(&agg.max), "papaya");
     }
 }

--- a/src/supertable/manifest/encoding.rs
+++ b/src/supertable/manifest/encoding.rs
@@ -84,6 +84,24 @@ pub enum DecodeError {
     UnexpectedBatchCount(usize),
 }
 
+/// Errors from the per-summary binary encoders.
+///
+/// Surfaced by [`encode_length1_array`] when the Arrow IPC writer rejects
+/// an array; the manifest-list encoder wraps it into its own encode error
+/// so a commit fails cleanly rather than panicking.
+#[derive(Debug, Error)]
+pub enum EncodeError {
+    /// Arrow IPC serialization failed.
+    #[error("arrow ipc encode failed: {0}")]
+    ArrowIpc(String),
+
+    /// A length-1 array was expected (an aggregate is a single value) but
+    /// the array had a different row count — caught before persisting so a
+    /// malformed manifest is never written.
+    #[error("expected a length-1 array, got {0} rows")]
+    WrongRowCount(usize),
+}
+
 // ---------------------------------------------------------
 // ScalarStatsTable: arrow-ipc encoding.
 // ---------------------------------------------------------
@@ -241,6 +259,78 @@ pub fn decode_scalar_stats(bytes: &[u8]) -> Result<ScalarStatsTable, DecodeError
         stats.cols.insert(base, (mn, mx));
     }
     Ok(stats)
+}
+
+/// Encode a single length-1 [`ArrayRef`] as Arrow-IPC stream bytes —
+/// the `ScalarStatsAgg.{min,max,sum}` wire shape (one batch, one
+/// column, one row). `field_name` is recorded in the IPC schema only;
+/// decoders read column 0 by position and ignore the name. Output is
+/// deterministic for identical inputs, which the manifest list's
+/// content-addressing relies on.
+///
+/// Returns [`EncodeError::WrongRowCount`] if `arr` is not exactly one row
+/// (an aggregate is a single value), or [`EncodeError::ArrowIpc`] if the
+/// Arrow IPC writer rejects the array (e.g. an unsupported data type). In
+/// practice the schema is built from the array's own `data_type`, so the
+/// batch always matches — but failures are surfaced rather than panicked so
+/// a bad array can't abort a commit.
+pub(crate) fn encode_length1_array(
+    field_name: &str,
+    arr: &ArrayRef,
+) -> Result<Vec<u8>, EncodeError> {
+    // Enforce the single-value contract before writing — fail fast here
+    // rather than persisting a manifest that `decode_length1_array` would
+    // later reject.
+    if arr.len() != 1 {
+        return Err(EncodeError::WrongRowCount(arr.len()));
+    }
+    let field = Field::new(field_name, arr.data_type().clone(), true);
+    let schema = Arc::new(Schema::new(vec![field]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![arr.clone()])
+        .map_err(|e| EncodeError::ArrowIpc(e.to_string()))?;
+    let mut out = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut out, &schema)
+            .map_err(|e| EncodeError::ArrowIpc(e.to_string()))?;
+        writer
+            .write(&batch)
+            .map_err(|e| EncodeError::ArrowIpc(e.to_string()))?;
+        writer
+            .finish()
+            .map_err(|e| EncodeError::ArrowIpc(e.to_string()))?;
+    }
+    Ok(out)
+}
+
+/// Decode the bytes produced by [`encode_length1_array`] back into the
+/// single length-1 [`ArrayRef`] (column 0 of the one-batch stream).
+pub(crate) fn decode_length1_array(bytes: &[u8]) -> Result<ArrayRef, DecodeError> {
+    let reader = StreamReader::try_new(Cursor::new(bytes), None)
+        .map_err(|e| DecodeError::ArrowIpc(e.to_string()))?;
+    let batches: Vec<RecordBatch> = reader
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| DecodeError::ArrowIpc(e.to_string()))?;
+    if batches.len() != 1 {
+        return Err(DecodeError::UnexpectedBatchCount(batches.len()));
+    }
+    let batch = &batches[0];
+    if batch.num_columns() != 1 {
+        return Err(DecodeError::ArrowIpc(format!(
+            "expected exactly one column, got {}",
+            batch.num_columns()
+        )));
+    }
+    // The aggregate is a single value; callers read index 0 as the only
+    // element. Reject any other row count so malformed manifest data fails
+    // loudly here rather than silently yielding a wrong min/max (which would
+    // corrupt list-level prune decisions).
+    if batch.num_rows() != 1 {
+        return Err(DecodeError::ArrowIpc(format!(
+            "expected exactly one row, got {}",
+            batch.num_rows()
+        )));
+    }
+    Ok(batch.column(0).clone())
 }
 
 // ---------------------------------------------------------
@@ -513,8 +603,9 @@ mod decode_error_tests {
     use arrow_schema::{DataType, Field, Schema};
 
     use super::{
-        DecodeError, decode_fts_summary_map, decode_scalar_stats, decode_vector_summary,
-        decode_vector_summary_map, encode_scalar_stats, read_n, read_u32,
+        DecodeError, decode_fts_summary_map, decode_length1_array, decode_scalar_stats,
+        decode_vector_summary, decode_vector_summary_map, encode_length1_array,
+        encode_scalar_stats, read_n, read_u32,
     };
     use crate::supertable::manifest::ScalarStatsTable;
 
@@ -569,6 +660,53 @@ mod decode_error_tests {
             vec![Arc::new(Int64Array::from(vec![1])) as ArrayRef],
         );
         let err = decode_scalar_stats(&bytes).expect_err("bad suffix");
+        assert!(matches!(err, DecodeError::ArrowIpc(_)), "got {err:?}");
+    }
+
+    /// A single length-1 array round-trips through encode/decode.
+    #[test]
+    fn decode_length1_array_round_trips_single_row() {
+        let arr: ArrayRef = Arc::new(Int64Array::from(vec![42]));
+        let bytes = encode_length1_array("v", &arr).expect("encode");
+        let decoded = decode_length1_array(&bytes).expect("decode");
+        assert_eq!(decoded.to_data(), arr.to_data());
+    }
+
+    /// Encoding a non-length-1 array fails fast, before any bytes are
+    /// written, so an invalid aggregate never reaches a persisted manifest.
+    #[test]
+    fn encode_length1_array_rejects_non_single_row() {
+        use super::EncodeError;
+        let multi: ArrayRef = Arc::new(Int64Array::from(vec![1, 2]));
+        let err = encode_length1_array("v", &multi).expect_err("multi-row");
+        assert!(matches!(err, EncodeError::WrongRowCount(2)), "got {err:?}");
+
+        let empty: ArrayRef = Arc::new(Int64Array::from(Vec::<i64>::new()));
+        let err = encode_length1_array("v", &empty).expect_err("zero-row");
+        assert!(matches!(err, EncodeError::WrongRowCount(0)), "got {err:?}");
+    }
+
+    /// A multi-row batch is rejected — callers read index 0 as the only
+    /// element, so accepting >1 rows would silently produce a wrong
+    /// aggregate min/max and corrupt list-level prune decisions.
+    #[test]
+    fn decode_length1_array_rejects_multi_row() {
+        let bytes = ipc_batch(
+            vec![Field::new("v", DataType::Int64, true)],
+            vec![Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef],
+        );
+        let err = decode_length1_array(&bytes).expect_err("multi-row");
+        assert!(matches!(err, DecodeError::ArrowIpc(_)), "got {err:?}");
+    }
+
+    /// A zero-row batch is rejected for the same single-value contract.
+    #[test]
+    fn decode_length1_array_rejects_zero_row() {
+        let bytes = ipc_batch(
+            vec![Field::new("v", DataType::Int64, true)],
+            vec![Arc::new(Int64Array::from(Vec::<i64>::new())) as ArrayRef],
+        );
+        let err = decode_length1_array(&bytes).expect_err("zero-row");
         assert!(matches!(err, DecodeError::ArrowIpc(_)), "got {err:?}");
     }
 

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -15,13 +15,15 @@
 //!
 //! [`ManifestPart`]: super::part::ManifestPart
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
+use arrow_array::ArrayRef;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use super::encoding::{DecodeError, EncodeError, decode_length1_array, encode_length1_array};
 use super::part::{BLAKE3_DIGEST_BYTES, BLAKE3_HEX_LEN, ContentHash, PartId};
 
 /// Wire format version for the manifest list.
@@ -138,7 +140,7 @@ pub struct ManifestListEntry {
     /// Per-scalar-column aggregate min/max across all
     /// superfiles in this part. An empty map is interpreted as
     /// "always-keep" by the list-level pruner.
-    pub scalar_stats_agg: BTreeMap<String, ScalarStatsAgg>,
+    pub scalar_stats_agg: HashMap<String, ScalarStatsAgg>,
     /// Per-FTS-column aggregate bloom-union + range-union.
     /// Empty → always-keep.
     pub fts_summary_agg: BTreeMap<String, FtsSummaryAgg>,
@@ -148,22 +150,47 @@ pub struct ManifestListEntry {
 }
 
 /// Aggregate scalar stats across a part's superfiles. Min/max
-/// are Arrow-IPC bytes of length-1 arrays (matches
-/// `ScalarStatsTable.cols` per-column shape).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// (and the exact sum) are held as length-1 [`ArrayRef`]s of the
+/// column's Arrow type — the same in-memory shape the per-superfile
+/// `ScalarStatsTable.cols` uses. They are decoded once when the
+/// manifest list is loaded, so the list-level scalar prune
+/// ([`crate::supertable::query::prune`]) compares against them
+/// without a per-query Arrow-IPC decode. The JSON wire form still
+/// stores them as base64 Arrow-IPC bytes (see [`ScalarStatsAggDto`]).
+#[derive(Debug, Clone)]
 pub struct ScalarStatsAgg {
-    pub min: Vec<u8>,
-    pub max: Vec<u8>,
+    pub min: ArrayRef,
+    pub max: ArrayRef,
     /// Σ null_count across the part's segments; `None` when any
     /// segment lacks the stat (total unknowable, never zero).
     pub null_count: Option<u64>,
-    /// Part-wide exact sum as Arrow-IPC length-1 bytes (same typing
+    /// Part-wide exact sum as a length-1 [`ArrayRef`] (same typing
     /// as the per-segment `ScalarStatsTable.sums`); `None` when any
     /// segment lacks it or the fold overflowed.
-    pub sum: Option<Vec<u8>>,
+    pub sum: Option<ArrayRef>,
     /// Merged HLL distinct sketch (raw registers); `None` when any
     /// segment lacks one.
     pub hll: Option<Vec<u8>>,
+}
+
+impl PartialEq for ScalarStatsAgg {
+    /// Equality compares the Arrow array contents (via [`ArrayRef::to_data`])
+    /// rather than pointer identity, so two independently-built aggregates
+    /// carrying the same values compare equal — the behaviour the round-trip
+    /// tests rely on. `ArrayRef` is not `Eq` (floats), so this type only
+    /// implements `PartialEq`.
+    fn eq(&self, other: &Self) -> bool {
+        let sum_eq = match (&self.sum, &other.sum) {
+            (Some(a), Some(b)) => a.to_data() == b.to_data(),
+            (None, None) => true,
+            _ => false,
+        };
+        self.min.to_data() == other.min.to_data()
+            && self.max.to_data() == other.max.to_data()
+            && self.null_count == other.null_count
+            && sum_eq
+            && self.hll == other.hll
+    }
 }
 
 /// Aggregate FTS summary across a part's superfiles.
@@ -220,6 +247,11 @@ pub enum ListParseError {
     BadPartId(String),
     #[error("bad value for field {0}: {1:?}")]
     BadFieldValue(&'static str, String),
+    #[error("scalar stats decode failed for {field}: {source}")]
+    ScalarStats {
+        field: &'static str,
+        source: DecodeError,
+    },
     #[error("incompatible major version: got {got}, supported {supported}")]
     IncompatibleMajorVersion { got: String, supported: String },
 }
@@ -228,6 +260,11 @@ pub enum ListParseError {
 pub enum ListEncodeError {
     #[error("json encode failed: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("scalar stats encode failed for {field}: {source}")]
+    ScalarStats {
+        field: &'static str,
+        source: EncodeError,
+    },
 }
 
 // ---------- Wire (serde) types ----------
@@ -389,8 +426,35 @@ fn decode_b64(s: &str, field: &'static str) -> Result<Vec<u8>, ListParseError> {
         .map_err(|source| ListParseError::Base64 { field, source })
 }
 
-fn entry_to_dto(e: &ManifestListEntry) -> ManifestListEntryDto {
-    ManifestListEntryDto {
+fn encode_scalar_array(
+    column: &str,
+    field: &'static str,
+    arr: &ArrayRef,
+) -> Result<String, ListEncodeError> {
+    let bytes = encode_length1_array(column, arr)
+        .map_err(|source| ListEncodeError::ScalarStats { field, source })?;
+    Ok(encode_b64(&bytes))
+}
+
+fn entry_to_dto(e: &ManifestListEntry) -> Result<ManifestListEntryDto, ListEncodeError> {
+    let mut scalar_stats_agg = BTreeMap::new();
+    for (k, v) in &e.scalar_stats_agg {
+        let sum = match &v.sum {
+            None => None,
+            Some(s) => Some(encode_scalar_array(k, "scalar_stats_agg.sum", s)?),
+        };
+        scalar_stats_agg.insert(
+            k.clone(),
+            ScalarStatsAggDto {
+                min: encode_scalar_array(k, "scalar_stats_agg.min", &v.min)?,
+                max: encode_scalar_array(k, "scalar_stats_agg.max", &v.max)?,
+                null_count: v.null_count,
+                sum,
+                hll: v.hll.as_deref().map(encode_b64),
+            },
+        );
+    }
+    Ok(ManifestListEntryDto {
         part_id: e.part_id.0.to_string(),
         uri: e.uri.clone(),
         n_superfiles: e.n_superfiles,
@@ -399,22 +463,7 @@ fn entry_to_dto(e: &ManifestListEntry) -> ManifestListEntryDto {
         content_hash: encode_hash(&e.content_hash),
         partition_key: encode_b64(&e.partition_key),
         id_range: (e.id_range.0.to_string(), e.id_range.1.to_string()),
-        scalar_stats_agg: e
-            .scalar_stats_agg
-            .iter()
-            .map(|(k, v)| {
-                (
-                    k.clone(),
-                    ScalarStatsAggDto {
-                        min: encode_b64(&v.min),
-                        max: encode_b64(&v.max),
-                        null_count: v.null_count,
-                        sum: v.sum.as_deref().map(encode_b64),
-                        hll: v.hll.as_deref().map(encode_b64),
-                    },
-                )
-            })
-            .collect(),
+        scalar_stats_agg,
         fts_summary_agg: e
             .fts_summary_agg
             .iter()
@@ -448,7 +497,7 @@ fn entry_to_dto(e: &ManifestListEntry) -> ManifestListEntryDto {
                 )
             })
             .collect(),
-    }
+    })
 }
 
 fn entry_from_dto(d: ManifestListEntryDto) -> Result<ManifestListEntry, ListParseError> {
@@ -457,19 +506,38 @@ fn entry_from_dto(d: ManifestListEntryDto) -> Result<ManifestListEntry, ListPars
     );
     let content_hash = decode_hash(&d.content_hash)?;
     let partition_key = decode_b64(&d.partition_key, "partition_key")?;
-    let mut scalar_stats_agg = BTreeMap::new();
+    let mut scalar_stats_agg = HashMap::new();
     for (k, v) in d.scalar_stats_agg {
+        let min = decode_length1_array(&decode_b64(&v.min, "scalar_stats_agg.min")?).map_err(
+            |source| ListParseError::ScalarStats {
+                field: "scalar_stats_agg.min",
+                source,
+            },
+        )?;
+        let max = decode_length1_array(&decode_b64(&v.max, "scalar_stats_agg.max")?).map_err(
+            |source| ListParseError::ScalarStats {
+                field: "scalar_stats_agg.max",
+                source,
+            },
+        )?;
+        let sum = match v.sum.as_deref() {
+            None => None,
+            Some(s) => Some(
+                decode_length1_array(&decode_b64(s, "scalar_stats_agg.sum")?).map_err(
+                    |source| ListParseError::ScalarStats {
+                        field: "scalar_stats_agg.sum",
+                        source,
+                    },
+                )?,
+            ),
+        };
         scalar_stats_agg.insert(
             k,
             ScalarStatsAgg {
-                min: decode_b64(&v.min, "scalar_stats_agg.min")?,
-                max: decode_b64(&v.max, "scalar_stats_agg.max")?,
+                min,
+                max,
                 null_count: v.null_count,
-                sum: v
-                    .sum
-                    .as_deref()
-                    .map(|s| decode_b64(s, "scalar_stats_agg.sum"))
-                    .transpose()?,
+                sum,
                 hll: v
                     .hll
                     .as_deref()
@@ -578,8 +646,13 @@ fn strategy_from_dto(d: PartitionStrategyDto) -> Result<PartitionStrategy, ListP
     })
 }
 
-fn list_to_dto(l: &ManifestList) -> ManifestListDto {
-    ManifestListDto {
+fn list_to_dto(l: &ManifestList) -> Result<ManifestListDto, ListEncodeError> {
+    let parts = l
+        .parts
+        .iter()
+        .map(entry_to_dto)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(ManifestListDto {
         format_version: l.format_version.clone(),
         manifest_id: l.manifest_id,
         options_hash: encode_hash(&l.options_hash),
@@ -598,8 +671,8 @@ fn list_to_dto(l: &ManifestList) -> ManifestListDto {
             })
             .collect(),
         partition_strategy: strategy_to_dto(&l.partition_strategy),
-        parts: l.parts.iter().map(entry_to_dto).collect(),
-    }
+        parts,
+    })
 }
 
 fn list_from_dto(d: ManifestListDto) -> Result<ManifestList, ListParseError> {
@@ -640,7 +713,7 @@ fn list_from_dto(d: ManifestListDto) -> Result<ManifestList, ListParseError> {
 /// types, so byte-output is deterministic for content-equal
 /// inputs.
 pub fn encode(list: &ManifestList) -> Result<Vec<u8>, ListEncodeError> {
-    let dto = list_to_dto(list);
+    let dto = list_to_dto(list)?;
     Ok(serde_json::to_vec_pretty(&dto)?)
 }
 
@@ -682,7 +755,9 @@ mod tests {
     //! jq-friendly.
     use super::super::part::{ContentHash, PartId};
     use super::*;
-    use std::collections::BTreeMap;
+    use arrow_array::Int64Array;
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
     use uuid::Uuid;
 
     fn empty_list() -> ManifestList {
@@ -703,17 +778,23 @@ mod tests {
     }
 
     fn rich_entry(seed: u8) -> ManifestListEntry {
-        let mut scalar = BTreeMap::new();
-        scalar.insert(
-            "ts".into(),
-            ScalarStatsAgg {
-                min: vec![seed, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
-                max: vec![seed, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9],
-                null_count: Some(u64::from(seed)),
-                sum: Some(vec![seed, 0x10, 0x20]),
-                hll: Some(vec![seed; 4]),
-            },
-        );
+        // Several columns (inserted out of sorted order) so the JSON
+        // round-trip and byte-equality tests actually exercise the
+        // HashMap → BTreeMap re-sort that keeps the wire form
+        // deterministic for content-addressing.
+        let mut scalar = HashMap::new();
+        for col in ["ts", "amount", "_id"] {
+            scalar.insert(
+                col.to_string(),
+                ScalarStatsAgg {
+                    min: Arc::new(Int64Array::from(vec![i64::from(seed)])) as ArrayRef,
+                    max: Arc::new(Int64Array::from(vec![i64::from(seed) + 1_000])) as ArrayRef,
+                    null_count: Some(u64::from(seed)),
+                    sum: Some(Arc::new(Int64Array::from(vec![i64::from(seed) * 7])) as ArrayRef),
+                    hll: Some(vec![seed; 4]),
+                },
+            );
+        }
 
         let mut fts = BTreeMap::new();
         fts.insert(

--- a/src/supertable/manifest/list_prune.rs
+++ b/src/supertable/manifest/list_prune.rs
@@ -537,10 +537,9 @@ mod tests {
             .scalar_stats_agg
             .get("ts")
             .expect("ts scalar agg present");
-        // IPC byte introspection is a separate concern; here we just
-        // confirm presence + non-empty encoding.
-        assert!(!s.min.is_empty(), "ts min IPC bytes must be non-empty");
-        assert!(!s.max.is_empty(), "ts max IPC bytes must be non-empty");
+        // The aggregate min/max are length-1 arrays of the column type.
+        assert_eq!(s.min.len(), 1, "ts min must be a length-1 array");
+        assert_eq!(s.max.len(), 1, "ts max must be a length-1 array");
     }
 
     #[test]

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -28,7 +28,6 @@
 
 use std::sync::Arc;
 
-use arrow::ipc::reader::StreamReader;
 use datafusion::scalar::ScalarValue;
 
 use crate::superfile::fts::reader::BoolMode;
@@ -89,8 +88,10 @@ impl PruneLeaf {
 /// the predicate's column could satisfy it. A missing aggregate or
 /// undecodable bounds → keep (conservative — never a false prune).
 ///
-/// The aggregate min/max live as length-1 Arrow IPC batches
-/// (`ScalarStatsAgg.{min,max}`); we decode them and reuse the same
+/// The aggregate min/max are held as length-1 [`ArrayRef`]s
+/// (`ScalarStatsAgg.{min,max}`), already decoded when the manifest list
+/// was loaded — so this hot path reads the [`ScalarValue`] straight from
+/// the array with no per-query Arrow-IPC decode, then reuses the same
 /// comparison core the superfile tier uses ([`scalar_value_may_match`]).
 fn scalar_keep_parts(list: &ManifestList, pred: &ScalarPredicate) -> Vec<PartId> {
     list.parts
@@ -100,8 +101,8 @@ fn scalar_keep_parts(list: &ManifestList, pred: &ScalarPredicate) -> Vec<PartId>
                 None => true,
                 Some(agg) => {
                     match (
-                        decode_length1_scalar(&agg.min),
-                        decode_length1_scalar(&agg.max),
+                        ScalarValue::try_from_array(agg.min.as_ref(), 0).ok(),
+                        ScalarValue::try_from_array(agg.max.as_ref(), 0).ok(),
                     ) {
                         (Some(min), Some(max)) => {
                             scalar_value_may_match(&min, &max, pred.op, &pred.value)
@@ -113,21 +114,6 @@ fn scalar_keep_parts(list: &ManifestList, pred: &ScalarPredicate) -> Vec<PartId>
             keep.then_some(entry.part_id)
         })
         .collect()
-}
-
-/// Decode a length-1 Arrow IPC stream (the `ScalarStatsAgg.{min,max}`
-/// wire shape — one batch, one column, one row) into its single
-/// `ScalarValue`. `None` on any decode failure, which callers treat as
-/// "keep".
-fn decode_length1_scalar(bytes: &[u8]) -> Option<ScalarValue> {
-    let reader = StreamReader::try_new(bytes, None).ok()?;
-    for batch in reader {
-        let batch = batch.ok()?;
-        if batch.num_columns() >= 1 && batch.num_rows() >= 1 {
-            return ScalarValue::try_from_array(batch.column(0).as_ref(), 0).ok();
-        }
-    }
-    None
 }
 
 /// Select the superfiles a predicate could match, newest-first in


### PR DESCRIPTION
### What does this PR do?
- Stores ManifestListEntry level stats as HashMap<String, StatsAgg>, Stats Agg stores certain data as ArrayRef ( similar to StatsTable )

### Why do we need this change?
- Speed up query pruning, as we don't need to convert from Vec<u8> to ArrayRef during the pruning query
- Migrate towards a single StatsAgg structure ( for superfile entries and ManifestListEntries )