### PR TITLE
chore: use reader pool for vector searches

### DIFF
--- a/benches/utils/bin/profile_superfile.rs
+++ b/benches/utils/bin/profile_superfile.rs
@@ -157,6 +157,7 @@ fn mean_recall_filtered(
             opts(nprobe, rerank_mult),
             Some(Arc::clone(allow)),
             None,
+            None,
         ))
         .expect("vector_hits_filtered");
         sum += corpus::recall_at_k(&hits, truth);

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -35,12 +35,19 @@ use std::{
     time::{Duration, Instant},
 };
 
+use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
 use futures::future::join_all;
 use infino::{
+    VectorSearchOptions,
     storage::{LocalFsStorageProvider, StorageProvider},
-    superfile::fts::reader::BoolMode,
-    supertable::Supertable,
-    test_helpers::{build_title_batch, default_supertable_options},
+    superfile::{
+        builder::{FtsConfig, VectorConfig},
+        fts::reader::BoolMode,
+        vector::{distance::Metric, rerank_codec::RerankCodec},
+    },
+    supertable::{Supertable, SupertableOptions},
+    test_helpers::default_tokenizer,
 };
 use tempfile::TempDir;
 
@@ -56,6 +63,12 @@ const DEFAULT_DURATION_SECS: u64 = 15;
 const DEFAULT_WARMUP_SECS: u64 = 3;
 const QUERY_FIELD: &str = "title";
 const QUERY_TERM: &str = "alpha";
+const VEC_COLUMN: &str = "emb";
+/// dim=128 is large enough for the shortlist+rerank CPU to show pool-routing
+/// impact under contention, but small enough for fast fixture builds.
+const VEC_DIM: usize = 128;
+const VEC_N_CENT: usize = 32;
+const VEC_ROT_SEED: u64 = 7;
 const TOP_K: usize = 10;
 const WRITER_BATCH: usize = 1_024;
 const CORPUS_CHUNKS: usize = 8;
@@ -95,6 +108,12 @@ fn warmup_secs() -> u64 {
     env_u64("INFINO_BENCH_CONCURRENT_WARMUP", DEFAULT_WARMUP_SECS)
 }
 
+fn run_baseline() -> bool {
+    std::env::var("INFINO_BENCH_CONCURRENT_BASELINE")
+        .map(|v| v != "0")
+        .unwrap_or(true)
+}
+
 // ─── Runtime ──────────────────────────────────────────────────────────────────
 
 // Simulates the SaaS/axum process-level runtime.
@@ -116,12 +135,75 @@ struct Fixture {
     _dir: TempDir,
 }
 
+fn concurrent_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new(
+            VEC_COLUMN,
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                VEC_DIM as i32,
+            ),
+            false,
+        ),
+    ]))
+}
+
+fn build_batch(start: usize, n: usize) -> RecordBatch {
+    let titles_owned: Vec<String> = (start..start + n)
+        .map(|i| format!("alpha row{i:08}"))
+        .collect();
+    let titles: Vec<&str> = titles_owned.iter().map(|s| s.as_str()).collect();
+    let title_arr = LargeStringArray::from(titles);
+
+    // Deterministic non-zero vectors: coord j = (row_idx + j) as f32 % 1.0
+    let floats: Vec<f32> = (start..start + n)
+        .flat_map(|i| (0..VEC_DIM).map(move |j| ((i + j) % 97) as f32 + 0.1))
+        .collect();
+    let values = Arc::new(Float32Array::from(floats)) as Arc<dyn arrow_array::Array>;
+    let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+    let emb_arr = FixedSizeListArray::try_new(item_field, VEC_DIM as i32, values, None)
+        .expect("FixedSizeListArray from f32 values");
+
+    RecordBatch::try_new(
+        concurrent_schema(),
+        vec![Arc::new(title_arr), Arc::new(emb_arr)],
+    )
+    .expect("RecordBatch shape matches concurrent_schema")
+}
+
+fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOptions {
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .expect("rayon pool"),
+    );
+    SupertableOptions::new(
+        concurrent_schema(),
+        vec![FtsConfig {
+            column: "title".into(),
+        }],
+        vec![VectorConfig {
+            column: VEC_COLUMN.into(),
+            dim: VEC_DIM,
+            n_cent: VEC_N_CENT,
+            rot_seed: VEC_ROT_SEED,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Fp32,
+        }],
+        Some(default_tokenizer()),
+    )
+    .expect("SupertableOptions with FTS + vector")
+    .with_writer_pool(pool)
+    .with_storage(storage)
+}
+
 fn build_fixture(n_docs: usize) -> Fixture {
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("localfs"));
-    let st = Supertable::create(default_supertable_options().with_storage(storage))
-        .expect("create supertable");
+    let st = Supertable::create(build_supertable_options(storage)).expect("create supertable");
 
     let chunk_size = n_docs.div_ceil(CORPUS_CHUNKS);
     let mut w = st.writer().expect("writer");
@@ -131,9 +213,7 @@ fn build_fixture(n_docs: usize) -> Fixture {
         if start >= end {
             break;
         }
-        let titles_owned: Vec<String> = (start..end).map(|i| format!("alpha row{i:08}")).collect();
-        let titles: Vec<&str> = titles_owned.iter().map(|s| s.as_str()).collect();
-        let batch = build_title_batch(&titles);
+        let batch = build_batch(start, end - start);
         w.append(&batch).expect("append");
         w.commit().expect("commit");
     }
@@ -201,15 +281,10 @@ async fn reader_loop(
 // Single-writer slot is fine — in production each table has one writer.
 async fn writer_loop(st: Supertable, stop: Arc<AtomicBool>) -> usize {
     let mut commits = 0usize;
-    let mut batch_start = 0usize;
+    let mut batch_start = 1_000_000usize;
     while !stop.load(Ordering::Relaxed) {
         if let Ok(mut w) = st.writer() {
-            let start = batch_start;
-            let titles_owned: Vec<String> = (start..start + WRITER_BATCH)
-                .map(|i| format!("alpha extra{i:08}"))
-                .collect();
-            let titles: Vec<&str> = titles_owned.iter().map(|s| s.as_str()).collect();
-            let batch = build_title_batch(&titles);
+            let batch = build_batch(batch_start, WRITER_BATCH);
             let _ = w.append(&batch);
             let _ = w.commit();
             batch_start += WRITER_BATCH;
@@ -219,13 +294,49 @@ async fn writer_loop(st: Supertable, stop: Arc<AtomicBool>) -> usize {
     commits
 }
 
+// Vector reader loop: exercises the global-pool escape at vector/reader.rs:2052,2280.
+async fn vector_reader_loop(
+    st: Supertable,
+    stop: Arc<AtomicBool>,
+    phase_start: Instant,
+    warmup: Duration,
+) -> Vec<Duration> {
+    // Fixed unit-ish query vector — direction matters for cosine, magnitude doesn't.
+    let query: Vec<f32> = (0..VEC_DIM).map(|j| (j % 13) as f32 + 0.5).collect();
+    let mut latencies = Vec::new();
+    while !stop.load(Ordering::Relaxed) {
+        let t0 = Instant::now();
+        let _ = black_box(
+            st.vector_search(
+                VEC_COLUMN,
+                &query,
+                TOP_K,
+                VectorSearchOptions::new(),
+                None,
+                None,
+            )
+            .expect("vector_search"),
+        );
+        if phase_start.elapsed() > warmup {
+            latencies.push(t0.elapsed());
+        }
+    }
+    latencies
+}
+
+struct PhaseResult {
+    fts: PhaseStat,
+    vec: PhaseStat,
+    commits: usize,
+}
+
 fn run_phase(
     st: &Supertable,
     n_readers: usize,
     with_writer: bool,
     total: Duration,
     warmup: Duration,
-) -> (PhaseStat, usize) {
+) -> PhaseResult {
     let rt = build_sim_runtime();
     let stop = Arc::new(AtomicBool::new(false));
     let phase_start = Instant::now();
@@ -238,7 +349,7 @@ fn run_phase(
         None
     };
 
-    let readers: Vec<_> = (0..n_readers)
+    let fts_readers: Vec<_> = (0..n_readers)
         .map(|_| {
             let st_r = st.clone();
             let stop_r = Arc::clone(&stop);
@@ -246,16 +357,30 @@ fn run_phase(
         })
         .collect();
 
+    let vec_readers: Vec<_> = (0..n_readers)
+        .map(|_| {
+            let st_r = st.clone();
+            let stop_r = Arc::clone(&stop);
+            rt.spawn(async move { vector_reader_loop(st_r, stop_r, phase_start, warmup).await })
+        })
+        .collect();
+
     // Sleep on the calling thread; the rt drives tasks concurrently.
     std::thread::sleep(total);
     stop.store(true, Ordering::Relaxed);
 
-    let all: Vec<Duration> = rt.block_on(async {
-        join_all(readers)
+    let (fts_all, vec_all): (Vec<Duration>, Vec<Duration>) = rt.block_on(async {
+        let fts = join_all(fts_readers)
             .await
             .into_iter()
-            .flat_map(|r| r.expect("reader task"))
-            .collect()
+            .flat_map(|r| r.expect("fts reader task"))
+            .collect();
+        let vec = join_all(vec_readers)
+            .await
+            .into_iter()
+            .flat_map(|r| r.expect("vec reader task"))
+            .collect();
+        (fts, vec)
     });
 
     let commits = match writer {
@@ -264,7 +389,11 @@ fn run_phase(
     };
 
     let measure_secs = (total - warmup).as_secs_f64();
-    (stat_from(all, measure_secs), commits)
+    PhaseResult {
+        fts: stat_from(fts_all, measure_secs),
+        vec: stat_from(vec_all, measure_secs),
+        commits,
+    }
 }
 
 // ─── Entry point ──────────────────────────────────────────────────────────────
@@ -288,14 +417,26 @@ pub fn run() {
     let mut report = Report::load("concurrent");
     let mut rows: Vec<Vec<Cell>> = Vec::new();
 
+    let with_baseline = run_baseline();
+
     for tenant in 0..tenants {
         let fixture = build_fixture(docs);
 
-        eprintln!("[concurrent] table {tenant}: baseline ({readers} readers, no writer)...");
-        let (base, _) = run_phase(&fixture.st, readers, false, dur, warmup);
+        let base = if with_baseline {
+            eprintln!(
+                "[concurrent] table {tenant}: baseline ({readers} fts+vec readers, no writer)..."
+            );
+            Some(run_phase(&fixture.st, readers, false, dur, warmup))
+        } else {
+            eprintln!(
+                "[concurrent] table {tenant}: skipping baseline (INFINO_BENCH_CONCURRENT_BASELINE=0)"
+            );
+            None
+        };
 
-        eprintln!("[concurrent] table {tenant}: contention ({readers}r+1w)...");
-        let (contend, commits) = run_phase(&fixture.st, readers, true, dur, warmup);
+        eprintln!("[concurrent] table {tenant}: contention ({readers} fts+vec readers + 1w)...");
+        let contend = run_phase(&fixture.st, readers, true, dur, warmup);
+        let commits = contend.commits;
 
         let label = if tenants == 1 {
             "single table".to_string()
@@ -303,72 +444,99 @@ pub fn run() {
             format!("table {tenant}")
         };
 
-        let p99_delta_pct = if base.p99 > Duration::ZERO {
-            100.0 * (contend.p99.as_secs_f64() - base.p99.as_secs_f64()) / base.p99.as_secs_f64()
-        } else {
-            0.0
-        };
+        // Emit one row per modality (FTS, vector) per condition (baseline, contention).
+        #[allow(clippy::type_complexity)]
+        let modalities: &[(&str, fn(&PhaseResult) -> &PhaseStat)] =
+            &[("fts", |r| &r.fts), ("vec", |r| &r.vec)];
 
-        let qps_delta_pct = if base.qps > 0.0 {
-            100.0 * (contend.qps - base.qps) / base.qps
-        } else {
-            0.0
-        };
+        for (modality, stat_fn) in modalities {
+            let contend_stat = stat_fn(&contend);
 
-        let base_p50 = base.p50.as_nanos() as f64;
-        let base_p95 = base.p95.as_nanos() as f64;
-        let base_p99 = base.p99.as_nanos() as f64;
-        let contend_p50 = contend.p50.as_nanos() as f64;
-        let contend_p95 = contend.p95.as_nanos() as f64;
-        let contend_p99 = contend.p99.as_nanos() as f64;
+            if let Some(ref b) = base {
+                let base_stat = stat_fn(b);
+                let base_p50 = base_stat.p50.as_nanos() as f64;
+                let base_p95 = base_stat.p95.as_nanos() as f64;
+                let base_p99 = base_stat.p99.as_nanos() as f64;
+                rows.push(vec![
+                    text(format!("{label} / {modality}")),
+                    text("baseline".to_string()),
+                    metric(base_p50, fmt_time(base_p50), Better::Lower),
+                    metric(base_p95, fmt_time(base_p95), Better::Lower),
+                    metric(base_p99, fmt_time(base_p99), Better::Lower),
+                    metric(
+                        base_stat.qps,
+                        format!("{:.0} q/s", base_stat.qps),
+                        Better::Higher,
+                    ),
+                    text(format!("{}", base_stat.n)),
+                ]);
+            }
 
-        rows.push(vec![
-            text(label.clone()),
-            text("baseline"),
-            metric(base_p50, fmt_time(base_p50), Better::Lower),
-            metric(base_p95, fmt_time(base_p95), Better::Lower),
-            metric(base_p99, fmt_time(base_p99), Better::Lower),
-            metric(base.qps, format!("{:.0} q/s", base.qps), Better::Higher),
-            text(format!("{}", base.n)),
-        ]);
-        rows.push(vec![
-            text(label),
-            text(format!("{readers}r+1w")),
-            metric(contend_p50, fmt_time(contend_p50), Better::Lower),
-            metric(contend_p95, fmt_time(contend_p95), Better::Lower),
-            metric(contend_p99, fmt_time(contend_p99), Better::Lower),
-            metric(
-                contend.qps,
-                format!("{:.0} q/s ({:+.1}%)", contend.qps, qps_delta_pct),
-                Better::Higher,
-            ),
-            text(format!(
-                "{} / {} commits (p99 {:+.1}%)",
-                contend.n, commits, p99_delta_pct
-            )),
-        ]);
+            let p99_delta_pct = base.as_ref().map(|b| {
+                let base_stat = stat_fn(b);
+                if base_stat.p99 > Duration::ZERO {
+                    100.0 * (contend_stat.p99.as_secs_f64() - base_stat.p99.as_secs_f64())
+                        / base_stat.p99.as_secs_f64()
+                } else {
+                    0.0
+                }
+            });
+            let qps_delta_pct = base.as_ref().map(|b| {
+                let base_stat = stat_fn(b);
+                if base_stat.qps > 0.0 {
+                    100.0 * (contend_stat.qps - base_stat.qps) / base_stat.qps
+                } else {
+                    0.0
+                }
+            });
 
-        eprintln!(
-            "[concurrent] table {tenant}: baseline {:.0} q/s | contention {:.0} q/s ({:+.1}%) | writer {:.1} commits/s | p99 {:+.1}%",
-            base.qps,
-            contend.qps,
-            qps_delta_pct,
-            commits as f64 / measure_secs,
-            p99_delta_pct,
-        );
+            let cp50 = contend_stat.p50.as_nanos() as f64;
+            let cp95 = contend_stat.p95.as_nanos() as f64;
+            let cp99 = contend_stat.p99.as_nanos() as f64;
+            let n_note = match p99_delta_pct {
+                Some(d) => format!("{} / {} commits (p99 {:+.1}%)", contend_stat.n, commits, d),
+                None => format!("{} / {} commits", contend_stat.n, commits),
+            };
+            let qps_label = match qps_delta_pct {
+                Some(d) => format!("{:.0} q/s ({:+.1}%)", contend_stat.qps, d),
+                None => format!("{:.0} q/s", contend_stat.qps),
+            };
+            rows.push(vec![
+                text(format!("{label} / {modality}")),
+                text(format!("{readers}r+1w")),
+                metric(cp50, fmt_time(cp50), Better::Lower),
+                metric(cp95, fmt_time(cp95), Better::Lower),
+                metric(cp99, fmt_time(cp99), Better::Lower),
+                metric(contend_stat.qps, qps_label, Better::Higher),
+                text(n_note),
+            ]);
+
+            eprintln!(
+                "[concurrent] table {tenant} / {modality}: baseline {:.0} q/s | contention {:.0} q/s | p99 {} | writer {:.1} commits/s",
+                base.as_ref().map(|b| stat_fn(b).qps).unwrap_or(0.0),
+                contend_stat.qps,
+                match p99_delta_pct {
+                    Some(d) => format!("{:+.1}%", d),
+                    None => "—".into(),
+                },
+                commits as f64 / measure_secs,
+            );
+        }
     }
 
     report.emit(&Section {
         anchor: "bench/concurrent/contention".into(),
         title: format!(
-            "Concurrent ingest+query — {tenants} table(s), {docs} docs, {readers} readers, {:.0}s window",
+            "Concurrent ingest+query — {tenants} table(s), {docs} docs, {readers} fts+vec readers, {:.0}s window",
             dur.as_secs_f64()
         ),
         note: format!(
             "Duration-based ({:.0}s total, {:.0}s warmup discarded). \
-             Readers fire in tight loops; writer commits {WRITER_BATCH}-row batches continuously. \
+             Each reader group fires FTS (bm25_search) and vector (vector_search dim={VEC_DIM}) queries in tight loops; \
+             writer commits {WRITER_BATCH}-row batches continuously. \
              Runs on multi_thread tokio runtime (bridge_sync_to_async → block_in_place). \
-             QPS delta and p99 delta measure contention overhead. \
+             Vector queries exercise the global-pool escape at superfile/vector/reader.rs:2052,2280. \
+             QPS delta and p99 delta measure contention overhead vs baseline. \
              INFINO_BENCH_CONCURRENT_DOCS/READERS/TENANTS/DURATION/WARMUP to adjust. Δ vs previous run.",
             dur.as_secs_f64(),
             warmup.as_secs_f64(),

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -1162,6 +1162,7 @@ pub mod vector {
                 opts,
                 Some(Arc::clone(allow)),
                 None,
+                None,
             ))
             .expect("filtered sweep query");
             sum += corpus::recall_at_k(&hits, gt);
@@ -1301,6 +1302,7 @@ pub mod vector {
                     TOP_K,
                     opts,
                     Some(Arc::clone(allow)),
+                    None,
                     None,
                 ))
                 .expect("filtered latency query");
@@ -1483,6 +1485,7 @@ pub mod vector {
                             ),
                             Some(Arc::clone(&allow)),
                             None,
+                            None,
                         ))
                         .expect("filtered recall query");
                         recalls.push(corpus::recall_at_k(&hits, gt));
@@ -1570,6 +1573,7 @@ pub mod vector {
                                 TOP_K,
                                 exec_vec::search_opts(nominal_nprobe, nominal_rerank),
                                 set.clone(),
+                                None,
                                 None,
                             ))
                             .expect("filtered vector search");

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -39,6 +39,7 @@ use parquet::{
     },
     file::metadata::{PageIndexPolicy, ParquetMetaData},
 };
+use rayon::ThreadPool;
 use roaring::RoaringBitmap;
 
 use crate::{
@@ -1120,7 +1121,7 @@ impl SuperfileReader {
         k: usize,
         options: VectorSearchOptions,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        self.vector_hits_filtered_async(column, query, k, options, None, None)
+        self.vector_hits_filtered_async(column, query, k, options, None, None, None)
             .await
     }
 
@@ -1143,6 +1144,7 @@ impl SuperfileReader {
         options: VectorSearchOptions,
         allow: Option<Arc<RoaringBitmap>>,
         deny: Option<Arc<RoaringBitmap>>,
+        pool: Option<Arc<ThreadPool>>,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let filtered = allow.is_some();
         let (nprobe, rerank_mult) = options.resolve(filtered);
@@ -1151,7 +1153,7 @@ impl SuperfileReader {
             .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
         let rerank_mult = v.public_rerank_mult(column, rerank_mult);
         Ok(
-            v.search_async(column, query, k, nprobe, rerank_mult, allow, deny)
+            v.search_async(column, query, k, nprobe, rerank_mult, allow, deny, pool)
                 .await?,
         )
     }
@@ -1169,7 +1171,7 @@ impl SuperfileReader {
         clusters: &[u32],
         options: VectorSearchOptions,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        self.vector_search_clusters_filtered(column, query, k, clusters, options, None, None)
+        self.vector_search_clusters_filtered(column, query, k, clusters, options, None, None, None)
             .await
     }
 
@@ -1190,6 +1192,7 @@ impl SuperfileReader {
         options: VectorSearchOptions,
         allow: Option<Arc<RoaringBitmap>>,
         deny: Option<Arc<RoaringBitmap>>,
+        pool: Option<Arc<ThreadPool>>,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let filtered = allow.is_some();
         let (_, rerank_mult) = options.resolve(filtered);
@@ -1198,7 +1201,7 @@ impl SuperfileReader {
             .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
         let rerank_mult = v.public_rerank_mult(column, rerank_mult);
         Ok(
-            v.search_clusters_async(column, query, k, clusters, rerank_mult, allow, deny)
+            v.search_clusters_async(column, query, k, clusters, rerank_mult, allow, deny, pool)
                 .await?,
         )
     }

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use rayon::prelude::*;
+use rayon::{ThreadPool, prelude::*};
 use roaring::RoaringBitmap;
 use serde::Deserialize;
 use tokio::sync::oneshot;
@@ -166,6 +166,8 @@ struct ProbeCtx<'a> {
     // enters ranking — so the top-k ranks only live rows and never
     // contains deleted docs. The opposite-polarity sibling of `allow`.
     deny: Option<Arc<RoaringBitmap>>,
+    /// Rayon pool for CPU work. `None` falls back to the global pool.
+    pool: Option<Arc<ThreadPool>>,
 }
 
 impl ColumnReader {
@@ -1354,6 +1356,7 @@ impl VectorReader {
             rerank_mult,
             allow: None,
             deny: None,
+            pool: None,
         };
         let (candidates, survivor_full_ranges) = match build_shortlist(
             col,
@@ -1396,6 +1399,7 @@ impl VectorReader {
             &candidates,
             col,
             query,
+            None,
             k,
         )
         .await
@@ -1414,7 +1418,7 @@ impl VectorReader {
     /// `bm25_search_pretokenized` path — rather than serializing cold
     /// object-store GETs. The CPU steps (centroid/code scoring,
     /// rerank) call the same helpers as the sync path and parallelize
-    /// on the global rayon pool; warm/in-memory ranges still resolve
+    /// on the configured rayon pool; warm/in-memory ranges still resolve
     /// sync/zero-copy via `try_get_range_sync` with no `await`.
     pub async fn search_async(
         &self,
@@ -1430,6 +1434,7 @@ impl VectorReader {
         // Tombstone deny-set excluded before ranking on the unfiltered
         // path; `None` leaves ranking unchanged.
         deny: Option<Arc<RoaringBitmap>>,
+        pool: Option<Arc<ThreadPool>>,
     ) -> Result<Vec<(u32, f32)>, VectorError> {
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
@@ -1484,6 +1489,7 @@ impl VectorReader {
             rerank_mult: rerank_mult_eff,
             allow,
             deny,
+            pool,
         };
         self.probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
             .await
@@ -1510,6 +1516,7 @@ impl VectorReader {
         // Tombstone deny-set excluded before ranking on the unfiltered
         // path; `None` leaves ranking unchanged.
         deny: Option<Arc<RoaringBitmap>>,
+        pool: Option<Arc<ThreadPool>>,
     ) -> Result<Vec<(u32, f32)>, VectorError> {
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
@@ -1540,6 +1547,7 @@ impl VectorReader {
             rerank_mult: effective_filtered_rerank_mult(rerank_mult, filter_mult),
             allow,
             deny,
+            pool,
         };
         self.probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
             .await
@@ -1647,6 +1655,7 @@ impl VectorReader {
             &candidates,
             col,
             query,
+            ctx.pool.clone(),
             ctx.k,
         )
         .await
@@ -1969,6 +1978,14 @@ enum ShortlistOutcome {
     },
 }
 
+/// Dispatch `f` onto `pool` if provided, or the global rayon pool otherwise.
+fn spawn_on<F: FnOnce() + Send + 'static>(pool: Option<&ThreadPool>, f: F) {
+    match pool {
+        Some(p) => p.spawn(f),
+        None => rayon::spawn(f),
+    }
+}
+
 /// Pure-CPU stage shared by the sync and async vector search paths.
 ///
 /// Scores the probed clusters' 1-bit codes into a bounded shortlist,
@@ -2032,7 +2049,7 @@ async fn build_shortlist(
             );
         };
     let shortlist_heap = if total_candidates >= PARALLEL_SCAN_MIN && cluster_meta.len() > 1 {
-        // Parallelize the coarse 1-bit scan across the global rayon pool,
+        // Parallelize the coarse 1-bit scan across the configured rayon pool,
         // bridged back via a oneshot so no tokio worker blocks under the
         // compute. Cluster scoring is order-independent — every survivor
         // is re-sorted below — so chunked-parallel and serial shortlists
@@ -2049,7 +2066,7 @@ async fn build_shortlist(
         // Same for the tombstone deny-set.
         let deny_owned = ctx.deny.clone();
         let (tx, rx) = oneshot::channel();
-        rayon::spawn(move || {
+        spawn_on(ctx.pool.as_deref(), move || {
             let acc = meta_owned
                 .par_chunks(chunk)
                 .zip(blocks_owned.par_chunks(chunk))
@@ -2262,12 +2279,12 @@ fn parallel_chunks(n_items: usize) -> usize {
         .max(1)
 }
 
-/// Map `f` over `items` on the global rayon pool, preserving input
+/// Map `f` over `items` on the configured rayon pool, preserving input
 /// order. The order-independent vector scans (rerank) use this; the
 /// compute runs on rayon (`par_iter().map().collect()`) bridged back to
 /// the async caller via a oneshot, so no tokio worker blocks under it.
 /// `f` and the items must be `'static` so the work can move onto rayon.
-async fn par_map<T, R, F>(items: Vec<T>, f: F) -> Vec<R>
+async fn par_map<T, R, F>(items: Vec<T>, f: F, pool: Option<Arc<ThreadPool>>) -> Vec<R>
 where
     T: Send + Sync + 'static,
     R: Send + 'static,
@@ -2277,7 +2294,7 @@ where
         return items.iter().map(&f).collect();
     }
     let (tx, rx) = oneshot::channel();
-    rayon::spawn(move || {
+    spawn_on(pool.as_deref(), move || {
         let out: Vec<R> = items.par_iter().map(f).collect();
         let _ = tx.send(out);
     });
@@ -2497,6 +2514,7 @@ async fn rerank_candidates_from_blocks(
     candidates: &[RerankCandidate],
     col: &ColumnReader,
     query: &[f32],
+    pool: Option<Arc<ThreadPool>>,
     k: usize,
 ) -> Result<Vec<(u32, f32)>, LazyByteSourceError> {
     let stride = col.rerank_codec.per_vector_bytes(col.dim);
@@ -2514,15 +2532,19 @@ async fn rerank_candidates_from_blocks(
                 let survivors: Option<Arc<Vec<Bytes>>> =
                     survivor_full_rows.map(|s| Arc::new(s.to_vec()));
                 let query: Arc<Vec<f32>> = Arc::new(query.to_vec());
-                par_map(candidates.to_vec(), move |cand: &RerankCandidate| {
-                    let bytes = candidate_full_bytes(
-                        &blocks,
-                        survivors.as_deref().map(|s| s.as_slice()),
-                        cand,
-                        stride,
-                    );
-                    (cand.did, distance_bytes_codec(metric, codec, &query, bytes))
-                })
+                par_map(
+                    candidates.to_vec(),
+                    move |cand: &RerankCandidate| {
+                        let bytes = candidate_full_bytes(
+                            &blocks,
+                            survivors.as_deref().map(|s| s.as_slice()),
+                            cand,
+                            stride,
+                        );
+                        (cand.did, distance_bytes_codec(metric, codec, &query, bytes))
+                    },
+                    pool.clone(),
+                )
                 .await
             } else {
                 candidates
@@ -2562,6 +2584,7 @@ async fn rerank_candidates_from_blocks(
                         scale,
                         offset,
                         per_doc_norms.clone(),
+                        pool.clone(),
                         k,
                         stride,
                     )
@@ -2591,6 +2614,7 @@ async fn rerank_candidates_from_blocks(
                             parsed.scale.as_slice(),
                             parsed.offset.as_slice(),
                             parsed.per_doc_norms.clone(),
+                            pool.clone(),
                             k,
                             stride,
                         )
@@ -2757,6 +2781,7 @@ async fn sq8_score_and_refine(
     scale: &[f32],
     offset: &[f32],
     per_doc_norms: Option<Arc<[f32]>>,
+    pool: Option<Arc<ThreadPool>>,
     k: usize,
     stride: usize,
 ) -> Vec<(u32, f32)> {
@@ -2798,26 +2823,30 @@ async fn sq8_score_and_refine(
         let blocks: Arc<Vec<Bytes>> = Arc::new(cluster_blocks.to_vec());
         let survivors: Option<Arc<Vec<Bytes>>> = survivor_full_rows.map(|s| Arc::new(s.to_vec()));
         let items: Vec<(usize, RerankCandidate)> = candidates.iter().cloned().enumerate().collect();
-        par_map(items, move |item: &(usize, RerankCandidate)| {
-            let (i, cand) = (item.0, &item.1);
-            let row = candidate_full_bytes(
-                &blocks,
-                survivors.as_deref().map(|s| s.as_slice()),
-                cand,
-                stride,
-            );
-            let code = &row[..dim];
-            let kernel = kernels
-                .get(&cand.cluster_id)
-                .expect("kernel prebuilt for every probed cluster");
-            (
-                cand.did,
-                kernel.distance_at(cand.pos, code),
-                i,
-                cand.pos,
-                cand.cluster_id,
-            )
-        })
+        par_map(
+            items,
+            move |item: &(usize, RerankCandidate)| {
+                let (i, cand) = (item.0, &item.1);
+                let row = candidate_full_bytes(
+                    &blocks,
+                    survivors.as_deref().map(|s| s.as_slice()),
+                    cand,
+                    stride,
+                );
+                let code = &row[..dim];
+                let kernel = kernels
+                    .get(&cand.cluster_id)
+                    .expect("kernel prebuilt for every probed cluster");
+                (
+                    cand.did,
+                    kernel.distance_at(cand.pos, code),
+                    i,
+                    cand.pos,
+                    cand.cluster_id,
+                )
+            },
+            pool,
+        )
         .await
     } else {
         candidates.iter().enumerate().map(score_one).collect()
@@ -3361,7 +3390,7 @@ mod tests {
         let (k, rerank, n_cent) = (5usize, 5usize, 4u32);
 
         let full = r
-            .search_async("v", q, k, n_cent as usize, rerank, None, None)
+            .search_async("v", q, k, n_cent as usize, rerank, None, None, None)
             .await
             .expect("search_async");
         let probed = r
@@ -3371,6 +3400,7 @@ mod tests {
                 k,
                 &(0..n_cent).collect::<Vec<_>>(),
                 rerank,
+                None,
                 None,
                 None,
             )
@@ -3388,7 +3418,7 @@ mod tests {
 
         // Probing no clusters returns nothing.
         let none = r
-            .search_clusters_async("v", q, k, &[], rerank, None, None)
+            .search_clusters_async("v", q, k, &[], rerank, None, None, None)
             .await
             .expect("search_clusters_async empty");
         assert!(none.is_empty(), "probing no clusters returns no hits");
@@ -6296,7 +6326,7 @@ mod tests {
     #[tokio::test]
     async fn par_map_serial_fallback_for_small_input() {
         // parallel_chunks(items) <= 1 takes the serial map arm.
-        let out = par_map(vec![1u32, 2, 3], |x| x * 10).await;
+        let out = par_map(vec![1u32, 2, 3], |x| x * 10, None).await;
         assert_eq!(out, vec![10, 20, 30]);
     }
 
@@ -6496,11 +6526,11 @@ mod tests {
         .expect("open_lazy");
 
         let hits_lazy = r_lazy
-            .search_async("v", &all[17], 5, 4, 20, None, None)
+            .search_async("v", &all[17], 5, 4, 20, None, None, None)
             .await
             .expect("lazy cold Sq8 search_async");
         let hits_eager = r_eager
-            .search_async("v", &all[17], 5, 4, 20, None, None)
+            .search_async("v", &all[17], 5, 4, 20, None, None, None)
             .await
             .expect("eager Sq8 search_async");
         // As in the sync lazy-Sq8 test, pin set overlap rather than exact
@@ -6533,11 +6563,11 @@ mod tests {
 
         let clusters: Vec<u32> = (0..4).collect();
         let hits_lazy = r_lazy
-            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None, None)
+            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None, None, None)
             .await
             .expect("lazy cold search_clusters_async");
         let hits_eager = r_eager
-            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None, None)
+            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None, None, None)
             .await
             .expect("eager search_clusters_async");
         assert_eq!(
@@ -6547,7 +6577,7 @@ mod tests {
         // Out-of-range cluster ids are ignored; an empty selection yields
         // no hits.
         let none = r_lazy
-            .search_clusters_async("embedding", &all[19], 5, &[999u32], 5, None, None)
+            .search_clusters_async("embedding", &all[19], 5, &[999u32], 5, None, None, None)
             .await
             .expect("out-of-range clusters");
         assert!(none.is_empty(), "ids >= n_cent are ignored");
@@ -6559,16 +6589,16 @@ mod tests {
         let (blob, json) = build_blob(32, 16, 4, Metric::L2Sq);
         let r = VectorReader::open(blob, &json).expect("open");
         let unknown = r
-            .search_async("nope", &[0.0; 16], 5, 4, 5, None, None)
+            .search_async("nope", &[0.0; 16], 5, 4, 5, None, None, None)
             .await;
         assert!(matches!(unknown, Err(VectorError::UnknownColumn(_))));
         let dim = r
-            .search_async("embedding", &[0.0; 8], 5, 4, 5, None, None)
+            .search_async("embedding", &[0.0; 8], 5, 4, 5, None, None, None)
             .await;
         assert!(matches!(dim, Err(VectorError::DimensionMismatch { .. })));
         // k == 0 short-circuits to an empty result.
         let empty = r
-            .search_async("embedding", &[0.0; 16], 0, 4, 5, None, None)
+            .search_async("embedding", &[0.0; 16], 0, 4, 5, None, None, None)
             .await
             .expect("k=0 empty");
         assert!(empty.is_empty());
@@ -7162,7 +7192,7 @@ mod tests {
         .expect("open_lazy for search_async");
         flaky_a.fail_from_now();
         let err = ra
-            .search_async("embedding", &all[0], 5, 4, 5, None, None)
+            .search_async("embedding", &all[0], 5, 4, 5, None, None, None)
             .await
             .expect_err("search_async must surface failure");
         assert!(
@@ -7180,7 +7210,7 @@ mod tests {
         .expect("open_lazy for search_clusters_async");
         flaky_c.fail_from_now();
         let err = rc
-            .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None, None)
+            .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None, None, None)
             .await
             .expect_err("search_clusters_async must surface failure");
         assert!(
@@ -7405,7 +7435,7 @@ mod tests {
             .expect("open_lazy search_async");
             flaky_a.fail_after_call(fail_at);
             match ra
-                .search_async("embedding", &all[0], 5, 4, 5, None, None)
+                .search_async("embedding", &all[0], 5, 4, 5, None, None, None)
                 .await
             {
                 Err(VectorError::LazySource(_)) => async_errors += 1,
@@ -7423,7 +7453,7 @@ mod tests {
             .expect("open_lazy search_clusters_async");
             flaky_c.fail_after_call(fail_at);
             match rc
-                .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None, None)
+                .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None, None, None)
                 .await
             {
                 Err(VectorError::LazySource(_)) => clusters_errors += 1,

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -284,6 +284,7 @@ impl SupertableReader {
         // config, not table size. Skipped superfiles issue zero GETs.
         let column_arc = Arc::new(column.to_owned());
         let query_arc = Arc::new(query.to_vec());
+        let reader_pool = Arc::clone(&manifest.options.reader_pool);
 
         // `fanout_with`, not `fanout`: the body needs each superfile's  tombstone bitmap *before* its kernel
         // to push it in as a deny set (`fanout` only drops tombstones post-rank, which underflows).
@@ -294,6 +295,7 @@ impl SupertableReader {
                          (probe, bitmap): (Probe, Option<Arc<RoaringBitmap>>)| {
             let column = Arc::clone(&column_arc);
             let query = Arc::clone(&query_arc);
+            let reader_pool = Arc::clone(&reader_pool);
             async move {
                 // For unfiltered path:
                 //  - it resolve this superfile's tombstone  bitmap once (a warm cache hit after the orchestrator's
@@ -307,17 +309,20 @@ impl SupertableReader {
                     }
                     _ => None,
                 };
+                let pool = Some(Arc::clone(&reader_pool));
                 let hits = match probe {
                     Probe::Clusters(ids) => {
                         reader
                             .vector_search_clusters_filtered(
-                                &column, &query, k, &ids, options, bitmap, deny,
+                                &column, &query, k, &ids, options, bitmap, deny, pool,
                             )
                             .await
                     }
                     Probe::Nprobe => {
                         reader
-                            .vector_hits_filtered_async(&column, &query, k, options, bitmap, deny)
+                            .vector_hits_filtered_async(
+                                &column, &query, k, options, bitmap, deny, pool,
+                            )
                             .await
                     }
                 }


### PR DESCRIPTION
### What is the change about?

Earlier we were using Global rayon pool for Vector searches and for all the other searches we were using the reader pool. This caused cpu contention when read(bm_25, vectors) writes were done together.

This PR enforces reader pool for vector search

### how much did it improve


Before fix:
- FTS under contention: 1253 q/s, p99 +919% over baseline
- Vec under contention: 582 q/s, p99 +877% over baseline

After fix:
- FTS under contention: 1310 q/s (+4.5%), p99 +869%
- Vec under contention: 586 q/s (+0.7%), p99 +834%

Modest improvement because at 50K docs, CPU waves are brief the dominant contention at this scale is I/O (commit flushes). At production scale (millions of docs) where rerank is expensive, the global-pool escape would have been far more damaging.

The next set of PRs helps in making the pools at process level, so that CPU contention caused during runs on multiple supertables will get fixed.