### PR TITLE
release process: version-sync guard in CI and at publish time

### DIFF
--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -188,6 +188,12 @@ jobs:
             echo "::error::tag v$tag does not match infino-node/package.json version $pkg"
             exit 1
           fi
+      # The version about to publish is package.json's — assert it sits on the
+      # crate's major.minor release line and the infx-* pins track it
+      # (docs/versioning.md). Guards manual dispatches from a branch that
+      # never went through the PR gate.
+      - name: Check versions against the crate's release line
+        run: python3 scripts/check_version_sync.py
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -82,6 +82,12 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "target=$target" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v5
+      # The version about to publish must sit on the crate's major.minor
+      # release line (docs/versioning.md). Catches a mistyped manual dispatch
+      # — previously unvalidated — before the wheel matrix spins up.
+      - name: Check version against the crate's release line
+        run: python3 scripts/check_version_sync.py --release-version "${{ steps.check.outputs.version }}"
 
   build:
     name: wheel ${{ matrix.target }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,12 +1,14 @@
 name: Publish Python package
 
 # Release of the `infino` Python package: validate the version, build one binary
-# wheel per platform/arch, then upload. A `v<version>` tag publishes to real
-# PyPI with the version derived from the tag — but ONLY for a coordinated
-# minor/major release (patch == 0, e.g. `v0.2.0`); a crate-only patch tag (e.g.
-# `v0.1.1`) is skipped, since patch is independent per package. A manual run
-# (workflow_dispatch) — the path for an independent Python patch — chooses the
-# version and the PyPI (default) / TestPyPI target.
+# wheel per platform/arch, then upload. The version is the one committed in
+# `infino-python/Cargo.toml` (stamped by `make release-prep`). A `v<version>`
+# tag publishes to real PyPI after asserting the tag matches the tree — but
+# ONLY for a coordinated minor/major release (patch == 0, e.g. `v0.2.0`); a
+# crate-only patch tag (e.g. `v0.1.1`) is skipped, since patch is independent
+# per package. A manual run (workflow_dispatch) — the path for an independent
+# Python patch — publishes the tree's version to the PyPI (default) / TestPyPI
+# target.
 #
 # Two facts shape the whole pipeline:
 #   - abi3 (pyo3 `abi3-py39`) → a single wheel per platform/arch covers all
@@ -20,10 +22,6 @@ on:
     tags: ["v[0-9]*"]
   workflow_dispatch:
     inputs:
-      version:
-        description: "Release version, SemVer (e.g. 0.1.0, 0.1.0-rc.1)"
-        required: true
-        type: string
       target:
         description: "Index to publish to"
         required: true
@@ -62,18 +60,24 @@ jobs:
       version: ${{ steps.check.outputs.version }}
       target: ${{ steps.check.outputs.target }}
     steps:
-      # On a tag push, derive the version from the tag (`v0.1.0` -> `0.1.0`) and
-      # publish to real PyPI; a manual run uses its inputs (PyPI default).
-      # Reject a non-SemVer version before the matrix spins up: Cargo's
-      # `version` requires SemVer (it rejects PEP 440 like `0.1.0rc1`), and
-      # maturin renders SemVer to the wheel's PEP 440 (`0.1.0-rc.1` → `0.1.0rc1`).
+      - uses: actions/checkout@v5
+      # The version is the one committed in infino-python/Cargo.toml (stamped
+      # by `make release-prep`). On a tag push, assert the tag matches it — a
+      # coordinated release can't ship an unstamped tree. Reject a non-SemVer
+      # version before the matrix spins up: Cargo's `version` requires SemVer
+      # (it rejects PEP 440 like `0.1.0rc1`), and maturin renders SemVer to
+      # the wheel's PEP 440 (`0.1.0-rc.1` → `0.1.0rc1`).
       - id: check
         run: |
+          version="$(sed -n 's/^version = "\(.*\)"/\1/p' infino-python/Cargo.toml | head -1)"
           if [ "${{ github.event_name }}" = "push" ]; then
-            version="${GITHUB_REF_NAME#v}"
+            tag="${GITHUB_REF_NAME#v}"
+            if [ "$tag" != "$version" ]; then
+              echo "::error::tag v$tag does not match infino-python/Cargo.toml version $version"
+              exit 1
+            fi
             target="pypi"
           else
-            version="${{ inputs.version }}"
             target="${{ inputs.target }}"
           fi
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
@@ -82,10 +86,9 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "target=$target" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v5
       # The version about to publish must sit on the crate's major.minor
-      # release line (docs/versioning.md). Catches a mistyped manual dispatch
-      # — previously unvalidated — before the wheel matrix spins up.
+      # release line (docs/versioning.md), and the whole tree must be
+      # version-consistent, before the wheel matrix spins up.
       - name: Check version against the crate's release line
         run: python3 scripts/check_version_sync.py --release-version "${{ steps.check.outputs.version }}"
 
@@ -129,36 +132,9 @@ jobs:
           python-version: "3.12"
 
       # Version is dynamic (pyproject `dynamic = ["version"]`) → maturin reads
-      # it from Cargo.toml. Stamp it into Cargo.toml *and* Cargo.lock so the
-      # build stays --locked. python3 over sed: one script, every runner,
-      # Windows included.
-      - name: Stamp version
-        shell: bash
-        env:
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          python3 - "$VERSION" <<'PY'
-          import pathlib, re, sys
-
-          version = sys.argv[1]
-
-          toml = pathlib.Path("infino-python/Cargo.toml")
-          patched, count = re.subn(
-              r'(?m)^version = "[^"]*"', f'version = "{version}"',
-              toml.read_text(), count=1)
-          assert count == 1, "[package] version not found in Cargo.toml"
-          toml.write_text(patched)
-
-          lock = pathlib.Path("infino-python/Cargo.lock")
-          patched, count = re.subn(
-              r'(?ms)(\[\[package\]\]\nname = "infino-python"\nversion = ")[^"]*(")',
-              rf"\g<1>{version}\g<2>", lock.read_text(), count=1)
-          assert count == 1, "infino-python entry not found in Cargo.lock"
-          lock.write_text(patched)
-
-          print(f"stamped infino-python -> {version}")
-          PY
-
+      # it straight from the committed infino-python/Cargo.toml; `make
+      # release-prep` stamps Cargo.toml and Cargo.lock together, so the build
+      # stays --locked with no CI-side rewriting.
       # `manylinux` is honored only for Linux targets and ignored elsewhere;
       # musl targets need the musllinux image, every other target builds glibc.
       # `sccache` caches inside the container, avoiding a host cache whose glibc mismatches it.

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,83 @@
+name: Tag release
+
+# Merging a release PR (stamped by `make release-prep PACKAGE=crate|all`)
+# changes the crate version on main. This workflow notices that, pushes the
+# matching `v<version>` tag, and kicks off the publish workflows — so a
+# release is: run release-prep, merge the PR, done.
+#
+# Tags pushed with the workflow's own GITHUB_TOKEN deliberately do not fire
+# tag-push workflows (GitHub's recursion guard), so after tagging this
+# dispatches the publish workflows explicitly, pinned to the tag ref: the
+# crate always; for a coordinated `vX.Y.0`, Node and Python too — the same
+# split the tag-push path encodes in the workflows' own gates.
+#
+# Binding-only patches (Node/Python bumped, crate untouched) never reach this
+# workflow — they don't change the root Cargo.toml. Those are dispatched
+# manually per docs/versioning.md.
+
+on:
+  push:
+    branches: [main]
+    paths: ["Cargo.toml"]
+
+permissions:
+  contents: write # push the tag
+  actions: write # dispatch the publish workflows
+
+# One tagging run at a time; never cancel one mid-flight.
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Tag and kick off publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # HEAD^ is the pre-merge main tip (squash and merge commits alike);
+          # depth 2 is enough for the before/after version comparison.
+          fetch-depth: 2
+      # A release merge is "the [package] version changed and its tag doesn't
+      # exist yet". Dependency edits to Cargo.toml leave the version alone and
+      # skip; a deliberately deleted tag stays deleted (version unchanged). A
+      # version *changed to an already-tagged value* is a broken state —
+      # registries are immutable — so that fails loudly instead of re-tagging.
+      - id: detect
+        run: |
+          version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+          previous="$(git show HEAD^:Cargo.toml | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
+          if [ "$version" = "$previous" ]; then
+            echo "version unchanged ($version); not a release merge"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git ls-remote --exit-code origin "refs/tags/v$version" >/dev/null 2>&1; then
+            echo "::error::Cargo.toml changed to $version but tag v$version already exists"
+            exit 1
+          fi
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      # Refuse to tag an inconsistent tree: the same guard the PR gate runs,
+      # plus the release-line check on the new version.
+      - name: Check the tree is version-consistent
+        if: steps.detect.outputs.release == 'true'
+        run: python3 scripts/check_version_sync.py --release-version "${{ steps.detect.outputs.version }}"
+      - name: Push tag
+        if: steps.detect.outputs.release == 'true'
+        run: |
+          git tag "v${{ steps.detect.outputs.version }}"
+          git push origin "v${{ steps.detect.outputs.version }}"
+      - name: Kick off publish workflows
+        if: steps.detect.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.detect.outputs.version }}
+        run: |
+          gh workflow run crate-publish.yml --ref "v$VERSION" -f dry_run=false
+          if [ "${VERSION##*.}" = "0" ]; then
+            gh workflow run node-publish.yml --ref "v$VERSION" -f dry_run=false
+            gh workflow run publish-python.yml --ref "v$VERSION" -f target=pypi
+          fi

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
         coverage coverage-summary \
         bench bench-quick miri asan ci clean \
         public-api public-api-update api-parity api-parity-update \
-        version-sync doc-check \
+        version-sync release-prep doc-check \
         python-test python-typecheck python-wheel python-examples-test \
         node-test node-build node-verify node-example
 
@@ -55,6 +55,14 @@ api-parity-update:
 version-sync:
 	python3 -m unittest discover -s scripts -q
 	python3 scripts/check_version_sync.py
+
+# Stamp every version file for a release and print the follow-up step.
+# PACKAGE selects the scope: crate | node | python (single-package patch,
+# stays on the crate's release line) or all (coordinated minor/major,
+# patch must be 0). See docs/versioning.md.
+#   make release-prep PACKAGE=node VERSION=0.1.5
+release-prep:
+	python3 scripts/release_prep.py --package $(PACKAGE) --version $(VERSION)
 
 # Doc-surface gate. Every public item on the default (docs.rs) surface must be
 # documented, and every intra-doc link must resolve. Uses default features so

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: check fmt test doctest doc \
         coverage coverage-summary \
         bench bench-quick miri asan ci clean \
-        public-api public-api-update api-parity api-parity-update doc-check \
+        public-api public-api-update api-parity api-parity-update \
+        version-sync doc-check \
         python-test python-typecheck python-wheel python-examples-test \
         node-test node-build node-verify node-example
 
@@ -13,6 +14,7 @@ check:
 	cargo fmt --all -- --check --config $(RUSTFMT_OPTS)
 	cargo clippy --all-targets --features test-helpers -- -D warnings
 	$(MAKE) api-parity
+	$(MAKE) version-sync
 	$(MAKE) doc-check
 
 # Apply formatting, including the import-layout rules above.
@@ -43,6 +45,16 @@ api-parity:
 
 api-parity-update:
 	python3 scripts/check_api_parity.py --update
+
+# Version-sync guard: the crate and both bindings must sit on one
+# `major.minor` release line (patch is independent per package), the
+# `infx-*` platform pins must track the Node package version, and each
+# Cargo.lock must record its own package's manifest version so `--locked`
+# publishes don't fail at release time. See docs/versioning.md. Pure
+# Python 3; no toolchain needed. The unittest run covers the guard itself.
+version-sync:
+	python3 -m unittest discover -s scripts -q
+	python3 scripts/check_version_sync.py
 
 # Doc-surface gate. Every public item on the default (docs.rs) surface must be
 # documented, and every intra-doc link must resolve. Uses default features so

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,13 @@ version-sync:
 
 # Stamp every version file for a release and print the follow-up step.
 # PACKAGE selects the scope: crate | node | python (single-package patch,
-# stays on the crate's release line) or all (coordinated minor/major,
-# patch must be 0). See docs/versioning.md.
+# stays on the crate's release line), each (every package to its own next
+# patch; no VERSION), or all (coordinated minor/major, patch must be 0).
+# See docs/versioning.md.
 #   make release-prep PACKAGE=node VERSION=0.1.5
+#   make release-prep PACKAGE=each
 release-prep:
-	python3 scripts/release_prep.py --package $(PACKAGE) --version $(VERSION)
+	python3 scripts/release_prep.py --package $(PACKAGE) $(if $(VERSION),--version $(VERSION))
 
 # Doc-surface gate. Every public item on the default (docs.rs) surface must be
 # documented, and every intra-doc link must resolve. Uses default features so

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -62,21 +62,24 @@ A `v<version>` tag is the release trigger; what it publishes depends on whether
 it is a patch or a coordinated minor/major.
 
 - **Crate patch** (`vX.Y.Z`, `Z > 0`, e.g. `v0.1.1`) — bump `version` in the root
-  `Cargo.toml`, then push the matching tag. The `Publish crate` workflow
-  (`.github/workflows/crate-publish.yml`) asserts the tag matches `Cargo.toml` and
-  publishes to crates.io. **The Node and Python workflows skip a patch tag** —
-  their coordinated-release gate fires only when `patch == 0` — so the crate
-  patches alone. (You can also run `Publish crate` manually from the Actions
-  tab — the default is a dry run.)
+  `Cargo.toml` (`make release-prep PACKAGE=crate`) and land it. On merge, the
+  `Tag release` workflow (`.github/workflows/tag-release.yml`) pushes the
+  matching tag and kicks off `Publish crate`
+  (`.github/workflows/crate-publish.yml`), which publishes to crates.io.
+  **The Node and Python workflows skip a crate patch** — their
+  coordinated-release gate fires only when `patch == 0` — so the crate patches
+  alone. (Pushing a `v<version>` tag by hand still triggers the same publish,
+  and `Publish crate` can be run manually from the Actions tab — the default
+  is a dry run.)
 - **Coordinated minor/major** (`vX.Y.0`, e.g. `v0.2.0`) — land the engine change,
   **update the Node and Python binding code for any new or changed engine
-  surface**, bump the crate *and* both bindings (`infino-node/package.json`,
-  `infino-python/Cargo.toml`) to the same `X.Y.0`, then push the `vX.Y.0` tag. All
-  three publish workflows fire on it — crate → crates.io, Node → npm, Python →
-  PyPI — at `X.Y.0`. (Node's `napi prepublish` derives the per-platform package
-  versions and `optionalDependencies` pins from that single `package.json`
-  field.) The bindings must never ship a new minor before their code exposes that
-  minor's engine changes.
+  surface**, bump the crate *and* both bindings to the same `X.Y.0`
+  (`make release-prep PACKAGE=all`), and land the bump. On merge, `Tag release`
+  pushes the `vX.Y.0` tag and kicks off all three publish workflows — crate →
+  crates.io, Node → npm, Python → PyPI — at `X.Y.0`. (Node's `napi prepublish`
+  derives the per-platform package versions and `optionalDependencies` pins
+  from that single `package.json` field.) The bindings must never ship a new
+  minor before their code exposes that minor's engine changes.
 - **Binding-only patch** (Node or Python, independent of the crate's patch) — bump
   that binding's version (`make release-prep PACKAGE=node|python VERSION=…`),
   land it, then run its workflow **manually** (`Node publish` /

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -117,4 +117,7 @@ Patches diverge between coordinated minors; a minor bump realigns everything on
   `infino-node/package.json`, and `infino-python/Cargo.toml` all agree (patch
   ignored), that the `infx-*` platform pins track the Node package version, and
   that each Cargo.lock records its manifest's version so `--locked` publishes
-  don't fail at the tag. See `scripts/check_version_sync.py`.
+  don't fail at the tag. The binding publish workflows run the same guard
+  before building — `publish-python` validates the dispatched version against
+  the crate's line, `Node publish` validates the in-tree state. See
+  `scripts/check_version_sync.py`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -52,6 +52,12 @@ contract for how their versions relate.
 
 ## How to release
 
+Stamp the version files with `make release-prep PACKAGE=<crate|node|python|all>
+VERSION=X.Y.Z` — it validates the bump against the rules above, rewrites every
+file carrying that package's version (manifest, lockfile, and the Node
+platform pins), re-runs the drift guard, and prints the follow-up step. Land
+the stamped change as an ordinary PR, then trigger the publish:
+
 A `v<version>` tag is the release trigger; what it publishes depends on whether
 it is a patch or a coordinated minor/major.
 
@@ -72,8 +78,11 @@ it is a patch or a coordinated minor/major.
   field.) The bindings must never ship a new minor before their code exposes that
   minor's engine changes.
 - **Binding-only patch** (Node or Python, independent of the crate's patch) — bump
-  that binding's version and run its workflow **manually** (`Node publish` /
-  `publish-python`, `workflow_dispatch`). No tag; the crate is untouched.
+  that binding's version (`make release-prep PACKAGE=node|python VERSION=…`),
+  land it, then run its workflow **manually** (`Node publish` /
+  `publish-python`, `workflow_dispatch`). No tag; the crate is untouched. Both
+  workflows publish the version committed in the tree — Node from
+  `infino-node/package.json`, Python from `infino-python/Cargo.toml`.
 
 **Patch counters are independent per package and never shared**, so the crate's
 patch and a binding's patch can never collide on a registry — only `major.minor`

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -55,8 +55,11 @@ contract for how their versions relate.
 Stamp the version files with `make release-prep PACKAGE=<crate|node|python|all>
 VERSION=X.Y.Z` — it validates the bump against the rules above, rewrites every
 file carrying that package's version (manifest, lockfile, and the Node
-platform pins), re-runs the drift guard, and prints the follow-up step. Land
-the stamped change as an ordinary PR, then trigger the publish:
+platform pins), re-runs the drift guard, and prints the follow-up step.
+`make release-prep PACKAGE=each` (no `VERSION`) bumps every package to its own
+next patch in one go — for a fix that genuinely ships in all three; patch
+counters stay independent. Land the stamped change as an ordinary PR, then
+trigger the publish:
 
 A `v<version>` tag is the release trigger; what it publishes depends on whether
 it is a patch or a coordinated minor/major.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -112,6 +112,9 @@ Patches diverge between coordinated minors; a minor bump realigns everything on
   `v<version>` tag; Node and Python still publish via their own manual workflows.
   Still worth naming a clear owner for the engine's version bumps so the crate
   doesn't fall behind the bindings on the shared release line.
-- **No drift guard yet.** A small CI check that asserts the `major.minor` of the
-  root `Cargo.toml`, `infino-node/package.json`, and `infino-python/Cargo.toml`
-  all agree (patch ignored) would enforce rule 2 cheaply. Recommended.
+- **Drift guard: done.** `make version-sync` (part of `make check`, so it runs
+  on every PR) asserts the `major.minor` of the root `Cargo.toml`,
+  `infino-node/package.json`, and `infino-python/Cargo.toml` all agree (patch
+  ignored), that the `infx-*` platform pins track the Node package version, and
+  that each Cargo.lock records its manifest's version so `--locked` publishes
+  don't fail at the tag. See `scripts/check_version_sync.py`.

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "infino-node"
-version = "0.1.0"
+version = "0.1.4"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-node/Cargo.toml
+++ b/infino-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-node"
-version = "0.1.0"
+version = "0.1.4"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "infino-python"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-python"
-version = "0.1.0"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -112,6 +112,25 @@ def check(root, release_version=None):
                     f"the package version is {node}; the platform pins "
                     f"track the package version"
                 )
+        # The node crate is unpublished (`publish = false`), but its version
+        # must track package.json so no committed version file lies.
+        node_crate = manifest_version(root / "infino-node" / "Cargo.toml")
+        if node_crate != node:
+            errors.append(
+                f"infino-node/Cargo.toml records {node_crate} but "
+                f"infino-node/package.json says {node}; the node crate "
+                f"manifest tracks the npm package version"
+            )
+        else:
+            node_crate_locked = locked_version(
+                root / "infino-node" / "Cargo.lock", "infino-node"
+            )
+            if node_crate_locked != node_crate:
+                errors.append(
+                    f"infino-node/Cargo.lock records infino-node "
+                    f"{node_crate_locked} but infino-node/Cargo.toml says "
+                    f"{node_crate}; regenerate the lockfile"
+                )
 
     python = manifest_version(root / "infino-python" / "Cargo.toml")
     if python is None:

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Guard that the three published packages stay on one release line.
+
+infino ships three artifacts from this repo — the Rust crate (root
+`Cargo.toml`), the Node binding (`infino-node/package.json`), and the
+Python binding (`infino-python/Cargo.toml`). Per `docs/versioning.md`,
+their `major.minor` is locked in sync (the crate defines the line) while
+each package bumps its own patch independently.
+
+The check fails (non-zero exit) when:
+  (a) a binding sits on a different `major.minor` than the crate
+  (b) an `infx-*` platform pin in `infino-node/package.json`
+      `optionalDependencies` differs from the package's own version
+  (c) a Cargo.lock records a different version for its own package than
+      the matching Cargo.toml — a bump that skipped the lockfile breaks
+      the `--locked` publish at release time
+
+Usage:
+  check_version_sync.py    # verify; non-zero exit on any drift
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_VERSION = re.compile(r'version\s*=\s*"([^"]+)"')
+
+
+def manifest_version(toml_path):
+    """The `[package]` version of a Cargo.toml (regex; stdlib-only on 3.9)."""
+    section = None
+    for raw in toml_path.read_text().splitlines():
+        line = raw.strip()
+        if line.startswith("["):
+            section = line
+        elif section == "[package]":
+            m = _VERSION.match(line)
+            if m:
+                return m.group(1)
+    return None
+
+
+def locked_version(lock_path, name):
+    """The version Cargo.lock records for package `name`."""
+    lines = [line.strip() for line in lock_path.read_text().splitlines()]
+    for i, line in enumerate(lines[:-1]):
+        if line == f'name = "{name}"':
+            m = _VERSION.match(lines[i + 1])
+            if m:
+                return m.group(1)
+    return None
+
+
+def release_line(version):
+    """major.minor — the release line a version sits on."""
+    return ".".join(version.split(".")[:2])
+
+
+def check(root):
+    """Verify the version contract under `root`; return error strings."""
+    root = Path(root)
+    errors = []
+
+    crate = manifest_version(root / "Cargo.toml")
+    if crate is None:
+        errors.append("no [package] version found in Cargo.toml")
+    else:
+        crate_locked = locked_version(root / "Cargo.lock", "infino")
+        if crate_locked != crate:
+            errors.append(
+                f"Cargo.lock records infino {crate_locked} but Cargo.toml "
+                f"says {crate}; regenerate the lockfile (releases publish "
+                f"with --locked)"
+            )
+
+    node_manifest = json.loads((root / "infino-node" / "package.json").read_text())
+    node = node_manifest.get("version")
+    if node is None:
+        errors.append("no version field found in infino-node/package.json")
+    else:
+        if crate is not None and release_line(node) != release_line(crate):
+            errors.append(
+                f"infino-node/package.json is on the {release_line(node)} "
+                f"line ({node}) but the crate is on {release_line(crate)} "
+                f"({crate}); major.minor is locked across the three "
+                f"packages (docs/versioning.md)"
+            )
+        for pin, pinned in sorted(node_manifest.get("optionalDependencies", {}).items()):
+            if pin.startswith("infx-") and pinned != node:
+                errors.append(
+                    f"infino-node/package.json pins {pin} at {pinned} but "
+                    f"the package version is {node}; the platform pins "
+                    f"track the package version"
+                )
+
+    python = manifest_version(root / "infino-python" / "Cargo.toml")
+    if python is None:
+        errors.append("no [package] version found in infino-python/Cargo.toml")
+    else:
+        if crate is not None and release_line(python) != release_line(crate):
+            errors.append(
+                f"infino-python/Cargo.toml is on the {release_line(python)} "
+                f"line ({python}) but the crate is on {release_line(crate)} "
+                f"({crate}); major.minor is locked across the three "
+                f"packages (docs/versioning.md)"
+            )
+        python_locked = locked_version(
+            root / "infino-python" / "Cargo.lock", "infino-python"
+        )
+        if python_locked != python:
+            errors.append(
+                f"infino-python/Cargo.lock records infino-python "
+                f"{python_locked} but infino-python/Cargo.toml says {python}; "
+                f"regenerate the lockfile (releases publish with --locked)"
+            )
+
+    return errors
+
+
+def main():
+    errors = check(ROOT)
+    if errors:
+        for error in errors:
+            print(f"version drift: {error}", file=sys.stderr)
+        return 1
+    crate = manifest_version(ROOT / "Cargo.toml")
+    print(f"version sync OK: all packages on the {release_line(crate)} line")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -16,9 +16,13 @@ The check fails (non-zero exit) when:
       the `--locked` publish at release time
 
 Usage:
-  check_version_sync.py    # verify; non-zero exit on any drift
+  check_version_sync.py                          # verify; non-zero exit on drift
+  check_version_sync.py --release-version 0.2.1  # also assert a version about
+                                                 # to publish sits on the
+                                                 # crate's release line
 """
 
+import argparse
 import json
 import re
 import sys
@@ -59,8 +63,13 @@ def release_line(version):
     return ".".join(version.split(".")[:2])
 
 
-def check(root):
-    """Verify the version contract under `root`; return error strings."""
+def check(root, release_version=None):
+    """Verify the version contract under `root`; return error strings.
+
+    `release_version` is a version about to be published (e.g. the value a
+    publish workflow was dispatched with); it must sit on the crate's
+    release line.
+    """
     root = Path(root)
     errors = []
 
@@ -68,6 +77,14 @@ def check(root):
     if crate is None:
         errors.append("no [package] version found in Cargo.toml")
     else:
+        if (release_version is not None
+                and release_line(release_version) != release_line(crate)):
+            errors.append(
+                f"release version {release_version} is on the "
+                f"{release_line(release_version)} line but the crate is on "
+                f"{release_line(crate)} ({crate}); major.minor is locked "
+                f"across the three packages (docs/versioning.md)"
+            )
         crate_locked = locked_version(root / "Cargo.lock", "infino")
         if crate_locked != crate:
             errors.append(
@@ -121,7 +138,14 @@ def check(root):
 
 
 def main():
-    errors = check(ROOT)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--release-version",
+        help="a version about to be published; must sit on the crate's "
+             "major.minor release line",
+    )
+    args = parser.parse_args()
+    errors = check(ROOT, release_version=args.release_version)
     if errors:
         for error in errors:
             print(f"version drift: {error}", file=sys.stderr)

--- a/scripts/release_prep.py
+++ b/scripts/release_prep.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
 """Stamp every version file for a release, per docs/versioning.md.
 
-One engine, three published packages, three kinds of release:
+One engine, three published packages, four kinds of release:
 
   release_prep.py --package crate  --version 0.1.5   # engine patch
   release_prep.py --package node   --version 0.1.5   # Node-only patch
   release_prep.py --package python --version 0.1.6   # Python-only patch
+  release_prep.py --package each                     # every package, own next patch
   release_prep.py --package all    --version 0.2.0   # coordinated minor/major
 
 A single-package bump must stay on the crate's `major.minor` release line
 and move that package strictly forward (registries are immutable — every
-publish needs a fresh version). A coordinated release must have patch 0
-(the binding publish workflows key on the `.0` tag suffix) and moves all
-three packages onto the new line together.
+publish needs a fresh version). `each` bumps every package to its own next
+patch — patch counters are independent, so no version argument applies. A
+coordinated release must have patch 0 (the binding publish workflows key on
+the `.0` tag suffix) and moves all three packages onto the new line together.
 
 Each scope stamps every file that carries that package's version — manifest,
 lockfile, and for Node the `infx-*` platform pins — then re-runs the
@@ -46,6 +48,9 @@ FOLLOW_UP = {
               " package' workflow (it reads the version from the tree)",
     "all": "merge the release PR — the 'Tag release' workflow pushes v{v}"
            " and kicks off all three publish workflows",
+    "each": "merge the release PR — 'Tag release' tags and publishes the"
+            " crate; then dispatch 'Node publish' (uncheck dry_run) and"
+            " 'Publish Python package' for the bindings",
 }
 
 
@@ -105,11 +110,28 @@ def current_versions(root):
     }
 
 
+def next_patch(version):
+    major, minor, patch = parse_version(version)
+    return f"{major}.{minor}.{patch + 1}"
+
+
 def validate(root, package, version):
-    """Raise ReleasePrepError unless the bump obeys the versioning rules."""
-    requested = parse_version(version)
+    """Check the bump obeys the versioning rules; return {package: version}
+    targets to stamp. Raises ReleasePrepError on any violation."""
     current = current_versions(root)
     crate = current["crate"]
+
+    if package == "each":
+        if version is not None:
+            raise ReleasePrepError(
+                "a version does not apply to 'each' — every package moves"
+                " to its own next patch (their counters are independent)"
+            )
+        return {name: next_patch(cur) for name, cur in current.items()}
+
+    if version is None:
+        raise ReleasePrepError(f"a version is required for '{package}'")
+    requested = parse_version(version)
 
     if package == "all":
         if requested[2] != 0:
@@ -123,45 +145,50 @@ def validate(root, package, version):
                     f"coordinated version {version} does not move {name}"
                     f" forward (currently {cur})"
                 )
-    else:
-        if release_line(version) != release_line(crate):
-            raise ReleasePrepError(
-                f"a {package} patch must stay on the crate's release line"
-                f" {release_line(crate)} (got {version}); changing the line"
-                f" is a coordinated release (--package all)"
-            )
-        cur = current[package]
-        if requested <= parse_version(cur):
-            raise ReleasePrepError(
-                f"{package} is already at {cur}; the new version must move"
-                f" it strictly forward (got {version})"
-            )
+        return {name: version for name in current}
+
+    if release_line(version) != release_line(crate):
+        raise ReleasePrepError(
+            f"a {package} patch must stay on the crate's release line"
+            f" {release_line(crate)} (got {version}); changing the line"
+            f" is a coordinated release (--package all)"
+        )
+    cur = current[package]
+    if requested <= parse_version(cur):
+        raise ReleasePrepError(
+            f"{package} is already at {cur}; the new version must move"
+            f" it strictly forward (got {version})"
+        )
+    return {package: version}
 
 
-def prepare(root, package, version):
-    """Validate, then stamp every file carrying `package`'s version.
+def prepare(root, package, version=None):
+    """Validate, then stamp every file carrying each target's version.
 
     Returns the repo-relative paths that were rewritten. Nothing is written
     if validation fails.
     """
     root = Path(root)
-    validate(root, package, version)
+    targets = validate(root, package, version)
 
     changed = []
-    if package in ("crate", "all"):
-        stamp_manifest(root / "Cargo.toml", version)
-        stamp_lock(root / "Cargo.lock", "infino", version)
+    if "crate" in targets:
+        stamp_manifest(root / "Cargo.toml", targets["crate"])
+        stamp_lock(root / "Cargo.lock", "infino", targets["crate"])
         changed += ["Cargo.toml", "Cargo.lock"]
-    if package in ("node", "all"):
-        stamp_node_package(root / "infino-node" / "package.json", version)
-        stamp_manifest(root / "infino-node" / "Cargo.toml", version)
-        stamp_lock(root / "infino-node" / "Cargo.lock", "infino-node", version)
+    if "node" in targets:
+        stamp_node_package(root / "infino-node" / "package.json",
+                           targets["node"])
+        stamp_manifest(root / "infino-node" / "Cargo.toml", targets["node"])
+        stamp_lock(root / "infino-node" / "Cargo.lock", "infino-node",
+                   targets["node"])
         changed += ["infino-node/package.json", "infino-node/Cargo.toml",
                     "infino-node/Cargo.lock"]
-    if package in ("python", "all"):
-        stamp_manifest(root / "infino-python" / "Cargo.toml", version)
+    if "python" in targets:
+        stamp_manifest(root / "infino-python" / "Cargo.toml",
+                       targets["python"])
         stamp_lock(root / "infino-python" / "Cargo.lock", "infino-python",
-                   version)
+                   targets["python"])
         changed += ["infino-python/Cargo.toml", "infino-python/Cargo.lock"]
 
     drift = check(root)
@@ -176,9 +203,9 @@ def prepare(root, package, version):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--package", required=True,
-                        choices=["crate", "node", "python", "all"])
-    parser.add_argument("--version", required=True,
-                        help="new version, plain X.Y.Z")
+                        choices=["crate", "node", "python", "each", "all"])
+    parser.add_argument("--version",
+                        help="new version, plain X.Y.Z (omit for 'each')")
     args = parser.parse_args()
 
     try:
@@ -187,14 +214,22 @@ def main():
         print(f"release-prep: {error}", file=sys.stderr)
         return 1
 
-    print(f"stamped {args.package} -> {args.version}:")
+    stamped = current_versions(ROOT)
+    markers = {"crate": "Cargo.toml", "node": "infino-node/package.json",
+               "python": "infino-python/Cargo.toml"}
+    print("stamped:")
+    for name, marker in markers.items():
+        if marker in changed:
+            print(f"  {name} -> {stamped[name]}")
     for path in changed:
         print(f"  {path}")
+
+    slug = args.version if args.version else stamped["crate"]
     print("\nnext steps:")
     print(f"  1. commit on a branch and open the release PR, e.g.:")
-    print(f"       git checkout -b release-{args.package}-{args.version}")
-    print(f"       git commit -am 'release: {args.package} {args.version}'")
-    print(f"  2. {FOLLOW_UP[args.package].format(v=args.version)}")
+    print(f"       git checkout -b release-{args.package}-{slug}")
+    print(f"       git commit -am 'release: {args.package} {slug}'")
+    print(f"  2. {FOLLOW_UP[args.package].format(v=slug)}")
     return 0
 
 

--- a/scripts/release_prep.py
+++ b/scripts/release_prep.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Stamp every version file for a release, per docs/versioning.md.
+
+One engine, three published packages, three kinds of release:
+
+  release_prep.py --package crate  --version 0.1.5   # engine patch
+  release_prep.py --package node   --version 0.1.5   # Node-only patch
+  release_prep.py --package python --version 0.1.6   # Python-only patch
+  release_prep.py --package all    --version 0.2.0   # coordinated minor/major
+
+A single-package bump must stay on the crate's `major.minor` release line
+and move that package strictly forward (registries are immutable — every
+publish needs a fresh version). A coordinated release must have patch 0
+(the binding publish workflows key on the `.0` tag suffix) and moves all
+three packages onto the new line together.
+
+Each scope stamps every file that carries that package's version — manifest,
+lockfile, and for Node the `infx-*` platform pins — then re-runs the
+version-sync guard as a self-check, and prints the follow-up step (which tag
+to push or which workflow to dispatch).
+
+Plain `X.Y.Z` versions only; pre-releases are rare enough to stamp by hand.
+Typical use, from the repo root:
+
+  make release-prep PACKAGE=node VERSION=0.1.5
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from check_version_sync import check, manifest_version, release_line
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_STRICT_VERSION = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+FOLLOW_UP = {
+    "crate": "merge the release PR, then push tag v{v} — the crate publishes;"
+             " the bindings' workflows skip a patch tag",
+    "node": "merge the release PR, then dispatch the 'Node publish' workflow"
+            " (uncheck dry_run to publish)",
+    "python": "merge the release PR, then dispatch the 'Publish Python"
+              " package' workflow (it reads the version from the tree)",
+    "all": "merge the release PR, then push tag v{v} — all three publish"
+           " workflows fire",
+}
+
+
+class ReleasePrepError(Exception):
+    """A requested release violates the versioning contract."""
+
+
+def parse_version(version):
+    m = _STRICT_VERSION.match(version)
+    if not m:
+        raise ReleasePrepError(
+            f"version must be plain X.Y.Z (got {version!r}); stamp"
+            f" pre-releases by hand"
+        )
+    return tuple(int(part) for part in m.groups())
+
+
+def stamp_manifest(path, version):
+    """Rewrite the `[package]` version of a Cargo.toml."""
+    text, count = re.subn(
+        r'(?m)^version = "[^"]*"', f'version = "{version}"',
+        path.read_text(), count=1,
+    )
+    if count != 1:
+        raise ReleasePrepError(f"no [package] version found in {path}")
+    path.write_text(text)
+
+
+def stamp_lock(path, name, version):
+    """Rewrite the version Cargo.lock records for package `name`."""
+    text, count = re.subn(
+        rf'(?ms)(\[\[package\]\]\nname = "{name}"\nversion = ")[^"]*(")',
+        rf"\g<1>{version}\g<2>", path.read_text(), count=1,
+    )
+    if count != 1:
+        raise ReleasePrepError(f"no {name} entry found in {path}")
+    path.write_text(text)
+
+
+def stamp_node_package(path, version):
+    """Rewrite package.json's version and its infx-* platform pins."""
+    manifest = json.loads(path.read_text())
+    manifest["version"] = version
+    for pin in manifest.get("optionalDependencies", {}):
+        if pin.startswith("infx-"):
+            manifest["optionalDependencies"][pin] = version
+    path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+
+
+def current_versions(root):
+    return {
+        "crate": manifest_version(root / "Cargo.toml"),
+        "node": json.loads(
+            (root / "infino-node" / "package.json").read_text()
+        )["version"],
+        "python": manifest_version(root / "infino-python" / "Cargo.toml"),
+    }
+
+
+def validate(root, package, version):
+    """Raise ReleasePrepError unless the bump obeys the versioning rules."""
+    requested = parse_version(version)
+    current = current_versions(root)
+    crate = current["crate"]
+
+    if package == "all":
+        if requested[2] != 0:
+            raise ReleasePrepError(
+                f"a coordinated release needs patch 0 (got {version}); the"
+                f" binding publish workflows fire only on a vX.Y.0 tag"
+            )
+        for name, cur in current.items():
+            if requested <= parse_version(cur):
+                raise ReleasePrepError(
+                    f"coordinated version {version} does not move {name}"
+                    f" forward (currently {cur})"
+                )
+    else:
+        if release_line(version) != release_line(crate):
+            raise ReleasePrepError(
+                f"a {package} patch must stay on the crate's release line"
+                f" {release_line(crate)} (got {version}); changing the line"
+                f" is a coordinated release (--package all)"
+            )
+        cur = current[package]
+        if requested <= parse_version(cur):
+            raise ReleasePrepError(
+                f"{package} is already at {cur}; the new version must move"
+                f" it strictly forward (got {version})"
+            )
+
+
+def prepare(root, package, version):
+    """Validate, then stamp every file carrying `package`'s version.
+
+    Returns the repo-relative paths that were rewritten. Nothing is written
+    if validation fails.
+    """
+    root = Path(root)
+    validate(root, package, version)
+
+    changed = []
+    if package in ("crate", "all"):
+        stamp_manifest(root / "Cargo.toml", version)
+        stamp_lock(root / "Cargo.lock", "infino", version)
+        changed += ["Cargo.toml", "Cargo.lock"]
+    if package in ("node", "all"):
+        stamp_node_package(root / "infino-node" / "package.json", version)
+        stamp_manifest(root / "infino-node" / "Cargo.toml", version)
+        stamp_lock(root / "infino-node" / "Cargo.lock", "infino-node", version)
+        changed += ["infino-node/package.json", "infino-node/Cargo.toml",
+                    "infino-node/Cargo.lock"]
+    if package in ("python", "all"):
+        stamp_manifest(root / "infino-python" / "Cargo.toml", version)
+        stamp_lock(root / "infino-python" / "Cargo.lock", "infino-python",
+                   version)
+        changed += ["infino-python/Cargo.toml", "infino-python/Cargo.lock"]
+
+    drift = check(root)
+    if drift:
+        raise ReleasePrepError(
+            "stamping left the tree inconsistent (bug in this script):\n  "
+            + "\n  ".join(drift)
+        )
+    return changed
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package", required=True,
+                        choices=["crate", "node", "python", "all"])
+    parser.add_argument("--version", required=True,
+                        help="new version, plain X.Y.Z")
+    args = parser.parse_args()
+
+    try:
+        changed = prepare(ROOT, args.package, args.version)
+    except ReleasePrepError as error:
+        print(f"release-prep: {error}", file=sys.stderr)
+        return 1
+
+    print(f"stamped {args.package} -> {args.version}:")
+    for path in changed:
+        print(f"  {path}")
+    print("\nnext steps:")
+    print(f"  1. commit on a branch and open the release PR, e.g.:")
+    print(f"       git checkout -b release-{args.package}-{args.version}")
+    print(f"       git commit -am 'release: {args.package} {args.version}'")
+    print(f"  2. {FOLLOW_UP[args.package].format(v=args.version)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release_prep.py
+++ b/scripts/release_prep.py
@@ -38,14 +38,14 @@ ROOT = Path(__file__).resolve().parent.parent
 _STRICT_VERSION = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 
 FOLLOW_UP = {
-    "crate": "merge the release PR, then push tag v{v} — the crate publishes;"
-             " the bindings' workflows skip a patch tag",
+    "crate": "merge the release PR — the 'Tag release' workflow pushes v{v}"
+             " and kicks off the crate publish (bindings skip a patch)",
     "node": "merge the release PR, then dispatch the 'Node publish' workflow"
             " (uncheck dry_run to publish)",
     "python": "merge the release PR, then dispatch the 'Publish Python"
               " package' workflow (it reads the version from the tree)",
-    "all": "merge the release PR, then push tag v{v} — all three publish"
-           " workflows fire",
+    "all": "merge the release PR — the 'Tag release' workflow pushes v{v}"
+           " and kicks off all three publish workflows",
 }
 
 

--- a/scripts/test_check_version_sync.py
+++ b/scripts/test_check_version_sync.py
@@ -129,6 +129,19 @@ class CheckVersionSync(unittest.TestCase):
         errors = check(self.root)
         self.assertEqual(len(errors), 2)
 
+    def test_release_version_on_the_crate_line_passes(self):
+        # A binding patch release (any patch) is fine as long as it sits on
+        # the crate's major.minor line.
+        write_fixture(self.root, crate="0.3.4")
+        self.assertEqual(check(self.root, release_version="0.3.9"), [])
+
+    def test_release_version_off_the_crate_line_fails(self):
+        write_fixture(self.root, crate="0.3.4")
+        errors = check(self.root, release_version="0.4.0")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("release version 0.4.0", errors[0])
+        self.assertIn("0.3", errors[0])
+
     def test_missing_version_field_fails_loudly(self):
         write_fixture(self.root)
         (self.root / "infino-python" / "Cargo.toml").write_text(

--- a/scripts/test_check_version_sync.py
+++ b/scripts/test_check_version_sync.py
@@ -1,0 +1,143 @@
+"""Unit tests for check_version_sync.py. Run from the repo root:
+
+  python3 -m unittest discover -s scripts -q
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_version_sync import check
+
+PLATFORM_PACKAGES = (
+    "infx-darwin-x64",
+    "infx-darwin-arm64",
+    "infx-linux-x64-gnu",
+    "infx-linux-arm64-gnu",
+    "infx-linux-x64-musl",
+    "infx-linux-arm64-musl",
+)
+
+
+def write_fixture(root, crate="0.3.4", crate_lock=None, node="0.3.2",
+                  pins=None, python="0.3.5", python_lock=None):
+    """Materialize the minimal manifest/lockfile tree the guard reads."""
+    root = Path(root)
+    crate_lock = crate_lock if crate_lock is not None else crate
+    python_lock = python_lock if python_lock is not None else python
+    pins = pins if pins is not None else {p: node for p in PLATFORM_PACKAGES}
+
+    (root / "Cargo.toml").write_text(
+        "[package]\n"
+        'name = "infino"\n'
+        f'version = "{crate}"\n'
+        'edition = "2024"\n'
+        "\n"
+        "[dependencies]\n"
+        'arrow = { version = "58" }\n'
+    )
+    (root / "Cargo.lock").write_text(
+        "[[package]]\n"
+        'name = "arrow"\n'
+        'version = "58.0.0"\n'
+        "\n"
+        "[[package]]\n"
+        'name = "infino"\n'
+        f'version = "{crate_lock}"\n'
+    )
+
+    node_dir = root / "infino-node"
+    node_dir.mkdir()
+    (node_dir / "package.json").write_text(json.dumps({
+        "name": "@infino-ai/infino",
+        "version": node,
+        "optionalDependencies": pins,
+    }))
+
+    py_dir = root / "infino-python"
+    py_dir.mkdir()
+    (py_dir / "Cargo.toml").write_text(
+        "[package]\n"
+        'name = "infino-python"\n'
+        f'version = "{python}"\n'
+    )
+    (py_dir / "Cargo.lock").write_text(
+        "[[package]]\n"
+        'name = "infino"\n'
+        f'version = "{crate}"\n'
+        "\n"
+        "[[package]]\n"
+        'name = "infino-python"\n'
+        f'version = "{python_lock}"\n'
+    )
+    return root
+
+
+class CheckVersionSync(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def test_in_sync_tree_with_divergent_patches_passes(self):
+        # Patch numbers legitimately diverge; only major.minor must agree.
+        write_fixture(self.root, crate="0.3.4", node="0.3.2", python="0.3.5")
+        self.assertEqual(check(self.root), [])
+
+    def test_node_on_a_different_minor_fails(self):
+        write_fixture(self.root, crate="0.3.4", node="0.2.9",
+                      pins={p: "0.2.9" for p in PLATFORM_PACKAGES})
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("infino-node/package.json", errors[0])
+        self.assertIn("0.2", errors[0])
+        self.assertIn("0.3", errors[0])
+
+    def test_python_on_a_different_minor_fails(self):
+        write_fixture(self.root, crate="0.3.4", python="0.4.0",
+                      python_lock="0.4.0")
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("infino-python/Cargo.toml", errors[0])
+
+    def test_platform_pin_out_of_step_with_package_version_fails(self):
+        pins = {p: "0.3.2" for p in PLATFORM_PACKAGES}
+        pins["infx-linux-arm64-musl"] = "0.3.1"
+        write_fixture(self.root, node="0.3.2", pins=pins)
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("infx-linux-arm64-musl", errors[0])
+        self.assertIn("0.3.1", errors[0])
+
+    def test_crate_lockfile_behind_manifest_fails(self):
+        # A version bump that skips Cargo.lock breaks `cargo publish --locked`
+        # at release time; catch it on the PR instead.
+        write_fixture(self.root, crate="0.3.5", crate_lock="0.3.4")
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Cargo.lock", errors[0])
+
+    def test_python_lockfile_behind_manifest_fails(self):
+        write_fixture(self.root, python="0.3.6", python_lock="0.3.5")
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("infino-python/Cargo.lock", errors[0])
+
+    def test_all_drift_reported_not_just_first(self):
+        write_fixture(self.root, crate="0.4.0", node="0.3.2", python="0.3.5")
+        errors = check(self.root)
+        self.assertEqual(len(errors), 2)
+
+    def test_missing_version_field_fails_loudly(self):
+        write_fixture(self.root)
+        (self.root / "infino-python" / "Cargo.toml").write_text(
+            "[package]\n"
+            'name = "infino-python"\n'
+        )
+        errors = check(self.root)
+        self.assertTrue(any("infino-python/Cargo.toml" in e for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_version_sync.py
+++ b/scripts/test_check_version_sync.py
@@ -21,10 +21,13 @@ PLATFORM_PACKAGES = (
 
 
 def write_fixture(root, crate="0.3.4", crate_lock=None, node="0.3.2",
-                  pins=None, python="0.3.5", python_lock=None):
+                  pins=None, node_crate=None, node_crate_lock=None,
+                  python="0.3.5", python_lock=None):
     """Materialize the minimal manifest/lockfile tree the guard reads."""
     root = Path(root)
     crate_lock = crate_lock if crate_lock is not None else crate
+    node_crate = node_crate if node_crate is not None else node
+    node_crate_lock = node_crate_lock if node_crate_lock is not None else node_crate
     python_lock = python_lock if python_lock is not None else python
     pins = pins if pins is not None else {p: node for p in PLATFORM_PACKAGES}
 
@@ -53,7 +56,21 @@ def write_fixture(root, crate="0.3.4", crate_lock=None, node="0.3.2",
         "name": "@infino-ai/infino",
         "version": node,
         "optionalDependencies": pins,
-    }))
+    }, indent=2) + "\n")
+    (node_dir / "Cargo.toml").write_text(
+        "[package]\n"
+        'name = "infino-node"\n'
+        f'version = "{node_crate}"\n'
+    )
+    (node_dir / "Cargo.lock").write_text(
+        "[[package]]\n"
+        'name = "infino"\n'
+        f'version = "{crate}"\n'
+        "\n"
+        "[[package]]\n"
+        'name = "infino-node"\n'
+        f'version = "{node_crate_lock}"\n'
+    )
 
     py_dir = root / "infino-python"
     py_dir.mkdir()
@@ -109,6 +126,23 @@ class CheckVersionSync(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertIn("infx-linux-arm64-musl", errors[0])
         self.assertIn("0.3.1", errors[0])
+
+    def test_node_crate_manifest_out_of_step_with_package_json_fails(self):
+        # infino-node/Cargo.toml is unpublished (`publish = false`) but its
+        # version must track package.json so no version file lies.
+        write_fixture(self.root, node="0.3.2", node_crate="0.3.1",
+                      node_crate_lock="0.3.1")
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("infino-node/Cargo.toml", errors[0])
+        self.assertIn("0.3.1", errors[0])
+
+    def test_node_crate_lockfile_behind_manifest_fails(self):
+        write_fixture(self.root, node="0.3.2", node_crate="0.3.2",
+                      node_crate_lock="0.3.1")
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("infino-node/Cargo.lock", errors[0])
 
     def test_crate_lockfile_behind_manifest_fails(self):
         # A version bump that skips Cargo.lock breaks `cargo publish --locked`

--- a/scripts/test_release_prep.py
+++ b/scripts/test_release_prep.py
@@ -1,0 +1,119 @@
+"""Unit tests for release_prep.py. Run from the repo root:
+
+  python3 -m unittest discover -s scripts -q
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_version_sync import check, locked_version, manifest_version
+from release_prep import ReleasePrepError, prepare
+from test_check_version_sync import PLATFORM_PACKAGES, write_fixture
+
+
+class Prepare(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        # crate 0.3.4, node 0.3.2, python 0.3.5 — the worked example of
+        # legitimate patch divergence from docs/versioning.md.
+        write_fixture(self.root)
+
+    def node_manifest(self):
+        return json.loads((self.root / "infino-node" / "package.json").read_text())
+
+    def test_crate_patch_stamps_only_the_root_manifest_and_lock(self):
+        changed = prepare(self.root, "crate", "0.3.5")
+        self.assertEqual(sorted(changed), ["Cargo.lock", "Cargo.toml"])
+        self.assertEqual(manifest_version(self.root / "Cargo.toml"), "0.3.5")
+        self.assertEqual(locked_version(self.root / "Cargo.lock", "infino"), "0.3.5")
+        self.assertEqual(self.node_manifest()["version"], "0.3.2")
+        self.assertEqual(
+            manifest_version(self.root / "infino-python" / "Cargo.toml"), "0.3.5"
+        )
+        self.assertEqual(check(self.root), [])
+
+    def test_node_patch_stamps_package_json_pins_and_node_crate(self):
+        changed = prepare(self.root, "node", "0.3.3")
+        self.assertEqual(
+            sorted(changed),
+            ["infino-node/Cargo.lock", "infino-node/Cargo.toml",
+             "infino-node/package.json"],
+        )
+        manifest = self.node_manifest()
+        self.assertEqual(manifest["version"], "0.3.3")
+        for pin in PLATFORM_PACKAGES:
+            self.assertEqual(manifest["optionalDependencies"][pin], "0.3.3")
+        self.assertEqual(
+            manifest_version(self.root / "infino-node" / "Cargo.toml"), "0.3.3"
+        )
+        self.assertEqual(
+            locked_version(self.root / "infino-node" / "Cargo.lock", "infino-node"),
+            "0.3.3",
+        )
+        self.assertEqual(manifest_version(self.root / "Cargo.toml"), "0.3.4")
+        self.assertEqual(check(self.root), [])
+
+    def test_python_patch_stamps_only_the_python_manifest_and_lock(self):
+        changed = prepare(self.root, "python", "0.3.6")
+        self.assertEqual(
+            sorted(changed),
+            ["infino-python/Cargo.lock", "infino-python/Cargo.toml"],
+        )
+        self.assertEqual(
+            manifest_version(self.root / "infino-python" / "Cargo.toml"), "0.3.6"
+        )
+        self.assertEqual(
+            locked_version(
+                self.root / "infino-python" / "Cargo.lock", "infino-python"
+            ),
+            "0.3.6",
+        )
+        self.assertEqual(check(self.root), [])
+
+    def test_coordinated_release_realigns_all_three_packages(self):
+        changed = prepare(self.root, "all", "0.4.0")
+        self.assertEqual(len(changed), 7)
+        self.assertEqual(manifest_version(self.root / "Cargo.toml"), "0.4.0")
+        self.assertEqual(self.node_manifest()["version"], "0.4.0")
+        self.assertEqual(
+            manifest_version(self.root / "infino-python" / "Cargo.toml"), "0.4.0"
+        )
+        self.assertEqual(check(self.root), [])
+
+    def test_rejects_coordinated_release_with_nonzero_patch(self):
+        with self.assertRaisesRegex(ReleasePrepError, "patch"):
+            prepare(self.root, "all", "0.4.1")
+
+    def test_rejects_single_package_bump_off_the_crate_line(self):
+        with self.assertRaisesRegex(ReleasePrepError, "0.3"):
+            prepare(self.root, "node", "0.4.0")
+
+    def test_rejects_version_not_above_the_current_one(self):
+        with self.assertRaisesRegex(ReleasePrepError, "0.3.2"):
+            prepare(self.root, "node", "0.3.2")
+        with self.assertRaisesRegex(ReleasePrepError, "0.3.4"):
+            prepare(self.root, "crate", "0.3.3")
+
+    def test_rejects_coordinated_version_that_moves_a_package_backwards(self):
+        # Every package sits above 0.3.0 (python at 0.3.5); a "coordinated"
+        # 0.3.0 would move them backwards (and registries are immutable).
+        with self.assertRaisesRegex(ReleasePrepError, "does not move"):
+            prepare(self.root, "all", "0.3.0")
+
+    def test_rejects_malformed_version(self):
+        with self.assertRaisesRegex(ReleasePrepError, "X.Y.Z"):
+            prepare(self.root, "crate", "1.2")
+
+    def test_rejected_prepare_leaves_the_tree_untouched(self):
+        before = (self.root / "Cargo.toml").read_text()
+        with self.assertRaises(ReleasePrepError):
+            prepare(self.root, "all", "0.4.1")
+        self.assertEqual((self.root / "Cargo.toml").read_text(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_prep.py
+++ b/scripts/test_release_prep.py
@@ -104,6 +104,29 @@ class Prepare(unittest.TestCase):
         with self.assertRaisesRegex(ReleasePrepError, "does not move"):
             prepare(self.root, "all", "0.3.0")
 
+    def test_each_bumps_every_package_to_its_own_next_patch(self):
+        # crate 0.3.4 / node 0.3.2 / python 0.3.5 move independently —
+        # divergent patch counters stay divergent, everyone steps forward.
+        changed = prepare(self.root, "each")
+        self.assertEqual(len(changed), 7)
+        self.assertEqual(manifest_version(self.root / "Cargo.toml"), "0.3.5")
+        manifest = self.node_manifest()
+        self.assertEqual(manifest["version"], "0.3.3")
+        for pin in PLATFORM_PACKAGES:
+            self.assertEqual(manifest["optionalDependencies"][pin], "0.3.3")
+        self.assertEqual(
+            manifest_version(self.root / "infino-python" / "Cargo.toml"), "0.3.6"
+        )
+        self.assertEqual(check(self.root), [])
+
+    def test_each_rejects_an_explicit_version(self):
+        with self.assertRaisesRegex(ReleasePrepError, "next patch"):
+            prepare(self.root, "each", "0.4.0")
+
+    def test_single_package_scope_requires_a_version(self):
+        with self.assertRaisesRegex(ReleasePrepError, "required"):
+            prepare(self.root, "crate", None)
+
     def test_rejects_malformed_version(self):
         with self.assertRaisesRegex(ReleasePrepError, "X.Y.Z"):
             prepare(self.root, "crate", "1.2")


### PR DESCRIPTION
## What

Release-process hardening in four layers: version drift caught on every PR, versions validated again at publish time, one command that stamps every version file for a release, and automatic tagging + publishing when a release merge lands.

`docs/versioning.md` locks the crate and both bindings to one `major.minor` release line with independent per-package patches — but nothing enforced it, and cutting a release meant hand-editing up to ten version strings, merging, then hand-pushing a tag.

**Commit 1 — drift guard on every PR.** `scripts/check_version_sync.py` (pure Python 3 stdlib, same shape as `check_api_parity.py`), wired into `make check` via a new `version-sync` target: the three packages must agree on `major.minor` (patch independent), the six `infx-*` platform pins must track the Node package version, and each `Cargo.lock` must record its manifest's version so a bump that skips the lockfile can't break a `--locked` publish.

**Commit 2 — the same guard at publish time.** The script gains `--release-version`; `publish-python` validates the release version before the wheel matrix spins up, and `Node publish` checks the in-tree versions and pins before touching npm.

**Commit 3 — `make release-prep PACKAGE=<crate|node|python|all> VERSION=X.Y.Z`.** One command stamps every file carrying that package's version, validates the bump against the versioning rules (single-package patches stay on the crate's line and move strictly forward; `all` requires patch 0 and moves every package forward), re-runs the guard as a self-check, and prints the follow-up step. Python's version moves in-tree (`infino-python/Cargo.toml` at 0.1.5, matching PyPI): `publish-python` now reads the tree — its `version` dispatch input and CI-side stamp step are gone, and a coordinated tag asserts it matches the tree. `infino-node/Cargo.toml`+lock now track `package.json` under two new guard checks.

**Commit 4 — auto-tag on merge.** A new `Tag release` workflow watches `main` for changes to the root `Cargo.toml`: when the `[package]` version changed and its tag doesn't exist, it re-runs the guard against the merged tree, pushes `v<version>`, and kicks off the publishes — the crate always, plus Node and Python for a coordinated `X.Y.0`. Tags pushed with the workflow's `GITHUB_TOKEN` don't fire tag-push workflows (GitHub's recursion guard), so the publishes are dispatched explicitly at the tag ref — no long-lived PAT. Dependency-only `Cargo.toml` edits skip; a version changed to an already-tagged value fails loudly; hand-pushed tags still work.

**Commit 5 — `PACKAGE=each`.** For a fix that ships in all three packages: `make release-prep PACKAGE=each` (no `VERSION` — the targets differ by construction, since patch counters are independent) computes each package's next patch itself and stamps all seven version files in one go. E.g. from today's state it produces crate 0.1.5, Node 0.1.5, Python 0.1.6.

**A release is now: `make release-prep`, merge the PR, done.** (Binding-only patches keep their one manual dispatch click, by design.)

## Testing

- 25 unit tests across `test_check_version_sync.py` and `test_release_prep.py` (each scope stamps exactly its own files; `each` bumps every package independently; rejections for nonzero-patch coordinated releases, off-line patches, non-monotonic and malformed versions; rejected runs leave the tree untouched); `make version-sync` runs them before the guard
- Real-tree smokes: `make release-prep` stamps correctly for `crate` and `node` scopes and passes the guard (reverted); off-line bump correctly rejected
- `Tag release` detect logic simulated in a scratch repo: version-change comparison via `HEAD^` works for squash/merge commits; patch-suffix parsing correctly classifies `0.2.0` as coordinated and `0.2.10` as a patch
- `make version-sync` green; all three touched workflow files parse

CI/tooling only — no Rust code touched, so no bench run.