### PR TITLE
[2/n] feat memory: wire the connection budget through connect + config

### DIFF
--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -98,8 +98,8 @@ use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use infino::{
     config::{
-        CompactionSettings, Config, StorageBackend, StorageColdFetchMode, StorageSettings,
-        SupertableSettings,
+        CompactionSettings, Config, MemorySettings, StorageBackend, StorageColdFetchMode,
+        StorageSettings, SupertableSettings,
     },
     superfile::{
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder, VectorConfig},
@@ -1879,6 +1879,7 @@ pub(crate) mod diag {
                 ..StorageSettings::default()
             },
             compaction: CompactionSettings::default(),
+            memory: MemorySettings::default(),
         }
     }
 

--- a/public-api.txt
+++ b/public-api.txt
@@ -159,6 +159,7 @@ pub fn infino::ConnectOptions::new() -> Self
 pub fn infino::ConnectOptions::with_cache_budget_bytes(self, u64) -> Self
 pub fn infino::ConnectOptions::with_cache_dir(self, impl core::convert::Into<std::path::PathBuf>) -> Self
 pub fn infino::ConnectOptions::with_cold_fetch_mode(self, infino::ColdFetchMode) -> Self
+pub fn infino::ConnectOptions::with_connection_memory_budget_bytes(self, u64) -> Self
 pub fn infino::ConnectOptions::with_storage_option(self, impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn infino::ConnectOptions::with_validate(self, bool) -> Self
 impl core::clone::Clone for infino::ConnectOptions

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -42,6 +42,8 @@ use uri::{Backend, parse_uri};
 
 use crate::{
     InfinoError,
+    config::DEFAULT_CONNECTION_BUDGET_BYTES,
+    memory::ConnectionMemoryBudget,
     runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, build_query_runtime},
     storage::{StorageError, StorageProvider},
     superfile::{
@@ -103,11 +105,22 @@ pub fn connect_with(
             CatalogStore::Storage(root)
         }
     };
+
+    // Budget comes from `ConnectOptions`; unset falls back to the engine
+    // default (measure-only today). The `config.yaml` default takes a separate
+    // path (`apply_config`), so `connect` never reads config.
+    let connection_memory_budget = ConnectionMemoryBudget::from_budget_bytes(
+        options
+            .connection_memory_budget_bytes
+            .unwrap_or(DEFAULT_CONNECTION_BUDGET_BYTES),
+    );
+
     Ok(Connection {
         inner: Arc::new(ConnectionInner {
             backend,
             options,
             store,
+            connection_memory_budget,
             query_runtime: OnceLock::new(),
         }),
     })
@@ -124,6 +137,10 @@ struct ConnectionInner {
     backend: Backend,
     options: ConnectOptions,
     store: CatalogStore,
+    /// Per-connection memory budget, minted once at `connect` and shared
+    /// (cloned `Arc`) into every table's `SupertableOptions`. See
+    /// [`crate::memory`].
+    connection_memory_budget: Arc<ConnectionMemoryBudget>,
     /// Runtime for the table-free `query_sql` fallback — search TVFs name
     /// their table in an argument, not a `FROM` relation, so no supertable
     /// runtime is in scope. See [`build_query_runtime`] for why it must be
@@ -183,7 +200,14 @@ impl Connection {
 
         match &self.inner.store {
             CatalogStore::Memory(map) => {
-                let opts = build_options(schema, fts_cfg, vec_cfg, tokenizer, None)?;
+                let opts = build_options(
+                    schema,
+                    fts_cfg,
+                    vec_cfg,
+                    tokenizer,
+                    None,
+                    Arc::clone(&self.inner.connection_memory_budget),
+                )?;
                 let handle = Supertable::create(opts)?;
                 let mut map = map.lock().expect("catalog mutex poisoned");
                 if map.contains_key(name) {
@@ -230,8 +254,14 @@ impl Connection {
                 // cache directory; superfile keys carry the location, so a
                 // re-created table never reads a dropped generation's bytes.
                 let disk_cache = build_disk_cache(&self.inner.options, &table_storage, name)?;
-                let mut opts =
-                    build_options(schema, fts_cfg, vec_cfg, tokenizer, Some(table_storage))?;
+                let mut opts = build_options(
+                    schema,
+                    fts_cfg,
+                    vec_cfg,
+                    tokenizer,
+                    Some(table_storage),
+                    Arc::clone(&self.inner.connection_memory_budget),
+                )?;
                 if let Some(cache) = disk_cache {
                     opts = opts.with_disk_cache(cache);
                 }
@@ -311,8 +341,14 @@ impl Connection {
                 // Cache directory is keyed on the stable name, matching
                 // `create_table` (the on-storage subtree is `entry.location`).
                 let disk_cache = build_disk_cache(&self.inner.options, &table_storage, name)?;
-                let mut opts =
-                    build_options(schema, fts_cfg, vec_cfg, tokenizer, Some(table_storage))?;
+                let mut opts = build_options(
+                    schema,
+                    fts_cfg,
+                    vec_cfg,
+                    tokenizer,
+                    Some(table_storage),
+                    Arc::clone(&self.inner.connection_memory_budget),
+                )?;
                 if let Some(cache) = disk_cache {
                     opts = opts.with_disk_cache(cache);
                 }
@@ -509,11 +545,14 @@ fn build_options(
     vectors: Vec<VectorConfig>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
     storage: Option<Arc<dyn StorageProvider>>,
+    connection_memory_budget: Arc<ConnectionMemoryBudget>,
 ) -> Result<SupertableOptions, InfinoError> {
     let mut opts = SupertableOptions::new(schema, fts, vectors, tokenizer)?;
     if let Some(s) = storage {
         opts = opts.with_storage(s);
     }
+    // Set last so no builder step can reset the shared connection budget.
+    opts.connection_memory_budget = connection_memory_budget;
     Ok(opts)
 }
 
@@ -644,7 +683,7 @@ fn now_unix() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path};
+    use std::{fs, path::Path, sync::Arc};
 
     use arrow_schema::{DataType, Field, Schema};
 
@@ -685,6 +724,76 @@ mod tests {
         assert!(matches!(
             conn.open_table("docs"),
             Err(InfinoError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn connection_memory_budget_is_measured_by_default() {
+        let conn = connect("memory://").expect("connect");
+        assert_eq!(conn.inner.connection_memory_budget.limit(), None);
+    }
+
+    #[test]
+    fn with_connection_memory_budget_bytes_mints_a_bounded_budget_at_the_gate() {
+        let conn = connect_with(
+            "memory://",
+            ConnectOptions::new().with_connection_memory_budget_bytes(1000),
+        )
+        .expect("connect");
+        // 90% headroom gate: 1000 configured -> 900 enforced.
+        assert_eq!(conn.inner.connection_memory_budget.limit(), Some(900));
+    }
+
+    #[test]
+    fn zero_connection_memory_budget_is_measured() {
+        let conn = connect_with(
+            "memory://",
+            ConnectOptions::new().with_connection_memory_budget_bytes(0),
+        )
+        .expect("connect");
+        assert_eq!(conn.inner.connection_memory_budget.limit(), None);
+    }
+
+    #[test]
+    fn all_tables_share_one_connection_memory_budget() {
+        let conn = connect_with(
+            "memory://",
+            ConnectOptions::new().with_connection_memory_budget_bytes(1000),
+        )
+        .expect("connect");
+        let a = conn
+            .create_table("a", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create a");
+        let b = conn
+            .create_table("b", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create b");
+
+        // Every table sees the one budget the connection minted, not a copy.
+        assert!(Arc::ptr_eq(
+            &a.options().connection_memory_budget,
+            &b.options().connection_memory_budget
+        ));
+        assert!(Arc::ptr_eq(
+            &a.options().connection_memory_budget,
+            &conn.inner.connection_memory_budget
+        ));
+    }
+
+    #[test]
+    fn reopened_table_shares_the_connection_memory_budget() {
+        // open_table threads the same shared budget as create_table.
+        let conn = connect_with(
+            "memory://",
+            ConnectOptions::new().with_connection_memory_budget_bytes(1000),
+        )
+        .expect("connect");
+        conn.create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create");
+        let reopened = conn.open_table("docs").expect("open");
+
+        assert!(Arc::ptr_eq(
+            &reopened.options().connection_memory_budget,
+            &conn.inner.connection_memory_budget
         ));
     }
 

--- a/src/catalog/options.rs
+++ b/src/catalog/options.rs
@@ -62,6 +62,11 @@ pub struct ConnectOptions {
     pub(crate) cache_budget_bytes: Option<u64>,
     /// Cold-fetch strategy when the disk cache is enabled.
     pub(crate) cold_fetch_mode: ColdFetchMode,
+    /// Per-connection memory (heap) budget in bytes. `None` (default) tracks
+    /// usage without enforcing; `Some(n)` enforces a ceiling so one connection
+    /// can't exhaust process memory. Applies to the whole connection, shared
+    /// across supertables.
+    pub(crate) connection_memory_budget_bytes: Option<u64>,
     /// Probe the backend at `connect`. Default `false`; opt in for
     /// fail-fast on bad credentials.
     pub(crate) validate: bool,
@@ -94,6 +99,15 @@ impl ConnectOptions {
     /// meaningful with [`with_cache_dir`](Self::with_cache_dir).
     pub fn with_cold_fetch_mode(mut self, mode: ColdFetchMode) -> Self {
         self.cold_fetch_mode = mode;
+        self
+    }
+
+    /// Set a per-connection memory budget, in bytes. Unset (the default)
+    /// tracks usage without enforcing; a positive value enforces a ceiling so
+    /// one connection can't exhaust process memory. Shared across all of the
+    /// connection's tables.
+    pub fn with_connection_memory_budget_bytes(mut self, bytes: u64) -> Self {
+        self.connection_memory_budget_bytes = Some(bytes);
         self
     }
 

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -134,3 +134,21 @@ compaction:
 
   # Maximum memory budget for materializing inputs during a single merge, in MiB.
   max_memory_mb: 3072
+
+# Per-connection memory budget: a ceiling on the anonymous heap the query
+# and ingest paths allocate (result batches, the vector shortlist, ingest
+# buffers), so one connection can't grow memory until the process is OOM-
+# killed. The memory-mapped superfiles and the disk cache are bounded
+# separately; this bounds heap only.
+#
+# Applies to connections built from this config file. Code that opens a
+# connection programmatically sets the budget on ConnectOptions
+# (with_connection_memory_budget_bytes) instead.
+#
+# Env override:
+#   INFINO_MEMORY__CONNECTION_BUDGET_BYTES=8589934592
+memory:
+  # Bytes. 0 (default) is measure-only: usage is tracked but never refused.
+  # A positive value enforces the ceiling (the engine reserves at 90% of it,
+  # leaving headroom for small untracked allocations).
+  connection_budget_bytes: 0

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -85,7 +85,43 @@ pub struct Config {
     /// Compaction settings.
     #[serde(default)]
     pub compaction: CompactionSettings,
+    /// Per-connection memory budget.
+    #[serde(default)]
+    pub memory: MemorySettings,
 }
+
+/// Memory subsection of [`Config`]. All memory-related settings for Infino here.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct MemorySettings {
+    /// Per-connection memory (heap) budget in bytes. `0` (the default) is
+    /// measure-only: usage is tracked but never refused. A positive value
+    /// enforces a ceiling so one connection can't exhaust process memory.
+    ///
+    /// Applies to connections built from a config file (`apply_config`). Code
+    /// that opens a connection programmatically sets the budget on
+    /// [`ConnectOptions::with_connection_memory_budget_bytes`] instead.
+    ///
+    /// [`ConnectOptions::with_connection_memory_budget_bytes`]: crate::ConnectOptions::with_connection_memory_budget_bytes
+    pub connection_budget_bytes: u64,
+}
+
+impl Default for MemorySettings {
+    fn default() -> Self {
+        Self {
+            connection_budget_bytes: DEFAULT_CONNECTION_BUDGET_BYTES,
+        }
+    }
+}
+
+/// Engine default connection budget when none is configured; used by both
+/// [`MemorySettings`] and the connect path. `0` is the deliberate measure-only
+/// (no-ceiling) sentinel that `from_budget_bytes` maps to a measured budget.
+///
+/// A future non-trivial default (e.g. a fraction of system RAM) changes here.
+/// `from_budget_bytes` stays a pure value mapper; the only added work then is
+/// letting the config field distinguish "unset" from an explicit `0`.
+pub(crate) const DEFAULT_CONNECTION_BUDGET_BYTES: u64 = 0;
 
 /// Supertable subsection of [`Config`]. Keeps supertable-
 /// specific knobs grouped so they don't crowd the top-level
@@ -644,6 +680,12 @@ storage:
         let cfg = Config::defaults().expect("embedded default must parse");
         assert_eq!(cfg.supertable.reader_threads, ThreadCount::Auto);
         assert_eq!(cfg.supertable.writer_threads, ThreadCount::Auto);
+    }
+
+    #[test]
+    fn memory_budget_defaults_to_measure_only() {
+        let cfg = Config::defaults().expect("embedded default must parse");
+        assert_eq!(cfg.memory.connection_budget_bytes, 0);
     }
 
     #[test]

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -130,12 +130,13 @@ impl ConnectionMemoryBudget {
     }
 
     /// A bounded budget. `configured_bytes` is the operator-facing value; the
-    /// enforced ceiling is the headroom-adjusted fraction of it (90%).
+    /// enforced ceiling is 90% of it, leaving headroom for small untracked
+    /// allocations.
     ///
-    /// Expects `configured_bytes > 0` — choosing "0 / unset means measured" is
-    /// the caller's job (in config), not this constructor's. Note the gate
-    /// floors: a configured value below ~10 bytes rounds to a `0` ceiling that
-    /// refuses everything. Irrelevant at real (MB/GB) budgets.
+    /// Expects `configured_bytes > 0`; use
+    /// [`from_budget_bytes`](Self::from_budget_bytes) when `0` should mean
+    /// measure-only. A value below ~10 bytes rounds down to a `0` ceiling that
+    /// refuses everything, but that never happens at real (MB/GB) budgets.
     pub fn with_limit(configured_bytes: u64) -> Arc<Self> {
         debug_assert!(
             configured_bytes > 0,
@@ -150,6 +151,19 @@ impl ConnectionMemoryBudget {
             used: AtomicUsize::new(0),
             denials: AtomicU64::new(0),
         })
+    }
+
+    /// Map a configured byte value to a budget: `0` is measure-only
+    /// ([`measured`](Self::measured)), anything positive is bounded
+    /// ([`with_limit`](Self::with_limit)). Both config sources (`ConnectOptions`
+    /// and `config.yaml`) route through here, so "0 means measure-only" is
+    /// defined in exactly one place.
+    pub fn from_budget_bytes(bytes: u64) -> Arc<Self> {
+        if bytes > 0 {
+            Self::with_limit(bytes)
+        } else {
+            Self::measured()
+        }
     }
 
     /// Reserve `n` bytes, returning a guard that frees them on drop. Fails with
@@ -324,6 +338,17 @@ mod tests {
         // 1000 configured -> gate at 900 (9/10).
         let budget = ConnectionMemoryBudget::with_limit(1000);
         assert_eq!(budget.limit(), Some(900));
+    }
+
+    #[test]
+    fn from_budget_bytes_maps_zero_to_measured_and_positive_to_bounded() {
+        // The config / ConnectOptions convention: 0 means measure-only.
+        assert_eq!(ConnectionMemoryBudget::from_budget_bytes(0).limit(), None);
+        // Positive -> bounded, with the same 90% gate as with_limit.
+        assert_eq!(
+            ConnectionMemoryBudget::from_budget_bytes(1000).limit(),
+            Some(900)
+        );
     }
 
     #[test]

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -52,6 +52,7 @@ use super::{
 };
 use crate::{
     config::{Config, StorageBackend, StorageColdFetchMode},
+    memory::ConnectionMemoryBudget,
     storage::{AzureStorageProvider, LocalFsStorageProvider, S3StorageProvider, StorageProvider},
     superfile::{
         OpenOptions,
@@ -278,6 +279,13 @@ pub struct SupertableOptions {
     /// idle-threshold madvise sweep on its existing schedule
     /// but does NOT proactively bound the RSS.
     pub memory_budget_bytes: Option<u64>,
+    /// Per-connection heap budget, shared (cloned `Arc`) by every supertable
+    /// the owning connection opens. The query and ingest paths reserve against
+    /// it before allocating; `measured()` by default, so it tracks usage but
+    /// never refuses until a limit is set. Distinct from `memory_budget_bytes`:
+    /// that bounds the mmap resident set, this bounds anonymous heap. See
+    /// [`crate::memory`].
+    pub(crate) connection_memory_budget: Arc<ConnectionMemoryBudget>,
     /// When `true` (default), each commit pre-populates the
     /// attached `disk_cache` with the superfile bytes it just
     /// wrote (so the producer's own next query skips the
@@ -529,6 +537,10 @@ impl SupertableOptions {
             disk_cache: None,
             manifest_disk_cache: None,
             memory_budget_bytes: None,
+            // Placeholder: standalone options (tests, direct callers) get an unshared measure-only budget.
+            // The catalog's `build_options` overwrites this with the connection's shared budget, and
+            // `apply_config` replaces it from `config.yaml`.
+            connection_memory_budget: ConnectionMemoryBudget::measured(),
             prepopulate_cache_on_commit: true,
             partition_strategy: None,
             target_superfiles_per_part: DEFAULT_TARGET_SUPERFILES_PER_PART,
@@ -821,6 +833,13 @@ impl SupertableOptions {
         );
         self.commit_threshold_size_mb = cfg.supertable.commit_threshold_size_mb;
         self.verify_crc_on_open = cfg.supertable.verify_crc_on_open;
+        // The `config.yaml` source for the connection budget; the connect path
+        // uses `ConnectOptions` instead. 0, the shipped default, is measure-only.
+        // Note this replaces the budget outright: don't call `apply_config` on
+        // options that already carry a shared connection budget, or the sharing
+        // is silently dropped.
+        self.connection_memory_budget =
+            ConnectionMemoryBudget::from_budget_bytes(cfg.memory.connection_budget_bytes);
         if cfg.supertable.id_column != self.id_column {
             if self
                 .schema
@@ -1345,6 +1364,29 @@ supertable:
         assert_eq!(opts.commit_threshold_size_mb, 7);
         assert_eq!(opts.reader_pool.current_num_threads(), 3);
         assert_eq!(opts.writer_pool.current_num_threads(), 5);
+    }
+
+    #[test]
+    fn apply_config_sets_connection_memory_budget_from_config() {
+        use figment::{
+            Figment,
+            providers::{Format, Yaml},
+        };
+
+        // A positive config value -> bounded budget, gated at 90%.
+        let yaml = "memory:\n  connection_budget_bytes: 1000\n";
+        let cfg =
+            Config::from_figment(Figment::new().merge(Yaml::string(yaml))).expect("parse config");
+        let opts = plain_opts().apply_config(&cfg).expect("apply_config");
+        assert_eq!(opts.connection_memory_budget.limit(), Some(900));
+    }
+
+    #[test]
+    fn apply_config_default_leaves_connection_memory_budget_measured() {
+        // The shipped default (0) is measure-only.
+        let cfg = Config::defaults().expect("embedded default");
+        let opts = plain_opts().apply_config(&cfg).expect("apply_config");
+        assert_eq!(opts.connection_memory_budget.limit(), None);
     }
 
     #[test]

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -67,8 +67,8 @@ use arrow_schema::{DataType, Field, Schema};
 use infino::{
     VectorSearchOptions,
     config::{
-        CompactionSettings, Config, OptimizeOptions, StorageBackend, StorageColdFetchMode,
-        StorageSettings, SupertableSettings, ThreadCount,
+        CompactionSettings, Config, MemorySettings, OptimizeOptions, StorageBackend,
+        StorageColdFetchMode, StorageSettings, SupertableSettings, ThreadCount,
     },
     superfile::{
         builder::{FtsConfig, VectorConfig},
@@ -203,6 +203,7 @@ fn azure_compact_config(container: &str, prefix: &str, cache_root: &std::path::P
             ..StorageSettings::default()
         },
         compaction: CompactionSettings::default(),
+        memory: MemorySettings::default(),
     }
 }
 

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -44,8 +44,8 @@ use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use infino::{
     config::{
-        CompactionSettings, Config, StorageBackend, StorageColdFetchMode, StorageSettings,
-        SupertableSettings,
+        CompactionSettings, Config, MemorySettings, StorageBackend, StorageColdFetchMode,
+        StorageSettings, SupertableSettings,
     },
     superfile::builder::{FtsConfig, VectorConfig},
     supertable::{
@@ -159,6 +159,7 @@ fn real_azure_config(container: &str, prefix: &str, cache_root: &std::path::Path
             ..StorageSettings::default()
         },
         compaction: CompactionSettings::default(),
+        memory: MemorySettings::default(),
     }
 }
 

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -59,8 +59,8 @@ use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, Rec
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
     config::{
-        CompactionSettings, Config, StorageBackend, StorageColdFetchMode, StorageSettings,
-        SupertableSettings,
+        CompactionSettings, Config, MemorySettings, StorageBackend, StorageColdFetchMode,
+        StorageSettings, SupertableSettings,
     },
     superfile::builder::{FtsConfig, VectorConfig},
     supertable::{
@@ -237,6 +237,7 @@ fn real_s3_config(bucket: &str, prefix: &str, cache_root: &std::path::Path) -> C
             ..StorageSettings::default()
         },
         compaction: CompactionSettings::default(),
+        memory: MemorySettings::default(),
     }
 }
 


### PR DESCRIPTION
### What does this PR do?
Makes the per-connection memory budget from #316 actually usable: each connection gets one budget, shared by all its tables, and you can set it either at connect or in the config file. The default stays measure-only, so nothing changes until a limit is set.

### Why do we need this change?
The budget existed but nothing could reach it. It belongs to the whole connection, not a single table, so it has to be built once when you connect and shared by every table underneath. And it needs a way to be set, in the two places infino already takes config: at connect, and from the config file.

### How do we do this change?
- At connect, the budget is built once and shared (a cloned pointer) into every table the connection opens.
- It's set one of two ways: an option at connect, or a `memory` key in the config file. The connect path never reads the config file, the same split we use for storage credentials.
- Both ways agree on one rule, kept in a single place so they can't drift: `0` means measure-only, anything positive is a limit.

### Performance
No behaviour change. The default only measures and nothing reserves against it yet. Connect reads no extra files, and each table just clones a pointer, so there's nothing on the query path.

### Notes
- `public-api.txt` gains one line for the new connect option. It's additive, so the existing python / node bindings keep working unchanged.

A part for #325 