### PR TITLE
docs: install infino from PyPI instead of TestPyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@
 **Python**
 
 ```sh
-# Install from TestPyPI.
-pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ infino
+pip install infino
 
 # Or with uv (https://docs.astral.sh/uv/):
-uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ infino
+uv pip install infino
 ```
 
 **Node.js**


### PR DESCRIPTION
## What
README Python install block now uses plain `pip install infino` / `uv pip install infino`, dropping the TestPyPI `--index-url` / `--extra-index-url` flags.

## Why
The `infino` wheel is published on PyPI (v0.1.0 live), so the TestPyPI workaround is no longer needed.

Node and Rust install instructions unchanged; publish workflow left as-is (manual `target` dropdown still offers both indexes).