### PR TITLE
fix table manifest: allow opening tables without any data appended

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -771,6 +771,43 @@ mod tests {
     }
 
     #[test]
+    fn create_without_append_reopens_as_empty_table() {
+        // A table created but never appended to is still durably
+        // registered in the catalog. Reopening it in a fresh connection
+        // (i.e. after a program restart) must succeed and yield an empty
+        // table — not fail because no manifest pointer was ever written.
+        // The pointer is only written on the first commit, so `create`
+        // alone leaves the physical table with a catalog entry but no
+        // `_supertable/current`; open must tolerate that the same way
+        // `create` does when it probes and finds no pointer.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        {
+            let conn = connect(&uri).expect("connect");
+            conn.create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+                .expect("create");
+            // No append/commit: the manifest pointer is never written.
+        }
+
+        // Reopen in a fresh connection, simulating a program restart.
+        let conn = connect(&uri).expect("reconnect");
+        assert_eq!(conn.list_tables().expect("list"), vec!["docs".to_string()]);
+        let docs = conn
+            .open_table("docs")
+            .expect("open a created-but-empty table");
+        assert_eq!(
+            n_rows(
+                &docs
+                    .bm25_search("title", "fox", TOP_K, BoolMode::Or, None)
+                    .expect("search")
+            ),
+            0,
+            "a created-but-empty table has no hits"
+        );
+    }
+
+    #[test]
     fn drop_with_purge_reclaims_the_storage_subtree() {
         /// Count regular files under `dir` whose path contains a
         /// component starting with `prefix` (the table's unique

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -281,7 +281,7 @@ impl Supertable {
     // catalog `Connection` calls it internally, tests/benches reach it via
     // `test-helpers`.
     test_visible! {
-    /// Open an existing persisted supertable.
+    /// Open a persisted supertable.
     ///
     /// Reads the pointer file at
     /// `<root>/_supertable/current` via the storage provider
@@ -291,8 +291,17 @@ impl Supertable {
     /// `Supertable` is ready to serve queries from the
     /// snapshot at the pointer's `manifest_id`.
     ///
+    /// A genuinely absent pointer is **not** an error: it means
+    /// nothing has been committed yet, so open returns an empty
+    /// supertable (`manifest_id == 0`). Uncommitted data is
+    /// invisible by design, so "no pointer" and "empty table" are
+    /// the same observable state. A *corrupt* pointer is a distinct
+    /// error (`ManifestLoadError::PointerParse`) and still fails, so
+    /// corruption is never silently swallowed.
+    ///
     /// Errors:
-    /// - [`OpenError::ManifestLoadError`] for manifest load failures.
+    /// - [`OpenError::ManifestLoadError`] for manifest load failures
+    ///   *other than* a missing pointer (parse / corruption / fetch).
     /// - [`OpenError::Build`] if `options.storage` is `None`
     ///   (open requires a storage backend).
     /// - [`OpenError::Storage`], [`OpenError::ManifestListParse`],

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -307,6 +307,21 @@ impl ManifestSnapshot {
         self.get_cached_part_by_id(&part_id)
     }
 
+    /// Load the committed manifest from storage.
+    ///
+    /// Missing-pointer behaviour depends on `current_manifest`:
+    /// - **Fresh open** (`None`): a genuinely absent pointer means
+    ///   nothing has been committed, so an empty manifest
+    ///   (`manifest_id == 0`) is returned rather than an error —
+    ///   uncommitted data is invisible by design, so "no pointer" and
+    ///   "empty table" are the same observable state.
+    /// - **Refresh** (`Some`): an absent pointer is returned as
+    ///   [`ManifestLoadError::PointerNotFound`] so the caller can no-op
+    ///   and keep its current in-memory manifest — a missing pointer
+    ///   must never blank out live state.
+    ///
+    /// A *corrupt* pointer is a different error variant (`PointerParse`)
+    /// and always propagates, so corruption is never masked.
     pub(crate) async fn load(
         current_manifest: Option<Arc<Self>>,
         storage: Arc<dyn StorageProvider>,
@@ -315,10 +330,18 @@ impl ManifestSnapshot {
         // 1. Read the pointer file.
         let (pointer, _) = match read_pointer(storage.as_ref()).await? {
             Some(p) => p,
-            // No pointer yet means nobody has committed; our next
-            // attempt will write the initial pointer with
-            // expected_prev_etag = None.
-            None => return Err(ManifestLoadError::PointerNotFound),
+            // No pointer yet means nobody has committed. On a fresh open
+            // (no baseline manifest) that's an empty table, not an error;
+            // on a refresh we keep the signal so the caller preserves its
+            // current manifest instead of blanking it out.
+            None => {
+                return match options {
+                    Some(options) if current_manifest.is_none() => {
+                        Ok(Arc::new(Self::empty(options)))
+                    }
+                    _ => Err(ManifestLoadError::PointerNotFound),
+                };
+            }
         };
 
         if let Some(current_manifest) = &current_manifest

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -76,19 +76,20 @@ fn open_sees_writes_made_by_a_different_handle() {
 }
 
 #[test]
-fn open_on_fresh_tempdir_returns_pointer_unreadable() {
-    // The open-or-create trigger: no pointer exists, so
-    // open() must surface a typed error the caller can
-    // pattern-match on for fallback to Supertable::create.
+fn open_on_fresh_tempdir_yields_empty_table() {
+    // No pointer exists on a fresh directory. Nothing has been
+    // committed, and uncommitted data is invisible by design, so
+    // "no pointer" is the same observable state as "empty table":
+    // open succeeds and serves an empty manifest (`manifest_id ==
+    // 0`) rather than erroring. (A *corrupt* pointer is a distinct
+    // error and still fails — see the content-hash test below.)
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-    let err = Supertable::open(default_supertable_options().with_storage(storage))
-        .expect_err("must reject fresh dir");
-    assert!(
-        matches!(err, OpenError::ManifestLoadError(_)),
-        "expected PointerUnreadable, got {err:?}"
-    );
+    let st = Supertable::open(default_supertable_options().with_storage(storage))
+        .expect("fresh dir opens as an empty table");
+    assert_eq!(st.manifest_id(), 0, "empty table starts at manifest_id 0");
+    assert_eq!(st.reader().n_superfiles(), 0, "no committed superfiles");
 }
 
 #[test]

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -19,11 +19,12 @@
 //!
 //!   - The pointer file is missing or still references the
 //!     prior committed `manifest_id` → open returns the prior
-//!     state (or `PointerUnreadable` on a fresh supertable).
-//!     Any superfile / manifest-part / manifest-list bytes
-//!     written before the crash but never referenced by a
-//!     committed pointer are **orphans**: tolerated by
-//!     readers and GC'd by compaction.
+//!     state (or an empty table when no pointer was ever
+//!     committed — nothing was durably committed, so an empty
+//!     table is the correct recovered state). Any superfile /
+//!     manifest-part / manifest-list bytes written before the
+//!     crash but never referenced by a committed pointer are
+//!     **orphans**: tolerated by readers and GC'd by compaction.
 //!   - The pointer file has been atomically replaced with
 //!     the new version → open returns the new state. The
 //!     crash happened AFTER the visibility barrier; the
@@ -39,8 +40,8 @@
 //!
 //! | Test fn                                                      | Crash point                                | Expected post-crash open state                    |
 //! |--------------------------------------------------------------|---------------------------------------------|----------------------------------------------------|
-//! | `crash_post_superfile_no_prior_commit_yields_pointer_unreadable` | After 1st superfile PUT, before list/pointer | `OpenError::PointerUnreadable`                     |
-//! | `crash_post_list_no_prior_commit_yields_pointer_unreadable`    | After 1st list PUT, before pointer         | `OpenError::PointerUnreadable`                     |
+//! | `crash_post_superfile_no_prior_commit_opens_empty`           | After 1st superfile PUT, before list/pointer | empty table (`manifest_id == 0`), orphan superfile |
+//! | `crash_post_list_no_prior_commit_opens_empty`                | After 1st list PUT, before pointer         | empty table (`manifest_id == 0`), orphan list      |
 //! | `crash_post_superfile_on_second_commit_yields_v1`                | First commit succeeds; 2nd commit's superfile PUT triggers | `manifest_id == 1` (v_prev), orphan v2 superfile    |
 //! | `crash_post_list_on_second_commit_yields_v1`                   | First commit succeeds; 2nd commit's list PUT triggers   | `manifest_id == 1`, orphan v2 list + part         |
 //! | `crash_post_pointer_on_second_commit_yields_v2`                | First commit succeeds; 2nd commit's pointer PUT triggers AFTER it lands | `manifest_id == 2` (commit was durable)           |
@@ -66,7 +67,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use infino::{
     supertable::{
-        OpenError, Supertable,
+        Supertable,
         storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
     test_helpers::{build_title_batch, default_supertable_options},
@@ -272,25 +273,30 @@ fn dispatch_child_if_set() -> Option<()> {
 }
 
 #[test]
-fn crash_post_superfile_no_prior_commit_yields_pointer_unreadable() {
+fn crash_post_superfile_no_prior_commit_opens_empty() {
     if dispatch_child_if_set().is_some() {
         return; // unreachable; child never returns
     }
     let dir = spawn_crash_child(
-        "crash_post_superfile_no_prior_commit_yields_pointer_unreadable",
+        "crash_post_superfile_no_prior_commit_opens_empty",
         KP_SEG_FIRST,
     );
 
     // Parent verifies. The crash fired after the first
     // superfile PUT, before any manifest writes. No pointer
-    // exists yet → open must return PointerUnreadable.
+    // exists → nothing was durably committed, so open yields an
+    // empty table (`manifest_id == 0`). Uncommitted data is
+    // invisible by design; "no pointer" and "empty table" are the
+    // same observable state.
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));
-    let err = Supertable::open(default_supertable_options().with_storage(storage))
-        .expect_err("must reject post-crash state with no pointer");
-    assert!(
-        matches!(err, OpenError::ManifestLoadError(_)),
-        "expected PointerUnreadable, got {err:?}"
+    let st = Supertable::open(default_supertable_options().with_storage(storage))
+        .expect("post-crash state with no pointer opens as an empty table");
+    assert_eq!(st.manifest_id(), 0, "no commit landed → empty manifest");
+    assert_eq!(
+        st.reader().n_superfiles(),
+        0,
+        "the pre-crash superfile is an orphan; readers don't see it without a committed manifest"
     );
 
     // The orphan superfile file is present and ignored — the
@@ -307,23 +313,21 @@ fn crash_post_superfile_no_prior_commit_yields_pointer_unreadable() {
 }
 
 #[test]
-fn crash_post_list_no_prior_commit_yields_pointer_unreadable() {
+fn crash_post_list_no_prior_commit_opens_empty() {
     if dispatch_child_if_set().is_some() {
         return;
     }
-    let dir = spawn_crash_child(
-        "crash_post_list_no_prior_commit_yields_pointer_unreadable",
-        KP_LIST_FIRST,
-    );
+    let dir = spawn_crash_child("crash_post_list_no_prior_commit_opens_empty", KP_LIST_FIRST);
 
+    // Crash fired after the 1st manifest-list PUT, before the
+    // pointer. No pointer → nothing committed → open yields an
+    // empty table; the orphan list + superfile are ignored.
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));
-    let err = Supertable::open(default_supertable_options().with_storage(storage))
-        .expect_err("must reject post-crash state with no pointer");
-    assert!(
-        matches!(err, OpenError::ManifestLoadError(_)),
-        "expected PointerUnreadable, got {err:?}"
-    );
+    let st = Supertable::open(default_supertable_options().with_storage(storage))
+        .expect("post-crash state with no pointer opens as an empty table");
+    assert_eq!(st.manifest_id(), 0, "no commit landed → empty manifest");
+    assert_eq!(st.reader().n_superfiles(), 0);
 
     // The orphan manifest is on disk but unreferenced.
     let manifest_dir = dir.join("manifest");


### PR DESCRIPTION
### What does this PR do?
- Fixes #336 