### PR TITLE
storage: re-issue transient put_atomic failures

### DIFF
--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -239,15 +239,24 @@ impl StorageProvider for AzureStorageProvider {
 
     async fn put_atomic(&self, uri: &str, bytes: Bytes) -> Result<Option<String>, StorageError> {
         let path = self.path(uri)?;
-        let opts = PutOptions {
-            mode: PutMode::Create,
-            ..Default::default()
-        };
-        self.store
-            .put_opts(&path, PutPayload::from_bytes(bytes), opts)
-            .await
-            .map(|r| r.e_tag)
-            .map_err(|e| translate(uri, e))
+        // Re-issue transient failures like the read paths. Only
+        // `TransientExhausted` re-issues, so an OCC `PreconditionFailed` still
+        // surfaces immediately; a create-only PUT that never landed is safe to retry.
+        retry::with_reissue(|| {
+            let bytes = bytes.clone();
+            async {
+                let opts = PutOptions {
+                    mode: PutMode::Create,
+                    ..Default::default()
+                };
+                self.store
+                    .put_opts(&path, PutPayload::from_bytes(bytes), opts)
+                    .await
+                    .map(|r| r.e_tag)
+                    .map_err(|e| translate(uri, e))
+            }
+        })
+        .await
     }
 
     async fn put_if_match(

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -362,15 +362,24 @@ impl StorageProvider for S3StorageProvider {
 
     async fn put_atomic(&self, uri: &str, bytes: Bytes) -> Result<Option<String>, StorageError> {
         let path = self.path(uri)?;
-        let opts = PutOptions {
-            mode: PutMode::Create,
-            ..Default::default()
-        };
-        self.store
-            .put_opts(&path, PutPayload::from_bytes(bytes), opts)
-            .await
-            .map(|r| r.e_tag)
-            .map_err(|e| translate(uri, e))
+        // Re-issue transient failures like the read paths. Only
+        // `TransientExhausted` re-issues, so an OCC `PreconditionFailed` still
+        // surfaces immediately; a create-only PUT that never landed is safe to retry.
+        retry::with_reissue(|| {
+            let bytes = bytes.clone();
+            async {
+                let opts = PutOptions {
+                    mode: PutMode::Create,
+                    ..Default::default()
+                };
+                self.store
+                    .put_opts(&path, PutPayload::from_bytes(bytes), opts)
+                    .await
+                    .map(|r| r.e_tag)
+                    .map_err(|e| translate(uri, e))
+            }
+        })
+        .await
     }
 
     async fn put_if_match(


### PR DESCRIPTION
## What

Route `put_atomic` through the app-level `retry::with_reissue` on both S3 and Azure, matching the read paths (`get` / `get_range` / `tail`).

## Why

A connect-phase timeout surfaces as `TransientExhausted { retries: 0 }` — `object_store`'s retry budget (20 retries / 300s) does not classify a connect timeout as retryable, so it gives up after the 5s connect timeout with zero retries. `put_atomic` was the only whole-object op **not** wrapped in the app-level reissue, so that single transient propagated straight to the caller. In the superfile bench this hit `.expect("upload superfile")` and panicked the entire run — red-X'ing PRs that never touched the storage path (#270).

Reads already had two retry layers (lib + app); writes only had the lib layer, which is exactly the one that misses connect timeouts.

## Correctness

`is_retryable` re-issues **only** `TransientExhausted`. A create-only `PreconditionFailed` (the OCC conflict that `put_atomic` relies on for first-commit pointer publish in `manifest/commit.rs`) still surfaces immediately — never retried, never swallowed. A transient that never landed is safe to re-dial; the reissue also drops the dead pooled socket.

Resilient to transient flake, not a down store: after ~8 re-dials a genuinely unreachable backend still returns `Err`, which is the correct outcome for a bench.

## Tests

- `make check` green (fmt + clippy `-D warnings`)
- `cargo test --lib storage::` → 90 pass, incl. `put_atomic_twice_is_precondition_failed` exercising the wrapper against the in-process `s3s-fs` harness — confirms OCC conflict still surfaces through the reissue path.

Retry mechanics (transient re-issues, `PreconditionFailed` short-circuits) are covered centrally in `retry.rs`, same precedent as the existing read-path reissue.

Fixes #270