### PR TITLE
fix vector query: exclude tombstones before kNN ranking

### DIFF
--- a/benches/utils/bin/profile_superfile.rs
+++ b/benches/utils/bin/profile_superfile.rs
@@ -156,6 +156,7 @@ fn mean_recall_filtered(
             TOP_K,
             opts(nprobe, rerank_mult),
             Some(Arc::clone(allow)),
+            None,
         ))
         .expect("vector_hits_filtered");
         sum += corpus::recall_at_k(&hits, truth);

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -1089,6 +1089,7 @@ pub mod vector {
                 TOP_K,
                 opts,
                 Some(Arc::clone(allow)),
+                None,
             ))
             .expect("filtered sweep query");
             sum += corpus::recall_at_k(&hits, gt);
@@ -1228,6 +1229,7 @@ pub mod vector {
                     TOP_K,
                     opts,
                     Some(Arc::clone(allow)),
+                    None,
                 ))
                 .expect("filtered latency query");
                 std::hint::black_box(hits);
@@ -1408,6 +1410,7 @@ pub mod vector {
                                 FILTERED_DEFAULT_RERANK_MULT,
                             ),
                             Some(Arc::clone(&allow)),
+                            None,
                         ))
                         .expect("filtered recall query");
                         recalls.push(corpus::recall_at_k(&hits, gt));
@@ -1495,6 +1498,7 @@ pub mod vector {
                                 TOP_K,
                                 exec_vec::search_opts(nominal_nprobe, nominal_rerank),
                                 set.clone(),
+                                None,
                             ))
                             .expect("filtered vector search");
                             samples.push(t0.elapsed());

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1120,7 +1120,7 @@ impl SuperfileReader {
         k: usize,
         options: VectorSearchOptions,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        self.vector_hits_filtered_async(column, query, k, options, None)
+        self.vector_hits_filtered_async(column, query, k, options, None, None)
             .await
     }
 
@@ -1130,6 +1130,11 @@ impl SuperfileReader {
     /// shortlist, so the returned top-k is the true k-nearest among
     /// matching rows — pushdown, not post-filter, with no underflow.
     /// `allow == None` is identical to [`Self::vector_hits_async`].
+    ///
+    /// `deny` (when `Some`) is a per-superfile tombstone set excluded
+    /// before ranking on the unfiltered path, so a delete never shrinks
+    /// the top-k. It is independent of `allow`; the filtered path passes
+    /// `None` because its `allow` already has tombstones subtracted.
     pub async fn vector_hits_filtered_async(
         &self,
         column: &str,
@@ -1137,6 +1142,7 @@ impl SuperfileReader {
         k: usize,
         options: VectorSearchOptions,
         allow: Option<Arc<RoaringBitmap>>,
+        deny: Option<Arc<RoaringBitmap>>,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let filtered = allow.is_some();
         let (nprobe, rerank_mult) = options.resolve(filtered);
@@ -1144,8 +1150,10 @@ impl SuperfileReader {
             .vec()
             .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
         let rerank_mult = v.public_rerank_mult(column, rerank_mult);
-        Ok(v.search_async(column, query, k, nprobe, rerank_mult, allow)
-            .await?)
+        Ok(
+            v.search_async(column, query, k, nprobe, rerank_mult, allow, deny)
+                .await?,
+        )
     }
 
     /// As [`Self::vector_search`], but probes an **externally chosen**
@@ -1161,7 +1169,7 @@ impl SuperfileReader {
         clusters: &[u32],
         options: VectorSearchOptions,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        self.vector_search_clusters_filtered(column, query, k, clusters, options, None)
+        self.vector_search_clusters_filtered(column, query, k, clusters, options, None, None)
             .await
     }
 
@@ -1169,6 +1177,10 @@ impl SuperfileReader {
     /// ranking to the `local_doc_id`s in `allow` (a per-superfile
     /// predicate allow-set), applied inside the coarse shortlist.
     /// `allow == None` is identical to [`Self::vector_search_clusters`].
+    ///
+    /// `deny` (when `Some`) is a per-superfile tombstone set excluded
+    /// before ranking on the unfiltered path; see
+    /// [`Self::vector_hits_filtered_async`].
     pub async fn vector_search_clusters_filtered(
         &self,
         column: &str,
@@ -1177,6 +1189,7 @@ impl SuperfileReader {
         clusters: &[u32],
         options: VectorSearchOptions,
         allow: Option<Arc<RoaringBitmap>>,
+        deny: Option<Arc<RoaringBitmap>>,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let filtered = allow.is_some();
         let (_, rerank_mult) = options.resolve(filtered);
@@ -1185,7 +1198,7 @@ impl SuperfileReader {
             .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
         let rerank_mult = v.public_rerank_mult(column, rerank_mult);
         Ok(
-            v.search_clusters_async(column, query, k, clusters, rerank_mult, allow)
+            v.search_clusters_async(column, query, k, clusters, rerank_mult, allow, deny)
                 .await?,
         )
     }

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -162,6 +162,10 @@ struct ProbeCtx<'a> {
     k: usize,
     rerank_mult: usize,
     allow: Option<Arc<RoaringBitmap>>,
+    // Per-superfile tombstone (deny) set, excluded *before* a candidate
+    // enters ranking — so the top-k ranks only live rows and never
+    // contains deleted docs. The opposite-polarity sibling of `allow`.
+    deny: Option<Arc<RoaringBitmap>>,
 }
 
 impl ColumnReader {
@@ -1349,6 +1353,7 @@ impl VectorReader {
             k,
             rerank_mult,
             allow: None,
+            deny: None,
         };
         let (candidates, survivor_full_ranges) = match build_shortlist(
             col,
@@ -1422,6 +1427,9 @@ impl VectorReader {
         // `None` = unfiltered; threaded to the coarse shortlist so the
         // top-k is the true k-nearest among matching rows.
         allow: Option<Arc<RoaringBitmap>>,
+        // Tombstone deny-set excluded before ranking on the unfiltered
+        // path; `None` leaves ranking unchanged.
+        deny: Option<Arc<RoaringBitmap>>,
     ) -> Result<Vec<(u32, f32)>, VectorError> {
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
@@ -1475,6 +1483,7 @@ impl VectorReader {
             k,
             rerank_mult: rerank_mult_eff,
             allow,
+            deny,
         };
         self.probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
             .await
@@ -1498,6 +1507,9 @@ impl VectorReader {
         // `None` = unfiltered; threaded to the coarse shortlist so the
         // top-k is the true k-nearest among matching rows.
         allow: Option<Arc<RoaringBitmap>>,
+        // Tombstone deny-set excluded before ranking on the unfiltered
+        // path; `None` leaves ranking unchanged.
+        deny: Option<Arc<RoaringBitmap>>,
     ) -> Result<Vec<(u32, f32)>, VectorError> {
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
@@ -1527,6 +1539,7 @@ impl VectorReader {
             k,
             rerank_mult: effective_filtered_rerank_mult(rerank_mult, filter_mult),
             allow,
+            deny,
         };
         self.probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
             .await
@@ -2014,6 +2027,7 @@ async fn build_shortlist(
                 &col.quant,
                 ctx.q_rot,
                 ctx.allow.as_deref(),
+                ctx.deny.as_deref(),
                 heap,
             );
         };
@@ -2032,6 +2046,8 @@ async fn build_shortlist(
         // Move an `Arc` clone of the allow-set into the rayon task; each
         // chunk borrows it as `Option<&RoaringBitmap>` via `as_deref`.
         let allow_owned = ctx.allow.clone();
+        // Same for the tombstone deny-set.
+        let deny_owned = ctx.deny.clone();
         let (tx, rx) = oneshot::channel();
         rayon::spawn(move || {
             let acc = meta_owned
@@ -2053,6 +2069,7 @@ async fn build_shortlist(
                             &quant,
                             &q_rot_v,
                             allow_owned.as_deref(),
+                            deny_owned.as_deref(),
                             &mut heap,
                         );
                     }
@@ -2277,6 +2294,7 @@ fn score_cluster_codes_into_heap(
     quant: &BitQuantizer,
     q_rot: &[f32],
     allow: Option<&roaring::RoaringBitmap>,
+    deny: Option<&roaring::RoaringBitmap>,
     out: &mut BoundedCoarseHeap,
 ) {
     let cb = quant.code_bytes();
@@ -2296,6 +2314,13 @@ fn score_cluster_codes_into_heap(
         // post-filter. Decode the code (the hot work) only for an
         // allowed candidate.
         if allow.is_some_and(|bm| !bm.contains(did)) {
+            continue;
+        }
+        // Tombstone deny-set: a deleted row is skipped here, before it
+        // can take a coarse-heap slot. The unfiltered path's top-k is
+        // therefore the true k-nearest among *live* rows — no over-fetch,
+        // no post-rank underflow.
+        if deny.is_some_and(|bm| bm.contains(did)) {
             continue;
         }
         let code = &cluster_codes[i * cb..(i + 1) * cb];
@@ -3336,11 +3361,19 @@ mod tests {
         let (k, rerank, n_cent) = (5usize, 5usize, 4u32);
 
         let full = r
-            .search_async("v", q, k, n_cent as usize, rerank, None)
+            .search_async("v", q, k, n_cent as usize, rerank, None, None)
             .await
             .expect("search_async");
         let probed = r
-            .search_clusters_async("v", q, k, &(0..n_cent).collect::<Vec<_>>(), rerank, None)
+            .search_clusters_async(
+                "v",
+                q,
+                k,
+                &(0..n_cent).collect::<Vec<_>>(),
+                rerank,
+                None,
+                None,
+            )
             .await
             .expect("search_clusters_async");
 
@@ -3355,7 +3388,7 @@ mod tests {
 
         // Probing no clusters returns nothing.
         let none = r
-            .search_clusters_async("v", q, k, &[], rerank, None)
+            .search_clusters_async("v", q, k, &[], rerank, None, None)
             .await
             .expect("search_clusters_async empty");
         assert!(none.is_empty(), "probing no clusters returns no hits");
@@ -6463,11 +6496,11 @@ mod tests {
         .expect("open_lazy");
 
         let hits_lazy = r_lazy
-            .search_async("v", &all[17], 5, 4, 20, None)
+            .search_async("v", &all[17], 5, 4, 20, None, None)
             .await
             .expect("lazy cold Sq8 search_async");
         let hits_eager = r_eager
-            .search_async("v", &all[17], 5, 4, 20, None)
+            .search_async("v", &all[17], 5, 4, 20, None, None)
             .await
             .expect("eager Sq8 search_async");
         // As in the sync lazy-Sq8 test, pin set overlap rather than exact
@@ -6500,11 +6533,11 @@ mod tests {
 
         let clusters: Vec<u32> = (0..4).collect();
         let hits_lazy = r_lazy
-            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None)
+            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None, None)
             .await
             .expect("lazy cold search_clusters_async");
         let hits_eager = r_eager
-            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None)
+            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None, None)
             .await
             .expect("eager search_clusters_async");
         assert_eq!(
@@ -6514,7 +6547,7 @@ mod tests {
         // Out-of-range cluster ids are ignored; an empty selection yields
         // no hits.
         let none = r_lazy
-            .search_clusters_async("embedding", &all[19], 5, &[999u32], 5, None)
+            .search_clusters_async("embedding", &all[19], 5, &[999u32], 5, None, None)
             .await
             .expect("out-of-range clusters");
         assert!(none.is_empty(), "ids >= n_cent are ignored");
@@ -6525,13 +6558,17 @@ mod tests {
         // resolve_column error arms reached through the async entry point.
         let (blob, json) = build_blob(32, 16, 4, Metric::L2Sq);
         let r = VectorReader::open(blob, &json).expect("open");
-        let unknown = r.search_async("nope", &[0.0; 16], 5, 4, 5, None).await;
+        let unknown = r
+            .search_async("nope", &[0.0; 16], 5, 4, 5, None, None)
+            .await;
         assert!(matches!(unknown, Err(VectorError::UnknownColumn(_))));
-        let dim = r.search_async("embedding", &[0.0; 8], 5, 4, 5, None).await;
+        let dim = r
+            .search_async("embedding", &[0.0; 8], 5, 4, 5, None, None)
+            .await;
         assert!(matches!(dim, Err(VectorError::DimensionMismatch { .. })));
         // k == 0 short-circuits to an empty result.
         let empty = r
-            .search_async("embedding", &[0.0; 16], 0, 4, 5, None)
+            .search_async("embedding", &[0.0; 16], 0, 4, 5, None, None)
             .await
             .expect("k=0 empty");
         assert!(empty.is_empty());
@@ -7125,7 +7162,7 @@ mod tests {
         .expect("open_lazy for search_async");
         flaky_a.fail_from_now();
         let err = ra
-            .search_async("embedding", &all[0], 5, 4, 5, None)
+            .search_async("embedding", &all[0], 5, 4, 5, None, None)
             .await
             .expect_err("search_async must surface failure");
         assert!(
@@ -7143,7 +7180,7 @@ mod tests {
         .expect("open_lazy for search_clusters_async");
         flaky_c.fail_from_now();
         let err = rc
-            .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None)
+            .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None, None)
             .await
             .expect_err("search_clusters_async must surface failure");
         assert!(
@@ -7367,7 +7404,10 @@ mod tests {
             .await
             .expect("open_lazy search_async");
             flaky_a.fail_after_call(fail_at);
-            match ra.search_async("embedding", &all[0], 5, 4, 5, None).await {
+            match ra
+                .search_async("embedding", &all[0], 5, 4, 5, None, None)
+                .await
+            {
                 Err(VectorError::LazySource(_)) => async_errors += 1,
                 Ok(_) => {}
                 other => panic!("search_async unexpected outcome: {other:?}"),
@@ -7383,7 +7423,7 @@ mod tests {
             .expect("open_lazy search_clusters_async");
             flaky_c.fail_after_call(fail_at);
             match rc
-                .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None)
+                .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None, None)
                 .await
             {
                 Err(VectorError::LazySource(_)) => clusters_errors += 1,

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -35,6 +35,7 @@
 use std::{future::Future, sync::Arc, time::Instant};
 
 use futures::future::try_join_all;
+use roaring::RoaringBitmap;
 use uuid::Uuid;
 
 use super::SuperfileHit;
@@ -84,9 +85,25 @@ pub(crate) fn tag_hits(entry: &SuperfileEntry, hits: Vec<(u32, f32)>) -> Vec<Sup
         .collect()
 }
 
-/// Drop tombstoned `local_doc_id`s from one superfile's hits. After the
-/// orchestrator's batched [`SidecarCache::prefetch`] every lookup here
-/// is an in-memory cache hit, so this is a cheap retain pass.
+/// Resolve a superfile's tombstones to a non-empty deny bitmap, or `None`
+/// when it has none. After the orchestrator's batched
+/// [`SidecarCache::prefetch`] this is an in-memory cache hit. The single
+/// source of the "look up the bitmap, treat empty as absent" step shared
+/// by the post-rank filter here, the allow-set subtraction, and the
+/// unfiltered deny-set pushdown.
+pub(crate) fn tombstone_deny_set(
+    cache: &SidecarCache,
+    superfile_id: Uuid,
+    now: Instant,
+) -> Result<Option<Arc<RoaringBitmap>>, QueryError> {
+    let bitmap = cache
+        .bitmap_for(superfile_id, now)
+        .map_err(|e| QueryError::Store(format!("tombstone cache: {e}")))?;
+    Ok((!bitmap.is_empty()).then_some(bitmap))
+}
+
+/// Drop tombstoned `local_doc_id`s from one superfile's hits — the
+/// post-rank filter for query paths that rank without a deny set (FTS).
 pub(crate) fn apply_tombstone_filter(
     cache: Option<&Arc<SidecarCache>>,
     entry: &SuperfileEntry,
@@ -96,12 +113,9 @@ pub(crate) fn apply_tombstone_filter(
     let Some(cache) = cache else {
         return Ok(());
     };
-    let bitmap = cache
-        .bitmap_for(entry.superfile_id, now)
-        .map_err(|e| QueryError::Store(format!("tombstone cache: {e}")))?;
-    if bitmap.is_empty() {
+    let Some(bitmap) = tombstone_deny_set(cache, entry.superfile_id, now)? else {
         return Ok(());
-    }
+    };
     hits.retain(|h| !bitmap.contains(h.local_doc_id));
     Ok(())
 }

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -277,38 +277,55 @@ impl SupertableReader {
             return Ok(Vec::new());
         }
 
-        // Fan out through the shared [`query::dispatch::fanout`] (also
-        // used by FTS), but in waves capped by the configured reader
-        // pool width. A cold vector kernel can hold large selected-cluster
-        // `[codes][doc_ids]` prefix blocks while it builds its shortlist;
-        // capping the number of concurrent superfiles keeps that transient
-        // memory bounded by instance configuration instead of table size.
-        // Skipped superfiles issue zero GETs.
+        // The filtered path fans out in waves capped by the reader-pool
+        // width: a cold vector kernel can hold large `[codes][doc_ids]`
+        // cluster blocks while building its shortlist, so capping
+        // concurrent superfiles keeps that transient memory bounded by
+        // config, not table size. Skipped superfiles issue zero GETs.
         let column_arc = Arc::new(column.to_owned());
         let query_arc = Arc::new(query.to_vec());
-        let kernel =
-            move |reader: Arc<SuperfileReader>,
-                  (probe, bitmap): (Probe, Option<Arc<RoaringBitmap>>)| {
-                let column = Arc::clone(&column_arc);
-                let query = Arc::clone(&query_arc);
-                async move {
-                    let res = match probe {
-                        Probe::Clusters(ids) => {
-                            reader
-                                .vector_search_clusters_filtered(
-                                    &column, &query, k, &ids, options, bitmap,
-                                )
-                                .await
-                        }
-                        Probe::Nprobe => {
-                            reader
-                                .vector_hits_filtered_async(&column, &query, k, options, bitmap)
-                                .await
-                        }
-                    };
-                    res.map_err(|e| QueryError::Parquet(e.to_string()))
+
+        // `fanout_with`, not `fanout`: the body needs each superfile's  tombstone bitmap *before* its kernel
+        // to push it in as a deny set (`fanout` only drops tombstones post-rank, which underflows).
+        let body = move |reader: Arc<SuperfileReader>,
+                         entry: Arc<SuperfileEntry>,
+                         tombstone_cache: Option<Arc<SidecarCache>>,
+                         now: Instant,
+                         (probe, bitmap): (Probe, Option<Arc<RoaringBitmap>>)| {
+            let column = Arc::clone(&column_arc);
+            let query = Arc::clone(&query_arc);
+            async move {
+                // For unfiltered path:
+                //  - it resolve this superfile's tombstone  bitmap once (a warm cache hit after the orchestrator's
+                //    prefetch) and push it down as the deny set.
+                //  - A clean superfile resolves to `None`, leaving the hot path unchanged.
+                //
+                // Filtered search leaves it `None` throughout — its allow-set already excludes tombstones.
+                let deny = match tombstone_cache.as_ref() {
+                    Some(cache) if bitmap.is_none() => {
+                        dispatch::tombstone_deny_set(cache, entry.superfile_id, now)?
+                    }
+                    _ => None,
+                };
+                let hits = match probe {
+                    Probe::Clusters(ids) => {
+                        reader
+                            .vector_search_clusters_filtered(
+                                &column, &query, k, &ids, options, bitmap, deny,
+                            )
+                            .await
+                    }
+                    Probe::Nprobe => {
+                        reader
+                            .vector_hits_filtered_async(&column, &query, k, options, bitmap, deny)
+                            .await
+                    }
                 }
-            };
+                .map_err(|e| QueryError::Parquet(e.to_string()))?;
+
+                Ok::<Vec<SuperfileHit>, QueryError>(dispatch::tag_hits(&entry, hits))
+            }
+        };
         // Filtered search holds a per-superfile RoaringBitmap while the
         // kernel builds its shortlist; wave-cap the fan-out by reader-pool
         // width so transient memory stays bounded. The unfiltered path
@@ -320,11 +337,11 @@ impl SupertableReader {
             while !units.is_empty() {
                 let n = fanout_width.min(units.len());
                 let wave: Vec<_> = units.drain(..n).collect();
-                collected.extend(dispatch::fanout(self, wave, kernel.clone()).await?);
+                collected.extend(dispatch::fanout_with(self, wave, body.clone()).await?);
             }
             collected
         } else {
-            dispatch::fanout(self, units, kernel).await?
+            dispatch::fanout_with(self, units, body).await?
         };
 
         Ok(top_k_ascending(per_superfile, k))
@@ -609,13 +626,10 @@ fn subtract_tombstones(
     tombstone_cache: Option<&SidecarCache>,
     now: Instant,
 ) -> Result<(), QueryError> {
-    if let Some(cache) = tombstone_cache {
-        let deleted = cache
-            .bitmap_for(entry.superfile_id, now)
-            .map_err(|e| QueryError::Store(format!("tombstone cache: {e}")))?;
-        if !deleted.is_empty() {
-            *bm -= &*deleted;
-        }
+    if let Some(cache) = tombstone_cache
+        && let Some(deleted) = dispatch::tombstone_deny_set(cache, entry.superfile_id, now)?
+    {
+        *bm -= &*deleted;
     }
     Ok(())
 }
@@ -795,6 +809,7 @@ mod tests {
     };
     use arrow_schema::{DataType, Field, Schema};
     use bytes::Bytes;
+    use datafusion::prelude::{Expr, col, lit};
     use roaring::RoaringBitmap;
     use tokio::runtime;
 
@@ -1023,6 +1038,177 @@ mod tests {
             .vector_hits("emb", &q, 7, VectorSearchOptions::new(), None)
             .expect("query");
         assert_eq!(hits.len(), 7);
+    }
+
+    // Deleting the rows nearest a query must not shrink an unfiltered
+    // result below the live count — the delete-then-kNN underflow.
+    //  - one superfile, so a hit's `local_doc_id` is its row index.
+    //  - rank all rows, then tombstone the nearest `d` (well past the
+    //    small-k candidate pool, so survivors fall outside any post-rank
+    //    backfill).
+    //  - `k=1` must return the nearest *live* row, never empty.
+    //  - a full sweep returns exactly the `n - d` live rows.
+    // Pre-fix the filter ran on the already-truncated top-k with no
+    // backfill, so a deleted row in the top-k just vanished.
+    #[test]
+    fn vector_search_returns_k_live_rows_after_deletes() {
+        let dim = 16;
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let st = Supertable::create(options_one_superfile_per_commit(dim).with_storage(storage))
+            .expect("create");
+
+        // Spread pseudo-random vectors (integer hash → [0, 1)) give a
+        // strict nearest ordering, unlike one-hot rows that tie.
+        let n = 64usize;
+        let pseudo = |i: usize, d: usize| -> f32 {
+            let mut h = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(
+                (d as u64)
+                    .wrapping_add(1)
+                    .wrapping_mul(0x2545_F491_4F6C_DD1D),
+            );
+            h ^= h >> 33;
+            ((h >> 40) & 0xFFFF) as f32 / 65536.0
+        };
+        let schema = st.options().schema.clone();
+        let titles = LargeStringArray::from((0..n).map(|i| format!("doc {i}")).collect::<Vec<_>>());
+        let mut flat = Vec::<f32>::with_capacity(n * dim);
+        for i in 0..n {
+            for d in 0..dim {
+                flat.push(pseudo(i, d));
+            }
+        }
+        let fsl = FixedSizeListArray::try_new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim as i32,
+            Arc::new(Float32Array::from(flat)) as Arc<dyn Array>,
+            None,
+        )
+        .expect("fsl");
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(titles), Arc::new(fsl)]).expect("batch");
+        {
+            let mut w = st.writer().expect("writer");
+            w.append(&batch).expect("append");
+            w.commit().expect("commit");
+        }
+
+        let q: Vec<f32> = (0..dim).map(|d| pseudo(0, d)).collect();
+
+        let baseline = st
+            .reader()
+            .vector_hits("emb", &q, n, VectorSearchOptions::new(), None)
+            .expect("baseline");
+        assert_eq!(baseline.len(), n);
+        let d = 56usize;
+        let deleted_ids: HashSet<u32> = baseline[..d].iter().map(|h| h.local_doc_id).collect();
+        let deleted: Vec<Expr> = deleted_ids
+            .iter()
+            .map(|id| lit(format!("doc {id}")))
+            .collect();
+        let stats = st
+            .delete(col("title").in_list(deleted, false))
+            .expect("delete");
+        assert_eq!(stats.n_tombstoned(), d);
+
+        // k=1 must return the nearest *live* row, not an empty result.
+        let hits = st
+            .reader()
+            .vector_hits("emb", &q, 1, VectorSearchOptions::new(), None)
+            .expect("search");
+        assert_eq!(hits.len(), 1, "k=1 returned no live row after deletes");
+        assert!(
+            !deleted_ids.contains(&hits[0].local_doc_id),
+            "returned a deleted row: local_doc_id={}",
+            hits[0].local_doc_id
+        );
+
+        // And a larger k returns exactly the live remainder.
+        let live = n - d;
+        let many = st
+            .reader()
+            .vector_hits("emb", &q, n, VectorSearchOptions::new(), None)
+            .expect("search many");
+        assert_eq!(many.len(), live, "expected all {live} live rows");
+        assert!(many.iter().all(|h| !deleted_ids.contains(&h.local_doc_id)));
+    }
+
+    // The deny set is per-superfile, so the fix must hold across the
+    // fan-out, not just within one file.
+    //  - 3 superfiles × 16 one-hot docs; titles repeat per file, so
+    //    `doc 0` names row 0 (the dim-0-active, distance-0 row) in each.
+    //  - query e_0's only distance-0 neighbors are those three `doc 0`s.
+    //  - deleting `doc 0` tombstones all three at once.
+    // k=1 must then return a live distance-1 row from some superfile, not
+    // empty — the global merge backfills past the per-file tombstones.
+    #[test]
+    fn vector_search_after_deletes_holds_across_superfiles() {
+        let dim = 16;
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let st = Supertable::create(options_one_superfile_per_commit(dim).with_storage(storage))
+            .expect("create");
+        let schema = st.options().schema.clone();
+        {
+            let mut w = st.writer().expect("writer");
+            for chunk in 0..3u64 {
+                w.append(&build_vector_batch(chunk * 16, 16, dim, schema.clone()))
+                    .expect("append");
+                w.commit().expect("commit");
+            }
+        }
+        assert_eq!(st.reader().n_superfiles(), 3);
+
+        let mut q = vec![0f32; dim];
+        q[0] = 1.0;
+        // The three distance-0 neighbors (one per superfile) all carry the
+        // title `doc 0`; one delete tombstones every one of them.
+        let stats = st
+            .delete(col("title").in_list(vec![lit("doc 0")], false))
+            .expect("delete");
+        assert_eq!(stats.n_tombstoned(), 3);
+
+        let hits = st
+            .reader()
+            .vector_hits("emb", &q, 1, VectorSearchOptions::new(), None)
+            .expect("search");
+        assert_eq!(hits.len(), 1, "k=1 underflowed across the fan-out");
+        // Survivors are orthogonal to e_0 → cosine distance 1, never the
+        // deleted distance-0 rows.
+        assert!(hits[0].score > 0.5, "returned a deleted distance-0 row");
+    }
+
+    // Deleting every row must return empty, not panic or wrap — the deny
+    // set excludes the whole superfile and the heap stays empty.
+    #[test]
+    fn vector_search_all_rows_deleted_returns_empty() {
+        let dim = 16;
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let st = Supertable::create(options_one_superfile_per_commit(dim).with_storage(storage))
+            .expect("create");
+        let schema = st.options().schema.clone();
+        let n = 8usize;
+        {
+            let mut w = st.writer().expect("writer");
+            w.append(&build_vector_batch(0, n, dim, schema)).expect("a");
+            w.commit().expect("c");
+        }
+        let titles: Vec<Expr> = (0..n).map(|i| lit(format!("doc {i}"))).collect();
+        let stats = st
+            .delete(col("title").in_list(titles, false))
+            .expect("delete");
+        assert_eq!(stats.n_tombstoned(), n);
+
+        let q = vec![0.1f32; dim];
+        let hits = st
+            .reader()
+            .vector_hits("emb", &q, 5, VectorSearchOptions::new(), None)
+            .expect("search");
+        assert!(hits.is_empty(), "expected no live rows, got {}", hits.len());
     }
 
     #[test]

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -22,13 +22,21 @@
 
 use std::sync::Arc;
 
-use arrow_array::Array;
+use arrow_array::{
+    Array, ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch,
+};
+use arrow_schema::{DataType, Field, Schema};
 use chrono::Utc;
+use datafusion::prelude::{Expr, col, lit};
 use infino::{
     storage::{LocalFsStorageProvider, StorageProvider},
-    superfile::{builder::FtsConfig, fts::reader::BoolMode},
+    superfile::{
+        builder::FtsConfig,
+        fts::{reader::BoolMode, tokenize::Tokenizer},
+    },
     supertable::{
         Supertable, SupertableOptions,
+        query::vector::VectorSearchOptions,
         wal::{
             WalStore,
             pipeline::run_tombstone_phase,
@@ -38,7 +46,9 @@ use infino::{
             },
         },
     },
-    test_helpers::{build_title_batch, default_supertable_options},
+    test_helpers::{
+        build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
+    },
 };
 use tempfile::TempDir;
 
@@ -196,17 +206,17 @@ async fn sql_query_excludes_tombstoned_row() {
     assert_eq!(titles, vec!["bb", "dd"]);
 }
 
-// The vector-query end-to-end test ran into a vector-reader
-// edge case unrelated to the tombstone filter (the IVF + lazy
-// source path doesn't tolerate the tiny synthetic batches this
-// integration shape produces). The vector filter hook is
-// structurally identical to the FTS path's hook — both call
-// `apply_tombstone_filter(...)` with the same `Vec<SuperfileHit>`
-// + bitmap inputs — so the FTS test's coverage carries over.
-// A dedicated direct-call unit test lives in
-// `src/supertable/query/vector.rs::tests`.
+// Deleting the row nearest a query must not shrink an unfiltered result
+// — the delete-then-kNN underflow, end to end through the WAL pipeline.
+//  - one superfile here: the underflow bites *within* a superfile (a
+//    multi-superfile merge backfills from other shards and hides it —
+//    that case is the next test). A single shard also makes a hit's
+//    `local_doc_id` its unambiguous row index.
+//  - tombstone the query's nearest row via `run_tombstone_phase`.
+//  - `k=1` must return the next-nearest *live* row, never empty.
+// Pre-fix the filter ran on the already-truncated top-k with no
+// backfill, so a deleted row in the top-k just vanished.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "vector reader synthetic-batch issue orthogonal to the filter hook"]
 async fn vector_query_excludes_tombstoned_row() {
     use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
@@ -264,6 +274,15 @@ async fn vector_query_excludes_tombstoned_row() {
             .build()
             .expect("rayon"),
     );
+    // Single-thread writer pool → one superfile (the why is in the test
+    // note above). Distinct from `worker_threads = 2`, which is the tokio
+    // runtime the WAL tombstone phase needs — not a writer pool.
+    let writer_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(RAYON_POOL_THREADS)
+            .build()
+            .expect("rayon writer"),
+    );
     let tk: Arc<dyn Tokenizer> = default_tokenizer();
     let opts = SupertableOptions::new(
         schema_with_vec(),
@@ -275,6 +294,7 @@ async fn vector_query_excludes_tombstoned_row() {
     )
     .expect("opts")
     .with_reader_pool(pool)
+    .with_writer_pool(writer_pool)
     .with_storage(Arc::clone(&storage));
 
     let st = Supertable::create(opts).expect("create");
@@ -317,9 +337,29 @@ async fn vector_query_excludes_tombstoned_row() {
         .await
         .expect("tombstone phase");
 
-    // Query close to the origin. The tombstoned row (local doc_id
-    // 0) must not appear in the result list.
-    let q = [0.0f32; DIM];
+    // Query is the lane-0 unit vector — row 0 (now tombstoned) was its
+    // exact nearest, row 1 (lane-0, lightly perturbed) is the nearest
+    // live neighbour.
+    let mut q = [0.0f32; DIM];
+    q[0] = 1.0;
+
+    // k=1 is the underflow repro: the single nearest is the deleted row,
+    // so a no-backfill filter returns empty. It must return row 1.
+    let top1 = st
+        .reader()
+        .vector_hits("embedding", &q, 1, VectorSearchOptions::new(), None)
+        .expect("vector k=1");
+    assert_eq!(
+        top1.len(),
+        1,
+        "k=1 underflowed after deleting the nearest row"
+    );
+    assert_eq!(
+        top1[0].local_doc_id, 1,
+        "k=1 must return the nearest live row, not the tombstoned one"
+    );
+
+    // A wider k must never surface the tombstoned row either.
     let hits = st
         .reader()
         .vector_hits(
@@ -335,6 +375,170 @@ async fn vector_query_excludes_tombstoned_row() {
         assert_ne!(
             hit.local_doc_id, 0,
             "the tombstoned row (local doc_id 0) must not appear"
+        );
+    }
+}
+
+// The realistic-write-path counterpart to the single-superfile test
+// above. The default writer pool shards a commit across many superfiles,
+// where the underflow is normally hidden — the global merge backfills a
+// deleted near-row from another shard. This pins that backfill end to
+// end through the public `vector_search` surface:
+//  - delete the k nearest rows to a query (spread across superfiles),
+//  - re-query top-k: it must still return k rows (the next-nearest live
+//    ones), and none of the deleted rows.
+// Identity is the unique `title` / stable `_id`, never the per-shard
+// `local_doc_id` — so the assertion is well-defined across superfiles.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vector_query_backfills_across_superfiles_after_deletes() {
+    const DIM: usize = 16;
+    const N: usize = 90;
+    const COMMITS: usize = 3;
+    // Delete the k nearest, then ask for k again — every returned row must
+    // be a live backfill.
+    const K: usize = 10;
+
+    // Deterministic spread vectors: an integer hash mixed to [0, 1), so
+    // distances are distinct (no one-hot ties) and the nearest set is
+    // well-defined.
+    fn pseudo(i: usize, d: usize) -> f32 {
+        let mut h = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(
+            (d as u64)
+                .wrapping_add(1)
+                .wrapping_mul(0x2545_F491_4F6C_DD1D),
+        );
+        h ^= h >> 33;
+        ((h >> 40) & 0xFFFF) as f32 / 65536.0
+    }
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new(
+                "embedding",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, false)),
+                    DIM as i32,
+                ),
+                false,
+            ),
+        ]))
+    }
+
+    fn batch(start: usize, end: usize) -> RecordBatch {
+        let titles: ArrayRef = Arc::new(LargeStringArray::from(
+            (start..end).map(|i| format!("doc {i}")).collect::<Vec<_>>(),
+        ));
+        let mut flat = Vec::<f32>::with_capacity((end - start) * DIM);
+        for i in start..end {
+            for d in 0..DIM {
+                flat.push(pseudo(i, d));
+            }
+        }
+        let emb: ArrayRef = Arc::new(
+            FixedSizeListArray::try_new(
+                Arc::new(Field::new("item", DataType::Float32, false)),
+                DIM as i32,
+                Arc::new(Float32Array::from(flat)),
+                None,
+            )
+            .expect("FixedSizeList"),
+        );
+        RecordBatch::try_new(schema(), vec![titles, emb]).expect("batch")
+    }
+
+    // Read the `title` column out of a result batch set.
+    fn titles_of(batches: &[RecordBatch]) -> Vec<String> {
+        batches
+            .iter()
+            .flat_map(|b| {
+                let c = b
+                    .column_by_name("title")
+                    .expect("title column")
+                    .as_any()
+                    .downcast_ref::<LargeStringArray>()
+                    .expect("LargeStringArray");
+                (0..c.len())
+                    .map(|i| c.value(i).to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let tk: Arc<dyn Tokenizer> = default_tokenizer();
+    // Default writer pool — the realistic path that shards the commit.
+    let st = Supertable::create(
+        SupertableOptions::new(
+            schema(),
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![default_vector_config("embedding", VECTOR_ROT_SEED)],
+            Some(tk),
+        )
+        .expect("opts")
+        .with_storage(Arc::clone(&storage)),
+    )
+    .expect("create");
+
+    // Commit in chunks so the table spans several superfiles.
+    let chunk = N.div_ceil(COMMITS);
+    {
+        let mut w = st.writer().expect("writer");
+        for c in 0..COMMITS {
+            let (start, end) = (c * chunk, ((c + 1) * chunk).min(N));
+            if start >= end {
+                break;
+            }
+            w.append(&batch(start, end)).expect("append");
+            w.commit().expect("commit");
+        }
+    }
+    assert!(
+        st.reader().n_superfiles() > 1,
+        "fixture must span multiple superfiles to exercise the merge backfill"
+    );
+
+    // Project `title` so the result is identified by its stable, unique
+    // title rather than a per-superfile `local_doc_id`.
+    let q: Vec<f32> = (0..DIM).map(|d| pseudo(0, d)).collect();
+    let opts = VectorSearchOptions::new().with_nprobe(DIM);
+    let proj = ["title", "score"];
+
+    let before = st
+        .reader()
+        .vector_search("embedding", &q, K, opts, None, Some(&proj))
+        .expect("search before");
+    let deleted: Vec<String> = titles_of(&before);
+    assert_eq!(deleted.len(), K, "expected k nearest before delete");
+
+    // Delete exactly those k nearest rows.
+    let preds: Vec<Expr> = deleted.iter().map(|t| lit(t.as_str())).collect();
+    let stats = st
+        .delete(col("title").in_list(preds, false))
+        .expect("delete");
+    assert_eq!(stats.n_tombstoned(), K, "all k nearest must tombstone");
+
+    // Re-query: the merge must backfill k live rows from the surviving
+    // ranks across superfiles, none of them the deleted ones.
+    let after = st
+        .reader()
+        .vector_search("embedding", &q, K, opts, None, Some(&proj))
+        .expect("search after");
+    let survivors = titles_of(&after);
+    assert_eq!(
+        survivors.len(),
+        K,
+        "result underflowed instead of backfilling past tombstones"
+    );
+    let deleted_set: std::collections::HashSet<&String> = deleted.iter().collect();
+    for title in &survivors {
+        assert!(
+            !deleted_set.contains(title),
+            "a tombstoned row ({title}) resurfaced after delete"
         );
     }
 }


### PR DESCRIPTION
### What does this PR do?
Fixes #259. Unfiltered vector_search no longer under-returns after deletes. For e.g. k=1 returns the nearest live row instead of an empty result, and any k returns the true k-nearest among live rows.

### Why do we need this change?
A delete only writes a tombstone; the row stays in the superfile until compaction. The unfiltered fan-out removed tombstones "after" each superfile's kernel ranked all rows (tombstoned included) and truncated to its top-k, so the final result has fewer than k responses, i.e,  giving incomplete results.
  
However, the filtered path was already immune: its allow-set has tombstones subtracted (subtract_tombstones) and is applied inside the coarse shortlist. The unfiltered path had no equivalent. Surfaced via LangChain's VectorStore delete-compliance tests.

### How do we do this change?
By excluding tombstones before ranking, not after.

For each superfile we resolve its tombstone set once and hand it to the scorer as a **deny set**. A deleted row is skipped as candidates are scanned; before it can take a slot in the candidate heap. So, the top-k is filled purely from live rows. No over-fetch, no post-rank trimming, no backfill to get wrong.

## Performance

Two infino strategies measured head-to-head across `k` × delete-ratio (6K docs, 2 superfiles, dim 1024). `deny` is what this PR ships; `over-fetch` is the alternative (see Notes).

  | k | delete ratio | deny (this PR) | over-fetch |
  |---|---|---|---|
  | 1 | 0% | `15.8 ms` | `15.9 ms` |
  | 1 | 5% | `15.9 ms` | `21.4 ms` |
  | 1 | 50% | `13.2 ms` | `20.6 ms` |
  | 10 | 50% | `13.1 ms` | `20.4 ms` |
  | 100 | 50% | `13.4 ms` | `20.7 ms` |
 
  - No regression with no deletes: all paths tie (deny = None short-circuits the hot path).
  - Faster under deletes:  excluding tombstones from the coarse heap shrinks the rerank survivor pool, so there's less full-precision work; deny gets faster as deletes grow, ~1.3–1.6x ahead of over-fetch at 50%.
  - Cold object-store cost is strategy-neutral: nprobe is fixed, so all paths issue the same range GETs (123–124 GETs, ~46 MiB, within ~1%); the rerank vectors ride in those same per-cluster block fetches.


### Notes
- Over-fetch (the alternative): fetch k + tombstone_count then drop post-rank. Correct, but rerank width grows with delete volume per superfile, so it carries the warm-latency / RSS regression seen above and on bench, with no compensating cold-cost saving. Deny is exact (no margin to tune) and cheaper, so this PR supersedes that approach.
- Recall is unchanged by construction: deny only removes tombstoned rows from the candidate set; live-row ranking is identical.