### PR TITLE
ci: trigger Node and Python publishes on a v* release tag

### DIFF
--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -4,12 +4,16 @@ name: Node publish
 # thin `infino` package plus its per-platform binary packages (`infino-<triple>`)
 # to npm.
 #
-# Triggered manually. The default run is a dry run: it packs and validates the
-# main package and every platform package without uploading anything. Re-run
-# with dry_run unchecked to publish for real. A real run needs the NPM_TOKEN
+# Triggered two ways: (1) a `v<version>` tag pushes a real publish as part of a
+# coordinated release (crate + Node + Python) — the version comes from
+# package.json and a guard asserts it matches the tag; (2) a manual run
+# (workflow_dispatch) defaults to a dry run — pack + validate, upload nothing —
+# re-run with dry_run unchecked to publish. A real run needs the NPM_TOKEN
 # secret, with publish rights to the packages under the infino-ai org.
 
 on:
+  push:
+    tags: ["v[0-9]*"]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -124,6 +128,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      # On a tag push the published version comes from package.json — assert it
+      # matches the tag so a coordinated release can't ship a mismatched version.
+      - name: Check package.json version matches tag
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(jq -r .version infino-node/package.json)"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::tag v$tag does not match infino-node/package.json version $pkg"
+            exit 1
+          fi
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -151,7 +166,7 @@ jobs:
       - name: Stage binaries into platform packages
         run: cd infino-node && npm run artifacts
       - name: Validate (dry run)
-        if: ${{ inputs.dry_run }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
           cd infino-node
           npx napi prepublish -t npm --skip-gh-release --dry-run
@@ -162,7 +177,7 @@ jobs:
       # includes a higher version, so npm won't move the latest tag onto
       # 0.1.0 implicitly. Passing it explicitly sets latest to the engine.
       - name: Publish to npm
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
         run: |
           cd infino-node
           npx napi prepublish -t npm --skip-gh-release

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -4,7 +4,7 @@ name: Publish Python package
 # wheel per platform/arch, then upload. A `v<version>` tag publishes to real
 # PyPI with the version derived from the tag (a coordinated release with the
 # crate + Node); a manual run (workflow_dispatch) chooses the version and the
-# TestPyPI (default) / PyPI target.
+# PyPI (default) / TestPyPI target.
 #
 # Two facts shape the whole pipeline:
 #   - abi3 (pyo3 `abi3-py39`) → a single wheel per platform/arch covers all
@@ -25,9 +25,9 @@ on:
       target:
         description: "Index to publish to"
         required: true
-        default: testpypi
+        default: pypi
         type: choice
-        options: [testpypi, pypi]
+        options: [pypi, testpypi]
 
 # One release per index at a time; never cancel a publish in flight.
 concurrency:
@@ -53,7 +53,7 @@ jobs:
       target: ${{ steps.check.outputs.target }}
     steps:
       # On a tag push, derive the version from the tag (`v0.1.0` -> `0.1.0`) and
-      # publish to real PyPI; a manual run uses its inputs (TestPyPI default).
+      # publish to real PyPI; a manual run uses its inputs (PyPI default).
       # Reject a non-SemVer version before the matrix spins up: Cargo's
       # `version` requires SemVer (it rejects PEP 440 like `0.1.0rc1`), and
       # maturin renders SemVer to the wheel's PEP 440 (`0.1.0-rc.1` → `0.1.0rc1`).

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,8 +1,10 @@
 name: Publish Python package
 
-# Manually-triggered release of the `infino` Python package: validate the
-# version, build one binary wheel per platform/arch, then upload to TestPyPI
-# (default) or PyPI.
+# Release of the `infino` Python package: validate the version, build one binary
+# wheel per platform/arch, then upload. A `v<version>` tag publishes to real
+# PyPI with the version derived from the tag (a coordinated release with the
+# crate + Node); a manual run (workflow_dispatch) chooses the version and the
+# TestPyPI (default) / PyPI target.
 #
 # Two facts shape the whole pipeline:
 #   - abi3 (pyo3 `abi3-py39`) → a single wheel per platform/arch covers all
@@ -12,6 +14,8 @@ name: Publish Python package
 #     and the matrix is kept wide enough that pip never falls back to source.
 
 on:
+  push:
+    tags: ["v[0-9]*"]
   workflow_dispatch:
     inputs:
       version:
@@ -46,18 +50,28 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
+      target: ${{ steps.check.outputs.target }}
     steps:
+      # On a tag push, derive the version from the tag (`v0.1.0` -> `0.1.0`) and
+      # publish to real PyPI; a manual run uses its inputs (TestPyPI default).
       # Reject a non-SemVer version before the matrix spins up: Cargo's
       # `version` requires SemVer (it rejects PEP 440 like `0.1.0rc1`), and
       # maturin renders SemVer to the wheel's PEP 440 (`0.1.0-rc.1` → `0.1.0rc1`).
       - id: check
         run: |
-          version="${{ inputs.version }}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            version="${GITHUB_REF_NAME#v}"
+            target="pypi"
+          else
+            version="${{ inputs.version }}"
+            target="${{ inputs.target }}"
+          fi
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
             echo "::error::invalid release version (must be SemVer): $version"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "target=$target" >> "$GITHUB_OUTPUT"
 
   build:
     name: wheel ${{ matrix.target }}
@@ -164,8 +178,8 @@ jobs:
           if-no-files-found: error
 
   publish:
-    name: Publish to ${{ inputs.target }}
-    needs: build
+    name: Publish to ${{ needs.validate.outputs.target }}
+    needs: [build, validate]
     runs-on: ubuntu-latest
     # `environment` is load-bearing, not decoration: the PyPI/TestPyPI trusted
     # publisher is keyed to it (plus repo + workflow file), and it can gate
@@ -174,7 +188,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    environment: ${{ inputs.target }}
+    environment: ${{ needs.validate.outputs.target }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -190,8 +204,8 @@ jobs:
           python3 -m twine check dist/*
       # Trusted Publishing: no `password` — the action exchanges the OIDC
       # token with the index. `repository-url` selects PyPI vs TestPyPI.
-      - name: Upload to ${{ inputs.target }}
+      - name: Upload to ${{ needs.validate.outputs.target }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
-          repository-url: ${{ inputs.target == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          repository-url: ${{ needs.validate.outputs.target == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -29,9 +29,12 @@ on:
         type: choice
         options: [pypi, testpypi]
 
-# One release per index at a time; never cancel a publish in flight.
+# One release per index at a time; never cancel a publish in flight. A tag push
+# always targets PyPI (see the validate step), so derive the index from the
+# event — `inputs.target` is empty on a push and would otherwise split tag
+# releases into a separate group from manual PyPI runs.
 concurrency:
-  group: publish-python-${{ inputs.target }}
+  group: publish-python-${{ github.event_name == 'push' && 'pypi' || inputs.target }}
   cancel-in-progress: false
 
 # Least privilege by default; the publish job widens to `id-token: write`

--- a/infino-node/package-lock.json
+++ b/infino-node/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "infino",
+  "name": "@infino-ai/infino",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "infino",
+      "name": "@infino-ai/infino",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -243,22 +243,112 @@
       }
     },
     "node_modules/infx-darwin-arm64": {
-      "optional": true
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/infx-darwin-arm64/-/infx-darwin-arm64-0.1.0.tgz",
+      "integrity": "sha512-WtZNvW9CwrcYsw6ytXXDgbWmQdlsKMj/P0RGnfYxZ8+iqlVc4qBHvI1XCi0INlGSaTcD6t5ynwpoQwcEeAD2lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/infx-darwin-x64": {
-      "optional": true
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/infx-darwin-x64/-/infx-darwin-x64-0.1.0.tgz",
+      "integrity": "sha512-XNqD8E8vs3Rno8VbkCqZaXaxnUzd6CW/0xrXYOOXBq8Tupqm9JjImBXHmuSWtX86RLBZDfzLhzhHnGs3EObwdw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/infx-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/infx-linux-arm64-gnu/-/infx-linux-arm64-gnu-0.1.0.tgz",
+      "integrity": "sha512-KsQG7LY3PAbSimdrFikDenccnu+NLECV6Z9uCvKkdutoK5ExVeh8T/DfKqil1jbb7upXKZc2DF7e3iAfL6YexA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/infx-linux-arm64-musl": {
-      "optional": true
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/infx-linux-arm64-musl/-/infx-linux-arm64-musl-0.1.0.tgz",
+      "integrity": "sha512-Ptbb4eXBC8v1AjhgRZAk4aeHehZVJyMiW45nViCAUPLGeQlwB0YjZS1QVKmhuH6ajsMiIzhfTwlvnhPllKRzyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/infx-linux-x64-gnu": {
-      "optional": true
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/infx-linux-x64-gnu/-/infx-linux-x64-gnu-0.1.0.tgz",
+      "integrity": "sha512-fOmXgl6zAJy50hlyATeE7fx2OhoHAoWEPSUQC3Nu3Wwd6jO7kX8BRPzW7Ajmx2iL2wEhg/gufiFMJbBhxxoN6g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/infx-linux-x64-musl": {
-      "optional": true
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/infx-linux-x64-musl/-/infx-linux-x64-musl-0.1.0.tgz",
+      "integrity": "sha512-ydLnmBMoUHZJLw9w0NjDZhbMpPgdsCepx7OZyEMylTSLj7XO+ihv1DLLSXA9kuqiAEVz/BvT5ReOFv88S5F1tQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/json-bignum": {
       "version": "0.0.3",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Trigger Node and Python on tags

- Guard Node version against release tag

- Derive Python publish target dynamically

- Default manual Python publishes to PyPI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  tag["v<version> tag push"]
  node["Node publish workflow"]
  guard["Check package.json matches tag"]
  npm["Publish to npm"]
  py["Python publish workflow"]
  validate["Derive version and target"]
  pypi["Publish to PyPI"]

  tag -- "triggers" --> node
  node -- "verifies" --> guard
  guard -- "allows" --> npm
  tag -- "triggers" --> py
  py -- "runs" --> validate
  validate -- "publishes" --> pypi
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-publish.yml</strong><dd><code>Enable tag-driven Node publishing with version guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/node-publish.yml

<ul><li>Add <code>push</code> trigger for <code>v[0-9]*</code> tags<br> <li> Document coordinated tag-based and manual releases<br> <li> Verify <code>infino-node/package.json</code> version matches tag<br> <li> Restrict dry-run and publish steps by event</ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/252/files#diff-b265e1ad8447440ef66fb9a008be77d38cfd013c3065286bf5682ed87831415a">+20/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>publish-python.yml</strong><dd><code>Support coordinated Python releases from tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish-python.yml

<ul><li>Add <code>push</code> trigger for <code>v[0-9]*</code> tags<br> <li> Default manual publish target to <code>pypi</code><br> <li> Derive version and target from tag pushes<br> <li> Route publish job environment and upload dynamically</ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/252/files#diff-40a8e37be878e2b8c149cbae07d713e9b42743acfaac10c4a266bd7ded764019">+25/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

