### PR TITLE
verify-pack: fix the reuse guard to grep the platform-package name

### DIFF
--- a/infino-node/scripts/verify-pack.sh
+++ b/infino-node/scripts/verify-pack.sh
@@ -26,6 +26,10 @@ cd "$ROOT"
 # napi binary prefix.
 PKG_NAME="$(node -p "require('./package.json').name")"
 BIN_NAME="$(node -p "require('./package.json').napi.name")"
+# Per-platform packages are named after napi.package.name (e.g.
+# infx-linux-x64-gnu), NOT the npm package name — that's what the
+# generated loader requires, so it's what the reuse guard must grep for.
+PLAT_PKG="$(node -p "const p=require('./package.json'); (p.napi.package && p.napi.package.name) || p.name")"
 
 # Host platform in napi's node-platform naming.
 PLATFORM="$(node -p 'process.platform')"
@@ -86,7 +90,7 @@ done
 # A reused loader from a previous package name (after a napi.name change)
 # requires a different platform package and would fail at load — rebuild if
 # native.js doesn't reference the current platform package name.
-if [ "$NEED_BUILD" = "0" ] && ! grep -q "${PKG_NAME}-${TRIPLE}" infino/native.js 2>/dev/null; then
+if [ "$NEED_BUILD" = "0" ] && ! grep -q "${PLAT_PKG}-${TRIPLE}" infino/native.js 2>/dev/null; then
   NEED_BUILD=1
 fi
 if [ "$NEED_BUILD" = "1" ]; then


### PR DESCRIPTION
Follow-up to #380 (this commit missed that merge). Root cause of the rebuilds the floor check caught: `verify-pack.sh` greps `native.js` for `${PKG_NAME}-${TRIPLE}`, where `PKG_NAME` is the npm package name (`@infino-ai/infino`) — but the generated loader references per-platform packages named after `napi.package.name` (`infx-<triple>`). The grep can never match, so the reuse guard has rebuilt the addon on every run since the `infx` rename: ~10 wasted minutes per CI leg before, and with the glibc-baseline container builds it replaced the 2.31-floor binary with a host-linked 2.39 one (which the post-verify floor check from #380 correctly failed).

Fix: derive the platform-package prefix from `napi.package.name` (falling back to the npm name) and grep for that. Verified `infx-linux-x64-gnu` matches the current generated `native.js`. Expected on the next publish run: `==> [1/5] reusing existing infino.<triple>.node` on both gnu legs, floor check passes, Linux legs ~10 minutes faster.