### PR TITLE
ci: run benches only when perf-relevant code changes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,10 +8,30 @@ name: Benchmark
 on:
   push:
     branches: [main]
+    # Only refresh the baseline when perf-relevant code lands. Doc/example/
+    # binding-only merges can't move performance, so skip the VM spin-up.
+    # (GitHub Actions ignores YAML anchors, so the list is repeated below.)
+    paths:
+      - "src/**"
+      - "benches/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/bench.yml"
+      - ".github/workflows/supertable-bench-azure.yml"
   pull_request_target:
     branches: [main]
     # Code/state changes only — never on label or comment activity.
     types: [opened, synchronize, reopened]
+    # Same allowlist: skip the 4-VM bench on doc/example/binding-only PRs.
+    paths:
+      - "src/**"
+      - "benches/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/bench.yml"
+      - ".github/workflows/supertable-bench-azure.yml"
 
 jobs:
   bench:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - "src/**"
       - "benches/**"
+      - "build.rs"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
@@ -27,6 +28,7 @@ on:
     paths:
       - "src/**"
       - "benches/**"
+      - "build.rs"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"


### PR DESCRIPTION
The benchmark workflow fires four Azure bench VMs (1M docs each) on every PR, even when the diff is docs, examples, or language bindings — none of which can move engine performance.

Gate `bench.yml` on a `paths` allowlist for both the PR and push triggers:

- `src/**`, `benches/**`
- `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`
- `bench.yml`, `supertable-bench-azure.yml`

Anything else (docs, examples, `infino-python`, `infino-node`, `*.md`) no longer triggers the bench.

The bench stays non-required, so a skipped run never blocks a merge — a trigger-level `paths` allowlist is enough; no gate job needed. GitHub Actions ignores YAML anchors, so the list is repeated for each trigger.
