### PR TITLE
fts: score windowed union postings four-wide

### DIFF
--- a/src/superfile/fts/bm25.rs
+++ b/src/superfile/fts/bm25.rs
@@ -35,9 +35,10 @@ pub const B: f32 = 0.75;
 /// `idf >= 0`) for every valid `(N, df)` — the "BM25+1" form.
 const IDF_SMOOTHING: f64 = 0.5;
 
-/// SIMD lane count for the four-wide BM25 scorer ([`f32x4`]). The
-/// multi-term path scores this many cursors at one doc per call.
-const SCORE_SIMD_LANES: usize = 4;
+/// SIMD lane count for the four-wide BM25 scorers ([`f32x4`]). The
+/// multi-term path scores this many cursors at one doc per call; the
+/// windowed-union path scores this many docs from one cursor.
+pub(super) const SCORE_SIMD_LANES: usize = 4;
 
 /// BM25 inverse-document-frequency. Plus-half smoothing keeps the log
 /// argument ≥ 1, so `idf(N, df) >= 0` for all valid `(N, df)`.
@@ -119,6 +120,23 @@ pub fn score_simd_x4(
     let num = idf_v * tf_v;
     let scores = num / denom;
     scores.reduce_add()
+}
+
+/// Score one cursor at four documents in one SIMD operation. Each
+/// document has its own term frequency and length normalization; the
+/// cursor's precomputed `idf * (K1 + 1)` is shared across all lanes.
+/// Returns the four independent contributions without reducing them.
+/// Callers pass posting-list term frequencies (`tf > 0`); unlike
+/// [`score_simd_x4`], this path does not use zero-padded lanes.
+#[inline(always)]
+pub(super) fn score_one_term_x4(
+    idf_x_k1p1: f32,
+    tfs: [u32; SCORE_SIMD_LANES],
+    dl_norm_k1: [f32; SCORE_SIMD_LANES],
+) -> [f32; SCORE_SIMD_LANES] {
+    let tf_v = f32x4::from([tfs[0] as f32, tfs[1] as f32, tfs[2] as f32, tfs[3] as f32]);
+    let scores = f32x4::splat(idf_x_k1p1) * tf_v / (tf_v + f32x4::from(dl_norm_k1));
+    scores.to_array()
 }
 
 #[cfg(test)]
@@ -333,5 +351,22 @@ mod tests {
         ];
         let simd = score_simd_x4(idfs_x_k1p1, tfs, k1_norm);
         assert!((scalar - simd).abs() < 1e-4, "simd={simd} scalar={scalar}");
+    }
+
+    #[test]
+    fn one_term_simd_x4_equals_scalar_lanes() {
+        let idf_x_k1p1 = idf(1_000_000, 10_000) * (K1 + 1.0);
+        let tfs = [1, 2, 5, 9];
+        let dl_norm_k1 = [0.4, 0.9, 1.2, 3.5];
+        let simd = score_one_term_x4(idf_x_k1p1, tfs, dl_norm_k1);
+
+        for lane in 0..SCORE_SIMD_LANES {
+            let scalar = score_with_dl_norm_k1(idf_x_k1p1, tfs[lane], dl_norm_k1[lane]);
+            assert!(
+                approx(simd[lane], scalar, 1e-6),
+                "lane {lane}: simd={} scalar={scalar}",
+                simd[lane]
+            );
+        }
     }
 }

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -2383,6 +2383,39 @@ impl FtsReader {
                     if d >= window_end {
                         break;
                     }
+                    let pos = c.pos;
+                    if pos + bm25::SCORE_SIMD_LANES <= c.block_n {
+                        let doc_ids = [
+                            c.block_doc_ids[pos],
+                            c.block_doc_ids[pos + 1],
+                            c.block_doc_ids[pos + 2],
+                            c.block_doc_ids[pos + 3],
+                        ];
+                        if doc_ids[bm25::SCORE_SIMD_LANES - 1] < window_end {
+                            let contributions = bm25::score_one_term_x4(
+                                c.idf_x_k1p1,
+                                [
+                                    c.block_tfs[pos],
+                                    c.block_tfs[pos + 1],
+                                    c.block_tfs[pos + 2],
+                                    c.block_tfs[pos + 3],
+                                ],
+                                [
+                                    dl_norm_k1[doc_ids[0] as usize],
+                                    dl_norm_k1[doc_ids[1] as usize],
+                                    dl_norm_k1[doc_ids[2] as usize],
+                                    dl_norm_k1[doc_ids[3] as usize],
+                                ],
+                            );
+                            for lane in 0..bm25::SCORE_SIMD_LANES {
+                                let local = (doc_ids[lane] - base) as usize;
+                                scores[local] += contributions[lane];
+                                present[local >> 6] |= 1u64 << (local & 63);
+                            }
+                            c.advance_by(bm25::SCORE_SIMD_LANES);
+                            continue;
+                        }
+                    }
                     let local = (d - base) as usize;
                     scores[local] += bm25::score_with_dl_norm_k1(
                         c.idf_x_k1p1,
@@ -3478,19 +3511,41 @@ impl TermCursor {
 
     /// Advance one position. Crosses block boundaries automatically;
     /// decodes the next block on demand.
+    #[inline(always)]
     fn next(&mut self) {
         if self.is_exhausted() {
             return;
         }
         self.pos += 1;
         if self.pos >= self.block_n {
-            self.current_block += 1;
-            if self.current_block > self.inspect_block {
-                self.inspect_block = self.current_block;
-            }
-            if self.current_block < self.blocks.len() {
-                self.decode_current_block();
-            }
+            self.advance_block();
+        }
+    }
+
+    /// Advance a known in-block batch, crossing to the next block when
+    /// `count` consumes its remaining postings. Unlike [`Self::next`],
+    /// callers must not start at or advance past the decoded block end.
+    #[inline(always)]
+    fn advance_by(&mut self, count: usize) {
+        debug_assert!(!self.is_exhausted());
+        debug_assert!(count > 0 && self.pos + count <= self.block_n);
+        self.pos += count;
+        // The assertion above makes equality equivalent to `>=` here.
+        if self.pos == self.block_n {
+            self.advance_block();
+        }
+    }
+
+    /// Move to and decode the next posting block, or mark the cursor
+    /// exhausted when the current block is the last one.
+    #[inline(always)]
+    fn advance_block(&mut self) {
+        self.current_block += 1;
+        if self.current_block > self.inspect_block {
+            self.inspect_block = self.current_block;
+        }
+        if self.current_block < self.blocks.len() {
+            self.decode_current_block();
         }
     }
 
@@ -4586,7 +4641,7 @@ mod tests {
         let mut b = FtsBuilder::new(tok);
         b.register_column("body".into()).expect("register");
         for i in 0..N_DOCS {
-            let mut text = String::from("alpha "); // ~every doc
+            let mut text = String::from("alpha zeta eta theta "); // ~every doc
             if i % 2 == 0 {
                 text.push_str("beta ");
             }
@@ -4604,12 +4659,23 @@ mod tests {
         let blob = Bytes::from(b.finish().expect("finish"));
         let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
         let r = FtsReader::open(blob, json).expect("open");
+        let col = r.resolve_column_id("body").expect("col");
+        let uniform_terms: &[&str] = &["zeta", "eta", "theta"];
+        let uniform_cursors = r
+            .build_term_cursors(col, uniform_terms)
+            .await
+            .expect("uniform cursors");
+        assert!(
+            prefer_windowed_union(&uniform_cursors),
+            "production router should select windowed union for equal upper bounds"
+        );
 
         let shapes: &[&[&str]] = &[
             &["alpha", "beta"],
             &["alpha", "beta", "gamma"],
             &["beta", "gamma", "delta"], // no single dominator
             &["alpha", "beta", "gamma", "delta", "epsilon"],
+            uniform_terms,
         ];
         for terms in shapes {
             for k in [1usize, 5, 50, 1000] {

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -485,6 +485,10 @@ const TERM_BETA_PERIOD: u64 = 4;
 const TERM_GAMMA_PERIOD: u64 = 5;
 const TERM_DELTA_PERIOD: u64 = 7;
 const TERM_EPSILON_PERIOD: u64 = 20;
+/// Planting period for equal-frequency terms in the multi-block OR oracle.
+const UNIFORM_OR_TERM_PERIOD: u64 = 2;
+/// Number of document-length variants in the multi-block OR oracle.
+const OR_DOC_LENGTH_VARIANTS: u64 = 5;
 /// Filler-token bucket count (`no00`..`no49`) for doc-length variation.
 const FILLER_TERM_MODULUS: u64 = 50;
 /// AND top-k retrieving the full large intersection.
@@ -541,6 +545,55 @@ pub fn build_multi_block_corpus() -> Vec<(u64, String)> {
 pub fn build_multi_block_reader(owned: &[(u64, String)]) -> SuperfileReader {
     let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
     build_infino_superfile(&refs)
+}
+
+#[tokio::test]
+async fn oracle_or_multi_block_scores_match_brute_force() {
+    // Equal posting lists give these terms identical upper bounds, so
+    // the public OR dispatcher selects windowed union by construction.
+    // The lists span several blocks with full SIMD batches and a scalar
+    // final-block tail; extra filler varies document-length norms.
+    let mut corp_owned = Vec::with_capacity(MULTI_BLOCK_N_DOCS as usize);
+    for doc in 0..MULTI_BLOCK_N_DOCS {
+        let mut text = if doc.is_multiple_of(UNIFORM_OR_TERM_PERIOD) {
+            String::from("alpha beta gamma delta")
+        } else {
+            String::from("filler")
+        };
+        for _ in 0..doc % OR_DOC_LENGTH_VARIANTS {
+            text.push_str(" filler");
+        }
+        corp_owned.push((doc, text));
+    }
+    let corp_refs: Vec<(u64, &str)> = corp_owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let reader = build_infino_superfile(&corp_refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp_refs, tok.as_ref());
+    let query = "alpha beta gamma delta";
+
+    let mut infino_hits = reader
+        .bm25_hits_async("title", query, MULTI_BLOCK_N_DOCS as usize, BoolMode::Or)
+        .await
+        .expect("OR search");
+    let mut oracle_hits = oracle.top_k(query, MULTI_BLOCK_N_DOCS as usize, tok.as_ref());
+    infino_hits.sort_unstable_by_key(|(doc, _)| *doc);
+    oracle_hits.sort_unstable_by_key(|(doc, _)| *doc);
+
+    assert_eq!(
+        infino_hits.len(),
+        oracle_hits.len(),
+        "OR hit counts disagree"
+    );
+    for ((infino_doc, infino_score), (oracle_doc, oracle_score)) in
+        infino_hits.iter().zip(&oracle_hits)
+    {
+        assert_eq!(*infino_doc as u64, *oracle_doc, "OR doc-id mismatch");
+        let delta = (infino_score - oracle_score).abs();
+        assert!(
+            delta < BM25_SCORE_ABS_TOLERANCE,
+            "score divergence on doc {infino_doc}: infino={infino_score} oracle={oracle_score} delta={delta}"
+        );
+    }
 }
 
 /// Compute the expected AND intersection for the multi-block corpus


### PR DESCRIPTION
Closes #401.

## Summary

- score four consecutive postings from one cursor with `f32x4` in the
  windowed-union BM25 path
- retain scalar scoring for decoded-block and union-window tails
- add batch cursor advancement without changing skip/decode semantics
- cover SIMD lane equivalence, block/tail handling, routing, and
  brute-force BM25 score agreement

This adds no dependency, public API, on-disk-format, or unsafe-code change.

## Correctness

The candidate passed:

```text
cargo test --features test-helpers --lib superfile::fts::
  187 passed

cargo test --features test-helpers --test superfile fts::
  47 passed

cargo fmt --all -- --check \
  --config imports_granularity=Crate,group_imports=StdExternalCrate
```

All six benchmark runs also passed the built-in self-consistency checks,
seven BMW-versus-brute-force comparisons, df=1/common-term edge checks, and
identical OR/AND match cardinalities.

## Performance

Host: Intel Core i5-13600K, 14C/20T, 31 GiB RAM, Linux x86_64, Rust 1.95.0
(LLVM 22.1.2). CPU scaling governor was `powersave`.

Baseline: `bd56c6d46ade42f84e4e8c77372708d6424a6be7` (`main`)

Candidate: `617b1f5a539238f3090aa0aec1bcfc9ac2332f64`

Command:

```text
INFINO_BENCH_SUPERFILE_DOCS=1000000 \
cargo bench --features test-helpers --bench bench -- superfile fts warm
```

Three measurements per revision were interleaved `B, C, C, B, B, C`.
Positive percentages mean lower latency.

| Query | Baseline p50 runs | Candidate p50 runs | Median p50 improvement | Median-min improvement |
| --- | ---: | ---: | ---: | ---: |
| `three_similar_or` | 2.34 / 2.37 / 2.35 ms | 1.96 / 1.97 / 1.96 ms | 16.6% | 16.4% |
| `five_term_or` | 3.67 / 3.62 / 3.66 ms | 2.97 / 2.97 / 2.96 ms | 18.9% | 19.0% |
| `ten_term_or` | 6.33 / 6.61 / 6.46 ms | 5.13 / 5.18 / 5.16 ms | 20.1% | 18.4% |
| `twenty_term_or` | 11.62 / 11.18 / 11.18 ms | 9.06 / 9.10 / 9.11 ms | 18.6% | 19.0% |
| `forty_term_or` | 20.09 / 19.76 / 20.00 ms | 15.48 / 15.53 / 15.67 ms | 22.4% | 22.6% |

WAND+BMW probes were effectively unchanged. MaxScore+BMM improved 5.9% on
the five-similar-term probe and 5.2% on the ten-similar-term probe. Median
peak RSS moved from 4.29 GiB to 4.21 GiB, within normal run-to-run noise.

### Caveats

- `five_term_or` median p90 moved from 3.69 ms to 4.02 ms (8.9% slower),
  despite its minimum and p50 improving by about 19%.
- `three_wide_or` p50 was 1.7% slower.
- A noisy `two_term_and` control showed a 7.6% median-p50 slowdown, but its
  raw runs were bimodal and median minimum (4.5% slower), median p90 (1.4%
  slower), top-1000 (unchanged), and count timing (5.3% faster) did not
  establish a repeatable regression.
- Full `make ci` and the complete all-tier benchmark suite have not been run
  yet; this is opened as a draft for feedback on the optimization and tail
  behavior.
