### PR TITLE
vector: coalesce cold IVF search into a single read wave

### DIFF
--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -1582,31 +1582,45 @@ impl VectorReader {
             .iter()
             .map(|range| self.source.try_get_range_sync(range.clone()))
             .collect();
-        let survivor_only_rerank_fetch = true;
-        let (cluster_blocks, lazy_sq8_meta_bytes) = if let Some(prefix_blocks) = prefix_blocks_sync
-        {
-            let meta_bytes = if let Some(range) = lazy_sq8_meta_range {
-                let mut fetched = self
-                    .source
-                    .get_ranges_parallel_async(&[range])
-                    .await
-                    .map_err(|e| VectorError::LazySource(e.to_string()))?;
-                fetched.pop()
+        let (cluster_blocks, lazy_sq8_meta_bytes, survivor_only_rerank_fetch) =
+            if let Some(prefix_blocks) = prefix_blocks_sync {
+                // Warm: prefixes resident. Keep the survivor-only rerank
+                // split — the survivor `full[]` rows resolve sync/zero-copy
+                // below (no round-trip), so there is nothing to coalesce and
+                // we avoid touching the unneeded rerank bytes.
+                let meta_bytes = if let Some(range) = lazy_sq8_meta_range {
+                    let mut fetched = self
+                        .source
+                        .get_ranges_parallel_async(&[range])
+                        .await
+                        .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                    fetched.pop()
+                } else {
+                    None
+                };
+                (prefix_blocks, meta_bytes, true)
             } else {
-                None
+                // Cold: fetch the **full** per-cluster blocks
+                // (`[codes][doc_ids][full]`) + Sq8 meta in one coalesced batch, so
+                // the survivor rerank rows arrive *with* the codes — collapsing the
+                // dependent rerank round-trip into this wave. Cold latency is
+                // RTT/wave-bound, so trading a few extra rerank bytes for one fewer
+                // serial round-trip on object storage is a win.
+                // `survivor_only_rerank_fetch = false` tells `build_shortlist` the
+                // rerank rows are in-block (no second fetch).
+                let cluster_full_ranges: Vec<Range<usize>> = cluster_meta
+                    .iter()
+                    .map(|&(_, off, cnt)| col.cluster_block_range(off, cnt))
+                    .collect();
+                let (blocks, meta) = get_cluster_ranges_coalesced_with_extra_async(
+                    &self.source,
+                    &cluster_full_ranges,
+                    lazy_sq8_meta_range,
+                )
+                .await
+                .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                (blocks, meta, false)
             };
-            (prefix_blocks, meta_bytes)
-        } else {
-            // Cold: codes+doc_ids prefixes (coalesced) + Sq8 meta in one
-            // concurrent batch on the caller's runtime.
-            get_cluster_ranges_coalesced_with_extra_async(
-                &self.source,
-                &cluster_prefix_ranges,
-                lazy_sq8_meta_range,
-            )
-            .await
-            .map_err(|e| VectorError::LazySource(e.to_string()))?
-        };
         debug_assert_eq!(cluster_blocks.len(), cluster_meta.len());
 
         // Shared pure-CPU shortlist + candidate-build stage (see


### PR DESCRIPTION
## What

On a cold (non-resident) vector search, `probe_clusters_async` does two
*dependent* object-store round-trips per probe:

1. fetch the per-cluster `codes + doc_id` prefixes → build the Sq8 shortlist
2. a **second**, dependent fetch for the survivors' rerank rows

On object storage that second wave is a serial RTT sitting directly on the
query's critical path.

This change fetches the **full per-cluster blocks** (`[codes][doc_ids][rerank]`)
in **one coalesced batch** on the cold path, so the survivor rerank rows arrive
together with the codes and the dependent round-trip is eliminated. Rerank reads
in-block via the existing `full_off` path (`survivor_only_rerank_fetch = false`).

**Warm/resident search is unchanged**: when the prefixes are already resident,
the survivor rows resolve sync/zero-copy with no round-trip, so we keep the
survivor-only split and never touch the unneeded rerank bytes.

## Impact

Measured on the supertable vector cold-search bench (1M × dim=1024, object
storage, p=4–8, r=256):

- **cold-search p50 ≈ 40% lower on the cold IVF path** — eliminating the dependent
  rerank round-trip removes one serial object-store wave from the critical path.
- At a low rerank multiplier (r=4) the old path degraded sharply: survivor rows
  are scattered across the cluster blocks, so the second wave becomes many small,
  uncoalesced range GETs (an RTT storm). The single-wave path avoids that.
- **Warm path unchanged** (~1 ms).

## Tradeoff

The cold path now reads the full rerank rows for the probed clusters' candidates
up front, rather than only the survivors. This is the right call when cold
latency is RTT/wave-bound and the rerank pool is large (the common high-recall
serving config): those bytes are pulled regardless, we just front-load them to
drop a serial round-trip. For a workload with a very small rerank pool the old
survivor-only path reads fewer bytes; making the choice adaptive on pool size is
a possible follow-up.

## Scope

- Single function (`probe_clusters_async`); warm path untouched.
- No on-disk format change — uses the existing `cluster_block_range` / `full_off`
  helpers.

Refs #49
