### PR TITLE
supertable/manifest: record min/max for temporal columns & use it for SQL pruning

### DIFF
--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -1243,7 +1243,7 @@ mod tests {
         sync::Arc,
     };
 
-    use arrow_array::{BooleanArray, Date32Array, Int64Array, StringArray};
+    use arrow_array::{BinaryArray, BooleanArray, Int64Array, StringArray};
     use arrow_schema::{DataType, Field};
     use uuid::Uuid;
 
@@ -1399,8 +1399,10 @@ mod tests {
 
     #[test]
     fn scalar_agg_from_column_unorderable_type_is_none() {
-        // Date32 isn't in `column_min_max`'s supported set → no stats at all.
-        let arr: ArrayRef = Arc::new(Date32Array::from(vec![1, 2, 3]));
+        // Binary has no meaningful ordering, so it isn't in `column_min_max`'s
+        // supported set → no stats at all. (Temporal types now *are* supported;
+        // see `min_max_stats_cover_temporal_columns` in the parent module.)
+        let arr: ArrayRef = Arc::new(BinaryArray::from(vec![&b"a"[..], b"b", b"c"]));
         assert!(ScalarStatsAgg::from_column(&arr).is_none());
     }
 
@@ -1408,10 +1410,10 @@ mod tests {
 
     #[test]
     fn scalar_agg_from_batches_skips_unorderable_column() {
-        let schema = Schema::new(vec![Field::new("d", DataType::Date32, true)]);
+        let schema = Schema::new(vec![Field::new("d", DataType::Binary, true)]);
         let batch = RecordBatch::try_new(
             Arc::new(schema.clone()),
-            vec![Arc::new(Date32Array::from(vec![1, 2])) as ArrayRef],
+            vec![Arc::new(BinaryArray::from(vec![&b"a"[..], b"b"])) as ArrayRef],
         )
         .expect("batch");
         let table = ScalarStatsAgg::from_batches(&schema, &[&batch]);

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -44,7 +44,7 @@ use std::{
 
 use arrow::compute::kernels::aggregate as agg;
 use arrow_array::*;
-use arrow_schema::DataType;
+use arrow_schema::{DataType, TimeUnit};
 use dashmap::DashMap;
 use futures::future;
 /// Re-export the per-column skip aggregates so callers can refer to them as
@@ -1339,6 +1339,28 @@ pub(crate) fn merge_min_max_arrays(
         }};
     }
 
+    // Same fold, re-attaching the column's timezone (the constructor drops
+    // it) so the merged bound keeps the exact type its inputs carried.
+    macro_rules! ts_merge {
+        ($array_ty:ty, $tz:expr) => {{
+            let exn = existing_min.as_any().downcast_ref::<$array_ty>()?;
+            let otn = other_min.as_any().downcast_ref::<$array_ty>()?;
+            let exx = existing_max.as_any().downcast_ref::<$array_ty>()?;
+            let otx = other_max.as_any().downcast_ref::<$array_ty>()?;
+            let at = |a: &$array_ty| (!a.is_null(0)).then(|| a.value(0));
+            Some((
+                Arc::new(
+                    <$array_ty>::from(vec![merge_opt(at(exn), at(otn), true)])
+                        .with_timezone_opt($tz.clone()),
+                ) as ArrayRef,
+                Arc::new(
+                    <$array_ty>::from(vec![merge_opt(at(exx), at(otx), false)])
+                        .with_timezone_opt($tz.clone()),
+                ) as ArrayRef,
+            ))
+        }};
+    }
+
     match existing_min.data_type() {
         DataType::UInt8 => prim_merge!(UInt8Array),
         DataType::UInt16 => prim_merge!(UInt16Array),
@@ -1413,6 +1435,20 @@ pub(crate) fn merge_min_max_arrays(
                 ),
             ))
         }
+
+        // Mirror `column_min_max`'s temporal set; without these arms a
+        // multi-superfile (or compacted) temporal column errors the merge and
+        // drops its stat, silently regressing the fold and range prune.
+        DataType::Date32 => prim_merge!(Date32Array),
+        DataType::Date64 => prim_merge!(Date64Array),
+        DataType::Time32(TimeUnit::Second) => prim_merge!(Time32SecondArray),
+        DataType::Time32(TimeUnit::Millisecond) => prim_merge!(Time32MillisecondArray),
+        DataType::Time64(TimeUnit::Microsecond) => prim_merge!(Time64MicrosecondArray),
+        DataType::Time64(TimeUnit::Nanosecond) => prim_merge!(Time64NanosecondArray),
+        DataType::Timestamp(TimeUnit::Second, tz) => ts_merge!(TimestampSecondArray, tz),
+        DataType::Timestamp(TimeUnit::Millisecond, tz) => ts_merge!(TimestampMillisecondArray, tz),
+        DataType::Timestamp(TimeUnit::Microsecond, tz) => ts_merge!(TimestampMicrosecondArray, tz),
+        DataType::Timestamp(TimeUnit::Nanosecond, tz) => ts_merge!(TimestampNanosecondArray, tz),
         _ => None,
     }
 }
@@ -1423,7 +1459,8 @@ pub(crate) fn merge_min_max_arrays(
 /// supported type yields length-1 *null* min/max arrays (not `None`), so
 /// its null count is still recorded and `IS [NOT] NULL` can prune on it.
 /// Supported set: integer (signed + unsigned, all widths), float
-/// (f32, f64), boolean, Utf8, LargeUtf8. The supertable schema
+/// (f32, f64), boolean, Utf8, LargeUtf8, Decimal128, and temporal
+/// (Date32/64, Time32/64, Timestamp). The supertable schema
 /// rejects vector columns up at the SupertableOptions layer, so
 /// `FixedSizeList<Float32>` won't appear here in practice.
 /// Exact column sum as a length-1 array typed to match SQL `SUM`'s
@@ -1560,6 +1597,21 @@ pub(crate) fn column_min_max(col: &ArrayRef) -> Option<(ArrayRef, ArrayRef)> {
         }};
     }
 
+    // Timestamps are the same primitive fold, but the `from(vec![..])`
+    // constructor builds a zone-less array; re-attach the column's zone so
+    // the bound keeps its exact type (a naive-vs-zoned mismatch would fail
+    // the cross-superfile merge and stat reconstruction).
+    macro_rules! ts {
+        ($array_ty:ty, $tz:expr) => {{
+            let a = col.as_any().downcast_ref::<$array_ty>()?;
+            let mn_arr: ArrayRef =
+                Arc::new(<$array_ty>::from(vec![agg::min(a)]).with_timezone_opt($tz.clone()));
+            let mx_arr: ArrayRef =
+                Arc::new(<$array_ty>::from(vec![agg::max(a)]).with_timezone_opt($tz.clone()));
+            Some((mn_arr, mx_arr))
+        }};
+    }
+
     match col.data_type() {
         DataType::UInt8 => prim!(UInt8Array),
         DataType::UInt16 => prim!(UInt16Array),
@@ -1607,6 +1659,19 @@ pub(crate) fn column_min_max(col: &ArrayRef) -> Option<(ArrayRef, ArrayRef)> {
                 ),
             ))
         }
+
+        // Temporal columns are numeric-backed and orderable, so min/max fold
+        // (DataFusion's aggregate fast-path) and prune the same as integers.
+        DataType::Date32 => prim!(Date32Array),
+        DataType::Date64 => prim!(Date64Array),
+        DataType::Time32(TimeUnit::Second) => prim!(Time32SecondArray),
+        DataType::Time32(TimeUnit::Millisecond) => prim!(Time32MillisecondArray),
+        DataType::Time64(TimeUnit::Microsecond) => prim!(Time64MicrosecondArray),
+        DataType::Time64(TimeUnit::Nanosecond) => prim!(Time64NanosecondArray),
+        DataType::Timestamp(TimeUnit::Second, tz) => ts!(TimestampSecondArray, tz),
+        DataType::Timestamp(TimeUnit::Millisecond, tz) => ts!(TimestampMillisecondArray, tz),
+        DataType::Timestamp(TimeUnit::Microsecond, tz) => ts!(TimestampMicrosecondArray, tz),
+        DataType::Timestamp(TimeUnit::Nanosecond, tz) => ts!(TimestampNanosecondArray, tz),
         _ => None,
     }
 }
@@ -1805,8 +1870,11 @@ impl ClusterCentroids {
 mod tests {
     use std::{hint::black_box, slice::from_ref, sync::Arc, time::Instant};
 
-    use arrow_array::{Array, Int64Array};
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_array::{
+        Array, Date32Array, Date64Array, Int64Array, Time64MicrosecondArray,
+        TimestampMicrosecondArray,
+    };
+    use arrow_schema::{DataType, Field, Schema, TimeUnit};
     use dashmap::DashMap;
     use datafusion::scalar::ScalarValue;
     use tempfile::TempDir;
@@ -1865,6 +1933,61 @@ mod tests {
         assert_eq!(scalar(&mx), ScalarValue::Int64(Some(9)));
         let (mn, mx) = merge_min_max_arrays(&null1, &null1, &null1, &null1).expect("merge null");
         assert!(mn.is_null(0) && mx.is_null(0));
+    }
+
+    #[test]
+    fn min_max_stats_cover_temporal_columns() {
+        let scalar = |a: &ArrayRef| ScalarValue::try_from_array(a, 0).expect("decode");
+
+        // Date32 (the ClickBench `EventDate` case that used to carry no stat):
+        // numeric-backed, so min/max record and fold like an integer.
+        let d: ArrayRef = Arc::new(Date32Array::from(vec![Some(20100), Some(19000), None]));
+        let (mn, mx) = column_min_max(&d).expect("date stat");
+        assert_eq!(scalar(&mn), ScalarValue::Date32(Some(19000)));
+        assert_eq!(scalar(&mx), ScalarValue::Date32(Some(20100)));
+
+        // Two superfiles' date bounds fold to the outer extremes.
+        let lo: ArrayRef = Arc::new(Date32Array::from(vec![Some(19000)]));
+        let hi: ArrayRef = Arc::new(Date32Array::from(vec![Some(20100)]));
+        let olo: ArrayRef = Arc::new(Date32Array::from(vec![Some(18000)]));
+        let ohi: ArrayRef = Arc::new(Date32Array::from(vec![Some(21000)]));
+        let (mn, mx) = merge_min_max_arrays(&lo, &olo, &hi, &ohi).expect("date merge");
+        assert_eq!(scalar(&mn), ScalarValue::Date32(Some(18000)));
+        assert_eq!(scalar(&mx), ScalarValue::Date32(Some(21000)));
+
+        // Timestamp keeps its timezone through both build and merge. A
+        // naive-vs-zoned mismatch would fail the merge and silently drop the
+        // stat, so assert the type survives, not just the value.
+        let tz = "+05:30";
+        let ts: ArrayRef = Arc::new(
+            TimestampMicrosecondArray::from(vec![Some(200i64), Some(100)]).with_timezone(tz),
+        );
+        let zoned = DataType::Timestamp(TimeUnit::Microsecond, Some(tz.into()));
+        let (mn, mx) = column_min_max(&ts).expect("ts stat");
+        assert_eq!(mn.data_type(), &zoned);
+        assert_eq!(
+            scalar(&mn),
+            ScalarValue::TimestampMicrosecond(Some(100), Some(tz.into()))
+        );
+        assert_eq!(
+            scalar(&mx),
+            ScalarValue::TimestampMicrosecond(Some(200), Some(tz.into()))
+        );
+        let (mmn, _mmx) = merge_min_max_arrays(&mn, &mn, &mx, &mx).expect("ts merge keeps tz");
+        assert_eq!(mmn.data_type(), &zoned);
+
+        // Date64 (ms-since-epoch) and Time64 ride the same `prim!` arm as
+        // Date32; spot-check that each records and reconstructs to its type.
+        let d64: ArrayRef = Arc::new(Date64Array::from(vec![Some(9i64), Some(2)]));
+        assert_eq!(
+            scalar(&column_min_max(&d64).expect("date64 stat").0),
+            ScalarValue::Date64(Some(2))
+        );
+        let t64: ArrayRef = Arc::new(Time64MicrosecondArray::from(vec![Some(7i64), Some(3)]));
+        assert_eq!(
+            scalar(&column_min_max(&t64).expect("time64 stat").0),
+            ScalarValue::Time64Microsecond(Some(3))
+        );
     }
 
     /// Folded Sq8-domain scoring must equal dequantize-then-distance

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -392,7 +392,7 @@ pub(crate) fn scalar_value_may_match(
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
-    use arrow_array::{ArrayRef, Int64Array, LargeStringArray};
+    use arrow_array::{ArrayRef, Date32Array, Int64Array, LargeStringArray};
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::scalar::ScalarValue;
     use uuid::Uuid;
@@ -690,6 +690,17 @@ mod tests {
         Arc::new(e)
     }
 
+    // Date32 bounds stored as days-since-epoch, the ClickBench `EventDate`
+    // shape now that temporal columns carry manifest min/max.
+    fn seg_with_date_stats(col: &str, min: i32, max: i32) -> Arc<SuperfileEntry> {
+        let mut e = empty_superfile();
+        let mn: ArrayRef = Arc::new(Date32Array::from(vec![min]));
+        let mx: ArrayRef = Arc::new(Date32Array::from(vec![max]));
+        e.scalar_stats
+            .insert(col.to_string(), ScalarStatsAgg::from_min_max(mn, mx));
+        Arc::new(e)
+    }
+
     fn pred(column: &str, op: ScalarOp, value: ScalarValue) -> ScalarPredicate {
         ScalarPredicate {
             column: column.to_string(),
@@ -839,6 +850,39 @@ mod tests {
                 &[pred("x", ScalarOp::LtEq, ScalarValue::Int64(Some(0)))]
             ),
             vec![true, false]
+        );
+    }
+
+    #[test]
+    fn scalar_skip_range_ops_prune_temporal_columns() {
+        // Two date superfiles with disjoint ranges (as ClickBench's
+        // time-ordered `hits` produces). Before temporal min/max landed these
+        // carried no bounds and neither could ever be pruned.
+        let d = |day| ScalarValue::Date32(Some(day));
+        let segs = vec![
+            seg_with_date_stats("EventDate", 100, 200),
+            seg_with_date_stats("EventDate", 500, 600),
+        ];
+        // EventDate > 300 → A.max=200 can't; B kept.
+        assert_eq!(
+            scalar_skip(&segs, &[pred("EventDate", ScalarOp::Gt, d(300))]),
+            vec![false, true]
+        );
+        // EventDate < 300 → A.min=100 ok; B.min=500 can't.
+        assert_eq!(
+            scalar_skip(&segs, &[pred("EventDate", ScalarOp::Lt, d(300))]),
+            vec![true, false]
+        );
+        // BETWEEN 250 AND 450 (>=250 AND <=450) → both disjoint ranges pruned.
+        assert_eq!(
+            scalar_skip(
+                &segs,
+                &[
+                    pred("EventDate", ScalarOp::GtEq, d(250)),
+                    pred("EventDate", ScalarOp::LtEq, d(450)),
+                ]
+            ),
+            vec![false, false]
         );
     }
 

--- a/tests/supertable/query/stats_fold.rs
+++ b/tests/supertable/query/stats_fold.rs
@@ -14,7 +14,7 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use arrow_array::{Array, Int64Array, LargeStringArray, RecordBatch};
+use arrow_array::{Array, Date32Array, Int64Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::prelude::{col, lit};
 use infino::{
@@ -229,5 +229,136 @@ fn tombstoned_tables_degrade_but_stay_correct() {
     assert_eq!(
         scalar_string(&st, "SELECT MAX(title) FROM supertable"),
         "delta"
+    );
+}
+
+// ---- temporal columns (Date32) ------------------------------------
+//
+// The manifest now records min/max for temporal types, so `MIN`/`MAX`
+// on a date column fold like an integer. This is the ClickBench
+// `EventDate` shape. `id` is a monotonic Int64 aligned with `day`, so a
+// delete can target the extremum row by a plain integer literal.
+
+/// Schema `(day: Date32, id: Int64)`; `id` tracks `day` so the max id is
+/// the max day.
+fn options_day_id() -> SupertableOptions {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("day", DataType::Date32, false),
+        Field::new("id", DataType::Int64, false),
+    ]));
+    SupertableOptions::new(schema, vec![], vec![], None).expect("valid options")
+}
+
+/// Base day (days-since-epoch) for commit 0; later commits and rows step
+/// strictly upward so extrema have closed forms.
+const DAY_BASE: i32 = 15000;
+
+fn build_day_batch(idx: usize, schema: Arc<Schema>) -> RecordBatch {
+    let days: Vec<i32> = (0..ROWS_PER_COMMIT)
+        .map(|r| DAY_BASE + (idx * 100 + r) as i32)
+        .collect();
+    let ids: Vec<i64> = (0..ROWS_PER_COMMIT)
+        .map(|r| (idx * 1000 + r) as i64)
+        .collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Date32Array::from(days)),
+            Arc::new(Int64Array::from(ids)),
+        ],
+    )
+    .expect("batch")
+}
+
+/// Single-cell Date32 (days-since-epoch) result of an aggregate query.
+fn scalar_date32(st: &Supertable, sql: &str) -> i32 {
+    let batches = st.reader().query_sql(sql).expect("sql");
+    let batch = batches.iter().find(|b| b.num_rows() > 0).expect("one row");
+    batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Date32Array>()
+        .expect("date32 result")
+        .value(0)
+}
+
+#[test]
+fn temporal_aggregates_fold_without_scanning() {
+    let st = Supertable::create(options_day_id()).expect("create");
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    for idx in 0..COMMITS {
+        w.append(&build_day_batch(idx, schema.clone()))
+            .expect("append");
+        w.commit().expect("commit");
+    }
+    drop(w);
+
+    let min_day = DAY_BASE;
+    let max_day = DAY_BASE + ((COMMITS - 1) * 100 + ROWS_PER_COMMIT - 1) as i32;
+
+    // Values first — the fold must never change results.
+    assert_eq!(
+        scalar_date32(&st, "SELECT MIN(day) FROM supertable"),
+        min_day
+    );
+    assert_eq!(
+        scalar_date32(&st, "SELECT MAX(day) FROM supertable"),
+        max_day
+    );
+
+    // Plan shape: a tombstone-free date column folds from manifest stats,
+    // so the physical plan has no scan node. This is the regression that
+    // fails before temporal min/max is recorded (the column had no bounds,
+    // so `MIN`/`MAX(day)` fell back to a full `DataSourceExec` scan).
+    for sql in [
+        "SELECT MIN(day) FROM supertable",
+        "SELECT MAX(day) FROM supertable",
+    ] {
+        let plan = explain(&st, sql);
+        assert!(
+            !plan.contains("DataSourceExec"),
+            "{sql}: expected temporal statistics fold (no scan); plan was:\n{plan}"
+        );
+    }
+}
+
+#[test]
+fn temporal_fold_excludes_deleted_extremum() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(options_day_id().with_storage(storage)).expect("create");
+    let schema = st.options().schema.clone();
+
+    let mut w = st.writer().expect("writer");
+    for idx in 0..COMMITS {
+        w.append(&build_day_batch(idx, schema.clone()))
+            .expect("append");
+        w.commit().expect("commit");
+    }
+
+    let max_day = DAY_BASE + ((COMMITS - 1) * 100 + ROWS_PER_COMMIT - 1) as i32;
+    let second_max_day = max_day - 1;
+    let max_id = ((COMMITS - 1) * 1000 + ROWS_PER_COMMIT - 1) as i64;
+
+    // Clean table: max folds to the true extremum.
+    assert_eq!(
+        scalar_date32(&st, "SELECT MAX(day) FROM supertable"),
+        max_day
+    );
+
+    // Delete the row holding the max day (by its aligned id). The manifest
+    // max is now a dead row: a fold would report the stale `max_day`; the
+    // clean-view gate must decline the fold and the scan must report the
+    // true survivor max.
+    let pending = w.delete(col("id").eq(lit(max_id))).expect("delete");
+    assert_eq!(pending.matched, 1);
+    w.commit().expect("commit delete");
+    drop(w);
+
+    assert_eq!(
+        scalar_date32(&st, "SELECT MAX(day) FROM supertable"),
+        second_max_day
     );
 }


### PR DESCRIPTION
### What does this PR do?
Makes MIN/MAX over a date, time, or timestamp column fold from the manifest's stored min/max instead of scanning, and lets date/time range filters prune superfiles by range, hence making those queries faster. The manifest already did this for number, text, and decimal columns.

### Why do we need this change?
Temporal columns were left out of the per-column min/max summary, so MIN/MAX over a date scanned every row and date filters pruned nothing, both worse with scale, even though dates order like integers.

### How do we do this change?
  - `column_min_max` and `merge_min_max_arrays` gain Date32/64, Time32/64, and Timestamp arms; they're integer-backed, so they reuse the primitive min/max path.
  - Timestamp re-attaches the column's timezone (the array constructor drops it) so the bound keeps its type through the cross-superfile merge.
  - Serialization, fold, and prune are already type-generic, so nothing else changes.

### Performance
MIN/MAX over a temporal column folds to a literal (no scan, flat with table size); range filters prune out-of-range superfiles. Cost is one length-1 min/max per temporal column at write, off the query path. Fail-safe: an unordered type records no stat, so the worst case is a missed fold, never a wrong result.
