### PR TITLE
ci bench: skip benchmark workflow on forks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,6 +39,8 @@ on:
 
 jobs:
   bench:
+    # Skip on forks (no Azure secrets); fork PRs into upstream still run.
+    if: github.repository == 'infino-ai/infino'
     strategy:
       fail-fast: false # one member failing must not cancel the other
       matrix:


### PR DESCRIPTION
## What
Guard the `bench` job on `github.repository == 'infino-ai/infino'`.

## Why
On a fork, a `main` sync push carries the full range of upstream commits — some touch `src/**`/`benches/**`, so the `on.push.paths` filter matches (filters evaluate the union of files across all commits in the push). The bench workflow then spins up the Azure VM legs, which fail immediately at Azure login: forks have no Azure secrets or `ci` environment. Result is recurring red runs on every fork sync.

## Change
One-line job-level `if` guard, matching the pattern already in `bench-janitor.yml`. Fork PRs into upstream are unaffected — `pull_request_target` runs in the base-repo context, so `github.repository` is `infino-ai/infino` and the bench still runs (e.g. #308).