### PR TITLE
chore: add gc controls in optimise settings

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -216,6 +216,27 @@ impl core::marker::Unpin for infino::GcReport
 impl core::marker::UnsafeUnpin for infino::GcReport
 impl core::panic::unwind_safe::RefUnwindSafe for infino::GcReport
 impl core::panic::unwind_safe::UnwindSafe for infino::GcReport
+pub struct infino::GcSettings
+pub infino::GcSettings::safety_gap: core::time::Duration
+impl infino::GcSettings
+pub fn infino::GcSettings::with_safety_gap(self, core::time::Duration) -> Self
+impl core::clone::Clone for infino::GcSettings
+pub fn infino::GcSettings::clone(&self) -> infino::GcSettings
+impl core::cmp::Eq for infino::GcSettings
+impl core::cmp::PartialEq for infino::GcSettings
+pub fn infino::GcSettings::eq(&self, &infino::GcSettings) -> bool
+impl core::default::Default for infino::GcSettings
+pub fn infino::GcSettings::default() -> Self
+impl core::fmt::Debug for infino::GcSettings
+pub fn infino::GcSettings::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for infino::GcSettings
+impl core::marker::Freeze for infino::GcSettings
+impl core::marker::Send for infino::GcSettings
+impl core::marker::Sync for infino::GcSettings
+impl core::marker::Unpin for infino::GcSettings
+impl core::marker::UnsafeUnpin for infino::GcSettings
+impl core::panic::unwind_safe::RefUnwindSafe for infino::GcSettings
+impl core::panic::unwind_safe::UnwindSafe for infino::GcSettings
 pub struct infino::IndexSpec
 impl infino::IndexSpec
 pub fn infino::IndexSpec::fts(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -257,6 +278,7 @@ impl core::panic::unwind_safe::UnwindSafe for infino::MutationStats
 pub struct infino::OptimizeOptions
 impl infino::OptimizeOptions
 pub fn infino::OptimizeOptions::compact(infino::CompactionSettings) -> Self
+pub fn infino::OptimizeOptions::with_gc(self, infino::GcSettings) -> Self
 impl core::clone::Clone for infino::OptimizeOptions
 pub fn infino::OptimizeOptions::clone(&self) -> infino::OptimizeOptions
 impl core::default::Default for infino::OptimizeOptions

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -214,6 +214,29 @@ impl Default for CompactionSettings {
 /// Minimum age an unreferenced object must reach before [`crate::Supertable::optimize`] deletes it.
 pub const DEFAULT_GC_SAFETY_GAP: Duration = Duration::from_secs(86_400);
 
+/// Gc settings used by `optimize()`'s bundled gc sweep.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcSettings {
+    /// Minimum age an unreferenced object must reach before it's deleted.
+    pub safety_gap: Duration,
+}
+
+impl Default for GcSettings {
+    fn default() -> Self {
+        Self {
+            safety_gap: DEFAULT_GC_SAFETY_GAP,
+        }
+    }
+}
+
+impl GcSettings {
+    /// Gc settings with the given safety gap;
+    pub fn with_safety_gap(mut self, gap: Duration) -> Self {
+        self.safety_gap = gap;
+        self
+    }
+}
+
 /// Options for [`crate::Supertable::optimize`].
 ///
 /// Additional operation kinds (e.g. vector-index maintenance) will be
@@ -221,6 +244,7 @@ pub const DEFAULT_GC_SAFETY_GAP: Duration = Duration::from_secs(86_400);
 #[derive(Debug, Clone, Default)]
 pub struct OptimizeOptions {
     pub(crate) compaction: CompactionSettings,
+    pub(crate) gc: GcSettings,
 }
 
 impl OptimizeOptions {
@@ -228,7 +252,14 @@ impl OptimizeOptions {
     pub fn compact(settings: CompactionSettings) -> Self {
         Self {
             compaction: settings,
+            gc: GcSettings::default(),
         }
+    }
+
+    /// Override the gc settings `optimize()`'s bundled sweep uses.
+    pub fn with_gc(mut self, gc: GcSettings) -> Self {
+        self.gc = gc;
+        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub use arrow_schema;
 /// Catalog entry points and handle: open a `Connection`, then create /
 /// open / drop / list tables.
 pub use catalog::{ColdFetchMode, ConnectOptions, Connection, IndexSpec, connect, connect_with};
-pub use config::{CompactionSettings, OptimizeOptions};
+pub use config::{CompactionSettings, GcSettings, OptimizeOptions};
 /// The single public error type for the curated API.
 pub use error::InfinoError;
 /// Value types named by the public method signatures.

--- a/src/supertable/optimize/mod.rs
+++ b/src/supertable/optimize/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     Supertable,
-    config::{DEFAULT_GC_SAFETY_GAP, OptimizeOptions},
+    config::OptimizeOptions,
     supertable::{
         error::{GcError, OptimizeError},
         wal::gc::GcError as WalGcError,
@@ -19,7 +19,7 @@ impl Supertable {
     #[doc(alias = "compact")]
     pub fn optimize(&self, opts: &OptimizeOptions) -> Result<(), OptimizeError> {
         self.compact(&opts.compaction)?;
-        match self.gc(DEFAULT_GC_SAFETY_GAP) {
+        match self.gc(opts.gc.safety_gap) {
             Ok(_) | Err(GcError::NoStorage) => {}
             Err(e) => return Err(OptimizeError::Gc(e)),
         }

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::Duration};
 use chrono::{Duration as ChronoDuration, Utc};
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
-    CompactionSettings, OptimizeOptions,
+    CompactionSettings, GcSettings, OptimizeOptions,
     superfile::fts::reader::BoolMode,
     supertable::{
         Supertable,
@@ -299,5 +299,72 @@ async fn optimize_reaps_completed_wal_past_grace() {
         count_dir(&wal_dir),
         0,
         "optimize must reap a completed wal past its grace window"
+    );
+}
+
+#[test]
+fn optimize_honors_overridden_gc_safety_gap() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("create");
+
+    // Ten commits so combined live_bytes clear the compaction floor, same
+    // as `compact_then_gc_removes_stale_files_and_preserves_queries`.
+    let markers = [
+        "alphatoken",
+        "betatoken",
+        "gammatoken",
+        "deltatoken",
+        "epsilontoken",
+        "zetatoken",
+        "etatoken",
+        "thetatoken",
+        "iotatoken",
+        "kappatoken",
+    ];
+    for m in &markers {
+        commit_titles(
+            &st,
+            &[&format!("{m} marker"), "filler alpha", "filler bravo"],
+        );
+    }
+
+    let data_dir = dir.path().join("data");
+    let n_commits = count_dir(&data_dir);
+
+    // Default gc_safety_gap (1 day): the stale pre-compaction superfiles
+    // were just written, so optimize()'s bundled gc sweep must not touch
+    // them, even though compaction ran and left them orphaned.
+    st.optimize(&small_optimize_opts())
+        .expect("optimize with default gc_safety_gap");
+    let n_after_compact = st.reader().n_superfiles();
+    assert!(
+        n_after_compact < n_commits,
+        "compaction must have merged the ten commits into fewer superfiles"
+    );
+    assert_eq!(
+        count_dir(&data_dir),
+        n_commits + n_after_compact,
+        "default gc_safety_gap must keep freshly orphaned superfiles on disk \
+         alongside the newly compacted ones"
+    );
+
+    // Zeroing gc_safety_gap on the same table now reclaims them in the
+    // same optimize() call, with no separate st.gc() needed.
+    let opts = OptimizeOptions::compact(CompactionSettings {
+        target_superfile_size_mb: 1,
+        min_fill_percent: 1,
+        ..CompactionSettings::default()
+    })
+    .with_gc(GcSettings::default().with_safety_gap(Duration::ZERO));
+    st.optimize(&opts).expect("optimize with gc safety_gap=0");
+
+    let r = st.reader();
+    assert_eq!(
+        count_dir(&data_dir),
+        r.n_superfiles(),
+        "gc_safety_gap=0 must reclaim every orphaned superfile down to the live set"
     );
 }


### PR DESCRIPTION
### why do we need this change?

The current gc safety delay is 1 day, leading to a lot of inactive manifest parts associated with evey commit. 
Stats: for 10gb of ingest with 1300 commits, the size of manifest parts is around 46gb (inactive) active manifest is only around couple of mbs.

### how to use it

If the user is not using snapshot queries and is dealing with higher number of commits (smaller batch size) then user should set GC_SAFETY_GAP_DURATION as 5 seconds. Why couple of seconds? if there are queries running when Optimise is called, the buffer is enough for queries to finish (most of the times) without erroring out.

Also fixes partially these issues

#405 
#408 