### PR TITLE
improv query: add str to bool mode convertor

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -7,6 +7,8 @@ pub fn infino::BoolMode::clone(&self) -> infino::BoolMode
 impl core::cmp::Eq for infino::BoolMode
 impl core::cmp::PartialEq for infino::BoolMode
 pub fn infino::BoolMode::eq(&self, &infino::BoolMode) -> bool
+impl core::convert::From<&str> for infino::BoolMode
+pub fn infino::BoolMode::from(&str) -> Self
 impl core::fmt::Debug for infino::BoolMode
 pub fn infino::BoolMode::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for infino::BoolMode

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -56,6 +56,16 @@ pub enum BoolMode {
     Or,
 }
 
+impl From<&str> for BoolMode {
+    fn from(s: &str) -> Self {
+        match s {
+            "and" => BoolMode::And,
+            "or" => BoolMode::Or,
+            _ => BoolMode::Or,
+        }
+    }
+}
+
 /// Multi-term OR algorithm selector for the bench harness's
 /// `search_with_algo_for_bench` entry point. Production code routes
 /// through `FtsReader::dispatch_multi_term_or`, which picks


### PR DESCRIPTION
### What does this PR do?
Adds an `Into` trait to create a BoolMode object from a str