### PR TITLE
bench: simplify the PR comment and split supertable CI by modality

### DIFF
--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 """Summarize benchmark deltas for a PR comment.
 
-Diffs this run against the `main` baseline, keeps only changes past the noise
-threshold, annotates each with main's own trend, and writes a lean markdown
-summary. Foundry narrates; the percentages are computed here, never by the
-model. On any model failure or missing creds the deterministic tables are the
-summary on their own. Stdlib only — the runner needs no pip install.
+Diffs this run against the latest `main` baseline, keeps only changes past the
+noise threshold, and writes a lean markdown summary. Foundry narrates; the
+percentages are computed here, never by the model. On any model failure or
+missing creds the deterministic tables are the summary on their own. Stdlib
+only — the runner needs no pip install.
 
 Inputs (env):
   REPORTS                  space-separated report names (basenames, no .json)
   BASELINE_DIR             dir holding <report>.json from the main baseline
   CURRENT_DIR              dir holding <report>.json from this run
-  HISTORY_DIR              dir with <report>/<idx>-<sha>.json main-history points
   BENCH_NOISE_THRESHOLD_PCT  threshold in percent (default 10)
   OUT_FILE                 markdown destination (default /tmp/ai-summary.md)
   BENCH_LABEL              human label for the run (the `bench` input)
@@ -58,8 +57,6 @@ MIN_LATENCY_NS = 100_000.0
 DEFAULT_MODEL = "gpt-5.4"
 DEFAULT_OUT = "/tmp/ai-summary.md"
 DEFAULT_THRESHOLD = 10.0
-# Most recent main commits read when describing main's own trend.
-HISTORY_WINDOW = 10
 # Cap each table so a broad swing can't blow past GitHub's comment limit.
 MAX_ROWS = 15
 # Foundry latency ceiling; the fallback tables cover us if we trip it.
@@ -110,35 +107,7 @@ def load(path):
         return {}
 
 
-def load_history(history_dir, report):
-    """Main-history metric maps for `report`, oldest→newest (≤ window)."""
-    path = os.path.join(history_dir, report)
-    try:
-        names = sorted(n for n in os.listdir(path) if n.endswith(".json"))
-    except OSError:
-        return []
-    maps = [load(os.path.join(path, n)) for n in names[-HISTORY_WINDOW:]]
-    return [m for m in maps if m]
-
-
-def main_trend(history_maps, key, header, threshold):
-    """How `main` drifted across the window — a PR regression on a metric main
-    has already been pushing the wrong way is the case worth flagging.
-    Returns (note, short), or (None, None) without enough points."""
-    series = [m[key] for m in history_maps if key in m and m[key] != 0.0]
-    if len(series) < 2 or series[0] == 0.0:
-        return None, None
-    drift = (series[-1] - series[0]) / series[0] * 100.0
-    n = len(series)
-    if abs(drift) < threshold:
-        return f"main stable ({drift:+.0f}% over {n} commits)", "flat"
-    improved = drift > 0 if higher_is_better(header) else drift < 0
-    word = "improving" if improved else "degrading"
-    short = f"{word} {abs(drift):.0f}%"
-    return f"main {word} {drift:+.0f}% over {n} commits", short
-
-
-def diff(reports, baseline_dir, current_dir, history_dir, threshold):
+def diff(reports, baseline_dir, current_dir, threshold):
     """Classify changes per report.
 
     Returns (regressions, improvements, had_baseline, cost_present).
@@ -153,7 +122,6 @@ def diff(reports, baseline_dir, current_dir, history_dir, threshold):
         if not cur:
             continue
         subsystem, area = SUBSYSTEM.get(report, (report, ""))
-        history = load_history(history_dir, report)
         for key, new in cur.items():
             parts = key.split("|")
             if len(parts) != KEY_PARTS:
@@ -174,7 +142,6 @@ def diff(reports, baseline_dir, current_dir, history_dir, threshold):
             if abs(pct) < threshold:
                 continue
             improved = pct > 0 if higher_is_better(header) else pct < 0
-            note, short = main_trend(history, key, header, threshold)
             entry = {
                 "subsystem": subsystem,
                 "area": area,
@@ -182,8 +149,6 @@ def diff(reports, baseline_dir, current_dir, history_dir, threshold):
                 "change": f"{human(header, old)} → {human(header, new)}",
                 "pct": round(pct, 1),
                 "is_cold": "cold" in header.lower(),
-                "main_trend": note,
-                "main_trend_short": short or "—",
             }
             (improvements if improved else regressions).append(entry)
     regressions.sort(key=lambda e: -abs(e["pct"]))
@@ -192,14 +157,14 @@ def diff(reports, baseline_dir, current_dir, history_dir, threshold):
 
 
 def table(rows):
-    out = ["| Subsystem | Metric | main → run | Δ | Main (10c) |",
-           "|---|---|---|---|---|"]
+    out = ["| Subsystem | Metric | main → run | Δ |",
+           "|---|---|---|---|"]
     for e in rows[:MAX_ROWS]:
         out.append(f"| {e['subsystem']} | {e['metric']} | {e['change']} "
-                   f"| {e['pct']:+.0f}% | {e['main_trend_short']} |")
+                   f"| {e['pct']:+.0f}% |")
     extra = len(rows) - MAX_ROWS
     if extra > 0:
-        out.append(f"| _+{extra} more_ | | | | |")
+        out.append(f"| _+{extra} more_ | | | |")
     return "\n".join(out)
 
 
@@ -212,10 +177,9 @@ def narrate(payload, endpoint, key, model):
         "benchmark run. You are given JSON of metric changes ALREADY filtered "
         "past the noise threshold, plus any run failures. Write 2-5 lines of "
         "GitHub markdown:\n"
-        "- Line 1: a one-line verdict (net regression / net improvement / mixed / clean).\n"
-        "- Then call out ONLY the biggest regressions and any failures, with the "
-        "main_trend woven in (a regression on a metric main was already worsening "
-        "is worse news). Do NOT restate every row — tables below carry the detail.\n"
+        "- Line 1: a one-line verdict (net slower / net faster / mixed / no change).\n"
+        "- Then call out ONLY the biggest things that got worse and any failures. "
+        "Do NOT restate every row — tables below carry the detail.\n"
         "- Cite ONLY numbers in the payload. Never invent or recompute a value.\n"
         "- If there are no changes and no failures, say "
         f"'No significant changes (within ±{payload['threshold']}%).'\n"
@@ -254,7 +218,6 @@ def main():
     reports = os.environ.get("REPORTS", "").split()
     baseline_dir = os.environ.get("BASELINE_DIR", "baseline")
     current_dir = os.environ.get("CURRENT_DIR", "current")
-    history_dir = os.environ.get("HISTORY_DIR", "history")
     out_file = os.environ.get("OUT_FILE", DEFAULT_OUT)
     label = os.environ.get("BENCH_LABEL", "benchmark")
     run_url = os.environ.get("RUN_URL", "")
@@ -265,7 +228,7 @@ def main():
 
     failures = [ln.strip() for ln in os.environ.get("ERRORS", "").splitlines() if ln.strip()]
     regressions, improvements, had_baseline, cost_present = diff(
-        reports, baseline_dir, current_dir, history_dir, threshold)
+        reports, baseline_dir, current_dir, threshold)
 
     prose = narrate(
         {
@@ -279,18 +242,15 @@ def main():
         os.environ.get("AZURE_AI_MODEL", DEFAULT_MODEL),
     )
 
-    def plural(n, word):
-        return f"{n} {word}{'' if n == 1 else 's'}"
-
     if failures or (regressions and not improvements):
-        badge = "🔴"  # pure bad: failures, or regressions with no offsetting wins
+        badge = "🔴"  # pure bad: failures, or things got worse with no offsetting wins
     elif regressions:
-        badge = "🟡"  # mixed: regressions alongside improvements
+        badge = "🟡"  # mixed: some worse, some better
     elif improvements:
         badge = "🟢"
     else:
         badge = "⚪"
-    counts = f"{plural(len(regressions), 'regression')} · {plural(len(improvements), 'improvement')}"
+    counts = f"{len(regressions)} worse · {len(improvements)} better"
     parts = [f"## {badge} Benchmark `{label}` — {counts} (±{threshold:g}% vs main)", ""]
 
     if prose:
@@ -302,17 +262,14 @@ def main():
     elif not regressions and not improvements:
         parts += [f"No significant changes (within ±{threshold:g}%).", ""]
 
-    # Regressions are what gate a merge — keep them visible; fold improvements.
+    # The things that got worse are what gate a merge — keep them visible; fold the wins.
     if regressions:
-        parts += [f"### 🔴 Regressions ({len(regressions)})", table(regressions), ""]
+        parts += [f"### 🔴 Worse ({len(regressions)})", table(regressions), ""]
     if improvements:
-        parts += [f"<details><summary>🟢 Improvements ({len(improvements)})</summary>",
+        parts += [f"<details><summary>🟢 Better ({len(improvements)})</summary>",
                   "", table(improvements), "", "</details>", ""]
 
     if regressions or improvements:
-        parts.append("_`Δ` = this PR vs `main` — the regression/improvement verdict. "
-                     "`Main (10c)` = how `main` itself moved over its last ≤10 commits, "
-                     "independent of this PR (a regression on an `improving` metric means this PR reverses that trend)._")
         touched = {e["subsystem"]: e["area"] for e in regressions + improvements if e.get("area")}
         if touched:
             parts.append("_Where to look: " + " · ".join(
@@ -329,8 +286,8 @@ def main():
     body = "\n".join(parts).rstrip() + "\n"
     with open(out_file, "w", encoding="utf-8") as fh:
         fh.write(body)
-    print(f"wrote {out_file}: {len(regressions)} regression(s), {len(improvements)} "
-          f"improvement(s), {len(failures)} failure line(s), "
+    print(f"wrote {out_file}: {len(regressions)} worse, {len(improvements)} better, "
+          f"{len(failures)} failure line(s), "
           f"baseline={'yes' if had_baseline else 'no'}")
 
 

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -361,8 +361,9 @@ jobs:
           REMOTE
 
       # Publish the metrics as the latest-main pointer (overwritten, what PRs
-      # diff against) and an immutable per-commit history blob (the trend).
-      # Runs only on a successful bench, so a broken run never poisons it.
+      # diff against) plus an immutable per-commit history blob retained for
+      # archival. Runs only on a successful bench, so a broken run never
+      # poisons it.
       - name: Publish baseline + history
         # success() is implicit, but explicit here: never publish from a
         # failed/partial bench run.
@@ -408,102 +409,6 @@ jobs:
             fi
             echo "published: $j ($SHA)"
           done
-
-      # Render latency / memory / throughput trends over the last (≤10) main
-      # commits as Mermaid charts in the run summary. Best-effort: a fetch
-      # hiccup drops a point but never fails the step.
-      - name: Render trend charts
-        if: ${{ inputs.update_baseline && success() }}
-        env:
-          ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-          KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
-          CONTAINER: ${{ secrets.INFINO_REAL_AZURE_CONTAINER }}
-          VM_SIZE: ${{ inputs.vm_size }}
-          DOCS: ${{ inputs.docs }}
-          # Reports this run produced — also the history-blob basenames each
-          # series reads from. A series renders only if its report is here.
-          REPORTS: ${{ steps.resolve.outputs.reports }}
-        run: |
-          set -uo pipefail
-          SUMMARY="$GITHUB_STEP_SUMMARY"
-
-          # One row per chart, tab-separated:
-          #   section <TAB> report <TAB> metric-key <TAB> divisor <TAB> unit <TAB> title
-          # The divisor maps the stored raw value into the chart unit:
-          #   latency ns → ms (1000000), bytes → MiB (1048576), docs/s raw (1).
-          # Keys come from the per-modality reports the bench emits today; the
-          # retired consolidated `supertable` report is not used. Cost
-          # (queries/$) keys are excluded — they embed volatile text (heap
-          # size, probe params), so the key changes per commit and can't trend.
-          # The leading indent on each row is a YAML block-scalar artifact and
-          # is stripped once, below.
-          series=$'Latency — warm search (ms)\tsupertable_vector\tbench/vector/supertable/search||default|warm\t1000000\tms\tSupertable vector warm search
-          Latency — warm search (ms)\tsupertable_sql\tbench/sql/supertable/warm|Search table functions (bm25 / vector / hybrid / token / exact)|bm25_search|p50\t1000000\tms\tSupertable SQL bm25_search p50
-          Latency — warm search (ms)\tsupertable_sql\tbench/sql/supertable/warm|Search table functions (bm25 / vector / hybrid / token / exact)|vector_search|p50\t1000000\tms\tSupertable SQL vector_search p50
-          Latency — warm search (ms)\tsupertable_sql\tbench/sql/supertable/warm|Search table functions (bm25 / vector / hybrid / token / exact)|hybrid_search|p50\t1000000\tms\tSupertable SQL hybrid_search p50
-          Latency — warm search (ms)\tsuperfile_vector\tbench/vector/superfile/search||default|warm\t1000000\tms\tSuperfile vector warm search
-          Memory — P90 RSS (MiB)\tsupertable_fts\tbench/fts/supertable/ingest||FTS-only|P90 RSS\t1048576\tMiB\tSupertable FTS ingest
-          Memory — P90 RSS (MiB)\tsupertable_vector\tbench/vector/supertable/ingest||vector-only|P90 RSS\t1048576\tMiB\tSupertable vector ingest
-          Memory — P90 RSS (MiB)\tsql\tbench/sql/build||1 writer|P90 RSS\t1048576\tMiB\tSQL 1-writer build
-          Memory — P90 RSS (MiB)\tsql\tbench/sql/query|Search table functions (bm25 / vector / hybrid / token / exact)|bm25_search|P90 RSS\t1048576\tMiB\tSQL bm25_search
-          Throughput — ingest (docs/s)\tsupertable_fts\tbench/fts/supertable/ingest||FTS-only|Throughput\t1\tdocs/s\tSupertable FTS ingest
-          Throughput — ingest (docs/s)\tsupertable_vector\tbench/vector/supertable/ingest||vector-only|Throughput\t1\tdocs/s\tSupertable vector ingest'
-          series="$(printf '%s\n' "$series" | sed 's/^[[:space:]]*//')"
-
-          printf '## Trends (last 10 main commits)\n' >> "$SUMMARY"
-
-          # Guard against series/report drift: if no row matches REPORTS the
-          # section would be silently empty (the bug that hid the broken gate).
-          matched=0
-          last_section=""
-
-          # FDs 3/4 keep the loop input clear of the az calls' own stdin reads.
-          while IFS=$'\t' read -r -u 3 section report key divisor unit title; do
-            case " $REPORTS " in *" $report "*) ;; *) continue ;; esac
-            matched=$((matched + 1))
-            if [ "$section" != "$last_section" ]; then
-              printf '### %s\n' "$section" >> "$SUMMARY"
-              last_section="$section"
-            fi
-
-            # Last ≤10 history points for this metric, ordered oldest→newest
-            # by commit time; keep only the name and short sha of each.
-            blobs="$(az storage blob list -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
-                       --prefix "bench/${report}/history/${VM_SIZE}-${DOCS}-" --include m \
-                       --query "[].{name:name, ts:metadata.ts, sha:metadata.sha}" -o tsv 2>/dev/null \
-                     | sort -k2 -n | tail -10)"
-
-            labels=(); values=(); points=0
-            while IFS=$'\t' read -r -u 4 name _ sha; do
-              [ -n "$name" ] || continue
-              az storage blob download -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
-                -n "$name" -f /tmp/point.json -o none 2>/dev/null || continue
-              value="$(jq -r --arg k "$key" '.[$k] // empty' /tmp/point.json)"
-              [ -n "$value" ] || continue
-              labels+=("${sha:0:7}")
-              values+=("$(awk -v v="$value" -v d="$divisor" 'BEGIN{printf "%g", v / d}')")
-              points=$((points + 1))
-            done 4<<< "$blobs"
-
-            if [ "$points" -lt 2 ]; then
-              printf '_%s: %d data point(s) — need ≥2 to chart._\n' "$title" "$points" >> "$SUMMARY"
-              continue
-            fi
-            {
-              echo '```mermaid'
-              echo 'xychart-beta'
-              echo "    title \"${title} (${unit})\""
-              printf '    x-axis [%s]\n' "$(IFS=,; echo "${labels[*]}")"
-              echo "    y-axis \"${unit}\""
-              printf '    line [%s]\n' "$(IFS=,; echo "${values[*]}")"
-              echo '```'
-            } >> "$SUMMARY"
-          done 3<<< "$series"
-
-          if [ "$matched" -eq 0 ]; then
-            echo "::warning::no trend series matched reports [$REPORTS] — check the series table"
-            echo "_No trend series matched reports: \`$REPORTS\`._" >> "$SUMMARY"
-          fi
 
       - name: Summarize results
         if: ${{ !cancelled() }}
@@ -611,50 +516,15 @@ jobs:
               || echo "no metrics for $j — skipping"
           done
 
-      # Last ≤10 main-history points per report, so the summary can say whether
-      # a flagged metric is a one-off or part of a sustained drift on main.
-      # Best-effort: a missing series just drops the trend annotation.
-      - name: Collect main history
-        if: ${{ !cancelled() && inputs.pr_number != '' }}
-        env:
-          ACC: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-          KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
-          CONTAINER: ${{ secrets.INFINO_REAL_AZURE_CONTAINER }}
-          VM_SIZE: ${{ inputs.vm_size }}
-          DOCS: ${{ inputs.docs }}
-          REPORTS: ${{ steps.resolve.outputs.reports }}
-        run: |
-          set -uo pipefail
-          mkdir -p history
-          for j in $REPORTS; do
-            mkdir -p "history/$j"
-            # Oldest→newest by commit time; keep the last 10.
-            blobs="$(az storage blob list -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
-                       --prefix "bench/${j}/history/${VM_SIZE}-${DOCS}-" --include m \
-                       --query '[].{name:name, ts:metadata.ts, sha:metadata.sha}' -o tsv 2>/dev/null \
-                     | sort -k2 -n | tail -10)"
-            i=0
-            while IFS=$'\t' read -r name _ts sha; do
-              [ -n "$name" ] || continue
-              # Index prefix preserves chronological order under lexical sort.
-              idx="$(printf '%02d' "$i")"
-              az storage blob download -c "$CONTAINER" --account-name "$ACC" --account-key "$KEY" \
-                -n "$name" -f "history/${j}/${idx}-${sha:0:7}.json" -o none 2>/dev/null \
-                || echo "::warning::history download failed for $j ($sha)"
-              i=$((i + 1))
-            done <<< "$blobs"
-          done
-
-      # Diff vs main, keep only changes past the threshold, and have Foundry
-      # narrate them. Falls back to the deterministic delta table on any model
-      # failure or missing creds — the comment is always correct.
+      # Diff vs latest main, keep only changes past the threshold, and have
+      # Foundry narrate them. Falls back to the deterministic delta table on any
+      # model failure or missing creds — the comment is always correct.
       - name: AI summary
         if: ${{ !cancelled() && inputs.pr_number != '' }}
         env:
           REPORTS: ${{ steps.resolve.outputs.reports }}
           BASELINE_DIR: baseline
           CURRENT_DIR: current
-          HISTORY_DIR: history
           OUT_FILE: /tmp/ai-summary.md
           BENCH_LABEL: ${{ inputs.bench }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Two related cleanups to the Azure benchmark CI/reporting.

## 1. Simplify the PR comment

The comment carried a per-row "Main (10c)" annotation and Mermaid charts tracking the last 10 main commits, plus a glossary footnote. It now reports only the clean **PR-vs-latest-main** delta.

- Remove `load_history` / `main_trend` and the `Main (10c)` column from `bench_summary.py`; drop the "Render trend charts" and "Collect main history" workflow steps.
- Per-commit history blobs are still published for archival; only their display is gone.
- Rename user-facing `regression`/`improvement` to neutral **Worse / Better**.

## 2. Split supertable CI by modality

The `supertable` leg ran all three modalities on one VM and posted one combined comment, so a noisy modality muddied the rest with no per-modality control.

- Fan supertable into three CI legs — **fts**, **vector**, **sql** — each on its own VM with its own baseline and sticky PR comment.
- Add `supertable_{fts,vector,sql}` tokens to the reusable workflow; collapse the duplicate `supertable`/`supertable_all` arm and drop the now-dead `fts`/`vector`/`combined`/`sql` tokens (unreferenced).
- `supertable`/`supertable_all` stay for manual all-in-one dispatch.

## Validation

- `bench_summary.py` validated end-to-end against the real Azure container (deterministic table, live Foundry verdict, and the model-unavailable fallback).
- Both workflow YAMLs parse; unique-resource keys (VM name, NIC, NSG, comment marker, concurrency group) confirmed distinct per leg; per-modality baseline blobs already exist so deltas render immediately.