### PR TITLE
ci/bench: AI-summarized PR comment, only significant deltas

### DIFF
--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Summarize benchmark deltas for a PR comment.
+
+Diffs this run against the `main` baseline, keeps only changes past the noise
+threshold, annotates each with main's own trend, and writes a lean markdown
+summary. Foundry narrates; the percentages are computed here, never by the
+model. On any model failure or missing creds the deterministic delta table is
+the summary on its own. Stdlib only — the runner needs no pip install.
+
+Inputs (env):
+  REPORTS                  space-separated report names (basenames, no .json)
+  BASELINE_DIR             dir holding <report>.json from the main baseline
+  CURRENT_DIR              dir holding <report>.json from this run
+  HISTORY_DIR              dir with <report>/<idx>-<sha>.json main-history points
+  BENCH_NOISE_THRESHOLD_PCT  threshold in percent (default 10)
+  OUT_FILE                 markdown destination (default /tmp/ai-summary.md)
+  BENCH_LABEL              human label for the run (the `bench` input)
+  RUN_URL                  link to the full Actions run
+  ERRORS                   newline-separated panic/error lines (may be empty)
+  AZURE_AI_ENDPOINT        Foundry OpenAI-compatible base (…/openai/v1)
+  AZURE_AI_API_KEY         Foundry key (Bearer)
+  AZURE_AI_MODEL           model deployment (default gpt-5.4)
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# Report keys are "anchor|subtitle|label|header"; split on this into 4 fields.
+KEY_PARTS = 4
+
+# Mirrors the bench renderer's Better enum: these headers are higher-is-better,
+# everything else comparable is lower-is-better. Text-only columns are skipped.
+HIGHER_BETTER = ("Throughput", "Bandwidth")
+TEXT_ONLY = ("Corpus", "Superfiles")
+
+# Map a report basename to (subsystem label, source area) shown in the summary.
+SUBSYSTEM = {
+    "supertable": ("Ingest", "src/supertable/writer.rs"),
+    "supertable_fts": ("FTS", "src/superfile/fts/"),
+    "supertable_vector": ("Vector", "src/superfile/vector/"),
+    "supertable_sql": ("SQL", "src/supertable/query/"),
+    "superfile_fts": ("FTS", "src/superfile/fts/"),
+    "superfile_vector": ("Vector", "src/superfile/vector/"),
+    "sql": ("SQL", "src/supertable/query/"),
+}
+
+# Recall is a pass/fail merge gate, not a noise-banded latency metric: any
+# drop below this bar is flagged regardless of percentage delta.
+RECALL_GATE = 0.99
+
+DEFAULT_MODEL = "gpt-5.4"
+DEFAULT_OUT = "/tmp/ai-summary.md"
+DEFAULT_THRESHOLD = 10.0
+# Most recent main commits to read when describing main's own trend.
+HISTORY_WINDOW = 10
+# Cap each list so a broad regression can't blow past GitHub's comment limit.
+MAX_ROWS = 12
+# Foundry latency ceiling; the fallback table covers us if we trip it.
+HTTP_TIMEOUT_S = 60
+
+
+def is_text_only(header):
+    return any(t in header for t in TEXT_ONLY)
+
+
+def higher_is_better(header):
+    return any(t in header for t in HIGHER_BETTER)
+
+
+def human(header, value):
+    """Format a raw f64 into a unit appropriate to its header token."""
+    h = header.lower()
+    if "throughput" in h:
+        return f"{value:,.0f} docs/s"
+    if "bandwidth" in h:
+        return f"{value / 1048576:,.1f} MiB/s"
+    if "rss" in h or "stored" in h:
+        if value >= 1073741824:
+            return f"{value / 1073741824:.2f} GiB"
+        return f"{value / 1048576:.1f} MiB"
+    # Latency-like (Time, p50/p90, cold, latency) is stored in nanoseconds.
+    if value >= 1e9:
+        return f"{value / 1e9:.2f} s"
+    return f"{value / 1e6:.2f} ms"
+
+
+def load(path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            obj = json.load(fh)
+        return {k: float(v) for k, v in obj.items() if isinstance(v, (int, float))}
+    except (OSError, ValueError):
+        return {}
+
+
+def load_history(history_dir, report):
+    """Main-history metric maps for `report`, oldest→newest (≤ window)."""
+    path = os.path.join(history_dir, report)
+    try:
+        names = sorted(n for n in os.listdir(path) if n.endswith(".json"))
+    except OSError:
+        return []
+    maps = [load(os.path.join(path, n)) for n in names[-HISTORY_WINDOW:]]
+    return [m for m in maps if m]
+
+
+def main_trend(history_maps, key, header, threshold):
+    """How `main` drifted across the window — a PR regression on a metric
+    main has already been pushing the wrong way is the case worth flagging.
+    Returns (note, short), or (None, None) without enough points."""
+    series = [m[key] for m in history_maps if key in m and m[key] != 0.0]
+    if len(series) < 2 or series[0] == 0.0:
+        return None, None
+    drift = (series[-1] - series[0]) / series[0] * 100.0
+    n = len(series)
+    if abs(drift) < threshold:
+        return f"main stable ({drift:+.0f}% over {n}c)", "stable"
+    improved = drift > 0 if higher_is_better(header) else drift < 0
+    word = "improving" if improved else "worsening"
+    return f"main {word} {drift:+.0f}% over {n} commits", f"{drift:+.0f}%/{n}c"
+
+
+def diff(reports, baseline_dir, current_dir, history_dir, threshold):
+    """Classify changes per report.
+
+    Returns (regressions, improvements, gates, had_baseline, cost_present).
+    `had_baseline` distinguishes 'nothing moved' from 'nothing to compare'.
+    """
+    regressions, improvements, gates = [], [], []
+    had_baseline = False
+    cost_present = False
+    for report in reports:
+        base = load(os.path.join(baseline_dir, f"{report}.json"))
+        cur = load(os.path.join(current_dir, f"{report}.json"))
+        if not cur:
+            continue
+        subsystem, area = SUBSYSTEM.get(report, (report, ""))
+        history = load_history(history_dir, report)
+        for key, new in cur.items():
+            parts = key.split("|")
+            if len(parts) != KEY_PARTS:
+                continue
+            _anchor, _subtitle, label, header = parts
+            if "$" in key:
+                cost_present = True
+            # Recall is a hard gate, evaluated on its absolute value.
+            if "recall" in f"{label} {header}".lower():
+                breach = new < RECALL_GATE if new <= 1.0 else new < RECALL_GATE * 100
+                gates.append({
+                    "subsystem": subsystem,
+                    "metric": f"{label} / {header}".strip(" /"),
+                    "value": f"{new:.4f}" if new <= 1.0 else f"{new:.2f}",
+                    "breach": breach,
+                })
+                continue
+            if is_text_only(header):
+                continue
+            old = base.get(key)
+            if old is None or old == 0.0:
+                continue
+            had_baseline = True
+            pct = (new - old) / old * 100.0
+            if abs(pct) < threshold:
+                continue
+            improved = pct > 0 if higher_is_better(header) else pct < 0
+            note, short = main_trend(history, key, header, threshold)
+            entry = {
+                "subsystem": subsystem,
+                "area": area,
+                "metric": f"{label} / {header}".strip(" /"),
+                "old": human(header, old),
+                "new": human(header, new),
+                "pct": round(pct, 1),
+                "verdict": "improvement" if improved else "regression",
+                "main_trend": note,
+                "main_trend_short": short,
+            }
+            (improvements if improved else regressions).append(entry)
+    regressions.sort(key=lambda e: -abs(e["pct"]))
+    improvements.sort(key=lambda e: -abs(e["pct"]))
+    return regressions, improvements, gates, had_baseline, cost_present
+
+
+def verdict_badge(regressions, gates, failures, improvements):
+    if failures or any(g["breach"] for g in gates) or regressions:
+        return "🔴"
+    if improvements:
+        return "🟢"
+    return "⚪"
+
+
+def gate_table(gates):
+    breached = [g for g in gates if g["breach"]]
+    if not breached:
+        return ""
+    rows = ["| Gate | Subsystem | Value | Bar |", "|---|---|---|---|"]
+    for g in breached:
+        rows.append(f"| 🛑 {g['metric']} | {g['subsystem']} | {g['value']} | ≥ {RECALL_GATE} |")
+    return "\n".join(rows)
+
+
+def delta_table(regressions, improvements):
+    """Deterministic markdown table — the always-correct fallback body."""
+    rows = regressions[:MAX_ROWS] + improvements[:MAX_ROWS]
+    if not rows:
+        return "", 0
+    out = ["| Verdict | Subsystem | Metric | main | this run | Δ% | Main trend |",
+           "|---|---|---|---|---|---|---|"]
+    for e in rows:
+        mark = "🔴" if e["verdict"] == "regression" else "🟢"
+        trend = e.get("main_trend_short") or "—"
+        out.append(
+            f"| {mark} {e['verdict']} | {e['subsystem']} | {e['metric']} "
+            f"| {e['old']} | {e['new']} | {e['pct']:+.1f}% | {trend} |"
+        )
+    dropped = max(0, len(regressions) - MAX_ROWS) + max(0, len(improvements) - MAX_ROWS)
+    return "\n".join(out), dropped
+
+
+def narrate(payload, endpoint, key, model):
+    """Ask Foundry for prose. Return None on any failure (fallback handles it)."""
+    if not endpoint or not key:
+        return None
+    system = (
+        "You are a performance engineer summarizing benchmark results for a "
+        "pull-request reviewer. You are given a JSON payload of metric changes "
+        "ALREADY filtered to exceed the noise threshold, plus recall gate "
+        "checks and any run failures. Write a terse summary in GitHub markdown:\n"
+        "- Open with a one-line verdict (net regression / net improvement / mixed / clean).\n"
+        "- Call out failures and any breached gate FIRST and plainly.\n"
+        "- Then bullet the notable changes grouped by subsystem (Ingest, FTS, "
+        "Vector, SQL). Regressions before improvements.\n"
+        "- When a change has a 'main_trend', weave it in: a regression on a "
+        "metric main is already worsening is more serious than a one-off.\n"
+        "- Cite ONLY numbers in the payload. Never invent or recompute a value.\n"
+        "- If there are no changes, no breached gates, and no failures, say "
+        f"'No significant changes (within ±{payload['threshold']}%).'\n"
+        "Keep it to what a reviewer needs at a glance. No preamble, no sign-off, "
+        "no restating the raw table."
+    )
+    body = json.dumps({
+        "model": model,
+        "temperature": 0.1,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": json.dumps(payload)},
+        ],
+    }).encode("utf-8")
+    url = endpoint.rstrip("/") + "/chat/completions"
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {key}",
+            "api-key": key,  # Azure accepts either on the /openai/v1 surface.
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+            data = json.load(resp)
+        text = data["choices"][0]["message"]["content"].strip()
+        return text or None
+    except (urllib.error.URLError, OSError, ValueError, KeyError, IndexError) as exc:
+        print(f"::warning::Foundry summary unavailable ({exc}); using delta table", file=sys.stderr)
+        return None
+
+
+def main():
+    reports = os.environ.get("REPORTS", "").split()
+    baseline_dir = os.environ.get("BASELINE_DIR", "baseline")
+    current_dir = os.environ.get("CURRENT_DIR", "current")
+    history_dir = os.environ.get("HISTORY_DIR", "history")
+    out_file = os.environ.get("OUT_FILE", DEFAULT_OUT)
+    label = os.environ.get("BENCH_LABEL", "benchmark")
+    run_url = os.environ.get("RUN_URL", "")
+    try:
+        threshold = float(os.environ.get("BENCH_NOISE_THRESHOLD_PCT", DEFAULT_THRESHOLD))
+    except ValueError:
+        threshold = DEFAULT_THRESHOLD
+
+    failures = [ln.strip() for ln in os.environ.get("ERRORS", "").splitlines() if ln.strip()]
+    regressions, improvements, gates, had_baseline, cost_present = diff(
+        reports, baseline_dir, current_dir, history_dir, threshold)
+
+    payload = {
+        "threshold": threshold,
+        "regressions": regressions[:MAX_ROWS],
+        "improvements": improvements[:MAX_ROWS],
+        "gates": gates,
+        "failures": failures[:20],
+    }
+
+    prose = narrate(
+        payload,
+        os.environ.get("AZURE_AI_ENDPOINT", ""),
+        os.environ.get("AZURE_AI_API_KEY", ""),
+        os.environ.get("AZURE_AI_MODEL", DEFAULT_MODEL),
+    )
+
+    badge = verdict_badge(regressions, gates, failures, improvements)
+    parts = [f"## {badge} Benchmark `{label}` — significant changes (±{threshold:g}% threshold)", ""]
+
+    if prose:
+        parts += [prose, ""]
+    else:
+        # Deterministic fallback body: gates + failures + the delta table.
+        if not had_baseline:
+            parts += ["_No `main` baseline to diff against (first run or new config) — see the full report._", ""]
+        elif not regressions and not improvements and not gates:
+            parts += [f"No significant changes (within ±{threshold:g}%).", ""]
+        gt = gate_table(gates)
+        if gt:
+            parts += ["### 🛑 Gate breach", gt, ""]
+        if failures:
+            parts += ["### 🛑 Failures", "```", "\n".join(failures[:20]), "```", ""]
+
+    table, dropped = delta_table(regressions, improvements)
+    if table:
+        parts += ["<details><summary>Significant deltas vs <code>main</code></summary>", "", table]
+        if dropped:
+            parts += ["", f"_…and {dropped} more change(s) past threshold — see the full report._"]
+        parts += ["", "</details>", ""]
+
+    # Source-area hints for the subsystems that actually moved.
+    touched = {}
+    for e in regressions + improvements:
+        if e.get("area"):
+            touched[e["subsystem"]] = e["area"]
+    if touched:
+        hints = " · ".join(f"{s} → `{a}`" for s, a in sorted(touched.items()))
+        parts += [f"_Where to look: {hints}_", ""]
+
+    if cost_present:
+        parts += ["_Cost metrics (bytes / requests / queries-per-$) are not delta-tracked "
+                  "(volatile keys) — check the full report._", ""]
+
+    if run_url:
+        parts.append(f"[Full report & logs ↗]({run_url})")
+
+    body = "\n".join(parts).rstrip() + "\n"
+    with open(out_file, "w", encoding="utf-8") as fh:
+        fh.write(body)
+    print(f"wrote {out_file}: {len(regressions)} regression(s), {len(improvements)} "
+          f"improvement(s), {len(gates)} gate(s), {len(failures)} failure line(s), "
+          f"baseline={'yes' if had_baseline else 'no'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -133,8 +133,8 @@ def main_trend(history_maps, key, header, threshold):
     if abs(drift) < threshold:
         return f"main stable ({drift:+.0f}% over {n} commits)", "flat"
     improved = drift > 0 if higher_is_better(header) else drift < 0
-    word = "improving" if improved else "worsening"
-    short = f"{'better' if improved else 'worse'} {abs(drift):.0f}%"
+    word = "improving" if improved else "degrading"
+    short = f"{word} {abs(drift):.0f}%"
     return f"main {word} {drift:+.0f}% over {n} commits", short
 
 
@@ -310,8 +310,9 @@ def main():
                   "", table(improvements), "", "</details>", ""]
 
     if regressions or improvements:
-        parts.append("_`main → run` = baseline vs this PR · `Main (10c)` = how main "
-                     "itself trended over its last ≤10 commits._")
+        parts.append("_`Δ` = this PR vs `main` — the regression/improvement verdict. "
+                     "`Main (10c)` = how `main` itself moved over its last ≤10 commits, "
+                     "independent of this PR (a regression on an `improving` metric means this PR reverses that trend)._")
         touched = {e["subsystem"]: e["area"] for e in regressions + improvements if e.get("area")}
         if touched:
             parts.append("_Where to look: " + " · ".join(

--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -47,9 +47,9 @@ SUBSYSTEM = {
     "sql": ("SQL", "src/supertable/query/"),
 }
 
-# Latency below this (ns) is sub-millisecond timing noise — a big percentage
-# of nearly-nothing. Don't flag it. 0.5 ms.
-MIN_LATENCY_NS = 500_000.0
+# Latency at/under this (ns) rounds to ~0.00 ms — a big percentage of nearly
+# nothing. Don't flag it; real sub-ms queries above it still count. 0.1 ms.
+MIN_LATENCY_NS = 100_000.0
 
 DEFAULT_MODEL = "gpt-5.4"
 DEFAULT_OUT = "/tmp/ai-summary.md"
@@ -269,8 +269,11 @@ def main():
         os.environ.get("AZURE_AI_MODEL", DEFAULT_MODEL),
     )
 
+    def plural(n, word):
+        return f"{n} {word}{'' if n == 1 else 's'}"
+
     badge = "🔴" if (failures or regressions) else ("🟢" if improvements else "⚪")
-    counts = f"{len(regressions)} regression(s) · {len(improvements)} improvement(s)"
+    counts = f"{plural(len(regressions), 'regression')} · {plural(len(improvements), 'improvement')}"
     parts = [f"## {badge} Benchmark `{label}` — {counts} (±{threshold:g}% vs main)", ""]
 
     if prose:

--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -282,7 +282,14 @@ def main():
     def plural(n, word):
         return f"{n} {word}{'' if n == 1 else 's'}"
 
-    badge = "🔴" if (failures or regressions) else ("🟢" if improvements else "⚪")
+    if failures or (regressions and not improvements):
+        badge = "🔴"  # pure bad: failures, or regressions with no offsetting wins
+    elif regressions:
+        badge = "🟡"  # mixed: regressions alongside improvements
+    elif improvements:
+        badge = "🟢"
+    else:
+        badge = "⚪"
     counts = f"{plural(len(regressions), 'regression')} · {plural(len(improvements), 'improvement')}"
     parts = [f"## {badge} Benchmark `{label}` — {counts} (±{threshold:g}% vs main)", ""]
 

--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -35,6 +35,10 @@ KEY_PARTS = 4
 # everything else comparable is lower-is-better. Text-only columns are skipped.
 HIGHER_BETTER = ("Throughput", "Bandwidth")
 TEXT_ONLY = ("Corpus", "Superfiles")
+# Cost cells are USD/queries-per-$ figures, not nanoseconds, and their keys
+# embed volatile text — they don't diff cleanly. Skip them (the comment says
+# so) rather than mis-unit them as latency.
+COST_TOKENS = ("$", "cost", "measured", "per-unit")
 
 # Map a report basename to (subsystem label, source area).
 SUBSYSTEM = {
@@ -70,8 +74,13 @@ def higher_is_better(header):
     return any(t in header for t in HIGHER_BETTER)
 
 
+def is_cost(header):
+    h = header.lower()
+    return any(t in h for t in COST_TOKENS)
+
+
 def is_latency(header):
-    """Lower-is-better and measured in nanoseconds (Time, p50, cold, latency)."""
+    """Lower-is-better and measured in nanoseconds (Time, p50, cold, count())."""
     h = header.lower()
     return not higher_is_better(header) and "rss" not in h and "stored" not in h
 
@@ -150,9 +159,10 @@ def diff(reports, baseline_dir, current_dir, history_dir, threshold):
             if len(parts) != KEY_PARTS:
                 continue
             _anchor, _subtitle, label, header = parts
-            if "$" in key:
-                cost_present = True
             if is_text_only(header):
+                continue
+            if is_cost(header):
+                cost_present = True
                 continue
             old = base.get(key)
             if old is None or old == 0.0:

--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -4,8 +4,8 @@
 Diffs this run against the `main` baseline, keeps only changes past the noise
 threshold, annotates each with main's own trend, and writes a lean markdown
 summary. Foundry narrates; the percentages are computed here, never by the
-model. On any model failure or missing creds the deterministic delta table is
-the summary on its own. Stdlib only — the runner needs no pip install.
+model. On any model failure or missing creds the deterministic tables are the
+summary on their own. Stdlib only — the runner needs no pip install.
 
 Inputs (env):
   REPORTS                  space-separated report names (basenames, no .json)
@@ -36,7 +36,7 @@ KEY_PARTS = 4
 HIGHER_BETTER = ("Throughput", "Bandwidth")
 TEXT_ONLY = ("Corpus", "Superfiles")
 
-# Map a report basename to (subsystem label, source area) shown in the summary.
+# Map a report basename to (subsystem label, source area).
 SUBSYSTEM = {
     "supertable": ("Ingest", "src/supertable/writer.rs"),
     "supertable_fts": ("FTS", "src/superfile/fts/"),
@@ -47,18 +47,18 @@ SUBSYSTEM = {
     "sql": ("SQL", "src/supertable/query/"),
 }
 
-# Recall is a pass/fail merge gate, not a noise-banded latency metric: any
-# drop below this bar is flagged regardless of percentage delta.
-RECALL_GATE = 0.99
+# Latency below this (ns) is sub-millisecond timing noise — a big percentage
+# of nearly-nothing. Don't flag it. 0.5 ms.
+MIN_LATENCY_NS = 500_000.0
 
 DEFAULT_MODEL = "gpt-5.4"
 DEFAULT_OUT = "/tmp/ai-summary.md"
 DEFAULT_THRESHOLD = 10.0
-# Most recent main commits to read when describing main's own trend.
+# Most recent main commits read when describing main's own trend.
 HISTORY_WINDOW = 10
-# Cap each list so a broad regression can't blow past GitHub's comment limit.
-MAX_ROWS = 12
-# Foundry latency ceiling; the fallback table covers us if we trip it.
+# Cap each table so a broad swing can't blow past GitHub's comment limit.
+MAX_ROWS = 15
+# Foundry latency ceiling; the fallback tables cover us if we trip it.
 HTTP_TIMEOUT_S = 60
 
 
@@ -68,6 +68,12 @@ def is_text_only(header):
 
 def higher_is_better(header):
     return any(t in header for t in HIGHER_BETTER)
+
+
+def is_latency(header):
+    """Lower-is-better and measured in nanoseconds (Time, p50, cold, latency)."""
+    h = header.lower()
+    return not higher_is_better(header) and "rss" not in h and "stored" not in h
 
 
 def human(header, value):
@@ -81,7 +87,6 @@ def human(header, value):
         if value >= 1073741824:
             return f"{value / 1073741824:.2f} GiB"
         return f"{value / 1048576:.1f} MiB"
-    # Latency-like (Time, p50/p90, cold, latency) is stored in nanoseconds.
     if value >= 1e9:
         return f"{value / 1e9:.2f} s"
     return f"{value / 1e6:.2f} ms"
@@ -108,8 +113,8 @@ def load_history(history_dir, report):
 
 
 def main_trend(history_maps, key, header, threshold):
-    """How `main` drifted across the window — a PR regression on a metric
-    main has already been pushing the wrong way is the case worth flagging.
+    """How `main` drifted across the window — a PR regression on a metric main
+    has already been pushing the wrong way is the case worth flagging.
     Returns (note, short), or (None, None) without enough points."""
     series = [m[key] for m in history_maps if key in m and m[key] != 0.0]
     if len(series) < 2 or series[0] == 0.0:
@@ -117,19 +122,20 @@ def main_trend(history_maps, key, header, threshold):
     drift = (series[-1] - series[0]) / series[0] * 100.0
     n = len(series)
     if abs(drift) < threshold:
-        return f"main stable ({drift:+.0f}% over {n}c)", "stable"
+        return f"main stable ({drift:+.0f}% over {n} commits)", "flat"
     improved = drift > 0 if higher_is_better(header) else drift < 0
     word = "improving" if improved else "worsening"
-    return f"main {word} {drift:+.0f}% over {n} commits", f"{drift:+.0f}%/{n}c"
+    short = f"{'better' if improved else 'worse'} {abs(drift):.0f}%"
+    return f"main {word} {drift:+.0f}% over {n} commits", short
 
 
 def diff(reports, baseline_dir, current_dir, history_dir, threshold):
     """Classify changes per report.
 
-    Returns (regressions, improvements, gates, had_baseline, cost_present).
+    Returns (regressions, improvements, had_baseline, cost_present).
     `had_baseline` distinguishes 'nothing moved' from 'nothing to compare'.
     """
-    regressions, improvements, gates = [], [], []
+    regressions, improvements = [], []
     had_baseline = False
     cost_present = False
     for report in reports:
@@ -146,22 +152,14 @@ def diff(reports, baseline_dir, current_dir, history_dir, threshold):
             _anchor, _subtitle, label, header = parts
             if "$" in key:
                 cost_present = True
-            # Recall is a hard gate, evaluated on its absolute value.
-            if "recall" in f"{label} {header}".lower():
-                breach = new < RECALL_GATE if new <= 1.0 else new < RECALL_GATE * 100
-                gates.append({
-                    "subsystem": subsystem,
-                    "metric": f"{label} / {header}".strip(" /"),
-                    "value": f"{new:.4f}" if new <= 1.0 else f"{new:.2f}",
-                    "breach": breach,
-                })
-                continue
             if is_text_only(header):
                 continue
             old = base.get(key)
             if old is None or old == 0.0:
                 continue
             had_baseline = True
+            if is_latency(header) and max(abs(old), abs(new)) < MIN_LATENCY_NS:
+                continue
             pct = (new - old) / old * 100.0
             if abs(pct) < threshold:
                 continue
@@ -171,53 +169,28 @@ def diff(reports, baseline_dir, current_dir, history_dir, threshold):
                 "subsystem": subsystem,
                 "area": area,
                 "metric": f"{label} / {header}".strip(" /"),
-                "old": human(header, old),
-                "new": human(header, new),
+                "change": f"{human(header, old)} → {human(header, new)}",
                 "pct": round(pct, 1),
-                "verdict": "improvement" if improved else "regression",
+                "is_cold": "cold" in header.lower(),
                 "main_trend": note,
-                "main_trend_short": short,
+                "main_trend_short": short or "—",
             }
             (improvements if improved else regressions).append(entry)
     regressions.sort(key=lambda e: -abs(e["pct"]))
     improvements.sort(key=lambda e: -abs(e["pct"]))
-    return regressions, improvements, gates, had_baseline, cost_present
+    return regressions, improvements, had_baseline, cost_present
 
 
-def verdict_badge(regressions, gates, failures, improvements):
-    if failures or any(g["breach"] for g in gates) or regressions:
-        return "🔴"
-    if improvements:
-        return "🟢"
-    return "⚪"
-
-
-def gate_table(gates):
-    breached = [g for g in gates if g["breach"]]
-    if not breached:
-        return ""
-    rows = ["| Gate | Subsystem | Value | Bar |", "|---|---|---|---|"]
-    for g in breached:
-        rows.append(f"| 🛑 {g['metric']} | {g['subsystem']} | {g['value']} | ≥ {RECALL_GATE} |")
-    return "\n".join(rows)
-
-
-def delta_table(regressions, improvements):
-    """Deterministic markdown table — the always-correct fallback body."""
-    rows = regressions[:MAX_ROWS] + improvements[:MAX_ROWS]
-    if not rows:
-        return "", 0
-    out = ["| Verdict | Subsystem | Metric | main | this run | Δ% | Main trend |",
-           "|---|---|---|---|---|---|---|"]
-    for e in rows:
-        mark = "🔴" if e["verdict"] == "regression" else "🟢"
-        trend = e.get("main_trend_short") or "—"
-        out.append(
-            f"| {mark} {e['verdict']} | {e['subsystem']} | {e['metric']} "
-            f"| {e['old']} | {e['new']} | {e['pct']:+.1f}% | {trend} |"
-        )
-    dropped = max(0, len(regressions) - MAX_ROWS) + max(0, len(improvements) - MAX_ROWS)
-    return "\n".join(out), dropped
+def table(rows):
+    out = ["| Subsystem | Metric | main → run | Δ | Main (10c) |",
+           "|---|---|---|---|---|"]
+    for e in rows[:MAX_ROWS]:
+        out.append(f"| {e['subsystem']} | {e['metric']} | {e['change']} "
+                   f"| {e['pct']:+.0f}% | {e['main_trend_short']} |")
+    extra = len(rows) - MAX_ROWS
+    if extra > 0:
+        out.append(f"| _+{extra} more_ | | | | |")
+    return "\n".join(out)
 
 
 def narrate(payload, endpoint, key, model):
@@ -225,21 +198,18 @@ def narrate(payload, endpoint, key, model):
     if not endpoint or not key:
         return None
     system = (
-        "You are a performance engineer summarizing benchmark results for a "
-        "pull-request reviewer. You are given a JSON payload of metric changes "
-        "ALREADY filtered to exceed the noise threshold, plus recall gate "
-        "checks and any run failures. Write a terse summary in GitHub markdown:\n"
-        "- Open with a one-line verdict (net regression / net improvement / mixed / clean).\n"
-        "- Call out failures and any breached gate FIRST and plainly.\n"
-        "- Then bullet the notable changes grouped by subsystem (Ingest, FTS, "
-        "Vector, SQL). Regressions before improvements.\n"
-        "- When a change has a 'main_trend', weave it in: a regression on a "
-        "metric main is already worsening is more serious than a one-off.\n"
+        "You are a performance engineer giving a PR reviewer the headline on a "
+        "benchmark run. You are given JSON of metric changes ALREADY filtered "
+        "past the noise threshold, plus any run failures. Write 2-5 lines of "
+        "GitHub markdown:\n"
+        "- Line 1: a one-line verdict (net regression / net improvement / mixed / clean).\n"
+        "- Then call out ONLY the biggest regressions and any failures, with the "
+        "main_trend woven in (a regression on a metric main was already worsening "
+        "is worse news). Do NOT restate every row — tables below carry the detail.\n"
         "- Cite ONLY numbers in the payload. Never invent or recompute a value.\n"
-        "- If there are no changes, no breached gates, and no failures, say "
+        "- If there are no changes and no failures, say "
         f"'No significant changes (within ±{payload['threshold']}%).'\n"
-        "Keep it to what a reviewer needs at a glance. No preamble, no sign-off, "
-        "no restating the raw table."
+        "No preamble, no sign-off, no tables."
     )
     body = json.dumps({
         "model": model,
@@ -263,10 +233,10 @@ def narrate(payload, endpoint, key, model):
     try:
         with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
             data = json.load(resp)
-        text = data["choices"][0]["message"]["content"].strip()
-        return text or None
+        text_out = data["choices"][0]["message"]["content"].strip()
+        return text_out or None
     except (urllib.error.URLError, OSError, ValueError, KeyError, IndexError) as exc:
-        print(f"::warning::Foundry summary unavailable ({exc}); using delta table", file=sys.stderr)
+        print(f"::warning::Foundry summary unavailable ({exc}); using tables", file=sys.stderr)
         return None
 
 
@@ -284,60 +254,53 @@ def main():
         threshold = DEFAULT_THRESHOLD
 
     failures = [ln.strip() for ln in os.environ.get("ERRORS", "").splitlines() if ln.strip()]
-    regressions, improvements, gates, had_baseline, cost_present = diff(
+    regressions, improvements, had_baseline, cost_present = diff(
         reports, baseline_dir, current_dir, history_dir, threshold)
 
-    payload = {
-        "threshold": threshold,
-        "regressions": regressions[:MAX_ROWS],
-        "improvements": improvements[:MAX_ROWS],
-        "gates": gates,
-        "failures": failures[:20],
-    }
-
     prose = narrate(
-        payload,
+        {
+            "threshold": threshold,
+            "regressions": regressions[:MAX_ROWS],
+            "improvements": improvements[:MAX_ROWS],
+            "failures": failures[:20],
+        },
         os.environ.get("AZURE_AI_ENDPOINT", ""),
         os.environ.get("AZURE_AI_API_KEY", ""),
         os.environ.get("AZURE_AI_MODEL", DEFAULT_MODEL),
     )
 
-    badge = verdict_badge(regressions, gates, failures, improvements)
-    parts = [f"## {badge} Benchmark `{label}` — significant changes (±{threshold:g}% threshold)", ""]
+    badge = "🔴" if (failures or regressions) else ("🟢" if improvements else "⚪")
+    counts = f"{len(regressions)} regression(s) · {len(improvements)} improvement(s)"
+    parts = [f"## {badge} Benchmark `{label}` — {counts} (±{threshold:g}% vs main)", ""]
 
     if prose:
         parts += [prose, ""]
-    else:
-        # Deterministic fallback body: gates + failures + the delta table.
-        if not had_baseline:
-            parts += ["_No `main` baseline to diff against (first run or new config) — see the full report._", ""]
-        elif not regressions and not improvements and not gates:
-            parts += [f"No significant changes (within ±{threshold:g}%).", ""]
-        gt = gate_table(gates)
-        if gt:
-            parts += ["### 🛑 Gate breach", gt, ""]
-        if failures:
-            parts += ["### 🛑 Failures", "```", "\n".join(failures[:20]), "```", ""]
+    elif failures:
+        parts += ["### 🛑 Failures", "```", "\n".join(failures[:20]), "```", ""]
+    elif not had_baseline:
+        parts += ["_No `main` baseline to diff against (first run or new config) — see the full report._", ""]
+    elif not regressions and not improvements:
+        parts += [f"No significant changes (within ±{threshold:g}%).", ""]
 
-    table, dropped = delta_table(regressions, improvements)
-    if table:
-        parts += ["<details><summary>Significant deltas vs <code>main</code></summary>", "", table]
-        if dropped:
-            parts += ["", f"_…and {dropped} more change(s) past threshold — see the full report._"]
-        parts += ["", "</details>", ""]
+    # Regressions are what gate a merge — keep them visible; fold improvements.
+    if regressions:
+        parts += [f"### 🔴 Regressions ({len(regressions)})", table(regressions), ""]
+    if improvements:
+        parts += [f"<details><summary>🟢 Improvements ({len(improvements)})</summary>",
+                  "", table(improvements), "", "</details>", ""]
 
-    # Source-area hints for the subsystems that actually moved.
-    touched = {}
-    for e in regressions + improvements:
-        if e.get("area"):
-            touched[e["subsystem"]] = e["area"]
-    if touched:
-        hints = " · ".join(f"{s} → `{a}`" for s, a in sorted(touched.items()))
-        parts += [f"_Where to look: {hints}_", ""]
-
-    if cost_present:
-        parts += ["_Cost metrics (bytes / requests / queries-per-$) are not delta-tracked "
-                  "(volatile keys) — check the full report._", ""]
+    if regressions or improvements:
+        parts.append("_`main → run` = baseline vs this PR · `Main (10c)` = how main "
+                     "itself trended over its last ≤10 commits._")
+        touched = {e["subsystem"]: e["area"] for e in regressions + improvements if e.get("area")}
+        if touched:
+            parts.append("_Where to look: " + " · ".join(
+                f"{s} → `{a}`" for s, a in sorted(touched.items())) + "_")
+        if any(e["is_cold"] for e in regressions + improvements):
+            parts.append("_Cold metrics are single-run and noisy — treat large cold deltas as directional._")
+        if cost_present:
+            parts.append("_Cost metrics (bytes / requests / queries-per-$) are not delta-tracked — see the full report._")
+        parts.append("")
 
     if run_url:
         parts.append(f"[Full report & logs ↗]({run_url})")
@@ -346,7 +309,7 @@ def main():
     with open(out_file, "w", encoding="utf-8") as fh:
         fh.write(body)
     print(f"wrote {out_file}: {len(regressions)} regression(s), {len(improvements)} "
-          f"improvement(s), {len(gates)} gate(s), {len(failures)} failure line(s), "
+          f"improvement(s), {len(failures)} failure line(s), "
           f"baseline={'yes' if had_baseline else 'no'}")
 
 

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -60,6 +60,11 @@ on:
         required: false
         default: ""
         type: string
+      noise_threshold_pct:
+        description: "Min |Δ%| vs main to flag in the PR comment; smaller is noise."
+        required: false
+        default: "10"
+        type: string
   # Callable from other workflows (e.g. the PR group in ci.yml). Same
   # inputs; `choice` isn't valid here so `bench` is a string.
   workflow_call:
@@ -81,6 +86,8 @@ on:
       skip_calibration: { type: boolean, required: false, default: false }
       # PR to post the sticky results comment on. Blank ⇒ summary only.
       pr_number:       { type: string, required: false, default: "" }
+      # Min |Δ%| vs main to flag in the PR comment; smaller is noise.
+      noise_threshold_pct: { type: string, required: false, default: "10" }
 
 permissions:
   id-token: write       # Azure OIDC federated login
@@ -111,6 +118,14 @@ jobs:
     # Auto-stop ceiling on VM billing; teardown runs on timeout.
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     steps:
+      # The bench itself builds/runs on the VM, but the runner needs the repo
+      # for the AI-summary script. Match the ref under test so the summarizer
+      # tracks the PR. Cleans the workdir, so it must precede baseline staging.
+      - name: Checkout (runner-side tooling)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
       - name: Resolve bench selection
         id: resolve
         run: |
@@ -288,12 +303,16 @@ jobs:
         run: |
           set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          # Stage the main baseline JSONs on the runner too — the AI-summary
+          # step diffs them against this run's metrics (scp'd back later).
+          mkdir -p baseline
           ssh -o StrictHostKeyChecking=no "${ADMIN}@${VM_IP}" \
             "mkdir -p infino-src/target/infino-bench"
           for j in $REPORTS; do
             blob="bench/${j}/baseline/${VM_SIZE}-${DOCS}.json"
             if az storage blob download --account-name "$ACC" --account-key "$KEY" \
                  -c "$CONTAINER" -n "$blob" -f "${j}.json" 2>/dev/null; then
+              cp "${j}.json" "baseline/${j}.json"
               # Best-effort: a transient scp flake must not fail the bench —
               # the run just renders "(new)" without the baseline.
               if scp -o StrictHostKeyChecking=no "${j}.json" \
@@ -540,6 +559,8 @@ jobs:
           # Panics, runtime errors, and compile errors (error[E…]); the
           # panic line carries the full chain.
           ERRORS="$(grep -nE 'panicked|error\[|HTTP error|storage error|transient error|AppendFlush|PointerParse|child exited|no shapes produced|skipped:|content-hash mismatch|short read' "$LOG" || true)"
+          # Hand the error lines to the AI-summary step (same job, /tmp persists).
+          printf '%s\n' "$ERRORS" > /tmp/bench.errors
           if [ -n "$ERRORS" ]; then
             {
               echo "### 🛑 Errors & panics"
@@ -573,6 +594,79 @@ jobs:
             exit 1
           fi
 
+      # Pull this run's metric JSONs off the VM so the AI-summary step can diff
+      # them against the staged main baseline. Best-effort per report.
+      - name: Collect current metrics
+        if: ${{ always() && inputs.pr_number != '' }}
+        env:
+          REPORTS: ${{ steps.resolve.outputs.reports }}
+        run: |
+          set -uo pipefail
+          VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          mkdir -p current
+          for j in $REPORTS; do
+            scp -o StrictHostKeyChecking=no \
+              "${ADMIN}@${VM_IP}:infino-src/target/infino-bench/${j}.json" "current/${j}.json" \
+              2>/dev/null && echo "collected: $j" \
+              || echo "no metrics for $j — skipping"
+          done
+
+      # Last ≤10 main-history points per report, so the summary can say whether
+      # a flagged metric is a one-off or part of a sustained drift on main.
+      # Best-effort: a missing series just drops the trend annotation.
+      - name: Collect main history
+        if: ${{ always() && inputs.pr_number != '' }}
+        env:
+          ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
+          CONTAINER: ${{ secrets.INFINO_REAL_AZURE_CONTAINER }}
+          VM_SIZE: ${{ inputs.vm_size }}
+          DOCS: ${{ inputs.docs }}
+          REPORTS: ${{ steps.resolve.outputs.reports }}
+        run: |
+          set -uo pipefail
+          mkdir -p history
+          for j in $REPORTS; do
+            mkdir -p "history/$j"
+            # Oldest→newest by commit time; keep the last 10.
+            blobs="$(az storage blob list -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
+                       --prefix "bench/${j}/history/${VM_SIZE}-${DOCS}-" --include m \
+                       --query '[].{name:name, ts:metadata.ts, sha:metadata.sha}' -o tsv 2>/dev/null \
+                     | sort -k2 -n | tail -10)"
+            i=0
+            while IFS=$'\t' read -r name _ts sha; do
+              [ -n "$name" ] || continue
+              # Index prefix preserves chronological order under lexical sort.
+              idx="$(printf '%02d' "$i")"
+              az storage blob download -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
+                -n "$name" -f "history/${j}/${idx}-${sha:0:7}.json" -o none 2>/dev/null \
+                || echo "::warning::history download failed for $j ($sha)"
+              i=$((i + 1))
+            done <<< "$blobs"
+          done
+
+      # Diff vs main, keep only changes past the threshold, and have Foundry
+      # narrate them. Falls back to the deterministic delta table on any model
+      # failure or missing creds — the comment is always correct.
+      - name: AI summary
+        if: ${{ always() && inputs.pr_number != '' }}
+        env:
+          REPORTS: ${{ steps.resolve.outputs.reports }}
+          BASELINE_DIR: baseline
+          CURRENT_DIR: current
+          HISTORY_DIR: history
+          OUT_FILE: /tmp/ai-summary.md
+          BENCH_LABEL: ${{ inputs.bench }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BENCH_NOISE_THRESHOLD_PCT: ${{ inputs.noise_threshold_pct }}
+          AZURE_AI_ENDPOINT: ${{ secrets.AZURE_AI_ENDPOINT }}
+          AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
+        run: |
+          set -uo pipefail
+          # Error lines captured by the Summarize step (empty file if none).
+          ERRORS="$(cat /tmp/bench.errors 2>/dev/null || true)" \
+            python3 .github/scripts/bench_summary.py
+
       # Sticky PR comment, one per matrix leg. The hidden marker lets a new
       # push edit in place instead of stacking comments.
       - name: Post results to PR
@@ -585,9 +679,14 @@ jobs:
             const fs = require('fs');
             // GitHub caps comment bodies at 65536 chars; full output is the artifact.
             const LIMIT = 60000;
+            // The lean AI summary is the comment body; the full report stays in
+            // the run's step summary + the uploaded log artifact.
             let body;
-            try { body = fs.readFileSync('/tmp/summary.md', 'utf8'); }
-            catch { body = '_No summary produced — see the run logs._'; }
+            try { body = fs.readFileSync('/tmp/ai-summary.md', 'utf8'); }
+            catch {
+              try { body = fs.readFileSync('/tmp/summary.md', 'utf8'); }
+              catch { body = '_No summary produced — see the run logs._'; }
+            }
             if (body.length > LIMIT) {
               body = body.slice(0, LIMIT) + '\n\n_…truncated — see the artifact._';
             }


### PR DESCRIPTION
## What

The Azure bench workflow posted the **entire** raw report as the PR comment, burying the few metrics that actually moved under run-to-run noise.

This replaces the comment body with a focused summary:

- Diff this run against the `main` baseline; keep only changes past a configurable threshold (`noise_threshold_pct`, default ±10%, both directions).
- Annotate each change with how `main` itself has been trending (one-off vs sustained drift).
- Flag recall-gate breaches (`< 0.99`) regardless of % delta.
- Foundry narrates; **percentages are computed in the script, never by the model**.
- On any model failure or missing creds → deterministic delta table, so the comment is always correct.
- Full raw report stays in the run's step summary + log artifact, linked from the comment.

## Changes

- New `noise_threshold_pct` input.
- Runner-side checkout, baseline staging, current-metrics + main-history scp-back, AI-summary step, comment swap.
- New stdlib-only `.github/scripts/bench_summary.py`.

## Notes

- No source/bench changes — workflow + one script only.
- Reuses the existing `AZURE_AI_ENDPOINT` / `AZURE_AI_API_KEY` secrets; the AI key stays runner-side, never sent to the VM.
- Recall gate is matched by key pattern; worth confirming it fires on a real run.