### PR TITLE
[7/n] refactor memory: route every over-budget refusal to InfinoError::OverBudget

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -122,15 +122,18 @@ impl From<StorageError> for InfinoError {
 
 impl From<QueryError> for InfinoError {
     fn from(e: QueryError) -> Self {
-        match e {
-            QueryError::OverBudget(msg) => InfinoError::OverBudget(msg),
-            other => InfinoError::Query(other.to_string()),
+        if let Some(msg) = e.over_budget() {
+            return InfinoError::OverBudget(msg.to_string());
         }
+        InfinoError::Query(e.to_string())
     }
 }
 
 impl From<SuperfileReadError> for InfinoError {
     fn from(e: SuperfileReadError) -> Self {
+        if let Some(msg) = e.over_budget() {
+            return InfinoError::OverBudget(msg.to_string());
+        }
         InfinoError::Query(e.to_string())
     }
 }
@@ -143,12 +146,10 @@ impl From<SuperfileBuildError> for InfinoError {
 
 impl From<SupertableBuildError> for InfinoError {
     fn from(e: SupertableBuildError) -> Self {
-        match e {
-            // A budget refusal during ingest keeps its own variant so it
-            // surfaces as the public over-budget error, not a schema error.
-            SupertableBuildError::OverBudget(msg) => InfinoError::OverBudget(msg),
-            other => InfinoError::Schema(other.to_string()),
+        if let Some(msg) = e.over_budget() {
+            return InfinoError::OverBudget(msg.to_string());
         }
+        InfinoError::Schema(e.to_string())
     }
 }
 
@@ -168,6 +169,8 @@ impl From<MutationError> for InfinoError {
     fn from(e: MutationError) -> Self {
         let msg = e.to_string();
         match e {
+            // Routes over-budget through From<QueryError> when the predicate
+            // eval was the budget refusal.
             MutationError::PredicateEval(q) => InfinoError::from(q),
             MutationError::Storage(s) => InfinoError::from(s),
             MutationError::CardinalityMismatch { .. }
@@ -180,14 +183,10 @@ impl From<MutationError> for InfinoError {
 
 impl From<MutationCommitError> for InfinoError {
     fn from(e: MutationCommitError) -> Self {
-        match e {
-            // An ingest budget refusal fails the append-flush phase; preserve it
-            // as over-budget rather than flattening to a generic backend error.
-            MutationCommitError::AppendFlush(SupertableBuildError::OverBudget(msg)) => {
-                InfinoError::OverBudget(msg)
-            }
-            other => InfinoError::Backend(other.to_string()),
+        if let Some(msg) = e.over_budget() {
+            return InfinoError::OverBudget(msg.to_string());
         }
+        InfinoError::Backend(e.to_string())
     }
 }
 
@@ -284,6 +283,26 @@ mod tests {
         ));
         assert!(matches!(
             InfinoError::from(OpenError::ManifestListParse("m".into())),
+            InfinoError::Backend(_)
+        ));
+    }
+
+    #[test]
+    fn over_budget_routes_through_wrappers() {
+        // A budget refusal nested under a wrapper (here the commit's
+        // append-flush phase) still routes to OverBudget: each wrapper's
+        // over_budget() delegates to the inner error's.
+        let nested =
+            MutationCommitError::AppendFlush(SupertableBuildError::OverBudget("deep".into()));
+        assert!(matches!(
+            InfinoError::from(nested),
+            InfinoError::OverBudget(_)
+        ));
+        // A non-budget error in the same wrapper stays a generic backend error.
+        assert!(matches!(
+            InfinoError::from(MutationCommitError::AppendFlush(
+                SupertableBuildError::NoDocsToBuild
+            )),
             InfinoError::Backend(_)
         ));
     }

--- a/src/memory/datafusion_pool.rs
+++ b/src/memory/datafusion_pool.rs
@@ -59,10 +59,14 @@ impl MemoryPool for ConnectionBudgetPool {
     }
 
     fn try_grow(&self, _reservation: &MemoryReservation, additional: usize) -> DfResult<()> {
-        self.budget.try_grow(additional).map_err(|_| {
-            DataFusionError::ResourcesExhausted(format!(
-                "connection memory budget exhausted: {additional} more bytes would cross the limit"
-            ))
+        // DataFusion's spilling operators (sort, aggregate) call try_grow and, on `Err`, spill to disk
+        // and retry rather than fail. They branch on the error variant (`ResourcesExhausted`), never on
+        // its message, so the text here only surfaces if the query still can't fit after spilling.
+        //
+        // We label it "during SQL query" so that final error matches the ingest and vector over-budget
+        // messages once it reaches InfinoError::OverBudget.
+        self.budget.try_grow(additional).map_err(|over| {
+            DataFusionError::ResourcesExhausted(format!("during SQL query, {over}"))
         })
     }
 

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -151,6 +151,18 @@ pub enum ReadError {
     Columnar(String),
 }
 
+impl ReadError {
+    /// The over-budget message if this, or the vector error it wraps, is a
+    /// budget refusal, else `None`. Lets a `From` impl route to
+    /// `InfinoError::OverBudget` without matching the nested shape.
+    pub(crate) fn over_budget(&self) -> Option<&str> {
+        match self {
+            ReadError::Vector(v) => v.over_budget(),
+            _ => None,
+        }
+    }
+}
+
 impl From<FtsError> for ReadError {
     fn from(e: FtsError) -> Self {
         ReadError::Fts(Box::new(e))
@@ -198,11 +210,22 @@ pub enum VectorError {
     #[error("lazy source error during vector search: {0}")]
     LazySource(String),
 
-    /// A cold cluster-block fetch would cross the connection memory budget;
-    /// the search is refused before the fetch. Surfaces as
-    /// `InfinoError::OverBudget`.
-    #[error("vector search exceeded the connection memory budget: {0}")]
+    /// A cold cluster-block fetch would cross the connection memory budget; the
+    /// search is refused before the fetch. The string is already labelled with
+    /// the operation ("vector search, ..."); it routes to
+    /// `InfinoError::OverBudget` via [`VectorError::over_budget`].
+    #[error("{0}")]
     OverBudget(String),
+}
+
+impl VectorError {
+    /// The over-budget message if this is a budget refusal, else `None`.
+    pub(crate) fn over_budget(&self) -> Option<&str> {
+        match self {
+            VectorError::OverBudget(m) => Some(m),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3117,7 +3117,7 @@ fn reserve_cold_fetch(
     budget
         .try_reserve(cold_bytes)
         .map(Some)
-        .map_err(|e| VectorError::OverBudget(e.to_string()))
+        .map_err(|e| VectorError::OverBudget(format!("vector search, {e}")))
 }
 
 fn get_cluster_ranges_coalesced_with_extra(

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -100,8 +100,9 @@ pub enum BuildError {
     #[error("error from underlying superfile layer: {0}")]
     Superfile(#[from] SuperfileBuildError),
 
-    /// Ingest build refused: would cross the connection memory budget. The string
-    /// is already a full, labelled message, so `#[error("{0}")]` passes it through.
+    /// Ingest build refused: would cross the connection memory budget. The
+    /// string is already labelled ("during ingest, ..."); routes to
+    /// `InfinoError::OverBudget` via [`BuildError::over_budget`].
     #[error("{0}")]
     OverBudget(String),
 
@@ -140,6 +141,16 @@ pub enum BuildError {
     /// back. Caller fixes config or schema.
     #[error("partition column missing in schema: {0}")]
     PartitionColumnMissing(String),
+}
+
+impl BuildError {
+    /// The over-budget message if this is a budget refusal, else `None`.
+    pub(crate) fn over_budget(&self) -> Option<&str> {
+        match self {
+            BuildError::OverBudget(m) => Some(m),
+            _ => None,
+        }
+    }
 }
 
 /// Errors raised by the supertable's commit path — building +
@@ -420,9 +431,22 @@ pub enum QueryError {
     #[error("DataFusion failed to execute the query: {0}")]
     Execute(String),
 
-    #[error("query exceeded the connection memory budget: {0}")]
+    /// A query crossed the connection memory budget. The string is already
+    /// labelled with the operation; routes to `InfinoError::OverBudget` via
+    /// [`QueryError::over_budget`].
+    #[error("{0}")]
     OverBudget(String),
 
     #[error("manifest load error: {0}")]
     ManifestLoad(ManifestLoadError),
+}
+
+impl QueryError {
+    /// The over-budget message if this is a budget refusal, else `None`.
+    pub(crate) fn over_budget(&self) -> Option<&str> {
+        match self {
+            QueryError::OverBudget(m) => Some(m),
+            _ => None,
+        }
+    }
 }

--- a/src/supertable/mutations.rs
+++ b/src/supertable/mutations.rs
@@ -165,6 +165,17 @@ pub enum MutationError {
     TombstonePhase(#[from] TombstonePhaseError),
 }
 
+impl MutationError {
+    /// The over-budget message if a budget-refused predicate eval caused this,
+    /// else `None`. The append phase isn't budget-gated, so it never carries one.
+    pub(crate) fn over_budget(&self) -> Option<&str> {
+        match self {
+            MutationError::PredicateEval(q) => q.over_budget(),
+            _ => None,
+        }
+    }
+}
+
 /// Value returned from [`SupertableWriter::update`]. Carries the
 /// count of rows the predicate resolved to at call time so the
 /// caller can decide whether to proceed to `commit()`. Captured
@@ -240,4 +251,15 @@ pub enum CommitError {
         total: usize,
         cause: Box<MutationError>,
     },
+}
+
+impl CommitError {
+    /// The over-budget message if the append flush, or a buffered mutation's
+    /// predicate eval, was budget-refused, else `None`.
+    pub(crate) fn over_budget(&self) -> Option<&str> {
+        match self {
+            CommitError::AppendFlush(b) => b.over_budget(),
+            CommitError::PartialCommit { cause, .. } => cause.over_budget(),
+        }
+    }
 }

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -42,12 +42,32 @@ use crate::{
         reader::{rank_back_indices, row_selection_for_ids},
     },
     supertable::{
+        error::QueryError,
         handle::SupertableReader,
         manifest::SuperfileUri,
         options::{DECIMAL128_PRECISION, DECIMAL128_SCALE},
         query::{SuperfileHit, superfile_reader::superfile_reader},
     },
 };
+
+/// Map a search TVF's `QueryError` into a DataFusion error at the
+/// execution-node boundary.
+///
+/// The kNN runs off-SQL (in a custom `ExecutionPlan`), so its error must cross
+/// back into DataFusion to bubble up through `collect()`. A connection-memory
+/// budget refusal has to re-enter as `ResourcesExhausted`, the same channel
+/// DataFusion's own memory pool uses, so the SQL error classifier routes it to
+/// `InfinoError::OverBudget` rather than flattening it to a generic query
+/// error. Every other failure is a plain execution error.
+///
+/// Shared by the `vector_search` and `hybrid_search` nodes; without it a hybrid
+/// query would flatten the budget refusal that the plain vector query preserves.
+pub(crate) fn search_query_df_error(e: QueryError) -> DataFusionError {
+    match e.over_budget() {
+        Some(msg) => DataFusionError::ResourcesExhausted(msg.to_string()),
+        None => DataFusionError::Execution(e.to_string()),
+    }
+}
 
 /// Resolve `hits` to one `RecordBatch`, with `projection` naming the
 /// output columns (any of `_id`, the visible scalar columns, or the
@@ -601,6 +621,21 @@ mod tests {
             "emb"
         );
         assert!(arg_to_string(&lit(3_i64), "column").is_err());
+    }
+
+    #[test]
+    fn search_query_df_error_maps_over_budget_to_resources_exhausted() {
+        // Pins the boundary contract both search nodes depend on: a budget
+        // refusal maps to ResourcesExhausted (the shape the SQL classifier
+        // routes back to OverBudget), any other failure to Execution.
+        assert!(matches!(
+            search_query_df_error(QueryError::OverBudget("vector search, over".into())),
+            DataFusionError::ResourcesExhausted(_)
+        ));
+        assert!(matches!(
+            search_query_df_error(QueryError::Plan("boom".into())),
+            DataFusionError::Execution(_)
+        ));
     }
 
     #[test]

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -44,10 +44,15 @@ use datafusion::{
     },
 };
 
-use super::common::{arg_to_string, arg_to_usize, output_schema_with_score, resolve_hits};
 use crate::{
     superfile::fts::reader::BoolMode,
-    supertable::handle::{SupertableReader, WeakReader},
+    supertable::{
+        handle::{SupertableReader, WeakReader},
+        query::exec::common::{
+            arg_to_string, arg_to_usize, output_schema_with_score, resolve_hits,
+            search_query_df_error,
+        },
+    },
 };
 
 /// SQL name for the term-based BM25 TVF.
@@ -380,7 +385,7 @@ impl ExecutionPlan for Bm25Exec {
                     reader.bm25_search_prefix_async(&column, prefix, k).await
                 }
             }
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            .map_err(search_query_df_error)?;
             resolve_hits(
                 &reader,
                 &hits,

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -64,12 +64,6 @@ use datafusion::{
 use futures::{future, stream};
 use tracing::debug;
 
-use super::{
-    common::{
-        arg_to_string, arg_to_usize, output_schema_with_score, resolve_hits, resolve_hits_named,
-    },
-    vector_exec::arg_to_query_vector,
-};
 use crate::{
     InfinoError,
     superfile::{fts::reader::BoolMode, reader::VectorSearchOptions},
@@ -77,7 +71,16 @@ use crate::{
         QueryError,
         handle::{Supertable, SupertableReader, WeakReader},
         manifest::SuperfileUri,
-        query::SuperfileHit,
+        query::{
+            SuperfileHit,
+            exec::{
+                common::{
+                    arg_to_string, arg_to_usize, output_schema_with_score, resolve_hits,
+                    resolve_hits_named, search_query_df_error,
+                },
+                vector_exec::arg_to_query_vector,
+            },
+        },
     },
 };
 
@@ -471,7 +474,7 @@ impl ExecutionPlan for HybridSearchExec {
             let fused = reader
                 .hybrid_search_async(&text_col, &q_text, mode, &vec_col, &q_vec, options, k)
                 .await
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                .map_err(search_query_df_error)?;
             resolve_hits(
                 &reader,
                 &fused,

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -46,13 +46,17 @@ use datafusion::{
 };
 use futures::stream;
 
-use super::{
-    common::{arg_to_string, output_schema_with_score, resolve_hits},
-    fts_exec::arg_to_bool_mode,
-};
 use crate::{
     superfile::fts::reader::BoolMode,
-    supertable::handle::{SupertableReader, WeakReader},
+    supertable::{
+        handle::{SupertableReader, WeakReader},
+        query::exec::{
+            common::{
+                arg_to_string, output_schema_with_score, resolve_hits, search_query_df_error,
+            },
+            fts_exec::arg_to_bool_mode,
+        },
+    },
 };
 
 /// SQL name for the unranked token-match TVF.
@@ -359,7 +363,7 @@ impl ExecutionPlan for MatchExec {
                 }
                 MatchQuery::Exact { value } => reader.exact_match_async(&column, value).await,
             }
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            .map_err(search_query_df_error)?;
             resolve_hits(
                 &reader,
                 &hits,

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -56,12 +56,17 @@ use datafusion::{
 };
 use futures::stream;
 
-use super::common::{arg_to_string, arg_to_usize, output_schema_with_score, resolve_hits};
 use crate::{
     superfile::reader::VectorSearchOptions,
     supertable::{
         handle::{SupertableReader, WeakReader},
-        query::candidate::CandidatePlan,
+        query::{
+            candidate::CandidatePlan,
+            exec::common::{
+                arg_to_string, arg_to_usize, output_schema_with_score, resolve_hits,
+                search_query_df_error,
+            },
+        },
     },
 };
 
@@ -382,7 +387,7 @@ impl ExecutionPlan for VectorSearchExec {
                         .await
                 }
             }
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            .map_err(search_query_df_error)?;
             resolve_hits(
                 &reader,
                 &hits,

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -76,10 +76,7 @@ use super::{SuperfileHit, candidate::CandidatePlan, dispatch, exec::common::reso
 pub use crate::superfile::reader::VectorSearchOptions;
 use crate::{
     superfile::{
-        SuperfileReader,
-        error::{ReadError, VectorError},
-        fts::reader::BoolMode,
-        vector::distance::Metric,
+        SuperfileReader, error::ReadError, fts::reader::BoolMode, vector::distance::Metric,
     },
     supertable::{
         error::QueryError,
@@ -90,17 +87,13 @@ use crate::{
 };
 
 /// Map a per-superfile vector-search error to a query error. A budget refusal
-/// (the kernel's `VectorError::OverBudget`, boxed in `ReadError::Vector`) keeps
-/// its own variant so it surfaces as the public `InfinoError::OverBudget`;
-/// anything else is a generic query error.
+/// keeps its own variant (found via `ReadError::over_budget`) so it surfaces as
+/// the public `InfinoError::OverBudget`; anything else is a generic query error.
 fn vector_read_query_error(e: ReadError) -> QueryError {
-    match e {
-        ReadError::Vector(v) => match *v {
-            VectorError::OverBudget(m) => QueryError::OverBudget(m),
-            other => QueryError::Parquet(other.to_string()),
-        },
-        other => QueryError::Parquet(other.to_string()),
+    if let Some(msg) = e.over_budget() {
+        return QueryError::OverBudget(msg.to_string());
     }
+    QueryError::Parquet(e.to_string())
 }
 
 /// An optional text-predicate filter for vector kNN search. When

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -992,6 +992,174 @@ async fn supertable_cold_vector_search_over_budget_via_s3_wire_protocol() {
     );
 }
 
+/// The same cold-fetch budget refusal, but the vector search is embedded in a
+/// SQL query (the `vector_search` table function) instead of the direct API.
+///
+/// The kNN runs in a custom execution node, so its `QueryError::OverBudget`
+/// has to cross the DataFusion error boundary and back. The node maps it to
+/// `DataFusionError::ResourcesExhausted` (the same channel the SQL memory pool
+/// uses for a spill refusal), so the SQL error classifier routes it to the
+/// public `InfinoError::OverBudget` rather than flattening it to a generic
+/// query error. A measured control runs the identical SQL to completion.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn supertable_cold_vector_search_over_budget_via_sql_wire_protocol() {
+    if std::env::var("INFINO_TEST_S3").is_err() {
+        eprintln!(
+            "supertable_cold_vector_search_over_budget_via_sql_wire_protocol: skipped \
+             (set INFINO_TEST_S3=1 to enable)"
+        );
+        return;
+    }
+
+    let (addr, _fs_root_guard) = spawn_s3s_fs().await;
+    let endpoint = format!("http://{}", addr);
+    let dim = EMB_DIM;
+
+    // Producer: commit a vector batch through the S3 wire protocol.
+    let storage = budget_s3_provider(&endpoint);
+    {
+        let producer = Supertable::create(real_s3_options(dim).with_storage(Arc::clone(&storage)))
+            .expect("create budget producer");
+        let mut w = producer.writer().expect("budget producer writer");
+        w.append(&budget_vector_batch(dim, BUDGET_N_ROWS))
+            .expect("append large vector+FTS batch");
+        w.commit().expect("budget producer commit via S3");
+    }
+
+    // One-hot query at dim 0 as the SQL table-function's CSV argument.
+    let mut q = vec![0.0f32; dim];
+    q[0] = 1.0;
+    let q_csv = q
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!("SELECT _id FROM vector_search('emb', '{q_csv}', {VECTOR_SEARCH_K})");
+
+    // Cold consumer under a bounded 1-byte budget: the kNN's cold cluster-block
+    // fetch is refused, and the refusal must survive the SQL boundary as
+    // `InfinoError::OverBudget`. `map_err(InfinoError::from)` is the same
+    // conversion the curated public surface applies.
+    let (consumer, _cache_guard) = open_budget_consumer(dim, &storage, TINY_BUDGET_BYTES);
+    let result = consumer.reader().query_sql(&sql).map_err(InfinoError::from);
+    match result {
+        Err(InfinoError::OverBudget(msg)) => {
+            eprintln!("[s3-budget-sql] cold vector search in SQL refused as OverBudget: {msg}");
+        }
+        Err(other) => panic!("expected InfinoError::OverBudget, got {other:?}"),
+        Ok(batches) => panic!(
+            "expected InfinoError::OverBudget under a {TINY_BUDGET_BYTES}-byte budget; \
+             cold vector search in SQL returned {} batch(es)",
+            batches.len()
+        ),
+    }
+    let bounded_budget = consumer.options().connection_budget();
+    assert!(
+        bounded_budget.denials() >= 1,
+        "bounded budget must record >=1 denial; got {}",
+        bounded_budget.denials()
+    );
+
+    // Control: the identical SQL over a measured (unbounded) budget runs to
+    // completion, so the deny above is the budget's doing, not a broken plan.
+    let (control, _control_cache_guard) = open_budget_consumer(dim, &storage, 0);
+    let control_rows: usize = control
+        .reader()
+        .query_sql(&sql)
+        .expect("measured cold vector search in SQL should run to completion")
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert!(
+        control_rows >= 1,
+        "measured cold vector search in SQL returned no rows over S3"
+    );
+    assert_eq!(
+        control.options().connection_budget().denials(),
+        0,
+        "measured budget must never deny"
+    );
+}
+
+/// Same cold-fetch budget refusal, but through the `hybrid_search` table
+/// function (BM25 + vector fused with RRF). Hybrid runs the vector kNN in its
+/// own execution node, distinct from `vector_search`, so it has its own error
+/// boundary. This pins that the vector arm's `OverBudget` survives that node
+/// too and isn't flattened to a generic query error. A measured control runs
+/// the identical SQL to completion.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn supertable_cold_hybrid_search_over_budget_via_sql_wire_protocol() {
+    if std::env::var("INFINO_TEST_S3").is_err() {
+        eprintln!(
+            "supertable_cold_hybrid_search_over_budget_via_sql_wire_protocol: skipped \
+             (set INFINO_TEST_S3=1 to enable)"
+        );
+        return;
+    }
+
+    let (addr, _fs_root_guard) = spawn_s3s_fs().await;
+    let endpoint = format!("http://{}", addr);
+    let dim = EMB_DIM;
+
+    let storage = budget_s3_provider(&endpoint);
+    {
+        let producer = Supertable::create(real_s3_options(dim).with_storage(Arc::clone(&storage)))
+            .expect("create budget producer");
+        let mut w = producer.writer().expect("budget producer writer");
+        w.append(&budget_vector_batch(dim, BUDGET_N_ROWS))
+            .expect("append large vector+FTS batch");
+        w.commit().expect("budget producer commit via S3");
+    }
+
+    // 'budget' is in every title (see budget_vector_batch), so BM25 matches;
+    // the vector arm is what crosses the budget on its cold cluster fetch.
+    let mut q = vec![0.0f32; dim];
+    q[0] = 1.0;
+    let q_csv = q
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT _id FROM hybrid_search('title', 'budget', 'emb', '{q_csv}', {VECTOR_SEARCH_K})"
+    );
+
+    let (consumer, _cache_guard) = open_budget_consumer(dim, &storage, TINY_BUDGET_BYTES);
+    match consumer.reader().query_sql(&sql).map_err(InfinoError::from) {
+        Err(InfinoError::OverBudget(msg)) => {
+            eprintln!("[s3-budget-sql] cold hybrid search refused as OverBudget: {msg}");
+        }
+        Err(other) => panic!("expected InfinoError::OverBudget, got {other:?}"),
+        Ok(batches) => panic!(
+            "expected InfinoError::OverBudget under a {TINY_BUDGET_BYTES}-byte budget; \
+             cold hybrid search returned {} batch(es)",
+            batches.len()
+        ),
+    }
+    assert!(
+        consumer.options().connection_budget().denials() >= 1,
+        "bounded budget must record >=1 denial"
+    );
+
+    let (control, _control_cache_guard) = open_budget_consumer(dim, &storage, 0);
+    let control_rows: usize = control
+        .reader()
+        .query_sql(&sql)
+        .expect("measured cold hybrid search should run to completion")
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert!(
+        control_rows >= 1,
+        "measured cold hybrid search returned no rows over S3"
+    );
+    assert_eq!(
+        control.options().connection_budget().denials(),
+        0,
+        "measured budget must never deny"
+    );
+}
+
 /// The per-connection budget is shared across the multi-superfile fan-out, so
 /// several superfiles' cold fetches accumulate against one ceiling. A
 /// per-superfile budget would never add up, and this is what pins that.


### PR DESCRIPTION
### What does this PR do?
Makes every over-budget refusal (SQL, vector, ingest) surface as `InfinoError::OverBudget` through one shared path instead of per-layer match arms, and fixes a gap where a `hybrid_search` query that crossed the budget surfaced as a generic query error.

### Why do we need this change?
Previous changes added their own `OverBudget` variant plus a hand-written `From` arm into the public error. For future changes, that is easy to miss, and can silently mislabel an over-budget error instead of failing loudly. `hybrid_search` was exactly that gap we found in here.

### How do we do this change?
- **One accessor per error layer.** Each error enum grows an `over_budget()` returning the labelled message if it (or an error it wraps) is a refusal; wrappers delegate to the inner one. The `From<…> for InfinoError` impls call it, so a nested refusal routes without any layer matching the nested shape, and a new layer needs no new arm.
- **One helper for the search functions.** The kNN runs off-SQL, so its error re-enters DataFusion as `ResourcesExhausted` (the SQL pool's own channel) and the SQL classifier routes it back to `OverBudget`. Shared by `vector_search`, `hybrid_search`, `bm25`, `match`.
- **Labelled at the source** ("during SQL query" / "vector search" / "during ingest"), so the public message reads the same for all three.

### Performance
No behaviour change. `over_budget()` borrows, no allocation, and the routing is error-path only.

### Notes
- FTS (`bm25` / `match`) isn't budget-gated today, so those nodes never produce a refusal; they use the same helper anyway so the pattern is uniform and FTS gating slots in later with no new arm.