### PR TITLE
chore tracing: add basic logs throughout the library

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -38,6 +38,7 @@ use manifest::{
 };
 pub use options::{ColdFetchMode, ConnectOptions};
 use tokio::runtime::Runtime;
+use tracing::{debug, info};
 use uri::{Backend, parse_uri};
 
 use crate::{
@@ -115,6 +116,7 @@ pub fn connect_with(
             .unwrap_or(DEFAULT_CONNECTION_BUDGET_BYTES),
     );
 
+    debug!(backend = ?backend, validate = options.validate, "catalog connected");
     Ok(Connection {
         inner: Arc::new(ConnectionInner {
             backend,
@@ -214,6 +216,7 @@ impl Connection {
                     return Err(InfinoError::AlreadyExists(name.to_string()));
                 }
                 map.insert(name.to_string(), handle.clone());
+                info!(table = name, backend = "memory", "created table");
                 Ok(handle)
             }
             CatalogStore::Storage(root) => {
@@ -271,14 +274,15 @@ impl Connection {
                 // catalog OCC below decides the single name winner.
                 let handle = Supertable::create(opts)?;
 
-                let name = name.to_string();
+                let name_owned = name.to_string();
                 bridge_sync_to_async(commit_catalog(root.as_ref(), move |body| {
-                    if body.tables.contains_key(&name) {
-                        return Err(InfinoError::AlreadyExists(name.clone()));
+                    if body.tables.contains_key(&name_owned) {
+                        return Err(InfinoError::AlreadyExists(name_owned.clone()));
                     }
-                    body.tables.insert(name.clone(), entry.clone());
+                    body.tables.insert(name_owned.clone(), entry.clone());
                     Ok(())
                 }))?;
+                info!(table = name, location = %location, "created table");
                 Ok(handle)
             }
         }
@@ -299,6 +303,7 @@ impl Connection {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn open_table(&self, name: &str) -> Result<Supertable, InfinoError> {
+        debug!(table = name, "opening table");
         match &self.inner.store {
             CatalogStore::Memory(map) => map
                 .lock()
@@ -381,6 +386,7 @@ impl Connection {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn drop_table(&self, name: &str, purge: bool) -> Result<(), InfinoError> {
+        info!(table = name, purge, "dropping table");
         match &self.inner.store {
             CatalogStore::Memory(map) => map
                 .lock()
@@ -468,6 +474,7 @@ impl Connection {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn query_sql(&self, sql: &str) -> Result<Vec<RecordBatch>, InfinoError> {
+        debug!(sql, "running sql query");
         let ctx = SessionContext::new();
 
         // Resolve the relations the query names and register each that is a

--- a/src/storage/retry.rs
+++ b/src/storage/retry.rs
@@ -11,6 +11,7 @@ use std::{error::Error, future::Future, ops::Range, time::Duration};
 use bytes::{Bytes, BytesMut};
 use object_store::RetryConfig;
 use tokio::time;
+use tracing::warn;
 
 use super::StorageError;
 
@@ -78,6 +79,7 @@ where
         match op().await {
             Ok(v) => return Ok(v),
             Err(e) if is_retryable(&e) && attempt < MAX_TRANSIENT_RETRIES => {
+                warn!(attempt, error = %e, "transient object-store error; re-issuing");
                 time::sleep(backoff(attempt)).await;
                 attempt += 1;
             }
@@ -114,6 +116,7 @@ where
         let chunk = match fetch(cursor..range.end).await {
             Ok(c) => c,
             Err(e) if is_retryable(&e) && attempt < MAX_TRANSIENT_RETRIES => {
+                warn!(uri, attempt, error = %e, "transient range GET error; re-issuing tail");
                 time::sleep(backoff(attempt)).await;
                 attempt += 1;
                 continue;

--- a/src/supertable/gc/mod.rs
+++ b/src/supertable/gc/mod.rs
@@ -6,6 +6,8 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use tracing::{debug, warn};
+
 use crate::{
     Supertable,
     runtime_bridge::bridge_on_runtime,
@@ -70,13 +72,20 @@ impl Supertable {
                         report.objects_deleted += 1;
                         report.bytes_freed += meta.size;
                     }
-                    Err(_) => {
+                    Err(e) => {
+                        warn!(object = %key, error = %e, "gc: failed to delete orphan object");
                         report.delete_errors += 1;
                     }
                 }
             }
         }
 
+        debug!(
+            deleted = report.objects_deleted,
+            bytes_freed = report.bytes_freed,
+            delete_errors = report.delete_errors,
+            "gc sweep complete"
+        );
         Ok(report)
     }
 }

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -28,6 +28,7 @@ use arrow_schema::SchemaRef;
 use chrono::Utc;
 use datafusion::execution::context::SessionContext;
 use tokio::runtime::Runtime;
+use tracing::{debug, warn};
 
 use super::{
     error::{BuildError, OpenError},
@@ -270,8 +271,12 @@ impl Supertable {
         if st.inner.options.storage.is_some() {
             // Best-effort: a sweep failure here doesn't fail handle
             // construction; the next sweep gets another shot.
-            let _ = st.run_recovery_sweep_once_blocking();
-            let _ = bridge_sync_to_async(async { st.run_gc_sweep_once().await.map_err(|_| ()) });
+            if let Err(e) = st.run_recovery_sweep_once_blocking() {
+                warn!(error = %e, "open-time recovery sweep failed (best-effort)");
+            }
+            if let Err(e) = bridge_sync_to_async(async { st.run_gc_sweep_once().await }) {
+                warn!(error = %e, "open-time gc sweep failed (best-effort)");
+            }
         }
         Ok(st)
     }
@@ -357,6 +362,10 @@ impl Supertable {
             last_pointer_check: Mutex::new(None),
         });
         install_disk_cache_pinning(&inner);
+        debug!(
+            manifest_id = inner.manifest.load().manifest_id,
+            "opened supertable"
+        );
         let st = Self { inner };
         // Open-time recovery sweep — drives every Intent /
         // Appended WAL discovered in `wal/mutations/` to
@@ -364,12 +373,16 @@ impl Supertable {
         // to drive). Best-effort: a sweep failure doesn't fail
         // `open` because the supertable is still functional —
         // the next sweep gets another shot.
-        let _ = st.run_recovery_sweep_once().await;
+        if let Err(e) = st.run_recovery_sweep_once().await {
+            warn!(error = %e, "open-time recovery sweep failed (best-effort)");
+        }
         // GC sweep follows recovery on the same LIST: reaps
         // Complete WALs past `T_wal_grace` and orphan arrow
         // sidecars past `T_sidecar_grace`. Best-effort; same
         // sweep budget.
-        let _ = st.run_gc_sweep_once().await;
+        if let Err(e) = st.run_gc_sweep_once().await {
+            warn!(error = %e, "open-time gc sweep failed (best-effort)");
+        }
         Ok(st)
     }
 
@@ -412,6 +425,10 @@ impl Supertable {
             Err(err) => return Err(OpenError::ManifestLoadError(err)),
         };
         self.inner.manifest.store(manifest);
+        debug!(
+            manifest_id = self.inner.manifest.load().manifest_id,
+            "refreshed manifest"
+        );
         Ok(true)
     }
 
@@ -462,7 +479,9 @@ impl Supertable {
         match self.inner.options.read_consistency {
             Consistency::Snapshot => {}
             Consistency::Strong => {
-                let _ = bridge_sync_to_async(self.refresh());
+                if let Err(e) = bridge_sync_to_async(self.refresh()) {
+                    debug!(error = %e, "strong-consistency refresh failed; serving current snapshot");
+                }
             }
             Consistency::BoundedStaleness(window) => {
                 // Decide whether a check is due under the lock, stamp
@@ -481,8 +500,8 @@ impl Supertable {
                     }
                     due
                 };
-                if due {
-                    let _ = bridge_sync_to_async(self.refresh());
+                if due && let Err(e) = bridge_sync_to_async(self.refresh()) {
+                    debug!(error = %e, "bounded-staleness refresh failed; serving current snapshot");
                 }
             }
         }

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -36,6 +36,7 @@ use std::{future::Future, sync::Arc, time::Instant};
 
 use futures::future::try_join_all;
 use roaring::RoaringBitmap;
+use tracing::trace;
 use uuid::Uuid;
 
 use super::SuperfileHit;
@@ -201,6 +202,7 @@ where
     if units.is_empty() {
         return Ok(Vec::new());
     }
+    trace!(units = units.len(), "fanning query out across superfiles");
     let manifest = reader.manifest();
     let store = Arc::clone(&manifest.options.store);
     let disk_cache = manifest.options.disk_cache.as_ref().map(Arc::clone);

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -62,6 +62,7 @@ use datafusion::{
     },
 };
 use futures::{future, stream};
+use tracing::debug;
 
 use super::{
     common::{
@@ -178,6 +179,7 @@ impl Supertable {
         k: usize,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
+        debug!(text_col, vec_col, k, "hybrid_search");
         let reader = self.reader();
         let hits = reader
             .hybrid_search(text_col, q_text, mode, vec_col, q_vec, options, k)

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -81,6 +81,7 @@ use std::{
 
 use arrow::record_batch::RecordBatch;
 use roaring::RoaringBitmap;
+use tracing::debug;
 use uuid::Uuid;
 
 pub use crate::superfile::fts::reader::BoolMode;
@@ -986,6 +987,7 @@ impl Supertable {
         mode: BoolMode,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
+        debug!(column, k, mode = ?mode, "bm25_search");
         self.reader()
             .bm25_search(column, query, k, mode, projection)
             .map_err(InfinoError::from)
@@ -1004,6 +1006,7 @@ impl Supertable {
         mode: BoolMode,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
+        debug!(column, mode = ?mode, "token_match");
         let reader = self.reader();
         let hits = reader
             .token_match(column, query, mode)
@@ -1030,6 +1033,7 @@ impl Supertable {
         value: &str,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
+        debug!(column, "exact_match");
         let reader = self.reader();
         let hits = reader
             .exact_match(column, value)

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -70,6 +70,7 @@ use std::{
 
 use arrow::record_batch::RecordBatch;
 use roaring::RoaringBitmap;
+use tracing::debug;
 
 use super::{SuperfileHit, candidate::CandidatePlan, dispatch, exec::common::resolve_hits_named};
 pub use crate::superfile::reader::VectorSearchOptions;
@@ -792,6 +793,7 @@ impl Supertable {
         filter: Option<VectorFilter<'_>>,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, crate::InfinoError> {
+        debug!(column, k, dim = query.len(), "vector_search");
         self.reader()
             .vector_search(column, query, k, options, filter, projection)
             .map_err(crate::InfinoError::from)

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -67,6 +67,7 @@ use datafusion::prelude::Expr;
 use object_store::{PutPayload, UploadPart};
 use rayon::prelude::*;
 use tokio::{runtime::Handle, task::block_in_place, time::sleep};
+use tracing::{debug, error};
 
 use super::{
     build::fanout_shards,
@@ -725,6 +726,12 @@ impl SupertableWriter {
                     let remaining: Vec<PendingUpdateEntry> =
                         updates_to_run.split_off(update_cursor + 1);
                     self.pending_updates = remaining;
+                    error!(
+                        committed = outcomes.len(),
+                        total = total_mutations,
+                        error = %cause,
+                        "partial commit: update failed mid-flush"
+                    );
                     // Don't lose the not-yet-attempted deletes
                     // either — they stay where they were on
                     // self.pending_deletes (we hadn't taken
@@ -754,6 +761,12 @@ impl SupertableWriter {
                     let remaining: Vec<PendingDeleteEntry> =
                         deletes_to_run.split_off(delete_cursor + 1);
                     self.pending_deletes = remaining;
+                    error!(
+                        committed = outcomes.len(),
+                        total = total_mutations,
+                        error = %cause,
+                        "partial commit: delete failed mid-flush"
+                    );
                     return Err(CommitError::PartialCommit {
                         committed_wal_ids,
                         committed: outcomes.len(),
@@ -965,6 +978,11 @@ impl SupertableWriter {
             build_one_shard(slice.as_slice(), &self.inner.options)
         })?;
 
+        debug!(
+            rows = total_rows,
+            superfiles = outputs.len(),
+            "published appended superfiles"
+        );
         publish_superfiles(&self.inner, outputs)?;
         Ok(())
     }


### PR DESCRIPTION
### What does this PR do?
- Uses the tracing crate to add basic logs across some important functions

### Why do we need this change?
- Improve tracing and make it easy to debug issues

### How do we do this change?
- We've purposely started with less logs, erroring on the side of less verbose logging. This is to prevent excessive logs making it hard to debug issues and affecting performance. As we see the need, we'll incrementally keep on adding more logs.