### PR TITLE
examples: retry transient HuggingFace Hub errors when loading datasets

### DIFF
--- a/infino-python/examples/_shared/loaders.py
+++ b/infino-python/examples/_shared/loaders.py
@@ -10,7 +10,18 @@ import os
 os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 os.environ.setdefault("HF_HUB_VERBOSITY", "error")
 
-from datasets import load_dataset
+from datasets import load_dataset as _hf_load_dataset
+from huggingface_hub.utils import HfHubHTTPError
+from requests.exceptions import RequestException
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+# The Hub intermittently 5xxs or times out; retry transient failures with backoff.
+load_dataset = retry(
+    retry=retry_if_exception_type((HfHubHTTPError, RequestException)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, max=32),
+    reraise=True,
+)(_hf_load_dataset)
 
 
 def load_arxiv(n: int = 200) -> list[dict]:

--- a/infino-python/examples/requirements.txt
+++ b/infino-python/examples/requirements.txt
@@ -5,4 +5,5 @@ pyarrow>=14
 duckdb>=1                  # read superfiles as plain Parquet (parquet_interop.py)
 sentence-transformers>=3   # local embeddings, no API key needed
 datasets>=2               # pulls the real public corpora from HuggingFace
+tenacity>=8               # retry/backoff around transient HuggingFace Hub errors
 openai>=1.40              # optional: LLM answers (Azure AI Foundry or OpenAI)


### PR DESCRIPTION
## What

Wrap `datasets.load_dataset` in the shared example loaders with tenacity retry/backoff.

## Why

CI ([run #28363283248](https://github.com/infino-ai/infino/actions/runs/28363283248/job/84022862125)) failed loading `microsoft/ms_marco` with `HfHubHTTPError: 504 Gateway Time-out` while the Hub resolved the dataset file tree. Transient Hub-side fault, not our code. All six loaders route through `load_dataset`, so one wrapper covers them.

## Details

- `load_dataset` now retries `HfHubHTTPError` / `requests` `RequestException`, 3 attempts, exponential backoff capped at 32s, `reraise=True` so the original error surfaces on final failure.
- Added `tenacity>=8` to `examples/requirements.txt` (examples-only dep, not the shipped crate).