### PR TITLE
fts: lucene-style query clauses — +must, should, -must-not

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -178,7 +178,13 @@ pub mod fts {
     use std::collections::HashMap;
 
     use infino::{
-        superfile::{SuperfileReader, fts::reader::BoolMode as InfinoBoolMode},
+        superfile::{
+            SuperfileReader,
+            fts::{
+                reader::BoolMode as InfinoBoolMode,
+                tokenize::{AsciiLowerTokenizer, Tokenizer},
+            },
+        },
         supertable::SupertableReader,
     };
 
@@ -377,6 +383,23 @@ pub mod fts {
             ],
             mode: BoolMode::And,
         },
+        // Mixed clause shapes (`+must` + bare shoulds under Or): the
+        // must intersection drives the walk, shoulds are scoring-only.
+        FtsQuery {
+            name: "must_common_should_common",
+            terms: &["+term00050", "term00001"],
+            mode: BoolMode::Or,
+        },
+        FtsQuery {
+            name: "must_rare_should_common",
+            terms: &["+term09999", "term00001"],
+            mode: BoolMode::Or,
+        },
+        FtsQuery {
+            name: "must_two_should_two",
+            terms: &["+term00050", "+term00051", "term00001", "term00052"],
+            mode: BoolMode::Or,
+        },
     ];
 
     /// OR query names, in table order.
@@ -400,6 +423,13 @@ pub mod fts {
         "three_similar_and",
         "five_term_and",
         "ten_term_and",
+    ];
+
+    /// Mixed must/should clause query names, in table order.
+    pub const CLAUSE_QUERIES: &[&str] = &[
+        "must_common_should_common",
+        "must_rare_should_common",
+        "must_two_should_two",
     ];
 
     pub fn to_infino_mode(mode: BoolMode) -> InfinoBoolMode {
@@ -465,9 +495,10 @@ pub mod fts {
         /// Count phase: the matching-doc count from the dedicated count
         /// primitives — single-term `term_df` (O(1) from the dictionary
         /// header), multi-term `token_match` cardinality — with no BM25
-        /// scoring and no row materialization. `terms` are the
-        /// already-tokenized query terms.
-        fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64;
+        /// scoring and no row materialization. `query` is the raw query
+        /// string so `+must` clause sigils resolve exactly as the
+        /// production count path resolves them.
+        fn count_matching(&self, column: &str, query: &str, mode: InfinoBoolMode) -> u64;
     }
 
     /// Fetch-phase measurement for a raw superfile reader: kernel hits,
@@ -510,20 +541,32 @@ pub mod fts {
             superfile_rows_fetched(self, column, query, k, mode)
         }
 
-        fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
+        fn count_matching(&self, column: &str, query: &str, mode: InfinoBoolMode) -> u64 {
             crate::tiers::block_on(async {
+                // Resolve the match set exactly as the supertable count
+                // does: with `+must` clauses, the count is the musts'
+                // intersection (shoulds only affect scores, so they
+                // never change which docs count); otherwise the bare
+                // terms match under `mode`.
+                let clauses = AsciiLowerTokenizer.parse(query).into_clauses(mode);
+                let (terms, eff_mode) = if clauses.musts.is_empty() {
+                    (clauses.shoulds, mode)
+                } else {
+                    (clauses.musts, InfinoBoolMode::And)
+                };
+                let refs: Vec<&str> = terms.iter().map(|t| &**t).collect();
                 // Single term: df is the exact match count, read O(1) from
                 // the dictionary header. Multi-term: the dedicated count
                 // primitive (union/intersection cardinality, no scoring,
                 // no id materialization) — the same path the supertable
                 // count uses, not `token_match().len()` (which would
                 // materialize the id list through the slower merge walk).
-                if terms.len() == 1 {
-                    self.term_df(column, terms[0])
+                if refs.len() == 1 {
+                    self.term_df(column, refs[0])
                         .await
                         .expect("superfile term_df")
                 } else {
-                    self.token_match_count(column, terms, mode)
+                    self.token_match_count(column, &refs, eff_mode)
                         .await
                         .expect("superfile token_match_count")
                 }
@@ -554,9 +597,8 @@ pub mod fts {
                 .sum()
         }
 
-        fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
-            let query = terms.join(" ");
-            self.count(column, &query, mode).expect("supertable count")
+        fn count_matching(&self, column: &str, query: &str, mode: InfinoBoolMode) -> u64 {
+            self.count(column, query, mode).expect("supertable count")
         }
     }
 
@@ -765,13 +807,21 @@ pub mod fts {
         };
         let and_block = Block {
             subtitle: "AND queries".into(),
-            headers: header_cols,
+            headers: header_cols.clone(),
             rows: AND_QUERIES
                 .iter()
                 .map(|&n| search_row(n, warm_map.as_ref(), cold))
                 .collect(),
         };
-        let mut blocks = vec![or_block, and_block];
+        let clause_block = Block {
+            subtitle: "Must/should queries (+must, bare should)".into(),
+            headers: header_cols,
+            rows: CLAUSE_QUERIES
+                .iter()
+                .map(|&n| search_row(n, warm_map.as_ref(), cold))
+                .collect(),
+        };
+        let mut blocks = vec![or_block, and_block, clause_block];
         if let Some(probes) = probes {
             blocks.push(Block {
                 subtitle: "Per-algorithm probes (WAND+BMW vs MaxScore+BMM)".into(),
@@ -822,11 +872,12 @@ pub mod fts {
             .map(|q| {
                 eprintln!("[{log_prefix}] count: query {}...", q.name);
                 let mode = to_infino_mode(q.mode);
-                let n = reader.count_matching(column, q.terms, mode);
+                let query = q.terms.join(" ");
+                let n = reader.count_matching(column, &query, mode);
                 let mut samples = Vec::with_capacity(iters);
                 for _ in 0..iters {
                     let t = Instant::now();
-                    let got = reader.count_matching(column, q.terms, mode);
+                    let got = reader.count_matching(column, &query, mode);
                     samples.push(t.elapsed());
                     std::hint::black_box(got);
                 }
@@ -876,14 +927,19 @@ pub mod fts {
         };
         let and_block = Block {
             subtitle: "AND queries".into(),
-            headers,
+            headers: headers.clone(),
             rows: AND_QUERIES.iter().map(|&n| count_row(n, &map)).collect(),
+        };
+        let clause_block = Block {
+            subtitle: "Must/should queries (count = must intersection)".into(),
+            headers,
+            rows: CLAUSE_QUERIES.iter().map(|&n| count_row(n, &map)).collect(),
         };
         report.emit(&Section {
             anchor: anchor.into(),
             title,
             note: note.into(),
-            blocks: vec![or_block, and_block],
+            blocks: vec![or_block, and_block, clause_block],
         });
     }
 }

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -781,8 +781,8 @@ pub mod fts {
             exec_fts::superfile_rows_fetched(&self.reader, column, query, k, mode)
         }
 
-        fn count_matching(&self, column: &str, terms: &[&str], mode: InfinoBoolMode) -> u64 {
-            self.reader.count_matching(column, terms, mode)
+        fn count_matching(&self, column: &str, query: &str, mode: InfinoBoolMode) -> u64 {
+            self.reader.count_matching(column, query, mode)
         }
     }
 

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -873,10 +873,10 @@ pub mod fts {
         fn count_matching(
             &self,
             column: &str,
-            terms: &[&str],
+            query: &str,
             mode: infino::superfile::fts::reader::BoolMode,
         ) -> u64 {
-            self.consumer.reader().count_matching(column, terms, mode)
+            self.consumer.reader().count_matching(column, query, mode)
         }
     }
 }

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -775,31 +775,44 @@ impl FtsReader {
         // below `floor` makes those comparisons exactly "strictly
         // below floor is dead, equal-to-floor survives".
         let floor_eff = floor.next_down();
-        self.search_with_filters(column_id, terms, k, mode, None, floor_eff)
+        // A flat term list under one mode is the degenerate clause
+        // shape: `And` makes every term a must, `Or` a should.
+        let (musts, shoulds): (&[&str], &[&str]) = match mode {
+            BoolMode::And => (terms, &[]),
+            BoolMode::Or => (&[], terms),
+        };
+        self.search_clauses(column_id, musts, shoulds, k, None, floor_eff)
             .await
     }
 
-    /// BM25 search with negated (`-term`) terms excluded.
+    /// BM25 search over explicit clause lists, with negated terms
+    /// excluded.
     ///
-    /// `positives` are scored under `mode` as in [`Self::search`];
-    /// `negatives` filter out any doc containing one of them, regardless
-    /// of score. Both lists are already tokenized.
+    /// `musts` all have to match (their intersection is the match
+    /// set); `shoulds` are scoring-only — a matching should raises a
+    /// doc's score but never adds or removes a match. With no musts,
+    /// the shoulds' union is the match set (a plain OR query).
+    /// `negatives` filter out any doc containing one of them,
+    /// regardless of score. All lists are already tokenized; the
+    /// default-operator resolution (bare token → must or should)
+    /// happened at parse time via `ParsedQuery::into_clauses`.
     ///
-    /// No positives → [`FtsError::NegationOnly`] (nothing to rank).
-    /// Empty positives *and* negatives → empty result.
+    /// No musts and no shoulds → [`FtsError::NegationOnly`] (nothing
+    /// to rank) when negatives exist, else an empty result.
     pub(crate) async fn search_excluding(
         &self,
         column: &str,
-        positives: &[&str],
+        musts: &[&str],
+        shoulds: &[&str],
         negatives: &[&str],
         k: usize,
-        mode: BoolMode,
+        floor: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
         let column_id = self.resolve_column_id(column)?;
         if k == 0 {
             return Ok(Vec::new());
         }
-        if positives.is_empty() {
+        if musts.is_empty() && shoulds.is_empty() {
             if negatives.is_empty() {
                 return Ok(Vec::new());
             }
@@ -813,58 +826,63 @@ impl FtsReader {
             )),
         };
 
-        // Negated string queries carry no cross-segment floor today;
-        // NEG_INFINITY disables floor pruning (see `search_with_floor`).
-        self.search_with_filters(
-            column_id,
-            positives,
-            k,
-            mode,
-            filter.as_mut(),
-            f32::NEG_INFINITY,
-        )
-        .await
+        let floor_eff = floor.next_down();
+        self.search_clauses(column_id, musts, shoulds, k, filter.as_mut(), floor_eff)
+            .await
     }
 
     /// Shared dispatch for [`Self::search_with_floor`] and
-    /// [`Self::search_excluding`]: routes positives to the single-term
-    /// / OR / AND kernel, threading `filter` to the heap-admission
-    /// sites and `floor_eff` (already `next_down`-adjusted) to every
-    /// pruning structure.
-    async fn search_with_filters(
+    /// [`Self::search_excluding`]: routes the clause lists to the
+    /// single-term / OR / AND / must+should kernel, threading `filter`
+    /// to the heap-admission sites and `floor_eff` (already
+    /// `next_down`-adjusted) to every pruning structure.
+    async fn search_clauses(
         &self,
         column_id: u32,
-        terms: &[&str],
+        musts: &[&str],
+        shoulds: &[&str],
         k: usize,
-        mode: BoolMode,
         filter: Option<&mut ExcludeFilter>,
         floor_eff: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
-        // Single-term fast path: BlockMaxWAND-driven block skipping.
-        // Walks blocks in order, populating a top-k min-heap. Once the
-        // heap is full, blocks whose skip-table-recorded `max_bm25`
-        // can't beat the kth-best (or the seeded floor) are skipped
-        // without decoding.
-        if terms.len() == 1 {
+        // Single-atom fast path: BlockMaxWAND-driven block skipping.
+        // One term scores identically whichever clause list it sits
+        // in (a lone must and a lone should both rank that term's
+        // postings), so both shapes take it.
+        if musts.len() + shoulds.len() == 1 {
+            let term = musts.iter().chain(shoulds).next().expect("one atom");
             return self
-                .search_single_term_bmw(column_id, terms[0], k, filter, floor_eff)
+                .search_single_term_bmw(column_id, term, k, filter, floor_eff)
                 .await;
         }
-        match mode {
-            BoolMode::Or => {
-                self.dispatch_multi_term_or(column_id, terms, k, filter, floor_eff)
-                    .await
-            }
-            BoolMode::And => {
-                // Build cursors; if any term is missing, the
-                // intersection is empty.
-                let cursors = self.build_term_cursors(column_id, terms).await?;
-                if cursors.len() != terms.len() {
-                    return Ok(Vec::new());
-                }
-                self.run_and_intersect(column_id, cursors, k, filter, floor_eff)
-            }
+        if musts.is_empty() {
+            return self
+                .dispatch_multi_term_or(column_id, shoulds, k, filter, floor_eff)
+                .await;
         }
+        // Build must cursors; if any must is missing, the
+        // intersection is empty.
+        let must_cursors = self.build_term_cursors(column_id, musts).await?;
+        if must_cursors.len() != musts.len() {
+            return Ok(Vec::new());
+        }
+        if shoulds.is_empty() {
+            return self.run_and_intersect(column_id, must_cursors, k, filter, floor_eff);
+        }
+        // Shoulds absent from this superfile contribute nothing;
+        // when none survive, the walk is a plain must intersection.
+        let should_cursors = self.build_term_cursors(column_id, shoulds).await?;
+        if should_cursors.is_empty() {
+            return self.run_and_intersect(column_id, must_cursors, k, filter, floor_eff);
+        }
+        self.run_must_should(
+            column_id,
+            must_cursors,
+            should_cursors,
+            k,
+            filter,
+            floor_eff,
+        )
     }
 
     /// Unranked token match over a **token list** — the no-scoring
@@ -1593,6 +1611,46 @@ impl FtsReader {
             floor_eff,
         };
         self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
+        Ok(drain_top_k_desc(heap))
+    }
+
+    /// Ranked must+should walk: the match set is the musts'
+    /// intersection (driven by the same flat-merge as
+    /// [`run_and_intersect`](Self::run_and_intersect), so the two
+    /// always agree on which docs match), and each matching doc's
+    /// score additionally collects every should term that lands on it.
+    /// Shoulds never affect matching — a doc containing every must and
+    /// no should still matches, with its must-only score.
+    fn run_must_should(
+        &self,
+        column_id: u32,
+        mut must_cursors: Vec<TermCursor>,
+        should_cursors: Vec<TermCursor>,
+        k: usize,
+        filter: Option<&mut ExcludeFilter>,
+        floor_eff: f32,
+    ) -> Result<Vec<(u32, f32)>, FtsError> {
+        debug_assert!(
+            !must_cursors.is_empty() && !should_cursors.is_empty(),
+            "dispatch routes empty-side shapes to the AND/OR kernels"
+        );
+        let col_meta = &self.columns[column_id as usize];
+        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        must_cursors.sort_by_key(|c| c.block_count());
+
+        let initial_cap = k.min(self.n_docs as usize).max(1);
+        let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
+        let should_ub = should_cursors.iter().map(|c| c.term_max_bm25).sum();
+        let mut sink = MustShouldSink {
+            heap: &mut heap,
+            k,
+            filter,
+            floor_eff,
+            shoulds: should_cursors,
+            should_ub,
+            dl_norm_k1,
+        };
+        self.and_flat_merge(&mut must_cursors, dl_norm_k1, &mut sink);
         Ok(drain_top_k_desc(heap))
     }
 
@@ -2862,6 +2920,66 @@ impl AndSink for ScoreSink<'_> {
 
     fn emit(&mut self, doc: u32, score: f32) {
         // Floor gate: strictly-below-floor docs are dead to the caller.
+        if score > self.floor_eff {
+            and_heap_push(self.heap, self.k, self.filter.as_deref_mut(), score, doc);
+        }
+    }
+}
+
+/// Ranked must+should sink: scores the must intersection like
+/// [`ScoreSink`], then adds each should term's contribution for docs
+/// it lands on before heap admission. The should cursors ride inside
+/// the sink — the AND walk emits docs in ascending order, so each
+/// should list is `skip_to`-streamed forward at most once per query,
+/// exactly like [`ExcludeFilter`]'s negated cursors.
+struct MustShouldSink<'a> {
+    heap: &'a mut BinaryHeap<TopKEntry>,
+    k: usize,
+    filter: Option<&'a mut ExcludeFilter>,
+    floor_eff: f32,
+    shoulds: Vec<TermCursor>,
+    /// Σ `term_max_bm25` over the should cursors — the most the
+    /// shoulds can add to any single doc's score.
+    should_ub: f32,
+    /// Per-doc BM25 length normalization for the column, for scoring
+    /// the should terms at emitted docs.
+    dl_norm_k1: &'a [f32],
+}
+
+impl AndSink for MustShouldSink<'_> {
+    fn bar(&self) -> f32 {
+        // The AND walk's block-max arithmetic bounds the MUST portion
+        // of a doc's score only, so the pruning bar is lowered by the
+        // most the shoulds could add: a must block that can't reach
+        // (kth-best − should_ub) can't produce a top-k doc even with
+        // every should matching at its maximum.
+        let full_bar = if self.heap.len() >= self.k {
+            self.heap
+                .peek()
+                .expect("heap len == k")
+                .0
+                .max(self.floor_eff)
+        } else {
+            self.floor_eff
+        };
+        full_bar - self.should_ub
+    }
+
+    fn needs_score(&self) -> bool {
+        true
+    }
+
+    fn emit(&mut self, doc: u32, must_score: f32) {
+        let norm = self.dl_norm_k1[doc as usize];
+        let mut score = must_score;
+        for c in &mut self.shoulds {
+            c.skip_to(doc);
+            if !c.is_exhausted() && c.current_doc_id() == doc {
+                score += bm25::score_with_dl_norm_k1(c.idf_x_k1p1, c.current_tf(), norm);
+            }
+        }
+        // Floor gate on the FULL score — a must-only score below the
+        // floor can still survive once its shoulds are added.
         if score > self.floor_eff {
             and_heap_push(self.heap, self.k, self.filter.as_deref_mut(), score, doc);
         }
@@ -4390,7 +4508,7 @@ mod tests {
         let r = FtsReader::open(blob, &json).expect("open");
         // "runtime" hits docs 0 and 1; negate "async" (only in doc 0).
         let hits = r
-            .search_excluding("body", &["runtime"], &["async"], 10, BoolMode::Or)
+            .search_excluding("body", &[], &["runtime"], &["async"], 10, f32::NEG_INFINITY)
             .await
             .expect("search excluding");
         let ids: Vec<u32> = hits.iter().map(|(d, _)| *d).collect();
@@ -4402,7 +4520,7 @@ mod tests {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
         let err = r
-            .search_excluding("body", &[], &["rust"], 10, BoolMode::Or)
+            .search_excluding("body", &[], &[], &["rust"], 10, f32::NEG_INFINITY)
             .await
             .expect_err("negation-only");
         assert!(matches!(err, FtsError::NegationOnly));
@@ -4413,7 +4531,7 @@ mod tests {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
         let hits = r
-            .search_excluding("body", &[], &[], 10, BoolMode::Or)
+            .search_excluding("body", &[], &[], &[], 10, f32::NEG_INFINITY)
             .await
             .expect("empty");
         assert!(hits.is_empty());

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -47,12 +47,18 @@ use crate::superfile::{
     lazy_source::{LazyByteSource, PrefetchedSource, Source},
 };
 
-/// Boolean-mode for multi-term queries.
+/// Default operator for a query's bare (sigil-less) terms. Terms
+/// carrying an explicit clause sigil keep their polarity regardless
+/// of mode: `+term` is a must (every hit contains it), `-term` a
+/// must-not (hard exclusion).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BoolMode {
-    /// All query terms must match the doc.
+    /// Bare terms are musts: all of them must match the doc.
     And,
-    /// Any query term matching contributes to the doc's score.
+    /// Bare terms are shoulds: any of them matching contributes to
+    /// the doc's score. When the query also carries `+must` terms,
+    /// the musts alone define the match set and bare terms become
+    /// scoring-only.
     Or,
 }
 

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
 //! Tokenization, plus BM25 query parsing ([`Tokenizer::parse`]).
-//! The parser lives here because the `-` negation sigil must be
-//! handled before tokenizing — the tokenizer splits on `-`.
+//! The parser lives here because the `+` / `-` clause sigils must be
+//! handled before tokenizing — the tokenizer splits on both.
 //!
 //! Ships one tokenizer: [`AsciiLowerTokenizer`]. The [`Tokenizer`]
 //! trait is the extension point for ICU / language-aware stemmers /
@@ -27,6 +27,8 @@ use std::{
 };
 
 use wide::u8x16;
+
+use super::reader::BoolMode;
 
 /// Smallest byte value that is non-ASCII (has the high bit set). The
 /// v1 ASCII-only rule drops any token containing a byte `>= this`.
@@ -95,15 +97,23 @@ pub trait Tokenizer: Send + Sync + 'static {
         self.tokenize_each(text, &mut |t| f(Cow::Owned(t.to_owned())));
     }
 
-    /// Used to parse a query: `"rust -python"` → positives `["rust"]`,
-    /// negatives `["python"]`. A query with no positives is not an
-    /// error here; the caller checks.
+    /// Used to parse a query into its clauses by leading sigil:
+    /// `"+rust async -python"` → musts `["rust"]`, positives
+    /// `["async"]`, negatives `["python"]`. A `+`-prefixed run is a
+    /// **must** clause (the doc must contain it), a `-`-prefixed run
+    /// a **must-not** clause (hard exclusion), and a bare run lands
+    /// in `positives`, whose polarity the query layer resolves from
+    /// the default operator (`BoolMode`). A query with no must or
+    /// positive clause is not an error here; the caller checks.
     fn parse<'q>(&self, query: &'q str) -> ParsedQuery<'q> {
         let mut parsed = ParsedQuery::default();
         for run in query.split_whitespace() {
-            match run.strip_prefix('-') {
-                Some(rest) if !rest.is_empty() => {
+            match (run.strip_prefix('-'), run.strip_prefix('+')) {
+                (Some(rest), _) if !rest.is_empty() => {
                     self.tokenize_each_query(rest, &mut |t| parsed.negatives.push(t));
+                }
+                (_, Some(rest)) if !rest.is_empty() => {
+                    self.tokenize_each_query(rest, &mut |t| parsed.musts.push(t));
                 }
                 _ => self.tokenize_each_query(run, &mut |t| parsed.positives.push(t)),
             }
@@ -326,13 +336,60 @@ fn simd_scan_token_run(bytes: &[u8], mut pos: usize) -> (usize, bool, bool) {
     (pos, had_upper, had_non_ascii)
 }
 
-/// A parsed BM25 query: positive (scored) and negative (excluding)
-/// tokens. Tokens may borrow the query string, so this can't outlive
-/// the query.
+/// A parsed BM25 query, split into its clause lists by leading sigil:
+/// `+term` → `musts`, bare `term` → `positives`, `-term` →
+/// `negatives`. Tokens may borrow the query string, so this can't
+/// outlive the query.
 #[derive(Debug, Default)]
 pub struct ParsedQuery<'q> {
+    /// `+`-sigiled tokens: the doc must contain every one.
+    pub musts: Vec<Cow<'q, str>>,
+    /// Bare (sigil-less) tokens. Their polarity comes from the
+    /// default operator: [`BoolMode::And`] treats them as musts,
+    /// [`BoolMode::Or`] as shoulds (scoring-only once any must
+    /// exists; a plain union when none does).
     pub positives: Vec<Cow<'q, str>>,
+    /// `-`-sigiled tokens: any doc containing one is excluded.
     pub negatives: Vec<Cow<'q, str>>,
+}
+
+/// A query's clause lists with the default operator already applied —
+/// what [`ParsedQuery::into_clauses`] produces and the search kernels
+/// consume. `shoulds` is non-empty only under [`BoolMode::Or`].
+#[derive(Debug, Default)]
+pub struct QueryClauses<'q> {
+    /// Every doc in the result must contain all of these.
+    pub musts: Vec<Cow<'q, str>>,
+    /// Scoring-only when `musts` is non-empty; otherwise the match is
+    /// their union.
+    pub shoulds: Vec<Cow<'q, str>>,
+    /// Docs containing any of these are excluded.
+    pub negatives: Vec<Cow<'q, str>>,
+}
+
+impl<'q> ParsedQuery<'q> {
+    /// Resolve the bare tokens' polarity from the default operator
+    /// `mode`: `And` folds them into `musts`, `Or` makes them
+    /// `shoulds`. Sigiled tokens keep their explicit polarity.
+    pub fn into_clauses(self, mode: BoolMode) -> QueryClauses<'q> {
+        let ParsedQuery {
+            mut musts,
+            positives,
+            negatives,
+        } = self;
+        let shoulds = match mode {
+            BoolMode::And => {
+                musts.extend(positives);
+                Vec::new()
+            }
+            BoolMode::Or => positives,
+        };
+        QueryClauses {
+            musts,
+            shoulds,
+            negatives,
+        }
+    }
 }
 
 impl Tokenizer for AsciiLowerTokenizer {
@@ -676,8 +733,99 @@ mod tests {
     #[test]
     fn parse_empty_query() {
         let p = parse("");
+        assert!(p.musts.is_empty());
         assert!(p.positives.is_empty());
         assert!(p.negatives.is_empty());
+    }
+
+    // ---- parse (the `+` must sigil) ----
+
+    #[test]
+    fn parse_must_sigil() {
+        let p = parse("+climate policy");
+        assert_eq!(p.musts, vec!["climate"]);
+        assert_eq!(p.positives, vec!["policy"]);
+        assert!(p.negatives.is_empty());
+    }
+
+    #[test]
+    fn parse_all_must() {
+        let p = parse("+griffith +observatory");
+        assert_eq!(p.musts, vec!["griffith", "observatory"]);
+        assert!(p.positives.is_empty());
+    }
+
+    #[test]
+    fn parse_must_with_negation() {
+        let p = parse("+python -snake -monty");
+        assert_eq!(p.musts, vec!["python"]);
+        assert!(p.positives.is_empty());
+        assert_eq!(p.negatives, vec!["snake", "monty"]);
+    }
+
+    #[test]
+    fn parse_interior_plus_is_not_must() {
+        // `a+b` is one run with an interior `+`; the scan splits it
+        // into two bare tokens. Nothing is a must clause.
+        let p = parse("a+b");
+        assert!(p.musts.is_empty());
+        assert_eq!(p.positives, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn parse_bare_plus_contributes_nothing() {
+        let p = parse("rust + python");
+        assert!(p.musts.is_empty());
+        assert_eq!(p.positives, vec!["rust", "python"]);
+    }
+
+    #[test]
+    fn parse_must_term_is_normalized() {
+        // The must side is lower-cased like the index.
+        let p = parse("+RUST async");
+        assert_eq!(p.musts, vec!["rust"]);
+        assert_eq!(p.positives, vec!["async"]);
+    }
+
+    #[test]
+    fn parse_minus_wins_over_plus_ordering() {
+        // `-` is checked first, so `-+x` negates (strip `-`, the scan
+        // drops the `+`); `+-x` is a must (strip `+`, scan drops `-`).
+        let p = parse("-+x");
+        assert_eq!(p.negatives, vec!["x"]);
+        let p = parse("+-x");
+        assert_eq!(p.musts, vec!["x"]);
+    }
+
+    // ---- into_clauses (default-operator resolution) ----
+
+    #[test]
+    fn into_clauses_or_maps_bare_to_should() {
+        let c = parse("+climate policy -spam").into_clauses(BoolMode::Or);
+        assert_eq!(c.musts, vec!["climate"]);
+        assert_eq!(c.shoulds, vec!["policy"]);
+        assert_eq!(c.negatives, vec!["spam"]);
+    }
+
+    #[test]
+    fn into_clauses_and_folds_bare_into_musts() {
+        let c = parse("+climate policy -spam").into_clauses(BoolMode::And);
+        assert_eq!(c.musts, vec!["climate", "policy"]);
+        assert!(c.shoulds.is_empty());
+        assert_eq!(c.negatives, vec!["spam"]);
+    }
+
+    #[test]
+    fn into_clauses_legacy_shapes_unchanged() {
+        // Sigil-less queries resolve exactly as the pre-clause model:
+        // Or ⇒ all shoulds (union), And ⇒ all musts (intersection).
+        let c = parse("rust async").into_clauses(BoolMode::Or);
+        assert!(c.musts.is_empty());
+        assert_eq!(c.shoulds, vec!["rust", "async"]);
+
+        let c = parse("rust async").into_clauses(BoolMode::And);
+        assert_eq!(c.musts, vec!["rust", "async"]);
+        assert!(c.shoulds.is_empty());
     }
 
     #[test]

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -757,12 +757,16 @@ impl SuperfileReader {
     /// hits ordered by descending score — this is the hit kernel, not a
     /// row-returning search; row materialization is `take_by_local_doc_ids`.
     ///
-    /// ## Negation (`-term`)
+    /// ## Clause sigils (`+term`, `-term`)
     ///
-    /// A `-`-prefixed term excludes every doc containing it, regardless
-    /// of score; `mode` applies to the positive terms only. Example:
-    /// `"rust -python"` scores docs with `rust`, dropping any that also
-    /// contain `python`. A query with only negated terms is rejected
+    /// A `+`-prefixed term is a **must**: every result contains it. A
+    /// `-`-prefixed term is a **must-not**: any doc containing it is
+    /// excluded, regardless of score. Bare terms take their polarity
+    /// from `mode`, the default operator: `And` requires them like
+    /// musts; `Or` makes them scoring-only **shoulds** when a must
+    /// exists (`"+climate policy"` matches docs with `climate`, and
+    /// docs also mentioning `policy` rank higher) and a plain union
+    /// when none does. A query with only negated terms is rejected
     /// (`FtsError::NegationOnly`).
     pub async fn bm25_hits_async(
         &self,
@@ -773,12 +777,14 @@ impl SuperfileReader {
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let tok = AsciiLowerTokenizer;
 
-        // Split the query into positive and negated terms. The parsed
+        // Split the query into clause lists and resolve the bare
+        // tokens' polarity from the default operator. The parsed
         // tokens borrow `query`, so nothing is copied here.
-        let parsed = tok.parse(query);
-        let positives: Vec<&str> = parsed.positives.iter().map(|t| &**t).collect();
-        let negatives: Vec<&str> = parsed.negatives.iter().map(|t| &**t).collect();
-        self.bm25_search_pretokenized_excluding(column, &positives, &negatives, k, mode)
+        let clauses = tok.parse(query).into_clauses(mode);
+        let musts: Vec<&str> = clauses.musts.iter().map(|t| &**t).collect();
+        let shoulds: Vec<&str> = clauses.shoulds.iter().map(|t| &**t).collect();
+        let negatives: Vec<&str> = clauses.negatives.iter().map(|t| &**t).collect();
+        self.bm25_search_clauses(column, &musts, &shoulds, &negatives, k, f32::NEG_INFINITY)
             .await
     }
 
@@ -924,23 +930,28 @@ impl SuperfileReader {
         Ok(out)
     }
 
-    /// Pre-tokenized BM25 search with negated terms excluded — the
-    /// negation sibling of [`Self::bm25_search_pretokenized`]. The
-    /// supertable fan-out parses the `-` sigil once at the orchestrator
-    /// and hands every superfile the split lists through here.
-    pub(crate) async fn bm25_search_pretokenized_excluding(
+    /// Pre-tokenized BM25 search over explicit clause lists — the
+    /// clause sibling of [`Self::bm25_search_pretokenized`]. The
+    /// supertable fan-out parses the `+`/`-` sigils and resolves the
+    /// default operator once at the orchestrator, then hands every
+    /// superfile the split lists through here. `musts` all have to
+    /// match; `shoulds` only raise scores; `negatives` exclude. Docs
+    /// scoring strictly below `floor` are pruned
+    /// (`f32::NEG_INFINITY` disables the floor).
+    pub(crate) async fn bm25_search_clauses(
         &self,
         column: &str,
-        positives: &[&str],
+        musts: &[&str],
+        shoulds: &[&str],
         negatives: &[&str],
         k: usize,
-        mode: BoolMode,
+        floor: f32,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
         Ok(fts
-            .search_excluding(column, positives, negatives, k, mode)
+            .search_excluding(column, musts, shoulds, negatives, k, floor)
             .await?)
     }
 

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -228,41 +228,49 @@ impl SupertableReader {
         let pool_threads = manifest.options.reader_pool.current_num_threads();
         let column_owned = column.to_owned();
 
-        // Parse the query once here, not per superfile. The fan-out
-        // closures below need owned ('static) data for tokio::spawn,
-        // so this is the one place the tokens are copied — the prune
-        // and every per-superfile search reuse them.
-        let parsed = AsciiLowerTokenizer.parse(query);
-        let positives: Vec<String> = parsed.positives.into_iter().map(Cow::into_owned).collect();
-        let negatives: Vec<String> = parsed.negatives.into_iter().map(Cow::into_owned).collect();
+        // Parse the query once here, not per superfile, resolving the
+        // bare tokens' polarity from the default operator (`And` ⇒
+        // must, `Or` ⇒ should). The fan-out closures below need owned
+        // ('static) data for tokio::spawn, so this is the one place
+        // the tokens are copied — the prune and every per-superfile
+        // search reuse them.
+        let clauses = AsciiLowerTokenizer.parse(query).into_clauses(mode);
+        let musts: Vec<String> = clauses.musts.into_iter().map(Cow::into_owned).collect();
+        let shoulds: Vec<String> = clauses.shoulds.into_iter().map(Cow::into_owned).collect();
+        let negatives: Vec<String> = clauses.negatives.into_iter().map(Cow::into_owned).collect();
 
-        // Negation-only (e.g. `-foo`): no positive anchor to rank. Reject
-        // up front so the per-superfile excluding kernel never has to, and
-        // so the unranked count / token_match path surfaces the identical
-        // error (see `parse_and_prune`).
-        if positives.is_empty() && !negatives.is_empty() {
+        if musts.is_empty() && shoulds.is_empty() {
+            // No scorable clause at all. Empty / punctuation-only
+            // queries match nothing (not an error); negation-only
+            // (e.g. `-foo`) has no anchor to rank — reject up front so
+            // the per-superfile kernel never has to, and so the
+            // unranked count / token_match path surfaces the identical
+            // error (see `parse_and_prune`).
+            if negatives.is_empty() {
+                return Ok(Vec::new());
+            }
             return Err(QueryError::InvalidQuery(NEGATION_ONLY_QUERY_MSG.to_owned()));
         }
 
         // Pick the superfiles to search, via the shared two-tier bloom
-        // prune. Only positive terms prune — a negated term must never
-        // drop a superfile: a superfile without it is the best case (none
-        // of its docs can be excluded), and under `And` it would even
-        // prune every superfile that lacks the negated term.
-        // The leaf takes `positives` by value to avoid cloning the
-        // list; we take it back right after the call.
+        // prune. Musts prune hardest: every match contains all of
+        // them, so a superfile lacking any must is skipped regardless
+        // of `mode`. A pure should query prunes exactly as the flat
+        // term list did. Negated terms never prune — a superfile
+        // without a negated term is the best case (none of its docs
+        // can be excluded) — and shoulds never prune once a must
+        // exists, since they only affect scores.
+        let (prune_terms, prune_mode) = if musts.is_empty() {
+            (shoulds.clone(), mode)
+        } else {
+            (musts.clone(), BoolMode::And)
+        };
         let prune_leaf = PruneLeaf::TermPresence {
             column: column_owned.clone(),
-            terms: positives,
-            mode,
+            terms: prune_terms,
+            mode: prune_mode,
         };
         let kept = select_superfiles(manifest.as_ref(), slice::from_ref(&prune_leaf)).await?;
-        let PruneLeaf::TermPresence {
-            terms: positives, ..
-        } = prune_leaf
-        else {
-            unreachable!("leaf constructed as TermPresence above")
-        };
         if kept.is_empty() {
             return Ok(Vec::new());
         }
@@ -271,9 +279,10 @@ impl SupertableReader {
         // threads than there are kept superfiles AND we're on the
         // multi-term OR hot path, slice each superfile into doc_id
         // sub-ranges so the fan-out can saturate every pool thread.
-        // Single-term OR and AND stay on the un-ranged call.
+        // Single-term OR, AND, and any query with a must or negated
+        // clause stay on the un-ranged call.
         let kept_refs: Vec<&Arc<SuperfileEntry>> = kept.iter().collect();
-        let fanout = fanout_for(mode, positives.len(), !negatives.is_empty());
+        let fanout = fanout_for(musts.len(), shoulds.len(), !negatives.is_empty());
         let work_units = build_work_units(&kept_refs, fanout, pool_threads);
         let units: Vec<(Arc<SuperfileEntry>, (Option<(u32, u32)>, Uuid))> = work_units
             .into_iter()
@@ -283,7 +292,8 @@ impl SupertableReader {
             })
             .collect();
 
-        let term_arc: Arc<Vec<String>> = Arc::new(positives);
+        let must_arc: Arc<Vec<String>> = Arc::new(musts);
+        let should_arc: Arc<Vec<String>> = Arc::new(shoulds);
         let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
         let column_arc = Arc::new(column_owned);
 
@@ -305,49 +315,43 @@ impl SupertableReader {
         // superfile) plus the superfile id for the tombstone-aware merge.
         let kernel = move |r: Arc<SuperfileReader>, (range, suid): (Option<(u32, u32)>, Uuid)| {
             let column_arc = Arc::clone(&column_arc);
-            let term_arc = Arc::clone(&term_arc);
+            let must_arc = Arc::clone(&must_arc);
+            let should_arc = Arc::clone(&should_arc);
             let neg_arc = Arc::clone(&neg_arc);
             let shared = Arc::clone(&shared);
             let tombstones = tombstones.clone();
             async move {
-                let term_refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
                 let floor = shared.floor();
                 let hits = match range {
-                    // Ranged units exist only for negation-free queries
-                    // (`fanout_for` never slices otherwise).
-                    Some((start, end)) => r
-                        .bm25_search_or_range_pretokenized_with_floor(
+                    // Ranged units exist only for pure multi-should
+                    // queries (`fanout_for` never slices when a must
+                    // or negated clause exists).
+                    Some((start, end)) => {
+                        let should_refs: Vec<&str> =
+                            should_arc.iter().map(|s| s.as_str()).collect();
+                        r.bm25_search_or_range_pretokenized_with_floor(
                             &column_arc,
-                            &term_refs,
+                            &should_refs,
                             k,
                             start,
                             end,
                             floor,
                         )
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?,
-                    None if neg_arc.is_empty() => r
-                        .bm25_search_pretokenized_with_floor(
-                            &column_arc,
-                            &term_refs,
-                            k,
-                            mode,
-                            floor,
-                        )
-                        .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                        .map_err(|e| QueryError::Parquet(e.to_string()))?
+                    }
                     None => {
-                        // Negated queries run unfloored (the excluding
-                        // kernel carries no cross-segment floor today);
-                        // their survivors still merge below, which is
-                        // harmless bookkeeping.
+                        let must_refs: Vec<&str> = must_arc.iter().map(|s| s.as_str()).collect();
+                        let should_refs: Vec<&str> =
+                            should_arc.iter().map(|s| s.as_str()).collect();
                         let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
-                        r.bm25_search_pretokenized_excluding(
+                        r.bm25_search_clauses(
                             &column_arc,
-                            &term_refs,
+                            &must_refs,
+                            &should_refs,
                             &neg_refs,
                             k,
-                            mode,
+                            floor,
                         )
                         .await
                         .map_err(|e| QueryError::Parquet(e.to_string()))?
@@ -471,33 +475,51 @@ impl SupertableReader {
     /// positive, e.g. `-foo`) is rejected with [`QueryError::InvalidQuery`],
     /// the same as the scored search path — there is no positive anchor to
     /// match against.
+    /// Parse `query` into clauses, resolve the unranked **match set**
+    /// terms, and bloom-prune the superfile list.
+    ///
+    /// Unranked matching has no scores for a should clause to raise,
+    /// so the match set is the musts' intersection whenever any must
+    /// exists (`+a b` matches exactly the docs containing `a`; the
+    /// bare `b` is scoring-only and contributes nothing here) —
+    /// keeping `token_match` / `count` consistent with which docs the
+    /// scored search returns. With no musts, the bare terms match
+    /// under `mode` exactly as before.
+    ///
+    /// Returns `(match_terms, match_mode, negatives, kept)`.
     async fn parse_and_prune(
         &self,
         column: &str,
         query: &str,
         mode: BoolMode,
-    ) -> Result<(Vec<String>, Vec<String>, Vec<Arc<SuperfileEntry>>), QueryError> {
-        let parsed = AsciiLowerTokenizer.parse(query);
-        let positives: Vec<String> = parsed.positives.into_iter().map(Cow::into_owned).collect();
-        let negatives: Vec<String> = parsed.negatives.into_iter().map(Cow::into_owned).collect();
-        if positives.is_empty() {
+    ) -> Result<(Vec<String>, BoolMode, Vec<String>, Vec<Arc<SuperfileEntry>>), QueryError> {
+        let clauses = AsciiLowerTokenizer.parse(query).into_clauses(mode);
+        let musts: Vec<String> = clauses.musts.into_iter().map(Cow::into_owned).collect();
+        let shoulds: Vec<String> = clauses.shoulds.into_iter().map(Cow::into_owned).collect();
+        let negatives: Vec<String> = clauses.negatives.into_iter().map(Cow::into_owned).collect();
+        if musts.is_empty() && shoulds.is_empty() {
             if negatives.is_empty() {
                 // No tokens at all (empty/whitespace query) — nothing to
                 // match, not an error.
-                return Ok((positives, negatives, Vec::new()));
+                return Ok((Vec::new(), mode, negatives, Vec::new()));
             }
             // Negation-only (e.g. `-foo`): reject, matching the scored
             // search path, which has no positive anchor to rank or match.
             return Err(QueryError::InvalidQuery(NEGATION_ONLY_QUERY_MSG.to_owned()));
         }
+        let (match_terms, match_mode) = if musts.is_empty() {
+            (shoulds, mode)
+        } else {
+            (musts, BoolMode::And)
+        };
         let prune_leaf = PruneLeaf::TermPresence {
             column: column.to_owned(),
-            terms: positives.clone(),
-            mode,
+            terms: match_terms.clone(),
+            mode: match_mode,
         };
         let kept =
             select_superfiles(self.manifest().as_ref(), slice::from_ref(&prune_leaf)).await?;
-        Ok((positives, negatives, kept))
+        Ok((match_terms, match_mode, negatives, kept))
     }
 
     /// Unranked token match across the pinned snapshot. Returns
@@ -505,6 +527,10 @@ impl SupertableReader {
     /// token, `And` = every token) as [`SuperfileHit`]s — **no scoring**
     /// (`score` is left `0.0`; these results are unordered). Superfile
     /// skip uses the same term-bloom prune as BM25.
+    ///
+    /// With a `+must` clause, the match set is the musts' intersection
+    /// and bare (should) tokens are ignored — they only affect scores,
+    /// and there are none here (see [`Self::parse_and_prune`]).
     ///
     /// `pub(crate)` async kernel; the public surface is the sync
     /// [`SupertableReader::token_match`].
@@ -518,14 +544,15 @@ impl SupertableReader {
         query: &str,
         mode: BoolMode,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
-        let (positives, negatives, kept) = self.parse_and_prune(column, query, mode).await?;
+        let (match_terms, match_mode, negatives, kept) =
+            self.parse_and_prune(column, query, mode).await?;
         if kept.is_empty() {
             return Ok(Vec::new());
         }
         let has_negatives = !negatives.is_empty();
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
         let column_arc = Arc::new(column.to_owned());
-        let term_arc: Arc<Vec<String>> = Arc::new(positives);
+        let term_arc: Arc<Vec<String>> = Arc::new(match_terms);
         let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
         let kernel = move |r: Arc<SuperfileReader>, _: ()| {
             let column_arc = Arc::clone(&column_arc);
@@ -534,7 +561,7 @@ impl SupertableReader {
             async move {
                 let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
                 let docs = r
-                    .token_match(&column_arc, &refs, mode)
+                    .token_match(&column_arc, &refs, match_mode)
                     .await
                     .map_err(|e| QueryError::Parquet(e.to_string()))?;
                 // Drop any positive match that also carries a negated
@@ -567,6 +594,12 @@ impl SupertableReader {
     /// pinned snapshot — **count only, no scoring and no row
     /// materialization**.
     ///
+    /// With a `+must` clause, the count is the musts' intersection
+    /// cardinality — bare (should) tokens affect only scores, so they
+    /// never change which docs are counted (see
+    /// [`Self::parse_and_prune`]). `count("+climate policy")` is the
+    /// number of docs containing `climate`.
+    ///
     /// Fast path: a single-token query against a superfile with no
     /// tombstones resolves from the term dictionary's stored document
     /// frequency ([`SuperfileReader::term_df`]) — O(1) per superfile, no
@@ -580,15 +613,16 @@ impl SupertableReader {
         query: &str,
         mode: BoolMode,
     ) -> Result<u64, QueryError> {
-        let (positives, negatives, kept) = self.parse_and_prune(column, query, mode).await?;
+        let (match_terms, match_mode, negatives, kept) =
+            self.parse_and_prune(column, query, mode).await?;
         if kept.is_empty() {
             return Ok(0);
         }
 
-        let single_term = positives.len() == 1;
+        let single_term = match_terms.len() == 1;
         let has_negatives = !negatives.is_empty();
         let column_arc = Arc::new(column.to_owned());
-        let term_arc: Arc<Vec<String>> = Arc::new(positives);
+        let term_arc: Arc<Vec<String>> = Arc::new(match_terms);
         let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
 
@@ -622,7 +656,7 @@ impl SupertableReader {
                     // (union of the negatives) or a tombstone.
                     if has_negatives || tomb.is_some() {
                         let docs = r
-                            .token_match(&column_arc, &refs, mode)
+                            .token_match(&column_arc, &refs, match_mode)
                             .await
                             .map_err(|e| QueryError::Parquet(e.to_string()))?;
                         let excluded: RoaringBitmap = if has_negatives {
@@ -653,7 +687,7 @@ impl SupertableReader {
                             .await
                             .map_err(|e| QueryError::Parquet(e.to_string()))?
                     } else {
-                        r.token_match_count(&column_arc, &refs, mode)
+                        r.token_match_count(&column_arc, &refs, match_mode)
                             .await
                             .map_err(|e| QueryError::Parquet(e.to_string()))?
                     };
@@ -843,11 +877,12 @@ enum FanOut {
     SubRanges,
 }
 
-/// Pick the fan-out for a term query: only multi-term OR has a
-/// range-aware kernel, and negation has no ranged kernel (v1), so
-/// everything else stays one un-ranged unit per superfile.
-fn fanout_for(mode: BoolMode, n_positives: usize, has_negatives: bool) -> FanOut {
-    if mode == BoolMode::Or && n_positives >= OR_FANOUT_MIN_TERMS && !has_negatives {
+/// Pick the fan-out for a term query: only the pure multi-should
+/// union (a flat multi-term OR — no must and no negated clause) has a
+/// range-aware kernel, so everything else stays one un-ranged unit
+/// per superfile.
+fn fanout_for(n_musts: usize, n_shoulds: usize, has_negatives: bool) -> FanOut {
+    if n_musts == 0 && n_shoulds >= OR_FANOUT_MIN_TERMS && !has_negatives {
         FanOut::SubRanges
     } else {
         FanOut::PerSuperfile
@@ -1645,6 +1680,104 @@ mod tests {
         assert!(hits.is_empty());
     }
 
+    /// Two-superfile fixture for the clause model: `climate` docs are
+    /// split across superfiles, and one superfile has no `climate` at
+    /// all (so the must prune drops it).
+    fn seeded_clause_supertable() -> Supertable {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(
+            0,
+            &["climate change policy", "climate science report"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+        w.append(&build_batch(
+            10,
+            &["policy analysis quarterly", "climate policy summit"],
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+        st
+    }
+
+    #[test]
+    fn must_should_match_set_and_count_across_superfiles() {
+        let st = seeded_clause_supertable();
+        let r = st.reader();
+
+        // 3 docs contain `climate`; `policy` is scoring-only and must
+        // not pull in "policy analysis quarterly".
+        let hits = r
+            .bm25_hits("title", "+climate policy", 10, BoolMode::Or)
+            .expect("bm25 +climate policy");
+        assert_eq!(hits.len(), 3, "match set is the must set");
+
+        // Count agrees with the scored match set and ignores shoulds.
+        let n = r
+            .count("title", "+climate policy", BoolMode::Or)
+            .expect("count +climate policy");
+        assert_eq!(n, 3);
+        // Flat OR over the same tokens is the union — strictly bigger.
+        let union = r
+            .count("title", "climate policy", BoolMode::Or)
+            .expect("count union");
+        assert_eq!(union, 4);
+
+        // Docs matching must+should outrank must-only docs: both
+        // climate∧policy docs come first.
+        let top2: Vec<f32> = hits.iter().take(2).map(|h| h.score).collect();
+        let third = hits[2].score;
+        assert!(
+            top2.iter().all(|s| *s > third),
+            "climate∧policy docs must outrank climate-only: {hits:?}"
+        );
+    }
+
+    #[test]
+    fn must_should_token_match_matches_musts_only() {
+        let st = seeded_clause_supertable();
+        let r = st.reader();
+        // Unranked matching has no scores for the should to raise —
+        // the match set is exactly the must set.
+        let tm = r
+            .token_match("title", "+climate policy", BoolMode::Or)
+            .expect("tm +climate policy");
+        assert_eq!(tm.len(), 3);
+    }
+
+    #[test]
+    fn must_should_with_negation_across_superfiles() {
+        let st = seeded_clause_supertable();
+        let r = st.reader();
+        // Negation still excludes: drop the summit doc from the
+        // climate must set.
+        let hits = r
+            .bm25_hits("title", "+climate policy -summit", 10, BoolMode::Or)
+            .expect("bm25 with negation");
+        assert_eq!(hits.len(), 2);
+        let n = r
+            .count("title", "+climate policy -summit", BoolMode::Or)
+            .expect("count with negation");
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn absent_must_prunes_every_superfile() {
+        let st = seeded_clause_supertable();
+        let r = st.reader();
+        // The must term exists nowhere: bloom-prune (or the empty
+        // intersection) yields no hits despite the common should.
+        let hits = r
+            .bm25_hits("title", "+zzzabsent policy", 10, BoolMode::Or)
+            .expect("bm25 absent must");
+        assert!(hits.is_empty());
+        let n = r
+            .count("title", "+zzzabsent policy", BoolMode::Or)
+            .expect("count absent must");
+        assert_eq!(n, 0);
+    }
+
     #[test]
     fn token_match_no_match_returns_empty() {
         let st = seeded_three_doc_supertable();
@@ -1657,26 +1790,17 @@ mod tests {
 
     #[test]
     fn fanout_for_only_multi_term_or_without_negation_subranges() {
-        // Multi-term OR, no negation → sub-range eligible.
-        assert!(matches!(
-            fanout_for(BoolMode::Or, 2, false),
-            FanOut::SubRanges
-        ));
-        // Single-term OR stays per-superfile.
-        assert!(matches!(
-            fanout_for(BoolMode::Or, 1, false),
-            FanOut::PerSuperfile
-        ));
+        // Multi-should union (flat multi-term OR), no negation →
+        // sub-range eligible.
+        assert!(matches!(fanout_for(0, 2, false), FanOut::SubRanges));
+        // Single should stays per-superfile.
+        assert!(matches!(fanout_for(0, 1, false), FanOut::PerSuperfile));
         // Negation disables sub-ranges.
-        assert!(matches!(
-            fanout_for(BoolMode::Or, 2, true),
-            FanOut::PerSuperfile
-        ));
-        // And mode stays per-superfile.
-        assert!(matches!(
-            fanout_for(BoolMode::And, 2, false),
-            FanOut::PerSuperfile
-        ));
+        assert!(matches!(fanout_for(0, 2, true), FanOut::PerSuperfile));
+        // Any must clause (including flat And queries, whose bare
+        // terms all resolve to musts) stays per-superfile.
+        assert!(matches!(fanout_for(2, 0, false), FanOut::PerSuperfile));
+        assert!(matches!(fanout_for(1, 1, false), FanOut::PerSuperfile));
     }
 
     #[test]

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -783,12 +783,17 @@ impl SupertableReader {
     /// sync→async bridge ([`SupertableReader::block_on`]). Returns up
     /// to `k` hits sorted by BM25 score *descending*.
     ///
-    /// ## Negation (`-term`)
+    /// ## Query clauses (`+term`, `-term`)
     ///
-    /// A `-`-prefixed query term excludes every doc containing it,
-    /// regardless of score; `mode` applies to the positive terms only.
-    /// `"rust -python"` scores docs with `rust`, dropping any that also
-    /// contain `python`. A query with only negated terms is an error.
+    /// A `+`-prefixed term is a **must**: every hit contains it. A
+    /// `-`-prefixed term is a **must-not**: docs containing it are
+    /// excluded, regardless of score. Bare terms take their polarity
+    /// from `mode`, the default operator — `And` requires them like
+    /// musts; `Or` makes them scoring-only **shoulds** when a must
+    /// exists (`"+climate policy"` matches the docs containing
+    /// `climate`, ranking those that also mention `policy` higher)
+    /// and a plain union when none does. A query with only negated
+    /// terms is an error.
     pub fn bm25_hits(
         &self,
         column: &str,
@@ -812,7 +817,10 @@ impl SupertableReader {
 
     /// Unranked token match over this reader's pinned snapshot. Returns
     /// every row whose `column` matches `query`'s tokens under `mode`
-    /// (`Or` = any token, `And` = every token). The returned hits are
+    /// (`Or` = any token, `And` = every token). With a `+must` clause
+    /// the match set is the musts' intersection and bare terms are
+    /// ignored — unranked matching has no scores for a should to
+    /// raise; `-term` exclusions apply. The returned hits are
     /// **unranked** — `score` is `0.0` and order is unspecified — unlike
     /// the ranked [`SupertableReader::bm25_search`]. Drives the async
     /// kernel via the sync→async bridge ([`SupertableReader::block_on`]).
@@ -995,6 +1003,14 @@ impl Supertable {
     /// Single-column BM25 search over the current snapshot, returning
     /// Arrow rows best-score-first (BM25 relevance, higher is better).
     ///
+    /// The query string carries lucene-style clause sigils: `+term`
+    /// is a must (every hit contains it), `-term` a must-not (hard
+    /// exclusion), and bare terms take their polarity from `mode`,
+    /// the default operator (`And` ⇒ must, `Or` ⇒ scoring-only should
+    /// once any must exists). `"+climate policy"` under `Or` matches
+    /// the docs containing `climate` and ranks those also mentioning
+    /// `policy` higher.
+    ///
     /// `score` is a similarity (higher is better) — the opposite
     /// direction from [`Supertable::vector_search`]'s distance. Fuse the
     /// two with [`Supertable::hybrid_search`], not by raw score.
@@ -1047,10 +1063,13 @@ impl Supertable {
 
     /// Unranked token match over one FTS column: every row whose
     /// `column` matches `query`'s tokens under `mode` (`Or` = any token,
-    /// `And` = every token). Returns Arrow rows like
-    /// [`Supertable::bm25_search`], but the `score` column is `0.0` and
-    /// row order is unspecified — a candidate set, not a ranking.
-    /// `projection` follows the same rules as `bm25_search`.
+    /// `And` = every token). With a `+must` clause the match set is
+    /// the musts' intersection and bare terms are ignored (no scores
+    /// for a should to raise); `-term` exclusions apply. Returns
+    /// Arrow rows like [`Supertable::bm25_search`], but the `score`
+    /// column is `0.0` and row order is unspecified — a candidate
+    /// set, not a ranking. `projection` follows the same rules as
+    /// `bm25_search`.
     #[cfg_attr(
         feature = "detailed-tracing",
         tracing::instrument(skip_all, fields(column = column, mode = ?mode))
@@ -1116,6 +1135,12 @@ impl Supertable {
     /// superfile from the term dictionary's document frequency, so
     /// counting a high-frequency term is cheap.
     ///
+    /// With a `+must` clause the count is the musts' intersection
+    /// cardinality — bare (should) terms affect only scores, never
+    /// which docs count, so `count("+climate policy")` is the number
+    /// of docs containing `climate`. A lone must keeps the O(1) df
+    /// fast path. `-term` exclusions apply as in search.
+    ///
     /// ```
     /// # use std::sync::Arc;
     /// # use infino::arrow_array::{LargeStringArray, RecordBatch};
@@ -1130,6 +1155,9 @@ impl Supertable {
     /// # )?)?;
     /// let n = posts.count("body", "fox", BoolMode::Or)?;
     /// assert_eq!(n, 1);
+    /// // `+must` defines the count; bare terms are scoring-only:
+    /// let n = posts.count("body", "+quick lazy", BoolMode::Or)?;
+    /// assert_eq!(n, 1); // docs containing `quick`
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn count(&self, column: &str, query: &str, mode: BoolMode) -> Result<u64, InfinoError> {

--- a/src/test_helpers/brute_force_bm25.rs
+++ b/src/test_helpers/brute_force_bm25.rs
@@ -152,6 +152,73 @@ impl BruteForceBm25 {
         scored
     }
 
+    /// Clause-model top-k: the match set is the docs containing
+    /// **every** must (or, with no musts, **any** should), minus docs
+    /// containing any negative. A matching doc's score sums its must
+    /// contributions plus each should that lands on it — shoulds are
+    /// scoring-only and never add or remove a match. Mirrors the
+    /// production must/should walk; tie-break is ascending doc_id,
+    /// identical to the other helpers.
+    pub fn top_k_clauses(
+        &self,
+        musts: &[String],
+        shoulds: &[String],
+        negatives: &[String],
+        k: usize,
+    ) -> Vec<(u64, f32)> {
+        if k == 0 || (musts.is_empty() && shoulds.is_empty()) || self.n == 0 {
+            return Vec::new();
+        }
+
+        let n = self.n as f32;
+        let avgdl = self.avgdl;
+
+        let mut scored: Vec<(u64, f32)> = Vec::with_capacity(self.docs.len());
+        'docs: for doc in &self.docs {
+            for neg in negatives {
+                if doc.tf.contains_key(neg) {
+                    continue 'docs;
+                }
+            }
+            for must in musts {
+                if !doc.tf.contains_key(must) {
+                    continue 'docs;
+                }
+            }
+            let dl = doc.dl as f32;
+            let dl_norm = K1 * (1.0 - B + B * dl / avgdl.max(f32::MIN_POSITIVE));
+            let mut score: f32 = 0.0;
+            let mut any_should = false;
+            for term in musts.iter().chain(shoulds) {
+                let Some(&tf) = doc.tf.get(term) else {
+                    continue;
+                };
+                any_should |= !musts.contains(term);
+                let df = *self.df.get(term).unwrap_or(&0) as f32;
+                if df == 0.0 {
+                    continue;
+                }
+                let idf = (1.0 + (n - df + 0.5) / (df + 0.5)).ln();
+                let tf_f = tf as f32;
+                score += idf * tf_f * (K1 + 1.0) / (tf_f + dl_norm);
+            }
+            // With musts, every surviving doc matches (score > 0 since
+            // idf is always positive); with none, only docs hit by at
+            // least one should are in the union.
+            if !musts.is_empty() || any_should {
+                scored.push((doc.doc_id, score));
+            }
+        }
+
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(Ordering::Equal)
+                .then(a.0.cmp(&b.0))
+        });
+        scored.truncate(k);
+        scored
+    }
+
     /// Same as [`Self::top_k_terms`] but with AND semantics: only docs
     /// that contain *every* query term contribute a score. Used by the
     /// AND-mode oracle tests against the reader's leapfrog

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
 pub mod brute_force_oracle;
+pub mod must_should;
 pub mod negation;
 pub mod pipeline;
 pub mod uses_spill_builder;

--- a/tests/superfile/fts/must_should.rs
+++ b/tests/superfile/fts/must_should.rs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! End-to-end tests for the flat clause model in `bm25_search`
+//! queries: `+term` (must), bare term (should under `Or`, must under
+//! `And`), `-term` (must-not). Expected sets are computed directly
+//! from the planted corpus text, and scored results are compared
+//! against the brute-force clause oracle, so each test pins the
+//! semantics:
+//!
+//! * musts define the match set — their intersection, regardless of
+//!   how many shoulds match;
+//! * a should is scoring-only — it can raise a matching doc's rank
+//!   but never adds or removes a match;
+//! * a `-term` is a hard filter, unchanged from the negation work;
+//! * under `And`, bare terms fold into the musts (default operator),
+//!   so the sigil is only observable under `Or`.
+
+use std::collections::HashSet;
+
+use infino::{
+    superfile::{SuperfileReader, fts::reader::BoolMode},
+    test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer},
+};
+
+use crate::fts::brute_force_oracle::{
+    build_infino_superfile, build_multi_block_corpus, build_multi_block_reader, corpus,
+};
+
+// ── corpus-truth helpers ──────────────────────────────────────────────
+//
+// The planted superfile has user `doc_id` == row index, so the reader's
+// `local_doc_id` is the user id. "Term in doc" = whitespace-token match,
+// which equals the tokenizer's view for this all-lowercase corpus.
+
+/// Doc-ids whose text contains `term` as a whitespace token.
+fn docs_with(corp: &[(u64, &str)], term: &str) -> HashSet<u64> {
+    corp.iter()
+        .filter(|(_, t)| t.split_whitespace().any(|w| w == term))
+        .map(|(i, _)| *i)
+        .collect()
+}
+
+/// Docs matching ALL of `terms` (the must intersection).
+fn and_match(corp: &[(u64, &str)], terms: &[&str]) -> HashSet<u64> {
+    let mut sets = terms.iter().map(|t| docs_with(corp, t));
+    let Some(first) = sets.next() else {
+        return HashSet::new();
+    };
+    sets.fold(first, |acc, s| acc.intersection(&s).copied().collect())
+}
+
+/// Remove every doc containing any of `negatives` from `base`.
+fn exclude(base: HashSet<u64>, corp: &[(u64, &str)], negatives: &[&str]) -> HashSet<u64> {
+    let drop: HashSet<u64> = negatives.iter().flat_map(|t| docs_with(corp, t)).collect();
+    base.difference(&drop).copied().collect()
+}
+
+/// Run a query and return the ranked hits.
+async fn search_hits(
+    reader: &SuperfileReader,
+    query: &str,
+    k: usize,
+    mode: BoolMode,
+) -> Vec<(u64, f32)> {
+    reader
+        .bm25_hits_async("title", query, k, mode)
+        .await
+        .expect("bm25 query")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect()
+}
+
+/// The hit set alone (order-insensitive).
+async fn search_set(
+    reader: &SuperfileReader,
+    query: &str,
+    k: usize,
+    mode: BoolMode,
+) -> HashSet<u64> {
+    search_hits(reader, query, k, mode)
+        .await
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect()
+}
+
+/// k large enough to capture every match on the 60-doc corpus, so
+/// top-k truncation never hides a set-membership disagreement.
+const K_ALL: usize = 64;
+
+/// k covering every match in the 1000-doc multi-block corpus.
+const K_ALL_MULTI_BLOCK: usize = 1024;
+
+/// Score-equality tolerance comparing the two BM25 scorers (they
+/// associate the identical formula's f32 operations differently).
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+
+// ── match-set semantics ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn must_defines_match_set_should_never_extends_it() {
+    // "+rust web": match set is exactly the rust docs. Docs with only
+    // "web" (e.g. javascript/go web docs) must not appear even though
+    // the should term hits them.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let got = search_set(&r, "+rust web", K_ALL, BoolMode::Or).await;
+    assert_eq!(got, docs_with(&corp, "rust"), "+rust web (Or)");
+}
+
+#[tokio::test]
+async fn matching_should_outranks_must_only_docs() {
+    // "+rust async": every rust∧async doc must rank strictly above
+    // every rust-only doc — the async idf dwarfs the dl-norm spread
+    // on this corpus.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let hits = search_hits(&r, "+rust async", K_ALL, BoolMode::Or).await;
+    let both = and_match(&corp, &["rust", "async"]);
+    assert!(!both.is_empty(), "corpus sanity: rust∧async docs exist");
+    let min_both = hits
+        .iter()
+        .filter(|(d, _)| both.contains(d))
+        .map(|(_, s)| *s)
+        .fold(f32::INFINITY, f32::min);
+    let max_must_only = hits
+        .iter()
+        .filter(|(d, _)| !both.contains(d))
+        .map(|(_, s)| *s)
+        .fold(f32::NEG_INFINITY, f32::max);
+    assert!(
+        min_both > max_must_only,
+        "rust∧async docs must outrank rust-only docs: {min_both} vs {max_must_only}"
+    );
+}
+
+#[tokio::test]
+async fn all_must_sigils_equal_and_mode() {
+    // "+rust +web" under Or ≡ "rust web" under And — identical hits
+    // AND identical scores (both run the same AND kernel).
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let sigils = search_hits(&r, "+rust +web", K_ALL, BoolMode::Or).await;
+    let and_mode = search_hits(&r, "rust web", K_ALL, BoolMode::And).await;
+    assert_eq!(sigils, and_mode, "+rust +web (Or) vs rust web (And)");
+}
+
+#[tokio::test]
+async fn and_mode_folds_bare_terms_into_musts() {
+    // Under And the bare term is a must too, so the sigil changes
+    // nothing: "+rust web" (And) ≡ "rust web" (And).
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let mixed = search_hits(&r, "+rust web", K_ALL, BoolMode::And).await;
+    let flat = search_hits(&r, "rust web", K_ALL, BoolMode::And).await;
+    assert_eq!(mixed, flat, "+rust web (And) vs rust web (And)");
+}
+
+#[tokio::test]
+async fn must_should_with_negation() {
+    // "+rust web -async": rust docs minus async docs; web only scores.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let got = search_set(&r, "+rust web -async", K_ALL, BoolMode::Or).await;
+    let want = exclude(docs_with(&corp, "rust"), &corp, &["async"]);
+    assert_eq!(got, want, "+rust web -async (Or)");
+}
+
+#[tokio::test]
+async fn absent_should_is_ignored() {
+    // A should term absent from the index contributes nothing — the
+    // hits (ids and scores) equal the bare must query's.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let with_ghost = search_hits(&r, "+rust zzzabsent", K_ALL, BoolMode::Or).await;
+    let without = search_hits(&r, "+rust", K_ALL, BoolMode::Or).await;
+    assert_eq!(with_ghost, without, "+rust zzzabsent vs +rust");
+}
+
+#[tokio::test]
+async fn absent_must_empties_the_result() {
+    // A must term absent from the index empties the intersection no
+    // matter how common the should is.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let got = search_set(&r, "+zzzabsent rust", K_ALL, BoolMode::Or).await;
+    assert!(got.is_empty(), "+zzzabsent rust (Or) must match nothing");
+}
+
+#[tokio::test]
+async fn bare_plus_token_contributes_nothing() {
+    // A lone "+" (no token after the sigil) is dropped by the parser;
+    // the query behaves as if it weren't there.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let with_bare = search_hits(&r, "rust + web", K_ALL, BoolMode::Or).await;
+    let without = search_hits(&r, "rust web", K_ALL, BoolMode::Or).await;
+    assert_eq!(with_bare, without, "bare + must be a no-op");
+}
+
+#[tokio::test]
+async fn single_must_equals_single_term_query() {
+    // One atom scores identically whichever clause list it sits in.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let must = search_hits(&r, "+rust", K_ALL, BoolMode::Or).await;
+    let bare = search_hits(&r, "rust", K_ALL, BoolMode::Or).await;
+    assert_eq!(must, bare, "+rust vs rust (single-atom fast path)");
+}
+
+// ── oracle comparison (scores, small corpus) ──────────────────────────
+
+/// Assert reader hits equal the clause oracle's: same doc set, and
+/// each doc's score within tolerance. Rank order can differ on f32
+/// ties, so compare per-doc scores rather than sequence order.
+async fn assert_matches_clause_oracle(
+    reader: &SuperfileReader,
+    oracle: &BruteForceBm25,
+    query: &str,
+    mode: BoolMode,
+    k: usize,
+) {
+    let tok = default_tokenizer();
+    let clauses = tok.parse(query).into_clauses(mode);
+    let musts: Vec<String> = clauses.musts.iter().map(|t| t.to_string()).collect();
+    let shoulds: Vec<String> = clauses.shoulds.iter().map(|t| t.to_string()).collect();
+    let negatives: Vec<String> = clauses.negatives.iter().map(|t| t.to_string()).collect();
+
+    let got = search_hits(reader, query, k, mode).await;
+    let want = oracle.top_k_clauses(&musts, &shoulds, &negatives, k);
+
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();
+    let want_ids: HashSet<u64> = want.iter().map(|(d, _)| *d).collect();
+    assert_eq!(got_ids, want_ids, "query {query:?}: match sets disagree");
+
+    let want_scores: std::collections::HashMap<u64, f32> = want.into_iter().collect();
+    for (d, s) in &got {
+        let w = want_scores[d];
+        assert!(
+            (s - w).abs() <= SCORE_ABS_TOLERANCE,
+            "query {query:?} doc {d}: reader score {s} vs oracle {w}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn oracle_must_should_small_corpus() {
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    assert_matches_clause_oracle(&r, &oracle, "+rust async", BoolMode::Or, K_ALL).await;
+    assert_matches_clause_oracle(&r, &oracle, "+rust web async", BoolMode::Or, K_ALL).await;
+    assert_matches_clause_oracle(&r, &oracle, "+web +framework rust", BoolMode::Or, K_ALL).await;
+    assert_matches_clause_oracle(&r, &oracle, "+rust web -async", BoolMode::Or, K_ALL).await;
+}
+
+// ── oracle comparison (multi-block corpus) ────────────────────────────
+
+#[tokio::test]
+async fn oracle_must_should_multi_block() {
+    // The 1000-doc planted corpus gives every clause term a
+    // multi-block posting list, so the must walk crosses block
+    // boundaries and the should cursors stream through skip_to across
+    // blocks — the shapes the block-max bar arithmetic must survive.
+    let owned = build_multi_block_corpus();
+    let r = build_multi_block_reader(&owned);
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+
+    // must=alpha (~334 postings, 3 blocks), should=beta (~250, 2 blocks)
+    assert_matches_clause_oracle(&r, &oracle, "+alpha beta", BoolMode::Or, K_ALL_MULTI_BLOCK).await;
+    // two musts, two shoulds
+    assert_matches_clause_oracle(
+        &r,
+        &oracle,
+        "+alpha +beta gamma delta",
+        BoolMode::Or,
+        K_ALL_MULTI_BLOCK,
+    )
+    .await;
+    // rare must, common should, negation
+    assert_matches_clause_oracle(
+        &r,
+        &oracle,
+        "+epsilon alpha -delta",
+        BoolMode::Or,
+        K_ALL_MULTI_BLOCK,
+    )
+    .await;
+    // truncated top-k (k ≪ matches) exercises the lowered pruning bar
+    assert_matches_clause_oracle(&r, &oracle, "+alpha beta gamma", BoolMode::Or, 10).await;
+}
+
+// ── error semantics ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn negation_only_still_errors() {
+    // The clause model doesn't change the negation-only rule: no must
+    // and no should ⇒ nothing to rank.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let err = r
+        .bm25_hits_async("title", "-rust", K_ALL, BoolMode::Or)
+        .await
+        .expect_err("negation-only must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("negat") || msg.contains("Negation"),
+        "unexpected error: {msg}"
+    );
+}


### PR DESCRIPTION
## What

`bm25_search` / `bm25_hits` / `token_match` / `count` queries now support lucene `BooleanQuery`-style clause sigils, parsed natively:

- `+term` — **must**: every hit contains it; the musts' intersection defines the match set.
- `-term` — **must-not**: hard exclusion (unchanged from the existing negation support).
- bare term — polarity from `BoolMode`, which becomes the **default operator**: `And` requires bare terms like musts; `Or` makes them scoring-only **shoulds** once any must exists, and a plain union when none does.

`"+climate policy"` under `Or` matches exactly the docs containing `climate` and ranks those also mentioning `policy` higher. Counts follow the match set: `count("+climate policy")` is the number of docs containing `climate`, and a lone must keeps the O(1) df fast path.

## Why

Mixed must/should queries are a standard lucene query shape that previously mis-executed: `+` was stripped as punctuation, so `+climate policy` silently ran as the union `climate OR policy` — returning wrong match sets and wrong counts. Every sigil-less query behaves bit-for-bit as before; the only behavior change is that `+` now means must, which is what anyone writing it intended.

## How

- Parser (`Tokenizer::parse`): a `+`-prefixed run is a must clause; `ParsedQuery::into_clauses(mode)` resolves bare-term polarity once at parse time.
- Kernel: the must intersection drives the existing AND flat-merge; should cursors ride in the emit sink, `skip_to`-streamed to each intersection doc (each should list is traversed at most once per query). Block-max pruning stays sound by lowering the admission bar by the shoulds' summed term-max upper bound. Single-atom, pure-OR, and pure-AND queries route to the exact kernels they used before — zero added cost to existing shapes. The clause path also threads the cross-segment score floor that the negation path previously lacked.
- Supertable: musts prune superfiles with AND-presence semantics; unranked `token_match`/`count` use the must set (there are no scores for a should to raise).

## Tests

Brute-force clause oracle (`top_k_clauses`) in `test_helpers`; planted-corpus tests at the superfile layer (12, incl. multi-block corpora crossing PFOR block boundaries and truncated-top-k pruning) and supertable layer (4, cross-superfile prune + count); parser unit tests pinning every legacy shape parses identically. `make ci` green (fmt, clippy, api-parity, doc-check, doctests, coverage).

## Performance

Validated on the public search-benchmark-game harness (5M-doc English Wikipedia corpus, full 962-query set): infino-ai/search-benchmark-game#1 — mixed must/should counts now agree exactly with lucene 10.4 and tantivy 0.26 on every command (previously all 40 mixed queries diverged), mixed-shape COUNT dropped from 224µs to 50µs mean (−78%, must-driven count replaces the full-union walk), and no query shape regressed. Three mixed-clause rows were added to the internal fts bench battery (`must_common_should_common`, `must_rare_should_common`, `must_two_should_two`).