### PR TITLE
feat SQL: prune manifest-parts & superfiles for same-column OR-of-equalities

### DIFF
--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -311,7 +311,7 @@ impl SupertableProvider {
         let predicates = exprs_to_scalar_predicates(filters, &self.schema);
         let mut leaves = self.predicates_to_prune_leaves(predicates);
 
-        leaves.extend(exprs_to_in_list_leaves(
+        leaves.extend(exprs_to_value_set_leaves(
             filters,
             &self.schema,
             &self.fts_cols_set(),
@@ -1126,19 +1126,16 @@ pub(crate) fn exprs_to_scalar_predicates(
     out
 }
 
-/// Build prune leaves for the `column IN (...)` filters in `filters`. Each yields:
-///  i)  a `ScalarInList` (min/max) leaf — on every column;
+/// Build prune leaves for the `column IN (...)` and same-column
+/// `a = x OR a = y` filters in `filters`. Each yields:
+///  i)  a `ScalarValueSet` (min/max) leaf — on every column;
 ///  ii) plus, on an FTS-indexed column, a `TermPresence{Or}` leaf over the
 ///      values' tokens, which prunes on which superfiles hold the term.
 ///
-/// A `NOT IN`, a non-literal item, a function-wrapped or unknown column
-/// yields no leaf — that filter just isn't pruned (the scan stays correct).
-///
-/// Handles any `Expr::InList`, whatever its length. In practice SQL
-/// planning rewrites a short `IN` first — a 1-value to `=`, a 2–3 value
-/// to `OR` — so only 4+ value lists usually reach here, but that's the
-/// optimizer's behavior, not a precondition this helper relies on.
-pub(crate) fn exprs_to_in_list_leaves(
+/// A `NOT IN`, a non-literal item, a function-wrapped or unknown column,
+/// or a mixed/cross-column `OR` yields no leaf — that filter just isn't
+/// pruned (the scan stays correct).
+pub(crate) fn exprs_to_value_set_leaves(
     filters: &[Expr],
     schema: &SchemaRef,
     fts_cols: &HashSet<&str>,
@@ -1147,21 +1144,16 @@ pub(crate) fn exprs_to_in_list_leaves(
     let mut out = Vec::new();
 
     for filter in filters {
-        collect_in_list_leaves(filter, schema, fts_cols, tokenizer, &mut out);
+        collect_value_set_leaves(filter, schema, fts_cols, tokenizer, &mut out);
     }
 
     out
 }
 
-/// e.g. `product IN ('Orange Juice', 'Pineapple')` on an FTS column →
-/// `[ TermPresence{Or, [orange, juice, pineapple]},
-///    ScalarInList{product, ['Orange Juice', 'Pineapple']} ]`
-/// — bloom leaf holds the lowercased tokens, min/max leaf the raw values.
-///
-/// Note: the bloom flattens all tokens into one `Or`, so a superfile with
-/// only `orange` is kept though no value matches. A tighter prune would be
-/// per-value `(orange AND juice) OR pineapple`; FilterExec verifies either way.
-fn collect_in_list_leaves(
+/// Walk one filter expression, lowering any `IN` or same-column
+/// `OR`-of-equalities to leaves. Descends `AND` (the predicate can sit on
+/// either side) and aliases; anything else yields nothing.
+fn collect_value_set_leaves(
     expr: &Expr,
     schema: &SchemaRef,
     fts_cols: &HashSet<&str>,
@@ -1172,22 +1164,27 @@ fn collect_in_list_leaves(
         // Filters reach us alias-free (Filter::try_new runs unalias_nested),
         // but an alias is a pure rename; descend it so pruning is unaffected
         // if one ever survives (e.g. a metadata-carrying alias).
-        Expr::Alias(a) => collect_in_list_leaves(&a.expr, schema, fts_cols, tokenizer, out),
-        // Descend AND; an IN can sit on either side.
+        Expr::Alias(a) => collect_value_set_leaves(&a.expr, schema, fts_cols, tokenizer, out),
+        // Descend AND; the predicate can sit on either side.
         Expr::BinaryExpr(be) if be.op == Operator::And => {
-            collect_in_list_leaves(&be.left, schema, fts_cols, tokenizer, out);
-            collect_in_list_leaves(&be.right, schema, fts_cols, tokenizer, out);
+            collect_value_set_leaves(&be.left, schema, fts_cols, tokenizer, out);
+            collect_value_set_leaves(&be.right, schema, fts_cols, tokenizer, out);
+        }
+        // A same-column `OR` of equalities is an `IN` in disguise; lower
+        // it the same way. A mixed or non-equality `OR` flattens to None.
+        Expr::BinaryExpr(be) if be.op == Operator::Or => {
+            if let Some((column, values)) = flatten_or_eq(expr, schema) {
+                emit_value_set_leaves(column, values, fts_cols, tokenizer, out);
+            }
         }
         Expr::InList(il) if !il.negated => {
             // Only a bare column maps to a min/max or bloom; else skip.
             let Expr::Column(c) = il.expr.as_ref() else {
                 return;
             };
-
             if schema.field_with_name(&c.name).is_err() {
                 return;
             }
-
             // Every item must be a literal to bound min/max; else skip.
             let mut values = Vec::with_capacity(il.list.len());
             for item in &il.list {
@@ -1196,37 +1193,88 @@ fn collect_in_list_leaves(
                 };
                 values.push(v.clone());
             }
-
-            // Empty IN list, nothing to bound.
-            if values.is_empty() {
-                return;
+            if !values.is_empty() {
+                emit_value_set_leaves(c.name.clone(), values, fts_cols, tokenizer, out);
             }
-
-            // Only for FTS indexed columns
-            if fts_cols.contains(c.name.as_str())
-                && let Some(tok) = tokenizer
-            {
-                // One deduped term set across all values — a word shared
-                // by several values (e.g. 'Orange Juice', 'Apple Juice'
-                // → one `juice`) is probed once.
-                let terms = unique_tokens(tok, values.iter().filter_map(scalar_as_str));
-                if !terms.is_empty() {
-                    // one bloom leaf holding all the values' tokens
-                    out.push(PruneLeaf::TermPresence {
-                        column: c.name.clone(),
-                        terms,
-                        mode: BoolMode::Or,
-                    });
-                }
-            }
-
-            // The min/max leaf — on every column.
-            out.push(PruneLeaf::ScalarInList {
-                column: c.name.clone(),
-                values,
-            });
         }
         _ => {}
+    }
+}
+
+/// Push the prune leaves for a recognized `column IN (values)` shape:
+///  - on an FTS-indexed column, a `TermPresence{Or}` bloom over the
+///    values' tokens — `'Orange Juice', 'Pineapple'` → `[juice, orange,
+///    pineapple]`, shared words deduped so a term is probed once;
+///  - always, a `ScalarValueSet` min/max leaf over the raw values.
+///
+/// The bloom flattens all tokens into one `Or`, so a superfile holding
+/// only `orange` is kept though no value matches; FilterExec verifies.
+fn emit_value_set_leaves(
+    column: String,
+    values: Vec<ScalarValue>,
+    fts_cols: &HashSet<&str>,
+    tokenizer: Option<&dyn Tokenizer>,
+    out: &mut Vec<PruneLeaf>,
+) {
+    if fts_cols.contains(column.as_str())
+        && let Some(tok) = tokenizer
+    {
+        let terms = unique_tokens(tok, values.iter().filter_map(scalar_as_str));
+        if !terms.is_empty() {
+            out.push(PruneLeaf::TermPresence {
+                column: column.clone(),
+                terms,
+                mode: BoolMode::Or,
+            });
+        }
+    }
+    // `column` moves into the last leaf — cloned above only for the bloom.
+    out.push(PruneLeaf::ScalarValueSet { column, values });
+}
+
+/// Flatten a same-column `OR` of equalities into `(column, values)` — e.g.
+/// `a = 1 OR a = 2` → `("a", [1, 2])`, the `IN` it's equivalent to.
+/// Returns None unless *every* branch is `column = literal` on one shared
+/// column: a partial match like `a = 1 OR a > 5` isn't a closed value set,
+/// so pruning on the equalities alone would wrongly drop the `> 5` rows.
+fn flatten_or_eq(expr: &Expr, schema: &SchemaRef) -> Option<(String, Vec<ScalarValue>)> {
+    let mut column = None;
+    let mut values = Vec::new();
+    collect_or_eq(expr, schema, &mut column, &mut values).then_some(())?;
+    Some((column?, values))
+}
+
+/// Accumulate the `column = literal` branches of an `OR` tree into `column`
+/// / `values`; false the moment a branch isn't an equality on that column.
+fn collect_or_eq(
+    expr: &Expr,
+    schema: &SchemaRef,
+    column: &mut Option<String>,
+    values: &mut Vec<ScalarValue>,
+) -> bool {
+    match expr {
+        Expr::BinaryExpr(be) if be.op == Operator::Or => {
+            collect_or_eq(&be.left, schema, column, values)
+                && collect_or_eq(&be.right, schema, column, values)
+        }
+        // Reuse the scalar extractor: it accepts only a bare column vs a
+        // literal (so a cast-wrapped column declines) and validates the
+        // schema. The `Or`/`Eq` guards above keep the mapped op `Eq`.
+        Expr::BinaryExpr(be) if be.op == Operator::Eq => {
+            match leaf_to_predicate(&be.left, be.op, &be.right, schema) {
+                Some(p) => {
+                    match column {
+                        Some(existing) if *existing != p.column => return false,
+                        None => *column = Some(p.column),
+                        Some(_) => {}
+                    }
+                    values.push(p.value);
+                    true
+                }
+                None => false,
+            }
+        }
+        _ => false,
     }
 }
 
@@ -1318,7 +1366,7 @@ mod tests {
     use arrow_array::{Int64Array, LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::{
-        prelude::{col, lit},
+        prelude::{cast, col, lit},
         scalar::ScalarValue,
     };
     use object_store::memory::InMemory;
@@ -1498,15 +1546,15 @@ mod tests {
         assert!(preds.is_empty());
     }
 
-    /// The `(column, value-count)` of each `ScalarInList` leaf, for asserting
+    /// The `(column, value-count)` of each `ScalarValueSet` leaf, for asserting
     /// extraction without matching on the full enum.
-    fn in_list_leaves(filters: &[Expr], schema: &SchemaRef) -> Vec<(String, usize)> {
+    fn value_set_leaves(filters: &[Expr], schema: &SchemaRef) -> Vec<(String, usize)> {
         // No FTS columns / tokenizer → only the scalar min/max leaf.
-        exprs_to_in_list_leaves(filters, schema, &HashSet::new(), None)
+        exprs_to_value_set_leaves(filters, schema, &HashSet::new(), None)
             .into_iter()
             .map(|l| match l {
-                PruneLeaf::ScalarInList { column, values } => (column, values.len()),
-                _ => panic!("expected a ScalarInList leaf"),
+                PruneLeaf::ScalarValueSet { column, values } => (column, values.len()),
+                _ => panic!("expected a ScalarValueSet leaf"),
             })
             .collect()
     }
@@ -1515,7 +1563,7 @@ mod tests {
     fn in_list_lowers_to_one_leaf_with_all_values() {
         let s = schema_xy();
         let expr = col("x").in_list(vec![lit(1_i64), lit(2_i64), lit(3_i64)], false);
-        assert_eq!(in_list_leaves(&[expr], &s), vec![("x".to_string(), 3)]);
+        assert_eq!(value_set_leaves(&[expr], &s), vec![("x".to_string(), 3)]);
     }
 
     #[test]
@@ -1524,7 +1572,7 @@ mod tests {
         let expr = col("x")
             .gt(lit(0_i64))
             .and(col("y").in_list(vec![lit(7_i64)], false));
-        assert_eq!(in_list_leaves(&[expr], &s), vec![("y".to_string(), 1)]);
+        assert_eq!(value_set_leaves(&[expr], &s), vec![("y".to_string(), 1)]);
     }
 
     #[test]
@@ -1536,14 +1584,112 @@ mod tests {
         let expr = col("x")
             .in_list(vec![lit(1_i64), lit(2_i64)], false)
             .alias("k");
-        assert_eq!(in_list_leaves(&[expr], &s), vec![("x".to_string(), 2)]);
+        assert_eq!(value_set_leaves(&[expr], &s), vec![("x".to_string(), 2)]);
+    }
+
+    #[test]
+    fn or_of_equalities_lowers_like_an_in_list() {
+        // `x = 1 OR x = 2` is `x IN (1, 2)` — one leaf, both values.
+        let s = schema_xy();
+        let expr = col("x").eq(lit(1_i64)).or(col("x").eq(lit(2_i64)));
+        assert_eq!(value_set_leaves(&[expr], &s), vec![("x".to_string(), 2)]);
+    }
+
+    #[test]
+    fn or_of_equalities_flattens_left_deep_tree() {
+        // `x = 1 OR x = 2 OR x = 3` parses left-deep; all three collected.
+        let s = schema_xy();
+        let expr = col("x")
+            .eq(lit(1_i64))
+            .or(col("x").eq(lit(2_i64)))
+            .or(col("x").eq(lit(3_i64)));
+        assert_eq!(value_set_leaves(&[expr], &s), vec![("x".to_string(), 3)]);
+    }
+
+    #[test]
+    fn or_with_literal_on_left_is_handled() {
+        // `1 = x OR 2 = x` — operand order flipped; still recognized.
+        let s = schema_xy();
+        let expr = lit(1_i64).eq(col("x")).or(lit(2_i64).eq(col("x")));
+        assert_eq!(value_set_leaves(&[expr], &s), vec![("x".to_string(), 2)]);
+    }
+
+    #[test]
+    fn or_under_and_is_found() {
+        // `x > 0 AND (y = 7 OR y = 8)` — the OR sits under the AND descent.
+        let s = schema_xy();
+        let expr = col("x")
+            .gt(lit(0_i64))
+            .and(col("y").eq(lit(7_i64)).or(col("y").eq(lit(8_i64))));
+        assert_eq!(value_set_leaves(&[expr], &s), vec![("y".to_string(), 2)]);
+    }
+
+    #[test]
+    fn or_across_columns_emits_no_leaf() {
+        // `x = 1 OR y = 2` spans two columns — not one closed value set.
+        let s = schema_xy();
+        let expr = col("x").eq(lit(1_i64)).or(col("y").eq(lit(2_i64)));
+        assert!(exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+    }
+
+    #[test]
+    fn or_with_non_equality_branch_emits_no_leaf() {
+        // `x = 1 OR x > 5` — pruning on `[1]` alone would drop the `> 5`
+        // rows, so the whole OR declines.
+        let s = schema_xy();
+        let expr = col("x").eq(lit(1_i64)).or(col("x").gt(lit(5_i64)));
+        assert!(exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+    }
+
+    #[test]
+    fn or_with_cast_branch_emits_no_leaf() {
+        // `CAST(x) = 1 OR CAST(x) = 2` — a cast crosses a coercion boundary
+        // (literal type vs the column's native min/max), so decline.
+        let s = schema_xy();
+        let expr =
+            cast(col("x"), DataType::Int32)
+                .eq(lit(1_i32))
+                .or(cast(col("x"), DataType::Int32).eq(lit(2_i32)));
+        assert!(exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+    }
+
+    #[test]
+    fn or_on_fts_column_also_emits_term_presence_bloom() {
+        use crate::superfile::fts::tokenize::AsciiLowerTokenizer;
+        let s = Arc::new(Schema::new(vec![Field::new("title", DataType::Utf8, true)]));
+        let fts = HashSet::from(["title"]);
+        let tok = AsciiLowerTokenizer;
+        // OR form of an FTS-column IN — same bloom + min/max as the IN arm.
+        let expr = col("title")
+            .eq(lit("Foo Bar"))
+            .or(col("title").eq(lit("Bar Baz")));
+        let leaves = exprs_to_value_set_leaves(&[expr], &s, &fts, Some(&tok));
+
+        assert!(
+            leaves
+                .iter()
+                .any(|l| matches!(l, PruneLeaf::ScalarValueSet { .. })),
+            "scalar min/max leaf still emitted"
+        );
+        let terms = leaves
+            .iter()
+            .find_map(|l| match l {
+                PruneLeaf::TermPresence { terms, mode, .. } if *mode == BoolMode::Or => Some(terms),
+                _ => None,
+            })
+            .expect("FTS column also emits a TermPresence{Or} bloom leaf");
+        assert_eq!(
+            terms,
+            &vec!["bar".to_string(), "baz".to_string(), "foo".to_string()],
+            "tokens deduped (shared `bar`) and sorted"
+        );
     }
 
     #[test]
     fn negated_in_list_emits_no_leaf() {
         let s = schema_xy();
         let expr = col("x").in_list(vec![lit(1_i64)], true);
-        assert!(exprs_to_in_list_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+        assert!(exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
     }
 
     #[test]
@@ -1551,14 +1697,14 @@ mod tests {
         let s = schema_xy();
         // `x IN (1, y)` — `y` is a column, not a literal; can't bound min/max.
         let expr = col("x").in_list(vec![lit(1_i64), col("y")], false);
-        assert!(exprs_to_in_list_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+        assert!(exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
     }
 
     #[test]
     fn in_list_on_unknown_column_emits_no_leaf() {
         let s = schema_xy();
         let expr = col("z").in_list(vec![lit(1_i64)], false);
-        assert!(exprs_to_in_list_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+        assert!(exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
     }
 
     #[test]
@@ -1570,12 +1716,12 @@ mod tests {
         // 'Foo Bar' → [foo, bar]; 'Bar Baz' → [bar, baz]. The shared `bar`
         // is deduped, and the terms come out sorted-unique.
         let expr = col("title").in_list(vec![lit("Foo Bar"), lit("Bar Baz")], false);
-        let leaves = exprs_to_in_list_leaves(&[expr], &s, &fts, Some(&tok));
+        let leaves = exprs_to_value_set_leaves(&[expr], &s, &fts, Some(&tok));
 
         assert!(
             leaves
                 .iter()
-                .any(|l| matches!(l, PruneLeaf::ScalarInList { .. })),
+                .any(|l| matches!(l, PruneLeaf::ScalarValueSet { .. })),
             "scalar min/max leaf still emitted"
         );
         let (col_name, terms, mode) = leaves
@@ -1604,9 +1750,9 @@ mod tests {
         let fts = HashSet::from(["title"]); // "x" not in the set
         let tok = crate::superfile::fts::tokenize::AsciiLowerTokenizer;
         let expr = col("x").in_list(vec![lit(1_i64), lit(2_i64), lit(3_i64), lit(4_i64)], false);
-        let leaves = exprs_to_in_list_leaves(&[expr], &s, &fts, Some(&tok));
+        let leaves = exprs_to_value_set_leaves(&[expr], &s, &fts, Some(&tok));
         assert_eq!(leaves.len(), 1);
-        assert!(matches!(leaves[0], PruneLeaf::ScalarInList { .. }));
+        assert!(matches!(leaves[0], PruneLeaf::ScalarValueSet { .. }));
     }
 
     #[test]

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -31,8 +31,8 @@ use std::sync::Arc;
 use datafusion::scalar::ScalarValue;
 
 use super::skip::{
-    ScalarOp, ScalarPredicate, fts_bloom_skip, fts_prefix_skip, scalar_in_list_skip, scalar_skip,
-    scalar_value_may_match,
+    ScalarOp, ScalarPredicate, fts_bloom_skip, fts_prefix_skip, scalar_skip,
+    scalar_value_may_match, scalar_value_set_skip,
 };
 use crate::{
     superfile::fts::reader::BoolMode,
@@ -66,7 +66,7 @@ pub(crate) enum PruneLeaf {
     /// Scalar comparison on a scalar column → per-column min/max.
     Scalar(ScalarPredicate),
     /// `column IN (values)` → keep if the min/max could hold any value.
-    ScalarInList {
+    ScalarValueSet {
         column: String,
         values: Vec<ScalarValue>,
     },
@@ -90,8 +90,8 @@ impl PruneLeaf {
                 Some(prune_parts_for_fts_prefix(list, column, prefix))
             }
             PruneLeaf::Scalar(pred) => Some(scalar_keep_parts(list, pred)),
-            PruneLeaf::ScalarInList { column, values } => {
-                Some(scalar_in_list_keep_parts(list, column, values))
+            PruneLeaf::ScalarValueSet { column, values } => {
+                Some(scalar_value_set_keep_parts(list, column, values))
             }
         }
     }
@@ -141,7 +141,11 @@ fn scalar_keep_parts(list: &Manifest, pred: &ScalarPredicate) -> Vec<PartId> {
 
 // Part-tier `IN` prune: keep parts whose min/max could hold *any* listed
 // value (an `IN` is a disjunction of equalities).
-fn scalar_in_list_keep_parts(list: &Manifest, column: &str, values: &[ScalarValue]) -> Vec<PartId> {
+fn scalar_value_set_keep_parts(
+    list: &Manifest,
+    column: &str,
+    values: &[ScalarValue],
+) -> Vec<PartId> {
     keep_parts_where(list, column, |min, max| {
         values
             .iter()
@@ -203,8 +207,11 @@ pub(crate) async fn select_superfiles(
             PruneLeaf::Prefix { column, prefix } => {
                 and_into(&mut mask, &fts_prefix_skip(&superfiles, column, prefix));
             }
-            PruneLeaf::ScalarInList { column, values } => {
-                and_into(&mut mask, &scalar_in_list_skip(&superfiles, column, values));
+            PruneLeaf::ScalarValueSet { column, values } => {
+                and_into(
+                    &mut mask,
+                    &scalar_value_set_skip(&superfiles, column, values),
+                );
             }
             // Scalar leaves handled above as one conjunction.
             PruneLeaf::Scalar(_) => {}
@@ -229,10 +236,14 @@ fn and_into(dst: &mut [bool], src: &[bool]) {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, slice::from_ref};
+    use std::{
+        collections::{HashMap, HashSet},
+        slice::from_ref,
+    };
 
     use arrow_array::{Int64Array, LargeStringArray};
     use arrow_schema::{DataType, Field, Schema};
+    use datafusion::prelude::{col, lit};
     use uuid::Uuid;
 
     use super::*;
@@ -247,7 +258,7 @@ mod tests {
                 list::{FORMAT_VERSION, Manifest, ManifestPartEntry, PartitionStrategy},
                 part::{ContentHash, PartId},
             },
-            query::skip::ScalarOp,
+            query::{provider::exprs_to_value_set_leaves, skip::ScalarOp},
         },
         test_helpers::default_tokenizer,
     };
@@ -343,7 +354,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_in_list_keep_parts_keeps_every_part_holding_a_listed_value() {
+    fn scalar_value_set_keep_parts_keeps_every_part_holding_a_listed_value() {
         let p0 = part_from(&[seg_int("x", 0, 10)], 0);
         let p1 = part_from(&[seg_int("x", 100, 110)], 1);
         let p2 = part_from(&[seg_int("x", 200, 210)], 2);
@@ -352,15 +363,49 @@ mod tests {
 
         // IN (5, 205) → p0 ([0,10]) and p2 ([200,210]); not p1.
         assert_eq!(
-            scalar_in_list_keep_parts(&list, "x", &[i(5), i(205)]),
+            scalar_value_set_keep_parts(&list, "x", &[i(5), i(205)]),
             vec![p0.part_id, p2.part_id]
         );
         // IN (50) → in no part's range.
-        assert!(scalar_in_list_keep_parts(&list, "x", &[i(50)]).is_empty());
+        assert!(scalar_value_set_keep_parts(&list, "x", &[i(50)]).is_empty());
         // Unknown column → conservative keep-all.
         assert_eq!(
-            scalar_in_list_keep_parts(&list, "missing", &[i(5)]),
+            scalar_value_set_keep_parts(&list, "missing", &[i(5)]),
             vec![p0.part_id, p1.part_id, p2.part_id]
+        );
+    }
+
+    #[test]
+    fn or_of_equalities_prunes_at_both_tiers() {
+        // `x = 5 OR x = 205` lowers to the same ScalarValueSet the IN path
+        // builds; measure the drop each tier makes for that leaf.
+        let s = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, true)]));
+        let expr = col("x").eq(lit(5_i64)).or(col("x").eq(lit(205_i64)));
+        let leaves = exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), None);
+        let (column, values) = match leaves.as_slice() {
+            [PruneLeaf::ScalarValueSet { column, values }] => (column.as_str(), values.clone()),
+            _ => panic!("expected one ScalarValueSet leaf from the OR"),
+        };
+
+        // Tier A — part aggregates: 3 parts → 2; p1's [100,110] holds
+        // neither value, so the part-level prune drops it.
+        let p0 = part_from(&[seg_int("x", 0, 10)], 0);
+        let p1 = part_from(&[seg_int("x", 100, 110)], 1);
+        let p2 = part_from(&[seg_int("x", 200, 210)], 2);
+        let list = list_with(vec![p0.clone(), p1, p2.clone()]);
+        assert_eq!(
+            scalar_value_set_keep_parts(&list, column, &values),
+            vec![p0.part_id, p2.part_id],
+            "part tier prunes 1 of 3"
+        );
+
+        // Tier B — per-superfile stats: within a surviving part, 2
+        // superfiles → 1; [50,60] holds neither value, dropped here.
+        let segs = vec![seg_int("x", 0, 10), seg_int("x", 50, 60)];
+        assert_eq!(
+            scalar_value_set_skip(&segs, column, &values),
+            vec![true, false],
+            "superfile tier prunes 1 of 2"
         );
     }
 

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -261,7 +261,7 @@ pub fn scalar_skip(
 /// Keep each superfile whose `column` min/max could hold *any* of
 /// `values` (an `IN` list is a disjunction). Empty `values` keeps all.
 /// The SQL-side sibling of [`scalar_skip`] for the `IN` shape.
-pub fn scalar_in_list_skip(
+pub fn scalar_value_set_skip(
     superfiles: &[Arc<SuperfileEntry>],
     column: &str,
     values: &[ScalarValue],
@@ -671,7 +671,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_in_list_skip_keeps_superfiles_holding_any_listed_value() {
+    fn scalar_value_set_skip_keeps_superfiles_holding_any_listed_value() {
         let segs = vec![
             seg_with_int_stats("x", 0, 10),
             seg_with_int_stats("x", 100, 110),
@@ -680,18 +680,21 @@ mod tests {
         let i = |n| ScalarValue::Int64(Some(n));
         // IN (5, 205) → A's [0,10] and C's [200,210], not B.
         assert_eq!(
-            scalar_in_list_skip(&segs, "x", &[i(5), i(205)]),
+            scalar_value_set_skip(&segs, "x", &[i(5), i(205)]),
             vec![true, false, true]
         );
         // IN (50) → matches no range.
         assert_eq!(
-            scalar_in_list_skip(&segs, "x", &[i(50)]),
+            scalar_value_set_skip(&segs, "x", &[i(50)]),
             vec![false, false, false]
         );
         // Empty list and unknown column both keep all (conservative).
-        assert_eq!(scalar_in_list_skip(&segs, "x", &[]), vec![true, true, true]);
         assert_eq!(
-            scalar_in_list_skip(&segs, "missing", &[i(5)]),
+            scalar_value_set_skip(&segs, "x", &[]),
+            vec![true, true, true]
+        );
+        assert_eq!(
+            scalar_value_set_skip(&segs, "missing", &[i(5)]),
             vec![true, true, true]
         );
     }

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -401,10 +401,10 @@ fn sql_single_value_in_prunes_parts_via_equality_rewrite() {
 #[test]
 fn sql_multi_value_in_returns_exact_rows_across_parts() {
     // `title IN ('Straw Berry', 'Orange Juice')`, matches in parts 1 and 2.
-    //  - DataFusion rewrites a multi-value IN to `title = a OR title = b`.
-    //  - the manifest prune doesn't descend `OR`, so all 3 parts load.
-    //  - correctness comes from `FilterExec`, not pruning.
-    // This test pins the rows; pruning the `OR` form is future work.
+    //  - DataFusion rewrites a 2-value IN to `title = a OR title = b`.
+    //  - the same-column OR lowers to the IN leaves, so part 0 (neither
+    //    value in its min/max, neither token in its bloom) is pruned.
+    //  - the surviving 2 parts return the exact rows.
     let dir = TempDir::new().expect("tempdir");
     build_3_parts_two_superfiles_each(
         dir.path(),
@@ -427,10 +427,11 @@ fn sql_multi_value_in_returns_exact_rows_across_parts() {
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(rows, 2, "'Orange Juice' (part 1) + 'Straw Berry' (part 2)");
 
-    // Multi-value IN lowers to OR-of-equalities → no manifest prune today,
-    // so all parts load. Correctness still holds via FilterExec.
-    let (_loaded, total) = parts_loaded(&consumer);
+    // The OR-of-equalities now prunes: part 0 holds neither value, so only
+    // the 2 matching parts load.
+    let (loaded, total) = parts_loaded(&consumer);
     assert_eq!(total, 3, "6 commits / 2-per-part = 3 parts");
+    assert_eq!(loaded, 2, "part 0 pruned; got {loaded}/3");
 
     // Token-superset that isn't a full match → FilterExec drops it.
     // 'Straw' shares the `straw` token with 'Straw Berry' but isn't an
@@ -521,6 +522,44 @@ fn fts_in_bloom_prunes_parts_min_max_cannot() {
     assert_eq!(
         loaded, 1,
         "min/max keeps all 3 (range [aaa,zzz]); the bloom must narrow to part 1; got {loaded}/3"
+    );
+}
+
+#[test]
+fn sql_or_on_fts_column_bloom_prunes_parts_min_max_cannot() {
+    // Same-column OR (a 2-value IN's rewritten form) on an FTS column,
+    // min/max-blind by the anchor trick:
+    //  - every part holds "aaa"+"zzz" → min/max [aaa,zzz] keeps all 3.
+    //  - 'bravo' lives only in part 1 → the OR's TermPresence{Or} bloom
+    //    narrows to part 1, the other value exists nowhere.
+    let dir = TempDir::new().expect("tempdir");
+    build_3_parts_two_superfiles_each(
+        dir.path(),
+        &[
+            ["aaa", "alpha"], // part 0
+            ["zzz", "filler0"],
+            ["aaa", "bravo"], // part 1: holds 'bravo'
+            ["zzz", "filler1"],
+            ["aaa", "charlie"], // part 2
+            ["zzz", "filler2"],
+        ],
+    );
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_lazy_consumer(dir.path(), cache_dir.path());
+
+    // 2 values → arrives as `title = 'bravo' OR title = 'qx'`.
+    let batches = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE title = 'bravo' OR title = 'qx'")
+        .expect("query");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 1, "only the 'bravo' title matches");
+
+    let (loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3);
+    assert_eq!(
+        loaded, 1,
+        "min/max keeps all 3 (range [aaa,zzz]); the OR bloom must narrow to part 1; got {loaded}/3"
     );
 }
 


### PR DESCRIPTION
 Closes #181

### What does this PR do?
Extends the value-set superfile pruning from #251 to same-column `OR`-of-equalities (`a = x OR a = y`), lowering it to the same leaves an `IN` produces.

### Why do we need this change?
#251 pruned only `Expr::InList`. A same-column `OR` of equalities, whether written directly or one an `IN` can lower to before it reaches the provider, carried no prune leaf and opened every superfile. This closes that gap.

### Performance
An `OR` query now opens only the superfiles that might match. The tests below pin how many parts and superfiles survive each prune tier: 
  | filter | part tier | superfile tier |
  | --- | --- | --- |
  | scalar `x = 5 OR x = 205` | 3 parts → 2 | 2 → 1 |
  | FTS `OR`, min/max blind | 3 parts → 1 (bloom) | 2 → 1 (bloom) |
  | 2-value `IN` → `OR` | 3 parts → 2 | n/a |

Each skipped manifest-part or superfile is one avoided cold open. Non-`OR` queries are untouched.

### Notes
- Cross-column `OR` (`a = 1 OR b = 2`) stays out: it needs a disjunctive (union) leaf, not a single value set. Declined, so unpruned but correct. Tracked as follow-up.