### PR TITLE
chore: run gc alongside compact in optimize

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -43,6 +43,8 @@ impl core::panic::unwind_safe::UnwindSafe for infino::ColdFetchMode
 pub enum infino::GcError
 pub infino::GcError::NoStorage
 pub infino::GcError::Storage(infino::storage::StorageError)
+impl core::convert::From<infino::GcError> for infino::OptimizeError
+pub fn infino::OptimizeError::from(infino::GcError) -> Self
 impl core::error::Error for infino::GcError
 pub fn infino::GcError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for infino::GcError
@@ -101,6 +103,7 @@ pub infino::OptimizeError::AlreadyRunning
 pub infino::OptimizeError::Build(alloc::string::String)
 pub infino::OptimizeError::Commit(alloc::string::String)
 pub infino::OptimizeError::EmptyMergedSuperfile
+pub infino::OptimizeError::Gc(infino::GcError)
 pub infino::OptimizeError::NoStorage
 pub infino::OptimizeError::Refresh(alloc::string::String)
 pub infino::OptimizeError::Seal(alloc::string::String)
@@ -108,7 +111,10 @@ pub infino::OptimizeError::SidecarConflict
 pub infino::OptimizeError::SidecarConflict::existing_compaction_id: uuid::Uuid
 pub infino::OptimizeError::SidecarConflict::superfile_id: uuid::Uuid
 pub infino::OptimizeError::SuperfileNotFound(uuid::Uuid)
+impl core::convert::From<infino::GcError> for infino::OptimizeError
+pub fn infino::OptimizeError::from(infino::GcError) -> Self
 impl core::error::Error for infino::OptimizeError
+pub fn infino::OptimizeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for infino::OptimizeError
 pub fn infino::OptimizeError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for infino::OptimizeError
@@ -118,8 +124,8 @@ impl core::marker::Send for infino::OptimizeError
 impl core::marker::Sync for infino::OptimizeError
 impl core::marker::Unpin for infino::OptimizeError
 impl core::marker::UnsafeUnpin for infino::OptimizeError
-impl core::panic::unwind_safe::RefUnwindSafe for infino::OptimizeError
-impl core::panic::unwind_safe::UnwindSafe for infino::OptimizeError
+impl !core::panic::unwind_safe::RefUnwindSafe for infino::OptimizeError
+impl !core::panic::unwind_safe::UnwindSafe for infino::OptimizeError
 pub struct infino::CompactionSettings
 pub infino::CompactionSettings::max_memory_mb: u64
 pub infino::CompactionSettings::min_fill_percent: u8

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,6 +36,7 @@
 use std::{
     env, fmt,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use figment::{
@@ -163,6 +164,9 @@ impl Default for CompactionSettings {
         }
     }
 }
+
+/// Minimum age an unreferenced object must reach before [`crate::Supertable::optimize`] deletes it.
+pub const DEFAULT_GC_SAFETY_GAP: Duration = Duration::from_secs(86_400);
 
 /// Options for [`crate::Supertable::optimize`].
 ///

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -284,6 +284,8 @@ pub enum OptimizeError {
     Refresh(String),
     #[error("optimize already in progress on this handle")]
     AlreadyRunning,
+    #[error("gc failed during optimize: {0}")]
+    Gc(#[from] GcError),
 }
 
 impl From<CompactionError> for OptimizeError {

--- a/src/supertable/optimize/mod.rs
+++ b/src/supertable/optimize/mod.rs
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-use crate::{Supertable, config::OptimizeOptions, supertable::error::OptimizeError};
+use crate::{
+    Supertable,
+    config::{DEFAULT_GC_SAFETY_GAP, OptimizeOptions},
+    supertable::error::OptimizeError,
+};
 
 impl Supertable {
     pub fn optimize(&self, opts: &OptimizeOptions) -> Result<(), OptimizeError> {
-        self.compact(&opts.compaction).map_err(OptimizeError::from)
+        self.compact(&opts.compaction)?;
+        self.gc(DEFAULT_GC_SAFETY_GAP)?;
+        Ok(())
     }
 }

--- a/src/supertable/optimize/mod.rs
+++ b/src/supertable/optimize/mod.rs
@@ -4,13 +4,16 @@
 use crate::{
     Supertable,
     config::{DEFAULT_GC_SAFETY_GAP, OptimizeOptions},
-    supertable::error::OptimizeError,
+    supertable::error::{GcError, OptimizeError},
 };
 
 impl Supertable {
     pub fn optimize(&self, opts: &OptimizeOptions) -> Result<(), OptimizeError> {
         self.compact(&opts.compaction)?;
-        self.gc(DEFAULT_GC_SAFETY_GAP)?;
+        match self.gc(DEFAULT_GC_SAFETY_GAP) {
+            Ok(_) | Err(GcError::NoStorage) => {}
+            Err(e) => return Err(OptimizeError::Gc(e)),
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Run GC after compaction

- Add default GC safety gap

- Surface GC failures in optimize

- Ignore missing storage during GC


___

### Diagram Walkthrough


```mermaid
flowchart LR
  opt["Supertable::optimize"] 
  compact["Compaction step"]
  gc["GC with default safety gap"]
  nostorage["Ignore GcError::NoStorage"]
  fail["Return OptimizeError::Gc"]

  opt -- "runs" --> compact
  compact -- "then runs" --> gc
  gc -- "missing storage" --> nostorage
  gc -- "other GC errors" --> fail
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add default GC safety gap constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/mod.rs

<ul><li>Import <code>Duration</code> for time-based defaults<br> <li> Add <code>DEFAULT_GC_SAFETY_GAP</code> constant<br> <li> Document GC deletion delay for optimize</ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/269/files#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Execute GC as part of optimize</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/supertable/optimize/mod.rs

<ul><li>Run <code>gc</code> after successful compaction<br> <li> Use <code>DEFAULT_GC_SAFETY_GAP</code> for cleanup<br> <li> Ignore <code>GcError::NoStorage</code> during optimize<br> <li> Return GC errors via <code>OptimizeError::Gc</code></ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/269/files#diff-4662f8a09eaa3a86dbadb76ccfd8ad505bdcca17b51084ed38604281eb2164d4">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Extend optimize errors with GC failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/supertable/error.rs

<ul><li>Add <code>OptimizeError::Gc</code> variant<br> <li> Convert <code>GcError</code> into optimize failures<br> <li> Provide dedicated GC failure message</ul>


</details>


  </td>
  <td><a href="https://github.com/infino-ai/infino/pull/269/files#diff-d1a0aa15856bf7ed6530701dcd1c8d3422e3395a3dce2aa13b178485ccb0e9b8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

