### PR TITLE
docs: add download badges to Python and Node READMEs

### DIFF
--- a/infino-node/README.md
+++ b/infino-node/README.md
@@ -1,5 +1,10 @@
 # infino
 
+[![npm](https://img.shields.io/npm/v/@infino-ai/infino.svg)](https://www.npmjs.com/package/@infino-ai/infino)
+[![Node](https://img.shields.io/node/v/@infino-ai/infino.svg)](https://www.npmjs.com/package/@infino-ai/infino)
+[![Downloads](https://img.shields.io/npm/dm/@infino-ai/infino.svg)](https://www.npmjs.com/package/@infino-ai/infino)
+[![License](https://img.shields.io/npm/l/@infino-ai/infino.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
 **SQL, full-text, and vector search over your data on object storage — one engine, no server to run.**
 
 Infino keeps your data in Apache Parquet on object storage (local disk, Amazon

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/infino.svg)](https://pypi.org/project/infino/)
 [![Python](https://img.shields.io/pypi/pyversions/infino.svg)](https://pypi.org/project/infino/)
+[![Downloads](https://img.shields.io/pypi/dm/infino.svg)](https://pypi.org/project/infino/)
 [![License](https://img.shields.io/pypi/l/infino.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 **SQL, full-text, and vector search over your data on object storage — one engine, no server to run.**


### PR DESCRIPTION
## What
Add download badges to the published-package READMEs:

- **infino-python** — add PyPI monthly downloads badge (`pypi/dm/infino`).
- **infino-node** — add npm badges (version, Node version, monthly downloads, license); the Node README had no badges at all.

## Why
Download counts are a standard signal on package landing pages and were missing.

## Notes
Badges are shields.io endpoints resolved against PyPI / npm — no build or code impact.