### PR TITLE
node: release 0.1.2, and slim both binding READMEs

### DIFF
--- a/infino-node/README.md
+++ b/infino-node/README.md
@@ -9,14 +9,9 @@ and vector indexes embedded directly inside it; a table composes many such files
 with snapshot-isolated reads, append-only writes, and atomic commits. It runs in
 your process — there is no daemon, no cluster, and no managed service to operate.
 
-Use it for **RAG**, **agent memory**, **hybrid search**, and **semantic search**:
-it's an embedded **vector database**, **full-text (BM25)** search engine, and
-**SQL** query engine in one library — no separate vector database or search
-server to run.
-
-Synchronous, Arrow at the boundary: pass arrays of objects (or apache-arrow
-`Table`s) in, get plain records out; pass `{ arrow: true }` to a search or query
-for an apache-arrow `Table` instead.
+Use it for **RAG**, **agent memory**, **hybrid search**, and **semantic
+search**: an embedded **vector database**, **full-text (BM25)** search engine,
+and **SQL** query engine in one library.
 
 ## Install
 
@@ -33,8 +28,8 @@ toolchain required. Supported platforms:
 | Linux (glibc)         | x64, arm64    |
 | Linux (musl / Alpine) | x64, arm64    |
 
-`apache-arrow` is installed as a dependency and used at the boundary (passing in
-`Table`s, or `{ arrow: true }` results). Requires Node.js >= 18.
+Requires Node.js >= 18. `apache-arrow` is installed as a dependency and used at
+the boundary (passing in `Table`s, or `{ arrow: true }` results).
 
 ## Quickstart
 
@@ -64,333 +59,44 @@ docs.append([
   { source: "blog",        body: "Enable dark mode under Settings then Appearance.",        embedding: embed(1) },
 ]);
 
-// Three ways to retrieve context to ground an agent's next answer:
-const keyword  = docs.bm25Search("body", "cancel subscription", 5);            // BM25
-const semantic = docs.vectorSearch("embedding", embed(0), 5);                  // vector kNN
-const billing  = db.querySql("SELECT body FROM docs WHERE source = 'help-center'");  // SQL filter
+// Retrieve context to ground an agent's next answer — keyword, vector,
+// hybrid (BM25 + vector fused in one pass), or SQL:
+const keyword  = docs.bm25Search("body", "cancel subscription", 5);                          // BM25
+const semantic = docs.vectorSearch("embedding", embed(0), 5);                                // vector kNN
+const hybrid   = docs.hybridSearch("body", "cancel subscription", "embedding", embed(0), 5); // fused
+const billing  = db.querySql("SELECT body FROM docs WHERE source = 'help-center'");          // SQL filter
 ```
 
 CommonJS works too — `const { connect, IndexSpec } = require("@infino-ai/infino");`.
 
-## Examples
+> The API is synchronous. In a long-running server, run calls in a
+> [`worker_thread`](https://nodejs.org/api/worker_threads.html) so a query
+> doesn't block the event loop.
 
-Runnable, end-to-end examples in [`examples/`](examples) (each its own folder
-with a README; build the addon first, then `npm install && node index.mjs`):
+## Documentation
 
-- [`agent-memory/`](examples/agent-memory) — infino as an AI agent's long-term
-  memory: load a real multi-session conversation, then recall it with hybrid
-  search, query it with SQL (`GROUP BY`, filters), and forget parts of it.
-- [`hybrid-search-api/`](examples/hybrid-search-api) — an embedded HTTP search
-  service over a real product catalog, ranked by native `hybrid_search` — with
-  no separate search server to run.
+Full docs, guides, and the API reference live at **[docs.infino.ai](https://docs.infino.ai)**:
 
-## Core concepts
-
-- **Connection** — a handle to a catalog (a set of tables under one URI). Open
-  it with `connect(uri)`.
-- **Table** — an append-only, snapshot-isolated collection of rows. Each table
-  carries an auto-generated `_id` column.
-- **IndexSpec** — declares which columns are full-text (BM25) and which are
-  vector indexed. Columns without an index are still stored, filterable in SQL,
-  and returnable via projection.
-- **Commits** — every `append`, `update`, and `delete` is a single atomic
-  commit. Readers see a consistent snapshot and are never torn by a concurrent
-  write.
-- **Arrow at the boundary** — searches return plain records (or an apache-arrow
-  `Table` with `{ arrow: true }`); `append` and `update` accept an array of
-  objects or an apache-arrow `Table` / `RecordBatch`.
-
-## Full-text search
-
-```javascript
-const docs = db.createTable("docs", { title: "large_utf8" }, new IndexSpec().fts("title"));
-docs.append([{ title: "the quick brown fox" }, { title: "a lazy dog" }]);
-
-// Ranked BM25 — higher score is a better match.
-docs.bm25Search("title", "quick fox", 10);                  // OR by default
-docs.bm25Search("title", "quick fox", 10, { mode: "and" }); // require all terms
-
-// Unranked matching (score is 0): every row containing the term(s),
-// or an exact whole-value match.
-docs.tokenMatch("title", "fox");
-docs.exactMatch("title", "the quick brown fox");
-
-// Count matches without materializing any rows.
-docs.count("title", "fox");                                 // OR by default
-docs.count("title", "quick fox", { mode: "and" });         // require all terms
-```
-
-## Vector search
-
-Vector columns are `FixedSizeList<Float32, dim>` with `dim` in `[16, 4096]`. The
-distance metric is fixed when you declare the index (`"cosine"`, `"l2sq"`, or
-`"negdot"`); for vector results a smaller score is nearer. The query vector is a
-`number[]` or `Float32Array`.
-
-```javascript
-const spec = new IndexSpec().vector("emb", 384, 256, "cosine"); // (column, dim, nCent, metric)
-const vecs = db.createTable("vecs", { emb: { vector: 384 } }, spec);
-
-vecs.vectorSearch("emb", queryVector, 10);                    // top-10 nearest
-vecs.vectorSearch("emb", queryVector, 10, { nprobe: 32 });    // probe more partitions (recall)
-vecs.vectorSearch("emb", queryVector, 10, { rerankMult: 4 }); // wider exact-rerank pool (recall)
-```
-
-**Filtered vector search.** Restrict the kNN to rows matching a text predicate —
-a pushdown *pre-filter*, so you get the nearest *matching* rows (not a
-post-filter over the global top-k). The filter `column` must be FTS-indexed.
-
-```javascript
-vecs.vectorSearch("emb", queryVector, 10, {
-  filter: { column: "title", query: "billing", mode: "or" },
-});
-```
-
-## Hybrid search
-
-Combine BM25 and vector search in **one call** — a single pass over both
-indexes, fused inside the engine with reciprocal-rank fusion (no separate
-reranker service, no two round-trips). Keyword-only search misses paraphrases;
-vector-only search misses exact terms — hybrid gets both. Results come back
-best-first with a fused `score` (higher is better).
-
-```javascript
-const spec = new IndexSpec().fts("body").vector("emb", 384, 256, "cosine");
-const docs = db.createTable("docs", { body: "large_utf8", emb: { vector: 384 } }, spec);
-docs.append([{ body: "To cancel a subscription, open Settings then Billing.", emb: embed(/* … */) }]);
-
-// hybridSearch(textColumn, textQuery, vectorColumn, vectorQuery, k, opts?)
-docs.hybridSearch("body", "cancel subscription", "emb", embed("how do I stop my plan?"), 10);
-// opts: { mode } tunes the BM25 side, { nprobe } the vector side.
-
-// The same fusion is also a SQL table function, so it composes in a query:
-const qvec = embed("how do I stop my plan?").join(",");
-db.querySql(
-  `SELECT _id, score FROM hybrid_search('docs', 'body', 'cancel subscription', 'emb', '${qvec}', 10)`,
-);
-```
-
-For a complete, runnable hybrid search service see the
-[`hybrid-search-api` example](examples/hybrid-search-api).
-
-## SQL
-
-Run SQL across the catalog's tables for analytics and filtering; the search
-functions are also available as SQL table functions. Results come back as plain
-records (or an apache-arrow `Table` with `{ arrow: true }`).
-
-```javascript
-db.querySql("SELECT COUNT(*) AS n FROM docs");
-db.querySql("SELECT title FROM docs WHERE title = 'a lazy dog'");
-
-// The search methods are also SQL table functions — bm25_search, vector_search,
-// and hybrid_search (see "Hybrid search" above) — so you can filter, join, and
-// aggregate over search results.
-db.querySql("SELECT _id, score FROM bm25_search('docs', 'title', 'fox', 10)");
-```
-
-## Projections
-
-By default a search returns just `_id` and `score` — no row data is decoded.
-Name the columns you want to materialize:
-
-```javascript
-docs.bm25Search("title", "fox", 10);                                   // _id + score only
-docs.bm25Search("title", "fox", 10, { projection: ["_id", "title", "score"] });
-```
-
-## Updates and deletes
-
-Mutations require durable storage (a local path or object store, not
-`memory://`). The predicate is a SQL boolean expression — the same thing you'd
-write after `WHERE` — evaluated against the table's columns.
-
-```javascript
-docs.append([{ title: "draft post" }, { title: "spam" }]);
-
-// Delete every row matching the predicate.
-docs.delete("title = 'spam'");
-
-// Replace matched rows 1:1 with new rows (same input shapes as append).
-const stats = docs.update("title = 'draft post'", [{ title: "published post" }]);
-console.log(stats.matched, stats.nTombstoned, stats.nNotFound);
-```
-
-`update` is a one-to-one replacement: the number of matched rows must equal the
-number you supply, otherwise it throws. Both methods return `{ matched,
-nTombstoned, nNotFound }`.
-
-## Optimize
-
-Many small appends produce many small files. `optimize` compacts them —
-merging small or underfilled files into larger ones — which keeps reads efficient.
-
-```javascript
-docs.optimize();                                                  // engine defaults
-docs.optimize({ targetSuperfileSizeMb: 256, minFillPercent: 50 });
-```
-
-Compaction and interrupted writes can leave behind storage objects that are no
-longer referenced. `gc` deletes them, reclaiming space. It only removes objects
-older than a grace window (in seconds) so it never races a concurrent reader or
-writer; requires durable storage.
-
-```javascript
-const report = docs.gc(3600);                                     // older than 1 hour
-console.log(report.bytesFreed, report.objectsDeleted);
-```
-
-## Storage backends
-
-`connect` selects the backend from the URI:
-
-| URI                      | Backend                                  |
-| ------------------------ | ---------------------------------------- |
-| `./data`, `/abs/path`    | Local filesystem                         |
-| `s3://bucket/prefix`     | Amazon S3 / S3-compatible object storage |
-| `az://container/prefix`  | Azure Blob Storage                       |
-| `memory://`              | In-process, ephemeral (testing)          |
-
-Credentials go in `storageOptions`, keyed by the standard `object_store` config
-strings (`aws_*` / `azure_*` — the same names the AWS and Azure SDKs use). Omit
-them to use ambient cloud identity (IAM instance role / managed identity);
-infino reads no credentials from the environment.
-
-```javascript
-// S3
-const db = connect("s3://bucket/prefix", {
-  storageOptions: {
-    aws_access_key_id: "…",
-    aws_secret_access_key: "…",
-    aws_region: "us-east-1",
-  },
-});
-
-// Azure
-const db = connect("az://container/prefix", {
-  storageOptions: {
-    azure_storage_account_name: "…",
-    azure_storage_account_key: "…",
-  },
-});
-```
-
-Common keys:
-
-| Backend | Keys |
-| ------- | ---- |
-| S3      | `aws_access_key_id`, `aws_secret_access_key`, `aws_region`, `aws_session_token`, `aws_endpoint` |
-| Azure   | `azure_storage_account_name`, `azure_storage_account_key`, `azure_storage_sas_key`, `azure_storage_client_id`, `azure_storage_client_secret`, `azure_storage_tenant_id` |
-
-The full set is whatever `object_store` accepts for the backend; an unknown key
-is rejected at `connect`. Pass `validate: true` to probe the backend at
-`connect`, so wrong credentials or an unreachable bucket throw there instead of
-on the first query. For an S3-compatible endpoint (MinIO / R2 / Ceph), set
-`aws_endpoint` (with `aws_allow_http: "true"` for plain HTTP) alongside the
-credentials.
-
-### Local disk cache
-
-For object-storage-backed catalogs, a local disk cache keeps hot data on fast
-local storage. `coldFetchMode` controls how cache misses are served:
-`"hybrid_with_prefetch"`, `"range_only"`, or
-`"lazy_foreground_with_background_fill"`.
-
-```javascript
-const db = connect("s3://bucket/prefix", {
-  cacheDir: "/mnt/nvme/infino-cache",
-  cacheBudgetBytes: 64 * 1024 ** 3,
-  coldFetchMode: "lazy_foreground_with_background_fill",
-});
-```
-
-## Schema and type requirements
-
-- Full-text columns must be Arrow `LargeUtf8` (`"large_utf8"` in a descriptor).
-- Vector columns must be `FixedSizeList<Float32, dim>` (`{ vector: dim }`) with
-  `dim` in `[16, 4096]`.
-- The `_id` column is generated by the engine; do not declare it. It comes back
-  as a JavaScript `bigint`.
-- `createTable` accepts an apache-arrow `Schema` or a plain `{ column: type }`
-  descriptor; `append` / `update` accept an array of objects or an apache-arrow
-  `Table` / `RecordBatch`, coerced against the table's declared schema.
-
-## API reference
-
-- `connect(uri, options?)` — backend from the URI scheme. `options`:
-  `storageOptions` (credentials, keyed by `object_store`'s `aws_*` / `azure_*`
-  strings), `validate`, and a local disk cache (`cacheDir`, `cacheBudgetBytes`,
-  `coldFetchMode`).
-- `Connection`
-  - `createTable(name, schema, IndexSpec)` / `openTable(name)` /
-    `dropTable(name, purge?)` (`purge = true` also deletes the data) /
-    `listTables()` / `querySql(sql, { arrow? })`.
-- `Table`
-  - `append(data)` — one `append` is one commit.
-  - `bm25Search(col, q, k, { mode?, projection?, arrow? })` — ranked BM25.
-  - `vectorSearch(col, query, k, { nprobe?, rerankMult?, filter?, projection?, arrow? })`
-    — ranked kNN; `filter` (`{ column, query, mode? }`, `column` FTS-indexed) is
-    a pushdown pre-filter.
-  - `tokenMatch(col, q, { mode?, projection?, arrow? })` /
-    `exactMatch(col, value, { projection?, arrow? })` — unranked (`score` is `0`).
-  - `count(col, q, { mode? })` — match tally, no rows fetched.
-  - `update(predicate, data)` / `delete(predicate)` — mutate rows matching a SQL
-    predicate; return `{ matched, nTombstoned, nNotFound }`; require durable
-    storage.
-  - `optimize({ maxMemoryMb?, minFillPercent?, targetSuperfileSizeMb? })`.
-  - `gc(graceSecs)` — delete orphaned storage objects older than the grace
-    window; returns `{ bytesFreed, objectsDeleted, objectsSkippedLive,
-    objectsSkippedTooNew, deleteErrors }`; requires durable storage.
-  - `schema()` — the table's apache-arrow `Schema`.
-- `IndexSpec().fts(col).vector(col, dim, nCent, metric)`.
-- `BUILDER_ID` (named export) — the engine's build identifier string.
-
-Search results default to `_id` + `score`; name columns in `projection` to
-materialize row data.
+- [Quickstart](https://docs.infino.ai/quickstart) — install to first query
+- [Core concepts](https://docs.infino.ai/core-concepts) — superfiles, commits, and indexes
+- Guides — [Tables & indexing](https://docs.infino.ai/guides/tables) ·
+  [Search: BM25, vector, hybrid](https://docs.infino.ai/guides/search) ·
+  [Embeddings](https://docs.infino.ai/guides/embeddings) ·
+  [Storage & credentials](https://docs.infino.ai/guides/storage)
+- [SQL reference](https://docs.infino.ai/sql-reference) — query tables and the search table-valued functions
+- [API reference](https://docs.infino.ai/api-reference) — the full Node surface, generated from the package
+- [Integrations](https://docs.infino.ai/integrations) — LangChain, CrewAI, Vercel AI SDK, MCP
+- [Examples](examples) — runnable agent-memory and hybrid-search-service demos
 
 ## Building from source
 
-The binding is built with [napi-rs](https://napi.rs/). Building requires a Rust
-toolchain and access to crates.io.
+The binding is built with [napi-rs](https://napi.rs/) and requires a Rust
+toolchain.
 
 ```sh
 cd infino-node
 npm install && npm run build && npm test
 ```
-
-## Notes
-
-- The API is **synchronous**. In a long-running server, run calls in a
-  `worker_thread` so a query doesn't block the event loop.
-
-## FAQ
-
-**Is infino a vector database?** It does vector search, but it's more than that —
-an embedded engine that runs vector search *and* full-text (BM25) *and* SQL over
-one copy of your data. Reach for it wherever you'd use a vector database, plus the
-cases a vector store alone can't cover: keyword search, filtering, joins, and
-aggregates.
-
-**Does it need a server?** No. It runs in your Node.js process — no daemon, no
-cluster, no managed service. Your data is Parquet on local disk or S3.
-
-**Can it do hybrid (keyword + vector) search?** Yes, natively — BM25 and vector
-fused in a single pass via `hybrid_search` (see [Hybrid search](#hybrid-search)),
-not a client-side rerank.
-
-**Where is my data stored?** As Apache Parquet files on local disk or any
-S3-compatible object store; each file embeds its own BM25 and vector indexes.
-
-**Does it work with TypeScript?** Yes — the package ships type definitions and the
-API is identical from JavaScript and TypeScript. Both ESM `import` and CommonJS
-`require` work.
-
-**Do I need a Rust toolchain to install it?** No — a prebuilt native binary is
-selected automatically at install (macOS and Linux, x64 and arm64).
-
-**Is it a good fit for RAG or agent memory?** Yes, that's a primary use case:
-store documents or conversation history once, retrieve with hybrid search, and
-filter/aggregate with SQL. See the runnable [examples](examples).
 
 ## License
 

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.1.1",
-    "infx-darwin-arm64": "0.1.1",
-    "infx-linux-x64-gnu": "0.1.1",
-    "infx-linux-arm64-gnu": "0.1.1",
-    "infx-linux-x64-musl": "0.1.1",
-    "infx-linux-arm64-musl": "0.1.1"
+    "infx-darwin-x64": "0.1.2",
+    "infx-darwin-arm64": "0.1.2",
+    "infx-linux-x64-gnu": "0.1.2",
+    "infx-linux-arm64-gnu": "0.1.2",
+    "infx-linux-x64-musl": "0.1.2",
+    "infx-linux-arm64-musl": "0.1.2"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",

--- a/infino-python/README.md
+++ b/infino-python/README.md
@@ -14,8 +14,9 @@ table composes many such files with snapshot-isolated reads, append-only
 writes, and atomic commits. It runs in your process — there is no daemon,
 no cluster, and no managed service to operate.
 
-Apache Arrow is the interchange: schemas and batches cross the boundary
-as `pyarrow` objects, and every search returns a `pyarrow.Table`.
+Use it for **RAG**, **agent memory**, **hybrid search**, and **semantic
+search**: an embedded **vector database**, **full-text (BM25)** search
+engine, and **SQL** query engine in one library.
 
 ## Installation
 
@@ -43,334 +44,63 @@ import pyarrow as pa
 # "memory://" is ephemeral and handy for tests.
 db = infino.connect("./data")
 
+# Tiny stand-in for your embedding model so this runs as-is — a 16-dim
+# one-hot by topic. Real embeddings are dense and higher-dimensional.
+def embed(topic):
+    v = [0.0] * 16
+    v[topic] = 1.0
+    return v
+
 # Declare a schema and which columns to index. An "_id" column is added
 # automatically — you don't define it.
-schema = pa.schema([pa.field("title", pa.large_utf8(), nullable=False)])
-docs = db.create_table("docs", schema, infino.IndexSpec().fts("title"))
+schema = pa.schema([
+    pa.field("source", pa.large_utf8(), nullable=False),
+    pa.field("body", pa.large_utf8(), nullable=False),
+    pa.field("embedding", pa.list_(pa.float32(), 16), nullable=False),
+])
+docs = db.create_table(
+    "docs", schema, infino.IndexSpec().fts("body").vector("embedding", 16, 1, "cosine")
+)
 
 # Append rows. One append is one atomic commit.
-docs.append([{"title": "the quick brown fox"}, {"title": "a lazy dog"}])
+docs.append([
+    {"source": "help-center", "body": "To cancel a subscription, open Settings then Billing.", "embedding": embed(0)},
+    {"source": "help-center", "body": "Refunds return to the original payment method.",         "embedding": embed(0)},
+    {"source": "blog",        "body": "Enable dark mode under Settings then Appearance.",        "embedding": embed(1)},
+])
 
-# Full-text search. Returns a pyarrow.Table of (_id, score).
-hits = docs.bm25_search("title", "fox", k=10)
-print(hits.column_names)        # ['_id', 'score']
+# Retrieve context to ground an agent's next answer — keyword, vector,
+# hybrid (BM25 + vector fused in one pass), or SQL. Each returns a pyarrow.Table.
+keyword  = docs.bm25_search("body", "cancel subscription", k=5)                           # BM25
+semantic = docs.vector_search("embedding", embed(0), k=5)                                 # vector kNN
+hybrid   = docs.hybrid_search("body", "cancel subscription", "embedding", embed(0), k=5)  # fused
+billing  = db.query_sql("SELECT body FROM docs WHERE source = 'help-center'")             # SQL filter
 ```
 
-## Core concepts
+## Documentation
 
-- **Connection** — a handle to a catalog (a set of tables under one URI).
-  Open it with `infino.connect(uri)`.
-- **Table** — an append-only, snapshot-isolated collection of rows. Each
-  table carries an auto-generated `_id` column.
-- **IndexSpec** — declares which columns are full-text (BM25) and which
-  are vector indexed. Columns without an index are still stored,
-  filterable in SQL, and returnable via projection.
-- **Commits** — every `append`, `update`, and `delete` is a single atomic
-  commit. Readers see a consistent snapshot and are never torn by a
-  concurrent write. Batch rows into one `append` rather than calling it
-  per row — each call writes a file and commits.
-- **Arrow everywhere** — searches return `pyarrow.Table`; `append` and
-  `update` accept Arrow, pandas, or `list[dict]`.
+Full docs, guides, and the API reference live at **[docs.infino.ai](https://docs.infino.ai)**:
 
-## Full-text search
-
-```python
-docs = db.create_table("docs", schema, infino.IndexSpec().fts("title"))
-docs.append([{"title": "the quick brown fox"}, {"title": "a lazy dog"}])
-
-# Ranked BM25 — higher score is a better match.
-docs.bm25_search("title", "quick fox", k=10)               # OR by default
-docs.bm25_search("title", "quick fox", k=10, mode="and")   # require all terms
-
-# Unranked matching (score is 0.0): every row containing the term(s),
-# or an exact whole-value match.
-docs.token_match("title", "fox")
-docs.exact_match("title", "the quick brown fox")
-
-# Count matches without materializing any rows.
-docs.count("title", "fox")                                 # OR by default
-docs.count("title", "quick fox", mode="and")               # require all terms
-```
-
-## Vector search
-
-Vector columns are `fixed_size_list<float32, dim>` with `dim` in
-`[16, 4096]`. The distance metric is fixed when you declare the index
-(`"cosine"`, `"l2sq"`, or `"negdot"`); for vector results a smaller score
-is nearer.
-
-```python
-dim = 384
-schema = pa.schema([pa.field("emb", pa.list_(pa.float32(), dim), nullable=False)])
-spec = infino.IndexSpec().vector("emb", dim, n_cent=256, metric="cosine")
-vecs = db.create_table("vecs", schema, spec)
-
-vecs.append(pa.record_batch([pa.array(embeddings, type=pa.list_(pa.float32(), dim))],
-                            names=["emb"]))
-
-vecs.vector_search("emb", query_vector, k=10)              # query_vector: list[float]
-vecs.vector_search("emb", query_vector, k=10, nprobe=32)   # probe more partitions
-```
-
-To restrict the kNN to rows matching a text predicate, pass `filter_column`
-and `filter_query` together (the column must be FTS-indexed) — a pushdown
-pre-filter, so results are the nearest *matching* rows, not a post-filter over
-the global top-k. `filter_mode` is `"or"` (default) or `"and"`:
-
-```python
-vecs.vector_search("emb", query_vector, k=10,
-                   filter_column="body", filter_query="cancel subscription")
-```
-
-## Hybrid search
-
-`hybrid_search` runs BM25 and vector kNN over the same table and fuses the
-two rankings with reciprocal-rank fusion — a higher `score` is a better
-blended match. The table needs both an FTS column and a vector column:
-
-```python
-docs = db.create_table(
-    "docs", schema, infino.IndexSpec().fts("title").vector("emb", dim, n_cent=256, metric="cosine")
-)
-
-docs.hybrid_search("title", "quick fox", "emb", query_vector, k=10)
-# mode (BM25 boolean mode) and nprobe (vector probes) are optional:
-docs.hybrid_search("title", "quick fox", "emb", query_vector, k=10,
-                   mode="and", nprobe=32)
-```
-
-## SQL
-
-Run SQL across the catalog's tables for analytics and filtering. Results
-come back as a `pyarrow.Table`.
-
-```python
-db.query_sql("SELECT COUNT(*) AS n FROM docs")
-db.query_sql("SELECT title FROM docs WHERE title = 'a lazy dog'")
-```
-
-### Search inside SQL
-
-Search is also exposed as table-valued functions, so a ranked retrieval is
-a relation you can join, filter, and aggregate over. Each takes the table
-name as its first argument and yields `_id`, any scalar columns, and a
-trailing `score`:
-
-| Function                                                        | Returns                                  |
-| --------------------------------------------------------------- | ---------------------------------------- |
-| `bm25_search(table, column, query, k)`                          | Ranked BM25 (higher score is better)     |
-| `bm25_search_prefix(table, column, prefix, k)`                  | BM25 with the last term prefix-expanded  |
-| `vector_search(table, column, query_vector, k)`                 | kNN (smaller score is nearer)            |
-| `hybrid_search(table, text_col, query, vec_col, query_vector, k)` | BM25 + vector fused with RRF (higher is better) |
-| `token_match(table, column, query)`                             | Unranked term match (`score` is `0.0`)   |
-| `exact_match(table, column, value)`                             | Unranked exact-value match               |
-
-A query vector is written as a comma-separated string or a SQL array
-literal; build it from a Python list with `",".join(map(str, vec))`.
-
-```python
-# Hybrid search: lexical + vector, fused by reciprocal-rank fusion.
-qv = ",".join(map(str, query_vector))
-db.query_sql(f"""
-    SELECT _id, score
-    FROM hybrid_search('docs', 'title', 'quick fox', 'emb', '{qv}', 10)
-    ORDER BY score DESC
-""")
-
-# Compose retrieval with relational filtering and the catalog's other tables.
-db.query_sql("""
-    SELECT s._id, s.score
-    FROM bm25_search('docs', 'title', 'fox', 50) AS s
-    WHERE s._id IN (SELECT _id FROM docs WHERE title <> 'a lazy dog')
-""")
-```
-
-Most table functions have a direct `Table` method equivalent
-(`bm25_search`, `vector_search`, `hybrid_search`, `token_match`,
-`exact_match`); `bm25_search_prefix` is available only in SQL. The direct
-methods also expose optional arguments the SQL forms omit — SQL
-`vector_search` and `hybrid_search` take no `nprobe` (or filter), so use
-the `Table` methods when you need those.
-
-## Projections
-
-By default a search returns just `_id` and `score` — no row data is
-decoded. Name the columns you want to materialize:
-
-```python
-docs.bm25_search("title", "fox", k=10)                          # _id + score only
-docs.bm25_search("title", "fox", k=10, projection=["_id", "title", "score"])
-vecs.vector_search("emb", query_vector, k=10, projection=["_id", "emb", "score"])
-```
-
-The SQL table-valued functions differ: they decode every scalar column by
-default (`_id`, all scalars, trailing `score`). To return only `_id` and
-`score`, select those columns explicitly in the query.
-
-## Updates and deletes
-
-Mutations require durable storage (a local path or object store, not
-`memory://`). The predicate is a SQL boolean expression — the same thing
-you would write after `WHERE` — evaluated against the table's columns.
-
-```python
-docs.append([{"title": "draft post"}, {"title": "spam"}])
-
-# Delete every row matching the predicate.
-docs.delete("title = 'spam'")
-
-# Replace matched rows 1:1 with new rows (same input shapes as append).
-stats = docs.update("title = 'draft post'", [{"title": "published post"}])
-print(stats.matched, stats.n_tombstoned, stats.n_not_found)
-```
-
-`update` is a one-to-one replacement: the number of rows the predicate
-matches must equal the number of rows you supply, otherwise it raises.
-Both methods return a `MutationStats` with `matched`, `n_tombstoned`, and
-`n_not_found`.
-
-## Optimization
-
-Many small appends produce many small files. `optimize` merges small or
-underfilled files into larger ones, which keeps reads efficient.
-
-```python
-docs.optimize()                                             # engine defaults
-docs.optimize(infino.OptimizeOptions(target_superfile_size_mb=256,
-                                     min_fill_percent=50))
-```
-
-Compaction and interrupted writes can leave behind storage objects that
-are no longer referenced. `gc` deletes them, reclaiming space. It only
-removes objects older than a grace window (in seconds) so it never races
-a concurrent reader or writer; requires durable storage.
-
-```python
-report = docs.gc(3600.0)                                    # older than 1 hour
-print(report.bytes_freed, report.objects_deleted)
-```
-
-## Storage backends
-
-`connect` selects the backend from the URI:
-
-| URI                      | Backend                                  |
-| ------------------------ | ---------------------------------------- |
-| `./data`, `/abs/path`    | Local filesystem                         |
-| `s3://bucket/prefix`     | Amazon S3 / S3-compatible object storage |
-| `az://container/prefix`  | Azure Blob Storage                       |
-| `memory://`              | In-process, ephemeral (testing)          |
-
-Credentials are passed as `storage_options`, keyed by the standard
-`object_store` config strings (`aws_*` / `azure_*` — same names the AWS
-and Azure SDKs use). Omit them to use ambient cloud identity (IAM
-instance role / managed identity). Infino reads no credentials from the
-environment.
-
-```python
-# S3
-db = infino.connect("s3://bucket/prefix", storage_options={
-    "aws_access_key_id": "…",
-    "aws_secret_access_key": "…",
-    "aws_region": "us-east-1",
-})
-
-# Azure
-db = infino.connect("az://container/prefix", storage_options={
-    "azure_storage_account_name": "…",
-    "azure_storage_account_key": "…",
-})
-```
-
-Common keys:
-
-| Backend | Keys |
-| ------- | ---- |
-| S3      | `aws_access_key_id`, `aws_secret_access_key`, `aws_region`, `aws_session_token`, `aws_endpoint` |
-| Azure   | `azure_storage_account_name`, `azure_storage_account_key`, `azure_storage_sas_key`, `azure_storage_client_id`, `azure_storage_client_secret`, `azure_storage_tenant_id` |
-
-The full set is whatever `object_store` accepts for the backend; an
-unknown key is rejected at `connect`. Pass `validate=True` to probe the
-backend at `connect`, so wrong credentials or an unreachable bucket fail
-there instead of on the first query. For an S3-compatible endpoint (MinIO /
-R2 / Ceph), set `aws_endpoint` (with `aws_allow_http: "true"` for plain
-HTTP) alongside the credentials.
-
-### Local disk cache
-
-For object-storage-backed catalogs, a local disk cache keeps hot data on
-fast local storage. `cold_fetch_mode` controls how cache misses are
-served: `"hybrid_with_prefetch"`, `"range_only"`, or
-`"lazy_foreground_with_background_fill"`.
-
-```python
-db = infino.connect(
-    "s3://bucket/prefix",
-    cache_dir="/mnt/nvme/infino-cache",
-    cache_budget_bytes=64 * 1024**3,
-    cold_fetch_mode="lazy_foreground_with_background_fill",
-)
-```
-
-## Schema and type requirements
-
-- Full-text columns must be Arrow `large_utf8`.
-- Vector columns must be `fixed_size_list<float32, dim>` with `dim` in
-  `[16, 4096]`.
-- The `_id` column is generated by the engine; do not declare it.
-- `append` and `update` accept a `pyarrow.RecordBatch` or `Table`, a
-  pandas `DataFrame`, or a `list[dict]`, coerced to Arrow against the
-  table's declared schema.
-
-## API reference
-
-- `infino.connect(uri, *, storage_options=None, cache_dir=None, cache_budget_bytes=None, cold_fetch_mode=None, validate=None) -> Connection`
-- `Connection`
-  - `create_table(name, schema, index_spec) -> Table`
-  - `open_table(name) -> Table`
-  - `drop_table(name, purge=False)` — `purge=True` also deletes the data
-  - `list_tables() -> list[str]`
-  - `query_sql(sql) -> pyarrow.Table` — also exposes the search
-    table-valued functions `bm25_search`, `bm25_search_prefix`,
-    `vector_search`, `hybrid_search`, `token_match`, and `exact_match`
-    (each takes the table name first)
-- `Table`
-  - `append(data)`
-  - `bm25_search(column, query, k, mode="or", projection=None) -> pyarrow.Table`
-  - `vector_search(column, query, k, nprobe=None, filter_column=None, filter_query=None, filter_mode=None, projection=None) -> pyarrow.Table`
-  - `hybrid_search(text_column, text_query, vector_column, vector_query, k, mode=None, nprobe=None, projection=None) -> pyarrow.Table`
-  - `token_match(column, query, mode="or", projection=None) -> pyarrow.Table`
-  - `exact_match(column, value, projection=None) -> pyarrow.Table`
-  - `count(column, query, mode="or") -> int` — match tally, no rows fetched
-  - `delete(predicate) -> MutationStats`
-  - `update(predicate, new_rows) -> MutationStats`
-  - `optimize(settings=None)`
-  - `gc(grace_secs) -> GcReport` — delete orphaned storage objects older than the grace window
-  - `schema() -> pyarrow.Schema`
-- `IndexSpec().fts(column).vector(column, dim, n_cent, metric)`
-- `OptimizeOptions(max_memory_mb=None, min_fill_percent=None, target_superfile_size_mb=None)`
-- `MutationStats` — returned by `delete` / `update`; read-only attributes `matched`, `n_tombstoned`, `n_not_found`
-- `GcReport` — returned by `gc`; read-only attributes `bytes_freed`, `objects_deleted`, `objects_skipped_live`, `objects_skipped_too_new`, `delete_errors`
+- [Quickstart](https://docs.infino.ai/quickstart) — install to first query
+- [Core concepts](https://docs.infino.ai/core-concepts) — superfiles, commits, and indexes
+- Guides — [Tables & indexing](https://docs.infino.ai/guides/tables) ·
+  [Search: BM25, vector, hybrid](https://docs.infino.ai/guides/search) ·
+  [Embeddings](https://docs.infino.ai/guides/embeddings) ·
+  [Storage & credentials](https://docs.infino.ai/guides/storage)
+- [SQL reference](https://docs.infino.ai/sql-reference) — query tables and the search table-valued functions
+- [API reference](https://docs.infino.ai/api-reference) — the full Python surface, generated from the package
+- [Integrations](https://docs.infino.ai/integrations) — LangChain, CrewAI, Vercel AI SDK, MCP
 
 ## Building from source
 
-The bindings are built with [maturin](https://www.maturin.rs/). Building
-requires a Rust toolchain and access to crates.io.
+The bindings are built with [maturin](https://www.maturin.rs/) and require a
+Rust toolchain.
 
 ```sh
 python3 -m venv .venv && source .venv/bin/activate
 pip install maturin pytest pyarrow
 maturin develop          # compile the extension and install it into the venv
 pytest tests/
-```
-
-Or with [uv](https://docs.astral.sh/uv/):
-
-```sh
-uv venv && source .venv/bin/activate
-uv pip install maturin pytest pyarrow
-maturin develop          # compile the extension and install it into the venv
-uv run pytest tests/
 ```
 
 ## License


### PR DESCRIPTION
Two things, bundled since they ship together in the 0.1.2 npm package:

### Node release 0.1.2
Bumps the Node binding to **0.1.2** so the new `count` and `gc` methods (#331) reach npm. Independent binding patch — `major.minor` (0.1) is unchanged; the crate and Python are untouched. Published manually via the `Node publish` workflow, which reads the version from `package.json`; the platform `optionalDependencies` pins are bumped to match. No lockfile change (as with 0.1.1, `napi prepublish` derives versions from `package.json` at release).

### Slim both binding READMEs
The Node and Python READMEs had grown to ~390 lines each, duplicating the guides now on [docs.infino.ai](https://docs.infino.ai). Trimmed both to a landing-page shape — intro, install, one runnable quickstart, and links to the docs — and dropped the per-feature sections, storage/schema prose, API cheatsheet, Notes, and FAQ (all covered by the guides).

The quickstart now leads with hybrid search alongside keyword / vector / SQL, showcasing first-class fused retrieval; the Python quickstart gained a vector column so it can demo it too.

_(The Python README update lands here but ships to PyPI on the next Python publish.)_