### PR TITLE
catalog: preserve schema for zero-row query_sql results

### DIFF
--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -119,6 +119,18 @@ def test_query_sql_returns_pyarrow_table():
     assert out.column("n")[0].as_py() == 3
 
 
+def test_query_sql_zero_row_result_returns_empty_table_with_schema():
+    # A zero-row result must be an empty table with the projected schema.
+    db = infino.connect("memory://")
+    table = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    table.append(_title_batch(["alpha", "beta"]))
+
+    out = db.query_sql("SELECT title FROM docs WHERE title = 'no_match'")
+    assert out.num_rows == 0
+    assert out.to_pylist() == []
+    assert out.schema.get_field_index("title") != -1
+
+
 def test_query_sql_bm25_tvf():
     db = infino.connect("memory://")
     table = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -119,16 +119,20 @@ def test_query_sql_returns_pyarrow_table():
     assert out.column("n")[0].as_py() == 3
 
 
-def test_query_sql_zero_row_result_returns_empty_table_with_schema():
-    # A zero-row result must be an empty table with the projected schema.
+def test_query_sql_zero_row_filter_preserves_projected_schema():
     db = infino.connect("memory://")
     table = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
     table.append(_title_batch(["alpha", "beta"]))
 
+    # Ground-truth schema from a query that returns rows.
+    with_rows = db.query_sql("SELECT title FROM docs")
+    expected_schema = with_rows.schema
+
+    # Zero-row result must carry the identical schema.
     out = db.query_sql("SELECT title FROM docs WHERE title = 'no_match'")
     assert out.num_rows == 0
     assert out.to_pylist() == []
-    assert out.schema.get_field_index("title") != -1
+    assert out.schema == expected_schema
 
 
 def test_query_sql_bm25_tvf():

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -502,7 +502,15 @@ impl Connection {
                 .sql(&sql)
                 .await
                 .map_err(|e| InfinoError::Query(e.to_string()))?;
-            df.collect().await.map_err(sql_exec_error)
+            // Preserve the output schema so a zero-row result is a well-formed
+            // empty batch rather than a schema-less Vec.
+            let output_schema: SchemaRef = df.schema().inner().clone();
+            let batches = df.collect().await.map_err(sql_exec_error)?;
+            if batches.is_empty() {
+                Ok(vec![RecordBatch::new_empty(output_schema)])
+            } else {
+                Ok(batches)
+            }
         };
         // A query that names a `FROM` catalog table drives on that table's
         // runtime; otherwise the connection's own. The fallback still has to
@@ -1121,6 +1129,35 @@ mod tests {
             .query_sql("SELECT title FROM docs")
             .expect("a streaming scan is not gated");
         assert_eq!(n_rows(&out), n);
+    }
+
+    #[test]
+    fn query_sql_zero_row_result_carries_projected_schema() {
+        // A WHERE predicate that matches nothing must return a batch with the projected schema
+        let conn = connect("memory://").expect("connect");
+        let docs = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create docs");
+        docs.append(&build_title_batch(&["alpha", "beta"]))
+            .expect("append");
+
+        let batches = conn
+            .query_sql("SELECT title FROM docs WHERE title = 'no_match'")
+            .expect("zero-row query must not error");
+        assert!(
+            !batches.is_empty(),
+            "must contain at least one (empty) batch"
+        );
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 0, "no rows should match");
+        assert!(
+            batches[0]
+                .schema()
+                .fields()
+                .iter()
+                .any(|f| f.name() == "title"),
+            "projected schema must include 'title'"
+        );
     }
 
     #[test]

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -502,8 +502,12 @@ impl Connection {
                 .sql(&sql)
                 .await
                 .map_err(|e| InfinoError::Query(e.to_string()))?;
-            // Preserve the output schema so a zero-row result is a well-formed
-            // empty batch rather than a schema-less Vec.
+
+            // A RecordBatch carries the schema; an empty Vec does not. Capture
+            // the output schema before collect() consumes the DataFrame so a
+            // zero-row result returns one empty batch with the projected
+            // schema, rather than a schema-less Vec — which the Python binding's
+            // Table.from_batches([]) can't build from.
             let output_schema: SchemaRef = df.schema().inner().clone();
             let batches = df.collect().await.map_err(sql_exec_error)?;
             if batches.is_empty() {
@@ -1132,8 +1136,40 @@ mod tests {
     }
 
     #[test]
-    fn query_sql_zero_row_result_carries_projected_schema() {
-        // A WHERE predicate that matches nothing must return a batch with the projected schema
+    fn query_sql_zero_row_filter_preserves_projected_schema() {
+        let conn = connect("memory://").expect("connect");
+        let docs = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create docs");
+        docs.append(&build_title_batch(&["alpha", "beta"]))
+            .expect("append");
+
+        // Same projection with rows gives the ground-truth schema to compare against.
+        let with_rows = conn
+            .query_sql("SELECT _id, title FROM docs")
+            .expect("query with rows");
+        let expected_schema = with_rows[0].schema();
+
+        let batches = conn
+            .query_sql("SELECT _id, title FROM docs WHERE title = 'no_match'")
+            .expect("zero-row query must not error");
+        assert!(
+            !batches.is_empty(),
+            "must contain at least one (empty) batch"
+        );
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 0, "no rows should match");
+        assert_eq!(
+            batches[0].schema(),
+            expected_schema,
+            "zero-row schema must match the with-rows schema"
+        );
+    }
+
+    #[test]
+    fn query_sql_zero_row_group_by_preserves_projected_schema() {
+        // GROUP BY is a different DataFusion operator path from a filtered scan;
+        // zero matching groups must still produce a schema-bearing empty batch.
         let conn = connect("memory://").expect("connect");
         let docs = conn
             .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
@@ -1142,21 +1178,24 @@ mod tests {
             .expect("append");
 
         let batches = conn
-            .query_sql("SELECT title FROM docs WHERE title = 'no_match'")
-            .expect("zero-row query must not error");
+            .query_sql(
+                "SELECT title, COUNT(*) AS n FROM docs WHERE title = 'no_match' GROUP BY title",
+            )
+            .expect("zero-row GROUP BY must not error");
         assert!(
             !batches.is_empty(),
             "must contain at least one (empty) batch"
         );
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-        assert_eq!(total_rows, 0, "no rows should match");
+        assert_eq!(total_rows, 0, "no groups should form");
+        let schema = batches[0].schema();
         assert!(
-            batches[0]
-                .schema()
-                .fields()
-                .iter()
-                .any(|f| f.name() == "title"),
+            schema.fields().iter().any(|f| f.name() == "title"),
             "projected schema must include 'title'"
+        );
+        assert!(
+            schema.fields().iter().any(|f| f.name() == "n"),
+            "projected schema must include 'n'"
         );
     }
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1177,6 +1177,14 @@ mod tests {
         docs.append(&build_title_batch(&["alpha", "beta"]))
             .expect("append");
 
+        // The same aggregate over matching rows gives the ground-truth schema:
+        // an aggregate's output schema (group keys + aggregate exprs) must be
+        // identical whether or not any group forms.
+        let with_groups = conn
+            .query_sql("SELECT title, COUNT(*) AS n FROM docs GROUP BY title")
+            .expect("GROUP BY with rows");
+        let expected_schema = with_groups[0].schema();
+
         let batches = conn
             .query_sql(
                 "SELECT title, COUNT(*) AS n FROM docs WHERE title = 'no_match' GROUP BY title",
@@ -1188,14 +1196,10 @@ mod tests {
         );
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 0, "no groups should form");
-        let schema = batches[0].schema();
-        assert!(
-            schema.fields().iter().any(|f| f.name() == "title"),
-            "projected schema must include 'title'"
-        );
-        assert!(
-            schema.fields().iter().any(|f| f.name() == "n"),
-            "projected schema must include 'n'"
+        assert_eq!(
+            batches[0].schema(),
+            expected_schema,
+            "zero-group schema must match the with-groups schema"
         );
     }
 


### PR DESCRIPTION
## What

`query_sql()` raises `ValueError: Must pass schema, or at least one RecordBatch` when the query matches zero rows. Calling `.num_rows` or `.to_pylist()` on the result both fail, making any legitimately-empty result (selective filter, absent term, empty facet column) crash the caller.

## Why 

`df.collect()` returns an empty `Vec<RecordBatch>` when no rows match. The schema is not carried on the `Vec` itself, so the Python binding's `pyarrow.Table.from_batches([])` call has no schema to build from and raises.

## How

Capture the output schema from the `DataFrame` before consuming it with `collect()`. If the collected batches are empty, return a single `RecordBatch::new_empty(schema)` so callers always receive a well-formed result with the projected schema intact.

## Testing

Added a Rust unit test (`query_sql_zero_row_result_carries_projected_schema`) and a Python integration test (`test_query_sql_zero_row_result_returns_empty_table_with_schema`).

## Performance
Off the hot path. Schema cloning is a simple O(1) clone, and `RecordBatch::new_empty` is only called on the empty query results path.

---
Fixes #326 