### PR TITLE
ci: bench janitor to reclaim leaked Azure bench VMs

### DIFF
--- a/.github/workflows/bench-janitor.yml
+++ b/.github/workflows/bench-janitor.yml
@@ -31,6 +31,8 @@ env:
 jobs:
   sweep:
     runs-on: ubuntu-latest
+    # OIDC subject and Azure secrets are scoped to `ci`.
+    environment: ci
     steps:
       - name: Azure login (OIDC)
         uses: azure/login@v2

--- a/.github/workflows/bench-janitor.yml
+++ b/.github/workflows/bench-janitor.yml
@@ -1,0 +1,92 @@
+name: Bench janitor (Azure)
+
+# Reclaims ephemeral bench VMs (and their networking/disks) that outlive
+# their TTL. The bench workflows tear down on exit, but that is skipped on
+# force-cancel or a lost runner; this sweep is the independent backstop.
+
+on:
+  schedule:
+    - cron: "17 * * * *" # hourly, offset off the hour
+  workflow_dispatch:
+    inputs:
+      ttl_hours:
+        description: "Delete bench resources older than this many hours."
+        default: "3"
+      dry_run:
+        description: "List what would be deleted without deleting."
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: bench-janitor
+  cancel-in-progress: false
+
+env:
+  RG: rg-infino-bench
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sweep expired bench resources
+        env:
+          TTL_HOURS: ${{ inputs.ttl_hours || '3' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          now=$(date -u +%s)
+          cutoff=$(( now - TTL_HOURS * 3600 ))
+
+          # Delete, or just announce under dry-run. Best-effort: a resource
+          # another sweep already removed must not fail the run.
+          del() {
+            if [ "$DRY_RUN" = "true" ]; then echo "DRY-RUN would delete: $*"; return; fi
+            echo "deleting: $*"; "$@" || true
+          }
+
+          # Expired = delete-after tag in the past, or timeCreated older
+          # than the TTL (the latter backstops VMs with no tag).
+          live_vms=()
+          while IFS=$'\t' read -r name created after; do
+            [ -z "$name" ] && continue
+            expired=false
+            [ -n "$after" ] && [ "$now" -gt "$(date -u -d "$after" +%s)" ] && expired=true
+            [ "$(date -u -d "$created" +%s)" -lt "$cutoff" ] && expired=true
+            if [ "$expired" = true ]; then
+              del az vm delete -g "$RG" -n "$name" --yes
+            else
+              live_vms+=("$name")
+            fi
+          done < <(az vm list -g "$RG" -o json \
+            | jq -r '.[] | [.name, .timeCreated, (.tags["delete-after"] // "")] | @tsv')
+
+          # Networking/disks are untagged, so attribute each to its VM by
+          # name and reclaim it once that VM is gone (a live VM still owns
+          # its resources, so in-flight runs are never touched).
+          owner() { sed -E 's/(VMNic|-osdisk|-nsg|-pip|-vnet)$//' <<<"$1"; }
+          is_live() { local v; for v in "${live_vms[@]:-}"; do [ "$v" = "$1" ] && return 0; done; return 1; }
+
+          # NICs first (they hold the IP/NSG/subnet), then disks, then the
+          # IP/NSG/VNet the NICs freed.
+          for kind in "network nic" "disk" "network public-ip" "network nsg" "network vnet"; do
+            read -ra cmd <<<"$kind"
+            while IFS= read -r n; do
+              [ -z "$n" ] && continue
+              is_live "$(owner "$n")" && continue
+              if [ "$kind" = "disk" ]; then del az "${cmd[@]}" delete -g "$RG" -n "$n" --yes
+              else del az "${cmd[@]}" delete -g "$RG" -n "$n"; fi
+            done < <(az "${cmd[@]}" list -g "$RG" --query '[].name' -o tsv 2>/dev/null || true)
+          done
+
+          echo "resources remaining in $RG: $(az resource list -g "$RG" --query 'length(@)' -o tsv)"

--- a/.github/workflows/dataset-bench-vm.yml
+++ b/.github/workflows/dataset-bench-vm.yml
@@ -146,10 +146,12 @@ jobs:
         run: |
           set -euo pipefail
           SIZE="${{ inputs.vm_size }}"
-          # Tags attribute spend in Cost Management. Every resource is named
-          # from $VM so teardown deletes by exact name. No default inbound
-          # rule; SSH is opened only to the runner's address, below.
-          TAGS=(purpose=dataset-bench "run-id=${{ github.run_id }}" "ref=${{ inputs.ref }}" "modality=${{ inputs.modality }}")
+          # Tags attribute spend by purpose / run; delete-after lets the
+          # bench janitor reclaim this if teardown is skipped (cancel / lost
+          # runner). Every resource is named from $VM so teardown deletes by
+          # exact name. No default inbound rule; SSH opens to the runner IP below.
+          DELETE_AFTER="$(date -u -d '+3 hours' +%Y-%m-%dT%H:%M:%SZ)"
+          TAGS=(purpose=dataset-bench "run-id=${{ github.run_id }}" "ref=${{ inputs.ref }}" "modality=${{ inputs.modality }}" auto-delete=true "delete-after=${DELETE_AFTER}")
           az vm create \
             -g "$RG" -n "$VM" \
             --image Ubuntu2204 \

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -205,8 +205,10 @@ jobs:
           LOC="${{ inputs.location }}"
           SIZE="${{ inputs.vm_size }}"
 
-          # Tag the VM so Cost Management attributes spend by purpose / run.
-          TAGS=(purpose=supertable-bench "run-id=${{ github.run_id }}" "ref=${{ inputs.ref }}")
+          # Tags attribute spend by purpose / run; delete-after lets the
+          # bench janitor reclaim this if teardown is skipped (cancel / lost runner).
+          DELETE_AFTER="$(date -u -d '+3 hours' +%Y-%m-%dT%H:%M:%SZ)"
+          TAGS=(purpose=supertable-bench "run-id=${{ github.run_id }}" "ref=${{ inputs.ref }}" auto-delete=true "delete-after=${DELETE_AFTER}")
 
           # Every resource is named with the unique per-run VM name so
           # teardown can delete this run's resources by exact name (never


### PR DESCRIPTION
## What

A scheduled janitor that reclaims ephemeral bench Azure resources the bench workflows leak, plus a `delete-after` tag so it can target them.

- **`.github/workflows/bench-janitor.yml`** — hourly (+ manual `workflow_dispatch` with `ttl_hours` / `dry_run`). In `rg-infino-bench` it deletes VMs whose `delete-after` tag is past or whose `timeCreated` is older than the TTL, then sweeps the now-orphaned NIC → disk → public-IP → NSG → VNet (attributed to their VM by name; a live VM still owns its resources, so in-flight runs are never touched).
- **`supertable-bench-azure.yml`** + **`dataset-bench-vm.yml`** — provision step now tags `auto-delete=true` + `delete-after=<now+3h>`.

## Why

Both bench workflows tear down on exit via `if: always()`, but that is **skipped when a run is force-cancelled mid-teardown** (the sequential `az delete` calls exceed the cancellation grace window) **or the runner is lost** — leaving running VMs (compute spend) and orphaned networking/disks (public IPs and disks bill even detached). A recent cancelled run plus a 12-day-old debug run had left 3 running VMs and ~90 orphaned resources in `rg-infino-bench`. The janitor is an independent backstop that doesn't depend on any run completing its own teardown.

## Design notes

- **TTL 3h** — above a normal bench run; the per-workflow `delete-after` tag and the janitor default agree. (If a dataset prepare ever runs longer than 3h, bump its tag separately.)
- **Safety** — `dry_run` lists without deleting; deletes are best-effort and self-healing (a failed delete retries next sweep); only `rg-infino-bench` is touched.

## Testing

- `actionlint` clean on all three workflows.
- Recommend a `workflow_dispatch` run with `dry_run: true` after merge to confirm OIDC auth + that it targets only true orphans before trusting the schedule.
