### PR TITLE
catalog: re-export arrow_array and arrow_schema at crate root

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ const billing  = db.querySql("SELECT body FROM docs WHERE source = 'help-center'
 ```rust
 use std::sync::Arc;
 
-use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
+use infino::arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use infino::arrow_schema::{DataType, Field, Schema};
 use infino::{connect, BoolMode, IndexSpec, Metric, VectorFilter, VectorSearchOptions};
 
 // Tiny stand-in for your embedding model so this runs as-is — a 16-dim
@@ -342,8 +342,8 @@ base, fuse the two rankings (reciprocal-rank fusion), and join provenance
 ```rust
 use std::sync::Arc;
 
-use arrow_array::{FixedSizeListArray, Float32Array, Int64Array, LargeStringArray, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
+use infino::arrow_array::{FixedSizeListArray, Float32Array, Int64Array, LargeStringArray, RecordBatch};
+use infino::arrow_schema::{DataType, Field, Schema};
 use infino::{connect, IndexSpec, Metric};
 
 // Tiny stand-in for your embedding model so this runs as-is; real

--- a/crate-docs.md
+++ b/crate-docs.md
@@ -34,8 +34,8 @@ allocator, turn it off to avoid a second one:
 ```rust
 use std::sync::Arc;
 
-use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
+use infino::arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use infino::arrow_schema::{DataType, Field, Schema};
 use infino::{connect, BoolMode, IndexSpec, Metric, VectorFilter, VectorSearchOptions};
 
 // Tiny stand-in for your embedding model so this runs as-is — a 16-dim

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -18,8 +18,8 @@
 use std::sync::Arc;
 
 use arrow::util::pretty::pretty_format_batches;
-use arrow_array::{LargeStringArray, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
+use infino::arrow_array::{LargeStringArray, RecordBatch};
+use infino::arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use datafusion::prelude::*;
 use infino::{

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -18,11 +18,11 @@
 use std::sync::Arc;
 
 use arrow::util::pretty::pretty_format_batches;
-use infino::arrow_array::{LargeStringArray, RecordBatch};
-use infino::arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use datafusion::prelude::*;
 use infino::{
+    arrow_array::{LargeStringArray, RecordBatch},
+    arrow_schema::{DataType, Field, Schema},
     superfile::{
         SuperfileReader, VectorSearchOptions,
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder, VectorConfig},

--- a/examples/locomo-recall/main.rs
+++ b/examples/locomo-recall/main.rs
@@ -42,9 +42,12 @@ use std::{
     sync::Arc,
 };
 
-use infino::arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
-use infino::arrow_schema::{DataType, Field, Schema};
-use infino::{BoolMode, IndexSpec, Metric, VectorSearchOptions, connect};
+use infino::{
+    BoolMode, IndexSpec, Metric, VectorSearchOptions,
+    arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch},
+    arrow_schema::{DataType, Field, Schema},
+    connect,
+};
 use serde::Deserialize;
 
 /// Top-k retrieved per query (headline is recall@10).

--- a/examples/locomo-recall/main.rs
+++ b/examples/locomo-recall/main.rs
@@ -42,8 +42,8 @@ use std::{
     sync::Arc,
 };
 
-use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
+use infino::arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use infino::arrow_schema::{DataType, Field, Schema};
 use infino::{BoolMode, IndexSpec, Metric, VectorSearchOptions, connect};
 use serde::Deserialize;
 

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -16,9 +16,12 @@
 use std::sync::Arc;
 
 use arrow::util::pretty::pretty_format_batches;
-use infino::arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
-use infino::arrow_schema::{DataType, Field, Schema};
-use infino::{BoolMode, IndexSpec, Metric, VectorFilter, VectorSearchOptions, connect};
+use infino::{
+    BoolMode, IndexSpec, Metric, VectorFilter, VectorSearchOptions,
+    arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch},
+    arrow_schema::{DataType, Field, Schema},
+    connect,
+};
 
 /// Embedding width for the demo vector column. Small on purpose (the
 /// engine's minimum is 16) — the point is the API shape, not recall.

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -16,8 +16,8 @@
 use std::sync::Arc;
 
 use arrow::util::pretty::pretty_format_batches;
-use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
+use infino::arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use infino::arrow_schema::{DataType, Field, Schema};
 use infino::{BoolMode, IndexSpec, Metric, VectorFilter, VectorSearchOptions, connect};
 
 /// Embedding width for the demo vector column. Small on purpose (the

--- a/public-api.txt
+++ b/public-api.txt
@@ -1,4 +1,6 @@
 pub mod infino
+pub use infino::arrow_array
+pub use infino::arrow_schema
 pub enum infino::BoolMode
 pub infino::BoolMode::And
 pub infino::BoolMode::Or

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -159,7 +159,7 @@ impl Connection {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// use infino::{connect, IndexSpec};
     ///
     /// let db = connect("memory://")?;
@@ -272,7 +272,7 @@ impl Connection {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use infino::{connect, IndexSpec};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::LargeUtf8, false)]));
@@ -355,7 +355,7 @@ impl Connection {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use infino::{connect, IndexSpec};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::LargeUtf8, false)]));
@@ -441,8 +441,8 @@ impl Connection {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_array::{LargeStringArray, RecordBatch};
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_array::{LargeStringArray, RecordBatch};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use infino::{connect, IndexSpec};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::LargeUtf8, false)]));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,10 @@ mod runtime_bridge;
 
 // ---- Curated public surface ----
 
+/// Arrow `Schema` / `RecordBatch` builders for the public API.
+/// Import as `infino::arrow_schema` and `infino::arrow_array`.
+pub use arrow_array;
+pub use arrow_schema;
 /// Catalog entry points and handle: open a `Connection`, then create /
 /// open / drop / list tables.
 pub use catalog::{ColdFetchMode, ConnectOptions, Connection, IndexSpec, connect, connect_with};

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -513,7 +513,7 @@ impl Supertable {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use infino::{connect, IndexSpec};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::LargeUtf8, false)]));

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -963,8 +963,8 @@ impl Supertable {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_array::{LargeStringArray, RecordBatch};
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_array::{LargeStringArray, RecordBatch};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use infino::{connect, BoolMode, IndexSpec};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::LargeUtf8, false)]));
@@ -1058,8 +1058,8 @@ impl Supertable {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_array::{LargeStringArray, RecordBatch};
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_array::{LargeStringArray, RecordBatch};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use infino::{connect, BoolMode, IndexSpec};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::LargeUtf8, false)]));

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -760,9 +760,9 @@ impl Supertable {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_array::{FixedSizeListArray, Float32Array, RecordBatch};
-    /// # use arrow_array::types::Float32Type;
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_array::{FixedSizeListArray, Float32Array, RecordBatch};
+    /// # use infino::arrow_array::types::Float32Type;
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use infino::{connect, IndexSpec, Metric, VectorSearchOptions};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new(

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -276,8 +276,8 @@ impl Supertable {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_array::{LargeStringArray, RecordBatch};
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_array::{LargeStringArray, RecordBatch};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use infino::{connect, IndexSpec};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::LargeUtf8, false)]));
@@ -302,8 +302,8 @@ impl Supertable {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_array::{LargeStringArray, RecordBatch};
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_array::{LargeStringArray, RecordBatch};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use datafusion::prelude::{col, lit};
     /// # use infino::{connect, IndexSpec};
     /// # let dir = tempfile::tempdir()?; // update/delete need durable storage
@@ -332,8 +332,8 @@ impl Supertable {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow_array::{LargeStringArray, RecordBatch};
-    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use infino::arrow_array::{LargeStringArray, RecordBatch};
+    /// # use infino::arrow_schema::{DataType, Field, Schema};
     /// # use datafusion::prelude::{col, lit};
     /// # use infino::{connect, IndexSpec};
     /// # let dir = tempfile::tempdir()?; // update/delete need durable storage

--- a/tests/arrow_reexport.rs
+++ b/tests/arrow_reexport.rs
@@ -8,7 +8,10 @@
 use std::sync::Arc;
 
 use infino::{
-    IndexSpec, arrow_array::{LargeStringArray, RecordBatch}, arrow_schema::{DataType, Field, Schema}, connect,
+    IndexSpec,
+    arrow_array::{LargeStringArray, RecordBatch},
+    arrow_schema::{DataType, Field, Schema},
+    connect,
 };
 
 #[test]
@@ -36,11 +39,8 @@ fn arrow_reexports_work_for_create_table_and_append() {
         .create_table("docs", schema.clone(), IndexSpec::new().fts("body"))
         .expect("create_table accepts re-exported Schema");
 
-    let batch = RecordBatch::try_new(
-        schema,
-        vec![Arc::new(LargeStringArray::from(vec!["ok"]))],
-    )
-    .expect("valid batch");
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(LargeStringArray::from(vec!["ok"]))])
+        .expect("valid batch");
 
     table
         .append(&batch)

--- a/tests/arrow_reexport.rs
+++ b/tests/arrow_reexport.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Smoke test that Arrow types are reachable through the crate-root
+//! re-exports (`infino::arrow_array`, `infino::arrow_schema`) without
+//! depending on `arrow-array` or `arrow-schema` as direct imports.
+
+use std::sync::Arc;
+
+use infino::{
+    arrow_array::{LargeStringArray, RecordBatch},
+    arrow_schema::{DataType, Field, Schema},
+};
+
+#[test]
+fn arrow_types_reexported_at_crate_root() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "x",
+        DataType::LargeUtf8,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(LargeStringArray::from(vec!["ok"]))])
+        .expect("valid batch");
+    assert_eq!(batch.num_rows(), 1);
+}

--- a/tests/arrow_reexport.rs
+++ b/tests/arrow_reexport.rs
@@ -8,8 +8,7 @@
 use std::sync::Arc;
 
 use infino::{
-    arrow_array::{LargeStringArray, RecordBatch},
-    arrow_schema::{DataType, Field, Schema},
+    IndexSpec, arrow_array::{LargeStringArray, RecordBatch}, arrow_schema::{DataType, Field, Schema}, connect,
 };
 
 #[test]
@@ -22,4 +21,28 @@ fn arrow_types_reexported_at_crate_root() {
     let batch = RecordBatch::try_new(schema, vec![Arc::new(LargeStringArray::from(vec!["ok"]))])
         .expect("valid batch");
     assert_eq!(batch.num_rows(), 1);
+}
+
+#[test]
+fn arrow_reexports_work_for_create_table_and_append() {
+    let db = connect("memory://").expect("connect");
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "body",
+        DataType::LargeUtf8,
+        false,
+    )]));
+
+    let table = db
+        .create_table("docs", schema.clone(), IndexSpec::new().fts("body"))
+        .expect("create_table accepts re-exported Schema");
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(LargeStringArray::from(vec!["ok"]))],
+    )
+    .expect("valid batch");
+
+    table
+        .append(&batch)
+        .expect("append accepts the re-exported RecordBatch");
 }


### PR DESCRIPTION
Implemented the core fix: pub use arrow_schema and pub use arrow_array at the crate root, updated public doctests + public-api.txt, and added tests/arrow_reexport.rs as a smoke test.

Audited public-api.txt — only those two Arrow crates appear in the public contract; types like Schema, Field, DataType, RecordBatch are covered via those re-exports.

Left for follow-up unless you want them in this PR: README / crate-docs.md / examples still use direct arrow_* imports; semver policy for Arrow major bumps; optional public-dependency CI check.

cargo test --doc and make public-api pass on my branch.

Closes #357 