### PR TITLE
examples: add LangChain example suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,19 @@ python-examples-test:
 	# Drop infino from the requirements; the from-source build above is what runs.
 	grep -v '^[[:space:]]*infino' infino-python/examples/requirements.txt \
 		| infino-python/.venv/bin/pip install -q -r /dev/stdin
+	# The langchain examples add the langchain-infino integration and its stack.
+	# Strip every infino line (incl. langchain-infino) so pip never pulls infino
+	# from PyPI over the from-source build; install langchain-infino with --no-deps
+	# so it links against the build above instead of dragging in its own infino.
+	grep -v 'infino' infino-python/examples/langchain/requirements.txt \
+		| infino-python/.venv/bin/pip install -q -r /dev/stdin
+	infino-python/.venv/bin/pip install -q --no-deps langchain-infino
 	infino-python/.venv/bin/pip install -q nbconvert ipykernel
 	# Warm the shared embedding model so parallel workers don't race the download.
 	PYTHONPATH=infino-python/examples infino-python/.venv/bin/python \
 		-c "from _shared.embedding import _get_model; _get_model()" >/dev/null
+	# Run every example notebook, including the langchain/ suite. Notebooks that
+	# need an LLM degrade to a printed note when no key is set (e.g. fork PRs).
 	@ls infino-python/examples/*/[0-9]*.ipynb | \
 	PY=infino-python/.venv/bin/python xargs -P $(CONCURRENT_EXAMPLE_TESTS) -I {} \
 		sh -c 'echo "executing {}"; "$$PY" -m nbconvert --to notebook --execute \

--- a/infino-python/examples/_shared/lc.py
+++ b/infino-python/examples/_shared/lc.py
@@ -1,0 +1,52 @@
+"""LangChain glue for the examples: a local embedder and an optional chat model.
+
+`MiniLMEmbeddings` exposes the same local `all-MiniLM-L6-v2` model the rest of
+the suite uses (384-dim, cosine) through LangChain's `Embeddings` interface, so
+the examples stay key-free. `chat_model()` returns a configured LangChain chat
+model (Azure AI Foundry or OpenAI, same env convention as `_shared/llm.py`) or
+`None` when no key is set — callers degrade to printing retrieved context.
+"""
+
+import os
+
+from langchain_core.embeddings import Embeddings
+
+from _shared.embedding import embed, embed_query
+from _shared.llm import _load_env_files  # reuse the suite's .env loader
+
+
+class MiniLMEmbeddings(Embeddings):
+    """LangChain `Embeddings` over the suite's local all-MiniLM-L6-v2 (dim 384)."""
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return embed(list(texts))
+
+    def embed_query(self, text: str) -> list[float]:
+        return embed_query(text)
+
+
+def chat_model(temperature: float = 0.0):
+    """A LangChain chat model from the environment, or `None` if no key is set.
+
+    Prefers Azure AI Foundry (`AZURE_AI_ENDPOINT`, `AZURE_AI_API_KEY`,
+    `DEFAULT_AZURE_MODEL`) over OpenAI (`OPENAI_API_KEY`, optional `OPENAI_MODEL`),
+    matching `_shared/llm.py`. Imported lazily so the embeddings path needs no
+    `langchain-openai` install.
+    """
+    _load_env_files()
+    from langchain_openai import ChatOpenAI
+
+    azure_endpoint = os.environ.get("AZURE_AI_ENDPOINT")
+    azure_key = os.environ.get("AZURE_AI_API_KEY")
+    if azure_endpoint and azure_key:
+        model = os.environ.get("DEFAULT_AZURE_MODEL", "gpt-4o-mini")
+        return ChatOpenAI(
+            base_url=azure_endpoint, api_key=azure_key, model=model,
+            temperature=temperature,
+        )
+
+    if os.environ.get("OPENAI_API_KEY"):
+        model = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+        return ChatOpenAI(model=model, temperature=temperature)
+
+    return None

--- a/infino-python/examples/langchain/01_live_data_rag.ipynb
+++ b/infino-python/examples/langchain/01_live_data_rag.ipynb
@@ -7,11 +7,9 @@
    "source": [
     "# Live-data RAG: a vector store you can write to\n",
     "\n",
-    "Most LangChain vector stores are rebuild-only \u2014 change your data and you\n",
-    "re-embed and re-index from scratch. **Infino is a vector store you can safely\n",
-    "*write* to.** Append new items, upsert by id, delete \u2014 and both retrieval *and*\n",
-    "SQL reflect every change immediately, with no reindex, and survive a reopen from\n",
-    "object storage.\n",
+    "**Infino is a vector store you can write to.** Append new items, upsert by id,\n",
+    "delete \u2014 and both retrieval *and* SQL reflect every change immediately, with no\n",
+    "reindex, and survive a reopen from object storage.\n",
     "\n",
     "This example keeps a product catalog live: index it, answer a question, add new\n",
     "stock, mark an item down, clear some out, then reopen from disk and confirm\n",
@@ -152,7 +150,7 @@
     "## Append new stock \u2014 searchable immediately\n",
     "\n",
     "`add_texts` embeds and commits the new product. Re-ask the *same* question: the\n",
-    "just-added item is now the top hit. No reindex, no separate write path."
+    "just-added item is now the top hit, live for search the moment it's added."
    ]
   },
   {
@@ -237,8 +235,7 @@
     "Everything committed lives on disk (object storage in production). Drop the\n",
     "handles, reconnect, and reopen the table with the same `InfinoVectorStore`\n",
     "constructor: the markdown, the new stock, and the deletions are all still there.\n",
-    "The full-text index and SQL views stay correct after every mutation \u2014 no\n",
-    "rebuild."
+    "The full-text index and SQL views stay correct after every mutation."
    ]
   },
   {
@@ -269,9 +266,8 @@
     "\n",
     "One Infino table served as a **mutable, durable** LangChain vector store: append,\n",
     "upsert, and delete flowed straight through to vector retrieval and SQL, and\n",
-    "survived a reopen \u2014 no rebuild, no second write path, no separate metadata\n",
-    "store. The same table also answers BM25, hybrid, and SQL queries (see the other\n",
-    "examples)."
+    "survived a reopen from disk. The same table also answers BM25, hybrid, and SQL\n",
+    "queries (see the other examples)."
    ]
   }
  ],

--- a/infino-python/examples/langchain/01_live_data_rag.ipynb
+++ b/infino-python/examples/langchain/01_live_data_rag.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Live-data RAG: a vector store you can write to\n",
+    "\n",
+    "Most LangChain vector stores are rebuild-only \u2014 change your data and you\n",
+    "re-embed and re-index from scratch. **Infino is a vector store you can safely\n",
+    "*write* to.** Append new items, upsert by id, delete \u2014 and both retrieval *and*\n",
+    "SQL reflect every change immediately, with no reindex, and survive a reopen from\n",
+    "object storage.\n",
+    "\n",
+    "This example keeps a product catalog live: index it, answer a question, add new\n",
+    "stock, mark an item down, clear some out, then reopen from disk and confirm\n",
+    "every change persisted. The retrieval path runs **key-free**; set an LLM key\n",
+    "(see the README) to also generate answers \u2014 otherwise the notebook prints the\n",
+    "retrieved context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-01",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path.cwd().parent))  # examples/ root, where _shared/ lives\n",
+    "\n",
+    "import infino\n",
+    "import pyarrow as pa\n",
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "from langchain_infino import InfinoVectorStore\n",
+    "\n",
+    "from _shared.lc import MiniLMEmbeddings, chat_model\n",
+    "from _shared.embedding import DIM, METRIC\n",
+    "from _shared.loaders import load_amazon\n",
+    "from _shared.sql import query\n",
+    "\n",
+    "DB_DIR = \"./live_inventory_data\"\n",
+    "TABLE = \"products\"\n",
+    "shutil.rmtree(DB_DIR, ignore_errors=True)  # start fresh each run\n",
+    "\n",
+    "embeddings = MiniLMEmbeddings()\n",
+    "llm = chat_model()  # None when no key is set; the demo still runs (prints context)\n",
+    "print(\"LLM answers:\", \"on\" if llm else \"off (retrieval only)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "## Build the store\n",
+    "\n",
+    "`InfinoVectorStore.from_texts` creates one Infino table and indexes the catalog.\n",
+    "`price` and `rating` are **promoted to scalar columns** (`metadata_columns`) so\n",
+    "they're filterable in SQL and attached to every retrieved `Document`; `title`\n",
+    "and `category` ride along in the JSON metadata. We pass stable `ids` so we can\n",
+    "upsert and delete specific products later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-03",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "products = load_amazon(n=600)\n",
+    "ids = [f\"p-{i}\" for i in range(len(products))]\n",
+    "texts = [p[\"text\"] for p in products]\n",
+    "metadatas = [\n",
+    "    {\"title\": p[\"title\"], \"category\": p[\"category\"],\n",
+    "     \"price\": p[\"price\"], \"rating\": p[\"rating\"]}\n",
+    "    for p in products\n",
+    "]\n",
+    "metadata_columns = [\n",
+    "    pa.field(\"price\", pa.float64(), nullable=False),\n",
+    "    pa.field(\"rating\", pa.float64(), nullable=False),\n",
+    "]\n",
+    "\n",
+    "db = infino.connect(DB_DIR)\n",
+    "store = InfinoVectorStore.from_texts(\n",
+    "    texts, embeddings, metadatas,\n",
+    "    connection=db, table_name=TABLE, dim=DIM, metric=METRIC,\n",
+    "    ids=ids, metadata_columns=metadata_columns,\n",
+    ")\n",
+    "print(\"indexed\", query(db, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0], \"products\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "## RAG over the live catalog\n",
+    "\n",
+    "`store.as_retriever()` returns a standard LangChain `BaseRetriever`, so the chain\n",
+    "below is plain LCEL. We ask for a product the catalog doesn't carry yet \u2014 note\n",
+    "the answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-05",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "retriever = store.as_retriever(search_kwargs={\"k\": 4})\n",
+    "\n",
+    "PROMPT = ChatPromptTemplate.from_template(\n",
+    "    \"You are a shopping assistant. Answer using only the catalog context.\\n\\n\"\n",
+    "    \"Context:\\n{context}\\n\\nQuestion: {question}\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def format_docs(docs) -> str:\n",
+    "    return \"\\n\".join(\n",
+    "        f\"- {d.metadata.get('title', '')} \"\n",
+    "        f\"(${d.metadata.get('price')}, {d.metadata.get('rating')}\u2605)\"\n",
+    "        for d in docs\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def answer(question: str) -> None:\n",
+    "    docs = retriever.invoke(question)\n",
+    "    print(f\"Q: {question}\\nretrieved:\\n{format_docs(docs)}\")\n",
+    "    if llm is not None:\n",
+    "        chain = PROMPT | llm | StrOutputParser()\n",
+    "        print(\"answer:\", chain.invoke(\n",
+    "            {\"context\": format_docs(docs), \"question\": question}))\n",
+    "\n",
+    "\n",
+    "QUESTION = \"wireless earbuds for running, sweatproof\"\n",
+    "answer(QUESTION)  # baseline \u2014 no such product in the catalog yet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "## Append new stock \u2014 searchable immediately\n",
+    "\n",
+    "`add_texts` embeds and commits the new product. Re-ask the *same* question: the\n",
+    "just-added item is now the top hit. No reindex, no separate write path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-07",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "store.add_texts(\n",
+    "    [\"NovaSound Z9 wireless running earbuds, sweatproof, 30h battery\"],\n",
+    "    metadatas=[{\"title\": \"NovaSound Z9\", \"category\": \"Electronics\",\n",
+    "                \"price\": 79.0, \"rating\": 4.7}],\n",
+    "    ids=[\"sku-novasound-z9\"],\n",
+    ")\n",
+    "answer(QUESTION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "## Update = upsert by id\n",
+    "\n",
+    "Re-adding the same `id` overwrites the row (Infino superfiles are immutable, so\n",
+    "an upsert is delete-then-append under the hood). Mark the price down: the change\n",
+    "shows up, and the row count is **unchanged** \u2014 it's an update, not a duplicate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-09",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "total_before = query(db, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0]\n",
+    "store.add_texts(\n",
+    "    [\"NovaSound Z9 wireless running earbuds, sweatproof, 30h battery\"],\n",
+    "    metadatas=[{\"title\": \"NovaSound Z9\", \"category\": \"Electronics\",\n",
+    "                \"price\": 49.0, \"rating\": 4.7}],\n",
+    "    ids=[\"sku-novasound-z9\"],  # same id -> overwrite, not a second row\n",
+    ")\n",
+    "total_after = query(db, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0]\n",
+    "doc = store.get_by_ids([\"sku-novasound-z9\"])[0]\n",
+    "print(f\"price -> ${doc.metadata.get('price')}, \"\n",
+    "      f\"row count {total_before} -> {total_after} (unchanged)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## Delete (clearance)\n",
+    "\n",
+    "`delete(ids=...)` removes rows from retrieval **and** SQL at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-11",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "before = query(db, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0]\n",
+    "store.delete([\"p-0\", \"p-1\", \"p-2\"])\n",
+    "after = query(db, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0]\n",
+    "print(f\"cleared 3 -> rows {before} then {after}\")\n",
+    "print(\"p-0 still present:\", bool(store.get_by_ids([\"p-0\"])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "## Durability \u2014 reopen from disk\n",
+    "\n",
+    "Everything committed lives on disk (object storage in production). Drop the\n",
+    "handles, reconnect, and reopen the table with the same `InfinoVectorStore`\n",
+    "constructor: the markdown, the new stock, and the deletions are all still there.\n",
+    "The full-text index and SQL views stay correct after every mutation \u2014 no\n",
+    "rebuild."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-13",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "del store, db  # drop the handles, simulate a fresh process\n",
+    "\n",
+    "db2 = infino.connect(DB_DIR)\n",
+    "store2 = InfinoVectorStore(\n",
+    "    db2, TABLE, embeddings, dim=DIM, metric=METRIC,\n",
+    "    metadata_columns=metadata_columns,\n",
+    ")\n",
+    "doc = store2.get_by_ids([\"sku-novasound-z9\"])[0]\n",
+    "total = query(db2, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0]\n",
+    "print(f\"reopened: {total} products; NovaSound Z9 still ${doc.metadata.get('price')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-14",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "One Infino table served as a **mutable, durable** LangChain vector store: append,\n",
+    "upsert, and delete flowed straight through to vector retrieval and SQL, and\n",
+    "survived a reopen \u2014 no rebuild, no second write path, no separate metadata\n",
+    "store. The same table also answers BM25, hybrid, and SQL queries (see the other\n",
+    "examples)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/infino-python/examples/langchain/01_live_data_rag.ipynb
+++ b/infino-python/examples/langchain/01_live_data_rag.ipynb
@@ -8,22 +8,37 @@
     "# Live-data RAG: a vector store you can write to\n",
     "\n",
     "**Infino is a vector store you can write to.** Append new items, upsert by id,\n",
-    "delete \u2014 and both retrieval *and* SQL reflect every change immediately, with no\n",
+    "delete — and both retrieval *and* SQL reflect every change immediately, with no\n",
     "reindex, and survive a reopen from object storage.\n",
     "\n",
     "This example keeps a product catalog live: index it, answer a question, add new\n",
     "stock, mark an item down, clear some out, then reopen from disk and confirm\n",
     "every change persisted. The retrieval path runs **key-free**; set an LLM key\n",
-    "(see the README) to also generate answers \u2014 otherwise the notebook prints the\n",
+    "(see the README) to also generate answers — otherwise the notebook prints the\n",
     "retrieved context."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "cell-01",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:27:09.707545Z",
+     "iopub.status.busy": "2026-06-24T07:27:09.707453Z",
+     "iopub.status.idle": "2026-06-24T07:27:11.781710Z",
+     "shell.execute_reply": "2026-06-24T07:27:11.781399Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LLM answers: on\n"
+     ]
+    }
+   ],
    "source": [
     "import sys\n",
     "import shutil\n",
@@ -67,10 +82,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "cell-03",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:27:11.782907Z",
+     "iopub.status.busy": "2026-06-24T07:27:11.782807Z",
+     "iopub.status.idle": "2026-06-24T07:27:53.246899Z",
+     "shell.execute_reply": "2026-06-24T07:27:53.246496Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "indexed 600 products\n"
+     ]
+    }
+   ],
    "source": [
     "products = load_amazon(n=600)\n",
     "ids = [f\"p-{i}\" for i in range(len(products))]\n",
@@ -102,16 +132,49 @@
     "## RAG over the live catalog\n",
     "\n",
     "`store.as_retriever()` returns a standard LangChain `BaseRetriever`, so the chain\n",
-    "below is plain LCEL. We ask for a product the catalog doesn't carry yet \u2014 note\n",
+    "below is plain LCEL. We ask for a product the catalog doesn't carry yet — note\n",
     "the answer."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "cell-05",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:27:53.248074Z",
+     "iopub.status.busy": "2026-06-24T07:27:53.247937Z",
+     "iopub.status.idle": "2026-06-24T07:27:57.187339Z",
+     "shell.execute_reply": "2026-06-24T07:27:57.186572Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q: wireless earbuds for running, sweatproof\n",
+      "retrieved:\n",
+      "- WURGIIX Ribbed Stretch Bandie Women's Headbands Headwraps Hair Bands Bows Hair Accessories（Wine red）Mother's day gift ($5.99, 4.1★)\n",
+      "- Big Bunny Ears Headband for Easter,Halloween Party Costume Accessories/Sweet Sexy Rabbit Ear Hair(Black) ($6.99, 4.3★)\n",
+      "- Picoway 20 Pack Mouse Ears Solid Black and Red Bow Headband ($15.99, 4.8★)\n",
+      "- Ariel Ear Headband Ariel Mouse Ears Headband Ariel Minnie Ears Headband ($39.99, 4.8★)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "answer: I couldn’t find any wireless earbuds in the catalog.\n",
+      "\n",
+      "Available items are only headbands/accessories:\n",
+      "- WURGIIX Ribbed Stretch Bandie Women's Headbands Headwraps Hair Bands Bows Hair Accessories（Wine red） — $5.99, 4.1★\n",
+      "- Big Bunny Ears Headband for Easter,Halloween Party Costume Accessories/Sweet Sexy Rabbit Ear Hair(Black) — $6.99, 4.3★\n",
+      "- Picoway 20 Pack Mouse Ears Solid Black and Red Bow Headband — $15.99, 4.8★\n",
+      "- Ariel Ear Headband Ariel Mouse Ears Headband Ariel Minnie Ears Headband — $39.99, 4.8★\n"
+     ]
+    }
+   ],
    "source": [
     "retriever = store.as_retriever(search_kwargs={\"k\": 4})\n",
     "\n",
@@ -124,7 +187,7 @@
     "def format_docs(docs) -> str:\n",
     "    return \"\\n\".join(\n",
     "        f\"- {d.metadata.get('title', '')} \"\n",
-    "        f\"(${d.metadata.get('price')}, {d.metadata.get('rating')}\u2605)\"\n",
+    "        f\"(${d.metadata.get('price')}, {d.metadata.get('rating')}★)\"\n",
     "        for d in docs\n",
     "    )\n",
     "\n",
@@ -139,7 +202,7 @@
     "\n",
     "\n",
     "QUESTION = \"wireless earbuds for running, sweatproof\"\n",
-    "answer(QUESTION)  # baseline \u2014 no such product in the catalog yet"
+    "answer(QUESTION)  # baseline — no such product in the catalog yet"
    ]
   },
   {
@@ -147,7 +210,7 @@
    "id": "cell-06",
    "metadata": {},
    "source": [
-    "## Append new stock \u2014 searchable immediately\n",
+    "## Append new stock — searchable immediately\n",
     "\n",
     "`add_texts` embeds and commits the new product. Re-ask the *same* question: the\n",
     "just-added item is now the top hit, live for search the moment it's added."
@@ -155,10 +218,37 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "cell-07",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:27:57.188941Z",
+     "iopub.status.busy": "2026-06-24T07:27:57.188809Z",
+     "iopub.status.idle": "2026-06-24T07:27:58.158425Z",
+     "shell.execute_reply": "2026-06-24T07:27:58.157821Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q: wireless earbuds for running, sweatproof\n",
+      "retrieved:\n",
+      "- NovaSound Z9 ($79.0, 4.7★)\n",
+      "- WURGIIX Ribbed Stretch Bandie Women's Headbands Headwraps Hair Bands Bows Hair Accessories（Wine red）Mother's day gift ($5.99, 4.1★)\n",
+      "- Big Bunny Ears Headband for Easter,Halloween Party Costume Accessories/Sweet Sexy Rabbit Ear Hair(Black) ($6.99, 4.3★)\n",
+      "- Picoway 20 Pack Mouse Ears Solid Black and Red Bow Headband ($15.99, 4.8★)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "answer: NovaSound Z9 — $79.0, 4.7★\n"
+     ]
+    }
+   ],
    "source": [
     "store.add_texts(\n",
     "    [\"NovaSound Z9 wireless running earbuds, sweatproof, 30h battery\"],\n",
@@ -178,15 +268,30 @@
     "\n",
     "Re-adding the same `id` overwrites the row (Infino superfiles are immutable, so\n",
     "an upsert is delete-then-append under the hood). Mark the price down: the change\n",
-    "shows up, and the row count is **unchanged** \u2014 it's an update, not a duplicate."
+    "shows up, and the row count is **unchanged** — it's an update, not a duplicate."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "cell-09",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:27:58.160370Z",
+     "iopub.status.busy": "2026-06-24T07:27:58.160230Z",
+     "iopub.status.idle": "2026-06-24T07:27:58.204915Z",
+     "shell.execute_reply": "2026-06-24T07:27:58.204536Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "price -> $49.0, row count 601 -> 601 (unchanged)\n"
+     ]
+    }
+   ],
    "source": [
     "total_before = query(db, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0]\n",
     "store.add_texts(\n",
@@ -213,10 +318,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "cell-11",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:27:58.206255Z",
+     "iopub.status.busy": "2026-06-24T07:27:58.206192Z",
+     "iopub.status.idle": "2026-06-24T07:27:58.221050Z",
+     "shell.execute_reply": "2026-06-24T07:27:58.220679Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cleared 3 -> rows 601 then 598\n",
+      "p-0 still present: False\n"
+     ]
+    }
+   ],
    "source": [
     "before = query(db, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0]\n",
     "store.delete([\"p-0\", \"p-1\", \"p-2\"])\n",
@@ -230,7 +351,7 @@
    "id": "cell-12",
    "metadata": {},
    "source": [
-    "## Durability \u2014 reopen from disk\n",
+    "## Durability — reopen from disk\n",
     "\n",
     "Everything committed lives on disk (object storage in production). Drop the\n",
     "handles, reconnect, and reopen the table with the same `InfinoVectorStore`\n",
@@ -240,10 +361,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "cell-13",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:27:58.222031Z",
+     "iopub.status.busy": "2026-06-24T07:27:58.221976Z",
+     "iopub.status.idle": "2026-06-24T07:27:58.231508Z",
+     "shell.execute_reply": "2026-06-24T07:27:58.231192Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reopened: 598 products; NovaSound Z9 still $49.0\n"
+     ]
+    }
+   ],
    "source": [
     "del store, db  # drop the handles, simulate a fresh process\n",
     "\n",
@@ -278,7 +414,16 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/infino-python/examples/langchain/02_research_assistant.ipynb
+++ b/infino-python/examples/langchain/02_research_assistant.ipynb
@@ -10,10 +10,9 @@
     "Two questions decide a RAG system's quality: *which retrieval mode fits my data?*\n",
     "and *how do I combine semantic search with hard constraints?* Infino answers both\n",
     "on **one** store \u2014 every retrieval mode (vector, BM25, hybrid) runs over the same\n",
-    "table, so comparing them is one line each, and structured filters push down to\n",
-    "SQL with no second metadata database.\n",
+    "table, so comparing them is one line each, and structured filters push down to SQL.\n",
     "\n",
-    "This example (1) measures `recall@10` for vector vs BM25 vs hybrid on a labeled IR\n",
+    "This example (1) measures `recall@10` for vector, BM25, and hybrid on a labeled IR\n",
     "benchmark, (2) filters semantic search by a metadata predicate, and (3) lets an\n",
     "LLM turn a natural-language request into that filter automatically (self-query).\n",
     "Parts 1\u20132 run **key-free**; part 3 needs an LLM key."
@@ -56,12 +55,10 @@
    "source": [
     "## Part 1 \u2014 which retrieval mode? Measure it.\n",
     "\n",
-    "BM25 nails exact terms but misses paraphrases; vector captures meaning but can\n",
-    "miss a literal token; **hybrid** fuses both with Reciprocal Rank Fusion. The\n",
-    "usual LangChain way to get hybrid is an `EnsembleRetriever` over a *separate*\n",
-    "BM25 retriever and vector store with hand-tuned weights. Infino runs all three\n",
-    "over **one** table \u2014 `as_bm25_retriever`, `as_retriever`, `as_hybrid_retriever`\n",
-    "\u2014 so you can measure them head to head on your own data.\n",
+    "BM25 matches exact terms; vector captures meaning; **hybrid** fuses both with\n",
+    "Reciprocal Rank Fusion. All three run over **one** Infino table \u2014\n",
+    "`as_bm25_retriever`, `as_retriever`, `as_hybrid_retriever` \u2014 so you can measure\n",
+    "them head to head on your own data.\n",
     "\n",
     "We index MS MARCO passages (each carries a ground-truth set of relevant passage\n",
     "ids) and report `recall@10`."
@@ -109,12 +106,12 @@
    "id": "cell-04",
    "metadata": {},
    "source": [
-    "**Read the numbers, don't assume.** On MS MARCO's paraphrased queries the\n",
-    "semantic signal is strong, so vector tends to lead, BM25 trails, and hybrid lands\n",
-    "just behind vector \u2014 *never the worst*. On keyword-heavy corpora (codes, SKUs,\n",
-    "identifiers) the ranking flips and BM25/hybrid lead. The point: with one store\n",
-    "you A/B the modalities in one line each and pick per your data \u2014 hybrid is the\n",
-    "safe default when the query mix is unknown."
+    "**Read the numbers, don't assume.** Which mode wins depends on your data:\n",
+    "on these paraphrased queries the semantic signal is strong, so vector leads; on\n",
+    "keyword-heavy corpora (codes, SKUs, identifiers) BM25 and hybrid come into their\n",
+    "own. Because all three run on one store, you measure them in one line each and\n",
+    "pick what fits \u2014 hybrid is a solid default when the query mix is mixed or\n",
+    "unknown."
    ]
   },
   {
@@ -125,8 +122,8 @@
     "## Part 2 \u2014 semantic search with a metadata filter (key-free)\n",
     "\n",
     "Promote metadata to scalar columns and Infino filters them as a SQL predicate\n",
-    "*pushed down* into the search \u2014 no second metadata store, no post-filtering in\n",
-    "Python. Here: papers about a topic, restricted to recent years."
+    "*pushed down* into the search. Here: papers about a topic, restricted to recent\n",
+    "years."
    ]
   },
   {
@@ -194,11 +191,10 @@
    "source": [
     "## Takeaway\n",
     "\n",
-    "One Infino table let us **measure** three retrieval modes head to head (no second\n",
-    "system to stand up), **filter** semantic search by a SQL predicate (no second\n",
-    "metadata store), and let an LLM **write** that filter from plain English. Pick the\n",
-    "retrieval mode your numbers justify; reach for hybrid when the query mix is\n",
-    "unknown."
+    "One Infino table let us **measure** three retrieval modes head to head, **filter**\n",
+    "semantic search by a SQL predicate, and let an LLM **write** that filter from plain\n",
+    "English. Pick the retrieval mode your numbers justify; reach for hybrid when the\n",
+    "query mix is mixed or unknown."
    ]
   }
  ],

--- a/infino-python/examples/langchain/02_research_assistant.ipynb
+++ b/infino-python/examples/langchain/02_research_assistant.ipynb
@@ -9,21 +9,36 @@
     "\n",
     "Two questions decide a RAG system's quality: *which retrieval mode fits my data?*\n",
     "and *how do I combine semantic search with hard constraints?* Infino answers both\n",
-    "on **one** store \u2014 every retrieval mode (vector, BM25, hybrid) runs over the same\n",
+    "on **one** store — every retrieval mode (vector, BM25, hybrid) runs over the same\n",
     "table, so comparing them is one line each, and structured filters push down to SQL.\n",
     "\n",
     "This example (1) measures `recall@10` for vector, BM25, and hybrid on a labeled IR\n",
     "benchmark, (2) filters semantic search by a metadata predicate, and (3) lets an\n",
     "LLM turn a natural-language request into that filter automatically (self-query).\n",
-    "Parts 1\u20132 run **key-free**; part 3 needs an LLM key."
+    "Parts 1–2 run **key-free**; part 3 needs an LLM key."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "cell-01",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:28:02.022560Z",
+     "iopub.status.busy": "2026-06-24T07:28:02.022475Z",
+     "iopub.status.idle": "2026-06-24T07:28:04.055423Z",
+     "shell.execute_reply": "2026-06-24T07:28:04.055034Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LLM (part 3): on\n"
+     ]
+    }
+   ],
    "source": [
     "import sys\n",
     "import shutil\n",
@@ -53,11 +68,11 @@
    "id": "cell-02",
    "metadata": {},
    "source": [
-    "## Part 1 \u2014 which retrieval mode? Measure it.\n",
+    "## Part 1 — which retrieval mode? Measure it.\n",
     "\n",
     "BM25 matches exact terms; vector captures meaning; **hybrid** fuses both with\n",
-    "Reciprocal Rank Fusion. All three run over **one** Infino table \u2014\n",
-    "`as_bm25_retriever`, `as_retriever`, `as_hybrid_retriever` \u2014 so you can measure\n",
+    "Reciprocal Rank Fusion. All three run over **one** Infino table —\n",
+    "`as_bm25_retriever`, `as_retriever`, `as_hybrid_retriever` — so you can measure\n",
     "them head to head on your own data.\n",
     "\n",
     "We index MS MARCO passages (each carries a ground-truth set of relevant passage\n",
@@ -66,10 +81,40 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "cell-03",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:28:04.056534Z",
+     "iopub.status.busy": "2026-06-24T07:28:04.056429Z",
+     "iopub.status.idle": "2026-06-24T07:28:34.460820Z",
+     "shell.execute_reply": "2026-06-24T07:28:34.460305Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "indexed 1031 passages, 120 labeled queries\n",
+      "recall@10    bm25: 0.900\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recall@10  vector: 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recall@10  hybrid: 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "passages, queries = load_ms_marco(n_queries=120)\n",
     "marco = InfinoVectorStore.from_texts(\n",
@@ -110,7 +155,7 @@
     "on these paraphrased queries the semantic signal is strong, so vector leads; on\n",
     "keyword-heavy corpora (codes, SKUs, identifiers) BM25 and hybrid come into their\n",
     "own. Because all three run on one store, you measure them in one line each and\n",
-    "pick what fits \u2014 hybrid is a solid default when the query mix is mixed or\n",
+    "pick what fits — hybrid is a solid default when the query mix is mixed or\n",
     "unknown."
    ]
   },
@@ -119,7 +164,7 @@
    "id": "cell-05",
    "metadata": {},
    "source": [
-    "## Part 2 \u2014 semantic search with a metadata filter (key-free)\n",
+    "## Part 2 — semantic search with a metadata filter (key-free)\n",
     "\n",
     "Promote metadata to scalar columns and Infino filters them as a SQL predicate\n",
     "*pushed down* into the search. Here: papers about a topic, restricted to recent\n",
@@ -128,10 +173,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "cell-06",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:28:34.462159Z",
+     "iopub.status.busy": "2026-06-24T07:28:34.462006Z",
+     "iopub.status.idle": "2026-06-24T07:28:47.657614Z",
+     "shell.execute_reply": "2026-06-24T07:28:47.657252Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "filter year>=2023 -> [2023, 2024, 2024, 2024]\n"
+     ]
+    }
+   ],
    "source": [
     "papers = load_arxiv(150)\n",
     "years = [2019, 2021, 2022, 2023, 2024] * ((len(papers) // 5) + 1)\n",
@@ -152,7 +212,7 @@
    "id": "cell-07",
    "metadata": {},
    "source": [
-    "## Part 3 \u2014 self-query: let the LLM write the filter (needs an LLM key)\n",
+    "## Part 3 — self-query: let the LLM write the filter (needs an LLM key)\n",
     "\n",
     "A `SelfQueryRetriever` uses the LLM to parse a natural-language request into a\n",
     "structured query; `InfinoTranslator` turns that into Infino's SQL filter. So\n",
@@ -164,10 +224,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "cell-08",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:28:47.658875Z",
+     "iopub.status.busy": "2026-06-24T07:28:47.658821Z",
+     "iopub.status.idle": "2026-06-24T07:28:49.790490Z",
+     "shell.execute_reply": "2026-06-24T07:28:49.790028Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "self-query -> [2023, 2024, 2024, 2024]\n"
+     ]
+    }
+   ],
    "source": [
     "if llm:\n",
     "    from langchain_classic.retrievers.self_query.base import SelfQueryRetriever\n",
@@ -181,7 +256,7 @@
     "    out = self_query.invoke(\"papers about neural networks published since 2023\")\n",
     "    print(\"self-query ->\", sorted(d.metadata[\"year\"] for d in out))\n",
     "else:\n",
-    "    print(\"skipped \u2014 set an LLM key to run self-query (see the README)\")"
+    "    print(\"skipped — set an LLM key to run self-query (see the README)\")"
    ]
   },
   {
@@ -205,7 +280,16 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/infino-python/examples/langchain/02_research_assistant.ipynb
+++ b/infino-python/examples/langchain/02_research_assistant.ipynb
@@ -1,0 +1,217 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Research assistant: measure retrieval, filter by meaning *and* metadata\n",
+    "\n",
+    "Two questions decide a RAG system's quality: *which retrieval mode fits my data?*\n",
+    "and *how do I combine semantic search with hard constraints?* Infino answers both\n",
+    "on **one** store \u2014 every retrieval mode (vector, BM25, hybrid) runs over the same\n",
+    "table, so comparing them is one line each, and structured filters push down to\n",
+    "SQL with no second metadata database.\n",
+    "\n",
+    "This example (1) measures `recall@10` for vector vs BM25 vs hybrid on a labeled IR\n",
+    "benchmark, (2) filters semantic search by a metadata predicate, and (3) lets an\n",
+    "LLM turn a natural-language request into that filter automatically (self-query).\n",
+    "Parts 1\u20132 run **key-free**; part 3 needs an LLM key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-01",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path.cwd().parent))  # examples/ root, where _shared/ lives\n",
+    "\n",
+    "import infino\n",
+    "import pyarrow as pa\n",
+    "from langchain_infino import InfinoVectorStore, InfinoTranslator\n",
+    "\n",
+    "from _shared.lc import MiniLMEmbeddings, chat_model\n",
+    "from _shared.embedding import DIM, METRIC\n",
+    "from _shared.loaders import load_ms_marco, load_arxiv\n",
+    "\n",
+    "DB_DIR = \"./research_data\"\n",
+    "shutil.rmtree(DB_DIR, ignore_errors=True)  # start fresh each run\n",
+    "\n",
+    "embeddings = MiniLMEmbeddings()\n",
+    "llm = chat_model()  # None when no key is set; only part 3 needs it\n",
+    "db = infino.connect(DB_DIR)\n",
+    "print(\"LLM (part 3):\", \"on\" if llm else \"off\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "## Part 1 \u2014 which retrieval mode? Measure it.\n",
+    "\n",
+    "BM25 nails exact terms but misses paraphrases; vector captures meaning but can\n",
+    "miss a literal token; **hybrid** fuses both with Reciprocal Rank Fusion. The\n",
+    "usual LangChain way to get hybrid is an `EnsembleRetriever` over a *separate*\n",
+    "BM25 retriever and vector store with hand-tuned weights. Infino runs all three\n",
+    "over **one** table \u2014 `as_bm25_retriever`, `as_retriever`, `as_hybrid_retriever`\n",
+    "\u2014 so you can measure them head to head on your own data.\n",
+    "\n",
+    "We index MS MARCO passages (each carries a ground-truth set of relevant passage\n",
+    "ids) and report `recall@10`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-03",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "passages, queries = load_ms_marco(n_queries=120)\n",
+    "marco = InfinoVectorStore.from_texts(\n",
+    "    [p[\"text\"] for p in passages], embeddings,\n",
+    "    connection=db, table_name=\"passages\", dim=DIM, metric=METRIC,\n",
+    "    ids=[str(p[\"pid\"]) for p in passages],  # doc id == passage id, for scoring\n",
+    ")\n",
+    "print(f\"indexed {len(passages)} passages, {len(queries)} labeled queries\")\n",
+    "\n",
+    "K = 10\n",
+    "retrievers = {\n",
+    "    \"bm25\": marco.as_bm25_retriever(k=K),\n",
+    "    \"vector\": marco.as_retriever(search_kwargs={\"k\": K}),\n",
+    "    \"hybrid\": marco.as_hybrid_retriever(k=K),\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def recall_at_k(retriever, sample) -> float:\n",
+    "    total = 0.0\n",
+    "    for q in sample:\n",
+    "        got = {int(d.id) for d in retriever.invoke(q[\"query\"]) if d.id is not None}\n",
+    "        relevant = set(q[\"relevant_pids\"])\n",
+    "        total += len(got & relevant) / len(relevant)\n",
+    "    return total / len(sample)\n",
+    "\n",
+    "\n",
+    "sample = queries[:80]\n",
+    "for name, r in retrievers.items():\n",
+    "    print(f\"recall@{K}  {name:>6}: {recall_at_k(r, sample):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "**Read the numbers, don't assume.** On MS MARCO's paraphrased queries the\n",
+    "semantic signal is strong, so vector tends to lead, BM25 trails, and hybrid lands\n",
+    "just behind vector \u2014 *never the worst*. On keyword-heavy corpora (codes, SKUs,\n",
+    "identifiers) the ranking flips and BM25/hybrid lead. The point: with one store\n",
+    "you A/B the modalities in one line each and pick per your data \u2014 hybrid is the\n",
+    "safe default when the query mix is unknown."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-05",
+   "metadata": {},
+   "source": [
+    "## Part 2 \u2014 semantic search with a metadata filter (key-free)\n",
+    "\n",
+    "Promote metadata to scalar columns and Infino filters them as a SQL predicate\n",
+    "*pushed down* into the search \u2014 no second metadata store, no post-filtering in\n",
+    "Python. Here: papers about a topic, restricted to recent years."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-06",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "papers = load_arxiv(150)\n",
+    "years = [2019, 2021, 2022, 2023, 2024] * ((len(papers) // 5) + 1)\n",
+    "arxiv = InfinoVectorStore.from_texts(\n",
+    "    [p[\"abstract\"] for p in papers], embeddings,\n",
+    "    metadatas=[{\"title\": p[\"title\"], \"year\": y} for p, y in zip(papers, years)],\n",
+    "    connection=db, table_name=\"papers\", dim=DIM, metric=METRIC,\n",
+    "    metadata_columns=[pa.field(\"year\", pa.int64(), nullable=False)],\n",
+    ")\n",
+    "hits = arxiv.similarity_search(\n",
+    "    \"representation learning\", k=4, filter={\"year\": {\"$gte\": 2023}}\n",
+    ")\n",
+    "print(\"filter year>=2023 ->\", sorted(d.metadata[\"year\"] for d in hits))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-07",
+   "metadata": {},
+   "source": [
+    "## Part 3 \u2014 self-query: let the LLM write the filter (needs an LLM key)\n",
+    "\n",
+    "A `SelfQueryRetriever` uses the LLM to parse a natural-language request into a\n",
+    "structured query; `InfinoTranslator` turns that into Infino's SQL filter. So\n",
+    "*\"papers about neural networks published since 2023\"* becomes a semantic search\n",
+    "plus `year >= 2023`, with no hand-written predicate.\n",
+    "\n",
+    "Requires `langchain-classic` and `lark` (see `requirements.txt`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-08",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "if llm:\n",
+    "    from langchain_classic.retrievers.self_query.base import SelfQueryRetriever\n",
+    "    from langchain_classic.chains.query_constructor.schema import AttributeInfo\n",
+    "\n",
+    "    self_query = SelfQueryRetriever.from_llm(\n",
+    "        llm, arxiv, \"Machine learning paper abstracts\",\n",
+    "        [AttributeInfo(name=\"year\", description=\"publication year\", type=\"integer\")],\n",
+    "        structured_query_translator=InfinoTranslator(),\n",
+    "    )\n",
+    "    out = self_query.invoke(\"papers about neural networks published since 2023\")\n",
+    "    print(\"self-query ->\", sorted(d.metadata[\"year\"] for d in out))\n",
+    "else:\n",
+    "    print(\"skipped \u2014 set an LLM key to run self-query (see the README)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-09",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "One Infino table let us **measure** three retrieval modes head to head (no second\n",
+    "system to stand up), **filter** semantic search by a SQL predicate (no second\n",
+    "metadata store), and let an LLM **write** that filter from plain English. Pick the\n",
+    "retrieval mode your numbers justify; reach for hybrid when the query mix is\n",
+    "unknown."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/infino-python/examples/langchain/03_support_ops_agent.ipynb
+++ b/infino-python/examples/langchain/03_support_ops_agent.ipynb
@@ -23,10 +23,10 @@
    "id": "cell-01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:43:29.782672Z",
-     "iopub.status.busy": "2026-06-24T07:43:29.782616Z",
-     "iopub.status.idle": "2026-06-24T07:43:32.587030Z",
-     "shell.execute_reply": "2026-06-24T07:43:32.586566Z"
+     "iopub.execute_input": "2026-06-24T08:08:01.170339Z",
+     "iopub.status.busy": "2026-06-24T08:08:01.170241Z",
+     "iopub.status.idle": "2026-06-24T08:08:03.911792Z",
+     "shell.execute_reply": "2026-06-24T08:08:03.911381Z"
     }
    },
    "outputs": [],
@@ -81,10 +81,10 @@
    "id": "cell-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:43:32.588215Z",
-     "iopub.status.busy": "2026-06-24T07:43:32.588107Z",
-     "iopub.status.idle": "2026-06-24T07:44:22.337013Z",
-     "shell.execute_reply": "2026-06-24T07:44:22.336585Z"
+     "iopub.execute_input": "2026-06-24T08:08:03.913044Z",
+     "iopub.status.busy": "2026-06-24T08:08:03.912936Z",
+     "iopub.status.idle": "2026-06-24T08:08:30.278536Z",
+     "shell.execute_reply": "2026-06-24T08:08:30.278097Z"
     }
    },
    "outputs": [
@@ -145,10 +145,10 @@
    "id": "cell-05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:44:22.338315Z",
-     "iopub.status.busy": "2026-06-24T07:44:22.338175Z",
-     "iopub.status.idle": "2026-06-24T07:44:22.343080Z",
-     "shell.execute_reply": "2026-06-24T07:44:22.342675Z"
+     "iopub.execute_input": "2026-06-24T08:08:30.280085Z",
+     "iopub.status.busy": "2026-06-24T08:08:30.279639Z",
+     "iopub.status.idle": "2026-06-24T08:08:30.284505Z",
+     "shell.execute_reply": "2026-06-24T08:08:30.284138Z"
     }
    },
    "outputs": [],
@@ -199,10 +199,10 @@
    "id": "cell-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:44:22.344102Z",
-     "iopub.status.busy": "2026-06-24T07:44:22.344049Z",
-     "iopub.status.idle": "2026-06-24T07:44:35.810538Z",
-     "shell.execute_reply": "2026-06-24T07:44:35.809939Z"
+     "iopub.execute_input": "2026-06-24T08:08:30.285337Z",
+     "iopub.status.busy": "2026-06-24T08:08:30.285298Z",
+     "iopub.status.idle": "2026-06-24T08:08:43.091594Z",
+     "shell.execute_reply": "2026-06-24T08:08:43.090626Z"
     }
    },
    "outputs": [
@@ -212,14 +212,13 @@
      "text": [
       "\n",
       "Q: I want wireless earbuds for running, budget around $50\n",
-      "A: A good match is **NovaSound Z9** — **$49.00**, **4.7★**.\n",
+      "A: A good match is:\n",
       "\n",
-      "It fits your needs well for running because it appears to be:\n",
-      "- **Wireless**\n",
-      "- **Around your $50 budget**\n",
-      "- Likely a **sports/running-oriented** option based on the match quality\n",
+      "- **NovaSound Z9 — $49.00 — 4.7★**\n",
       "\n",
-      "I should note the search results also retu\n"
+      "It appears to fit your needs best: **wireless earbuds**, **good for running**, and right on your **~$50 budget**.\n",
+      "\n",
+      "I did see some irrelevant “ears/headband” results mixed in, so the search quality was a bit noisy. If you want,\n"
      ]
     },
     {
@@ -228,7 +227,7 @@
      "text": [
       "\n",
       "Q: do you carry the NovaSound earbuds, and what's the price?\n",
-      "A: Yes — we have **NovaSound Z9** earbuds listed at **$49.00**.\n"
+      "A: Yes — **NovaSound Z9** is in the catalog at **$49.00**.\n"
      ]
     },
     {
@@ -237,7 +236,7 @@
      "text": [
       "\n",
       "Q: how many products are rated 4.5 or higher?\n",
-      "A: There are **139** products rated **4.5 or higher**.\n"
+      "A: There are **139 products** rated **4.5 or higher**.\n"
      ]
     },
     {
@@ -246,27 +245,30 @@
      "text": [
       "\n",
       "Q: of the highly rated ones, suggest a gift under $40\n",
-      "A: A nice option is **Victoria's Secret Love Spell and Pure Seduction Fragrance Lotion** — **$28.80**, **4.7★**.\n",
+      "A: There are **123 highly rated products under $40**.\n",
       "\n",
-      "It fits your request because it is:\n",
-      "- **Under $40**\n",
-      "- **Highly rated**\n",
-      "- A fairly **giftable** personal care item\n",
+      "A gift suggestion from those results:\n",
+      "- **LOWOSAIWOR Vintage 20s Headpiece for Women** — **$10.30** — **4.7★**\n",
       "\n",
-      "Another under-$40 highly rated option:\n",
-      "- **LOWOSAIWOR \n"
+      "Other search results were a bit noisy, so if you want, I can refine gift ideas by recipient, like:\n",
+      "- **for her**\n",
+      "- *\n"
      ]
     }
    ],
    "source": [
-    "agent = create_agent(\n",
-    "    llm, [semantic_search, keyword_search, query_catalog],\n",
-    "    checkpointer=MemorySaver(),\n",
+    "agent = (\n",
+    "    create_agent(llm, [semantic_search, keyword_search, query_catalog],\n",
+    "                 checkpointer=MemorySaver())\n",
+    "    if llm is not None else None\n",
     ")\n",
     "CONFIG = {\"configurable\": {\"thread_id\": \"shopper-1\"}}\n",
     "\n",
     "\n",
     "def ask(question: str) -> None:\n",
+    "    if agent is None:\n",
+    "        print(f\"Q: {question}\\n(needs an LLM key — skipped)\")\n",
+    "        return\n",
     "    out = agent.invoke({\"messages\": [(\"user\", question)]}, CONFIG)\n",
     "    print(f\"\\nQ: {question}\\nA: {out['messages'][-1].content[:280]}\")\n",
     "\n",
@@ -297,10 +299,10 @@
    "id": "cell-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:44:35.812361Z",
-     "iopub.status.busy": "2026-06-24T07:44:35.812234Z",
-     "iopub.status.idle": "2026-06-24T07:44:37.395004Z",
-     "shell.execute_reply": "2026-06-24T07:44:37.394624Z"
+     "iopub.execute_input": "2026-06-24T08:08:43.094436Z",
+     "iopub.status.busy": "2026-06-24T08:08:43.094239Z",
+     "iopub.status.idle": "2026-06-24T08:08:44.811944Z",
+     "shell.execute_reply": "2026-06-24T08:08:44.811492Z"
     }
    },
    "outputs": [
@@ -308,19 +310,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "first call 1.55s  ->  paraphrase 0.02s (served from cache)\n"
+      "first call 1.68s  ->  paraphrase 0.03s (served from cache)\n"
      ]
     }
    ],
    "source": [
-    "set_llm_cache(InfinoSemanticCache(\n",
-    "    db, embeddings, dim=DIM, table_name=\"llm_cache\", score_threshold=0.25))\n",
+    "if llm is None:\n",
+    "    print(\"(needs an LLM key — skipped)\")\n",
+    "else:\n",
+    "    set_llm_cache(InfinoSemanticCache(\n",
+    "        db, embeddings, dim=DIM, table_name=\"llm_cache\", score_threshold=0.25))\n",
     "\n",
-    "prompt = \"In one sentence, what is BM25 search?\"\n",
-    "paraphrase = \"Briefly, in a single sentence, explain BM25 search.\"\n",
-    "t = time.time(); llm.invoke(prompt); first = time.time() - t\n",
-    "t = time.time(); llm.invoke(paraphrase); cached = time.time() - t\n",
-    "print(f\"first call {first:.2f}s  ->  paraphrase {cached:.2f}s (served from cache)\")"
+    "    prompt = \"In one sentence, what is BM25 search?\"\n",
+    "    paraphrase = \"Briefly, in a single sentence, explain BM25 search.\"\n",
+    "    t = time.time(); llm.invoke(prompt); first = time.time() - t\n",
+    "    t = time.time(); llm.invoke(paraphrase); cached = time.time() - t\n",
+    "    print(f\"first call {first:.2f}s  ->  paraphrase {cached:.2f}s (served from cache)\")"
    ]
   },
   {

--- a/infino-python/examples/langchain/03_support_ops_agent.ipynb
+++ b/infino-python/examples/langchain/03_support_ops_agent.ipynb
@@ -8,10 +8,10 @@
     "# Support/ops agent: one store, every retrieval tool\n",
     "\n",
     "A useful agent reaches for the *right* kind of search per question \u2014 semantic for\n",
-    "vague needs, exact keyword for a named product, SQL for counts and filters. The\n",
-    "usual cost is four backends to run and keep in sync. Here a LangGraph agent gets\n",
-    "all of them from **one** Infino store: vector, BM25, and SQL search as tools,\n",
-    "plus a semantic LLM cache and multi-turn memory backed by the same engine.\n",
+    "vague needs, exact keyword for a named product, SQL for counts and filters. A\n",
+    "LangGraph agent gets all of them from **one** Infino store: vector, BM25, and SQL\n",
+    "search as tools, plus a semantic LLM cache and multi-turn memory backed by the\n",
+    "same engine.\n",
     "\n",
     "**This example needs an LLM key** (the agent is tool-calling) \u2014 see the README.\n",
     "Building and indexing the store is key-free; the agent and cache need the key."
@@ -113,8 +113,8 @@
     "\n",
     "Each tool is a thin wrapper over a different Infino retrieval mode. The agent\n",
     "reads the docstrings and picks: `semantic_search` for intent, `keyword_search`\n",
-    "for a named product, `query_catalog` for counts and filters. No second system \u2014\n",
-    "all three hit the same table."
+    "for a named product, `query_catalog` for counts and filters \u2014 all three over the\n",
+    "same table."
    ]
   },
   {
@@ -228,9 +228,8 @@
     "## Takeaway\n",
     "\n",
     "One Infino store gave the agent semantic, keyword, and SQL search as tools, plus\n",
-    "a semantic LLM cache and conversation memory \u2014 capabilities that usually mean a\n",
-    "vector DB, a search cluster, a SQL warehouse, and a cache service, each wired and\n",
-    "kept in sync. Here it's one engine over one copy of the data."
+    "a semantic LLM cache and conversation memory \u2014 all from one engine over one copy\n",
+    "of the data."
    ]
   }
  ],

--- a/infino-python/examples/langchain/03_support_ops_agent.ipynb
+++ b/infino-python/examples/langchain/03_support_ops_agent.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Support/ops agent: one store, every retrieval tool\n",
+    "\n",
+    "A useful agent reaches for the *right* kind of search per question \u2014 semantic for\n",
+    "vague needs, exact keyword for a named product, SQL for counts and filters. The\n",
+    "usual cost is four backends to run and keep in sync. Here a LangGraph agent gets\n",
+    "all of them from **one** Infino store: vector, BM25, and SQL search as tools,\n",
+    "plus a semantic LLM cache and multi-turn memory backed by the same engine.\n",
+    "\n",
+    "**This example needs an LLM key** (the agent is tool-calling) \u2014 see the README.\n",
+    "Building and indexing the store is key-free; the agent and cache need the key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-01",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import shutil\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path.cwd().parent))  # examples/ root, where _shared/ lives\n",
+    "\n",
+    "import infino\n",
+    "import pyarrow as pa\n",
+    "from langchain.agents import create_agent\n",
+    "from langchain_core.globals import set_llm_cache\n",
+    "from langchain_core.tools import tool\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
+    "\n",
+    "from langchain_infino import InfinoSemanticCache, InfinoVectorStore\n",
+    "\n",
+    "from _shared.lc import MiniLMEmbeddings, chat_model\n",
+    "from _shared.embedding import DIM, METRIC\n",
+    "from _shared.loaders import load_amazon\n",
+    "from _shared.sql import query\n",
+    "\n",
+    "DB_DIR = \"./agent_data\"\n",
+    "TABLE = \"catalog\"\n",
+    "shutil.rmtree(DB_DIR, ignore_errors=True)  # start fresh each run\n",
+    "\n",
+    "embeddings = MiniLMEmbeddings()\n",
+    "llm = chat_model()\n",
+    "db = infino.connect(DB_DIR)\n",
+    "if llm is None:\n",
+    "    print(\"This example needs an LLM key (tool-calling agent). See the README.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "## Build the catalog store\n",
+    "\n",
+    "One `InfinoVectorStore` over a product catalog, with `price` and `rating`\n",
+    "promoted to scalar columns so SQL and filters can use them. We append a few\n",
+    "known featured items so the demo questions have clear targets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-03",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "products = load_amazon(n=300)\n",
+    "store = InfinoVectorStore.from_texts(\n",
+    "    [p[\"text\"] for p in products], embeddings,\n",
+    "    metadatas=[{\"title\": p[\"title\"], \"category\": p[\"category\"],\n",
+    "                \"price\": p[\"price\"], \"rating\": p[\"rating\"]} for p in products],\n",
+    "    connection=db, table_name=TABLE, dim=DIM, metric=METRIC,\n",
+    "    metadata_columns=[pa.field(\"price\", pa.float64(), nullable=False),\n",
+    "                      pa.field(\"rating\", pa.float64(), nullable=False)],\n",
+    ")\n",
+    "\n",
+    "FEATURED = [\n",
+    "    (\"NovaSound Z9 wireless running earbuds, sweatproof, 30h battery\",\n",
+    "     \"NovaSound Z9\", 49.0, 4.7),\n",
+    "    (\"HydroPeak insulated steel water bottle, 32oz, keeps drinks cold 24h\",\n",
+    "     \"HydroPeak 32oz Bottle\", 24.0, 4.6),\n",
+    "    (\"ZenFlow non-slip yoga mat, 6mm cushioned eco TPE\",\n",
+    "     \"ZenFlow Yoga Mat\", 33.0, 4.8),\n",
+    "    (\"LumaDesk LED desk lamp, adjustable warmth, USB-C charging\",\n",
+    "     \"LumaDesk LED Lamp\", 39.0, 4.4),\n",
+    "]\n",
+    "store.add_texts(\n",
+    "    [f[0] for f in FEATURED],\n",
+    "    metadatas=[{\"title\": f[1], \"category\": \"Featured\", \"price\": f[2],\n",
+    "                \"rating\": f[3]} for f in FEATURED],\n",
+    "    ids=[f\"sku-{i}\" for i in range(len(FEATURED))],\n",
+    ")\n",
+    "print(\"indexed\", query(db, f\"SELECT COUNT(*) AS n FROM {TABLE}\")[\"n\"][0], \"products\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "## Tools \u2014 three retrieval modes over the one store\n",
+    "\n",
+    "Each tool is a thin wrapper over a different Infino retrieval mode. The agent\n",
+    "reads the docstrings and picks: `semantic_search` for intent, `keyword_search`\n",
+    "for a named product, `query_catalog` for counts and filters. No second system \u2014\n",
+    "all three hit the same table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-05",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "@tool\n",
+    "def semantic_search(need: str) -> str:\n",
+    "    \"\"\"Find products by meaning or intent (e.g. 'something for a workout').\n",
+    "    Use for vague or descriptive needs. Returns titles with price and rating.\"\"\"\n",
+    "    docs = store.as_retriever(search_kwargs={\"k\": 4}).invoke(need)\n",
+    "    return \"\\n\".join(\n",
+    "        f\"{d.metadata['title'][:60]} (${d.metadata['price']}, {d.metadata['rating']}*)\"\n",
+    "        for d in docs)\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def keyword_search(terms: str) -> str:\n",
+    "    \"\"\"Find products by exact words, brand, or model name in the listing (BM25).\n",
+    "    Use when the shopper names a specific product. Returns titles with price.\"\"\"\n",
+    "    docs = store.as_bm25_retriever(k=4).invoke(terms)\n",
+    "    return \"\\n\".join(\n",
+    "        f\"{d.metadata['title'][:60]} (${d.metadata['price']}, {d.metadata['rating']}*)\"\n",
+    "        for d in docs)\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def query_catalog(sql: str) -> str:\n",
+    "    \"\"\"Run a read-only SQL SELECT over the catalog for counts, averages, or filters.\n",
+    "    Table 'catalog' has columns: doc_id, page_content, price (float), rating (float).\n",
+    "    Example: SELECT COUNT(*) AS n FROM catalog WHERE price < 40 AND rating >= 4.5\"\"\"\n",
+    "    return str(db.query_sql(sql).to_pydict())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "## The agent \u2014 tools + memory\n",
+    "\n",
+    "`create_agent` wires the tools to the LLM; a `MemorySaver` checkpointer keyed by\n",
+    "`thread_id` gives the conversation memory, so follow-ups resolve against earlier\n",
+    "turns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-07",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "agent = create_agent(\n",
+    "    llm, [semantic_search, keyword_search, query_catalog],\n",
+    "    checkpointer=MemorySaver(),\n",
+    ")\n",
+    "CONFIG = {\"configurable\": {\"thread_id\": \"shopper-1\"}}\n",
+    "\n",
+    "\n",
+    "def ask(question: str) -> None:\n",
+    "    out = agent.invoke({\"messages\": [(\"user\", question)]}, CONFIG)\n",
+    "    print(f\"\\nQ: {question}\\nA: {out['messages'][-1].content[:280]}\")\n",
+    "\n",
+    "\n",
+    "ask(\"I want wireless earbuds for running, budget around $50\")     # -> semantic\n",
+    "ask(\"do you carry the NovaSound earbuds, and what's the price?\")  # -> keyword\n",
+    "ask(\"how many products are rated 4.5 or higher?\")                 # -> SQL\n",
+    "ask(\"of the highly rated ones, suggest a gift under $40\")         # -> memory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "## Semantic cache \u2014 paraphrased repeats skip the LLM\n",
+    "\n",
+    "`InfinoSemanticCache` stores prompts and their answers in the same engine and\n",
+    "returns a cached answer when a new prompt is *semantically* close (not just\n",
+    "identical). A paraphrase of an earlier question is served without another LLM\n",
+    "call. `score_threshold` is the cosine-distance cutoff for a hit \u2014 loosen it to\n",
+    "catch looser paraphrases, tighten it to require near-duplicates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-09",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "set_llm_cache(InfinoSemanticCache(\n",
+    "    db, embeddings, dim=DIM, table_name=\"llm_cache\", score_threshold=0.25))\n",
+    "\n",
+    "prompt = \"In one sentence, what is BM25 search?\"\n",
+    "paraphrase = \"Briefly, in a single sentence, explain BM25 search.\"\n",
+    "t = time.time(); llm.invoke(prompt); first = time.time() - t\n",
+    "t = time.time(); llm.invoke(paraphrase); cached = time.time() - t\n",
+    "print(f\"first call {first:.2f}s  ->  paraphrase {cached:.2f}s (served from cache)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "One Infino store gave the agent semantic, keyword, and SQL search as tools, plus\n",
+    "a semantic LLM cache and conversation memory \u2014 capabilities that usually mean a\n",
+    "vector DB, a search cluster, a SQL warehouse, and a cache service, each wired and\n",
+    "kept in sync. Here it's one engine over one copy of the data."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/infino-python/examples/langchain/03_support_ops_agent.ipynb
+++ b/infino-python/examples/langchain/03_support_ops_agent.ipynb
@@ -7,21 +7,28 @@
    "source": [
     "# Support/ops agent: one store, every retrieval tool\n",
     "\n",
-    "A useful agent reaches for the *right* kind of search per question \u2014 semantic for\n",
+    "A useful agent reaches for the *right* kind of search per question — semantic for\n",
     "vague needs, exact keyword for a named product, SQL for counts and filters. A\n",
     "LangGraph agent gets all of them from **one** Infino store: vector, BM25, and SQL\n",
     "search as tools, plus a semantic LLM cache and multi-turn memory backed by the\n",
     "same engine.\n",
     "\n",
-    "**This example needs an LLM key** (the agent is tool-calling) \u2014 see the README.\n",
+    "**This example needs an LLM key** (the agent is tool-calling) — see the README.\n",
     "Building and indexing the store is key-free; the agent and cache need the key."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "cell-01",
-   "metadata": {},
-   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:28:53.633668Z",
+     "iopub.status.busy": "2026-06-24T07:28:53.633586Z",
+     "iopub.status.idle": "2026-06-24T07:28:56.394799Z",
+     "shell.execute_reply": "2026-06-24T07:28:56.394352Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import sys\n",
@@ -70,10 +77,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "cell-03",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:28:56.396042Z",
+     "iopub.status.busy": "2026-06-24T07:28:56.395934Z",
+     "iopub.status.idle": "2026-06-24T07:29:43.708013Z",
+     "shell.execute_reply": "2026-06-24T07:29:43.707680Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "indexed 304 products\n"
+     ]
+    }
+   ],
    "source": [
     "products = load_amazon(n=300)\n",
     "store = InfinoVectorStore.from_texts(\n",
@@ -109,19 +131,26 @@
    "id": "cell-04",
    "metadata": {},
    "source": [
-    "## Tools \u2014 three retrieval modes over the one store\n",
+    "## Tools — three retrieval modes over the one store\n",
     "\n",
     "Each tool is a thin wrapper over a different Infino retrieval mode. The agent\n",
     "reads the docstrings and picks: `semantic_search` for intent, `keyword_search`\n",
-    "for a named product, `query_catalog` for counts and filters \u2014 all three over the\n",
+    "for a named product, `query_catalog` for counts and filters — all three over the\n",
     "same table."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "cell-05",
-   "metadata": {},
-   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:29:43.710059Z",
+     "iopub.status.busy": "2026-06-24T07:29:43.709818Z",
+     "iopub.status.idle": "2026-06-24T07:29:43.714914Z",
+     "shell.execute_reply": "2026-06-24T07:29:43.714505Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@tool\n",
@@ -157,7 +186,7 @@
    "id": "cell-06",
    "metadata": {},
    "source": [
-    "## The agent \u2014 tools + memory\n",
+    "## The agent — tools + memory\n",
     "\n",
     "`create_agent` wires the tools to the LLM; a `MemorySaver` checkpointer keyed by\n",
     "`thread_id` gives the conversation memory, so follow-ups resolve against earlier\n",
@@ -166,10 +195,68 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "cell-07",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:29:43.716242Z",
+     "iopub.status.busy": "2026-06-24T07:29:43.716193Z",
+     "iopub.status.idle": "2026-06-24T07:29:56.124768Z",
+     "shell.execute_reply": "2026-06-24T07:29:56.123885Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Q: I want wireless earbuds for running, budget around $50\n",
+      "A: Here’s the best match I found for **wireless earbuds for running around $50**:\n",
+      "\n",
+      "- **NovaSound Z9** — **$49.00**, **4.7★**\n",
+      "\n",
+      "It appears to fit your budget and use case best from the results.\n",
+      "\n",
+      "If you want, I can also help narrow further by priorities like:\n",
+      "- **most secure fit for ru\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Q: do you carry the NovaSound earbuds, and what's the price?\n",
+      "A: Yes — **NovaSound Z9** is available in the catalog at **$49.00**.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Q: how many products are rated 4.5 or higher?\n",
+      "A: There are **139 products** rated **4.5 or higher**.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Q: of the highly rated ones, suggest a gift under $40\n",
+      "A: A good gift option under **$40** from the highly rated items is:\n",
+      "\n",
+      "- **Victoria's Secret Love Spell and Pure Seduction Fragrance Lotion** — **$28.80**, **4.7★**\n",
+      "\n",
+      "Another solid option:\n",
+      "- **LOWOSAIWOR Vintage 20s Headpiece for Women** — **$10.30**, **4.7★**\n",
+      "\n",
+      "If you want, I can sugge\n"
+     ]
+    }
+   ],
    "source": [
     "agent = create_agent(\n",
     "    llm, [semantic_search, keyword_search, query_catalog],\n",
@@ -194,21 +281,36 @@
    "id": "cell-08",
    "metadata": {},
    "source": [
-    "## Semantic cache \u2014 paraphrased repeats skip the LLM\n",
+    "## Semantic cache — paraphrased repeats skip the LLM\n",
     "\n",
     "`InfinoSemanticCache` stores prompts and their answers in the same engine and\n",
     "returns a cached answer when a new prompt is *semantically* close (not just\n",
     "identical). A paraphrase of an earlier question is served without another LLM\n",
-    "call. `score_threshold` is the cosine-distance cutoff for a hit \u2014 loosen it to\n",
+    "call. `score_threshold` is the cosine-distance cutoff for a hit — loosen it to\n",
     "catch looser paraphrases, tighten it to require near-duplicates."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "cell-09",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T07:29:56.127082Z",
+     "iopub.status.busy": "2026-06-24T07:29:56.126904Z",
+     "iopub.status.idle": "2026-06-24T07:29:57.743649Z",
+     "shell.execute_reply": "2026-06-24T07:29:57.743269Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "first call 1.58s  ->  paraphrase 0.03s (served from cache)\n"
+     ]
+    }
+   ],
    "source": [
     "set_llm_cache(InfinoSemanticCache(\n",
     "    db, embeddings, dim=DIM, table_name=\"llm_cache\", score_threshold=0.25))\n",
@@ -228,7 +330,7 @@
     "## Takeaway\n",
     "\n",
     "One Infino store gave the agent semantic, keyword, and SQL search as tools, plus\n",
-    "a semantic LLM cache and conversation memory \u2014 all from one engine over one copy\n",
+    "a semantic LLM cache and conversation memory — all from one engine over one copy\n",
     "of the data."
    ]
   }
@@ -240,7 +342,16 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/infino-python/examples/langchain/03_support_ops_agent.ipynb
+++ b/infino-python/examples/langchain/03_support_ops_agent.ipynb
@@ -23,10 +23,10 @@
    "id": "cell-01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:28:53.633668Z",
-     "iopub.status.busy": "2026-06-24T07:28:53.633586Z",
-     "iopub.status.idle": "2026-06-24T07:28:56.394799Z",
-     "shell.execute_reply": "2026-06-24T07:28:56.394352Z"
+     "iopub.execute_input": "2026-06-24T07:43:29.782672Z",
+     "iopub.status.busy": "2026-06-24T07:43:29.782616Z",
+     "iopub.status.idle": "2026-06-24T07:43:32.587030Z",
+     "shell.execute_reply": "2026-06-24T07:43:32.586566Z"
     }
    },
    "outputs": [],
@@ -81,10 +81,10 @@
    "id": "cell-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:28:56.396042Z",
-     "iopub.status.busy": "2026-06-24T07:28:56.395934Z",
-     "iopub.status.idle": "2026-06-24T07:29:43.708013Z",
-     "shell.execute_reply": "2026-06-24T07:29:43.707680Z"
+     "iopub.execute_input": "2026-06-24T07:43:32.588215Z",
+     "iopub.status.busy": "2026-06-24T07:43:32.588107Z",
+     "iopub.status.idle": "2026-06-24T07:44:22.337013Z",
+     "shell.execute_reply": "2026-06-24T07:44:22.336585Z"
     }
    },
    "outputs": [
@@ -145,17 +145,17 @@
    "id": "cell-05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:29:43.710059Z",
-     "iopub.status.busy": "2026-06-24T07:29:43.709818Z",
-     "iopub.status.idle": "2026-06-24T07:29:43.714914Z",
-     "shell.execute_reply": "2026-06-24T07:29:43.714505Z"
+     "iopub.execute_input": "2026-06-24T07:44:22.338315Z",
+     "iopub.status.busy": "2026-06-24T07:44:22.338175Z",
+     "iopub.status.idle": "2026-06-24T07:44:22.343080Z",
+     "shell.execute_reply": "2026-06-24T07:44:22.342675Z"
     }
    },
    "outputs": [],
    "source": [
     "@tool\n",
     "def semantic_search(need: str) -> str:\n",
-    "    \"\"\"Find products by meaning or intent (e.g. 'something for a workout').\n",
+    "    \"\"\"Find products by meaning or intent (e.g. 'a comfortable backpack for travel').\n",
     "    Use for vague or descriptive needs. Returns titles with price and rating.\"\"\"\n",
     "    docs = store.as_retriever(search_kwargs={\"k\": 4}).invoke(need)\n",
     "    return \"\\n\".join(\n",
@@ -177,7 +177,7 @@
     "def query_catalog(sql: str) -> str:\n",
     "    \"\"\"Run a read-only SQL SELECT over the catalog for counts, averages, or filters.\n",
     "    Table 'catalog' has columns: doc_id, page_content, price (float), rating (float).\n",
-    "    Example: SELECT COUNT(*) AS n FROM catalog WHERE price < 40 AND rating >= 4.5\"\"\"\n",
+    "    Example: SELECT AVG(price) AS avg_price FROM catalog WHERE rating >= 4.0\"\"\"\n",
     "    return str(db.query_sql(sql).to_pydict())"
    ]
   },
@@ -199,10 +199,10 @@
    "id": "cell-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:29:43.716242Z",
-     "iopub.status.busy": "2026-06-24T07:29:43.716193Z",
-     "iopub.status.idle": "2026-06-24T07:29:56.124768Z",
-     "shell.execute_reply": "2026-06-24T07:29:56.123885Z"
+     "iopub.execute_input": "2026-06-24T07:44:22.344102Z",
+     "iopub.status.busy": "2026-06-24T07:44:22.344049Z",
+     "iopub.status.idle": "2026-06-24T07:44:35.810538Z",
+     "shell.execute_reply": "2026-06-24T07:44:35.809939Z"
     }
    },
    "outputs": [
@@ -212,14 +212,14 @@
      "text": [
       "\n",
       "Q: I want wireless earbuds for running, budget around $50\n",
-      "A: Here’s the best match I found for **wireless earbuds for running around $50**:\n",
+      "A: A good match is **NovaSound Z9** — **$49.00**, **4.7★**.\n",
       "\n",
-      "- **NovaSound Z9** — **$49.00**, **4.7★**\n",
+      "It fits your needs well for running because it appears to be:\n",
+      "- **Wireless**\n",
+      "- **Around your $50 budget**\n",
+      "- Likely a **sports/running-oriented** option based on the match quality\n",
       "\n",
-      "It appears to fit your budget and use case best from the results.\n",
-      "\n",
-      "If you want, I can also help narrow further by priorities like:\n",
-      "- **most secure fit for ru\n"
+      "I should note the search results also retu\n"
      ]
     },
     {
@@ -228,7 +228,7 @@
      "text": [
       "\n",
       "Q: do you carry the NovaSound earbuds, and what's the price?\n",
-      "A: Yes — **NovaSound Z9** is available in the catalog at **$49.00**.\n"
+      "A: Yes — we have **NovaSound Z9** earbuds listed at **$49.00**.\n"
      ]
     },
     {
@@ -237,7 +237,7 @@
      "text": [
       "\n",
       "Q: how many products are rated 4.5 or higher?\n",
-      "A: There are **139 products** rated **4.5 or higher**.\n"
+      "A: There are **139** products rated **4.5 or higher**.\n"
      ]
     },
     {
@@ -246,14 +246,15 @@
      "text": [
       "\n",
       "Q: of the highly rated ones, suggest a gift under $40\n",
-      "A: A good gift option under **$40** from the highly rated items is:\n",
+      "A: A nice option is **Victoria's Secret Love Spell and Pure Seduction Fragrance Lotion** — **$28.80**, **4.7★**.\n",
       "\n",
-      "- **Victoria's Secret Love Spell and Pure Seduction Fragrance Lotion** — **$28.80**, **4.7★**\n",
+      "It fits your request because it is:\n",
+      "- **Under $40**\n",
+      "- **Highly rated**\n",
+      "- A fairly **giftable** personal care item\n",
       "\n",
-      "Another solid option:\n",
-      "- **LOWOSAIWOR Vintage 20s Headpiece for Women** — **$10.30**, **4.7★**\n",
-      "\n",
-      "If you want, I can sugge\n"
+      "Another under-$40 highly rated option:\n",
+      "- **LOWOSAIWOR \n"
      ]
     }
    ],
@@ -296,10 +297,10 @@
    "id": "cell-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T07:29:56.127082Z",
-     "iopub.status.busy": "2026-06-24T07:29:56.126904Z",
-     "iopub.status.idle": "2026-06-24T07:29:57.743649Z",
-     "shell.execute_reply": "2026-06-24T07:29:57.743269Z"
+     "iopub.execute_input": "2026-06-24T07:44:35.812361Z",
+     "iopub.status.busy": "2026-06-24T07:44:35.812234Z",
+     "iopub.status.idle": "2026-06-24T07:44:37.395004Z",
+     "shell.execute_reply": "2026-06-24T07:44:37.394624Z"
     }
    },
    "outputs": [
@@ -307,7 +308,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "first call 1.58s  ->  paraphrase 0.03s (served from cache)\n"
+      "first call 1.55s  ->  paraphrase 0.02s (served from cache)\n"
      ]
     }
    ],

--- a/infino-python/examples/langchain/README.md
+++ b/infino-python/examples/langchain/README.md
@@ -3,8 +3,7 @@
 Build LangChain apps on [Infino](https://pypi.org/project/infino/) through the
 [`langchain-infino`](https://pypi.org/project/langchain-infino/) integration —
 **one** vector store that does vector, full-text (BM25), hybrid, self-query, and
-SQL over a single copy of your data on object storage. No `EnsembleRetriever`
-over two backends, no separate metadata database, no second cache to run.
+SQL over a single copy of your data on object storage.
 
 Each example uses a **real public dataset** (HuggingFace Hub) and the same local
 `all-MiniLM-L6-v2` embeddings as the rest of the suite, so the retrieval path
@@ -16,8 +15,8 @@ an LLM key; each notebook says so up front and degrades gracefully without one.
 | Notebook | What it shows | LLM |
 | -------- | ------------- | --- |
 | [`01_live_data_rag.ipynb`](01_live_data_rag.ipynb) | A vector store you can safely **write to**: append / upsert / delete, and retrieval *and* SQL reflect every change immediately and survive a reopen from disk. | optional |
-| [`02_research_assistant.ipynb`](02_research_assistant.ipynb) | Natural-language filters compile to a SQL `WHERE` push-down (self-query), hybrid RRF retrieval beats vector-only and BM25-only — **measured** with recall@10 — plus conversational follow-ups with citations. | partial |
-| [`03_support_ops_agent.ipynb`](03_support_ops_agent.ipynb) | A LangGraph agent whose tools are all backed by **one** Infino store — semantic docs, exact error-code lookup (BM25), order/inventory SQL, and product-scoped filtered retrieval — with a semantic LLM cache and multi-turn memory. | required |
+| [`02_research_assistant.ipynb`](02_research_assistant.ipynb) | Compare vector, BM25, and hybrid retrieval over one store — **measured** with recall@10 — then filter semantic search by a metadata predicate (SQL push-down), with the filter written by hand or by an LLM (self-query). | partial |
+| [`03_support_ops_agent.ipynb`](03_support_ops_agent.ipynb) | A LangGraph agent whose tools are all backed by **one** Infino store — semantic product search, exact keyword/brand lookup (BM25), and catalog SQL — with a semantic LLM cache and multi-turn memory. | required |
 
 ## Setup
 

--- a/infino-python/examples/langchain/README.md
+++ b/infino-python/examples/langchain/README.md
@@ -1,0 +1,50 @@
+# LangChain + Infino examples
+
+Build LangChain apps on [Infino](https://pypi.org/project/infino/) through the
+[`langchain-infino`](https://pypi.org/project/langchain-infino/) integration —
+**one** vector store that does vector, full-text (BM25), hybrid, self-query, and
+SQL over a single copy of your data on object storage. No `EnsembleRetriever`
+over two backends, no separate metadata database, no second cache to run.
+
+Each example uses a **real public dataset** (HuggingFace Hub) and the same local
+`all-MiniLM-L6-v2` embeddings as the rest of the suite, so the retrieval path
+runs **locally and key-free**. Generating answers (and the agent example) needs
+an LLM key; each notebook says so up front and degrades gracefully without one.
+
+## Examples
+
+| Notebook | What it shows | LLM |
+| -------- | ------------- | --- |
+| [`01_live_data_rag.ipynb`](01_live_data_rag.ipynb) | A vector store you can safely **write to**: append / upsert / delete, and retrieval *and* SQL reflect every change immediately and survive a reopen from disk. | optional |
+| [`02_research_assistant.ipynb`](02_research_assistant.ipynb) | Natural-language filters compile to a SQL `WHERE` push-down (self-query), hybrid RRF retrieval beats vector-only and BM25-only — **measured** with recall@10 — plus conversational follow-ups with citations. | partial |
+| [`03_support_ops_agent.ipynb`](03_support_ops_agent.ipynb) | A LangGraph agent whose tools are all backed by **one** Infino store — semantic docs, exact error-code lookup (BM25), order/inventory SQL, and product-scoped filtered retrieval — with a semantic LLM cache and multi-turn memory. | required |
+
+## Setup
+
+```sh
+python -m venv venv
+source venv/bin/activate        # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+The first run downloads the embedding model (~90 MB) and a dataset sample, so
+the first cell can take a minute; later runs use the cache.
+
+### Optional: LLM answers
+
+The notebooks pick up a key automatically (via `_shared/llm.py`'s env handling),
+reading a local `.azure.env` / `.env` if present:
+
+- **Azure AI Foundry** (preferred): `AZURE_AI_ENDPOINT`, `AZURE_AI_API_KEY`, `DEFAULT_AZURE_MODEL`.
+- **OpenAI**: `OPENAI_API_KEY` (optionally `OPENAI_MODEL`).
+
+Keep credentials in an untracked env file — never commit keys.
+
+## How this maps to LangChain
+
+These examples are idiomatic LangChain — `InfinoVectorStore` is a standard
+`VectorStore`, `as_retriever()` returns a normal `BaseRetriever`, and the chains
+are plain LCEL / LangGraph. The shared glue lives one level up in
+[`../_shared/`](../_shared/): `lc.py` wraps the local embedder as a LangChain
+`Embeddings` and exposes an optional `chat_model()`; `loaders.py`, `embedding.py`,
+and `llm.py` are reused unchanged from the base suite.

--- a/infino-python/examples/langchain/requirements.txt
+++ b/infino-python/examples/langchain/requirements.txt
@@ -1,10 +1,11 @@
 infino
 langchain-infino>=0.1.0
+langchain>=1.0             # create_agent (support/ops agent example)
 langchain-core>=0.3
 langchain-openai>=0.2      # optional: LLM answers (Azure AI Foundry or OpenAI)
 langchain-classic>=1.0     # SelfQueryRetriever (research-assistant self-query)
 lark>=1.1                  # query parser used by SelfQueryRetriever
-langgraph>=0.2             # the support/ops agent example
+langgraph>=0.2             # checkpointer/memory for the agent example
 sentence-transformers>=3   # local embeddings, no API key needed
 datasets>=2                # pulls the real public corpora from HuggingFace
 pyarrow>=14

--- a/infino-python/examples/langchain/requirements.txt
+++ b/infino-python/examples/langchain/requirements.txt
@@ -1,0 +1,8 @@
+infino
+langchain-infino>=0.1.0
+langchain-core>=0.3
+langchain-openai>=0.2      # optional: LLM answers (Azure AI Foundry or OpenAI)
+langgraph>=0.2             # the support/ops agent example
+sentence-transformers>=3   # local embeddings, no API key needed
+datasets>=2                # pulls the real public corpora from HuggingFace
+pyarrow>=14

--- a/infino-python/examples/langchain/requirements.txt
+++ b/infino-python/examples/langchain/requirements.txt
@@ -2,6 +2,8 @@ infino
 langchain-infino>=0.1.0
 langchain-core>=0.3
 langchain-openai>=0.2      # optional: LLM answers (Azure AI Foundry or OpenAI)
+langchain-classic>=1.0     # SelfQueryRetriever (research-assistant self-query)
+lark>=1.1                  # query parser used by SelfQueryRetriever
 langgraph>=0.2             # the support/ops agent example
 sentence-transformers>=3   # local embeddings, no API key needed
 datasets>=2                # pulls the real public corpora from HuggingFace


### PR DESCRIPTION
## What

Adds a LangChain example suite under `infino-python/examples/langchain/`, built on the [`langchain-infino`](https://pypi.org/project/langchain-infino/) integration. Three application-grade notebooks, each exercising several Infino capabilities over one store:

| Notebook | Shows | LLM |
| --- | --- | --- |
| `01_live_data_rag.ipynb` | A vector store you can write to: append / upsert / delete flow straight through to vector retrieval and SQL, and survive a reopen from disk. | optional |
| `02_research_assistant.ipynb` | Compare vector / BM25 / hybrid retrieval over one store (recall@10), then filter semantic search by a metadata predicate (SQL push-down) — by hand or via self-query. | partial |
| `03_support_ops_agent.ipynb` | A LangGraph agent whose tools are all backed by one store — semantic, keyword (BM25), and SQL search — with a semantic LLM cache and multi-turn memory. | required |

Shared glue lives in `_shared/lc.py` (the suite's local MiniLM embedder as a LangChain `Embeddings`, plus an optional `chat_model()`); `loaders.py`, `embedding.py`, and `llm.py` are reused unchanged.

## Why

The existing examples cover Infino's native API; this suite shows the same engine through LangChain — a `VectorStore`, retrievers, self-query, agent tools, and a semantic cache — so LangChain users can adopt Infino with idiomatic code.

## Notes

- Retrieval paths run locally and key-free (local `all-MiniLM-L6-v2`, HuggingFace Hub datasets). Notebooks that generate answers or run the agent need an LLM key and say so up front; they degrade gracefully without one.
- Notebooks are committed executed, with stdout outputs, matching the existing examples.
- Existing examples are unchanged. New dependencies (`langchain`, `langchain-classic`, `lark`, `langgraph`, `langchain-openai`) are scoped to the suite's own `requirements.txt`, not the core package.