### PR TITLE
bench: split supertable CI into per-modality legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,11 +300,14 @@ jobs:
     strategy:
       fail-fast: false # one member failing must not cancel the other
       matrix:
-        # `suffix` makes each leg's Azure resources unique — both legs
-        # share one run_id, so without it they'd collide / cross-delete.
+        # One supertable modality per leg, each on its own VM with its own
+        # baseline and PR comment. `suffix` keeps every leg's Azure resources,
+        # VM name, and comment marker unique (all legs share one run_id).
         include:
-          - { bench: superfile, docs: "1000000", suffix: sf }
-          - { bench: supertable, docs: "1000000", suffix: st }
+          - { bench: superfile,         docs: "1000000", suffix: sf }
+          - { bench: supertable_fts,    docs: "1000000", suffix: st-fts }
+          - { bench: supertable_vector, docs: "1000000", suffix: st-vec }
+          - { bench: supertable_sql,    docs: "1000000", suffix: st-sql }
     # PR: a new push cancels the in-flight run. main: serialize per bench so
     # concurrent merges don't race the baseline blob (never cancel).
     concurrency:

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -14,7 +14,7 @@ on:
         required: false
         default: supertable_all
         type: choice
-        options: [superfile, supertable, supertable_all, fts, vector, combined, sql, all]
+        options: [superfile, supertable, supertable_all, supertable_fts, supertable_vector, supertable_sql, all]
       docs:
         description: "Doc count (plain integer, NOT 1M/100K — those do not parse)"
         required: false
@@ -130,20 +130,18 @@ jobs:
         id: resolve
         run: |
           set -euo pipefail
-          # All benches live in the single `bench` cargo target; cells are
-          # selected with positional tokens (`<tier> <modality> [phase]`).
-          # Map the legacy `bench` input vocabulary to (a) the binary's
-          # args and (b) the report JSONs (target/infino-bench/<name>.json)
-          # used for baseline restore / publish.
+          # Map the `bench` input to (a) the cargo bench target's positional
+          # cell selectors and (b) the report JSONs it emits
+          # (target/infino-bench/<name>.json) for baseline restore / publish.
+          # The supertable_* tokens select one cell each: CI fans them out
+          # one-per-VM so a modality's numbers stay isolated.
           case "${{ inputs.bench }}" in
-            superfile)      args="superfile";             reports="superfile_fts superfile_vector sql" ;;
-            supertable)     args="supertable";            reports="supertable supertable_fts supertable_vector supertable_sql" ;;
-            supertable_all) args="supertable";            reports="supertable supertable_fts supertable_vector supertable_sql" ;;
-            fts)            args="supertable fts";        reports="supertable supertable_fts" ;;
-            vector)         args="supertable vector";     reports="supertable supertable_vector" ;;
-            combined)       args="supertable fts vector"; reports="supertable supertable_fts supertable_vector" ;;
-            sql)            args="superfile sql";         reports="sql" ;;
-            all)            args="all";                   reports="supertable supertable_fts supertable_vector supertable_sql superfile_fts superfile_vector sql" ;;
+            superfile)                 args="superfile";         reports="superfile_fts superfile_vector sql" ;;
+            supertable|supertable_all) args="supertable";        reports="supertable supertable_fts supertable_vector supertable_sql" ;;
+            supertable_fts)            args="supertable fts";    reports="supertable_fts" ;;
+            supertable_vector)         args="supertable vector"; reports="supertable_vector" ;;
+            supertable_sql)            args="supertable sql";    reports="supertable_sql" ;;
+            all)                       args="all";               reports="supertable supertable_fts supertable_vector supertable_sql superfile_fts superfile_vector sql" ;;
             *) echo "::error::unknown bench ${{ inputs.bench }}"; exit 1 ;;
           esac
           echo "args=$args"       >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Split the single `supertable` benchmark CI job into three per-modality legs — **fts**, **vector**, **sql** — each on its own ephemeral Azure VM with its own baseline blob and its own sticky PR comment.

## Why

The `supertable` leg ran all three modalities on one VM and posted one combined comment, so a noisy modality (vector cold swings a lot) muddied the others, with no per-modality control. Per-modality baselines already exist in blob storage, so deltas render immediately.

## Changes

- `ci.yml`: replace the single `supertable` leg with `st-fts` / `st-vec` / `st-sql`. Unique suffixes keep each leg's Azure resources, VM name, concurrency group, and PR-comment marker distinct.
- `supertable-bench-azure.yml`: add `supertable_{fts,vector,sql}` tokens (each selects one supertable cell, one report). Collapse the duplicate `supertable`/`supertable_all` arm; drop the now-dead `fts`/`vector`/`combined`/`sql` tokens (nothing referenced them). `supertable`/`supertable_all` stay for manual all-in-one dispatch.

## Tradeoffs

- 3 VMs instead of 1 → +2 provision/teardown cycles; sccache is shared so builds stay cheap, compute ≈ same, wall-clock faster (parallel).
- 3 sticky PR comments instead of 1 — intended, for per-modality isolation.
- The consolidated `supertable` ingest-summary report is no longer produced (no leg runs all modalities); per-modality ingest rows remain.

## Notes

- `(Tier::Supertable, Modality::Sql)` is a valid bench cell (`benches/bench/main.rs`).
- Both workflow YAMLs validated; resource-uniqueness confirmed per leg.
- Follow-up to #255 (kept separate; touches CI topology, not the comment formatting).