### PR TITLE
release: bump crate and node binding to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.1.3",
-    "infx-darwin-arm64": "0.1.3",
-    "infx-linux-x64-gnu": "0.1.3",
-    "infx-linux-arm64-gnu": "0.1.3",
-    "infx-linux-x64-musl": "0.1.3",
-    "infx-linux-arm64-musl": "0.1.3"
+    "infx-darwin-x64": "0.1.4",
+    "infx-darwin-arm64": "0.1.4",
+    "infx-linux-x64-gnu": "0.1.4",
+    "infx-linux-arm64-gnu": "0.1.4",
+    "infx-linux-x64-musl": "0.1.4",
+    "infx-linux-arm64-musl": "0.1.4"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "apache-avro",
  "arc-swap",


### PR DESCRIPTION
Patch bumps for the next release: crate `0.1.3 -> 0.1.4` and `@infino-ai/infino` `0.1.3 -> 0.1.4` (including the `infx-*` platform-package pins in `optionalDependencies`), with lockfiles synced in the root and both binding workspaces so `--locked` builds pass.

These are the first releases to ship the Google Cloud Storage backend (#349, #369) in published packages, and the first Node binaries built on the glibc-2.31 baseline (#376).