### PR TITLE
ci: run the Python RAG examples end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,46 @@ jobs:
       # Builds the extension + runs the smoke tests (self-contained venv).
       - run: make python-test
 
+  python-examples:
+    name: Python examples (end to end)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Build infino as a normal dep — don't fail on a transitive deprecation warning.
+    env:
+      RUSTFLAGS: ""
+      # Azure LLM creds; absent on fork PRs, where notebooks print context instead.
+      AZURE_AI_ENDPOINT: ${{ secrets.AZURE_AI_ENDPOINT }}
+      AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
+      DEFAULT_AZURE_MODEL: gpt-5.4
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: infino-python
+      # Cache the model + dataset samples the notebooks download.
+      - name: Cache HuggingFace assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ runner.os }}-${{ hashFiles('infino-python/examples/_shared/loaders.py', 'infino-python/examples/_shared/embedding.py') }}
+          restore-keys: hf-${{ runner.os }}-
+      # Run every notebook; the LLM answer step runs when the secrets are present.
+      - run: make python-examples-test
+
   python-wheels:
     name: Wheel (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
         coverage coverage-summary \
         bench bench-quick miri asan ci clean \
         public-api public-api-update \
-        python-test python-wheel \
+        python-test python-wheel python-examples-test \
         node-test node-build node-verify
 
 check:
@@ -115,6 +115,26 @@ python-wheel:
 	python3 -m venv infino-python/.venv
 	infino-python/.venv/bin/pip install -q --upgrade pip maturin
 	infino-python/.venv/bin/maturin build --release --locked --out infino-python/dist -m infino-python/Cargo.toml
+
+# Build the bindings from source, install the examples' deps, and run every
+# notebook with nbconvert (a failing cell fails the target). Scratch tables are
+# cleaned afterwards; the venv is a reused throwaway (gitignored).
+python-examples-test:
+	python3 -m venv infino-python/.venv
+	infino-python/.venv/bin/pip install -q --upgrade pip maturin
+	VIRTUAL_ENV=$(CURDIR)/infino-python/.venv infino-python/.venv/bin/maturin develop --locked -m infino-python/Cargo.toml
+	# Drop infino from the requirements; the from-source build above is what runs.
+	grep -v '^[[:space:]]*infino' infino-python/examples/requirements.txt \
+		| infino-python/.venv/bin/pip install -q -r /dev/stdin
+	infino-python/.venv/bin/pip install -q nbconvert ipykernel
+	@status=0; \
+	for nb in infino-python/examples/[0-9]*.ipynb; do \
+		echo "executing $$nb"; \
+		infino-python/.venv/bin/python -m nbconvert --to notebook --execute \
+			--stdout --ExecutePreprocessor.timeout=900 "$$nb" >/dev/null || { status=1; break; }; \
+	done; \
+	rm -rf infino-python/examples/*_data infino-python/examples/_shared/__pycache__; \
+	exit $$status
 
 # Node bindings (napi-rs). Built standalone — `infino-node` is excluded
 # from the cargo workspace, so the core crate never needs a Node

--- a/infino-python/examples/_shared/embedding.py
+++ b/infino-python/examples/_shared/embedding.py
@@ -4,7 +4,6 @@ Swap in a hosted embedder by editing `embed` / `embed_query` and `DIM` / `METRIC
 """
 
 import os
-import threading
 
 import pyarrow as pa
 
@@ -17,20 +16,17 @@ DIM = 384          # must match the vector index dim
 METRIC = "cosine"  # MiniLM outputs are normalized
 
 _model = None
-_model_lock = threading.Lock()
 
 
 def _get_model():
-    """Load the model once, lazily."""
+    """Load the embedding model once, on first use."""
     global _model
     if _model is None:
-        with _model_lock:
-            if _model is None:
-                from sentence_transformers import SentenceTransformer
-                from transformers.utils import logging as hf_logging
+        from sentence_transformers import SentenceTransformer
+        from transformers.utils import logging as hf_logging
 
-                hf_logging.set_verbosity_error()
-                _model = SentenceTransformer(MODEL_NAME)
+        hf_logging.set_verbosity_error()
+        _model = SentenceTransformer(MODEL_NAME)
     return _model
 
 

--- a/infino-python/examples/_shared/llm.py
+++ b/infino-python/examples/_shared/llm.py
@@ -49,20 +49,12 @@ def _client_and_model():
     return None, None
 
 
-def have_llm() -> bool:
-    """True if an LLM backend is configured."""
-    client, _ = _client_and_model()
-    return client is not None
-
-
-def complete(prompt: str, system: str | None = None) -> str | None:
-    """Generate a completion, or return None if no LLM is configured."""
+def complete(prompt: str) -> str | None:
+    """Answer `prompt` with the configured LLM, or return None if none is set."""
     client, model = _client_and_model()
     if client is None:
         return None
-    messages = []
-    if system:
-        messages.append({"role": "system", "content": system})
-    messages.append({"role": "user", "content": prompt})
-    reply = client.chat.completions.create(model=model, messages=messages)
+    reply = client.chat.completions.create(
+        model=model, messages=[{"role": "user", "content": prompt}]
+    )
     return reply.choices[0].message.content


### PR DESCRIPTION
## What

Adds a CI job that runs the `infino-python/examples/` notebooks end to end against a **from-source** build of the bindings, so the examples can't silently rot.

- **`make python-examples-test`** — builds the extension with `maturin develop` (not the published wheel), installs the examples' dependencies with `infino` filtered out so the from-source build is what runs, then executes every notebook with `nbconvert`. A failing cell fails the target; per-run scratch tables are cleaned up afterwards (pass or fail).
- **`python-examples` job** in `ci.yml`, alongside the existing jobs. The LLM answer step runs when the Azure secrets are present; on fork PRs (no secrets) the notebooks fall back to printing retrieved context, so the job still passes.

Also drops a little speculative code from the example helpers (unused `have_llm()`, `complete()`'s never-passed `system` param, and a single-thread-only lock) — surfaced while reviewing the examples for the CI run.

## Why

The examples are the front door for the Python package; this guarantees they actually run on the current bindings on every change, instead of being validated by hand.

## Notes for reviewers

- Scoped to the bindings + examples flow; core changes are already covered by the `python` job.
- To make this merge-blocking, add **Python examples (end to end)** to the required-checks list.
- Verified locally: `make python-examples-test` is green end to end, and failure propagation (failing cell → non-zero `nbconvert` → non-zero recipe → red job) is confirmed.