### PR TITLE
ci: guard bench janitor to the upstream repo

### DIFF
--- a/.github/workflows/bench-janitor.yml
+++ b/.github/workflows/bench-janitor.yml
@@ -31,6 +31,8 @@ env:
 jobs:
   sweep:
     runs-on: ubuntu-latest
+    # Never run in a fork: the schedule/dispatch would sweep the shared RG.
+    if: github.repository == 'infino-ai/infino'
     # OIDC subject and Azure secrets are scoped to `ci`.
     environment: ci
     steps:


### PR DESCRIPTION
## What

Add a job-level `if: github.repository == 'infino-ai/infino'` guard to the bench-janitor `sweep` job.

## Why

`bench-janitor.yml` is triggered by `schedule` (hourly cron) and `workflow_dispatch`, but had no repository guard — the only such workflow in the repo. In a **fork** with Actions enabled:

- the scheduled cron runs the fork's copy of the workflow, and
- `workflow_dispatch` is triggerable directly,

so both would spin a runner and attempt an Azure login/sweep against the shared `rg-infino-bench` resource group. `environment: ci` only scopes *secrets*; the job still executes.

Sibling `bench.yml` gates forks via `pull_request_target` + `is_fork_pr`, but that PR-shaped pattern doesn't apply to a scheduled janitor. This guard blocks execution entirely on forks while leaving cron + manual dispatch working upstream.

## Risk

None — pure gate; upstream behavior unchanged.