### PR TITLE
node: bump version to 0.1.1

### DIFF
--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.1.0",
-    "infx-darwin-arm64": "0.1.0",
-    "infx-linux-x64-gnu": "0.1.0",
-    "infx-linux-arm64-gnu": "0.1.0",
-    "infx-linux-x64-musl": "0.1.0",
-    "infx-linux-arm64-musl": "0.1.0"
+    "infx-darwin-x64": "0.1.1",
+    "infx-darwin-arm64": "0.1.1",
+    "infx-linux-x64-gnu": "0.1.1",
+    "infx-linux-arm64-gnu": "0.1.1",
+    "infx-linux-x64-musl": "0.1.1",
+    "infx-linux-arm64-musl": "0.1.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",


### PR DESCRIPTION
Bumps the npm package `@infino-ai/infino` from 0.1.0 to 0.1.1 (main `version` plus the per-platform `optionalDependencies` pins that `napi prepublish` keys off).

This releases the Node binding with the config-driven connect surface already on `main`: `storageOptions` for cloud credentials and the opt-in `validate` probe. npm 0.1.0 is already published, so this takes the next independent patch (`major.minor` stays in sync with the engine; patch is per-package).

No binding code changes — that surface landed earlier; this is the version bump only.

After merge, publish via Actions → **Node publish** → Run workflow (dry run first, then re-run with `dry_run` unchecked).