### PR TITLE
chore: make npm package public

### DIFF
--- a/.github/workflows/crate-publish.yml
+++ b/.github/workflows/crate-publish.yml
@@ -3,11 +3,14 @@ name: Publish crate
 # Publishes the core `infino` crate to crates.io (and, transitively, triggers
 # the docs.rs build).
 #
+# The engine is the only artifact released by tag; the Node and Python bindings
+# publish independently via their own manually-triggered workflows (no tags),
+# so a bare `v*` tag is unambiguous here.
+#
 # Two ways to run:
-#   - Push a `crate-v<version>` tag (e.g. `crate-v0.1.0`) — the per-artifact
-#     release tag from docs/versioning.md — to publish for real. The job
-#     asserts the tag version matches the version in Cargo.toml before it
-#     uploads anything.
+#   - Push a `v<version>` tag (e.g. `v0.1.0`) — the engine release tag from
+#     docs/versioning.md — to publish for real. The job asserts the tag version
+#     matches the version in Cargo.toml before it uploads anything.
 #   - Run it manually (workflow_dispatch). The default is a DRY RUN: it packs
 #     and verify-builds the crate exactly as a downstream `cargo add` would
 #     receive it, but uploads nothing. Re-run with `dry_run` unchecked to
@@ -18,7 +21,10 @@ name: Publish crate
 
 on:
   push:
-    tags: ["crate-v*"]
+    # Version tags only (`v0.1.0`, `v1.2.3`); `v[0-9]*` ignores stray v-prefixed
+    # tags. The engine is the sole tag-released artifact (bindings publish via
+    # their own manual workflows), so no `crate-`/`node-`/`py-` prefix is needed.
+    tags: ["v[0-9]*"]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -76,7 +82,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       # Resolve the published version from Cargo.toml and, on a tag push,
-      # assert the tag matches it (`crate-v0.1.0` -> `0.1.0`). Guards against
+      # assert the tag matches it (`v0.1.0` -> `0.1.0`). Guards against
       # tagging one version and shipping another.
       - name: Resolve & check version
         id: version
@@ -86,9 +92,9 @@ jobs:
           echo "Cargo.toml version: $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           if [ "${{ github.event_name }}" = "push" ]; then
-            tag="${GITHUB_REF_NAME#crate-v}"
+            tag="${GITHUB_REF_NAME#v}"
             if [ "$tag" != "$version" ]; then
-              echo "::error::tag crate-v$tag does not match Cargo.toml version $version"
+              echo "::error::tag v$tag does not match Cargo.toml version $version"
               exit 1
             fi
           fi

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           cd infino-node
           npx napi prepublish -t npm --skip-gh-release --dry-run
-          npm publish --dry-run --tag latest
+          npm publish --dry-run --tag latest --access public
       # Publishes the per-platform packages and pins them in the main
       # package's optionalDependencies, then publishes the main package.
       # `--tag latest` is required (not just default): the name's history
@@ -166,7 +166,7 @@ jobs:
         run: |
           cd infino-node
           npx napi prepublish -t npm --skip-gh-release
-          npm publish --tag latest
+          npm publish --tag latest --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # Emit provenance for the main package AND every per-platform package

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -54,9 +54,12 @@ contract for how their versions relate.
 
 For a **patch**, release only the package that needs it:
 
-- **Rust** — bump `version` in the root `Cargo.toml`, then publish to crates.io.
-  *(There is no Rust publish workflow yet — see "Open gaps" below. Until one
-  exists this is a manual `cargo publish` by a designated owner.)*
+- **Rust** — bump `version` in the root `Cargo.toml`, then push a matching
+  `v<version>` tag (e.g. `v0.1.1`). The `Publish crate` workflow
+  (`.github/workflows/crate-publish.yml`) asserts the tag matches `Cargo.toml`
+  and publishes to crates.io. The engine is the **only** artifact released by a
+  tag; a bare `v*` tag is therefore unambiguous. (You can also run the workflow
+  manually from the Actions tab — the default is a dry run.)
 - **Node** — bump `version` in `infino-node/package.json`, then run the
   `Node publish` workflow (`.github/workflows/node-publish.yml`). `napi
   prepublish` derives the per-platform package versions and rewrites the
@@ -66,8 +69,11 @@ For a **patch**, release only the package that needs it:
   `publish-python` workflow.
 
 For a **minor** (feature or breaking change), do all three in the same release
-cycle so `major.minor` never drifts: bump the crate, then the two bindings to
-the matching `0.<minor>.0`, and publish all three.
+cycle so `major.minor` never drifts: land the engine change first, then **update
+the Node and Python binding code to cover any new or changed engine surface**,
+bump the crate and the two bindings to the matching `0.<minor>.0`, and publish
+all three. The bindings must never be released on a new minor before their code
+actually exposes that minor's engine changes.
 
 ## Worked example
 
@@ -97,10 +103,11 @@ Patches diverge between coordinated minors; a minor bump realigns everything on
 
 ## Open gaps
 
-- **No Rust publish automation.** There is a `node-publish` and a
-  `publish-python` workflow but no crates.io publish workflow, and no clear owner
-  for the engine's version bumps. Assign an owner and add a publish workflow so
-  the crate doesn't fall behind the bindings on the shared release line.
+- **Rust publish automation: done.** The `Publish crate` workflow
+  (`.github/workflows/crate-publish.yml`) publishes the engine to crates.io on a
+  `v<version>` tag; Node and Python still publish via their own manual workflows.
+  Still worth naming a clear owner for the engine's version bumps so the crate
+  doesn't fall behind the bindings on the shared release line.
 - **No drift guard yet.** A small CI check that asserts the `major.minor` of the
   root `Cargo.toml`, `infino-node/package.json`, and `infino-python/Cargo.toml`
   all agree (patch ignored) would enforce rule 2 cheaply. Recommended.

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://github.com/infino-ai/infino#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Make npm package publish publicly

- Add public access defaults

- Simplify crate release tag format

- Update release process documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pkg["infino-node/package.json public publish config"]
  nodewf["node-publish.yml npm publish flags"]
  cratewf["crate-publish.yml tag trigger and validation"]
  docs["docs/versioning.md release guidance"]

  pkg -- "defaults npm access" --> nodewf
  cratewf -- "uses bare version tags" --> docs
  nodewf -- "documents public npm publishing" --> docs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crate-publish.yml</strong><dd><code>Switch crate publishing to bare version tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/crate-publish.yml

<ul><li>Change crate publish trigger from <code>crate-v*</code> to <code>v[0-9]*</code><br> <li> Update workflow comments to describe bare version tags<br> <li> Adjust tag parsing from <code>crate-v</code> to <code>v</code><br> <li> Update mismatch error message for new tag format</ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/247/files#diff-6e5135f3106dd98a670d3ff2a6c2cbbc36ade4f0969bc065941168a744c41d96">+14/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node-publish.yml</strong><dd><code>Ensure npm publishes use public access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/node-publish.yml

<ul><li>Add <code>--access public</code> to dry-run npm publish<br> <li> Add <code>--access public</code> to real npm publish<br> <li> Keep explicit <code>latest</code> tag behavior unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/247/files#diff-b265e1ad8447440ef66fb9a008be77d38cfd013c3065286bf5682ed87831415a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versioning.md</strong><dd><code>Update versioning and release workflow guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/versioning.md

<ul><li>Document Rust releases via <code>v<version></code> tags<br> <li> Clarify crate workflow now handles crates.io publishing<br> <li> Explain bindings still publish through manual workflows<br> <li> Strengthen minor release guidance for binding coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/247/files#diff-c1cc304e56dd03cbb5cf65c32d83c9b7ab069800b2ce780249ac87d320e76789">+16/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Set npm package default access to public</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infino-node/package.json

<ul><li>Add <code>publishConfig.access</code> set to <code>public</code><br> <li> Make package-level npm access default explicit</ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/247/files#diff-f4cbd20701f4c80afe798359f6b2c691e581b5b548872906f82ebb92e40ecf3e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

