### PR TITLE
[5/n] feat memory: gate vector search's cold fetch on the connection memory budget

### DIFF
--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -1163,6 +1163,7 @@ pub mod vector {
                 Some(Arc::clone(allow)),
                 None,
                 None,
+                None,
             ))
             .expect("filtered sweep query");
             sum += corpus::recall_at_k(&hits, gt);
@@ -1302,6 +1303,7 @@ pub mod vector {
                     TOP_K,
                     opts,
                     Some(Arc::clone(allow)),
+                    None,
                     None,
                     None,
                 ))
@@ -1486,6 +1488,7 @@ pub mod vector {
                             Some(Arc::clone(&allow)),
                             None,
                             None,
+                            None,
                         ))
                         .expect("filtered recall query");
                         recalls.push(corpus::recall_at_k(&hits, gt));
@@ -1573,6 +1576,7 @@ pub mod vector {
                                 TOP_K,
                                 exec_vec::search_opts(nominal_nprobe, nominal_rerank),
                                 set.clone(),
+                                None,
                                 None,
                                 None,
                             ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,13 @@ pub mod supertable;
 #[cfg(not(feature = "test-helpers"))]
 pub(crate) mod supertable;
 
+// Same reason: benches/tests that drive the vector kernel name
+// `ConnectionMemoryBudget` in its signatures.
+#[cfg(feature = "test-helpers")]
+pub mod memory;
+#[cfg(not(feature = "test-helpers"))]
+pub(crate) mod memory;
+
 // `roaring` is already an internal dependency. Re-export it under
 // `test-helpers` only, so a bench can build an allow-set for the filtered
 // vector kernel without its own `roaring` dependency. Off the public
@@ -130,7 +137,6 @@ pub use roaring;
 // public items are re-exported at the crate root below.
 mod catalog;
 mod error;
-mod memory;
 mod runtime_bridge;
 mod utils;
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -109,8 +109,12 @@ const ENFORCED_BUDGET_DENOMINATOR: u128 = 10;
 /// limit, not a different policy — so there is no trait. The one trait we do
 /// implement is the query engine's memory-pool interface, in a thin adapter
 /// that forwards to an `Arc<ConnectionMemoryBudget>`.
+///
+/// Must be `pub`: the `pub` vector-search functions take this type as an
+/// argument. It is still not public API, because `lib.rs` makes the whole `memory`
+/// module `pub` only under `test-helpers``, so a shipped build keeps this type crate-internal.
 #[derive(Debug)]
-pub(crate) struct ConnectionMemoryBudget {
+pub struct ConnectionMemoryBudget {
     // Enforced ceiling in bytes, already reduced to the headroom gate.
     // `None` is measure-only: count usage, never refuse.
     limit: Option<usize>,
@@ -179,7 +183,7 @@ impl ConnectionMemoryBudget {
     /// Reserve `n` bytes, returning a guard that frees them on drop. Fails with
     /// [`OverBudget`] if the reservation would cross the ceiling; a measured
     /// budget always succeeds.
-    pub fn try_reserve(self: &Arc<Self>, n: usize) -> Result<Reservation, OverBudget> {
+    pub(crate) fn try_reserve(self: &Arc<Self>, n: usize) -> Result<Reservation, OverBudget> {
         self.try_grow(n)?;
 
         Ok(Reservation {
@@ -246,19 +250,28 @@ impl ConnectionMemoryBudget {
         self.used.load(Ordering::Relaxed)
     }
 
-    /// The largest [`used`](Self::used) ever reached. Only grows; never reset.
-    pub(crate) fn peak(&self) -> usize {
-        self.peak_used.load(Ordering::Relaxed)
+    test_visible! {
+        /// The largest [`used`](Self::used) ever reached. Only grows; never reset.
+        /// Test-visible so integration tests can assert a query actually reserved
+        /// against the budget: a peak above 0 means the budget was wired and exercised.
+        fn peak(&self) -> usize {
+            self.peak_used.load(Ordering::Relaxed)
+        }
     }
 
-    /// The enforced ceiling, or `None` when measured.
-    pub(crate) fn limit(&self) -> Option<usize> {
-        self.limit
+    test_visible! {
+        /// The enforced ceiling, or `None` when measured.
+        fn limit(&self) -> Option<usize> {
+            self.limit
+        }
     }
 
-    /// Reservations refused so far.
-    pub(crate) fn denials(&self) -> u64 {
-        self.denials.load(Ordering::Relaxed)
+    test_visible! {
+        /// Reservations refused so far. Test-visible so integration tests can
+        /// assert the gate fired on an over-budget query.
+        fn denials(&self) -> u64 {
+            self.denials.load(Ordering::Relaxed)
+        }
     }
 }
 
@@ -284,6 +297,7 @@ impl fmt::Display for ConnectionMemoryBudget {
 #[derive(Debug)]
 pub(crate) struct Reservation {
     budget: Arc<ConnectionMemoryBudget>,
+    // memory in bytes, which is to be reserved
     size: usize,
 }
 

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -197,6 +197,12 @@ pub enum VectorError {
     /// `LazyByteSourceError` should match on the source directly.
     #[error("lazy source error during vector search: {0}")]
     LazySource(String),
+
+    /// A cold cluster-block fetch would cross the connection memory budget;
+    /// the search is refused before the fetch. Surfaces as
+    /// `InfinoError::OverBudget`.
+    #[error("vector search exceeded the connection memory budget: {0}")]
+    OverBudget(String),
 }
 
 #[cfg(test)]

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -43,6 +43,7 @@ use rayon::ThreadPool;
 use roaring::RoaringBitmap;
 
 use crate::{
+    memory::ConnectionMemoryBudget,
     superfile::{
         BytesLazyByteSource, LazyByteSource, LazySubSource, ReadError,
         format::{self, footer, kv},
@@ -1121,7 +1122,7 @@ impl SuperfileReader {
         k: usize,
         options: VectorSearchOptions,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        self.vector_hits_filtered_async(column, query, k, options, None, None, None)
+        self.vector_hits_filtered_async(column, query, k, options, None, None, None, None)
             .await
     }
 
@@ -1145,6 +1146,7 @@ impl SuperfileReader {
         allow: Option<Arc<RoaringBitmap>>,
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
+        budget: Option<Arc<ConnectionMemoryBudget>>,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let filtered = allow.is_some();
         let (nprobe, rerank_mult) = options.resolve(filtered);
@@ -1152,10 +1154,18 @@ impl SuperfileReader {
             .vec()
             .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
         let rerank_mult = v.public_rerank_mult(column, rerank_mult);
-        Ok(
-            v.search_async(column, query, k, nprobe, rerank_mult, allow, deny, pool)
-                .await?,
+        Ok(v.search_async(
+            column,
+            query,
+            k,
+            nprobe,
+            rerank_mult,
+            allow,
+            deny,
+            pool,
+            budget,
         )
+        .await?)
     }
 
     /// As [`Self::vector_search`], but probes an **externally chosen**
@@ -1171,8 +1181,10 @@ impl SuperfileReader {
         clusters: &[u32],
         options: VectorSearchOptions,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        self.vector_search_clusters_filtered(column, query, k, clusters, options, None, None, None)
-            .await
+        self.vector_search_clusters_filtered(
+            column, query, k, clusters, options, None, None, None, None,
+        )
+        .await
     }
 
     /// As [`Self::vector_search_clusters`], but restricts the kNN
@@ -1193,6 +1205,7 @@ impl SuperfileReader {
         allow: Option<Arc<RoaringBitmap>>,
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
+        budget: Option<Arc<ConnectionMemoryBudget>>,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let filtered = allow.is_some();
         let (_, rerank_mult) = options.resolve(filtered);
@@ -1200,10 +1213,18 @@ impl SuperfileReader {
             .vec()
             .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
         let rerank_mult = v.public_rerank_mult(column, rerank_mult);
-        Ok(
-            v.search_clusters_async(column, query, k, clusters, rerank_mult, allow, deny, pool)
-                .await?,
+        Ok(v.search_clusters_async(
+            column,
+            query,
+            k,
+            clusters,
+            rerank_mult,
+            allow,
+            deny,
+            pool,
+            budget,
         )
+        .await?)
     }
 }
 

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -26,26 +26,29 @@ use serde::Deserialize;
 use tokio::sync::oneshot;
 
 pub(crate) use crate::superfile::lazy_source::Source;
-use crate::superfile::{
-    ReadError,
-    error::VectorError,
-    format::{
-        checksum::crc32c,
-        vec::{
-            CLUSTER_IDX_COUNT_OFFSET, CLUSTER_IDX_ENTRY_BYTES, MAGIC_BYTES, U32_BYTES, U64_BYTES,
-            dir_entry, outer_hdr, sub_hdr,
+use crate::{
+    memory::{ConnectionMemoryBudget, Reservation},
+    superfile::{
+        ReadError,
+        error::VectorError,
+        format::{
+            checksum::crc32c,
+            vec::{
+                CLUSTER_IDX_COUNT_OFFSET, CLUSTER_IDX_ENTRY_BYTES, MAGIC_BYTES, U32_BYTES,
+                U64_BYTES, dir_entry, outer_hdr, sub_hdr,
+            },
+            {self},
         },
-        {self},
-    },
-    lazy_source::{LazyByteSource, LazyByteSourceError, PrefetchedSource},
-    vector::{
-        distance::{
-            Metric, SQ8_RESIDUAL_DIVISOR, Sq8Kernel, Sq8ResidualEpsilonKernel, decode_sq8_residual,
-            distance_bytes, distance_bytes_codec,
+        lazy_source::{LazyByteSource, LazyByteSourceError, PrefetchedSource},
+        vector::{
+            distance::{
+                Metric, SQ8_RESIDUAL_DIVISOR, Sq8Kernel, Sq8ResidualEpsilonKernel,
+                decode_sq8_residual, distance_bytes, distance_bytes_codec,
+            },
+            quant::BitQuantizer,
+            rerank_codec::RerankCodec,
+            rotation::RandomRotation,
         },
-        quant::BitQuantizer,
-        rerank_codec::RerankCodec,
-        rotation::RandomRotation,
     },
 };
 
@@ -168,6 +171,8 @@ struct ProbeCtx<'a> {
     deny: Option<Arc<RoaringBitmap>>,
     /// Rayon pool for CPU work. `None` falls back to the global pool.
     pool: Option<Arc<ThreadPool>>,
+    /// Connection memory budget for the cold cluster-block fetch. See [`reserve_cold_fetch`].
+    budget: Option<Arc<ConnectionMemoryBudget>>,
 }
 
 impl ColumnReader {
@@ -1357,6 +1362,9 @@ impl VectorReader {
             allow: None,
             deny: None,
             pool: None,
+            // `search` is a test/bench-only entry (production vector search goes
+            // through the async paths); its cold fetch is not budget-gated.
+            budget: None,
         };
         let (candidates, survivor_full_ranges) = match build_shortlist(
             col,
@@ -1435,6 +1443,7 @@ impl VectorReader {
         // path; `None` leaves ranking unchanged.
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
+        budget: Option<Arc<ConnectionMemoryBudget>>,
     ) -> Result<Vec<(u32, f32)>, VectorError> {
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
@@ -1490,6 +1499,7 @@ impl VectorReader {
             allow,
             deny,
             pool,
+            budget,
         };
         self.probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
             .await
@@ -1517,6 +1527,7 @@ impl VectorReader {
         // path; `None` leaves ranking unchanged.
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
+        budget: Option<Arc<ConnectionMemoryBudget>>,
     ) -> Result<Vec<(u32, f32)>, VectorError> {
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
@@ -1548,6 +1559,7 @@ impl VectorReader {
             allow,
             deny,
             pool,
+            budget,
         };
         self.probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
             .await
@@ -1590,6 +1602,12 @@ impl VectorReader {
             .iter()
             .map(|range| self.source.try_get_range_sync(range.clone()))
             .collect();
+
+        // Reserve the cold fetch against the connection budget before it fires;
+        // held for the rest of the probe (covers the cluster blocks). Warm slices
+        // reserve nothing.
+        let mut _cold_guard: Option<Reservation> = None;
+
         let (cluster_blocks, lazy_sq8_meta_bytes, survivor_only_rerank_fetch) =
             if let Some(prefix_blocks) = prefix_blocks_sync {
                 // Warm: prefixes resident. Keep the survivor-only rerank
@@ -1620,6 +1638,10 @@ impl VectorReader {
                     .iter()
                     .map(|&(_, off, cnt)| col.cluster_block_range(off, cnt))
                     .collect();
+
+                _cold_guard =
+                    reserve_cold_fetch(&self.source, &cluster_full_ranges, ctx.budget.as_ref())?;
+
                 let (blocks, meta) = get_cluster_ranges_coalesced_with_extra_async(
                     &self.source,
                     &cluster_full_ranges,
@@ -3059,6 +3081,45 @@ fn apply_coalesce(plan: &CoalescePlan, fetched: &[Bytes]) -> Vec<Bytes> {
         .collect()
 }
 
+// Reserve from the budget, the bytes a cold fetch is about to allocate, and if
+// they do not fit, refuse the search with [`VectorError::OverBudget`] before
+// anything is allocated.
+//
+// Only the ranges that must be fetched are counted. A range already in memory
+// is returned as a zero-copy slice and needs no new memory, so each range is
+// checked and only the missing ("cold") bytes are reserved.
+//
+// The returned guard owns the reservation: hold it while the fetched bytes are
+// in use, and dropping it returns them to the budget. A range evicted between
+// the check here and the fetch is read without a reservation and covered by
+// the budget's headroom.
+fn reserve_cold_fetch(
+    source: &Source,
+    ranges: &[Range<usize>],
+    budget: Option<&Arc<ConnectionMemoryBudget>>,
+) -> Result<Option<Reservation>, VectorError> {
+    let Some(budget) = budget else {
+        // No budget attached: measure-only, nothing to gate.
+        return Ok(None);
+    };
+
+    let cold_bytes: usize = ranges
+        .iter()
+        .filter(|r| source.try_get_range_sync((*r).clone()).is_none())
+        .map(|r| r.len())
+        .sum();
+
+    if cold_bytes == 0 {
+        // Everything already exists in memory.
+        return Ok(None);
+    }
+
+    budget
+        .try_reserve(cold_bytes)
+        .map(Some)
+        .map_err(|e| VectorError::OverBudget(e.to_string()))
+}
+
 fn get_cluster_ranges_coalesced_with_extra(
     source: &Source,
     ranges: &[Range<usize>],
@@ -3404,7 +3465,7 @@ mod tests {
         let (k, rerank, n_cent) = (5usize, 5usize, 4u32);
 
         let full = r
-            .search_async("v", q, k, n_cent as usize, rerank, None, None, None)
+            .search_async("v", q, k, n_cent as usize, rerank, None, None, None, None)
             .await
             .expect("search_async");
         let probed = r
@@ -3414,6 +3475,7 @@ mod tests {
                 k,
                 &(0..n_cent).collect::<Vec<_>>(),
                 rerank,
+                None,
                 None,
                 None,
                 None,
@@ -3432,7 +3494,7 @@ mod tests {
 
         // Probing no clusters returns nothing.
         let none = r
-            .search_clusters_async("v", q, k, &[], rerank, None, None, None)
+            .search_clusters_async("v", q, k, &[], rerank, None, None, None, None)
             .await
             .expect("search_clusters_async empty");
         assert!(none.is_empty(), "probing no clusters returns no hits");
@@ -6540,11 +6602,11 @@ mod tests {
         .expect("open_lazy");
 
         let hits_lazy = r_lazy
-            .search_async("v", &all[17], 5, 4, 20, None, None, None)
+            .search_async("v", &all[17], 5, 4, 20, None, None, None, None)
             .await
             .expect("lazy cold Sq8 search_async");
         let hits_eager = r_eager
-            .search_async("v", &all[17], 5, 4, 20, None, None, None)
+            .search_async("v", &all[17], 5, 4, 20, None, None, None, None)
             .await
             .expect("eager Sq8 search_async");
         // As in the sync lazy-Sq8 test, pin set overlap rather than exact
@@ -6557,6 +6619,135 @@ mod tests {
             eager_ids.intersection(&lazy_ids).count() >= 1,
             "lazy cold Sq8 search_async result set must overlap the eager top-5"
         );
+    }
+
+    #[tokio::test]
+    async fn cold_vector_search_over_budget_is_refused() {
+        // A cold lazy source must fetch the cluster blocks onto the heap. Under
+        // a 0-byte gate the reservation fails, so the search is refused as
+        // OverBudget before the fetch fires, rather than allocating.
+        let (blob, json, all) =
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8ResidualEpsilon, Metric::L2Sq);
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        counting.disable_sync(); // force the cold path: no resident slices
+
+        let r_lazy = VectorReader::open_lazy(
+            StdArc::clone(&counting) as StdArc<dyn LazyByteSource>,
+            &json,
+            OpenOptions::for_object_store(),
+        )
+        .await
+        .expect("open_lazy");
+
+        // with_limit(1) -> 0-byte enforced gate: any cold fetch is refused.
+        let budget = ConnectionMemoryBudget::with_limit(1);
+        let err = r_lazy
+            .search_async(
+                "v",
+                &all[0],
+                5,
+                4,
+                20,
+                None,
+                None,
+                None,
+                Some(budget.clone()),
+            )
+            .await
+            .expect_err("cold fetch over a 0-byte gate is refused");
+        assert!(matches!(err, VectorError::OverBudget(_)), "got {err:?}");
+
+        // The gate fired, and a refused reservation commits nothing.
+        assert!(budget.denials() >= 1, "refusal must be counted");
+        assert_eq!(budget.peak(), 0, "refused fetch commits nothing");
+    }
+
+    #[tokio::test]
+    async fn cold_vector_search_under_measured_budget_runs() {
+        // A measured budget tracks but never refuses, so the cold search runs.
+        let (blob, json, all) =
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8ResidualEpsilon, Metric::L2Sq);
+
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        counting.disable_sync();
+
+        let r_lazy = VectorReader::open_lazy(
+            StdArc::clone(&counting) as StdArc<dyn LazyByteSource>,
+            &json,
+            OpenOptions::for_object_store(),
+        )
+        .await
+        .expect("open_lazy");
+
+        let budget = ConnectionMemoryBudget::measured();
+        let hits = r_lazy
+            .search_async(
+                "v",
+                &all[0],
+                5,
+                4,
+                20,
+                None,
+                None,
+                None,
+                Some(budget.clone()),
+            )
+            .await
+            .expect("measured budget never refuses");
+        assert!(!hits.is_empty(), "measured cold search returns hits");
+
+        // A non-zero peak proves the cold fetch actually reserved against the
+        // budget (the reservation ran on the query path); a measured budget
+        // never denies. The cold cluster-block fetch for this fixture (32 docs,
+        // 4 clusters, 64-dim, Sq8 rerank) is a deterministic 4608 B; assert a
+        // band around it, wide enough to survive minor codec / layout drift.
+        const MEASURED_PEAK_LOW_BYTES: usize = 3_000;
+        const MEASURED_PEAK_HIGH_BYTES: usize = 8_000;
+
+        assert_eq!(budget.denials(), 0, "measured budget never denies");
+
+        let peak = budget.peak();
+        assert!(
+            (MEASURED_PEAK_LOW_BYTES..=MEASURED_PEAK_HIGH_BYTES).contains(&peak),
+            "measured cold search peak {peak} B outside expected \
+             [{MEASURED_PEAK_LOW_BYTES}, {MEASURED_PEAK_HIGH_BYTES}] band; \
+             a peak near 0 means the budget was never exercised"
+        );
+    }
+
+    #[tokio::test]
+    async fn warm_vector_search_is_not_gated() {
+        // An in-memory (resident) reader slices the cluster blocks zero-copy
+        // instead of fetching, so it allocates no per-query heap: even a 0-byte
+        // gate reserves nothing and the search runs.
+        let (blob, json, all) =
+            build_small_superfile(32, 4, 64, RerankCodec::Sq8ResidualEpsilon, Metric::L2Sq);
+        let r_eager = VectorReader::open(blob, &json).expect("eager open");
+        let budget = ConnectionMemoryBudget::with_limit(1);
+
+        let hits = r_eager
+            .search_async(
+                "v",
+                &all[0],
+                5,
+                4,
+                20,
+                None,
+                None,
+                None,
+                Some(budget.clone()),
+            )
+            .await
+            .expect("warm search allocates nothing, so it is not gated");
+        assert!(
+            !hits.is_empty(),
+            "warm search returns hits under a tiny budget"
+        );
+
+        // Resident slices reserve nothing: no denial, and peak stays 0 even
+        // under a 0-byte gate. This is what keeps warm queries off the gate.
+        assert_eq!(budget.denials(), 0, "warm search reserves nothing");
+        assert_eq!(budget.peak(), 0, "warm search commits no bytes");
     }
 
     #[tokio::test]
@@ -6577,11 +6768,31 @@ mod tests {
 
         let clusters: Vec<u32> = (0..4).collect();
         let hits_lazy = r_lazy
-            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None, None, None)
+            .search_clusters_async(
+                "embedding",
+                &all[19],
+                5,
+                &clusters,
+                5,
+                None,
+                None,
+                None,
+                None,
+            )
             .await
             .expect("lazy cold search_clusters_async");
         let hits_eager = r_eager
-            .search_clusters_async("embedding", &all[19], 5, &clusters, 5, None, None, None)
+            .search_clusters_async(
+                "embedding",
+                &all[19],
+                5,
+                &clusters,
+                5,
+                None,
+                None,
+                None,
+                None,
+            )
             .await
             .expect("eager search_clusters_async");
         assert_eq!(
@@ -6591,7 +6802,17 @@ mod tests {
         // Out-of-range cluster ids are ignored; an empty selection yields
         // no hits.
         let none = r_lazy
-            .search_clusters_async("embedding", &all[19], 5, &[999u32], 5, None, None, None)
+            .search_clusters_async(
+                "embedding",
+                &all[19],
+                5,
+                &[999u32],
+                5,
+                None,
+                None,
+                None,
+                None,
+            )
             .await
             .expect("out-of-range clusters");
         assert!(none.is_empty(), "ids >= n_cent are ignored");
@@ -6603,16 +6824,16 @@ mod tests {
         let (blob, json) = build_blob(32, 16, 4, Metric::L2Sq);
         let r = VectorReader::open(blob, &json).expect("open");
         let unknown = r
-            .search_async("nope", &[0.0; 16], 5, 4, 5, None, None, None)
+            .search_async("nope", &[0.0; 16], 5, 4, 5, None, None, None, None)
             .await;
         assert!(matches!(unknown, Err(VectorError::UnknownColumn(_))));
         let dim = r
-            .search_async("embedding", &[0.0; 8], 5, 4, 5, None, None, None)
+            .search_async("embedding", &[0.0; 8], 5, 4, 5, None, None, None, None)
             .await;
         assert!(matches!(dim, Err(VectorError::DimensionMismatch { .. })));
         // k == 0 short-circuits to an empty result.
         let empty = r
-            .search_async("embedding", &[0.0; 16], 0, 4, 5, None, None, None)
+            .search_async("embedding", &[0.0; 16], 0, 4, 5, None, None, None, None)
             .await
             .expect("k=0 empty");
         assert!(empty.is_empty());
@@ -7206,7 +7427,7 @@ mod tests {
         .expect("open_lazy for search_async");
         flaky_a.fail_from_now();
         let err = ra
-            .search_async("embedding", &all[0], 5, 4, 5, None, None, None)
+            .search_async("embedding", &all[0], 5, 4, 5, None, None, None, None)
             .await
             .expect_err("search_async must surface failure");
         assert!(
@@ -7224,7 +7445,17 @@ mod tests {
         .expect("open_lazy for search_clusters_async");
         flaky_c.fail_from_now();
         let err = rc
-            .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None, None, None)
+            .search_clusters_async(
+                "embedding",
+                &all[0],
+                5,
+                &[0, 1, 2, 3],
+                5,
+                None,
+                None,
+                None,
+                None,
+            )
             .await
             .expect_err("search_clusters_async must surface failure");
         assert!(
@@ -7449,7 +7680,7 @@ mod tests {
             .expect("open_lazy search_async");
             flaky_a.fail_after_call(fail_at);
             match ra
-                .search_async("embedding", &all[0], 5, 4, 5, None, None, None)
+                .search_async("embedding", &all[0], 5, 4, 5, None, None, None, None)
                 .await
             {
                 Err(VectorError::LazySource(_)) => async_errors += 1,
@@ -7467,7 +7698,17 @@ mod tests {
             .expect("open_lazy search_clusters_async");
             flaky_c.fail_after_call(fail_at);
             match rc
-                .search_clusters_async("embedding", &all[0], 5, &[0, 1, 2, 3], 5, None, None, None)
+                .search_clusters_async(
+                    "embedding",
+                    &all[0],
+                    5,
+                    &[0, 1, 2, 3],
+                    5,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
                 .await
             {
                 Err(VectorError::LazySource(_)) => clusters_errors += 1,

--- a/src/supertable/lazy_source.rs
+++ b/src/supertable/lazy_source.rs
@@ -427,6 +427,29 @@ mod tests {
         assert_eq!(storage.call_count(), 0);
     }
 
+    /// `StorageRangeSource` holds no local buffer, so it can never satisfy a
+    /// range synchronously: `try_get_range_sync` is always `None` and every
+    /// read falls to the async `range` GET. Callers treat a `None` here as "not
+    /// resident, must fetch"; the connection memory budget keys off exactly
+    /// that, so a future sync cache that returned `Some` would read as resident
+    /// and silently escape the cold-fetch gate. This pins the invariant.
+    #[tokio::test]
+    async fn try_get_range_sync_is_never_resident() {
+        let blob = Bytes::from(vec![7u8; 256]);
+        let storage = Arc::new(ChunkedStorage::new(blob.clone(), 256, blob.len()));
+        let src = StorageRangeSource::with_known_size(
+            Arc::clone(&storage) as Arc<dyn StorageProvider>,
+            "seg.sf.parquet",
+            blob.len() as u64,
+        );
+
+        // `None` even for in-bounds ranges (nothing is buffered locally), and
+        // the check answers from memory without a storage call.
+        assert!(src.try_get_range_sync(0, 64).is_none());
+        assert!(src.try_get_range_sync(200, 56).is_none());
+        assert_eq!(storage.call_count(), 0);
+    }
+
     /// `new` issues one HEAD up-front and caches the discovered size,
     /// so `size()` is non-zero before any `range`/`tail` I/O.
     #[tokio::test]

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -816,6 +816,15 @@ impl SupertableOptions {
         }
     }
 
+    test_visible! {
+        /// The connection memory budget these options carry. Exposed for
+        /// integration tests that assert budget accounting (peak / denials)
+        /// after a query, confirming the budget was wired to the query path.
+        fn connection_budget(&self) -> &Arc<ConnectionMemoryBudget> {
+            &self.connection_memory_budget
+        }
+    }
+
     /// Apply system [`Config`] to this `SupertableOptions`.
     /// Rebuilds the reader / writer thread pools, copies
     /// supertable knobs, and attaches configured persistent

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -75,7 +75,12 @@ use tracing::debug;
 use super::{SuperfileHit, candidate::CandidatePlan, dispatch, exec::common::resolve_hits_named};
 pub use crate::superfile::reader::VectorSearchOptions;
 use crate::{
-    superfile::{SuperfileReader, fts::reader::BoolMode, vector::distance::Metric},
+    superfile::{
+        SuperfileReader,
+        error::{ReadError, VectorError},
+        fts::reader::BoolMode,
+        vector::distance::Metric,
+    },
     supertable::{
         error::QueryError,
         handle::{Supertable, SupertableReader},
@@ -83,6 +88,20 @@ use crate::{
         tombstones::SidecarCache,
     },
 };
+
+/// Map a per-superfile vector-search error to a query error. A budget refusal
+/// (the kernel's `VectorError::OverBudget`, boxed in `ReadError::Vector`) keeps
+/// its own variant so it surfaces as the public `InfinoError::OverBudget`;
+/// anything else is a generic query error.
+fn vector_read_query_error(e: ReadError) -> QueryError {
+    match e {
+        ReadError::Vector(v) => match *v {
+            VectorError::OverBudget(m) => QueryError::OverBudget(m),
+            other => QueryError::Parquet(other.to_string()),
+        },
+        other => QueryError::Parquet(other.to_string()),
+    }
+}
 
 /// An optional text-predicate filter for vector kNN search. When
 /// supplied, kNN is ranked only among rows matching the predicate
@@ -286,6 +305,8 @@ impl SupertableReader {
         let column_arc = Arc::new(column.to_owned());
         let query_arc = Arc::new(query.to_vec());
         let reader_pool = Arc::clone(&manifest.options.reader_pool);
+        // Per-connection memory budget: gates each superfile's cold cluster-block fetch.
+        let budget = Some(Arc::clone(&manifest.options.connection_memory_budget));
 
         // `fanout_with`, not `fanout`: the body needs each superfile's  tombstone bitmap *before* its kernel
         // to push it in as a deny set (`fanout` only drops tombstones post-rank, which underflows).
@@ -297,6 +318,7 @@ impl SupertableReader {
             let column = Arc::clone(&column_arc);
             let query = Arc::clone(&query_arc);
             let reader_pool = Arc::clone(&reader_pool);
+            let budget = budget.clone();
             async move {
                 // For unfiltered path:
                 //  - it resolve this superfile's tombstone  bitmap once (a warm cache hit after the orchestrator's
@@ -315,19 +337,19 @@ impl SupertableReader {
                     Probe::Clusters(ids) => {
                         reader
                             .vector_search_clusters_filtered(
-                                &column, &query, k, &ids, options, bitmap, deny, pool,
+                                &column, &query, k, &ids, options, bitmap, deny, pool, budget,
                             )
                             .await
                     }
                     Probe::Nprobe => {
                         reader
                             .vector_hits_filtered_async(
-                                &column, &query, k, options, bitmap, deny, pool,
+                                &column, &query, k, options, bitmap, deny, pool, budget,
                             )
                             .await
                     }
                 }
-                .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                .map_err(vector_read_query_error)?;
 
                 Ok::<Vec<SuperfileHit>, QueryError>(dispatch::tag_hits(&entry, hits))
             }
@@ -820,11 +842,13 @@ mod tests {
     use roaring::RoaringBitmap;
     use tokio::runtime;
 
-    use super::{VectorFilter, VectorSearchOptions};
+    use super::{VectorFilter, VectorSearchOptions, vector_read_query_error};
     use crate::{
+        InfinoError,
         superfile::{
             SuperfileReader,
             builder::{BuilderOptions, FtsConfig, SuperfileBuilder, VectorConfig},
+            error::{ReadError, VectorError},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{
@@ -846,6 +870,28 @@ mod tests {
             .build()
             .expect("test runtime")
             .block_on(fut)
+    }
+
+    #[test]
+    fn over_budget_vector_error_surfaces_as_infino_over_budget() {
+        // A cold vector search that crosses the budget returns
+        // `VectorError::OverBudget` (see the vector reader tests). Confirm it
+        // routes all the way to the public `InfinoError::OverBudget` and isn't
+        // flattened to a generic query error.
+        let read_err = ReadError::Vector(Box::new(VectorError::OverBudget("gate".into())));
+        let q = vector_read_query_error(read_err);
+
+        assert!(matches!(q, QueryError::OverBudget(_)), "got {q:?}");
+        assert!(matches!(
+            InfinoError::from(QueryError::OverBudget("x".into())),
+            InfinoError::OverBudget(_)
+        ));
+
+        // A non-budget read error stays a generic query error.
+        assert!(matches!(
+            vector_read_query_error(ReadError::MissingKv("k")),
+            QueryError::Parquet(_)
+        ));
     }
 
     fn fixed_list_f32(dim: usize) -> DataType {

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -78,6 +78,33 @@ pub fn default_disk_cache(
     DiskCacheStore::new(storage, cfg, pinned).expect("test disk cache")
 }
 
+/// A `DiskCacheStore` in `LazyForegroundWithBackgroundFill`: the foreground
+/// query reads through an `open_lazy` `StorageRangeSource`, so the superfile's
+/// bytes stay non-resident and every cold read is an object-store GET. That is
+/// the path the connection budget gates. `default_disk_cache`
+/// (`HybridWithPrefetch`) instead collects the cold responses into a resident
+/// in-memory reader, which reads warm and reserves nothing. Same budget,
+/// timers, and eviction otherwise.
+pub fn lazy_foreground_disk_cache(
+    storage: Arc<dyn StorageProvider>,
+    cache_root: &Path,
+) -> Arc<DiskCacheStore> {
+    let cfg = DiskCacheConfig {
+        cache_root: cache_root.to_path_buf(),
+        disk_budget_bytes: TEST_DISK_CACHE_BUDGET_BYTES,
+        cold_fetch_mode: ColdFetchMode::LazyForegroundWithBackgroundFill,
+        cold_fetch_streams: TEST_COLD_FETCH_STREAMS,
+        cold_fetch_chunk_bytes: TEST_COLD_FETCH_CHUNK_BYTES,
+        mmap_cold_threshold_secs: 0,
+        mmap_sweep_interval_secs: 0,
+        eviction: Box::new(LruPolicy::new()),
+        verify_crc_on_open: true,
+        ..Default::default()
+    };
+    let pinned: Arc<dyn Fn() -> HashSet<_> + Send + Sync> = Arc::new(HashSet::new);
+    DiskCacheStore::new(storage, cfg, pinned).expect("test lazy-foreground disk cache")
+}
+
 /// Build a `Decimal128Array(38, 0)` from `u64` ids.
 ///
 /// Centralizes the verbose three-step construction that

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -58,6 +58,7 @@ use std::{net::SocketAddr, sync::Arc};
 use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    InfinoError,
     config::{
         CompactionSettings, Config, MemorySettings, StorageBackend, StorageColdFetchMode,
         StorageSettings, SupertableSettings,
@@ -68,7 +69,10 @@ use infino::{
         query::VectorSearchOptions,
         storage::{S3StorageProvider, StorageProvider},
     },
-    test_helpers::{build_title_batch, default_disk_cache, default_supertable_options},
+    test_helpers::{
+        build_title_batch, default_disk_cache, default_supertable_options,
+        lazy_foreground_disk_cache,
+    },
 };
 
 /// Single-thread rayon pool for deterministic S3 smoke runs.
@@ -85,6 +89,40 @@ const VECTOR_SEARCH_K: usize = 3;
 const VECTOR_NPROBE: usize = 4;
 /// BM25 top-k for the smoke FTS query.
 const BM25_TOP_K: usize = 10;
+/// Connection memory budget for the over-budget e2e: 1 byte. The 90%
+/// gate floors to 0, so the first cold cluster-block fetch (which is
+/// always more than 0 bytes) is refused. Any positive value would do;
+/// 1 makes "the smallest possible allowance still denies" explicit.
+const TINY_BUDGET_BYTES: u64 = 1;
+/// Row count for the over-budget e2e fixture. Large enough that the IVF
+/// cluster blocks are a genuine cold object-store fetch rather than being
+/// swallowed by the lazy reader's open-range prefetch (which, on the tiny
+/// 8-row smoke fixture, would leave the whole vector subsection resident
+/// → warm → not gated). A few thousand rows puts real bytes in each
+/// cluster block.
+const BUDGET_N_ROWS: usize = 4096;
+/// Expected peak reservation for the measured control's cold vector search.
+/// The cold cluster-block fetch over the `BUDGET_N_ROWS` fixture (dim 16,
+/// `n_cent` 4, Sq8 rerank, `nprobe` 4) is a deterministic 126,464 B. Assert
+/// a band around it: tight enough to prove it's the real cluster fetch (not
+/// a stray small read), loose enough to survive minor codec / layout drift.
+const CONTROL_PEAK_LOW_BYTES: usize = 100_000;
+const CONTROL_PEAK_HIGH_BYTES: usize = 160_000;
+/// A bounded (enforcing) budget set generously above one cold fetch. Proves an
+/// enforcing budget admits an under-budget query rather than refusing on
+/// principle: the 90% gate is 900 KB, far above the ~126 KB fetch. Distinct
+/// from the measured control, whose `None` limit can never deny by construction.
+const AMPLE_BUDGET_BYTES: u64 = 1_000_000;
+/// The 90% gate `AMPLE_BUDGET_BYTES` resolves to (`limit()` returns the gate,
+/// not the raw config value). Asserted so the test proves the budget is truly
+/// bounded, not silently measured.
+const AMPLE_BUDGET_GATE_BYTES: usize = 900_000;
+/// Connection budget for the shared-budget (multi-superfile) e2e. Sized to
+/// admit one superfile's ~126 KB cold cluster-block fetch but not two at once:
+/// the 90% gate is ~180 KB, so a single fetch fits and the two concurrent
+/// fetches of the fan-out (~253 KB together) cross it. This is what proves the
+/// budget is shared across superfiles rather than per-superfile.
+const SHARED_BUDGET_BYTES: u64 = 200_000;
 use s3s::{auth::SimpleAuth, service::S3ServiceBuilder};
 use s3s_fs::FileSystem;
 use tempfile::TempDir;
@@ -218,6 +256,97 @@ fn real_s3_config(bucket: &str, prefix: &str, cache_root: &std::path::Path) -> C
         compaction: CompactionSettings::default(),
         memory: MemorySettings::default(),
     }
+}
+
+/// A `Config` that carries only a connection memory budget; storage
+/// backend is `None` so `apply_config` leaves the storage / disk cache
+/// unattached (the caller wires those explicitly afterward). Drives the
+/// bounded budget onto options via the same `apply_config` path a
+/// `config.yaml`-built connection takes.
+fn budget_only_config(connection_budget_bytes: u64) -> Config {
+    Config {
+        supertable: SupertableSettings::default(),
+        storage: StorageSettings {
+            backend: StorageBackend::None,
+            ..StorageSettings::default()
+        },
+        compaction: CompactionSettings::default(),
+        memory: MemorySettings {
+            connection_budget_bytes,
+        },
+    }
+}
+
+/// An `S3StorageProvider` pointed at the in-process s3s-fs `endpoint`, boxed as
+/// a trait object. Every budget-e2e handle (producer + consumers) reaches the
+/// same bucket through one of these.
+fn budget_s3_provider(endpoint: &str) -> Arc<dyn StorageProvider> {
+    Arc::new(
+        S3StorageProvider::new_with_endpoint(
+            endpoint,
+            TEST_BUCKET,
+            TEST_ACCESS_KEY,
+            TEST_SECRET_KEY,
+            TEST_REGION,
+        )
+        .expect("s3 provider for budget e2e"),
+    )
+}
+
+/// Open a fresh consumer against `storage` with a lazy-foreground disk cache
+/// (so vector reads stay cold / non-resident) and `connection_budget_bytes` as
+/// the connection budget (0 = measured). Returns the handle plus the cache's
+/// `TempDir` guard: it must outlive the query, since dropping it unlinks the
+/// cache files the reader is still reading through.
+fn open_budget_consumer(
+    dim: usize,
+    storage: &Arc<dyn StorageProvider>,
+    connection_budget_bytes: u64,
+) -> (Supertable, TempDir) {
+    let cache_dir = TempDir::new().expect("budget consumer cache tempdir");
+    let cache = lazy_foreground_disk_cache(Arc::clone(storage), cache_dir.path());
+    let consumer = Supertable::open(
+        real_s3_options(dim)
+            .apply_config(&budget_only_config(connection_budget_bytes))
+            .expect("apply budget config to consumer options")
+            .with_storage(Arc::clone(storage))
+            .with_disk_cache(cache),
+    )
+    .expect("Supertable::open via S3 (budget consumer)");
+    (consumer, cache_dir)
+}
+
+/// A larger vector+FTS batch for the over-budget e2e: `BUDGET_N_ROWS`
+/// rows so the IVF cluster blocks carry real bytes (see
+/// [`BUDGET_N_ROWS`]). Each row's embedding is a one-hot at `row % dim`
+/// (enough spread for `n_cent` clusters); the title carries the row
+/// index so FTS has content too.
+fn budget_vector_batch(dim: usize, n_rows: usize) -> RecordBatch {
+    let titles = LargeStringArray::from(
+        (0..n_rows)
+            .map(|i| format!("budget vector row {i}"))
+            .collect::<Vec<_>>(),
+    );
+    let mut flat = Vec::with_capacity(n_rows * dim);
+    for row in 0..n_rows {
+        for d in 0..dim {
+            flat.push(if d == row % dim { 1.0 } else { 0.0 });
+        }
+    }
+    let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+    let values = Float32Array::from(flat);
+    let vectors = FixedSizeListArray::try_new(
+        item_field,
+        dim as i32,
+        Arc::new(values) as Arc<dyn Array>,
+        None,
+    )
+    .expect("fixed-size vector array");
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("emb", fixed_list_f32(dim), false),
+    ]));
+    RecordBatch::try_new(schema, vec![Arc::new(titles), Arc::new(vectors)]).expect("batch")
 }
 
 fn real_s3_batch(dim: usize) -> RecordBatch {
@@ -678,5 +807,286 @@ async fn supertable_tvfs_through_query_sql_via_s3_wire_protocol() {
         "[s3-smoke-tvf] bm25 / vector / hybrid via query_sql over S3 OK; \
          n_cold_fetches={} cache_bytes={}",
         post.n_cold_fetches, post.current_bytes
+    );
+}
+
+/// A cold vector search over the S3 wire protocol, under a bounded
+/// per-connection memory budget, is refused with `InfinoError::OverBudget`.
+///
+/// The consumer opens with `TINY_BUDGET_BYTES` (bounded) and a
+/// lazy-foreground disk cache, so the foreground vector query reads through
+/// a `StorageRangeSource`:
+///  - the superfile's byte source is never resident, so the cold
+///    cluster-block fetch is a real object-store GET.
+///  - that GET reserves against the budget first; the reservation exceeds
+///    the (floored-to-0) gate and is refused before the GET is issued.
+///  - the refusal propagates the full chain to the public error:
+///    cold-fetch reserve (deny) -> VectorError::OverBudget ->
+///    ReadError::Vector -> QueryError::OverBudget -> InfinoError::OverBudget.
+///
+/// A measured (unbounded) control then runs the identical cold query to
+/// completion, so deny-on-cold is the only behavioral change the budget
+/// introduces. Warm (resident) queries are never gated.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn supertable_cold_vector_search_over_budget_via_s3_wire_protocol() {
+    if std::env::var("INFINO_TEST_S3").is_err() {
+        eprintln!(
+            "supertable_cold_vector_search_over_budget_via_s3_wire_protocol: skipped \
+             (set INFINO_TEST_S3=1 to enable)"
+        );
+        return;
+    }
+
+    let (addr, _fs_root_guard) = spawn_s3s_fs().await;
+    let endpoint = format!("http://{}", addr);
+    let dim = EMB_DIM;
+    eprintln!("[s3-budget] s3s-fs spawned on {endpoint} bucket={TEST_BUCKET}");
+
+    // Producer: commit a vector batch through the S3 wire protocol.
+    let storage = budget_s3_provider(&endpoint);
+    {
+        let producer = Supertable::create(real_s3_options(dim).with_storage(Arc::clone(&storage)))
+            .expect("create budget producer");
+        let mut w = producer.writer().expect("budget producer writer");
+        w.append(&budget_vector_batch(dim, BUDGET_N_ROWS))
+            .expect("append large vector+FTS batch");
+        w.commit().expect("budget producer commit via S3");
+        assert_eq!(producer.manifest_id(), 1);
+    }
+
+    // Consumer: fresh handle + lazy-foreground disk cache (reads stay
+    // non-resident) under a bounded connection budget. `_cache_guard` keeps
+    // the cache files alive for the query.
+    let (consumer, _cache_guard) = open_budget_consumer(dim, &storage, TINY_BUDGET_BYTES);
+    assert_eq!(consumer.manifest_id(), 1);
+    assert_eq!(consumer.reader().n_docs_total(), BUDGET_N_ROWS as u64);
+
+    // One-hot query at dim 0. Under a measured budget row 0 is the
+    // closest match; here the cold cluster-block fetch must be refused
+    // before the vector shortlist runs.
+    let mut q = vec![0.0f32; dim];
+    q[0] = 1.0;
+    let result = consumer.vector_search(
+        "emb",
+        &q,
+        VECTOR_SEARCH_K,
+        VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+        None,
+        None,
+    );
+
+    match result {
+        Err(InfinoError::OverBudget(msg)) => {
+            eprintln!("[s3-budget] cold vector search refused as OverBudget: {msg}");
+        }
+        Err(other) => panic!("expected InfinoError::OverBudget, got {other:?}"),
+        Ok(hits) => panic!(
+            "expected InfinoError::OverBudget under a {TINY_BUDGET_BYTES}-byte budget; \
+             cold vector search returned {} batch(es)",
+            hits.len()
+        ),
+    }
+
+    // Budget accounting on the refused path: the gate fired (>=1 denial) and,
+    // because a refused reservation commits nothing, peak usage stays 0.
+    let bounded_budget = consumer.options().connection_budget();
+    eprintln!(
+        "[s3-budget] bounded budget: denials={} peak={} B",
+        bounded_budget.denials(),
+        bounded_budget.peak()
+    );
+    assert!(
+        bounded_budget.denials() >= 1,
+        "bounded budget must record >=1 denial; got {}",
+        bounded_budget.denials()
+    );
+    assert_eq!(
+        bounded_budget.peak(),
+        0,
+        "a refused cold fetch commits nothing, so peak must stay 0"
+    );
+
+    // Control: the identical cold query over the identical fixture runs to
+    // completion under a measured (unbounded) budget. Proves the deny above
+    // is caused by the budget, not by a broken fixture or a cold-path error.
+    // Fresh consumer + fresh cache so the read is cold again.
+    let (control, _control_cache_guard) = open_budget_consumer(dim, &storage, 0);
+    let control_hits = control
+        .vector_search(
+            "emb",
+            &q,
+            VECTOR_SEARCH_K,
+            VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+            None,
+            None,
+        )
+        .expect("measured cold vector search should run to completion");
+    let control_rows: usize = control_hits.iter().map(|b| b.num_rows()).sum();
+    assert!(
+        control_rows >= 1,
+        "measured cold vector search returned no rows over S3"
+    );
+    // The measured budget never refuses, so the same cold cluster-block fetch
+    // that the bounded budget rejected is here reserved + released: peak > 0
+    // proves the reservation actually ran on the query path (never denied).
+    let control_budget = control.options().connection_budget();
+    eprintln!(
+        "[s3-budget] measured control: rows={control_rows} denials={} peak={} B",
+        control_budget.denials(),
+        control_budget.peak()
+    );
+    assert_eq!(
+        control_budget.denials(),
+        0,
+        "measured budget must never deny"
+    );
+    let control_peak = control_budget.peak();
+    assert!(
+        (CONTROL_PEAK_LOW_BYTES..=CONTROL_PEAK_HIGH_BYTES).contains(&control_peak),
+        "measured cold vector search peak {control_peak} B outside expected \
+         [{CONTROL_PEAK_LOW_BYTES}, {CONTROL_PEAK_HIGH_BYTES}] band; \
+         a peak near 0 means the budget was never exercised on the query path"
+    );
+
+    // Bounded but ample: an enforcing budget well above one fetch must admit
+    // the query. A bounded budget refuses only when a reservation would cross
+    // the gate, not on principle, so the same cold fetch that a 1-byte budget
+    // rejected runs here, reserves, and never denies.
+    let (ample, _ample_guard) = open_budget_consumer(dim, &storage, AMPLE_BUDGET_BYTES);
+    let ample_budget = ample.options().connection_budget();
+    // The limit is set (not `None`), so this is genuinely bounded, not measured.
+    assert_eq!(
+        ample_budget.limit(),
+        Some(AMPLE_BUDGET_GATE_BYTES),
+        "ample budget must be bounded (an enforced gate), not measured"
+    );
+    let ample_hits = ample
+        .vector_search(
+            "emb",
+            &q,
+            VECTOR_SEARCH_K,
+            VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+            None,
+            None,
+        )
+        .expect("under-budget cold vector search should run under a bounded budget");
+    let ample_rows: usize = ample_hits.iter().map(|b| b.num_rows()).sum();
+    let ample_peak = ample_budget.peak();
+    eprintln!(
+        "[s3-budget] bounded-ample: rows={ample_rows} denials={} peak={ample_peak} B",
+        ample_budget.denials()
+    );
+    assert!(
+        ample_rows >= 1,
+        "bounded-ample cold vector search returned no rows"
+    );
+    assert_eq!(
+        ample_budget.denials(),
+        0,
+        "an under-budget query must not be denied by a bounded budget"
+    );
+    assert!(
+        (CONTROL_PEAK_LOW_BYTES..=CONTROL_PEAK_HIGH_BYTES).contains(&ample_peak),
+        "bounded-ample peak {ample_peak} B outside expected \
+         [{CONTROL_PEAK_LOW_BYTES}, {CONTROL_PEAK_HIGH_BYTES}] band"
+    );
+}
+
+/// The per-connection budget is shared across the multi-superfile fan-out, so
+/// several superfiles' cold fetches accumulate against one ceiling. A
+/// per-superfile budget would never add up, and this is what pins that.
+///
+/// Two commits produce two superfiles, each with its own ~126 KB cold
+/// cluster-block fetch. The unfiltered fan-out probes them concurrently, so
+/// both reservations are live against the same budget at once:
+///  - measured (unbounded): both fetch, the query runs, and peak climbs past a
+///    single superfile's fetch (the two live reservations sum on one budget).
+///  - bounded to `SHARED_BUDGET_BYTES` (fits one fetch, not two): the second
+///    concurrent reservation crosses the ceiling and the query is refused as
+///    `InfinoError::OverBudget`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn supertable_vector_budget_is_shared_across_superfiles_via_s3_wire_protocol() {
+    if std::env::var("INFINO_TEST_S3").is_err() {
+        eprintln!(
+            "supertable_vector_budget_is_shared_across_superfiles_via_s3_wire_protocol: skipped \
+             (set INFINO_TEST_S3=1 to enable)"
+        );
+        return;
+    }
+
+    let (addr, _fs_root_guard) = spawn_s3s_fs().await;
+    let endpoint = format!("http://{}", addr);
+    let dim = EMB_DIM;
+    eprintln!("[s3-shared] s3s-fs spawned on {endpoint} bucket={TEST_BUCKET}");
+
+    // Producer: two commits => two superfiles, each `BUDGET_N_ROWS` rows.
+    let storage = budget_s3_provider(&endpoint);
+    {
+        let producer = Supertable::create(real_s3_options(dim).with_storage(Arc::clone(&storage)))
+            .expect("create shared-budget producer");
+        for commit in 0..2 {
+            let mut w = producer.writer().expect("shared-budget producer writer");
+            w.append(&budget_vector_batch(dim, BUDGET_N_ROWS))
+                .expect("append large vector+FTS batch");
+            w.commit().expect("shared-budget producer commit via S3");
+            assert_eq!(producer.manifest_id(), commit + 1);
+        }
+    }
+
+    let mut q = vec![0.0f32; dim];
+    q[0] = 1.0;
+    let search = |table: &Supertable| {
+        table.vector_search(
+            "emb",
+            &q,
+            VECTOR_SEARCH_K,
+            VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+            None,
+            None,
+        )
+    };
+
+    // Measured: both superfiles fetch, the query runs, and the peak exceeds a
+    // single superfile's fetch => the two reservations summed on one budget.
+    let (measured, _measured_guard) = open_budget_consumer(dim, &storage, 0);
+    assert_eq!(measured.reader().n_superfiles(), 2);
+    assert_eq!(measured.reader().n_docs_total(), (BUDGET_N_ROWS as u64) * 2);
+    let measured_hits = search(&measured).expect("measured search over two superfiles runs");
+    let measured_rows: usize = measured_hits.iter().map(|b| b.num_rows()).sum();
+    let measured_peak = measured.options().connection_budget().peak();
+    eprintln!("[s3-shared] measured: rows={measured_rows} peak={measured_peak} B");
+    assert!(
+        measured_rows >= 1,
+        "measured two-superfile search returned no rows"
+    );
+    assert!(
+        measured_peak > CONTROL_PEAK_HIGH_BYTES,
+        "peak {measured_peak} B should exceed one superfile's fetch \
+         ({CONTROL_PEAK_HIGH_BYTES} B): the two fetches must sum on one budget"
+    );
+
+    // Bounded to fit one fetch but not two: the second concurrent reservation
+    // crosses the ceiling, so the shared budget refuses the query.
+    let (bounded, _bounded_guard) = open_budget_consumer(dim, &storage, SHARED_BUDGET_BYTES);
+    let result = search(&bounded);
+    let bounded_budget = bounded.options().connection_budget();
+    eprintln!(
+        "[s3-shared] bounded: denials={} peak={} B result={}",
+        bounded_budget.denials(),
+        bounded_budget.peak(),
+        if result.is_ok() { "ok" } else { "over-budget" }
+    );
+    match result {
+        Err(InfinoError::OverBudget(_)) => {}
+        Err(other) => panic!("expected InfinoError::OverBudget, got {other:?}"),
+        Ok(hits) => panic!(
+            "two concurrent {CONTROL_PEAK_HIGH_BYTES}-B fetches must cross a \
+             {SHARED_BUDGET_BYTES}-B budget; got {} batch(es)",
+            hits.len()
+        ),
+    }
+    assert!(
+        bounded_budget.denials() >= 1,
+        "the shared budget must record the crossing"
     );
 }


### PR DESCRIPTION
### What does this PR do?
Makes the connection memory budget bound vector search. A vector query over object storage fetches its IVF cluster blocks onto the heap (the cold GET); we now reserve those bytes against the budget before fetching. Over budget, the search fails with `InfinoError::OverBudget` before it allocates; a warm query whose blocks are already resident reserves nothing. Measure-only by default, so nothing changes until a limit is set.

### Why do we need this change?
#352 gated SQL, but a vector search allocates outside DataFusion: the cold cluster-block fetch, which grows with `nprobe` and the number of superfiles probed. Until now a limit did nothing for it, so one vector query could still push memory arbitrarily high. This puts the same ceiling on the query's largest allocation.

### How do we do this change?
- The vector reader reserves the cold cluster-block bytes right before the fetch (`reserve_cold_fetch`) and holds the guard for the probe; drop frees them.
- Only non-resident ranges are reserved, so a warm (mmap / in-memory) query slices its blocks zero-copy and reserves nothing: the hot path is untouched.
- A refusal is a new `VectorError::OverBudget`, routed through `ReadError::Vector` to the public `InfinoError::OverBudget`.
- The budget is read once in the vector fan-out, so every path (public `vector_search`, the SQL `vector_search` / `hybrid_search` functions, and `WHERE`-pushdown) is gated at the same point.

### Performance
No behaviour change by default. Warm queries reserve nothing, so there's no cost on the hot path even at a tiny budget; the cold fetch pays one atomic reservation, off the object-store GET's critical path. Recall@10 is unchanged (the reservation gates fetching, not scoring): 0.994 L2Sq and 0.998 Cosine at nprobe 8 and 32 on the scale bench, both above the 0.99 bar. 