### PR TITLE
chore: compaction unseal tombstones if errored

### DIFF
--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -81,6 +81,9 @@ export interface OptimizeOptions {
   minFillPercent?: number;
   /** Target merged-superfile size, in MB. */
   targetSuperfileSizeMb?: number;
+  /** How old a sealed tombstone sidecar has to be, in milliseconds,
+   * before compaction treats its owner as dead and takes over. */
+  staleSealTimeoutMs?: number;
 }
 
 export interface Bm25SearchOptions {

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -225,6 +225,9 @@ pub struct OptimizeOptions {
     pub min_fill_percent: Option<u32>,
     /// Target merged-superfile size, in MB.
     pub target_superfile_size_mb: Option<u32>,
+    /// How old a sealed tombstone sidecar has to be, in milliseconds,
+    /// before compaction treats its owner as dead and takes over.
+    pub stale_seal_timeout_ms: Option<u32>,
 }
 
 /// Row counts from an `update` / `delete`.
@@ -670,6 +673,9 @@ impl Table {
             }
             if let Some(v) = o.target_superfile_size_mb {
                 s.target_superfile_size_mb = v as u64;
+            }
+            if let Some(v) = o.stale_seal_timeout_ms {
+                s.stale_seal_timeout_ms = v as u64;
             }
         }
         let opts = InfinoOptimizeOptions::compact(s);

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -127,4 +127,5 @@ class OptimizeOptions:
         max_memory_mb: int | None = ...,
         min_fill_percent: int | None = ...,
         target_superfile_size_mb: int | None = ...,
+        stale_seal_timeout_ms: int | None = ...,
     ) -> None: ...

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -323,21 +323,24 @@ struct CompactOptions {
     max_memory_mb: Option<u64>,
     min_fill_percent: Option<u8>,
     target_superfile_size_mb: Option<u64>,
+    stale_seal_timeout_ms: Option<u64>,
 }
 
 #[pymethods]
 impl CompactOptions {
     #[new]
-    #[pyo3(signature = (*, max_memory_mb=None, min_fill_percent=None, target_superfile_size_mb=None))]
+    #[pyo3(signature = (*, max_memory_mb=None, min_fill_percent=None, target_superfile_size_mb=None, stale_seal_timeout_ms=None))]
     fn new(
         max_memory_mb: Option<u64>,
         min_fill_percent: Option<u8>,
         target_superfile_size_mb: Option<u64>,
+        stale_seal_timeout_ms: Option<u64>,
     ) -> Self {
         Self {
             max_memory_mb,
             min_fill_percent,
             target_superfile_size_mb,
+            stale_seal_timeout_ms,
         }
     }
 }
@@ -615,6 +618,9 @@ impl Table {
             }
             if let Some(v) = o.target_superfile_size_mb {
                 s.target_superfile_size_mb = v;
+            }
+            if let Some(v) = o.stale_seal_timeout_ms {
+                s.stale_seal_timeout_ms = v;
             }
         }
         let opts = OptimizeOptions::compact(s);

--- a/public-api.txt
+++ b/public-api.txt
@@ -134,6 +134,7 @@ impl !core::panic::unwind_safe::UnwindSafe for infino::OptimizeError
 pub struct infino::CompactionSettings
 pub infino::CompactionSettings::max_memory_mb: u64
 pub infino::CompactionSettings::min_fill_percent: u8
+pub infino::CompactionSettings::stale_seal_timeout_ms: u64
 pub infino::CompactionSettings::target_superfile_size_mb: u64
 impl core::clone::Clone for infino::CompactionSettings
 pub fn infino::CompactionSettings::clone(&self) -> infino::CompactionSettings

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -179,6 +179,11 @@ const DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB: u64 = 1024;
 const DEFAULT_COMPACTION_MIN_FILL_PERCENT: u8 = 80;
 const DEFAULT_COMPACTION_MAX_MEMORY_MB: u64 = DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB + 2048;
 
+/// How old a tombstone sidecar seal has to be before compaction treats
+/// its owner as dead and takes over, instead of backing off.
+/// Scale this up if target_superfile_size_mb is raised well past the default
+pub const DEFAULT_STALE_SEAL_TIMEOUT_MS: u64 = 2 * 60 * 1000;
+
 /// Compaction settings: target size, fill floor, and memory budget.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
@@ -190,6 +195,9 @@ pub struct CompactionSettings {
     pub min_fill_percent: u8,
     /// Maximum memory budget for materializing inputs during a single merge, in MiB.
     pub max_memory_mb: u64,
+    /// How old a sealed tombstone sidecar has to be, in milliseconds,
+    /// before it's treated as abandoned
+    pub stale_seal_timeout_ms: u64,
 }
 
 impl Default for CompactionSettings {
@@ -198,6 +206,7 @@ impl Default for CompactionSettings {
             target_superfile_size_mb: DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB,
             min_fill_percent: DEFAULT_COMPACTION_MIN_FILL_PERCENT,
             max_memory_mb: DEFAULT_COMPACTION_MAX_MEMORY_MB,
+            stale_seal_timeout_ms: DEFAULT_STALE_SEAL_TIMEOUT_MS,
         }
     }
 }

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -232,6 +232,7 @@ impl Supertable {
             };
 
         // Build SuperfileStats for every superfile in the snapshot.
+        let now = Utc::now();
         let stats: Vec<SuperfileStats> = manifest
             .get_all_superfiles()
             .iter()
@@ -241,7 +242,9 @@ impl Supertable {
                     .cloned()
                     .unwrap_or_else(|| (Arc::new(RoaringBitmap::new()), None));
                 let tombstoned_docs = bitmap.len();
-                let sealed_by_other = seal.is_some();
+                let sealed_by_other = seal
+                    .as_ref()
+                    .is_some_and(|s| !tombstones_admin::is_seal_stale(s.sealed_at, now));
                 SuperfileStats {
                     superfile_id: entry.superfile_id,
                     partition_key: entry.partition_key.clone(),
@@ -357,12 +360,15 @@ impl Supertable {
             })
             .collect::<Result<_, _>>()?;
 
-        // Seal every input sidecar.
-        // once sealed, further incoming updates are rejected
-        // and this seal flag helps to prevent overlapping compactions
-        // on same files
+        // Seal every input sidecar so no writer can land a tombstone
+        // on a file that's about to disappear, and so another
+        // compactor doesn't pick up the same inputs. If we die
+        // before unsealing (crash, not a caught error), `seal`
+        // itself lets a later compactor take over once the seal
+        // goes stale.
         let compaction_id = Uuid::new_v4();
         let sealed_at = Utc::now();
+        let mut sealed_ids: Vec<Uuid> = Vec::with_capacity(inputs.len());
         for entry in &inputs {
             loop {
                 match tombstones_admin::seal(
@@ -373,7 +379,10 @@ impl Supertable {
                 )
                 .await
                 {
-                    Ok(_) => break,
+                    Ok(_) => {
+                        sealed_ids.push(entry.superfile_id);
+                        break;
+                    }
                     Err(TombstonesAdminError::CasLost { .. }) => {
                         // A writer landed a tombstone bit between our
                         // GET and our PUT. Re-read and retry — the
@@ -385,22 +394,27 @@ impl Supertable {
                         superfile_id,
                         existing_compaction_id,
                     }) => {
+                        unseal_all(&wal_store, compaction_id, &sealed_ids).await;
                         return Err(CompactionError::SidecarConflict {
                             superfile_id,
                             existing_compaction_id,
                         });
                     }
                     Err(TombstonesAdminError::WalStore(e)) => {
+                        unseal_all(&wal_store, compaction_id, &sealed_ids).await;
                         return Err(CompactionError::Seal(e.to_string()));
                     }
                 }
             }
         }
 
-        let merged_segment = self
-            .merge_superfiles(&inputs)
-            .await
-            .map_err(|e| CompactionError::Build(e.to_string()))?;
+        let merged_segment = match self.merge_superfiles(&inputs).await {
+            Ok(seg) => seg,
+            Err(e) => {
+                unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+                return Err(CompactionError::Build(e.to_string()));
+            }
+        };
 
         let PreparedSuperfile {
             entry: merged_entry,
@@ -479,18 +493,32 @@ impl Supertable {
                     return Ok(());
                 }
                 Err(CommitError::WriteContentionExhausted) if attempt + 1 < max_retries => {
-                    self.refresh()
-                        .await
-                        .map_err(|e| CompactionError::Refresh(e.to_string()))?;
+                    if let Err(e) = self.refresh().await {
+                        unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+                        return Err(CompactionError::Refresh(e.to_string()));
+                    }
                     time::sleep(backoff_delay(attempt)).await;
                 }
-                Err(e) => return Err(CompactionError::Commit(e.to_string())),
+                Err(e) => {
+                    unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+                    return Err(CompactionError::Commit(e.to_string()));
+                }
             }
         }
 
+        unseal_all(&wal_store, compaction_id, &sealed_ids).await;
         Err(CompactionError::Commit(
             "commit retries exhausted".to_string(),
         ))
+    }
+}
+
+/// Best-effort of clearing every seal this attempt placed
+async fn unseal_all(wal_store: &WalStore, compaction_id: Uuid, sealed_ids: &[Uuid]) {
+    for id in sealed_ids {
+        if let Err(e) = tombstones_admin::unseal(wal_store, *id, compaction_id).await {
+            warn!(superfile_id = %id, error = %e, "compact: failed to unseal after aborting");
+        }
     }
 }
 
@@ -688,6 +716,135 @@ mod tests {
         assert!(
             matches!(err, CompactionError::SuperfileNotFound(id) if id == bogus),
             "{err:?}"
+        );
+    }
+
+    /// If one input is already sealed by a different, still-live
+    /// compaction, we abort -- but must unseal whatever we already
+    /// sealed ourselves this attempt, not leave it stranded.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_unseals_its_own_inputs_when_a_later_one_conflicts() {
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+
+        commit_titles(&st, &["alpha first", "alpha second"]);
+        commit_titles(&st, &["bravo first", "bravo second"]);
+
+        let entries = st.reader().manifest().superfiles.clone();
+        assert_eq!(entries.len(), 2);
+        let (entry_a, entry_b) = (&entries[0], &entries[1]);
+
+        // entry_b is already held by a different, still-live compaction.
+        let storage = st
+            .inner()
+            .manifest
+            .load_full()
+            .options
+            .storage
+            .clone()
+            .expect("storage-backed table");
+        let wal_store = WalStore::new(storage);
+        let foreign_cid = Uuid::new_v4();
+        tombstones_admin::seal(&wal_store, entry_b.superfile_id, foreign_cid, Utc::now())
+            .await
+            .expect("seal entry_b as foreign");
+
+        let job = CompactionJob {
+            partition_key: entry_a.partition_key.clone(),
+            inputs: vec![entry_a.superfile_id, entry_b.superfile_id],
+            estimated_output_bytes: 1,
+        };
+        let err = st
+            .run_compaction_job(job)
+            .await
+            .expect_err("must conflict on entry_b");
+        assert!(matches!(err, CompactionError::SidecarConflict { .. }));
+
+        // entry_a got sealed by us first, then unsealed on the abort.
+        let (sidecar_a, _) = wal_store
+            .get_tombstones(entry_a.superfile_id)
+            .await
+            .expect("get")
+            .expect("present");
+        assert!(sidecar_a.seal.is_none());
+
+        // entry_b's foreign seal is untouched -- it's not ours to clear.
+        let (sidecar_b, _) = wal_store
+            .get_tombstones(entry_b.superfile_id)
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(
+            sidecar_b.seal.expect("still sealed").compaction_id,
+            foreign_cid
+        );
+    }
+
+    /// A stale seal (left behind by a crashed compactor, no error
+    /// ever caught to clean it up) must not exclude its superfile
+    /// from selection forever. Once it's older than
+    /// `DEFAULT_STALE_SEAL_TIMEOUT`, a fresh `compact_async` call
+    /// must pick it up and actually merge it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn compact_recovers_a_superfile_stuck_under_a_stale_seal() {
+        let dir = TempDir::new().expect("tempdir");
+        let st = make_st(&dir);
+
+        commit_titles(&st, &["alpha first", "alpha second"]);
+        commit_titles(&st, &["bravo first", "bravo second"]);
+        commit_titles(&st, &["charlie first", "charlie second"]);
+        commit_titles(&st, &["delta first", "delta second"]);
+        commit_titles(&st, &["echo first", "echo second"]);
+        commit_titles(&st, &["foxtrot first", "foxtrot second"]);
+        commit_titles(&st, &["golf first", "golf second"]);
+        commit_titles(&st, &["hotel first", "hotel second"]);
+        commit_titles(&st, &["india first", "india second"]);
+        commit_titles(&st, &["juliet first", "juliet second"]);
+
+        let entries = st.reader().manifest().superfiles.clone();
+        let crashed_entry = &entries[0];
+
+        // Simulate a compactor that sealed this file and then died
+        // long enough ago that its seal is now stale.
+        let storage = st
+            .inner()
+            .manifest
+            .load_full()
+            .options
+            .storage
+            .clone()
+            .expect("storage-backed table");
+        let wal_store = WalStore::new(storage);
+        let old_time = Utc::now()
+            - chrono::Duration::from_std(tombstones_admin::DEFAULT_STALE_SEAL_TIMEOUT)
+                .unwrap_or_default()
+            - chrono::Duration::seconds(1);
+        tombstones_admin::seal(
+            &wal_store,
+            crashed_entry.superfile_id,
+            Uuid::new_v4(),
+            old_time,
+        )
+        .await
+        .expect("simulate a stale seal");
+
+        st.compact_async(&small_compact_cfg())
+            .await
+            .expect("compact must succeed and recover the stale seal");
+
+        // The stuck superfile must not still be sitting in the
+        // manifest under its original id -- it has to have actually
+        // been picked up and merged, not just left alone while its
+        // 9 unsealed siblings merged around it.
+        let still_stuck = st
+            .reader()
+            .manifest()
+            .superfiles
+            .iter()
+            .any(|s| s.superfile_id == crashed_entry.superfile_id);
+        assert!(
+            !still_stuck,
+            "the stale-sealed superfile must have been merged, not left behind"
         );
     }
 

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -36,7 +36,7 @@ use crate::{
         error::CompactionError,
         query::dispatch::open_reader,
         wal::{
-            SealRecord, WalStore,
+            Etag, SealRecord, WalStore,
             tombstones_admin::{self, TombstonesAdminError},
         },
         writer::{
@@ -370,7 +370,7 @@ impl Supertable {
         // goes stale.
         let compaction_id = Uuid::new_v4();
         let sealed_at = Utc::now();
-        let mut sealed_ids: Vec<Uuid> = Vec::with_capacity(inputs.len());
+        let mut sealed: Vec<SealedInput> = Vec::with_capacity(inputs.len());
         for entry in &inputs {
             loop {
                 match tombstones_admin::seal(
@@ -382,8 +382,12 @@ impl Supertable {
                 )
                 .await
                 {
-                    Ok(_) => {
-                        sealed_ids.push(entry.superfile_id);
+                    Ok((sidecar, etag)) => {
+                        sealed.push(SealedInput {
+                            superfile_id: entry.superfile_id,
+                            bitmap: sidecar.bitmap,
+                            etag,
+                        });
                         break;
                     }
                     Err(TombstonesAdminError::CasLost { .. }) => {
@@ -397,14 +401,14 @@ impl Supertable {
                         superfile_id,
                         existing_compaction_id,
                     }) => {
-                        unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+                        unseal_all(&wal_store, sealed).await;
                         return Err(CompactionError::SidecarConflict {
                             superfile_id,
                             existing_compaction_id,
                         });
                     }
                     Err(TombstonesAdminError::WalStore(e)) => {
-                        unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+                        unseal_all(&wal_store, sealed).await;
                         return Err(CompactionError::Seal(e.to_string()));
                     }
                 }
@@ -414,7 +418,7 @@ impl Supertable {
         let merged_segment = match self.merge_superfiles(&inputs).await {
             Ok(seg) => seg,
             Err(e) => {
-                unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+                unseal_all(&wal_store, sealed).await;
                 return Err(CompactionError::Build(e.to_string()));
             }
         };
@@ -497,30 +501,49 @@ impl Supertable {
                 }
                 Err(CommitError::WriteContentionExhausted) if attempt + 1 < max_retries => {
                     if let Err(e) = self.refresh().await {
-                        unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+                        unseal_all(&wal_store, sealed).await;
                         return Err(CompactionError::Refresh(e.to_string()));
                     }
                     time::sleep(backoff_delay(attempt)).await;
                 }
                 Err(e) => {
-                    unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+                    unseal_all(&wal_store, sealed).await;
                     return Err(CompactionError::Commit(e.to_string()));
                 }
             }
         }
 
-        unseal_all(&wal_store, compaction_id, &sealed_ids).await;
+        unseal_all(&wal_store, sealed).await;
         Err(CompactionError::Commit(
             "commit retries exhausted".to_string(),
         ))
     }
 }
 
-/// Best-effort of clearing every seal this attempt placed
-async fn unseal_all(wal_store: &WalStore, compaction_id: Uuid, sealed_ids: &[Uuid]) {
-    for id in sealed_ids {
-        if let Err(e) = tombstones_admin::unseal(wal_store, *id, compaction_id).await {
-            warn!(superfile_id = %id, error = %e, "compact: failed to unseal after aborting");
+/// One superfile this attempt sealed: enough to unseal it later with
+/// no extra GET (`unseal` uses the etag + bitmap straight from `seal`).
+struct SealedInput {
+    superfile_id: Uuid,
+    bitmap: RoaringBitmap,
+    etag: Etag,
+}
+
+/// Best-effort: clear every seal this attempt placed, in parallel --
+/// each one is an independent sidecar, so there's no ordering or
+/// shared-state reason to do them one at a time.
+async fn unseal_all(wal_store: &WalStore, sealed: Vec<SealedInput>) {
+    let results = join_all(sealed.into_iter().map(|s| {
+        let wal_store = wal_store.clone();
+        async move {
+            let result =
+                tombstones_admin::unseal(&wal_store, s.superfile_id, s.bitmap, &s.etag).await;
+            (s.superfile_id, result)
+        }
+    }))
+    .await;
+    for (superfile_id, result) in results {
+        if let Err(e) = result {
+            warn!(superfile_id = %superfile_id, error = %e, "compact: failed to unseal after aborting");
         }
     }
 }

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -233,6 +233,7 @@ impl Supertable {
 
         // Build SuperfileStats for every superfile in the snapshot.
         let now = Utc::now();
+        let stale_seal_timeout = std::time::Duration::from_millis(cfg.stale_seal_timeout_ms);
         let stats: Vec<SuperfileStats> = manifest
             .get_all_superfiles()
             .iter()
@@ -242,9 +243,9 @@ impl Supertable {
                     .cloned()
                     .unwrap_or_else(|| (Arc::new(RoaringBitmap::new()), None));
                 let tombstoned_docs = bitmap.len();
-                let sealed_by_other = seal
-                    .as_ref()
-                    .is_some_and(|s| !tombstones_admin::is_seal_stale(s.sealed_at, now));
+                let sealed_by_other = seal.as_ref().is_some_and(|s| {
+                    !tombstones_admin::is_seal_stale(s.sealed_at, now, stale_seal_timeout)
+                });
                 SuperfileStats {
                     superfile_id: entry.superfile_id,
                     partition_key: entry.partition_key.clone(),
@@ -263,7 +264,7 @@ impl Supertable {
         let jobs = select(&stats, cfg);
 
         for job in jobs {
-            self.run_compaction_job(job).await?;
+            self.run_compaction_job(job, stale_seal_timeout).await?;
             self.refresh()
                 .await
                 .map_err(|e| CompactionError::Refresh(e.to_string()))?;
@@ -335,6 +336,7 @@ impl Supertable {
     pub(crate) async fn run_compaction_job(
         &self,
         job: CompactionJob,
+        stale_seal_timeout: std::time::Duration,
     ) -> Result<(), CompactionError> {
         let inner = self.inner();
         let manifest = inner.manifest.load_full();
@@ -376,6 +378,7 @@ impl Supertable {
                     entry.superfile_id,
                     compaction_id,
                     sealed_at,
+                    stale_seal_timeout,
                 )
                 .await
                 {
@@ -533,12 +536,16 @@ mod tests {
     use super::*;
     use crate::{
         BoolMode, Supertable,
+        config::DEFAULT_STALE_SEAL_TIMEOUT_MS,
         supertable::{
             error::CompactionError,
             storage::{LocalFsStorageProvider, StorageProvider},
         },
         test_helpers::{build_title_batch, default_supertable_options},
     };
+
+    const DEFAULT_STALE_SEAL_TIMEOUT: std::time::Duration =
+        std::time::Duration::from_millis(DEFAULT_STALE_SEAL_TIMEOUT_MS);
 
     fn mib(n: u64) -> u64 {
         n * MIB
@@ -710,7 +717,7 @@ mod tests {
             estimated_output_bytes: 0,
         };
         let err = st
-            .run_compaction_job(job)
+            .run_compaction_job(job, DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect_err("must error on unknown input");
         assert!(
@@ -745,9 +752,15 @@ mod tests {
             .expect("storage-backed table");
         let wal_store = WalStore::new(storage);
         let foreign_cid = Uuid::new_v4();
-        tombstones_admin::seal(&wal_store, entry_b.superfile_id, foreign_cid, Utc::now())
-            .await
-            .expect("seal entry_b as foreign");
+        tombstones_admin::seal(
+            &wal_store,
+            entry_b.superfile_id,
+            foreign_cid,
+            Utc::now(),
+            DEFAULT_STALE_SEAL_TIMEOUT,
+        )
+        .await
+        .expect("seal entry_b as foreign");
 
         let job = CompactionJob {
             partition_key: entry_a.partition_key.clone(),
@@ -755,7 +768,7 @@ mod tests {
             estimated_output_bytes: 1,
         };
         let err = st
-            .run_compaction_job(job)
+            .run_compaction_job(job, DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect_err("must conflict on entry_b");
         assert!(matches!(err, CompactionError::SidecarConflict { .. }));
@@ -816,14 +829,14 @@ mod tests {
             .expect("storage-backed table");
         let wal_store = WalStore::new(storage);
         let old_time = Utc::now()
-            - chrono::Duration::from_std(tombstones_admin::DEFAULT_STALE_SEAL_TIMEOUT)
-                .unwrap_or_default()
+            - chrono::Duration::from_std(DEFAULT_STALE_SEAL_TIMEOUT).unwrap_or_default()
             - chrono::Duration::seconds(1);
         tombstones_admin::seal(
             &wal_store,
             crashed_entry.superfile_id,
             Uuid::new_v4(),
             old_time,
+            DEFAULT_STALE_SEAL_TIMEOUT,
         )
         .await
         .expect("simulate a stale seal");
@@ -2208,9 +2221,15 @@ mod tests {
         let abandoned_compaction_id = Uuid::new_v4();
         let sealed_at = Utc::now();
         for id in &stranded_ids {
-            tombstones_admin::seal(&wal_store, *id, abandoned_compaction_id, sealed_at)
-                .await
-                .expect("seal");
+            tombstones_admin::seal(
+                &wal_store,
+                *id,
+                abandoned_compaction_id,
+                sealed_at,
+                DEFAULT_STALE_SEAL_TIMEOUT,
+            )
+            .await
+            .expect("seal");
         }
 
         // New data arrives and a generous compaction config runs.

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -59,6 +59,7 @@ use std::{collections::HashMap, io::Cursor, sync::Arc, time::Duration};
 use arrow::ipc::reader::StreamReader;
 use arrow_array::{ArrayRef, Decimal128Array, RecordBatch};
 use bytes::Bytes;
+use chrono::Utc;
 use roaring::RoaringBitmap;
 use tokio::time::sleep;
 use uuid::Uuid;
@@ -82,6 +83,7 @@ use crate::{
             state_doc::{
                 IdSpan, OpKind, RowId, TombstoneEntry, TombstoneOutcome, WalState, WalStateDoc,
             },
+            tombstones_admin,
             tombstones_codec::TombstonesSidecar,
         },
         writer::{build_subsection_offsets, persist_commit},
@@ -626,9 +628,10 @@ fn build_vector_summary(
 // 2. **CAS-PUT the tombstone sidecar** under
 //    `superfiles/<superfile_id>.tombstones`: GET (etag), union
 //    the new doc-id bit, PUT with `If-Match`. Loops on CAS-loss.
-//    A `seal.is_some()` response means a compactor is mid-flight;
-//    the writer must re-read the manifest and re-resolve against
-//    the merged target.
+//    A fresh (non-stale) seal means a compactor is mid-flight; the
+//    writer must re-read the manifest and re-resolve against the
+//    merged target. A stale seal (compactor crashed before
+//    unsealing) is taken over instead of backed off on.
 // 3. **Per-target WAL state CAS:** the entry flips to `Tombstoned`
 //    or `NotFound`, with `tombstoned_in_superfile` recorded for
 //    audit.
@@ -965,15 +968,20 @@ async fn resolve_and_tombstone_one(
 enum SidecarCasOutcome {
     /// The new doc-id bit is now durable in the sidecar.
     Landed,
-    /// The current sidecar carries a non-`None` seal — a compactor
-    /// is mid-flight against this superfile. The caller must
-    /// re-read the manifest and re-resolve.
+    /// The current sidecar carries a fresh (non-stale) seal — a
+    /// compactor is presumed still mid-flight against this
+    /// superfile. The caller must re-read the manifest and re-resolve.
+    /// A *stale* seal doesn't produce this outcome; we take it over
+    /// instead (see `cas_tombstone_bit`).
     Sealed,
 }
 
 /// GET → union-the-bit → PUT with bounded CAS-loss retries.
-/// Detects sealed sidecars and surfaces them up via the typed
-/// outcome so the caller's outer loop can re-resolve.
+/// Detects *fresh* sealed sidecars and surfaces them up via the typed
+/// outcome so the caller's outer loop can re-resolve. A stale seal
+/// (its compactor crashed before unsealing) is treated as no seal at
+/// all: we proceed to land the bit and clear it, same as
+/// `tombstones_admin::seal`'s own steal-if-stale behavior.
 async fn cas_tombstone_bit(
     wal_store: &WalStore,
     superfile_id: Uuid,
@@ -986,9 +994,21 @@ async fn cas_tombstone_bit(
             None => (None, None),
         };
 
-        // Sealed → bail out to the outer resolve loop.
+        // Sealed → bail out to the outer resolve loop, but only while
+        // the seal is still fresh. A stale seal means its compactor
+        // crashed before unsealing (see `tombstones_admin::seal`'s
+        // steal-if-stale logic) -- if we kept treating it as live,
+        // this update/delete would retry and eventually fail with
+        // `SealedSidecarRetryExhausted` even long after the seal
+        // stopped meaning anything. Falling through here lands our
+        // bit with `seal: None` below, clearing the dead seal too.
         if let Some(sc) = &existing
-            && sc.seal.is_some()
+            && let Some(seal) = sc.seal.as_ref()
+            && !tombstones_admin::is_seal_stale(
+                seal.sealed_at,
+                Utc::now(),
+                Duration::from_millis(tombstones_admin::DEFAULT_STALE_SEAL_TIMEOUT_MS),
+            )
         {
             return Ok(SidecarCasOutcome::Sealed);
         }
@@ -2156,5 +2176,64 @@ mod tests {
             post.tombstone_progress[0].outcome,
             TombstoneOutcome::Pending
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stale_seal_does_not_block_a_delete() {
+        // Same setup as `sealed_sidecar_surfaces_after_retry_budget`,
+        // but the seal is old enough to be stale (its compactor is
+        // presumed dead, e.g. a crash mid-merge). The delete must
+        // land its tombstone bit right away instead of backing off
+        // and eventually exhausting the sealed-retry budget.
+        let (_dir, st, ws, sf_id, id_min, _id_max) =
+            published_superfile_fixture(&["seal"], 60_000).await;
+
+        let stale_sealed_at = Utc::now()
+            - chrono::Duration::from_std(Duration::from_millis(
+                tombstones_admin::DEFAULT_STALE_SEAL_TIMEOUT_MS,
+            ))
+            .unwrap_or_default()
+            - chrono::Duration::seconds(1);
+        let sealed = TombstonesSidecar {
+            seal: Some(SealRecord {
+                compaction_id: Uuid::from_u128(0xDEAD_C0DE),
+                sealed_at: stale_sealed_at,
+            }),
+            bitmap: RoaringBitmap::new(),
+        };
+        ws.put_tombstones(sf_id, None, &sealed)
+            .await
+            .expect("seed stale-sealed sidecar");
+
+        let (wal, etag) = create_delete_wal(&ws, 207, &[id_min]).await;
+
+        // Must complete well within one sealed-retry backoff step,
+        // not fall into the retry loop at all.
+        let (outcome, new_wal, _) = timeout(
+            Duration::from_millis(500),
+            run_tombstone_phase(&st, &ws, &wal, &etag),
+        )
+        .await
+        .expect("must not enter the sealed-retry loop for a stale seal")
+        .expect("tombstone phase must succeed");
+
+        assert_eq!(
+            outcome,
+            TombstonePhaseOutcome::Applied {
+                n_tombstoned: 1,
+                n_not_found: 0,
+            }
+        );
+        assert_eq!(new_wal.state, WalState::Complete);
+
+        // The bit landed, and the stale seal got cleared along with it.
+        let bitmap = read_sidecar_bitmap(&ws, sf_id).await;
+        assert_eq!(bitmap.iter().collect::<Vec<u32>>(), vec![0u32]);
+        let (post_sidecar, _) = ws
+            .get_tombstones(sf_id)
+            .await
+            .expect("get")
+            .expect("present");
+        assert!(post_sidecar.seal.is_none());
     }
 }

--- a/src/supertable/wal/tombstones_admin.rs
+++ b/src/supertable/wal/tombstones_admin.rs
@@ -23,6 +23,8 @@
 //! after that swap, the writer's re-resolve routes to the
 //! merged target and lands the tombstone there.
 
+use std::time::Duration;
+
 use uuid::Uuid;
 
 use crate::supertable::wal::{
@@ -59,11 +61,27 @@ pub enum TombstonesAdminError {
     WalStore(#[from] WalStoreError),
 }
 
+/// How old a seal has to be before we treat its owner as dead and
+/// take over, instead of backing off. A crashed compactor never
+/// gets to unseal its own inputs, so this is what actually
+/// recovers them.
+pub const DEFAULT_STALE_SEAL_TIMEOUT: Duration = Duration::from_secs(2 * 60);
+
+/// `true` if a seal placed at `sealed_at` is older than
+/// [`DEFAULT_STALE_SEAL_TIMEOUT`] as of `now`. Shared by [`seal`]
+/// (deciding whether to steal it) and the compactor's candidate
+/// selection (deciding whether a sealed superfile is even worth
+/// proposing again).
+pub fn is_seal_stale(
+    sealed_at: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    let age = (now - sealed_at).to_std().unwrap_or(Duration::ZERO);
+    age >= DEFAULT_STALE_SEAL_TIMEOUT
+}
+
 /// Atomically stamp the seal flag on a per-superfile tombstone
-/// sidecar. Idempotent only on the same `compaction_id`:
-/// repeating the seal call with a different `compaction_id`
-/// surfaces `AlreadySealed` so the caller can pick up the
-/// abandoned merge.
+/// sidecar.
 ///
 /// Behaviour:
 ///
@@ -72,14 +90,14 @@ pub enum TombstonesAdminError {
 /// - Sidecar present + unsealed → preserve the existing bitmap,
 ///   stamp the seal, CAS-PUT.
 /// - Sidecar present + sealed by **the same `compaction_id`** →
-///   no-op success; return the existing sidecar. Lets the
-///   compactor's recovery path replay seal calls safely.
-/// - Sidecar present + sealed by a different compaction →
-///   `AlreadySealed` so the compactor knows to recover that
-///   work first.
-/// - CAS-loss on the PUT → `CasLost` so the compactor can
-///   re-read + decide whether to retry (typically yes, after
-///   re-reading the manifest).
+///   no-op, return the existing sidecar.
+/// - Sidecar present + sealed by a different compaction, not
+///   stale yet → `AlreadySealed`, someone else's live work, leave
+///   it alone.
+/// - Sidecar present + sealed by a different compaction, stale →
+///   that compactor is presumed dead, take the seal over.
+/// - CAS-loss on the PUT → `CasLost` so the caller can re-read +
+///   retry.
 pub async fn seal(
     wal_store: &WalStore,
     superfile_id: Uuid,
@@ -91,21 +109,20 @@ pub async fn seal(
         None => (None, None),
     };
 
-    // Already sealed → idempotent on the same compaction id,
-    // error otherwise. The mismatched-id case means a previous
-    // compaction sealed this sidecar and didn't finish; the
-    // caller has to drive that abandoned merge to completion
-    // (or unwind it) before sealing again with a fresh id.
     if let Some(existing) = &existing
         && let Some(existing_seal) = existing.seal.as_ref()
     {
         if existing_seal.compaction_id == compaction_id {
             return Ok(existing.clone());
         }
-        return Err(TombstonesAdminError::AlreadySealed {
-            superfile_id,
-            existing_compaction_id: existing_seal.compaction_id,
-        });
+        if !is_seal_stale(existing_seal.sealed_at, sealed_at) {
+            return Err(TombstonesAdminError::AlreadySealed {
+                superfile_id,
+                existing_compaction_id: existing_seal.compaction_id,
+            });
+        }
+        // Stale: that compactor is presumed dead, fall through and
+        // take the seal over.
     }
 
     let bitmap = existing
@@ -126,6 +143,37 @@ pub async fn seal(
         Ok(_new_etag) => Ok(sealed),
         Err(WalStoreError::CasFailed { .. }) => Err(TombstonesAdminError::CasLost { superfile_id }),
         Err(other) => Err(other.into()),
+    }
+}
+
+/// Clear the seal on a sidecar, but only if it's still sealed by
+/// same compaction_id
+pub async fn unseal(
+    wal_store: &WalStore,
+    superfile_id: Uuid,
+    compaction_id: Uuid,
+) -> Result<(), TombstonesAdminError> {
+    let Some((existing, etag)) = wal_store.get_tombstones(superfile_id).await? else {
+        return Ok(());
+    };
+    match &existing.seal {
+        Some(seal) if seal.compaction_id == compaction_id => {
+            let unsealed = TombstonesSidecar {
+                seal: None,
+                bitmap: existing.bitmap,
+            };
+            match wal_store
+                .put_tombstones(superfile_id, Some(&etag), &unsealed)
+                .await
+            {
+                Ok(_) => Ok(()),
+                Err(WalStoreError::CasFailed { .. }) => {
+                    Err(TombstonesAdminError::CasLost { superfile_id })
+                }
+                Err(other) => Err(other.into()),
+            }
+        }
+        _ => Ok(()),
     }
 }
 
@@ -255,6 +303,40 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seal_steals_a_stale_seal_from_a_different_compaction() {
+        let (_dir, ws) = fixture();
+        let sf = Uuid::from_u128(0x450);
+        let cid_a = Uuid::from_u128(0x1111);
+        let cid_b = Uuid::from_u128(0x2222);
+        let old_time = Utc::now()
+            - chrono::Duration::from_std(DEFAULT_STALE_SEAL_TIMEOUT).unwrap_or_default()
+            - chrono::Duration::seconds(1);
+        let _ = seal(&ws, sf, cid_a, old_time).await.expect("seal-a");
+
+        // cid_a's seal is older than the timeout, so it's presumed
+        // dead and cid_b can take over.
+        let stolen = seal(&ws, sf, cid_b, Utc::now())
+            .await
+            .expect("seal-b should steal the stale seal");
+        assert_eq!(stolen.seal.expect("set").compaction_id, cid_b);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seal_does_not_steal_a_fresh_seal() {
+        let (_dir, ws) = fixture();
+        let sf = Uuid::from_u128(0x460);
+        let cid_a = Uuid::from_u128(0x1111);
+        let cid_b = Uuid::from_u128(0x2222);
+        let _ = seal(&ws, sf, cid_a, Utc::now()).await.expect("seal-a");
+
+        // cid_a's seal is fresh; cid_b must not be able to take over.
+        let err = seal(&ws, sf, cid_b, Utc::now())
+            .await
+            .expect_err("must not steal a fresh seal");
+        assert!(matches!(err, TombstonesAdminError::AlreadySealed { .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn live_rows_absent_sidecar_returns_full_range() {
         let (_dir, ws) = fixture();
         let sf = Uuid::from_u128(0x500);
@@ -316,5 +398,42 @@ mod tests {
         // Live-rows excludes the tombstoned row.
         let rows = live_rows(&ws, sf, 5).await.expect("live");
         assert_eq!(rows, vec![0u32, 1, 2, 4]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unseal_clears_our_own_seal() {
+        let (_dir, ws) = fixture();
+        let sf = Uuid::from_u128(0x900);
+        let cid = Uuid::from_u128(0xAAAA);
+        let _ = seal(&ws, sf, cid, Utc::now()).await.expect("seal");
+
+        unseal(&ws, sf, cid).await.expect("unseal");
+
+        let (after, _etag) = ws.get_tombstones(sf).await.expect("get").expect("present");
+        assert!(after.seal.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unseal_leaves_someone_elses_seal_alone() {
+        let (_dir, ws) = fixture();
+        let sf = Uuid::from_u128(0x901);
+        let cid_a = Uuid::from_u128(0xAAAA);
+        let cid_b = Uuid::from_u128(0xBBBB);
+        let _ = seal(&ws, sf, cid_a, Utc::now()).await.expect("seal");
+
+        // cid_b was never the owner, so this must be a no-op.
+        unseal(&ws, sf, cid_b).await.expect("unseal");
+
+        let (after, _etag) = ws.get_tombstones(sf).await.expect("get").expect("present");
+        assert_eq!(after.seal.expect("still sealed").compaction_id, cid_a);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unseal_on_absent_sidecar_is_a_noop() {
+        let (_dir, ws) = fixture();
+        let sf = Uuid::from_u128(0x902);
+        unseal(&ws, sf, Uuid::from_u128(0xAAAA))
+            .await
+            .expect("unseal on absent sidecar must not error");
     }
 }

--- a/src/supertable/wal/tombstones_admin.rs
+++ b/src/supertable/wal/tombstones_admin.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 
 use uuid::Uuid;
 
+pub use crate::config::DEFAULT_STALE_SEAL_TIMEOUT_MS;
 use crate::supertable::wal::{
     persistence::{WalStore, WalStoreError},
     state_doc::SealRecord,
@@ -61,23 +62,20 @@ pub enum TombstonesAdminError {
     WalStore(#[from] WalStoreError),
 }
 
-/// How old a seal has to be before we treat its owner as dead and
-/// take over, instead of backing off. A crashed compactor never
-/// gets to unseal its own inputs, so this is what actually
-/// recovers them.
-pub const DEFAULT_STALE_SEAL_TIMEOUT: Duration = Duration::from_secs(2 * 60);
-
 /// `true` if a seal placed at `sealed_at` is older than
-/// [`DEFAULT_STALE_SEAL_TIMEOUT`] as of `now`. Shared by [`seal`]
-/// (deciding whether to steal it) and the compactor's candidate
-/// selection (deciding whether a sealed superfile is even worth
-/// proposing again).
+/// `stale_timeout` as of `now`. Shared by [`seal`] (deciding whether
+/// to steal it) and the compactor's candidate selection (deciding
+/// whether a sealed superfile is even worth proposing again). Callers
+/// pass [`DEFAULT_STALE_SEAL_TIMEOUT_MS`] (converted to a `Duration`)
+/// unless a table's `CompactionSettings::stale_seal_timeout_ms`
+/// overrides it.
 pub fn is_seal_stale(
     sealed_at: chrono::DateTime<chrono::Utc>,
     now: chrono::DateTime<chrono::Utc>,
+    stale_timeout: Duration,
 ) -> bool {
     let age = (now - sealed_at).to_std().unwrap_or(Duration::ZERO);
-    age >= DEFAULT_STALE_SEAL_TIMEOUT
+    age >= stale_timeout
 }
 
 /// Atomically stamp the seal flag on a per-superfile tombstone
@@ -103,6 +101,7 @@ pub async fn seal(
     superfile_id: Uuid,
     compaction_id: Uuid,
     sealed_at: chrono::DateTime<chrono::Utc>,
+    stale_timeout: Duration,
 ) -> Result<TombstonesSidecar, TombstonesAdminError> {
     let (existing, etag_opt) = match wal_store.get_tombstones(superfile_id).await? {
         Some((sc, etag)) => (Some(sc), Some(etag)),
@@ -115,7 +114,7 @@ pub async fn seal(
         if existing_seal.compaction_id == compaction_id {
             return Ok(existing.clone());
         }
-        if !is_seal_stale(existing_seal.sealed_at, sealed_at) {
+        if !is_seal_stale(existing_seal.sealed_at, sealed_at, stale_timeout) {
             return Err(TombstonesAdminError::AlreadySealed {
                 superfile_id,
                 existing_compaction_id: existing_seal.compaction_id,
@@ -219,6 +218,9 @@ mod tests {
     use super::*;
     use crate::storage::{LocalFsStorageProvider, StorageProvider};
 
+    const DEFAULT_STALE_SEAL_TIMEOUT: Duration =
+        Duration::from_millis(DEFAULT_STALE_SEAL_TIMEOUT_MS);
+
     fn fixture() -> (TempDir, WalStore) {
         let dir = TempDir::new().expect("tempdir");
         let storage: Arc<dyn StorageProvider> =
@@ -231,7 +233,9 @@ mod tests {
         let (_dir, ws) = fixture();
         let sf = Uuid::from_u128(0x100);
         let cid = Uuid::from_u128(0xC0DE);
-        let sealed = seal(&ws, sf, cid, Utc::now()).await.expect("seal");
+        let sealed = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal");
         assert_eq!(sealed.seal.expect("set").compaction_id, cid);
         assert!(sealed.bitmap.is_empty());
 
@@ -261,7 +265,9 @@ mod tests {
         .expect("seed");
 
         let cid = Uuid::from_u128(0xABCD);
-        let sealed = seal(&ws, sf, cid, Utc::now()).await.expect("seal");
+        let sealed = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal");
         assert_eq!(sealed.bitmap, bitmap, "seal must preserve the bitmap");
         assert_eq!(sealed.seal.expect("set").compaction_id, cid);
     }
@@ -271,8 +277,12 @@ mod tests {
         let (_dir, ws) = fixture();
         let sf = Uuid::from_u128(0x300);
         let cid = Uuid::from_u128(0xDEAD);
-        let first = seal(&ws, sf, cid, Utc::now()).await.expect("seal-1");
-        let again = seal(&ws, sf, cid, Utc::now()).await.expect("seal-2");
+        let first = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal-1");
+        let again = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal-2");
         // SealRecord's sealed_at goes through ms-precision
         // truncation on disk so we compare the
         // compaction-identifying fields only, not the timestamp.
@@ -289,8 +299,10 @@ mod tests {
         let sf = Uuid::from_u128(0x400);
         let cid_a = Uuid::from_u128(0x1111);
         let cid_b = Uuid::from_u128(0x2222);
-        let _ = seal(&ws, sf, cid_a, Utc::now()).await.expect("seal-a");
-        let err = seal(&ws, sf, cid_b, Utc::now())
+        let _ = seal(&ws, sf, cid_a, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal-a");
+        let err = seal(&ws, sf, cid_b, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect_err("must error");
         assert!(matches!(
@@ -311,11 +323,13 @@ mod tests {
         let old_time = Utc::now()
             - chrono::Duration::from_std(DEFAULT_STALE_SEAL_TIMEOUT).unwrap_or_default()
             - chrono::Duration::seconds(1);
-        let _ = seal(&ws, sf, cid_a, old_time).await.expect("seal-a");
+        let _ = seal(&ws, sf, cid_a, old_time, DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal-a");
 
         // cid_a's seal is older than the timeout, so it's presumed
         // dead and cid_b can take over.
-        let stolen = seal(&ws, sf, cid_b, Utc::now())
+        let stolen = seal(&ws, sf, cid_b, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect("seal-b should steal the stale seal");
         assert_eq!(stolen.seal.expect("set").compaction_id, cid_b);
@@ -327,10 +341,12 @@ mod tests {
         let sf = Uuid::from_u128(0x460);
         let cid_a = Uuid::from_u128(0x1111);
         let cid_b = Uuid::from_u128(0x2222);
-        let _ = seal(&ws, sf, cid_a, Utc::now()).await.expect("seal-a");
+        let _ = seal(&ws, sf, cid_a, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal-a");
 
         // cid_a's seal is fresh; cid_b must not be able to take over.
-        let err = seal(&ws, sf, cid_b, Utc::now())
+        let err = seal(&ws, sf, cid_b, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect_err("must not steal a fresh seal");
         assert!(matches!(err, TombstonesAdminError::AlreadySealed { .. }));
@@ -368,7 +384,9 @@ mod tests {
             .await
             .expect("seed");
         let cid = Uuid::from_u128(0xC0DEC0DE);
-        let _ = seal(&ws, sf, cid, Utc::now()).await.expect("seal");
+        let _ = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal");
         let rows = live_rows(&ws, sf, 4).await.expect("live");
         assert_eq!(rows, vec![0u32, 1, 3]);
     }
@@ -393,7 +411,9 @@ mod tests {
 
         // Compactor-side: seal afterwards.
         let cid = Uuid::from_u128(0xC0DEFACE);
-        let _ = seal(&ws, sf, cid, Utc::now()).await.expect("seal");
+        let _ = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal");
 
         // Live-rows excludes the tombstoned row.
         let rows = live_rows(&ws, sf, 5).await.expect("live");
@@ -405,7 +425,9 @@ mod tests {
         let (_dir, ws) = fixture();
         let sf = Uuid::from_u128(0x900);
         let cid = Uuid::from_u128(0xAAAA);
-        let _ = seal(&ws, sf, cid, Utc::now()).await.expect("seal");
+        let _ = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal");
 
         unseal(&ws, sf, cid).await.expect("unseal");
 
@@ -419,7 +441,9 @@ mod tests {
         let sf = Uuid::from_u128(0x901);
         let cid_a = Uuid::from_u128(0xAAAA);
         let cid_b = Uuid::from_u128(0xBBBB);
-        let _ = seal(&ws, sf, cid_a, Utc::now()).await.expect("seal");
+        let _ = seal(&ws, sf, cid_a, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal");
 
         // cid_b was never the owner, so this must be a no-op.
         unseal(&ws, sf, cid_b).await.expect("unseal");

--- a/src/supertable/wal/tombstones_admin.rs
+++ b/src/supertable/wal/tombstones_admin.rs
@@ -29,7 +29,7 @@ use uuid::Uuid;
 
 pub use crate::config::DEFAULT_STALE_SEAL_TIMEOUT_MS;
 use crate::supertable::wal::{
-    persistence::{WalStore, WalStoreError},
+    persistence::{Etag, WalStore, WalStoreError},
     state_doc::SealRecord,
     tombstones_codec::TombstonesSidecar,
 };
@@ -79,7 +79,10 @@ pub fn is_seal_stale(
 }
 
 /// Atomically stamp the seal flag on a per-superfile tombstone
-/// sidecar.
+/// sidecar. Returns the sealed sidecar plus the etag the PUT (or,
+/// on the idempotent no-op branch, the GET) landed under -- callers
+/// that later call [`unseal`] pass that etag straight through, no
+/// re-read needed.
 ///
 /// Behaviour:
 ///
@@ -102,7 +105,7 @@ pub async fn seal(
     compaction_id: Uuid,
     sealed_at: chrono::DateTime<chrono::Utc>,
     stale_timeout: Duration,
-) -> Result<TombstonesSidecar, TombstonesAdminError> {
+) -> Result<(TombstonesSidecar, Etag), TombstonesAdminError> {
     let (existing, etag_opt) = match wal_store.get_tombstones(superfile_id).await? {
         Some((sc, etag)) => (Some(sc), Some(etag)),
         None => (None, None),
@@ -112,7 +115,8 @@ pub async fn seal(
         && let Some(existing_seal) = existing.seal.as_ref()
     {
         if existing_seal.compaction_id == compaction_id {
-            return Ok(existing.clone());
+            let etag = etag_opt.expect("sidecar present implies its GET returned an etag");
+            return Ok((existing.clone(), etag));
         }
         if !is_seal_stale(existing_seal.sealed_at, sealed_at, stale_timeout) {
             return Err(TombstonesAdminError::AlreadySealed {
@@ -139,40 +143,32 @@ pub async fn seal(
         .put_tombstones(superfile_id, etag_opt.as_ref(), &sealed)
         .await
     {
-        Ok(_new_etag) => Ok(sealed),
+        Ok(new_etag) => Ok((sealed, new_etag)),
         Err(WalStoreError::CasFailed { .. }) => Err(TombstonesAdminError::CasLost { superfile_id }),
         Err(other) => Err(other.into()),
     }
 }
 
-/// Clear the seal on a sidecar, but only if it's still sealed by
-/// same compaction_id
+/// Clear a seal previously placed by [`seal`], using the bitmap and
+/// etag that call returned. No GET: one CAS-PUT. If the sidecar has
+/// changed since (a writer bypassed our now-stale seal, or another
+/// compactor stole it), the CAS fails and we no-op -- whatever
+/// changed it already resolved the seal, there's nothing left for us
+/// to clear.
 pub async fn unseal(
     wal_store: &WalStore,
     superfile_id: Uuid,
-    compaction_id: Uuid,
+    bitmap: roaring::RoaringBitmap,
+    etag: &Etag,
 ) -> Result<(), TombstonesAdminError> {
-    let Some((existing, etag)) = wal_store.get_tombstones(superfile_id).await? else {
-        return Ok(());
-    };
-    match &existing.seal {
-        Some(seal) if seal.compaction_id == compaction_id => {
-            let unsealed = TombstonesSidecar {
-                seal: None,
-                bitmap: existing.bitmap,
-            };
-            match wal_store
-                .put_tombstones(superfile_id, Some(&etag), &unsealed)
-                .await
-            {
-                Ok(_) => Ok(()),
-                Err(WalStoreError::CasFailed { .. }) => {
-                    Err(TombstonesAdminError::CasLost { superfile_id })
-                }
-                Err(other) => Err(other.into()),
-            }
-        }
-        _ => Ok(()),
+    let unsealed = TombstonesSidecar { seal: None, bitmap };
+    match wal_store
+        .put_tombstones(superfile_id, Some(etag), &unsealed)
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(WalStoreError::CasFailed { .. }) => Ok(()),
+        Err(other) => Err(other.into()),
     }
 }
 
@@ -233,7 +229,7 @@ mod tests {
         let (_dir, ws) = fixture();
         let sf = Uuid::from_u128(0x100);
         let cid = Uuid::from_u128(0xC0DE);
-        let sealed = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+        let (sealed, _etag) = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect("seal");
         assert_eq!(sealed.seal.expect("set").compaction_id, cid);
@@ -265,7 +261,7 @@ mod tests {
         .expect("seed");
 
         let cid = Uuid::from_u128(0xABCD);
-        let sealed = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+        let (sealed, _etag) = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect("seal");
         assert_eq!(sealed.bitmap, bitmap, "seal must preserve the bitmap");
@@ -277,10 +273,10 @@ mod tests {
         let (_dir, ws) = fixture();
         let sf = Uuid::from_u128(0x300);
         let cid = Uuid::from_u128(0xDEAD);
-        let first = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+        let (first, _etag1) = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect("seal-1");
-        let again = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+        let (again, _etag2) = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect("seal-2");
         // SealRecord's sealed_at goes through ms-precision
@@ -329,7 +325,7 @@ mod tests {
 
         // cid_a's seal is older than the timeout, so it's presumed
         // dead and cid_b can take over.
-        let stolen = seal(&ws, sf, cid_b, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+        let (stolen, _etag) = seal(&ws, sf, cid_b, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect("seal-b should steal the stale seal");
         assert_eq!(stolen.seal.expect("set").compaction_id, cid_b);
@@ -425,39 +421,61 @@ mod tests {
         let (_dir, ws) = fixture();
         let sf = Uuid::from_u128(0x900);
         let cid = Uuid::from_u128(0xAAAA);
-        let _ = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+        let (sealed, etag) = seal(&ws, sf, cid, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
             .expect("seal");
 
-        unseal(&ws, sf, cid).await.expect("unseal");
+        unseal(&ws, sf, sealed.bitmap, &etag).await.expect("unseal");
 
         let (after, _etag) = ws.get_tombstones(sf).await.expect("get").expect("present");
         assert!(after.seal.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn unseal_leaves_someone_elses_seal_alone() {
+    async fn unseal_no_ops_when_the_seal_has_since_changed() {
+        // Simulates: our seal went stale mid-merge and a different
+        // compactor stole it (or a writer bypassed it) before we got
+        // around to unsealing. Our stale etag must not be able to
+        // clobber whatever is there now.
         let (_dir, ws) = fixture();
         let sf = Uuid::from_u128(0x901);
         let cid_a = Uuid::from_u128(0xAAAA);
         let cid_b = Uuid::from_u128(0xBBBB);
-        let _ = seal(&ws, sf, cid_a, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+        let (sealed_a, etag_a) = seal(&ws, sf, cid_a, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
             .await
-            .expect("seal");
+            .expect("seal-a");
 
-        // cid_b was never the owner, so this must be a no-op.
-        unseal(&ws, sf, cid_b).await.expect("unseal");
+        // Someone else re-seals under a different compaction_id,
+        // moving the etag forward.
+        let old_time = Utc::now()
+            - chrono::Duration::from_std(DEFAULT_STALE_SEAL_TIMEOUT).unwrap_or_default()
+            - chrono::Duration::seconds(1);
+        // Force cid_a's seal to look stale so cid_b can steal it,
+        // simulating the time-of-check having since moved on.
+        ws.put_tombstones(
+            sf,
+            Some(&etag_a),
+            &TombstonesSidecar {
+                seal: Some(SealRecord {
+                    compaction_id: cid_a,
+                    sealed_at: old_time,
+                }),
+                bitmap: sealed_a.bitmap.clone(),
+            },
+        )
+        .await
+        .expect("backdate seal-a");
+        let _ = seal(&ws, sf, cid_b, Utc::now(), DEFAULT_STALE_SEAL_TIMEOUT)
+            .await
+            .expect("seal-b steals the now-stale seal");
+
+        // cid_a's unseal, using its now-stale etag, must no-op rather
+        // than clobber cid_b's live seal.
+        unseal(&ws, sf, sealed_a.bitmap, &etag_a)
+            .await
+            .expect("unseal must no-op, not error");
 
         let (after, _etag) = ws.get_tombstones(sf).await.expect("get").expect("present");
-        assert_eq!(after.seal.expect("still sealed").compaction_id, cid_a);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn unseal_on_absent_sidecar_is_a_noop() {
-        let (_dir, ws) = fixture();
-        let sf = Uuid::from_u128(0x902);
-        unseal(&ws, sf, Uuid::from_u128(0xAAAA))
-            .await
-            .expect("unseal on absent sidecar must not error");
+        assert_eq!(after.seal.expect("still sealed").compaction_id, cid_b);
     }
 }


### PR DESCRIPTION
As part of https://github.com/infino-ai/infino/issues/378

### What is this change required?

Today in case of error or crash we don't have a mechanism to unseal the sealed tombstones during compaction process. This will lead to certain superfiles not getting compacting and always sealed.


### How do we fix it?

We introduce a default_stale_timeout which helps the next running compaction job to include sealed tombstones if they have surpassed the stale timeout. This ensures that the orphan superfile will be picked up eventually. Right now the stale timeout is set to 2mins. Through process is for 1gb of compacted merged file size it takes 12seconds, so with current default CompactionSettings and with some buffer 2mins is enough for compaction jobs to complete successfully. Even after that if the file is sealed which means the process crashed.

In case of errors during compaction we unseal the files explicitly so that the next optimize/compaction run can pick it.