### PR TITLE
docs: show superfiles read as plain Parquet (eg: DuckDB/pyarrow)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ doc:
 python-test:
 	python3 -m venv infino-python/.venv
 	infino-python/.venv/bin/pip install -q --upgrade pip
-	infino-python/.venv/bin/pip install -q maturin pytest pyarrow pandas
+	infino-python/.venv/bin/pip install -q maturin pytest pyarrow pandas duckdb
 	VIRTUAL_ENV=$(CURDIR)/infino-python/.venv infino-python/.venv/bin/maturin develop --locked -m infino-python/Cargo.toml
 	infino-python/.venv/bin/python -m pytest infino-python/tests/ -v
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 - **Speed per dollar** — infino optimizes for speed per dollar, making tradeoffs to achieve object-storage economics at search engine speeds. On a 1-million-document index, warm BM25 queries return in the microsecond range — see [benchmarks](benches/README.md).
 - **Multi-modal queries** — keyword (BM25), vector, and SQL queries over the same rows, offering flexible query paths for agents.
-- **Object-storage-native** — data lives on S3, Azure, or local disk, with snapshot-isolated reads and atomic commits. 
+- **Object-storage-native** — data lives on S3, Azure, or local disk, with snapshot-isolated reads and atomic commits.
 - **Open format, no lock in** — text and numeric data is stored as spec-compliant Parquet, so anything that reads Parquet can read your data.
 
 ## Contents
@@ -210,6 +210,59 @@ Bindings live in [`infino-python/`](infino-python/) (PyO3 + maturin) and
 The Node API is synchronous — objects in, plain records out, with `_id`
 returned as a JavaScript `bigint`.
 
+### Open format: read it as Parquet
+
+A superfile *is* a spec-compliant Parquet file. The embedded BM25 and
+vector index regions are spliced in ahead of a standard Parquet footer
+and pointed at by `inf.*` key/value metadata keys, which any conformant
+Parquet reader ignores. So the columnar body opens in DuckDB, pandas,
+pyarrow, or DataFusion with **no infino in the read path** and no export
+step:
+
+```python
+import infino, pyarrow as pa, glob, duckdb
+
+db = infino.connect("./data")          # persist to disk (not "memory://")
+docs = db.create_table(
+    "docs",
+    pa.schema([
+        pa.field("source", pa.large_utf8(), nullable=False),
+        pa.field("body", pa.large_utf8(), nullable=False),
+    ]),
+    infino.IndexSpec().fts("body"),
+)
+docs.append([
+    {"source": "help-center", "body": "To cancel a subscription, open Settings then Billing."},
+    {"source": "help-center", "body": "Refunds return to the original payment method."},
+    {"source": "blog",        "body": "Enable dark mode under Settings then Appearance."},
+])
+
+# The superfiles are ordinary files on disk (one write can shard into
+# several, so read them as a set):
+files = glob.glob("data/**/*.sf.parquet", recursive=True)
+print(files[0])   # e.g. data/docs-18bc4051eb6a9468-0/data/seg-....sf.parquet
+
+# Read them with a third-party engine, no infino in this line:
+duckdb.sql("SELECT source, count(*) FROM read_parquet('data/**/*.sf.parquet') GROUP BY source").show()
+# ┌─────────────┬──────────────┐
+# │   source    │ count_star() │
+# ├─────────────┼──────────────┤
+# │ help-center │            2 │
+# │ blog        │            1 │
+# └─────────────┴──────────────┘
+```
+
+**Read-only openness.** Standard tools *read* a superfile's columns with
+no export step. Rewriting it through a generic Parquet writer (e.g.
+`pyarrow.parquet.write_table`) produces valid Parquet that has silently
+dropped the embedded BM25/vector indexes, so it's no longer a superfile.
+The compatibility is one-directional.
+
+The shortest end-to-end demo (write a corpus, run BM25 + vector +
+SQL/hybrid retrieval against it, then read the very same file back with
+DuckDB *and* pyarrow) is
+[`infino-python/examples/parquet_interop.py`](infino-python/examples/parquet_interop.py).
+
 ## Architecture
 
 Three docs cover the design, from the high-level tour down to the
@@ -367,7 +420,7 @@ shared layer.
 
 Retrieval composes the same way. The ranked `bm25_search` /
 `vector_search` / `hybrid_search` and the unranked `token_match` /
-`exact_match` are table functions so a candidate set is the 
+`exact_match` are table functions so a candidate set is the
 *first stage of a plan* rather than its result:
 
 ```sql

--- a/infino-python/examples/parquet_interop.py
+++ b/infino-python/examples/parquet_interop.py
@@ -1,0 +1,123 @@
+# Open-format proof: a superfile is a spec-compliant Parquet file.
+#
+# Shortest end-to-end demo for "anything that reads Parquet can read your data":
+#
+#   1. write a small corpus with infino, persisted to a local directory;
+#   2. run BM25, vector, and SQL/hybrid retrieval against that same table;
+#   3. locate the produced superfile on disk;
+#   4. read that file back with DuckDB *and* pyarrow, no infino in the
+#      read path, no export step.
+#
+# The embedded BM25/vector index regions live ahead of a standard Parquet
+# footer and are referenced by `inf.*` key/value metadata, which a
+# conformant Parquet reader simply ignores.
+#
+# Run:  pip install infino pyarrow duckdb pandas && python parquet_interop.py
+
+import glob
+import shutil
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import infino
+
+# Where the table is persisted. A real directory on disk so there is an
+# actual file to open with third-party tools afterwards. Cleaned first so
+# re-runs start from an empty catalog.
+DATA_DIR = "./parquet_interop_data"
+
+# 16-dim one-hot "embeddings" by topic so the demo runs with no model:
+#   0 = billing, 1 = appearance. Real embeddings are dense and far larger.
+DIM = 16
+
+
+def embed(topic: int) -> list[float]:
+    v = [0.0] * DIM
+    v[topic] = 1.0
+    return v
+
+
+def main() -> None:
+    shutil.rmtree(DATA_DIR, ignore_errors=True)
+
+    # 1. Write a corpus with infino, indexed for BM25 + vector.
+    db = infino.connect(DATA_DIR)
+    schema = pa.schema([
+        pa.field("source", pa.large_utf8(), nullable=False),
+        pa.field("body", pa.large_utf8(), nullable=False),
+        pa.field("embedding", pa.list_(pa.float32(), DIM), nullable=False),
+    ])
+    docs = db.create_table(
+        "docs",
+        schema,
+        infino.IndexSpec().fts("body").vector("embedding", DIM, 1, "cosine"),
+    )
+    docs.append([
+        {"source": "help-center", "body": "To cancel a subscription, open Settings then Billing.", "embedding": embed(0)},
+        {"source": "help-center", "body": "Refunds return to the original payment method.",         "embedding": embed(0)},
+        {"source": "blog",        "body": "Enable dark mode under Settings then Appearance.",        "embedding": embed(1)},
+    ])
+
+    # 2. Retrieve against the same table: BM25, vector, and a hybrid SQL
+    #    query that fuses both rankings (reciprocal-rank fusion).
+    print("== infino retrieval ==")
+    bm25 = docs.bm25_search("body", "cancel subscription", 5, projection=["body"])
+    print(f"  BM25  'cancel subscription' -> {bm25.num_rows} hit(s): {bm25.column('body').to_pylist()}")
+
+    knn = docs.vector_search("embedding", embed(0), 5, projection=["body"])
+    print(f"  kNN   topic=billing         -> {knn.num_rows} hit(s)")
+
+    qvec = ",".join(str(x) for x in embed(0))
+    hybrid = db.query_sql(f"""
+        WITH lexical AS (
+            SELECT _id, ROW_NUMBER() OVER (ORDER BY score DESC) AS rank
+            FROM bm25_search('docs', 'body', 'cancel subscription', 50)
+        ),
+        semantic AS (
+            SELECT _id, ROW_NUMBER() OVER (ORDER BY score ASC) AS rank
+            FROM vector_search('docs', 'embedding', '{qvec}', 50)
+        )
+        SELECT COALESCE(l._id, s._id) AS id,
+               COALESCE(1.0/(60+l.rank), 0.0) + COALESCE(1.0/(60+s.rank), 0.0) AS relevance
+        FROM lexical l
+        FULL OUTER JOIN semantic s ON l._id = s._id
+        ORDER BY relevance DESC
+        LIMIT 5
+    """)
+    print(f"  hybrid (RRF over BM25+vector) -> {hybrid.num_rows} ranked row(s)")
+
+    # 3. Locate the superfiles on disk. They are ordinary files; the table
+    #    lives under a per-table directory and superfiles carry a
+    #    `.sf.parquet` suffix. A single write can shard into several
+    #    superfiles, so read them as a set.
+    glob_pat = f"{DATA_DIR}/**/*.sf.parquet"
+    files = sorted(glob.glob(glob_pat, recursive=True))
+    print(f"\n== on disk ({len(files)} superfile(s)) ==")
+    for f in files:
+        print(f"  {f}")
+
+    # 4a. Read them back with DuckDB, no infino in this path.
+    print("\n== DuckDB reads the same files ==")
+    duckdb.sql(
+        f"SELECT source, count(*) AS n FROM read_parquet('{glob_pat}') GROUP BY source ORDER BY source"
+    ).show()
+
+    # 4b. ...and with pyarrow/pandas, likewise no infino.
+    print("== pyarrow reads the same files ==")
+    table = pa.concat_tables([pq.read_table(f) for f in files])
+    counts = table.select(["source"]).to_pandas().groupby("source").size()
+    print(counts.to_string())
+
+    # The index regions are invisible to a standard reader; only the
+    # columnar body comes through. The vector column (`embedding`) is
+    # consumed into the embedded index, not stored as a Parquet column, so
+    # a standard reader sees `_id`, `source`, and `body`. The `inf.*` keys
+    # live in the file metadata but carry no columns.
+    print("\n== Parquet sees only the stored columns, indexes ignored ==")
+    print(f"  columns: {table.column_names}")
+
+
+if __name__ == "__main__":
+    main()

--- a/infino-python/examples/requirements.txt
+++ b/infino-python/examples/requirements.txt
@@ -2,6 +2,7 @@
 # Install with:  pip install -r requirements.txt
 infino
 pyarrow>=14
+duckdb>=1                  # read superfiles as plain Parquet (parquet_interop.py)
 sentence-transformers>=3   # local embeddings, no API key needed
 datasets>=2               # pulls the real public corpora from HuggingFace
 openai>=1.40              # optional: LLM answers (Azure AI Foundry or OpenAI)

--- a/infino-python/tests/test_parquet_interop.py
+++ b/infino-python/tests/test_parquet_interop.py
@@ -1,0 +1,129 @@
+"""Open-format proof, wired into CI.
+
+A superfile is a spec-compliant Parquet file: third-party readers
+(DuckDB, pyarrow) open its columnar body with no infino in the read
+path. This mirrors the README "Open format" snippet and the
+`examples/parquet_interop.py` demo.
+"""
+
+import glob
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import infino
+
+DIM = 16  # infino requires vector dim in [16, 4096]
+
+
+def _onehot(i: int) -> list[float]:
+    v = [0.0] * DIM
+    v[i] = 1.0
+    return v
+
+
+def _write_corpus(uri: str):
+    db = infino.connect(uri)
+    schema = pa.schema([
+        pa.field("source", pa.large_utf8(), nullable=False),
+        pa.field("body", pa.large_utf8(), nullable=False),
+        pa.field("embedding", pa.list_(pa.float32(), DIM), nullable=False),
+    ])
+    docs = db.create_table(
+        "docs",
+        schema,
+        infino.IndexSpec().fts("body").vector("embedding", DIM, 1, "cosine"),
+    )
+    docs.append([
+        {"source": "help-center", "body": "To cancel a subscription, open Settings then Billing.", "embedding": _onehot(0)},
+        {"source": "help-center", "body": "Refunds return to the original payment method.",         "embedding": _onehot(0)},
+        {"source": "blog",        "body": "Enable dark mode under Settings then Appearance.",        "embedding": _onehot(0)},
+    ])
+    return db, docs
+
+
+# Stored Parquet columns. The auto-injected `_id` and the user's scalar
+# columns are stored columnar; the vector column (`embedding`) is consumed
+# into the embedded index, not written as a Parquet column.
+STORED_COLUMNS = {"_id", "source", "body"}
+
+
+def _superfile_glob(uri: str) -> str:
+    # The catalog manifest (`_catalog/current`) and per-table state are not
+    # `.parquet`, so this matches only superfiles.
+    return f"{uri}/**/*.sf.parquet"
+
+
+def _superfile_paths(uri: str) -> list[str]:
+    # A single write can shard into several superfiles (the commit path
+    # builds shards in parallel), so the table is the union of all of them.
+    matches = sorted(glob.glob(_superfile_glob(uri), recursive=True))
+    assert matches, f"no superfile written under {uri}"
+    return matches
+
+
+def test_infino_retrieval_still_works(tmp_path):
+    # Sanity: the writer side (the thing being proven open) actually
+    # indexes BM25 + vector before we read it as plain Parquet.
+    _, docs = _write_corpus(str(tmp_path / "data"))
+    assert docs.bm25_search("body", "cancel subscription", 5).num_rows >= 1
+    assert docs.vector_search("embedding", _onehot(0), 5).num_rows >= 1
+
+
+def test_superfile_is_on_disk(tmp_path):
+    uri = str(tmp_path / "data")
+    _write_corpus(uri)
+    for path in _superfile_paths(uri):
+        assert path.endswith(".sf.parquet")
+
+
+def test_pyarrow_reads_superfile_as_parquet(tmp_path):
+    uri = str(tmp_path / "data")
+    _write_corpus(uri)
+    paths = _superfile_paths(uri)
+
+    # No infino in the read path: pyarrow's own Parquet reader, unioning
+    # the shards a single write produced.
+    table = pa.concat_tables([pq.read_table(p) for p in paths])
+    # Only the columnar body is visible; the embedded index regions and
+    # `inf.*` metadata keys are ignored by a standard reader.
+    assert set(table.column_names) == STORED_COLUMNS
+
+    counts = dict(
+        table.select(["source"]).to_pandas().groupby("source").size().items()
+    )
+    assert counts == {"help-center": 2, "blog": 1}
+
+
+def test_duckdb_reads_superfile_as_parquet(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    uri = str(tmp_path / "data")
+    _write_corpus(uri)
+
+    # The exact shape the README advertises: read_parquet over the glob +
+    # GROUP BY, no infino import in this query.
+    rows = duckdb.sql(
+        f"SELECT source, count(*) AS n FROM read_parquet('{_superfile_glob(uri)}') "
+        "GROUP BY source ORDER BY source"
+    ).fetchall()
+    assert dict(rows) == {"blog": 1, "help-center": 2}
+
+
+def test_round_trip_through_generic_writer_drops_indexes(tmp_path):
+    # The honest limit: rewriting a superfile through a generic Parquet
+    # writer yields valid Parquet that is no longer a superfile. We can't
+    # cheaply assert "indexes gone" from Python, but we can show the
+    # round-trip produces a plain file that re-opens with the same
+    # columns, i.e. the columnar body survives, which is all a generic
+    # writer preserves.
+    uri = str(tmp_path / "data")
+    _write_corpus(uri)
+    table = pa.concat_tables([pq.read_table(p) for p in _superfile_paths(uri)])
+
+    rewritten = tmp_path / "rewritten.parquet"
+    pq.write_table(table, rewritten)
+
+    reopened = pq.read_table(str(rewritten))
+    assert reopened.num_rows == 3
+    assert set(reopened.column_names) == STORED_COLUMNS


### PR DESCRIPTION
## What does this PR do?
  
Examples to showcase that "superfiles are spec-compliant Parquet, so anything that reads Parquet can read your data". A short snippet writes a corpus, locates the file on disk, and reads it back with DuckDB and pyarrow (no infino in the read path) returning a real GROUP BY result.

It also notes the honest limit: the openness is read-only. Rewriting a superfile through a generic Parquet writer drops the embedded indexes, so it's no longer a superfile.

Ships as a runnable example (BM25 + vector + SQL/hybrid, then read as Parquet) and a test in the python-test lane too.

Closes #144.