### PR TITLE
catalog: memoize table handles so query_sql reuses the warm cache

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -30,6 +30,7 @@ use std::{
 
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
+use dashmap::DashMap;
 use datafusion::{config::Dialect, error::DataFusionError};
 use futures::future::try_join_all;
 pub use index_spec::IndexSpec;
@@ -54,7 +55,7 @@ use crate::{
     },
     supertable::{
         Supertable,
-        options::SupertableOptions,
+        options::{Consistency, SupertableOptions},
         reader_cache::{DiskCacheConfig, DiskCacheStore},
     },
 };
@@ -103,7 +104,11 @@ pub fn connect_with(
             if options.validate {
                 bridge_sync_to_async(read_catalog(root.as_ref()))?;
             }
-            CatalogStore::Storage(root)
+            CatalogStore::Storage {
+                root,
+                handles: DashMap::new(),
+                building: DashMap::new(),
+            }
         }
     };
 
@@ -149,7 +154,37 @@ struct ConnectionInner {
 /// the tables themselves) in-process.
 enum CatalogStore {
     Memory(Mutex<HashMap<String, Supertable>>),
-    Storage(Arc<dyn StorageProvider>),
+    /// Durable backend. `handles` is the warm cache (name → live `Supertable`);
+    /// `building` is a per-name lock guarding the build or evict of an entry.
+    /// Both, because the read must be lock-free but the build must be single:
+    /// two `Supertable`s for one name would race their cold-fetch finalizers on
+    /// the same cache file (a SIGBUS in the mmap path).
+    ///
+    /// Lifecycle of one name:
+    ///   1. `open_table` / `query_sql` checks `handles` first: a hit is a
+    ///      lock-free clone, the common path (`memory://` memoizes the same way
+    ///      via `Memory`).
+    ///   2. A miss takes that name's `building` lock, re-checks `handles` (a
+    ///      peer may have just built it), then builds the `Supertable` once and
+    ///      inserts it. Same-name openers queue on the lock so exactly one store
+    ///      is built; different names build in parallel.
+    ///   3. `create_table` inserts under the same lock, `drop_table` evicts
+    ///      under it. So build, create, and drop of one name never overlap, and
+    ///      a dropped name is never left behind in `handles`.
+    Storage {
+        root: Arc<dyn StorageProvider>,
+        /// Warm cache of live handles. Sharded so concurrent queries on one
+        /// `Connection` don't serialize on a lock.
+        handles: DashMap<String, Supertable>,
+        /// Per-name build/evict lock. Never removed once created: a concurrent
+        /// opener may hold or await the `Arc`, so evicting it mid-use would let
+        /// two builds proceed.
+        ///
+        /// One empty `Arc<Mutex<()>>` therefore lingers per distinct name ever
+        /// seen. We can bound it with refcount-gated eviction (drop only when no
+        /// one holds the `Arc`) later.
+        building: DashMap<String, Arc<Mutex<()>>>,
+    },
 }
 
 impl Connection {
@@ -198,7 +233,11 @@ impl Connection {
                 info!(table = name, backend = "memory", "created table");
                 Ok(handle)
             }
-            CatalogStore::Storage(root) => {
+            CatalogStore::Storage {
+                root,
+                handles,
+                building,
+            } => {
                 // Record what was actually used to build the table, so
                 // `open_table` reconstructs matching options (the
                 // supertable's options-hash check then validates them).
@@ -247,11 +286,21 @@ impl Connection {
                 if let Some(cache) = disk_cache {
                     opts = opts.with_disk_cache(cache);
                 }
+
+                // Match `open_table`'s memoized handles: Strong keeps every
+                // query re-checking the manifest pointer (see `open_table`).
+                opts = opts.with_read_consistency(Consistency::Strong);
+
                 // Create the physical table at its unique location, then
                 // register the name. A losing racer that also created a
                 // (distinct) location just orphans its empty subtree; the
                 // catalog OCC below decides the single name winner.
                 let handle = Supertable::create(opts)?;
+
+                // Gate the commit + memo insert: else a racing `open_table`
+                // sees the commit, misses the memo, and builds a rival store.
+                let gate = single_flight_gate(building, name);
+                let _built = gate.lock().expect("catalog build gate poisoned");
 
                 let name_owned = name.to_string();
                 bridge_sync_to_async(commit_catalog(root.as_ref(), move |body| {
@@ -261,6 +310,11 @@ impl Connection {
                     body.tables.insert(name_owned.clone(), entry.clone());
                     Ok(())
                 }))?;
+
+                // Seed the memo: `query_sql` reads back through this same
+                // handle, so in-process writes are visible at once.
+                handles.insert(name.to_string(), handle.clone());
+
                 info!(table = name, location = %location, "created table");
                 Ok(handle)
             }
@@ -290,7 +344,28 @@ impl Connection {
                 .get(name)
                 .cloned()
                 .ok_or_else(|| InfinoError::NotFound(name.to_string())),
-            CatalogStore::Storage(root) => {
+
+            CatalogStore::Storage {
+                root,
+                handles,
+                building,
+            } => {
+                // Warm path: lock-free sharded lookup, no serialization.
+                if let Some(handle) = handles.get(name) {
+                    return Ok(handle.clone());
+                }
+
+                // Cold path: build once under the gate. Blocks here if a
+                // same-name peer is mid-build (same `Arc`, same mutex); the
+                // winner builds, the rest wake to find a warm `handles`.
+                let gate = single_flight_gate(building, name);
+                let _built = gate.lock().expect("catalog build gate poisoned");
+
+                // A peer may have built it while we waited on the gate.
+                if let Some(handle) = handles.get(name) {
+                    return Ok(handle.clone());
+                }
+
                 let (body, _etag) = bridge_sync_to_async(read_catalog(root.as_ref()))?;
                 let entry = body
                     .tables
@@ -322,6 +397,7 @@ impl Connection {
                     &self.inner.options,
                 )?
                 .expect("non-memory backend yields a storage provider");
+
                 // Cache directory is keyed on the stable name, matching
                 // `create_table` (the on-storage subtree is `entry.location`).
                 let disk_cache = build_disk_cache(&self.inner.options, &table_storage, name)?;
@@ -336,7 +412,15 @@ impl Connection {
                 if let Some(cache) = disk_cache {
                     opts = opts.with_disk_cache(cache);
                 }
-                Ok(Supertable::open(opts)?)
+
+                // Strong: re-check the manifest pointer per query (cheap,
+                // short-circuits when unchanged), matching the old rebuild's
+                // freshness without its cost.
+                opts = opts.with_read_consistency(Consistency::Strong);
+                let handle = Supertable::open(opts)?;
+                handles.insert(name.to_string(), handle.clone());
+
+                Ok(handle)
             }
         }
     }
@@ -373,7 +457,21 @@ impl Connection {
                 .remove(name)
                 .map(|_| ())
                 .ok_or_else(|| InfinoError::NotFound(name.to_string())),
-            CatalogStore::Storage(root) => {
+            CatalogStore::Storage {
+                root,
+                handles,
+                building,
+            } => {
+                // Gate the evict + commit: else a racing `open_table` that read
+                // the pre-commit catalog re-inserts the handle after we evict,
+                // and the warm path keeps serving the dropped table.
+                let gate = single_flight_gate(building, name);
+                let _dropping = gate.lock().expect("catalog build gate poisoned");
+
+                // Evict first: a later create/open rebuilds fresh, and this
+                // frees the handle's `DiskCacheStore`.
+                handles.remove(name);
+
                 // Capture the removed entry's location out of the OCC
                 // closure; on a retry the freshest body is re-read, so
                 // the last successful attempt's location wins.
@@ -427,7 +525,7 @@ impl Connection {
                 names.sort();
                 Ok(names)
             }
-            CatalogStore::Storage(root) => {
+            CatalogStore::Storage { root, .. } => {
                 let (body, _etag) = bridge_sync_to_async(read_catalog(root.as_ref()))?;
                 Ok(body.tables.into_keys().collect())
             }
@@ -626,6 +724,16 @@ fn build_disk_cache(
     Ok(Some(cache))
 }
 
+/// The per-name single-flight gate, created on first use. Returned as an owned
+/// `Arc` (not a `DashMap` reference) so the caller locks it *after* the map
+/// access returns, never holding a shard across the build's blocking I/O.
+fn single_flight_gate(building: &DashMap<String, Arc<Mutex<()>>>, name: &str) -> Arc<Mutex<()>> {
+    building
+        .entry(name.to_string())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
 /// Table names are flat, case-sensitive `[A-Za-z0-9_-]+` identifiers
 /// that may not start with `_` — they are SQL identifiers and
 /// object-store path segments, and the `_`-prefixed namespace is
@@ -698,8 +806,9 @@ fn now_unix() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path, sync::Arc};
+    use std::{fs, path::Path, sync::Arc, thread};
 
+    use arrow_array::Int64Array;
     use arrow_schema::{DataType, Field, Schema};
 
     use super::*;
@@ -780,6 +889,306 @@ mod tests {
             .bm25_search("title", "fox", TOP_K, BoolMode::Or, None)
             .expect("bm25_search after append");
         assert_eq!(n_rows(&hits), 1, "expected one hit for 'fox' after append");
+    }
+
+    /// Row count via SQL — used by the memoization tests below.
+    fn count_rows(conn: &Connection, table: &str) -> i64 {
+        let batches = conn
+            .query_sql(&format!("SELECT COUNT(*) FROM {table}"))
+            .expect("count query");
+        batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("COUNT(*) yields Int64")
+            .value(0)
+    }
+
+    /// The memoized storage handle must reuse its warm disk cache across
+    /// `query_sql` calls: the first query cold-fetches the superfile, the
+    /// second hits the cache and does no further cold fetch. Guards the
+    /// `open_table` handle memoization for durable backends.
+    #[test]
+    fn storage_query_sql_reuses_warm_disk_cache_across_calls() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = tempfile::tempdir().expect("cache dir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        // Writer connection creates + fills the table. Its own writer path
+        // populates the in-memory reader tier, so a reader that did NOT write
+        // the superfile is needed to exercise the disk-cache cold path.
+        let writer = connect(&uri).expect("connect writer");
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["the quick brown fox"]))
+            .expect("append");
+
+        // Fresh reader connection with a disk cache: empty in-memory tier, so
+        // the first read cold-fetches through the disk cache. A projecting
+        // scan (reads `title`) forces a real superfile read, unlike `COUNT(*)`
+        // which is answered from manifest stats.
+        let reader = connect_with(
+            &uri,
+            ConnectOptions::new().with_cache_dir(cache.path().to_path_buf()),
+        )
+        .expect("connect reader");
+
+        reader.query_sql("SELECT title FROM docs").expect("scan q1");
+        let cold_after_q1 = reader
+            .open_table("docs")
+            .expect("open")
+            .stats()
+            .n_cold_fetches
+            .expect("disk cache attached");
+        assert!(
+            cold_after_q1 > 0,
+            "first query should cold-fetch the superfile"
+        );
+
+        // Query 2 reuses the memoized handle: it must hit the warm cache, not
+        // re-fetch. Before memoization this rebuilt the store and cold-fetched
+        // again.
+        reader.query_sql("SELECT title FROM docs").expect("scan q2");
+        let cold_after_q2 = reader
+            .open_table("docs")
+            .expect("open")
+            .stats()
+            .n_cold_fetches
+            .expect("disk cache attached");
+        assert_eq!(
+            cold_after_q2, cold_after_q1,
+            "second query must reuse the warm disk cache, not cold-fetch again"
+        );
+    }
+
+    /// A server holds one `Connection` and fans out concurrent queries. Many
+    /// parallel first-opens of the same table must single-flight: build exactly
+    /// one `Supertable`/`DiskCacheStore`, so the one superfile is cold-fetched
+    /// once, not once per racing thread. A double-build would spin up rival
+    /// stores that each cold-fetch (and race their finalizers on the same cache
+    /// file, the SIGBUS in the mmap path).
+    #[test]
+    fn storage_concurrent_first_opens_build_one_store() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = tempfile::tempdir().expect("cache dir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let writer = connect(&uri).expect("connect writer");
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["the quick brown fox"]))
+            .expect("append");
+
+        let reader = connect_with(
+            &uri,
+            ConnectOptions::new().with_cache_dir(cache.path().to_path_buf()),
+        )
+        .expect("connect reader");
+
+        // 8 threads race through open_table for the same, not-yet-open table.
+        thread::scope(|s| {
+            let joins: Vec<_> = (0..8)
+                .map(|_| s.spawn(|| reader.query_sql("SELECT title FROM docs").expect("scan")))
+                .collect();
+            for j in joins {
+                j.join().expect("query thread");
+            }
+        });
+
+        // One store built (single-flight) and one superfile, so exactly one
+        // cold fetch despite 8 concurrent queries. More would mean rival stores.
+        let cold = reader
+            .open_table("docs")
+            .expect("open")
+            .stats()
+            .n_cold_fetches
+            .expect("disk cache attached");
+        assert_eq!(
+            cold, 1,
+            "concurrent first-opens must build one store and cold-fetch the superfile once"
+        );
+    }
+
+    /// Sequential self-heal: dropping a table clears its memoized handle, so a
+    /// later `open_table` reads the catalog and reports `NotFound` rather than
+    /// serving the dropped table from the warm memo fast path.
+    #[test]
+    fn storage_drop_invalidates_memo_then_open_is_not_found() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+        let conn = connect(&uri).expect("connect");
+        conn.create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["fox"]))
+            .expect("append");
+        // Warm the memo so the drop must actively evict it.
+        conn.open_table("docs").expect("open before drop");
+
+        conn.drop_table("docs", true).expect("drop");
+
+        assert!(
+            matches!(conn.open_table("docs"), Err(InfinoError::NotFound(_))),
+            "open after drop must be NotFound, not a stale memoized handle"
+        );
+    }
+
+    /// `drop_table` racing `open_table` on the same name must not leave a stale
+    /// memoized handle: an open that read the pre-commit catalog must not
+    /// re-insert after the drop evicts. The `building` gate (held across evict +
+    /// commit) serializes them, so once the drop settles the table stays gone.
+    /// Loop many rounds to hit the window; post-join `open_table` is `NotFound`.
+    #[test]
+    fn storage_concurrent_drop_and_open_never_serves_dropped() {
+        const ROUNDS: usize = 20;
+        const OPENERS: usize = 4;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+        let conn = connect(&uri).expect("connect");
+
+        for round in 0..ROUNDS {
+            let name = format!("t{round}");
+            conn.create_table(&name, schema_id_title(), IndexSpec::new().fts("title"))
+                .expect("create_table")
+                .append(&build_title_batch(&["fox"]))
+                .expect("append");
+            // Warm the memo, so a racing open can observe (and must not restore)
+            // an entry the drop is removing.
+            conn.open_table(&name).expect("open before race");
+
+            thread::scope(|s| {
+                for _ in 0..OPENERS {
+                    s.spawn(|| {
+                        // Both Ok (raced before the drop) and NotFound (raced
+                        // after) are valid mid-race; neither may panic.
+                        let _ = conn.open_table(&name);
+                    });
+                }
+                s.spawn(|| {
+                    conn.drop_table(&name, false).expect("drop");
+                });
+            });
+
+            assert!(
+                matches!(conn.open_table(&name), Err(InfinoError::NotFound(_))),
+                "round {round}: table must stay dropped, no stale handle in the memo"
+            );
+        }
+    }
+
+    /// `create_table` racing `open_table` on the same name: benign, but must
+    /// stay so. The gate serializes the create's commit + memo insert against
+    /// the open, so no rival store is memoized. A racing open sees the table or
+    /// `NotFound`, never a panic or other error; afterward the table queries.
+    #[test]
+    fn storage_concurrent_create_and_open_stays_consistent() {
+        const ROUNDS: usize = 20;
+        const OPENERS: usize = 4;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+        let conn = connect(&uri).expect("connect");
+
+        for round in 0..ROUNDS {
+            let name = format!("t{round}");
+
+            thread::scope(|s| {
+                s.spawn(|| {
+                    conn.create_table(&name, schema_id_title(), IndexSpec::new().fts("title"))
+                        .expect("create_table")
+                        .append(&build_title_batch(&["fox"]))
+                        .expect("append");
+                });
+                for _ in 0..OPENERS {
+                    s.spawn(|| {
+                        // Pre-commit opens see NotFound; post-commit opens see
+                        // the table. Both are fine; a panic or other error is
+                        // not.
+                        match conn.open_table(&name) {
+                            Ok(_) | Err(InfinoError::NotFound(_)) => {}
+                            Err(e) => panic!("round {round}: unexpected open error: {e}"),
+                        }
+                    });
+                }
+            });
+
+            // After the race the table is present and the appended row is
+            // readable through the memoized handle (one store, writes visible).
+            assert_eq!(
+                count_rows(&conn, &name),
+                1,
+                "round {round}: created table must be queryable with its row"
+            );
+        }
+    }
+
+    /// A commit made after a table has been queried (so its handle is
+    /// memoized and warm) must be visible to the next query. Guards that
+    /// memoizing the handle does not serve a stale manifest.
+    #[test]
+    fn storage_query_sql_sees_commit_after_the_handle_is_memoized() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+        let conn = connect(&uri).expect("connect");
+        let table = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table");
+        table
+            .append(&build_title_batch(&["one"]))
+            .expect("append 1");
+
+        // First query memoizes + warms the handle.
+        assert_eq!(count_rows(&conn, "docs"), 1);
+
+        // Commit a second row through a handle from the same connection
+        // (the memoized one), then re-query: the memoized handle must see it.
+        conn.open_table("docs")
+            .expect("open")
+            .append(&build_title_batch(&["two"]))
+            .expect("append 2");
+        assert_eq!(
+            count_rows(&conn, "docs"),
+            2,
+            "the memoized handle must reflect the new commit, not a stale snapshot"
+        );
+    }
+
+    /// Cross-connection freshness: memoizing must not pin the snapshot a handle
+    /// first saw. A second connection commits on the same storage; the first
+    /// connection's memoized handle sees it on the next query, because it opens
+    /// `Strong` and re-reads the manifest pointer. This is the guarantee the old
+    /// rebuild-per-query gave for free and the reason memoized handles use
+    /// `Strong` rather than the default bounded staleness.
+    #[test]
+    fn storage_memoized_handle_sees_another_connections_commit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let writer = connect(&uri).expect("connect writer");
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["one"]))
+            .expect("append 1");
+
+        // A separate connection memoizes + warms its own handle for `docs`.
+        let reader = connect(&uri).expect("connect reader");
+        assert_eq!(count_rows(&reader, "docs"), 1);
+
+        // The other connection commits a second row.
+        writer
+            .open_table("docs")
+            .expect("reopen for append")
+            .append(&build_title_batch(&["two"]))
+            .expect("append 2");
+
+        assert_eq!(
+            count_rows(&reader, "docs"),
+            2,
+            "memoized handle must reflect another connection's commit, not a pinned snapshot"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

When you run SQL against a table that lives on object storage, the engine now keeps the table open and reuses it across queries, instead of opening it again from scratch on every query. The first query still loads what it needs; every query after that reads from the cache that is already warm.

## Why

Today every query reopens the table and starts with an empty cache. So each query downloads the whole table from object storage all over again, and the cache never gets a chance to warm up. Every query ends up as slow as the very first one, no matter how many times you have already read the same data. Keeping the table open between queries fixes this: the data is fetched once, and later queries reuse it.

## How

- **Two maps on `CatalogStore::Storage`.** `handles: DashMap<name, Supertable>` is the warm cache, sharded so parallel queries on one connection don't serialize. `building: DashMap<name, Arc<Mutex<()>>>` is a per-name build/evict lock.
- **`open_table` single-flights the build.** Lock-free `handles` lookup; on a miss, take the name's gate, re-check, build once, insert. Same-name openers wait on the gate so exactly one store is built (two would race their cold-fetch finalizers on the same cache file); different names build in parallel.
- **`create_table` and `drop_table` take the same gate.** `create_table` seeds the memo under it; `drop_table` evicts under it, across both the memo removal and the catalog commit. So build, create, and drop of one name never overlap, and a racing `open_table` cannot re-insert a handle after a drop removes it.
- **Memoized handles open `Strong`.** They re-read the manifest pointer per query, so they stay as fresh as the old rebuild-per-query, in-process and across connections.

## Performance

Every query after the first drops from a whole-object fetch of all superfiles to a warm range-read of the projected columns. The warm path is a lock-free sharded lookup with no serialization across concurrent queries; same-name first-opens single-flight so one cold fetch serves them all. 

## Testing

- Warm-cache reuse: the second `query_sql` hits the cache, no extra cold fetch.
- Freshness: a commit is visible on the next query both in-process and from a second `Connection` on the same storage (guards the `Strong` choice).
- Concurrency: same-name first-opens build one store (one cold fetch across 8 threads); `drop_table` racing `open_table` leaves no stale handle; `create_table` racing `open_table` stays consistent. Stressed 50x, no flake.

Closes #373