### PR TITLE
ci: gate fork-PR benchmarks on maintainer approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,11 +292,8 @@ jobs:
   # Informational benchmark — superfile + supertable tiers, one in-region
   # Azure VM each, in parallel. Never blocks merge. On a PR: diff vs main's baseline.
   # On merge to main: publish the run as that baseline + a per-commit history
-  # point. Same-repo only (fork PRs can't use the Azure OIDC secrets).
+  # point. Fork PRs are gated on maintainer approval (see `is_fork_pr`).
   bench:
-    if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false # one member failing must not cancel the other
       matrix:
@@ -324,4 +321,6 @@ jobs:
       name_suffix: -${{ matrix.suffix }}
       update_baseline: ${{ github.event_name == 'push' }}
       pr_number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+      # Fork PR ⇒ gate on maintainer approval before secrets are exposed.
+      is_fork_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets: inherit

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -88,6 +88,8 @@ on:
       pr_number:       { type: string, required: false, default: "" }
       # Min |Δ%| vs main to flag in the PR comment; smaller is noise.
       noise_threshold_pct: { type: string, required: false, default: "10" }
+      # Fork PR ⇒ gate the run on maintainer approval (see `environment`).
+      is_fork_pr:      { type: boolean, required: false, default: false }
 
 permissions:
   id-token: write       # Azure OIDC federated login
@@ -111,10 +113,11 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    # Run under the `ci` environment so the OIDC subject is
-    # repo:…:environment:ci — branch-independent, so one federated
-    # credential authorizes runs from any branch.
-    environment: ci
+    # `ci`: same-repo, no gate. `bench`: required reviewers, so a maintainer
+    # approves before secrets reach fork code. The env name is the OIDC
+    # subject (repo:…:environment:<name>) — each needs its own Azure
+    # federated credential.
+    environment: ${{ inputs.is_fork_pr && 'bench' || 'ci' }}
     # Auto-stop ceiling on VM billing; teardown runs on timeout.
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     steps:


### PR DESCRIPTION
## What

Fork PRs no longer skip the benchmark job. They now run, but only after a maintainer approves the run.

## Why

The bench job was gated to same-repo runs (`head.repo.full_name == github.repository`) because it needs Azure secrets that GitHub withholds from fork PRs. That meant zero bench signal on external contributions.

Instead of giving fork code unconditional secret access (unsafe), fork runs are routed through a GitHub Environment with **required reviewers**: the job parks in *Waiting* until a maintainer reviews the diff and approves, then secrets are exposed and the bench runs.

## How

- `ci.yml`: drop the same-repo guard; pass `is_fork_pr` to the reusable workflow.
- `supertable-bench-azure.yml`: add `is_fork_pr` input; select the environment per run — `ci` for same-repo/main (automatic, unchanged), `bench` for fork PRs (gated).

Bench remains **non-required** in branch protection, so it never blocks merge either way.

## Out-of-band setup (done)

- `bench` environment created with required reviewers.
- Its 6 Azure infra secrets set (mirroring `ci`).
- Azure federated credential for subject `repo:infino-ai/infino:environment:bench` (the env name is the OIDC subject, distinct from `ci`).

## Reviewer note

Approving a fork bench run = vouching the fork diff won't exfiltrate secrets. Read the diff before approving.