### PR TITLE
fix: flock deadlock in LocalFS conditional-PUT

### DIFF
--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -31,6 +31,10 @@ use super::{ObjectMeta, StorageError, StorageProvider};
 pub struct LocalFsStorageProvider {
     root: PathBuf,
     store: Arc<LocalFileSystem>,
+    // Serializes conditional-PUT contenders within this process so
+    // they `.await` each other instead of piling up on `flock`,
+    // which would starve the tokio worker pool.
+    commit_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl LocalFsStorageProvider {
@@ -54,6 +58,7 @@ impl LocalFsStorageProvider {
         Ok(Self {
             root,
             store: Arc::new(store),
+            commit_lock: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 
@@ -187,6 +192,11 @@ impl StorageProvider for LocalFsStorageProvider {
             // don't need this scaffolding — see
             // `S3StorageProvider::put_if_match`.
             Some(expected) => {
+                // In-process contenders wait here instead of piling up
+                // on `flock` below, which is a blocking syscall and
+                // would starve the tokio worker pool.
+                let _guard = self.commit_lock.lock().await;
+
                 let lock_path = self.root.join("_supertable").join(".lock");
                 // The pointer commit path already creates
                 // `_supertable/` on the first write; doing it
@@ -208,18 +218,20 @@ impl StorageProvider for LocalFsStorageProvider {
                         uri: uri.into(),
                         source: Box::new(e),
                     })?;
-                lock_file
-                    .lock_exclusive()
-                    .map_err(|e| StorageError::Permanent {
-                        uri: uri.into(),
-                        source: Box::new(e),
-                    })?;
-                // Lock held below until `lock_file` drops at
-                // end of branch (or early-return). Holding it
-                // across `.await` points blocks the
-                // tokio worker; head + put on LocalFS are
-                // microseconds, so the worst-case stall is
-                // bounded.
+                // `flock` is a blocking syscall; run it on the
+                // blocking pool so it can't stall a tokio worker.
+                let lock_file = tokio::task::spawn_blocking(move || {
+                    lock_file.lock_exclusive().map(|_| lock_file)
+                })
+                .await
+                .map_err(|e| StorageError::Permanent {
+                    uri: uri.into(),
+                    source: Box::new(e),
+                })?
+                .map_err(|e| StorageError::Permanent {
+                    uri: uri.into(),
+                    source: Box::new(e),
+                })?;
 
                 let result: Result<Option<String>, StorageError> = async {
                     let current = self

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -20,7 +20,10 @@ use std::{
 
 use bytes::Bytes;
 use chrono::Utc;
-use futures::future::join_all;
+use futures::{
+    future::join_all,
+    stream::{self, StreamExt},
+};
 use roaring::RoaringBitmap;
 use tokio::time;
 use tracing::warn;
@@ -533,11 +536,16 @@ struct SealedInput {
     etag: Etag,
 }
 
-/// Best-effort: clear every seal this attempt placed, in parallel --
-/// each one is an independent sidecar, so there's no ordering or
-/// shared-state reason to do them one at a time.
+/// Cap on in-flight unseal calls. Single-writer model: one compactor
+/// commits at a time, so there's no throughput reason to fire every
+/// unseal at once.
+const MAX_CONCURRENT_UNSEALS: usize = 8;
+
+/// Best-effort: clear every seal this attempt placed. Each one is an
+/// independent sidecar, so order doesn't matter, but they're bounded
+/// to a small number in flight rather than all at once.
 async fn unseal_all(wal_store: &WalStore, sealed: Vec<SealedInput>) {
-    let results = join_all(sealed.into_iter().map(|s| {
+    let results = stream::iter(sealed.into_iter().map(|s| {
         let wal_store = wal_store.clone();
         async move {
             let result =
@@ -545,6 +553,8 @@ async fn unseal_all(wal_store: &WalStore, sealed: Vec<SealedInput>) {
             (s.superfile_id, result)
         }
     }))
+    .buffer_unordered(MAX_CONCURRENT_UNSEALS)
+    .collect::<Vec<_>>()
     .await;
     for (superfile_id, result) in results {
         if let Err(e) = result {


### PR DESCRIPTION
fixes https://github.com/infino-ai/infino/issues/411

### why is this fix required ? 

Compaction on LocalFS could hang forever. Cause: our conditional-write path takes a file lock (flock) and holds it while waiting on other async work, right on a tokio worker thread. Once enough of these pile up at once (compaction fires many in parallel), every worker thread is stuck waiting on the lock and nothing can run to release it. Runtime freezes.