### PR TITLE
Add Mintlify documentation site configuration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Infino",
+  "colors": {
+    "primary": "#5E6AD2"
+  },
+  "navigation": {
+    "groups": [
+      {
+        "group": "Get started",
+        "pages": ["docs/index"]
+      },
+      {
+        "group": "Concepts",
+        "pages": [
+          "docs/concepts/object-storage-native-retrieval",
+          "docs/concepts/hybrid-search",
+          "docs/concepts/retrieval-for-agents",
+          "docs/concepts/embedded-retrieval"
+        ]
+      },
+      {
+        "group": "Architecture",
+        "pages": [
+          "docs/architecture/overview",
+          "docs/architecture/superfile",
+          "docs/architecture/supertable"
+        ]
+      },
+      {
+        "group": "Reference",
+        "pages": ["docs/faq", "docs/tradeoffs", "docs/versioning"]
+      }
+    ]
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "GitHub",
+        "href": "https://github.com/infino-ai/infino"
+      }
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/infino-ai/infino"
+    }
+  }
+}

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,21 @@
+---
+title: "Infino"
+description: "The embedded retrieval engine for AI agents — full-text, vector, and hybrid search over Parquet on object storage, in-process."
+---
+
+Infino is an embedded retrieval engine. It runs SQL, full-text (BM25), vector, and
+hybrid search over a single copy of your data stored as Apache Parquet on object
+storage — in-process, with no separate search server or vector database to operate.
+
+## Start here
+
+- [Object-storage-native retrieval](/docs/concepts/object-storage-native-retrieval) — search directly on Parquet on object storage.
+- [Hybrid search](/docs/concepts/hybrid-search) — keyword + vector + SQL in one engine, over one copy of the data.
+- [Retrieval for agents](/docs/concepts/retrieval-for-agents) — hundreds of retrievals per task, where latency and cost compound.
+- [Embedded retrieval](/docs/concepts/embedded-retrieval) — in-process, no server.
+
+## Reference
+
+- [FAQ](/docs/faq)
+- [Tradeoffs](/docs/tradeoffs)
+- [Versioning](/docs/versioning)


### PR DESCRIPTION
Adds a Mintlify config so the existing `docs/` content can be published as a docs site.

- `docs.json` — site configuration; maps the current concept, architecture, and reference pages into navigation groups.
- `docs/index.mdx` — landing page (the config's first page).

Notes:
- The `primary` brand color in `docs.json` is a placeholder and can be swapped for the real brand hex.
- Page paths are prefixed `docs/` because `docs.json` sits at the repo root (Mintlify resolves paths relative to the config file).