### PR TITLE
fts: exclude negated terms from count and token_match

### DIFF
--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -386,6 +386,9 @@ pub enum QueryError {
     #[error("error reading parquet bytes during scan: {0}")]
     Parquet(String),
 
+    #[error("invalid query: {0}")]
+    InvalidQuery(String),
+
     #[error("DataFusion failed to plan the query: {0}")]
     Plan(String),
 

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -80,6 +80,7 @@ use std::{
 };
 
 use arrow::record_batch::RecordBatch;
+use roaring::RoaringBitmap;
 use uuid::Uuid;
 
 pub use crate::superfile::fts::reader::BoolMode;
@@ -446,41 +447,84 @@ impl SupertableReader {
     ///
     /// `pub(crate)` async kernel; the public surface is the sync
     /// [`SupertableReader::token_match`].
+    /// Parse `query` into positive and negated tokens, then select the
+    /// superfiles to scan. Pruning keys on the **positives only** — a
+    /// negated term must never drop a superfile: a superfile lacking it
+    /// excludes nothing, and under `And` keying on it would wrongly prune
+    /// every superfile that doesn't carry it. This mirrors the BM25
+    /// search path so the unranked `token_match` / `count` surfaces honor
+    /// negation the same way scored search does.
+    ///
+    /// Returns `(positives, negatives, kept)`. A query with no positive
+    /// token (negation-only, e.g. `-foo`) yields an empty `kept`: there
+    /// is no positive anchor to match, so the caller returns the empty
+    /// result — the same outcome the scored path produces when it rejects
+    /// a negation-only query.
+    async fn parse_and_prune(
+        &self,
+        column: &str,
+        query: &str,
+        mode: BoolMode,
+    ) -> Result<(Vec<String>, Vec<String>, Vec<Arc<SuperfileEntry>>), QueryError> {
+        let parsed = AsciiLowerTokenizer.parse(query);
+        let positives: Vec<String> = parsed.positives.into_iter().map(Cow::into_owned).collect();
+        let negatives: Vec<String> = parsed.negatives.into_iter().map(Cow::into_owned).collect();
+        if positives.is_empty() {
+            return Ok((positives, negatives, Vec::new()));
+        }
+        let prune_leaf = PruneLeaf::TermPresence {
+            column: column.to_owned(),
+            terms: positives.clone(),
+            mode,
+        };
+        let kept =
+            select_superfiles(self.manifest().as_ref(), slice::from_ref(&prune_leaf)).await?;
+        Ok((positives, negatives, kept))
+    }
+
     pub(crate) async fn token_match_async(
         &self,
         column: &str,
         query: &str,
         mode: BoolMode,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
-        let manifest = self.manifest();
-        let term_strings: Vec<String> = AsciiLowerTokenizer.tokenize(query).collect();
-        if term_strings.is_empty() {
-            return Ok(Vec::new());
-        }
-        let kept = select_superfiles(
-            manifest.as_ref(),
-            &[PruneLeaf::TermPresence {
-                column: column.to_owned(),
-                terms: term_strings.clone(),
-                mode,
-            }],
-        )
-        .await?;
+        let (positives, negatives, kept) = self.parse_and_prune(column, query, mode).await?;
         if kept.is_empty() {
             return Ok(Vec::new());
         }
+        let has_negatives = !negatives.is_empty();
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
         let column_arc = Arc::new(column.to_owned());
-        let term_arc: Arc<Vec<String>> = Arc::new(term_strings);
+        let term_arc: Arc<Vec<String>> = Arc::new(positives);
+        let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
         let kernel = move |r: Arc<SuperfileReader>, _: ()| {
             let column_arc = Arc::clone(&column_arc);
             let term_arc = Arc::clone(&term_arc);
+            let neg_arc = Arc::clone(&neg_arc);
             async move {
                 let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
                 let docs = r
                     .token_match(&column_arc, &refs, mode)
                     .await
                     .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                // Drop any positive match that also carries a negated
+                // term (union of the negatives). The df / count fast
+                // paths can't express exclusion, so negation forces a
+                // materialized walk over both sets.
+                let docs = if has_negatives {
+                    let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
+                    let excluded: RoaringBitmap = r
+                        .token_match(&column_arc, &neg_refs, BoolMode::Or)
+                        .await
+                        .map_err(|e| QueryError::Parquet(e.to_string()))?
+                        .into_iter()
+                        .collect();
+                    docs.into_iter()
+                        .filter(|d| !excluded.contains(*d))
+                        .collect::<Vec<_>>()
+                } else {
+                    docs
+                };
                 Ok(docs.into_iter().map(|d| (d, 0.0f32)).collect::<Vec<_>>())
             }
         };
@@ -506,27 +550,16 @@ impl SupertableReader {
         query: &str,
         mode: BoolMode,
     ) -> Result<u64, QueryError> {
-        let manifest = self.manifest();
-        let term_strings: Vec<String> = AsciiLowerTokenizer.tokenize(query).collect();
-        if term_strings.is_empty() {
-            return Ok(0);
-        }
-        let kept = select_superfiles(
-            manifest.as_ref(),
-            &[PruneLeaf::TermPresence {
-                column: column.to_owned(),
-                terms: term_strings.clone(),
-                mode,
-            }],
-        )
-        .await?;
+        let (positives, negatives, kept) = self.parse_and_prune(column, query, mode).await?;
         if kept.is_empty() {
             return Ok(0);
         }
 
-        let single_term = term_strings.len() == 1;
+        let single_term = positives.len() == 1;
+        let has_negatives = !negatives.is_empty();
         let column_arc = Arc::new(column.to_owned());
-        let term_arc: Arc<Vec<String>> = Arc::new(term_strings);
+        let term_arc: Arc<Vec<String>> = Arc::new(positives);
+        let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
 
         // Shared fan-out (`dispatch::fanout_with`): warms tombstones,
@@ -539,6 +572,7 @@ impl SupertableReader {
             move |r, entry, tombstone_cache, now, _params: ()| {
                 let column_arc = Arc::clone(&column_arc);
                 let term_arc = Arc::clone(&term_arc);
+                let neg_arc = Arc::clone(&neg_arc);
                 async move {
                     // Tombstone bitmap for this superfile (None = no deletes).
                     let tomb = match tombstone_cache.as_ref() {
@@ -551,22 +585,39 @@ impl SupertableReader {
                         None => None,
                     };
                     let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
-                    // Deletes present: materialize the matching ids and
-                    // subtract the tombstoned ones (a df read or a bare
-                    // match count would over-count the deleted rows).
-                    if let Some(b) = tomb {
+                    // Negated terms or deletes both force materialization:
+                    // the df read and the bare match count can't subtract
+                    // excluded or tombstoned docs. Materialize the positive
+                    // matches, then drop any doc carrying a negated term
+                    // (union of the negatives) or a tombstone.
+                    if has_negatives || tomb.is_some() {
                         let docs = r
                             .token_match(&column_arc, &refs, mode)
                             .await
                             .map_err(|e| QueryError::Parquet(e.to_string()))?;
-                        return Ok::<u64, QueryError>(
-                            docs.iter().filter(|d| !b.contains(**d)).count() as u64,
-                        );
+                        let excluded: RoaringBitmap = if has_negatives {
+                            let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
+                            r.token_match(&column_arc, &neg_refs, BoolMode::Or)
+                                .await
+                                .map_err(|e| QueryError::Parquet(e.to_string()))?
+                                .into_iter()
+                                .collect()
+                        } else {
+                            RoaringBitmap::new()
+                        };
+                        let n = docs
+                            .iter()
+                            .filter(|d| {
+                                !excluded.contains(**d)
+                                    && tomb.as_ref().is_none_or(|b| !b.contains(**d))
+                            })
+                            .count() as u64;
+                        return Ok::<u64, QueryError>(n);
                     }
-                    // No deletes (the common case): count without
-                    // materializing ids — a single token resolves O(1)
-                    // from the stored df, multi-token tallies the match
-                    // walk through the counting sink.
+                    // No negatives and no deletes (the common case): count
+                    // without materializing ids — a single token resolves
+                    // O(1) from the stored df, multi-token tallies the
+                    // match walk through the counting sink.
                     let n = if single_term {
                         r.term_df(&column_arc, &term_arc[0])
                             .await
@@ -1791,6 +1842,102 @@ mod tests {
         // term_df still says 3; the count must subtract the tombstone → 2.
         assert_eq!(
             st.count("title", "alpha", BoolMode::Or)
+                .expect("count after delete"),
+            2
+        );
+    }
+
+    #[test]
+    fn count_excludes_negated_terms() {
+        // A count query with a negated term must drop the docs matching
+        // that term, the same way a scored search does. The earlier count
+        // path tokenized "alpha -beta" into ["alpha", "beta"] and counted
+        // "beta" as a positive, so it over-counted instead of excluding.
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(0, &["alpha beta", "alpha gamma"]))
+            .expect("append");
+        w.commit().expect("commit");
+        w.append(&build_batch(2, &["alpha delta"])).expect("append");
+        w.commit().expect("commit");
+        w.append(&build_batch(3, &["beta gamma"])).expect("append");
+        w.commit().expect("commit");
+
+        // "alpha" matches three docs across the superfiles; "-beta" drops
+        // the one that also contains beta → 2. Mirrors the search-side
+        // `negation_excludes_across_superfiles`.
+        assert_eq!(
+            st.count("title", "alpha -beta", BoolMode::Or)
+                .expect("count"),
+            2
+        );
+        // Positive-only count is unchanged: all three alpha docs.
+        assert_eq!(st.count("title", "alpha", BoolMode::Or).expect("count"), 3);
+        // A negated term absent from the corpus excludes nothing.
+        assert_eq!(
+            st.count("title", "alpha -absent", BoolMode::Or)
+                .expect("count"),
+            3
+        );
+    }
+
+    #[test]
+    fn count_with_negation_agrees_with_token_match() {
+        // The count↔token_match invariant must hold for negated queries
+        // too, across OR / AND and single- vs multi-positive shapes.
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(
+            0,
+            &["alpha beta", "alpha gamma", "beta delta", "gamma delta"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+        let r = st.reader();
+        for (q, mode) in [
+            ("alpha -beta", BoolMode::Or),
+            ("alpha gamma -delta", BoolMode::Or),
+            ("alpha -gamma", BoolMode::And),
+            ("beta -alpha", BoolMode::Or),
+        ] {
+            let c = r.count("title", q, mode).expect("count");
+            let n = r.token_match("title", q, mode).expect("token_match").len() as u64;
+            assert_eq!(c, n, "count vs token_match for {q:?} {mode:?}");
+        }
+    }
+
+    #[test]
+    fn count_excludes_negated_terms_and_tombstones() {
+        // Negation and deletes compose: the materialized count drops both
+        // negated-term docs and tombstoned docs in one pass.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let st = Supertable::create(options_one_superfile_per_commit().with_storage(storage))
+            .expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(
+            0,
+            &["alpha one", "alpha two", "alpha beta", "alpha three"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+        drop(w); // release the writer slot so `delete` can acquire it
+
+        // 4 alpha docs minus the one also containing beta → 3.
+        assert_eq!(
+            st.count("title", "alpha -beta", BoolMode::Or)
+                .expect("count"),
+            3
+        );
+
+        // Delete one of the surviving alpha docs; the count drops it too.
+        let stats = st
+            .delete(col("title").eq(lit("alpha two")))
+            .expect("delete");
+        assert_eq!(stats.matched(), 1);
+        assert_eq!(
+            st.count("title", "alpha -beta", BoolMode::Or)
                 .expect("count after delete"),
             2
         );

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -87,7 +87,7 @@ pub use crate::superfile::fts::reader::BoolMode;
 use crate::{
     InfinoError,
     superfile::{
-        FtsError, SuperfileReader,
+        SuperfileReader,
         fts::tokenize::{AsciiLowerTokenizer, Tokenizer},
     },
     supertable::{
@@ -101,6 +101,11 @@ use crate::{
         },
     },
 };
+
+/// Rejection message for a query with negated terms but no positive
+/// anchor (e.g. `-foo`). Shared by the scored and unranked FTS paths so
+/// both reject the case identically.
+const NEGATION_ONLY_QUERY_MSG: &str = "only negated terms; at least one positive term is required";
 
 /// Cross-segment top-k score sharing for the BM25 fan-out.
 ///
@@ -225,6 +230,14 @@ impl SupertableReader {
         let parsed = AsciiLowerTokenizer.parse(query);
         let positives: Vec<String> = parsed.positives.into_iter().map(Cow::into_owned).collect();
         let negatives: Vec<String> = parsed.negatives.into_iter().map(Cow::into_owned).collect();
+
+        // Negation-only (e.g. `-foo`): no positive anchor to rank. Reject
+        // up front so the per-superfile excluding kernel never has to, and
+        // so the unranked count / token_match path surfaces the identical
+        // error (see `parse_and_prune`).
+        if positives.is_empty() && !negatives.is_empty() {
+            return Err(QueryError::InvalidQuery(NEGATION_ONLY_QUERY_MSG.to_owned()));
+        }
 
         // Pick the superfiles to search, via the shared two-tier bloom
         // prune. Only positive terms prune — a negated term must never
@@ -450,7 +463,7 @@ impl SupertableReader {
     /// Returns `(positives, negatives, kept)`. A query with no tokens at
     /// all yields an empty `kept`, so the caller returns the empty result
     /// (`[]` / count `0`). A negation-only query (negated terms but no
-    /// positive, e.g. `-foo`) is rejected with [`FtsError::NegationOnly`],
+    /// positive, e.g. `-foo`) is rejected with [`QueryError::InvalidQuery`],
     /// the same as the scored search path — there is no positive anchor to
     /// match against.
     async fn parse_and_prune(
@@ -470,7 +483,7 @@ impl SupertableReader {
             }
             // Negation-only (e.g. `-foo`): reject, matching the scored
             // search path, which has no positive anchor to rank or match.
-            return Err(QueryError::Parquet(FtsError::NegationOnly.to_string()));
+            return Err(QueryError::InvalidQuery(NEGATION_ONLY_QUERY_MSG.to_owned()));
         }
         let prune_leaf = PruneLeaf::TermPresence {
             column: column.to_owned(),

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -87,7 +87,7 @@ pub use crate::superfile::fts::reader::BoolMode;
 use crate::{
     InfinoError,
     superfile::{
-        SuperfileReader,
+        FtsError, SuperfileReader,
         fts::tokenize::{AsciiLowerTokenizer, Tokenizer},
     },
     supertable::{
@@ -439,14 +439,6 @@ impl SupertableReader {
         Ok(top_k_descending(per_unit, k))
     }
 
-    /// Unranked token match across the pinned snapshot. Returns
-    /// every row matching `query`'s tokens under `mode` (`Or` = any
-    /// token, `And` = every token) as [`SuperfileHit`]s — **no scoring**
-    /// (`score` is left `0.0`; these results are unordered). Superfile
-    /// skip uses the same term-bloom prune as BM25.
-    ///
-    /// `pub(crate)` async kernel; the public surface is the sync
-    /// [`SupertableReader::token_match`].
     /// Parse `query` into positive and negated tokens, then select the
     /// superfiles to scan. Pruning keys on the **positives only** — a
     /// negated term must never drop a superfile: a superfile lacking it
@@ -455,11 +447,12 @@ impl SupertableReader {
     /// search path so the unranked `token_match` / `count` surfaces honor
     /// negation the same way scored search does.
     ///
-    /// Returns `(positives, negatives, kept)`. A query with no positive
-    /// token (negation-only, e.g. `-foo`) yields an empty `kept`: there
-    /// is no positive anchor to match, so the caller returns the empty
-    /// result — the same outcome the scored path produces when it rejects
-    /// a negation-only query.
+    /// Returns `(positives, negatives, kept)`. A query with no tokens at
+    /// all yields an empty `kept`, so the caller returns the empty result
+    /// (`[]` / count `0`). A negation-only query (negated terms but no
+    /// positive, e.g. `-foo`) is rejected with [`FtsError::NegationOnly`],
+    /// the same as the scored search path — there is no positive anchor to
+    /// match against.
     async fn parse_and_prune(
         &self,
         column: &str,
@@ -470,7 +463,14 @@ impl SupertableReader {
         let positives: Vec<String> = parsed.positives.into_iter().map(Cow::into_owned).collect();
         let negatives: Vec<String> = parsed.negatives.into_iter().map(Cow::into_owned).collect();
         if positives.is_empty() {
-            return Ok((positives, negatives, Vec::new()));
+            if negatives.is_empty() {
+                // No tokens at all (empty/whitespace query) — nothing to
+                // match, not an error.
+                return Ok((positives, negatives, Vec::new()));
+            }
+            // Negation-only (e.g. `-foo`): reject, matching the scored
+            // search path, which has no positive anchor to rank or match.
+            return Err(QueryError::Parquet(FtsError::NegationOnly.to_string()));
         }
         let prune_leaf = PruneLeaf::TermPresence {
             column: column.to_owned(),
@@ -482,6 +482,14 @@ impl SupertableReader {
         Ok((positives, negatives, kept))
     }
 
+    /// Unranked token match across the pinned snapshot. Returns
+    /// every row matching `query`'s tokens under `mode` (`Or` = any
+    /// token, `And` = every token) as [`SuperfileHit`]s — **no scoring**
+    /// (`score` is left `0.0`; these results are unordered). Superfile
+    /// skip uses the same term-bloom prune as BM25.
+    ///
+    /// `pub(crate)` async kernel; the public surface is the sync
+    /// [`SupertableReader::token_match`].
     pub(crate) async fn token_match_async(
         &self,
         column: &str,
@@ -1221,6 +1229,39 @@ mod tests {
         let r = st.reader();
         let res = r.bm25_hits("title", "-alpha", 10, BoolMode::Or);
         assert!(res.is_err(), "negation-only must error; got {res:?}");
+    }
+
+    #[test]
+    fn count_and_token_match_negation_only_query_errors() {
+        // The unranked count / token_match surfaces reject a negation-only
+        // query (`-foo`) the same way the scored path does — there is no
+        // positive anchor to match against. A token-less query (empty /
+        // whitespace) is still 0 / empty, not an error.
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(0, &["alpha beta"])).expect("append");
+        w.commit().expect("commit");
+        let r = st.reader();
+
+        for mode in [BoolMode::Or, BoolMode::And] {
+            assert!(
+                r.count("title", "-alpha", mode).is_err(),
+                "negation-only count must error ({mode:?})"
+            );
+            assert!(
+                r.token_match("title", "-alpha", mode).is_err(),
+                "negation-only token_match must error ({mode:?})"
+            );
+        }
+        // No positive anchor across several negated terms either.
+        assert!(r.count("title", "-alpha -beta", BoolMode::Or).is_err());
+        // Token-less queries stay non-error, 0 / empty.
+        assert_eq!(r.count("title", "", BoolMode::Or).expect("empty"), 0);
+        assert!(
+            r.token_match("title", "   ", BoolMode::Or)
+                .expect("blank")
+                .is_empty()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Closes #261. Count queries (and the unranked `token_match`) returned incorrect values when the query contained a negated term. For a query like `alpha -beta`, the count included the documents that matched `beta` instead of excluding them — diverging from what a scored search returns and from other engines.

## Root cause

`token_match_count_async` and `token_match_async` parsed the query with the *indexing* tokenizer (`tokenize()`), which knows nothing about query syntax. `alpha -beta` was split into `["alpha", "beta"]`, silently turning the negated term into a positive one. The scored `bm25_search` path already parsed correctly (`parse()` → positives + negatives) and excluded negatives; the two unranked paths did not.

## Fix

- New shared `parse_and_prune` helper: parses positives/negatives and prunes superfiles on **positives only** (a negated term must never drop a superfile — same rule the scored path follows).
- `token_match_count_async`: the `term_df` (O(1)) and counting-sink fast paths now run only when there are no negatives and no deletes. When negatives are present, positive matches are materialized and any doc that also matches a negated term (union) or carries a tombstone is dropped in one filter pass.
- `token_match_async`: same negation handling, preserving the documented `count == token_match.len()` invariant.

## Tests

Added regression coverage that fails before the fix and passes after:
- `count_excludes_negated_terms` — `alpha -beta` → 2, not 3, across multiple superfiles.
- `count_with_negation_agrees_with_token_match` — the count↔token_match invariant under negation, across OR/AND and single/multi-positive shapes.
- `count_excludes_negated_terms_and_tombstones` — negation and deletes compose.

`cargo fmt --check`, `cargo clippy --lib --tests`, and the full `fts` query test module are green.

## Performance

Touches the FTS query fan-out but not BM25/vector scoring math, distance/SIMD kernels, codecs, or the commit path. The negation-free, delete-free common case keeps its existing fast paths unchanged; negation now forces a materialized walk (correctness over the prior — wrong — fast count). No bench-relevant hot path changed.