### PR TITLE
fts: faster multi-term OR count via block-at-a-time disjunction cardinality

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -103,6 +103,78 @@ pub mod fts {
     /// Nanoseconds per second, for time-cell formatting.
     const NS_PER_SEC: f64 = 1e9;
 
+    /// Twenty mid-rank common terms (`term00050`..`term00069`) — a dense
+    /// disjunction whose match set covers a large fraction of the corpus.
+    /// Exercises the large-union count path, where a naive per-doc k-way
+    /// merge degrades super-linearly in the term count.
+    const TWENTY_COMMON_TERMS: &[&str] = &[
+        "term00050",
+        "term00051",
+        "term00052",
+        "term00053",
+        "term00054",
+        "term00055",
+        "term00056",
+        "term00057",
+        "term00058",
+        "term00059",
+        "term00060",
+        "term00061",
+        "term00062",
+        "term00063",
+        "term00064",
+        "term00065",
+        "term00066",
+        "term00067",
+        "term00068",
+        "term00069",
+    ];
+
+    /// Forty mid-rank common terms (`term00050`..`term00089`) — the extreme
+    /// large-union shape; the count path's worst case at this scale.
+    const FORTY_COMMON_TERMS: &[&str] = &[
+        "term00050",
+        "term00051",
+        "term00052",
+        "term00053",
+        "term00054",
+        "term00055",
+        "term00056",
+        "term00057",
+        "term00058",
+        "term00059",
+        "term00060",
+        "term00061",
+        "term00062",
+        "term00063",
+        "term00064",
+        "term00065",
+        "term00066",
+        "term00067",
+        "term00068",
+        "term00069",
+        "term00070",
+        "term00071",
+        "term00072",
+        "term00073",
+        "term00074",
+        "term00075",
+        "term00076",
+        "term00077",
+        "term00078",
+        "term00079",
+        "term00080",
+        "term00081",
+        "term00082",
+        "term00083",
+        "term00084",
+        "term00085",
+        "term00086",
+        "term00087",
+        "term00088",
+        "term00089",
+    ];
+
     /// The full FTS query battery — single source of truth for both
     /// tiers' warm + cold search and the cross-engine recall grading.
     pub const FTS_BATTERY: &[FtsQuery] = &[
@@ -164,6 +236,16 @@ pub mod fts {
             mode: BoolMode::Or,
         },
         FtsQuery {
+            name: "twenty_term_or",
+            terms: TWENTY_COMMON_TERMS,
+            mode: BoolMode::Or,
+        },
+        FtsQuery {
+            name: "forty_term_or",
+            terms: FORTY_COMMON_TERMS,
+            mode: BoolMode::Or,
+        },
+        FtsQuery {
             name: "two_term_and",
             terms: &["term00001", "term00050"],
             mode: BoolMode::And,
@@ -217,6 +299,8 @@ pub mod fts {
         "three_similar_or",
         "five_term_or",
         "ten_term_or",
+        "twenty_term_or",
+        "forty_term_or",
     ];
 
     /// AND query names, in table order.

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -422,18 +422,20 @@ pub mod fts {
 
         fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
             crate::tiers::block_on(async {
-                // Single term: df is the exact match count, read O(1)
-                // from the dictionary header. Multi-term: the union /
-                // intersection cardinality from `token_match`.
+                // Single term: df is the exact match count, read O(1) from
+                // the dictionary header. Multi-term: the dedicated count
+                // primitive (union/intersection cardinality, no scoring,
+                // no id materialization) — the same path the supertable
+                // count uses, not `token_match().len()` (which would
+                // materialize the id list through the slower merge walk).
                 if terms.len() == 1 {
                     self.term_df(column, terms[0])
                         .await
                         .expect("superfile term_df")
                 } else {
-                    self.token_match(column, terms, mode)
+                    self.token_match_count(column, terms, mode)
                         .await
-                        .expect("superfile token_match")
-                        .len() as u64
+                        .expect("superfile token_match_count")
                 }
             })
         }

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -161,9 +161,26 @@ pub mod fts {
 
     /// Top-k for every search.
     pub const K: usize = 10;
-    /// Large top-k, run as a second warm pass to gate how query latency
-    /// scales with k — the heap/collector cost the small-k tables hide.
+    /// Large top-k, timed query-only for a few representative shapes to
+    /// gate how collection cost scales with k — the cost the small-k
+    /// table hides. Query phase only over [`K_LARGE_SHAPE_NAMES`]: timing
+    /// the whole battery's *fetch* phase at this k would dominate the
+    /// bench budget without adding large-k signal.
     pub const K_LARGE: usize = 1000;
+    /// Representative shapes for the large-k gate: a common term, a small
+    /// and a large OR, and an AND — enough to see collection cost track k
+    /// across query types without timing all 15 shapes.
+    const K_LARGE_SHAPE_NAMES: &[&str] = &[
+        "single_common",
+        "two_term_or",
+        "ten_term_or",
+        "two_term_and",
+    ];
+    /// Large-union shapes that exist only to stress the multi-term count
+    /// path. Excluded from the cold object-store search tier, where their
+    /// near-full-corpus unions cost ~1 s per fresh-cache iteration for no
+    /// added count signal (the count battery runs warm).
+    const LARGE_UNION_NAMES: &[&str] = &["twenty_term_or", "forty_term_or"];
     /// Timed warm-search repetitions per query (after one warmup). `run_fts`
     /// reports the p50 over these.
     pub const WARM_ITERS: usize = 50;
@@ -487,33 +504,47 @@ pub mod fts {
                 );
             }
             if phases.warm {
-                eprintln!(
-                    "[superfile_fts] top-{K_LARGE} battery: {} queries × {WARM_ITERS} timed iters...",
-                    FTS_BATTERY.len(),
-                );
-                let warm_large = exec_fts::measure_warm(
-                    index.reader(),
-                    FTS_BATTERY,
-                    FTS_COLUMN,
-                    K_LARGE,
-                    WARM_ITERS,
-                    "superfile_fts",
-                );
-                exec_fts::emit_search(
-                    &mut report,
-                    "bench/fts/superfile/search-large-k",
-                    format!(
-                        "Superfile FTS — search top-{K_LARGE}, single-superfile / in-memory ({} docs)",
+                // Large-k gate: query-phase p50 at k = K_LARGE for a few
+                // representative shapes, to surface top-k collection cost
+                // that the top-K table hides. Query phase only over a
+                // curated subset — the full battery's fetch phase at this
+                // k dominates the bench budget without adding signal.
+                let reader = index.reader();
+                let large_k: Vec<(&'static str, Duration)> = FTS_BATTERY
+                    .iter()
+                    .filter(|q| K_LARGE_SHAPE_NAMES.contains(&q.name))
+                    .map(|q| {
+                        let query = q.terms.join(" ");
+                        let mode = exec_fts::to_infino_mode(q.mode);
+                        (
+                            q.name,
+                            hot_p50(|| reader.bm25_rows(FTS_COLUMN, &query, K_LARGE, mode)),
+                        )
+                    })
+                    .collect();
+                report.emit(&Section {
+                    anchor: "bench/fts/superfile/search-large-k".into(),
+                    title: format!(
+                        "Superfile FTS — search top-{K_LARGE} (query phase), single-superfile / in-memory ({} docs)",
                         fmt_count(n_docs)
                     ),
-                    &format!(
-                        "Identical warm path to the top-{K} table but with k = {K_LARGE}, to gate how \
-                         top-k collection cost scales with k. Δ is vs the previous run."
+                    note: format!(
+                        "Query-phase p50 at k = {K_LARGE} for representative shapes — gates how \
+                         top-k collection cost scales with k vs the top-{K} table. Δ is vs the \
+                         previous run."
                     ),
-                    Some(&warm_large),
-                    None,
-                    None,
-                );
+                    blocks: vec![Block {
+                        subtitle: format!("top-{K_LARGE} queries"),
+                        headers: vec!["Query".into(), "warm (query)".into()],
+                        rows: large_k
+                            .iter()
+                            .map(|(name, d)| {
+                                let ns = d.as_secs_f64() * 1e9;
+                                vec![text(*name), metric(ns, fmt_time(ns), Better::Lower)]
+                            })
+                            .collect(),
+                    }],
+                });
             }
             if let Some(rows) = negations {
                 report.emit(&Section {
@@ -681,15 +712,24 @@ pub mod fts {
         let committed = tiers::block_on(tiers::commit_superfile(&Bytes::copy_from_slice(
             index.bytes(),
         )));
+        // Skip the large-union shapes in the cold tier: their
+        // near-full-corpus unions cost ~1 s per fresh-cache iteration
+        // (object-store reads, no warm cache) and add no cold signal the
+        // smaller shapes don't — they exist to stress the warm count path.
+        let cold_battery: Vec<_> = FTS_BATTERY
+            .iter()
+            .copied()
+            .filter(|q| !LARGE_UNION_NAMES.contains(&q.name))
+            .collect();
         eprintln!(
             "[superfile_fts] cold search: {} queries × {COLD_ITERS} fresh-cache iters...",
-            FTS_BATTERY.len(),
+            cold_battery.len(),
         );
         let storage = Arc::clone(&committed.storage);
         let uri = committed.uri;
         exec_fts::measure_cold(
             || SuperfileColdGuard::open(Arc::clone(&storage), uri, committed.object_size),
-            FTS_BATTERY,
+            &cold_battery,
             FTS_COLUMN,
             K,
             COLD_ITERS,

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -161,6 +161,9 @@ pub mod fts {
 
     /// Top-k for every search.
     pub const K: usize = 10;
+    /// Large top-k, run as a second warm pass to gate how query latency
+    /// scales with k — the heap/collector cost the small-k tables hide.
+    pub const K_LARGE: usize = 1000;
     /// Timed warm-search repetitions per query (after one warmup). `run_fts`
     /// reports the p50 over these.
     pub const WARM_ITERS: usize = 50;
@@ -481,6 +484,35 @@ pub mod fts {
                     warm.as_deref(),
                     None,
                     probes.as_deref(),
+                );
+            }
+            if phases.warm {
+                eprintln!(
+                    "[superfile_fts] top-{K_LARGE} battery: {} queries × {WARM_ITERS} timed iters...",
+                    FTS_BATTERY.len(),
+                );
+                let warm_large = exec_fts::measure_warm(
+                    index.reader(),
+                    FTS_BATTERY,
+                    FTS_COLUMN,
+                    K_LARGE,
+                    WARM_ITERS,
+                    "superfile_fts",
+                );
+                exec_fts::emit_search(
+                    &mut report,
+                    "bench/fts/superfile/search-large-k",
+                    format!(
+                        "Superfile FTS — search top-{K_LARGE}, single-superfile / in-memory ({} docs)",
+                        fmt_count(n_docs)
+                    ),
+                    &format!(
+                        "Identical warm path to the top-{K} table but with k = {K_LARGE}, to gate how \
+                         top-k collection cost scales with k. Δ is vs the previous run."
+                    ),
+                    Some(&warm_large),
+                    None,
+                    None,
                 );
             }
             if let Some(rows) = negations {

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -525,6 +525,19 @@ pub mod fts {
         fts::{FTS_BATTERY, FtsRead},
     };
 
+    /// Large top-k for the serving-scale query-phase scaling gate —
+    /// mirrors the superfile tier. Query phase only, over a small subset
+    /// (the full battery's fetch at this k would dominate the budget).
+    const K_LARGE: usize = 1000;
+    /// Representative shapes for the large-k gate: a common term, a small
+    /// and a large OR, and an AND.
+    const K_LARGE_SHAPE_NAMES: &[&str] = &[
+        "single_common",
+        "two_term_or",
+        "ten_term_or",
+        "two_term_and",
+    ];
+
     /// Build an FTS-only supertable, then measure warm and cold BM25
     /// reads through the shared FTS executor (same code superfile runs).
     pub fn run(phases: Phases) {
@@ -563,9 +576,9 @@ pub mod fts {
             drop(cache_dir);
         }
 
-        let (warm, counts) = match phases.warm.then(|| measure_warm(&built)) {
-            Some((w, c)) => (Some(w), Some(c)),
-            None => (None, None),
+        let (warm, counts, large_k) = match phases.warm.then(|| measure_warm(&built)) {
+            Some((w, c, l)) => (Some(w), Some(c), Some(l)),
+            None => (None, None, None),
         };
         let cold = phases.cold.then(|| measure_cold(&built));
         if phases.warm || phases.cold {
@@ -583,6 +596,32 @@ pub mod fts {
                 cold.as_ref(),
                 None,
             );
+        }
+
+        if let Some(large_k) = &large_k {
+            report.emit(&Section {
+                anchor: "bench/fts/supertable/search-large-k".into(),
+                title: format!(
+                    "Supertable FTS — search top-{K_LARGE} (query phase), multi-superfile / object-store ({} docs)",
+                    fmt_count(n_docs)
+                ),
+                note: format!(
+                    "Query-phase p50 at k = {K_LARGE} for representative shapes — gates how top-k \
+                     collection cost scales with k vs the top-{TOP_K} table at serving scale. Δ is \
+                     vs the previous run."
+                ),
+                blocks: vec![Block {
+                    subtitle: format!("top-{K_LARGE} queries"),
+                    headers: vec!["Query".into(), "warm (query)".into()],
+                    rows: large_k
+                        .iter()
+                        .map(|(name, d)| {
+                            let ns = d.as_secs_f64() * 1e9;
+                            vec![text(*name), metric(ns, fmt_time(ns), Better::Lower)]
+                        })
+                        .collect(),
+                }],
+            });
         }
 
         if let Some(counts) = &counts {
@@ -653,7 +692,11 @@ pub mod fts {
 
     fn measure_warm(
         built: &supertable::IngestResult,
-    ) -> (Vec<exec_fts::FtsQueryStat>, Vec<exec_fts::CountStat>) {
+    ) -> (
+        Vec<exec_fts::FtsQueryStat>,
+        Vec<exec_fts::CountStat>,
+        Vec<(&'static str, Duration)>,
+    ) {
         eprintln!(
             "[supertable_fts] warm: opening shared consumer, prewarm + wait_until_warm once..."
         );
@@ -706,9 +749,31 @@ pub mod fts {
             "supertable_fts",
         );
         crate::rss::log_rss_breakdown("supertable_fts after count battery");
+        // Large-k gate (query phase only, representative subset): surfaces
+        // top-k collection cost at serving scale that the top-K table hides.
+        eprintln!(
+            "[supertable_fts] large-k: timing top-{K_LARGE} query phase × {WARM_ITERS} iters..."
+        );
+        let large_k: Vec<(&'static str, Duration)> = FTS_BATTERY
+            .iter()
+            .filter(|q| K_LARGE_SHAPE_NAMES.contains(&q.name))
+            .map(|q| {
+                let query = q.terms.join(" ");
+                let mode = exec_fts::to_infino_mode(q.mode);
+                let _ = reader.bm25_rows(supertable::TEXT_COLUMN, &query, K_LARGE, mode);
+                let mut samples = Vec::with_capacity(WARM_ITERS);
+                for _ in 0..WARM_ITERS {
+                    let t = Instant::now();
+                    let n = reader.bm25_rows(supertable::TEXT_COLUMN, &query, K_LARGE, mode);
+                    samples.push(t.elapsed());
+                    std::hint::black_box(n);
+                }
+                (q.name, crate::executors::p50(&mut samples))
+            })
+            .collect();
         drop(consumer);
         drop(cache_dir);
-        (out, counts)
+        (out, counts, large_k)
     }
 
     fn measure_cold(

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -2925,11 +2925,61 @@ fn or_merge_unranked(cursors: Vec<TermCursor>) -> Vec<u32> {
     out
 }
 
-/// The union's cardinality ([`or_walk_unranked`] counted) — no `Vec`
-/// materialized, for the count path.
-fn or_count_unranked(cursors: Vec<TermCursor>) -> u64 {
+/// The union's cardinality via a block-at-a-time disjunction count.
+/// Walks the cursors one fixed doc-id window at a time, marks each
+/// matching doc in a small presence bitset, and accumulates the
+/// per-window popcount. Windows partition the doc-id space disjointly,
+/// so a doc matching several terms is counted once and no doc spans two
+/// windows — the tally equals the distinct-doc union size.
+///
+/// This replaces the per-doc k-way merge the count path used to share
+/// with [`or_merge_unranked`]: that walk rescanned every cursor for each
+/// matched doc (cost ∝ union size × term count), which degraded
+/// super-linearly on long common-term unions. The windowed walk advances
+/// each cursor once per doc and scans the cursor set only once per
+/// window, so its cost scales with the union size, not the product. It
+/// mirrors the window machinery of [`FtsReader::run_windowed_union`] but
+/// drops scoring and the top-k heap, since a count needs neither order
+/// nor scores. No doc-id list is materialized.
+fn or_count_unranked(mut cursors: Vec<TermCursor>) -> u64 {
+    let mut present = [0u64; OR_WINDOW_WORDS];
     let mut n = 0u64;
-    or_walk_unranked(cursors, |_| n += 1);
+    loop {
+        // Smallest current doc among live cursors, aligned down to a
+        // window boundary — O(terms) per window, not per doc.
+        let mut min_doc = u32::MAX;
+        for c in &cursors {
+            if !c.is_exhausted() {
+                min_doc = min_doc.min(c.current_doc_id());
+            }
+        }
+        if min_doc == u32::MAX {
+            break;
+        }
+        let base = min_doc & !(OR_WINDOW - 1);
+        // Saturate so a doc id within OR_WINDOW of u32::MAX can't overflow
+        // `base + OR_WINDOW` (matches run_windowed_union); real doc ids
+        // never reach that range, so the window stays full-width.
+        let window_end = base.saturating_add(OR_WINDOW);
+        // Mark each cursor's docs in [base, window_end). `d - base` is in
+        // range because every live cursor sits at >= min_doc >= base.
+        for c in &mut cursors {
+            while !c.is_exhausted() {
+                let d = c.current_doc_id();
+                if d >= window_end {
+                    break;
+                }
+                let local = (d - base) as usize;
+                present[local >> 6] |= 1u64 << (local & 63);
+                c.next();
+            }
+        }
+        // Count distinct docs in this window and clear for reuse.
+        for word in present.iter_mut() {
+            n += word.count_ones() as u64;
+            *word = 0;
+        }
+    }
     n
 }
 
@@ -3585,6 +3635,68 @@ mod tests {
                 .expect("token_match_count");
             assert_eq!(count, len, "count vs len for {tokens:?} {mode:?}");
         }
+    }
+
+    #[tokio::test]
+    async fn or_count_spans_multiple_windows() {
+        // The windowed disjunction count must equal the union's true
+        // cardinality when the doc-id space spans several OR_WINDOW
+        // windows — exercising cross-window accumulation, the per-window
+        // popcount + clear, and dedup of docs that match multiple terms
+        // within one window. The naive ascending merge (token_match
+        // length) is the reference. Tied to OR_WINDOW so it keeps crossing
+        // the boundary if the window size changes.
+        const N_DOCS: u32 = OR_WINDOW * 2 + 500;
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into()).expect("register");
+        for i in 0..N_DOCS {
+            let mut text = String::from("alpha "); // every doc
+            if i % 2 == 0 {
+                text.push_str("beta ");
+            }
+            if i % 3 == 0 {
+                text.push_str("gamma ");
+            }
+            if i % 5 == 0 {
+                text.push_str("delta ");
+            }
+            b.add_doc(0, i, text.trim()).expect("add doc");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+
+        let shapes: &[&[&str]] = &[
+            &["alpha"],                           // every doc
+            &["beta", "gamma"],                   // overlap on docs % 6
+            &["alpha", "beta", "gamma", "delta"], // all overlapping
+            &["gamma", "zzz_absent"],             // one absent term
+        ];
+        for terms in shapes {
+            let merge_len = r
+                .token_match("body", terms, BoolMode::Or)
+                .await
+                .expect("token_match")
+                .len() as u64;
+            let count = r
+                .token_match_count("body", terms, BoolMode::Or)
+                .await
+                .expect("token_match_count");
+            assert_eq!(
+                count, merge_len,
+                "windowed count vs merge len for {terms:?}"
+            );
+        }
+        // `alpha` is in every doc, so its union count is exactly N_DOCS —
+        // pins the absolute multi-window cardinality, not just agreement
+        // with the merge.
+        assert_eq!(
+            r.token_match_count("body", &["alpha"], BoolMode::Or)
+                .await
+                .expect("count"),
+            N_DOCS as u64
+        );
     }
 
     #[tokio::test]

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -217,6 +217,19 @@ where
         cache.prefetch(&ids, now).await;
     }
 
+    // Single unit (the common case for a compacted, single-superfile
+    // table): run the body inline on the current task. `tokio::spawn`
+    // here would only add a thread handoff and a join with nothing to
+    // overlap against — the spawn path's win is concurrency across units,
+    // which doesn't exist at one unit. Semantically identical to the
+    // fan-out below with a one-element result.
+    if units.len() == 1 {
+        let (entry, params) = units.into_iter().next().expect("len == 1");
+        let r = open_reader(&store, disk_cache.as_ref(), storage.as_ref(), &entry).await?;
+        let out = body(r, entry, tombstone_cache, now, params).await?;
+        return Ok(vec![out]);
+    }
+
     let handles = units.into_iter().map(|(entry, params)| {
         let store = Arc::clone(&store);
         let disk_cache = disk_cache.clone();


### PR DESCRIPTION
## What

Speeds up the matching-doc **count** for multi-term OR queries, with supporting bench coverage and a small serving-path win.

### Multi-term OR count — block-at-a-time disjunction cardinality

Multi-term OR count used a per-doc k-way merge: for every doc in the union it rescanned all cursors to find the minimum and again to advance. Cost scaled with `union_size × term_count`, degrading super-linearly on long common-term unions.

This replaces it with a block-at-a-time disjunction count — walk the cursors one fixed doc-id window at a time, mark each matching doc in a small presence bitset, and accumulate the per-window popcount. Windows partition the doc-id space disjointly, so a doc matching several terms is counted once and nothing is double-counted across windows; the tally equals the distinct-doc union size. No scoring, no top-k heap, no doc-id list materialized. The per-doc k-way merge stays for the path that genuinely needs ordered ids.

**Numbers (1M-doc single superfile, warm, OR-count p50):**

| terms | before | after | speedup |
|---|---|---|---|
| 2 | 5.50 ms | 2.46 ms | 2.2× |
| 5 | 15.82 ms | 2.96 ms | 5.3× |
| 10 | 33.52 ms | 5.71 ms | 5.9× |
| 20 | 65.40 ms | 10.65 ms | 6.1× |
| 40 | 118.39 ms | 18.76 ms | 6.3× |

The scaling flattens from linear-in-terms to decode-bound. The win carries to the multi-superfile object-store path (10-term OR count −85% at 1M docs on the Azure bench). Single-term count (df fast path) and AND count are unchanged.

### Single-superfile fan-out runs inline

The per-superfile query fan-out spawned a `tokio` task even for a single work unit. With one unit there's no concurrency to gain — the spawn + join is pure overhead — so it now runs the body inline. Helps every query (count and search) on a compacted, single-superfile table.

### Bench coverage

- Added 20- and 40-term OR shapes to the count battery (the large-union shapes that degraded most), on both the superfile and supertable tiers.
- Added a top-1000 query-phase gate (representative shapes) on both tiers, so large-`k` collection cost is tracked going forward.
- The superfile count battery now measures the dedicated count primitive — it had been measuring the ordered-merge path, so it never exercised the count fast path; now consistent with the supertable tier.
- Trimmed the superfile large-`k`/cold cost to keep the bench within its time budget.

## Tests

- Extended the count-vs-merge equivalence test and added a multi-window count test (corpus spans multiple windows; checks agreement with the merge and an exact known cardinality).
- Full FTS reader unit suite, the supertable integration suite (198 tests, over LocalFs), `cargo fmt`, and `cargo clippy` all green. All four Azure bench legs pass.
