### PR TITLE
node-publish: restore workspace ownership after the container build

### DIFF
--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -102,6 +102,12 @@ jobs:
                      npm install --ignore-scripts && \
                      npx napi build --platform --release --strip --js native.js --dts native.d.ts infino && \
                      npx tsc"
+      # The container runs as root, so everything it wrote on the mounted
+      # workspace (node_modules, target/, the addon) is root-owned — the
+      # host-side verify step then fails with EACCES. Hand it all back.
+      - name: Restore workspace ownership after container build
+        if: ${{ matrix.glibc_image }}
+        run: sudo chown -R "$(id -u):$(id -g)" .
       - name: Check binary glibc floor
         if: ${{ matrix.glibc_image }}
         run: |

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -108,12 +108,9 @@ jobs:
       - name: Restore workspace ownership after container build
         if: ${{ matrix.glibc_image }}
         run: sudo chown -R "$(id -u):$(id -g)" .
-      - name: Check binary glibc floor
+      - name: List container build outputs
         if: ${{ matrix.glibc_image }}
-        run: |
-          MAX=$(objdump -T infino-node/infino/*.node | grep -oE 'GLIBC_[0-9.]+' | sort -Vu | tail -1)
-          echo "max glibc symbol: $MAX"
-          [ "$(printf '%s\n' "$MAX" GLIBC_2.31 | sort -V | tail -1)" = "GLIBC_2.31" ]
+        run: ls -la infino-node/infino/ || true
       # Smoke-test the AS-SHIPPED package on this platform: pack the tarballs,
       # install them into a throwaway project, and run a real query — proving the
       # loader resolves the per-platform binary from a clean install (not the
@@ -121,6 +118,16 @@ jobs:
       - name: Verify packaged binary (native)
         if: ${{ !matrix.musl }}
         run: make node-verify
+      # Runs AFTER verify on purpose: verify-pack rebuilds the addon on the
+      # host if any generated file is missing, which would silently raise the
+      # glibc floor of the artifact that gets uploaded. Checking last means
+      # that failure mode breaks the build instead of shipping.
+      - name: Check binary glibc floor
+        if: ${{ matrix.glibc_image }}
+        run: |
+          MAX=$(objdump -T infino-node/infino/*.node | grep -oE 'GLIBC_[0-9.]+' | sort -Vu | tail -1)
+          echo "max glibc symbol: $MAX"
+          [ "$(printf '%s\n' "$MAX" GLIBC_2.31 | sort -V | tail -1)" = "GLIBC_2.31" ]
       # --- musl build (Alpine, via the napi-rs builder image; cc is musl) ---
       # Runs on the host runner (so the disk-free step above still applies) but
       # compiles inside Alpine, where the target arch matches the runner arch —


### PR DESCRIPTION
Second follow-up to #376: the glibc-baseline container runs as root, so the `npm install` / `napi build` outputs on the mounted workspace come back root-owned. The host-side `make node-verify` step then fails with `EACCES: permission denied, rename .../node_modules/apache-arrow` when npm (running as the `runner` user) tries to rework that directory.

Fix: a `sudo chown -R` of the workspace back to the runner user between the container build and the verify step. The build itself was succeeding — only the handoff to the host verify was broken.