### PR TITLE
feat manifest: add cache for manifest parts

### DIFF
--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -87,6 +87,12 @@ storage:
   # while background fill promotes the full superfile to mmap.
   disk_cache_root:
   disk_budget_bytes: 10737418240
+  # Byte budget for the content-addressed manifest-part cache, held in a
+  # manifest-parts/ subdirectory of disk_cache_root. On a hit the part
+  # loader reads bytes from local disk instead of object storage; parts
+  # are content-addressed, so cached files are never stale and survive
+  # restarts. Independent of disk_budget_bytes. Default 2 GiB.
+  manifest_disk_budget_bytes: 2147483648
   cold_fetch_mode: lazy_foreground_with_background_fill
   cold_fetch_streams: 8
   cold_fetch_chunk_bytes: 4194304

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -247,6 +247,12 @@ pub struct StorageSettings {
     /// through the object-store lazy/cached path.
     pub disk_cache_root: Option<PathBuf>,
     pub disk_budget_bytes: u64,
+    /// Byte budget for the content-addressed manifest-part cache, kept
+    /// in a `manifest-parts/` subdirectory of `disk_cache_root`. The
+    /// loader reads part bytes from local disk on a hit instead of
+    /// fetching from object storage. Independent of `disk_budget_bytes`
+    /// (which sizes the superfile-content cache). Default 2 GiB.
+    pub manifest_disk_budget_bytes: u64,
     pub cold_fetch_mode: StorageColdFetchMode,
     pub cold_fetch_streams: usize,
     pub cold_fetch_chunk_bytes: u64,
@@ -274,6 +280,7 @@ impl Default for StorageSettings {
             prefix: String::new(),
             disk_cache_root: None,
             disk_budget_bytes: DEFAULT_DISK_BUDGET_BYTES,
+            manifest_disk_budget_bytes: DEFAULT_MANIFEST_DISK_BUDGET_BYTES,
             cold_fetch_mode: StorageColdFetchMode::LazyForegroundWithBackgroundFill,
             cold_fetch_streams: DEFAULT_COLD_FETCH_STREAMS,
             cold_fetch_chunk_bytes: DEFAULT_COLD_FETCH_CHUNK_BYTES,
@@ -286,6 +293,9 @@ impl Default for StorageSettings {
 
 /// Default disk-cache byte budget exposed in the shipped config (10 GiB).
 const DEFAULT_DISK_BUDGET_BYTES: u64 = 10 * (1 << 30);
+/// Default manifest-part cache byte budget (2 GiB). Parts are small
+/// (KB–few MB each), so this holds a large working set of parts.
+const DEFAULT_MANIFEST_DISK_BUDGET_BYTES: u64 = 2 * (1 << 30);
 /// Default parallel cold-fetch streams at the config layer.
 const DEFAULT_COLD_FETCH_STREAMS: usize = 8;
 /// Default cold-fetch range chunk size (4 MiB).

--- a/src/supertable/manifest/disk_cache.rs
+++ b/src/supertable/manifest/disk_cache.rs
@@ -1,0 +1,515 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! [`ManifestDiskCache`] — a content-addressed on-disk cache for the
+//! compressed (Avro+zstd) bytes of manifest parts.
+//!
+//! Manifest parts are immutable and addressed by the blake3 hash of
+//! their compressed bytes (see [`crate::supertable::manifest::part`]).
+//! That makes them an ideal disk-cache target: the content hash is the
+//! key, so a cached file can never be stale — if the logical content
+//! changes, the hash changes, and the new content lands under a new
+//! filename. No invalidation logic is needed; old files simply become
+//! eviction candidates.
+//!
+//! ## What this buys
+//!
+//! [`ManifestPartLoader`](super::ManifestPartLoader) consults this
+//! cache before issuing a `StorageProvider::get`. On a hit the part
+//! bytes come off local disk instead of object storage, eliminating
+//! the network round-trip (the dominant cost on a cold part load over
+//! S3). The cache also survives process restarts: the on-disk files
+//! persist and the in-memory accounting index is rebuilt by a
+//! directory scan at construction.
+//!
+//! ## What this does NOT cache
+//!
+//! Superfile *byte content* is cached one layer over, by
+//! [`DiskCacheStore`](crate::supertable::reader_cache::DiskCacheStore).
+//! This cache holds only manifest-part bytes. The two caches are
+//! independent and use separate byte budgets.
+
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Instant,
+};
+
+use dashmap::{DashMap, Entry};
+
+use crate::supertable::manifest::part::ContentHash;
+
+/// File-name prefix for a cached manifest part. The blake3 hex of the
+/// part's compressed bytes follows; the `.avro.zst` suffix mirrors the
+/// storage-side layout so the on-disk file is self-describing.
+const CACHE_FILE_PREFIX: &str = "part-";
+/// File-name suffix for a cached manifest part. Matches the
+/// storage-side part object naming.
+const CACHE_FILE_SUFFIX: &str = ".avro.zst";
+/// File-name suffix for an in-flight cache write, atomically renamed
+/// onto the final name once the bytes are durable.
+const CACHE_TMP_SUFFIX: &str = ".tmp";
+
+/// Per-entry bookkeeping for the in-memory accounting index. The bytes
+/// themselves live on disk; this only tracks what eviction needs.
+struct CacheEntry {
+    size_bytes: u64,
+    /// Microseconds-since-construction of the last access. Monotonic
+    /// per [`ManifestDiskCache`] instance; drives LRU eviction.
+    last_access_us: AtomicU64,
+}
+
+/// Snapshot of the manifest cache's load. Surfaced via
+/// [`ManifestDiskCache::stats`] for tests and observability.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ManifestCacheStats {
+    pub n_entries: u64,
+    pub current_bytes: u64,
+    pub budget_bytes: u64,
+    pub n_hits: u64,
+    pub n_misses: u64,
+    pub n_evictions: u64,
+}
+
+/// Content-addressed disk cache for manifest-part bytes.
+///
+/// Construction is sync (a directory scan); `get` / `put` are async
+/// because file I/O is handed to `tokio::fs` so tokio workers aren't
+/// blocked on the syscall. Verification (blake3 over the cached bytes)
+/// runs inline, matching the loader's existing hash check.
+pub struct ManifestDiskCache {
+    cache_root: PathBuf,
+    budget_bytes: u64,
+    started_at: Instant,
+    /// Accounting index: content hash → size + last-access. The bytes
+    /// are on disk under [`Self::cache_path`]; this map exists only so
+    /// eviction can pick victims without stat-ing the directory.
+    entries: DashMap<ContentHash, CacheEntry>,
+    current_bytes: AtomicU64,
+    n_hits: AtomicU64,
+    n_misses: AtomicU64,
+    n_evictions: AtomicU64,
+}
+
+impl ManifestDiskCache {
+    /// Construct a cache rooted at `cache_root` (created if absent)
+    /// with a byte budget of `budget_bytes`. Scans `cache_root` for
+    /// pre-existing `part-<hex>.avro.zst` files and seeds the
+    /// accounting index from them, so a freshly-opened process reuses
+    /// the parts a prior run cached (restart survival).
+    pub fn new(cache_root: PathBuf, budget_bytes: u64) -> std::io::Result<Arc<Self>> {
+        fs::create_dir_all(&cache_root)?;
+        let cache = Self {
+            cache_root,
+            budget_bytes,
+            started_at: Instant::now(),
+            entries: DashMap::new(),
+            current_bytes: AtomicU64::new(0),
+            n_hits: AtomicU64::new(0),
+            n_misses: AtomicU64::new(0),
+            n_evictions: AtomicU64::new(0),
+        };
+        cache.scan_existing();
+        Ok(Arc::new(cache))
+    }
+
+    /// Walk the cache directory and register every well-formed cache
+    /// file in the accounting index. A leftover `.tmp` file (an
+    /// interrupted write) is removed. Unparseable names are ignored.
+    fn scan_existing(&self) {
+        let Ok(read_dir) = fs::read_dir(&self.cache_root) else {
+            return;
+        };
+        let now = self.now_us();
+        for dirent in read_dir.flatten() {
+            let path = dirent.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if name.ends_with(CACHE_TMP_SUFFIX) {
+                let _ = fs::remove_file(&path);
+                continue;
+            }
+            let Some(hash) = parse_cache_filename(name) else {
+                continue;
+            };
+            let Ok(meta) = dirent.metadata() else {
+                continue;
+            };
+            let size = meta.len();
+            self.entries.insert(
+                hash,
+                CacheEntry {
+                    size_bytes: size,
+                    last_access_us: AtomicU64::new(now),
+                },
+            );
+            self.current_bytes.fetch_add(size, Ordering::AcqRel);
+        }
+    }
+
+    /// Look up a part's compressed bytes by content hash.
+    ///
+    /// Returns `Some(bytes)` on a verified hit and `None` on a miss.
+    /// The cached bytes are re-hashed and compared against the
+    /// requested `hash`; a mismatch (disk corruption) is treated as a
+    /// miss and the bad file is removed, so the loader transparently
+    /// falls back to storage.
+    pub async fn get(&self, hash: &ContentHash) -> Option<Vec<u8>> {
+        // Fast negative: not in the accounting index ⇒ not cached.
+        if !self.entries.contains_key(hash) {
+            self.n_misses.fetch_add(1, Ordering::AcqRel);
+            return None;
+        }
+        let path = self.cache_path(hash);
+        let bytes = match tokio::fs::read(&path).await {
+            Ok(b) => b,
+            Err(_) => {
+                // File vanished out from under the index (manual
+                // delete, external eviction). Drop the stale entry.
+                self.drop_entry(hash);
+                self.n_misses.fetch_add(1, Ordering::AcqRel);
+                return None;
+            }
+        };
+        // Content-addressing guarantee: the bytes must hash to the key.
+        // A mismatch means on-disk corruption — discard and miss.
+        if ContentHash::of(&bytes) != *hash {
+            let _ = tokio::fs::remove_file(&path).await;
+            self.drop_entry(hash);
+            self.n_misses.fetch_add(1, Ordering::AcqRel);
+            return None;
+        }
+        if let Some(entry) = self.entries.get(hash) {
+            entry.last_access_us.store(self.now_us(), Ordering::Release);
+        }
+        self.n_hits.fetch_add(1, Ordering::AcqRel);
+        Some(bytes)
+    }
+
+    /// Insert a part's compressed bytes under its content hash.
+    ///
+    /// Best-effort: the cache is a pure optimization, so any failure
+    /// (budget exhausted with no evictable victims, I/O error) is
+    /// swallowed — the caller already holds the bytes and can proceed.
+    /// Idempotent: an already-cached hash is a no-op. `hash` must be
+    /// the blake3 of `bytes`; the caller (the loader) has already
+    /// verified this.
+    pub async fn put(&self, hash: ContentHash, bytes: &[u8]) {
+        if self.entries.contains_key(&hash) {
+            return;
+        }
+        let size = bytes.len() as u64;
+        // A single part larger than the whole budget can never fit;
+        // don't bother evicting everything for a doomed insert.
+        if size > self.budget_bytes {
+            return;
+        }
+        if !self.reserve(size) {
+            return;
+        }
+
+        let final_path = self.cache_path(&hash);
+        let tmp_path = self.tmp_path(&hash);
+        let write_result = async {
+            tokio::fs::write(&tmp_path, bytes).await?;
+            tokio::fs::rename(&tmp_path, &final_path).await
+        }
+        .await;
+
+        if write_result.is_err() {
+            // Roll back the reservation; leave no partial tmp behind.
+            self.current_bytes.fetch_sub(size, Ordering::Release);
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return;
+        }
+
+        // Commit into the accounting index. If a concurrent put raced
+        // us to the same hash, release our reservation — the file on
+        // disk is byte-identical either way (content addressing).
+        match self.entries.entry(hash) {
+            Entry::Vacant(v) => {
+                v.insert(CacheEntry {
+                    size_bytes: size,
+                    last_access_us: AtomicU64::new(self.now_us()),
+                });
+            }
+            Entry::Occupied(_) => {
+                self.current_bytes.fetch_sub(size, Ordering::Release);
+            }
+        }
+    }
+
+    /// Reserve `size` bytes of budget, evicting LRU victims as needed.
+    /// Returns `false` if the budget can't be made to fit (every entry
+    /// got evicted and there still isn't room — only possible under a
+    /// race, since oversized parts are rejected before calling this).
+    fn reserve(&self, size: u64) -> bool {
+        loop {
+            let cur = self.current_bytes.load(Ordering::Acquire);
+            if cur + size <= self.budget_bytes {
+                if self
+                    .current_bytes
+                    .compare_exchange_weak(cur, cur + size, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return true;
+                }
+                continue;
+            }
+            let needed = (cur + size).saturating_sub(self.budget_bytes);
+            if !self.evict_at_least(needed) {
+                return false;
+            }
+        }
+    }
+
+    /// Evict least-recently-accessed entries until at least
+    /// `bytes_needed` is freed. Returns `false` if there were no
+    /// entries left to evict before reaching the target.
+    fn evict_at_least(&self, bytes_needed: u64) -> bool {
+        let mut candidates: Vec<(ContentHash, u64, u64)> = self
+            .entries
+            .iter()
+            .map(|e| {
+                (
+                    *e.key(),
+                    e.value().size_bytes,
+                    e.value().last_access_us.load(Ordering::Acquire),
+                )
+            })
+            .collect();
+        // Oldest-access first.
+        candidates.sort_by_key(|(_, _, last)| *last);
+
+        let mut freed = 0u64;
+        for (hash, size, _) in candidates {
+            if freed >= bytes_needed {
+                break;
+            }
+            // Atomic gate: only the caller that wins the remove runs
+            // the unlink + decrement, so concurrent evictions of the
+            // same victim can't double-count.
+            if self.entries.remove(&hash).is_some() {
+                let _ = fs::remove_file(self.cache_path(&hash));
+                self.current_bytes.fetch_sub(size, Ordering::Release);
+                self.n_evictions.fetch_add(1, Ordering::AcqRel);
+                freed = freed.saturating_add(size);
+            }
+        }
+        freed >= bytes_needed
+    }
+
+    /// Remove an entry from the accounting index and release its
+    /// reserved bytes. The on-disk file is left to the caller.
+    fn drop_entry(&self, hash: &ContentHash) {
+        if let Some((_, entry)) = self.entries.remove(hash) {
+            self.current_bytes
+                .fetch_sub(entry.size_bytes, Ordering::Release);
+        }
+    }
+
+    /// Snapshot of the cache's load. Cheap: reads atomics + a
+    /// `DashMap::len`.
+    pub fn stats(&self) -> ManifestCacheStats {
+        ManifestCacheStats {
+            n_entries: self.entries.len() as u64,
+            current_bytes: self.current_bytes.load(Ordering::Acquire),
+            budget_bytes: self.budget_bytes,
+            n_hits: self.n_hits.load(Ordering::Acquire),
+            n_misses: self.n_misses.load(Ordering::Acquire),
+            n_evictions: self.n_evictions.load(Ordering::Acquire),
+        }
+    }
+
+    fn now_us(&self) -> u64 {
+        self.started_at.elapsed().as_micros() as u64
+    }
+
+    fn cache_path(&self, hash: &ContentHash) -> PathBuf {
+        self.cache_root.join(cache_filename(hash))
+    }
+
+    fn tmp_path(&self, hash: &ContentHash) -> PathBuf {
+        self.cache_root
+            .join(format!("{}{CACHE_TMP_SUFFIX}", cache_filename(hash)))
+    }
+}
+
+impl std::fmt::Debug for ManifestDiskCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ManifestDiskCache")
+            .field("cache_root", &self.cache_root)
+            .field("budget_bytes", &self.budget_bytes)
+            .field("current_bytes", &self.current_bytes.load(Ordering::Acquire))
+            .field("n_entries", &self.entries.len())
+            .finish()
+    }
+}
+
+/// Build the on-disk file name for a cached part: `part-<hex>.avro.zst`.
+fn cache_filename(hash: &ContentHash) -> String {
+    format!("{CACHE_FILE_PREFIX}{}{CACHE_FILE_SUFFIX}", hash.to_hex())
+}
+
+/// Parse a cache file name back into its [`ContentHash`]. Returns
+/// `None` for any name that doesn't match the `part-<hex>.avro.zst`
+/// shape (so unrelated files in the directory are ignored).
+fn parse_cache_filename(name: &str) -> Option<ContentHash> {
+    let hex = name
+        .strip_prefix(CACHE_FILE_PREFIX)?
+        .strip_suffix(CACHE_FILE_SUFFIX)?;
+    ContentHash::from_hex(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic content hash for a payload (mirrors the loader's
+    /// own `ContentHash::of`).
+    fn hash_of(bytes: &[u8]) -> ContentHash {
+        ContentHash::of(bytes)
+    }
+
+    fn tmp_root(tag: &str) -> PathBuf {
+        // Unique-enough per test: the test name plus the entries this
+        // cache will hold. No Date/random in scripts, but std tests
+        // can use the process + a counter via the tag.
+        std::env::temp_dir().join(format!("infino-manifest-cache-test-{tag}"))
+    }
+
+    #[tokio::test]
+    async fn put_then_get_roundtrips() {
+        let root = tmp_root("roundtrip");
+        let _ = fs::remove_dir_all(&root);
+        let cache = ManifestDiskCache::new(root.clone(), 1 << 20).expect("cache");
+
+        let bytes = b"compressed-part-bytes".to_vec();
+        let h = hash_of(&bytes);
+        cache.put(h, &bytes).await;
+
+        let got = cache.get(&h).await.expect("hit");
+        assert_eq!(got, bytes);
+        let stats = cache.stats();
+        assert_eq!(stats.n_entries, 1);
+        assert_eq!(stats.n_hits, 1);
+        assert_eq!(stats.current_bytes, bytes.len() as u64);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn miss_on_unknown_hash() {
+        let root = tmp_root("miss");
+        let _ = fs::remove_dir_all(&root);
+        let cache = ManifestDiskCache::new(root.clone(), 1 << 20).expect("cache");
+        let h = hash_of(b"never-inserted");
+        assert!(cache.get(&h).await.is_none());
+        assert_eq!(cache.stats().n_misses, 1);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn put_is_idempotent() {
+        let root = tmp_root("idempotent");
+        let _ = fs::remove_dir_all(&root);
+        let cache = ManifestDiskCache::new(root.clone(), 1 << 20).expect("cache");
+        let bytes = b"abc".to_vec();
+        let h = hash_of(&bytes);
+        cache.put(h, &bytes).await;
+        cache.put(h, &bytes).await;
+        assert_eq!(cache.stats().n_entries, 1);
+        assert_eq!(cache.stats().current_bytes, bytes.len() as u64);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn oversized_part_is_not_cached() {
+        let root = tmp_root("oversized");
+        let _ = fs::remove_dir_all(&root);
+        let cache = ManifestDiskCache::new(root.clone(), 4).expect("cache");
+        let bytes = b"way too big for a 4 byte budget".to_vec();
+        let h = hash_of(&bytes);
+        cache.put(h, &bytes).await;
+        assert_eq!(cache.stats().n_entries, 0);
+        assert!(cache.get(&h).await.is_none());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn lru_eviction_frees_room() {
+        let root = tmp_root("lru");
+        let _ = fs::remove_dir_all(&root);
+        // Budget fits two 10-byte parts but not three.
+        let cache = ManifestDiskCache::new(root.clone(), 25).expect("cache");
+        let a = vec![1u8; 10];
+        let b = vec![2u8; 10];
+        let c = vec![3u8; 10];
+        let (ha, hb, hc) = (hash_of(&a), hash_of(&b), hash_of(&c));
+        cache.put(ha, &a).await;
+        cache.put(hb, &b).await;
+        // Touch `a` so `b` becomes the LRU victim.
+        assert!(cache.get(&ha).await.is_some());
+        cache.put(hc, &c).await;
+
+        assert!(cache.get(&ha).await.is_some(), "a kept (recently used)");
+        assert!(cache.get(&hc).await.is_some(), "c kept (just inserted)");
+        assert!(cache.get(&hb).await.is_none(), "b evicted (LRU)");
+        assert!(cache.stats().n_evictions >= 1);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn corrupt_file_is_treated_as_miss() {
+        let root = tmp_root("corrupt");
+        let _ = fs::remove_dir_all(&root);
+        let cache = ManifestDiskCache::new(root.clone(), 1 << 20).expect("cache");
+        let bytes = b"genuine-bytes".to_vec();
+        let h = hash_of(&bytes);
+        cache.put(h, &bytes).await;
+        // Overwrite the on-disk file with garbage that won't hash to h.
+        let path = cache.cache_path(&h);
+        tokio::fs::write(&path, b"tampered")
+            .await
+            .expect("write tampered file");
+        assert!(cache.get(&h).await.is_none(), "corruption ⇒ miss");
+        // The bad file is gone and the entry dropped.
+        assert!(!path.exists());
+        assert_eq!(cache.stats().n_entries, 0);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn restart_scan_rebuilds_index() {
+        let root = tmp_root("restart");
+        let _ = fs::remove_dir_all(&root);
+        let bytes = b"survives-restart".to_vec();
+        let h = hash_of(&bytes);
+        {
+            let cache = ManifestDiskCache::new(root.clone(), 1 << 20).expect("cache");
+            cache.put(h, &bytes).await;
+        }
+        // New cache over the same root: index rebuilt from disk.
+        let reopened = ManifestDiskCache::new(root.clone(), 1 << 20).expect("reopen");
+        assert_eq!(reopened.stats().n_entries, 1);
+        assert_eq!(reopened.stats().current_bytes, bytes.len() as u64);
+        assert_eq!(reopened.get(&h).await.expect("hit after restart"), bytes);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn filename_roundtrips_through_parse() {
+        let h = hash_of(b"some-part");
+        let name = cache_filename(&h);
+        assert!(name.starts_with(CACHE_FILE_PREFIX));
+        assert!(name.ends_with(CACHE_FILE_SUFFIX));
+        assert_eq!(parse_cache_filename(&name), Some(h));
+        // Unrelated names are rejected.
+        assert_eq!(parse_cache_filename("not-a-part.txt"), None);
+        assert_eq!(parse_cache_filename("part-xyz.avro.zst"), None);
+    }
+}

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -25,6 +25,7 @@
 pub mod aggregates;
 pub mod bloom;
 pub mod commit;
+pub mod disk_cache;
 pub mod encoding;
 pub mod hll;
 pub mod list;
@@ -68,6 +69,7 @@ use crate::{
                 EncodedPart, PointerFile, frame_content_size, part_uri, read_pointer,
                 translate_contention, write_manifest, write_part_bytes, write_pointer,
             },
+            disk_cache::ManifestDiskCache,
             list::{
                 FORMAT_VERSION as LIST_FORMAT_VERSION, Manifest, ManifestPartEntry,
                 PartitionStrategy,
@@ -219,7 +221,12 @@ impl ManifestSnapshot {
         if let Some(storage) = storage
             && let Some(list) = list
         {
-            let loader = Arc::new(ManifestPartLoader::new(Arc::clone(&storage), &list));
+            let manifest_cache = superfile_list.options.manifest_disk_cache.clone();
+            let loader = Arc::new(ManifestPartLoader::new_with_cache(
+                Arc::clone(&storage),
+                &list,
+                manifest_cache,
+            ));
             Self {
                 superfile_list,
                 list: Some(list),
@@ -352,7 +359,11 @@ impl ManifestSnapshot {
         }
 
         // 3. Build the loader, superfiles & parts
-        let loader = Arc::new(ManifestPartLoader::new(Arc::clone(&storage), &list));
+        let loader = Arc::new(ManifestPartLoader::new_with_cache(
+            Arc::clone(&storage),
+            &list,
+            options.manifest_disk_cache.clone(),
+        ));
         let parts: DashMap<_, _> = DashMap::new();
         let mut all_superfiles: Vec<Arc<SuperfileEntry>> = Vec::new();
         if let Some(current_manifest) = &current_manifest {
@@ -865,10 +876,13 @@ impl ManifestSnapshot {
             options: self.get_opts(),
             superfiles: new_superfile_list,
         };
-        let loader = opts
-            .storage
-            .as_ref()
-            .map(|storage| Arc::new(ManifestPartLoader::new(storage.clone(), &new_list)));
+        let loader = opts.storage.as_ref().map(|storage| {
+            Arc::new(ManifestPartLoader::new_with_cache(
+                storage.clone(),
+                &new_list,
+                opts.manifest_disk_cache.clone(),
+            ))
+        });
         // Inherit only the cached parts the new list still
         // references — entries for rewritten/removed parts are
         // dropped rather than carried forward, so the in-memory
@@ -955,15 +969,32 @@ fn rebuild_part_and_entry(
 /// One `ManifestPartLoader` per `Manifest`. The same `Arc<dyn
 /// StorageProvider>` is shared with the `DiskCacheStore` —
 /// one auth handshake, one connection pool.
+///
+/// An optional [`ManifestDiskCache`] short-circuits the storage GET
+/// when the part's compressed bytes are already on local disk. Because
+/// parts are content-addressed, a cache hit can never be stale.
 pub struct ManifestPartLoader {
     storage: Arc<dyn StorageProvider>,
     /// Maps `PartId → (expected content_hash, uri)`. Built from
     /// the manifest list at construction; immutable per-`Manifest`.
     parts_index: HashMap<PartId, (ContentHash, String)>,
+    /// On-disk cache for compressed part bytes. `None` disables the
+    /// cache (in-process-only supertables, tests, or storage attached
+    /// without a `disk_cache_root` configured).
+    manifest_disk_cache: Option<Arc<ManifestDiskCache>>,
 }
 
 impl ManifestPartLoader {
     pub fn new(storage: Arc<dyn StorageProvider>, list: &Manifest) -> Self {
+        Self::new_with_cache(storage, list, None)
+    }
+
+    /// Like [`Self::new`] but attaches an on-disk part-bytes cache.
+    pub fn new_with_cache(
+        storage: Arc<dyn StorageProvider>,
+        list: &Manifest,
+        manifest_disk_cache: Option<Arc<ManifestDiskCache>>,
+    ) -> Self {
         let mut idx = HashMap::with_capacity(list.parts.len());
         for entry in &list.parts {
             idx.insert(entry.part_id, (entry.content_hash, entry.uri.clone()));
@@ -971,16 +1002,31 @@ impl ManifestPartLoader {
         Self {
             storage,
             parts_index: idx,
+            manifest_disk_cache,
         }
     }
 
     /// Fetch + verify + decode one part. Returns the parsed
     /// `Arc<ManifestPart>`.
+    ///
+    /// Consults the on-disk cache first (a hit skips the storage GET);
+    /// on a miss the freshly-fetched bytes are written back to the
+    /// cache (best-effort) before decoding.
     pub async fn load(&self, part_id: PartId) -> Result<Arc<ManifestPart>, ManifestLoadError> {
         let (expected_hash, uri) = self
             .parts_index
             .get(&part_id)
             .ok_or(ManifestLoadError::PartNotInList { part_id })?;
+
+        // Disk-cache hit: bytes are verified against `expected_hash`
+        // inside `get`, so they're known-good here.
+        if let Some(cache) = &self.manifest_disk_cache
+            && let Some(bytes) = cache.get(expected_hash).await
+        {
+            let parsed = part::decode(&bytes)?;
+            return Ok(Arc::new(parsed));
+        }
+
         let (bytes, _) = self
             .storage
             .get(uri)
@@ -992,6 +1038,11 @@ impl ManifestPartLoader {
                 expected: expected_hash.to_hex(),
                 actual: actual_hash.to_hex(),
             });
+        }
+        // Populate the cache for next time (best-effort; the hash is
+        // already verified, satisfying `put`'s contract).
+        if let Some(cache) = &self.manifest_disk_cache {
+            cache.put(actual_hash, &bytes).await;
         }
         let parsed = part::decode(&bytes)?;
         Ok(Arc::new(parsed))
@@ -2358,6 +2409,72 @@ mod tests {
                 storage.get_call_count(),
                 0,
                 "missing-id check happens before any storage.get"
+            );
+        }
+
+        #[tokio::test]
+        async fn disk_cache_hit_serves_second_loader_without_storage_get() {
+            // Two independent loaders sharing one on-disk manifest cache
+            // (models a fresh manifest snapshot, or a process restart):
+            // the first populates the cache from storage, the second
+            // reads the part bytes off local disk with zero storage GETs.
+            let part = make_test_part(23);
+            let (objects, entries) = encode_and_index(from_ref(&part));
+            let storage = Arc::new(CountingMockStorage::new(objects));
+            let storage_dyn = Arc::clone(&storage) as Arc<dyn StorageProvider>;
+            let list = fresh_list(entries);
+
+            let cache_root = std::env::temp_dir()
+                .join("infino-manifest-cache-loader-test-disk_cache_hit_second_loader");
+            let _ = std::fs::remove_dir_all(&cache_root);
+            let cache = ManifestDiskCache::new(cache_root.clone(), 1 << 20).expect("cache");
+
+            // Loader A: cold — one storage GET, cache populated.
+            let loader_a = ManifestPartLoader::new_with_cache(
+                Arc::clone(&storage_dyn),
+                &list,
+                Some(Arc::clone(&cache)),
+            );
+            let a = loader_a.load(part.part_id).await.expect("first load");
+            assert_eq!(a.part_id, part.part_id);
+            assert_eq!(storage.get_call_count(), 1, "first loader fetches once");
+            assert_eq!(cache.stats().n_entries, 1, "part bytes cached on disk");
+
+            // Loader B: fresh loader, same cache — disk hit, no new GET.
+            let loader_b = ManifestPartLoader::new_with_cache(
+                Arc::clone(&storage_dyn),
+                &list,
+                Some(Arc::clone(&cache)),
+            );
+            let b = loader_b.load(part.part_id).await.expect("second load");
+            assert_eq!(b.part_id, part.part_id);
+            assert_eq!(
+                storage.get_call_count(),
+                1,
+                "disk-cache hit ⇒ no additional storage.get"
+            );
+            assert!(cache.stats().n_hits >= 1, "recorded a cache hit");
+
+            let _ = std::fs::remove_dir_all(&cache_root);
+        }
+
+        #[tokio::test]
+        async fn loader_without_cache_always_hits_storage() {
+            // Sanity: with no cache attached, each loader load is a
+            // storage GET — confirms the cache is what removes them.
+            let part = make_test_part(29);
+            let (objects, entries) = encode_and_index(from_ref(&part));
+            let storage = Arc::new(CountingMockStorage::new(objects));
+            let storage_dyn = Arc::clone(&storage) as Arc<dyn StorageProvider>;
+            let list = fresh_list(entries);
+
+            let loader = ManifestPartLoader::new(Arc::clone(&storage_dyn), &list);
+            loader.load(part.part_id).await.expect("load 1");
+            loader.load(part.part_id).await.expect("load 2");
+            assert_eq!(
+                storage.get_call_count(),
+                2,
+                "no cache ⇒ every load round-trips to storage"
             );
         }
 

--- a/src/supertable/manifest/part.rs
+++ b/src/supertable/manifest/part.rs
@@ -112,6 +112,22 @@ impl ContentHash {
         }
         out
     }
+
+    /// Parse a lower/upper-case hex string back into a `ContentHash`.
+    /// Returns `None` unless `hex` is exactly [`BLAKE3_HEX_LEN`]
+    /// hex characters. Inverse of [`Self::to_hex`]; used to recover a
+    /// hash from a content-addressed cache file name.
+    pub fn from_hex(hex: &str) -> Option<Self> {
+        if hex.len() != BLAKE3_HEX_LEN {
+            return None;
+        }
+        let mut out = [0u8; BLAKE3_DIGEST_BYTES];
+        for (i, slot) in out.iter_mut().enumerate() {
+            let byte = hex.get(i * 2..i * 2 + 2)?;
+            *slot = u8::from_str_radix(byte, 16).ok()?;
+        }
+        Some(Self(out))
+    }
 }
 
 impl fmt::Debug for ContentHash {

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -58,7 +58,7 @@ use crate::{
         builder::{BuilderOptions, FtsConfig, VectorConfig},
         fts::tokenize::Tokenizer,
     },
-    supertable::manifest::list::PartitionStrategy,
+    supertable::manifest::{disk_cache::ManifestDiskCache, list::PartitionStrategy},
 };
 
 /// Vector column dim must be in this inclusive range. Mirrors
@@ -122,6 +122,11 @@ const DEFAULT_PART_SIZE_THRESHOLD_BYTES: u64 = 10 * (1 << 20);
 /// Default: eager-load manifest parts at open when there are at most
 /// this many (open latency vs memory trade-off).
 const DEFAULT_EAGER_LOAD_THRESHOLD_PARTS: u32 = 4;
+/// Subdirectory under the disk-cache root that holds the
+/// content-addressed manifest-part byte cache. Kept separate from the
+/// superfile cache files so the two budgets and eviction sets don't
+/// interfere.
+const MANIFEST_CACHE_SUBDIR: &str = "manifest-parts";
 /// Default optimistic-commit retry budget under contention.
 const DEFAULT_MAX_COMMIT_RETRIES: u32 = 10;
 /// Default writer auto-flush threshold (1 GiB, in MiB units).
@@ -242,6 +247,14 @@ pub struct SupertableOptions {
     /// storage is a configuration error caught at
     /// [`Supertable::create`] / [`Supertable::open`] time.
     pub disk_cache: Option<Arc<DiskCacheStore>>,
+    /// On-disk cache for compressed manifest-part bytes. When set,
+    /// [`ManifestPartLoader`](crate::supertable::manifest::ManifestPartLoader)
+    /// reads a part's bytes from local disk on a hit instead of
+    /// round-tripping to object storage. Parts are content-addressed,
+    /// so cached files are never stale and the cache survives process
+    /// restarts. Independent of `disk_cache` (which caches superfile
+    /// content) and uses its own byte budget. `None` disables it.
+    pub manifest_disk_cache: Option<Arc<ManifestDiskCache>>,
     /// Best-effort memory budget for the disk cache's mmap
     /// working set, in bytes. When set together with
     /// `disk_cache`, the supertable triggers
@@ -512,6 +525,7 @@ impl SupertableOptions {
             store,
             storage: None,
             disk_cache: None,
+            manifest_disk_cache: None,
             memory_budget_bytes: None,
             prepopulate_cache_on_commit: true,
             partition_strategy: None,
@@ -651,6 +665,17 @@ impl SupertableOptions {
     /// resulting `Arc<DiskCacheStore>` here.
     pub fn with_disk_cache(mut self, cache: Arc<DiskCacheStore>) -> Self {
         self.disk_cache = Some(cache);
+        self
+    }
+
+    /// Attach an on-disk cache for compressed manifest-part bytes.
+    /// On a cache hit the part loader reads bytes from local disk
+    /// instead of round-tripping to object storage. Construction stays
+    /// user-managed — build the [`ManifestDiskCache`] with the cache
+    /// root and byte budget that fit the deployment and pass the
+    /// resulting `Arc` here.
+    pub fn with_manifest_disk_cache(mut self, cache: Arc<ManifestDiskCache>) -> Self {
+        self.manifest_disk_cache = Some(cache);
         self
     }
 
@@ -868,6 +893,16 @@ impl SupertableOptions {
             let cache = DiskCacheStore::new_unpinned(Arc::clone(&storage), disk_cfg)
                 .map_err(|e| BuildError::Store(format!("disk cache construction: {e}")))?;
             self.disk_cache = Some(cache);
+
+            // Manifest-part bytes get their own content-addressed cache
+            // under a sibling subdirectory, with an independent budget.
+            let manifest_cache_root = cache_root.join(MANIFEST_CACHE_SUBDIR);
+            let manifest_cache =
+                ManifestDiskCache::new(manifest_cache_root, cfg.storage.manifest_disk_budget_bytes)
+                    .map_err(|e| {
+                        BuildError::Store(format!("manifest disk cache construction: {e}"))
+                    })?;
+            self.manifest_disk_cache = Some(manifest_cache);
         }
 
         self.storage = Some(storage);

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -30,10 +30,18 @@
 
 #![deny(clippy::unwrap_used)]
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    ops::Range,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
+use async_trait::async_trait;
 use infino::{
     config::{
         CompactionSettings, Config, StorageBackend, StorageColdFetchMode, StorageSettings,
@@ -42,9 +50,10 @@ use infino::{
     superfile::builder::{FtsConfig, VectorConfig},
     supertable::{
         Supertable,
+        manifest::disk_cache::ManifestDiskCache,
         query::VectorSearchOptions,
         reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
-        storage::{AzureStorageProvider, StorageProvider},
+        storage::{AzureStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
     test_helpers::{build_title_batch, default_supertable_options},
 };
@@ -53,6 +62,12 @@ use tempfile::TempDir;
 use super::azure_helpers::{
     EMULATOR_ENDPOINT, delete_emulator_container, ensure_emulator_container,
 };
+
+/// Substring identifying a manifest-part object URI
+/// (`<prefix>/manifest-parts/part-<hex>.avro.zst`). Lets the counting
+/// wrapper tell a manifest-part GET apart from pointer / manifest-list /
+/// superfile GETs.
+const MANIFEST_PART_URI_MARKER: &str = "manifest-parts/part-";
 
 /// Single-thread rayon pool for deterministic Azure smoke runs.
 const RAYON_POOL_THREADS: usize = 1;
@@ -496,4 +511,291 @@ async fn supertable_real_azure_round_trip() {
     }
     eprintln!("[real-azure] cleanup OK; deleted keys under prefix={prefix}");
     result.expect("real Azure integration failed");
+}
+
+/// A [`StorageProvider`] decorator that delegates to an inner provider
+/// and counts GETs, separating manifest-part GETs from everything else.
+/// Used to prove the manifest disk cache eliminates Azure round-trips
+/// for part bytes on a warm open.
+#[derive(Debug)]
+struct CountingStorage {
+    inner: Arc<dyn StorageProvider>,
+    part_gets: AtomicUsize,
+    total_gets: AtomicUsize,
+}
+
+impl CountingStorage {
+    fn new(inner: Arc<dyn StorageProvider>) -> Self {
+        Self {
+            inner,
+            part_gets: AtomicUsize::new(0),
+            total_gets: AtomicUsize::new(0),
+        }
+    }
+
+    fn reset(&self) {
+        self.part_gets.store(0, Ordering::Release);
+        self.total_gets.store(0, Ordering::Release);
+    }
+
+    fn part_gets(&self) -> usize {
+        self.part_gets.load(Ordering::Acquire)
+    }
+
+    fn note_get(&self, uri: &str) {
+        self.total_gets.fetch_add(1, Ordering::AcqRel);
+        if uri.contains(MANIFEST_PART_URI_MARKER) {
+            self.part_gets.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+}
+
+#[async_trait]
+impl StorageProvider for CountingStorage {
+    async fn head(&self, uri: &str) -> Result<ObjectMeta, StorageError> {
+        self.inner.head(uri).await
+    }
+
+    async fn get(&self, uri: &str) -> Result<(bytes::Bytes, ObjectMeta), StorageError> {
+        self.note_get(uri);
+        self.inner.get(uri).await
+    }
+
+    async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<bytes::Bytes, StorageError> {
+        // Manifest parts load via `get` (full object); count any
+        // part-range GETs too so the warm-path assertion stays honest.
+        self.note_get(uri);
+        self.inner.get_range(uri, range).await
+    }
+
+    async fn tail(&self, uri: &str, len: u64) -> Result<(bytes::Bytes, u64), StorageError> {
+        self.inner.tail(uri, len).await
+    }
+
+    async fn put_atomic(
+        &self,
+        uri: &str,
+        bytes: bytes::Bytes,
+    ) -> Result<Option<String>, StorageError> {
+        self.inner.put_atomic(uri, bytes).await
+    }
+
+    async fn put_if_match(
+        &self,
+        uri: &str,
+        bytes: bytes::Bytes,
+        expected_etag: Option<&str>,
+    ) -> Result<Option<String>, StorageError> {
+        self.inner.put_if_match(uri, bytes, expected_etag).await
+    }
+
+    async fn put_multipart(
+        &self,
+        uri: &str,
+    ) -> Result<Box<dyn object_store::MultipartUpload>, StorageError> {
+        self.inner.put_multipart(uri).await
+    }
+
+    async fn delete(&self, uri: &str) -> Result<(), StorageError> {
+        self.inner.delete(uri).await
+    }
+
+    async fn list_with_prefix_metadata(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<(String, ObjectMeta)>, StorageError> {
+        self.inner.list_with_prefix_metadata(prefix).await
+    }
+}
+
+/// Real-Azure validation of the manifest-part disk cache.
+///
+/// 1. A producer commits a batch to Azure (creates ≥1 manifest part).
+/// 2. A cold consumer opens with a fresh [`ManifestDiskCache`] — the
+///    eager part load fetches the part from Azure (≥1 part GET) and
+///    populates the cache.
+/// 3. A warm consumer opens with a **new** `ManifestDiskCache` instance
+///    over the **same** cache directory (models a process restart): the
+///    index is rebuilt from disk, the eager load is served from local
+///    disk, and **zero** Azure part GETs occur.
+///
+/// Gated on `INFINO_TEST_REAL_AZURE=1` + `AZURE_STORAGE_CONTAINER_NAME`
+/// (with the standard `AZURE_STORAGE_*` credential env chain).
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn manifest_disk_cache_serves_parts_without_azure_refetch() {
+    if std::env::var("INFINO_TEST_REAL_AZURE").ok().as_deref() != Some("1") {
+        eprintln!(
+            "manifest_disk_cache_serves_parts_without_azure_refetch: skipped \
+             (set INFINO_TEST_REAL_AZURE=1 and AZURE_STORAGE_CONTAINER_NAME to enable)"
+        );
+        return;
+    }
+    let container = match std::env::var("AZURE_STORAGE_CONTAINER_NAME") {
+        Ok(c) => c,
+        Err(_) => {
+            eprintln!(
+                "manifest_disk_cache_serves_parts_without_azure_refetch: skipped \
+                 (missing AZURE_STORAGE_CONTAINER_NAME)"
+            );
+            return;
+        }
+    };
+    let prefix_root = std::env::var("INFINO_TEST_REAL_AZURE_PREFIX")
+        .unwrap_or_else(|_| "infino-real-azure-manifest-cache".to_string());
+    let prefix = format!("{}/{}", prefix_root.trim_matches('/'), uuid::Uuid::new_v4());
+    eprintln!("[real-azure mcache] container={container} prefix={prefix}");
+
+    let dim = EMB_DIM;
+    let cache_dir = TempDir::new().expect("manifest-cache tempdir");
+    // The manifest cache's own subdirectory; reused across both opens so
+    // the warm open's fresh instance scans the cold open's files.
+    let manifest_cache_root = cache_dir.path().join("manifest-parts");
+
+    let result = async {
+        let azure: Arc<dyn StorageProvider> = Arc::new(
+            AzureStorageProvider::new_with_prefix(&container, &prefix)
+                .map_err(|e| format!("azure provider: {e}"))?,
+        );
+        let counting = Arc::new(CountingStorage::new(Arc::clone(&azure)));
+        let counting_dyn: Arc<dyn StorageProvider> =
+            Arc::clone(&counting) as Arc<dyn StorageProvider>;
+
+        // 1. Producer commit → ≥1 manifest part on Azure.
+        {
+            let producer =
+                Supertable::create(real_azure_options(dim).with_storage(Arc::clone(&counting_dyn)))
+                    .map_err(|e| format!("create producer: {e}"))?;
+            let mut writer = producer
+                .writer()
+                .map_err(|e| format!("producer writer: {e}"))?;
+            writer
+                .append(&real_azure_batch(dim))
+                .map_err(|e| format!("append: {e}"))?;
+            writer.commit().map_err(|e| format!("commit: {e}"))?;
+            if producer.manifest_id() != 1 {
+                return Err(format!("producer manifest_id={}", producer.manifest_id()));
+            }
+            eprintln!("[real-azure mcache] producer commit OK; manifest_id=1");
+        }
+
+        // 2. Cold open: fresh manifest cache → part fetched from Azure.
+        let cold_cache_dir = cache_dir.path().join("cold-superfiles");
+        {
+            let manifest_cache = ManifestDiskCache::new(manifest_cache_root.clone(), 1 << 30)
+                .map_err(|e| format!("cold manifest cache: {e}"))?;
+            let disk_cache = make_cache(Arc::clone(&counting_dyn), &cold_cache_dir);
+            counting.reset();
+            let consumer = Supertable::open(
+                real_azure_options(dim)
+                    .with_storage(Arc::clone(&counting_dyn))
+                    .with_disk_cache(disk_cache)
+                    .with_manifest_disk_cache(Arc::clone(&manifest_cache)),
+            )
+            .map_err(|e| format!("cold open: {e}"))?;
+
+            if consumer.reader().n_docs_total() != EXPECTED_N_DOCS {
+                return Err(format!(
+                    "cold n_docs_total mismatch: {}",
+                    consumer.reader().n_docs_total()
+                ));
+            }
+            let cold_part_gets = counting.part_gets();
+            let stats = manifest_cache.stats();
+            if cold_part_gets < 1 {
+                return Err(format!(
+                    "cold open should fetch ≥1 part from Azure; part_gets={cold_part_gets}"
+                ));
+            }
+            if stats.n_entries < 1 {
+                return Err(format!(
+                    "cold open did not populate manifest cache; {stats:?}"
+                ));
+            }
+            eprintln!(
+                "[real-azure mcache] cold open OK; azure_part_gets={cold_part_gets} \
+                 cache_entries={} cache_misses={}",
+                stats.n_entries, stats.n_misses
+            );
+        }
+
+        // 3. Warm open: NEW cache instance over the same dir (restart).
+        let warm_cache_dir = cache_dir.path().join("warm-superfiles");
+        {
+            let manifest_cache = ManifestDiskCache::new(manifest_cache_root.clone(), 1 << 30)
+                .map_err(|e| format!("warm manifest cache: {e}"))?;
+            // Restart survival: the index is rebuilt from the cold open's
+            // files at construction, before any load.
+            let scanned = manifest_cache.stats();
+            if scanned.n_entries < 1 {
+                return Err(format!(
+                    "warm cache did not rebuild index from disk; {scanned:?}"
+                ));
+            }
+
+            let disk_cache = make_cache(Arc::clone(&counting_dyn), &warm_cache_dir);
+            counting.reset();
+            let consumer = Supertable::open(
+                real_azure_options(dim)
+                    .with_storage(Arc::clone(&counting_dyn))
+                    .with_disk_cache(disk_cache)
+                    .with_manifest_disk_cache(Arc::clone(&manifest_cache)),
+            )
+            .map_err(|e| format!("warm open: {e}"))?;
+
+            if consumer.reader().n_docs_total() != EXPECTED_N_DOCS {
+                return Err(format!(
+                    "warm n_docs_total mismatch: {}",
+                    consumer.reader().n_docs_total()
+                ));
+            }
+            let warm_part_gets = counting.part_gets();
+            let stats = manifest_cache.stats();
+            if warm_part_gets != 0 {
+                return Err(format!(
+                    "warm open must serve parts from disk cache; \
+                     got {warm_part_gets} Azure part GETs (expected 0)"
+                ));
+            }
+            if stats.n_hits < 1 {
+                return Err(format!("warm open recorded no cache hit; {stats:?}"));
+            }
+            eprintln!(
+                "[real-azure mcache] warm open OK; azure_part_gets=0 \
+                 cache_hits={} (parts served from disk)",
+                stats.n_hits
+            );
+
+            // Collect cleanup keys from the warm consumer's manifest.
+            let reader = consumer.reader();
+            let manifest = reader.manifest();
+            let mut keys = vec![
+                "_supertable/current".to_string(),
+                infino::supertable::manifest::commit::manifest_uri(consumer.manifest_id()),
+            ];
+            keys.extend(
+                manifest
+                    .get_all_list_entries()
+                    .iter()
+                    .map(|p| p.uri.clone()),
+            );
+            keys.extend(manifest.superfiles.iter().map(|e| e.uri.storage_path()));
+            Ok::<Vec<String>, String>(keys)
+        }
+    }
+    .await;
+
+    let cleanup = AzureStorageProvider::new_with_prefix(&container, &prefix)
+        .expect("real Azure cleanup provider");
+    match &result {
+        Ok(keys) => {
+            for key in keys {
+                let _ = cleanup.delete(key).await;
+            }
+        }
+        Err(_) => {
+            let _ = cleanup.delete("_supertable/current").await;
+        }
+    }
+    eprintln!("[real-azure mcache] cleanup done under prefix={prefix}");
+    result.expect("real Azure manifest-cache test failed");
 }


### PR DESCRIPTION
### What does this PR do?
- Adds a cache for storing manifest parts

### Why do we need this change?
- The manifest data is the first thing a query touches, to prune superfiles. Without a cache, the manifest parts need to be fetched from S3 ( across restarts ). This PR reduces this round trip and network calls to S3
- This speeds up the query, and reduces S3 costs

### How do we do the change?
- We allow the user to set the maximum size of the cache for manifest parts ( default 2GB )
- Manifest Loader adds a manifest_disk_cache which takes care of all the cache responsibilities

### How has this been tested?
- Tests to verify that number of network calls have decreased.
- Current benchmark tests to ensure that warm queries ( across restarts ) are faster.