### PR TITLE
[10/n] feat node: expose the connection memory budget in connect()

### DIFF
--- a/infino-node/__test__/smoke.test.mjs
+++ b/infino-node/__test__/smoke.test.mjs
@@ -339,3 +339,29 @@ test("connect parses cache + cold-fetch options", () => {
 test("connect rejects an invalid coldFetchMode", () => {
   assert.throws(() => connect("memory://", { coldFetchMode: "nonsense" }));
 });
+
+test("connectionMemoryBudgetBytes: ample admits, over-budget throws", () => {
+  // A generous heap budget must not refuse ordinary work.
+  const ample = connect("memory://", { connectionMemoryBudgetBytes: 1 << 30 });
+  const ok = ample.createTable("docs", { title: "large_utf8" }, new IndexSpec().fts("title"));
+  ok.append([{ title: "the quick brown fox" }]);
+  assert.equal(ok.bm25Search("title", "fox", 10).length, 1);
+
+  // A 1-byte budget floors the enforced gate to 0, so building the appended
+  // rows crosses it. The refusal throws an Error prefixed
+  // `ConnectionMemoryBudgetError:`, not a crash.
+  const tight = connect("memory://", { connectionMemoryBudgetBytes: 1 });
+  const docs = tight.createTable("docs", { title: "large_utf8" }, new IndexSpec().fts("title"));
+  assert.throws(
+    () => docs.append([{ title: "the quick brown fox" }, { title: "a lazy dog" }]),
+    /ConnectionMemoryBudgetError:/,
+  );
+});
+
+test("connectionMemoryBudgetBytes: 0 measures without enforcing", () => {
+  // 0 (like omitting it) measures usage but never denies.
+  const db = connect("memory://", { connectionMemoryBudgetBytes: 0 });
+  const docs = db.createTable("docs", { title: "large_utf8" }, new IndexSpec().fts("title"));
+  docs.append([{ title: "the quick brown fox" }]);
+  assert.equal(docs.bm25Search("title", "fox", 10).length, 1);
+});

--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -40,6 +40,15 @@ export interface ConnectOptions {
   cacheDir?: string;
   /** Disk-cache budget in bytes. */
   cacheBudgetBytes?: number;
+  /**
+   * Per-connection heap budget in bytes: the working memory ingesting and
+   * querying use. Crossing it throws an Error whose message starts with
+   * `ConnectionMemoryBudgetError:`, instead of risking an out-of-memory crash.
+   * `0` or omitted measures without enforcing. Separate from `cacheBudgetBytes`
+   * (the disk cache). See
+   * https://infino.ai/docs/guides/storage#connection-memory-budget
+   */
+  connectionMemoryBudgetBytes?: number;
   /** How cold misses are serviced. */
   coldFetchMode?: "hybrid_with_prefetch" | "range_only" | "lazy_foreground_with_background_fill";
   /**

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -55,13 +55,14 @@ use infino::{
 // ---------------------------------------------------------------------------
 
 /// Map a core [`InfinoError`] to a JS error, mirroring the Python
-/// bindings' grouping: not-found vs. bad-argument vs. runtime. The bucket
-/// is encoded in the napi [`Status`] (surfaced as `err.code` in JS) and
-/// the message is preserved.
+/// bindings' grouping: not-found vs. bad-argument vs. runtime, plus the
+/// connection-memory-budget refusal. The bucket is encoded in the napi
+/// [`Status`] (surfaced as `err.code` in JS) and the message is preserved;
+/// where several kinds share a `Status`, a message prefix tells them apart
+/// (as `NotFound:` does).
 //
-// TODO: refine into distinct JS `Error` subclasses once the surface
-// settles; the three-bucket split is the same contract as Python's
-// KeyError / ValueError / RuntimeError mapping.
+// TODO: refine into distinct JS `Error` subclasses once the surface settles,
+// matching Python's `InfinoError` base + `ConnectionMemoryBudgetError`.
 fn map_err(e: InfinoError) -> Error {
     match e {
         InfinoError::NotFound(m) => Error::new(Status::GenericFailure, format!("NotFound: {m}")),
@@ -70,6 +71,13 @@ fn map_err(e: InfinoError) -> Error {
         | InfinoError::Cardinality(m)
         | InfinoError::Query(m) => Error::new(Status::InvalidArg, m),
         InfinoError::Io(m) | InfinoError::Backend(m) => Error::new(Status::GenericFailure, m),
+        // A recoverable connection-memory-budget refusal. Prefixed with the same
+        // name Python raises (`ConnectionMemoryBudgetError`) so the concept reads
+        // the same across bindings and a caller can tell it apart to back off.
+        InfinoError::OverBudget(m) => Error::new(
+            Status::GenericFailure,
+            format!("ConnectionMemoryBudgetError: {m}"),
+        ),
         // `InfinoError` is `#[non_exhaustive]`: future variants fall back
         // to a generic runtime error carrying the message.
         other => Error::new(Status::GenericFailure, other.to_string()),
@@ -208,6 +216,9 @@ pub struct ConnectOptions {
     pub cache_dir: Option<String>,
     /// Disk-cache budget in bytes (a JS number; up to 2^53).
     pub cache_budget_bytes: Option<f64>,
+    /// Per-connection heap budget in bytes (a JS number; up to 2^53). `0` or
+    /// omitted measures usage without enforcing.
+    pub connection_memory_budget_bytes: Option<f64>,
     /// Cold-miss strategy: `"hybrid_with_prefetch"` | `"range_only"` |
     /// `"lazy_foreground_with_background_fill"`.
     pub cold_fetch_mode: Option<String>,
@@ -368,6 +379,9 @@ pub fn connect(uri: String, options: Option<ConnectOptions>) -> Result<Connectio
             }
             if let Some(bytes) = o.cache_budget_bytes {
                 opts = opts.with_cache_budget_bytes(bytes as u64);
+            }
+            if let Some(bytes) = o.connection_memory_budget_bytes {
+                opts = opts.with_connection_memory_budget_bytes(bytes as u64);
             }
             if let Some(mode) = o.cold_fetch_mode {
                 opts = opts.with_cold_fetch_mode(cold_fetch_from_str(&mode)?);


### PR DESCRIPTION
### What does this PR do?
Exposes the connection memory budget in the Node binding: `ConnectOptions` gains `connectionMemoryBudgetBytes`, and an over-budget refusal throws a distinguishable error.

### Why do we need this change?
The engine already caps a connection's heap, but Node callers had no way to set it, so the budget was unreachable from Node. And an over-budget error fell into the generic-failure bucket, indistinguishable from any other runtime error.

### How do we do this change?
- **`ConnectOptions` option:** `connectionMemoryBudgetBytes` forwards to `ConnectOptions::with_connection_memory_budget_bytes`; `0` or omitting it measures without enforcing.