### PR TITLE
docs: make the docs.rs page complete and navigable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,12 @@ exclude = [
 # binaries.
 autobenches = false
 
+# docs.rs renders the default-feature surface (the public API); the internal
+# `test-helpers` modules stay off it. `--cfg docsrs` turns on the availability
+# annotations rustdoc emits under that cfg.
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 # Declare an explicit workspace so the bench-utils crate is a
 # first-class member rather than only a dev-dependency path
 # package. Without this, `infino` (root) dev-depends on

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: check fmt test doctest doc \
         coverage coverage-summary \
         bench bench-quick miri asan ci clean \
-        public-api public-api-update api-parity api-parity-update \
+        public-api public-api-update api-parity api-parity-update doc-check \
         python-test python-typecheck python-wheel python-examples-test \
         node-test node-build node-verify node-example
 
@@ -13,6 +13,7 @@ check:
 	cargo fmt --all -- --check --config $(RUSTFMT_OPTS)
 	cargo clippy --all-targets --features test-helpers -- -D warnings
 	$(MAKE) api-parity
+	$(MAKE) doc-check
 
 # Apply formatting, including the import-layout rules above.
 fmt:
@@ -42,6 +43,13 @@ api-parity:
 
 api-parity-update:
 	python3 scripts/check_api_parity.py --update
+
+# Doc-surface gate. Every public item on the default (docs.rs) surface must be
+# documented, and every intra-doc link must resolve. Uses default features so
+# the internal `test-helpers` modules stay out of scope — this is exactly the
+# page docs.rs renders. Keeps the reference fully populated and navigable.
+doc-check:
+	RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps --lib
 
 test:
 	cargo test --features test-helpers

--- a/crate-docs.md
+++ b/crate-docs.md
@@ -80,6 +80,11 @@ docs.append(&RecordBatch::try_new(
 // Retrieve context to ground the agent's next answer:
 let keyword = docs.bm25_search("body", "cancel subscription", 5, BoolMode::Or, None)?;
 let semantic = docs.vector_search("embedding", &embed(0), 5, VectorSearchOptions::new(), None, None)?;
+// hybrid: BM25 + vector, fused with reciprocal-rank fusion:
+let hybrid = docs.hybrid_search(
+    "body", "cancel subscription", BoolMode::Or,
+    "embedding", &embed(0), VectorSearchOptions::new(), 5, None,
+)?;
 // vector kNN, restricted to rows whose body matches a keyword (pushdown filter):
 let filtered = docs.vector_search(
     "embedding", &embed(0), 5, VectorSearchOptions::new(),
@@ -88,30 +93,55 @@ let filtered = docs.vector_search(
 let billing = db.query_sql("SELECT body FROM docs WHERE source = 'help-center'")?;
 assert_eq!(keyword.iter().map(|b| b.num_rows()).sum::<usize>(), 1);   // BM25
 assert!(semantic.iter().map(|b| b.num_rows()).sum::<usize>() >= 1);   // vector kNN
+assert!(hybrid.iter().map(|b| b.num_rows()).sum::<usize>() >= 1);     // hybrid (BM25 + vector)
 assert_eq!(filtered.iter().map(|b| b.num_rows()).sum::<usize>(), 1);  // vector + keyword filter
 assert_eq!(billing.iter().map(|b| b.num_rows()).sum::<usize>(), 2);   // SQL filter
 # Ok(())
 # }
 ```
 
-## API overview
+## Operations
 
-The public surface is a small connection-and-table API:
+The public surface is a small connection-and-table API. Everything except the
+two entry-point functions is a method on one of two handles, so the operations
+live on the [`Connection`] and [`Supertable`] pages:
 
-- `connect` / `connect_with` open a `Connection`. The backend follows the URI
-  scheme (`s3://`, `az://`, `gs://`, `file://`, bare path, `memory://`);
-  credentials are passed via `ConnectOptions::with_storage_option`
+- [`connect`] / [`connect_with`] open a [`Connection`]. The backend follows the
+  URI scheme (`s3://`, `az://`, `gs://`, `file://`, bare path, `memory://`);
+  credentials are passed via [`ConnectOptions::with_storage_option`]
   (object_store's `aws_*` / `azure_*` / `google_*` keys), never read from the
   environment.
-- `Connection` — `create_table`, `open_table`, `drop_table`, `list_tables`, `query_sql`.
-- `Supertable` (the table handle) — `append`, `update`, `delete`, `schema`, and the
-  search methods `bm25_search`, `vector_search`, `hybrid_search`, `token_match`,
-  and `exact_match` (each returns Arrow rows as `Vec<RecordBatch>`).
-- Supporting types — `IndexSpec`, `Metric`, `BoolMode`, `VectorSearchOptions`,
-  `ConnectOptions`, `MutationStats`, and the `InfinoError` enum.
+- [`Connection`] — the catalog: [`create_table`](Connection::create_table),
+  [`open_table`](Connection::open_table), [`drop_table`](Connection::drop_table),
+  [`list_tables`](Connection::list_tables), and
+  [`query_sql`](Connection::query_sql).
+- [`Supertable`] — a single table:
+  - **Search** — [`bm25_search`](Supertable::bm25_search),
+    [`vector_search`](Supertable::vector_search),
+    [`hybrid_search`](Supertable::hybrid_search),
+    [`token_match`](Supertable::token_match),
+    [`exact_match`](Supertable::exact_match), and
+    [`count`](Supertable::count). Each search returns Arrow rows as
+    `Vec<RecordBatch>`.
+  - **Write** — [`append`](Supertable::append),
+    [`update`](Supertable::update), [`delete`](Supertable::delete).
+  - **Maintain** — [`optimize`](Supertable::optimize),
+    [`gc`](Supertable::gc), and [`schema`](Supertable::schema).
+
+Supporting types: [`IndexSpec`], [`Metric`], [`BoolMode`],
+[`VectorSearchOptions`], [`VectorFilter`], [`ConnectOptions`], [`MutationStats`],
+[`GcReport`], and the [`InfinoError`], [`OptimizeError`], and [`GcError`] error
+enums.
+
+## Cargo features
+
+- `default` — enables the bundled [mimalloc](https://github.com/microsoft/mimalloc)
+  global allocator. Disable with `default-features = false` if your process
+  already installs a global allocator.
 
 ## Other languages
 
 infino also ships **Python** (`pip install infino`) and **Node.js**
-(`npm install @infino-ai/infino`) bindings. For multi-language guides and
-examples, see the [project repository](https://github.com/infino-ai/infino).
+(`npm install @infino-ai/infino`) bindings. For concepts, guides, and
+multi-language examples, see the full documentation at
+[docs.infino.ai](https://docs.infino.ai).

--- a/crate-docs.md
+++ b/crate-docs.md
@@ -144,4 +144,4 @@ enums.
 infino also ships **Python** (`pip install infino`) and **Node.js**
 (`npm install @infino-ai/infino`) bindings. For concepts, guides, and
 multi-language examples, see the full documentation at
-[docs.infino.ai](https://docs.infino.ai).
+[infino.ai/docs](https://infino.ai/docs).

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -215,6 +215,7 @@ pub struct OptimizeOptions {
 }
 
 impl OptimizeOptions {
+    /// Options for a compaction-only optimize with the given settings.
     pub fn compact(settings: CompactionSettings) -> Self {
         Self {
             compaction: settings,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@
 // runs as a `cargo test --doc` doctest so it can't drift from the API. The
 // Python/Node guides live in their own bindings and on the docs site.
 #![doc = include_str!("../crate-docs.md")]
+#![doc(
+    html_logo_url = "https://docs.infino.ai/logo/infino-logo.png",
+    html_favicon_url = "https://docs.infino.ai/favicon.png"
+)]
 // `coverage_nightly` is set by `cargo +nightly llvm-cov`. Under it we opt
 // into `#[coverage(off)]` annotations on stable-uncoverable error paths
 // (OOM handlers, overflow guards). On stable the feature flag is inert

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@
 // Python/Node guides live in their own bindings and on the docs site.
 #![doc = include_str!("../crate-docs.md")]
 #![doc(
-    html_logo_url = "https://docs.infino.ai/logo/infino-logo.png",
-    html_favicon_url = "https://docs.infino.ai/favicon.png"
+    html_logo_url = "https://infino.ai/docs/logo/infino-logo.png",
+    html_favicon_url = "https://infino.ai/docs/favicon.png"
 )]
 // `coverage_nightly` is set by `cargo +nightly llvm-cov`. Under it we opt
 // into `#[coverage(off)]` annotations on stable-uncoverable error paths

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1233,20 +1233,26 @@ impl VectorSearchOptions {
     /// Filtered default `nprobe` (internal; applied when the query carries a filter).
     pub(crate) const FILTERED_DEFAULT_NPROBE: usize = 8;
 
+    /// Default options — engine-default `nprobe` and rerank multiplier.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Set the number of IVF partitions to probe. Higher improves recall at
+    /// the cost of more work.
     pub fn with_nprobe(mut self, n: usize) -> Self {
         self.nprobe = Some(n);
         self
     }
 
+    /// Set the over-fetch multiplier for the exact-rerank stage. Higher
+    /// improves recall at the cost of more work.
     pub fn with_rerank_mult(mut self, n: usize) -> Self {
         self.rerank_mult = Some(n.max(1));
         self
     }
 
+    /// The configured rerank multiplier, if one was set.
     pub fn rerank_mult(&self) -> Option<usize> {
         self.rerank_mult
     }

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -261,29 +261,44 @@ pub enum OpenError {
 /// Errors raised by [`crate::supertable::Supertable::optimize`].
 #[derive(Debug, thiserror::Error)]
 pub enum OptimizeError {
+    /// No durable storage backend is configured (e.g. `memory://`); optimize
+    /// needs one.
     #[error("optimize requires a storage backend")]
     NoStorage,
+    /// A superfile selected for compaction was absent from the manifest
+    /// snapshot.
     #[error("superfile {0} not found in manifest snapshot")]
     SuperfileNotFound(uuid::Uuid),
+    /// Compaction produced an empty merged superfile.
     #[error("empty merged superfile")]
     EmptyMergedSuperfile,
+    /// The tombstone sidecar for a superfile was already sealed by another
+    /// compaction.
     #[error(
         "tombstone sidecar for {superfile_id} already sealed by compaction {existing_compaction_id}"
     )]
     SidecarConflict {
+        /// The superfile whose sidecar conflicted.
         superfile_id: uuid::Uuid,
+        /// The compaction that had already sealed the sidecar.
         existing_compaction_id: uuid::Uuid,
     },
+    /// Sealing the compaction output failed.
     #[error("seal failed: {0}")]
     Seal(String),
+    /// Building a merged superfile failed.
     #[error("failed to build superfile: {0}")]
     Build(String),
+    /// Committing the compaction to the manifest failed.
     #[error("failed to commit: {0}")]
     Commit(String),
+    /// Refreshing the in-memory manifest after the commit failed.
     #[error("post-commit manifest refresh failed: {0}")]
     Refresh(String),
+    /// Another optimize is already running on this handle.
     #[error("optimize already in progress on this handle")]
     AlreadyRunning,
+    /// The post-compaction garbage-collection step failed.
     #[error("gc failed during optimize: {0}")]
     Gc(#[from] GcError),
 }
@@ -363,9 +378,12 @@ pub(crate) enum CompactionError {
 /// Errors raised by [`crate::supertable::Supertable::gc`].
 #[derive(Debug, thiserror::Error)]
 pub enum GcError {
+    /// No durable storage backend is configured (e.g. `memory://`); gc needs
+    /// one.
     #[error("gc requires a storage backend")]
     NoStorage,
 
+    /// A storage operation failed while listing or deleting objects.
     #[error("storage error during gc: {0}")]
     Storage(#[from] crate::storage::StorageError),
 }

--- a/src/supertable/gc/mod.rs
+++ b/src/supertable/gc/mod.rs
@@ -18,12 +18,19 @@ use crate::{
     },
 };
 
+/// Outcome of a [`Supertable::gc`] sweep: what was reclaimed and what was
+/// intentionally kept.
 #[derive(Debug, Default, Clone)]
 pub struct GcReport {
+    /// Orphaned objects deleted.
     pub objects_deleted: u64,
+    /// Total bytes reclaimed by the deleted objects.
     pub bytes_freed: u64,
+    /// Objects kept because they are still referenced by the live set.
     pub objects_skipped_live: u64,
+    /// Objects kept because they are younger than the safety gap.
     pub objects_skipped_too_new: u64,
+    /// Objects that could not be deleted (left for a later sweep).
     pub delete_errors: u64,
 }
 
@@ -41,6 +48,10 @@ fn build_live_set(manifest: &ManifestSnapshot) -> HashSet<String> {
 }
 
 impl Supertable {
+    /// Delete orphaned storage objects left by compaction or interrupted
+    /// writes. Only objects older than `safety_gap` are removed, so a
+    /// concurrent reader or writer is never raced. Requires durable storage.
+    #[doc(alias = "vacuum")]
     pub fn gc(&self, safety_gap: Duration) -> Result<GcReport, GcError> {
         bridge_on_runtime(self.gc_async(safety_gap), &self.inner().query_runtime())
     }

--- a/src/supertable/optimize/mod.rs
+++ b/src/supertable/optimize/mod.rs
@@ -8,6 +8,10 @@ use crate::{
 };
 
 impl Supertable {
+    /// Merge small or underfilled superfiles into larger ones, then run a
+    /// best-effort gc sweep. Pass [`OptimizeOptions::default`] for engine
+    /// defaults. Requires durable storage.
+    #[doc(alias = "compact")]
     pub fn optimize(&self, opts: &OptimizeOptions) -> Result<(), OptimizeError> {
         self.compact(&opts.compaction)?;
         match self.gc(DEFAULT_GC_SAFETY_GAP) {


### PR DESCRIPTION
The docs.rs reference read as sparse next to the Node/Python ones — the crate root only surfaces `connect`/`connect_with` under "Functions" (everything else is a method on `Connection`/`Supertable`, one click away), and ~1/3 of public items were undocumented. This closes those gaps without touching the public API surface.

### Coverage
Document every remaining public item on the default (docs.rs) surface, so nothing renders bare:
- `OptimizeError` / `GcError` variants (+ the `SidecarConflict` fields)
- `GcReport` struct and its fields
- `Supertable::optimize`, `Supertable::gc`, `OptimizeOptions::compact`
- `VectorSearchOptions::{new, with_nprobe, with_rerank_mult, rerank_mult}`

### Landing page (`crate-docs.md`)
- Replace the flat "API overview" prose with an **Operations** map that uses **intra-doc links** straight to the `Connection`/`Supertable` methods, grouped Search / Write / Maintain — so the operations are discoverable even though only two free functions show under "Functions".
- Add `hybrid_search` to the doctested quickstart.
- Add a Cargo features note and a docs.infino.ai pointer.

### Polish
- Logo + favicon (`#![doc(html_logo_url/…)]`), a `[package.metadata.docs.rs]` entry (`--cfg docsrs`), and `#[doc(alias)]` on `optimize`/`gc`.

### Regression gate
- New `doc-check` make target (wired into `make check`) runs `cargo doc` with `-D missing_docs -D rustdoc::broken_intra_doc_links` on the default surface, so coverage and links can't silently regress.

No signature changes — `public-api.txt` is unaffected. Verified: `make doc-check` clean, all 16 doctests pass (incl. the crate-docs quickstart).