### PR TITLE
python docs: fix search projection examples and TVF note

### DIFF
--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -67,7 +67,8 @@ print(hits.column_names)        # ['_id', 'score']
   filterable in SQL, and returnable via projection.
 - **Commits** — every `append`, `update`, and `delete` is a single atomic
   commit. Readers see a consistent snapshot and are never torn by a
-  concurrent write.
+  concurrent write. Batch rows into one `append` rather than calling it
+  per row — each call writes a file and commits.
 - **Arrow everywhere** — searches return `pyarrow.Table`; `append` and
   `update` accept Arrow, pandas, or `list[dict]`.
 
@@ -175,7 +176,12 @@ decoded. Name the columns you want to materialize:
 ```python
 docs.bm25_search("title", "fox", k=10)                          # _id + score only
 docs.bm25_search("title", "fox", k=10, projection=["_id", "title", "score"])
+vecs.vector_search("emb", query_vector, k=10, projection=["_id", "emb", "score"])
 ```
+
+The SQL table-valued functions differ: they decode every scalar column by
+default (`_id`, all scalars, trailing `score`). To return only `_id` and
+`score`, select those columns explicitly in the query.
 
 ## Updates and deletes
 


### PR DESCRIPTION
## What

Closes #148. Doc-only changes to `infino-python/README.md`:

- Add a `vector_search` projection example (Projections section showed only `bm25_search`).
- Flag the method/TVF default asymmetry: the `Table.*` search methods return `_id + score` and decode no scalars; the SQL table-valued functions decode every scalar column by default.
- Advise batching rows into one `append` (each call writes a file and commits).

## Why

The README's core projection claim (bm25 returning scalar columns) was already corrected in a prior rewrite, so this closes the remaining gaps the issue lists. The method↔TVF default difference is the one easy-to-miss point, since projection is central to the API's performance story.

## Notes

No code, binding, Rust API, or packaging changes — README only.