### PR TITLE
docs: add infino's on-disk layout architecture doc

### DIFF
--- a/docs/architecture/on-disk-layout.md
+++ b/docs/architecture/on-disk-layout.md
@@ -1,0 +1,130 @@
+# On-disk layout
+
+The files infino writes under a database root, and how a read walks from the root down to the [superfile](./superfile.md) that holds the data. The single-file superfile format is described in [superfile](./superfile.md); the table model and commit protocol in [supertable](./supertable.md). This document is the physical view: what is on disk, and which file points to which.
+
+Everything on disk is immutable except the two `current` pointer files. A commit writes new immutable files first, then atomically renames one pointer to publish them, so a reader sees either the state before a commit or the state after it, never a partial one.
+
+## Directory tree
+
+Legend: `dir/` is a directory, a bare name is a file. `stores` is its main contents, `used` is what reads it.
+
+```text
+mydb/                                     database root (the connect() path)
+│
+├── _catalog/
+│   └── current                           JSON · the catalog
+│       ├ stores : catalog_id; tables{ name -> { location, schema_ipc,
+│       │          fts[], vectors[], created_at_unix } }
+│       └ used   : read on connect() to resolve a table name to its subtree
+│
+├── table1-18bf675d94bf6360-0/            one table (name "table1")
+│   │                                     dir = {name}-{nanos:x}-{seq:x}; a re-created
+│   │                                     table lands on a fresh subtree (drop-safe)
+│   │
+│   ├── _supertable/
+│   │   └── current                       text KV · the live-version pointer
+│   │       ├ stores : manifest_id, manifest_uri, content_hash=blake3:...
+│   │       └ used   : the only file ever atomically renamed = the commit barrier
+│   │
+│   ├── manifest/
+│   │   └── manifest-000004.json          JSON · immutable manifest version
+│   │       ├ stores : parts[] (each: uri + content_hash), schema, fts/vector
+│   │       │          column specs, partition strategy
+│   │       └ used   : one written per commit (NNNNNN bumps); names the live parts
+│   │
+│   ├── manifest-parts/
+│   │   └── part-<blake3>.avro.zst        Avro+zstd · immutable, content-addressed
+│   │       ├ stores : superfiles[] entries, each with uri, n_docs, id_min/max,
+│   │       │          bloom + min/max summaries
+│   │       └ used   : skip-pruning; reject superfiles before reading their bytes
+│   │
+│   ├── data/
+│   │   └── <superfile>.sf.parquet        the superfiles (files prefixed seg-)
+│   │       ├ stores : valid Parquet columns + embedded BM25 + vector index,
+│   │       │          all in one file
+│   │       └ used   : the actual data + search; immutable, never rewritten
+│   │
+│   ├── superfiles/                       not superfiles: tombstone sidecars only
+│   │   └── <superfile_id>.tombstones     binary · magic "INFTOMB\0"
+│   │       ├ stores : a RoaringBitmap of deleted row positions in the
+│   │       │          superfile of that id (+ optional compaction seal record)
+│   │       └ used   : update/delete tombstones rows instead of rewriting a superfile
+│   │
+│   └── wal/
+│       └── mutations/                    write-ahead log for update/delete
+│           ├── <walid>.json              state-doc: the pending mutation + its state
+│           └── <walid>.arrow             IPC sidecar with the new rows (UPDATE only)
+│               ├ stores : one entry per in-flight mutation (walid is a time-ordered id)
+│               └ used   : crash recovery; drained after commit, so empty at rest
+│
+└── table2-18bf9efdf7479d90-0/           second table, identical shape
+    └── ...                               (a table with no vector column has vectors[]
+                                          empty in the catalog and no vector index)
+```
+
+## Logical view
+
+Who points to whom, and how many. The catalog lists many tables; each table pins exactly one live manifest; that manifest lists many parts; each part carries many superfile entries; each entry names exactly one superfile. table2 has the same shape and is collapsed here to save room.
+
+```text
+                        ┌─────────────────────┐
+                        │  _catalog/current   │
+                        └──────────┬──────────┘
+                                   │ tables[name].location
+               ┌───────────────────┴───────────────────┐
+               ▼                                       ▼
+      ┌──────────────────┐                    ┌──────────────────┐
+      │ table1/          │                    │ table2/          │
+      │  _supertable/    │                    │  _supertable/    │
+      │  current         │                    │  current         │
+      └────────┬─────────┘                    └────────┬─────────┘
+               |                                       |
+               │ manifest_uri                          │ manifest_uri
+               ▼                                       ▼
+   ┌───────────────────────┐                ┌───────────────────────┐
+   │ manifest-000004.json  │                │ manifest-000001.json  │
+   └───────────┬───────────┘                └───────────────────────┘
+               │ parts[].uri                    (same shape below)
+               │
+               |
+               ├──▶ ┌──────────────────┐  superfiles[].uri
+               │    │ manifest part 1  │─ entry ━━━━━▶ seg-A.sf.parquet ╌╌╌╌╌▶ A.tombstones
+               │    │  (avro.zst)      │─ entry ━━━━━▶ seg-B.sf.parquet ╌╌╌╌╌▶ B.tombstones
+               │    └──────────────────┘
+               │
+               └──▶ ┌──────────────────┐
+                    │ manifest part 2  │─ entry ━━━━━▶ seg-C.sf.parquet ╌╌╌╌╌▶ C.tombstones
+                    │  (avro.zst)      │─ entry ━━━━━▶ seg-D.sf.parquet ╌╌╌╌╌▶ (none yet, as nothing deleted/updated)
+                    └──────────────────┘
+
+   Legend
+     seg-X            = data/seg-<id>.sf.parquet   (the superfile: Parquet + BM25 + vector)
+     X.tombstones     = superfiles/<id>.tombstones (shares the superfile's id)
+
+     ━━━━━▶   stored pointer: the labelled field names the next file
+     ╌╌╌╌╌▶   NOT a stored pointer: derived from the superfile id; the
+              tombstone file appears only after a row in it is deleted
+```
+
+Every hop below the two pointer files is content-addressed with a blake3 hash, so identical bytes always resolve to the same uri. A commit that does not touch a part reuses its existing entries by uri, so successive manifests can point at the same superfile bytes.
+
+## Notes
+
+- `data/` holds the superfiles; `superfiles/` holds only their tombstones. The directory name is misleading.
+- The live set is whatever the current manifest names. An update writes a new superfile and tombstones the old one, so `data/` accumulates more `.sf.parquet` files than the table's live row count until GC removes the dead ones.
+- `wal/mutations/` is normally empty. A `<walid>.json` (and, for UPDATE, its `.arrow` sidecar) exists only while a mutation is in flight or was interrupted; the next recovery sweep drains it.
+
+## Source references
+
+Anchored by symbol so they survive line moves:
+
+| On disk | Defined by | File |
+| --- | --- | --- |
+| table subtree name `{name}-{nanos:x}-{seq:x}` | `unique_location` | [src/catalog/mod.rs](../../src/catalog/mod.rs) |
+| `_supertable/current` pointer text format + atomic-rename commit | `PointerFile`, `POINTER_PATH`, `commit_manifest` | [src/supertable/manifest/commit.rs](../../src/supertable/manifest/commit.rs) |
+| `manifest/manifest-NNNNNN.json` and `manifest-parts/part-<hash>.avro.zst` names | `MANIFEST_DIR`, `MANIFEST_PARTS_DIR`, `manifest_uri` | [src/supertable/manifest/commit.rs](../../src/supertable/manifest/commit.rs) |
+| `data/seg-<uuid>.sf.parquet` name | `SuperfileUri::storage_path` | [src/supertable/manifest/mod.rs](../../src/supertable/manifest/mod.rs) |
+| manifest-part Avro schema (`superfiles[].uri`, summaries) | `SuperfileEntry` schema | [src/supertable/manifest/part.rs](../../src/supertable/manifest/part.rs) |
+| `wal/mutations/` state-doc + `.arrow` sidecar | `WAL_DIR`, `WalStore` | [src/supertable/wal/persistence.rs](../../src/supertable/wal/persistence.rs) |
+| `superfiles/<id>.tombstones` sidecar paths | `SUPERFILES_DIR`, `tombstones_path` | [src/supertable/wal/persistence.rs](../../src/supertable/wal/persistence.rs) |
+| tombstone binary format (`INFTOMB\0` + RoaringBitmap) | `MAGIC`, layout doc | [src/supertable/wal/tombstones_codec.rs](../../src/supertable/wal/tombstones_codec.rs) |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 # Infino Architecture Overview
 
 A plain-language tour of what Infino is, how it's built, and how it
-differs from the database, search engine, and vector database alternatives. 
+differs from the database, search engine, and vector database alternatives.
 For more technical detail, see [superfile](./superfile.md) (the superfile format) and
 [supertable](./supertable.md) (the table layer).
 
@@ -11,8 +11,8 @@ For more technical detail, see [superfile](./superfile.md) (the superfile format
 
 For most retrieval and RAG workloads, hybrid queries are useful for improving the cost, latency, and accuracy of results. In Infino, SQL, keyword, and vector run over **one copy of the data** through **one query path**, making **hybrid search** a first-class, single-pass operation.
 
- The data lives in object storage at object-storage prices, and  
-compute pulls in only what a query actually touches, caching the hot  
+ The data lives in object storage at object-storage prices, and
+compute pulls in only what a query actually touches, caching the hot
 parts locally for speed. You do not need to maintain a separate cluster.
 
 ## The mental model
@@ -52,6 +52,8 @@ Think of three ideas:
                       Object storage (S3) — cheap, durable,
                               the source of truth
 ```
+
+To see how these pieces land as actual files (the catalog, per-table subtrees, manifests, superfiles, and tombstones) and how a read walks from one to the next, see [on-disk layout](./on-disk-layout.md).
 
 ## Opening Infino
 
@@ -301,4 +303,3 @@ SQL filters, over one copy of the data and one snapshot.
 behind fast approximate vector search.
 - **Object storage / S3** — cheap, durable, near-infinite remote
 storage used as the source of truth.
-

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -39,15 +39,16 @@ Think of three ideas:
         Application
             │  connect(uri) → Connection
             ▼
-        Connection  ── catalog of tables (name → supertable) ──┐
+        Connection  ── catalog of tables (name → supertable) ───┐
             │  create / open / list / drop · cross-table SQL    │
-            ▼                                                    │
-        Supertable  ── manifest (the file list) ──┐             │
-            │                                      │             │
+            ▼                                                   │
+        Supertable  ── manifest (the file list) ───┐            │
+            │                                      │            │
    stateless compute                       immutable files      │
-   + local cache (hot)                     (superfiles)          │
-            │                                      │             │
-            └──────────── byte-range reads ────────┴─────────────┘
+   + local cache (hot)                     (superfiles)         │
+            │                                      │            │
+            └──────────── byte-range reads ────────┴────────────┘
+                                 |
                                  ▼
                       Object storage (S3) — cheap, durable,
                               the source of truth

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -6,7 +6,9 @@ supports SQL, full-text, and vector search, while keeping readers
 consistent under concurrent writes.
 
 This document describes the table model and its guarantees. The superfile
-format is described in [superfile](./superfile.md).
+format is described in [superfile](./superfile.md); the physical files this
+layer writes and the pointer chain between them are in
+[on-disk layout](./on-disk-layout.md).
 
 ## Design
 

--- a/llms.txt
+++ b/llms.txt
@@ -38,6 +38,9 @@ https://docs.infino.ai.
 - [Supertable layer](docs/architecture/supertable.md): the table layer over
   many superfiles — manifest snapshots, atomic commits, skip-pruning, and
   concurrency.
+- [On-disk layout](docs/architecture/on-disk-layout.md): the physical view:
+  the files infino writes under a database root, and the pointer chain from
+  the catalog down to each superfile.
 
 ## Reference
 


### PR DESCRIPTION
### What
Adds `docs/architecture/on-disk-layout.md`, a physical view of what infino writes under a database root. Linked from `llms.txt` and cross-referenced from `supertable.md`.

### Why
`superfile.md` covers the single-file byte format and `supertable.md` covers the manifest/commit model, but nothing showed the actual directory tree a user sees under a database root, or how a read resolves from the catalog down to a superfile. Someone inspecting a `data/` directory had no doc to map files to meaning.