### PR TITLE
[6/n] feat memory: gate the ingest - used while building superfiles - on connection memory budget

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1487,6 +1487,23 @@ mod tests {
         titles.len()
     }
 
+    /// Ingest the fixture on a measured connection, then return a 0-byte-gate
+    /// connection over the same durable store plus the row count. Ingest is
+    /// gated by the budget too, so setup runs on a measured connection and only
+    /// the query connection carries the gate. Hold the `TempDir`: dropping it
+    /// deletes the store.
+    fn tiny_budget_conn_after_ingest() -> (tempfile::TempDir, Connection, usize) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+        let n = append_titles(&connect(&uri).expect("writer connect"));
+        let conn = connect_with(
+            &uri,
+            ConnectOptions::new().with_connection_memory_budget_bytes(1),
+        )
+        .expect("query connect");
+        (dir, conn, n)
+    }
+
     const HEAVY_GROUP_BY: &str = "SELECT title, COUNT(*) AS n FROM docs GROUP BY title";
 
     #[test]
@@ -1517,12 +1534,7 @@ mod tests {
     fn query_sql_over_a_tiny_budget_is_refused_as_over_budget() {
         // 0-byte gate: the aggregate can't reserve its first byte, and spilling
         // needs memory it doesn't have, so it's refused as OverBudget.
-        let conn = connect_with(
-            "memory://",
-            ConnectOptions::new().with_connection_memory_budget_bytes(1),
-        )
-        .expect("connect");
-        append_titles(&conn);
+        let (_dir, conn, _n) = tiny_budget_conn_after_ingest();
         let err = conn
             .query_sql(HEAVY_GROUP_BY)
             .expect_err("a 0-byte gate refuses the aggregate");
@@ -1536,12 +1548,7 @@ mod tests {
     fn query_sql_streaming_scan_is_not_refused_under_a_tiny_budget() {
         // A projection streams (no buffering), so it reserves nothing and runs
         // even at a 0-byte gate: the budget bounds sort/aggregate/join, not scans.
-        let conn = connect_with(
-            "memory://",
-            ConnectOptions::new().with_connection_memory_budget_bytes(1),
-        )
-        .expect("connect");
-        let n = append_titles(&conn);
+        let (_dir, conn, n) = tiny_budget_conn_after_ingest();
         let out = conn
             .query_sql("SELECT title FROM docs")
             .expect("a streaming scan is not gated");

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,7 +109,12 @@ impl From<SuperfileBuildError> for InfinoError {
 
 impl From<SupertableBuildError> for InfinoError {
     fn from(e: SupertableBuildError) -> Self {
-        InfinoError::Schema(e.to_string())
+        match e {
+            // A budget refusal during ingest keeps its own variant so it
+            // surfaces as the public over-budget error, not a schema error.
+            SupertableBuildError::OverBudget(msg) => InfinoError::OverBudget(msg),
+            other => InfinoError::Schema(other.to_string()),
+        }
     }
 }
 
@@ -141,7 +146,14 @@ impl From<MutationError> for InfinoError {
 
 impl From<MutationCommitError> for InfinoError {
     fn from(e: MutationCommitError) -> Self {
-        InfinoError::Backend(e.to_string())
+        match e {
+            // An ingest budget refusal fails the append-flush phase; preserve it
+            // as over-budget rather than flattening to a generic backend error.
+            MutationCommitError::AppendFlush(SupertableBuildError::OverBudget(msg)) => {
+                InfinoError::OverBudget(msg)
+            }
+            other => InfinoError::Backend(other.to_string()),
+        }
     }
 }
 

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -100,6 +100,11 @@ pub enum BuildError {
     #[error("error from underlying superfile layer: {0}")]
     Superfile(#[from] SuperfileBuildError),
 
+    /// Ingest build refused: would cross the connection memory budget. The string
+    /// is already a full, labelled message, so `#[error("{0}")]` passes it through.
+    #[error("{0}")]
+    OverBudget(String),
+
     #[error(
         "another SupertableWriter is already outstanding for this Supertable; \
          drop it before acquiring a new one"

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -313,6 +313,7 @@ mod tests {
 
     use crate::{
         memory::ConnectionMemoryBudget,
+        storage::{LocalFsStorageProvider, StorageProvider},
         superfile::{
             builder::{FtsConfig, VectorConfig},
             vector::{distance::Metric, rerank_codec::RerankCodec},
@@ -352,12 +353,26 @@ mod tests {
         .with_writer_pool(pool)
     }
 
-    // Bounded budget so the reader's SQL path gates DataFusion's heap.
-    // `with_limit(1)` is a 0-byte gate (90% of 1 floors to 0): refuse everything.
-    fn options_with_zero_gate() -> SupertableOptions {
-        let mut opts = options_id_cat_title();
-        opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
-        opts
+    // Ingest `batch` on a measured supertable, then return a second handle over
+    // the same durable storage under a 0-byte gate. Ingest is gated by the
+    // budget too, so a query-gating test can't reuse one tiny-budget handle for
+    // both; this does the setup on a measured handle and hands back the gated
+    // reader. The returned `TempDir` guard must be held: dropping it deletes the
+    // store the reader is still reading through.
+    fn zero_gate_reader_after_ingest(batch: &RecordBatch) -> (tempfile::TempDir, Supertable) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("localfs"));
+
+        let ingest = Supertable::create(options_id_cat_title().with_storage(Arc::clone(&storage)))
+            .expect("create");
+        let mut w = ingest.writer().expect("writer");
+        w.append(batch).expect("append");
+        w.commit().expect("commit");
+
+        let mut qopts = options_id_cat_title().with_storage(storage);
+        qopts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
+        (dir, Supertable::open(qopts).expect("open"))
     }
 
     /// Build a small categorical batch — start id sequence at
@@ -467,17 +482,11 @@ mod tests {
     fn query_sql_group_by_over_budget_is_refused() {
         // The reader path (second production ctx site) is gated too: a 0-byte
         // gate refuses the aggregate and surfaces as QueryError::OverBudget.
-        let st = Supertable::create(options_with_zero_gate()).expect("create");
-        let mut w = st.writer().expect("writer");
-
-        w.append(&build_cat_batch(
+        let (_dir, st) = zero_gate_reader_after_ingest(&build_cat_batch(
             0,
             &["rust", "python", "rust"],
             &["a", "b", "c"],
-        ))
-        .expect("append");
-
-        w.commit().expect("commit");
+        ));
 
         let err = st
             .reader()
@@ -491,13 +500,8 @@ mod tests {
     fn query_sql_streaming_scan_is_not_refused_under_a_zero_gate() {
         // A projection streams (no buffering), so it runs even at a 0-byte gate:
         // the budget bounds sort/aggregate/join, not scans.
-        let st = Supertable::create(options_with_zero_gate()).expect("create");
-        let mut w = st.writer().expect("writer");
-
-        w.append(&build_cat_batch(0, &["rust", "python"], &["a", "b"]))
-            .expect("append");
-
-        w.commit().expect("commit");
+        let (_dir, st) =
+            zero_gate_reader_after_ingest(&build_cat_batch(0, &["rust", "python"], &["a", "b"]));
 
         let rows: usize = st
             .reader()

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -124,17 +124,26 @@ use crate::{
     },
 };
 
-// An approximate multiple for the memory the build will use, reserved up front rather than accounted for exactly.
-// Building the superfile here holds the FTS and vector blobs plus the serialized file in memory at once, so the
-// real peak is a few times the raw ingested bytes.
+// Approximate multiples for the memory the build will use, reserved up front rather than
+// accounted for exactly. Building the superfile holds the FTS and vector blobs plus the
+// serialized file in memory at once, so the real peak is a few times the raw ingested bytes.
 //
-// Reserving "5 x ingested_raw_bytes" is a cheap estimate. It covers the measured scalar-only (~2-3x) and
-// FTS (~3-4x) cases, but vector-heavy builds reach ~5-8x (worse for small batches and across concurrent
-// shards), so 5x can still under-reserve those.
+// Each kind of blob has a separate factor, so the estimate tracks the schema & ingestion data
+// closely: memory for building vector blobs >> memory for the FTS blob >> memory for plain
+// scalar columns.
 //
-// A better way later is a dynamic factor, since it depends on the schema a lot:
-// memory for building vector blobs >> memory for the FTS blob >> memory for plain scalar columns
-const BUILD_SCRATCH_FACTOR: usize = 5;
+// Stored as numerator over DENOM so the estimate stays integer-only (halves).
+const BUILD_SCRATCH_DENOM: usize = 2;
+
+// Scalar columns, held then serialized into the Parquet body: ~2.5x.
+const BUILD_SCALAR_NUM: usize = 5;
+
+// f32 vector payload, rebuilt as quantized + rerank codecs alongside the raw input: ~6.5x.
+const BUILD_VECTOR_NUM: usize = 13;
+
+// FTS text, ~1.5x for the FST + postings structures. Added on top of the scalar factor, not
+// instead of it: the same text bytes are held as a column and drive the index build at once.
+const BUILD_FTS_NUM: usize = 3;
 
 /// Single-writer append + commit handle.
 ///
@@ -148,9 +157,16 @@ pub struct SupertableWriter {
     /// SuperfileBuilder) owns the buffer so commit() can rayon-
     /// shard it across workers, each running its own builder.
     buffer: Vec<BufferedBatch>,
-    /// Estimated byte cost of `buffer` so append() can auto-flush
-    /// when the buffer crosses the configured threshold.
-    buffer_bytes: usize,
+    /// Held Arrow scalar bytes across `buffer` (id + user columns,
+    /// including the FTS text columns).
+    buffer_scalar_bytes: usize,
+    /// Held f32 vector payload bytes across `buffer`.
+    buffer_vector_bytes: usize,
+    /// Byte size of the FTS-indexed text columns within `buffer`. A
+    /// subset of `buffer_scalar_bytes`, not extra held memory; tracked
+    /// only to weight the build-scratch reserve, since the FTS index
+    /// structures built at commit scale with the text input.
+    buffer_fts_bytes: usize,
     /// Pending update entries, in buffer order. Each is
     /// fully-resolved at `update()` call time (predicate
     /// captured, `_id` range minted, IPC sidecar bytes encoded);
@@ -188,7 +204,7 @@ impl fmt::Debug for SupertableWriter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SupertableWriter")
             .field("buffered_batches", &self.buffer.len())
-            .field("buffered_bytes", &self.buffer_bytes)
+            .field("buffered_bytes", &self.buffered_bytes())
             .field("manifest_id", &self.inner.manifest.load().manifest_id)
             .finish()
     }
@@ -393,7 +409,9 @@ impl Supertable {
             Ok(_) => Ok(SupertableWriter {
                 inner: Arc::clone(self.inner()),
                 buffer: Vec::new(),
-                buffer_bytes: 0,
+                buffer_scalar_bytes: 0,
+                buffer_vector_bytes: 0,
+                buffer_fts_bytes: 0,
                 pending_updates: Vec::new(),
                 pending_deletes: Vec::new(),
             }),
@@ -410,9 +428,12 @@ impl SupertableWriter {
         self.buffer.len()
     }
 
-    /// Estimated bytes of buffered (un-committed) data.
+    /// Bytes of buffered (un-committed) data actually held in memory:
+    /// the scalar columns plus the f32 vector payload. This is the
+    /// figure the auto-flush threshold is compared against (the FTS
+    /// weighting only affects the build-scratch reserve, not held size).
     pub fn buffered_bytes(&self) -> usize {
-        self.buffer_bytes
+        self.buffer_scalar_bytes + self.buffer_vector_bytes
     }
 
     /// Add one batch to the in-memory buffer. Triggers an
@@ -436,29 +457,30 @@ impl SupertableWriter {
         // Validate + split. Batch schema is user_schema (no id col).
         let (scalar_no_id, _vector_slices) = split_vectors(batch, options)?;
 
-        // Re-derive owned Arc<Float32Array> handles for each
-        // vector column. We can't keep the &[f32] slices from
-        // split_vectors in the buffer (their lifetime is tied to
-        // `batch`, which the caller reclaims after this returns).
-        // The Arc<Float32Array> shares the same underlying buffer
-        // — no bytes copied.
+        // Re-derive owned Arc<Float32Array> handles for each vector column. We can't keep the &[f32] slices from
+        // split_vectors in the buffer (their lifetime is tied to `batch`, which the caller reclaims after this returns).
+        // The Arc<Float32Array> shares the same underlying buffer — no bytes copied.
         let mut vectors = Vec::with_capacity(options.vector_columns.len());
         for vc in &options.vector_columns {
             let col_idx = batch
                 .schema()
                 .index_of(&vc.column)
                 .map_err(|_| BuildError::BatchSchemaMismatch)?;
+
             let fsl = batch
                 .column(col_idx)
                 .as_any()
                 .downcast_ref::<FixedSizeListArray>()
                 .ok_or(BuildError::BatchSchemaMismatch)?;
+
             let values = fsl.values();
+
             let f32_arr = values
                 .as_any()
                 .downcast_ref::<Float32Array>()
                 .ok_or(BuildError::BatchSchemaMismatch)?
                 .clone();
+
             vectors.push(Arc::new(f32_arr));
         }
 
@@ -478,6 +500,7 @@ impl SupertableWriter {
                 ids.push(generator.next_id());
             }
         }
+
         let id_array = Decimal128Array::from(ids)
             .with_precision_and_scale(DECIMAL128_PRECISION, DECIMAL128_SCALE)
             .expect(
@@ -490,24 +513,33 @@ impl SupertableWriter {
         let scalar = RecordBatch::try_new(options.scalar_schema(), columns)
             .map_err(|_| BuildError::BatchSchemaMismatch)?;
 
-        // Estimate byte cost: Arrow scalar columns + f32 vector
-        // payload. RecordBatch::get_array_memory_size accounts
-        // for buffer allocations (rough but good enough for
-        // threshold gating).
-        let bytes = scalar.get_array_memory_size()
-            + vectors
-                .iter()
-                .map(|v| v.len() * mem::size_of::<f32>())
-                .sum::<usize>();
+        // Estimate byte cost per input class. get_array_memory_size accounts for
+        // Arrow buffer allocations (rough but good enough); the vector payload is
+        // its exact f32 size. The FTS text columns are a subset of the scalar
+        // columns, summed separately only to weight the build-scratch reserve.
+        let scalar_bytes = scalar.get_array_memory_size();
+        let vector_bytes = vectors
+            .iter()
+            .map(|v| v.len() * mem::size_of::<f32>())
+            .sum::<usize>();
+        let fts_bytes = options
+            .fts_columns
+            .iter()
+            .filter_map(|fc| scalar.schema().index_of(&fc.column).ok())
+            .map(|idx| scalar.column(idx).get_array_memory_size())
+            .sum::<usize>();
 
         self.buffer.push(BufferedBatch { scalar, vectors });
-        self.buffer_bytes += bytes;
+        self.buffer_scalar_bytes += scalar_bytes;
+        self.buffer_vector_bytes += vector_bytes;
+        self.buffer_fts_bytes += fts_bytes;
 
-        // Auto-flush if over threshold.
+        // Auto-flush on held bytes (scalar + vector); the FTS weighting is a
+        // reserve-time concern, not held memory.
         let threshold = (options.commit_threshold_size_mb as usize)
             .saturating_mul(1024)
             .saturating_mul(1024);
-        if threshold > 0 && self.buffer_bytes >= threshold {
+        if threshold > 0 && self.buffered_bytes() >= threshold {
             self.commit_appends_internal()?;
         }
 
@@ -994,11 +1026,15 @@ impl SupertableWriter {
         // Held until this function returns, i.e. past `publish_superfiles` below.
         let _build_guard = reserve_build_scratch(
             &self.inner.options.connection_memory_budget,
-            self.buffer_bytes,
+            self.buffer_scalar_bytes,
+            self.buffer_vector_bytes,
+            self.buffer_fts_bytes,
         )?;
 
         let buffer = mem::take(&mut self.buffer);
-        self.buffer_bytes = 0;
+        self.buffer_scalar_bytes = 0;
+        self.buffer_vector_bytes = 0;
+        self.buffer_fts_bytes = 0;
 
         let total_rows: usize = buffer.iter().map(|b| b.scalar.num_rows()).sum();
         if total_rows == 0 {
@@ -1094,14 +1130,31 @@ impl ShardOutput {
     }
 }
 
-/// Reserve the build's estimated heap (`raw_bytes` times [`BUILD_SCRATCH_FACTOR`]);
+/// Reserve the build's estimated transient heap:
+///
+/// estimate = (2.5*scalar_raw_bytes + 6.5*vector_raw_bytes + 1.5*fts_text_raw_bytes)
+///
 /// returns `OverBudget` when a bounded budget can't fit it.
 fn reserve_build_scratch(
     budget: &Arc<ConnectionMemoryBudget>,
-    raw_bytes: usize,
+    scalar_bytes: usize,
+    vector_bytes: usize,
+    fts_bytes: usize,
 ) -> Result<Reservation, BuildError> {
+    //  The constants are kept integer rather than float, so the estimate is calculated as such:
+    //
+    //     (BUILD_SCALAR_NUM * scalar_bytes) + (BUILD_VECTOR_NUM * vector_bytes) + (BUILD_FTS_NUM * fts_bytes)
+    //   ------------------------------------------------------------------------------------------------------
+    //                                            BUILD_SCRATCH_DENOM
+    //
+    let estimate = scalar_bytes
+        .saturating_mul(BUILD_SCALAR_NUM)
+        .saturating_add(vector_bytes.saturating_mul(BUILD_VECTOR_NUM))
+        .saturating_add(fts_bytes.saturating_mul(BUILD_FTS_NUM))
+        / BUILD_SCRATCH_DENOM;
+
     budget
-        .try_reserve(raw_bytes.saturating_mul(BUILD_SCRATCH_FACTOR))
+        .try_reserve(estimate)
         // Label the message "during ingest" so it can be told apart from a query
         // or SQL over-budget error once it reaches the public InfinoError.
         .map_err(|e| BuildError::OverBudget(format!("during ingest, {e}")))
@@ -2180,9 +2233,48 @@ mod tests {
     // ---- ingest memory budget ----------------------------------------
 
     #[test]
+    fn reserve_build_scratch_weights_each_input_class() {
+        // Pins the per-class estimate against the constants: a measured budget
+        // never denies, so `used()` is exactly the reserved amount. The point of
+        // the split (vs one blanket factor) is that a byte of vector payload
+        // reserves more than a byte of scalar, and the FTS term is additive on
+        // top of the scalar hold, not a replacement.
+        let budget = ConnectionMemoryBudget::measured();
+        let (scalar, vector, fts) = (1000usize, 2000usize, 400usize);
+
+        let guard = reserve_build_scratch(&budget, scalar, vector, fts)
+            .expect("measured budget never denies");
+        let expected =
+            (BUILD_SCALAR_NUM * scalar + BUILD_VECTOR_NUM * vector + BUILD_FTS_NUM * fts)
+                / BUILD_SCRATCH_DENOM;
+        assert_eq!(budget.used(), expected);
+        drop(guard);
+        assert_eq!(budget.used(), 0, "reservation released on drop");
+
+        // Same byte count, different class: vector costs strictly more than
+        // scalar, and adding FTS text raises the reserve further. Read `used()`
+        // while the guard is alive, then release it before the next call.
+        let reserved = |s, v, f| {
+            let _guard = reserve_build_scratch(&budget, s, v, f).expect("measured");
+            budget.used()
+        };
+        let scalar_only = reserved(1000, 0, 0);
+        let vector_only = reserved(0, 1000, 0);
+        let scalar_plus_fts = reserved(1000, 0, 1000);
+        assert!(
+            vector_only > scalar_only,
+            "a vector byte must reserve more than a scalar byte ({vector_only} vs {scalar_only})"
+        );
+        assert!(
+            scalar_plus_fts > scalar_only,
+            "the FTS term is additive on top of scalar ({scalar_plus_fts} vs {scalar_only})"
+        );
+    }
+
+    #[test]
     fn append_over_budget_is_refused() {
         // A 1-byte bounded budget floors the enforced gate to 0, so building
-        // any batch (which reserves buffer_bytes x factor > 0) is refused. The
+        // any non-empty batch (whose weighted reserve is > 0) is refused. The
         // public folded append surfaces it as InfinoError::OverBudget.
         let mut opts = options_id_title_serial();
         opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -96,6 +96,7 @@ use super::{
 use crate::superfile::ReadError;
 use crate::{
     InfinoError,
+    memory::{ConnectionMemoryBudget, Reservation},
     storage::{StorageError, StorageProvider},
     superfile::{
         SuperfileReader,
@@ -122,6 +123,18 @@ use crate::{
         reader_cache::DiskCacheStore,
     },
 };
+
+// An approximate multiple for the memory the build will use, reserved up front rather than accounted for exactly.
+// Building the superfile here holds the FTS and vector blobs plus the serialized file in memory at once, so the
+// real peak is a few times the raw ingested bytes.
+//
+// Reserving "5 x ingested_raw_bytes" is a cheap estimate. It covers the measured scalar-only (~2-3x) and
+// FTS (~3-4x) cases, but vector-heavy builds reach ~5-8x (worse for small batches and across concurrent
+// shards), so 5x can still under-reserve those.
+//
+// A better way later is a dynamic factor, since it depends on the schema a lot:
+// memory for building vector blobs >> memory for the FTS blob >> memory for plain scalar columns
+const BUILD_SCRATCH_FACTOR: usize = 5;
 
 /// Single-writer append + commit handle.
 ///
@@ -974,6 +987,16 @@ impl SupertableWriter {
         if self.buffer.is_empty() {
             return Ok(());
         }
+
+        // Try reserving the transient heap from the ConnectionMemoryBudget before draining the buffer.
+        // For now, if memory reservation is refused, the buffer is left untouched, but this behaviour can be changed.
+        //
+        // Held until this function returns, i.e. past `publish_superfiles` below.
+        let _build_guard = reserve_build_scratch(
+            &self.inner.options.connection_memory_budget,
+            self.buffer_bytes,
+        )?;
+
         let buffer = mem::take(&mut self.buffer);
         self.buffer_bytes = 0;
 
@@ -1008,7 +1031,10 @@ impl SupertableWriter {
             superfiles = outputs.len(),
             "published appended superfiles"
         );
+
         publish_superfiles(&self.inner, outputs)?;
+
+        // Reserved memory (if any) via _build_guard is freed now.
         Ok(())
     }
 }
@@ -1066,6 +1092,19 @@ impl ShardOutput {
             scalar_stats,
         }
     }
+}
+
+/// Reserve the build's estimated heap (`raw_bytes` times [`BUILD_SCRATCH_FACTOR`]);
+/// returns `OverBudget` when a bounded budget can't fit it.
+fn reserve_build_scratch(
+    budget: &Arc<ConnectionMemoryBudget>,
+    raw_bytes: usize,
+) -> Result<Reservation, BuildError> {
+    budget
+        .try_reserve(raw_bytes.saturating_mul(BUILD_SCRATCH_FACTOR))
+        // Label the message "during ingest" so it can be told apart from a query
+        // or SQL over-budget error once it reaches the public InfinoError.
+        .map_err(|e| BuildError::OverBudget(format!("during ingest, {e}")))
 }
 
 /// Build one superfile from one slice of buffered batches. Runs on
@@ -2143,6 +2182,152 @@ mod tests {
         let titles =
             LargeStringArray::from((0..n).map(|i| format!("doc {i} alpha")).collect::<Vec<_>>());
         RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)]).expect("build batch")
+    }
+
+    // ---- ingest memory budget ----------------------------------------
+
+    #[test]
+    fn append_over_budget_is_refused() {
+        // A 1-byte bounded budget floors the enforced gate to 0, so building
+        // any batch (which reserves buffer_bytes x factor > 0) is refused. The
+        // public folded append surfaces it as InfinoError::OverBudget.
+        let mut opts = options_id_title_serial();
+        opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
+        let st = Supertable::create(opts).expect("create");
+
+        let err = st
+            .append(&build_simple_batch(0, 8))
+            .expect_err("build over a 0-byte gate is refused");
+        let InfinoError::OverBudget(msg) = err else {
+            panic!("expected InfinoError::OverBudget, got {err:?}");
+        };
+        // The message names the ingest path, so a caller can tell it apart from
+        // a query or SQL over-budget error (which share the OverBudget variant).
+        assert!(
+            msg.contains("ingest"),
+            "over-budget message should identify ingest: {msg}"
+        );
+
+        // Nothing was published, and a refused reservation commits nothing.
+        assert_eq!(st.reader().n_docs_total(), 0);
+        assert!(st.options().connection_memory_budget.denials() >= 1);
+        assert_eq!(st.options().connection_memory_budget.peak(), 0);
+    }
+
+    #[test]
+    fn append_under_measured_budget_runs_and_tracks_peak() {
+        // Measured budget never refuses; the build still reserves, so peak > 0
+        // proves the reservation ran on the ingest path.
+        let mut opts = options_id_title_serial();
+        opts.connection_memory_budget = ConnectionMemoryBudget::measured();
+        let st = Supertable::create(opts).expect("create");
+
+        st.append(&build_simple_batch(0, 8))
+            .expect("measured budget never refuses");
+        assert_eq!(st.reader().n_docs_total(), 8);
+
+        let budget = &st.options().connection_memory_budget;
+        assert_eq!(budget.denials(), 0);
+        assert!(
+            budget.peak() > 0,
+            "the build must reserve against the budget"
+        );
+    }
+
+    #[test]
+    fn append_under_ample_bounded_budget_runs() {
+        // A bounded (enforcing) budget well above the build must admit the
+        // ingest, not refuse on principle.
+        const AMPLE_BUDGET_BYTES: u64 = 1 << 30; // 1 GiB, far above an 8-row batch.
+        let mut opts = options_id_title_serial();
+        opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(AMPLE_BUDGET_BYTES);
+        let st = Supertable::create(opts).expect("create");
+
+        st.append(&build_simple_batch(0, 8))
+            .expect("under-budget append runs under a bounded budget");
+        assert_eq!(st.reader().n_docs_total(), 8);
+
+        let budget = &st.options().connection_memory_budget;
+        assert_eq!(budget.denials(), 0);
+        assert!(budget.limit().is_some(), "bounded, not measured");
+    }
+
+    #[test]
+    fn over_budget_commit_preserves_the_buffer() {
+        // Reserving before draining the buffer means a refused commit leaves the
+        // buffered rows intact, so the caller can retry or back off.
+        let mut opts = options_id_title_serial();
+        opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
+        let st = Supertable::create(opts).expect("create");
+
+        let mut w = st.writer().expect("writer");
+        w.append(&build_simple_batch(0, 8)).expect("append buffers");
+        assert_eq!(w.buffered_batches(), 1);
+
+        let err = w
+            .commit()
+            .expect_err("commit over a 0-byte gate is refused");
+        assert!(
+            matches!(err, CommitError::AppendFlush(BuildError::OverBudget(_))),
+            "got {err:?}"
+        );
+        // The buffer was not drained.
+        assert_eq!(w.buffered_batches(), 1);
+    }
+
+    #[test]
+    fn auto_flush_over_budget_is_refused_from_append() {
+        // With a commit threshold set, `append` auto-flushes once the buffer
+        // crosses it, so the refusal surfaces out of `append` itself (the
+        // auto-flush exit) rather than an explicit `commit`. A batch large
+        // enough to exceed the 1 MiB threshold in one call trips it.
+        const AUTO_FLUSH_TRIP_ROWS: usize = 40_000;
+        let mut opts = options_id_title_serial().with_commit_threshold_size_mb(1);
+        opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
+        let st = Supertable::create(opts).expect("create");
+
+        let mut w = st.writer().expect("writer");
+        let err = w
+            .append(&build_simple_batch(0, AUTO_FLUSH_TRIP_ROWS))
+            .expect_err("auto-flush over a 0-byte gate is refused");
+        assert!(matches!(err, BuildError::OverBudget(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn vector_ingest_over_budget_is_refused() {
+        // The gate covers the vector build path too: a vector-schema ingest over
+        // a 0-byte gate is refused as the public OverBudget, nothing published.
+        let dim = 16;
+        let mut opts = options_with_vector(dim);
+        opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
+        let st = Supertable::create(opts).expect("create");
+
+        let err = st
+            .append(&build_vector_batch(0, 8, dim))
+            .expect_err("vector build over a 0-byte gate is refused");
+        assert!(matches!(err, InfinoError::OverBudget(_)), "got {err:?}");
+        assert_eq!(st.reader().n_docs_total(), 0);
+    }
+
+    #[test]
+    fn vector_ingest_reserves_and_runs_under_measured() {
+        // Measured never refuses; peak > 0 proves the vector build (kmeans +
+        // quantization + serialized blob) actually reserved against the budget.
+        let dim = 16;
+        let mut opts = options_with_vector(dim);
+        opts.connection_memory_budget = ConnectionMemoryBudget::measured();
+        let st = Supertable::create(opts).expect("create");
+
+        st.append(&build_vector_batch(0, 8, dim))
+            .expect("measured vector ingest runs");
+        assert_eq!(st.reader().n_docs_total(), 8);
+
+        let budget = &st.options().connection_memory_budget;
+        assert_eq!(budget.denials(), 0);
+        assert!(
+            budget.peak() > 0,
+            "the vector build must reserve against the budget"
+        );
     }
 
     // ---- writer slot exclusion ---------------------------------------


### PR DESCRIPTION
### What does this PR do?
Bounds heap memory used during ingestion, against the connection memory budget.

### Why do we need this change?
#352 gated SQL and #371 gated vector search, but the write path was still open. Building a superfile (the FTS blob, the vector index, and the Parquet columnar data) from the buffered rows is the largest allocation on the write path: it materializes the whole index and the serialized file in RAM before the object-store PUT. This happens at commit, or mid-`append` once `commit_threshold_size_mb` is breached, so one big append could exhaust memory even with a budget set.

### How do we do this change?
- Before draining the buffer, the writer reserves the estimated build heap against the budget via `reserve_build_scratch`, held across the concurrent shard build and the publish, freed on drop. Reserving before the drain is what leaves the buffer untouched on a refusal.
- Per-column-type estimate: The peak-to-input ratio differs a lot by column kind (measured ~2-3x scalar-only, ~3-4x with FTS, ~5-8x with vectors). So,  each input class is weighted on its own and summed: `2.5*scalar + 6.5*vector + 1.5*fts_text`; the FTS term is additive on top of the scalar hold since the same text drives the index build.

These are central estimates, not worst-case ceilings; a fully dynamic per-schema factor can be future work.

### Performance
No behaviour change by default.  The only added work is one atomic reservation per commit, off the per-row path. 

### Notes
**The update path isn't gated yet.** `Supertable::update` builds its new-row superfile through a separate WAL pipeline. Append is the common, high-volume write path, so it's gated first; the update build is worth designing when an update-heavy workload makes it matter, so it lands as its own slice. The design there is a placement plus refusal-semantics choice, not a WAL change: the new rows are durable before the build, so a refusal either rejects before durability (clean, retryable) or defers to the recovery sweep (which isn't budget-aware and could get stuck).