### PR TITLE
release: infino crate 0.1.3 + node binding 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.1.2",
-    "infx-darwin-arm64": "0.1.2",
-    "infx-linux-x64-gnu": "0.1.2",
-    "infx-linux-arm64-gnu": "0.1.2",
-    "infx-linux-x64-musl": "0.1.2",
-    "infx-linux-arm64-musl": "0.1.2"
+    "infx-darwin-x64": "0.1.3",
+    "infx-darwin-arm64": "0.1.3",
+    "infx-linux-x64-gnu": "0.1.3",
+    "infx-linux-arm64-gnu": "0.1.3",
+    "infx-linux-x64-musl": "0.1.3",
+    "infx-linux-arm64-musl": "0.1.3"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "apache-avro",
  "arc-swap",


### PR DESCRIPTION
Cuts the **0.1.3** release for the crate and the Node binding together. Both carry the `docs.infino.ai → infino.ai/docs` migration now on main (the old domain is retired), so their published pages/READMEs stop pointing at the dead domain.

### Crate `infino` 0.1.3 (crates.io)
- Root `Cargo.toml` `0.1.2 → 0.1.3` (+ root `Cargo.lock`).
- Refreshes the docs.rs page: logo/favicon + docs link resolve at `infino.ai/docs` (0.1.2's docs.rs logo/favicon 404), plus the fuller API-surface docs from #344.

### Node `@infino-ai/infino` 0.1.3 (npm)
- `infino-node/package.json` version + the six `infx-*` `optionalDependencies` `0.1.2 → 0.1.3`.
- Ships the slimmed README with `infino.ai/docs` links to npm.

### Binding lock sync
- `infino-python/Cargo.lock` + `infino-node/Cargo.lock` bumped to the `0.1.3` `infino` path-dep so their `--locked` maturin/napi builds pass. Binding `Cargo.toml`s use a bare `path` dep, so no manifest change.
- Python (PyPI) is **not** bumped here — it can pick up the doc-link fix on its next release whenever convenient.

### Release steps (after merge)
Two independent triggers (patch numbers are per-registry, so crate 0.1.3 and node 0.1.3 don't collide):
```
# crate -> crates.io
git tag v0.1.3 && git push origin v0.1.3
# node -> npm (workflow_dispatch; patch tags skip the binding workflows)
gh workflow run node-publish.yml --repo infino-ai/infino --ref main -f dry_run=false
```

Verified `cargo metadata --locked` passes for the root and both binding manifests; package.json version + all `optionalDependencies` are `0.1.3`.