### PR TITLE
supertable: persist initial manifest on create; keep open strict (supersedes #338)

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -727,6 +727,46 @@ mod tests {
         ));
     }
 
+    /// Regression: on durable storage, `open_table` on a table that was
+    /// created but never appended to must succeed and yield an empty,
+    /// usable table. `create` leaves no pointer file until the first commit,
+    /// so a fresh `open` — any reconnect (another process, a restart) before
+    /// the first append — must treat the missing pointer as an empty table
+    /// rather than failing. Previously it surfaced a "manifest load error",
+    /// and the create handle only worked because it never went through `open`.
+    #[test]
+    fn durable_open_before_first_append_yields_empty_usable_table() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+        let conn = connect(&uri).expect("connect");
+
+        // Create, but do NOT append through the returned handle.
+        let _created = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table");
+
+        // Open fresh — the reconnect path. This must not error.
+        let opened = conn
+            .open_table("docs")
+            .expect("open_table before first append");
+
+        // Starts empty.
+        let before = opened
+            .bm25_search("title", "fox", TOP_K, BoolMode::Or, None)
+            .expect("bm25_search on empty table");
+        assert_eq!(n_rows(&before), 0, "freshly opened table starts empty");
+
+        // Fully usable: the first commit lands through the reopened handle,
+        // then the query round-trips.
+        opened
+            .append(&build_title_batch(&["the quick brown fox"]))
+            .expect("append via reopened handle");
+        let hits = opened
+            .bm25_search("title", "fox", TOP_K, BoolMode::Or, None)
+            .expect("bm25_search after append");
+        assert_eq!(n_rows(&hits), 1, "expected one hit for 'fox' after append");
+    }
+
     #[test]
     fn connection_memory_budget_is_measured_by_default() {
         let conn = connect("memory://").expect("connect");

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -30,7 +30,7 @@ use datafusion::execution::context::SessionContext;
 use tokio::runtime::Runtime;
 
 use super::{
-    error::{BuildError, OpenError},
+    error::{BuildError, CommitError, OpenError},
     manifest::ManifestSnapshot,
     options::SupertableOptions,
 };
@@ -244,13 +244,50 @@ impl Supertable {
         }
 
         let options = Arc::new(options);
-        let initial = ManifestSnapshot::empty(options.clone());
+        // Build the initial in-memory manifest. A durable table also *persists*
+        // it here — its list plus the pointer at `manifest_id 0` — so the
+        // freshly created table is openable right away: before any append,
+        // after a reopen, and from another process. `open` requires a pointer,
+        // and this doesn't shift the id sequence (the first append still
+        // commits `manifest_id 1`). An in-memory table keeps the lighter
+        // in-process-only empty snapshot, with nothing to persist.
+        let initial: Arc<ManifestSnapshot> = if let Some(storage) = options.storage.clone() {
+            let materialized = Arc::new(ManifestSnapshot::materialized_empty(options.clone()));
+            let write_result = {
+                let manifest = Arc::clone(&materialized);
+                let storage = Arc::clone(&storage);
+                // `expected_prev_etag = None` is the initial-commit shape: no
+                // prior pointer to fence on.
+                bridge_sync_to_async(
+                    async move { manifest.write(storage.as_ref(), None, &[]).await },
+                )
+            };
+            match write_result {
+                Ok(()) => materialized,
+                // Lost the initial-pointer race to a concurrent creator on the
+                // same storage: adopt their committed manifest rather than
+                // failing. This matches `create`'s create-or-open contract — a
+                // pointer that appeared between our probe and our write is the
+                // same as "pointer already present" (which the probe above
+                // routes to `open`).
+                Err(CommitError::WriteContentionExhausted) => {
+                    let storage = Arc::clone(&storage);
+                    let options = options.clone();
+                    bridge_sync_to_async(async move {
+                        ManifestSnapshot::load(None, storage, Some(options)).await
+                    })?
+                }
+                Err(e) => return Err(e.into()),
+            }
+        } else {
+            Arc::new(ManifestSnapshot::empty(options.clone()))
+        };
         let tombstone_cache = build_tombstone_cache(&options);
         let id_generator = IdGenerator::new();
         let handle_id = SupertableHandleId(id_generator.next_id());
         let inner = Arc::new(SupertableInner {
             options,
-            manifest: ArcSwap::new(Arc::new(initial)),
+            manifest: ArcSwap::new(initial),
             writer_outstanding: AtomicBool::new(false),
             compaction_outstanding: AtomicBool::new(false),
             id_generator: Mutex::new(id_generator),
@@ -291,17 +328,16 @@ impl Supertable {
     /// `Supertable` is ready to serve queries from the
     /// snapshot at the pointer's `manifest_id`.
     ///
-    /// A genuinely absent pointer is **not** an error: it means
-    /// nothing has been committed yet, so open returns an empty
-    /// supertable (`manifest_id == 0`). Uncommitted data is
-    /// invisible by design, so "no pointer" and "empty table" are
-    /// the same observable state. A *corrupt* pointer is a distinct
-    /// error (`ManifestLoadError::PointerParse`) and still fails, so
-    /// corruption is never silently swallowed.
+    /// A genuinely absent pointer is a [`ManifestLoadError::PointerNotFound`]
+    /// error, not an empty table: `create` persists the initial pointer, so
+    /// a registered table always has one, and a missing pointer is the
+    /// open-or-create trigger (or a lost pointer) — surfaced, never masked
+    /// as a silently-empty table.
     ///
     /// Errors:
-    /// - [`OpenError::ManifestLoadError`] for manifest load failures
-    ///   *other than* a missing pointer (parse / corruption / fetch).
+    /// - [`OpenError::ManifestLoadError`] for manifest load failures,
+    ///   including a missing pointer (`PointerNotFound`), parse, corruption,
+    ///   or fetch.
     /// - [`OpenError::Build`] if `options.storage` is `None`
     ///   (open requires a storage backend).
     /// - [`OpenError::Storage`], [`OpenError::ManifestListParse`],

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -262,6 +262,70 @@ impl ManifestSnapshot {
         }
     }
 
+    /// A *materialized* empty manifest at `manifest_id = 0`, ready to persist.
+    /// Unlike [`Self::empty`] (which is in-process-only, `list: None`), this
+    /// carries a `Some(list)`, so [`Self::write`] emits the initial (empty)
+    /// manifest list + pointer. `Supertable::create` persists this on durable
+    /// storage so the table is openable immediately — before its first append,
+    /// after a reopen, or from another process — without shifting the
+    /// `manifest_id` sequence (the first append still commits `manifest_id 1`).
+    pub(crate) fn materialized_empty(options: Arc<SupertableOptions>) -> Self {
+        let strategy = options.effective_partition_strategy();
+        let list = Self::build_list(&options, strategy, 0, Vec::new());
+        let loader = options.storage.as_ref().map(|storage| {
+            Arc::new(ManifestPartLoader::new_with_cache(
+                storage.clone(),
+                &list,
+                options.manifest_disk_cache.clone(),
+            ))
+        });
+        Self {
+            superfile_list: SuperfileList::empty(options),
+            list: Some(list),
+            parts: DashMap::new(),
+            loader,
+        }
+    }
+
+    /// Build a manifest list from the supertable `options` at `manifest_id`,
+    /// carrying `parts`. Shared by the commit path ([`Self::update`]) and the
+    /// initial empty-manifest materialization ([`Self::materialized_empty`]) so
+    /// the options→list field mapping lives in one place.
+    fn build_list(
+        options: &SupertableOptions,
+        strategy: PartitionStrategy,
+        manifest_id: u64,
+        parts: Vec<ManifestPartEntry>,
+    ) -> Manifest {
+        Manifest {
+            format_version: LIST_FORMAT_VERSION.into(),
+            manifest_id,
+            options_hash: options_hash::compute_options_hash(options, &strategy),
+            schema: Vec::new(),
+            id_column: options.id_column.clone(),
+            fts_columns: options
+                .fts_columns
+                .iter()
+                .map(|f| list::FtsColumnInfo {
+                    column: f.column.clone(),
+                })
+                .collect(),
+            vector_columns: options
+                .vector_columns
+                .iter()
+                .map(|v| list::VectorColumnInfo {
+                    column: v.column.clone(),
+                    dim: v.dim,
+                    n_cent: v.n_cent,
+                    rot_seed: v.rot_seed,
+                    metric: format!("{:?}", v.metric).to_lowercase(),
+                })
+                .collect(),
+            partition_strategy: strategy,
+            parts,
+        }
+    }
+
     pub fn get_manifest_id(&self) -> u64 {
         self.superfile_list.manifest_id
     }
@@ -309,19 +373,14 @@ impl ManifestSnapshot {
 
     /// Load the committed manifest from storage.
     ///
-    /// Missing-pointer behaviour depends on `current_manifest`:
-    /// - **Fresh open** (`None`): a genuinely absent pointer means
-    ///   nothing has been committed, so an empty manifest
-    ///   (`manifest_id == 0`) is returned rather than an error —
-    ///   uncommitted data is invisible by design, so "no pointer" and
-    ///   "empty table" are the same observable state.
-    /// - **Refresh** (`Some`): an absent pointer is returned as
-    ///   [`ManifestLoadError::PointerNotFound`] so the caller can no-op
-    ///   and keep its current in-memory manifest — a missing pointer
-    ///   must never blank out live state.
-    ///
-    /// A *corrupt* pointer is a different error variant (`PointerParse`)
-    /// and always propagates, so corruption is never masked.
+    /// A genuinely absent pointer is [`ManifestLoadError::PointerNotFound`]:
+    /// `Supertable::create` persists the initial (empty) pointer, so a
+    /// registered table always has one. A missing pointer is therefore the
+    /// open-or-create trigger for a never-created table, or a *lost* pointer
+    /// on a created one — either way an error the caller sees, never a
+    /// silently-empty table (which would mask committed-then-lost data). A
+    /// *corrupt* pointer is a different error variant (`PointerParse`) and
+    /// also propagates, so corruption is never masked.
     pub(crate) async fn load(
         current_manifest: Option<Arc<Self>>,
         storage: Arc<dyn StorageProvider>,
@@ -330,18 +389,7 @@ impl ManifestSnapshot {
         // 1. Read the pointer file.
         let (pointer, _) = match read_pointer(storage.as_ref()).await? {
             Some(p) => p,
-            // No pointer yet means nobody has committed. On a fresh open
-            // (no baseline manifest) that's an empty table, not an error;
-            // on a refresh we keep the signal so the caller preserves its
-            // current manifest instead of blanking it out.
-            None => {
-                return match options {
-                    Some(options) if current_manifest.is_none() => {
-                        Ok(Arc::new(Self::empty(options)))
-                    }
-                    _ => Err(ManifestLoadError::PointerNotFound),
-                };
-            }
+            None => return Err(ManifestLoadError::PointerNotFound),
         };
 
         if let Some(current_manifest) = &current_manifest
@@ -853,34 +901,12 @@ impl ManifestSnapshot {
             out_list_entries_after_removal.push(fresh_entry);
         }
 
-        let opts_hash = options_hash::compute_options_hash(opts.as_ref(), &strategy);
-        let new_list = Manifest {
-            format_version: LIST_FORMAT_VERSION.into(),
-            manifest_id: self.get_next_manifest_id(),
-            options_hash: opts_hash,
-            schema: Vec::new(),
-            id_column: opts.id_column.clone(),
-            fts_columns: opts
-                .fts_columns
-                .iter()
-                .map(|f| list::FtsColumnInfo {
-                    column: f.column.clone(),
-                })
-                .collect(),
-            vector_columns: opts
-                .vector_columns
-                .iter()
-                .map(|v| list::VectorColumnInfo {
-                    column: v.column.clone(),
-                    dim: v.dim,
-                    n_cent: v.n_cent,
-                    rot_seed: v.rot_seed,
-                    metric: format!("{:?}", v.metric).to_lowercase(),
-                })
-                .collect(),
-            partition_strategy: strategy,
-            parts: out_list_entries_after_removal,
-        };
+        let new_list = Self::build_list(
+            opts.as_ref(),
+            strategy,
+            self.get_next_manifest_id(),
+            out_list_entries_after_removal,
+        );
 
         let ids_to_remove = entries_to_remove
             .iter()

--- a/tests/supertable/commit/id_uniqueness.rs
+++ b/tests/supertable/commit/id_uniqueness.rs
@@ -123,6 +123,14 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
     const N_HANDLES: usize = 4;
     const ROWS_PER_HANDLE: u64 = 100;
 
+    // Create the table once up front, then have the concurrent handles below
+    // open it. `create` now materializes and publishes the initial empty
+    // manifest, so the realistic shape is one creator followed by many
+    // concurrent writers opening the same table — not several handles racing
+    // to materialize the same manifest at the same location.
+    let _ = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("create");
+
     // Each handle appends a small batch and commits. The
     // commits race on the storage's manifest pointer; OCC
     // retry inside `persist_commit` serializes them in some
@@ -133,8 +141,8 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
     for handle_idx in 0..N_HANDLES {
         let storage = Arc::clone(&storage);
         tasks.push(tokio::task::spawn_blocking(move || {
-            let st = Supertable::create(default_supertable_options().with_storage(storage))
-                .expect("create");
+            let st =
+                Supertable::open(default_supertable_options().with_storage(storage)).expect("open");
             let mut w = st.writer().expect("writer");
             let titles: Vec<String> = (0..ROWS_PER_HANDLE)
                 .map(|i| format!("h{handle_idx}_doc{i}"))

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -76,20 +76,21 @@ fn open_sees_writes_made_by_a_different_handle() {
 }
 
 #[test]
-fn open_on_fresh_tempdir_yields_empty_table() {
-    // No pointer exists on a fresh directory. Nothing has been
-    // committed, and uncommitted data is invisible by design, so
-    // "no pointer" is the same observable state as "empty table":
-    // open succeeds and serves an empty manifest (`manifest_id ==
-    // 0`) rather than erroring. (A *corrupt* pointer is a distinct
-    // error and still fails — see the content-hash test below.)
+fn open_on_fresh_tempdir_returns_pointer_not_found() {
+    // The open-or-create trigger: a fresh directory has no pointer, and
+    // `create` (not raw `open`) is what persists the initial one. A raw
+    // `open` on a never-created directory must surface a typed error the
+    // caller can pattern-match on for fallback to `Supertable::create`,
+    // not silently serve an empty table.
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-    let st = Supertable::open(default_supertable_options().with_storage(storage))
-        .expect("fresh dir opens as an empty table");
-    assert_eq!(st.manifest_id(), 0, "empty table starts at manifest_id 0");
-    assert_eq!(st.reader().n_superfiles(), 0, "no committed superfiles");
+    let err = Supertable::open(default_supertable_options().with_storage(storage))
+        .expect_err("fresh dir has no pointer");
+    assert!(
+        matches!(err, OpenError::ManifestLoadError(_)),
+        "expected a manifest-load error on a fresh dir, got {err:?}"
+    );
 }
 
 #[test]

--- a/tests/supertable/commit/persistence.rs
+++ b/tests/supertable/commit/persistence.rs
@@ -121,13 +121,17 @@ fn two_successive_commits_both_publish() {
         "two commits ⇒ pointer at manifest_id=2"
     );
 
-    // Both manifest versions persist (immutable per id).
+    // Each manifest version persists (immutable per id): the empty manifest
+    // published by `create` (id 0) plus the two commits (ids 1 + 2).
     let manifest_dir = dir.path().join("manifest");
     let n_manifests = std::fs::read_dir(&manifest_dir)
         .expect("readdir")
         .filter_map(|e| e.ok())
         .count();
-    assert_eq!(n_manifests, 2, "two manifest files (manifest_id 1 + 2)");
+    assert_eq!(
+        n_manifests, 3,
+        "three manifest files (manifest_id 0 + 1 + 2)"
+    );
 
     // Manifest part count = 2 (each commit writes a fresh part
     // under content-addressed URI; single-partition mode
@@ -279,11 +283,19 @@ fn manifest_id_increments_only_on_non_empty_commits() {
     w.commit().expect("empty commit"); // no buffer → no-op
     drop(w);
 
-    // Pointer doesn't exist yet (no real commit happened).
-    let pointer = futures::executor::block_on(read_pointer(&*storage)).expect("read");
-    assert!(pointer.is_none(), "empty commit must not publish a pointer");
+    // `create` publishes the initial empty manifest, so the pointer already
+    // exists at manifest_id=0. The empty commit above is a no-op: it must
+    // neither advance the id nor republish.
+    let (pointer, _) = futures::executor::block_on(read_pointer(&*storage))
+        .expect("read")
+        .expect("create publishes the initial empty-manifest pointer");
+    assert_eq!(
+        pointer.get_manifest_id(),
+        0,
+        "empty commit must not advance the manifest_id past create's id 0"
+    );
 
-    // Now do a real commit; pointer appears at manifest_id=1.
+    // Now do a real commit; pointer advances to manifest_id=1.
     let mut w = st.writer().expect("w");
     w.append(&build_title_batch(&["only", "real"]))
         .expect("append");

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -89,10 +89,12 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
         n_commits,
         "one superfile per commit before compact"
     );
+    // One manifest per commit, plus the empty manifest `create` published
+    // (manifest_id 0) before the first append.
     assert_eq!(
         count_dir(&manifest_dir),
-        n_commits,
-        "one manifest per commit before compact"
+        n_commits + 1,
+        "one manifest per commit, plus create's empty manifest, before compact"
     );
 
     let r = st.reader();

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -19,12 +19,11 @@
 //!
 //!   - The pointer file is missing or still references the
 //!     prior committed `manifest_id` → open returns the prior
-//!     state (or an empty table when no pointer was ever
-//!     committed — nothing was durably committed, so an empty
-//!     table is the correct recovered state). Any superfile /
-//!     manifest-part / manifest-list bytes written before the
-//!     crash but never referenced by a committed pointer are
-//!     **orphans**: tolerated by readers and GC'd by compaction.
+//!     state (or `PointerUnreadable` on a fresh supertable).
+//!     Any superfile / manifest-part / manifest-list bytes
+//!     written before the crash but never referenced by a
+//!     committed pointer are **orphans**: tolerated by
+//!     readers and GC'd by compaction.
 //!   - The pointer file has been atomically replaced with
 //!     the new version → open returns the new state. The
 //!     crash happened AFTER the visibility barrier; the
@@ -36,12 +35,17 @@
 //! commit succeed?" reduces to "did the pointer's rename
 //! complete?" — a single atomic operation on LocalFS.
 //!
+//! `Supertable::create` publishes an initial empty manifest
+//! (id 0) before any commit, so a freshly created table is
+//! already durably openable. The kill points below account for
+//! create's initial list + pointer PUTs (see `kill_point_config`).
+//!
 //! Kill points exercised (one test function each):
 //!
 //! | Test fn                                                      | Crash point                                | Expected post-crash open state                    |
 //! |--------------------------------------------------------------|---------------------------------------------|----------------------------------------------------|
-//! | `crash_post_superfile_no_prior_commit_opens_empty`           | After 1st superfile PUT, before list/pointer | empty table (`manifest_id == 0`), orphan superfile |
-//! | `crash_post_list_no_prior_commit_opens_empty`                | After 1st list PUT, before pointer         | empty table (`manifest_id == 0`), orphan list      |
+//! | `crash_post_superfile_no_prior_commit_yields_empty_table`      | After 1st commit's superfile PUT, before its list/pointer | `manifest_id == 0` (create's empty manifest), orphan superfile |
+//! | `crash_post_list_no_prior_commit_yields_pointer_unreadable`    | After create's list PUT, before its pointer | `OpenError::PointerUnreadable`                     |
 //! | `crash_post_superfile_on_second_commit_yields_v1`                | First commit succeeds; 2nd commit's superfile PUT triggers | `manifest_id == 1` (v_prev), orphan v2 superfile    |
 //! | `crash_post_list_on_second_commit_yields_v1`                   | First commit succeeds; 2nd commit's list PUT triggers   | `manifest_id == 1`, orphan v2 list + part         |
 //! | `crash_post_pointer_on_second_commit_yields_v2`                | First commit succeeds; 2nd commit's pointer PUT triggers AFTER it lands | `manifest_id == 2` (commit was durable)           |
@@ -67,7 +71,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use infino::{
     supertable::{
-        Supertable,
+        OpenError, Supertable,
         storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
     test_helpers::{build_title_batch, default_supertable_options},
@@ -179,12 +183,22 @@ impl StorageProvider for CrashStorage {
 /// to configure `CrashStorage` and decide how many successful
 /// commits to land before the crashing one.
 fn kill_point_config(kp: &str) -> (&'static str, usize, usize) {
+    // `Supertable::create` publishes an initial empty manifest before any
+    // commit: one PUT to `manifest/` (the id-0 list) and one to
+    // `_supertable/current` (the id-0 pointer), and zero to `data/`. The
+    // nth-match counts below account for that initial write:
+    //   - `KP_LIST_FIRST` (nth=1) now fires on create's own list write —
+    //     still "no pointer written yet", so still yields PointerUnreadable.
+    //   - the second-commit list/pointer kill points are +1 (nth=3): create's
+    //     initial write occupies the first match, the first commit the second,
+    //     the crashing second commit the third.
+    //   - `data/` counts are unaffected (create writes no superfile).
     match kp {
         KP_SEG_FIRST => ("data/", 1, 1),
         KP_LIST_FIRST => ("manifest/", 1, 1),
         KP_SEG_SECOND => ("data/", 2, 2),
-        KP_LIST_SECOND => ("manifest/", 2, 2),
-        KP_POINTER_SECOND => ("_supertable/current", 2, 2),
+        KP_LIST_SECOND => ("manifest/", 3, 2),
+        KP_POINTER_SECOND => ("_supertable/current", 3, 2),
         other => panic!("unknown kill point {other}"),
     }
 }
@@ -273,30 +287,33 @@ fn dispatch_child_if_set() -> Option<()> {
 }
 
 #[test]
-fn crash_post_superfile_no_prior_commit_opens_empty() {
+fn crash_post_superfile_no_prior_commit_yields_empty_table() {
     if dispatch_child_if_set().is_some() {
         return; // unreachable; child never returns
     }
     let dir = spawn_crash_child(
-        "crash_post_superfile_no_prior_commit_opens_empty",
+        "crash_post_superfile_no_prior_commit_yields_empty_table",
         KP_SEG_FIRST,
     );
 
-    // Parent verifies. The crash fired after the first
-    // superfile PUT, before any manifest writes. No pointer
-    // exists → nothing was durably committed, so open yields an
-    // empty table (`manifest_id == 0`). Uncommitted data is
-    // invisible by design; "no pointer" and "empty table" are the
-    // same observable state.
+    // Parent verifies. The crash fired after the first commit's superfile PUT,
+    // before that commit's manifest list/pointer. `create` already published
+    // the initial empty manifest (id 0), so open recovers that durable empty
+    // state rather than failing — the uncommitted superfile is an orphan the
+    // reader ignores.
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));
-    let st = Supertable::open(default_supertable_options().with_storage(storage))
-        .expect("post-crash state with no pointer opens as an empty table");
-    assert_eq!(st.manifest_id(), 0, "no commit landed → empty manifest");
+    let recovered = Supertable::open(default_supertable_options().with_storage(storage))
+        .expect("open recovers create's empty id-0 manifest");
     assert_eq!(
-        st.reader().n_superfiles(),
+        recovered.manifest_id(),
         0,
-        "the pre-crash superfile is an orphan; readers don't see it without a committed manifest"
+        "no commit landed → recover create's empty id-0 manifest"
+    );
+    assert_eq!(
+        recovered.reader().n_superfiles(),
+        0,
+        "the orphan superfile is invisible without a committed manifest list"
     );
 
     // The orphan superfile file is present and ignored — the
@@ -313,21 +330,23 @@ fn crash_post_superfile_no_prior_commit_opens_empty() {
 }
 
 #[test]
-fn crash_post_list_no_prior_commit_opens_empty() {
+fn crash_post_list_no_prior_commit_yields_pointer_unreadable() {
     if dispatch_child_if_set().is_some() {
         return;
     }
-    let dir = spawn_crash_child("crash_post_list_no_prior_commit_opens_empty", KP_LIST_FIRST);
+    let dir = spawn_crash_child(
+        "crash_post_list_no_prior_commit_yields_pointer_unreadable",
+        KP_LIST_FIRST,
+    );
 
-    // Crash fired after the 1st manifest-list PUT, before the
-    // pointer. No pointer → nothing committed → open yields an
-    // empty table; the orphan list + superfile are ignored.
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));
-    let st = Supertable::open(default_supertable_options().with_storage(storage))
-        .expect("post-crash state with no pointer opens as an empty table");
-    assert_eq!(st.manifest_id(), 0, "no commit landed → empty manifest");
-    assert_eq!(st.reader().n_superfiles(), 0);
+    let err = Supertable::open(default_supertable_options().with_storage(storage))
+        .expect_err("must reject post-crash state with no pointer");
+    assert!(
+        matches!(err, OpenError::ManifestLoadError(_)),
+        "expected PointerUnreadable, got {err:?}"
+    );
 
     // The orphan manifest is on disk but unreferenced.
     let manifest_dir = dir.join("manifest");


### PR DESCRIPTION
## Problem

Creating a table on durable storage (`file://`, S3, …) returned an in-memory handle but did not persist a manifest pointer until the first append's commit. So `open_table` on a freshly created table — from another process, after a restart, or before the first append — failed with a manifest-load error (`PointerNotFound`). This only worked on `memory://`, so the documented `create_table` → `open_table` sequence was effectively broken on durable backends.

## Fix

`Supertable::create` now materializes and persists the initial empty manifest — its list plus the pointer at `manifest_id 0` — so a freshly created durable table is openable immediately.

- **No id shift:** persisted at `manifest_id 0`, so the first append still commits `manifest_id 1`.
- **Race-tolerant:** if a concurrent creator wins the initial-pointer CAS, `create` adopts their committed manifest.
- **No orphan:** the stale id-0 manifest is reclaimed by GC after compaction.

## Relationship to #338 (supersedes)

#338 fixed the same bug (#336) the other way — it made `open` **tolerant**: a missing pointer returns an empty table. This PR takes the **eager + strict** approach instead, and reverts #338's tolerant-open, because:

> With tolerant-open, *any* absent current-pointer reads as an empty table — including a pointer **lost/deleted after data was committed** (bad GC, partial delete, storage issue). That silently surfaces committed data as "0 rows" instead of erroring.

Since `create` now guarantees a persisted pointer for every registered table, `open` can stay **strict**: a genuinely missing pointer is `PointerNotFound` — the open-or-create trigger for a never-created table, or a lost pointer on a created one — surfaced as an error, never masked as an empty table. (A *corrupt* pointer remains a distinct error too.)

## Tests

- `create_without_append_reopens_as_empty_table` (catalog) and `durable_open_before_first_append_yields_empty_usable_table` — a created durable table reopens as empty+usable via the persisted pointer.
- `open_on_fresh_tempdir_returns_pointer_not_found` — a never-created dir still errors (strict open-or-create trigger).
- Crash-safety contract (`supertable_commit_crash_localfs`) updated for the new reality that `create` publishes an id-0 pointer, incl. `crash_post_list_no_prior_commit_yields_pointer_unreadable` (strict). All 5 pass.
- Full `make ci` green: fmt, clippy, doctests, **public-api (no drift)**, commit / catalog / supertable suites.
