### PR TITLE
ci: answer /ask replies on inline review comments

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   contents: read


### PR DESCRIPTION
Lets the reviewer respond in-thread to inline review comments.

## Change
- `pr-review.yml`: subscribe to `pull_request_review_comment` (created).

## Usage
Reply on any inline review comment with `/ask <question>` — the bot answers in-thread with the line context.

## Notes
- OSS supports `/ask`-prefixed replies only; free-text auto-reply is not available.
- Like other comment events, this runs the workflow from `main`, so it takes effect once merged.