### PR TITLE
release: sync binding lockfiles' crate entry on version bumps

### DIFF
--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -14,6 +14,10 @@ The check fails (non-zero exit) when:
   (c) a Cargo.lock records a different version for its own package than
       the matching Cargo.toml — a bump that skipped the lockfile breaks
       the `--locked` publish at release time
+  (d) a binding's Cargo.lock records a different version for `infino`
+      than the root Cargo.toml — the bindings build the crate as a path
+      dependency, so a stale entry breaks their `--locked` builds
+      (maturin / napi) the same way
 
 Usage:
   check_version_sync.py                          # verify; non-zero exit on drift
@@ -112,6 +116,18 @@ def check(root, release_version=None):
                     f"the package version is {node}; the platform pins "
                     f"track the package version"
                 )
+        if crate is not None:
+            node_lock_infino = locked_version(
+                root / "infino-node" / "Cargo.lock", "infino"
+            )
+            if node_lock_infino != crate:
+                errors.append(
+                    f"infino-node/Cargo.lock records infino "
+                    f"{node_lock_infino} but the crate is {crate}; the "
+                    f"binding builds the crate as a path dependency — "
+                    f"regenerate the lockfile (its --locked build breaks "
+                    f"otherwise)"
+                )
         # The node crate is unpublished (`publish = false`), but its version
         # must track package.json so no committed version file lies.
         node_crate = manifest_version(root / "infino-node" / "Cargo.toml")
@@ -152,6 +168,18 @@ def check(root, release_version=None):
                 f"{python_locked} but infino-python/Cargo.toml says {python}; "
                 f"regenerate the lockfile (releases publish with --locked)"
             )
+        if crate is not None:
+            python_lock_infino = locked_version(
+                root / "infino-python" / "Cargo.lock", "infino"
+            )
+            if python_lock_infino != crate:
+                errors.append(
+                    f"infino-python/Cargo.lock records infino "
+                    f"{python_lock_infino} but the crate is {crate}; the "
+                    f"binding builds the crate as a path dependency — "
+                    f"regenerate the lockfile (its --locked build breaks "
+                    f"otherwise)"
+                )
 
     return errors
 

--- a/scripts/release_prep.py
+++ b/scripts/release_prep.py
@@ -175,7 +175,15 @@ def prepare(root, package, version=None):
     if "crate" in targets:
         stamp_manifest(root / "Cargo.toml", targets["crate"])
         stamp_lock(root / "Cargo.lock", "infino", targets["crate"])
-        changed += ["Cargo.toml", "Cargo.lock"]
+        # The bindings build the crate as a path dependency, so their
+        # lockfiles record its version too; sync them or their --locked
+        # builds (maturin / napi) fail at release time.
+        stamp_lock(root / "infino-node" / "Cargo.lock", "infino",
+                   targets["crate"])
+        stamp_lock(root / "infino-python" / "Cargo.lock", "infino",
+                   targets["crate"])
+        changed += ["Cargo.toml", "Cargo.lock", "infino-node/Cargo.lock",
+                    "infino-python/Cargo.lock"]
     if "node" in targets:
         stamp_node_package(root / "infino-node" / "package.json",
                            targets["node"])
@@ -191,6 +199,7 @@ def prepare(root, package, version=None):
                    targets["python"])
         changed += ["infino-python/Cargo.toml", "infino-python/Cargo.lock"]
 
+    changed = list(dict.fromkeys(changed))
     drift = check(root)
     if drift:
         raise ReleasePrepError(

--- a/scripts/test_check_version_sync.py
+++ b/scripts/test_check_version_sync.py
@@ -22,13 +22,16 @@ PLATFORM_PACKAGES = (
 
 def write_fixture(root, crate="0.3.4", crate_lock=None, node="0.3.2",
                   pins=None, node_crate=None, node_crate_lock=None,
-                  python="0.3.5", python_lock=None):
+                  node_lock_infino=None, python="0.3.5", python_lock=None,
+                  python_lock_infino=None):
     """Materialize the minimal manifest/lockfile tree the guard reads."""
     root = Path(root)
     crate_lock = crate_lock if crate_lock is not None else crate
     node_crate = node_crate if node_crate is not None else node
     node_crate_lock = node_crate_lock if node_crate_lock is not None else node_crate
+    node_lock_infino = node_lock_infino if node_lock_infino is not None else crate
     python_lock = python_lock if python_lock is not None else python
+    python_lock_infino = python_lock_infino if python_lock_infino is not None else crate
     pins = pins if pins is not None else {p: node for p in PLATFORM_PACKAGES}
 
     (root / "Cargo.toml").write_text(
@@ -65,7 +68,7 @@ def write_fixture(root, crate="0.3.4", crate_lock=None, node="0.3.2",
     (node_dir / "Cargo.lock").write_text(
         "[[package]]\n"
         'name = "infino"\n'
-        f'version = "{crate}"\n'
+        f'version = "{node_lock_infino}"\n'
         "\n"
         "[[package]]\n"
         'name = "infino-node"\n'
@@ -82,7 +85,7 @@ def write_fixture(root, crate="0.3.4", crate_lock=None, node="0.3.2",
     (py_dir / "Cargo.lock").write_text(
         "[[package]]\n"
         'name = "infino"\n'
-        f'version = "{crate}"\n'
+        f'version = "{python_lock_infino}"\n'
         "\n"
         "[[package]]\n"
         'name = "infino-python"\n'
@@ -140,6 +143,23 @@ class CheckVersionSync(unittest.TestCase):
     def test_node_crate_lockfile_behind_manifest_fails(self):
         write_fixture(self.root, node="0.3.2", node_crate="0.3.2",
                       node_crate_lock="0.3.1")
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("infino-node/Cargo.lock", errors[0])
+
+    def test_python_lockfile_with_stale_crate_dep_fails(self):
+        # The bindings depend on the crate by path, so their lockfiles record
+        # the crate's version too. A crate bump that skips them breaks the
+        # bindings' --locked builds (maturin/napi) at release time.
+        write_fixture(self.root, crate="0.3.4", python_lock_infino="0.3.3")
+        errors = check(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("infino-python/Cargo.lock", errors[0])
+        self.assertIn("0.3.3", errors[0])
+        self.assertIn("0.3.4", errors[0])
+
+    def test_node_lockfile_with_stale_crate_dep_fails(self):
+        write_fixture(self.root, crate="0.3.4", node_lock_infino="0.3.3")
         errors = check(self.root)
         self.assertEqual(len(errors), 1)
         self.assertIn("infino-node/Cargo.lock", errors[0])

--- a/scripts/test_release_prep.py
+++ b/scripts/test_release_prep.py
@@ -25,14 +25,28 @@ class Prepare(unittest.TestCase):
     def node_manifest(self):
         return json.loads((self.root / "infino-node" / "package.json").read_text())
 
-    def test_crate_patch_stamps_only_the_root_manifest_and_lock(self):
+    def test_crate_patch_stamps_root_and_syncs_binding_lockfiles(self):
         changed = prepare(self.root, "crate", "0.3.5")
-        self.assertEqual(sorted(changed), ["Cargo.lock", "Cargo.toml"])
+        self.assertEqual(
+            sorted(changed),
+            ["Cargo.lock", "Cargo.toml", "infino-node/Cargo.lock",
+             "infino-python/Cargo.lock"],
+        )
         self.assertEqual(manifest_version(self.root / "Cargo.toml"), "0.3.5")
         self.assertEqual(locked_version(self.root / "Cargo.lock", "infino"), "0.3.5")
+        # The bindings' own versions stay put, but their lockfiles' record
+        # of the crate (a path dependency) moves with it.
         self.assertEqual(self.node_manifest()["version"], "0.3.2")
         self.assertEqual(
+            locked_version(self.root / "infino-node" / "Cargo.lock", "infino"),
+            "0.3.5",
+        )
+        self.assertEqual(
             manifest_version(self.root / "infino-python" / "Cargo.toml"), "0.3.5"
+        )
+        self.assertEqual(
+            locked_version(self.root / "infino-python" / "Cargo.lock", "infino"),
+            "0.3.5",
         )
         self.assertEqual(check(self.root), [])
 


### PR DESCRIPTION
The bindings build the core crate as a path dependency, so their lockfiles record the crate's version alongside their own. A crate bump that leaves those `infino` entries stale breaks the bindings' `--locked` builds (maturin / napi) — exactly how #410 first failed CI, and the same gap behind the older hand-made "sync Cargo.lock to crate" commits.

Two-sided fix:

- `release-prep` stamps the `infino` entry in both binding lockfiles whenever the crate version changes (`crate`, `each`, and `all` scopes)
- the version-sync guard gains the matching check, so this drift now fails `make version-sync` / `make check` on the PR — before any build sees it

## Testing

- 2 new guard tests (stale `infino` entry in each binding lockfile) and an extended crate-scope release-prep test asserting the sync; 27 tests total, all green
- The new guard check reproduces the #410 failure class: with a stale entry it fails with a one-line explanation instead of a cryptic maturin error
- Real-tree smoke: `release_prep.py --package each` now lists both binding lockfiles among stamped files and `cargo metadata --locked` accepts the result (verified on the #410 branch, which was fixed with this exact stamp)