### PR TITLE
docs/ci: document and verify uv install for the Python package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,15 @@ jobs:
         with:
           workspaces: infino-python
       - run: make python-wheel
+      # The README advertises `uv pip install infino`; verify that path
+      # against the freshly built wheel, not just pip.
+      - name: Smoke-test wheel with uv
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade uv
+          uv venv /tmp/uv-smoke
+          uv pip install --python /tmp/uv-smoke infino-python/dist/*.whl pytest pyarrow pandas
+          /tmp/uv-smoke/bin/python -m pytest infino-python/tests/ -v
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@
 ```sh
 # Install from TestPyPI.
 pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ infino
+
+# Or with uv (https://docs.astral.sh/uv/):
+uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ infino
 ```
 
 **Node.js**

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -23,6 +23,13 @@ as `pyarrow` objects, and every search returns a `pyarrow.Table`.
 pip install infino
 ```
 
+Or with [uv](https://docs.astral.sh/uv/):
+
+```sh
+uv add infino            # add to a uv-managed project
+uv pip install infino    # install into the active environment
+```
+
 Requires Python 3.9 or newer. `pyarrow` is installed as a dependency;
 `pandas` is optional and used only if you pass DataFrames.
 
@@ -290,6 +297,15 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install maturin pytest pyarrow
 maturin develop          # compile the extension and install it into the venv
 pytest tests/
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```sh
+uv venv && source .venv/bin/activate
+uv pip install maturin pytest pyarrow
+maturin develop          # compile the extension and install it into the venv
+uv run pytest tests/
 ```
 
 ## License


### PR DESCRIPTION
## What

- Document installing the Python package with **uv** alongside pip — in both the root `README.md` and `infino-python/README.md` (install + build-from-source).
- Smoke-test the freshly built wheel through the uv install path in the `python-wheels` CI job, so the instructions stay honest.

## Why

The READMEs only showed `pip`. uv is a common installer for Python users, and an advertised install path should be exercised by CI rather than left untested.

## CI change

In `python-wheels`, after `make python-wheel`: bootstrap uv with pip, create a clean `uv venv`, `uv pip install` the wheel, and run the test suite against it. Mirrors the existing pip-based smoke test in `publish-python.yml`, exercising the uv path instead.

## Validation

- `ci.yml` YAML parses.
- Rebuilt a fresh wheel locally and ran the exact CI step (`uv pip install <wheel>` + pytest): **24 passed**.

Two commits, kept separate: docs, then CI.