### PR TITLE
ci: scope object-store e2e jobs to ci environment for Azure secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,7 @@ jobs:
   object-store-e2e-guard:
     name: Object store e2e (secret check)
     runs-on: ubuntu-latest
+    environment: ci
     outputs:
       present: ${{ steps.check.outputs.present }}
     steps:
@@ -286,6 +287,7 @@ jobs:
     needs: object-store-e2e-guard
     if: needs.object-store-e2e-guard.outputs.present == 'true'
     runs-on: ubuntu-latest
+    environment: ci
     timeout-minutes: 30
     env:
       RUSTFLAGS: ""


### PR DESCRIPTION
## What
Add `environment: ci` to the `object-store-e2e-guard` and `object-store-e2e` jobs.

## Why
The Azure storage secrets the guard probes for are scoped to the `ci` GitHub environment, not repo secrets. Neither job declared an environment, so the secrets resolved to empty — the guard rendered `if [ -n "" ] && [ -n "" ]`, emitted `present=false`, and the real-Azure e2e job was skipped (0s) on every run, including main.

Opting both jobs into the `ci` environment lets the guard see the secrets and the e2e job use them.

## Notes
The `ci` environment has no protection rules, so this does not gate or pause the run.