### PR TITLE
feat SQL: prune manifest-parts/superfiles for SQL IN-list filters

### DIFF
--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -22,6 +22,7 @@
 use std::{
     any::Any,
     borrow::Cow,
+    collections::BTreeSet,
     str::{from_utf8, from_utf8_unchecked},
 };
 
@@ -109,6 +110,21 @@ pub trait Tokenizer: Send + Sync + 'static {
         }
         parsed
     }
+}
+
+/// Tokenize several `texts` into one sorted, de-duplicated term list.
+/// For building a single term set from many values (e.g. an `IN` list)
+/// where a word shared across values must be probed only once.
+pub(crate) fn unique_tokens<'a>(
+    tok: &dyn Tokenizer,
+    texts: impl IntoIterator<Item = &'a str>,
+) -> Vec<String> {
+    texts
+        .into_iter()
+        .flat_map(|t| tok.tokenize(t))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 /// ASCII whitespace + punctuation split, ASCII lowercase, no stemming,
@@ -458,6 +474,14 @@ mod tests {
     #[test]
     fn single_token_lowercased() {
         assert_eq!(tokens("Hello"), vec!["hello"]);
+    }
+
+    #[test]
+    fn unique_tokens_dedups_and_sorts_across_values() {
+        let tok = AsciiLowerTokenizer;
+        // values share 'juice'; result is one sorted set, no repeat
+        let got = unique_tokens(&tok, ["Orange Juice", "Apple Juice"]);
+        assert_eq!(got, vec!["apple", "juice", "orange"]);
     }
 
     #[test]

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -305,7 +305,9 @@ impl SupertableProvider {
     // survive the two-tier prune — per-part aggregates (ManifestPartEntry)
     // first, then per-superfile stats (SuperfileEntry).
     //
-    // These superfiles are then opened and scanned by DataFusion.
+    // The survivors are returned to `scan`, which opens each through the
+    // superfile reader for its byte source + footer, then lets
+    // DataFusion's Parquet engine decode the rows over that byte source.
     async fn select_survivors(&self, filters: &[Expr]) -> DfResult<Vec<Arc<SuperfileEntry>>> {
         let predicates = exprs_to_scalar_predicates(filters, &self.schema);
         let mut leaves = self.predicates_to_prune_leaves(predicates);
@@ -1133,8 +1135,10 @@ pub(crate) fn exprs_to_scalar_predicates(
 /// A `NOT IN`, a non-literal item, a function-wrapped or unknown column
 /// yields no leaf — that filter just isn't pruned (the scan stays correct).
 ///
-/// Only sees `Expr::InList` (4+ values): DataFusion rewrites a 1-value
-/// `IN` to `=` and a 2–3 value `IN` to `OR` before the provider.
+/// Handles any `Expr::InList`, whatever its length. In practice SQL
+/// planning rewrites a short `IN` first — a 1-value to `=`, a 2–3 value
+/// to `OR` — so only 4+ value lists usually reach here, but that's the
+/// optimizer's behavior, not a precondition this helper relies on.
 pub(crate) fn exprs_to_in_list_leaves(
     filters: &[Expr],
     schema: &SchemaRef,
@@ -1166,6 +1170,10 @@ fn collect_in_list_leaves(
     out: &mut Vec<PruneLeaf>,
 ) {
     match expr {
+        // Filters reach us alias-free (Filter::try_new runs unalias_nested),
+        // but an alias is a pure rename; descend it so pruning is unaffected
+        // if one ever survives (e.g. a metadata-carrying alias).
+        Expr::Alias(a) => collect_in_list_leaves(&a.expr, schema, fts_cols, tokenizer, out),
         // Descend AND; an IN can sit on either side.
         Expr::BinaryExpr(be) if be.op == Operator::And => {
             collect_in_list_leaves(&be.left, schema, fts_cols, tokenizer, out);
@@ -1518,6 +1526,18 @@ mod tests {
             .gt(lit(0_i64))
             .and(col("y").in_list(vec![lit(7_i64)], false));
         assert_eq!(in_list_leaves(&[expr], &s), vec![("y".to_string(), 1)]);
+    }
+
+    #[test]
+    fn in_list_under_alias_is_found() {
+        // Filters reach us unaliased, but the descent must still find an
+        // IN wrapped in an alias if one ever survives (a pure rename
+        // doesn't change the column the leaf prunes on).
+        let s = schema_xy();
+        let expr = col("x")
+            .in_list(vec![lit(1_i64), lit(2_i64)], false)
+            .alias("k");
+        assert_eq!(in_list_leaves(&[expr], &s), vec![("x".to_string(), 2)]);
     }
 
     #[test]

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -305,9 +305,8 @@ impl SupertableProvider {
     // survive the two-tier prune — per-part aggregates (ManifestPartEntry)
     // first, then per-superfile stats (SuperfileEntry).
     //
-    // The survivors are returned to `scan`, which opens each through the
-    // superfile reader for its byte source + footer, then lets
-    // DataFusion's Parquet engine decode the rows over that byte source.
+    // Pure manifest work: reads stats only, opens no superfile. Returns the
+    // survivor entries; `scan` is what opens and reads them.
     async fn select_survivors(&self, filters: &[Expr]) -> DfResult<Vec<Arc<SuperfileEntry>>> {
         let predicates = exprs_to_scalar_predicates(filters, &self.schema);
         let mut leaves = self.predicates_to_prune_leaves(predicates);

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -94,7 +94,10 @@ use uuid::Uuid;
 use crate::{
     superfile::{
         LazyByteSource,
-        fts::{reader::BoolMode, tokenize::Tokenizer},
+        fts::{
+            reader::BoolMode,
+            tokenize::{Tokenizer, unique_tokens},
+        },
     },
     supertable::{
         SuperfileEntry,
@@ -1196,12 +1199,10 @@ fn collect_in_list_leaves(
             if fts_cols.contains(c.name.as_str())
                 && let Some(tok) = tokenizer
             {
-                let terms: Vec<String> = values
-                    .iter()
-                    .filter_map(scalar_as_str)
-                    .flat_map(|s| tok.tokenize(s))
-                    .collect();
-
+                // One deduped term set across all values — a word shared
+                // by several values (e.g. 'Orange Juice', 'Apple Juice'
+                // → one `juice`) is probed once.
+                let terms = unique_tokens(tok, values.iter().filter_map(scalar_as_str));
                 if !terms.is_empty() {
                     // one bloom leaf holding all the values' tokens
                     out.push(PruneLeaf::TermPresence {
@@ -1547,8 +1548,9 @@ mod tests {
         let s = Arc::new(Schema::new(vec![Field::new("title", DataType::Utf8, true)]));
         let fts = HashSet::from(["title"]);
         let tok = AsciiLowerTokenizer;
-        // 'Foo Bar' → [foo, bar]; 'baz' → [baz].
-        let expr = col("title").in_list(vec![lit("Foo Bar"), lit("baz")], false);
+        // 'Foo Bar' → [foo, bar]; 'Bar Baz' → [bar, baz]. The shared `bar`
+        // is deduped, and the terms come out sorted-unique.
+        let expr = col("title").in_list(vec![lit("Foo Bar"), lit("Bar Baz")], false);
         let leaves = exprs_to_in_list_leaves(&[expr], &s, &fts, Some(&tok));
 
         assert!(
@@ -1572,7 +1574,8 @@ mod tests {
         assert_eq!(mode, BoolMode::Or);
         assert_eq!(
             terms,
-            &vec!["foo".to_string(), "bar".to_string(), "baz".to_string()]
+            &vec!["bar".to_string(), "baz".to_string(), "foo".to_string()],
+            "tokens are deduped (shared `bar`) and sorted"
         );
     }
 

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -92,7 +92,10 @@ use roaring::RoaringBitmap;
 use uuid::Uuid;
 
 use crate::{
-    superfile::{LazyByteSource, fts::reader::BoolMode},
+    superfile::{
+        LazyByteSource,
+        fts::{reader::BoolMode, tokenize::Tokenizer},
+    },
     supertable::{
         SuperfileEntry,
         manifest::{ManifestSnapshot, add_sum_arrays, hll::HllSketch},
@@ -295,20 +298,32 @@ impl SupertableProvider {
         leaves
     }
 
-    /// Lower `filters` to prune leaves and return the superfiles that
-    /// survive the two-tier prune — exactly the inputs the scan hands to
-    /// DataFusion.
+    // Lower `filters` to prune leaves and select the superfiles that
+    // survive the two-tier prune — per-part aggregates (ManifestPartEntry)
+    // first, then per-superfile stats (SuperfileEntry).
+    //
+    // These superfiles are then opened and scanned by DataFusion.
     async fn select_survivors(&self, filters: &[Expr]) -> DfResult<Vec<Arc<SuperfileEntry>>> {
         let predicates = exprs_to_scalar_predicates(filters, &self.schema);
-        let leaves = self.predicates_to_prune_leaves(predicates);
+        let mut leaves = self.predicates_to_prune_leaves(predicates);
+
+        leaves.extend(exprs_to_in_list_leaves(
+            filters,
+            &self.schema,
+            &self.fts_cols_set(),
+            self.manifest.options.tokenizer.as_deref(),
+        ));
+
         let mut survivors = select_superfiles(self.manifest.as_ref(), &leaves)
             .await
             .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+
         // Covered/residual residual scans read only their boundary
         // superfiles; everything else was answered from statistics.
         if let Some(allowed) = self.segment_filter.as_ref() {
             survivors.retain(|entry| allowed.contains(&entry.superfile_id));
         }
+
         Ok(survivors)
     }
 
@@ -1107,6 +1122,106 @@ pub(crate) fn exprs_to_scalar_predicates(
     out
 }
 
+/// Build prune leaves for the `column IN (...)` filters in `filters`. Each yields:
+///  i)  a `ScalarInList` (min/max) leaf — on every column;
+///  ii) plus, on an FTS-indexed column, a `TermPresence{Or}` leaf over the
+///      values' tokens, which prunes on which superfiles hold the term.
+///
+/// A `NOT IN`, a non-literal item, a function-wrapped or unknown column
+/// yields no leaf — that filter just isn't pruned (the scan stays correct).
+///
+/// Only sees `Expr::InList` (4+ values): DataFusion rewrites a 1-value
+/// `IN` to `=` and a 2–3 value `IN` to `OR` before the provider.
+pub(crate) fn exprs_to_in_list_leaves(
+    filters: &[Expr],
+    schema: &SchemaRef,
+    fts_cols: &HashSet<&str>,
+    tokenizer: Option<&dyn Tokenizer>,
+) -> Vec<PruneLeaf> {
+    let mut out = Vec::new();
+
+    for filter in filters {
+        collect_in_list_leaves(filter, schema, fts_cols, tokenizer, &mut out);
+    }
+
+    out
+}
+
+/// e.g. `product IN ('Orange Juice', 'Pineapple')` on an FTS column →
+/// `[ TermPresence{Or, [orange, juice, pineapple]},
+///    ScalarInList{product, ['Orange Juice', 'Pineapple']} ]`
+/// — bloom leaf holds the lowercased tokens, min/max leaf the raw values.
+///
+/// Note: the bloom flattens all tokens into one `Or`, so a superfile with
+/// only `orange` is kept though no value matches. A tighter prune would be
+/// per-value `(orange AND juice) OR pineapple`; FilterExec verifies either way.
+fn collect_in_list_leaves(
+    expr: &Expr,
+    schema: &SchemaRef,
+    fts_cols: &HashSet<&str>,
+    tokenizer: Option<&dyn Tokenizer>,
+    out: &mut Vec<PruneLeaf>,
+) {
+    match expr {
+        // Descend AND; an IN can sit on either side.
+        Expr::BinaryExpr(be) if be.op == Operator::And => {
+            collect_in_list_leaves(&be.left, schema, fts_cols, tokenizer, out);
+            collect_in_list_leaves(&be.right, schema, fts_cols, tokenizer, out);
+        }
+        Expr::InList(il) if !il.negated => {
+            // Only a bare column maps to a min/max or bloom; else skip.
+            let Expr::Column(c) = il.expr.as_ref() else {
+                return;
+            };
+
+            if schema.field_with_name(&c.name).is_err() {
+                return;
+            }
+
+            // Every item must be a literal to bound min/max; else skip.
+            let mut values = Vec::with_capacity(il.list.len());
+            for item in &il.list {
+                let Expr::Literal(v, _) = item else {
+                    return;
+                };
+                values.push(v.clone());
+            }
+
+            // Empty IN list, nothing to bound.
+            if values.is_empty() {
+                return;
+            }
+
+            // Only for FTS indexed columns
+            if fts_cols.contains(c.name.as_str())
+                && let Some(tok) = tokenizer
+            {
+                let terms: Vec<String> = values
+                    .iter()
+                    .filter_map(scalar_as_str)
+                    .flat_map(|s| tok.tokenize(s))
+                    .collect();
+
+                if !terms.is_empty() {
+                    // one bloom leaf holding all the values' tokens
+                    out.push(PruneLeaf::TermPresence {
+                        column: c.name.clone(),
+                        terms,
+                        mode: BoolMode::Or,
+                    });
+                }
+            }
+
+            // The min/max leaf — on every column.
+            out.push(PruneLeaf::ScalarInList {
+                column: c.name.clone(),
+                values,
+            });
+        }
+        _ => {}
+    }
+}
+
 /// Recurse through `AND` nodes, pushing any recognized
 /// `column <op> literal` leaf into `out`.
 fn collect_conjuncts(expr: &Expr, schema: &SchemaRef, out: &mut Vec<ScalarPredicate>) {
@@ -1373,6 +1488,103 @@ mod tests {
         let s = schema_xy();
         let preds = exprs_to_scalar_predicates(&[col("x").gt(col("y"))], &s);
         assert!(preds.is_empty());
+    }
+
+    /// The `(column, value-count)` of each `ScalarInList` leaf, for asserting
+    /// extraction without matching on the full enum.
+    fn in_list_leaves(filters: &[Expr], schema: &SchemaRef) -> Vec<(String, usize)> {
+        // No FTS columns / tokenizer → only the scalar min/max leaf.
+        exprs_to_in_list_leaves(filters, schema, &HashSet::new(), None)
+            .into_iter()
+            .map(|l| match l {
+                PruneLeaf::ScalarInList { column, values } => (column, values.len()),
+                _ => panic!("expected a ScalarInList leaf"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn in_list_lowers_to_one_leaf_with_all_values() {
+        let s = schema_xy();
+        let expr = col("x").in_list(vec![lit(1_i64), lit(2_i64), lit(3_i64)], false);
+        assert_eq!(in_list_leaves(&[expr], &s), vec![("x".to_string(), 3)]);
+    }
+
+    #[test]
+    fn in_list_under_and_is_found() {
+        let s = schema_xy();
+        let expr = col("x")
+            .gt(lit(0_i64))
+            .and(col("y").in_list(vec![lit(7_i64)], false));
+        assert_eq!(in_list_leaves(&[expr], &s), vec![("y".to_string(), 1)]);
+    }
+
+    #[test]
+    fn negated_in_list_emits_no_leaf() {
+        let s = schema_xy();
+        let expr = col("x").in_list(vec![lit(1_i64)], true);
+        assert!(exprs_to_in_list_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+    }
+
+    #[test]
+    fn in_list_with_non_literal_item_emits_no_leaf() {
+        let s = schema_xy();
+        // `x IN (1, y)` — `y` is a column, not a literal; can't bound min/max.
+        let expr = col("x").in_list(vec![lit(1_i64), col("y")], false);
+        assert!(exprs_to_in_list_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+    }
+
+    #[test]
+    fn in_list_on_unknown_column_emits_no_leaf() {
+        let s = schema_xy();
+        let expr = col("z").in_list(vec![lit(1_i64)], false);
+        assert!(exprs_to_in_list_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+    }
+
+    #[test]
+    fn in_list_on_fts_column_also_emits_term_presence_bloom() {
+        use crate::superfile::fts::tokenize::AsciiLowerTokenizer;
+        let s = Arc::new(Schema::new(vec![Field::new("title", DataType::Utf8, true)]));
+        let fts = HashSet::from(["title"]);
+        let tok = AsciiLowerTokenizer;
+        // 'Foo Bar' → [foo, bar]; 'baz' → [baz].
+        let expr = col("title").in_list(vec![lit("Foo Bar"), lit("baz")], false);
+        let leaves = exprs_to_in_list_leaves(&[expr], &s, &fts, Some(&tok));
+
+        assert!(
+            leaves
+                .iter()
+                .any(|l| matches!(l, PruneLeaf::ScalarInList { .. })),
+            "scalar min/max leaf still emitted"
+        );
+        let (col_name, terms, mode) = leaves
+            .iter()
+            .find_map(|l| match l {
+                PruneLeaf::TermPresence {
+                    column,
+                    terms,
+                    mode,
+                } => Some((column.as_str(), terms, *mode)),
+                _ => None,
+            })
+            .expect("FTS column also emits a TermPresence bloom leaf");
+        assert_eq!(col_name, "title");
+        assert_eq!(mode, BoolMode::Or);
+        assert_eq!(
+            terms,
+            &vec!["foo".to_string(), "bar".to_string(), "baz".to_string()]
+        );
+    }
+
+    #[test]
+    fn in_list_on_non_fts_column_emits_only_scalar_leaf() {
+        let s = schema_xy();
+        let fts = HashSet::from(["title"]); // "x" not in the set
+        let tok = crate::superfile::fts::tokenize::AsciiLowerTokenizer;
+        let expr = col("x").in_list(vec![lit(1_i64), lit(2_i64), lit(3_i64), lit(4_i64)], false);
+        let leaves = exprs_to_in_list_leaves(&[expr], &s, &fts, Some(&tok));
+        assert_eq!(leaves.len(), 1);
+        assert!(matches!(leaves[0], PruneLeaf::ScalarInList { .. }));
     }
 
     #[test]

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -31,7 +31,8 @@ use std::sync::Arc;
 use datafusion::scalar::ScalarValue;
 
 use super::skip::{
-    ScalarPredicate, fts_bloom_skip, fts_prefix_skip, scalar_skip, scalar_value_may_match,
+    ScalarOp, ScalarPredicate, fts_bloom_skip, fts_prefix_skip, scalar_in_list_skip, scalar_skip,
+    scalar_value_may_match,
 };
 use crate::{
     superfile::fts::reader::BoolMode,
@@ -39,7 +40,7 @@ use crate::{
         error::QueryError,
         manifest::{
             ManifestSnapshot, SuperfileEntry,
-            list::Manifest,
+            list::{Manifest, ManifestPartEntry},
             list_prune::{prune_parts_for_fts_prefix, prune_parts_for_fts_terms},
             part::PartId,
         },
@@ -64,11 +65,17 @@ pub(crate) enum PruneLeaf {
     Prefix { column: String, prefix: Vec<u8> },
     /// Scalar comparison on a scalar column → per-column min/max.
     Scalar(ScalarPredicate),
+    /// `column IN (values)` → keep if the min/max could hold any value.
+    ScalarInList {
+        column: String,
+        values: Vec<ScalarValue>,
+    },
 }
 
 impl PruneLeaf {
-    /// Part-tier keep set for this leaf, or `None` when the leaf has no
-    /// part-level pruner (it imposes no part constraint → keep all).
+    /// Identified Which manifest parts this leaf keeps, from the part-level
+    /// aggregates (`ManifestPartEntry`). `None` = no part constraint →
+    /// keep all parts. The per-superfile tier runs separately.
     pub(crate) fn keep_parts(&self, list: &Manifest) -> Option<Vec<PartId>> {
         match self {
             PruneLeaf::TermPresence {
@@ -83,40 +90,63 @@ impl PruneLeaf {
                 Some(prune_parts_for_fts_prefix(list, column, prefix))
             }
             PruneLeaf::Scalar(pred) => Some(scalar_keep_parts(list, pred)),
+            PruneLeaf::ScalarInList { column, values } => {
+                Some(scalar_in_list_keep_parts(list, column, values))
+            }
         }
     }
 }
 
-/// Part-tier scalar prune: keep each part whose aggregate min/max for
-/// the predicate's column could satisfy it. A missing aggregate or
-/// undecodable bounds → keep (conservative — never a false prune).
-///
-/// The aggregate min/max are held as length-1 [`ArrayRef`]s
-/// (`ScalarStatsAgg.{min,max}`), already decoded when the manifest list
-/// was loaded — so this hot path reads the [`ScalarValue`] straight from
-/// the array with no per-query Arrow-IPC decode, then reuses the same
-/// comparison core the superfile tier uses ([`scalar_value_may_match`]).
-fn scalar_keep_parts(list: &Manifest, pred: &ScalarPredicate) -> Vec<PartId> {
+/// Keep each part whose aggregate min/max for `column` satisfies
+/// `may_match`. A missing aggregate or undecodable bounds keeps the part
+/// (conservative — never a false prune). The bounds are length-1
+/// [`ArrayRef`]s decoded when the list loaded, so reading the
+/// [`ScalarValue`] here is free of per-query Arrow decode.
+fn keep_parts_where(
+    list: &Manifest,
+    column: &str,
+    may_match: impl Fn(&ScalarValue, &ScalarValue) -> bool,
+) -> Vec<PartId> {
     list.parts
         .iter()
         .filter_map(|entry| {
-            let keep = match entry.scalar_stats_agg.get(&pred.column) {
+            let keep = match part_minmax(entry, column) {
+                Some((min, max)) => may_match(&min, &max),
                 None => true,
-                Some(agg) => {
-                    match (
-                        ScalarValue::try_from_array(agg.min.as_ref(), 0).ok(),
-                        ScalarValue::try_from_array(agg.max.as_ref(), 0).ok(),
-                    ) {
-                        (Some(min), Some(max)) => {
-                            scalar_value_may_match(&min, &max, pred.op, &pred.value)
-                        }
-                        _ => true,
-                    }
-                }
             };
             keep.then_some(entry.part_id)
         })
         .collect()
+}
+
+// The manifest part's aggregate min/max for `column`, or `None` when the column
+// has no aggregate or the bounds don't decode (caller keeps).
+fn part_minmax(entry: &ManifestPartEntry, column: &str) -> Option<(ScalarValue, ScalarValue)> {
+    let agg = entry.scalar_stats_agg.get(column)?;
+    match (
+        ScalarValue::try_from_array(agg.min.as_ref(), 0),
+        ScalarValue::try_from_array(agg.max.as_ref(), 0),
+    ) {
+        (Ok(min), Ok(max)) => Some((min, max)),
+        _ => None,
+    }
+}
+
+// Part-tier scalar prune: keep parts whose min/max could satisfy `pred`.
+fn scalar_keep_parts(list: &Manifest, pred: &ScalarPredicate) -> Vec<PartId> {
+    keep_parts_where(list, &pred.column, |min, max| {
+        scalar_value_may_match(min, max, pred.op, &pred.value)
+    })
+}
+
+// Part-tier `IN` prune: keep parts whose min/max could hold *any* listed
+// value (an `IN` is a disjunction of equalities).
+fn scalar_in_list_keep_parts(list: &Manifest, column: &str, values: &[ScalarValue]) -> Vec<PartId> {
+    keep_parts_where(list, column, |min, max| {
+        values
+            .iter()
+            .any(|v| scalar_value_may_match(min, max, ScalarOp::Eq, v))
+    })
 }
 
 /// Select the superfiles a predicate could match, newest-first in
@@ -172,6 +202,9 @@ pub(crate) async fn select_superfiles(
             }
             PruneLeaf::Prefix { column, prefix } => {
                 and_into(&mut mask, &fts_prefix_skip(&superfiles, column, prefix));
+            }
+            PruneLeaf::ScalarInList { column, values } => {
+                and_into(&mut mask, &scalar_in_list_skip(&superfiles, column, values));
             }
             // Scalar leaves handled above as one conjunction.
             PruneLeaf::Scalar(_) => {}
@@ -306,6 +339,28 @@ mod tests {
         assert_eq!(
             scalar_keep_parts(&list, &pred("x", ScalarOp::Gt, 50)),
             vec![p1.part_id]
+        );
+    }
+
+    #[test]
+    fn scalar_in_list_keep_parts_keeps_every_part_holding_a_listed_value() {
+        let p0 = part_from(&[seg_int("x", 0, 10)], 0);
+        let p1 = part_from(&[seg_int("x", 100, 110)], 1);
+        let p2 = part_from(&[seg_int("x", 200, 210)], 2);
+        let list = list_with(vec![p0.clone(), p1.clone(), p2.clone()]);
+        let i = |n| ScalarValue::Int64(Some(n));
+
+        // IN (5, 205) → p0 ([0,10]) and p2 ([200,210]); not p1.
+        assert_eq!(
+            scalar_in_list_keep_parts(&list, "x", &[i(5), i(205)]),
+            vec![p0.part_id, p2.part_id]
+        );
+        // IN (50) → in no part's range.
+        assert!(scalar_in_list_keep_parts(&list, "x", &[i(50)]).is_empty());
+        // Unknown column → conservative keep-all.
+        assert_eq!(
+            scalar_in_list_keep_parts(&list, "missing", &[i(5)]),
+            vec![p0.part_id, p1.part_id, p2.part_id]
         );
     }
 

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -258,21 +258,50 @@ pub fn scalar_skip(
         .collect()
 }
 
+/// Keep each superfile whose `column` min/max could hold *any* of
+/// `values` (an `IN` list is a disjunction). Empty `values` keeps all.
+/// The SQL-side sibling of [`scalar_skip`] for the `IN` shape.
+pub fn scalar_in_list_skip(
+    superfiles: &[Arc<SuperfileEntry>],
+    column: &str,
+    values: &[ScalarValue],
+) -> Vec<bool> {
+    if values.is_empty() {
+        return vec![true; superfiles.len()];
+    }
+
+    superfiles
+        .iter()
+        .map(|entry| match superfile_minmax(entry, column) {
+            None => true,
+            Some((min, max)) => values
+                .iter()
+                .any(|v| scalar_value_may_match(&min, &max, ScalarOp::Eq, v)),
+        })
+        .collect()
+}
+
 /// Whether `entry` *could* contain a row satisfying `pred`, judged
 /// only from the superfile's persisted min/max. Conservative: any
 /// uncertainty returns `true` (keep).
 fn superfile_may_match(entry: &SuperfileEntry, pred: &ScalarPredicate) -> bool {
-    let Some(agg) = entry.scalar_stats.get(&pred.column) else {
-        // No stats for this column — can't prove irrelevance.
-        return true;
-    };
-    let (Ok(min), Ok(max)) = (
+    match superfile_minmax(entry, &pred.column) {
+        None => true,
+        Some((min, max)) => scalar_value_may_match(&min, &max, pred.op, &pred.value),
+    }
+}
+
+/// The superfile's persisted min/max for `column`, or `None` when the
+/// column has no stats or the bounds don't decode (caller keeps).
+fn superfile_minmax(entry: &SuperfileEntry, column: &str) -> Option<(ScalarValue, ScalarValue)> {
+    let agg = entry.scalar_stats.get(column)?;
+    match (
         ScalarValue::try_from_array(agg.min.as_ref(), 0),
         ScalarValue::try_from_array(agg.max.as_ref(), 0),
-    ) else {
-        return true;
-    };
-    scalar_value_may_match(&min, &max, pred.op, &pred.value)
+    ) {
+        (Ok(min), Ok(max)) => Some((min, max)),
+        _ => None,
+    }
 }
 
 /// Conservative `min`/`max`-vs-`value` comparison core, shared by the
@@ -639,6 +668,32 @@ mod tests {
             seg_with_int_stats("x", 100, 110),
         ];
         assert_eq!(scalar_skip(&segs, &[]), vec![true, true]);
+    }
+
+    #[test]
+    fn scalar_in_list_skip_keeps_superfiles_holding_any_listed_value() {
+        let segs = vec![
+            seg_with_int_stats("x", 0, 10),
+            seg_with_int_stats("x", 100, 110),
+            seg_with_int_stats("x", 200, 210),
+        ];
+        let i = |n| ScalarValue::Int64(Some(n));
+        // IN (5, 205) → A's [0,10] and C's [200,210], not B.
+        assert_eq!(
+            scalar_in_list_skip(&segs, "x", &[i(5), i(205)]),
+            vec![true, false, true]
+        );
+        // IN (50) → matches no range.
+        assert_eq!(
+            scalar_in_list_skip(&segs, "x", &[i(50)]),
+            vec![false, false, false]
+        );
+        // Empty list and unknown column both keep all (conservative).
+        assert_eq!(scalar_in_list_skip(&segs, "x", &[]), vec![true, true, true]);
+        assert_eq!(
+            scalar_in_list_skip(&segs, "missing", &[i(5)]),
+            vec![true, true, true]
+        );
     }
 
     #[test]

--- a/tests/supertable/query/covered_agg.rs
+++ b/tests/supertable/query/covered_agg.rs
@@ -266,3 +266,145 @@ fn tombstoned_covered_segment_demotes_to_residual() {
     assert_eq!(scalar_i64(&st, &count_sql), commit_range_count(1, 2) - 1);
     assert_eq!(scalar_i64(&st, &sum_sql), commit_range_sum(1, 2) - 1005);
 }
+
+/// `IN`-list scalar pruning must keep every superfile holding a listed
+/// value (the disjoint rating blocks put each value in its own superfile):
+///  - a wrong prune would drop a superfile and undercount.
+///  - `FilterExec` verifies rows, so the count is the exact oracle.
+#[test]
+fn in_list_filter_returns_every_matching_row_across_superfiles() {
+    let st = build_table();
+
+    // 5 → commit 0, 1005 → commit 1, 3005 → commit 3: three superfiles.
+    let spanning = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable WHERE rating IN (5, 1005, 3005)",
+    );
+    assert_eq!(spanning, 3, "one row per value, across three superfiles");
+
+    // A value outside every superfile's range matches nothing.
+    let absent = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable WHERE rating IN (99999)",
+    );
+    assert_eq!(absent, 0);
+
+    // Mixed present/absent → only the present values contribute.
+    let mixed = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable WHERE rating IN (5, 99999, 2005)",
+    );
+    assert_eq!(mixed, 2);
+}
+
+// ---- How DataFusion reshapes a numeric IN before the provider ----
+//
+// Verified against DataFusion 53.1.0 source (`datafusion-optimizer`):
+// `ShortenInListSimplifier` in `simplify_expressions/inlist_simplifier.rs`
+// rewrites `expr IN (list)` when:
+//   * `list.len() == 1`            → `expr = A` (any expr), OR
+//   * `list.len() <= THRESHOLD_INLINE_INLIST` (=3) AND `expr` is a bare
+//     column → `expr = A OR expr = B OR …` (negated → AND of `!=`).
+// Otherwise the node is kept as `Expr::InList` (len ≥ 4, or a 2–3 list
+// over a non-column expression).
+//
+// So, for a plain `col IN (...)` the scan sees:
+//   IN (x)         → `col = x`               (BinaryExpr Eq)
+//   IN (a,b,c) ≤3  → OR-of-equalities        (top-level Operator::Or)
+//   IN (a,b,c,d)≥4 → `Expr::InList`          (kept)
+//   IN (SELECT …)  → `Expr::InSubquery`, decorrelated to a LeftSemi join
+//                    by `DecorrelatePredicateSubquery` → the OUTER scan
+//                    gets ZERO pushed filters.
+//
+// Correctness pins — the count is identical regardless of shape, since
+// `FilterExec` verifies above the scan.
+
+#[test]
+fn numeric_in_single_value_rewrites_to_equality() {
+    let st = build_table();
+    let n = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable WHERE rating IN (5)",
+    );
+    assert_eq!(n, 1);
+}
+
+#[test]
+fn numeric_in_small_list_lowers_to_or() {
+    // 2 elements → `rating=5 OR rating=1005`.
+    let st = build_table();
+    let n = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable WHERE rating IN (5, 1005)",
+    );
+    assert_eq!(n, 2);
+}
+
+#[test]
+fn numeric_in_large_list_stays_inlist() {
+    // 6 elements → kept as `Expr::InList` (≥ 4). 1,2,3 in commit 0;
+    // 1001,1002 in commit 1; 2001 in commit 2.
+    let st = build_table();
+    let n = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable WHERE rating IN (1, 2, 3, 1001, 1002, 2001)",
+    );
+    assert_eq!(n, 6);
+}
+
+#[test]
+fn subquery_in_becomes_a_semi_join_not_a_pushed_filter() {
+    // `rating IN (SELECT rating FROM supertable WHERE rating < 10)` →
+    // a semi-join: the inner scan filters `rating < 10` (commit 0's
+    // ratings 0..9 = 10 rows), the outer scan gets no pushed filter, and
+    // they join. The IN never reaches the provider as a prunable filter.
+    let st = build_table();
+    let n = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable \
+         WHERE rating IN (SELECT rating FROM supertable WHERE rating < 10)",
+    );
+    assert_eq!(n, 10);
+}
+
+#[test]
+fn function_wrapped_small_in_stays_inlist_not_or() {
+    // A 2-value IN over a *function* expression stays `Expr::InList`:
+    //  - the 2-3 element OR rewrite requires a bare column
+    //    (`expr.try_as_col()` in ShortenInListSimplifier).
+    //  - `lower(category)` fails that, so no OR rewrite.
+    // category = 'cat{idx}_{r:03}'; 'cat0_005' + 'cat1_005' → 2 rows.
+    let st = build_table();
+    let n = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable \
+         WHERE lower(category) IN ('cat0_005', 'cat1_005')",
+    );
+    assert_eq!(n, 2);
+}
+
+#[test]
+fn not_in_returns_the_complement() {
+    // NOT IN never prunes here:
+    //  - small (≤3) → AND of `!=`; ≥4 → a negated InList.
+    //  - `collect_in_list_leaves` bails on `negated`, and `!=` doesn't
+    //    prune meaningfully → full scan + FilterExec.
+    // So just assert the exact complement (no rows wrongly dropped).
+    // 4 commits × 50 = 200 rows; ratings are unique.
+    let st = build_table();
+    let total = (COMMITS * ROWS_PER_COMMIT) as i64;
+
+    // Small NOT IN (2 values) → `rating != 5 AND rating != 1005`.
+    let n = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable WHERE rating NOT IN (5, 1005)",
+    );
+    assert_eq!(n, total - 2);
+
+    // Large NOT IN (≥4) → negated InList (kept as-is, no leaf emitted).
+    let n = scalar_i64(
+        &st,
+        "SELECT COUNT(*) AS n FROM supertable WHERE rating NOT IN (1, 2, 3, 1001)",
+    );
+    assert_eq!(n, total - 4);
+}

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -317,6 +317,306 @@ fn sql_loads_all_parts_returns_correct_count() {
     );
 }
 
+/// Build a manifest with `target_superfiles_per_part = 2`: each commit
+/// is one superfile, two superfiles pack into a part, then a new part
+/// rolls over. 6 commits → 3 parts. `titles[i]` is commit i's batch.
+fn build_3_parts_two_superfiles_each(storage_dir: &std::path::Path, commits: &[[&str; 2]]) {
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir).expect("provider"));
+    let producer = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_target_superfiles_per_part(2),
+    )
+    .expect("create");
+    for titles in commits.iter() {
+        let mut w = producer.writer().expect("writer");
+        w.append(&build_title_batch(&titles[..])).expect("append");
+        w.commit().expect("commit");
+    }
+}
+
+fn open_lazy_consumer(storage_dir: &std::path::Path, cache_dir: &std::path::Path) -> Supertable {
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir).expect("provider"));
+    let cache = make_cache(Arc::clone(&storage), cache_dir);
+    Supertable::open(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_eager_load_threshold(EAGER_LOAD_THRESHOLD_FORCE_LAZY)
+            .with_disk_cache(Arc::clone(&cache)),
+    )
+    .expect("open")
+}
+
+/// How many parts are currently resident (loaded) in the consumer's
+/// manifest — the observable behind "did the prune skip parts?".
+fn parts_loaded(consumer: &Supertable) -> (usize, usize) {
+    let r = consumer.reader();
+    let m = r.manifest();
+    let entries = m.get_all_list_entries();
+    let loaded = entries
+        .iter()
+        .filter(|e| m.get_cached_part_by_id(&e.part_id).is_some())
+        .count();
+    (loaded, entries.len())
+}
+
+#[test]
+fn sql_single_value_in_prunes_parts_via_equality_rewrite() {
+    // Single-value `IN ('Fig Roll')` on the FTS `title` column:
+    //  - DataFusion rewrites a 1-value IN to `title = 'Fig Roll'`.
+    //  - equality on an FTS column → a `TermPresence` bloom leaf.
+    //  - so only the one part holding the value is loaded.
+    let dir = TempDir::new().expect("tempdir");
+    build_3_parts_two_superfiles_each(
+        dir.path(),
+        &[
+            ["Apple Pie", "Apricot Tart"], // part 0: [Apple Pie, Banana Bread]
+            ["Avocado Toast", "Banana Bread"],
+            ["Cherry Cake", "Date Loaf"], // part 1: [Cherry Cake, Grape Jam]
+            ["Fig Roll", "Grape Jam"],
+            ["Kiwi Smoothie", "Lemon Tart"], // part 2: [Kiwi Smoothie, Orange Juice]
+            ["Mango Lassi", "Orange Juice"],
+        ],
+    );
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_lazy_consumer(dir.path(), cache_dir.path());
+
+    let batches = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE title IN ('Fig Roll')")
+        .expect("query");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 1, "exactly one row has title 'Fig Roll'");
+
+    let (loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3, "6 commits / 2-per-part = 3 parts");
+    assert_eq!(
+        loaded, 1,
+        "min/max prune must load only part 1; got {loaded}/3"
+    );
+}
+
+#[test]
+fn sql_multi_value_in_returns_exact_rows_across_parts() {
+    // `title IN ('Straw Berry', 'Orange Juice')`, matches in parts 1 and 2.
+    //  - DataFusion rewrites a multi-value IN to `title = a OR title = b`.
+    //  - the manifest prune doesn't descend `OR`, so all 3 parts load.
+    //  - correctness comes from `FilterExec`, not pruning.
+    // This test pins the rows; pruning the `OR` form is future work.
+    let dir = TempDir::new().expect("tempdir");
+    build_3_parts_two_superfiles_each(
+        dir.path(),
+        &[
+            ["Apple Pie", "Banana Bread"], // part 0: [Apple Pie, Date Loaf] — neither match
+            ["Cherry Cake", "Date Loaf"],
+            ["Mango Lassi", "Orange Juice"], // part 1: holds 'Orange Juice'
+            ["Peach Melba", "Plum Cake"],
+            ["Raspberry Pie", "Straw Berry"], // part 2: holds 'Straw Berry'
+            ["Vanilla Slice", "Walnut Bread"],
+        ],
+    );
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_lazy_consumer(dir.path(), cache_dir.path());
+
+    let batches = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE title IN ('Straw Berry', 'Orange Juice')")
+        .expect("query");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 2, "'Orange Juice' (part 1) + 'Straw Berry' (part 2)");
+
+    // Multi-value IN lowers to OR-of-equalities → no manifest prune today,
+    // so all parts load. Correctness still holds via FilterExec.
+    let (_loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3, "6 commits / 2-per-part = 3 parts");
+
+    // Token-superset that isn't a full match → FilterExec drops it.
+    // 'Straw' shares the `straw` token with 'Straw Berry' but isn't an
+    // exact title; the other literal exists nowhere.
+    let none = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE title IN ('Straw', 'Iced Coffee Blend')")
+        .expect("query");
+    assert_eq!(
+        none.iter().map(|b| b.num_rows()).sum::<usize>(),
+        0,
+        "no row's full title equals either literal"
+    );
+}
+
+#[test]
+fn fts_in_bloom_prunes_parts_min_max_cannot() {
+    // Bloom prunes where min/max can't. `title IN (...)`, 4 values:
+    //  - every part holds anchors "aaa"+"zzz" → min/max is [aaa,zzz] for
+    //    all → the ScalarInList leaf keeps all 3 parts.
+    //  - "bravo" lives only in part 1 → the TermPresence{Or} bloom leaf
+    //    narrows to part 1.
+    //  - 4 values keeps it an `Expr::InList` (≤3 would lower to OR).
+    let dir = TempDir::new().expect("tempdir");
+    build_3_parts_two_superfiles_each(
+        dir.path(),
+        &[
+            ["aaa", "alpha"], // part 0: tokens aaa, alpha, zzz, filler0
+            ["zzz", "filler0"],
+            ["aaa", "bravo"], // part 1: holds 'bravo'
+            ["zzz", "filler1"],
+            ["aaa", "charlie"], // part 2
+            ["zzz", "filler2"],
+        ],
+    );
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_lazy_consumer(dir.path(), cache_dir.path());
+
+    // 4 values → stays InList (not lowered to OR). 'bravo' matches part 1;
+    // the other three exist nowhere.
+    let batches = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE title IN ('bravo', 'qx', 'qy', 'qz')")
+        .expect("query");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 1, "only the 'bravo' title matches");
+
+    let (loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3);
+    assert_eq!(
+        loaded, 1,
+        "min/max keeps all 3 (range [aaa,zzz]); the bloom must narrow to part 1; got {loaded}/3"
+    );
+}
+
+#[test]
+fn fts_in_multitoken_bloom_spans_parts_and_skips_the_unmatched() {
+    // Multi-word values, again min/max-blind (all parts [aaa,zzz]).
+    // `title IN ('new york', 'los angeles', 'qx', 'qy')`:
+    //  - bloom leaf = `TermPresence{Or, [new,york,los,angeles,qx,qy]}`.
+    //  - part 1 (san/diego) holds none of those tokens → dropped.
+    //  - parts 0 (new york) + 2 (los angeles) kept → FilterExec keeps the
+    //    two exact full-title matches.
+    let dir = TempDir::new().expect("tempdir");
+    build_3_parts_two_superfiles_each(
+        dir.path(),
+        &[
+            ["aaa", "new york"], // part 0
+            ["zzz", "filler0"],
+            ["aaa", "san diego"], // part 1 — no query token
+            ["zzz", "filler1"],
+            ["aaa", "los angeles"], // part 2
+            ["zzz", "filler2"],
+        ],
+    );
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_lazy_consumer(dir.path(), cache_dir.path());
+
+    let batches = consumer
+        .reader()
+        .query_sql(
+            "SELECT _id FROM supertable \
+             WHERE title IN ('new york', 'los angeles', 'qx', 'qy')",
+        )
+        .expect("query");
+    assert_eq!(
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        2,
+        "'new york' (part 0) + 'los angeles' (part 2)"
+    );
+    let (loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3);
+    assert_eq!(loaded, 2, "bloom drops part 1 (san/diego); got {loaded}/3");
+}
+
+#[test]
+fn fts_in_all_values_absent_prunes_every_part() {
+    // Same fixture; none of the IN values' tokens are in any part's
+    // bloom → every part dropped → zero parts opened, zero rows.
+    let dir = TempDir::new().expect("tempdir");
+    build_3_parts_two_superfiles_each(
+        dir.path(),
+        &[
+            ["aaa", "new york"],
+            ["zzz", "filler0"],
+            ["aaa", "san diego"],
+            ["zzz", "filler1"],
+            ["aaa", "los angeles"],
+            ["zzz", "filler2"],
+        ],
+    );
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_lazy_consumer(dir.path(), cache_dir.path());
+
+    let batches = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE title IN ('qx', 'qy', 'qz', 'qw')")
+        .expect("query");
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+    let (loaded, _total) = parts_loaded(&consumer);
+    assert_eq!(loaded, 0, "no token in any part bloom → open nothing");
+}
+
+#[test]
+fn fts_in_multiword_mixedcase_value_bloom_and_exact_filter() {
+    // A 3-token, mixed-case value: "lives in Mumbai". Covers:
+    //   - tokenizer lowercases → bloom terms [lives, in, mumbai];
+    //   - a COMMON token ("in") shared across parts → Or-mode bloom
+    //     over-keeps the part that only shares "in" (sound, looser);
+    //   - FilterExec is CASE-SENSITIVE on the full string.
+    let dir = TempDir::new().expect("tempdir");
+    build_3_parts_two_superfiles_each(
+        dir.path(),
+        &[
+            ["aaa", "lives in Mumbai"], // part 0 — the target
+            ["zzz", "filler0"],
+            ["aaa", "works in Delhi"], // part 1 — shares the common token "in"
+            ["zzz", "filler1"],
+            ["aaa", "stays at Pune"], // part 2 — no shared token
+            ["zzz", "filler2"],
+        ],
+    );
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_lazy_consumer(dir.path(), cache_dir.path());
+
+    // Exact-case query (4 values → InList):
+    //  - bloom keeps part 0 (lives,in,mumbai) and part 1 (shares "in" — over-keep).
+    //  - part 2 dropped.
+    //  - FilterExec keeps only the exact "lives in Mumbai" row.
+    let batches = consumer
+        .reader()
+        .query_sql(
+            "SELECT _id FROM supertable \
+             WHERE title IN ('lives in Mumbai', 'qx', 'qy', 'qz')",
+        )
+        .expect("query");
+    assert_eq!(
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        1,
+        "only the exact 'lives in Mumbai' row matches"
+    );
+    let (loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3);
+    assert_eq!(
+        loaded, 2,
+        "bloom keeps part 0 + part 1 (shared token 'in'); part 2 skipped; got {loaded}/3"
+    );
+
+    // Case-mismatched query ('lives in MUMBAI'):
+    //  - bloom still matches (tokens are lowercased on both sides).
+    //  - but FilterExec's full-string equality is case-sensitive → 0 rows.
+    // So the bloom is a presence superset; the exact filter is correctness.
+    let none = consumer
+        .reader()
+        .query_sql(
+            "SELECT _id FROM supertable \
+             WHERE title IN ('lives in MUMBAI', 'qx', 'qy', 'qz')",
+        )
+        .expect("query");
+    assert_eq!(
+        none.iter().map(|b| b.num_rows()).sum::<usize>(),
+        0,
+        "stored 'lives in Mumbai' != literal 'lives in MUMBAI' (case-sensitive)"
+    );
+}
+
 #[test]
 fn eager_mode_query_paths_observationally_unchanged() {
     // 1 part + default threshold (4) → eager mode. All

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -447,6 +447,44 @@ fn sql_multi_value_in_returns_exact_rows_across_parts() {
 }
 
 #[test]
+fn sql_between_returns_exact_rows_across_parts() {
+    // `title BETWEEN 'C' AND 'G'` — a range predicate, sibling of IN.
+    //  - DataFusion expands BETWEEN to `title >= 'C' AND title <= 'G'`,
+    //    two comparisons the scalar conjunct path lowers to range leaves.
+    //  - so this never enters the IN path, and min/max still prunes:
+    //    part 2's titles all sort above 'G', so its range can't match.
+    //  - pins both the rows and the prune so the IN work can't regress it.
+    let dir = TempDir::new().expect("tempdir");
+    build_3_parts_two_superfiles_each(
+        dir.path(),
+        &[
+            ["Apple", "Cherry"], // part 0: matches Cherry, Date
+            ["Banana", "Date"],
+            ["Egg", "Fig"], // part 1: matches Egg, Fig
+            ["Grape", "Berry"],
+            ["Mango", "Orange"], // part 2: all > 'G', no match
+            ["Tango", "Plum"],
+        ],
+    );
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_lazy_consumer(dir.path(), cache_dir.path());
+
+    let batches = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE title BETWEEN 'C' AND 'G'")
+        .expect("query");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 4, "Cherry, Date (part 0) + Egg, Fig (part 1)");
+
+    let (loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3, "6 commits / 2-per-part = 3 parts");
+    assert_eq!(
+        loaded, 2,
+        "min/max range prune skips part 2 (all titles > 'G'); got {loaded}/3"
+    );
+}
+
+#[test]
 fn fts_in_bloom_prunes_parts_min_max_cannot() {
     // Bloom prunes where min/max can't. `title IN (...)`, 4 values:
     //  - every part holds anchors "aaa"+"zzz" → min/max is [aaa,zzz] for


### PR DESCRIPTION
Closes #180 

### What does this PR do?
Extends `WHERE`-clause superfile pruning to `column IN (...)`. So an `IN` query opens only the superfiles whose stats say they might hold a listed value ; the same "ask the manifest before touching bytes" pruning.

### Why do we need this change?
Today an `IN` filter reaches `SupertableProvider::scan` but isn't lowered to any prune leaf, so it contributes nothing and **every** superfile is opened. Equality (`col = x`) and prefix already prune; `IN` was the gap.

### How do we do this change?
Each `column IN (...)` filter becomes a manifest check that skips superfiles before opening them:
- a **min/max** check (every column); skip if the value range can't hold any listed value;
- on a **full-text column**, also a **bloom** check; skip if the text holds none of the values' words.

Run in two tiers (manifest parts, then superfiles); only survivors are opened. This PR deals only with  4+ value lists (DataFusion rewrites smaller `IN`s to `=`/`OR`); `NOT IN`, non-literals, and function/unknown columns produce no leaf and just scan.


### Performance
Cold tier, 1M docs / ~16 superfiles, `key IN (4 keys)` on the FTS-indexed, unsorted `key` column (min/max can't prune it; only the bloom can):

| | cold search p50 | superfiles opened |
| --- | --- | --- |
| before | 2.86 s | all ~16 |
| after | 0.51 s | only the ~4 holding |

≈ 5.6× improv; the bloom skips the cold opens (object-store GET + footer + decode) of the superfiles holding none of the keys.

### Notes
- Multi-word FTS values (`'Orange Juice'` → `orange, juice`) flatten into one `Or` bloom over all tokens - a conservative superset (it over-keeps a superfile holding only `orange`); `FilterExec` verifies. A tighter per-value `(orange AND juice) OR pineapple` is possible but needs a disjunctive leaf.

