### PR TITLE
docs: clarify vector score is distance, opposite of BM25 similarity

### DIFF
--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -316,7 +316,9 @@ export class Table {
     this.inner.append(dataToIpc(data, () => this.schema()));
   }
 
-  /** Ranked BM25 search; rows as records (or an Arrow `Table`). */
+  /** Ranked BM25 search; rows as records (or an Arrow `Table`). `score` is a
+   * similarity (higher is better) — opposite direction from `vectorSearch`'s
+   * distance. Fuse with `hybridSearch`. */
   bm25Search(column: string, query: string, k: number, opts: Bm25SearchOptions & { arrow: true }): arrow.Table;
   bm25Search(column: string, query: string, k: number, opts?: Bm25SearchOptions): RowRecord[];
   bm25Search(column: string, query: string, k: number, opts: Bm25SearchOptions = {}): RowRecord[] | arrow.Table {
@@ -324,7 +326,9 @@ export class Table {
     return decode(buf, opts.arrow);
   }
 
-  /** Vector kNN; rows as records (or an Arrow `Table`). */
+  /** Vector kNN; rows as records (or an Arrow `Table`). `score` is a distance
+   * (`0.0` = perfect match) — opposite direction from `bm25Search`'s
+   * similarity. Fuse with `hybridSearch`. */
   vectorSearch(column: string, query: number[] | Float32Array, k: number, opts: VectorSearchOptions & { arrow: true }): arrow.Table;
   vectorSearch(column: string, query: number[] | Float32Array, k: number, opts?: VectorSearchOptions): RowRecord[];
   vectorSearch(column: string, query: number[] | Float32Array, k: number, opts: VectorSearchOptions = {}): RowRecord[] | arrow.Table {

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -484,6 +484,8 @@ impl Table {
     /// IPC `Buffer` (read with `tableFromIPC`). `mode` is `"or"` (default)
     /// or `"and"`. `projection` selects the returned columns — pass
     /// `["_id", "score"]` for just id + score, or omit for full rows.
+    /// `score` is a similarity (higher is better) — opposite direction
+    /// from `vectorSearch`'s distance. Fuse with `hybridSearch`.
     #[napi]
     pub fn bm25_search(
         &self,
@@ -508,7 +510,9 @@ impl Table {
     /// (crosses by reference — no copy). Returns matching rows as an Arrow
     /// IPC `Buffer` (read with `tableFromIPC`). `projection` selects the
     /// returned columns (`["_id", "score"]` for just id + score, or omit
-    /// for full rows).
+    /// for full rows). `score` is a distance (`0.0` = perfect match) —
+    /// opposite direction from `bm25Search`'s similarity. Fuse with
+    /// `hybridSearch`.
     #[napi]
     #[allow(clippy::too_many_arguments)]
     pub fn vector_search(

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -414,10 +414,13 @@ impl Table {
 
     /// BM25 search over one FTS column. Returns a pyarrow `Table`.
     /// `projection` names the output columns (`_id`, any scalar column,
-    /// or the trailing `score` — higher is better); omitting it returns
-    /// the engine-native `_id` + `score` pair with no scalar decode.
-    /// Materializing row data is an explicit opt-in by naming columns.
-    /// `mode` is `"or"` (default) or `"and"`.
+    /// or the trailing `score` — a similarity, higher is better);
+    /// omitting it returns the engine-native `_id` + `score` pair with
+    /// no scalar decode. Materializing row data is an explicit opt-in by
+    /// naming columns. `mode` is `"or"` (default) or `"and"`.
+    ///
+    /// `score` is a similarity (higher is better) — opposite direction
+    /// from `vector_search`'s distance. Fuse with `hybrid_search`.
     #[pyo3(signature = (column, query, k, mode=None, projection=None))]
     fn bm25_search<'py>(
         &self,
@@ -441,10 +444,15 @@ impl Table {
 
     /// Vector kNN over one vector column. `query` is a `list[float]`.
     /// Returns a pyarrow `Table`. `projection` names the output columns
-    /// (`_id`, any scalar column, or the trailing `score` — distance,
-    /// smaller is nearer); omitting it returns the engine-native
-    /// `_id` + `score` pair with no scalar decode. Materializing row
-    /// data is an explicit opt-in by naming columns.
+    /// (`_id`, any scalar column, or the trailing `score` — a distance,
+    /// `0.0` is a perfect match and larger is farther); omitting it
+    /// returns the engine-native `_id` + `score` pair with no scalar
+    /// decode. Materializing row data is an explicit opt-in by naming
+    /// columns.
+    ///
+    /// `score` is a distance (`0.0` = perfect match) — opposite
+    /// direction from `bm25_search`'s similarity. Fuse with
+    /// `hybrid_search`.
     ///
     /// Pass `filter_column` and `filter_query` together to restrict the
     /// search to rows whose (FTS-indexed) `filter_column` matches the

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -960,6 +960,10 @@ impl Supertable {
     /// Single-column BM25 search over the current snapshot, returning
     /// Arrow rows best-score-first (BM25 relevance, higher is better).
     ///
+    /// `score` is a similarity (higher is better) — the opposite
+    /// direction from [`Supertable::vector_search`]'s distance. Fuse the
+    /// two with [`Supertable::hybrid_search`], not by raw score.
+    ///
     /// Pins a fresh reader (applying the read-consistency policy), runs
     /// the BM25 fan-out, and resolves the top-`k` hits to Arrow rows.
     ///

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -763,6 +763,10 @@ impl Supertable {
     /// returning Arrow rows nearest-first (distance score, smaller is
     /// nearer).
     ///
+    /// `score` is a distance (`0.0` = perfect match) — the opposite
+    /// direction from [`Supertable::bm25_search`]'s similarity. Fuse the
+    /// two with [`Supertable::hybrid_search`], not by raw score.
+    ///
     /// Pins a fresh reader (applying the read-consistency policy), runs
     /// the IVF fan-out, and resolves the top-`k` nearest hits to Arrow
     /// rows.


### PR DESCRIPTION
## What

Documents the per-modality `score` convention on the public search methods across all three surfaces (Rust, Python, Node).

`vector_search` returns a **distance** (`0.0` = perfect match, larger is farther), while `bm25_search` returns a **similarity** (higher is better). Same `score` field name, opposite direction — a perfect vector match reads as `score = 0.0`, which looks like "no match" until you know the convention.

## Why

Reported in #319: the direction mismatch cost a confused minute and a `cos = 1 - score` conversion in app code before fusing the two lanes.

## Changes

- `Supertable::vector_search` / `bm25_search` doc-comments now state the direction and cross-reference each other.
- Python pyo3 docstrings and Node `index.ts` (→ generated `index.d.ts`) carry the same note.
- Each points users at `hybrid_search` to fuse the two lanes rather than combining raw scores.

Docs-only: no behavior or public-API change (`public-api.txt` unchanged; api-parity and doc-check green; `make check` passes).

Closes #319.