### PR TITLE
feat sql supertable/query: scan string columns as Utf8View

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -29,7 +29,7 @@ use std::{
 };
 
 use arrow::record_batch::RecordBatch;
-use arrow_schema::{DataType, SchemaRef};
+use arrow_schema::SchemaRef;
 use dashmap::DashMap;
 use datafusion::{config::Dialect, error::DataFusionError};
 use futures::future::try_join_all;
@@ -56,7 +56,6 @@ use crate::{
     supertable::{
         Supertable,
         options::{Consistency, SupertableOptions},
-        query::sql::{cast_back_schema, cast_back_views},
         reader_cache::{DiskCacheConfig, DiskCacheError, DiskCacheStore},
     },
 };
@@ -622,23 +621,6 @@ impl Connection {
         // not as a `FROM` relation — still resolves).
         search_tvf::register_search_tvfs(&ctx, self.clone());
 
-        // Declared string types for cast-back, from each table's cached map (so
-        // a wide schema is walked once per table, not per query). A single-table
-        // query uses its map directly; a join merges, first table winning a name
-        // collision (rare).
-        let declared: Arc<HashMap<String, DataType>> = match handles.as_slice() {
-            [single] => Arc::clone(single.sql_schemas().declared()),
-            tables => {
-                let mut merged = HashMap::new();
-                for t in tables {
-                    for (name, ty) in t.sql_schemas().declared().iter() {
-                        merged.entry(name.clone()).or_insert_with(|| ty.clone());
-                    }
-                }
-                Arc::new(merged)
-            }
-        };
-
         let sql = sql.to_owned();
         let drive = async move {
             let df = ctx
@@ -648,20 +630,16 @@ impl Connection {
 
             // A RecordBatch carries the schema; an empty Vec does not. Capture
             // the output schema before collect() consumes the DataFrame so a
-            // zero-row result returns one empty batch with the projected
-            // schema, rather than a schema-less Vec — which the Python binding's
-            // Table.from_batches([]) can't build from. `cast_back_schema` so the
-            // empty-result schema matches the cast-back applied below.
-            let output_schema: SchemaRef = cast_back_schema(df.schema().inner(), &declared);
+            // zero-row result returns one empty batch with the projected schema,
+            // rather than a schema-less Vec, which the Python binding's
+            // Table.from_batches([]) can't build from. The scan's `Utf8View`
+            // columns are already coerced back to `LargeUtf8` here by
+            // `expand_views_at_output`, so the schema needs no further fixup.
+            let output_schema: SchemaRef = df.schema().inner().clone();
             let batches = df
                 .collect()
                 .await
                 .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;
-
-            // Views are internal to the scan; restore each result column to its
-            // declared type before it leaves the public API.
-            let batches = cast_back_views(batches, &declared)
-                .map_err(|e| InfinoError::Query(e.to_string()).with_context("query_sql", None))?;
             if batches.is_empty() {
                 Ok(vec![RecordBatch::new_empty(output_schema)])
             } else {
@@ -1745,10 +1723,9 @@ mod tests {
         );
     }
 
-    /// Public-path cast-back: a non-FTS `LargeUtf8` column is scanned as
-    /// `Utf8View` but `Connection::query_sql` (the public entry point) returns
-    /// it as the declared `LargeUtf8`, so no `Utf8View` leaks to a caller. The
-    /// public-path version of the internal-reader test in `sql.rs`.
+    /// Public path: a non-FTS `LargeUtf8` column is scanned as `Utf8View`, but
+    /// `Connection::query_sql` returns it as `LargeUtf8` (the scan view is
+    /// coerced at the plan output), so no `Utf8View` leaks to a caller.
     #[test]
     fn query_sql_public_string_result_is_large_utf8_not_view() {
         let conn = connect("memory://").expect("connect");
@@ -1781,9 +1758,31 @@ mod tests {
         );
     }
 
-    /// Cross-table join whose key is a viewed string column: exercises the
-    /// multi-table declared-type merge and confirms the join key comes back the
-    /// declared `LargeUtf8`, not a view.
+    /// Ungrouped `MIN`/`MAX` over a viewed string column through the public
+    /// path (the shape that regressed before `expand_views_at_output`): must
+    /// not error and returns `LargeUtf8`.
+    #[test]
+    fn query_sql_public_ungrouped_min_max_string() {
+        let conn = connect("memory://").expect("connect");
+        let docs = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new())
+            .expect("create docs");
+        docs.append(&build_title_batch(&["beta", "alpha", "gamma"]))
+            .expect("append");
+
+        let batches = conn
+            .query_sql("SELECT MIN(title) lo, MAX(title) hi, COUNT(*) n FROM docs")
+            .expect("ungrouped min/max over a viewed column");
+        let lo = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("MIN(title) is LargeUtf8");
+        assert_eq!(lo.value(0), "alpha");
+    }
+
+    /// Cross-table join whose key is a viewed string column: the join key comes
+    /// back `LargeUtf8`, not a view.
     #[test]
     fn query_sql_join_across_tables_on_string_column() {
         let conn = connect("memory://").expect("connect");

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -627,11 +627,11 @@ impl Connection {
         // query uses its map directly; a join merges, first table winning a name
         // collision (rare).
         let declared: Arc<HashMap<String, DataType>> = match handles.as_slice() {
-            [single] => Arc::clone(&single.sql_schemas().declared),
+            [single] => Arc::clone(single.sql_schemas().declared()),
             tables => {
                 let mut merged = HashMap::new();
                 for t in tables {
-                    for (name, ty) in t.sql_schemas().declared.iter() {
+                    for (name, ty) in t.sql_schemas().declared().iter() {
                         merged.entry(name.clone()).or_insert_with(|| ty.clone());
                     }
                 }

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -29,7 +29,7 @@ use std::{
 };
 
 use arrow::record_batch::RecordBatch;
-use arrow_schema::SchemaRef;
+use arrow_schema::{DataType, SchemaRef};
 use dashmap::DashMap;
 use datafusion::{config::Dialect, error::DataFusionError};
 use futures::future::try_join_all;
@@ -56,6 +56,7 @@ use crate::{
     supertable::{
         Supertable,
         options::{Consistency, SupertableOptions},
+        query::sql::{cast_back_schema, cast_back_views},
         reader_cache::{DiskCacheConfig, DiskCacheError, DiskCacheStore},
     },
 };
@@ -621,6 +622,23 @@ impl Connection {
         // not as a `FROM` relation — still resolves).
         search_tvf::register_search_tvfs(&ctx, self.clone());
 
+        // Declared string types for cast-back, from each table's cached map (so
+        // a wide schema is walked once per table, not per query). A single-table
+        // query uses its map directly; a join merges, first table winning a name
+        // collision (rare).
+        let declared: Arc<HashMap<String, DataType>> = match handles.as_slice() {
+            [single] => Arc::clone(&single.sql_schemas().declared),
+            tables => {
+                let mut merged = HashMap::new();
+                for t in tables {
+                    for (name, ty) in t.sql_schemas().declared.iter() {
+                        merged.entry(name.clone()).or_insert_with(|| ty.clone());
+                    }
+                }
+                Arc::new(merged)
+            }
+        };
+
         let sql = sql.to_owned();
         let drive = async move {
             let df = ctx
@@ -632,12 +650,18 @@ impl Connection {
             // the output schema before collect() consumes the DataFrame so a
             // zero-row result returns one empty batch with the projected
             // schema, rather than a schema-less Vec — which the Python binding's
-            // Table.from_batches([]) can't build from.
-            let output_schema: SchemaRef = df.schema().inner().clone();
+            // Table.from_batches([]) can't build from. `cast_back_schema` so the
+            // empty-result schema matches the cast-back applied below.
+            let output_schema: SchemaRef = cast_back_schema(df.schema().inner(), &declared);
             let batches = df
                 .collect()
                 .await
                 .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;
+
+            // Views are internal to the scan; restore each result column to its
+            // declared type before it leaves the public API.
+            let batches = cast_back_views(batches, &declared)
+                .map_err(|e| InfinoError::Query(e.to_string()).with_context("query_sql", None))?;
             if batches.is_empty() {
                 Ok(vec![RecordBatch::new_empty(output_schema)])
             } else {
@@ -842,7 +866,7 @@ fn now_unix() -> u64 {
 mod tests {
     use std::{fs, path::Path, sync::Arc, thread};
 
-    use arrow_array::Int64Array;
+    use arrow_array::{Array, Int64Array, LargeStringArray, StringViewArray};
     use arrow_schema::{DataType, Field, Schema};
 
     use super::*;
@@ -1719,6 +1743,77 @@ mod tests {
             expected_schema,
             "zero-group schema must match the with-groups schema"
         );
+    }
+
+    /// Public-path cast-back: a non-FTS `LargeUtf8` column is scanned as
+    /// `Utf8View` but `Connection::query_sql` (the public entry point) returns
+    /// it as the declared `LargeUtf8`, so no `Utf8View` leaks to a caller. The
+    /// public-path version of the internal-reader test in `sql.rs`.
+    #[test]
+    fn query_sql_public_string_result_is_large_utf8_not_view() {
+        let conn = connect("memory://").expect("connect");
+        // No FTS on `title`, so it is a plain scalar string and gets viewed
+        // (the case the view targets).
+        let docs = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new())
+            .expect("create docs");
+        docs.append(&build_title_batch(&["alpha", "beta", "alpha"]))
+            .expect("append");
+
+        let batches = conn
+            .query_sql("SELECT title FROM docs GROUP BY title ORDER BY title")
+            .expect("group-by");
+        let col = batches[0].column(0);
+        assert_eq!(
+            col.data_type(),
+            &DataType::LargeUtf8,
+            "public result must be LargeUtf8, not Utf8View"
+        );
+        let titles = col
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("title downcasts to LargeStringArray");
+        let got: Vec<&str> = (0..titles.len()).map(|i| titles.value(i)).collect();
+        assert_eq!(got, vec!["alpha", "beta"], "distinct titles, ordered");
+        assert!(
+            col.as_any().downcast_ref::<StringViewArray>().is_none(),
+            "Utf8View must not leak to the caller"
+        );
+    }
+
+    /// Cross-table join whose key is a viewed string column: exercises the
+    /// multi-table declared-type merge and confirms the join key comes back the
+    /// declared `LargeUtf8`, not a view.
+    #[test]
+    fn query_sql_join_across_tables_on_string_column() {
+        let conn = connect("memory://").expect("connect");
+        // No FTS, so `title` is a plain scalar string (viewed) in both tables.
+        let a = conn
+            .create_table("a", schema_id_title(), IndexSpec::new())
+            .expect("create a");
+        let b = conn
+            .create_table("b", schema_id_title(), IndexSpec::new())
+            .expect("create b");
+        a.append(&build_title_batch(&["rust", "go"]))
+            .expect("append a");
+        b.append(&build_title_batch(&["rust", "go"]))
+            .expect("append b");
+
+        let batches = conn
+            .query_sql("SELECT a.title FROM a JOIN b ON a.title = b.title ORDER BY a.title")
+            .expect("cross-table join on a string key");
+        let col = batches[0].column(0);
+        assert_eq!(
+            col.data_type(),
+            &DataType::LargeUtf8,
+            "joined string key must be LargeUtf8, not a view"
+        );
+        let t = col
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("title is LargeUtf8");
+        let got: Vec<&str> = (0..t.len()).map(|i| t.value(i)).collect();
+        assert_eq!(got, vec!["go", "rust"]);
     }
 
     #[test]

--- a/src/memory/datafusion_pool.rs
+++ b/src/memory/datafusion_pool.rs
@@ -110,8 +110,21 @@ fn budgeted_runtime(budget: &Arc<ConnectionMemoryBudget>) -> DfResult<Arc<Runtim
 pub(crate) fn budgeted_session_context(
     budget: &Arc<ConnectionMemoryBudget>,
 ) -> DfResult<SessionContext> {
+    let mut config = SessionConfig::new();
+    // We scan string columns as `Utf8View` for fast comparisons, but a SQL
+    // result should be `LargeUtf8`. This flag makes DataFusion convert every
+    // `Utf8View` back to `LargeUtf8` at the query output, so the view stays
+    // internal to the scan and never reaches the caller.
+    //
+    // It also dodges a DataFusion 54 bug: an ungrouped MIN/MAX over a `Utf8View`
+    // column crashes the planner (`ProjectionPushdown`, `Utf8View`-vs-`LargeUtf8`
+    // mismatch). Converting the output to `LargeUtf8` keeps the types consistent.
+    //
+    // One consequence: a column the user themselves declared `Utf8View` is also
+    // converted, so SQL string results are always `LargeUtf8`, never a view.
+    config.options_mut().optimizer.expand_views_at_output = true;
     Ok(SessionContext::new_with_config_rt(
-        SessionConfig::new(),
+        config,
         budgeted_runtime(budget)?,
     ))
 }

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -602,7 +602,7 @@ impl Supertable {
         self.inner.options.user_schema()
     }
 
-    /// Cached per-table SQL schemas (scan view + declared string types).
+    /// Cached per-table SQL schemas (scan view + scalar schema).
     pub(crate) fn sql_schemas(&self) -> Arc<SqlSchemas> {
         self.inner.sql_schemas()
     }
@@ -1022,7 +1022,7 @@ impl SupertableReader {
         &self.inner.options
     }
 
-    /// Cached per-table SQL schemas (scan view + declared string types).
+    /// Cached per-table SQL schemas (scan view + scalar schema).
     pub(crate) fn sql_schemas(&self) -> Arc<SqlSchemas> {
         self.inner.sql_schemas()
     }

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -19,7 +19,7 @@ use std::{
     fmt,
     future::Future,
     io,
-    sync::{Arc, Mutex, Weak, atomic::AtomicBool},
+    sync::{Arc, Mutex, OnceLock, Weak, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -42,6 +42,7 @@ use crate::{
         ManifestLoadError, SuperfileUri, SupertableStats,
         manifest::commit::{PointerProbe, probe_pointer, read_pointer},
         options::Consistency,
+        query::sql::{SqlSchemas, build_sql_schemas},
         reader_cache::disk::{DiskCacheError, skip_background_fill},
         stats::process_rss_bytes,
         tombstones::{SidecarCache, TombstoneSeqView, cache::DEFAULT_SEAL_TTL},
@@ -146,6 +147,10 @@ pub(super) struct SupertableInner {
     /// (which rewrite the pointer without capturing its new etag) —
     /// the next probe then takes the full-read path and re-seeds it.
     pub(super) last_pointer_etag: Mutex<Option<String>>,
+    /// Cached SQL schemas, built once from the immutable `options` (lock-free
+    /// lazy init). A pure function of the schema, so no snapshot invalidation
+    /// (unlike `sql_session_cache`). See [`SqlSchemas`].
+    pub(super) sql_schemas: OnceLock<Arc<SqlSchemas>>,
 }
 
 impl SupertableInner {
@@ -154,6 +159,15 @@ impl SupertableInner {
     /// [`shared_query_runtime`].
     pub(super) fn query_runtime(&self) -> Arc<Runtime> {
         shared_io_runtime()
+    }
+
+    /// The table's cached SQL schemas, built once from the immutable options.
+    /// Cheap `Arc` clone on every call after the first.
+    pub(super) fn sql_schemas(&self) -> Arc<SqlSchemas> {
+        Arc::clone(
+            self.sql_schemas
+                .get_or_init(|| Arc::new(build_sql_schemas(&self.options))),
+        )
     }
 
     /// Push the current manifest's tombstone-seq view into the
@@ -281,6 +295,7 @@ impl Supertable {
             handle_id,
             last_pointer_check: Mutex::new(None),
             last_pointer_etag: Mutex::new(None),
+            sql_schemas: OnceLock::new(),
         });
         install_disk_cache_pinning(&inner);
         let st = Self { inner };
@@ -380,6 +395,7 @@ impl Supertable {
             handle_id,
             last_pointer_check: Mutex::new(None),
             last_pointer_etag: Mutex::new(None),
+            sql_schemas: OnceLock::new(),
         });
         install_disk_cache_pinning(&inner);
         debug!(
@@ -584,6 +600,11 @@ impl Supertable {
     /// ```
     pub fn schema(&self) -> SchemaRef {
         self.inner.options.user_schema()
+    }
+
+    /// Cached per-table SQL schemas (scan view + declared string types).
+    pub(crate) fn sql_schemas(&self) -> Arc<SqlSchemas> {
+        self.inner.sql_schemas()
     }
 
     /// Sync→async bridge for the public query surface. Mirrors the
@@ -996,6 +1017,11 @@ impl SupertableReader {
     /// Per-supertable configuration for this reader's snapshot.
     pub(crate) fn options(&self) -> &Arc<SupertableOptions> {
         &self.inner.options
+    }
+
+    /// Cached per-table SQL schemas (scan view + declared string types).
+    pub(crate) fn sql_schemas(&self) -> Arc<SqlSchemas> {
+        self.inner.sql_schemas()
     }
 
     /// Cached `SessionContext` keyed on the manifest `Arc`, reused by

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -54,7 +54,7 @@ use std::{
 };
 
 use arrow_array::ArrayRef;
-use arrow_schema::SchemaRef;
+use arrow_schema::{DataType, Schema, SchemaRef};
 use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::{
@@ -207,9 +207,35 @@ impl fmt::Debug for SupertableProvider {
     }
 }
 
+/// Rewrite non-FTS `Utf8`/`LargeUtf8` columns to `Utf8View` for the scan.
+///
+/// - Why: a view compares a 4-byte prefix before full bytes, so string
+///   GROUP BY / ORDER BY / equality skip most `memcmp`.
+/// - Stored bytes are unchanged; the result is cast back to each column's
+///   declared type at the query boundary (`cast_back_views`), so the view
+///   stays internal and a user-declared `Utf8View` is preserved.
+/// - FTS columns keep their stored type: pruning resolves them by it, so
+///   viewing one would silently disable its pruning.
+pub(crate) fn view_string_schema(schema: &Schema, fts_columns: &HashSet<&str>) -> SchemaRef {
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|f| match f.data_type() {
+            DataType::Utf8 | DataType::LargeUtf8 if !fts_columns.contains(f.name().as_str()) => {
+                // clone + retype: keeps nullability and metadata (`Field::new` drops it).
+                Arc::new(f.as_ref().clone().with_data_type(DataType::Utf8View))
+            }
+            _ => Arc::clone(f),
+        })
+        .collect::<Vec<_>>();
+
+    Arc::new(Schema::new_with_metadata(fields, schema.metadata().clone()))
+}
+
 impl SupertableProvider {
-    /// Build a provider over a pinned snapshot. The arguments
-    /// mirror what `Supertable::query_sql` already pins.
+    /// Build a provider over a pinned snapshot. `schema` is the scan schema
+    /// DataFusion plans against, already string-viewed and cached on the table
+    /// (`view_string_schema`); the provider stores it verbatim.
     pub(crate) fn new(
         schema: SchemaRef,
         manifest: Arc<ManifestSnapshot>,
@@ -220,6 +246,7 @@ impl SupertableProvider {
         let seq = STORE_URL_SEQ.fetch_add(1, atomic::Ordering::Relaxed);
         let store_url = ObjectStoreUrl::parse(format!("{SUPERFILE_STORE_URL_PREFIX}{seq}/"))
             .expect("invariant: a counter-derived store URL is always valid");
+
         Self {
             schema,
             manifest,
@@ -1424,6 +1451,63 @@ mod tests {
         },
         test_helpers::default_tokenizer,
     };
+
+    /// `view_string_schema` views scalar `Utf8`/`LargeUtf8` columns as
+    /// `Utf8View`, but leaves FTS columns as-is (their bloom / term-range
+    /// pruning resolves by the stored type) and passes non-string columns
+    /// through. Nullability and metadata are preserved.
+    #[test]
+    fn view_string_schema_views_scalars_excludes_fts_and_nonstrings() {
+        let mut schema_md = HashMap::new();
+        schema_md.insert("k".to_string(), "v".to_string());
+        // `category` carries per-field metadata: it must survive the retype
+        // (the reason we clone the field instead of `Field::new`).
+        let mut field_md = HashMap::new();
+        field_md.insert("ext".to_string(), "tag".to_string());
+        let schema = Schema::new_with_metadata(
+            vec![
+                Field::new("category", DataType::LargeUtf8, false).with_metadata(field_md), // -> view
+                Field::new("body", DataType::LargeUtf8, false), // FTS -> unchanged
+                Field::new("small", DataType::Utf8, true),      // scalar Utf8 -> view
+                Field::new("n", DataType::Int64, false),        // non-string -> unchanged
+            ],
+            schema_md,
+        );
+        let fts: HashSet<&str> = ["body"].into_iter().collect();
+
+        let out = view_string_schema(&schema, &fts);
+        assert_eq!(
+            out.field(0).data_type(),
+            &DataType::Utf8View,
+            "scalar LargeUtf8 becomes a view"
+        );
+        assert_eq!(
+            out.field(0).metadata().get("ext").map(String::as_str),
+            Some("tag"),
+            "per-field metadata must survive the retype"
+        );
+        assert_eq!(
+            out.field(1).data_type(),
+            &DataType::LargeUtf8,
+            "FTS column must stay LargeUtf8 or pruning silently breaks"
+        );
+        assert_eq!(
+            out.field(2).data_type(),
+            &DataType::Utf8View,
+            "scalar Utf8 becomes a view"
+        );
+        assert!(out.field(2).is_nullable(), "nullability preserved");
+        assert_eq!(
+            out.field(3).data_type(),
+            &DataType::Int64,
+            "non-string column untouched"
+        );
+        assert_eq!(
+            out.metadata().get("k").map(String::as_str),
+            Some("v"),
+            "schema-level metadata preserved"
+        );
+    }
 
     /// Build an in-memory Parquet file of `Int64` values `0..total`
     /// split into row groups of `rg_size` rows each.

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -210,9 +210,9 @@ impl fmt::Debug for SupertableProvider {
 ///
 /// - Why: a view compares a 4-byte prefix before full bytes, so string
 ///   GROUP BY / ORDER BY / equality skip most `memcmp`.
-/// - Stored bytes are unchanged; the result is cast back to each column's
-///   declared type at the query boundary (`cast_back_views`), so the view
-///   stays internal and a user-declared `Utf8View` is preserved.
+/// - Stored bytes are unchanged, and `expand_views_at_output` (set in
+///   `budgeted_session_context`) coerces the views back to `LargeUtf8` at the
+///   plan output, so the view stays internal and SQL results expose no view.
 /// - FTS columns keep their stored type: pruning resolves them by it, so
 ///   viewing one would silently disable its pruning.
 pub(crate) fn view_string_schema(schema: &Schema, fts_columns: &HashSet<&str>) -> SchemaRef {

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -46,10 +46,14 @@
 //! of each superfile was written with this same scalar schema, so
 //! round-trip shape matches without projection or rewrite.
 
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
-use arrow::record_batch::RecordBatch;
+use arrow::{compute::cast, record_batch::RecordBatch};
 use arrow_array::{Array, Decimal128Array};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use datafusion::{error::DataFusionError, execution::context::SessionContext, prelude::Expr};
 
 use crate::{
@@ -57,16 +61,51 @@ use crate::{
     supertable::{
         error::QueryError,
         handle::{Supertable, SupertableReader},
+        options::SupertableOptions,
         query::{
             covered_agg::CoveredAggregateRewrite,
             exec::{
                 fts_exec::register_bm25, hybrid_exec::register_hybrid_search,
                 match_exec::register_match, vector_exec::register_vector_search,
             },
-            provider::{SupertableProvider, TABLE_NAME},
+            provider::{SupertableProvider, TABLE_NAME, view_string_schema},
         },
     },
 };
+
+/// Per-table SQL schemas, built once (`build_sql_schemas`) and cached on the
+/// handle instead of recomputed per query. Cheap to clone (fields are `Arc`s).
+///
+/// - `scalar`: id + scalar + FTS columns, no vectors. What the search TVFs bind to.
+/// - `scan`: `scalar` with non-FTS strings viewed as `Utf8View`
+///   (`view_string_schema`). What the provider plans against.
+/// - `declared`: name -> declared string type, for `cast_back_views` at the
+///   result boundary.
+#[derive(Clone)]
+pub(crate) struct SqlSchemas {
+    pub(crate) scalar: SchemaRef,
+    pub(crate) scan: SchemaRef,
+    pub(crate) declared: Arc<HashMap<String, DataType>>,
+}
+
+/// Build the [`SqlSchemas`] for `options`. Called once per table; the result is
+/// cached on the handle. This is the one place that walks the full column set,
+/// so a wide (thousands of columns) table pays it once, not per query.
+pub(crate) fn build_sql_schemas(options: &SupertableOptions) -> SqlSchemas {
+    let scalar = options.scalar_schema();
+    let fts: HashSet<&str> = options
+        .fts_columns
+        .iter()
+        .map(|c| c.column.as_str())
+        .collect();
+    let scan = view_string_schema(&scalar, &fts);
+    let declared = Arc::new(declared_string_types(&scalar));
+    SqlSchemas {
+        scalar,
+        scan,
+        declared,
+    }
+}
 
 /// Classify a SQL execution error: budget exhaustion -> [`QueryError::OverBudget`]
 /// (the catalog surfaces it as `InfinoError::OverBudget`), else an execute error.
@@ -75,6 +114,106 @@ fn exec_query_error(e: DataFusionError) -> QueryError {
         DataFusionError::ResourcesExhausted(msg) => QueryError::OverBudget(msg),
         other => QueryError::Execute(other.to_string()),
     }
+}
+
+/// Name -> declared type for the string columns of the queried table(s). These
+/// are the only columns cast-back can restore to a user-declared type; non-string
+/// columns are irrelevant and skipped.
+pub(crate) fn declared_string_types(schema: &Schema) -> HashMap<String, DataType> {
+    schema
+        .fields()
+        .iter()
+        .filter(|f| {
+            matches!(
+                f.data_type(),
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+            )
+        })
+        .map(|f| (f.name().clone(), f.data_type().clone()))
+        .collect()
+}
+
+/// The type a result field should carry after cast-back, or `None` to leave it.
+///
+/// Only `Utf8View` result columns are touched (the scan views strings for
+/// speed). A view column is matched by name to `declared`: a column the user
+/// declared `Utf8View` is kept, one declared `Utf8`/`LargeUtf8` is restored to
+/// exactly that type. A view column with no declared match (an aggregate,
+/// alias, or other computed value) has no user-declared type, so it defaults to
+/// `LargeUtf8`.
+fn cast_back_type(field: &Field, declared: &HashMap<String, DataType>) -> Option<DataType> {
+    if field.data_type() != &DataType::Utf8View {
+        return None;
+    }
+    let target = declared
+        .get(field.name())
+        .cloned()
+        .unwrap_or(DataType::LargeUtf8);
+
+    (&target != field.data_type()).then_some(target)
+}
+
+/// Result schema after cast-back: each `Utf8View` field rewritten to its
+/// [`cast_back_type`], others unchanged. Types a zero-row result to match what
+/// a populated one returns.
+pub(crate) fn cast_back_schema(result: &Schema, declared: &HashMap<String, DataType>) -> SchemaRef {
+    let fields = result
+        .fields()
+        .iter()
+        .map(|f| match cast_back_type(f, declared) {
+            // clone + retype: keeps nullability and metadata (`Field::new` drops it).
+            Some(t) => Arc::new(f.as_ref().clone().with_data_type(t)),
+            None => Arc::clone(f),
+        })
+        .collect::<Vec<_>>();
+
+    Arc::new(Schema::new_with_metadata(fields, result.metadata().clone()))
+}
+
+/// Undo the scan's string viewing at the result boundary: cast each `Utf8View`
+/// column to its [`cast_back_type`], leave the rest. Keeps a user-declared
+/// `Utf8View` intact, restores columns we viewed to their declared type, and
+/// defaults computed view columns to `LargeUtf8`. Results are bounded, so the
+/// cast is cheap; no view column means no work.
+pub(crate) fn cast_back_views(
+    batches: Vec<RecordBatch>,
+    declared: &HashMap<String, DataType>,
+) -> Result<Vec<RecordBatch>, QueryError> {
+    let Some(first) = batches.first() else {
+        return Ok(batches);
+    };
+
+    if !first
+        .schema()
+        .fields()
+        .iter()
+        .any(|f| f.data_type() == &DataType::Utf8View)
+    {
+        return Ok(batches);
+    }
+
+    let target = cast_back_schema(first.schema().as_ref(), declared);
+    batches
+        .into_iter()
+        .map(|b| {
+            let cols = b
+                .columns()
+                .iter()
+                .zip(target.fields())
+                .map(|(c, tf)| {
+                    if c.data_type() == tf.data_type() {
+                        Ok(Arc::clone(c))
+                    } else {
+                        cast(c, tf.data_type())
+                            .map_err(|e| QueryError::Execute(format!("utf8view cast-back: {e}")))
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            RecordBatch::try_new(Arc::clone(&target), cols)
+                .map_err(|e| QueryError::Execute(format!("utf8view cast-back rebuild: {e}")))
+        })
+        .collect()
 }
 
 impl SupertableReader {
@@ -109,6 +248,10 @@ impl SupertableReader {
         // search TVFs. See [`SupertableReader::sql_session_context`].
         let ctx = self.sql_session_context()?;
 
+        // Cached declared string types: cast-back restores each result column
+        // to what the user declared (and keeps a declared `Utf8View`).
+        let schemas = self.sql_schemas();
+
         let sql = sql.to_owned();
         let drive = async move {
             let df = ctx
@@ -116,7 +259,8 @@ impl SupertableReader {
                 .await
                 .map_err(|e| QueryError::Plan(e.to_string()))?;
 
-            df.collect().await.map_err(exec_query_error)
+            let batches = df.collect().await.map_err(exec_query_error)?;
+            cast_back_views(batches, &schemas.declared)
         };
 
         // Drive through the shared sync→async bridge: ambient
@@ -161,9 +305,11 @@ impl SupertableReader {
 
         let store = Arc::clone(&self.options().store);
         let disk_cache = self.options().disk_cache.as_ref().map(Arc::clone);
-        let scalar_schema = self.options().scalar_schema();
+        // Cached per-table schemas: the provider scans the string-viewed `scan`
+        // schema; the TVFs bind to the plain `scalar` schema.
+        let schemas = self.sql_schemas();
         let provider = SupertableProvider::new(
-            Arc::clone(&scalar_schema),
+            schemas.scan.clone(),
             Arc::clone(&manifest),
             store,
             disk_cache,
@@ -186,11 +332,11 @@ impl SupertableReader {
         // Search TVFs (vector kNN, BM25 FTS, hybrid RRF) bound to
         // the pinned snapshot. They lower to custom `ExecutionPlan`
         // nodes that call the async kernels inside `execute()`.
-        register_vector_search(&ctx, Arc::clone(&reader), Arc::clone(&scalar_schema));
-        register_bm25(&ctx, Arc::clone(&reader), Arc::clone(&scalar_schema));
+        register_vector_search(&ctx, Arc::clone(&reader), schemas.scalar.clone());
+        register_bm25(&ctx, Arc::clone(&reader), schemas.scalar.clone());
         // Unranked token / exact match TVFs (siblings of bm25_search).
-        register_match(&ctx, Arc::clone(&reader), Arc::clone(&scalar_schema));
-        register_hybrid_search(&ctx, Arc::clone(&reader), Arc::clone(&scalar_schema));
+        register_match(&ctx, Arc::clone(&reader), schemas.scalar.clone());
+        register_hybrid_search(&ctx, Arc::clone(&reader), schemas.scalar.clone());
 
         *guard = Some((Arc::clone(&manifest), ctx.clone()));
 
@@ -258,9 +404,9 @@ impl Supertable {
         let manifest = Arc::clone(reader.manifest());
         let store = Arc::clone(&self.options().store);
         let disk_cache = self.options().disk_cache.as_ref().map(Arc::clone);
-        let scalar_schema = self.options().scalar_schema();
+        // Provider scans the cached string-viewed schema.
         let provider = SupertableProvider::new(
-            scalar_schema,
+            self.sql_schemas().scan.clone(),
             manifest,
             store,
             disk_cache,
@@ -303,7 +449,7 @@ fn extract_id_column(batches: &[RecordBatch]) -> Result<Vec<i128>, QueryError> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::HashMap, sync::Arc};
 
     use arrow_array::{
         Array, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray,
@@ -318,7 +464,13 @@ mod tests {
             builder::{FtsConfig, VectorConfig},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
-        supertable::{Supertable, SupertableOptions, error::QueryError},
+        supertable::{
+            Supertable, SupertableOptions,
+            error::QueryError,
+            query::sql::{
+                build_sql_schemas, cast_back_schema, cast_back_views, declared_string_types,
+            },
+        },
         test_helpers::default_tokenizer as tok,
     };
 
@@ -386,6 +538,17 @@ mod tests {
             vec![Arc::new(cat_arr), Arc::new(title_arr)],
         )
         .expect("build batch")
+    }
+
+    /// A single-superfile table seeded with one committed batch of
+    /// `cats`/`titles`. Collapses the create + append + commit boilerplate the
+    /// string-view tests share.
+    fn seeded(cats: &[&str], titles: &[&str]) -> Supertable {
+        let st = Supertable::create(options_id_cat_title()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_cat_batch(0, cats, titles)).expect("append");
+        w.commit().expect("commit");
+        st
     }
 
     /// Convenience: run a query and pull a single `Int64` aggregate
@@ -567,6 +730,502 @@ mod tests {
                 ("rust".to_string(), 3),
             ]
         );
+    }
+
+    // ---- Utf8View scan / cast-back ----------------------------------------
+
+    /// The scan runs strings as `Utf8View`; the result is cast back to the
+    /// declared type so no view leaks to a caller. Gate for the common case: a
+    /// GROUP BY key on a `LargeUtf8` column comes back `LargeUtf8`, not a view.
+    #[test]
+    fn query_sql_string_group_by_key_is_large_utf8_not_view() {
+        let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);
+
+        let batches = st
+            .reader()
+            .query_sql("SELECT category FROM supertable GROUP BY category")
+            .expect("group-by");
+        let col = batches[0].column(0);
+        assert_eq!(
+            col.data_type(),
+            &DataType::LargeUtf8,
+            "public result must be LargeUtf8, not Utf8View"
+        );
+        assert!(
+            col.as_any().downcast_ref::<LargeStringArray>().is_some(),
+            "category should downcast to LargeStringArray"
+        );
+        assert!(
+            col.as_any().downcast_ref::<StringViewArray>().is_none(),
+            "Utf8View must not leak to the caller"
+        );
+    }
+
+    /// A projected + `ORDER BY` string column returns `LargeUtf8` and the
+    /// values are correctly sorted (the view compare ran during the sort).
+    #[test]
+    fn query_sql_ordered_string_projection_is_large_utf8_and_sorted() {
+        let st = seeded(&["rust", "go", "python"], &["a", "b", "c"]);
+        let batches = st
+            .reader()
+            .query_sql("SELECT category FROM supertable ORDER BY category")
+            .expect("order-by");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("category is LargeUtf8 after cast-back");
+        let got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
+        assert_eq!(got, vec!["go", "python", "rust"]);
+    }
+
+    /// Grouped `MIN(string)` aggregates on the view and returns `LargeUtf8`
+    /// after cast-back, with correct per-group minima.
+    #[test]
+    fn query_sql_grouped_min_string_is_large_utf8() {
+        let st = seeded(&["rust", "rust", "go", "go"], &["b", "a", "d", "c"]);
+        let batches = st
+            .reader()
+            .query_sql(
+                "SELECT category, MIN(title) AS m FROM supertable \
+                 GROUP BY category ORDER BY category",
+            )
+            .expect("grouped min");
+        let cat = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("category is LargeUtf8 after cast-back");
+        let m = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("MIN(title) is LargeUtf8 after cast-back");
+        let got: Vec<(&str, &str)> = (0..cat.len()).map(|i| (cat.value(i), m.value(i))).collect();
+        assert_eq!(got, vec![("go", "c"), ("rust", "a")]);
+    }
+
+    /// KNOWN LIMITATION: an *ungrouped* `MIN`/`MAX(string)` over a `Utf8View`
+    /// column trips a DataFusion 53.1 `ProjectionPushdown` bug (`Schema
+    /// mismatch: Utf8View vs LargeUtf8`) before the cast-back can run. Grouped
+    /// MIN/MAX (above) is fine. Re-check on a DataFusion upgrade; if fixed
+    /// there, un-ignore this.
+    #[test]
+    #[ignore = "DataFusion 53.1 ProjectionPushdown bug on ungrouped MIN/MAX over Utf8View"]
+    fn query_sql_ungrouped_min_string_datafusion53_projection_pushdown_bug() {
+        let st = seeded(&["rust", "go", "python"], &["a", "b", "c"]);
+        let batches = st
+            .reader()
+            .query_sql("SELECT MIN(category) AS m FROM supertable")
+            .expect("ungrouped min (fails on DF 53.1 with the view)");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("MIN(string) is LargeUtf8 after cast-back");
+        assert_eq!(col.value(0), "go");
+    }
+
+    /// A declared map covering the three string cases the cast-back must honor.
+    fn declared(pairs: &[(&str, DataType)]) -> HashMap<String, DataType> {
+        pairs
+            .iter()
+            .map(|(n, t)| (n.to_string(), t.clone()))
+            .collect()
+    }
+
+    /// Unit: cast-back restores each `Utf8View` result column to its declared
+    /// type. A declared `Utf8View` is kept, a declared `Utf8`/`LargeUtf8` is
+    /// restored to exactly that (no widening), a column with no declared match
+    /// (computed) defaults to `LargeUtf8`, and non-string columns are untouched.
+    #[test]
+    fn cast_back_views_restores_each_column_to_its_declared_type() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("large", DataType::Utf8View, false), // declared LargeUtf8, viewed
+            Field::new("small", DataType::Utf8View, false), // declared Utf8, viewed
+            Field::new("keep", DataType::Utf8View, false),  // declared Utf8View, keep
+            Field::new("agg", DataType::Utf8View, false),   // computed, no declared type
+            Field::new("n", DataType::Int64, false),        // non-string
+        ]));
+        let str_col = || Arc::new(StringViewArray::from(vec!["a", "b"]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                str_col(),
+                str_col(),
+                str_col(),
+                str_col(),
+                Arc::new(Int64Array::from(vec![1, 2])),
+            ],
+        )
+        .expect("batch");
+
+        let declared = declared(&[
+            ("large", DataType::LargeUtf8),
+            ("small", DataType::Utf8),
+            ("keep", DataType::Utf8View),
+        ]);
+        let out = cast_back_views(vec![batch], &declared).expect("cast ok");
+        let s = out[0].schema();
+        assert_eq!(
+            s.field(0).data_type(),
+            &DataType::LargeUtf8,
+            "declared LargeUtf8 restored"
+        );
+        assert_eq!(
+            s.field(1).data_type(),
+            &DataType::Utf8,
+            "declared Utf8 restored, no widening"
+        );
+        assert_eq!(
+            s.field(2).data_type(),
+            &DataType::Utf8View,
+            "user-declared view kept"
+        );
+        assert_eq!(
+            s.field(3).data_type(),
+            &DataType::LargeUtf8,
+            "computed view defaults to LargeUtf8"
+        );
+        assert_eq!(
+            s.field(4).data_type(),
+            &DataType::Int64,
+            "non-string untouched"
+        );
+    }
+
+    /// Unit: nulls survive the cast-back intact.
+    #[test]
+    fn cast_back_views_preserves_nulls() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8View, true)]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringViewArray::from(vec![
+                Some("a"),
+                None,
+                Some("c"),
+            ]))],
+        )
+        .expect("batch");
+        let out =
+            cast_back_views(vec![batch], &declared(&[("s", DataType::LargeUtf8)])).expect("cast");
+        let s = out[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("view -> LargeUtf8");
+        assert!(!s.is_null(0));
+        assert!(s.is_null(1), "null preserved through cast-back");
+        assert_eq!(s.value(2), "c");
+    }
+
+    /// Unit: a result with no view column takes the fast path unchanged.
+    #[test]
+    fn cast_back_views_without_views_is_unchanged() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "c",
+            DataType::LargeUtf8,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(LargeStringArray::from(vec!["x"]))])
+            .expect("batch");
+        let out =
+            cast_back_views(vec![batch], &declared(&[("c", DataType::LargeUtf8)])).expect("ok");
+        assert_eq!(out[0].column(0).data_type(), &DataType::LargeUtf8);
+    }
+
+    /// Unit: `cast_back_schema` yields the same per-column types the data cast
+    /// produces, and preserves nullability + metadata.
+    #[test]
+    fn cast_back_schema_matches_the_data_cast() {
+        let mut md = HashMap::new();
+        md.insert("k".to_string(), "v".to_string());
+        let result = Schema::new_with_metadata(
+            vec![
+                Field::new("keep", DataType::Utf8View, true),
+                Field::new("large", DataType::Utf8View, false),
+                Field::new("n", DataType::Int64, false),
+            ],
+            md,
+        );
+        let out = cast_back_schema(
+            &result,
+            &declared(&[("keep", DataType::Utf8View), ("large", DataType::LargeUtf8)]),
+        );
+        assert_eq!(
+            out.field(0).data_type(),
+            &DataType::Utf8View,
+            "declared view kept"
+        );
+        assert!(out.field(0).is_nullable(), "nullability preserved");
+        assert_eq!(out.field(1).data_type(), &DataType::LargeUtf8);
+        assert_eq!(out.field(2).data_type(), &DataType::Int64);
+        assert_eq!(
+            out.metadata().get("k").map(String::as_str),
+            Some("v"),
+            "metadata preserved"
+        );
+    }
+
+    /// Unit: `build_sql_schemas` views the scan schema (non-FTS strings ->
+    /// `Utf8View`, FTS kept), keeps the plain `scalar`, and records declared
+    /// types. This is the walk done once per table.
+    #[test]
+    fn build_sql_schemas_views_scan_keeps_scalar_and_declares() {
+        let s = build_sql_schemas(&options_id_cat_title());
+        // scan: `category` (non-FTS string) viewed; `title` (FTS) kept.
+        assert_eq!(
+            s.scan
+                .field_with_name("category")
+                .expect("category")
+                .data_type(),
+            &DataType::Utf8View,
+        );
+        assert_eq!(
+            s.scan.field_with_name("title").expect("title").data_type(),
+            &DataType::LargeUtf8,
+            "FTS column stays LargeUtf8 in the scan schema",
+        );
+        // scalar: no viewing.
+        assert_eq!(
+            s.scalar
+                .field_with_name("category")
+                .expect("category")
+                .data_type(),
+            &DataType::LargeUtf8,
+        );
+        // declared: name -> declared type.
+        assert_eq!(s.declared.get("category"), Some(&DataType::LargeUtf8));
+        assert_eq!(s.declared.get("title"), Some(&DataType::LargeUtf8));
+    }
+
+    /// The per-table schemas are built once and memoized on the handle, not
+    /// rebuilt per query (the whole point of the cache for wide tables).
+    #[test]
+    fn sql_schemas_is_memoized_across_calls() {
+        let st = Supertable::create(options_id_cat_title()).expect("create");
+        let a = st.sql_schemas();
+        let b = st.sql_schemas();
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "sql_schemas must be cached (same Arc), not recomputed per call",
+        );
+    }
+
+    /// Unit: `declared_string_types` collects only string columns.
+    #[test]
+    fn declared_string_types_collects_string_columns_only() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::LargeUtf8, false),
+            Field::new("b", DataType::Utf8, false),
+            Field::new("c", DataType::Utf8View, false),
+            Field::new("n", DataType::Int64, false),
+        ]);
+        let m = declared_string_types(&schema);
+        assert_eq!(m.len(), 3, "only the three string columns");
+        assert_eq!(m.get("a"), Some(&DataType::LargeUtf8));
+        assert_eq!(m.get("b"), Some(&DataType::Utf8));
+        assert_eq!(m.get("c"), Some(&DataType::Utf8View));
+        assert!(!m.contains_key("n"), "non-string skipped");
+    }
+
+    /// A column the user explicitly declared `Utf8View` must come back
+    /// `Utf8View`: cast-back restores declared types, it does not force
+    /// `LargeUtf8` on a type the user chose.
+    #[test]
+    fn query_sql_keeps_user_declared_utf8view_column() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("category", DataType::Utf8View, false), // user declares a view
+            Field::new("title", DataType::LargeUtf8, false),   // FTS column must be LargeUtf8
+        ]));
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("rayon pool"),
+        );
+        let opts = SupertableOptions::new(
+            Arc::clone(&schema),
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(tok()),
+        )
+        .expect("valid options")
+        .with_writer_pool(pool);
+
+        let st = Supertable::create(opts).expect("create");
+        let mut w = st.writer().expect("writer");
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringViewArray::from(vec!["rust", "go", "rust"])),
+                Arc::new(LargeStringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .expect("batch");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+
+        let batches = st
+            .reader()
+            .query_sql("SELECT category FROM supertable GROUP BY category")
+            .expect("group-by");
+        assert_eq!(
+            batches[0].column(0).data_type(),
+            &DataType::Utf8View,
+            "a user-declared Utf8View column must not be rewritten by cast-back"
+        );
+    }
+
+    /// Alias on a viewed string column: the aliased output name has no declared
+    /// type, so it defaults to `LargeUtf8`; values stay correct.
+    #[test]
+    fn query_sql_aliased_string_column_is_large_utf8() {
+        let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);
+
+        let batches = st
+            .reader()
+            .query_sql("SELECT category AS c FROM supertable GROUP BY c ORDER BY c")
+            .expect("alias");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("aliased column is LargeUtf8");
+        let got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
+        assert_eq!(got, vec!["go", "rust"]);
+    }
+
+    /// String column projected through a CTE: the name survives, so it is
+    /// restored to its declared type.
+    #[test]
+    fn query_sql_cte_string_column_is_declared_type() {
+        let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);
+
+        let batches = st
+            .reader()
+            .query_sql(
+                "WITH t AS (SELECT category FROM supertable) \
+                 SELECT category FROM t GROUP BY category ORDER BY category",
+            )
+            .expect("cte");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("CTE column is LargeUtf8");
+        let got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
+        assert_eq!(got, vec!["go", "rust"]);
+    }
+
+    /// String column projected through a FROM-subquery.
+    #[test]
+    fn query_sql_subquery_string_column_is_declared_type() {
+        let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);
+
+        let batches = st
+            .reader()
+            .query_sql(
+                "SELECT category FROM (SELECT category FROM supertable) sub \
+                 GROUP BY category ORDER BY category",
+            )
+            .expect("subquery");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("subquery column is LargeUtf8");
+        let got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
+        assert_eq!(got, vec!["go", "rust"]);
+    }
+
+    /// No data loss through the view + cast-back for values that stress
+    /// `Utf8View`'s layout: strings past the 12-byte inline limit (stored
+    /// out-of-line), values sharing a 4-byte prefix (the view compares the
+    /// prefix first, so it must fall through to the full bytes and keep them
+    /// distinct), an empty string, and multi-byte unicode. GROUP BY exercises
+    /// both the comparison (distinct groups) and the cast-back (exact values).
+    #[test]
+    fn query_sql_string_values_survive_view_and_cast_back() {
+        let vals = [
+            "",                        // empty
+            "short",                   // inline (<= 12 bytes)
+            "sixteen_byte_val",        // 16 bytes, out-of-line
+            "prefabricated_alpha",     // shares "pref" 4-byte prefix ...
+            "prefabricated_omega",     // ... differs later, must stay distinct
+            "café_ünïcode_日本語_str", // multi-byte unicode, out-of-line
+            "sixteen_byte_val",        // duplicate: must fold to one group
+        ];
+        let titles: Vec<&str> = (0..vals.len()).map(|_| "t").collect();
+        let st = seeded(&vals, &titles);
+        let batches = st
+            .reader()
+            .query_sql("SELECT category FROM supertable GROUP BY category ORDER BY category")
+            .expect("group-by over layout-stressing values");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("category is LargeUtf8 after cast-back");
+        let mut got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
+        got.sort_unstable();
+
+        // Every distinct value survives byte-for-byte; the duplicate folds to
+        // one; the prefix-sharing pair stays as two.
+        let mut want: Vec<&str> = vec![
+            "",
+            "café_ünïcode_日本語_str",
+            "prefabricated_alpha",
+            "prefabricated_omega",
+            "short",
+            "sixteen_byte_val",
+        ];
+        want.sort_unstable();
+        assert_eq!(got, want);
+    }
+
+    /// `SELECT DISTINCT` on a viewed string column: dedup compares on the view,
+    /// result comes back the declared type.
+    #[test]
+    fn query_sql_distinct_string_is_declared_type() {
+        let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);
+
+        let batches = st
+            .reader()
+            .query_sql("SELECT DISTINCT category FROM supertable ORDER BY category")
+            .expect("distinct");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("distinct column is LargeUtf8");
+        let got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
+        assert_eq!(got, vec!["go", "rust"]);
+    }
+
+    /// Self-join whose join key is a viewed string column: the equality runs on
+    /// `Utf8View`, and the projected key comes back its declared type.
+    #[test]
+    fn query_sql_self_join_on_string_key() {
+        let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);
+
+        let batches = st
+            .reader()
+            .query_sql(
+                "SELECT a.category AS cat FROM supertable a \
+                 JOIN supertable b ON a.category = b.category \
+                 GROUP BY a.category ORDER BY a.category",
+            )
+            .expect("self-join on string key");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("join key projects as LargeUtf8");
+        let got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
+        assert_eq!(got, vec!["go", "rust"]);
     }
 
     #[test]

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -83,9 +83,26 @@ use crate::{
 ///   result boundary.
 #[derive(Clone)]
 pub(crate) struct SqlSchemas {
-    pub(crate) scalar: SchemaRef,
-    pub(crate) scan: SchemaRef,
-    pub(crate) declared: Arc<HashMap<String, DataType>>,
+    scalar: SchemaRef,
+    scan: SchemaRef,
+    declared: Arc<HashMap<String, DataType>>,
+}
+
+impl SqlSchemas {
+    /// Plain scalar schema (id + scalar + FTS, no vectors) the TVFs bind to.
+    pub(crate) fn scalar(&self) -> &SchemaRef {
+        &self.scalar
+    }
+
+    /// String-viewed schema the provider plans against.
+    pub(crate) fn scan(&self) -> &SchemaRef {
+        &self.scan
+    }
+
+    /// Declared string types, for restoring result columns at the boundary.
+    pub(crate) fn declared(&self) -> &Arc<HashMap<String, DataType>> {
+        &self.declared
+    }
 }
 
 /// Build the [`SqlSchemas`] for `options`. Called once per table; the result is
@@ -260,7 +277,7 @@ impl SupertableReader {
                 .map_err(|e| QueryError::Plan(e.to_string()))?;
 
             let batches = df.collect().await.map_err(exec_query_error)?;
-            cast_back_views(batches, &schemas.declared)
+            cast_back_views(batches, schemas.declared())
         };
 
         // Drive through the shared sync→async bridge: ambient
@@ -309,7 +326,7 @@ impl SupertableReader {
         // schema; the TVFs bind to the plain `scalar` schema.
         let schemas = self.sql_schemas();
         let provider = SupertableProvider::new(
-            schemas.scan.clone(),
+            schemas.scan().clone(),
             Arc::clone(&manifest),
             store,
             disk_cache,
@@ -332,11 +349,11 @@ impl SupertableReader {
         // Search TVFs (vector kNN, BM25 FTS, hybrid RRF) bound to
         // the pinned snapshot. They lower to custom `ExecutionPlan`
         // nodes that call the async kernels inside `execute()`.
-        register_vector_search(&ctx, Arc::clone(&reader), schemas.scalar.clone());
-        register_bm25(&ctx, Arc::clone(&reader), schemas.scalar.clone());
+        register_vector_search(&ctx, Arc::clone(&reader), schemas.scalar().clone());
+        register_bm25(&ctx, Arc::clone(&reader), schemas.scalar().clone());
         // Unranked token / exact match TVFs (siblings of bm25_search).
-        register_match(&ctx, Arc::clone(&reader), schemas.scalar.clone());
-        register_hybrid_search(&ctx, Arc::clone(&reader), schemas.scalar.clone());
+        register_match(&ctx, Arc::clone(&reader), schemas.scalar().clone());
+        register_hybrid_search(&ctx, Arc::clone(&reader), schemas.scalar().clone());
 
         *guard = Some((Arc::clone(&manifest), ctx.clone()));
 
@@ -406,7 +423,7 @@ impl Supertable {
         let disk_cache = self.options().disk_cache.as_ref().map(Arc::clone);
         // Provider scans the cached string-viewed schema.
         let provider = SupertableProvider::new(
-            self.sql_schemas().scan.clone(),
+            self.sql_schemas().scan().clone(),
             manifest,
             store,
             disk_cache,
@@ -975,28 +992,31 @@ mod tests {
         let s = build_sql_schemas(&options_id_cat_title());
         // scan: `category` (non-FTS string) viewed; `title` (FTS) kept.
         assert_eq!(
-            s.scan
+            s.scan()
                 .field_with_name("category")
                 .expect("category")
                 .data_type(),
             &DataType::Utf8View,
         );
         assert_eq!(
-            s.scan.field_with_name("title").expect("title").data_type(),
+            s.scan()
+                .field_with_name("title")
+                .expect("title")
+                .data_type(),
             &DataType::LargeUtf8,
             "FTS column stays LargeUtf8 in the scan schema",
         );
         // scalar: no viewing.
         assert_eq!(
-            s.scalar
+            s.scalar()
                 .field_with_name("category")
                 .expect("category")
                 .data_type(),
             &DataType::LargeUtf8,
         );
         // declared: name -> declared type.
-        assert_eq!(s.declared.get("category"), Some(&DataType::LargeUtf8));
-        assert_eq!(s.declared.get("title"), Some(&DataType::LargeUtf8));
+        assert_eq!(s.declared().get("category"), Some(&DataType::LargeUtf8));
+        assert_eq!(s.declared().get("title"), Some(&DataType::LargeUtf8));
     }
 
     /// The per-table schemas are built once and memoized on the handle, not

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -46,14 +46,11 @@
 //! of each superfile was written with this same scalar schema, so
 //! round-trip shape matches without projection or rewrite.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
-use arrow::{compute::cast, record_batch::RecordBatch};
+use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, Decimal128Array};
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::SchemaRef;
 use datafusion::{error::DataFusionError, execution::context::SessionContext, prelude::Expr};
 
 use crate::{
@@ -79,13 +76,10 @@ use crate::{
 /// - `scalar`: id + scalar + FTS columns, no vectors. What the search TVFs bind to.
 /// - `scan`: `scalar` with non-FTS strings viewed as `Utf8View`
 ///   (`view_string_schema`). What the provider plans against.
-/// - `declared`: name -> declared string type, for `cast_back_views` at the
-///   result boundary.
 #[derive(Clone)]
 pub(crate) struct SqlSchemas {
     scalar: SchemaRef,
     scan: SchemaRef,
-    declared: Arc<HashMap<String, DataType>>,
 }
 
 impl SqlSchemas {
@@ -97,11 +91,6 @@ impl SqlSchemas {
     /// String-viewed schema the provider plans against.
     pub(crate) fn scan(&self) -> &SchemaRef {
         &self.scan
-    }
-
-    /// Declared string types, for restoring result columns at the boundary.
-    pub(crate) fn declared(&self) -> &Arc<HashMap<String, DataType>> {
-        &self.declared
     }
 }
 
@@ -116,12 +105,7 @@ pub(crate) fn build_sql_schemas(options: &SupertableOptions) -> SqlSchemas {
         .map(|c| c.column.as_str())
         .collect();
     let scan = view_string_schema(&scalar, &fts);
-    let declared = Arc::new(declared_string_types(&scalar));
-    SqlSchemas {
-        scalar,
-        scan,
-        declared,
-    }
+    SqlSchemas { scalar, scan }
 }
 
 /// Classify a SQL execution error: budget exhaustion -> [`QueryError::OverBudget`]
@@ -131,106 +115,6 @@ fn exec_query_error(e: DataFusionError) -> QueryError {
         DataFusionError::ResourcesExhausted(msg) => QueryError::OverBudget(msg),
         other => QueryError::Execute(other.to_string()),
     }
-}
-
-/// Name -> declared type for the string columns of the queried table(s). These
-/// are the only columns cast-back can restore to a user-declared type; non-string
-/// columns are irrelevant and skipped.
-pub(crate) fn declared_string_types(schema: &Schema) -> HashMap<String, DataType> {
-    schema
-        .fields()
-        .iter()
-        .filter(|f| {
-            matches!(
-                f.data_type(),
-                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
-            )
-        })
-        .map(|f| (f.name().clone(), f.data_type().clone()))
-        .collect()
-}
-
-/// The type a result field should carry after cast-back, or `None` to leave it.
-///
-/// Only `Utf8View` result columns are touched (the scan views strings for
-/// speed). A view column is matched by name to `declared`: a column the user
-/// declared `Utf8View` is kept, one declared `Utf8`/`LargeUtf8` is restored to
-/// exactly that type. A view column with no declared match (an aggregate,
-/// alias, or other computed value) has no user-declared type, so it defaults to
-/// `LargeUtf8`.
-fn cast_back_type(field: &Field, declared: &HashMap<String, DataType>) -> Option<DataType> {
-    if field.data_type() != &DataType::Utf8View {
-        return None;
-    }
-    let target = declared
-        .get(field.name())
-        .cloned()
-        .unwrap_or(DataType::LargeUtf8);
-
-    (&target != field.data_type()).then_some(target)
-}
-
-/// Result schema after cast-back: each `Utf8View` field rewritten to its
-/// [`cast_back_type`], others unchanged. Types a zero-row result to match what
-/// a populated one returns.
-pub(crate) fn cast_back_schema(result: &Schema, declared: &HashMap<String, DataType>) -> SchemaRef {
-    let fields = result
-        .fields()
-        .iter()
-        .map(|f| match cast_back_type(f, declared) {
-            // clone + retype: keeps nullability and metadata (`Field::new` drops it).
-            Some(t) => Arc::new(f.as_ref().clone().with_data_type(t)),
-            None => Arc::clone(f),
-        })
-        .collect::<Vec<_>>();
-
-    Arc::new(Schema::new_with_metadata(fields, result.metadata().clone()))
-}
-
-/// Undo the scan's string viewing at the result boundary: cast each `Utf8View`
-/// column to its [`cast_back_type`], leave the rest. Keeps a user-declared
-/// `Utf8View` intact, restores columns we viewed to their declared type, and
-/// defaults computed view columns to `LargeUtf8`. Results are bounded, so the
-/// cast is cheap; no view column means no work.
-pub(crate) fn cast_back_views(
-    batches: Vec<RecordBatch>,
-    declared: &HashMap<String, DataType>,
-) -> Result<Vec<RecordBatch>, QueryError> {
-    let Some(first) = batches.first() else {
-        return Ok(batches);
-    };
-
-    if !first
-        .schema()
-        .fields()
-        .iter()
-        .any(|f| f.data_type() == &DataType::Utf8View)
-    {
-        return Ok(batches);
-    }
-
-    let target = cast_back_schema(first.schema().as_ref(), declared);
-    batches
-        .into_iter()
-        .map(|b| {
-            let cols = b
-                .columns()
-                .iter()
-                .zip(target.fields())
-                .map(|(c, tf)| {
-                    if c.data_type() == tf.data_type() {
-                        Ok(Arc::clone(c))
-                    } else {
-                        cast(c, tf.data_type())
-                            .map_err(|e| QueryError::Execute(format!("utf8view cast-back: {e}")))
-                    }
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            RecordBatch::try_new(Arc::clone(&target), cols)
-                .map_err(|e| QueryError::Execute(format!("utf8view cast-back rebuild: {e}")))
-        })
-        .collect()
 }
 
 impl SupertableReader {
@@ -265,10 +149,6 @@ impl SupertableReader {
         // search TVFs. See [`SupertableReader::sql_session_context`].
         let ctx = self.sql_session_context()?;
 
-        // Cached declared string types: cast-back restores each result column
-        // to what the user declared (and keeps a declared `Utf8View`).
-        let schemas = self.sql_schemas();
-
         let sql = sql.to_owned();
         let drive = async move {
             let df = ctx
@@ -276,8 +156,10 @@ impl SupertableReader {
                 .await
                 .map_err(|e| QueryError::Plan(e.to_string()))?;
 
-            let batches = df.collect().await.map_err(exec_query_error)?;
-            cast_back_views(batches, schemas.declared())
+            // The scan runs strings as `Utf8View`; `expand_views_at_output`
+            // (set in `budgeted_session_context`) coerces them back to
+            // `LargeUtf8` at the plan output, so the result carries no view.
+            df.collect().await.map_err(exec_query_error)
         };
 
         // Drive through the shared sync→async bridge: ambient
@@ -466,7 +348,7 @@ fn extract_id_column(batches: &[RecordBatch]) -> Result<Vec<i128>, QueryError> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::sync::Arc;
 
     use arrow_array::{
         Array, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray,
@@ -482,11 +364,7 @@ mod tests {
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{
-            Supertable, SupertableOptions,
-            error::QueryError,
-            query::sql::{
-                build_sql_schemas, cast_back_schema, cast_back_views, declared_string_types,
-            },
+            Supertable, SupertableOptions, error::QueryError, query::sql::build_sql_schemas,
         },
         test_helpers::default_tokenizer as tok,
     };
@@ -749,10 +627,10 @@ mod tests {
         );
     }
 
-    // ---- Utf8View scan / cast-back ----------------------------------------
+    // ---- Utf8View scan ----------------------------------------------------
 
-    /// The scan runs strings as `Utf8View`; the result is cast back to the
-    /// declared type so no view leaks to a caller. Gate for the common case: a
+    /// The scan runs strings as `Utf8View`, but `expand_views_at_output` coerces
+    /// them to `LargeUtf8` at the plan output, so no view leaks to a caller: a
     /// GROUP BY key on a `LargeUtf8` column comes back `LargeUtf8`, not a view.
     #[test]
     fn query_sql_string_group_by_key_is_large_utf8_not_view() {
@@ -791,13 +669,13 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<LargeStringArray>()
-            .expect("category is LargeUtf8 after cast-back");
+            .expect("category is LargeUtf8");
         let got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
         assert_eq!(got, vec!["go", "python", "rust"]);
     }
 
     /// Grouped `MIN(string)` aggregates on the view and returns `LargeUtf8`
-    /// after cast-back, with correct per-group minima.
+    ///, with correct per-group minima.
     #[test]
     fn query_sql_grouped_min_string_is_large_utf8() {
         let st = seeded(&["rust", "rust", "go", "go"], &["b", "a", "d", "c"]);
@@ -812,183 +690,40 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<LargeStringArray>()
-            .expect("category is LargeUtf8 after cast-back");
+            .expect("category is LargeUtf8");
         let m = batches[0]
             .column(1)
             .as_any()
             .downcast_ref::<LargeStringArray>()
-            .expect("MIN(title) is LargeUtf8 after cast-back");
+            .expect("MIN(title) is LargeUtf8");
         let got: Vec<(&str, &str)> = (0..cat.len()).map(|i| (cat.value(i), m.value(i))).collect();
         assert_eq!(got, vec![("go", "c"), ("rust", "a")]);
     }
 
-    /// KNOWN LIMITATION: an *ungrouped* `MIN`/`MAX(string)` over a `Utf8View`
-    /// column trips a DataFusion 53.1 `ProjectionPushdown` bug (`Schema
-    /// mismatch: Utf8View vs LargeUtf8`) before the cast-back can run. Grouped
-    /// MIN/MAX (above) is fine. Re-check on a DataFusion upgrade; if fixed
-    /// there, un-ignore this.
+    /// Ungrouped `MIN(string)` over a viewed column. On its own this trips a
+    /// DataFusion `ProjectionPushdown` schema mismatch (`Utf8View` vs
+    /// `LargeUtf8`); `expand_views_at_output` (set in `budgeted_session_context`)
+    /// coerces the view at the plan output and sidesteps it. Returns `LargeUtf8`.
     #[test]
-    #[ignore = "DataFusion 53.1 ProjectionPushdown bug on ungrouped MIN/MAX over Utf8View"]
-    fn query_sql_ungrouped_min_string_datafusion53_projection_pushdown_bug() {
+    fn query_sql_ungrouped_min_string() {
         let st = seeded(&["rust", "go", "python"], &["a", "b", "c"]);
         let batches = st
             .reader()
             .query_sql("SELECT MIN(category) AS m FROM supertable")
-            .expect("ungrouped min (fails on DF 53.1 with the view)");
+            .expect("ungrouped min");
         let col = batches[0]
             .column(0)
             .as_any()
             .downcast_ref::<LargeStringArray>()
-            .expect("MIN(string) is LargeUtf8 after cast-back");
+            .expect("MIN(string) is LargeUtf8");
         assert_eq!(col.value(0), "go");
     }
 
-    /// A declared map covering the three string cases the cast-back must honor.
-    fn declared(pairs: &[(&str, DataType)]) -> HashMap<String, DataType> {
-        pairs
-            .iter()
-            .map(|(n, t)| (n.to_string(), t.clone()))
-            .collect()
-    }
-
-    /// Unit: cast-back restores each `Utf8View` result column to its declared
-    /// type. A declared `Utf8View` is kept, a declared `Utf8`/`LargeUtf8` is
-    /// restored to exactly that (no widening), a column with no declared match
-    /// (computed) defaults to `LargeUtf8`, and non-string columns are untouched.
-    #[test]
-    fn cast_back_views_restores_each_column_to_its_declared_type() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("large", DataType::Utf8View, false), // declared LargeUtf8, viewed
-            Field::new("small", DataType::Utf8View, false), // declared Utf8, viewed
-            Field::new("keep", DataType::Utf8View, false),  // declared Utf8View, keep
-            Field::new("agg", DataType::Utf8View, false),   // computed, no declared type
-            Field::new("n", DataType::Int64, false),        // non-string
-        ]));
-        let str_col = || Arc::new(StringViewArray::from(vec!["a", "b"]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![
-                str_col(),
-                str_col(),
-                str_col(),
-                str_col(),
-                Arc::new(Int64Array::from(vec![1, 2])),
-            ],
-        )
-        .expect("batch");
-
-        let declared = declared(&[
-            ("large", DataType::LargeUtf8),
-            ("small", DataType::Utf8),
-            ("keep", DataType::Utf8View),
-        ]);
-        let out = cast_back_views(vec![batch], &declared).expect("cast ok");
-        let s = out[0].schema();
-        assert_eq!(
-            s.field(0).data_type(),
-            &DataType::LargeUtf8,
-            "declared LargeUtf8 restored"
-        );
-        assert_eq!(
-            s.field(1).data_type(),
-            &DataType::Utf8,
-            "declared Utf8 restored, no widening"
-        );
-        assert_eq!(
-            s.field(2).data_type(),
-            &DataType::Utf8View,
-            "user-declared view kept"
-        );
-        assert_eq!(
-            s.field(3).data_type(),
-            &DataType::LargeUtf8,
-            "computed view defaults to LargeUtf8"
-        );
-        assert_eq!(
-            s.field(4).data_type(),
-            &DataType::Int64,
-            "non-string untouched"
-        );
-    }
-
-    /// Unit: nulls survive the cast-back intact.
-    #[test]
-    fn cast_back_views_preserves_nulls() {
-        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8View, true)]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![Arc::new(StringViewArray::from(vec![
-                Some("a"),
-                None,
-                Some("c"),
-            ]))],
-        )
-        .expect("batch");
-        let out =
-            cast_back_views(vec![batch], &declared(&[("s", DataType::LargeUtf8)])).expect("cast");
-        let s = out[0]
-            .column(0)
-            .as_any()
-            .downcast_ref::<LargeStringArray>()
-            .expect("view -> LargeUtf8");
-        assert!(!s.is_null(0));
-        assert!(s.is_null(1), "null preserved through cast-back");
-        assert_eq!(s.value(2), "c");
-    }
-
-    /// Unit: a result with no view column takes the fast path unchanged.
-    #[test]
-    fn cast_back_views_without_views_is_unchanged() {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "c",
-            DataType::LargeUtf8,
-            false,
-        )]));
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(LargeStringArray::from(vec!["x"]))])
-            .expect("batch");
-        let out =
-            cast_back_views(vec![batch], &declared(&[("c", DataType::LargeUtf8)])).expect("ok");
-        assert_eq!(out[0].column(0).data_type(), &DataType::LargeUtf8);
-    }
-
-    /// Unit: `cast_back_schema` yields the same per-column types the data cast
-    /// produces, and preserves nullability + metadata.
-    #[test]
-    fn cast_back_schema_matches_the_data_cast() {
-        let mut md = HashMap::new();
-        md.insert("k".to_string(), "v".to_string());
-        let result = Schema::new_with_metadata(
-            vec![
-                Field::new("keep", DataType::Utf8View, true),
-                Field::new("large", DataType::Utf8View, false),
-                Field::new("n", DataType::Int64, false),
-            ],
-            md,
-        );
-        let out = cast_back_schema(
-            &result,
-            &declared(&[("keep", DataType::Utf8View), ("large", DataType::LargeUtf8)]),
-        );
-        assert_eq!(
-            out.field(0).data_type(),
-            &DataType::Utf8View,
-            "declared view kept"
-        );
-        assert!(out.field(0).is_nullable(), "nullability preserved");
-        assert_eq!(out.field(1).data_type(), &DataType::LargeUtf8);
-        assert_eq!(out.field(2).data_type(), &DataType::Int64);
-        assert_eq!(
-            out.metadata().get("k").map(String::as_str),
-            Some("v"),
-            "metadata preserved"
-        );
-    }
-
     /// Unit: `build_sql_schemas` views the scan schema (non-FTS strings ->
-    /// `Utf8View`, FTS kept), keeps the plain `scalar`, and records declared
-    /// types. This is the walk done once per table.
+    /// `Utf8View`, FTS kept) and keeps the plain `scalar`. The walk done once
+    /// per table.
     #[test]
-    fn build_sql_schemas_views_scan_keeps_scalar_and_declares() {
+    fn build_sql_schemas_views_scan_and_keeps_scalar() {
         let s = build_sql_schemas(&options_id_cat_title());
         // scan: `category` (non-FTS string) viewed; `title` (FTS) kept.
         assert_eq!(
@@ -1014,9 +749,6 @@ mod tests {
                 .data_type(),
             &DataType::LargeUtf8,
         );
-        // declared: name -> declared type.
-        assert_eq!(s.declared().get("category"), Some(&DataType::LargeUtf8));
-        assert_eq!(s.declared().get("title"), Some(&DataType::LargeUtf8));
     }
 
     /// The per-table schemas are built once and memoized on the handle, not
@@ -1032,28 +764,60 @@ mod tests {
         );
     }
 
-    /// Unit: `declared_string_types` collects only string columns.
+    /// A NULL string value survives the view scan + output coercion.
     #[test]
-    fn declared_string_types_collects_string_columns_only() {
-        let schema = Schema::new(vec![
-            Field::new("a", DataType::LargeUtf8, false),
-            Field::new("b", DataType::Utf8, false),
-            Field::new("c", DataType::Utf8View, false),
-            Field::new("n", DataType::Int64, false),
-        ]);
-        let m = declared_string_types(&schema);
-        assert_eq!(m.len(), 3, "only the three string columns");
-        assert_eq!(m.get("a"), Some(&DataType::LargeUtf8));
-        assert_eq!(m.get("b"), Some(&DataType::Utf8));
-        assert_eq!(m.get("c"), Some(&DataType::Utf8View));
-        assert!(!m.contains_key("n"), "non-string skipped");
+    fn query_sql_null_string_survives() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("category", DataType::LargeUtf8, true), // nullable, so we can plant a NULL
+            Field::new("title", DataType::LargeUtf8, false),
+        ]));
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("rayon pool"),
+        );
+        let opts = SupertableOptions::new(
+            Arc::clone(&schema),
+            vec![FtsConfig {
+                column: "title".into(),
+            }],
+            vec![],
+            Some(tok()),
+        )
+        .expect("valid options")
+        .with_writer_pool(pool);
+
+        let st = Supertable::create(opts).expect("create");
+        let mut w = st.writer().expect("writer");
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(LargeStringArray::from(vec![Some("rust"), None, Some("go")])),
+                Arc::new(LargeStringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .expect("batch");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+
+        let batches = st
+            .reader()
+            .query_sql("SELECT category FROM supertable")
+            .expect("select");
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("category is LargeUtf8");
+        assert_eq!(col.null_count(), 1, "the NULL survives the view + coercion");
     }
 
-    /// A column the user explicitly declared `Utf8View` must come back
-    /// `Utf8View`: cast-back restores declared types, it does not force
-    /// `LargeUtf8` on a type the user chose.
+    /// A column the user declared `Utf8View` comes back `LargeUtf8`: the view
+    /// is an internal scan type, and `expand_views_at_output` coerces every
+    /// view to `LargeUtf8` at the plan output, so SQL results never expose one.
     #[test]
-    fn query_sql_keeps_user_declared_utf8view_column() {
+    fn query_sql_declared_utf8view_column_returns_large_utf8() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("category", DataType::Utf8View, false), // user declares a view
             Field::new("title", DataType::LargeUtf8, false),   // FTS column must be LargeUtf8
@@ -1094,8 +858,8 @@ mod tests {
             .expect("group-by");
         assert_eq!(
             batches[0].column(0).data_type(),
-            &DataType::Utf8View,
-            "a user-declared Utf8View column must not be rewritten by cast-back"
+            &DataType::LargeUtf8,
+            "views are internal; SQL results expose LargeUtf8, not Utf8View"
         );
     }
 
@@ -1119,7 +883,7 @@ mod tests {
     }
 
     /// String column projected through a CTE: the name survives, so it is
-    /// restored to its declared type.
+    /// returned as `LargeUtf8`.
     #[test]
     fn query_sql_cte_string_column_is_declared_type() {
         let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);
@@ -1161,14 +925,14 @@ mod tests {
         assert_eq!(got, vec!["go", "rust"]);
     }
 
-    /// No data loss through the view + cast-back for values that stress
+    /// No data loss through the view + coercion for values that stress
     /// `Utf8View`'s layout: strings past the 12-byte inline limit (stored
     /// out-of-line), values sharing a 4-byte prefix (the view compares the
     /// prefix first, so it must fall through to the full bytes and keep them
     /// distinct), an empty string, and multi-byte unicode. GROUP BY exercises
-    /// both the comparison (distinct groups) and the cast-back (exact values).
+    /// both the comparison (distinct groups) and the coercion (exact values).
     #[test]
-    fn query_sql_string_values_survive_view_and_cast_back() {
+    fn query_sql_string_values_survive_view_and_coercion() {
         let vals = [
             "",                        // empty
             "short",                   // inline (<= 12 bytes)
@@ -1188,7 +952,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<LargeStringArray>()
-            .expect("category is LargeUtf8 after cast-back");
+            .expect("category is LargeUtf8");
         let mut got: Vec<&str> = (0..col.len()).map(|i| col.value(i)).collect();
         got.sort_unstable();
 
@@ -1207,7 +971,7 @@ mod tests {
     }
 
     /// `SELECT DISTINCT` on a viewed string column: dedup compares on the view,
-    /// result comes back the declared type.
+    /// result comes back `LargeUtf8`.
     #[test]
     fn query_sql_distinct_string_is_declared_type() {
         let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);
@@ -1226,7 +990,7 @@ mod tests {
     }
 
     /// Self-join whose join key is a viewed string column: the equality runs on
-    /// `Utf8View`, and the projected key comes back its declared type.
+    /// `Utf8View`, and the projected key comes back `LargeUtf8`.
     #[test]
     fn query_sql_self_join_on_string_key() {
         let st = seeded(&["rust", "go", "rust"], &["a", "b", "c"]);


### PR DESCRIPTION
### What does this PR do?
Speeds up SQL queries that group, sort, or compare text columns.

### Why do we need this change?
Text-heavy queries spent most of their time comparing whole strings byte by byte. DataFusion can compare strings by a short leading slice first and only fall back to the full bytes when that ties, but we were handing it the columns in a form that forced the full byte comparison every time.

### How do we do this change?
- **Scan strings as views.** Non-FTS string columns are planned and scanned as [Utf8View](https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html#variant.Utf8View), whose comparison checks a short inline prefix before falling through to the full bytes. Full-text columns keep their stored type, so their pruning is unaffected.
- **Coerce views back at the output.** DataFusion turns every view column back into LargeUtf8 at the plan output, so results stay LargeUtf8 and the view never leaves the scan.
- **Build the scan schema once.** The viewed scan schema is a pure function of the immutable table schema, so it is cached on the handle instead of recomputed per query.

### Performance
The string `GROUP BY` / `ORDER BY` / `MIN` queries improve materially (for example a group-by with two `MIN(string)` aggregates drops from ~383ms to ~266ms at 10M rows); no query regresses.