### PR TITLE
fts: reuse per-document term-frequency table

### DIFF
--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -144,6 +144,14 @@ use crate::superfile::{
 ///     pointers through unrelated allocator buckets).
 type TermIdMap = HbHashMap<&'static str, u32, FxBuildHasher>;
 
+/// Reusable per-document term-frequency table for the in-RAM build path.
+///
+/// Keys borrow from [`FtsBuilder::bump`] with the same lifetime-extension
+/// discipline as [`TermIdMap`]. The table is drained after every document
+/// and cleared before the arena is reset, so only its bucket allocation
+/// persists across calls.
+type DocTfMap = HbHashMap<&'static str, u32, FxBuildHasher>;
+
 #[derive(Default)]
 struct FinishProfile {
     enabled: bool,
@@ -1085,6 +1093,14 @@ pub struct FtsBuilder {
     /// Tracks the number of distinct local_doc_ids ever seen by add_doc.
     /// Used as `n_docs` for the FTS blob header.
     n_docs: u32,
+    /// Per-document term-frequency table for the in-RAM path. Draining
+    /// keeps its bucket allocation, avoiding a fresh allocation and
+    /// repeated growth for every document.
+    ///
+    /// Declared before `bump` so it drops first. Its transient `&str`
+    /// keys borrow from that arena under the lifetime invariant described
+    /// on [`DocTfMap`].
+    doc_tf: DocTfMap,
     /// Per-shard bump arena reused across every `add_doc` call.
     /// Holds the transient `&str` keys of the per-doc tf hashmap.
     /// Reset at the top of each `add_doc` so the leftover bytes are
@@ -1144,6 +1160,7 @@ impl FtsBuilder {
             spill_partitions: DEFAULT_SPILL_PARTITIONS,
             max_partition_bytes: DEFAULT_MAX_PARTITION_BYTES,
             n_docs: 0,
+            doc_tf: DocTfMap::with_hasher(FxBuildHasher),
             bump: Bump::new(),
         }
     }
@@ -1473,12 +1490,9 @@ impl FtsBuilder {
             .downcast_ref::<AsciiLowerTokenizer>();
         let mut tokens_in_doc: u64 = 0;
 
-        // Reset the per-shard bump arena: leftover token bytes
-        // from the prior `add_doc` call are invalidated before we
-        // reuse the chunk. `Bump::reset` keeps the largest chunk
-        // (no system-allocator round trip on the steady-state
-        // doc) and frees any extra chunks the pathological-long
-        // doc grew.
+        // Clear borrowed keys before resetting their backing arena.
+        // Both containers retain their allocations for the next doc.
+        self.doc_tf.clear();
         self.bump.reset();
         let bump = &self.bump;
 
@@ -1486,8 +1500,7 @@ impl FtsBuilder {
         // with the *borrowed* `&str` token from the tokenizer's
         // input slice and only pays the `bump.alloc_str` copy on
         // the miss path. Hit-path cost: hash + load + increment.
-        let mut tf_per_term: HbHashMap<&'static str, u32, FxBuildHasher> =
-            HbHashMap::with_hasher(FxBuildHasher);
+        let tf_per_term = &mut self.doc_tf;
         let mut on_token = |tok: &str| {
             tokens_in_doc += 1;
             let hash = compute_hash(tf_per_term.hasher(), tok);
@@ -1502,15 +1515,14 @@ impl FtsBuilder {
                     // Miss path: copy borrowed token bytes into
                     // the bump arena so the key outlives the
                     // tokenizer's input lifetime, then widen the
-                    // bump ref to `'static` tied to the HashMap's
-                    // lifetime. The HashMap drops at the end of
-                    // this call — well before `self.bump` is
-                    // reset on the next call.
+                    // bump ref to `'static` tied to the scratch
+                    // table's lifetime.
                     let bumped: &str = bump.alloc_str(tok);
                     // SAFETY: the `'static` tag is a lie — the real
-                    // lifetime is `self.bump`, which is reset only on the
-                    // next call, after this HashMap (and `extended`) has
-                    // been dropped at the end of the current call.
+                    // lifetime is `self.bump`. The table is drained below,
+                    // cleared before the arena is reset on the next call,
+                    // and declared before `bump` so it also drops first if
+                    // unwinding leaves entries behind.
                     let extended: &'static str = unsafe { std::mem::transmute(bumped) };
                     e.insert_hashed_nocheck(hash, extended, 1);
                 }
@@ -1544,7 +1556,7 @@ impl FtsBuilder {
         // the miss path constructs a `Box::<str>::from(term)` for
         // insertion. Bytes accounting folds into the same loop.
         let mut new_bytes: usize = 0;
-        for (term, tf) in tf_per_term {
+        for (term, tf) in tf_per_term.drain() {
             let term_len = term.len();
             match terms.get_mut(term) {
                 Some(acc) => {
@@ -1671,8 +1683,11 @@ impl FtsBuilder {
             spill_partitions: _,
             max_partition_bytes: _,
             n_docs,
-            bump: _,
+            doc_tf,
+            bump,
         } = self;
+        drop(doc_tf);
+        drop(bump);
 
         let n_columns = columns.len() as u32;
         let mut n_terms_total_usize: usize = 0;
@@ -1808,8 +1823,11 @@ impl FtsBuilder {
             spill_partitions: _,
             max_partition_bytes,
             n_docs,
-            bump: _,
+            doc_tf,
+            bump,
         } = self;
+        drop(doc_tf);
+        drop(bump);
 
         let n_columns = columns.len() as u32;
         let mut n_terms_total_usize: usize = 0;
@@ -2826,6 +2844,26 @@ mod tests {
         b.register_column("title".into()).expect("register column");
         let err = b.add_doc(99, 0, "text").expect_err("expected error");
         assert!(matches!(err, BuildError::FtsColumnTypeInvalid { .. }));
+    }
+
+    #[test]
+    fn add_doc_reuses_term_frequency_table_capacity() {
+        let mut b = FtsBuilder::new(tokenizer());
+        b.register_column("title".into()).expect("register column");
+        b.add_doc(0, 0, "alpha beta gamma delta epsilon zeta eta theta")
+            .expect("add first doc");
+
+        assert!(b.doc_tf.is_empty(), "per-document table must be drained");
+        let capacity = b.doc_tf.capacity();
+        assert!(capacity > 0, "first document must allocate table buckets");
+
+        b.add_doc(0, 1, "alpha beta alpha").expect("add second doc");
+        assert!(b.doc_tf.is_empty(), "per-document table must be drained");
+        assert_eq!(
+            b.doc_tf.capacity(),
+            capacity,
+            "subsequent documents must reuse the existing buckets"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #403.

## Summary

- retain the per-document FTS term-frequency hash table across `add_doc` calls
- drain entries after each document while preserving the bucket allocation
- clear borrowed keys before resetting their bump arena and preserve safe drop order
- add a regression test that verifies the table is empty and retains capacity between documents

This is limited to FTS ingestion. It does not change the public API, file format, tokenization, scoring, or query path.

## Performance

Measured with the 1M-document superfile FTS workload (200 tokens/document, 10K-word Zipfian vocabulary). Baseline and candidate binaries were prebuilt in detached worktrees and run in `B,C,C,B,B,C` order.

| Build | Baseline runs | Candidate runs | Baseline median | Candidate median | Improvement |
| --- | --- | --- | ---: | ---: | ---: |
| 1 writer | 11.78 / 10.54 / 10.31 s | 10.17 / 10.32 / 9.98 s | 10.54 s | 10.17 s | 3.51% |
| 20 writers | 2.21 / 1.77 / 1.79 s | 1.57 / 1.61 / 1.69 s | 1.79 s | 1.61 s | 10.06% |

- Minimum latency improved 3.20% with one writer and 11.30% with 20 writers.
- Stored output remained exactly 636,015,441 bytes.
- Median peak RSS was unchanged with one writer and approximately 2.5% lower with 20 writers.
- Warm FTS query controls, WAND/MaxScore probes, and OR/AND cardinalities remained stable.
- The complete benchmark suite passed its correctness gates; vector recall@10 remained 1.000.

The first baseline run had elevated host load, so the decision uses all three interleaved runs and medians rather than selecting the best result. A separate direct-mapped term-ID cache experiment was rejected and removed after it made serial ingest approximately 11.5% slower.

## Validation

- `make ci`
- `cargo test --features test-helpers --lib superfile::fts::`
- `cargo test --features test-helpers --test superfile fts::`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=StdExternalCrate`
- `make asan`
- `MIRIFLAGS=-Zmiri-disable-isolation cargo +nightly miri test --lib superfile::fts::builder::tests::add_doc_reuses_term_frequency_table_capacity -- --exact`
- `make bench`

The full `make miri` target also fails on clean `main`: existing spill tests encounter Miri-only buffer-alignment behavior, and `std::io::copy` reaches an unsupported `copy_file_range` syscall. The changed map-reuse test passes under Miri, and the full 187-test FTS ASan lane passes.
