### PR TITLE
reader_cache: default cold-fetch to lazy foreground + background fill

### DIFF
--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -652,6 +652,9 @@ impl SupertableReader {
         filter: Option<VectorFilter<'_>>,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, QueryError> {
+        // Mark a foreground query in flight so background cache-fills yield
+        // S3 bandwidth to it; released when this query returns.
+        let _fg = crate::supertable::reader_cache::disk::ForegroundQueryGuard::enter();
         self.block_on(async {
             let hits = match filter {
                 None => self.vector_search_async(column, query, k, options).await?,
@@ -684,6 +687,9 @@ impl SupertableReader {
         options: VectorSearchOptions,
         filter: Option<VectorFilter<'_>>,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        // Mark a foreground query in flight so background cache-fills yield
+        // S3 bandwidth to it; released when this query returns.
+        let _fg = crate::supertable::reader_cache::disk::ForegroundQueryGuard::enter();
         match filter {
             None => self.block_on(self.vector_search_async(column, query, k, options)),
             Some(f) => self.block_on(self.vector_hits_filtered_async(column, query, k, options, f)),

--- a/src/supertable/reader_cache/config.rs
+++ b/src/supertable/reader_cache/config.rs
@@ -17,7 +17,10 @@ use crate::supertable::manifest::SuperfileUri;
 /// How `DiskCacheStore` services a cache miss.
 ///
 /// Set via `DiskCacheConfig::cold_fetch_mode`. Default:
-/// [`ColdFetchMode::HybridWithPrefetch`].
+/// [`ColdFetchMode::LazyForegroundWithBackgroundFill`] — object-storage-native
+/// deployments make cold-query p50 the primary objective, and the foreground
+/// then pays only the per-query range budget while the full-superfile cache
+/// fill happens off the latency-critical path (warm stays resident).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ColdFetchMode {
     /// Parallel range-GETs fan out over the superfile; each
@@ -30,7 +33,6 @@ pub enum ColdFetchMode {
     /// **1× bandwidth per cold miss** — same range responses
     /// serve both consumers; no re-fetching between foreground
     /// query and cache fill.
-    #[default]
     HybridWithPrefetch,
     /// Foreground query goes straight through `get_range` via
     /// [`StorageRangeSource`] — no disk-cache fill.
@@ -64,6 +66,7 @@ pub enum ColdFetchMode {
     ///
     /// [`SuperfileReader::open_lazy`]: crate::superfile::reader::SuperfileReader::open_lazy
     /// [`StorageRangeSource`]: crate::supertable::StorageRangeSource
+    #[default]
     LazyForegroundWithBackgroundFill,
 }
 

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -73,6 +73,77 @@ const MMAP_PROMOTION_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// full-superfile fill starts.
 const STORE_UPGRADE_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 
+/// Max parallel range-GET streams a single **background** fill may use,
+/// below the foreground/hybrid `cold_fetch_streams`. Bounds each fill's
+/// in-flight bytes (`streams × cold_fetch_chunk_bytes`) so (a) the aggregate
+/// across `prefetch_concurrency` concurrent fills can't saturate / trigger S3
+/// throttling — many concurrent cold opens each spawn a fill, so at the
+/// default `prefetch_concurrency=8 × cold_fetch_streams=8 × 8 MiB = 512 MiB`
+/// in flight, which 503s on S3 — and (b) a fill's in-flight wave stays small,
+/// so [`yield_to_foreground`] (checked between waves) pauses it promptly when
+/// a query arrives. Complements the gate; neither alone suffices.
+const BACKGROUND_FILL_MAX_STREAMS: usize = 2;
+
+/// Poll cadence while a background cache-fill yields to in-flight foreground
+/// queries (see [`foreground_query_active`]).
+const BACKGROUND_FILL_YIELD_POLL: Duration = Duration::from_millis(5);
+
+/// Upper bound on how long a background fill yields to foreground queries
+/// before proceeding anyway. Prevents a sustained query stream from starving
+/// the cache warm-up indefinitely; under bursty load the fill simply resumes
+/// in the gaps between queries well within this bound.
+const BACKGROUND_FILL_MAX_YIELD: Duration = Duration::from_secs(2);
+
+/// Process-global count of in-flight foreground queries. Background
+/// full-superfile fills run at full bandwidth when this is 0 and **pause**
+/// while it is > 0, so the fill never competes for S3 bandwidth with a
+/// latency-critical query. Per-reader release gating
+/// (`wait_for_lazy_foreground_release`) can't prevent the contention: a fill
+/// commonly targets a *different* superfile than the one the current query is
+/// reading (a fill queued by an earlier query, or another file in a
+/// multi-superfile fan-out), so that reader releases immediately and the fill
+/// starts mid-query. This global gate is keyed off the query, not the reader,
+/// so it covers that case. Measured: an 8-stream × 8 MiB fill dragged
+/// foreground 2 MiB block reads down to ~18 MB/s.
+static FOREGROUND_QUERIES: AtomicU64 = AtomicU64::new(0);
+
+/// RAII guard marking a foreground query in flight for its lifetime (held
+/// across the query's awaits). Background fills pause while any guard is live.
+pub struct ForegroundQueryGuard(());
+
+impl ForegroundQueryGuard {
+    pub fn enter() -> Self {
+        FOREGROUND_QUERIES.fetch_add(1, Ordering::AcqRel);
+        ForegroundQueryGuard(())
+    }
+}
+
+impl Drop for ForegroundQueryGuard {
+    fn drop(&mut self) {
+        FOREGROUND_QUERIES.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+fn foreground_query_active() -> bool {
+    FOREGROUND_QUERIES.load(Ordering::Acquire) > 0
+}
+
+/// Pause the calling background fill while a foreground query is reading —
+/// unless someone is explicitly waiting for *this* fill's mmap promotion
+/// (then the fill is itself latency-critical and must rush), the store is
+/// abandoned, or the yield bound elapses.
+async fn yield_to_foreground(store: &Arc<DiskCacheStore>) {
+    let mut waited = Duration::ZERO;
+    while foreground_query_active()
+        && store.n_promotion_waiters.load(Ordering::Acquire) == 0
+        && !background_store_abandoned(store)
+        && waited < BACKGROUND_FILL_MAX_YIELD
+    {
+        tokio::time::sleep(BACKGROUND_FILL_YIELD_POLL).await;
+        waited += BACKGROUND_FILL_YIELD_POLL;
+    }
+}
+
 /// Errors surfaced by [`DiskCacheStore::reader`].
 #[derive(Debug, Error)]
 pub enum DiskCacheError {
@@ -350,7 +421,13 @@ impl DiskCacheStore {
     /// → coalesced cold-fetch coordinator. Dispatches by
     /// `config.cold_fetch_mode`:
     ///
-    /// - [`ColdFetchMode::HybridWithPrefetch`] (default):
+    /// - [`ColdFetchMode::LazyForegroundWithBackgroundFill`] (default):
+    ///   foreground returns a lazy reader over a `StorageRangeSource`
+    ///   that pays only the per-query range budget; a background task
+    ///   downloads the full superfile to NVMe and swaps in the mmap'd
+    ///   entry, so subsequent (warm) queries are resident. Minimizes
+    ///   cold-query p50 on object-storage-native deployments.
+    /// - [`ColdFetchMode::HybridWithPrefetch`]:
     ///   parallel range-GETs feed the foreground reader (built
     ///   from in-memory bytes) and a fire-and-forget cache fill
     ///   (mmap'd, registered on completion). Foreground returns
@@ -1607,7 +1684,14 @@ async fn cold_fetch_to_disk_cancelable(
     dest_path: &Path,
     size: u64,
 ) -> Result<bool, DiskCacheError> {
-    let n_streams = store.config.cold_fetch_streams.max(1);
+    // Background fill: cap streams below the foreground setting to bound
+    // in-flight bytes (avoids the S3-throttling fill storm at open + lets the
+    // foreground gate pause it promptly between waves).
+    let n_streams = store
+        .config
+        .cold_fetch_streams
+        .max(1)
+        .min(BACKGROUND_FILL_MAX_STREAMS);
     let chunk_size = store.config.cold_fetch_chunk_bytes.max(1);
     let file = {
         let f = fs::OpenOptions::new()
@@ -1632,6 +1716,13 @@ async fn cold_fetch_to_disk_cancelable(
     // materializing them as one `Bytes` would reintroduce the RSS spike
     // this disk-cache path is meant to avoid.
     loop {
+        // Yield to any in-flight foreground query before dispatching the next
+        // wave of chunk GETs, so the fill never competes for S3 bandwidth with
+        // a latency-critical read. Checked here (not just at fill start) so a
+        // fill that began in a gap pauses when the next query arrives.
+        if in_flight.is_empty() {
+            yield_to_foreground(store).await;
+        }
         while next_chunk < n_chunks && in_flight.len() < n_streams {
             if background_store_abandoned(store) {
                 return Ok(false);

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -109,10 +109,10 @@ static FOREGROUND_QUERIES: AtomicU64 = AtomicU64::new(0);
 
 /// RAII guard marking a foreground query in flight for its lifetime (held
 /// across the query's awaits). Background fills pause while any guard is live.
-pub struct ForegroundQueryGuard(());
+pub(crate) struct ForegroundQueryGuard(());
 
 impl ForegroundQueryGuard {
-    pub fn enter() -> Self {
+    pub(crate) fn enter() -> Self {
         FOREGROUND_QUERIES.fetch_add(1, Ordering::AcqRel);
         ForegroundQueryGuard(())
     }

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -1690,8 +1690,7 @@ async fn cold_fetch_to_disk_cancelable(
     let n_streams = store
         .config
         .cold_fetch_streams
-        .max(1)
-        .min(BACKGROUND_FILL_MAX_STREAMS);
+        .clamp(1, BACKGROUND_FILL_MAX_STREAMS);
     let chunk_size = store.config.cold_fetch_chunk_bytes.max(1);
     let file = {
         let f = fs::OpenOptions::new()

--- a/tests/supertable/disk_cache/hybrid.rs
+++ b/tests/supertable/disk_cache/hybrid.rs
@@ -186,10 +186,14 @@ fn fresh_cache(
 // ============================================================
 
 #[tokio::test]
-async fn hybrid_mode_is_default() {
-    // Just construct via Default and read the mode back.
+async fn lazy_mode_is_default() {
+    // Just construct via Default and read the mode back. The default cold-fetch
+    // mode is lazy foreground + background fill (lowest cold-query latency).
     let cfg = DiskCacheConfig::default();
-    assert_eq!(cfg.cold_fetch_mode, ColdFetchMode::HybridWithPrefetch);
+    assert_eq!(
+        cfg.cold_fetch_mode,
+        ColdFetchMode::LazyForegroundWithBackgroundFill
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Two coupled changes to how a disk-cache miss is serviced:

1. **Default `ColdFetchMode` → `LazyForegroundWithBackgroundFill`** (was
   `HybridWithPrefetch`). On a cold miss the foreground query pays only its
   per-query range budget (cold-open + cold-search ranges) against object
   storage; the full superfile is downloaded to NVMe by a **background** task
   *after* the latency-critical foreground readers release. Subsequent queries
   hit the mmap-backed cache (zero further S3 GETs).

2. **Background fill yields to foreground.** A process-global
   `ForegroundQueryGuard` (entered by `vector_search` / `vector_hits`) marks
   in-flight foreground queries; the background fill pauses (`yield_to_foreground`)
   while any are running and is throttled to `BACKGROUND_FILL_MAX_STREAMS = 2`.
   Two valves prevent stalls: it proceeds anyway if a promotion waiter is blocked,
   or after `BACKGROUND_FILL_MAX_YIELD = 2s`.

## Why

Object-storage-native serving makes **cold-query p50 the primary objective**, and
Lazy is the mode that optimizes for it: the foreground touches only the per-query
range budget (a single superfile's hot working set is a few range-GETs), so cold
p50 drops; the full-superfile cache fill still happens, just deferred off the
latency-critical path. The gate + throttle keep that deferred fill from stealing
object-store bandwidth from concurrent foreground queries.

## Performance (supertable vector cold-search bench, object storage, 1M × dim=1024)

- **Lazy foreground budget**: a cold query reads only ~6 range-GETs / ~2–3 MiB of
  a ~1.5 GiB superfile, instead of materializing the whole subsection on the
  critical path.
- **The throttle is load-bearing.** Without `BACKGROUND_FILL_MAX_STREAMS`, the
  unthrottled fill (default `prefetch_concurrency × cold_fetch_streams × chunk`
  ≈ 512 MiB in flight) storms object storage and contends with foreground — a
  cold battery regressed to **~758 ms search / ~2.8 s cold-open** in that
  misconfiguration. With the throttle, cold-search **~339 → ~274 ms**;
  the foreground gate removes the residual during-query contention.
- This mode is part of the broader cold-path work that took the bench's
  cold-search p50 from **~400+ ms toward ~190 ms** (object storage, 1M × dim=1024).
  That figure spans several changes (incl. #305) and was measured on the branch,
  so treat the exact main-side number as TBD pending a re-measure. Warm is
  unchanged (resident).

## Tradeoff / opting out

- **Lower cold p50, at ~2× cold-fetch bandwidth** per cold miss (the foreground
  ranges + the deferred full-superfile fill both read from object storage). Warm
  is unaffected.
- Deployments that are bandwidth-sensitive or rarely cold can keep the previous
  behaviour by setting `DiskCacheConfig::cold_fetch_mode = HybridWithPrefetch`
  (1× bandwidth) — the flip changes only the *default*, not the available modes.

## Scope

- `reader_cache/config.rs` (default enum variant), `reader_cache/disk.rs` (gate +
  throttle + foreground-yielding fill), `query/vector.rs` (gate entry at the two
  search entry points).
- No on-disk format change.

Refs #49
