### PR TITLE
Fix/profile superfile budget arg

### DIFF
--- a/benches/utils/bin/profile_superfile.rs
+++ b/benches/utils/bin/profile_superfile.rs
@@ -158,6 +158,7 @@ fn mean_recall_filtered(
             Some(Arc::clone(allow)),
             None,
             None,
+            None
         ))
         .expect("vector_hits_filtered");
         sum += corpus::recall_at_k(&hits, truth);

--- a/benches/utils/bin/profile_superfile.rs
+++ b/benches/utils/bin/profile_superfile.rs
@@ -158,7 +158,7 @@ fn mean_recall_filtered(
             Some(Arc::clone(allow)),
             None,
             None,
-            None
+            None,
         ))
         .expect("vector_hits_filtered");
         sum += corpus::recall_at_k(&hits, truth);


### PR DESCRIPTION
## Summary
- Follow-up to #371: `profile_superfile` still called `vector_hits_filtered_async` with 7 args after `budget` was added.
- Pass `None` for the connection memory budget (same as other unbudgeted bench paths).

