### PR TITLE
improv tracing spans: add spans for tracking duration of important functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "wide",
  "xxhash-rust",
@@ -2589,6 +2590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,6 +2711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4257,6 +4276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -4270,14 +4290,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4413,6 +4451,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,15 @@ test-helpers = []
 # work or release-profile recall gates, but should not run as part of a
 # plain `cargo bench`.
 bench-diagnostics = []
+# Compiles the per-function timing spans (`#[tracing::instrument]`) on
+# the append/commit, SQL, search, superfile-open, and object-store
+# fetch paths. OFF by default: with the feature absent the
+# `cfg_attr`-gated attributes expand to nothing, so there is zero
+# runtime cost in a production build. Turn it on to profile where a
+# query or append spends its time; the always-on event logs (`debug!`
+# / `info!` / …) are independent of this flag and stay compiled in
+# regardless. Not part of the public API surface.
+detailed-tracing = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(coverage_nightly)"] }
@@ -276,6 +285,14 @@ tokio = { version = "1", features = ["test-util"] }
 
 proptest = "1"
 hdrhistogram = "7"
+
+# Subscriber for the `logging` example only — the library emits
+# `tracing` events/spans but never installs a subscriber (that is the
+# consumer's job). `env-filter` backs the example's `RUST_LOG` handling;
+# the default `fmt` feature supplies the formatter and the span
+# busy/idle timing output (`FmtSpan`). Dev-only; not part of the shipped
+# crate's dependency surface.
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # s3s + s3s-fs power the "real S3 wire protocol" smoke test.
 # s3s is the S3-compatible HTTP server library; s3s-fs is its
 # filesystem backend. The test crate spawns s3s-fs on a random

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! See what the library's `tracing` output looks like.
+//!
+//! The library emits `tracing` events but never installs a subscriber —
+//! that is the consumer's job. This example installs the standard
+//! `fmt` subscriber, then drives a storage-backed table through the
+//! lifecycle paths that carry logs (connect, create, append/commit,
+//! search, SQL, reopen, drop). Level is `RUST_LOG`-driven, defaulting
+//! to `info`:
+//!
+//! ```text
+//! cargo run --example logging                 # info + warn + error
+//! RUST_LOG=infino=debug cargo run --example logging   # + per-op debug
+//! RUST_LOG=infino=trace cargo run --example logging   # + query fanout
+//! ```
+//!
+//! The always-on events tell you *what* happened. To see *how long* each
+//! append/commit, search, SQL, superfile-open, and object-store fetch
+//! took, build with the `detailed-tracing` feature: it compiles in the
+//! per-function timing spans, and this example then configures the
+//! subscriber to print each span's busy/idle time as the span closes.
+//!
+//! ```text
+//! cargo run --example logging --features detailed-tracing
+//! RUST_LOG=infino=trace cargo run --example logging --features detailed-tracing
+//! ```
+//!
+//! Without the feature the spans compile to nothing, so there is no
+//! timing output (and no runtime cost) regardless of `RUST_LOG`.
+//!
+//! Backed by a temp directory (LocalFs) rather than `memory://`, so the
+//! storage-branch logs (durable create/drop, commit publish, the
+//! open-time recovery + GC sweeps) actually fire.
+
+use std::sync::Arc;
+
+use arrow_array::{LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use infino::{BoolMode, IndexSpec, connect};
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // With `detailed-tracing` on, emit each span's busy/idle time when it
+    // closes — the per-op timings. With the feature off the spans aren't
+    // compiled at all, so there is nothing to report and we ask for none.
+    #[cfg(feature = "detailed-tracing")]
+    let span_events = FmtSpan::CLOSE;
+    #[cfg(not(feature = "detailed-tracing"))]
+    let span_events = FmtSpan::NONE;
+
+    // `RUST_LOG` picks the level/target filter; fall back to `info` so a
+    // bare `cargo run --example logging` shows the info/warn/error tier.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_span_events(span_events)
+        .with_target(true)
+        .init();
+
+    // Durable backend so the storage-branch logs fire (memory:// would
+    // skip create/drop-on-storage, commit publish, and the sweeps).
+    let dir = tempfile::tempdir()?;
+    let uri = dir.path().to_str().expect("utf8 tempdir path");
+
+    let db = connect(uri)?;
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "title",
+        DataType::LargeUtf8,
+        false,
+    )]));
+    let docs = db.create_table("docs", schema.clone(), IndexSpec::new().fts("title"))?;
+
+    let titles = ["the quick brown fox", "a lazy sleeping dog"];
+    docs.append(&RecordBatch::try_new(
+        schema,
+        vec![Arc::new(LargeStringArray::from(titles.to_vec()))],
+    )?)?;
+
+    let _ = docs.bm25_search("title", "fox", 10, BoolMode::Or, Some(&["_id", "title"]))?;
+    let _ = db.query_sql("SELECT _id, title FROM docs ORDER BY _id")?;
+
+    // Reopen from storage (drives the open-time recovery + GC sweeps),
+    // then drop with purge to exercise the destructive lifecycle log.
+    let _reopened = db.open_table("docs")?;
+    db.drop_table("docs", true)?;
+
+    Ok(())
+}

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -452,6 +452,10 @@ impl Connection {
     /// assert_eq!(rows.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(sql = sql))
+    )]
     pub fn query_sql(&self, sql: &str) -> Result<Vec<RecordBatch>, InfinoError> {
         debug!(sql, "running sql query");
 

--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -211,6 +211,10 @@ impl StorageProvider for AzureStorageProvider {
         .await
     }
 
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(uri = uri, len = range.end - range.start))
+    )]
     async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
         let path = self.path(uri)?;
         retry::complete_range(uri, range, |r| async {

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -194,6 +194,10 @@ impl StorageProvider for GcsStorageProvider {
         .await
     }
 
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(uri = uri, len = range.end - range.start))
+    )]
     async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
         let path = self.path(uri)?;
         retry::complete_range(uri, range, |r| async {

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -127,6 +127,10 @@ impl StorageProvider for LocalFsStorageProvider {
         Ok((bytes, meta))
     }
 
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(uri = uri, len = range.end - range.start))
+    )]
     async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
         let path = Self::path(uri)?;
         self.store

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -290,6 +290,10 @@ impl StorageProvider for S3StorageProvider {
         .await
     }
 
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(uri = uri, len = range.end - range.start))
+    )]
     async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
         let path = self.path(uri)?;
         retry::complete_range(uri, range, |r| async {

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -181,6 +181,7 @@ impl SuperfileReader {
     /// promotion can verify after the full superfile is materialized.
     ///
     /// [`open_lazy`]: SuperfileReader::open_lazy
+    #[cfg_attr(feature = "detailed-tracing", tracing::instrument(skip_all))]
     pub async fn open_lazy_with(
         source: Arc<dyn LazyByteSource>,
         _opts: OpenOptions,

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -57,6 +57,10 @@ use crate::{
 /// Warm opens are in-memory cache hits (microseconds); cold opens
 /// fetch the superfile header/footer from object storage. Always
 /// `await`ed so the open I/O overlaps across the fan-out.
+#[cfg_attr(
+    feature = "detailed-tracing",
+    tracing::instrument(skip_all, fields(uri = ?entry.uri))
+)]
 pub(crate) async fn open_reader(
     store: &Arc<dyn SuperfileReaderCache>,
     disk_cache: Option<&Arc<DiskCacheStore>>,

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -118,6 +118,10 @@ impl SupertableReader {
     /// `pub(crate)` kernel; the public surface is the sync
     /// [`SupertableReader::hybrid_search`].
     #[allow(clippy::too_many_arguments)]
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(text_col = text_col, vec_col = vec_col, k = k, mode = ?mode))
+    )]
     pub(crate) async fn hybrid_search_async(
         &self,
         text_col: &str,
@@ -168,6 +172,10 @@ impl Supertable {
     /// bounds each retriever and the fused result. `projection` follows
     /// the same rules as [`Supertable::bm25_search`].
     #[allow(clippy::too_many_arguments)]
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(text_col = text_col, vec_col = vec_col, k = k, mode = ?mode))
+    )]
     pub fn hybrid_search(
         &self,
         text_col: &str,

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -210,6 +210,10 @@ impl SupertableReader {
     /// sync→async bridge.
     ///
     /// [`AsciiLowerTokenizer`]: crate::superfile::fts::tokenize::AsciiLowerTokenizer
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode))
+    )]
     pub(crate) async fn bm25_search_async(
         &self,
         column: &str,
@@ -504,6 +508,10 @@ impl SupertableReader {
     ///
     /// `pub(crate)` async kernel; the public surface is the sync
     /// [`SupertableReader::token_match`].
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column, mode = ?mode))
+    )]
     pub(crate) async fn token_match_async(
         &self,
         column: &str,
@@ -979,6 +987,10 @@ impl Supertable {
     /// assert_eq!(rows[0].num_columns(), 3);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode))
+    )]
     pub fn bm25_search(
         &self,
         column: &str,
@@ -999,6 +1011,10 @@ impl Supertable {
     /// [`Supertable::bm25_search`], but the `score` column is `0.0` and
     /// row order is unspecified — a candidate set, not a ranking.
     /// `projection` follows the same rules as `bm25_search`.
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column, mode = ?mode))
+    )]
     pub fn token_match(
         &self,
         column: &str,
@@ -1027,6 +1043,10 @@ impl Supertable {
     /// like [`Supertable::bm25_search`], with `score` fixed at `0.0` and
     /// unspecified row order. `projection` follows the same rules as
     /// `bm25_search`.
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column))
+    )]
     pub fn exact_match(
         &self,
         column: &str,

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -95,6 +95,10 @@ impl SupertableReader {
     // Single-table SQL — off the public surface; catalog-level SQL is the
     // public entry point. Reachable from tests/benches via `test-helpers`.
     #[cfg(any(test, feature = "test-helpers"))]
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(sql = sql))
+    )]
     pub fn query_sql(&self, sql: &str) -> Result<Vec<RecordBatch>, QueryError> {
         // Read-consistency was applied when `Supertable::reader()` created
         // this pinned reader. SQL therefore observes the same snapshot as
@@ -138,6 +142,7 @@ impl SupertableReader {
     ///
     /// Freshness policy is applied when the reader is created by
     /// [`Supertable::reader`](crate::supertable::handle::Supertable::reader).
+    #[cfg_attr(feature = "detailed-tracing", tracing::instrument(skip_all))]
     fn sql_session_context(&self) -> Result<SessionContext, QueryError> {
         // This reader already pins the snapshot; clone is a handful of
         // Arc refcount bumps.

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -123,6 +123,10 @@ impl SupertableReader {
     /// `pub(crate)` async kernel — the public surface is the sync
     /// [`SupertableReader::vector_search`], which drives this via the
     /// sync→async bridge.
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column, k = k, dim = query.len()))
+    )]
     pub(crate) async fn vector_search_async(
         &self,
         column: &str,
@@ -370,6 +374,10 @@ impl SupertableReader {
     ///
     /// `pub(crate)` async kernel — the public surface is the sync
     /// [`Self::vector_hits_filtered`].
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column, k = k, dim = query.len()))
+    )]
     pub(crate) async fn vector_hits_filtered_async(
         &self,
         column: &str,
@@ -784,6 +792,10 @@ impl Supertable {
     /// assert!(rows.iter().map(|b| b.num_rows()).sum::<usize>() >= 1);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column, k = k, dim = query.len()))
+    )]
     pub fn vector_search(
         &self,
         column: &str,

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -289,6 +289,10 @@ impl Supertable {
     /// posts.append(&batch)?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(rows = batch.num_rows()))
+    )]
     pub fn append(&self, batch: &RecordBatch) -> Result<(), InfinoError> {
         let mut w = self.writer()?;
         w.append(batch)?;
@@ -317,6 +321,10 @@ impl Supertable {
     /// assert_eq!(stats.matched(), 1);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(new_rows = new_rows.num_rows()))
+    )]
     pub fn update(
         &self,
         predicate: Expr,
@@ -346,6 +354,7 @@ impl Supertable {
     /// assert_eq!(stats.n_tombstoned(), 1);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg_attr(feature = "detailed-tracing", tracing::instrument(skip_all))]
     pub fn delete(&self, predicate: Expr) -> Result<MutationStats, InfinoError> {
         let mut w = self.writer()?;
         w.delete(predicate)?;
@@ -404,6 +413,10 @@ impl SupertableWriter {
     /// unconditionally; the buffered batch's schema therefore
     /// matches [`SupertableOptions::scalar_schema`] with the
     /// id column at position 0.
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(rows = batch.num_rows(), buffered = self.buffer.len()))
+    )]
     pub fn append(&mut self, batch: &RecordBatch) -> Result<(), BuildError> {
         let options = &self.inner.options;
 
@@ -692,6 +705,14 @@ impl SupertableWriter {
     /// [`CommitResult`]: crate::supertable::mutations::CommitResult
     /// [`MutationStats`]: crate::supertable::mutations::MutationStats
     /// [`CommitError::PartialCommit`]: crate::supertable::mutations::CommitError::PartialCommit
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(
+            buffered = self.buffer.len(),
+            updates = self.pending_updates.len(),
+            deletes = self.pending_deletes.len(),
+        ))
+    )]
     pub fn commit(&mut self) -> Result<CommitResult, CommitError> {
         // Step 1: flush appends. A failure here is atomic —
         // the buffer is preserved and no mutation WAL has
@@ -945,6 +966,10 @@ impl SupertableWriter {
     /// Rows are balanced evenly across shards regardless of the
     /// caller's `append()` cadence — many small appends followed by
     /// one `commit` produce the same shard layout as one large append.
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(buffered = self.buffer.len()))
+    )]
     fn commit_appends_internal(&mut self) -> Result<(), BuildError> {
         if self.buffer.is_empty() {
             return Ok(());
@@ -1757,6 +1782,10 @@ pub(in crate::supertable) fn persist_commit(
 // the parallelism below the threshold. The default
 // threshold (100 MiB) matches the S3 SDK's standard
 // cutoff.
+#[cfg_attr(
+    feature = "detailed-tracing",
+    tracing::instrument(skip_all, fields(superfiles = pending_storage_writes.len()))
+)]
 pub async fn write_superfile_list(
     storage: &Arc<dyn StorageProvider>,
     opts: &Arc<SupertableOptions>,


### PR DESCRIPTION
### What does this PR do?
- Adds a mechanism to track the time taken by some important functions ( e.g `commit`, `append`, `bm25_query`, `sql_query` etc

### Why do we need this change?
- Having the exact duration of the functions helps get insights on how long each function takes, which aids performance improvements

### How do we do this change?
- Introduce a `detailed-tracing` feature. When the engine is built with this feature, it logs the spans of some important functions. Having a separate feature prevents the production performance from being affected

### How has this been tested?
- Manual test
- Example added in examples/