### PR TITLE
feat query SQL: IS NULL / IS NOT NULL pruning + manifest null stats

### DIFF
--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -303,7 +303,11 @@ superfile is irrelevant, the superfile is kept. The pruning inputs are:
 
 - **Term queries** use each superfile's term presence filter.
 - **Prefix queries** use each superfile's lexicographic term range.
-- **Predicate (SQL) queries** use the per-column scalar statistics.
+- **Predicate (SQL) queries** use the per-column scalar statistics
+  (min/max and null count). `=` / `IN` / same-column `OR` prune on
+  min/max; `IS NULL` / `IS NOT NULL` prune on the null count — an
+  all-null column records a null-valued min/max plus its null count so
+  the all-null case is detectable.
 - **Vector queries** use the per-column vector summary to order and
 route work.
 
@@ -355,4 +359,3 @@ manifest over different superfiles.
 - One writer is active per table at a time.
 - Full-text and vector search are distinct query paths; combined
 relevance scoring is left to the caller.
-

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -211,7 +211,9 @@ impl ScalarStatsAgg {
     ///
     /// Returns `None` for types without a well-defined ordering (anything
     /// other than integer / float / boolean / utf8 / decimal) — those carry
-    /// no min/max, so there's nothing to prune on. When present, every
+    /// no min/max, so there's nothing to prune on. An all-null column of a
+    /// supported type still returns an aggregate: null min/max plus the
+    /// null count, so `IS [NOT] NULL` can prune on it. When present, every
     /// companion stat (null count, exact sum, HLL sketch) is computed in the
     /// same pass; sum/hll stay `None` for types that don't support them.
     pub fn from_column(column: &ArrayRef) -> Option<ScalarStatsAgg> {

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -1262,24 +1262,30 @@ pub(crate) fn merge_min_max_arrays(
     existing_max: &ArrayRef,
     other_max: &ArrayRef,
 ) -> Option<(ArrayRef, ArrayRef)> {
+    // Merge two optional bounds into the surviving one — smaller for a min,
+    // larger for a max. A `None` (the column is all-null on that side)
+    // yields to a present value; both `None` stays `None`, so an all-null
+    // column stays all-null through the fold, while a manifest part with any
+    // populated superfile keeps its real bound.
+    #[inline]
+    fn merge_opt<T: PartialOrd>(a: Option<T>, b: Option<T>, keep_min: bool) -> Option<T> {
+        match (a, b) {
+            (Some(a), Some(b)) => Some(if keep_min == (a <= b) { a } else { b }),
+            (Some(v), None) | (None, Some(v)) => Some(v),
+            (None, None) => None,
+        }
+    }
+
     macro_rules! prim_merge {
         ($array_ty:ty) => {{
-            let ex_min_arr = existing_min.as_any().downcast_ref::<$array_ty>()?;
-            let ot_min_arr = other_min.as_any().downcast_ref::<$array_ty>()?;
-            let ex_max_arr = existing_max.as_any().downcast_ref::<$array_ty>()?;
-            let ot_max_arr = other_max.as_any().downcast_ref::<$array_ty>()?;
-
-            let ex_min = ex_min_arr.value(0);
-            let ot_min = ot_min_arr.value(0);
-            let ex_max = ex_max_arr.value(0);
-            let ot_max = ot_max_arr.value(0);
-
-            let merged_min = if ex_min < ot_min { ex_min } else { ot_min };
-            let merged_max = if ex_max > ot_max { ex_max } else { ot_max };
-
+            let exn = existing_min.as_any().downcast_ref::<$array_ty>()?;
+            let otn = other_min.as_any().downcast_ref::<$array_ty>()?;
+            let exx = existing_max.as_any().downcast_ref::<$array_ty>()?;
+            let otx = other_max.as_any().downcast_ref::<$array_ty>()?;
+            let at = |a: &$array_ty| (!a.is_null(0)).then(|| a.value(0));
             Some((
-                Arc::new(<$array_ty>::from(vec![merged_min])) as ArrayRef,
-                Arc::new(<$array_ty>::from(vec![merged_max])) as ArrayRef,
+                Arc::new(<$array_ty>::from(vec![merge_opt(at(exn), at(otn), true)])) as ArrayRef,
+                Arc::new(<$array_ty>::from(vec![merge_opt(at(exx), at(otx), false)])) as ArrayRef,
             ))
         }};
     }
@@ -1295,93 +1301,64 @@ pub(crate) fn merge_min_max_arrays(
         DataType::Int64 => prim_merge!(Int64Array),
         DataType::Float32 => prim_merge!(Float32Array),
         DataType::Float64 => prim_merge!(Float64Array),
-        DataType::Boolean => {
-            let ex_min = existing_min
-                .as_any()
-                .downcast_ref::<BooleanArray>()?
-                .value(0);
-            let ot_min = other_min.as_any().downcast_ref::<BooleanArray>()?.value(0);
-            let ex_max = existing_max
-                .as_any()
-                .downcast_ref::<BooleanArray>()?
-                .value(0);
-            let ot_max = other_max.as_any().downcast_ref::<BooleanArray>()?.value(0);
-            let merged_min = ex_min && ot_min;
-            let merged_max = ex_max || ot_max;
-            Some((
-                Arc::new(BooleanArray::from(vec![merged_min])),
-                Arc::new(BooleanArray::from(vec![merged_max])),
-            ))
-        }
+        // `false < true`, so min folds like AND and max like OR.
+        DataType::Boolean => prim_merge!(BooleanArray),
         DataType::Utf8 => {
-            let ex_min = existing_min
-                .as_any()
-                .downcast_ref::<StringArray>()?
-                .value(0);
-            let ot_min = other_min.as_any().downcast_ref::<StringArray>()?.value(0);
-            let ex_max = existing_max
-                .as_any()
-                .downcast_ref::<StringArray>()?
-                .value(0);
-            let ot_max = other_max.as_any().downcast_ref::<StringArray>()?.value(0);
-            let merged_min = if ex_min < ot_min { ex_min } else { ot_min };
-            let merged_max = if ex_max > ot_max { ex_max } else { ot_max };
+            let exn = existing_min.as_any().downcast_ref::<StringArray>()?;
+            let otn = other_min.as_any().downcast_ref::<StringArray>()?;
+            let exx = existing_max.as_any().downcast_ref::<StringArray>()?;
+            let otx = other_max.as_any().downcast_ref::<StringArray>()?;
+            let min = merge_opt(
+                (!exn.is_null(0)).then(|| exn.value(0)),
+                (!otn.is_null(0)).then(|| otn.value(0)),
+                true,
+            );
+            let max = merge_opt(
+                (!exx.is_null(0)).then(|| exx.value(0)),
+                (!otx.is_null(0)).then(|| otx.value(0)),
+                false,
+            );
             Some((
-                Arc::new(StringArray::from(vec![merged_min])),
-                Arc::new(StringArray::from(vec![merged_max])),
+                Arc::new(StringArray::from(vec![min])),
+                Arc::new(StringArray::from(vec![max])),
             ))
         }
         DataType::LargeUtf8 => {
-            let ex_min = existing_min
-                .as_any()
-                .downcast_ref::<LargeStringArray>()?
-                .value(0);
-            let ot_min = other_min
-                .as_any()
-                .downcast_ref::<LargeStringArray>()?
-                .value(0);
-            let ex_max = existing_max
-                .as_any()
-                .downcast_ref::<LargeStringArray>()?
-                .value(0);
-            let ot_max = other_max
-                .as_any()
-                .downcast_ref::<LargeStringArray>()?
-                .value(0);
-            let merged_min = if ex_min < ot_min { ex_min } else { ot_min };
-            let merged_max = if ex_max > ot_max { ex_max } else { ot_max };
+            let exn = existing_min.as_any().downcast_ref::<LargeStringArray>()?;
+            let otn = other_min.as_any().downcast_ref::<LargeStringArray>()?;
+            let exx = existing_max.as_any().downcast_ref::<LargeStringArray>()?;
+            let otx = other_max.as_any().downcast_ref::<LargeStringArray>()?;
+            let min = merge_opt(
+                (!exn.is_null(0)).then(|| exn.value(0)),
+                (!otn.is_null(0)).then(|| otn.value(0)),
+                true,
+            );
+            let max = merge_opt(
+                (!exx.is_null(0)).then(|| exx.value(0)),
+                (!otx.is_null(0)).then(|| otx.value(0)),
+                false,
+            );
             Some((
-                Arc::new(LargeStringArray::from(vec![merged_min])),
-                Arc::new(LargeStringArray::from(vec![merged_max])),
+                Arc::new(LargeStringArray::from(vec![min])),
+                Arc::new(LargeStringArray::from(vec![max])),
             ))
         }
         DataType::Decimal128(precision, scale) => {
-            let ex_min = existing_min
-                .as_any()
-                .downcast_ref::<Decimal128Array>()?
-                .value(0);
-            let ot_min = other_min
-                .as_any()
-                .downcast_ref::<Decimal128Array>()?
-                .value(0);
-            let ex_max = existing_max
-                .as_any()
-                .downcast_ref::<Decimal128Array>()?
-                .value(0);
-            let ot_max = other_max
-                .as_any()
-                .downcast_ref::<Decimal128Array>()?
-                .value(0);
-            let merged_min = if ex_min < ot_min { ex_min } else { ot_min };
-            let merged_max = if ex_max > ot_max { ex_max } else { ot_max };
+            let exn = existing_min.as_any().downcast_ref::<Decimal128Array>()?;
+            let otn = other_min.as_any().downcast_ref::<Decimal128Array>()?;
+            let exx = existing_max.as_any().downcast_ref::<Decimal128Array>()?;
+            let otx = other_max.as_any().downcast_ref::<Decimal128Array>()?;
+            let at = |a: &Decimal128Array| (!a.is_null(0)).then(|| a.value(0));
+            let min = merge_opt(at(exn), at(otn), true);
+            let max = merge_opt(at(exx), at(otx), false);
             Some((
                 Arc::new(
-                    Decimal128Array::from(vec![merged_min])
+                    Decimal128Array::from(vec![min])
                         .with_precision_and_scale(*precision, *scale)
                         .ok()?,
                 ),
                 Arc::new(
-                    Decimal128Array::from(vec![merged_max])
+                    Decimal128Array::from(vec![max])
                         .with_precision_and_scale(*precision, *scale)
                         .ok()?,
                 ),
@@ -1393,7 +1370,9 @@ pub(crate) fn merge_min_max_arrays(
 
 /// Compute (min, max) for one Arrow array as length-1 `ArrayRef`s.
 ///
-/// Returns `None` for unsupported types or for all-null inputs.
+/// Returns `None` only for unsupported types. An all-null input of a
+/// supported type yields length-1 *null* min/max arrays (not `None`), so
+/// its null count is still recorded and `IS [NOT] NULL` can prune on it.
 /// Supported set: integer (signed + unsigned, all widths), float
 /// (f32, f64), boolean, Utf8, LargeUtf8. The supertable schema
 /// rejects vector columns up at the SupertableOptions layer, so
@@ -1520,13 +1499,14 @@ pub(crate) fn column_hll(col: &ArrayRef) -> Option<hll::HllSketch> {
 }
 
 pub(crate) fn column_min_max(col: &ArrayRef) -> Option<(ArrayRef, ArrayRef)> {
+    // An all-null column yields *null* min/max (not no-stat), so its null
+    // count is still recorded for `IS [NOT] NULL` pruning — hence the
+    // `Option` min/max are kept rather than `?`-unwrapped away.
     macro_rules! prim {
         ($array_ty:ty) => {{
             let a = col.as_any().downcast_ref::<$array_ty>()?;
-            let mn = agg::min(a)?;
-            let mx = agg::max(a)?;
-            let mn_arr: ArrayRef = Arc::new(<$array_ty>::from(vec![mn]));
-            let mx_arr: ArrayRef = Arc::new(<$array_ty>::from(vec![mx]));
+            let mn_arr: ArrayRef = Arc::new(<$array_ty>::from(vec![agg::min(a)]));
+            let mx_arr: ArrayRef = Arc::new(<$array_ty>::from(vec![agg::max(a)]));
             Some((mn_arr, mx_arr))
         }};
     }
@@ -1544,43 +1524,35 @@ pub(crate) fn column_min_max(col: &ArrayRef) -> Option<(ArrayRef, ArrayRef)> {
         DataType::Float64 => prim!(Float64Array),
         DataType::Boolean => {
             let a = col.as_any().downcast_ref::<BooleanArray>()?;
-            let mn = agg::min_boolean(a)?;
-            let mx = agg::max_boolean(a)?;
             Some((
-                Arc::new(BooleanArray::from(vec![mn])),
-                Arc::new(BooleanArray::from(vec![mx])),
+                Arc::new(BooleanArray::from(vec![agg::min_boolean(a)])),
+                Arc::new(BooleanArray::from(vec![agg::max_boolean(a)])),
             ))
         }
         DataType::Utf8 => {
             let a = col.as_any().downcast_ref::<StringArray>()?;
-            let mn = agg::min_string(a)?;
-            let mx = agg::max_string(a)?;
             Some((
-                Arc::new(StringArray::from(vec![mn])),
-                Arc::new(StringArray::from(vec![mx])),
+                Arc::new(StringArray::from(vec![agg::min_string(a)])),
+                Arc::new(StringArray::from(vec![agg::max_string(a)])),
             ))
         }
         DataType::LargeUtf8 => {
             let a = col.as_any().downcast_ref::<LargeStringArray>()?;
-            let mn = agg::min_string(a)?;
-            let mx = agg::max_string(a)?;
             Some((
-                Arc::new(LargeStringArray::from(vec![mn])),
-                Arc::new(LargeStringArray::from(vec![mx])),
+                Arc::new(LargeStringArray::from(vec![agg::min_string(a)])),
+                Arc::new(LargeStringArray::from(vec![agg::max_string(a)])),
             ))
         }
         DataType::Decimal128(precision, scale) => {
             let a = col.as_any().downcast_ref::<Decimal128Array>()?;
-            let mn = agg::min(a)?;
-            let mx = agg::max(a)?;
             Some((
                 Arc::new(
-                    Decimal128Array::from(vec![mn])
+                    Decimal128Array::from(vec![agg::min(a)])
                         .with_precision_and_scale(*precision, *scale)
                         .ok()?,
                 ),
                 Arc::new(
-                    Decimal128Array::from(vec![mx])
+                    Decimal128Array::from(vec![agg::max(a)])
                         .with_precision_and_scale(*precision, *scale)
                         .ok()?,
                 ),
@@ -1784,9 +1756,10 @@ impl ClusterCentroids {
 mod tests {
     use std::{hint::black_box, slice::from_ref, sync::Arc, time::Instant};
 
-    use arrow_array::Array;
+    use arrow_array::{Array, Int64Array};
     use arrow_schema::{DataType, Field, Schema};
     use dashmap::DashMap;
+    use datafusion::scalar::ScalarValue;
     use tempfile::TempDir;
     use tokio::sync::OnceCell;
 
@@ -1817,6 +1790,32 @@ mod tests {
         let counts: Vec<u32> = (0..nc).map(|c| if c == nc / 2 { 0 } else { 10 }).collect();
         let cc = ClusterCentroids::from_fp32(n_cent, dim, &centroids, counts);
         (cc, centroids)
+    }
+
+    #[test]
+    fn min_max_stats_record_and_fold_all_null_columns() {
+        let arr = |vals: Vec<Option<i64>>| Arc::new(Int64Array::from(vals)) as ArrayRef;
+        let scalar = |a: &ArrayRef| ScalarValue::try_from_array(a, 0).expect("decode");
+
+        // All-null column still yields a stat, with null min/max (so the
+        // null count is recorded and `IS [NOT] NULL` can prune on it).
+        let (mn, mx) = column_min_max(&arr(vec![None, None])).expect("all-null stat");
+        assert!(mn.is_null(0) && mx.is_null(0));
+
+        // Populated column → real min/max, nulls ignored.
+        let (mn, mx) = column_min_max(&arr(vec![Some(5), Some(2), None])).expect("stat");
+        assert_eq!(scalar(&mn), ScalarValue::Int64(Some(2)));
+        assert_eq!(scalar(&mx), ScalarValue::Int64(Some(5)));
+
+        // Fold: a real bound wins over a null bound; both-null stays null.
+        let null1 = arr(vec![None]);
+        let (mn, mx) =
+            merge_min_max_arrays(&null1, &arr(vec![Some(2)]), &null1, &arr(vec![Some(9)]))
+                .expect("merge real over null");
+        assert_eq!(scalar(&mn), ScalarValue::Int64(Some(2)));
+        assert_eq!(scalar(&mx), ScalarValue::Int64(Some(9)));
+        let (mn, mx) = merge_min_max_arrays(&null1, &null1, &null1, &null1).expect("merge null");
+        assert!(mn.is_null(0) && mx.is_null(0));
     }
 
     /// Folded Sq8-domain scoring must equal dequantize-then-distance

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -318,6 +318,8 @@ impl SupertableProvider {
             self.manifest.options.tokenizer.as_deref(),
         ));
 
+        leaves.extend(exprs_to_null_leaves(filters, &self.schema));
+
         let mut survivors = select_superfiles(self.manifest.as_ref(), &leaves)
             .await
             .map_err(|e| DataFusionError::Execution(e.to_string()))?;
@@ -1278,6 +1280,46 @@ fn collect_or_eq(
     }
 }
 
+/// Build prune leaves for the `column IS NULL` / `IS NOT NULL` filters in
+/// `filters`. Each lowers to a `NullCheck` leaf that skips a manifest part
+/// or superfile only when its null stats prove no row can match. A wrapped
+/// inner (`CAST(c) IS NULL`) or an unknown column yields no leaf.
+pub(crate) fn exprs_to_null_leaves(filters: &[Expr], schema: &SchemaRef) -> Vec<PruneLeaf> {
+    let mut out = Vec::new();
+    for filter in filters {
+        collect_null_leaves(filter, schema, &mut out);
+    }
+    out
+}
+
+/// Recurse one filter expression: the `IS NULL` / `IS NOT NULL` arms emit
+/// a leaf, `AND` and aliases descend, anything else yields nothing.
+fn collect_null_leaves(expr: &Expr, schema: &SchemaRef, out: &mut Vec<PruneLeaf>) {
+    match expr {
+        Expr::Alias(a) => collect_null_leaves(&a.expr, schema, out),
+        Expr::BinaryExpr(be) if be.op == Operator::And => {
+            collect_null_leaves(&be.left, schema, out);
+            collect_null_leaves(&be.right, schema, out);
+        }
+        Expr::IsNull(inner) => push_null_leaf(inner, true, schema, out),
+        Expr::IsNotNull(inner) => push_null_leaf(inner, false, schema, out),
+        _ => {}
+    }
+}
+
+/// Push a `NullCheck` leaf when `inner` is a bare column in the schema;
+/// anything wrapped (cast, arithmetic) declines.
+fn push_null_leaf(inner: &Expr, want_null: bool, schema: &SchemaRef, out: &mut Vec<PruneLeaf>) {
+    if let Expr::Column(c) = inner
+        && schema.field_with_name(&c.name).is_ok()
+    {
+        out.push(PruneLeaf::NullCheck {
+            column: c.name.clone(),
+            want_null,
+        });
+    }
+}
+
 /// Recurse through `AND` nodes, pushing any recognized
 /// `column <op> literal` leaf into `out`.
 fn collect_conjuncts(expr: &Expr, schema: &SchemaRef, out: &mut Vec<ScalarPredicate>) {
@@ -1690,6 +1732,50 @@ mod tests {
         let s = schema_xy();
         let expr = col("x").in_list(vec![lit(1_i64)], true);
         assert!(exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), None).is_empty());
+    }
+
+    /// The `(column, want_null)` of the first `NullCheck` leaf, if any.
+    fn null_leaf(filters: &[Expr], schema: &SchemaRef) -> Option<(String, bool)> {
+        exprs_to_null_leaves(filters, schema)
+            .into_iter()
+            .find_map(|l| match l {
+                PruneLeaf::NullCheck { column, want_null } => Some((column, want_null)),
+                _ => None,
+            })
+    }
+
+    #[test]
+    fn is_null_and_is_not_null_lower_to_null_check() {
+        let s = schema_xy();
+        assert_eq!(
+            null_leaf(&[col("x").is_null()], &s),
+            Some(("x".to_string(), true))
+        );
+        assert_eq!(
+            null_leaf(&[col("x").is_not_null()], &s),
+            Some(("x".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn null_check_on_wrapped_inner_emits_no_leaf() {
+        // `CAST(x) IS NULL` — inner isn't a bare column.
+        let s = schema_xy();
+        let expr = cast(col("x"), DataType::Int32).is_null();
+        assert!(exprs_to_null_leaves(&[expr], &s).is_empty());
+    }
+
+    #[test]
+    fn null_check_on_unknown_column_emits_no_leaf() {
+        let s = schema_xy();
+        assert!(exprs_to_null_leaves(&[col("z").is_null()], &s).is_empty());
+    }
+
+    #[test]
+    fn null_check_under_and_is_found() {
+        let s = schema_xy();
+        let expr = col("x").gt(lit(0_i64)).and(col("y").is_null());
+        assert_eq!(null_leaf(&[expr], &s), Some(("y".to_string(), true)));
     }
 
     #[test]

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -30,19 +30,19 @@ use std::sync::Arc;
 
 use datafusion::scalar::ScalarValue;
 
-use super::skip::{
-    ScalarOp, ScalarPredicate, fts_bloom_skip, fts_prefix_skip, scalar_skip,
-    scalar_value_may_match, scalar_value_set_skip,
-};
 use crate::{
     superfile::fts::reader::BoolMode,
     supertable::{
         error::QueryError,
         manifest::{
-            ManifestSnapshot, SuperfileEntry,
-            list::{Manifest, ManifestPartEntry},
+            ManifestSnapshot, ScalarStatsAgg, SuperfileEntry,
+            list::Manifest,
             list_prune::{prune_parts_for_fts_prefix, prune_parts_for_fts_terms},
             part::PartId,
+        },
+        query::skip::{
+            ScalarOp, ScalarPredicate, fts_bloom_skip, fts_prefix_skip, null_check_may_match,
+            null_check_skip, scalar_skip, scalar_value_may_match, scalar_value_set_skip,
         },
     },
 };
@@ -70,6 +70,9 @@ pub(crate) enum PruneLeaf {
         column: String,
         values: Vec<ScalarValue>,
     },
+    /// `column IS NULL` (`want_null`) / `IS NOT NULL` → keep via the
+    /// per-column null count and all-null check.
+    NullCheck { column: String, want_null: bool },
 }
 
 impl PruneLeaf {
@@ -93,36 +96,45 @@ impl PruneLeaf {
             PruneLeaf::ScalarValueSet { column, values } => {
                 Some(scalar_value_set_keep_parts(list, column, values))
             }
+            PruneLeaf::NullCheck { column, want_null } => {
+                Some(null_check_keep_parts(list, column, *want_null))
+            }
         }
     }
 }
 
-/// Keep each part whose aggregate min/max for `column` satisfies
-/// `may_match`. A missing aggregate or undecodable bounds keeps the part
-/// (conservative — never a false prune). The bounds are length-1
-/// [`ArrayRef`]s decoded when the list loaded, so reading the
-/// [`ScalarValue`] here is free of per-query Arrow decode.
+/// Keep each part whose `column` aggregate satisfies `keep`. A missing
+/// aggregate keeps the part (conservative — never a false prune). The
+/// stats are length-1 [`ArrayRef`]s decoded when the list loaded, so
+/// reading them here is free of per-query Arrow decode.
+fn keep_parts_where_agg(
+    list: &Manifest,
+    column: &str,
+    keep: impl Fn(&ScalarStatsAgg) -> bool,
+) -> Vec<PartId> {
+    list.parts
+        .iter()
+        .filter_map(|entry| {
+            let k = entry.scalar_stats_agg.get(column).is_none_or(&keep);
+            k.then_some(entry.part_id)
+        })
+        .collect()
+}
+
+// Keep each part whose aggregate min/max for `column` satisfies `may_match`;
+// undecodable bounds keep the part.
 fn keep_parts_where(
     list: &Manifest,
     column: &str,
     may_match: impl Fn(&ScalarValue, &ScalarValue) -> bool,
 ) -> Vec<PartId> {
-    list.parts
-        .iter()
-        .filter_map(|entry| {
-            let keep = match part_minmax(entry, column) {
-                Some((min, max)) => may_match(&min, &max),
-                None => true,
-            };
-            keep.then_some(entry.part_id)
-        })
-        .collect()
+    keep_parts_where_agg(list, column, |agg| {
+        agg_minmax(agg).is_none_or(|(min, max)| may_match(&min, &max))
+    })
 }
 
-// The manifest part's aggregate min/max for `column`, or `None` when the column
-// has no aggregate or the bounds don't decode (caller keeps).
-fn part_minmax(entry: &ManifestPartEntry, column: &str) -> Option<(ScalarValue, ScalarValue)> {
-    let agg = entry.scalar_stats_agg.get(column)?;
+// An aggregate's decoded min/max, or `None` when the bounds don't decode.
+fn agg_minmax(agg: &ScalarStatsAgg) -> Option<(ScalarValue, ScalarValue)> {
     match (
         ScalarValue::try_from_array(agg.min.as_ref(), 0),
         ScalarValue::try_from_array(agg.max.as_ref(), 0),
@@ -130,6 +142,11 @@ fn part_minmax(entry: &ManifestPartEntry, column: &str) -> Option<(ScalarValue, 
         (Ok(min), Ok(max)) => Some((min, max)),
         _ => None,
     }
+}
+
+// Part-tier `IS [NOT] NULL` prune; the superfile-tier sibling lives in `skip`.
+fn null_check_keep_parts(list: &Manifest, column: &str, want_null: bool) -> Vec<PartId> {
+    keep_parts_where_agg(list, column, |agg| null_check_may_match(agg, want_null))
 }
 
 // Part-tier scalar prune: keep parts whose min/max could satisfy `pred`.
@@ -212,6 +229,9 @@ pub(crate) async fn select_superfiles(
                     &mut mask,
                     &scalar_value_set_skip(&superfiles, column, values),
                 );
+            }
+            PruneLeaf::NullCheck { column, want_null } => {
+                and_into(&mut mask, &null_check_skip(&superfiles, column, *want_null));
             }
             // Scalar leaves handled above as one conjunction.
             PruneLeaf::Scalar(_) => {}

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -53,7 +53,7 @@ use crate::{
         fts::reader::BoolMode,
         vector::distance::{Metric, distance},
     },
-    supertable::manifest::{ManifestSnapshot, SuperfileEntry},
+    supertable::manifest::{ManifestSnapshot, ScalarStatsAgg, SuperfileEntry},
 };
 
 /// Bloom-skip mask for an exact-term BM25 search.
@@ -279,6 +279,43 @@ pub fn scalar_value_set_skip(
                 .any(|v| scalar_value_may_match(&min, &max, ScalarOp::Eq, v)),
         })
         .collect()
+}
+
+/// Keep each superfile whose `column` stats could still satisfy
+/// `IS [NOT] NULL`. A missing stat keeps the superfile.
+pub fn null_check_skip(
+    superfiles: &[Arc<SuperfileEntry>],
+    column: &str,
+    want_null: bool,
+) -> Vec<bool> {
+    superfiles
+        .iter()
+        .map(|entry| {
+            entry
+                .scalar_stats
+                .get(column)
+                .is_none_or(|agg| null_check_may_match(agg, want_null))
+        })
+        .collect()
+}
+
+/// Whether a column's stats could still match `IS [NOT] NULL`, shared by
+/// both prune tiers:
+///  - `IS NULL` (`want_null`): keep unless the stats prove zero nulls.
+///  - `IS NOT NULL`: keep unless the column is entirely null.
+pub(crate) fn null_check_may_match(agg: &ScalarStatsAgg, want_null: bool) -> bool {
+    if want_null {
+        agg.null_count != Some(0)
+    } else {
+        !agg_all_null(agg)
+    }
+}
+
+/// All values are null iff the min stat is null — no non-null value fed it.
+fn agg_all_null(agg: &ScalarStatsAgg) -> bool {
+    ScalarValue::try_from_array(agg.min.as_ref(), 0)
+        .map(|v| v.is_null())
+        .unwrap_or(false)
 }
 
 /// Whether `entry` *could* contain a row satisfying `pred`, judged
@@ -697,6 +734,46 @@ mod tests {
             scalar_value_set_skip(&segs, "missing", &[i(5)]),
             vec![true, true, true]
         );
+    }
+
+    #[test]
+    fn null_check_may_match_covers_both_predicates() {
+        let arr = |v: Option<i64>| Arc::new(Int64Array::from(vec![v])) as ArrayRef;
+        let agg = |min: Option<i64>, null_count: Option<u64>| ScalarStatsAgg {
+            min: arr(min),
+            max: arr(min),
+            null_count,
+            sum: None,
+            hll: None,
+        };
+
+        // No nulls: IS NULL drops, IS NOT NULL keeps.
+        let no_null = agg(Some(5), Some(0));
+        assert!(!null_check_may_match(&no_null, true));
+        assert!(null_check_may_match(&no_null, false));
+
+        // All null (min is null): IS NULL keeps, IS NOT NULL drops.
+        let all_null = agg(None, Some(10));
+        assert!(null_check_may_match(&all_null, true));
+        assert!(!null_check_may_match(&all_null, false));
+
+        // Some nulls (min present): both keep.
+        let mixed = agg(Some(5), Some(2));
+        assert!(null_check_may_match(&mixed, true));
+        assert!(null_check_may_match(&mixed, false));
+
+        // Unknown null count (None): can't prove zero nulls, both keep.
+        let unknown = agg(Some(5), None);
+        assert!(null_check_may_match(&unknown, true));
+        assert!(null_check_may_match(&unknown, false));
+    }
+
+    #[test]
+    fn null_check_skip_keeps_on_missing_stat() {
+        let segs = vec![seg_with_int_stats("x", 0, 10)];
+        // Column not in stats → conservative keep for either predicate.
+        assert_eq!(null_check_skip(&segs, "missing", true), vec![true]);
+        assert_eq!(null_check_skip(&segs, "missing", false), vec![true]);
     }
 
     #[test]

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -33,15 +33,18 @@
 
 use std::{collections::HashSet, sync::Arc};
 
+use arrow_array::{LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
 use infino::{
-    superfile::fts::reader::BoolMode,
+    superfile::{builder::FtsConfig, fts::reader::BoolMode},
     supertable::{
-        Supertable,
+        Supertable, SupertableOptions,
         reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
         storage::{LocalFsStorageProvider, StorageProvider},
     },
-    test_helpers::{build_title_batch, default_supertable_options},
+    test_helpers::{build_title_batch, default_supertable_options, default_tokenizer},
 };
+use rayon::ThreadPoolBuilder;
 
 /// Disk-cache byte budget (1 GiB) for the hierarchical-manifest tests.
 const DISK_CACHE_BUDGET_BYTES: u64 = 1 << 30;
@@ -561,6 +564,134 @@ fn sql_or_on_fts_column_bloom_prunes_parts_min_max_cannot() {
         loaded, 1,
         "min/max keeps all 3 (range [aaa,zzz]); the OR bloom must narrow to part 1; got {loaded}/3"
     );
+}
+
+// Schema for the null-prune fixture: FTS `title` plus a nullable `tag`.
+fn tag_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("tag", DataType::LargeUtf8, true),
+    ]))
+}
+
+fn tag_options() -> SupertableOptions {
+    // Single-thread writer pool mirrors `default_supertable_options`, so
+    // part rollup is deterministic (2 superfiles per part).
+    let pool = Arc::new(
+        ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .expect("rayon pool"),
+    );
+    SupertableOptions::new(
+        tag_schema(),
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    )
+    .expect("tag options")
+    .with_writer_pool(pool)
+}
+
+fn tag_batch(titles: &[&str], tags: &[Option<&str>]) -> RecordBatch {
+    RecordBatch::try_new(
+        tag_schema(),
+        vec![
+            Arc::new(LargeStringArray::from(titles.to_vec())),
+            Arc::new(LargeStringArray::from(tags.to_vec())),
+        ],
+    )
+    .expect("tag batch")
+}
+
+// Three parts (2 superfiles each): part 0 has an all-null `tag`, parts 1
+// and 2 have no nulls. Returns the storage dir so each query opens a
+// fresh cold consumer.
+fn build_tag_parts(storage_dir: &std::path::Path) {
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir).expect("provider"));
+    let producer = Supertable::create(
+        tag_options()
+            .with_storage(Arc::clone(&storage))
+            .with_target_superfiles_per_part(2),
+    )
+    .expect("create");
+    let commits: &[(&[&str], &[Option<&str>])] = &[
+        (&["a0", "a1"], &[None, None]), // part 0: tag all null
+        (&["b0", "b1"], &[None, None]),
+        (&["c0", "c1"], &[Some("x"), Some("y")]), // part 1: no nulls
+        (&["d0", "d1"], &[Some("x"), Some("y")]),
+        (&["e0", "e1"], &[Some("x"), Some("y")]), // part 2: no nulls
+        (&["f0", "f1"], &[Some("x"), Some("y")]),
+    ];
+    for (titles, tags) in commits {
+        let mut w = producer.writer().expect("writer");
+        w.append(&tag_batch(titles, tags)).expect("append");
+        w.commit().expect("commit");
+    }
+}
+
+fn open_tag_consumer(storage_dir: &std::path::Path, cache_dir: &std::path::Path) -> Supertable {
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(storage_dir).expect("provider"));
+    let cache = make_cache(Arc::clone(&storage), cache_dir);
+    Supertable::open(
+        tag_options()
+            .with_storage(Arc::clone(&storage))
+            .with_eager_load_threshold(EAGER_LOAD_THRESHOLD_FORCE_LAZY)
+            .with_disk_cache(Arc::clone(&cache)),
+    )
+    .expect("open")
+}
+
+#[test]
+fn sql_is_null_prunes_no_null_parts() {
+    // `tag IS NULL`:
+    //  - parts 1 and 2 have null_count == 0, so they're dropped.
+    //  - only part 0 (all-null tag) loads; its 4 rows match.
+    let dir = TempDir::new().expect("tempdir");
+    build_tag_parts(dir.path());
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_tag_consumer(dir.path(), cache_dir.path());
+
+    let rows: usize = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE tag IS NULL")
+        .expect("query")
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(rows, 4, "part 0's 4 rows have a null tag");
+
+    let (loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3);
+    assert_eq!(loaded, 1, "no-null parts pruned; got {loaded}/3");
+}
+
+#[test]
+fn sql_is_not_null_prunes_all_null_parts() {
+    // `tag IS NOT NULL`:
+    //  - part 0 is entirely null (min stat is null), so it's dropped.
+    //  - parts 1 and 2 load; their 8 rows match.
+    let dir = TempDir::new().expect("tempdir");
+    build_tag_parts(dir.path());
+    let cache_dir = TempDir::new().expect("cache");
+    let consumer = open_tag_consumer(dir.path(), cache_dir.path());
+
+    let rows: usize = consumer
+        .reader()
+        .query_sql("SELECT _id FROM supertable WHERE tag IS NOT NULL")
+        .expect("query")
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(rows, 8, "parts 1 and 2 have 8 non-null tags");
+
+    let (loaded, total) = parts_loaded(&consumer);
+    assert_eq!(total, 3);
+    assert_eq!(loaded, 2, "all-null part 0 pruned; got {loaded}/3");
 }
 
 #[test]


### PR DESCRIPTION
Closes #182
  
### What does this PR do?
Extends WHERE-clause superfile pruning to `c IS NULL` / `c IS NOT NULL`. `IS NULL` skips superfiles with no nulls; `IS NOT NULL` skips superfiles that are entirely null. The same check runs at the manifest-part tier, so a whole manifest part is skipped before it's opened. Builds on the IN (#251) / OR (#260) prune work. 
  
### Why do we need this change?
`IS NULL` / `IS NOT NULL` reached the provider but lowered to no prune leaf, so every superfile opened. The blocker for `IS NOT NULL`: a column that's entirely null in a superfile stored no stat at all, so "this superfile is all null" was undetectable.
  
### How do we do this change?
For a column that's entirely null in a superfile, we now keep a tiny stats entry we used to throw away. The entry (`ScalarStatsAgg`) is:
  - `min` = null, `max` = null (placeholders meaning "no value"), 
  - `null_count` = N (all rows null),
  - `sum` / `hll` stay empty.
  
Before: an all-null column had no entry at all, invisible to the pruner. Now it has this small entry, which is exactly what lets `IS NOT NULL` know "this superfile is all null, skip it." Only all-null columns get this; a populated column is unchanged. Dense schema adds ~nothing; sparse schema adds one small entry per all-null column.
  
It lives at both manifest levels (the per-part one is just the fold of the per-superfile ones, not computed twice):  
  | level | field | where on disk | loaded |
  | --- | --- | --- | --- |
  | per-superfile | `SuperfileEntry.scalar_stats` | inside manifest part files | lazily, when a manifest part is opened |
  | per-manifest-part (rollup) | `ManifestPartEntry.scalar_stats_agg` | top-level manifest list | on every open |
  
The prune: `IS NULL` keeps a manifest part / superfile only if its `null_count != 0`; `IS NOT NULL` keeps it only if its min stat is non-null (not all-null). Both run at both tiers, reusing the existing leaf / skip / keep-parts machinery. The stat fold (`merge_min_max_arrays`) is now null-aware, so a real bound from one superfile wins over a null bound from an all-null sibling when rolling up to the `ManifestPartEntry`.
  
### Performance
`IS NOT NULL`, 12-manifest-part LocalFs fixture (11 all-null parts + 1 populated, 5000 rows/part), cold p50:
  
  | | cold p50 | manifest parts opened |
  | --- | --- | --- |
  | before | 54.11 ms | 12 / 12 |
  | after | 3.06 ms | 1 / 12 |
  
≈ 17.7x, by opening 1 manifest part instead of 12 (avoided footer parse + page decode per skipped superfile). Common path is unchanged: populated columns produce the same stats as before, non-null queries emit no leaf, and storage is flat (585.58 MiB both runs, no all-null columns in the standard bench). No regression on the SQL battery. Measured on LocalFs; a real object store would widen the gap, since each skipped open also saves a GET.