### PR TITLE
docs: rename compact to optimize in Python/Node READMEs

### DIFF
--- a/infino-node/README.md
+++ b/infino-node/README.md
@@ -211,14 +211,14 @@ console.log(stats.matched, stats.nTombstoned, stats.nNotFound);
 number you supply, otherwise it throws. Both methods return `{ matched,
 nTombstoned, nNotFound }`.
 
-## Compaction
+## Optimization
 
-Many small appends produce many small files. `compact` merges small or
+Many small appends produce many small files. `optimize` merges small or
 underfilled files into larger ones, which keeps reads efficient.
 
 ```javascript
-docs.compact();                                                  // engine defaults
-docs.compact({ targetSuperfileSizeMb: 256, minFillPercent: 50 });
+docs.optimize();                                                 // engine defaults
+docs.optimize({ targetSuperfileSizeMb: 256, minFillPercent: 50 });
 ```
 
 ## Storage backends
@@ -290,7 +290,7 @@ const db = connect("s3://bucket/prefix", {
   - `update(predicate, data)` / `delete(predicate)` — mutate rows matching a SQL
     predicate; return `{ matched, nTombstoned, nNotFound }`; require durable
     storage.
-  - `compact({ maxMemoryMb?, minFillPercent?, targetSuperfileSizeMb? })`.
+  - `optimize({ maxMemoryMb?, minFillPercent?, targetSuperfileSizeMb? })`.
   - `schema()` — the table's apache-arrow `Schema`.
 - `IndexSpec().fts(col).vector(col, dim, nCent, metric)`.
 - `BUILDER_ID` (named export) — the engine's build identifier string.

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -199,15 +199,15 @@ matches must equal the number of rows you supply, otherwise it raises.
 Both methods return a `MutationStats` with `matched`, `n_tombstoned`, and
 `n_not_found`.
 
-## Compaction
+## Optimization
 
-Many small appends produce many small files. `compact` merges small or
+Many small appends produce many small files. `optimize` merges small or
 underfilled files into larger ones, which keeps reads efficient.
 
 ```python
-docs.compact()                                              # engine defaults
-docs.compact(infino.CompactOptions(target_superfile_size_mb=256,
-                                   min_fill_percent=50))
+docs.optimize()                                             # engine defaults
+docs.optimize(infino.OptimizeOptions(target_superfile_size_mb=256,
+                                     min_fill_percent=50))
 ```
 
 ## Storage backends
@@ -281,10 +281,10 @@ db = infino.connect(
   - `exact_match(column, value, projection=None) -> pyarrow.Table`
   - `delete(predicate) -> MutationStats`
   - `update(predicate, new_rows) -> MutationStats`
-  - `compact(settings=None)`
+  - `optimize(settings=None)`
   - `schema() -> pyarrow.Schema`
 - `IndexSpec().fts(column).vector(column, dim, n_cent, metric)`
-- `CompactOptions(max_memory_mb=None, min_fill_percent=None, target_superfile_size_mb=None)`
+- `OptimizeOptions(max_memory_mb=None, min_fill_percent=None, target_superfile_size_mb=None)`
 - `MutationStats` — returned by `delete` / `update`; read-only attributes `matched`, `n_tombstoned`, `n_not_found`
 
 ## Building from source


### PR DESCRIPTION
## What
Python and Node READMEs still documented the table-maintenance call as `compact` / `CompactOptions`. Renamed to match the shipped binding API:

- Python: `docs.optimize(...)`, `infino.OptimizeOptions(...)`
- Node: `docs.optimize(...)`, `OptimizeOptions`
- Section heading `Compaction` → `Optimization`; API-reference entries updated.

## Why
The bindings expose `optimize` (a wrapper over the internal compaction path) and the options type is `OptimizeOptions` in both bindings. The READMEs were the only stale surface — binding source, Rust `public-api.txt`, `docs/architecture/`, and the examples already use the current names.

## Scope
Docs only; no code change. Verified no other user-facing `compact(` / `CompactOptions` references remain in READMEs, `docs/`, or examples.