### PR TITLE
ci: validate every Python wheel target in the publish smoke test

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -178,7 +178,8 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install --force-reinstall dist/*.whl pytest
+          # Include optional interop deps so no test is silently skipped.
+          python3 -m pip install --force-reinstall dist/*.whl pytest pandas duckdb
           python3 -m pytest infino-python/tests -v
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -171,16 +171,26 @@ jobs:
           args: --release --locked --out dist -m infino-python/Cargo.toml
 
       # Install the freshly built wheel into a clean interpreter and run the
-      # smoke suite, proving it imports and round-trips before publish. Skipped
-      # for musl wheels, which can't install on the glibc-based runner.
-      - name: Smoke-test wheel
+      # smoke suite, proving it imports and round-trips before publish. glibc
+      # wheels install directly; musl wheels run in an Alpine container matching
+      # the runner arch, since they can't install on the glibc-based runner.
+      # Optional interop deps (pandas, duckdb) are installed so no test is
+      # silently skipped.
+      - name: Smoke-test wheel (glibc)
         if: ${{ !contains(matrix.target, 'musl') }}
         shell: bash
         run: |
           python3 -m pip install --upgrade pip
-          # Include optional interop deps so no test is silently skipped.
           python3 -m pip install --force-reinstall dist/*.whl pytest pandas duckdb
           python3 -m pytest infino-python/tests -v
+
+      - name: Smoke-test wheel (musl)
+        if: ${{ contains(matrix.target, 'musl') }}
+        shell: bash
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w python:3.12-alpine sh -c '
+            pip install --force-reinstall dist/*.whl pytest pandas duckdb &&
+            python -m pytest infino-python/tests -v'
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -170,12 +170,8 @@ jobs:
           manylinux: ${{ contains(matrix.target, 'musl') && 'musllinux_1_2' || 'auto' }}
           args: --release --locked --out dist -m infino-python/Cargo.toml
 
-      # Install the freshly built wheel into a clean interpreter and run the
-      # smoke suite, proving it imports and round-trips before publish. glibc
-      # wheels install directly; musl wheels run in an Alpine container matching
-      # the runner arch, since they can't install on the glibc-based runner.
-      # Optional interop deps (pandas, duckdb) are installed so no test is
-      # silently skipped.
+      # Smoke-test the wheel before publish. Interop deps (pandas, duckdb) keep
+      # tests from silently skipping; musl runs in Alpine (can't install on glibc).
       - name: Smoke-test wheel (glibc)
         if: ${{ !contains(matrix.target, 'musl') }}
         shell: bash


### PR DESCRIPTION
## What

The pre-publish wheel smoke test left gaps that let untested wheels ship:

- **Interop tests skipped.** The smoke env installed only the wheel + `pytest`, so the pandas/duckdb Parquet-interop tests were skipped — and one hard-failed on the missing `pandas` import. Now installs `pandas duckdb` alongside the wheel (matching the main CI smoke step in `ci.yml`).
- **musl wheels never smoke-tested.** The step was skipped entirely for musl targets (can't install on the glibc runner), so musl wheels published unvalidated. Now run the musl smoke suite in a `python:3.12-alpine` container matching the runner arch.

## Why

A broken interop path or a broken musl wheel could reach a release with the smoke gate green. This exercises every published wheel target with the same test suite and optional deps before publish.

## Notes

- Azure e2e tests stay out of the publish smoke by design — they need live Azure creds and are already covered by the secret-gated `object-store-e2e` job in `ci.yml`.
- The publish workflow is tag-triggered, so this can't be dry-run pre-merge; first real validation is the next release.