### PR TITLE
[3/n] feat memory: gate SQL heap on the connection budget

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -66,6 +66,7 @@ pub infino::InfinoError::Backend(alloc::string::String)
 pub infino::InfinoError::Cardinality(alloc::string::String)
 pub infino::InfinoError::Io(alloc::string::String)
 pub infino::InfinoError::NotFound(alloc::string::String)
+pub infino::InfinoError::OverBudget(alloc::string::String)
 pub infino::InfinoError::Query(alloc::string::String)
 pub infino::InfinoError::Schema(alloc::string::String)
 impl core::error::Error for infino::InfinoError

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -30,7 +30,7 @@ use std::{
 
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
-use datafusion::{config::Dialect, execution::context::SessionContext};
+use datafusion::{config::Dialect, error::DataFusionError};
 use futures::future::try_join_all;
 pub use index_spec::IndexSpec;
 use manifest::{
@@ -44,8 +44,8 @@ use uri::{Backend, parse_uri};
 use crate::{
     InfinoError,
     config::DEFAULT_CONNECTION_BUDGET_BYTES,
-    memory::ConnectionMemoryBudget,
-    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
+    memory::{ConnectionMemoryBudget, budgeted_session_context},
+    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, build_query_runtime},
     storage::{StorageError, StorageProvider},
     superfile::{
         builder::FtsConfig,
@@ -454,7 +454,11 @@ impl Connection {
     /// ```
     pub fn query_sql(&self, sql: &str) -> Result<Vec<RecordBatch>, InfinoError> {
         debug!(sql, "running sql query");
-        let ctx = SessionContext::new();
+
+        // Gate SQL heap on the connection budget: DataFusion allocates the
+        // working set (sort / aggregate / join), so its pool is the gate.
+        let ctx = budgeted_session_context(&self.inner.connection_memory_budget)
+            .map_err(|e| InfinoError::Query(e.to_string()))?;
 
         // Resolve the relations the query names and register each that is a
         // catalog table. Unknown names (CTEs, search TVFs, aliases) are
@@ -498,9 +502,7 @@ impl Connection {
                 .sql(&sql)
                 .await
                 .map_err(|e| InfinoError::Query(e.to_string()))?;
-            df.collect()
-                .await
-                .map_err(|e| InfinoError::Query(e.to_string()))
+            df.collect().await.map_err(sql_exec_error)
         };
         // A query that names a `FROM` catalog table drives on that table's
         // runtime; otherwise the connection's own. The fallback still has to
@@ -535,6 +537,15 @@ fn build_options(
     // Set last so no builder step can reset the shared connection budget.
     opts.connection_memory_budget = connection_memory_budget;
     Ok(opts)
+}
+
+/// Map a SQL execution error to the public error: a budget exhaustion becomes
+/// [`InfinoError::OverBudget`], anything else a generic query error.
+fn sql_exec_error(e: DataFusionError) -> InfinoError {
+    match e {
+        DataFusionError::ResourcesExhausted(msg) => InfinoError::OverBudget(msg),
+        other => InfinoError::Query(other.to_string()),
+    }
 }
 
 /// The v1 default tokenizer, required iff the spec has FTS columns.
@@ -1031,6 +1042,85 @@ mod tests {
             .map(|b| b.num_rows())
             .sum();
         assert_eq!(rows, 3, "2 from docs + 1 from more");
+    }
+
+    // Many distinct group keys force DataFusion's aggregate to build a real
+    // hash table, so its memory pool (the connection budget) is exercised.
+    fn many_distinct_titles() -> Vec<String> {
+        (0..4000)
+            .map(|i| format!("distinct title number {i} with some filler text"))
+            .collect()
+    }
+
+    fn append_titles(conn: &Connection) -> usize {
+        let docs = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create");
+        let titles = many_distinct_titles();
+        let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+        docs.append(&build_title_batch(&refs)).expect("append");
+        titles.len()
+    }
+
+    const HEAVY_GROUP_BY: &str = "SELECT title, COUNT(*) AS n FROM docs GROUP BY title";
+
+    #[test]
+    fn query_sql_under_measure_only_default_is_never_refused() {
+        // Default budget only measures, so even a heavy aggregate runs.
+        let conn = connect("memory://").expect("connect");
+        let n = append_titles(&conn);
+        let out = conn
+            .query_sql(HEAVY_GROUP_BY)
+            .expect("measure-only never refuses");
+        assert_eq!(n_rows(&out), n);
+    }
+
+    #[test]
+    fn query_sql_under_a_generous_budget_succeeds() {
+        // 1 GiB is far more than the query needs, so the gate never trips.
+        let conn = connect_with(
+            "memory://",
+            ConnectOptions::new().with_connection_memory_budget_bytes(1 << 30),
+        )
+        .expect("connect");
+        let n = append_titles(&conn);
+        let out = conn.query_sql(HEAVY_GROUP_BY).expect("well under 1 GiB");
+        assert_eq!(n_rows(&out), n);
+    }
+
+    #[test]
+    fn query_sql_over_a_tiny_budget_is_refused_as_over_budget() {
+        // 0-byte gate: the aggregate can't reserve its first byte, and spilling
+        // needs memory it doesn't have, so it's refused as OverBudget.
+        let conn = connect_with(
+            "memory://",
+            ConnectOptions::new().with_connection_memory_budget_bytes(1),
+        )
+        .expect("connect");
+        append_titles(&conn);
+        let err = conn
+            .query_sql(HEAVY_GROUP_BY)
+            .expect_err("a 0-byte gate refuses the aggregate");
+        assert!(
+            matches!(err, InfinoError::OverBudget(_)),
+            "expected OverBudget, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn query_sql_streaming_scan_is_not_refused_under_a_tiny_budget() {
+        // A projection streams (no buffering), so it reserves nothing and runs
+        // even at a 0-byte gate: the budget bounds sort/aggregate/join, not scans.
+        let conn = connect_with(
+            "memory://",
+            ConnectOptions::new().with_connection_memory_budget_bytes(1),
+        )
+        .expect("connect");
+        let n = append_titles(&conn);
+        let out = conn
+            .query_sql("SELECT title FROM docs")
+            .expect("a streaming scan is not gated");
+        assert_eq!(n_rows(&out), n);
     }
 
     #[test]

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     InfinoError,
     config::DEFAULT_CONNECTION_BUDGET_BYTES,
     memory::{ConnectionMemoryBudget, budgeted_session_context},
-    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, build_query_runtime},
+    runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
     storage::{StorageError, StorageProvider},
     superfile::{
         builder::FtsConfig,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,6 +53,15 @@ use serde::{
 /// Embedded baseline. Compiled in via `include_str!`.
 const EMBEDDED_DEFAULT: &str = include_str!("config.yaml");
 
+/// Engine default connection budget when none is configured; used by both
+/// [`MemorySettings`] and the connect path. `0` is the deliberate measure-only
+/// (no-ceiling) sentinel that `from_budget_bytes` maps to a measured budget.
+///
+/// A future non-trivial default (e.g. a fraction of system RAM) changes here.
+/// `from_budget_bytes` stays a pure value mapper; the only added work then is
+/// letting the config field distinguish "unset" from an explicit `0`.
+pub(crate) const DEFAULT_CONNECTION_BUDGET_BYTES: u64 = 0;
+
 /// Errors from config load + validation.
 ///
 /// `figment::Error` is ~200 bytes; boxing keeps the `Result` size
@@ -113,15 +122,6 @@ impl Default for MemorySettings {
         }
     }
 }
-
-/// Engine default connection budget when none is configured; used by both
-/// [`MemorySettings`] and the connect path. `0` is the deliberate measure-only
-/// (no-ceiling) sentinel that `from_budget_bytes` maps to a measured budget.
-///
-/// A future non-trivial default (e.g. a fraction of system RAM) changes here.
-/// `from_budget_bytes` stays a pure value mapper; the only added work then is
-/// letting the config field distinguish "unset" from an explicit `0`.
-pub(crate) const DEFAULT_CONNECTION_BUDGET_BYTES: u64 = 0;
 
 /// Supertable subsection of [`Config`]. Keeps supertable-
 /// specific knobs grouped so they don't crowd the top-level

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,14 @@ pub enum InfinoError {
     #[error("query: {0}")]
     Query(String),
 
+    /// A query exceeded the connection's memory budget (see
+    /// [`ConnectOptions::with_connection_memory_budget_bytes`]). For SQL the
+    /// engine spills first and only raises this when it still can't fit.
+    ///
+    /// [`ConnectOptions::with_connection_memory_budget_bytes`]: crate::ConnectOptions::with_connection_memory_budget_bytes
+    #[error("over budget: {0}")]
+    OverBudget(String),
+
     /// Backend / internal failure that doesn't map to a more specific
     /// variant.
     #[error("backend: {0}")]
@@ -80,7 +88,10 @@ impl From<StorageError> for InfinoError {
 
 impl From<QueryError> for InfinoError {
     fn from(e: QueryError) -> Self {
-        InfinoError::Query(e.to_string())
+        match e {
+            QueryError::OverBudget(msg) => InfinoError::OverBudget(msg),
+            other => InfinoError::Query(other.to_string()),
+        }
     }
 }
 
@@ -190,6 +201,11 @@ mod tests {
         assert!(matches!(
             InfinoError::from(QueryError::Plan("p".into())),
             InfinoError::Query(_)
+        ));
+        // A budget refusal keeps its own variant rather than collapsing to Query.
+        assert!(matches!(
+            InfinoError::from(QueryError::OverBudget("b".into())),
+            InfinoError::OverBudget(_)
         ));
         assert!(matches!(
             InfinoError::from(SuperfileReadError::MissingKv("k")),

--- a/src/memory/datafusion_pool.rs
+++ b/src/memory/datafusion_pool.rs
@@ -8,6 +8,25 @@
 //! connection budget and lets DataFusion spill instead of us reserving by hand.
 //!
 //! One counter per connection: a fresh pool per `SessionContext` still shares it.
+//!
+//! # Spill vs OverBudget
+//!
+//! For SQL query paths, when the gate refuses (`try_grow` returns `ResourcesExhausted`), what happens
+//! next is up to the operator that asked for memory:
+//!
+//! - Spillable operator like sort, grouped aggregate, sort-merge join: frees
+//!   memory by writing its buffered run to disk, then continues. The query still
+//!   succeeds, just slower.
+//! - Otherwise it surfaces as [`InfinoError::OverBudget`], when:
+//!     - the operator can't spill at all:
+//!        - non-spillable (hash-join build side, nested-loop join, window aggregate), or
+//!        - a streaming operator (scan / filter / projection) that buffers nothing, so a single
+//!          allocation already exceeds the budget and there is nothing to write out; or
+//!     - it is spillable but can't reserve even the minimum it needs to run the
+//!       spill / merge (e.g. the sort's merge reservation).
+//!
+//! Spilling needs a disk manager; we use DataFusion's default (OS temp dir).
+//!
 
 use std::sync::Arc;
 

--- a/src/memory/datafusion_pool.rs
+++ b/src/memory/datafusion_pool.rs
@@ -15,7 +15,7 @@ use datafusion::{
     error::{DataFusionError, Result as DfResult},
     execution::{
         memory_pool::{MemoryLimit, MemoryPool, MemoryReservation},
-        runtime_env::RuntimeEnvBuilder,
+        runtime_env::{RuntimeEnv, RuntimeEnvBuilder},
     },
     prelude::{SessionConfig, SessionContext},
 };
@@ -59,22 +59,23 @@ impl MemoryPool for ConnectionBudgetPool {
     }
 }
 
-/// A `SessionContext` whose SQL allocations are gated by `budget`. The default
-/// disk manager (OS temp) gives spillable operators somewhere to spill.
-pub(crate) fn budgeted_session_context(
-    budget: &Arc<ConnectionMemoryBudget>,
-) -> DfResult<SessionContext> {
+/// A `RuntimeEnv` whose memory pool is `budget`. The default disk manager (OS
+/// temp) gives spillable operators somewhere to spill.
+fn budgeted_runtime(budget: &Arc<ConnectionMemoryBudget>) -> DfResult<Arc<RuntimeEnv>> {
     let pool: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool {
         budget: Arc::clone(budget),
     });
 
-    let runtime = RuntimeEnvBuilder::new()
-        .with_memory_pool(pool)
-        .build_arc()?;
+    RuntimeEnvBuilder::new().with_memory_pool(pool).build_arc()
+}
 
+/// A `SessionContext` whose SQL allocations are gated by `budget`.
+pub(crate) fn budgeted_session_context(
+    budget: &Arc<ConnectionMemoryBudget>,
+) -> DfResult<SessionContext> {
     Ok(SessionContext::new_with_config_rt(
         SessionConfig::new(),
-        runtime,
+        budgeted_runtime(budget)?,
     ))
 }
 
@@ -194,11 +195,11 @@ mod tests {
         reservation_bytes: usize,
     ) -> (usize, bool, usize) {
         let budget = ConnectionMemoryBudget::with_limit(configured_bytes);
-        let pool: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool { budget });
-        let runtime = RuntimeEnvBuilder::new()
-            .with_memory_pool(pool)
-            .build_arc()
-            .expect("runtime env");
+
+        // Build through the production runtime + pool wiring (`budgeted_runtime`);
+        // only the SessionConfig is tuned here (that's DataFusion's, not our
+        // wiring) so the sort spills deterministically.
+        let runtime = budgeted_runtime(&budget).expect("runtime env");
         let mut cfg = SessionConfig::new();
         cfg.options_mut().execution.sort_spill_reservation_bytes = reservation_bytes;
         // One partition = one sorter. The default (num_cpus) gives N sorters,

--- a/src/memory/datafusion_pool.rs
+++ b/src/memory/datafusion_pool.rs
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! DataFusion [`MemoryPool`] backed by a connection's [`ConnectionMemoryBudget`].
+//!
+//! SQL is the one path where DataFusion, not infino, allocates the working set
+//! (sort / aggregate / join buffers). This pool charges those against the
+//! connection budget and lets DataFusion spill instead of us reserving by hand.
+//!
+//! One counter per connection: a fresh pool per `SessionContext` still shares it.
+
+use std::sync::Arc;
+
+use datafusion::{
+    error::{DataFusionError, Result as DfResult},
+    execution::{
+        memory_pool::{MemoryLimit, MemoryPool, MemoryReservation},
+        runtime_env::RuntimeEnvBuilder,
+    },
+    prelude::{SessionConfig, SessionContext},
+};
+
+use crate::memory::ConnectionMemoryBudget;
+
+/// A DataFusion memory pool over a [`ConnectionMemoryBudget`]: measured never
+/// refuses, bounded refuses at the 90% gate (DataFusion then spills, or errors
+/// if it can't).
+#[derive(Debug)]
+struct ConnectionBudgetPool {
+    budget: Arc<ConnectionMemoryBudget>,
+}
+
+impl MemoryPool for ConnectionBudgetPool {
+    fn grow(&self, _reservation: &MemoryReservation, additional: usize) {
+        self.budget.grow_unchecked(additional);
+    }
+
+    fn shrink(&self, _reservation: &MemoryReservation, shrink: usize) {
+        self.budget.release(shrink);
+    }
+
+    fn try_grow(&self, _reservation: &MemoryReservation, additional: usize) -> DfResult<()> {
+        self.budget.try_grow(additional).map_err(|_| {
+            DataFusionError::ResourcesExhausted(format!(
+                "connection memory budget exhausted: {additional} more bytes would cross the limit"
+            ))
+        })
+    }
+
+    fn reserved(&self) -> usize {
+        self.budget.used()
+    }
+
+    fn memory_limit(&self) -> MemoryLimit {
+        match self.budget.limit() {
+            Some(limit) => MemoryLimit::Finite(limit),
+            None => MemoryLimit::Infinite,
+        }
+    }
+}
+
+/// A `SessionContext` whose SQL allocations are gated by `budget`. The default
+/// disk manager (OS temp) gives spillable operators somewhere to spill.
+pub(crate) fn budgeted_session_context(
+    budget: &Arc<ConnectionMemoryBudget>,
+) -> DfResult<SessionContext> {
+    let pool: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool {
+        budget: Arc::clone(budget),
+    });
+
+    let runtime = RuntimeEnvBuilder::new()
+        .with_memory_pool(pool)
+        .build_arc()?;
+
+    Ok(SessionContext::new_with_config_rt(
+        SessionConfig::new(),
+        runtime,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::{
+            array::{Array, StringArray},
+            datatypes::{DataType, Field, Schema},
+            record_batch::RecordBatch,
+        },
+        datasource::MemTable,
+        execution::memory_pool::MemoryConsumer,
+        physical_plan::{ExecutionPlan, collect},
+    };
+    use tokio::runtime::Runtime;
+
+    use super::*;
+
+    #[test]
+    fn measured_pool_never_refuses() {
+        let budget = ConnectionMemoryBudget::measured();
+        let pool: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool {
+            budget: Arc::clone(&budget),
+        });
+        let res = MemoryConsumer::new("t").register(&pool);
+        res.try_grow(1 << 30).expect("measured never refuses");
+        assert_eq!(pool.reserved(), 1 << 30);
+        assert!(matches!(pool.memory_limit(), MemoryLimit::Infinite));
+    }
+
+    #[test]
+    fn bounded_pool_refuses_past_the_gate() {
+        // 1000 configured -> gate at 900.
+        let budget = ConnectionMemoryBudget::with_limit(1000);
+        let pool: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool {
+            budget: Arc::clone(&budget),
+        });
+        assert!(matches!(pool.memory_limit(), MemoryLimit::Finite(900)));
+
+        let res = MemoryConsumer::new("t").register(&pool);
+        res.try_grow(900).expect("exactly at the gate fits");
+        res.try_grow(1)
+            .expect_err("one byte over the gate is refused");
+
+        // A refusal leaves the counter untouched, and shrink frees it.
+        assert_eq!(pool.reserved(), 900);
+        res.shrink(900);
+        assert_eq!(pool.reserved(), 0);
+    }
+
+    #[test]
+    fn pools_over_one_budget_share_the_counter() {
+        // Two pools, one budget: the ceiling binds the connection, not one ctx.
+        let budget = ConnectionMemoryBudget::with_limit(1000); // gate 900
+        let pool_a: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool {
+            budget: Arc::clone(&budget),
+        });
+        let pool_b: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool {
+            budget: Arc::clone(&budget),
+        });
+        let a = MemoryConsumer::new("a").register(&pool_a);
+        let b = MemoryConsumer::new("b").register(&pool_b);
+
+        a.try_grow(600).expect("fits");
+        b.try_grow(300).expect("600 + 300 = 900 fits");
+        b.try_grow(1).expect_err("the two pools share one ceiling");
+    }
+
+    #[test]
+    fn grow_charges_past_the_limit_for_unspillable_reservations() {
+        // `grow` is infallible (DataFusion's must-succeed reservations): it
+        // charges via grow_unchecked, so usage can pass the gate.
+        let budget = ConnectionMemoryBudget::with_limit(1000); // gate 900
+        let pool: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool { budget });
+        let res = MemoryConsumer::new("must-succeed").register(&pool);
+        res.grow(5000); // far past the gate, infallible
+        assert_eq!(pool.reserved(), 5000);
+    }
+
+    // Total `spill_count` across the plan tree; the sort reports it on its node.
+    fn total_spill_count(plan: &dyn ExecutionPlan) -> usize {
+        let here = plan.metrics().and_then(|m| m.spill_count()).unwrap_or(0);
+        here + plan
+            .children()
+            .iter()
+            .map(|c| total_spill_count(c.as_ref()))
+            .sum::<usize>()
+    }
+
+    fn is_sorted(batches: &[RecordBatch]) -> bool {
+        let mut prev: Option<String> = None;
+        for b in batches {
+            let col = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("string column");
+            for i in 0..col.len() {
+                let v = col.value(i).to_string();
+                if prev.as_ref().is_some_and(|p| &v < p) {
+                    return false;
+                }
+                prev = Some(v);
+            }
+        }
+        true
+    }
+
+    /// Sort `batches` by their string column under a bounded budget; returns
+    /// `(rows_out, in_order, spill_count)`. Reservation + single partition are
+    /// pinned so the sizing is deterministic (see the caller).
+    async fn run_sorted_query(
+        schema: &Arc<Schema>,
+        batches: &[RecordBatch],
+        configured_bytes: u64,
+        reservation_bytes: usize,
+    ) -> (usize, bool, usize) {
+        let budget = ConnectionMemoryBudget::with_limit(configured_bytes);
+        let pool: Arc<dyn MemoryPool> = Arc::new(ConnectionBudgetPool { budget });
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(pool)
+            .build_arc()
+            .expect("runtime env");
+        let mut cfg = SessionConfig::new();
+        cfg.options_mut().execution.sort_spill_reservation_bytes = reservation_bytes;
+        // One partition = one sorter. The default (num_cpus) gives N sorters,
+        // each reserving its own merge budget, which crosses the gate for
+        // unrelated reasons.
+        cfg.options_mut().execution.target_partitions = 1;
+        let ctx = SessionContext::new_with_config_rt(cfg, runtime);
+        let table =
+            MemTable::try_new(Arc::clone(schema), vec![batches.to_vec()]).expect("memtable");
+        ctx.register_table("t", Arc::new(table)).expect("register");
+
+        let df = ctx.sql("SELECT s FROM t ORDER BY s").await.expect("plan");
+        let plan = df.create_physical_plan().await.expect("physical plan");
+        let out = collect(Arc::clone(&plan), ctx.task_ctx())
+            .await
+            .expect("collect");
+        let rows: usize = out.iter().map(|b| b.num_rows()).sum();
+        (rows, is_sorted(&out), total_spill_count(plan.as_ref()))
+    }
+
+    #[test]
+    fn bounded_pool_spills_a_large_sort_and_returns_correct_results() {
+        // Spill, don't refuse. 32 MiB of data through an 8.8 MiB buffer can only
+        // finish by spilling, so correct+complete output proves it spilled, and
+        // spill_count > 0 confirms it. The generous run below (no spill) shows
+        // the spill was the budget's doing. Sizing:
+        //
+        //   gate               28.8 MiB   (90% of 32 MiB configured)
+        //   merge reservation  20 MiB     (held back for the merge; RESERVATION)
+        //   sort buffer         8.8 MiB   (gate - reservation)
+        //   data               32 MiB     (524,288 rows x 64 B)
+        const ROWS: usize = 512 * 1024; // 524,288 rows
+        const CHUNK: usize = 8 * 1024; // 8,192/batch -> 512 KiB, 64 batches
+        const RESERVATION: usize = 20 * 1024 * 1024; // big, to shrink the buffer
+
+        // Column `s`: 8-digit key + 56 B filler = 64 B/row, keys counting DOWN so
+        // ORDER BY must reverse all of them:
+        //   "00524287xxx..." ... "00000000xxx..."  ->  "00000000..." ... "00524287..."
+        // Filler just pads to 64 B (so ~512k rows = ~32 MiB). Many small batches
+        // so the sort can spill between them, not one un-splittable input.
+        let filler = "x".repeat(56);
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, false)]));
+        let mut batches = Vec::new();
+        for start in (0..ROWS).step_by(CHUNK) {
+            let vals: Vec<String> = (start..(start + CHUNK).min(ROWS))
+                .map(|i| format!("{:08}{filler}", ROWS - 1 - i))
+                .collect();
+            batches.push(
+                RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(StringArray::from(vals))])
+                    .expect("batch"),
+            );
+        }
+
+        let runtime = Runtime::new().expect("tokio runtime");
+        runtime.block_on(async {
+            // Tight: 32 MiB budget, data > buffer -> spills.
+            let (rows, sorted, spills) =
+                run_sorted_query(&schema, &batches, 32 * 1024 * 1024, RESERVATION).await;
+            assert_eq!(rows, ROWS, "every row comes back despite spilling");
+            assert!(sorted, "spilled sort still returns rows in order");
+            assert!(spills > 0, "the sort must spill under the tight budget");
+
+            // Generous: 256 MiB budget, gate >> data -> no spill.
+            let (rows, sorted, spills) =
+                run_sorted_query(&schema, &batches, 256 * 1024 * 1024, RESERVATION).await;
+            assert_eq!(rows, ROWS);
+            assert!(sorted);
+            assert_eq!(spills, 0, "a generous budget sorts in memory, no spill");
+        });
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -91,6 +91,10 @@ use std::{
     },
 };
 
+mod datafusion_pool;
+
+pub(crate) use datafusion_pool::budgeted_session_context;
+
 /// The fraction of a configured budget we actually enforce: gate at 9/10 and
 /// leave the final 1/10 as headroom for allocations too small to track. Applied
 /// once, in [`ConnectionMemoryBudget::with_limit`].
@@ -179,9 +183,10 @@ impl ConnectionMemoryBudget {
     }
 
     /// Charge `n` bytes to the counter, refusing if that would cross the
-    /// ceiling. On refusal the counter is left unchanged. Backs both
-    /// [`Self::try_reserve`] and [`Reservation::try_grow`].
-    fn try_grow(&self, n: usize) -> Result<(), OverBudget> {
+    /// ceiling. On refusal the counter is left unchanged. Backs
+    /// [`Self::try_reserve`], [`Reservation::try_grow`], and the DataFusion
+    /// pool adapter's `try_grow`.
+    pub(crate) fn try_grow(&self, n: usize) -> Result<(), OverBudget> {
         match self.limit {
             // Unbounded
             None => {

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -397,6 +397,9 @@ pub enum QueryError {
     #[error("DataFusion failed to execute the query: {0}")]
     Execute(String),
 
+    #[error("query exceeded the connection memory budget: {0}")]
+    OverBudget(String),
+
     #[error("manifest load error: {0}")]
     ManifestLoad(ManifestLoadError),
 }

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -50,20 +50,32 @@ use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, Decimal128Array};
-use datafusion::{execution::context::SessionContext, prelude::Expr};
+use datafusion::{error::DataFusionError, execution::context::SessionContext, prelude::Expr};
 
-use crate::supertable::{
-    error::QueryError,
-    handle::{Supertable, SupertableReader},
-    query::{
-        covered_agg::CoveredAggregateRewrite,
-        exec::{
-            fts_exec::register_bm25, hybrid_exec::register_hybrid_search,
-            match_exec::register_match, vector_exec::register_vector_search,
+use crate::{
+    memory::budgeted_session_context,
+    supertable::{
+        error::QueryError,
+        handle::{Supertable, SupertableReader},
+        query::{
+            covered_agg::CoveredAggregateRewrite,
+            exec::{
+                fts_exec::register_bm25, hybrid_exec::register_hybrid_search,
+                match_exec::register_match, vector_exec::register_vector_search,
+            },
+            provider::{SupertableProvider, TABLE_NAME},
         },
-        provider::{SupertableProvider, TABLE_NAME},
     },
 };
+
+/// Classify a SQL execution error: budget exhaustion -> [`QueryError::OverBudget`]
+/// (the catalog surfaces it as `InfinoError::OverBudget`), else an execute error.
+fn exec_query_error(e: DataFusionError) -> QueryError {
+    match e {
+        DataFusionError::ResourcesExhausted(msg) => QueryError::OverBudget(msg),
+        other => QueryError::Execute(other.to_string()),
+    }
+}
 
 impl SupertableReader {
     /// Run a SQL query against this reader's pinned snapshot.
@@ -99,9 +111,8 @@ impl SupertableReader {
                 .sql(&sql)
                 .await
                 .map_err(|e| QueryError::Plan(e.to_string()))?;
-            df.collect()
-                .await
-                .map_err(|e| QueryError::Execute(e.to_string()))
+
+            df.collect().await.map_err(exec_query_error)
         };
 
         // Drive through the shared sync→async bridge: ambient
@@ -153,7 +164,12 @@ impl SupertableReader {
             disk_cache,
             reader.tombstone_cache.clone(),
         );
-        let ctx = SessionContext::new();
+
+        // Gate SQL heap on the connection budget (shared across contexts, so
+        // this reader's SQL counts against the same ceiling as the rest).
+        let ctx = budgeted_session_context(&self.options().connection_memory_budget)
+            .map_err(|e| QueryError::Plan(e.to_string()))?;
+
         // Covered/residual aggregate rewrite: filter-aligned range
         // aggregates answer covered segments from manifest statistics
         // and scan only the boundary segments. Appended after the
@@ -161,6 +177,7 @@ impl SupertableReader {
         ctx.add_optimizer_rule(Arc::new(CoveredAggregateRewrite));
         ctx.register_table(TABLE_NAME, Arc::new(provider))
             .map_err(|e| QueryError::Plan(e.to_string()))?;
+
         // Search TVFs (vector kNN, BM25 FTS, hybrid RRF) bound to
         // the pinned snapshot. They lower to custom `ExecutionPlan`
         // nodes that call the async kernels inside `execute()`.
@@ -169,7 +186,9 @@ impl SupertableReader {
         // Unranked token / exact match TVFs (siblings of bm25_search).
         register_match(&ctx, Arc::clone(&reader), Arc::clone(&scalar_schema));
         register_hybrid_search(&ctx, Arc::clone(&reader), Arc::clone(&scalar_schema));
+
         *guard = Some((Arc::clone(&manifest), ctx.clone()));
+
         Ok(ctx)
     }
 
@@ -208,10 +227,7 @@ impl SupertableReader {
                 .map_err(|e| QueryError::Plan(e.to_string()))?
                 .select_columns(&[id_column.as_str()])
                 .map_err(|e| QueryError::Plan(e.to_string()))?;
-            let batches = df
-                .collect()
-                .await
-                .map_err(|e| QueryError::Execute(e.to_string()))?;
+            let batches = df.collect().await.map_err(exec_query_error)?;
             extract_id_column(&batches)
         };
 
@@ -291,6 +307,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
 
     use crate::{
+        memory::ConnectionMemoryBudget,
         superfile::{
             builder::{FtsConfig, VectorConfig},
             vector::{distance::Metric, rerank_codec::RerankCodec},
@@ -328,6 +345,14 @@ mod tests {
         )
         .expect("valid options")
         .with_writer_pool(pool)
+    }
+
+    // Bounded budget so the reader's SQL path gates DataFusion's heap.
+    // `with_limit(1)` is a 0-byte gate (90% of 1 floors to 0): refuse everything.
+    fn options_with_zero_gate() -> SupertableOptions {
+        let mut opts = options_id_cat_title();
+        opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
+        opts
     }
 
     /// Build a small categorical batch — start id sequence at
@@ -431,6 +456,53 @@ mod tests {
             "SELECT COUNT(*) FROM supertable WHERE category = 'rust'",
         );
         assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn query_sql_group_by_over_budget_is_refused() {
+        // The reader path (second production ctx site) is gated too: a 0-byte
+        // gate refuses the aggregate and surfaces as QueryError::OverBudget.
+        let st = Supertable::create(options_with_zero_gate()).expect("create");
+        let mut w = st.writer().expect("writer");
+
+        w.append(&build_cat_batch(
+            0,
+            &["rust", "python", "rust"],
+            &["a", "b", "c"],
+        ))
+        .expect("append");
+
+        w.commit().expect("commit");
+
+        let err = st
+            .reader()
+            .query_sql("SELECT category, COUNT(*) FROM supertable GROUP BY category")
+            .expect_err("0-byte gate refuses the aggregate");
+
+        assert!(matches!(err, QueryError::OverBudget(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn query_sql_streaming_scan_is_not_refused_under_a_zero_gate() {
+        // A projection streams (no buffering), so it runs even at a 0-byte gate:
+        // the budget bounds sort/aggregate/join, not scans.
+        let st = Supertable::create(options_with_zero_gate()).expect("create");
+        let mut w = st.writer().expect("writer");
+
+        w.append(&build_cat_batch(0, &["rust", "python"], &["a", "b"]))
+            .expect("append");
+
+        w.commit().expect("commit");
+
+        let rows: usize = st
+            .reader()
+            .query_sql("SELECT title FROM supertable")
+            .expect("a streaming scan is not gated")
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+
+        assert_eq!(rows, 2);
     }
 
     #[test]


### PR DESCRIPTION
### What does this PR do?
Makes the connection memory budget actually bound SQL. DataFusion runs every SQL query and allocates the heavy parts itself (sort, GROUP BY, join buffers), so we hand it a memory pool backed by the connection budget. When the budget tightens it spills to disk; if it still can't fit, the query fails with an over-budget error. The default is measure-only, so nothing changes until a limit is set.

### Why do we need this change?
The budget was plumbed into every connection but nothing enforced it yet, so setting a limit did nothing. SQL is the right first place: it's where the biggest, data-proportional allocations happen, and DataFusion already knows how to spill when memory runs low. We just point it at our budget.

### How do we do this change?
- A small adapter (`ConnectionBudgetPool`) implements DataFusion's memory-pool interface over the budget: measure-only never refuses, a bounded budget refuses past the 90% gate.
- Both SQL context sites (catalog `query_sql` and the reader's cached session) build with this pool.
- A refusal surfaces as `InfinoError::OverBudget`, not a generic query error.
- One helper builds the context, and every pool on a connection shares the same counter, so SQL (and later vector / ingest) all compete for one ceiling.

### Performance
No behaviour change by default. The pool is atomic-only: no locks, nothing allocated on the query path. Streaming queries (scans, filters) reserve nothing and run untouched even at a tiny budget; only the buffering operators are bounded. Tested that a sort larger than the budget spills and still returns correct results, and that a query with no room fails cleanly as OverBudget.