### PR TITLE
chore: delete tombstones in optimise

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -117,6 +117,7 @@ pub infino::OptimizeError::SidecarConflict
 pub infino::OptimizeError::SidecarConflict::existing_compaction_id: uuid::Uuid
 pub infino::OptimizeError::SidecarConflict::superfile_id: uuid::Uuid
 pub infino::OptimizeError::SuperfileNotFound(uuid::Uuid)
+pub infino::OptimizeError::WalGc(infino::supertable::wal::gc::GcError)
 impl core::convert::From<infino::GcError> for infino::OptimizeError
 pub fn infino::OptimizeError::from(infino::GcError) -> Self
 impl core::error::Error for infino::OptimizeError

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -327,6 +327,9 @@ pub enum OptimizeError {
     /// The post-compaction garbage-collection step failed.
     #[error("gc failed during optimize: {0}")]
     Gc(#[from] GcError),
+    /// The post-compaction WAL sweep failed.
+    #[error("wal sweep failed during optimize: {0}")]
+    WalGc(#[from] crate::supertable::wal::gc::GcError),
 }
 
 impl From<CompactionError> for OptimizeError {

--- a/src/supertable/gc/mod.rs
+++ b/src/supertable/gc/mod.rs
@@ -15,6 +15,7 @@ use crate::{
         ManifestSnapshot,
         error::GcError,
         manifest::commit::{MANIFEST_DIR, MANIFEST_PARTS_DIR, POINTER_PATH, manifest_uri},
+        wal::persistence::{SUPERFILES_DIR, WalStore},
     },
 };
 
@@ -43,6 +44,7 @@ fn build_live_set(manifest: &ManifestSnapshot) -> HashSet<String> {
     }
     for sf in manifest.get_all_superfiles() {
         live.insert(sf.uri.storage_path());
+        live.insert(WalStore::tombstones_path(sf.superfile_id));
     }
     live
 }
@@ -67,7 +69,7 @@ impl Supertable {
 
         let mut report = GcReport::default();
 
-        for prefix in [MANIFEST_DIR, MANIFEST_PARTS_DIR, "data"] {
+        for prefix in [MANIFEST_DIR, MANIFEST_PARTS_DIR, "data", SUPERFILES_DIR] {
             let entries = storage.list_with_prefix_metadata(prefix).await?;
             for (key, meta) in entries {
                 if live.contains(&key) {

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -689,16 +689,12 @@ impl Supertable {
         bridge_on_runtime(drive, &self.inner.query_runtime())
     }
 
-    /// Operator hatch: run one GC sweep over this supertable's
-    /// `wal/mutations/` prefix. Reaps `Complete` WALs older
-    /// than the wal-grace window + orphan `.arrow` sidecars
-    /// older than the sidecar-grace window. Tests that need custom
-    /// grace windows call `crate::supertable::wal::gc::run_sweep`
-    /// directly.
-    /// Not public API: WAL/sidecar GC is engine-driven — it runs
-    /// automatically on [`Supertable::open`] and (production) on a
-    /// background cadence. This manual hook is a crate internal used
-    /// only by in-crate unit tests.
+    /// Run one GC sweep over this supertable's `wal/mutations/` prefix.
+    /// Reaps `Complete` WALs older than the wal-grace window + orphan
+    /// `.arrow` sidecars older than the sidecar-grace window. Runs at
+    /// `Supertable::open`/`create` and again on every `optimize()` call.
+    /// Not public API: exposed only as a manual hook for in-crate tests
+    /// that need custom grace windows via `wal::gc::run_sweep` directly.
     pub(crate) async fn run_gc_sweep_once(&self) -> Result<gc::GcReport, gc::GcError> {
         gc::run_sweep(
             self,
@@ -707,6 +703,13 @@ impl Supertable {
             gc::DEFAULT_SIDECAR_GRACE,
         )
         .await
+    }
+
+    /// Sync-bridged version of [`run_gc_sweep_once`], for callers (like
+    /// [`Supertable::optimize`]) that aren't already inside an async
+    /// context.
+    pub(crate) fn run_gc_sweep_once_blocking(&self) -> Result<gc::GcReport, gc::GcError> {
+        bridge_on_runtime(self.run_gc_sweep_once(), &self.inner.query_runtime())
     }
 
     /// Observability snapshot of the supertable's load.

--- a/src/supertable/optimize/mod.rs
+++ b/src/supertable/optimize/mod.rs
@@ -4,12 +4,17 @@
 use crate::{
     Supertable,
     config::{DEFAULT_GC_SAFETY_GAP, OptimizeOptions},
-    supertable::error::{GcError, OptimizeError},
+    supertable::{
+        error::{GcError, OptimizeError},
+        wal::gc::GcError as WalGcError,
+    },
 };
 
 impl Supertable {
     /// Merge small or underfilled superfiles into larger ones, then run a
-    /// best-effort gc sweep. Pass [`OptimizeOptions::default`] for engine
+    /// best-effort gc sweep (orphaned superfiles/manifests + dead tombstone
+    /// sidecars) and a best-effort WAL sweep (completed mutation state and
+    /// arrow sidecars). Pass [`OptimizeOptions::default`] for engine
     /// defaults. Requires durable storage.
     #[doc(alias = "compact")]
     pub fn optimize(&self, opts: &OptimizeOptions) -> Result<(), OptimizeError> {
@@ -17,6 +22,10 @@ impl Supertable {
         match self.gc(DEFAULT_GC_SAFETY_GAP) {
             Ok(_) | Err(GcError::NoStorage) => {}
             Err(e) => return Err(OptimizeError::Gc(e)),
+        }
+        match self.run_gc_sweep_once_blocking() {
+            Ok(_) | Err(WalGcError::NoStorageAttached) => {}
+            Err(e) => return Err(OptimizeError::WalGc(e)),
         }
         Ok(())
     }

--- a/src/supertable/wal/persistence.rs
+++ b/src/supertable/wal/persistence.rs
@@ -142,7 +142,7 @@ const STATE_EXT: &str = "json";
 const ARROW_EXT: &str = "arrow";
 
 /// Storage prefix for per-superfile tombstone sidecars.
-const SUPERFILES_DIR: &str = "superfiles";
+pub(crate) const SUPERFILES_DIR: &str = "superfiles";
 
 /// File extension for tombstone sidecars.
 const TOMBSTONES_EXT: &str = "tombstones";
@@ -175,7 +175,7 @@ impl WalStore {
         format!("{WAL_DIR}/{}.{ARROW_EXT}", wal_id.to_hex())
     }
 
-    fn tombstones_path(superfile_id: uuid::Uuid) -> String {
+    pub(crate) fn tombstones_path(superfile_id: uuid::Uuid) -> String {
         // UUID's default `Display` is the hyphenated 36-char hex
         // string we use everywhere else in the codebase for
         // superfile identifiers.

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -15,12 +15,21 @@
 
 use std::{sync::Arc, time::Duration};
 
+use chrono::{Duration as ChronoDuration, Utc};
+use datafusion::prelude::{Expr, col, lit};
 use infino::{
     CompactionSettings, OptimizeOptions,
     superfile::fts::reader::BoolMode,
     supertable::{
         Supertable,
         storage::{LocalFsStorageProvider, StorageProvider},
+        wal::{
+            persistence::WalStore,
+            state_doc::{
+                OpKind, RowId, SCHEMA_VERSION, TombstoneEntry, TombstoneOutcome, WalId, WalState,
+                WalStateDoc,
+            },
+        },
     },
     test_helpers::{build_title_batch, default_supertable_options},
 };
@@ -165,4 +174,130 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
             "marker {m} not found after GC"
         );
     }
+}
+
+#[test]
+fn gc_reaps_tombstone_sidecar_for_merged_away_superfile() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("create");
+
+    let markers = [
+        "alphatoken",
+        "betatoken",
+        "gammatoken",
+        "deltatoken",
+        "epsilontoken",
+        "zetatoken",
+        "etatoken",
+        "thetatoken",
+        "iotatoken",
+        "kappatoken",
+    ];
+    for m in &markers {
+        commit_titles(
+            &st,
+            &[&format!("{m} marker"), "filler alpha", "filler bravo"],
+        );
+    }
+
+    let mut w = st.writer().expect("writer");
+    let predicate: Expr = col("title").eq(lit("alphatoken marker"));
+    let pending = w.delete(predicate).expect("delete");
+    assert_eq!(pending.matched, 1);
+    w.commit().expect("commit delete");
+    drop(w);
+
+    let superfiles_dir = dir.path().join("superfiles");
+    assert_eq!(
+        count_dir(&superfiles_dir),
+        1,
+        "delete writes exactly one tombstone sidecar"
+    );
+
+    st.optimize(&small_optimize_opts()).expect("optimize");
+    // Compaction seals every input's sidecar (even untouched ones), so all
+    // 10 input superfiles now have a `.tombstones` file, all orphaned since
+    // none of those superfiles are in the manifest anymore.
+    assert_eq!(
+        count_dir(&superfiles_dir),
+        markers.len(),
+        "sidecars for merged-away superfiles aren't reaped yet: \
+         optimize's default gc safety gap is 24h"
+    );
+
+    let report = st.gc(Duration::ZERO).expect("gc");
+    assert!(
+        report.objects_deleted > 0,
+        "gc must delete the orphaned sidecars"
+    );
+    assert_eq!(
+        count_dir(&superfiles_dir),
+        0,
+        "orphaned tombstone sidecars reaped once their superfiles are gone from the manifest"
+    );
+
+    let r = st.reader();
+    assert_eq!(
+        r.bm25_hits("title", "alphatoken", TOP_K, BoolMode::Or)
+            .expect("query alpha after gc")
+            .len(),
+        0,
+        "deleted row stays gone"
+    );
+    for m in &markers[1..] {
+        assert_eq!(
+            r.bm25_hits("title", m, TOP_K, BoolMode::Or)
+                .expect("query after gc")
+                .len(),
+            1,
+            "marker {m} not found after GC"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn optimize_reaps_completed_wal_past_grace() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("create");
+
+    commit_titles(&st, &["alpha", "bravo"]);
+
+    let ws = WalStore::new(Arc::clone(&storage));
+    let leftover = WalStateDoc {
+        wal_id: WalId(1),
+        schema_version: SCHEMA_VERSION,
+        op_kind: OpKind::Delete,
+        state: WalState::Complete,
+        created_at: Utc::now() - ChronoDuration::minutes(10),
+        lease: None,
+        predicate_repr: "leftover from a crashed inline cleanup".into(),
+        target_ids: vec![RowId(1)],
+        new_row_count: None,
+        new_row_content_hash: None,
+        preallocated_superfile_id: None,
+        minted_id_spans: Vec::new(),
+        tombstone_progress: vec![TombstoneEntry {
+            target_id: RowId(1),
+            outcome: TombstoneOutcome::NotFound,
+            tombstoned_in_superfile: None,
+        }],
+    };
+    ws.create(&leftover).await.expect("seed leftover wal");
+
+    let wal_dir = dir.path().join("wal").join("mutations");
+    assert_eq!(count_dir(&wal_dir), 1, "leftover wal state doc seeded");
+
+    st.optimize(&small_optimize_opts()).expect("optimize");
+
+    assert_eq!(
+        count_dir(&wal_dir),
+        0,
+        "optimize must reap a completed wal past its grace window"
+    );
 }


### PR DESCRIPTION
### what is this change about

During compaction we merge a lot of small superfiles into one, the left over tombstones are never deleted. This PR fixes it and adds some tests around the fix