### PR TITLE
chore: speed up queries post compaction

### DIFF
--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -406,7 +406,7 @@ impl Supertable {
             entry: merged_entry,
             bytes_for_store,
             bytes_for_storage,
-            ..
+            bytes_for_cache,
         } = merged_segment;
         let merged_superfile_id = merged_entry.superfile_id;
         let new_entries = vec![merged_entry];
@@ -460,8 +460,19 @@ impl Supertable {
                             "compact: failed to warm reader cache for merged superfile"
                         );
                     }
-                    // Drop the merged-away inputs so the cache doesn't
-                    // grow forever across repeated compactions.
+                    // Same warm-up, disk-cache side: mirrors what a normal
+                    // write does when prepopulate_cache_on_commit is on.
+                    // Shares the writer's own insert_warm_or_warn so the
+                    // two paths can't drift out of sync again.
+                    if let Some((uri, bytes)) = bytes_for_cache
+                        && let Some(cache) = opts.disk_cache.as_ref()
+                    {
+                        cache.insert_warm_or_warn(&uri, bytes).await;
+                    }
+                    // Drop the merged-away inputs so the in-memory cache
+                    // doesn't grow forever across repeated compactions.
+                    // The disk cache is already size-bounded (LRU), so its
+                    // stale entries just age out on their own.
                     for entry in &entries_to_remove {
                         opts.store.remove(&entry.uri);
                     }
@@ -1672,6 +1683,68 @@ mod tests {
                 "merged-away superfile {uri:?} must be evicted from the in-memory cache"
             );
         }
+    }
+
+    /// Same as the in-memory case, but for a disk-cache-attached table:
+    /// the merged superfile should already be resident in the disk
+    /// cache right after compact, with no cold fetch needed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_warms_merged_superfile_into_disk_cache() {
+        use crate::supertable::reader_cache::{DiskCacheConfig, DiskCacheStore, LruPolicy};
+
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let cache = DiskCacheStore::new_unpinned(
+            Arc::clone(&storage),
+            DiskCacheConfig {
+                cache_root: dir.path().join("disk-cache"),
+                mmap_cold_threshold_secs: 0,
+                eviction: Box::new(LruPolicy::new()),
+                ..Default::default()
+            },
+        )
+        .expect("disk cache");
+        let st = Supertable::create(
+            default_supertable_options()
+                .with_storage(Arc::clone(&storage))
+                .with_disk_cache(Arc::clone(&cache)),
+        )
+        .expect("create supertable");
+
+        commit_titles(&st, &["alpha first", "alpha second"]);
+        commit_titles(&st, &["bravo first", "bravo second"]);
+        commit_titles(&st, &["charlie first", "charlie second"]);
+        commit_titles(&st, &["delta first", "delta second"]);
+        commit_titles(&st, &["echo first", "echo second"]);
+        commit_titles(&st, &["foxtrot first", "foxtrot second"]);
+        commit_titles(&st, &["golf first", "golf second"]);
+        commit_titles(&st, &["hotel first", "hotel second"]);
+        commit_titles(&st, &["india first", "india second"]);
+        commit_titles(&st, &["juliet first", "juliet second"]);
+
+        st.compact_async(&small_compact_cfg())
+            .await
+            .expect("compact");
+
+        let cold_fetches_after_compact = cache.stats().n_cold_fetches;
+
+        // A query against the merged file must not trigger a cold
+        // fetch -- it should already be resident from compaction's
+        // own warm-up.
+        let n: usize = st
+            .token_match("title", "alpha", BoolMode::And, None)
+            .expect("token_match")
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(n, 2);
+        assert_eq!(
+            cache.stats().n_cold_fetches,
+            cold_fetches_after_compact,
+            "querying the merged superfile should not cold-fetch -- it \
+             should already be warm in the disk cache from compaction"
+        );
     }
 
     /// Vocabulary for realistic term-frequency spread (no `rand` dep).

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -23,6 +23,7 @@ use chrono::Utc;
 use futures::future::join_all;
 use roaring::RoaringBitmap;
 use tokio::time;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::{
@@ -401,12 +402,16 @@ impl Supertable {
             .await
             .map_err(|e| CompactionError::Build(e.to_string()))?;
 
-        let new_entries = vec![merged_segment.entry];
-        let mut pending_storage_writes = vec![
-            merged_segment
-                .bytes_for_storage
-                .ok_or(CompactionError::EmptyMergedSuperfile)?,
-        ];
+        let PreparedSuperfile {
+            entry: merged_entry,
+            bytes_for_store,
+            bytes_for_storage,
+            ..
+        } = merged_segment;
+        let merged_superfile_id = merged_entry.superfile_id;
+        let new_entries = vec![merged_entry];
+        let mut pending_storage_writes =
+            vec![bytes_for_storage.ok_or(CompactionError::EmptyMergedSuperfile)?];
 
         let opts = Arc::clone(&inner.options);
         let max_retries = opts.max_commit_retries.max(1);
@@ -441,7 +446,27 @@ impl Supertable {
             )
             .await
             {
-                Ok(_) => return Ok(()),
+                Ok(_) => {
+                    // Warm the merged superfile into the cache, same as a
+                    // normal writer commit does. Without this every query
+                    // against it misses and re-fetches + re-opens from
+                    // storage every single time.
+                    if let Some((uri, bytes)) = bytes_for_store
+                        && let Err(e) = opts.store.insert(uri, bytes)
+                    {
+                        warn!(
+                            superfile_id = %merged_superfile_id,
+                            error = %e,
+                            "compact: failed to warm reader cache for merged superfile"
+                        );
+                    }
+                    // Drop the merged-away inputs so the cache doesn't
+                    // grow forever across repeated compactions.
+                    for entry in &entries_to_remove {
+                        opts.store.remove(&entry.uri);
+                    }
+                    return Ok(());
+                }
                 Err(CommitError::WriteContentionExhausted) if attempt + 1 < max_retries => {
                     self.refresh()
                         .await
@@ -1593,6 +1618,395 @@ mod tests {
                 .map(|b| b.num_rows())
                 .sum();
             assert_eq!(n, 2, "term '{term}' should match exactly 2 docs");
+        }
+    }
+
+    /// The merged superfile from compaction must be warmed into the
+    /// reader cache, and the merged-away inputs must be evicted from it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_warms_merged_superfile_and_evicts_merged_away_ones_from_cache() {
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+
+        // Combined size must clear small_compact_cfg()'s ~10KB floor,
+        // or select() emits no job at all.
+        commit_titles(&st, &["alpha first", "alpha second"]);
+        commit_titles(&st, &["bravo first", "bravo second"]);
+        commit_titles(&st, &["charlie first", "charlie second"]);
+        commit_titles(&st, &["delta first", "delta second"]);
+        commit_titles(&st, &["echo first", "echo second"]);
+        commit_titles(&st, &["foxtrot first", "foxtrot second"]);
+        commit_titles(&st, &["golf first", "golf second"]);
+        commit_titles(&st, &["hotel first", "hotel second"]);
+        commit_titles(&st, &["india first", "india second"]);
+        commit_titles(&st, &["juliet first", "juliet second"]);
+
+        let old_uris: Vec<_> = st
+            .reader()
+            .manifest()
+            .superfiles
+            .iter()
+            .map(|s| s.uri)
+            .collect();
+        assert_eq!(old_uris.len(), 10);
+        // Each commit already warmed the cache on its own.
+        for uri in &old_uris {
+            assert!(
+                st.inner().options.store.reader(uri).is_ok(),
+                "pre-merge superfile {uri:?} should already be warm from its own commit"
+            );
+        }
+
+        st.compact_async(&small_compact_cfg())
+            .await
+            .expect("compact");
+
+        let merged_uri = st.reader().manifest().superfiles[0].uri;
+        assert!(
+            st.inner().options.store.reader(&merged_uri).is_ok(),
+            "merged superfile must be warmed into the in-memory cache right after compact"
+        );
+        for uri in &old_uris {
+            assert!(
+                st.inner().options.store.reader(uri).is_err(),
+                "merged-away superfile {uri:?} must be evicted from the in-memory cache"
+            );
+        }
+    }
+
+    /// Vocabulary for realistic term-frequency spread (no `rand` dep).
+    const LATENCY_BENCH_WORDS: &[&str] = &[
+        "system",
+        "storage",
+        "query",
+        "index",
+        "engine",
+        "object",
+        "table",
+        "column",
+        "vector",
+        "search",
+        "cluster",
+        "replica",
+        "cache",
+        "buffer",
+        "stream",
+        "batch",
+        "record",
+        "field",
+        "schema",
+        "partition",
+    ];
+
+    fn env_usize(key: &str, default: usize) -> usize {
+        std::env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    /// Builds one superfile's worth of rows. `shard_tag` is this
+    /// superfile's unique narrow term; `broad_term` shows up in 1/3
+    /// rows.
+    fn latency_bench_shard_batch(
+        shard_tag: &str,
+        broad_term: &str,
+        row_offset: usize,
+        n_rows: usize,
+    ) -> arrow_array::RecordBatch {
+        let titles: Vec<String> = (0..n_rows)
+            .map(|local_i| {
+                let i = row_offset + local_i;
+                // Cheap multiplicative hash, spreads word choice without a rand dep.
+                let words: Vec<&str> = (0..5)
+                    .map(|k| {
+                        let h = (i as u64)
+                            .wrapping_mul(2_654_435_761)
+                            .wrapping_add(k as u64 * 40_503);
+                        LATENCY_BENCH_WORDS[(h % LATENCY_BENCH_WORDS.len() as u64) as usize]
+                    })
+                    .collect();
+                let common = if i.is_multiple_of(3) {
+                    format!(" {broad_term}")
+                } else {
+                    String::new()
+                };
+                format!("{shard_tag}{common} {} row{i}", words.join(" "))
+            })
+            .collect();
+        let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+        build_title_batch(&refs)
+    }
+
+    fn latency_bench_warm_median(
+        st: &Supertable,
+        query: &str,
+        warmup_iters: usize,
+        measured_iters: usize,
+    ) -> u128 {
+        for _ in 0..warmup_iters {
+            st.bm25_search("title", query, 10, BoolMode::Or, None)
+                .expect("bm25_search warmup");
+        }
+        let mut samples = Vec::with_capacity(measured_iters);
+        for _ in 0..measured_iters {
+            let start = Instant::now();
+            st.bm25_search("title", query, 10, BoolMode::Or, None)
+                .expect("bm25_search measured");
+            samples.push(start.elapsed().as_micros());
+        }
+        samples.sort_unstable();
+        samples[samples.len() / 2]
+    }
+
+    /// Exact match count (unlike `bm25_search`'s top-k), so it catches
+    /// old pre-compact files leaking back into results.
+    fn latency_bench_count_hits(st: &Supertable, query: &str) -> u64 {
+        st.count("title", query, BoolMode::Or).expect("count")
+    }
+
+    /// Warm `bm25_search` latency after merging many small superfiles
+    /// into one, on a real local-filesystem corpus (no cloud needed).
+    /// Scale via env vars: `INFINO_COMPACT_BENCH_TOTAL_MB` (default 500),
+    /// `INFINO_COMPACT_BENCH_N_SUPERFILES` (default 40),
+    /// `INFINO_COMPACT_BENCH_TARGET_MB` (default = total).
+    #[ignore = "perf diagnostic for issue #372/#378; run with --ignored --nocapture"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_latency_at_scale() {
+        const APPROX_BYTES_PER_DOC: u64 = 90;
+        const BROAD_TERM: &str = "broadterm";
+        const WARMUP_ITERS: usize = 20;
+        const MEASURED_ITERS: usize = 50;
+
+        let total_mb = env_usize("INFINO_COMPACT_BENCH_TOTAL_MB", 500);
+        let n_superfiles = env_usize("INFINO_COMPACT_BENCH_N_SUPERFILES", 40);
+        let compact_target_mb = env_usize("INFINO_COMPACT_BENCH_TARGET_MB", total_mb.max(1)) as u64;
+
+        let total_docs = (total_mb as u64 * 1_000_000) / APPROX_BYTES_PER_DOC;
+        let docs_per_superfile = (total_docs as usize / n_superfiles).max(1);
+
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("local fs provider"));
+        let st =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+                .expect("create supertable");
+
+        let narrow_term = format!("shard{}", n_superfiles / 2);
+
+        for i in 0..n_superfiles {
+            let shard_tag = format!("shard{i}");
+            let mut w = st.writer().expect("writer");
+            w.append(&latency_bench_shard_batch(
+                &shard_tag,
+                BROAD_TERM,
+                i * docs_per_superfile,
+                docs_per_superfile,
+            ))
+            .expect("append");
+            w.commit().expect("commit");
+        }
+
+        let n_before = st.reader().n_superfiles();
+        let docs_before = st.reader().n_docs_total();
+        let narrow_hits_before = latency_bench_count_hits(&st, &narrow_term);
+        let broad_hits_before = latency_bench_count_hits(&st, BROAD_TERM);
+        let narrow_before =
+            latency_bench_warm_median(&st, &narrow_term, WARMUP_ITERS, MEASURED_ITERS);
+        let broad_before = latency_bench_warm_median(&st, BROAD_TERM, WARMUP_ITERS, MEASURED_ITERS);
+
+        st.compact_async(&CompactionSettings {
+            target_superfile_size_mb: compact_target_mb,
+            min_fill_percent: 1,
+            ..CompactionSettings::default()
+        })
+        .await
+        .expect("compact");
+
+        let n_after = st.reader().n_superfiles();
+        assert!(n_after < n_before, "compact should reduce superfile count");
+
+        // No old-file double-counting: doc/hit counts must be identical.
+        assert_eq!(st.reader().n_docs_total(), docs_before);
+        assert_eq!(
+            latency_bench_count_hits(&st, &narrow_term),
+            narrow_hits_before
+        );
+        assert_eq!(latency_bench_count_hits(&st, BROAD_TERM), broad_hits_before);
+
+        let narrow_after =
+            latency_bench_warm_median(&st, &narrow_term, WARMUP_ITERS, MEASURED_ITERS);
+        let broad_after = latency_bench_warm_median(&st, BROAD_TERM, WARMUP_ITERS, MEASURED_ITERS);
+
+        eprintln!(
+            "superfiles: {n_before} -> {n_after}, narrow: {narrow_before}us -> {narrow_after}us, \
+             broad: {broad_before}us -> {broad_after}us"
+        );
+
+        // Narrow only ever touches one relevant superfile (bloom-skips
+        // the rest either way), so it must stay flat regardless of
+        // merge count.
+        assert!(
+            narrow_after <= narrow_before * 2,
+            "narrow query regressed: {narrow_before}us -> {narrow_after}us"
+        );
+
+        mem::forget(dir);
+    }
+
+    /// compact() drops the manifest's superfile count right away, but
+    /// the merged-away files stay on disk until a gc() sweep past the
+    /// safety gap deletes them.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_reduces_manifest_count_but_gc_safety_gap_leaves_old_files_on_disk() {
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+        let storage = st
+            .inner()
+            .manifest
+            .load_full()
+            .options
+            .storage
+            .clone()
+            .expect("storage-backed table");
+
+        for titles in [
+            ["alpha first", "alpha second"],
+            ["bravo first", "bravo second"],
+            ["charlie first", "charlie second"],
+            ["delta first", "delta second"],
+            ["echo first", "echo second"],
+            ["foxtrot first", "foxtrot second"],
+            ["golf first", "golf second"],
+            ["hotel first", "hotel second"],
+            ["india first", "india second"],
+            ["juliet first", "juliet second"],
+        ] {
+            commit_titles(&st, &titles);
+        }
+
+        let before_n_superfiles = st.reader().n_superfiles();
+        let before_data_objects = storage
+            .list_with_prefix_metadata("data")
+            .await
+            .expect("list data/ before compact")
+            .len();
+        assert_eq!(before_data_objects, before_n_superfiles);
+
+        st.compact_async(&small_compact_cfg())
+            .await
+            .expect("compact");
+
+        let after_n_superfiles = st.reader().n_superfiles();
+        assert!(
+            after_n_superfiles < before_n_superfiles,
+            "manifest superfile count must drop right after compact"
+        );
+
+        // Old inputs are orphaned, not deleted, until gc() runs.
+        let after_data_objects = storage
+            .list_with_prefix_metadata("data")
+            .await
+            .expect("list data/ after compact")
+            .len();
+        assert_eq!(after_data_objects, before_data_objects + 1);
+
+        // Default 1-day safety gap: everything here is brand new, so
+        // gc() deletes nothing yet.
+        let default_gap_report = st
+            .gc(crate::config::DEFAULT_GC_SAFETY_GAP)
+            .expect("gc with default safety gap");
+        assert_eq!(default_gap_report.objects_deleted, 0);
+        let after_default_gc_objects = storage
+            .list_with_prefix_metadata("data")
+            .await
+            .expect("list data/ after default-gap gc")
+            .len();
+        assert_eq!(after_default_gc_objects, before_data_objects + 1);
+
+        // A shrunk safety gap reclaims the orphaned inputs, and disk
+        // count catches up with the manifest.
+        let zero_gap_report = st
+            .gc(std::time::Duration::ZERO)
+            .expect("gc with zero safety gap");
+        assert!(
+            zero_gap_report.objects_deleted > 0,
+            "a gc() past the safety gap must reclaim the orphaned pre-merge inputs"
+        );
+        let after_zero_gap_objects = storage
+            .list_with_prefix_metadata("data")
+            .await
+            .expect("list data/ after zero-gap gc")
+            .len();
+        assert_eq!(after_zero_gap_objects, after_n_superfiles);
+
+        mem::forget(dir);
+    }
+
+    /// A superfile sealed by an abandoned compaction attempt (a merge
+    /// that started but never finished) is never unsealed, so
+    /// `pack_partition`'s `!sealed_by_other` filter excludes it from
+    /// every future compaction pass, forever.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn superfiles_sealed_by_an_abandoned_compaction_are_stranded_forever() {
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+
+        commit_titles(&st, &["alpha first", "alpha second"]);
+        commit_titles(&st, &["bravo first", "bravo second"]);
+
+        let stranded_ids: Vec<Uuid> = st
+            .reader()
+            .manifest()
+            .superfiles
+            .iter()
+            .map(|s| s.superfile_id)
+            .collect();
+        assert_eq!(stranded_ids.len(), 2);
+
+        // Simulate a compaction that sealed its inputs then died
+        // before committing the merge.
+        let storage = st
+            .inner()
+            .manifest
+            .load_full()
+            .options
+            .storage
+            .clone()
+            .expect("storage-backed table");
+        let wal_store = WalStore::new(storage);
+        let abandoned_compaction_id = Uuid::new_v4();
+        let sealed_at = Utc::now();
+        for id in &stranded_ids {
+            tombstones_admin::seal(&wal_store, *id, abandoned_compaction_id, sealed_at)
+                .await
+                .expect("seal");
+        }
+
+        // New data arrives and a generous compaction config runs.
+        commit_titles(&st, &["charlie first", "charlie second"]);
+        commit_titles(&st, &["delta first", "delta second"]);
+
+        let cfg = CompactionSettings {
+            target_superfile_size_mb: 1024,
+            min_fill_percent: 1,
+            ..CompactionSettings::default()
+        };
+        st.compact_async(&cfg)
+            .await
+            .expect("compact must not error");
+
+        // The two stranded superfiles are still sitting untouched —
+        // they can never be merged, so they leak permanently.
+        let remaining_ids: HashSet<Uuid> = st
+            .reader()
+            .manifest()
+            .superfiles
+            .iter()
+            .map(|s| s.superfile_id)
+            .collect();
+        for id in &stranded_ids {
+            assert!(remaining_ids.contains(id));
         }
     }
 

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -793,6 +793,18 @@ impl DiskCacheStore {
         Ok(())
     }
 
+    /// `insert_warm`, but best-effort: logs and swallows the error
+    /// instead of returning it. Shared by every committer (writer,
+    /// compaction) that pre-populates the cache after a superfile is
+    /// already durable in storage. A failure here just means the
+    /// next query cold-fetches instead of hitting a warm cache, it
+    /// never fails the commit itself.
+    pub async fn insert_warm_or_warn(self: &Arc<Self>, uri: &SuperfileUri, bytes: Bytes) {
+        if let Err(e) = self.insert_warm(uri, bytes).await {
+            tracing::warn!(uri = %uri.0, error = %e, "failed to warm disk cache");
+        }
+    }
+
     // ----- internals -----
 
     fn now_us(&self) -> u64 {

--- a/src/supertable/reader_cache/in_memory.rs
+++ b/src/supertable/reader_cache/in_memory.rs
@@ -131,6 +131,13 @@ impl SuperfileReaderCache for InMemoryReaderCache {
             .map(|e| e.bytes.len())
             .sum()
     }
+
+    fn remove(&self, uri: &SuperfileUri) {
+        self.inner
+            .write()
+            .expect("InMemoryReaderCache rwlock poisoned")
+            .remove(uri);
+    }
 }
 
 #[cfg(test)]

--- a/src/supertable/reader_cache/mod.rs
+++ b/src/supertable/reader_cache/mod.rs
@@ -83,6 +83,17 @@ pub trait SuperfileReaderCache: Send + Sync {
     /// cached superfile. Used by tests + observability that need to
     /// confirm RAM bounds match expectations.
     fn resident_bytes(&self) -> usize;
+
+    /// Drop a superfile's cached bytes once it's no longer referenced
+    /// by the manifest (e.g. merged away by compaction).
+    ///
+    /// Safe under concurrency: a caller already holding an
+    /// `Arc<SuperfileReader>` keeps it alive regardless. A later
+    /// `reader()` for this `uri` just misses and falls back to
+    /// storage, which still has the bytes until `gc()` reclaims them.
+    ///
+    /// Default no-op — bounded caches (e.g. LRU) don't need this.
+    fn remove(&self, _uri: &SuperfileUri) {}
 }
 
 /// Error type for [`SuperfileReaderCache`] operations.

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -2036,14 +2036,7 @@ fn warm_cache_after_commit(
     let cache = Arc::clone(cache);
     let drive = async move {
         for (uri, bytes) in pending {
-            if let Err(e) = cache.insert_warm(&uri, bytes).await {
-                tracing::warn!(
-                    "supertable: warm cache pre-population failed for {}: {} \
-                     (superfile is durable in storage; first query will cold-fetch)",
-                    uri.0,
-                    e
-                );
-            }
+            cache.insert_warm_or_warn(&uri, bytes).await;
         }
     };
     match Handle::try_current() {


### PR DESCRIPTION
### What is this PR about

This PR attempts to fix https://github.com/infino-ai/infino/issues/378 where post compaciton the queries were slower

### What was the issue

After compaction the newly created superfile was not added to reader cache, and thus for all the subsequent queries disk was being hit