### PR TITLE
release: crate 0.1.5, node 0.1.5, python 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "infino-node"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/infino-node/Cargo.toml
+++ b/infino-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-node"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.1.4",
-    "infx-darwin-arm64": "0.1.4",
-    "infx-linux-x64-gnu": "0.1.4",
-    "infx-linux-arm64-gnu": "0.1.4",
-    "infx-linux-x64-musl": "0.1.4",
-    "infx-linux-arm64-musl": "0.1.4"
+    "infx-darwin-x64": "0.1.5",
+    "infx-darwin-arm64": "0.1.5",
+    "infx-linux-x64-gnu": "0.1.5",
+    "infx-linux-arm64-gnu": "0.1.5",
+    "infx-linux-x64-musl": "0.1.5",
+    "infx-linux-arm64-musl": "0.1.5"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "infino-python"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-python"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Patch release of all three packages to their next available versions, stamped with `make release-prep PACKAGE=each`:

| Package | Current | New |
|---|---|---|
| crate (crates.io) | 0.1.4 | **0.1.5** |
| `@infino-ai/infino` (npm) | 0.1.4 | **0.1.5** |
| `infino` (PyPI) | 0.1.5 | **0.1.6** |

Mechanical version stamp only — 7 files, version strings and the `infx-*` pins; `make version-sync` green.

On merge, the `Tag release` workflow pushes `v0.1.5` and publishes the crate (first real exercise of the new auto-tag path). The bindings then ship via their manual dispatches: `Node publish` (dry_run unchecked) and `Publish Python package`.