### PR TITLE
release: bump crate to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "apache-avro",
  "arc-swap",


### PR DESCRIPTION
Patch release of the core `infino` crate, 0.1.1 → 0.1.2.

Picks up the config-driven connect surface already on `main`: `storage_options` for cloud credentials and the opt-in `validate` probe. No engine code changes here — this is the version bump only.

Bumps both `Cargo.toml` and the `infino` entry in `Cargo.lock` so the `--locked` publish build stays consistent (verified with `cargo metadata --locked`).

After merge, push the `v0.1.2` tag to trigger the crates.io publish. The tag is a crate patch, so the Node and Python binding workflows correctly skip it — they release independently.