### PR TITLE
chore: process-level tokio io runtime and rayon pools

### DIFF
--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -4,13 +4,26 @@
 //! Concurrent ingest + query contention harness.
 //!
 //! Measures sustained reader latency and throughput under two conditions:
-//! - **baseline**: N readers firing queries in a tight loop, no writer.
-//! - **contention**: same N readers + 1 writer committing continuously.
+//! - **baseline**: N readers per table firing queries in a tight loop, no writers.
+//! - **contention**: same readers + 1 writer per table committing continuously.
+//!
+//! **Multi-tenant**: all `TENANTS` tables are created up front and stay open
+//! for the whole run, so every table's reader pool, writer pool, and lazy
+//! query runtime exist simultaneously — the process-level thread inventory
+//! grows with the tenant count exactly as it does in a multi-tenant server.
+//! Both phases drive load on **all tables at once**; latencies are aggregated
+//! across tables per modality. Peak OS thread count is sampled per phase and
+//! reported alongside the latency table — the headline metric for pool /
+//! runtime consolidation work.
+//!
+//! Tables use **default pool construction** (no `with_reader_pool` /
+//! `with_writer_pool` overrides): what a production caller gets is what this
+//! harness measures.
 //!
 //! **Duration-based** (not iteration-based): each condition runs for a fixed
 //! wall-clock window (default 15 s; 3 s warmup discarded). Every query that
 //! completes during the measurement window is recorded. This guarantees
-//! sustained overlap between readers and the writer — the failure mode of
+//! sustained overlap between readers and writers — the failure mode of
 //! iteration-based benches is that readers finish in milliseconds before the
 //! writer commits even once.
 //!
@@ -18,11 +31,12 @@
 //! the `block_in_place` path — the same code path as axum/SaaS production.
 //!
 //! Knobs (env vars):
-//!   INFINO_BENCH_CONCURRENT_DOCS      corpus size (default 200_000)
-//!   INFINO_BENCH_CONCURRENT_READERS   concurrent reader tasks (default 8)
-//!   INFINO_BENCH_CONCURRENT_TENANTS   tables open simultaneously (default 1)
+//!   INFINO_BENCH_CONCURRENT_DOCS      corpus size per table (default 200_000)
+//!   INFINO_BENCH_CONCURRENT_READERS   reader tasks per modality per table (default 8)
+//!   INFINO_BENCH_CONCURRENT_TENANTS   tables open + loaded simultaneously (default 1)
 //!   INFINO_BENCH_CONCURRENT_DURATION  measurement window in seconds (default 15)
 //!   INFINO_BENCH_CONCURRENT_WARMUP    warmup seconds to discard (default 3)
+//!   INFINO_BENCH_CONCURRENT_BASELINE  set to 0 to skip the no-writer phase
 //!
 //! Invoked as `cargo bench -- concurrent`.
 
@@ -32,6 +46,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+    thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 
@@ -73,6 +88,9 @@ const TOP_K: usize = 10;
 const WRITER_BATCH: usize = 1_024;
 const CORPUS_CHUNKS: usize = 8;
 const FALLBACK_SIM_WORKERS: usize = 4;
+/// OS-thread-count poll cadence. Pools and runtimes are built lazily and
+/// live for whole phases, so 200 ms comfortably catches the peak.
+const THREAD_SAMPLE_INTERVAL: Duration = Duration::from_millis(200);
 
 fn env_usize(key: &str, default: usize) -> usize {
     std::env::var(key)
@@ -112,6 +130,66 @@ fn run_baseline() -> bool {
     std::env::var("INFINO_BENCH_CONCURRENT_BASELINE")
         .map(|v| v != "0")
         .unwrap_or(true)
+}
+
+// ─── OS thread count ──────────────────────────────────────────────────────────
+
+/// Current OS thread count of this process. Linux reads procfs; macOS
+/// counts `ps -M` rows (one per thread, one header line). `None` when
+/// neither source is available.
+fn current_thread_count() -> Option<usize> {
+    #[cfg(target_os = "linux")]
+    {
+        let s = std::fs::read_to_string("/proc/self/status").ok()?;
+        return s
+            .lines()
+            .find_map(|l| l.strip_prefix("Threads:"))
+            .and_then(|rest| rest.trim().parse().ok());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("ps")
+            .args(["-M", "-p", &std::process::id().to_string()])
+            .output()
+            .ok()?;
+        let rows = String::from_utf8_lossy(&out.stdout).lines().count();
+        return (rows > 1).then(|| rows - 1);
+    }
+    #[allow(unreachable_code)]
+    None
+}
+
+/// Background sampler recording the peak OS thread count over a phase.
+/// Same shape as `rss::PeakSampler`, but for threads and cross-platform.
+struct ThreadSampler {
+    stop: Arc<AtomicBool>,
+    handle: JoinHandle<usize>,
+}
+
+impl ThreadSampler {
+    fn start() -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_t = Arc::clone(&stop);
+        let handle = thread::Builder::new()
+            .name("thread-sampler".into())
+            .spawn(move || {
+                let mut peak = current_thread_count().unwrap_or(0);
+                while !stop_t.load(Ordering::Relaxed) {
+                    if let Some(n) = current_thread_count() {
+                        peak = peak.max(n);
+                    }
+                    thread::sleep(THREAD_SAMPLE_INTERVAL);
+                }
+                peak
+            })
+            .expect("spawn thread-sampler");
+        Self { stop, handle }
+    }
+
+    fn stop(self) -> usize {
+        self.stop.store(true, Ordering::Relaxed);
+        self.handle.join().expect("thread-sampler join")
+    }
 }
 
 // ─── Runtime ──────────────────────────────────────────────────────────────────
@@ -172,13 +250,9 @@ fn build_batch(start: usize, n: usize) -> RecordBatch {
     .expect("RecordBatch shape matches concurrent_schema")
 }
 
+// Default pool construction, deliberately: per-table pool/runtime growth is
+// part of what this harness measures.
 fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOptions {
-    let pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build()
-            .expect("rayon pool"),
-    );
     SupertableOptions::new(
         concurrent_schema(),
         vec![FtsConfig {
@@ -195,7 +269,6 @@ fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOpti
         Some(default_tokenizer()),
     )
     .expect("SupertableOptions with FTS + vector")
-    .with_writer_pool(pool)
     .with_storage(storage)
 }
 
@@ -294,7 +367,8 @@ async fn writer_loop(st: Supertable, stop: Arc<AtomicBool>) -> usize {
     commits
 }
 
-// Vector reader loop: exercises the global-pool escape at vector/reader.rs:2052,2280.
+// Vector reader loop: rides the supertable fan-out, so its shortlist+rerank
+// CPU lands on each table's reader_pool.
 async fn vector_reader_loop(
     st: Supertable,
     stop: Arc<AtomicBool>,
@@ -327,11 +401,19 @@ async fn vector_reader_loop(
 struct PhaseResult {
     fts: PhaseStat,
     vec: PhaseStat,
+    /// Total commits across all tables' writers.
     commits: usize,
+    /// Peak OS thread count observed during the phase (0 if unavailable).
+    peak_threads: usize,
+    /// Per-table query counts (fts, vec) — fairness check across tenants.
+    per_table_n: Vec<(usize, usize)>,
 }
 
+// Drives load on ALL tables simultaneously: n_readers fts + n_readers vec
+// tasks per table, plus one writer per table when `with_writer`. Latencies
+// aggregate across tables; per-table counts are kept for fairness logging.
 fn run_phase(
-    st: &Supertable,
+    tables: &[Supertable],
     n_readers: usize,
     with_writer: bool,
     total: Duration,
@@ -340,28 +422,47 @@ fn run_phase(
     let rt = build_sim_runtime();
     let stop = Arc::new(AtomicBool::new(false));
     let phase_start = Instant::now();
+    let threads = ThreadSampler::start();
 
-    let writer = if with_writer {
-        let st_w = st.clone();
-        let stop_w = Arc::clone(&stop);
-        Some(rt.spawn(async move { writer_loop(st_w, stop_w).await }))
+    let writers: Vec<_> = if with_writer {
+        tables
+            .iter()
+            .map(|st| {
+                let st_w = st.clone();
+                let stop_w = Arc::clone(&stop);
+                rt.spawn(async move { writer_loop(st_w, stop_w).await })
+            })
+            .collect()
     } else {
-        None
+        Vec::new()
     };
 
-    let fts_readers: Vec<_> = (0..n_readers)
-        .map(|_| {
-            let st_r = st.clone();
-            let stop_r = Arc::clone(&stop);
-            rt.spawn(async move { reader_loop(st_r, stop_r, phase_start, warmup).await })
+    // Per-table reader task groups so per-table counts survive aggregation.
+    let fts_readers: Vec<Vec<_>> = tables
+        .iter()
+        .map(|st| {
+            (0..n_readers)
+                .map(|_| {
+                    let st_r = st.clone();
+                    let stop_r = Arc::clone(&stop);
+                    rt.spawn(async move { reader_loop(st_r, stop_r, phase_start, warmup).await })
+                })
+                .collect()
         })
         .collect();
 
-    let vec_readers: Vec<_> = (0..n_readers)
-        .map(|_| {
-            let st_r = st.clone();
-            let stop_r = Arc::clone(&stop);
-            rt.spawn(async move { vector_reader_loop(st_r, stop_r, phase_start, warmup).await })
+    let vec_readers: Vec<Vec<_>> = tables
+        .iter()
+        .map(|st| {
+            (0..n_readers)
+                .map(|_| {
+                    let st_r = st.clone();
+                    let stop_r = Arc::clone(&stop);
+                    rt.spawn(
+                        async move { vector_reader_loop(st_r, stop_r, phase_start, warmup).await },
+                    )
+                })
+                .collect()
         })
         .collect();
 
@@ -369,30 +470,54 @@ fn run_phase(
     std::thread::sleep(total);
     stop.store(true, Ordering::Relaxed);
 
-    let (fts_all, vec_all): (Vec<Duration>, Vec<Duration>) = rt.block_on(async {
-        let fts = join_all(fts_readers)
+    let (fts_by_table, vec_by_table): (Vec<Vec<Duration>>, Vec<Vec<Duration>>) =
+        rt.block_on(async {
+            let mut fts = Vec::with_capacity(fts_readers.len());
+            for group in fts_readers {
+                let lats: Vec<Duration> = join_all(group)
+                    .await
+                    .into_iter()
+                    .flat_map(|r| r.expect("fts reader task"))
+                    .collect();
+                fts.push(lats);
+            }
+            let mut vec_l = Vec::with_capacity(vec_readers.len());
+            for group in vec_readers {
+                let lats: Vec<Duration> = join_all(group)
+                    .await
+                    .into_iter()
+                    .flat_map(|r| r.expect("vec reader task"))
+                    .collect();
+                vec_l.push(lats);
+            }
+            (fts, vec_l)
+        });
+
+    let commits: usize = rt.block_on(async {
+        join_all(writers)
             .await
             .into_iter()
-            .flat_map(|r| r.expect("fts reader task"))
-            .collect();
-        let vec = join_all(vec_readers)
-            .await
-            .into_iter()
-            .flat_map(|r| r.expect("vec reader task"))
-            .collect();
-        (fts, vec)
+            .map(|r| r.expect("writer task"))
+            .sum()
     });
 
-    let commits = match writer {
-        Some(w) => rt.block_on(w).expect("writer task"),
-        None => 0,
-    };
+    let peak_threads = threads.stop();
+
+    let per_table_n: Vec<(usize, usize)> = fts_by_table
+        .iter()
+        .zip(&vec_by_table)
+        .map(|(f, v)| (f.len(), v.len()))
+        .collect();
+    let fts_all: Vec<Duration> = fts_by_table.into_iter().flatten().collect();
+    let vec_all: Vec<Duration> = vec_by_table.into_iter().flatten().collect();
 
     let measure_secs = (total - warmup).as_secs_f64();
     PhaseResult {
         fts: stat_from(fts_all, measure_secs),
         vec: stat_from(vec_all, measure_secs),
         commits,
+        peak_threads,
+        per_table_n,
     }
 }
 
@@ -408,152 +533,208 @@ pub fn run() {
     let measure_secs = (dur - warmup).as_secs_f64();
 
     eprintln!(
-        "[concurrent] {tenants} table(s), {docs} docs/{CORPUS_CHUNKS} superfiles, \
-         {readers} reader tasks, {:.0}s window ({:.0}s warmup discarded)",
+        "[concurrent] {tenants} table(s), {docs} docs/{CORPUS_CHUNKS} superfiles each, \
+         {readers} fts + {readers} vec readers per table, {:.0}s window ({:.0}s warmup discarded)",
         dur.as_secs_f64(),
         warmup.as_secs_f64(),
     );
+
+    // All tables built up front and kept alive — every table's pools and
+    // lazy runtime coexist, as in a multi-tenant server process.
+    let fixtures: Vec<Fixture> = (0..tenants)
+        .map(|t| {
+            eprintln!("[concurrent] building table {t}...");
+            build_fixture(docs)
+        })
+        .collect();
+    let tables: Vec<Supertable> = fixtures.iter().map(|f| f.st.clone()).collect();
+
+    let idle_threads = current_thread_count().unwrap_or(0);
+    eprintln!("[concurrent] {idle_threads} OS threads after build, before load");
 
     let mut report = Report::load("concurrent");
     let mut rows: Vec<Vec<Cell>> = Vec::new();
 
     let with_baseline = run_baseline();
 
-    for tenant in 0..tenants {
-        let fixture = build_fixture(docs);
+    let base = if with_baseline {
+        eprintln!("[concurrent] baseline: readers on all {tenants} table(s), no writers...");
+        Some(run_phase(&tables, readers, false, dur, warmup))
+    } else {
+        eprintln!("[concurrent] skipping baseline (INFINO_BENCH_CONCURRENT_BASELINE=0)");
+        None
+    };
 
-        let base = if with_baseline {
-            eprintln!(
-                "[concurrent] table {tenant}: baseline ({readers} fts+vec readers, no writer)..."
-            );
-            Some(run_phase(&fixture.st, readers, false, dur, warmup))
-        } else {
-            eprintln!(
-                "[concurrent] table {tenant}: skipping baseline (INFINO_BENCH_CONCURRENT_BASELINE=0)"
-            );
-            None
-        };
+    eprintln!("[concurrent] contention: readers + 1 writer per table on all {tenants} table(s)...");
+    let contend = run_phase(&tables, readers, true, dur, warmup);
+    let commits = contend.commits;
 
-        eprintln!("[concurrent] table {tenant}: contention ({readers} fts+vec readers + 1w)...");
-        let contend = run_phase(&fixture.st, readers, true, dur, warmup);
-        let commits = contend.commits;
+    for (t, (f_n, v_n)) in contend.per_table_n.iter().enumerate() {
+        eprintln!(
+            "[concurrent] contention table {t}: {:.0} fts q/s, {:.0} vec q/s",
+            *f_n as f64 / measure_secs,
+            *v_n as f64 / measure_secs,
+        );
+    }
 
-        let label = if tenants == 1 {
-            "single table".to_string()
-        } else {
-            format!("table {tenant}")
-        };
+    let label = if tenants == 1 {
+        "single table".to_string()
+    } else {
+        format!("{tenants} tables agg")
+    };
 
-        // Emit one row per modality (FTS, vector) per condition (baseline, contention).
-        #[allow(clippy::type_complexity)]
-        let modalities: &[(&str, fn(&PhaseResult) -> &PhaseStat)] =
-            &[("fts", |r| &r.fts), ("vec", |r| &r.vec)];
+    // Emit one row per modality (FTS, vector) per condition (baseline, contention).
+    #[allow(clippy::type_complexity)]
+    let modalities: &[(&str, fn(&PhaseResult) -> &PhaseStat)] =
+        &[("fts", |r| &r.fts), ("vec", |r| &r.vec)];
 
-        for (modality, stat_fn) in modalities {
-            let contend_stat = stat_fn(&contend);
+    for (modality, stat_fn) in modalities {
+        let contend_stat = stat_fn(&contend);
 
-            if let Some(ref b) = base {
-                let base_stat = stat_fn(b);
-                let base_p50 = base_stat.p50.as_nanos() as f64;
-                let base_p95 = base_stat.p95.as_nanos() as f64;
-                let base_p99 = base_stat.p99.as_nanos() as f64;
-                rows.push(vec![
-                    text(format!("{label} / {modality}")),
-                    text("baseline".to_string()),
-                    metric(base_p50, fmt_time(base_p50), Better::Lower),
-                    metric(base_p95, fmt_time(base_p95), Better::Lower),
-                    metric(base_p99, fmt_time(base_p99), Better::Lower),
-                    metric(
-                        base_stat.qps,
-                        format!("{:.0} q/s", base_stat.qps),
-                        Better::Higher,
-                    ),
-                    text(format!("{}", base_stat.n)),
-                ]);
-            }
-
-            let p99_delta_pct = base.as_ref().map(|b| {
-                let base_stat = stat_fn(b);
-                if base_stat.p99 > Duration::ZERO {
-                    100.0 * (contend_stat.p99.as_secs_f64() - base_stat.p99.as_secs_f64())
-                        / base_stat.p99.as_secs_f64()
-                } else {
-                    0.0
-                }
-            });
-            let qps_delta_pct = base.as_ref().map(|b| {
-                let base_stat = stat_fn(b);
-                if base_stat.qps > 0.0 {
-                    100.0 * (contend_stat.qps - base_stat.qps) / base_stat.qps
-                } else {
-                    0.0
-                }
-            });
-
-            let cp50 = contend_stat.p50.as_nanos() as f64;
-            let cp95 = contend_stat.p95.as_nanos() as f64;
-            let cp99 = contend_stat.p99.as_nanos() as f64;
-            let n_note = match p99_delta_pct {
-                Some(d) => format!("{} / {} commits (p99 {:+.1}%)", contend_stat.n, commits, d),
-                None => format!("{} / {} commits", contend_stat.n, commits),
-            };
-            let qps_label = match qps_delta_pct {
-                Some(d) => format!("{:.0} q/s ({:+.1}%)", contend_stat.qps, d),
-                None => format!("{:.0} q/s", contend_stat.qps),
-            };
+        if let Some(ref b) = base {
+            let base_stat = stat_fn(b);
+            let base_p50 = base_stat.p50.as_nanos() as f64;
+            let base_p95 = base_stat.p95.as_nanos() as f64;
+            let base_p99 = base_stat.p99.as_nanos() as f64;
             rows.push(vec![
                 text(format!("{label} / {modality}")),
-                text(format!("{readers}r+1w")),
-                metric(cp50, fmt_time(cp50), Better::Lower),
-                metric(cp95, fmt_time(cp95), Better::Lower),
-                metric(cp99, fmt_time(cp99), Better::Lower),
-                metric(contend_stat.qps, qps_label, Better::Higher),
-                text(n_note),
+                text("baseline".to_string()),
+                metric(base_p50, fmt_time(base_p50), Better::Lower),
+                metric(base_p95, fmt_time(base_p95), Better::Lower),
+                metric(base_p99, fmt_time(base_p99), Better::Lower),
+                metric(
+                    base_stat.qps,
+                    format!("{:.0} q/s", base_stat.qps),
+                    Better::Higher,
+                ),
+                text(format!("{}", base_stat.n)),
             ]);
-
-            eprintln!(
-                "[concurrent] table {tenant} / {modality}: baseline {:.0} q/s | contention {:.0} q/s | p99 {} | writer {:.1} commits/s",
-                base.as_ref().map(|b| stat_fn(b).qps).unwrap_or(0.0),
-                contend_stat.qps,
-                match p99_delta_pct {
-                    Some(d) => format!("{:+.1}%", d),
-                    None => "—".into(),
-                },
-                commits as f64 / measure_secs,
-            );
         }
+
+        let p99_delta_pct = base.as_ref().map(|b| {
+            let base_stat = stat_fn(b);
+            if base_stat.p99 > Duration::ZERO {
+                100.0 * (contend_stat.p99.as_secs_f64() - base_stat.p99.as_secs_f64())
+                    / base_stat.p99.as_secs_f64()
+            } else {
+                0.0
+            }
+        });
+        let qps_delta_pct = base.as_ref().map(|b| {
+            let base_stat = stat_fn(b);
+            if base_stat.qps > 0.0 {
+                100.0 * (contend_stat.qps - base_stat.qps) / base_stat.qps
+            } else {
+                0.0
+            }
+        });
+
+        let cp50 = contend_stat.p50.as_nanos() as f64;
+        let cp95 = contend_stat.p95.as_nanos() as f64;
+        let cp99 = contend_stat.p99.as_nanos() as f64;
+        let n_note = match p99_delta_pct {
+            Some(d) => format!("{} / {} commits (p99 {:+.1}%)", contend_stat.n, commits, d),
+            None => format!("{} / {} commits", contend_stat.n, commits),
+        };
+        let qps_label = match qps_delta_pct {
+            Some(d) => format!("{:.0} q/s ({:+.1}%)", contend_stat.qps, d),
+            None => format!("{:.0} q/s", contend_stat.qps),
+        };
+        rows.push(vec![
+            text(format!("{label} / {modality}")),
+            text(format!("{readers}r+1w")),
+            metric(cp50, fmt_time(cp50), Better::Lower),
+            metric(cp95, fmt_time(cp95), Better::Lower),
+            metric(cp99, fmt_time(cp99), Better::Lower),
+            metric(contend_stat.qps, qps_label, Better::Higher),
+            text(n_note),
+        ]);
+
+        eprintln!(
+            "[concurrent] {label} / {modality}: baseline {:.0} q/s | contention {:.0} q/s | p99 {} | writers {:.1} commits/s",
+            base.as_ref().map(|b| stat_fn(b).qps).unwrap_or(0.0),
+            contend_stat.qps,
+            match p99_delta_pct {
+                Some(d) => format!("{:+.1}%", d),
+                None => "—".into(),
+            },
+            commits as f64 / measure_secs,
+        );
     }
+
+    // OS thread inventory — the consolidation headline. Idle = pools built
+    // by table creation; per-phase peaks add lazy runtimes + block_in_place
+    // replacement workers.
+    let mut thread_rows: Vec<Vec<Cell>> = vec![vec![
+        text("idle after build".to_string()),
+        metric(
+            idle_threads as f64,
+            format!("{idle_threads}"),
+            Better::Lower,
+        ),
+    ]];
+    if let Some(ref b) = base {
+        thread_rows.push(vec![
+            text("baseline peak".to_string()),
+            metric(
+                b.peak_threads as f64,
+                format!("{}", b.peak_threads),
+                Better::Lower,
+            ),
+        ]);
+    }
+    thread_rows.push(vec![
+        text("contention peak".to_string()),
+        metric(
+            contend.peak_threads as f64,
+            format!("{}", contend.peak_threads),
+            Better::Lower,
+        ),
+    ]);
+    eprintln!(
+        "[concurrent] OS threads: idle {idle_threads} | baseline peak {} | contention peak {}",
+        base.as_ref().map(|b| b.peak_threads).unwrap_or(0),
+        contend.peak_threads,
+    );
 
     report.emit(&Section {
         anchor: "bench/concurrent/contention".into(),
         title: format!(
-            "Concurrent ingest+query — {tenants} table(s), {docs} docs, {readers} fts+vec readers, {:.0}s window",
+            "Concurrent ingest+query — {tenants} table(s), {docs} docs each, {readers} fts+vec readers/table, {:.0}s window",
             dur.as_secs_f64()
         ),
         note: format!(
-            "Duration-based ({:.0}s total, {:.0}s warmup discarded). \
-             Each reader group fires FTS (bm25_search) and vector (vector_search dim={VEC_DIM}) queries in tight loops; \
-             writer commits {WRITER_BATCH}-row batches continuously. \
+            "Duration-based ({:.0}s total, {:.0}s warmup discarded). All tables open and \
+             loaded simultaneously with default pool construction; latencies aggregate across tables. \
+             Each table gets {readers} FTS (bm25_search) + {readers} vector (vector_search dim={VEC_DIM}) \
+             reader tasks in tight loops; each writer commits {WRITER_BATCH}-row batches continuously. \
              Runs on multi_thread tokio runtime (bridge_sync_to_async → block_in_place). \
-             Vector queries exercise the global-pool escape at superfile/vector/reader.rs:2052,2280. \
-             QPS delta and p99 delta measure contention overhead vs baseline. \
+             QPS delta and p99 delta measure contention overhead vs baseline; the OS-thread table \
+             tracks per-table pool/runtime growth. \
              INFINO_BENCH_CONCURRENT_DOCS/READERS/TENANTS/DURATION/WARMUP to adjust. Δ vs previous run.",
             dur.as_secs_f64(),
             warmup.as_secs_f64(),
         ),
-        blocks: vec![Block {
-            subtitle: String::new(),
-            headers: vec![
-                "Table".into(),
-                "Condition".into(),
-                "p50".into(),
-                "p95".into(),
-                "p99".into(),
-                "q/s".into(),
-                "n / commits".into(),
-            ],
-            rows,
-        }],
+        blocks: vec![
+            Block {
+                subtitle: String::new(),
+                headers: vec![
+                    "Table".into(),
+                    "Condition".into(),
+                    "p50".into(),
+                    "p95".into(),
+                    "p99".into(),
+                    "q/s".into(),
+                    "n / commits".into(),
+                ],
+                rows,
+            },
+            Block {
+                subtitle: "OS threads".into(),
+                headers: vec!["Phase".into(), "peak".into()],
+                rows: thread_rows,
+            },
+        ],
     });
     report.save();
 }

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -7,28 +7,17 @@
 //! - **baseline**: N readers per table firing queries in a tight loop, no writers.
 //! - **contention**: same readers + 1 writer per table committing continuously.
 //!
-//! **Multi-tenant**: all `TENANTS` tables are created up front and stay open
-//! for the whole run, so every table's reader pool, writer pool, and lazy
-//! query runtime exist simultaneously — the process-level thread inventory
-//! grows with the tenant count exactly as it does in a multi-tenant server.
-//! Both phases drive load on **all tables at once**; latencies are aggregated
-//! across tables per modality. Peak OS thread count is sampled per phase and
-//! reported alongside the latency table — the headline metric for pool /
-//! runtime consolidation work.
+//! All `TENANTS` tables are built up front and stay open, with default pool
+//! construction, so the process thread inventory grows with the tenant count
+//! exactly as in a multi-tenant server. Both phases load **all tables at
+//! once**; latencies aggregate across tables per modality, and peak OS
+//! thread count is sampled per phase — the headline metric for pool /
+//! runtime consolidation.
 //!
-//! Tables use **default pool construction** (no `with_reader_pool` /
-//! `with_writer_pool` overrides): what a production caller gets is what this
-//! harness measures.
-//!
-//! **Duration-based** (not iteration-based): each condition runs for a fixed
-//! wall-clock window (default 15 s; 3 s warmup discarded). Every query that
-//! completes during the measurement window is recorded. This guarantees
-//! sustained overlap between readers and writers — the failure mode of
-//! iteration-based benches is that readers finish in milliseconds before the
-//! writer commits even once.
-//!
-//! Runs on a `multi_thread` tokio runtime so `bridge_sync_to_async` takes
-//! the `block_in_place` path — the same code path as axum/SaaS production.
+//! Duration-based, not iteration-based: each condition runs a fixed
+//! wall-clock window (default 15 s, 3 s warmup discarded) so readers and
+//! writers genuinely overlap. Runs on a `multi_thread` tokio runtime so
+//! `bridge_sync_to_async` takes the `block_in_place` path, as in production.
 //!
 //! Knobs (env vars):
 //!   INFINO_BENCH_CONCURRENT_DOCS      corpus size per table (default 200_000)
@@ -88,8 +77,8 @@ const TOP_K: usize = 10;
 const WRITER_BATCH: usize = 1_024;
 const CORPUS_CHUNKS: usize = 8;
 const FALLBACK_SIM_WORKERS: usize = 4;
-/// OS-thread-count poll cadence. Pools and runtimes are built lazily and
-/// live for whole phases, so 200 ms comfortably catches the peak.
+/// Thread-count poll cadence — pools live for whole phases, so 200 ms
+/// catches the peak.
 const THREAD_SAMPLE_INTERVAL: Duration = Duration::from_millis(200);
 
 fn env_usize(key: &str, default: usize) -> usize {
@@ -134,9 +123,8 @@ fn run_baseline() -> bool {
 
 // ─── OS thread count ──────────────────────────────────────────────────────────
 
-/// Current OS thread count of this process. Linux reads procfs; macOS
-/// counts `ps -M` rows (one per thread, one header line). `None` when
-/// neither source is available.
+/// Current OS thread count of this process (procfs on Linux, `ps -M`
+/// on macOS).
 fn current_thread_count() -> Option<usize> {
     #[cfg(target_os = "linux")]
     {
@@ -159,8 +147,7 @@ fn current_thread_count() -> Option<usize> {
     None
 }
 
-/// Background sampler recording the peak OS thread count over a phase.
-/// Same shape as `rss::PeakSampler`, but for threads and cross-platform.
+/// Background sampler recording peak OS thread count over a phase.
 struct ThreadSampler {
     stop: Arc<AtomicBool>,
     handle: JoinHandle<usize>,
@@ -250,8 +237,8 @@ fn build_batch(start: usize, n: usize) -> RecordBatch {
     .expect("RecordBatch shape matches concurrent_schema")
 }
 
-// Default pool construction, deliberately: per-table pool/runtime growth is
-// part of what this harness measures.
+// Default pool construction — per-table pool/runtime growth is part of
+// what this harness measures.
 fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOptions {
     SupertableOptions::new(
         concurrent_schema(),
@@ -409,9 +396,8 @@ struct PhaseResult {
     per_table_n: Vec<(usize, usize)>,
 }
 
-// Drives load on ALL tables simultaneously: n_readers fts + n_readers vec
-// tasks per table, plus one writer per table when `with_writer`. Latencies
-// aggregate across tables; per-table counts are kept for fairness logging.
+// Drives n_readers fts + n_readers vec tasks per table on all tables at
+// once, plus one writer per table when `with_writer`.
 fn run_phase(
     tables: &[Supertable],
     n_readers: usize,
@@ -437,7 +423,7 @@ fn run_phase(
         Vec::new()
     };
 
-    // Per-table reader task groups so per-table counts survive aggregation.
+    // Grouped per table so per-table counts survive aggregation.
     let fts_readers: Vec<Vec<_>> = tables
         .iter()
         .map(|st| {
@@ -539,8 +525,7 @@ pub fn run() {
         warmup.as_secs_f64(),
     );
 
-    // All tables built up front and kept alive — every table's pools and
-    // lazy runtime coexist, as in a multi-tenant server process.
+    // All tables built up front and kept alive, as in a multi-tenant server.
     let fixtures: Vec<Fixture> = (0..tenants)
         .map(|t| {
             eprintln!("[concurrent] building table {t}...");
@@ -662,9 +647,7 @@ pub fn run() {
         );
     }
 
-    // OS thread inventory — the consolidation headline. Idle = pools built
-    // by table creation; per-phase peaks add lazy runtimes + block_in_place
-    // replacement workers.
+    // OS thread inventory — the consolidation headline.
     let mut thread_rows: Vec<Vec<Cell>> = vec![vec![
         text("idle after build".to_string()),
         metric(

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -22,7 +22,7 @@ mod uri;
 use std::{
     collections::{HashMap, HashSet},
     sync::{
-        Arc, Mutex, OnceLock,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     time::{SystemTime, UNIX_EPOCH},
@@ -45,7 +45,7 @@ use crate::{
     InfinoError,
     config::DEFAULT_CONNECTION_BUDGET_BYTES,
     memory::ConnectionMemoryBudget,
-    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, build_query_runtime},
+    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_query_runtime},
     storage::{StorageError, StorageProvider},
     superfile::{
         builder::FtsConfig,
@@ -123,7 +123,6 @@ pub fn connect_with(
             options,
             store,
             connection_memory_budget,
-            query_runtime: OnceLock::new(),
         }),
     })
 }
@@ -143,26 +142,6 @@ struct ConnectionInner {
     /// (cloned `Arc`) into every table's `SupertableOptions`. See
     /// [`crate::memory`].
     connection_memory_budget: Arc<ConnectionMemoryBudget>,
-    /// Runtime for the table-free `query_sql` fallback — search TVFs name
-    /// their table in an argument, not a `FROM` relation, so no supertable
-    /// runtime is in scope. See [`build_query_runtime`] for why it must be
-    /// multi-thread.
-    query_runtime: OnceLock<Arc<Runtime>>,
-}
-
-impl Drop for ConnectionInner {
-    /// `query_sql` builds `query_runtime` eagerly, and the sync API may be
-    /// called from inside the caller's own runtime — so dropping the last
-    /// `Connection` there must not trip tokio's "cannot drop a runtime from
-    /// within an async context" guard. `shutdown_background` consumes it
-    /// without blocking; `try_unwrap` shuts down only on the last owner.
-    fn drop(&mut self) {
-        if let Some(rt) = self.query_runtime.take()
-            && let Ok(rt) = Arc::try_unwrap(rt)
-        {
-            rt.shutdown_background();
-        }
-    }
 }
 
 /// Where the `name → table` map lives. Durable backends persist it on the
@@ -533,14 +512,9 @@ impl Connection {
         }
     }
 
-    /// Runtime for the table-free `query_sql` fallback (see
-    /// [`ConnectionInner::query_runtime`]).
+    /// Runtime for the table-free `query_sql` fallback.
     fn query_runtime(&self) -> Arc<Runtime> {
-        Arc::clone(
-            self.inner
-                .query_runtime
-                .get_or_init(|| build_query_runtime("catalog-query")),
-        )
+        shared_query_runtime()
     }
 }
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     InfinoError,
     config::DEFAULT_CONNECTION_BUDGET_BYTES,
     memory::ConnectionMemoryBudget,
-    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_query_runtime},
+    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
     storage::{StorageError, StorageProvider},
     superfile::{
         builder::FtsConfig,
@@ -514,7 +514,7 @@ impl Connection {
 
     /// Runtime for the table-free `query_sql` fallback.
     fn query_runtime(&self) -> Arc<Runtime> {
-        shared_query_runtime()
+        shared_io_runtime()
     }
 }
 

--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -106,10 +106,10 @@ where
 /// `Supertable` so open handles add zero tokio workers. Never shut
 /// down — the static keeps a reference until process exit, so handle
 /// drops from inside a caller's async context have nothing to tear down.
-static SHARED_QUERY_RUNTIME: OnceLock<Arc<runtime::Runtime>> = OnceLock::new();
+static SHARED_IO_RUNTIME: OnceLock<Arc<runtime::Runtime>> = OnceLock::new();
 
-pub(crate) fn shared_query_runtime() -> Arc<runtime::Runtime> {
-    Arc::clone(SHARED_QUERY_RUNTIME.get_or_init(|| build_query_runtime("infino-io")))
+pub(crate) fn shared_io_runtime() -> Arc<runtime::Runtime> {
+    Arc::clone(SHARED_IO_RUNTIME.get_or_init(|| build_query_runtime("infino-io")))
 }
 
 /// Shared multi-thread runtime for driving the sync query API's async I/O.

--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -31,7 +31,11 @@
 //! `multi_thread` runtime (the default for `#[tokio::main]`, axum,
 //! actix, etc.).
 
-use std::{future::Future, sync::Arc, thread};
+use std::{
+    future::Future,
+    sync::{Arc, OnceLock},
+    thread,
+};
 
 use tokio::{runtime, task::block_in_place};
 
@@ -98,6 +102,16 @@ where
     }
 }
 
+/// Process-wide query runtime, shared by every `Connection` and
+/// `Supertable` so open handles add zero tokio workers. Never shut
+/// down — the static keeps a reference until process exit, so handle
+/// drops from inside a caller's async context have nothing to tear down.
+static SHARED_QUERY_RUNTIME: OnceLock<Arc<runtime::Runtime>> = OnceLock::new();
+
+pub(crate) fn shared_query_runtime() -> Arc<runtime::Runtime> {
+    Arc::clone(SHARED_QUERY_RUNTIME.get_or_init(|| build_query_runtime("infino-query")))
+}
+
 /// Shared multi-thread runtime for driving the sync query API's async I/O.
 ///
 /// Multi-thread is required, not just preferred: the bridges above take the
@@ -105,7 +119,7 @@ where
 /// `block_in_place` panics on a `current_thread` runtime. Workers scale to
 /// the CPU count so a cold query's per-superfile fan-out overlaps instead
 /// of serializing.
-pub(crate) fn build_query_runtime(thread_name: &str) -> Arc<runtime::Runtime> {
+fn build_query_runtime(thread_name: &str) -> Arc<runtime::Runtime> {
     const FALLBACK_QUERY_RUNTIME_WORKERS: usize = 4;
     let workers = thread::available_parallelism()
         .map(|n| n.get())

--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -109,7 +109,7 @@ where
 static SHARED_QUERY_RUNTIME: OnceLock<Arc<runtime::Runtime>> = OnceLock::new();
 
 pub(crate) fn shared_query_runtime() -> Arc<runtime::Runtime> {
-    Arc::clone(SHARED_QUERY_RUNTIME.get_or_init(|| build_query_runtime("infino-query")))
+    Arc::clone(SHARED_QUERY_RUNTIME.get_or_init(|| build_query_runtime("infino-io")))
 }
 
 /// Shared multi-thread runtime for driving the sync query API's async I/O.

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -19,7 +19,7 @@ use std::{
     fmt,
     future::Future,
     io,
-    sync::{Arc, Mutex, OnceLock, Weak, atomic::AtomicBool},
+    sync::{Arc, Mutex, Weak, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -36,7 +36,7 @@ use super::{
     options::SupertableOptions,
 };
 use crate::{
-    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, build_query_runtime},
+    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_query_runtime},
     storage::StorageError,
     supertable::{
         ManifestLoadError, SuperfileUri, SupertableStats,
@@ -104,14 +104,6 @@ pub(super) struct SupertableInner {
     /// supertable, constructed fresh on `create()` /
     /// `open()` with a 40-bit random worker_id.
     pub(super) id_generator: Mutex<IdGenerator>,
-    /// Lazily-initialized tokio Runtime that drives DataFusion
-    /// plans for `query_sql`. Tokio is single-worker here — it
-    /// runs the async I/O state machine, not CPU-bound work
-    /// (that lives on `options.reader_pool`). One Runtime per
-    /// supertable, shared across all SQL queries; allocated on
-    /// first use rather than at `create()` so supertables that
-    /// never run SQL don't pay the runtime cost.
-    pub(super) query_runtime: OnceLock<Arc<Runtime>>,
     /// Cached `SessionContext` for `query_sql`, keyed on the
     /// manifest `Arc` it was built against. Building one is
     /// ~1.5 ms (default optimizer rules + 3 TVF re-registrations
@@ -148,45 +140,12 @@ pub(super) struct SupertableInner {
     pub(super) last_pointer_check: Mutex<Option<Instant>>,
 }
 
-impl Drop for SupertableInner {
-    /// Tear down the lazily-built query runtime without tripping
-    /// tokio's "cannot drop a runtime from within an async context"
-    /// guard.
-    ///
-    /// The public API is sync, but it explicitly supports being
-    /// called from inside a caller's own multi-thread runtime (the
-    /// sync→async bridge uses `block_in_place` there). In that mode a
-    /// sync query lazily builds the owned `query_runtime`. If the
-    /// caller then drops their last `Supertable` handle while still
-    /// inside their runtime, the default `Arc<Runtime>` drop would
-    /// panic. `shutdown_background` consumes the runtime without
-    /// blocking, so it is safe from any context. The `try_unwrap`
-    /// guard ensures we only shut it down when this is the last
-    /// owner; otherwise an outstanding transient clone (never the
-    /// last reference) just decrements normally.
-    fn drop(&mut self) {
-        if let Some(rt) = self.query_runtime.take()
-            && let Ok(rt) = Arc::try_unwrap(rt)
-        {
-            rt.shutdown_background();
-        }
-    }
-}
-
 impl SupertableInner {
-    /// Get (or lazily build) the runtime that drives the public sync
-    /// API's async kernels when the caller is not already on a Tokio
-    /// runtime (queries, SQL, writer commits). Sized to the host's
-    /// parallelism: the cold read path fans a query out across every
-    /// superfile via `tokio::spawn` + `spawn_blocking` (range GETs,
-    /// CRC verification, zstd decode), so a single worker would
-    /// serialize that fan-out and inflate cold latency. One worker per
-    /// CPU lets those overlap, matching what an async caller gets.
+    /// Runtime driving the sync API's async kernels when the caller
+    /// isn't already on a tokio runtime. Process-wide — see
+    /// [`shared_query_runtime`].
     pub(super) fn query_runtime(&self) -> Arc<Runtime> {
-        Arc::clone(
-            self.query_runtime
-                .get_or_init(|| build_query_runtime("supertable-query")),
-        )
+        shared_query_runtime()
     }
 }
 
@@ -255,7 +214,6 @@ impl Supertable {
             writer_outstanding: AtomicBool::new(false),
             compaction_outstanding: AtomicBool::new(false),
             id_generator: Mutex::new(id_generator),
-            query_runtime: OnceLock::new(),
             sql_session_cache: Mutex::new(None),
             tombstone_cache,
             handle_id,
@@ -355,7 +313,6 @@ impl Supertable {
             writer_outstanding: AtomicBool::new(false),
             compaction_outstanding: AtomicBool::new(false),
             id_generator: Mutex::new(id_generator),
-            query_runtime: OnceLock::new(),
             sql_session_cache: Mutex::new(None),
             tombstone_cache,
             handle_id,

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -36,7 +36,7 @@ use super::{
     options::SupertableOptions,
 };
 use crate::{
-    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_query_runtime},
+    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
     storage::StorageError,
     supertable::{
         ManifestLoadError, SuperfileUri, SupertableStats,
@@ -145,7 +145,7 @@ impl SupertableInner {
     /// isn't already on a tokio runtime. Process-wide — see
     /// [`shared_query_runtime`].
     pub(super) fn query_runtime(&self) -> Arc<Runtime> {
-        shared_query_runtime()
+        shared_io_runtime()
     }
 }
 

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -38,7 +38,12 @@
 //!
 //! [`utils::vector_split::split_vectors`]: super::utils::vector_split::split_vectors
 
-use std::{collections::HashSet, fmt, sync::Arc, time::Duration};
+use std::{
+    collections::HashSet,
+    fmt,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
 use arrow_schema::{DataType, Field, Schema};
 use rayon::{ThreadPool, ThreadPoolBuilder};
@@ -51,7 +56,7 @@ use super::{
     },
 };
 use crate::{
-    config::{Config, StorageBackend, StorageColdFetchMode},
+    config::{Config, StorageBackend, StorageColdFetchMode, ThreadCount},
     memory::ConnectionMemoryBudget,
     storage::{AzureStorageProvider, LocalFsStorageProvider, S3StorageProvider, StorageProvider},
     superfile::{
@@ -88,6 +93,39 @@ fn default_writer_thread_count() -> usize {
 /// across non-pruned superfiles saturates this pool.
 fn default_reader_thread_count() -> usize {
     num_cpus::get().max(1)
+}
+
+/// Process-wide reader pool, shared by every supertable that doesn't
+/// inject its own (via [`SupertableOptions::with_reader_pool`] or a
+/// `Fixed` count in [`Config`]) — M open tables cost N reader threads,
+/// not M×N.
+static SHARED_READER_POOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
+
+/// Process-wide writer pool; same sharing contract at half the cores.
+static SHARED_WRITER_POOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
+
+fn shared_reader_pool() -> Arc<ThreadPool> {
+    Arc::clone(SHARED_READER_POOL.get_or_init(|| {
+        Arc::new(
+            ThreadPoolBuilder::new()
+                .num_threads(default_reader_thread_count())
+                .thread_name(|i| format!("supertable-reader-{i}"))
+                .build()
+                .expect("invariant: rayon pool build only fails on thread-spawn failure"),
+        )
+    }))
+}
+
+fn shared_writer_pool() -> Arc<ThreadPool> {
+    Arc::clone(SHARED_WRITER_POOL.get_or_init(|| {
+        Arc::new(
+            ThreadPoolBuilder::new()
+                .num_threads(default_writer_thread_count())
+                .thread_name(|i| format!("supertable-writer-{i}"))
+                .build()
+                .expect("invariant: rayon pool build only fails on thread-spawn failure"),
+        )
+    }))
 }
 
 /// Default name of the supertable-injected primary-key column.
@@ -506,22 +544,9 @@ impl SupertableOptions {
             return Err(BuildError::MissingTokenizer);
         }
 
-        // 6. Build default thread pools + store.
-        let reader_pool = Arc::new(
-            ThreadPoolBuilder::new()
-                .num_threads(default_reader_thread_count())
-                .thread_name(|i| format!("supertable-reader-{i}"))
-                .build()
-                .map_err(|e| BuildError::ThreadPoolCreation(e.to_string()))?,
-        );
-        let writer_threads = default_writer_thread_count();
-        let writer_pool = Arc::new(
-            ThreadPoolBuilder::new()
-                .num_threads(writer_threads)
-                .thread_name(|i| format!("supertable-writer-{i}"))
-                .build()
-                .map_err(|e| BuildError::ThreadPoolCreation(e.to_string()))?,
-        );
+        // 6. Shared thread pools + a fresh store.
+        let reader_pool = shared_reader_pool();
+        let writer_pool = shared_writer_pool();
         let store: Arc<dyn SuperfileReaderCache> = Arc::new(InMemoryReaderCache::new());
 
         Ok(Self {
@@ -808,29 +833,28 @@ impl SupertableOptions {
     /// a user-schema field — same check as
     /// [`Self::with_id_column`].
     pub fn apply_config(mut self, cfg: &Config) -> Result<Self, BuildError> {
-        let reader_n = cfg
-            .supertable
-            .reader_threads
-            .resolve_or_default(default_reader_thread_count());
-        let writer_n = cfg
-            .supertable
-            .writer_threads
-            .resolve_or_default(default_writer_thread_count());
-
-        self.reader_pool = Arc::new(
-            ThreadPoolBuilder::new()
-                .num_threads(reader_n)
-                .thread_name(|i| format!("supertable-reader-{i}"))
-                .build()
-                .map_err(|e| BuildError::ThreadPoolCreation(e.to_string()))?,
-        );
-        self.writer_pool = Arc::new(
-            ThreadPoolBuilder::new()
-                .num_threads(writer_n)
-                .thread_name(|i| format!("supertable-writer-{i}"))
-                .build()
-                .map_err(|e| BuildError::ThreadPoolCreation(e.to_string()))?,
-        );
+        // `Auto` keeps the shared pool; `Fixed` builds a dedicated one
+        // (the config analogue of `with_reader_pool` / `with_writer_pool`).
+        self.reader_pool = match cfg.supertable.reader_threads {
+            ThreadCount::Auto => shared_reader_pool(),
+            ThreadCount::Fixed(n) => Arc::new(
+                ThreadPoolBuilder::new()
+                    .num_threads(n.max(1))
+                    .thread_name(|i| format!("supertable-reader-{i}"))
+                    .build()
+                    .map_err(|e| BuildError::ThreadPoolCreation(e.to_string()))?,
+            ),
+        };
+        self.writer_pool = match cfg.supertable.writer_threads {
+            ThreadCount::Auto => shared_writer_pool(),
+            ThreadCount::Fixed(n) => Arc::new(
+                ThreadPoolBuilder::new()
+                    .num_threads(n.max(1))
+                    .thread_name(|i| format!("supertable-writer-{i}"))
+                    .build()
+                    .map_err(|e| BuildError::ThreadPoolCreation(e.to_string()))?,
+            ),
+        };
         self.commit_threshold_size_mb = cfg.supertable.commit_threshold_size_mb;
         self.verify_crc_on_open = cfg.supertable.verify_crc_on_open;
         // The `config.yaml` source for the connection budget; the connect path


### PR DESCRIPTION
### Why

Part of #286

Every Connection and every Supertable built its own tokio query runtime, and every SupertableOptions built its own reader and writer rayon pools. On an N-core host with M open tables that is M × (N runtime + N reader + N/2 writer) OS threads and nearly all idle, but real. Under concurrent ingest+query they oversubscribe the host and thrash: profiling on a 10-core machine showed 59 threads all equally CPU-saturated with zero lock/futex contention (see #286).

A multi-tenant process pays this per table. The thread inventory must be process-level, not per-handle.

### What

Process-level singletons (runtime_bridge.rs, options.rs):

- One shared multi-thread query runtime. The per-Connection / per-Supertable OnceLock fields and their Drop shutdown guards are gone the static holds a permanent reference
- One shared reader pool and one shared writer pool, sized once from the host. SupertableOptions::new clones them.

### test / benches

The concurrent harness previously measured tables one at a time, so per-table thread growth was invisible. It now builds all TENANTS tables up front, keeps them open, and drives load on all of them simultaneously; peak OS thread count is sampled per phase and emitted as a diffable metric.


### benches number 

10-core host, 50K docs/table, 4 readers per modality per table, 15s window, before → after:
```
┌─────────┬──────────────┬─────────────────┬──────────────────┬──────────────────┐
│ Tenants │ Idle threads │ Contention peak │   Agg fts q/s    │   Agg vec q/s    │
├─────────┼──────────────┼─────────────────┼──────────────────┼──────────────────┤
│ 1       │ 32 → 32      │ 63 → 67         │ 841 → 864        │ 496 → 519        │
├─────────┼──────────────┼─────────────────┼──────────────────┼──────────────────┤
│ 2       │ 62 → 32      │ 102 → 66        │ 646 → 682        │ 451 → 463        │
├─────────┼──────────────┼─────────────────┼──────────────────┼──────────────────┤
│ 4       │ 122 → 32     │ 166 → 112       │ 430 → 532 (+24%) │ 365 → 438 (+20%) │
└─────────┴──────────────┴─────────────────┴──────────────────┴──────────────────┘
```
Idle thread count is now flat in the table count. Four-tenant aggregate throughput under contention improves 24% (fts) / 20% (vec), with per-table fairness preserved (133±2 q/s per table, up from 107±2). Single-table numbers are unchanged within noise and no regression for the single-tenant shape.