### PR TITLE
fts: token positions and exact phrase queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ bitpacking = "0.9"
 crc-fast = "1.10.0"
 wide = "1"
 fst = "0.4"
-bytemuck = "1"
+bytemuck = { version = "1", features = ["min_const_generics"] }
 
 # Allocator strategy: mimalloc as #[global_allocator], bumpalo for
 # per-query scratch, plus the custom MemoryArena in fts/arena.rs.

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -244,6 +244,7 @@ fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOpti
         concurrent_schema(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![VectorConfig {
             column: VEC_COLUMN.into(),

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -1050,7 +1050,7 @@ pub fn calibrate_superfile(
 /// both bench harnesses construct the index identically.
 pub fn build_fts_index(docs: &[String]) -> FtsBuilder {
     let mut b = FtsBuilder::new(default_tokenizer());
-    b.register_column("title".to_string(), false)
+    b.register_column("title".to_string(), true)
         .expect("register column");
     for (i, text) in docs.iter().enumerate() {
         b.add_doc(0, i as u32, text).expect("add doc");

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -1125,6 +1125,7 @@ pub fn build_superfile(docs: &[String], vectors: &[f32], n_cent: usize) -> Vec<u
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![SfVectorConfig {
             column: "emb".into(),
@@ -1171,6 +1172,7 @@ pub fn build_superfile_with_metric(
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![SfVectorConfig {
             column: "emb".into(),

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -1050,7 +1050,7 @@ pub fn calibrate_superfile(
 /// both bench harnesses construct the index identically.
 pub fn build_fts_index(docs: &[String]) -> FtsBuilder {
     let mut b = FtsBuilder::new(default_tokenizer());
-    b.register_column("title".to_string())
+    b.register_column("title".to_string(), false)
         .expect("register column");
     for (i, text) in docs.iter().enumerate() {
         b.add_doc(0, i as u32, text).expect("add doc");

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -400,6 +400,29 @@ pub mod fts {
             terms: &["+term00050", "+term00051", "term00001", "term00052"],
             mode: BoolMode::Or,
         },
+        // Exact phrases (quoted atoms). The Zipfian corpus gives the
+        // top terms frequent chance adjacency, so these measure the
+        // real intersect-then-verify pipeline with non-empty results.
+        FtsQuery {
+            name: "phrase_two_common",
+            terms: &[r#""term00001 term00002""#],
+            mode: BoolMode::Or,
+        },
+        FtsQuery {
+            name: "phrase_two_mixed",
+            terms: &[r#""term00001 term00500""#],
+            mode: BoolMode::Or,
+        },
+        FtsQuery {
+            name: "phrase_three_common",
+            terms: &[r#""term00001 term00002 term00003""#],
+            mode: BoolMode::Or,
+        },
+        FtsQuery {
+            name: "phrase_plus_must_term",
+            terms: &[r#"+"term00001 term00002""#, "+term00010"],
+            mode: BoolMode::Or,
+        },
     ];
 
     /// OR query names, in table order.
@@ -430,6 +453,14 @@ pub mod fts {
         "must_common_should_common",
         "must_rare_should_common",
         "must_two_should_two",
+    ];
+
+    /// Phrase query names, in table order.
+    pub const PHRASE_QUERIES: &[&str] = &[
+        "phrase_two_common",
+        "phrase_two_mixed",
+        "phrase_three_common",
+        "phrase_plus_must_term",
     ];
 
     pub fn to_infino_mode(mode: BoolMode) -> InfinoBoolMode {
@@ -547,13 +578,26 @@ pub mod fts {
                 // does: with `+must` clauses, the count is the musts'
                 // intersection (shoulds only affect scores, so they
                 // never change which docs count); otherwise the bare
-                // terms match under `mode`.
+                // terms match under `mode`. Phrase atoms take the
+                // phrase-aware walk.
                 let clauses = AsciiLowerTokenizer.parse(query).into_clauses(mode);
-                let (terms, eff_mode) = if clauses.musts.is_empty() {
-                    (clauses.shoulds, mode)
+                let has_musts = !clauses.musts.is_empty() || !clauses.must_phrases.is_empty();
+                let (terms, phrases, eff_mode) = if has_musts {
+                    (clauses.musts, clauses.must_phrases, InfinoBoolMode::And)
                 } else {
-                    (clauses.musts, InfinoBoolMode::And)
+                    (clauses.shoulds, clauses.should_phrases, mode)
                 };
+                if !phrases.is_empty() {
+                    let refs: Vec<&str> = terms.iter().map(|t| &**t).collect();
+                    let owned: Vec<Vec<String>> = phrases
+                        .into_iter()
+                        .map(|p| p.into_iter().map(|t| t.into_owned()).collect())
+                        .collect();
+                    return self
+                        .atoms_match_count(column, &refs, &owned, eff_mode)
+                        .await
+                        .expect("superfile atoms_match_count");
+                }
                 let refs: Vec<&str> = terms.iter().map(|t| &**t).collect();
                 // Single term: df is the exact match count, read O(1) from
                 // the dictionary header. Multi-term: the dedicated count
@@ -815,13 +859,21 @@ pub mod fts {
         };
         let clause_block = Block {
             subtitle: "Must/should queries (+must, bare should)".into(),
-            headers: header_cols,
+            headers: header_cols.clone(),
             rows: CLAUSE_QUERIES
                 .iter()
                 .map(|&n| search_row(n, warm_map.as_ref(), cold))
                 .collect(),
         };
-        let mut blocks = vec![or_block, and_block, clause_block];
+        let phrase_block = Block {
+            subtitle: "Phrase queries (exact adjacency)".into(),
+            headers: header_cols,
+            rows: PHRASE_QUERIES
+                .iter()
+                .map(|&n| search_row(n, warm_map.as_ref(), cold))
+                .collect(),
+        };
+        let mut blocks = vec![or_block, and_block, clause_block, phrase_block];
         if let Some(probes) = probes {
             blocks.push(Block {
                 subtitle: "Per-algorithm probes (WAND+BMW vs MaxScore+BMM)".into(),
@@ -932,14 +984,19 @@ pub mod fts {
         };
         let clause_block = Block {
             subtitle: "Must/should queries (count = must intersection)".into(),
-            headers,
+            headers: headers.clone(),
             rows: CLAUSE_QUERIES.iter().map(|&n| count_row(n, &map)).collect(),
+        };
+        let phrase_block = Block {
+            subtitle: "Phrase queries (count = verified matches)".into(),
+            headers,
+            rows: PHRASE_QUERIES.iter().map(|&n| count_row(n, &map)).collect(),
         };
         report.emit(&Section {
             anchor: anchor.into(),
             title,
             note: note.into(),
-            blocks: vec![or_block, and_block, clause_block],
+            blocks: vec![or_block, and_block, clause_block, phrase_block],
         });
     }
 }

--- a/benches/utils/harness/infino_engine.rs
+++ b/benches/utils/harness/infino_engine.rs
@@ -47,6 +47,7 @@ fn build_superfile(column: &str, docs: &[(u64, &str)]) -> Vec<u8> {
         ID_COLUMN,
         vec![FtsConfig {
             column: column.to_string(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/benches/utils/harness/infino_engine.rs
+++ b/benches/utils/harness/infino_engine.rs
@@ -36,8 +36,12 @@ const WRITE_CHUNK: usize = 65_536;
 
 /// Build one superfile (`.parquet` + embedded FTS blob) from `docs` with
 /// a single builder, returning the finished bytes. Shared by the
-/// queryable `write` and the build-throughput probe.
-fn build_superfile(column: &str, docs: &[(u64, &str)]) -> Vec<u8> {
+/// queryable `write` and the build-throughput probes. `positions`
+/// selects the FTS config: the queryable artifact is positional (the
+/// warm battery includes phrase queries), while the default-config
+/// build rows measure `positions: false` — what a table gets unless it
+/// opts in.
+fn build_superfile(column: &str, docs: &[(u64, &str)], positions: bool) -> Vec<u8> {
     let schema = Arc::new(Schema::new(vec![
         Field::new(ID_COLUMN, DataType::Decimal128(38, 0), false),
         Field::new(column, DataType::LargeUtf8, false),
@@ -47,7 +51,7 @@ fn build_superfile(column: &str, docs: &[(u64, &str)]) -> Vec<u8> {
         ID_COLUMN,
         vec![FtsConfig {
             column: column.to_string(),
-            positions: true,
+            positions,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -66,6 +70,36 @@ fn build_superfile(column: &str, docs: &[(u64, &str)]) -> Vec<u8> {
         builder.add_batch(&batch, &[]).expect("add_batch");
     }
     builder.finish().expect("SuperfileBuilder::finish")
+}
+
+/// Build-only run at `writers` parallelism: shard the corpus across
+/// `writers` builders, each emitting its own superfile (the same
+/// sharded-ingest shape a partitioned commit produces); bytes
+/// discarded. `writers <= 1` is a plain single-builder run.
+fn parallel_build(column: &str, docs: &[(u64, &str)], writers: usize, positions: bool) {
+    if writers <= 1 {
+        std::hint::black_box(build_superfile(column, docs, positions));
+        return;
+    }
+    let shard_len = docs.len().div_ceil(writers);
+    let shards: Vec<Vec<u8>> = docs
+        .par_chunks(shard_len)
+        .map(|shard| build_superfile(column, shard, positions))
+        .collect();
+    std::hint::black_box(shards);
+}
+
+/// Single-writer build at the default FTS config (`positions: false`),
+/// returning the finished bytes so the caller can report the
+/// default-config stored size alongside the timing.
+pub fn build_positionless(column: &str, docs: &[(u64, &str)]) -> Vec<u8> {
+    build_superfile(column, docs, false)
+}
+
+/// Build-only throughput probe at the default FTS config
+/// (`positions: false`) and `writers` parallelism.
+pub fn parallel_build_positionless(column: &str, docs: &[(u64, &str)], writers: usize) {
+    parallel_build(column, docs, writers, false);
 }
 
 /// infino as a comparison engine.
@@ -118,26 +152,14 @@ impl FtsEngine for InfinoFtsEngine {
     }
 
     fn write(index: &mut Self::Index, docs: &[(u64, &str)]) {
-        let bytes = build_superfile(&index.column, docs);
+        let bytes = build_superfile(&index.column, docs, true);
         index.reader =
             Some(SuperfileReader::open(Bytes::from(bytes.clone())).expect("open SuperfileReader"));
         index.bytes = Some(bytes);
     }
 
     fn parallel_write(column: &str, docs: &[(u64, &str)], writers: usize) {
-        if writers <= 1 {
-            std::hint::black_box(build_superfile(column, docs));
-            return;
-        }
-        // Parallel build: shard the corpus across `writers` builders,
-        // each emitting its own superfile (the same sharded-ingest shape
-        // a partitioned commit produces). Build-only — bytes discarded.
-        let shard_len = docs.len().div_ceil(writers);
-        let shards: Vec<Vec<u8>> = docs
-            .par_chunks(shard_len)
-            .map(|shard| build_superfile(column, shard))
-            .collect();
-        std::hint::black_box(shards);
+        parallel_build(column, docs, writers, true);
     }
 
     fn read(index: &Self::Index, terms: &[&str], k: usize, mode: BoolMode) -> Vec<Hit> {

--- a/benches/utils/harness/infino_engine.rs
+++ b/benches/utils/harness/infino_engine.rs
@@ -47,7 +47,7 @@ fn build_superfile(column: &str, docs: &[(u64, &str)]) -> Vec<u8> {
         ID_COLUMN,
         vec![FtsConfig {
             column: column.to_string(),
-            positions: false,
+            positions: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/benches/utils/harness/infino_sql_engine.rs
+++ b/benches/utils/harness/infino_sql_engine.rs
@@ -126,15 +126,19 @@ pub fn sql_options(n_rows: usize) -> SupertableOptions {
         vec![
             FtsConfig {
                 column: TITLE_COLUMN.into(),
+                positions: false,
             },
             FtsConfig {
                 column: BUCKET_COLUMN.into(),
+                positions: false,
             },
             FtsConfig {
                 column: KEY_COLUMN.into(),
+                positions: false,
             },
             FtsConfig {
                 column: CATEGORY_COLUMN.into(),
+                positions: false,
             },
         ],
         vec![VectorConfig {

--- a/benches/utils/harness/mod.rs
+++ b/benches/utils/harness/mod.rs
@@ -31,7 +31,9 @@ pub mod vector_driver;
 pub use driver::{
     BuildStat, EngineFtsResult, FtsQuery, PhaseStats, QueryStats, run_fts, run_fts_with_index,
 };
-pub use infino_engine::{InfinoFtsEngine, InfinoFtsIndex};
+pub use infino_engine::{
+    InfinoFtsEngine, InfinoFtsIndex, build_positionless, parallel_build_positionless,
+};
 pub use infino_sql_engine::{
     InfinoSqlEngine, InfinoSqlIndex, build_supertable_with_options, emb_for, sample_query_csv,
     scatter_key, sql_options, sql_schema,

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -204,7 +204,7 @@ pub fn options_for(
     let fts = if modality.has_fts() {
         vec![FtsConfig {
             column: TEXT_COLUMN.into(),
-            positions: false,
+            positions: true,
         }]
     } else {
         vec![]

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -204,6 +204,7 @@ pub fn options_for(
     let fts = if modality.has_fts() {
         vec![FtsConfig {
             column: TEXT_COLUMN.into(),
+            positions: false,
         }]
     } else {
         vec![]

--- a/benches/utils/sql_diag.rs
+++ b/benches/utils/sql_diag.rs
@@ -132,6 +132,7 @@ fn supertable_options() -> SupertableOptions {
         baseline_schema(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -144,7 +144,10 @@ pub mod fts {
             ColdTiming, fts as exec_fts,
             fts::{FTS_BATTERY, FtsRead},
         },
-        harness::{EngineFtsResult, InfinoFtsEngine, InfinoFtsIndex, run_fts_with_index},
+        harness::{
+            BuildStat, EngineFtsResult, InfinoFtsEngine, InfinoFtsIndex, PhaseStats,
+            build_positionless, parallel_build_positionless, run_fts_with_index,
+        },
         markdown::{fmt_bandwidth, fmt_count, fmt_throughput, fmt_time},
         report::{Better, Block, Cell, Report, Section, context, metric, text},
         rss::{self, RssStats},
@@ -452,10 +455,13 @@ pub mod fts {
         let mut report = Report::load("superfile_fts");
 
         if phases.build {
+            let (default_builds, default_stored) = measure_default_config_builds(&corpus);
             emit_build(
                 &mut report,
                 n_docs,
                 &corpus,
+                &default_builds,
+                default_stored,
                 &result,
                 index.bytes().len() as u64,
             );
@@ -674,6 +680,45 @@ pub mod fts {
         (corpus, result, index)
     }
 
+    /// Timed build-only runs at the default FTS config
+    /// (`positions: false`) — what a table gets unless it opts in. The
+    /// driver's builds above measure the positional config the query
+    /// battery needs (phrase rows); these rows keep the default build
+    /// path measured and comparable with its own history. Returns the
+    /// per-writer-count stats and the 1-writer artifact's stored size.
+    fn measure_default_config_builds(corpus: &MmapTextCorpus) -> (Vec<BuildStat>, u64) {
+        let docs = corpus.rows();
+        eprintln!("[superfile_fts] default-config (positionless) build probes...");
+        let sampler = rss::PeakSampler::start_default();
+        let t0 = Instant::now();
+        let bytes = build_positionless(FTS_COLUMN, &docs);
+        let wall = t0.elapsed();
+        let rss_stats = sampler.stop_stats();
+        let default_stored = bytes.len() as u64;
+        drop(bytes);
+        let mut builds = vec![BuildStat {
+            writers: 1,
+            phase: PhaseStats {
+                wall,
+                rss: rss_stats,
+            },
+        }];
+        let writers = corpus::parallel_writers();
+        if writers > 1 {
+            let sampler = rss::PeakSampler::start_default();
+            let t0 = Instant::now();
+            parallel_build_positionless(FTS_COLUMN, &docs, writers);
+            builds.push(BuildStat {
+                writers,
+                phase: PhaseStats {
+                    wall: t0.elapsed(),
+                    rss: sampler.stop_stats(),
+                },
+            });
+        }
+        (builds, default_stored)
+    }
+
     fn assert_correct(index: &InfinoFtsIndex, n_docs: usize) {
         eprintln!(
             "[superfile_fts] correctness check: self-consistency + BMW==brute-force on measured artifact..."
@@ -838,14 +883,19 @@ pub mod fts {
         report: &mut Report,
         n_docs: usize,
         corpus: &MmapTextCorpus,
-        result: &EngineFtsResult,
-        stored_bytes: u64,
+        default_builds: &[BuildStat],
+        default_stored: u64,
+        positional: &EngineFtsResult,
+        positional_stored: u64,
     ) {
         // Logical input payload: total corpus text bytes, identical across
         // every writer count (the parallel build shards the same corpus).
         let corpus_bytes = corpus.total_bytes();
-        let rows: Vec<Vec<Cell>> = result
-            .builds
+        // Default-config rows first (the historical `1 writer` /
+        // `N writers` labels keep measuring the positionless build),
+        // then the positional opt-in rows the query battery's
+        // artifact is built with.
+        let mut rows: Vec<Vec<Cell>> = default_builds
             .iter()
             .map(|b| {
                 ingest_row(
@@ -854,10 +904,20 @@ pub mod fts {
                     b.phase.wall,
                     b.phase.rss,
                     corpus_bytes,
-                    stored_bytes,
+                    default_stored,
                 )
             })
             .collect();
+        rows.extend(positional.builds.iter().map(|b| {
+            ingest_row(
+                &format!("{} (positions)", writer_label(b.writers)),
+                n_docs,
+                b.phase.wall,
+                b.phase.rss,
+                corpus_bytes,
+                positional_stored,
+            )
+        }));
         let block = Block {
             subtitle: String::new(),
             headers: super::ingest_headers(),
@@ -871,9 +931,12 @@ pub mod fts {
             ),
             note: "Build path: `SuperfileBuilder` → unified `.parquet` (same as production supertable \
                    commit), through the engine-generic `run_fts` driver the cross-engine comparison also \
-                   uses. Rows are by writer count: `1 writer` is the single-threaded build (and the index \
-                   queries run against); `N writers` is the sharded parallel build. Bandwidth is over the \
-                   logical input text payload. Δ is vs the previous run."
+                   uses. Rows are by writer count and FTS config: `1 writer` / `N writers` measure the \
+                   default config (no token positions); the `(positions)` rows measure the per-column \
+                   positional opt-in, and the 1-writer positional artifact is the index the queries run \
+                   against (the warm battery includes phrase queries, which need positions). `N writers` \
+                   is the sharded parallel build. Bandwidth is over the logical input text payload. Δ is \
+                   vs the previous run."
                 .into(),
             blocks: vec![block],
         });

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -239,6 +239,7 @@ fn build_superfile_bytes() -> Bytes {
         ID_COLUMN,
         vec![FtsConfig {
             column: FTS_COLUMN.into(),
+            positions: false,
         }],
         vec![VectorConfig {
             column: VEC_COLUMN.into(),
@@ -1899,6 +1900,7 @@ pub(crate) mod diag {
             schema,
             vec![FtsConfig {
                 column: FTS_COLUMN.into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: VEC_COLUMN.into(),

--- a/docs/architecture/superfile.md
+++ b/docs/architecture/superfile.md
@@ -93,6 +93,13 @@ more text columns. It is built in the following stages:
   and each block carries the maximum BM25 contribution any document in
   it can produce. This upper bound lets search skip whole blocks that
   cannot enter the top results.
+- **Token positions (opt-in).** A column configured with positions
+  additionally stores, for every (term, document) pair, the ordinals at
+  which the term occurs — delta-encoded variable-length runs in a
+  dedicated region, addressed from the term dictionary so a query
+  fetches only the runs it needs. Positions roughly double the column's
+  full-text footprint, so they are a per-column choice; they are what
+  make exact phrase queries answerable.
 
 A query runs in two stages:
 
@@ -101,6 +108,17 @@ A query runs in two stages:
 2. Walk the posting lists in document order, using the per-block upper
    bounds to skip blocks that cannot improve the current top results,
    and rank the surviving documents with BM25.
+
+A **phrase query** (a double-quoted run of words) adds a third step on
+a positions-indexed column: the member terms' posting lists are
+intersected, and each candidate document is verified by checking the
+members' position runs for an adjacent, in-order occurrence. The number
+of verified occurrences is the phrase's term frequency, and the phrase
+then ranks as a single BM25 atom. Ranked search skips verification for
+candidates whose score bound cannot reach the current top results;
+counting verifies every candidate, so phrase counts are exact. On a
+column built without positions, a phrase query is a typed error, never
+a silent bag-of-words approximation.
 
 The same inverted index also answers **unranked token matching**:
 resolve the query tokens to their posting lists and intersect them (all
@@ -188,10 +206,11 @@ first.
   table layer's responsibility (see [supertable](./supertable.md)).
 - A superfile is immutable and is queryable only once it is fully
   written.
-- Full-text search is bag-of-words: BM25 ranking and unranked token
-  matching (AND/OR) both run over the same posting lists. The format
-  stores **no token positions**, so there is no positional/phrase index.
-  Exact-string matching is therefore done as a two-pass operation — a
+- Full-text search is bag-of-words by default: BM25 ranking and
+  unranked token matching (AND/OR) both run over the same posting
+  lists, and token positions are stored only for columns that opt in.
+  On a positions-indexed column, quoted phrases are first-class query
+  atoms (see the full-text index section); on any column,
+  exact-string matching of a whole value is a two-pass operation — a
   token-AND prune on the index to gather candidate rows, then a
-  raw-value verification against the stored column — not by storing
-  positions.
+  raw-value verification against the stored column.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -84,6 +84,7 @@ fn demo_superfile() -> Bytes {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![VectorConfig::new(
             "emb".into(),

--- a/examples/locomo-recall/main.rs
+++ b/examples/locomo-recall/main.rs
@@ -259,6 +259,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     // --- retrieve every question through all three modes ---------------------
     let mut scored: Vec<Scored> = Vec::new();
     for case in &fx.cases {
+        // Questions are raw conversational text, and a few contain
+        // double-quote characters — which the query parser reads as
+        // exact-phrase atoms, a query form this table doesn't index
+        // for (and not the intent here). Strip them so every word of
+        // the question contributes as a plain term.
+        let question = case.question.replace('"', " ");
         let csv = case
             .query_vector
             .iter()
@@ -276,14 +282,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         )?)?;
         let keyword = ids_in_order(&table.bm25_search(
             "text",
-            &case.question,
+            &question,
             k,
             BoolMode::Or,
             Some(&["id", "score"]),
         )?)?;
         let hybrid = ids_in_order(&db.query_sql(&format!(
             "SELECT id, score FROM hybrid_search('mem', 'text', '{}', 'vector', '{}', {k}) ORDER BY score DESC",
-            sql_lit(&case.question),
+            sql_lit(&question),
             csv,
         ))?)?;
 

--- a/examples/profile_fts_build.rs
+++ b/examples/profile_fts_build.rs
@@ -42,7 +42,7 @@ fn main() {
 
     let mut builder = FtsBuilder::new(default_tokenizer());
     builder
-        .register_column("title".to_string())
+        .register_column("title".to_string(), false)
         .expect("register column");
 
     let t_add = Instant::now();

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -92,6 +92,7 @@ impl IndexSpec {
             .iter()
             .map(|column| FtsConfig {
                 column: column.clone(),
+                positions: false,
             })
             .collect();
         let vectors = self

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -109,6 +109,12 @@ use crate::superfile::{
 #[derive(Clone)]
 pub struct FtsConfig {
     pub column: String,
+    /// Record token positions for this column, enabling exact phrase
+    /// queries against it. Off by default: positions roughly double
+    /// the column's FTS index footprint, so the cost is a per-column
+    /// opt-in. Columns without positions answer phrase queries with a
+    /// typed error, never a silent bag-of-words fallback.
+    pub positions: bool,
 }
 
 // `VectorConfig` (the per-column vector config used by
@@ -253,6 +259,7 @@ impl BuilderOptions {
             fts.fts_columns_config()
                 .map(|c| FtsConfig {
                     column: c.name.clone(),
+                    positions: c.positions,
                 })
                 .collect::<Vec<_>>()
         } else {
@@ -831,7 +838,14 @@ fn fts_columns_json(cols: &[FtsConfig]) -> String {
         }
         s.push_str(r#"{"name":""#);
         s.push_str(&escape_json(&c.column));
-        s.push_str(r#"","tokenizer":"ascii_lower"}"#);
+        s.push_str(r#"","tokenizer":"ascii_lower""#);
+        // Emitted only when set: a positionless column's JSON stays
+        // byte-identical to files written before positions existed
+        // (the reader defaults a missing field to false).
+        if c.positions {
+            s.push_str(r#","positions":true"#);
+        }
+        s.push('}');
     }
     s.push(']');
     s
@@ -936,6 +950,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -981,6 +996,7 @@ mod tests {
                 "doc_id",
                 vec![FtsConfig {
                     column: "title".into(),
+                    positions: false,
                 }],
                 vec![],
                 Some(default_tokenizer()),
@@ -1001,6 +1017,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "nope".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -1020,6 +1037,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -1035,6 +1053,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![default_vector_config("title", 1)],
             Some(default_tokenizer()),
@@ -1076,6 +1095,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             None,
@@ -1229,9 +1249,11 @@ mod tests {
         let cols = vec![
             FtsConfig {
                 column: "title".into(),
+                positions: false,
             },
             FtsConfig {
                 column: "body".into(),
+                positions: false,
             },
         ];
         let s = fts_columns_json(&cols);
@@ -1239,6 +1261,36 @@ mod tests {
         assert!(s.contains(r#""name":"title""#));
         assert!(s.contains(r#""name":"body""#));
         assert!(s.contains(r#""tokenizer":"ascii_lower""#));
+        // Positionless columns emit no positions field at all — the
+        // JSON stays byte-identical to files written before the flag
+        // existed.
+        assert!(!s.contains("positions"));
+    }
+
+    /// The positions field appears only on the columns that opt in,
+    /// and a mixed declaration keeps the positionless column's entry
+    /// in the legacy shape.
+    #[test]
+    fn fts_columns_json_positions_emitted_only_when_true() {
+        let cols = vec![
+            FtsConfig {
+                column: "title".into(),
+                positions: true,
+            },
+            FtsConfig {
+                column: "body".into(),
+                positions: false,
+            },
+        ];
+        let s = fts_columns_json(&cols);
+        assert!(
+            s.contains(r#"{"name":"title","tokenizer":"ascii_lower","positions":true}"#),
+            "positional column carries the flag: {s}"
+        );
+        assert!(
+            s.contains(r#"{"name":"body","tokenizer":"ascii_lower"}"#),
+            "positionless column stays in the legacy shape: {s}"
+        );
     }
 
     #[test]
@@ -1275,6 +1327,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![default_vector_config("emb", 7)],
             Some(default_tokenizer()),
@@ -1397,6 +1450,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -1503,6 +1557,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -1554,6 +1609,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![default_vector_config("emb", 7)],
             Some(default_tokenizer()),
@@ -1731,6 +1787,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![default_vector_config("emb", 7)],
             Some(default_tokenizer()),
@@ -1818,6 +1875,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -1863,6 +1921,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -1921,6 +1980,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![default_vector_config("emb", 7)],
             Some(default_tokenizer()),
@@ -1968,6 +2028,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2017,6 +2078,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2157,6 +2219,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2228,6 +2291,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2308,6 +2372,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2404,6 +2469,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -474,7 +474,7 @@ impl SuperfileBuilder {
                 .clone();
             let mut fb = FtsBuilder::new(tk);
             for fc in &opts.fts_columns {
-                fb.register_column(fc.column.clone())?;
+                fb.register_column(fc.column.clone(), fc.positions)?;
             }
             Some(fb)
         };

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -192,6 +192,16 @@ pub enum FtsError {
     #[error("query has only negated terms; at least one positive term is required")]
     NegationOnly,
 
+    /// A phrase query needs token positions but the column was built
+    /// without them (`FtsConfig::positions` was false). A typed error
+    /// — never a silent bag-of-words fallback, which would return
+    /// wrong matches.
+    #[error(
+        "phrase query on column {column:?}, which was indexed without token \
+         positions; rebuild with positions enabled to use phrase queries"
+    )]
+    PositionsUnavailable { column: String },
+
     #[error("read error: {0}")]
     Read(#[from] ReadError),
 }

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -39,6 +39,12 @@ pub enum BuildError {
     #[error("user column name {0:?} contains reserved \\x1F separator")]
     ReservedSeparatorInColumnName(String),
 
+    #[error(
+        "FTS column {column:?}: document exceeds the u32::MAX token-position \
+         limit of the positional index"
+    )]
+    PositionOverflow { column: String },
+
     #[error("schema mismatch: self={mine:?} other={other:?}")]
     SchemaMismatch { mine: String, other: String },
 

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -26,8 +26,18 @@ pub mod fts {
     pub const MAGIC: &[u8; 8] = b"INFFTS01";
     /// Numeric version emitted in the blob header (redundant with magic
     /// suffix; future-proofing for a per-section version separate from
-    /// section identity).
+    /// section identity). Version 1 is the positionless layout with the
+    /// 48-byte header; files with no positional column keep writing it,
+    /// byte-identical to before positions existed.
     pub const VERSION: u32 = 1;
+
+    /// Header version written when any FTS column records token
+    /// positions: the header grows to [`HEADER_SIZE_V2`] with the
+    /// positions-region offset at [`hdr::POSITIONS_OFFSET_OFF`], and a
+    /// positions region sits between the postings region and the
+    /// doc-lengths directory. Readers accept both versions; only
+    /// files that actually carry positions require this one.
+    pub const VERSION_POSITIONS: u32 = 2;
 
     /// Fixed-point scale for the per-column average document length.
     /// The builder stores `round(avgdl × 1000)` in the doc-lengths
@@ -43,9 +53,15 @@ pub mod fts {
     /// write and read must agree on the scale.
     pub const BLOCK_MAX_BM25_FIXED_POINT_SCALE: f32 = 1000.0;
 
-    /// Total FTS blob header size in bytes. The FST directory begins
-    /// immediately after this fixed-size header.
+    /// Total FTS blob header size in bytes for [`VERSION`] (no
+    /// positions). The FST directory begins immediately after this
+    /// fixed-size header.
     pub const HEADER_SIZE: usize = 48;
+
+    /// Header size for [`VERSION_POSITIONS`]: the v1 fields plus the
+    /// trailing positions-region offset (`u64` at
+    /// [`hdr::POSITIONS_OFFSET_OFF`]).
+    pub const HEADER_SIZE_V2: usize = 56;
 
     /// Width of the 8-byte FTS magic field.
     pub const MAGIC_BYTES: usize = 8;
@@ -81,6 +97,13 @@ pub mod fts {
         pub const POSTINGS_OFFSET_OFF: usize = 32;
         /// `[40..48]` doc-lengths directory offset (`u64` LE).
         pub const DOC_LENGTHS_DIR_OFF: usize = 40;
+        /// `[48..56]` positions region offset (`u64` LE).
+        /// [`VERSION_POSITIONS`](super::VERSION_POSITIONS) headers
+        /// only — a v1 header ends at
+        /// [`HEADER_SIZE`](super::HEADER_SIZE). The region sits
+        /// between the postings region and the doc-lengths directory
+        /// so the lazy-open doc-lengths tail fetch stays small.
+        pub const POSITIONS_OFFSET_OFF: usize = 48;
     }
 
     /// Per-term metadata header field offsets (relative to a term's
@@ -92,6 +115,17 @@ pub mod fts {
     /// [12..16] postings_length (u32 LE)
     /// [16..20] num_blocks (u32 LE)
     /// ```
+    ///
+    /// Terms of a **positional column** carry an extended 32-byte
+    /// header — the 20-byte layout above plus:
+    ///
+    /// ```text
+    /// [20..28] positions_offset (u64 LE, absolute in the positions region)
+    /// [28..32] positions_length (u32 LE)
+    /// ```
+    ///
+    /// The column's positions flag (from `inf.fts.columns`) selects
+    /// the stride; the two layouts never mix within one column.
     pub mod term_meta {
         /// `[0..4]` document frequency (`u32` LE).
         pub const DF_OFF: usize = 0;
@@ -99,6 +133,12 @@ pub mod fts {
         pub const POSTINGS_LENGTH_OFF: usize = 12;
         /// `[16..20]` number of PFOR blocks / skip-table entries (`u32` LE).
         pub const NUM_BLOCKS_OFF: usize = 16;
+        /// `[20..28]` absolute offset of this term's position bytes in
+        /// the positions region (`u64` LE). Positional columns only.
+        pub const POSITIONS_OFFSET_OFF: usize = 20;
+        /// `[28..32]` byte length of this term's position bytes
+        /// (`u32` LE). Positional columns only.
+        pub const POSITIONS_LENGTH_OFF: usize = 28;
     }
 
     /// Skip-table entry field offsets (relative to the entry start;
@@ -108,8 +148,16 @@ pub mod fts {
     /// [ 0.. 4] last_doc_id (u32 LE)
     /// [ 4.. 8] block_offset (u32 LE, relative to term metadata start)
     /// [ 8..12] max_bm25_x1000 (u32 LE)
-    /// [12..16] reserved (u32)
+    /// [12..16] positions_block_offset (u32 LE; positional columns)
     /// ```
+    ///
+    /// The final field was reserved (always written zero) before
+    /// positions existed; for a positional column it now records the
+    /// byte offset of this block's position runs, relative to the
+    /// term's `positions_offset` — per-block random access into the
+    /// term's position bytes, aligned with the PFOR doc blocks.
+    /// Positionless columns keep writing zero, byte-identical to the
+    /// reserved era.
     pub mod skip_entry {
         /// `[0..4]` largest doc-id in the block (`u32` LE).
         pub const LAST_DOC_ID_OFF: usize = 0;
@@ -117,6 +165,10 @@ pub mod fts {
         pub const BLOCK_OFFSET_OFF: usize = 4;
         /// `[8..12]` fixed-point block-max BM25 bound (`u32` LE).
         pub const MAX_BM25_OFF: usize = 8;
+        /// `[12..16]` block's position-runs offset, relative to the
+        /// term's `positions_offset` (`u32` LE). Zero on positionless
+        /// columns (formerly the reserved field).
+        pub const POSITIONS_BLOCK_OFFSET_OFF: usize = 12;
     }
 }
 

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -24,19 +24,18 @@ pub const CRC_BYTES: usize = 4;
 pub mod fts {
     /// 8-byte magic at the start of the FTS blob: `INF` + `FTS` + version `01`.
     pub const MAGIC: &[u8; 8] = b"INFFTS01";
-    /// Numeric version emitted in the blob header (redundant with magic
-    /// suffix; future-proofing for a per-section version separate from
-    /// section identity). Version 1 is the positionless layout with the
-    /// 48-byte header; files with no positional column keep writing it,
-    /// byte-identical to before positions existed.
+    /// Legacy blob version: the positionless layout with the 48-byte
+    /// header. **Read-only** — files written before the positions
+    /// region existed carry it and stay readable forever; new code
+    /// always writes [`VERSION_POSITIONS`].
     pub const VERSION: u32 = 1;
 
-    /// Header version written when any FTS column records token
-    /// positions: the header grows to [`HEADER_SIZE_V2`] with the
-    /// positions-region offset at [`hdr::POSITIONS_OFFSET_OFF`], and a
-    /// positions region sits between the postings region and the
-    /// doc-lengths directory. Readers accept both versions; only
-    /// files that actually carry positions require this one.
+    /// The version new code writes: the header grows to
+    /// [`HEADER_SIZE_V2`] with the positions-region offset at
+    /// [`hdr::POSITIONS_OFFSET_OFF`], and a positions region —
+    /// empty unless a column records positions — sits between the
+    /// postings region and the doc-lengths directory. Readers accept
+    /// both versions.
     pub const VERSION_POSITIONS: u32 = 2;
 
     /// Fixed-point scale for the per-column average document length.

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -22,7 +22,11 @@ pub const CRC_BYTES: usize = 4;
 
 /// FTS section magic bytes and constants.
 pub mod fts {
-    /// 8-byte magic at the start of the FTS blob: `INF` + `FTS` + version `01`.
+    /// 8-byte magic at the start of the FTS blob: `INF` + `FTS` +
+    /// `01`. The trailing `01` is a fixed part of the section
+    /// identity, **not** a version — it never changes across blob
+    /// versions (v2 blobs carry this same magic). The blob's version
+    /// is the `u32` at [`hdr::VERSION_OFF`], and only that field.
     pub const MAGIC: &[u8; 8] = b"INFFTS01";
     /// Legacy blob version: the positionless layout with the 48-byte
     /// header. **Read-only** — files written before the positions

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -32,8 +32,8 @@ pub mod fts {
     /// header. **Read-only** — files written before the positions
     /// region existed carry it and stay readable until support is
     /// explicitly dropped; new code always writes
-    /// [`VERSION_POSITIONS`].
-    pub const VERSION_LEGACY: u32 = 1;
+    /// [`VERSION_V2`].
+    pub const VERSION_V1_LEGACY: u32 = 1;
 
     /// The version new code writes: the header grows to
     /// [`HEADER_SIZE_V2`] with the positions-region offset at
@@ -41,7 +41,7 @@ pub mod fts {
     /// empty unless a column records positions — sits between the
     /// postings region and the doc-lengths directory. Readers accept
     /// both versions.
-    pub const VERSION_POSITIONS: u32 = 2;
+    pub const VERSION_V2: u32 = 2;
 
     /// Fixed-point scale for the per-column average document length.
     /// The builder stores `round(avgdl × 1000)` in the doc-lengths
@@ -57,12 +57,12 @@ pub mod fts {
     /// write and read must agree on the scale.
     pub const BLOCK_MAX_BM25_FIXED_POINT_SCALE: f32 = 1000.0;
 
-    /// Total FTS blob header size in bytes for [`VERSION_LEGACY`] (no
+    /// Total FTS blob header size in bytes for [`VERSION_V1_LEGACY`] (no
     /// positions). The FST directory begins immediately after this
     /// fixed-size header.
-    pub const HEADER_SIZE: usize = 48;
+    pub const HEADER_SIZE_V1_LEGACY: usize = 48;
 
-    /// Header size for [`VERSION_POSITIONS`]: the v1 fields plus the
+    /// Header size for [`VERSION_V2`]: the v1 fields plus the
     /// trailing positions-region offset (`u64` at
     /// [`hdr::POSITIONS_OFFSET_OFF`]).
     pub const HEADER_SIZE_V2: usize = 56;
@@ -102,9 +102,9 @@ pub mod fts {
         /// `[40..48]` doc-lengths directory offset (`u64` LE).
         pub const DOC_LENGTHS_DIR_OFF: usize = 40;
         /// `[48..56]` positions region offset (`u64` LE).
-        /// [`VERSION_POSITIONS`](super::VERSION_POSITIONS) headers
+        /// [`VERSION_V2`](super::VERSION_V2) headers
         /// only — a v1 header ends at
-        /// [`HEADER_SIZE`](super::HEADER_SIZE). The region sits
+        /// [`HEADER_SIZE_V1_LEGACY`](super::HEADER_SIZE_V1_LEGACY). The region sits
         /// between the postings region and the doc-lengths directory
         /// so the lazy-open doc-lengths tail fetch stays small.
         pub const POSITIONS_OFFSET_OFF: usize = 48;

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -30,9 +30,10 @@ pub mod fts {
     pub const MAGIC: &[u8; 8] = b"INFFTS01";
     /// Legacy blob version: the positionless layout with the 48-byte
     /// header. **Read-only** — files written before the positions
-    /// region existed carry it and stay readable forever; new code
-    /// always writes [`VERSION_POSITIONS`].
-    pub const VERSION: u32 = 1;
+    /// region existed carry it and stay readable until support is
+    /// explicitly dropped; new code always writes
+    /// [`VERSION_POSITIONS`].
+    pub const VERSION_LEGACY: u32 = 1;
 
     /// The version new code writes: the header grows to
     /// [`HEADER_SIZE_V2`] with the positions-region offset at
@@ -56,7 +57,7 @@ pub mod fts {
     /// write and read must agree on the scale.
     pub const BLOCK_MAX_BM25_FIXED_POINT_SCALE: f32 = 1000.0;
 
-    /// Total FTS blob header size in bytes for [`VERSION`] (no
+    /// Total FTS blob header size in bytes for [`VERSION_LEGACY`] (no
     /// positions). The FST directory begins immediately after this
     /// fixed-size header.
     pub const HEADER_SIZE: usize = 48;

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -100,6 +100,7 @@ use crate::superfile::{
         bm25,
         dict::{DictBuilder, StreamingDictBuilder},
         fst_value::FstValue,
+        positions::encode_run,
         posting::{BLOCK_LEN, Block, EncodedBlock, encode_block},
         tokenize::{AsciiLowerTokenizer, Tokenizer},
     },
@@ -151,6 +152,14 @@ type TermIdMap = HbHashMap<&'static str, u32, FxBuildHasher>;
 /// and cleared before the arena is reset, so only its bucket allocation
 /// persists across calls.
 type DocTfMap = HbHashMap<&'static str, u32, FxBuildHasher>;
+
+/// Per-doc positional chain-head map — same key lifetime rules as
+/// [`DocTfMap`] (bump-arena keys, cleared before every arena reset).
+type DocPosHeadMap = HbHashMap<&'static str, u32, FxBuildHasher>;
+
+/// Chain terminator for the per-doc position chains
+/// (`FtsBuilder::doc_pos_chain`): no previous occurrence.
+const CHAIN_END: u32 = u32::MAX;
 
 #[derive(Default)]
 struct FinishProfile {
@@ -303,8 +312,16 @@ enum ColumnPostings {
     /// In-RAM term → posting list map. Small builds stay here forever.
     InRam {
         terms: FxHashMap<Box<str>, Vec<(u32, u32)>>,
-        /// Estimated bytes held by `terms` — used to drive the spill
-        /// threshold check. Approximate (see `ACCUM_*_BYTES`).
+        /// Per-term position runs for a **positional column**: the
+        /// concatenated [`positions`](crate::superfile::fts::positions)
+        /// varint runs, one run per `(doc, tf)` pair in `terms`, in the
+        /// same doc order — pair `i`'s run is the `i`-th run in the
+        /// buffer, delimited by its `tf`. Never populated for
+        /// positionless columns (zero cost off).
+        pos_runs: FxHashMap<Box<str>, Vec<u8>>,
+        /// Estimated bytes held by `terms` (+ `pos_runs`) — used to
+        /// drive the spill threshold check. Approximate (see
+        /// `ACCUM_*_BYTES`).
         bytes: usize,
     },
     /// Hash-partitioned spill files plus the per-column term
@@ -368,6 +385,7 @@ impl ColumnPostings {
     fn new() -> Self {
         Self::InRam {
             terms: FxHashMap::default(),
+            pos_runs: FxHashMap::default(),
             bytes: 0,
         }
     }
@@ -1106,6 +1124,20 @@ pub struct FtsBuilder {
     /// keys borrow from that arena under the lifetime invariant described
     /// on [`DocTfMap`].
     doc_tf: DocTfMap,
+    /// Per-doc chain heads for the positional capture path: term →
+    /// index of its LAST occurrence in `doc_pos_chain`. Shares its
+    /// `&'static str` keys with `doc_tf` (same bump arena, same
+    /// lifetime invariant), so it is likewise declared before `bump`
+    /// and cleared before the arena resets. Untouched for
+    /// positionless columns.
+    doc_pos_head: DocPosHeadMap,
+    /// Per-doc occurrence chain: `(position, prev_index)` per token,
+    /// `CHAIN_END` terminating each term's chain. Cleared per doc;
+    /// capacity persists.
+    doc_pos_chain: Vec<(u32, u32)>,
+    /// Scratch for one term's positions while draining a doc (chain
+    /// walk emits them descending; reversed here before encoding).
+    pos_scratch: Vec<u32>,
     /// Per-shard bump arena reused across every `add_doc` call.
     /// Holds the transient `&str` keys of the per-doc tf hashmap.
     /// Reset at the top of each `add_doc` so the leftover bytes are
@@ -1166,6 +1198,9 @@ impl FtsBuilder {
             max_partition_bytes: DEFAULT_MAX_PARTITION_BYTES,
             n_docs: 0,
             doc_tf: DocTfMap::with_hasher(FxBuildHasher),
+            doc_pos_head: DocPosHeadMap::with_hasher(FxBuildHasher),
+            doc_pos_chain: Vec::new(),
+            pos_scratch: Vec::new(),
             bump: Bump::new(),
         }
     }
@@ -1495,6 +1530,7 @@ impl FtsBuilder {
             .as_any()
             .downcast_ref::<AsciiLowerTokenizer>();
         let mut tokens_in_doc: u64 = 0;
+        let positional = self.columns[col_idx].positions;
 
         // Clear borrowed keys before resetting their backing arena.
         // Both containers retain their allocations for the next doc.
@@ -1507,37 +1543,94 @@ impl FtsBuilder {
         // input slice and only pays the `bump.alloc_str` copy on
         // the miss path. Hit-path cost: hash + load + increment.
         let tf_per_term = &mut self.doc_tf;
-        let mut on_token = |tok: &str| {
-            tokens_in_doc += 1;
-            let hash = compute_hash(tf_per_term.hasher(), tok);
-            match tf_per_term
-                .raw_entry_mut()
-                .from_hash(hash, |existing| *existing == tok)
-            {
-                RawEntryMut::Occupied(mut e) => {
-                    *e.get_mut() += 1;
+        if !positional {
+            let mut on_token = |tok: &str| {
+                tokens_in_doc += 1;
+                let hash = compute_hash(tf_per_term.hasher(), tok);
+                match tf_per_term
+                    .raw_entry_mut()
+                    .from_hash(hash, |existing| *existing == tok)
+                {
+                    RawEntryMut::Occupied(mut e) => {
+                        *e.get_mut() += 1;
+                    }
+                    RawEntryMut::Vacant(e) => {
+                        // Miss path: copy borrowed token bytes into
+                        // the bump arena so the key outlives the
+                        // tokenizer's input lifetime, then widen the
+                        // bump ref to `'static` tied to the scratch
+                        // table's lifetime.
+                        let bumped: &str = bump.alloc_str(tok);
+                        // SAFETY: the `'static` tag is a lie — the real
+                        // lifetime is `self.bump`. The table is drained below,
+                        // cleared before the arena is reset on the next call,
+                        // and declared before `bump` so it also drops first if
+                        // unwinding leaves entries behind.
+                        let extended: &'static str = unsafe { std::mem::transmute(bumped) };
+                        e.insert_hashed_nocheck(hash, extended, 1);
+                    }
                 }
-                RawEntryMut::Vacant(e) => {
-                    // Miss path: copy borrowed token bytes into
-                    // the bump arena so the key outlives the
-                    // tokenizer's input lifetime, then widen the
-                    // bump ref to `'static` tied to the scratch
-                    // table's lifetime.
-                    let bumped: &str = bump.alloc_str(tok);
-                    // SAFETY: the `'static` tag is a lie — the real
-                    // lifetime is `self.bump`. The table is drained below,
-                    // cleared before the arena is reset on the next call,
-                    // and declared before `bump` so it also drops first if
-                    // unwinding leaves entries behind.
-                    let extended: &'static str = unsafe { std::mem::transmute(bumped) };
-                    e.insert_hashed_nocheck(hash, extended, 1);
-                }
+            };
+            if let Some(ascii) = ascii_tok {
+                ascii.tokenize_each_inline(text, &mut on_token);
+            } else {
+                tokenizer.tokenize_each(text, &mut on_token);
             }
-        };
-        if let Some(ascii) = ascii_tok {
-            ascii.tokenize_each_inline(text, &mut on_token);
         } else {
-            tokenizer.tokenize_each(text, &mut on_token);
+            // Positional variant of the scan: same tf accumulation,
+            // plus each occurrence links its token position into a
+            // per-doc chained list headed per term. Chained (not
+            // sorted): O(1) per token, and the drain below walks each
+            // term's chain once. A separate closure so the
+            // positionless hot path above stays byte-identical.
+            self.doc_pos_head.clear();
+            self.doc_pos_chain.clear();
+            let doc_pos_head = &mut self.doc_pos_head;
+            let doc_pos_chain = &mut self.doc_pos_chain;
+            let mut pos_overflow = false;
+            let mut on_token = |tok: &str| {
+                let position = tokens_in_doc;
+                tokens_in_doc += 1;
+                let hash = compute_hash(tf_per_term.hasher(), tok);
+                let key: &'static str = match tf_per_term
+                    .raw_entry_mut()
+                    .from_hash(hash, |existing| *existing == tok)
+                {
+                    RawEntryMut::Occupied(mut e) => {
+                        *e.get_mut() += 1;
+                        *e.key()
+                    }
+                    RawEntryMut::Vacant(e) => {
+                        let bumped: &str = bump.alloc_str(tok);
+                        // SAFETY: same lifetime argument as the
+                        // positionless closure above — the map (and
+                        // the chain-head map, which shares its keys)
+                        // is drained/cleared before the arena resets.
+                        let extended: &'static str = unsafe { std::mem::transmute(bumped) };
+                        e.insert_hashed_nocheck(hash, extended, 1);
+                        extended
+                    }
+                };
+                if position > u32::MAX as u64 {
+                    // Positions are u32 ordinals; a doc this long is
+                    // a hard build error (checked after the scan).
+                    pos_overflow = true;
+                    return;
+                }
+                let idx = doc_pos_chain.len() as u32;
+                let prev = doc_pos_head.insert(key, idx).unwrap_or(CHAIN_END);
+                doc_pos_chain.push((position as u32, prev));
+            };
+            if let Some(ascii) = ascii_tok {
+                ascii.tokenize_each_inline(text, &mut on_token);
+            } else {
+                tokenizer.tokenize_each(text, &mut on_token);
+            }
+            if pos_overflow {
+                return Err(BuildError::PositionOverflow {
+                    column: self.columns[col_idx].name.clone(),
+                });
+            }
         }
 
         let col = &mut self.columns[col_idx];
@@ -1551,8 +1644,12 @@ impl FtsBuilder {
 
         let column_id = col_idx as u32;
         let col_post = &mut self.postings[col_idx];
-        let (terms, bytes) = match col_post {
-            ColumnPostings::InRam { terms, bytes } => (terms, bytes),
+        let (terms, pos_runs, bytes) = match col_post {
+            ColumnPostings::InRam {
+                terms,
+                pos_runs,
+                bytes,
+            } => (terms, pos_runs, bytes),
             ColumnPostings::Spilled { .. } => {
                 unreachable!("add_doc_inram called on Spilled column")
             }
@@ -1561,6 +1658,9 @@ impl FtsBuilder {
         // against a `Box<str>` key, no allocation on hits. Only
         // the miss path constructs a `Box::<str>::from(term)` for
         // insertion. Bytes accounting folds into the same loop.
+        let doc_pos_head = &self.doc_pos_head;
+        let doc_pos_chain = &self.doc_pos_chain;
+        let pos_scratch = &mut self.pos_scratch;
         let mut new_bytes: usize = 0;
         for (term, tf) in tf_per_term.drain() {
             let term_len = term.len();
@@ -1576,10 +1676,47 @@ impl FtsBuilder {
                     );
                 }
             }
+            if positional {
+                // Walk this term's per-doc chain (positions come out
+                // descending — the chain heads at the LAST occurrence),
+                // reverse to ascending, and append the delta-varint run
+                // to the term's run buffer. Pair order and run order
+                // stay aligned because both append once per (term, doc)
+                // in this same loop.
+                let head = doc_pos_head.get(term).copied().unwrap_or(CHAIN_END);
+                debug_assert_ne!(head, CHAIN_END, "tf term missing from position chain");
+                pos_scratch.clear();
+                let mut at = head;
+                while at != CHAIN_END {
+                    let (p, prev) = doc_pos_chain[at as usize];
+                    pos_scratch.push(p);
+                    at = prev;
+                }
+                pos_scratch.reverse();
+                debug_assert_eq!(pos_scratch.len() as u32, tf, "chain length must equal tf");
+                match pos_runs.get_mut(term) {
+                    Some(run) => {
+                        let before = run.len();
+                        encode_run(run, pos_scratch);
+                        new_bytes = new_bytes.saturating_add(run.len() - before);
+                    }
+                    None => {
+                        let mut run = Vec::new();
+                        encode_run(&mut run, pos_scratch);
+                        new_bytes = new_bytes
+                            .saturating_add(ACCUM_NEW_TERM_FIXED_BYTES + term_len + run.len());
+                        pos_runs.insert(Box::<str>::from(term), run);
+                    }
+                }
+            }
         }
         let new_total = bytes.saturating_add(new_bytes);
 
-        if new_total > self.spill_threshold_bytes {
+        // Positional columns stay in RAM for now: their spill-record
+        // format (fixed records + a positions blob) lands with the
+        // spilled write path, and transitioning without it would drop
+        // the accumulated runs.
+        if new_total > self.spill_threshold_bytes && !positional {
             // Crossed the threshold. Drain the in-RAM map into a
             // fresh set of spill files for this column, build the
             // interner from the drained vocab, transition to
@@ -1690,9 +1827,13 @@ impl FtsBuilder {
             max_partition_bytes: _,
             n_docs,
             doc_tf,
+            doc_pos_head,
+            doc_pos_chain: _,
+            pos_scratch: _,
             bump,
         } = self;
         drop(doc_tf);
+        drop(doc_pos_head);
         drop(bump);
 
         let n_columns = columns.len() as u32;
@@ -1745,7 +1886,7 @@ impl FtsBuilder {
                 name: col_name,
                 doc_lengths: col_doc_lengths_owned,
                 total_tokens: _,
-                positions: col_positions,
+                positions: _col_positions,
             } = col_state;
             let col_name_bytes = col_name.as_bytes();
             let avgdl = avgdl_per_col[orig_col_idx];
@@ -1754,7 +1895,11 @@ impl FtsBuilder {
             // In-RAM path invariant: dispatcher checked
             // `!any_spilled`, so every column is `InRam`.
             let terms = match posting_state {
-                ColumnPostings::InRam { terms, bytes: _ } => terms,
+                ColumnPostings::InRam {
+                    terms,
+                    pos_runs: _,
+                    bytes: _,
+                } => terms,
                 ColumnPostings::Spilled { .. } => unreachable!(
                     "finish_to_inram dispatched on !any_spilled; \
                      Spilled column cannot appear here"
@@ -1831,9 +1976,13 @@ impl FtsBuilder {
             max_partition_bytes,
             n_docs,
             doc_tf,
+            doc_pos_head,
+            doc_pos_chain: _,
+            pos_scratch: _,
             bump,
         } = self;
         drop(doc_tf);
+        drop(doc_pos_head);
         drop(bump);
 
         let n_columns = columns.len() as u32;
@@ -1907,14 +2056,18 @@ impl FtsBuilder {
                 name: col_name,
                 doc_lengths: col_doc_lengths_owned,
                 total_tokens: _,
-                positions: col_positions,
+                positions: _col_positions,
             } = col_state;
             let col_name_bytes = col_name.as_bytes();
             let avgdl = avgdl_per_col[orig_col_idx];
             let col_doc_lengths: &[u32] = &col_doc_lengths_owned;
 
             match posting_state {
-                ColumnPostings::InRam { terms, bytes: _ } => {
+                ColumnPostings::InRam {
+                    terms,
+                    pos_runs: _,
+                    bytes: _,
+                } => {
                     // Sort term keys; per-term doc lists are already
                     // in insertion order which is monotonically
                     // increasing local_doc_id per the add_doc

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -64,7 +64,7 @@
 //! ## Builder lifecycle
 //!
 //! 1. `FtsBuilder::new(tokenizer)` — empty builder.
-//! 2. `register_column(name)` per FTS column, in declaration order.
+//! 2. `register_column(name, false)` per FTS column, in declaration order.
 //! 3. `add_doc(column_id, local_doc_id, text)` per `(doc, column)` pair.
 //!    Caller passes monotonically-increasing `local_doc_id`s.
 //! 4. `finish()` (returns `Vec<u8>`) or `finish_to(impl Write)`
@@ -289,6 +289,11 @@ struct ColumnState {
     /// Total token count across every doc in this column. Used for
     /// `avgdl = total_tokens / n_docs`.
     total_tokens: u64,
+    /// Record token positions for this column (phrase support). Set
+    /// at registration from `FtsConfig::positions`; selects the
+    /// positional capture path in `add_doc` and the extended
+    /// per-term layout at emit.
+    positions: bool,
 }
 
 /// Per-column posting accumulator. Starts in `InRam` mode; transitions
@@ -1228,7 +1233,7 @@ impl FtsBuilder {
 
     /// Register an FTS column up-front. Returns its `column_id` (its
     /// index in declaration order).
-    pub fn register_column(&mut self, name: String) -> Result<u32, BuildError> {
+    pub fn register_column(&mut self, name: String, positions: bool) -> Result<u32, BuildError> {
         if name.as_bytes().contains(&FST_SEPARATOR) {
             return Err(BuildError::ReservedSeparatorInColumnName(name));
         }
@@ -1243,6 +1248,7 @@ impl FtsBuilder {
             name,
             doc_lengths: Vec::new(),
             total_tokens: 0,
+            positions,
         });
         self.postings.push(ColumnPostings::new());
         Ok(column_id)
@@ -1739,6 +1745,7 @@ impl FtsBuilder {
                 name: col_name,
                 doc_lengths: col_doc_lengths_owned,
                 total_tokens: _,
+                positions: col_positions,
             } = col_state;
             let col_name_bytes = col_name.as_bytes();
             let avgdl = avgdl_per_col[orig_col_idx];
@@ -1900,6 +1907,7 @@ impl FtsBuilder {
                 name: col_name,
                 doc_lengths: col_doc_lengths_owned,
                 total_tokens: _,
+                positions: col_positions,
             } = col_state;
             let col_name_bytes = col_name.as_bytes();
             let avgdl = avgdl_per_col[orig_col_idx];
@@ -2801,21 +2809,27 @@ mod tests {
     fn register_column_returns_sequential_ids() {
         let mut b = FtsBuilder::new(tokenizer());
         assert_eq!(
-            b.register_column("title".into()).expect("register column"),
+            b.register_column("title".into(), false)
+                .expect("register column"),
             0
         );
         assert_eq!(
-            b.register_column("body".into()).expect("register column"),
+            b.register_column("body".into(), false)
+                .expect("register column"),
             1
         );
-        assert_eq!(b.register_column("tag".into()).expect("register column"), 2);
+        assert_eq!(
+            b.register_column("tag".into(), false)
+                .expect("register column"),
+            2
+        );
     }
 
     #[test]
     fn register_column_rejects_separator_byte() {
         let mut b = FtsBuilder::new(tokenizer());
         let bad = String::from("ti\x1Ftle");
-        let err = b.register_column(bad).expect_err("expected error");
+        let err = b.register_column(bad, false).expect_err("expected error");
         assert!(matches!(err, BuildError::ReservedSeparatorInColumnName(_)));
     }
 
@@ -2823,7 +2837,7 @@ mod tests {
     fn register_column_rejects_reserved_prefix() {
         let mut b = FtsBuilder::new(tokenizer());
         let err = b
-            .register_column("inf.title".into())
+            .register_column("inf.title".into(), false)
             .expect_err("expected error");
         assert!(matches!(err, BuildError::ReservedPrefixInColumnName(_)));
     }
@@ -2831,9 +2845,10 @@ mod tests {
     #[test]
     fn register_column_rejects_duplicates() {
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("title".into()).expect("register column");
+        b.register_column("title".into(), false)
+            .expect("register column");
         let err = b
-            .register_column("title".into())
+            .register_column("title".into(), false)
             .expect_err("expected error");
         assert!(matches!(err, BuildError::DuplicateColumnName(_)));
     }
@@ -2841,7 +2856,8 @@ mod tests {
     #[test]
     fn add_doc_unknown_column_id_errors() {
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("title".into()).expect("register column");
+        b.register_column("title".into(), false)
+            .expect("register column");
         let err = b.add_doc(99, 0, "text").expect_err("expected error");
         assert!(matches!(err, BuildError::FtsColumnTypeInvalid { .. }));
     }
@@ -2849,7 +2865,8 @@ mod tests {
     #[test]
     fn add_doc_reuses_term_frequency_table_capacity() {
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("title".into()).expect("register column");
+        b.register_column("title".into(), false)
+            .expect("register column");
         b.add_doc(0, 0, "alpha beta gamma delta epsilon zeta eta theta")
             .expect("add first doc");
 
@@ -2873,7 +2890,8 @@ mod tests {
         use crate::superfile::fts::reader::{BoolMode, FtsReader};
 
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("title".into()).expect("register column");
+        b.register_column("title".into(), false)
+            .expect("register column");
         b.add_doc(0, 0, "rust rust rust async").expect("add doc");
 
         let blob = Bytes::from(b.finish().expect("finish"));
@@ -2905,8 +2923,12 @@ mod tests {
         use crate::superfile::fts::reader::{BoolMode, FtsReader};
 
         let mut b = FtsBuilder::new(tokenizer());
-        let title_id = b.register_column("title".into()).expect("register title");
-        let body_id = b.register_column("body".into()).expect("register body");
+        let title_id = b
+            .register_column("title".into(), false)
+            .expect("register title");
+        let body_id = b
+            .register_column("body".into(), false)
+            .expect("register body");
 
         // Doc 0: "rust" + "tokio" in title, "rust" + "async" in body.
         // Doc 1: only in body — "rust".
@@ -2971,7 +2993,8 @@ mod tests {
     #[test]
     fn add_doc_tracks_doc_lengths_clamped() {
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("body".into()).expect("register column");
+        b.register_column("body".into(), false)
+            .expect("register column");
         b.add_doc(0, 0, "alpha beta gamma").expect("add doc");
         b.add_doc(0, 1, "").expect("add doc"); // zero-token doc
         b.add_doc(0, 2, "delta").expect("add doc");
@@ -2983,7 +3006,8 @@ mod tests {
     #[test]
     fn add_doc_updates_n_docs_per_call() {
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("body".into()).expect("register column");
+        b.register_column("body".into(), false)
+            .expect("register column");
         // Contract: local_doc_id is consecutive from 0 (per column).
         // n_docs ends up == max(local_doc_id) + 1 == call count.
         b.add_doc(0, 0, "a").expect("add doc");
@@ -2995,7 +3019,8 @@ mod tests {
     #[test]
     fn finish_emits_valid_header() {
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("title".into()).expect("register column");
+        b.register_column("title".into(), false)
+            .expect("register column");
         b.add_doc(0, 0, "hello world").expect("add doc");
         let blob = b.finish().expect("finish");
 
@@ -3027,7 +3052,8 @@ mod tests {
     fn finish_to_matches_finish_byte_for_byte() {
         fn build() -> FtsBuilder {
             let mut b = FtsBuilder::new(tokenizer());
-            b.register_column("title".into()).expect("register title");
+            b.register_column("title".into(), false)
+                .expect("register title");
             for (i, text) in [
                 "rust async rust",
                 "tokio runtime",
@@ -3059,7 +3085,8 @@ mod tests {
         use crate::superfile::fts::reader::{BoolMode, FtsReader};
 
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("title".into()).expect("register title");
+        b.register_column("title".into(), false)
+            .expect("register title");
         for i in 0..256u32 {
             b.add_doc(0, i, &format!("common term{i:03}"))
                 .expect("add doc");
@@ -3088,7 +3115,8 @@ mod tests {
     #[test]
     fn finish_with_no_docs_still_produces_valid_blob() {
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("title".into()).expect("register column");
+        b.register_column("title".into(), false)
+            .expect("register column");
         let blob = b.finish().expect("finish");
         assert_eq!(&blob[0..8], format::fts::MAGIC);
         // n_docs == 0 (u32 at 16..20), n_terms_total == 0 (u32 at 20..24).
@@ -3110,7 +3138,8 @@ mod tests {
         let parent = tempfile::tempdir().expect("parent");
         let mut b = FtsBuilder::with_scratch(tokenizer(), parent.path().to_path_buf())
             .expect("with_scratch");
-        b.register_column("body".into()).expect("register col");
+        b.register_column("body".into(), false)
+            .expect("register col");
         for i in 0..100u32 {
             b.add_doc(0, i, &format!("alpha beta gamma{i}"))
                 .expect("add doc");
@@ -3151,7 +3180,8 @@ mod tests {
         // the in-RAM path uses the in-memory `DictBuilder`. Both
         // must produce identical FST bytes.
         fn build_corpus(b: &mut FtsBuilder) {
-            b.register_column("body".into()).expect("register col");
+            b.register_column("body".into(), false)
+                .expect("register col");
             // 1000 docs, each unique → 1000+ distinct terms forces
             // partitions to fill if threshold is low.
             for i in 0..1000u32 {
@@ -3244,7 +3274,7 @@ mod tests {
         // default (effectively unbounded) per-partition budget.
         fn build_corpus(builder: &mut FtsBuilder) {
             builder
-                .register_column("body".into())
+                .register_column("body".into(), false)
                 .expect("register col");
             // `common` appears in every doc → one term dominates one
             // hash partition. ~600 docs is enough that the per-record
@@ -3309,7 +3339,8 @@ mod tests {
 
         let mut b = FtsBuilder::with_scratch(tokenizer(), parent.path().to_path_buf())
             .expect("with_scratch");
-        b.register_column("body".into()).expect("register col");
+        b.register_column("body".into(), false)
+            .expect("register col");
         b.add_doc(0, 0, "alpha beta gamma").expect("add doc");
         let _blob = b.finish().expect("finish");
 
@@ -3330,7 +3361,8 @@ mod tests {
         // working set. Must still produce a queryable blob.
         let mut b = FtsBuilder::new(tokenizer());
         b.set_spill_partitions(256).expect("set partitions");
-        b.register_column("body".into()).expect("register col");
+        b.register_column("body".into(), false)
+            .expect("register col");
         for i in 0..50u32 {
             b.add_doc(0, i, &format!("alpha beta gamma{i:02}"))
                 .expect("add doc");
@@ -3351,7 +3383,8 @@ mod tests {
     #[test]
     fn finish_offsets_are_consistent() {
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("body".into()).expect("register column");
+        b.register_column("body".into(), false)
+            .expect("register column");
         for i in 0..10 {
             b.add_doc(0, i, &format!("term{i} common"))
                 .expect("add doc");
@@ -3378,7 +3411,8 @@ mod tests {
     fn set_spill_partitions_rejects_after_register_column() {
         // Must be called before the first `register_column`.
         let mut b = FtsBuilder::new(tokenizer());
-        b.register_column("body".into()).expect("register col");
+        b.register_column("body".into(), false)
+            .expect("register col");
         let err = b.set_spill_partitions(16).expect_err("expected error");
         match err {
             BuildError::Io(e) => {

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1624,9 +1624,16 @@ impl FtsBuilder {
             // headed per term in `dense_doc_poshead`.
             self.doc_pos_chain.clear();
             let doc_pos_chain = &mut self.doc_pos_chain;
-            let mut on_token = |tok: &str| {
-                let position = tokens_in_doc;
-                tokens_in_doc += 1;
+            // `record` interns the token, bumps its tf, and links its
+            // `position` into the per-doc chain. `position` is the
+            // gap-inclusive ordinal — a token the tokenizer drops still
+            // advances it, so a phrase never treats the tokens on either
+            // side of a dropped word as adjacent. The doc length
+            // (`tokens_in_doc`) counts only *emitted* tokens, bumped by
+            // the caller below, so it stays identical to the
+            // positionless build; the two coincide only when nothing is
+            // dropped.
+            let mut record = |tok: &str, position: u64| {
                 let (term_id, is_new) = intern_term_id(term_to_id, id_to_term, term_arena, tok);
                 let idx = term_id as usize;
                 if is_new {
@@ -1654,9 +1661,21 @@ impl FtsBuilder {
                 *head = chain_idx;
             };
             if let Some(ascii) = ascii_tok {
-                ascii.tokenize_each_inline(text, &mut on_token);
+                // Gap-aware: a dropped (non-ASCII) run advances the
+                // position ordinal but emits no token.
+                ascii.tokenize_each_inline_positioned(text, |tok, position| {
+                    record(tok, position);
+                    tokens_in_doc += 1;
+                });
             } else {
-                tokenizer.tokenize_each(text, &mut on_token);
+                // A custom tokenizer can't report dropped tokens through
+                // the current trait, so positions are plain emission
+                // ordinals; a tokenizer that silently drops tokens will
+                // not leave phrase gaps (see the `Tokenizer` trait docs).
+                tokenizer.tokenize_each(text, &mut |tok| {
+                    record(tok, tokens_in_doc);
+                    tokens_in_doc += 1;
+                });
             }
         }
         if pos_overflow {
@@ -1822,9 +1841,14 @@ impl FtsBuilder {
             let doc_pos_head = &mut self.doc_pos_head;
             let doc_pos_chain = &mut self.doc_pos_chain;
             let mut pos_overflow = false;
-            let mut on_token = |tok: &str| {
-                let position = tokens_in_doc;
-                tokens_in_doc += 1;
+            // `record` accumulates tf and links each occurrence's
+            // `position` into the per-doc chain. `position` is the
+            // gap-inclusive ordinal (a dropped token still advances it,
+            // so phrase adjacency isn't faked across a dropped word);
+            // the doc length (`tokens_in_doc`) counts only emitted
+            // tokens, bumped by the caller below — identical to the
+            // positionless build.
+            let mut record = |tok: &str, position: u64| {
                 let hash = compute_hash(tf_per_term.hasher(), tok);
                 let key: &'static str = match tf_per_term
                     .raw_entry_mut()
@@ -1856,9 +1880,20 @@ impl FtsBuilder {
                 doc_pos_chain.push((position as u32, prev));
             };
             if let Some(ascii) = ascii_tok {
-                ascii.tokenize_each_inline(text, &mut on_token);
+                // Gap-aware: a dropped (non-ASCII) run advances the
+                // position ordinal but emits no token.
+                ascii.tokenize_each_inline_positioned(text, |tok, position| {
+                    record(tok, position);
+                    tokens_in_doc += 1;
+                });
             } else {
-                tokenizer.tokenize_each(text, &mut on_token);
+                // A custom tokenizer can't report dropped tokens through
+                // the current trait, so positions are plain emission
+                // ordinals (see the `Tokenizer` trait docs).
+                tokenizer.tokenize_each(text, &mut |tok| {
+                    record(tok, tokens_in_doc);
+                    tokens_in_doc += 1;
+                });
             }
             if pos_overflow {
                 return Err(BuildError::PositionOverflow {

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -344,7 +344,7 @@ enum ColumnPostings {
     /// vocabulary, which is typically O(10^4 - 10^6) even on 10M-
     /// doc corpora — millions of bytes, not gigabytes.
     Spilled {
-        partitions: Vec<SpillPartition<PLAIN_RECORD_LANES>>,
+        partitions: SpillStore,
         term_to_id: TermIdMap,
         /// Per-id reverse lookup used by `finish_to` to recover term
         /// bytes for FST emit. Entries are `&'static str` slices
@@ -368,6 +368,11 @@ enum ColumnPostings {
         /// listed in `updated_terms`, so stale entries past the
         /// current `add_doc`'s set are ignored.
         dense_doc_tf: Vec<u32>,
+        /// Per-doc position-chain heads, indexed by `term_id` like
+        /// `dense_doc_tf` (`CHAIN_END` = no occurrence this doc).
+        /// Allocated (and maintained) only for positional columns;
+        /// stays empty otherwise.
+        dense_doc_poshead: Vec<u32>,
         /// Set of `term_id`s that were written in the current
         /// `add_doc` call. Drained at the end of each call to emit
         /// triples and zero out `dense_doc_tf` slots — bounded by
@@ -452,6 +457,57 @@ type Triple = [u32; 3];
 /// Lane count of the plain (positionless) spill record.
 const PLAIN_RECORD_LANES: usize = 3;
 
+/// Lane count of the positional spill record:
+/// `[term_id, doc_id, tf, pos_off_lo, pos_off_hi]`. The last two
+/// lanes carry the little-endian halves of the u64 byte offset of
+/// this posting's position run in the partition's positions blob.
+const POSITIONAL_RECORD_LANES: usize = 5;
+
+/// Pack a positions-blob byte offset into the positional record's
+/// two trailing lanes.
+#[inline(always)]
+fn pos_off_lanes(off: u64) -> (u32, u32) {
+    (off as u32, (off >> 32) as u32)
+}
+
+/// Recover the positions-blob byte offset from a positional record.
+#[inline(always)]
+fn record_pos_off(rec: &[u32; POSITIONAL_RECORD_LANES]) -> u64 {
+    (rec[3] as u64) | ((rec[4] as u64) << 32)
+}
+
+/// Per-partition positions blob for a positional column's spill: the
+/// delta-varint runs of every posting routed to this partition, in
+/// arrival order, addressed by the byte offsets riding in the
+/// partition's 5-lane records. Written during `add_doc` (and the
+/// in-RAM→spill transition), mmap'd read-only at merge time.
+struct PartitionPositions {
+    path: PathBuf,
+    writer: Option<BufWriter<File>>,
+    /// Bytes written so far — the next run's offset.
+    len: u64,
+}
+
+/// A spilled column's partition set. A positionless column spills
+/// plain 3-lane records; a positional column spills 5-lane records
+/// plus one positions blob per partition (parallel vectors).
+enum SpillStore {
+    Plain(Vec<SpillPartition<PLAIN_RECORD_LANES>>),
+    Positional {
+        partitions: Vec<SpillPartition<POSITIONAL_RECORD_LANES>>,
+        blobs: Vec<PartitionPositions>,
+    },
+}
+
+impl SpillStore {
+    fn n_partitions(&self) -> usize {
+        match self {
+            SpillStore::Plain(p) => p.len(),
+            SpillStore::Positional { partitions, .. } => partitions.len(),
+        }
+    }
+}
+
 #[inline(always)]
 fn triple_term_id<const N: usize>(t: &[u32; N]) -> u32 {
     t[0]
@@ -480,12 +536,12 @@ fn triple_tf<const N: usize>(t: &[u32; N]) -> u32 {
 /// the only one compiled, so this function isn't built at all.
 #[cfg(not(target_endian = "little"))]
 #[inline(always)]
-fn write_triple<W: Write>(w: &mut W, term_id: u32, doc_id: u32, tf: u32) -> Result<(), BuildError> {
-    let mut buf = [0u8; TRIPLE_BYTES];
-    buf[0..4].copy_from_slice(&term_id.to_le_bytes());
-    buf[4..8].copy_from_slice(&doc_id.to_le_bytes());
-    buf[8..12].copy_from_slice(&tf.to_le_bytes());
-    w.write_all(&buf)?;
+fn write_record<W: Write, const N: usize>(w: &mut W, rec: &[u32; N]) -> Result<(), BuildError> {
+    let mut buf = [0u8; MAX_RECORD_BYTES];
+    for (lane, v) in rec.iter().enumerate() {
+        buf[lane * 4..lane * 4 + 4].copy_from_slice(&v.to_le_bytes());
+    }
+    w.write_all(&buf[..mem::size_of::<[u32; N]>()])?;
     Ok(())
 }
 
@@ -539,7 +595,7 @@ fn flush_partition_batch<const N: usize>(
     #[cfg(not(target_endian = "little"))]
     {
         for t in &partition.batch {
-            write_triple(writer, t[0], t[1], t[2])?;
+            write_record(writer, t)?;
         }
     }
     partition.batch.clear();
@@ -851,7 +907,7 @@ fn write_records_sorted<const N: usize>(
     #[cfg(not(target_endian = "little"))]
     {
         for t in triples {
-            write_triple(&mut w, t[0], t[1], t[2])?;
+            write_record(&mut w, t)?;
         }
     }
     w.flush()?;
@@ -1142,6 +1198,10 @@ pub struct FtsBuilder {
     /// Scratch for one term's positions while draining a doc (chain
     /// walk emits them descending; reversed here before encoding).
     pos_scratch: Vec<u32>,
+    /// Scratch for one (term, doc) encoded position run on the
+    /// spilled positional drain path (the in-RAM path encodes
+    /// straight into the accumulator's per-term buffer instead).
+    run_scratch: Vec<u8>,
     /// Per-shard bump arena reused across every `add_doc` call.
     /// Holds the transient `&str` keys of the per-doc tf hashmap.
     /// Reset at the top of each `add_doc` so the leftover bytes are
@@ -1205,6 +1265,7 @@ impl FtsBuilder {
             doc_pos_head: DocPosHeadMap::with_hasher(FxBuildHasher),
             doc_pos_chain: Vec::new(),
             pos_scratch: Vec::new(),
+            run_scratch: Vec::new(),
             bump: Bump::new(),
         }
     }
@@ -1314,6 +1375,79 @@ impl FtsBuilder {
         Ok(partitions)
     }
 
+    /// Open one positions blob per spill partition for a positional
+    /// column. Sibling of
+    /// [`open_partitions_for_column`](Self::open_partitions_for_column);
+    /// the blob at index `p` carries the position runs of every record
+    /// routed to partition `p`.
+    fn open_position_blobs_for_column(
+        scratch_dir: &Path,
+        column_id: u32,
+        n_partitions: usize,
+    ) -> Result<Vec<PartitionPositions>, BuildError> {
+        let mut blobs = Vec::with_capacity(n_partitions);
+        for partition in 0..n_partitions {
+            let path = scratch_dir.join(format!("fts_col{column_id}_part{partition}.pos.bin"));
+            let file = File::create(&path)?;
+            blobs.push(PartitionPositions {
+                path,
+                writer: Some(BufWriter::with_capacity(PARTITION_BUF_SIZE, file)),
+                len: 0,
+            });
+        }
+        Ok(blobs)
+    }
+
+    /// Positional twin of
+    /// [`flush_in_ram_to_partitions`](Self::flush_in_ram_to_partitions):
+    /// drains the term → postings map *and* the parallel term →
+    /// position-runs map. Each `(doc, tf)` pair's run — delimited by
+    /// its `tf` varints within the term's concatenated buffer — is
+    /// appended to the partition's positions blob, and the record
+    /// carries the run's byte offset in its trailing lanes.
+    #[allow(clippy::too_many_arguments)]
+    fn flush_in_ram_to_positional_partitions(
+        terms: FxHashMap<Box<str>, Vec<(u32, u32)>>,
+        mut pos_runs: FxHashMap<Box<str>, Vec<u8>>,
+        partitions: &mut [SpillPartition<POSITIONAL_RECORD_LANES>],
+        blobs: &mut [PartitionPositions],
+        term_to_id: &mut TermIdMap,
+        id_to_term: &mut Vec<&'static str>,
+        arena: &Bump,
+    ) -> Result<(), BuildError> {
+        let n_part = partitions.len();
+        debug_assert_eq!(n_part, blobs.len(), "one blob per partition");
+        debug_assert!(
+            n_part.is_power_of_two(),
+            "spill_partitions must be a power of 2; got {n_part}"
+        );
+        let mask = n_part - 1;
+        for (term, postings) in terms {
+            let (term_id, _is_new) = intern_term_id(term_to_id, id_to_term, arena, &term);
+            let p = (term_id as usize) & mask;
+            let runs = pos_runs
+                .remove(&term)
+                .expect("positional term accumulated a position run");
+            let blob = &mut blobs[p];
+            let writer = blob
+                .writer
+                .as_mut()
+                .expect("positions blob writer is open before finish");
+            let mut at: usize = 0;
+            for (doc_id, tf) in postings {
+                let run_start = at;
+                skip_run(&runs, &mut at, tf).expect("builder-encoded runs are well-formed");
+                writer.write_all(&runs[run_start..at])?;
+                let pos_off = blob.len;
+                blob.len += (at - run_start) as u64;
+                let (lo, hi) = pos_off_lanes(pos_off);
+                push_record_batched(&mut partitions[p], [term_id, doc_id, tf, lo, hi])?;
+            }
+            debug_assert_eq!(at, runs.len(), "runs must cover exactly the pairs");
+        }
+        Ok(())
+    }
+
     /// Drain an in-RAM term → postings map into spill partitions,
     /// assigning a fresh `term_id` per term as it's first seen.
     /// Used once per column at the moment that column crosses the
@@ -1421,30 +1555,40 @@ impl FtsBuilder {
             .downcast_ref::<AsciiLowerTokenizer>();
         let mut tokens_in_doc: u64 = 0;
 
+        let positional = self.columns[col_idx].positions;
         let col_post = &mut self.postings[col_idx];
-        let (partitions, term_to_id, id_to_term, dense_doc_tf, updated_terms, term_arena) =
-            match col_post {
-                ColumnPostings::Spilled {
-                    partitions,
-                    term_to_id,
-                    id_to_term,
-                    dense_doc_tf,
-                    updated_terms,
-                    term_arena,
-                } => (
-                    partitions,
-                    term_to_id,
-                    id_to_term,
-                    dense_doc_tf,
-                    updated_terms,
-                    term_arena,
-                ),
-                ColumnPostings::InRam { .. } => {
-                    unreachable!("add_doc_spilled called on InRam column")
-                }
-            };
+        let (
+            store,
+            term_to_id,
+            id_to_term,
+            dense_doc_tf,
+            dense_doc_poshead,
+            updated_terms,
+            term_arena,
+        ) = match col_post {
+            ColumnPostings::Spilled {
+                partitions,
+                term_to_id,
+                id_to_term,
+                dense_doc_tf,
+                dense_doc_poshead,
+                updated_terms,
+                term_arena,
+            } => (
+                partitions,
+                term_to_id,
+                id_to_term,
+                dense_doc_tf,
+                dense_doc_poshead,
+                updated_terms,
+                term_arena,
+            ),
+            ColumnPostings::InRam { .. } => {
+                unreachable!("add_doc_spilled called on InRam column")
+            }
+        };
 
-        let n_part = partitions.len();
+        let n_part = store.n_partitions();
         debug_assert!(
             n_part.is_power_of_two(),
             "spill_partitions must be a power of 2"
@@ -1452,29 +1596,78 @@ impl FtsBuilder {
         let mask = n_part - 1;
 
         updated_terms.clear();
-        let mut on_token = |tok: &str| {
-            tokens_in_doc += 1;
-            let (term_id, is_new) = intern_term_id(term_to_id, id_to_term, term_arena, tok);
-            let idx = term_id as usize;
-            if is_new {
-                debug_assert_eq!(idx, dense_doc_tf.len());
-                dense_doc_tf.push(0);
+        let mut pos_overflow = false;
+        if !positional {
+            let mut on_token = |tok: &str| {
+                tokens_in_doc += 1;
+                let (term_id, is_new) = intern_term_id(term_to_id, id_to_term, term_arena, tok);
+                let idx = term_id as usize;
+                if is_new {
+                    debug_assert_eq!(idx, dense_doc_tf.len());
+                    dense_doc_tf.push(0);
+                }
+                // SAFETY: lockstep invariant between `dense_doc_tf`
+                // and `id_to_term` (see type-level docs above) holds
+                // here: `intern_term_id` returns `term_id <
+                // id_to_term.len()` and we just `push(0)` on `is_new`
+                // so `idx < dense_doc_tf.len()`.
+                let slot = unsafe { dense_doc_tf.get_unchecked_mut(idx) };
+                if *slot == 0 {
+                    updated_terms.push(term_id);
+                }
+                *slot += 1;
+            };
+            if let Some(ascii) = ascii_tok {
+                ascii.tokenize_each_inline(text, &mut on_token);
+            } else {
+                tokenizer.tokenize_each(text, &mut on_token);
             }
-            // SAFETY: lockstep invariant between `dense_doc_tf`
-            // and `id_to_term` (see type-level docs above) holds
-            // here: `intern_term_id` returns `term_id <
-            // id_to_term.len()` and we just `push(0)` on `is_new`
-            // so `idx < dense_doc_tf.len()`.
-            let slot = unsafe { dense_doc_tf.get_unchecked_mut(idx) };
-            if *slot == 0 {
-                updated_terms.push(term_id);
-            }
-            *slot += 1;
-        };
-        if let Some(ascii) = ascii_tok {
-            ascii.tokenize_each_inline(text, &mut on_token);
         } else {
-            tokenizer.tokenize_each(text, &mut on_token);
+            // Positional twin of the scan: same interning + dense-tf
+            // bump, plus each occurrence links its position into the
+            // per-doc chain (the same chain the in-RAM path uses),
+            // headed per term in `dense_doc_poshead`.
+            self.doc_pos_chain.clear();
+            let doc_pos_chain = &mut self.doc_pos_chain;
+            let mut on_token = |tok: &str| {
+                let position = tokens_in_doc;
+                tokens_in_doc += 1;
+                let (term_id, is_new) = intern_term_id(term_to_id, id_to_term, term_arena, tok);
+                let idx = term_id as usize;
+                if is_new {
+                    debug_assert_eq!(idx, dense_doc_tf.len());
+                    dense_doc_tf.push(0);
+                    dense_doc_poshead.push(CHAIN_END);
+                }
+                // SAFETY: same lockstep invariant as the positionless
+                // closure; `dense_doc_poshead` is pushed in the same
+                // `is_new` branch so it shares the bound.
+                let slot = unsafe { dense_doc_tf.get_unchecked_mut(idx) };
+                if *slot == 0 {
+                    updated_terms.push(term_id);
+                }
+                *slot += 1;
+                if position > u32::MAX as u64 {
+                    // Positions are u32 ordinals; checked after the
+                    // scan and surfaced as a hard build error.
+                    pos_overflow = true;
+                    return;
+                }
+                let chain_idx = doc_pos_chain.len() as u32;
+                let head = unsafe { dense_doc_poshead.get_unchecked_mut(idx) };
+                doc_pos_chain.push((position as u32, *head));
+                *head = chain_idx;
+            };
+            if let Some(ascii) = ascii_tok {
+                ascii.tokenize_each_inline(text, &mut on_token);
+            } else {
+                tokenizer.tokenize_each(text, &mut on_token);
+            }
+        }
+        if pos_overflow {
+            return Err(BuildError::PositionOverflow {
+                column: self.columns[col_idx].name.clone(),
+            });
         }
 
         // `self.columns[col_idx]` is a disjoint field from
@@ -1488,22 +1681,64 @@ impl FtsBuilder {
             self.n_docs = docs_now;
         }
 
-        // Per-doc drain: emit one 12-byte triple per touched
-        // term, then zero the dense slot to restore the
-        // `dense_doc_tf[tid] != 0 iff in updated_terms` invariant.
+        // Per-doc drain: emit one fixed-size record per touched term,
+        // then zero the dense slot to restore the `dense_doc_tf[tid]
+        // != 0 iff in updated_terms` invariant. The positional store
+        // additionally walks the term's chain, appends its run to the
+        // partition's positions blob, and rides the run's byte offset
+        // in the record's trailing lanes.
         //
-        // SAFETY: `p = term_id & mask` where
-        // `mask = partitions.len() - 1` (power-of-two enforced),
-        // so `p < partitions.len()`; the dense-slot index `idx`
-        // was already validated above.
-        for &term_id in updated_terms.iter() {
-            let idx = term_id as usize;
-            let slot = unsafe { dense_doc_tf.get_unchecked_mut(idx) };
-            let tf = *slot;
-            *slot = 0;
-            let p = (term_id as usize) & mask;
-            let partition = unsafe { partitions.get_unchecked_mut(p) };
-            push_record_batched(partition, [term_id, local_doc_id, tf])?;
+        // SAFETY: `p = term_id & mask` where `mask = n_partitions - 1`
+        // (power-of-two enforced), so `p` indexes the partition vec;
+        // the dense-slot index `idx` was already validated above.
+        match store {
+            SpillStore::Plain(partitions) => {
+                for &term_id in updated_terms.iter() {
+                    let idx = term_id as usize;
+                    let slot = unsafe { dense_doc_tf.get_unchecked_mut(idx) };
+                    let tf = *slot;
+                    *slot = 0;
+                    let p = (term_id as usize) & mask;
+                    let partition = unsafe { partitions.get_unchecked_mut(p) };
+                    push_record_batched(partition, [term_id, local_doc_id, tf])?;
+                }
+            }
+            SpillStore::Positional { partitions, blobs } => {
+                let doc_pos_chain = &self.doc_pos_chain;
+                let pos_scratch = &mut self.pos_scratch;
+                let run_buf = &mut self.run_scratch;
+                for &term_id in updated_terms.iter() {
+                    let idx = term_id as usize;
+                    let slot = unsafe { dense_doc_tf.get_unchecked_mut(idx) };
+                    let tf = *slot;
+                    *slot = 0;
+                    let head_slot = unsafe { dense_doc_poshead.get_unchecked_mut(idx) };
+                    let head = *head_slot;
+                    *head_slot = CHAIN_END;
+                    pos_scratch.clear();
+                    let mut at = head;
+                    while at != CHAIN_END {
+                        let (pos, prev) = doc_pos_chain[at as usize];
+                        pos_scratch.push(pos);
+                        at = prev;
+                    }
+                    pos_scratch.reverse();
+                    debug_assert_eq!(pos_scratch.len() as u32, tf, "chain length must equal tf");
+                    run_buf.clear();
+                    encode_run(run_buf, pos_scratch);
+                    let p = (term_id as usize) & mask;
+                    let blob = &mut blobs[p];
+                    let pos_off = blob.len;
+                    blob.writer
+                        .as_mut()
+                        .expect("positions blob writer is open before finish")
+                        .write_all(run_buf)?;
+                    blob.len += run_buf.len() as u64;
+                    let (lo, hi) = pos_off_lanes(pos_off);
+                    let partition = unsafe { partitions.get_unchecked_mut(p) };
+                    push_record_batched(partition, [term_id, local_doc_id, tf, lo, hi])?;
+                }
+            }
         }
 
         Ok(())
@@ -1716,40 +1951,69 @@ impl FtsBuilder {
         }
         let new_total = bytes.saturating_add(new_bytes);
 
-        // Positional columns stay in RAM for now: their spill-record
-        // format (fixed records + a positions blob) lands with the
-        // spilled write path, and transitioning without it would drop
-        // the accumulated runs.
-        if new_total > self.spill_threshold_bytes && !positional {
+        if new_total > self.spill_threshold_bytes {
             // Crossed the threshold. Drain the in-RAM map into a
             // fresh set of spill files for this column, build the
             // interner from the drained vocab, transition to
             // `Spilled` so subsequent `add_doc` calls route to
             // `add_doc_spilled`.
             let drained = mem::take(terms);
-            let mut partitions = Self::open_partitions_for_column(
-                self.scratch_dir.path(),
-                column_id,
-                self.spill_partitions,
-            )?;
+            let drained_pos_runs = mem::take(pos_runs);
             let term_arena = Bump::new();
             let mut term_to_id: TermIdMap = TermIdMap::default();
             // Pre-size to the exact post-flush vocab.
             let mut id_to_term: Vec<&'static str> = Vec::with_capacity(drained.len());
-            Self::flush_in_ram_to_partitions(
-                drained,
-                &mut partitions,
-                &mut term_to_id,
-                &mut id_to_term,
-                &term_arena,
-            )?;
+            let store = match positional {
+                false => {
+                    let mut partitions = Self::open_partitions_for_column(
+                        self.scratch_dir.path(),
+                        column_id,
+                        self.spill_partitions,
+                    )?;
+                    Self::flush_in_ram_to_partitions(
+                        drained,
+                        &mut partitions,
+                        &mut term_to_id,
+                        &mut id_to_term,
+                        &term_arena,
+                    )?;
+                    SpillStore::Plain(partitions)
+                }
+                true => {
+                    let mut partitions = Self::open_partitions_for_column(
+                        self.scratch_dir.path(),
+                        column_id,
+                        self.spill_partitions,
+                    )?;
+                    let mut blobs = Self::open_position_blobs_for_column(
+                        self.scratch_dir.path(),
+                        column_id,
+                        self.spill_partitions,
+                    )?;
+                    Self::flush_in_ram_to_positional_partitions(
+                        drained,
+                        drained_pos_runs,
+                        &mut partitions,
+                        &mut blobs,
+                        &mut term_to_id,
+                        &mut id_to_term,
+                        &term_arena,
+                    )?;
+                    SpillStore::Positional { partitions, blobs }
+                }
+            };
             let dense_doc_tf = vec![0u32; id_to_term.len()];
+            let dense_doc_poshead = match positional {
+                true => vec![CHAIN_END; id_to_term.len()],
+                false => Vec::new(),
+            };
             let updated_terms: Vec<u32> = Vec::new();
             *col_post = ColumnPostings::Spilled {
-                partitions,
+                partitions: store,
                 term_to_id,
                 id_to_term,
                 dense_doc_tf,
+                dense_doc_poshead,
                 updated_terms,
                 // Declared last in the variant so it drops last;
                 // see `TermIdMap` doc for the lifetime invariant.
@@ -1834,6 +2098,7 @@ impl FtsBuilder {
             doc_pos_head,
             doc_pos_chain: _,
             pos_scratch: _,
+            run_scratch: _,
             bump,
         } = self;
         drop(doc_tf);
@@ -2000,6 +2265,7 @@ impl FtsBuilder {
             doc_pos_head,
             doc_pos_chain: _,
             pos_scratch: _,
+            run_scratch: _,
             bump,
         } = self;
         drop(doc_tf);
@@ -2057,10 +2323,27 @@ impl FtsBuilder {
         let partition_flush_start = finish_profile.enabled.then(Instant::now);
         for (_, _, cp) in &mut work {
             if let ColumnPostings::Spilled { partitions, .. } = cp {
-                for partition in partitions {
-                    flush_partition_batch(partition)?;
-                    if let Some(mut writer) = partition.writer.take() {
-                        writer.flush()?;
+                match partitions {
+                    SpillStore::Plain(parts) => {
+                        for partition in parts {
+                            flush_partition_batch(partition)?;
+                            if let Some(mut writer) = partition.writer.take() {
+                                writer.flush()?;
+                            }
+                        }
+                    }
+                    SpillStore::Positional { partitions, blobs } => {
+                        for partition in partitions.iter_mut() {
+                            flush_partition_batch(partition)?;
+                            if let Some(mut writer) = partition.writer.take() {
+                                writer.flush()?;
+                            }
+                        }
+                        for blob in blobs.iter_mut() {
+                            if let Some(mut writer) = blob.writer.take() {
+                                writer.flush()?;
+                            }
+                        }
                     }
                 }
             }
@@ -2143,6 +2426,7 @@ impl FtsBuilder {
                     term_to_id,
                     id_to_term,
                     dense_doc_tf: _,
+                    dense_doc_poshead: _,
                     updated_terms: _,
                     term_arena,
                 } => {
@@ -2182,19 +2466,38 @@ impl FtsBuilder {
                     // O(n_partitions) cursors each holding one
                     // triple + a small read buffer.
                     let sort_start = finish_profile.enabled.then(Instant::now);
-                    let mut sorted_files: Vec<PathBuf> = Vec::with_capacity(partitions.len());
-                    for (partition_idx, partition) in partitions.iter().enumerate() {
+                    let mut sorted_files: Vec<PathBuf> =
+                        Vec::with_capacity(partitions.n_partitions());
+                    let partition_paths: Vec<PathBuf> = match &partitions {
+                        SpillStore::Plain(parts) => parts.iter().map(|p| p.path.clone()).collect(),
+                        SpillStore::Positional {
+                            partitions: parts, ..
+                        } => parts.iter().map(|p| p.path.clone()).collect(),
+                    };
+                    for (partition_idx, partition_path) in partition_paths.iter().enumerate() {
                         let sorted_path = scratch_path.join(format!(
                             "fts_col{orig_col_idx}_part{partition_idx}.sorted.bin"
                         ));
-                        sort_partition_to_file(
-                            &partition.path,
-                            &sorted_path,
-                            max_partition_bytes,
-                            &scratch_path,
-                            &format!("c{orig_col_idx}_p{partition_idx}"),
-                            &lex_rank,
-                        )?;
+                        match &partitions {
+                            SpillStore::Plain(_) => sort_partition_to_file::<PLAIN_RECORD_LANES>(
+                                partition_path,
+                                &sorted_path,
+                                max_partition_bytes,
+                                &scratch_path,
+                                &format!("c{orig_col_idx}_p{partition_idx}"),
+                                &lex_rank,
+                            )?,
+                            SpillStore::Positional { .. } => {
+                                sort_partition_to_file::<POSITIONAL_RECORD_LANES>(
+                                    partition_path,
+                                    &sorted_path,
+                                    max_partition_bytes,
+                                    &scratch_path,
+                                    &format!("c{orig_col_idx}_p{partition_idx}"),
+                                    &lex_rank,
+                                )?
+                            }
+                        }
                         sorted_files.push(sorted_path);
                     }
                     if let Some(t) = sort_start {
@@ -2231,41 +2534,6 @@ impl FtsBuilder {
                     // (zero-copy `&[Triple]` over page-cache-hot
                     // bytes), so the per-posting access is pointer
                     // arithmetic against contiguous memory.
-                    let mmap_start = finish_profile.enabled.then(Instant::now);
-                    let mut mmaps: Vec<Mmap> = Vec::with_capacity(sorted_files.len());
-                    for p in &sorted_files {
-                        let f = File::open(p)?;
-                        // SAFETY: the sorted-partition scratch file is
-                        // owned by this builder's `scratch_dir`; no
-                        // other process truncates or appends to it
-                        // for the lifetime of the `Mmap`.
-                        let mmap = unsafe { Mmap::map(&f)? };
-                        mmaps.push(mmap);
-                    }
-                    if let Some(t) = mmap_start {
-                        finish_profile.mmap_open += t.elapsed();
-                    }
-                    let sorted_slices: Vec<&[Triple]> = mmaps
-                        .iter()
-                        .map(|m| {
-                            if m.is_empty() {
-                                &[][..]
-                            } else {
-                                bytemuck::cast_slice::<u8, Triple>(&m[..])
-                            }
-                        })
-                        .collect();
-                    let mask = (sorted_slices.len() - 1) as u32;
-                    // Per-partition next-index into its sorted
-                    // slice. Walked forward only — each posting
-                    // is read exactly once.
-                    let mut cursors: Vec<usize> = vec![0usize; sorted_slices.len()];
-
-                    // Per-term posting buffer. Reused across all
-                    // terms in this column so we pay one
-                    // `Vec` growth schedule instead of one per
-                    // term.
-                    let mut group: Vec<(u32, u32)> = Vec::new();
                     let merge_profile_start = Instant::now();
                     let encode_calls_before = finish_profile.encode_calls;
                     let encode_df1_before = finish_profile.encode_df1;
@@ -2276,39 +2544,12 @@ impl FtsBuilder {
                     let encode_skip_write_before = finish_profile.encode_skip_write;
                     let encode_block_write_before = finish_profile.encode_block_write;
                     let fst_insert_before = finish_profile.fst_insert;
-                    for &term_id in &term_id_in_lex_order {
-                        let p = (term_id & mask) as usize;
-                        let slice = sorted_slices[p];
-                        let mut pos = cursors[p];
-                        group.clear();
-                        // Drain the contiguous run for this term.
-                        // Termination: either the partition runs
-                        // out, or the next triple's term_id
-                        // differs (next term in this partition's
-                        // lex-rank order, which can only be a
-                        // strictly higher `lex_rank` and so a
-                        // different `term_id`).
-                        while pos < slice.len() {
-                            let t = &slice[pos];
-                            if triple_term_id(t) != term_id {
-                                break;
-                            }
-                            group.push((triple_doc_id(t), triple_tf(t)));
-                            pos += 1;
-                        }
-                        cursors[p] = pos;
-                        if group.is_empty() {
-                            // Term registered in `id_to_term` but
-                            // no postings landed for it — only
-                            // possible if `flush_in_ram_to_partitions`
-                            // ran with an empty postings vec.
-                            // Defensive: skip without emitting.
-                            continue;
-                        }
-                        let term_bytes: &str = id_to_term[term_id as usize];
-                        encode_and_emit_term(
-                            term_bytes,
-                            &group,
+                    let n_emitted = match &partitions {
+                        SpillStore::Plain(_) => merge_sorted_spill::<PLAIN_RECORD_LANES, _>(
+                            &sorted_files,
+                            None,
+                            &term_id_in_lex_order,
+                            &id_to_term,
                             col_name_bytes,
                             col_doc_lengths,
                             avgdl,
@@ -2317,28 +2558,50 @@ impl FtsBuilder {
                             &mut postings_writer,
                             &mut postings_crc_acc,
                             &mut postings_len,
-                            None,
-                            Some(&mut fst_streaming),
-                            // Positional columns never transition to
-                            // the spill path, so a merged (spilled)
-                            // term has no positions.
-                            None,
+                            &mut fst_streaming,
+                            &mut positions_sink,
                             &mut finish_profile,
                             &mut term_scratch,
-                        )?;
-                        n_terms_total_usize += 1;
-                    }
-                    // Sanity: every partition should now be fully
-                    // drained. If not, we lost or mis-ordered
-                    // triples somewhere upstream.
-                    debug_assert!(
-                        cursors
-                            .iter()
-                            .zip(sorted_slices.iter())
-                            .all(|(c, s)| *c == s.len()),
-                        "lex-order partition traversal did not drain all triples; \
-                         partition assignment or sort invariant violated"
-                    );
+                        )?,
+                        SpillStore::Positional { blobs, .. } => {
+                            // mmap each partition's positions blob so
+                            // run assembly is pointer arithmetic; an
+                            // empty blob maps to an empty slice.
+                            let mut blob_mmaps: Vec<Option<Mmap>> = Vec::with_capacity(blobs.len());
+                            for blob in blobs {
+                                let f = File::open(&blob.path)?;
+                                // SAFETY: the blob scratch file is owned
+                                // by this builder's `scratch_dir`; its
+                                // writer was flushed + closed in the
+                                // partition-flush stage and nothing
+                                // mutates it for the Mmap's lifetime.
+                                let mmap = match blob.len {
+                                    0 => None,
+                                    _ => Some(unsafe { Mmap::map(&f)? }),
+                                };
+                                blob_mmaps.push(mmap);
+                            }
+                            merge_sorted_spill::<POSITIONAL_RECORD_LANES, _>(
+                                &sorted_files,
+                                Some(&blob_mmaps),
+                                &term_id_in_lex_order,
+                                &id_to_term,
+                                col_name_bytes,
+                                col_doc_lengths,
+                                avgdl,
+                                n_docs,
+                                &mut key_buf,
+                                &mut postings_writer,
+                                &mut postings_crc_acc,
+                                &mut postings_len,
+                                &mut fst_streaming,
+                                &mut positions_sink,
+                                &mut finish_profile,
+                                &mut term_scratch,
+                            )?
+                        }
+                    };
+                    n_terms_total_usize += n_emitted;
                     if finish_profile.enabled {
                         let merge_total = merge_profile_start.elapsed();
                         let encode_total = finish_profile.encode_total - encode_total_before;
@@ -2373,8 +2636,6 @@ impl FtsBuilder {
                     // partition files are owned by `partitions`
                     // and dropped at the next iteration boundary.)
                     let cleanup_start = finish_profile.enabled.then(Instant::now);
-                    drop(sorted_slices);
-                    drop(mmaps);
                     for p in &sorted_files {
                         let _ = fs::remove_file(p);
                     }
@@ -2804,6 +3065,153 @@ struct TermScratch {
     pos_block_offsets: Vec<u32>,
 }
 
+/// Merge one spilled column's sorted partition files and emit every
+/// term. Shared by the plain and positional stores: the lex-order
+/// walk, contiguous-run drain, and emit sequence are identical; a
+/// positional store (`blob_mmaps = Some`) additionally recovers each
+/// posting's position run from its partition's blob — sliced at the
+/// offset riding in the record's trailing lanes, delimited by the
+/// posting's `tf` — and hands the term's assembled runs to the
+/// encoder. Returns the number of terms emitted.
+#[allow(clippy::too_many_arguments)]
+fn merge_sorted_spill<const N: usize, W: Write>(
+    sorted_files: &[PathBuf],
+    blob_mmaps: Option<&[Option<Mmap>]>,
+    term_id_in_lex_order: &[u32],
+    id_to_term: &[&'static str],
+    col_name_bytes: &[u8],
+    col_doc_lengths: &[u32],
+    avgdl: f32,
+    n_docs: u32,
+    key_buf: &mut Vec<u8>,
+    postings_writer: &mut W,
+    postings_crc_acc: &mut u32,
+    postings_len: &mut u64,
+    fst_streaming: &mut StreamingDictBuilder<BufWriter<File>>,
+    positions_sink: &mut PositionsSink,
+    finish_profile: &mut FinishProfile,
+    term_scratch: &mut TermScratch,
+) -> Result<usize, BuildError> {
+    let mmap_start = finish_profile.enabled.then(Instant::now);
+    let mut mmaps: Vec<Mmap> = Vec::with_capacity(sorted_files.len());
+    for p in sorted_files {
+        let f = File::open(p)?;
+        // SAFETY: the sorted-partition scratch file is owned by this
+        // builder's `scratch_dir`; no other process truncates or
+        // appends to it for the lifetime of the `Mmap`.
+        let mmap = unsafe { Mmap::map(&f)? };
+        mmaps.push(mmap);
+    }
+    if let Some(t) = mmap_start {
+        finish_profile.mmap_open += t.elapsed();
+    }
+    let sorted_slices: Vec<&[[u32; N]]> = mmaps
+        .iter()
+        .map(|m| {
+            if m.is_empty() {
+                &[][..]
+            } else {
+                bytemuck::cast_slice::<u8, [u32; N]>(&m[..])
+            }
+        })
+        .collect();
+    let blob_slices: Vec<&[u8]> = match blob_mmaps {
+        Some(ms) => ms
+            .iter()
+            .map(|m| m.as_ref().map_or(&[][..], |m| &m[..]))
+            .collect(),
+        None => Vec::new(),
+    };
+    let mask = (sorted_slices.len() - 1) as u32;
+    // Per-partition next-index into its sorted slice. Walked forward
+    // only — each posting is read exactly once.
+    let mut cursors: Vec<usize> = vec![0usize; sorted_slices.len()];
+
+    // Per-term buffers, reused across all terms in this column so we
+    // pay one growth schedule instead of one per term.
+    let mut group: Vec<(u32, u32)> = Vec::new();
+    let mut group_pos: Vec<u64> = Vec::new();
+    let mut term_run: Vec<u8> = Vec::new();
+    let mut n_emitted = 0usize;
+    for &term_id in term_id_in_lex_order {
+        let p = (term_id & mask) as usize;
+        let slice = sorted_slices[p];
+        let mut pos = cursors[p];
+        group.clear();
+        group_pos.clear();
+        // Drain the contiguous run for this term. Termination: either
+        // the partition runs out, or the next record's term_id differs
+        // (next term in this partition's lex-rank order, which can
+        // only be a strictly higher `lex_rank` and so a different
+        // `term_id`).
+        while pos < slice.len() {
+            let t = &slice[pos];
+            if triple_term_id(t) != term_id {
+                break;
+            }
+            group.push((triple_doc_id(t), triple_tf(t)));
+            if blob_mmaps.is_some() {
+                group_pos.push((t[3] as u64) | ((t[4] as u64) << 32));
+            }
+            pos += 1;
+        }
+        cursors[p] = pos;
+        if group.is_empty() {
+            // Term registered in `id_to_term` but no postings landed
+            // for it — only possible if the in-RAM flush ran with an
+            // empty postings vec. Defensive: skip without emitting.
+            continue;
+        }
+        let term_positions = match blob_mmaps.is_some() {
+            true => {
+                // Assemble the term's position runs in merged (doc)
+                // order: slice each posting's run out of the blob,
+                // its end found by skipping `tf` varints.
+                term_run.clear();
+                let blob = blob_slices[p];
+                for (i, &(_, tf)) in group.iter().enumerate() {
+                    let start = group_pos[i] as usize;
+                    let mut at = start;
+                    skip_run(blob, &mut at, tf).expect("builder-encoded blob runs are well-formed");
+                    term_run.extend_from_slice(&blob[start..at]);
+                }
+                Some((&mut *positions_sink, term_run.as_slice()))
+            }
+            false => None,
+        };
+        let term_bytes: &str = id_to_term[term_id as usize];
+        encode_and_emit_term(
+            term_bytes,
+            &group,
+            col_name_bytes,
+            col_doc_lengths,
+            avgdl,
+            n_docs,
+            key_buf,
+            postings_writer,
+            postings_crc_acc,
+            postings_len,
+            None,
+            Some(fst_streaming),
+            term_positions,
+            finish_profile,
+            term_scratch,
+        )?;
+        n_emitted += 1;
+    }
+    // Sanity: every partition should now be fully drained. If not, we
+    // lost or mis-ordered records somewhere upstream.
+    debug_assert!(
+        cursors
+            .iter()
+            .zip(sorted_slices.iter())
+            .all(|(c, s)| *c == s.len()),
+        "lex-order partition traversal did not drain all records; \
+         partition assignment or sort invariant violated"
+    );
+    Ok(n_emitted)
+}
+
 /// Encode one term's posting list and emit the resulting FST entry
 /// into whichever sink the finish path uses. Exactly one of
 /// `fst_entries_inram` / `fst_streaming` is `Some`; the function
@@ -3071,7 +3479,7 @@ fn write_counted<W: Write>(
 /// `out_path` is `(lex_rank[term_id], doc_id)` so a downstream k-way
 /// merge over multiple sorted partitions produces global lex order
 /// in one pass.
-fn sort_partition_to_file(
+fn sort_partition_to_file<const N: usize>(
     in_path: &Path,
     out_path: &Path,
     max_partition_bytes: u64,
@@ -3079,7 +3487,7 @@ fn sort_partition_to_file(
     partition_label: &str,
     lex_rank: &[u32],
 ) -> Result<(), BuildError> {
-    let mut iter = open_partition_sorted(
+    let mut iter = open_partition_sorted::<N>(
         in_path,
         max_partition_bytes,
         scratch_dir,
@@ -3087,18 +3495,18 @@ fn sort_partition_to_file(
         lex_rank,
     )?;
     let mut w = BufWriter::with_capacity(PARTITION_BUF_SIZE, File::create(out_path)?);
-    let mut batch: Vec<Triple> = Vec::with_capacity(SORT_OUTPUT_BATCH_TRIPLES);
+    let mut batch: Vec<[u32; N]> = Vec::with_capacity(SORT_OUTPUT_BATCH_TRIPLES);
     while let Some(triple) = iter.next_with(lex_rank) {
         let t = triple?;
         batch.push(t);
         if batch.len() == SORT_OUTPUT_BATCH_TRIPLES {
             #[cfg(target_endian = "little")]
             {
-                w.write_all(bytemuck::cast_slice::<Triple, u8>(&batch))?;
+                w.write_all(bytemuck::cast_slice::<[u32; N], u8>(&batch))?;
             }
             #[cfg(not(target_endian = "little"))]
             for t in &batch {
-                write_triple(&mut w, t[0], t[1], t[2])?;
+                write_record(&mut w, t)?;
             }
             batch.clear();
         }
@@ -3106,11 +3514,11 @@ fn sort_partition_to_file(
     if !batch.is_empty() {
         #[cfg(target_endian = "little")]
         {
-            w.write_all(bytemuck::cast_slice::<Triple, u8>(&batch))?;
+            w.write_all(bytemuck::cast_slice::<[u32; N], u8>(&batch))?;
         }
         #[cfg(not(target_endian = "little"))]
         for t in &batch {
-            write_triple(&mut w, t[0], t[1], t[2])?;
+            write_record(&mut w, t)?;
         }
     }
     w.flush()?;
@@ -3908,6 +4316,106 @@ mod tests {
         // Per-column arrays (+ their CRCs) byte-for-byte.
         out.extend_from_slice(&v2[dir_start + dir_size + 4..]);
         out
+    }
+
+    /// Spill-forcing variant of [`build_title_blob`]: a 1-byte
+    /// threshold pushes the column through the in-RAM → spill
+    /// transition on the first doc; `max_partition_bytes` under the
+    /// partition size additionally forces the chunked external merge.
+    fn build_title_blob_spilled(
+        docs: &[String],
+        positional: bool,
+        max_partition_bytes: Option<u64>,
+    ) -> bytes::Bytes {
+        let mut b = FtsBuilder::new(tokenizer());
+        b.set_spill_threshold_bytes(1);
+        if let Some(m) = max_partition_bytes {
+            b.set_max_partition_bytes(m);
+        }
+        b.register_column("title".into(), positional)
+            .expect("register column");
+        for (i, text) in docs.iter().enumerate() {
+            b.add_doc(0, i as u32, text).expect("add doc");
+        }
+        bytes::Bytes::from(b.finish().expect("finish"))
+    }
+
+    /// The full positional query battery must agree bit-for-bit
+    /// across build paths: spilled positional vs in-RAM positional vs
+    /// in-RAM positionless. Covers the spilled capture (5-lane
+    /// records + positions blobs), the in-RAM → spill transition
+    /// carrying accumulated runs, the lex-order merge's run assembly,
+    /// and the df=1 inline packing fed from the spill path.
+    async fn assert_title_blobs_agree(
+        a: bytes::Bytes,
+        a_json: &str,
+        b: bytes::Bytes,
+        b_json: &str,
+        k: usize,
+    ) {
+        use crate::superfile::fts::reader::{BoolMode, FtsReader};
+        let ra = FtsReader::open(a, a_json).expect("open a");
+        let rb = FtsReader::open(b, b_json).expect("open b");
+        let queries: &[(&[&str], BoolMode)] = &[
+            (&["common"], BoolMode::Or),
+            (&["uniqueonce"], BoolMode::Or),
+            (&["dupdup"], BoolMode::Or),
+            (&["medium", "uniqueonce"], BoolMode::Or),
+            (&["common", "medium"], BoolMode::And),
+        ];
+        for (terms, mode) in queries {
+            let ha = ra.search("title", terms, k, *mode).await.expect("search a");
+            let hb = rb.search("title", terms, k, *mode).await.expect("search b");
+            assert_eq!(ha, hb, "results diverged for {terms:?} ({mode:?})");
+            assert!(!ha.is_empty(), "corpus sanity: {terms:?} matches");
+        }
+        for term in ["common", "medium", "uniqueonce", "dupdup"] {
+            assert_eq!(
+                ra.term_df("title", term).await.expect("df a"),
+                rb.term_df("title", term).await.expect("df b"),
+                "df diverged for {term}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn spilled_positional_build_searches_identically() {
+        let docs = positional_corpus();
+        let k = docs.len();
+        let spilled_pos = build_title_blob_spilled(&docs, true, None);
+        assert_eq!(
+            u32::from_le_bytes(spilled_pos[8..12].try_into().expect("version bytes")),
+            format::fts::VERSION_POSITIONS
+        );
+        let inram_pos = build_title_blob(&docs, true);
+        let inram_plain = build_title_blob(&docs, false);
+        assert_title_blobs_agree(
+            spilled_pos.clone(),
+            title_json(true),
+            inram_pos,
+            title_json(true),
+            k,
+        )
+        .await;
+        assert_title_blobs_agree(
+            spilled_pos,
+            title_json(true),
+            inram_plain,
+            title_json(false),
+            k,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn spilled_positional_external_merge_searches_identically() {
+        // A tiny per-partition sort budget forces the chunked
+        // external-merge path over the 5-lane records.
+        let docs = positional_corpus();
+        let k = docs.len();
+        let spilled = build_title_blob_spilled(&docs, true, Some(64));
+        let inram = build_title_blob(&docs, true);
+        assert_title_blobs_agree(spilled, title_json(true), inram, title_json(true), k).await;
     }
 
     #[tokio::test]

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -94,7 +94,6 @@ use crate::superfile::{
     format::{
         self, FST_SEPARATOR,
         checksum::{crc32c, crc32c_append},
-        fts::HEADER_SIZE as FTS_HEADER_SIZE,
     },
     fts::{
         bm25,
@@ -446,14 +445,10 @@ struct SpillPartition<const N: usize> {
 /// and reinterprets as `&[[u32; 3]]` via `bytemuck` — zero per-
 /// record allocation, no UTF-8 validation, no `Box<str>` round-
 /// trips.
-const TRIPLE_BYTES: usize = mem::size_of::<Triple>();
-
 /// Sortable + heap-mergeable posting triple. Matches the on-disk
 /// layout (`[term_id_le, doc_id_le, tf_le]`) exactly so a partition
 /// file's bytes can be reinterpreted as `&[Triple]` without copying
 /// on little-endian hosts.
-type Triple = [u32; 3];
-
 /// Lane count of the plain (positionless) spill record.
 const PLAIN_RECORD_LANES: usize = 3;
 
@@ -639,7 +634,7 @@ fn read_partition_records<const N: usize>(path: &Path) -> Result<Vec<[u32; N]>, 
         let records: &[[u32; N]] = bytemuck::try_cast_slice(&bytes).map_err(|_| {
             BuildError::Io(Error::new(
                 ErrorKind::InvalidData,
-                "bytemuck: spill bytes failed alignment for &[Triple]",
+                "bytemuck: spill bytes failed alignment for the record slice",
             ))
         })?;
         Ok(records.to_vec())
@@ -3151,7 +3146,13 @@ fn merge_sorted_spill<const N: usize, W: Write>(
             }
             group.push((triple_doc_id(t), triple_tf(t)));
             if blob_mmaps.is_some() {
-                group_pos.push((t[3] as u64) | ((t[4] as u64) << 32));
+                // The generic walk serves both widths; the offset
+                // lanes exist only on the positional record, which is
+                // the only case with `blob_mmaps` present.
+                debug_assert_eq!(N, POSITIONAL_RECORD_LANES);
+                let rec: &[u32; POSITIONAL_RECORD_LANES] =
+                    t[..].try_into().expect("positional record width");
+                group_pos.push(record_pos_off(rec));
             }
             pos += 1;
         }
@@ -4206,7 +4207,11 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("ragged.part");
         // One full triple plus a stray byte.
-        fs::write(&path, vec![0u8; TRIPLE_BYTES + 1]).expect("write ragged file");
+        fs::write(
+            &path,
+            vec![0u8; mem::size_of::<[u32; PLAIN_RECORD_LANES]>() + 1],
+        )
+        .expect("write ragged file");
         let err = read_partition_records::<PLAIN_RECORD_LANES>(&path).expect_err("expected error");
         match err {
             BuildError::Io(e) => {

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -344,7 +344,7 @@ enum ColumnPostings {
     /// vocabulary, which is typically O(10^4 - 10^6) even on 10M-
     /// doc corpora — millions of bytes, not gigabytes.
     Spilled {
-        partitions: Vec<SpillPartition>,
+        partitions: Vec<SpillPartition<PLAIN_RECORD_LANES>>,
         term_to_id: TermIdMap,
         /// Per-id reverse lookup used by `finish_to` to recover term
         /// bytes for FST emit. Entries are `&'static str` slices
@@ -410,7 +410,7 @@ impl ColumnPostings {
 /// branches instead of ~150M.
 const SPILL_BATCH_TRIPLES: usize = 341;
 
-struct SpillPartition {
+struct SpillPartition<const N: usize> {
     path: PathBuf,
     writer: Option<BufWriter<File>>,
     /// In-memory batch buffer flushed into `writer` when full.
@@ -429,7 +429,7 @@ struct SpillPartition {
     /// (LE hosts) — zero copy. BE hosts pay a per-triple byte-swap
     /// path. Capacity reserved to `SPILL_BATCH_TRIPLES` up front so
     /// the steady-state push is branch-free w.r.t. capacity.
-    batch: Vec<Triple>,
+    batch: Vec<[u32; N]>,
 }
 
 /// Fixed on-disk record size in the spill files: 4 bytes `term_id`
@@ -449,16 +449,19 @@ const TRIPLE_BYTES: usize = mem::size_of::<Triple>();
 /// on little-endian hosts.
 type Triple = [u32; 3];
 
+/// Lane count of the plain (positionless) spill record.
+const PLAIN_RECORD_LANES: usize = 3;
+
 #[inline(always)]
-fn triple_term_id(t: &Triple) -> u32 {
+fn triple_term_id<const N: usize>(t: &[u32; N]) -> u32 {
     t[0]
 }
 #[inline(always)]
-fn triple_doc_id(t: &Triple) -> u32 {
+fn triple_doc_id<const N: usize>(t: &[u32; N]) -> u32 {
     t[1]
 }
 #[inline(always)]
-fn triple_tf(t: &Triple) -> u32 {
+fn triple_tf<const N: usize>(t: &[u32; N]) -> u32 {
     t[2]
 }
 
@@ -500,13 +503,11 @@ fn write_triple<W: Write>(w: &mut W, term_id: u32, doc_id: u32, tf: u32) -> Resu
 /// which paid the `BufWriter`'s "does this fit in the inline
 /// buffer?" branch on every single posting.
 #[inline(always)]
-fn push_triple_batched(
-    partition: &mut SpillPartition,
-    term_id: u32,
-    doc_id: u32,
-    tf: u32,
+fn push_record_batched<const N: usize>(
+    partition: &mut SpillPartition<N>,
+    rec: [u32; N],
 ) -> Result<(), BuildError> {
-    partition.batch.push([term_id, doc_id, tf]);
+    partition.batch.push(rec);
     if partition.batch.len() >= SPILL_BATCH_TRIPLES {
         flush_partition_batch(partition)?;
     }
@@ -518,7 +519,9 @@ fn push_triple_batched(
 /// from `finish_to`'s flush stage so partial buffers reach disk
 /// before the merge starts.
 #[inline]
-fn flush_partition_batch(partition: &mut SpillPartition) -> Result<(), BuildError> {
+fn flush_partition_batch<const N: usize>(
+    partition: &mut SpillPartition<N>,
+) -> Result<(), BuildError> {
     if partition.batch.is_empty() {
         return Ok(());
     }
@@ -531,7 +534,7 @@ fn flush_partition_batch(partition: &mut SpillPartition) -> Result<(), BuildErro
     // the LE fast read path stays valid cross-arch.
     #[cfg(target_endian = "little")]
     {
-        writer.write_all(bytemuck::cast_slice::<Triple, u8>(&partition.batch))?;
+        writer.write_all(bytemuck::cast_slice::<[u32; N], u8>(&partition.batch))?;
     }
     #[cfg(not(target_endian = "little"))]
     {
@@ -552,20 +555,21 @@ fn flush_partition_batch(partition: &mut SpillPartition) -> Result<(), BuildErro
 /// On a big-endian host the same bytes are read but each triple
 /// is byte-swapped on the way in — kept behind a `cfg` so x86_64
 /// and arm64 hit the fast cast path.
-fn read_partition_triples(path: &Path) -> Result<Vec<Triple>, BuildError> {
+fn read_partition_records<const N: usize>(path: &Path) -> Result<Vec<[u32; N]>, BuildError> {
     let mut bytes = Vec::new();
     let mut f = File::open(path)?;
     f.read_to_end(&mut bytes)?;
     if bytes.is_empty() {
         return Ok(Vec::new());
     }
-    if bytes.len() % TRIPLE_BYTES != 0 {
+    let rec_bytes = mem::size_of::<[u32; N]>();
+    if bytes.len() % rec_bytes != 0 {
         return Err(BuildError::Io(Error::new(
             ErrorKind::InvalidData,
             format!(
                 "spill partition {path:?} length {} not a multiple of {}",
                 bytes.len(),
-                TRIPLE_BYTES
+                rec_bytes
             ),
         )));
     }
@@ -576,38 +580,30 @@ fn read_partition_triples(path: &Path) -> Result<Vec<Triple>, BuildError> {
         // returns a `Vec` whose buffer is aligned at least to
         // `align_of::<usize>()` (8 bytes on x86_64), so the cast
         // to `[u32; 3]` (alignment 4) is sound.
-        let triples: &[Triple] = bytemuck::try_cast_slice(&bytes).map_err(|_| {
+        let records: &[[u32; N]] = bytemuck::try_cast_slice(&bytes).map_err(|_| {
             BuildError::Io(Error::new(
                 ErrorKind::InvalidData,
                 "bytemuck: spill bytes failed alignment for &[Triple]",
             ))
         })?;
-        Ok(triples.to_vec())
+        Ok(records.to_vec())
     }
     #[cfg(not(target_endian = "little"))]
     {
-        let n = bytes.len() / TRIPLE_BYTES;
+        let n = bytes.len() / rec_bytes;
         let mut out = Vec::with_capacity(n);
         for i in 0..n {
-            let off = i * TRIPLE_BYTES;
-            let t = [
-                u32::from_le_bytes(
-                    bytes[off..off + 4]
+            let off = i * rec_bytes;
+            let mut rec = [0u32; N];
+            for (lane, slot) in rec.iter_mut().enumerate() {
+                let at = off + lane * 4;
+                *slot = u32::from_le_bytes(
+                    bytes[at..at + 4]
                         .try_into()
-                        .expect("invariant: 4-byte triple field"),
-                ),
-                u32::from_le_bytes(
-                    bytes[off + 4..off + 8]
-                        .try_into()
-                        .expect("invariant: 4-byte triple field"),
-                ),
-                u32::from_le_bytes(
-                    bytes[off + 8..off + 12]
-                        .try_into()
-                        .expect("invariant: 4-byte triple field"),
-                ),
-            ];
-            out.push(t);
+                        .expect("invariant: 4-byte record lane"),
+                );
+            }
+            out.push(rec);
         }
         Ok(out)
     }
@@ -726,28 +722,27 @@ fn intern_term_id(
 /// Ordering is inverted (heap returns the *smallest* sort key
 /// first) by implementing `Ord` reversed; `BinaryHeap` is a max-
 /// heap.
-struct MergeEntry {
+struct MergeEntry<const N: usize> {
     /// `(lex_rank as u64) << 32 | doc_id as u64`.
     sort_key: u64,
-    /// Original term_id (used at emit time to look up the term
-    /// bytes via `id_to_term`).
-    term_id: u32,
-    tf: u32,
+    /// The full record — term_id/doc_id/tf lanes plus, on positional
+    /// columns, the positions-blob offset lanes.
+    rec: [u32; N],
     reader_idx: usize,
 }
 
-impl PartialEq for MergeEntry {
+impl<const N: usize> PartialEq for MergeEntry<N> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
-impl Eq for MergeEntry {}
-impl PartialOrd for MergeEntry {
+impl<const N: usize> Eq for MergeEntry<N> {}
+impl<const N: usize> PartialOrd for MergeEntry<N> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-impl Ord for MergeEntry {
+impl<const N: usize> Ord for MergeEntry<N> {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reverse so the largest "smallest" wins on pop — gives
         // BinaryHeap min-heap behaviour over (lex_rank, doc_id).
@@ -776,50 +771,44 @@ fn pack_sort_key(lex_rank: u32, doc_id: u32) -> u64 {
 /// and then k-way-merged via a `BinaryHeap` of cursors so the
 /// finish-time sort never holds more than one chunk plus one
 /// record per chunk file at a time.
-enum PartitionIter {
-    InMemory(IntoIter<Triple>),
+enum PartitionIter<const N: usize> {
+    InMemory(IntoIter<[u32; N]>),
     Merge {
         readers: Vec<BufReader<File>>,
-        heap: BinaryHeap<MergeEntry>,
+        heap: BinaryHeap<MergeEntry<N>>,
         /// Sorted-chunk files; kept alive so their inodes don't
         /// get reaped before iteration finishes.
         _chunk_paths: Vec<PathBuf>,
     },
 }
 
-impl PartitionIter {
+impl<const N: usize> PartitionIter<N> {
     /// Pull the next sorted triple from this partition, looking up
     /// the sort key via `lex_rank` when refilling a merge cursor
     /// (so the heap stays minimal — only sort_key + tf + term_id
     /// + reader_idx).
-    fn next_with(&mut self, lex_rank: &[u32]) -> Option<Result<Triple, BuildError>> {
+    fn next_with(&mut self, lex_rank: &[u32]) -> Option<Result<[u32; N], BuildError>> {
         match self {
             PartitionIter::InMemory(it) => it.next().map(Ok),
             PartitionIter::Merge { readers, heap, .. } => {
                 let MergeEntry {
-                    sort_key,
-                    term_id,
-                    tf,
-                    reader_idx,
+                    rec, reader_idx, ..
                 } = heap.pop()?;
-                // Low 32 bits of the packed key carry doc_id.
-                let popped: Triple = [term_id, sort_key as u32, tf];
-                match read_one_triple(&mut readers[reader_idx]) {
+                match read_one_record::<_, N>(&mut readers[reader_idx]) {
                     Ok(Some(next_t)) => {
                         let next_id = triple_term_id(&next_t);
                         let next_doc = triple_doc_id(&next_t);
                         let key = pack_sort_key(lex_rank[next_id as usize], next_doc);
                         heap.push(MergeEntry {
                             sort_key: key,
-                            term_id: next_id,
-                            tf: triple_tf(&next_t),
+                            rec: next_t,
                             reader_idx,
                         });
                     }
                     Ok(None) => { /* chunk drained */ }
                     Err(e) => return Some(Err(e)),
                 }
-                Some(Ok(popped))
+                Some(Ok(rec))
             }
         }
     }
@@ -827,23 +816,32 @@ impl PartitionIter {
 
 /// Read a single 12-byte triple from a sorted-chunk file. Returns
 /// `Ok(None)` on clean EOF.
-fn read_one_triple<R: Read>(r: &mut R) -> Result<Option<Triple>, BuildError> {
-    let mut buf = [0u8; TRIPLE_BYTES];
-    match r.read_exact(&mut buf) {
+fn read_one_record<R: Read, const N: usize>(r: &mut R) -> Result<Option<[u32; N]>, BuildError> {
+    let mut buf = [0u8; MAX_RECORD_BYTES];
+    let rec_bytes = mem::size_of::<[u32; N]>();
+    match r.read_exact(&mut buf[..rec_bytes]) {
         Ok(()) => {}
         Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
         Err(e) => return Err(BuildError::Io(e)),
     }
-    Ok(Some([
-        u32::from_le_bytes(buf[0..4].try_into().expect("slice len 4")),
-        u32::from_le_bytes(buf[4..8].try_into().expect("slice len 4")),
-        u32::from_le_bytes(buf[8..12].try_into().expect("slice len 4")),
-    ]))
+    let mut rec = [0u32; N];
+    for (lane, slot) in rec.iter_mut().enumerate() {
+        let at = lane * 4;
+        *slot = u32::from_le_bytes(buf[at..at + 4].try_into().expect("slice len 4"));
+    }
+    Ok(Some(rec))
 }
+
+/// Stack-buffer bound for [`read_one_record`]: the widest spill
+/// record (the positional 5-lane form).
+const MAX_RECORD_BYTES: usize = mem::size_of::<[u32; 5]>();
 
 /// Write a slice of triples to a sorted-chunk file. Single
 /// `write_all` per chunk on LE hosts via `bytemuck` byte-cast.
-fn write_triples_sorted(triples: &[Triple], path: &Path) -> Result<(), BuildError> {
+fn write_records_sorted<const N: usize>(
+    triples: &[[u32; N]],
+    path: &Path,
+) -> Result<(), BuildError> {
     let mut w = BufWriter::with_capacity(PARTITION_BUF_SIZE, File::create(path)?);
     #[cfg(target_endian = "little")]
     {
@@ -860,17 +858,17 @@ fn write_triples_sorted(triples: &[Triple], path: &Path) -> Result<(), BuildErro
     Ok(())
 }
 
-fn spill_sorted_chunk(
-    chunk: &mut Vec<Triple>,
+fn spill_sorted_chunk<const N: usize>(
+    chunk: &mut Vec<[u32; N]>,
     scratch_dir: &Path,
     partition_label: &str,
     chunk_idx: usize,
     lex_rank: &[u32],
     out_paths: &mut Vec<PathBuf>,
 ) -> Result<(), BuildError> {
-    radix_sort_triples_by_lex_rank(chunk, lex_rank);
+    radix_sort_records_by_lex_rank(chunk, lex_rank);
     let path = scratch_dir.join(format!("{partition_label}_sorted{chunk_idx}.bin"));
-    write_triples_sorted(chunk, &path)?;
+    write_records_sorted(chunk, &path)?;
     chunk.clear();
     #[cfg(test)]
     finish_debug::record_chunk_path(&path);
@@ -952,7 +950,7 @@ mod finish_debug {
 ///
 /// Falls back to `sort_unstable_by` for tiny inputs where the counts
 /// allocation outweighs the algorithmic savings.
-fn radix_sort_triples_by_lex_rank(triples: &mut Vec<Triple>, lex_rank: &[u32]) {
+fn radix_sort_records_by_lex_rank<const N: usize>(triples: &mut Vec<[u32; N]>, lex_rank: &[u32]) {
     let n = triples.len();
     if n < RADIX_SORT_MIN_TRIPLES {
         triples.sort_unstable_by(|a, b| {
@@ -1004,7 +1002,7 @@ fn radix_sort_triples_by_lex_rank(triples: &mut Vec<Triple>, lex_rank: &[u32]) {
     // `triples` in arrival order and arrival order is `(doc_id,
     // term_id_within_doc)`, the within-rank order in `out` is the
     // partition's `doc_id` order — i.e. `(lex_rank, doc_id)`.
-    let mut out: Vec<Triple> = vec![[0u32; 3]; n];
+    let mut out: Vec<[u32; N]> = vec![[0u32; N]; n];
     for t in triples.iter() {
         let rank = unsafe { *lex_rank.get_unchecked(t[0] as usize) } as usize;
         let dst = unsafe { *offsets.get_unchecked(rank) } as usize;
@@ -1021,17 +1019,17 @@ fn radix_sort_triples_by_lex_rank(triples: &mut Vec<Triple>, lex_rank: &[u32]) {
 /// memory path when the on-disk partition is at or below
 /// `max_partition_bytes` and the external-merge path when it
 /// isn't.
-fn open_partition_sorted(
+fn open_partition_sorted<const N: usize>(
     partition_path: &Path,
     max_partition_bytes: u64,
     scratch_dir: &Path,
     partition_label: &str,
     lex_rank: &[u32],
-) -> Result<PartitionIter, BuildError> {
+) -> Result<PartitionIter<N>, BuildError> {
     let len = fs::metadata(partition_path)?.len();
     if len <= max_partition_bytes {
-        let mut triples = read_partition_triples(partition_path)?;
-        radix_sort_triples_by_lex_rank(&mut triples, lex_rank);
+        let mut triples = read_partition_records::<N>(partition_path)?;
+        radix_sort_records_by_lex_rank(&mut triples, lex_rank);
         return Ok(PartitionIter::InMemory(triples.into_iter()));
     }
 
@@ -1040,13 +1038,13 @@ fn open_partition_sorted(
     // in RAM, write sorted-chunk spill, then k-way merge. The
     // resident peak during this path is one chunk's triples plus
     // one triple per chunk file in the heap.
-    let chunk_triples = (max_partition_bytes as usize) / TRIPLE_BYTES;
+    let chunk_triples = (max_partition_bytes as usize) / mem::size_of::<[u32; N]>();
     let mut sorted_chunk_paths: Vec<PathBuf> = Vec::new();
     let mut r = BufReader::with_capacity(PARTITION_BUF_SIZE, File::open(partition_path)?);
-    let mut chunk: Vec<Triple> =
+    let mut chunk: Vec<[u32; N]> =
         Vec::with_capacity(chunk_triples.min(EXTERNAL_MERGE_CHUNK_CAP_TRIPLES));
     let mut chunk_idx: usize = 0;
-    while let Some(t) = read_one_triple(&mut r)? {
+    while let Some(t) = read_one_record::<_, N>(&mut r)? {
         chunk.push(t);
         if chunk.len() >= chunk_triples {
             spill_sorted_chunk(
@@ -1075,15 +1073,14 @@ fn open_partition_sorted(
     for p in &sorted_chunk_paths {
         readers.push(BufReader::with_capacity(PARTITION_BUF_SIZE, File::open(p)?));
     }
-    let mut heap: BinaryHeap<MergeEntry> = BinaryHeap::with_capacity(readers.len());
+    let mut heap: BinaryHeap<MergeEntry<N>> = BinaryHeap::with_capacity(readers.len());
     for (idx, reader) in readers.iter_mut().enumerate() {
-        if let Some(t) = read_one_triple(reader)? {
+        if let Some(t) = read_one_record::<_, N>(reader)? {
             let term_id = triple_term_id(&t);
             let doc_id = triple_doc_id(&t);
             heap.push(MergeEntry {
                 sort_key: pack_sort_key(lex_rank[term_id as usize], doc_id),
-                term_id,
-                tf: triple_tf(&t),
+                rec: t,
                 reader_idx: idx,
             });
         }
@@ -1299,11 +1296,11 @@ impl FtsBuilder {
     /// Open spill partition files for a column and return them.
     /// Called the first time a column's in-RAM accumulator crosses
     /// `spill_threshold_bytes`.
-    fn open_partitions_for_column(
+    fn open_partitions_for_column<const N: usize>(
         scratch_dir: &Path,
         column_id: u32,
         n_partitions: usize,
-    ) -> Result<Vec<SpillPartition>, BuildError> {
+    ) -> Result<Vec<SpillPartition<N>>, BuildError> {
         let mut partitions = Vec::with_capacity(n_partitions);
         for partition in 0..n_partitions {
             let path = scratch_dir.join(format!("fts_col{column_id}_part{partition}.bin"));
@@ -1329,7 +1326,7 @@ impl FtsBuilder {
     /// to intern any new terms they see.
     fn flush_in_ram_to_partitions(
         terms: FxHashMap<Box<str>, Vec<(u32, u32)>>,
-        partitions: &mut [SpillPartition],
+        partitions: &mut [SpillPartition<PLAIN_RECORD_LANES>],
         term_to_id: &mut TermIdMap,
         id_to_term: &mut Vec<&'static str>,
         arena: &Bump,
@@ -1349,7 +1346,7 @@ impl FtsBuilder {
             let (term_id, _is_new) = intern_term_id(term_to_id, id_to_term, arena, &term);
             let p = (term_id as usize) & mask;
             for (doc_id, tf) in postings {
-                push_triple_batched(&mut partitions[p], term_id, doc_id, tf)?;
+                push_record_batched(&mut partitions[p], [term_id, doc_id, tf])?;
             }
         }
         Ok(())
@@ -1506,7 +1503,7 @@ impl FtsBuilder {
             *slot = 0;
             let p = (term_id as usize) & mask;
             let partition = unsafe { partitions.get_unchecked_mut(p) };
-            push_triple_batched(partition, term_id, local_doc_id, tf)?;
+            push_record_batched(partition, [term_id, local_doc_id, tf])?;
         }
 
         Ok(())
@@ -3800,7 +3797,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("empty.part");
         fs::write(&path, []).expect("write empty file");
-        let triples = read_partition_triples(&path).expect("read empty");
+        let triples = read_partition_records::<PLAIN_RECORD_LANES>(&path).expect("read empty");
         assert!(triples.is_empty());
     }
 
@@ -3815,7 +3812,7 @@ mod tests {
             bytes.extend_from_slice(&field.to_le_bytes());
         }
         fs::write(&path, &bytes).expect("write triples");
-        let triples = read_partition_triples(&path).expect("read triples");
+        let triples = read_partition_records::<PLAIN_RECORD_LANES>(&path).expect("read triples");
         assert_eq!(triples, vec![[3u32, 4, 5], [6u32, 7, 8]]);
     }
 
@@ -3827,7 +3824,7 @@ mod tests {
         let path = dir.path().join("ragged.part");
         // One full triple plus a stray byte.
         fs::write(&path, vec![0u8; TRIPLE_BYTES + 1]).expect("write ragged file");
-        let err = read_partition_triples(&path).expect_err("expected error");
+        let err = read_partition_records::<PLAIN_RECORD_LANES>(&path).expect_err("expected error");
         match err {
             BuildError::Io(e) => {
                 assert_eq!(e.kind(), ErrorKind::InvalidData);
@@ -3844,14 +3841,12 @@ mod tests {
         // exercises the derived `PartialEq` / `PartialOrd` bridges too.
         let small = MergeEntry {
             sort_key: 10,
-            term_id: 1,
-            tf: 1,
+            rec: [1u32, 10, 1],
             reader_idx: 0,
         };
         let large = MergeEntry {
             sort_key: 20,
-            term_id: 2,
-            tf: 1,
+            rec: [2u32, 20, 1],
             reader_idx: 1,
         };
         // Reversed ordering: the smaller sort_key is the "greater"
@@ -3862,15 +3857,15 @@ mod tests {
 
         let small_dup = MergeEntry {
             sort_key: 10,
-            term_id: 9,
-            tf: 9,
+            rec: [9u32, 10, 9],
             reader_idx: 0,
         };
         // Equality is keyed on the comparator (sort_key then
-        // reader_idx); term_id / tf are payload and don't affect it.
+        // reader_idx); the record lanes are payload and don't
+        // affect it.
         assert!(small == small_dup);
 
-        let mut heap: BinaryHeap<MergeEntry> = BinaryHeap::new();
+        let mut heap: BinaryHeap<MergeEntry<PLAIN_RECORD_LANES>> = BinaryHeap::new();
         heap.push(large);
         heap.push(small);
         assert_eq!(heap.pop().expect("non-empty heap").sort_key, 10);

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -4291,7 +4291,7 @@ mod tests {
 
         let mut out = Vec::with_capacity(v2.len() - V2_HEADER + V1_HEADER);
         out.extend_from_slice(&v2[0..8]); // magic
-        out.extend_from_slice(&format::fts::VERSION.to_le_bytes());
+        out.extend_from_slice(&format::fts::VERSION_LEGACY.to_le_bytes());
         out.extend_from_slice(&v2[12..24]); // n_columns, n_docs, n_terms
         out.extend_from_slice(&(fst_off - HEADER_SHRINK).to_le_bytes());
         out.extend_from_slice(&(postings_off - HEADER_SHRINK).to_le_bytes());
@@ -4432,7 +4432,7 @@ mod tests {
         let v1_blob = bytes::Bytes::from(synthesize_v1_blob(&v2_blob));
         assert_eq!(
             u32::from_le_bytes(v1_blob[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION
+            format::fts::VERSION_LEGACY
         );
 
         let v1 = FtsReader::open(v1_blob, title_json(false)).expect("v1 opens");

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1598,7 +1598,7 @@ impl FtsBuilder {
                 {
                     RawEntryMut::Occupied(mut e) => {
                         *e.get_mut() += 1;
-                        *e.key()
+                        e.key()
                     }
                     RawEntryMut::Vacant(e) => {
                         let bumped: &str = bump.alloc_str(tok);

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1864,8 +1864,6 @@ impl FtsBuilder {
                 (state.total_tokens as f32) / (n as f32)
             };
         }
-        let any_positional = work.iter().any(|(_, state, _)| state.positions);
-
         let scratch_path = scratch_dir.path().to_path_buf();
         // Posting body scratch file. Encoded posting blocks for every
         // (column, term) flow here in lex order, then get streamed
@@ -1874,10 +1872,9 @@ impl FtsBuilder {
         let mut postings_writer = BufWriter::new(File::create(&postings_path)?);
         let mut postings_len: u64 = 0;
         let mut postings_crc_acc: u32 = 0;
-        let mut positions_sink = match any_positional {
-            true => Some(PositionsSink::create(&scratch_path)?),
-            false => None,
-        };
+        // Every blob carries a positions region (empty when no column
+        // records positions) — new code always writes the v2 layout.
+        let mut positions_sink = PositionsSink::create(&scratch_path)?;
         let mut key_buf: Vec<u8> = Vec::with_capacity(64);
         let mut term_scratch = TermScratch::default();
         let mut finish_profile = FinishProfile::from_env();
@@ -1935,12 +1932,7 @@ impl FtsBuilder {
                     false => Vec::new(),
                 };
                 let term_positions = match col_positions {
-                    true => Some((
-                        positions_sink
-                            .as_mut()
-                            .expect("sink created for positional builds"),
-                        term_runs.as_slice(),
-                    )),
+                    true => Some((&mut positions_sink, term_runs.as_slice())),
                     false => None,
                 };
                 encode_and_emit_term(
@@ -2035,17 +2027,14 @@ impl FtsBuilder {
             };
         }
 
-        let any_positional = work.iter().any(|(_, state, _)| state.positions);
-
         let scratch_path = scratch_dir.path().to_path_buf();
         let postings_path = scratch_path.join("infino_fts_postings.bin");
         let mut postings_writer = BufWriter::new(File::create(&postings_path)?);
         let mut postings_len: u64 = 0;
         let mut postings_crc_acc: u32 = 0;
-        let mut positions_sink = match any_positional {
-            true => Some(PositionsSink::create(&scratch_path)?),
-            false => None,
-        };
+        // Every blob carries a positions region (empty when no column
+        // records positions) — new code always writes the v2 layout.
+        let mut positions_sink = PositionsSink::create(&scratch_path)?;
         let mut key_buf: Vec<u8> = Vec::with_capacity(64);
         let mut term_scratch = TermScratch::default();
         let mut finish_profile = FinishProfile::from_env();
@@ -2126,12 +2115,7 @@ impl FtsBuilder {
                             false => Vec::new(),
                         };
                         let term_positions = match col_positions {
-                            true => Some((
-                                positions_sink
-                                    .as_mut()
-                                    .expect("sink created for positional builds"),
-                                term_runs.as_slice(),
-                            )),
+                            true => Some((&mut positions_sink, term_runs.as_slice())),
                             false => None,
                         };
                         encode_and_emit_term(
@@ -2500,13 +2484,11 @@ struct BlobAssemblyInputs {
     /// Bytes written so far to `postings_writer` (excluding trailer).
     /// Assembly grows this by 4 when it appends the CRC.
     postings_len: u64,
-    /// Positions region sink — `Some` iff any registered column is
-    /// positional, in which case the blob gets a v2 header and the
-    /// region lands between the postings and the doc-lengths
-    /// directory (even when empty, so region accounting stays
-    /// uniform). `None` produces a v1 blob byte-identical to builds
-    /// before positions existed.
-    positions_sink: Option<PositionsSink>,
+    /// Positions region sink. Always present: new code always writes
+    /// the v2 layout, with the region (possibly just its CRC-of-empty
+    /// trailer) between the postings and the doc-lengths directory.
+    /// v1 remains a read-only legacy format.
+    positions_sink: PositionsSink,
     /// Whichever FST sink was used during the per-column emit loop
     /// (exactly one of the two variants).
     fst_sink: FstSinkFinish,
@@ -2587,18 +2569,17 @@ fn assemble_and_write_blob<W: Write>(
     }
 
     // Close the positions region file the same way (CRC trailer +
-    // flush). An all-inline positional build leaves a body of zero
-    // bytes — the region is then just the 4-byte CRC-of-empty, the
-    // same legal shape an empty postings region takes.
-    let positions_region = match positions_sink {
-        Some(mut sink) => {
-            let crc_le = sink.crc_acc.to_le_bytes();
-            sink.writer.write_all(&crc_le)?;
-            sink.writer.flush()?;
-            drop(sink.writer);
-            Some((sink.path, sink.len + crc_le.len() as u64))
-        }
-        None => None,
+    // flush). A build with no positional column (or whose positional
+    // terms all inlined) leaves a body of zero bytes — the region is
+    // then just the 4-byte CRC-of-empty, the same legal shape an
+    // empty postings region takes.
+    let positions_region = {
+        let mut sink = positions_sink;
+        let crc_le = sink.crc_acc.to_le_bytes();
+        sink.writer.write_all(&crc_le)?;
+        sink.writer.flush()?;
+        drop(sink.writer);
+        (sink.path, sink.len + crc_le.len() as u64)
     };
 
     // Finalise the FST. Either path produces "FST bytes followed
@@ -2665,18 +2646,14 @@ fn assemble_and_write_blob<W: Write>(
         FstSource::InRam(bytes) => bytes.len() as u64,
         FstSource::Streamed { len, .. } => *len,
     };
-    let header_size: u64 = match positions_region {
-        Some(_) => format::fts::HEADER_SIZE_V2 as u64,
-        None => FTS_HEADER_SIZE as u64,
-    };
+    let header_size: u64 = format::fts::HEADER_SIZE_V2 as u64;
     let fst_offset: u64 = header_size;
     let postings_offset: u64 = fst_offset + fst_total_len;
     // The positions region sits between the postings and the
     // doc-lengths directory (keeping the lazy-open doc-lengths tail
     // fetch small); absent, the directory follows postings directly.
     let positions_offset: u64 = postings_offset + postings_len;
-    let positions_total_len: u64 = positions_region.as_ref().map_or(0, |(_, len)| *len);
-    let doc_lengths_table_offset: u64 = positions_offset + positions_total_len;
+    let doc_lengths_table_offset: u64 = positions_offset + positions_region.1;
     let mut doc_lengths_array_offset: u64 =
         doc_lengths_table_offset + (n_columns as u64) * (DOC_LENGTHS_ENTRY_SIZE as u64) + 4 /* dir CRC */;
 
@@ -2725,20 +2702,14 @@ fn assemble_and_write_blob<W: Write>(
     let blob_copy_start = finish_profile.enabled.then(Instant::now);
     let mut header = Vec::with_capacity(header_size as usize);
     header.extend_from_slice(format::fts::MAGIC); // 8
-    let version = match positions_region {
-        Some(_) => format::fts::VERSION_POSITIONS,
-        None => format::fts::VERSION,
-    };
-    header.extend_from_slice(&version.to_le_bytes()); // 4
+    header.extend_from_slice(&format::fts::VERSION_POSITIONS.to_le_bytes()); // 4
     header.extend_from_slice(&n_columns.to_le_bytes()); // 4
     header.extend_from_slice(&n_docs.to_le_bytes()); // 4
     header.extend_from_slice(&n_terms_total.to_le_bytes()); // 4
     header.extend_from_slice(&fst_offset.to_le_bytes()); // 8
     header.extend_from_slice(&postings_offset.to_le_bytes()); // 8
     header.extend_from_slice(&doc_lengths_table_offset.to_le_bytes()); // 8
-    if positions_region.is_some() {
-        header.extend_from_slice(&positions_offset.to_le_bytes()); // 8 (v2 only)
-    }
+    header.extend_from_slice(&positions_offset.to_le_bytes()); // 8
     debug_assert_eq!(header.len(), header_size as usize, "header size mismatch");
 
     w.write_all(&header)?;
@@ -2754,9 +2725,9 @@ fn assemble_and_write_blob<W: Write>(
         BufReader::with_capacity(PARTITION_BUF_SIZE, File::open(&postings_path)?);
     io::copy(&mut postings_reader, w)?;
     drop(postings_reader);
-    if let Some((positions_path, _)) = &positions_region {
+    {
         let mut positions_reader =
-            BufReader::with_capacity(PARTITION_BUF_SIZE, File::open(positions_path)?);
+            BufReader::with_capacity(PARTITION_BUF_SIZE, File::open(&positions_region.0)?);
         io::copy(&mut positions_reader, w)?;
     }
 
@@ -3372,9 +3343,9 @@ mod tests {
 
         // Magic.
         assert_eq!(&blob[0..8], format::fts::MAGIC);
-        // Version.
+        // Version — new code always writes the v2 (positions) layout.
         let version = u32::from_le_bytes([blob[8], blob[9], blob[10], blob[11]]);
-        assert_eq!(version, format::fts::VERSION);
+        assert_eq!(version, format::fts::VERSION_POSITIONS);
         // n_columns.
         let n_cols = u32::from_le_bytes([blob[12], blob[13], blob[14], blob[15]]);
         assert_eq!(n_cols, 1);
@@ -3384,11 +3355,11 @@ mod tests {
         // n_terms_total = 2 ("hello", "world") (u32 at 20..24).
         let n_terms = u32::from_le_bytes([blob[20], blob[21], blob[22], blob[23]]);
         assert_eq!(n_terms, 2);
-        // fst_offset == 48 (u64 at 24..32).
+        // fst_offset == the v2 header size (u64 at 24..32).
         let mut buf = [0u8; 8];
         buf.copy_from_slice(&blob[24..32]);
         let fst_off = u64::from_le_bytes(buf);
-        assert_eq!(fst_off, 48);
+        assert_eq!(fst_off, format::fts::HEADER_SIZE_V2 as u64);
     }
 
     /// Determinism gate: two independent in-RAM builds over the
@@ -3747,10 +3718,14 @@ mod tests {
         buf.copy_from_slice(&blob[40..48]);
         let dir_off = u64::from_le_bytes(buf) as usize;
 
-        assert_eq!(fst_off, 48);
+        assert_eq!(fst_off, format::fts::HEADER_SIZE_V2);
         assert!(postings_off > fst_off, "postings after FST");
         assert!(dir_off > postings_off, "directory after postings");
         assert!(dir_off <= blob.len(), "directory offset within blob");
+        buf.copy_from_slice(&blob[48..56]);
+        let positions_off = u64::from_le_bytes(buf) as usize;
+        assert!(positions_off > postings_off, "positions after postings");
+        assert!(dir_off > positions_off, "directory after positions");
     }
 
     #[test]
@@ -3873,6 +3848,101 @@ mod tests {
 
     // ---- positional format (v2 blob) ----
 
+    /// Rewrite a freshly-built positionless v2 blob into the legacy v1
+    /// layout: version 1, 48-byte header (drop the positions-offset
+    /// field), the empty positions region (4-byte CRC) removed, and
+    /// every absolute offset — the three header offsets plus each
+    /// doc-lengths directory entry's array offset — shifted
+    /// accordingly. This is exactly the byte layout pre-positions
+    /// code wrote, letting the "new code reads v1" contract be tested
+    /// without keeping a binary fixture.
+    fn synthesize_v1_blob(v2: &[u8]) -> Vec<u8> {
+        const V2_HEADER: usize = 56;
+        const V1_HEADER: usize = 48;
+        const HEADER_SHRINK: u64 = (V2_HEADER - V1_HEADER) as u64;
+        const EMPTY_REGION_CRC: u64 = 4;
+
+        let read_u64 = |at: usize| u64::from_le_bytes(v2[at..at + 8].try_into().expect("8 bytes"));
+        let read_u32 = |at: usize| u32::from_le_bytes(v2[at..at + 4].try_into().expect("4 bytes"));
+        assert_eq!(read_u32(8), format::fts::VERSION_POSITIONS);
+        let fst_off = read_u64(24);
+        let postings_off = read_u64(32);
+        let doc_lengths_off = read_u64(40);
+        let positions_off = read_u64(48);
+        assert_eq!(
+            doc_lengths_off - positions_off,
+            EMPTY_REGION_CRC,
+            "synthesis requires a positionless blob (empty region)"
+        );
+        let n_columns = read_u32(12) as usize;
+
+        let mut out = Vec::with_capacity(v2.len() - V2_HEADER + V1_HEADER);
+        out.extend_from_slice(&v2[0..8]); // magic
+        out.extend_from_slice(&format::fts::VERSION.to_le_bytes());
+        out.extend_from_slice(&v2[12..24]); // n_columns, n_docs, n_terms
+        out.extend_from_slice(&(fst_off - HEADER_SHRINK).to_le_bytes());
+        out.extend_from_slice(&(postings_off - HEADER_SHRINK).to_le_bytes());
+        let v1_doc_lengths_off = doc_lengths_off - HEADER_SHRINK - EMPTY_REGION_CRC;
+        out.extend_from_slice(&v1_doc_lengths_off.to_le_bytes());
+        // FST + postings regions byte-for-byte (their internal offsets
+        // are region-relative).
+        out.extend_from_slice(&v2[V2_HEADER..positions_off as usize]);
+        // Skip the empty positions region; doc-lengths directory
+        // entries carry ABSOLUTE array offsets — shift each by the
+        // total shrink. Entry layout: column_id u32 | array_off u64 |
+        // avgdl u32 (16 bytes), then a directory CRC we must
+        // recompute since its bytes changed.
+        let dir_start = doc_lengths_off as usize;
+        let dir_size = n_columns * 16;
+        let mut dir = Vec::with_capacity(dir_size);
+        for c in 0..n_columns {
+            let e = dir_start + c * 16;
+            dir.extend_from_slice(&v2[e..e + 4]);
+            let arr_off = read_u64(e + 4) - HEADER_SHRINK - EMPTY_REGION_CRC;
+            dir.extend_from_slice(&arr_off.to_le_bytes());
+            dir.extend_from_slice(&v2[e + 12..e + 16]);
+        }
+        let dir_crc = crc32c(&dir);
+        out.extend_from_slice(&dir);
+        out.extend_from_slice(&dir_crc.to_le_bytes());
+        // Per-column arrays (+ their CRCs) byte-for-byte.
+        out.extend_from_slice(&v2[dir_start + dir_size + 4..]);
+        out
+    }
+
+    #[tokio::test]
+    async fn new_code_reads_synthesized_v1_blob() {
+        use crate::superfile::fts::reader::{BoolMode, FtsReader};
+
+        let docs = positional_corpus();
+        let v2_blob = build_title_blob(&docs, false);
+        let v1_blob = bytes::Bytes::from(synthesize_v1_blob(&v2_blob));
+        assert_eq!(
+            u32::from_le_bytes(v1_blob[8..12].try_into().expect("version bytes")),
+            format::fts::VERSION
+        );
+
+        let v1 = FtsReader::open(v1_blob, title_json(false)).expect("v1 opens");
+        let v2 = FtsReader::open(v2_blob, title_json(false)).expect("v2 opens");
+        let queries: &[&[&str]] = &[&["common"], &["uniqueonce"], &["common", "medium"]];
+        for terms in queries {
+            let a = v1
+                .search("title", terms, docs.len(), BoolMode::Or)
+                .await
+                .expect("v1 search");
+            let b = v2
+                .search("title", terms, docs.len(), BoolMode::Or)
+                .await
+                .expect("v2 search");
+            assert_eq!(a, b, "v1/v2 results diverged for {terms:?}");
+            assert!(!a.is_empty());
+        }
+        assert_eq!(
+            v1.term_df("title", "common").await.expect("v1 df"),
+            v2.term_df("title", "common").await.expect("v2 df"),
+        );
+    }
+
     /// Column-json for the single "title" column, with or without the
     /// positions flag — matching what `fts_columns_json` emits.
     fn title_json(positional: bool) -> &'static str {
@@ -3917,25 +3987,32 @@ mod tests {
     }
 
     #[test]
-    fn positionless_blob_stays_v1_and_positional_writes_v2() {
+    fn every_build_writes_v2_and_positionless_region_is_empty() {
         let docs = positional_corpus();
-        let v1 = build_title_blob(&docs, false);
-        let v2 = build_title_blob(&docs, true);
+        let plain = build_title_blob(&docs, false);
+        let positional = build_title_blob(&docs, true);
 
         let version_of = |blob: &bytes::Bytes| {
             u32::from_le_bytes(blob[8..12].try_into().expect("4 header bytes"))
         };
-        assert_eq!(version_of(&v1), format::fts::VERSION);
-        assert_eq!(version_of(&v2), format::fts::VERSION_POSITIONS);
+        // New code always writes v2; v1 is a read-only legacy format.
+        assert_eq!(version_of(&plain), format::fts::VERSION_POSITIONS);
+        assert_eq!(version_of(&positional), format::fts::VERSION_POSITIONS);
+
+        // A positionless build's region is just the CRC-of-empty.
+        let read_u64_plain =
+            |at: usize| u64::from_le_bytes(plain[at..at + 8].try_into().expect("8 header bytes"));
+        let region_len = read_u64_plain(40) - read_u64_plain(48);
+        assert_eq!(region_len, 4, "positionless region = 4-byte CRC only");
 
         // The v2 positions-region offset points between the postings
         // region and the doc-lengths directory.
         let read_u64 = |blob: &bytes::Bytes, at: usize| {
             u64::from_le_bytes(blob[at..at + 8].try_into().expect("8 header bytes"))
         };
-        let postings_off = read_u64(&v2, 32);
-        let doc_lengths_off = read_u64(&v2, 40);
-        let positions_off = read_u64(&v2, 48);
+        let postings_off = read_u64(&positional, 32);
+        let doc_lengths_off = read_u64(&positional, 40);
+        let positions_off = read_u64(&positional, 48);
         assert!(postings_off < positions_off, "positions follow postings");
         assert!(
             positions_off < doc_lengths_off,

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -3875,4 +3875,170 @@ mod tests {
         heap.push(small);
         assert_eq!(heap.pop().expect("non-empty heap").sort_key, 10);
     }
+
+    // ---- positional format (v2 blob) ----
+
+    /// Column-json for the single "title" column, with or without the
+    /// positions flag — matching what `fts_columns_json` emits.
+    fn title_json(positional: bool) -> &'static str {
+        match positional {
+            true => r#"[{"name":"title","tokenizer":"ascii_lower","positions":true}]"#,
+            false => r#"[{"name":"title","tokenizer":"ascii_lower"}]"#,
+        }
+    }
+
+    /// Build a one-column blob from `docs`, positional or not.
+    fn build_title_blob(docs: &[String], positional: bool) -> bytes::Bytes {
+        let mut b = FtsBuilder::new(tokenizer());
+        b.register_column("title".into(), positional)
+            .expect("register column");
+        for (i, text) in docs.iter().enumerate() {
+            b.add_doc(0, i as u32, text).expect("add doc");
+        }
+        bytes::Bytes::from(b.finish().expect("finish"))
+    }
+
+    /// Corpus exercising every positional emit shape: a multi-block
+    /// common term (> 2 × BLOCK_LEN docs), a df=1 tf=1 term (inline
+    /// position packing), a df=1 tf>1 term (PFOR-forced df=1), and a
+    /// medium term with within-doc repeats (multi-varint runs).
+    fn positional_corpus() -> Vec<String> {
+        let n_docs = 3 * BLOCK_LEN + 7;
+        let mut docs = Vec::with_capacity(n_docs);
+        for i in 0..n_docs {
+            let mut t = String::from("common filler");
+            if i % 5 == 0 {
+                t.push_str(" medium medium");
+            }
+            if i == 42 {
+                t.push_str(" uniqueonce");
+            }
+            if i == 43 {
+                t.push_str(" dupdup dupdup dupdup");
+            }
+            docs.push(t);
+        }
+        docs
+    }
+
+    #[test]
+    fn positionless_blob_stays_v1_and_positional_writes_v2() {
+        let docs = positional_corpus();
+        let v1 = build_title_blob(&docs, false);
+        let v2 = build_title_blob(&docs, true);
+
+        let version_of = |blob: &bytes::Bytes| {
+            u32::from_le_bytes(blob[8..12].try_into().expect("4 header bytes"))
+        };
+        assert_eq!(version_of(&v1), format::fts::VERSION);
+        assert_eq!(version_of(&v2), format::fts::VERSION_POSITIONS);
+
+        // The v2 positions-region offset points between the postings
+        // region and the doc-lengths directory.
+        let read_u64 = |blob: &bytes::Bytes, at: usize| {
+            u64::from_le_bytes(blob[at..at + 8].try_into().expect("8 header bytes"))
+        };
+        let postings_off = read_u64(&v2, 32);
+        let doc_lengths_off = read_u64(&v2, 40);
+        let positions_off = read_u64(&v2, 48);
+        assert!(postings_off < positions_off, "positions follow postings");
+        assert!(
+            positions_off < doc_lengths_off,
+            "doc-lengths directory follows positions"
+        );
+        // The region is non-empty: the corpus has multi-doc terms
+        // whose runs must land in it (only df=1 tf=1 inlines skip it).
+        assert!(doc_lengths_off - positions_off > 4, "region has a body");
+    }
+
+    #[tokio::test]
+    async fn positional_build_searches_identically_to_positionless() {
+        use crate::superfile::fts::reader::{BoolMode, FtsReader};
+
+        let docs = positional_corpus();
+        let v1 = FtsReader::open(build_title_blob(&docs, false), title_json(false)).expect("v1");
+        let v2 = FtsReader::open(build_title_blob(&docs, true), title_json(true)).expect("v2");
+
+        // Positions must never change matching or scoring: identical
+        // (doc, score) lists for every query shape — multi-block
+        // common term, inline df=1 (tf=1), PFOR-forced df=1 (tf>1),
+        // AND / OR multi-term.
+        let queries: &[(&[&str], BoolMode)] = &[
+            (&["common"], BoolMode::Or),
+            (&["uniqueonce"], BoolMode::Or),
+            (&["dupdup"], BoolMode::Or),
+            (&["medium", "uniqueonce"], BoolMode::Or),
+            (&["common", "medium"], BoolMode::And),
+        ];
+        let k = docs.len();
+        for (terms, mode) in queries {
+            let a = v1
+                .search("title", terms, k, *mode)
+                .await
+                .expect("v1 search");
+            let b = v2
+                .search("title", terms, k, *mode)
+                .await
+                .expect("v2 search");
+            assert_eq!(a, b, "results diverged for {terms:?} ({mode:?})");
+            assert!(!a.is_empty(), "corpus sanity: {terms:?} matches");
+        }
+
+        // Count + df fast paths agree too (df reads the term meta's
+        // first bytes — layout-stable across the stride change).
+        for term in ["common", "medium", "uniqueonce", "dupdup"] {
+            let a = v1.term_df("title", term).await.expect("v1 df");
+            let b = v2.term_df("title", term).await.expect("v2 df");
+            assert_eq!(a, b, "df diverged for {term}");
+            let ca = v1
+                .token_match_count("title", &[term], BoolMode::Or)
+                .await
+                .expect("v1 count");
+            let cb = v2
+                .token_match_count("title", &[term], BoolMode::Or)
+                .await
+                .expect("v2 count");
+            assert_eq!(ca, cb, "count diverged for {term}");
+        }
+    }
+
+    #[tokio::test]
+    async fn mixed_columns_only_positional_column_pays() {
+        use crate::superfile::fts::reader::{BoolMode, FtsReader};
+
+        // Two columns, one positional: the blob is v2, and both
+        // columns keep answering queries (each with its own term-meta
+        // stride).
+        let mut b = FtsBuilder::new(tokenizer());
+        b.register_column("body".into(), false).expect("register");
+        b.register_column("title".into(), true).expect("register");
+        for i in 0..(BLOCK_LEN as u32 + 9) {
+            b.add_doc(0, i, "shared bodyterm").expect("body doc");
+            b.add_doc(1, i, "shared titleterm titleterm")
+                .expect("title doc");
+        }
+        let blob = bytes::Bytes::from(b.finish().expect("finish"));
+        assert_eq!(
+            u32::from_le_bytes(blob[8..12].try_into().expect("version bytes")),
+            format::fts::VERSION_POSITIONS
+        );
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"},{"name":"title","tokenizer":"ascii_lower","positions":true}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+        let body_hits = r
+            .search("body", &["bodyterm"], 10, BoolMode::Or)
+            .await
+            .expect("body search");
+        let title_hits = r
+            .search("title", &["titleterm"], 10, BoolMode::Or)
+            .await
+            .expect("title search");
+        assert_eq!(body_hits.len(), 10);
+        assert_eq!(title_hits.len(), 10);
+        // The same term string scoped to each column stays isolated.
+        let shared_body = r
+            .token_match_count("body", &["shared"], BoolMode::Or)
+            .await
+            .expect("shared body");
+        assert_eq!(shared_body, BLOCK_LEN as u64 + 9);
+    }
 }

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -99,8 +99,8 @@ use crate::superfile::{
     fts::{
         bm25,
         dict::{DictBuilder, StreamingDictBuilder},
-        fst_value::FstValue,
-        positions::encode_run,
+        fst_value::{FstValue, INLINE_TF_MAX},
+        positions::{encode_run, read_varint, skip_run},
         posting::{BLOCK_LEN, Block, EncodedBlock, encode_block},
         tokenize::{AsciiLowerTokenizer, Tokenizer},
     },
@@ -214,6 +214,13 @@ impl FinishProfile {
 /// `df`, `postings_length`, and `num_blocks` stay u32; only the absolute
 /// offset into the postings region needs the full u64 range.
 pub(crate) const TERM_META_SIZE: usize = 20;
+
+/// Extended per-term metadata header for terms of a **positional**
+/// column: the 20-byte layout plus `positions_offset` (u64, absolute
+/// within the positions region) and `positions_length` (u32). The
+/// column's positions flag selects the stride — the two layouts never
+/// mix within one column.
+pub(crate) const TERM_META_POSITIONAL_SIZE: usize = 32;
 
 /// Skip-table entry size in bytes.
 pub(crate) const SKIP_ENTRY_SIZE: usize = 16;
@@ -1860,6 +1867,7 @@ impl FtsBuilder {
                 (state.total_tokens as f32) / (n as f32)
             };
         }
+        let any_positional = work.iter().any(|(_, state, _)| state.positions);
 
         let scratch_path = scratch_dir.path().to_path_buf();
         // Posting body scratch file. Encoded posting blocks for every
@@ -1869,6 +1877,10 @@ impl FtsBuilder {
         let mut postings_writer = BufWriter::new(File::create(&postings_path)?);
         let mut postings_len: u64 = 0;
         let mut postings_crc_acc: u32 = 0;
+        let mut positions_sink = match any_positional {
+            true => Some(PositionsSink::create(&scratch_path)?),
+            false => None,
+        };
         let mut key_buf: Vec<u8> = Vec::with_capacity(64);
         let mut term_scratch = TermScratch::default();
         let mut finish_profile = FinishProfile::from_env();
@@ -1886,7 +1898,7 @@ impl FtsBuilder {
                 name: col_name,
                 doc_lengths: col_doc_lengths_owned,
                 total_tokens: _,
-                positions: _col_positions,
+                positions: col_positions,
             } = col_state;
             let col_name_bytes = col_name.as_bytes();
             let avgdl = avgdl_per_col[orig_col_idx];
@@ -1894,12 +1906,12 @@ impl FtsBuilder {
 
             // In-RAM path invariant: dispatcher checked
             // `!any_spilled`, so every column is `InRam`.
-            let terms = match posting_state {
+            let (terms, mut pos_runs) = match posting_state {
                 ColumnPostings::InRam {
                     terms,
-                    pos_runs: _,
+                    pos_runs,
                     bytes: _,
-                } => terms,
+                } => (terms, pos_runs),
                 ColumnPostings::Spilled { .. } => unreachable!(
                     "finish_to_inram dispatched on !any_spilled; \
                      Spilled column cannot appear here"
@@ -1916,6 +1928,24 @@ impl FtsBuilder {
             let mut entries: InRamEntries = terms.into_iter().collect();
             entries.sort_unstable_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
             for (term, postings) in entries {
+                // A positional column hands the term's runs (removed
+                // by value so the map shrinks as it drains) plus the
+                // shared region sink to the encoder.
+                let term_runs: Vec<u8> = match col_positions {
+                    true => pos_runs
+                        .remove(&term)
+                        .expect("positional term accumulated a position run"),
+                    false => Vec::new(),
+                };
+                let term_positions = match col_positions {
+                    true => Some((
+                        positions_sink
+                            .as_mut()
+                            .expect("sink created for positional builds"),
+                        term_runs.as_slice(),
+                    )),
+                    false => None,
+                };
                 encode_and_emit_term(
                     &term,
                     &postings,
@@ -1929,6 +1959,7 @@ impl FtsBuilder {
                     &mut postings_len,
                     Some(&mut fst_inram),
                     None,
+                    term_positions,
                     &mut finish_profile,
                     &mut term_scratch,
                 )?;
@@ -1944,6 +1975,7 @@ impl FtsBuilder {
                 postings_path,
                 postings_crc_acc,
                 postings_len,
+                positions_sink,
                 fst_sink: FstSinkFinish::InRam(fst_inram),
                 n_columns,
                 n_docs,
@@ -2006,11 +2038,17 @@ impl FtsBuilder {
             };
         }
 
+        let any_positional = work.iter().any(|(_, state, _)| state.positions);
+
         let scratch_path = scratch_dir.path().to_path_buf();
         let postings_path = scratch_path.join("infino_fts_postings.bin");
         let mut postings_writer = BufWriter::new(File::create(&postings_path)?);
         let mut postings_len: u64 = 0;
         let mut postings_crc_acc: u32 = 0;
+        let mut positions_sink = match any_positional {
+            true => Some(PositionsSink::create(&scratch_path)?),
+            false => None,
+        };
         let mut key_buf: Vec<u8> = Vec::with_capacity(64);
         let mut term_scratch = TermScratch::default();
         let mut finish_profile = FinishProfile::from_env();
@@ -2056,7 +2094,7 @@ impl FtsBuilder {
                 name: col_name,
                 doc_lengths: col_doc_lengths_owned,
                 total_tokens: _,
-                positions: _col_positions,
+                positions: col_positions,
             } = col_state;
             let col_name_bytes = col_name.as_bytes();
             let avgdl = avgdl_per_col[orig_col_idx];
@@ -2065,7 +2103,7 @@ impl FtsBuilder {
             match posting_state {
                 ColumnPostings::InRam {
                     terms,
-                    pos_runs: _,
+                    pos_runs: mut col_pos_runs,
                     bytes: _,
                 } => {
                     // Sort term keys; per-term doc lists are already
@@ -2080,6 +2118,25 @@ impl FtsBuilder {
                     // are unique.
                     entries.sort_unstable_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
                     for (term, postings) in entries {
+                        // Positional columns never spill (their
+                        // accumulator is pinned in RAM), so a spilled
+                        // build's positional terms all pass through
+                        // this arm with their runs.
+                        let term_runs: Vec<u8> = match col_positions {
+                            true => col_pos_runs
+                                .remove(&term)
+                                .expect("positional term accumulated a position run"),
+                            false => Vec::new(),
+                        };
+                        let term_positions = match col_positions {
+                            true => Some((
+                                positions_sink
+                                    .as_mut()
+                                    .expect("sink created for positional builds"),
+                                term_runs.as_slice(),
+                            )),
+                            false => None,
+                        };
                         encode_and_emit_term(
                             &term,
                             &postings,
@@ -2093,6 +2150,7 @@ impl FtsBuilder {
                             &mut postings_len,
                             None,
                             Some(&mut fst_streaming),
+                            term_positions,
                             &mut finish_profile,
                             &mut term_scratch,
                         )?;
@@ -2280,6 +2338,10 @@ impl FtsBuilder {
                             &mut postings_len,
                             None,
                             Some(&mut fst_streaming),
+                            // Positional columns never transition to
+                            // the spill path, so a merged (spilled)
+                            // term has no positions.
+                            None,
                             &mut finish_profile,
                             &mut term_scratch,
                         )?;
@@ -2376,6 +2438,7 @@ impl FtsBuilder {
                 postings_path,
                 postings_crc_acc,
                 postings_len,
+                positions_sink,
                 fst_sink: FstSinkFinish::Streaming {
                     builder: fst_streaming,
                     path: fst_streaming_path,
@@ -2398,6 +2461,34 @@ impl FtsBuilder {
 /// like "build everything, then assemble" instead of routing through
 /// a long positional argument list. All fields are consumed by
 /// assembly.
+/// Streaming sink for the positions region, mirroring the postings
+/// scratch-file quartet (writer, path, running CRC, running length).
+/// Created by a finish path iff any registered column is positional;
+/// its running `len` doubles as the next term's `positions_offset`
+/// (offsets in term metadata are relative to the region start).
+struct PositionsSink {
+    writer: BufWriter<File>,
+    path: PathBuf,
+    crc_acc: u32,
+    len: u64,
+}
+
+impl PositionsSink {
+    fn create(scratch_path: &Path) -> Result<Self, BuildError> {
+        let path = scratch_path.join("infino_fts_positions.bin");
+        Ok(Self {
+            writer: BufWriter::new(File::create(&path)?),
+            path,
+            crc_acc: 0,
+            len: 0,
+        })
+    }
+
+    fn write(&mut self, bytes: &[u8]) -> Result<(), BuildError> {
+        write_counted(&mut self.writer, &mut self.crc_acc, &mut self.len, bytes)
+    }
+}
+
 struct BlobAssemblyInputs {
     /// Open scratch writer holding every encoded posting block in
     /// lex order. Assembly closes it (CRC trailer + flush) before
@@ -2412,6 +2503,13 @@ struct BlobAssemblyInputs {
     /// Bytes written so far to `postings_writer` (excluding trailer).
     /// Assembly grows this by 4 when it appends the CRC.
     postings_len: u64,
+    /// Positions region sink — `Some` iff any registered column is
+    /// positional, in which case the blob gets a v2 header and the
+    /// region lands between the postings and the doc-lengths
+    /// directory (even when empty, so region accounting stays
+    /// uniform). `None` produces a v1 blob byte-identical to builds
+    /// before positions existed.
+    positions_sink: Option<PositionsSink>,
     /// Whichever FST sink was used during the per-column emit loop
     /// (exactly one of the two variants).
     fst_sink: FstSinkFinish,
@@ -2462,6 +2560,7 @@ fn assemble_and_write_blob<W: Write>(
         postings_path,
         postings_crc_acc,
         mut postings_len,
+        positions_sink,
         fst_sink,
         n_columns,
         n_docs,
@@ -2489,6 +2588,21 @@ fn assemble_and_write_blob<W: Write>(
     if let Some(t) = postings_close_start {
         finish_profile.postings_close += t.elapsed();
     }
+
+    // Close the positions region file the same way (CRC trailer +
+    // flush). An all-inline positional build leaves a body of zero
+    // bytes — the region is then just the 4-byte CRC-of-empty, the
+    // same legal shape an empty postings region takes.
+    let positions_region = match positions_sink {
+        Some(mut sink) => {
+            let crc_le = sink.crc_acc.to_le_bytes();
+            sink.writer.write_all(&crc_le)?;
+            sink.writer.flush()?;
+            drop(sink.writer);
+            Some((sink.path, sink.len + crc_le.len() as u64))
+        }
+        None => None,
+    };
 
     // Finalise the FST. Either path produces "FST bytes followed
     // by 4 trailing CRC bytes"; the source differs.
@@ -2554,10 +2668,18 @@ fn assemble_and_write_blob<W: Write>(
         FstSource::InRam(bytes) => bytes.len() as u64,
         FstSource::Streamed { len, .. } => *len,
     };
-    let header_size: u64 = FTS_HEADER_SIZE as u64;
+    let header_size: u64 = match positions_region {
+        Some(_) => format::fts::HEADER_SIZE_V2 as u64,
+        None => FTS_HEADER_SIZE as u64,
+    };
     let fst_offset: u64 = header_size;
     let postings_offset: u64 = fst_offset + fst_total_len;
-    let doc_lengths_table_offset: u64 = postings_offset + postings_len;
+    // The positions region sits between the postings and the
+    // doc-lengths directory (keeping the lazy-open doc-lengths tail
+    // fetch small); absent, the directory follows postings directly.
+    let positions_offset: u64 = postings_offset + postings_len;
+    let positions_total_len: u64 = positions_region.as_ref().map_or(0, |(_, len)| *len);
+    let doc_lengths_table_offset: u64 = positions_offset + positions_total_len;
     let mut doc_lengths_array_offset: u64 =
         doc_lengths_table_offset + (n_columns as u64) * (DOC_LENGTHS_ENTRY_SIZE as u64) + 4 /* dir CRC */;
 
@@ -2606,13 +2728,20 @@ fn assemble_and_write_blob<W: Write>(
     let blob_copy_start = finish_profile.enabled.then(Instant::now);
     let mut header = Vec::with_capacity(header_size as usize);
     header.extend_from_slice(format::fts::MAGIC); // 8
-    header.extend_from_slice(&format::fts::VERSION.to_le_bytes()); // 4
+    let version = match positions_region {
+        Some(_) => format::fts::VERSION_POSITIONS,
+        None => format::fts::VERSION,
+    };
+    header.extend_from_slice(&version.to_le_bytes()); // 4
     header.extend_from_slice(&n_columns.to_le_bytes()); // 4
     header.extend_from_slice(&n_docs.to_le_bytes()); // 4
     header.extend_from_slice(&n_terms_total.to_le_bytes()); // 4
     header.extend_from_slice(&fst_offset.to_le_bytes()); // 8
     header.extend_from_slice(&postings_offset.to_le_bytes()); // 8
     header.extend_from_slice(&doc_lengths_table_offset.to_le_bytes()); // 8
+    if positions_region.is_some() {
+        header.extend_from_slice(&positions_offset.to_le_bytes()); // 8 (v2 only)
+    }
     debug_assert_eq!(header.len(), header_size as usize, "header size mismatch");
 
     w.write_all(&header)?;
@@ -2628,6 +2757,11 @@ fn assemble_and_write_blob<W: Write>(
         BufReader::with_capacity(PARTITION_BUF_SIZE, File::open(&postings_path)?);
     io::copy(&mut postings_reader, w)?;
     drop(postings_reader);
+    if let Some((positions_path, _)) = &positions_region {
+        let mut positions_reader =
+            BufReader::with_capacity(PARTITION_BUF_SIZE, File::open(positions_path)?);
+        io::copy(&mut positions_reader, w)?;
+    }
 
     // Drop the scratch tempdir as soon as the streamed source
     // files (FST + posting body) have been copied into `w`. The
@@ -2696,6 +2830,10 @@ struct TermScratch {
     /// concatenated block bytes; written to `postings_writer` as one
     /// `write_counted` call.
     term_buf: Vec<u8>,
+    /// Per-term positions-block offsets (one per PFOR block, byte
+    /// offset of the block's first run within the term's positions
+    /// bytes) for positional columns. Reused like the other buffers.
+    pos_block_offsets: Vec<u32>,
 }
 
 /// Encode one term's posting list and emit the resulting FST entry
@@ -2719,6 +2857,7 @@ fn encode_and_emit_term<W: Write>(
     postings_len: &mut u64,
     fst_entries_inram: Option<&mut DictBuilder>,
     mut fst_streaming: Option<&mut StreamingDictBuilder<BufWriter<File>>>,
+    mut term_positions: Option<(&mut PositionsSink, &[u8])>,
     profile: &mut FinishProfile,
     scratch: &mut TermScratch,
 ) -> Result<(), BuildError> {
@@ -2738,10 +2877,31 @@ fn encode_and_emit_term<W: Write>(
 
     let df = pairs.len() as u64;
 
-    let fst_value: u64 = if df == 1 {
-        profile.encode_df1 += 1;
+    // A df=1 posting inlines into the FST value when the WHOLE
+    // posting fits: a positionless column always does (doc_id + tf);
+    // a positional column only when tf == 1 and the single position
+    // fits the 30-bit slot — the position rides where tf normally
+    // lives, tf implied 1 (one position is exactly what a phrase
+    // check needs). Otherwise even a df=1 term takes the PFOR form so
+    // its positions land in the region.
+    let inline_value: Option<u64> = if df == 1 {
         let (doc_id, tf) = pairs[0];
-        FstValue::pack_inline(doc_id, tf)
+        match &term_positions {
+            None => Some(FstValue::pack_inline(doc_id, tf)),
+            Some((_, runs)) if tf == 1 => {
+                let mut at = 0;
+                let pos = read_varint(runs, &mut at).expect("builder-encoded run is well-formed");
+                (pos <= INLINE_TF_MAX).then(|| FstValue::pack_inline(doc_id, pos))
+            }
+            Some(_) => None,
+        }
+    } else {
+        None
+    };
+
+    let fst_value: u64 = if let Some(v) = inline_value {
+        profile.encode_df1 += 1;
+        v
     } else {
         profile.encode_pfor += 1;
         let idf_t = bm25::idf(n_docs as u64, df);
@@ -2804,7 +2964,32 @@ fn encode_and_emit_term<W: Write>(
         let metadata_offset = *postings_len;
         let skip_table_size = encoded_blocks.len() * SKIP_ENTRY_SIZE;
         let blocks_total_size: usize = encoded_blocks.iter().map(|b| b.bytes.len()).sum();
-        let postings_length = (TERM_META_SIZE + skip_table_size + blocks_total_size) as u64;
+        let term_meta_size = match term_positions {
+            Some(_) => TERM_META_POSITIONAL_SIZE,
+            None => TERM_META_SIZE,
+        };
+        let postings_length = (term_meta_size + skip_table_size + blocks_total_size) as u64;
+
+        // Per-block byte offsets into this term's position runs: walk
+        // the runs once, recording where each 128-doc block's first
+        // run starts, so the reader can fetch/decode one block's
+        // positions without touching its predecessors.
+        let pos_block_offsets = &mut scratch.pos_block_offsets;
+        pos_block_offsets.clear();
+        if let Some((_, runs)) = &term_positions {
+            debug_assert!(
+                runs.len() <= u32::MAX as usize,
+                "single-term positions > 4 GiB"
+            );
+            let mut at: usize = 0;
+            for (i, &(_, tf)) in pairs.iter().enumerate() {
+                if i % BLOCK_LEN == 0 {
+                    pos_block_offsets.push(at as u32);
+                }
+                skip_run(runs, &mut at, tf).expect("builder-encoded runs are well-formed");
+            }
+            debug_assert_eq!(at, runs.len(), "runs must cover exactly the pairs");
+        }
 
         debug_assert!(df <= u32::MAX as u64, "df overflows u32");
         debug_assert!(
@@ -2825,12 +3010,16 @@ fn encode_and_emit_term<W: Write>(
         term_buf.extend_from_slice(&metadata_offset.to_le_bytes());
         term_buf.extend_from_slice(&(postings_length as u32).to_le_bytes());
         term_buf.extend_from_slice(&num_blocks.to_le_bytes());
-        debug_assert_eq!(term_buf.len(), TERM_META_SIZE);
+        if let Some((sink, runs)) = &term_positions {
+            term_buf.extend_from_slice(&sink.len.to_le_bytes());
+            term_buf.extend_from_slice(&(runs.len() as u32).to_le_bytes());
+        }
+        debug_assert_eq!(term_buf.len(), term_meta_size);
         if let Some(start) = meta_write_start {
             profile.encode_meta_write += start.elapsed();
         }
 
-        let mut block_offset: u32 = (TERM_META_SIZE + skip_table_size) as u32;
+        let mut block_offset: u32 = (term_meta_size + skip_table_size) as u32;
         let skip_write_start = profile.enabled.then(Instant::now);
         for (i, blk) in encoded_blocks.iter().enumerate() {
             let max_bm25 = block_ub_per_block[i];
@@ -2847,7 +3036,10 @@ fn encode_and_emit_term<W: Write>(
             term_buf.extend_from_slice(&blk.last_doc_id.to_le_bytes());
             term_buf.extend_from_slice(&block_offset.to_le_bytes());
             term_buf.extend_from_slice(&max_bm25_x1000.to_le_bytes());
-            term_buf.extend_from_slice(&0u32.to_le_bytes());
+            // Positionless columns keep writing zero here —
+            // byte-identical to the field's reserved era.
+            let pos_block_off = pos_block_offsets.get(i).copied().unwrap_or(0);
+            term_buf.extend_from_slice(&pos_block_off.to_le_bytes());
             block_offset += blk.bytes.len() as u32;
         }
         if let Some(start) = skip_write_start {
@@ -2862,6 +3054,10 @@ fn encode_and_emit_term<W: Write>(
         write_counted(postings_writer, postings_crc_acc, postings_len, term_buf)?;
         if let Some(start) = block_write_start {
             profile.encode_block_write += start.elapsed();
+        }
+
+        if let Some((sink, runs)) = term_positions.as_mut() {
+            sink.write(runs)?;
         }
 
         FstValue::pack_pfor(metadata_offset, postings_length as u32)

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -2958,7 +2958,7 @@ fn assemble_and_write_blob<W: Write>(
     let blob_copy_start = finish_profile.enabled.then(Instant::now);
     let mut header = Vec::with_capacity(header_size as usize);
     header.extend_from_slice(format::fts::MAGIC); // 8
-    header.extend_from_slice(&format::fts::VERSION_POSITIONS.to_le_bytes()); // 4
+    header.extend_from_slice(&format::fts::VERSION_V2.to_le_bytes()); // 4
     header.extend_from_slice(&n_columns.to_le_bytes()); // 4
     header.extend_from_slice(&n_docs.to_le_bytes()); // 4
     header.extend_from_slice(&n_terms_total.to_le_bytes()); // 4
@@ -3754,7 +3754,7 @@ mod tests {
         assert_eq!(&blob[0..8], format::fts::MAGIC);
         // Version — new code always writes the v2 (positions) layout.
         let version = u32::from_le_bytes([blob[8], blob[9], blob[10], blob[11]]);
-        assert_eq!(version, format::fts::VERSION_POSITIONS);
+        assert_eq!(version, format::fts::VERSION_V2);
         // n_columns.
         let n_cols = u32::from_le_bytes([blob[12], blob[13], blob[14], blob[15]]);
         assert_eq!(n_cols, 1);
@@ -4277,7 +4277,7 @@ mod tests {
 
         let read_u64 = |at: usize| u64::from_le_bytes(v2[at..at + 8].try_into().expect("8 bytes"));
         let read_u32 = |at: usize| u32::from_le_bytes(v2[at..at + 4].try_into().expect("4 bytes"));
-        assert_eq!(read_u32(8), format::fts::VERSION_POSITIONS);
+        assert_eq!(read_u32(8), format::fts::VERSION_V2);
         let fst_off = read_u64(24);
         let postings_off = read_u64(32);
         let doc_lengths_off = read_u64(40);
@@ -4291,7 +4291,7 @@ mod tests {
 
         let mut out = Vec::with_capacity(v2.len() - V2_HEADER + V1_HEADER);
         out.extend_from_slice(&v2[0..8]); // magic
-        out.extend_from_slice(&format::fts::VERSION_LEGACY.to_le_bytes());
+        out.extend_from_slice(&format::fts::VERSION_V1_LEGACY.to_le_bytes());
         out.extend_from_slice(&v2[12..24]); // n_columns, n_docs, n_terms
         out.extend_from_slice(&(fst_off - HEADER_SHRINK).to_le_bytes());
         out.extend_from_slice(&(postings_off - HEADER_SHRINK).to_le_bytes());
@@ -4390,7 +4390,7 @@ mod tests {
         let spilled_pos = build_title_blob_spilled(&docs, true, None);
         assert_eq!(
             u32::from_le_bytes(spilled_pos[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION_POSITIONS
+            format::fts::VERSION_V2
         );
         let inram_pos = build_title_blob(&docs, true);
         let inram_plain = build_title_blob(&docs, false);
@@ -4432,7 +4432,7 @@ mod tests {
         let v1_blob = bytes::Bytes::from(synthesize_v1_blob(&v2_blob));
         assert_eq!(
             u32::from_le_bytes(v1_blob[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION_LEGACY
+            format::fts::VERSION_V1_LEGACY
         );
 
         let v1 = FtsReader::open(v1_blob, title_json(false)).expect("v1 opens");
@@ -4509,8 +4509,8 @@ mod tests {
             u32::from_le_bytes(blob[8..12].try_into().expect("4 header bytes"))
         };
         // New code always writes v2; v1 is a read-only legacy format.
-        assert_eq!(version_of(&plain), format::fts::VERSION_POSITIONS);
-        assert_eq!(version_of(&positional), format::fts::VERSION_POSITIONS);
+        assert_eq!(version_of(&plain), format::fts::VERSION_V2);
+        assert_eq!(version_of(&positional), format::fts::VERSION_V2);
 
         // A positionless build's region is just the CRC-of-empty.
         let read_u64_plain =
@@ -4605,7 +4605,7 @@ mod tests {
         let blob = bytes::Bytes::from(b.finish().expect("finish"));
         assert_eq!(
             u32::from_le_bytes(blob[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION_POSITIONS
+            format::fts::VERSION_V2
         );
         let json = r#"[{"name":"body","tokenizer":"ascii_lower"},{"name":"title","tokenizer":"ascii_lower","positions":true}]"#;
         let r = FtsReader::open(blob, json).expect("open");

--- a/src/superfile/fts/mod.rs
+++ b/src/superfile/fts/mod.rs
@@ -9,5 +9,6 @@ pub mod builder;
 pub mod dict;
 pub(crate) mod fst_value;
 pub mod posting;
+pub(crate) mod positions;
 pub mod reader;
 pub mod tokenize;

--- a/src/superfile/fts/mod.rs
+++ b/src/superfile/fts/mod.rs
@@ -8,7 +8,7 @@ pub mod bm25;
 pub mod builder;
 pub mod dict;
 pub(crate) mod fst_value;
-pub mod posting;
 pub(crate) mod positions;
+pub mod posting;
 pub mod reader;
 pub mod tokenize;

--- a/src/superfile/fts/positions.rs
+++ b/src/superfile/fts/positions.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Position-run encoding for positional FTS columns.
+//!
+//! A **run** is one document's token positions for one term, stored as
+//! LEB128 varints: the first position absolute, each subsequent value
+//! the gap to the previous position (positions within a doc are
+//! strictly increasing, so gaps are ≥ 1 and small for clustered
+//! terms). A run's varint count equals the posting's `tf`, so runs
+//! need no length framing — the decoder reads exactly `tf` values.
+//!
+//! The positions region of the FTS blob is, per term, the
+//! concatenation of its runs in posting (doc-id) order; the skip
+//! table records each 128-doc block's starting byte so a block's runs
+//! are randomly addressable without decoding its predecessors.
+
+/// Largest byte length one encoded `u32` can occupy (LEB128: 5 × 7
+/// bits ≥ 32 bits). Used to reserve scratch capacity.
+pub(crate) const MAX_VARINT_BYTES: usize = 5;
+
+/// LEB128 continuation flag: high bit set ⇒ another byte follows.
+const CONTINUATION_BIT: u8 = 0x80;
+/// Payload bits per LEB128 byte.
+const PAYLOAD_BITS: u32 = 7;
+/// Payload mask per LEB128 byte.
+const PAYLOAD_MASK: u8 = 0x7f;
+
+/// Append one `u32` as LEB128 to `out`.
+#[inline]
+pub(crate) fn push_varint(out: &mut Vec<u8>, mut v: u32) {
+    loop {
+        let byte = (v as u8) & PAYLOAD_MASK;
+        v >>= PAYLOAD_BITS;
+        if v == 0 {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | CONTINUATION_BIT);
+    }
+}
+
+/// Decode one LEB128 `u32` from `bytes` starting at `*at`, advancing
+/// `*at` past it. Returns `None` on truncated input or a value that
+/// overflows `u32` — both only reachable on corrupt bytes, which the
+/// caller surfaces as a read error.
+#[inline]
+pub(crate) fn read_varint(bytes: &[u8], at: &mut usize) -> Option<u32> {
+    let mut v: u32 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        let &b = bytes.get(*at)?;
+        *at += 1;
+        let payload = (b & PAYLOAD_MASK) as u32;
+        v |= payload.checked_shl(shift)?;
+        if shift > 0 && payload >> (32 - shift.min(32)) != 0 {
+            // Payload bits past the 32-bit boundary ⇒ overflow.
+            return None;
+        }
+        if b & CONTINUATION_BIT == 0 {
+            return Some(v);
+        }
+        shift += PAYLOAD_BITS;
+        if shift >= 32 + PAYLOAD_BITS {
+            return None;
+        }
+    }
+}
+
+/// Append one document's position run — first value absolute, then
+/// gaps. `positions` must be strictly increasing (token positions
+/// within one doc always are).
+pub(crate) fn encode_run(out: &mut Vec<u8>, positions: &[u32]) {
+    let mut prev: u32 = 0;
+    for (i, &p) in positions.iter().enumerate() {
+        debug_assert!(i == 0 || p > prev, "positions must be strictly increasing");
+        let delta = if i == 0 { p } else { p - prev };
+        push_varint(out, delta);
+        prev = p;
+    }
+}
+
+/// Decode one run of exactly `tf` positions from `bytes` at `*at`,
+/// appending the absolute positions to `out` and advancing `*at`.
+/// `None` on corrupt (truncated / overflowing) bytes.
+pub(crate) fn decode_run(bytes: &[u8], at: &mut usize, tf: u32, out: &mut Vec<u32>) -> Option<()> {
+    let mut prev: u32 = 0;
+    for i in 0..tf {
+        let delta = read_varint(bytes, at)?;
+        let p = if i == 0 { delta } else { prev.checked_add(delta)? };
+        out.push(p);
+        prev = p;
+    }
+    Some(())
+}
+
+/// Advance `*at` past one run of `tf` positions without materializing
+/// them. `None` on truncated bytes.
+pub(crate) fn skip_run(bytes: &[u8], at: &mut usize, tf: u32) -> Option<()> {
+    for _ in 0..tf {
+        read_varint(bytes, at)?;
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn varint_round_trips_boundaries() {
+        for v in [0u32, 1, 127, 128, 16383, 16384, u32::MAX - 1, u32::MAX] {
+            let mut buf = Vec::new();
+            push_varint(&mut buf, v);
+            assert!(buf.len() <= MAX_VARINT_BYTES);
+            let mut at = 0;
+            assert_eq!(read_varint(&buf, &mut at), Some(v));
+            assert_eq!(at, buf.len());
+        }
+    }
+
+    #[test]
+    fn read_varint_rejects_truncation() {
+        let mut buf = Vec::new();
+        push_varint(&mut buf, 300);
+        let mut at = 0;
+        assert_eq!(read_varint(&buf[..1], &mut at), None);
+    }
+
+    #[test]
+    fn read_varint_rejects_overflow() {
+        // Six continuation bytes exceed a u32's 5-byte maximum.
+        let buf = [0xff, 0xff, 0xff, 0xff, 0xff, 0x01];
+        let mut at = 0;
+        assert_eq!(read_varint(&buf, &mut at), None);
+    }
+
+    #[test]
+    fn run_round_trips() {
+        let positions = [3u32, 4, 9, 100, 1_000_000];
+        let mut buf = Vec::new();
+        encode_run(&mut buf, &positions);
+        let mut at = 0;
+        let mut got = Vec::new();
+        decode_run(&buf, &mut at, positions.len() as u32, &mut got).expect("decode");
+        assert_eq!(got, positions);
+        assert_eq!(at, buf.len());
+    }
+
+    #[test]
+    fn runs_concatenate_and_skip() {
+        // Two docs' runs back to back; skip the first, decode the second.
+        let a = [5u32, 6];
+        let b = [0u32, 2, 4];
+        let mut buf = Vec::new();
+        encode_run(&mut buf, &a);
+        let a_end = buf.len();
+        encode_run(&mut buf, &b);
+        let mut at = 0;
+        skip_run(&buf, &mut at, a.len() as u32).expect("skip");
+        assert_eq!(at, a_end);
+        let mut got = Vec::new();
+        decode_run(&buf, &mut at, b.len() as u32, &mut got).expect("decode");
+        assert_eq!(got, b);
+    }
+
+    #[test]
+    fn decode_run_rejects_truncated_tail() {
+        let mut buf = Vec::new();
+        encode_run(&mut buf, &[1u32, 2, 3]);
+        let mut at = 0;
+        let mut got = Vec::new();
+        assert_eq!(
+            decode_run(&buf[..buf.len() - 1], &mut at, 3, &mut got),
+            None
+        );
+    }
+}

--- a/src/superfile/fts/positions.rs
+++ b/src/superfile/fts/positions.rs
@@ -17,6 +17,8 @@
 
 /// Largest byte length one encoded `u32` can occupy (LEB128: 5 × 7
 /// bits ≥ 32 bits). Used to reserve scratch capacity.
+/// (Consumed by the read path that follows in this series.)
+#[allow(dead_code)]
 pub(crate) const MAX_VARINT_BYTES: usize = 5;
 
 /// LEB128 continuation flag: high bit set ⇒ another byte follows.
@@ -44,6 +46,7 @@ pub(crate) fn push_varint(out: &mut Vec<u8>, mut v: u32) {
 /// `*at` past it. Returns `None` on truncated input or a value that
 /// overflows `u32` — both only reachable on corrupt bytes, which the
 /// caller surfaces as a read error.
+#[allow(dead_code)]
 #[inline]
 pub(crate) fn read_varint(bytes: &[u8], at: &mut usize) -> Option<u32> {
     let mut v: u32 = 0;
@@ -83,11 +86,16 @@ pub(crate) fn encode_run(out: &mut Vec<u8>, positions: &[u32]) {
 /// Decode one run of exactly `tf` positions from `bytes` at `*at`,
 /// appending the absolute positions to `out` and advancing `*at`.
 /// `None` on corrupt (truncated / overflowing) bytes.
+#[allow(dead_code)]
 pub(crate) fn decode_run(bytes: &[u8], at: &mut usize, tf: u32, out: &mut Vec<u32>) -> Option<()> {
     let mut prev: u32 = 0;
     for i in 0..tf {
         let delta = read_varint(bytes, at)?;
-        let p = if i == 0 { delta } else { prev.checked_add(delta)? };
+        let p = if i == 0 {
+            delta
+        } else {
+            prev.checked_add(delta)?
+        };
         out.push(p);
         prev = p;
     }
@@ -96,6 +104,7 @@ pub(crate) fn decode_run(bytes: &[u8], at: &mut usize, tf: u32, out: &mut Vec<u3
 
 /// Advance `*at` past one run of `tf` positions without materializing
 /// them. `None` on truncated bytes.
+#[allow(dead_code)]
 pub(crate) fn skip_run(bytes: &[u8], at: &mut usize, tf: u32) -> Option<()> {
     for _ in 0..tf {
         read_varint(bytes, at)?;

--- a/src/superfile/fts/positions.rs
+++ b/src/superfile/fts/positions.rs
@@ -46,7 +46,6 @@ pub(crate) fn push_varint(out: &mut Vec<u8>, mut v: u32) {
 /// `*at` past it. Returns `None` on truncated input or a value that
 /// overflows `u32` — both only reachable on corrupt bytes, which the
 /// caller surfaces as a read error.
-#[allow(dead_code)]
 #[inline]
 pub(crate) fn read_varint(bytes: &[u8], at: &mut usize) -> Option<u32> {
     let mut v: u32 = 0;
@@ -104,7 +103,6 @@ pub(crate) fn decode_run(bytes: &[u8], at: &mut usize, tf: u32, out: &mut Vec<u3
 
 /// Advance `*at` past one run of `tf` positions without materializing
 /// them. `None` on truncated bytes.
-#[allow(dead_code)]
 pub(crate) fn skip_run(bytes: &[u8], at: &mut usize, tf: u32) -> Option<()> {
     for _ in 0..tf {
         read_varint(bytes, at)?;

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -867,13 +867,52 @@ impl FtsReader {
                 out.push(None);
                 continue;
             }
-            let pos_ranges: Vec<(u64, u32)> = cursors
+            // Positional extras per member, kept off the term cursors
+            // (whose footprint the term-only kernels depend on): PFOR
+            // members re-parse their metadata header from their own
+            // bytes; an inline (df=1) member recovers its single
+            // position from the FST slot the tf-reinterpretation
+            // dropped during cursor build.
+            let mut positional: Vec<(Option<TermMeta>, Option<u32>)> =
+                Vec::with_capacity(cursors.len());
+            for (cursor, term) in cursors.iter().zip(&member_refs) {
+                match cursor.bytes.is_empty() {
+                    false => {
+                        let term_meta = TermMeta::parse(cursor.bytes.as_ref(), 0, true)?;
+                        positional.push((Some(term_meta), None));
+                    }
+                    true => {
+                        let fst_bytes = self.dict_bytes_async().await?;
+                        let dict = DictReader::open(&fst_bytes).map_err(|e| {
+                            FtsError::Read(ReadError::MalformedVersion(format!(
+                                "FST parse failed: {e}"
+                            )))
+                        })?;
+                        let key = make_key(&col_meta.name, term);
+                        let packed = dict
+                            .lookup(&key)
+                            .expect("inline member cursor was built from this dict");
+                        let position = match FstValue::unpack(packed) {
+                            FstValue::Inline { tf: slot, .. } => slot,
+                            FstValue::Pfor { .. } => {
+                                unreachable!("inline cursor from a PFOR FST value")
+                            }
+                        };
+                        positional.push((None, Some(position)));
+                    }
+                }
+            }
+            let pos_ranges: Vec<(u64, u32)> = positional
                 .iter()
-                .map(|c| (c.positions_offset, c.positions_length))
+                .map(|(term_meta, _)| {
+                    term_meta
+                        .map(|tm| (tm.positions_offset, tm.positions_length))
+                        .unwrap_or((0, 0))
+                })
                 .collect();
             let positions = self.fetch_term_positions(&pos_ranges).await?;
             out.push(Some(AnyCursor::Phrase(PhraseCursor::new(
-                cursors, positions,
+                cursors, positions, positional,
             )?)));
         }
         Ok(out)
@@ -1824,9 +1863,11 @@ impl FtsReader {
                     // the term's single position, tf implied 1 — the
                     // builder only inlines tf == 1 postings there.
                     // Scoring must use the implied tf, never the slot.
-                    let (tf, inline_position) = match col_meta.positions {
-                        true => (1, Some(tf)),
-                        false => (tf, None),
+                    // (Phrase members recover the position itself with
+                    // their own FST lookup — see `build_atom_cursors`.)
+                    let tf = match col_meta.positions {
+                        true => 1,
+                        false => tf,
                     };
                     let dl_norm_k1 = col_meta.dl_norm_k1[doc_id as usize];
                     cursors.push(TermCursor::new_inline(
@@ -1834,7 +1875,6 @@ impl FtsReader {
                         tf,
                         self.n_docs as u64,
                         dl_norm_k1,
-                        inline_position,
                     ));
                 }
                 Resolved::Pfor => {
@@ -3362,8 +3402,19 @@ fn drain_top_k_desc(heap: BinaryHeap<TopKEntry>) -> Vec<(u32, f32)> {
 struct PhraseMember {
     cursor: TermCursor,
     /// The term's complete position runs (empty for an inline df=1
-    /// member, whose single position rides on the cursor).
+    /// member, whose single position is `inline_position`).
     positions: Bytes,
+    /// The term's parsed metadata header, re-parsed from the cursor's
+    /// own bytes at member build — the source of the per-block
+    /// position-run offsets. `None` for an inline member (no postings
+    /// bytes). Kept here, not on [`TermCursor`] or [`BlockMeta`]:
+    /// plain term queries never touch positions, and their hot
+    /// structures must not grow for the phrase path's benefit.
+    term_meta: Option<TermMeta>,
+    /// The single position of an inline (df=1, tf=1) member — the
+    /// inline FST value's slot carries it instead of a tf. `None` for
+    /// PFOR members.
+    inline_position: Option<u32>,
     /// The member's bare idf (the cursor stores only `idf × (K1+1)`).
     idf: f32,
     /// Byte offset of each decoded-block pair's run within
@@ -3385,17 +3436,20 @@ impl PhraseMember {
     /// (not exhausted).
     fn decode_current_positions(&mut self) -> Result<(), FtsError> {
         self.pos_scratch.clear();
-        if let Some(p) = self.cursor.inline_position {
+        if let Some(p) = self.inline_position {
             self.pos_scratch.push(p);
             return Ok(());
         }
         let block = self.cursor.current_block;
         if self.run_offsets_block != block {
             // One forward walk locates every pair's run in this
-            // block: start at the block's recorded first-run offset,
-            // then skip each pair's `tf` varints.
+            // block: start at the block's recorded first-run offset
+            // (the skip entry's fourth field), then skip each pair's
+            // `tf` varints.
             self.run_offsets.clear();
-            let mut at = self.cursor.blocks[block].positions_block_offset as usize;
+            let term_meta = self.term_meta.as_ref().expect("PFOR member has term meta");
+            let mut at =
+                term_meta.positions_block_offset(self.cursor.bytes.as_ref(), block) as usize;
             for i in 0..self.cursor.block_n {
                 self.run_offsets.push(at as u32);
                 skip_run(&self.positions, &mut at, self.cursor.block_tfs[i]).ok_or_else(|| {
@@ -3446,23 +3500,33 @@ struct PhraseCursor {
 }
 
 impl PhraseCursor {
-    /// Build from member cursors (query order) and their fetched
-    /// position runs, then seek to the first matching doc.
-    fn new(cursors: Vec<TermCursor>, positions: Vec<Bytes>) -> Result<Self, FtsError> {
+    /// Build from member cursors (query order), their fetched
+    /// position runs, and their positional metadata — `(term_meta,
+    /// inline_position)` per member, exactly one of the two present —
+    /// then seek to the first matching doc.
+    fn new(
+        cursors: Vec<TermCursor>,
+        positions: Vec<Bytes>,
+        positional: Vec<(Option<TermMeta>, Option<u32>)>,
+    ) -> Result<Self, FtsError> {
         debug_assert!(cursors.len() >= 2, "single-token phrases degrade to terms");
         debug_assert_eq!(cursors.len(), positions.len());
+        debug_assert_eq!(cursors.len(), positional.len());
         let mut idf_sum = 0.0f32;
         let mut min_scaled_bound = f32::INFINITY;
         let members: Vec<PhraseMember> = cursors
             .into_iter()
             .zip(positions)
-            .map(|(cursor, positions)| {
+            .zip(positional)
+            .map(|((cursor, positions), (term_meta, inline_position))| {
                 let idf = cursor.idf_x_k1p1 / (bm25::K1 + 1.0);
                 min_scaled_bound = min_scaled_bound.min(cursor.term_max_bm25 / idf);
                 idf_sum += idf;
                 PhraseMember {
                     cursor,
                     positions,
+                    term_meta,
+                    inline_position,
                     idf,
                     run_offsets: Vec::new(),
                     run_offsets_block: NO_BLOCK_CACHED,
@@ -4327,10 +4391,6 @@ struct BlockMeta {
     /// Per-block BM25 upper bound, recovered from the skip table's
     /// fixed-point `max_bm25_x1000` field.
     block_max_bm25: f32,
-    /// Byte offset of this block's first position run within the
-    /// term's positions bytes (positional columns; zero otherwise —
-    /// the field is the skip entry's formerly-reserved slot).
-    positions_block_offset: u32,
 }
 
 /// Per-query-term cursor used by [`FtsReader::run_max_score_bmm`]
@@ -4392,18 +4452,14 @@ struct TermCursor {
     /// Mirrors the vector reader's per-probed-cluster buffers: the
     /// search hot loops index only the bytes this term touches, never
     /// the whole postings region.
+    ///
+    /// Deliberately carries NO positional state: term cursors are the
+    /// hot per-query unit the multi-cursor kernels iterate over, and
+    /// the positional extras matter only to phrase members —
+    /// [`PhraseMember`] re-derives them from these bytes instead, so
+    /// plain term queries never pay for them in cursor or block-meta
+    /// footprint.
     bytes: Bytes,
-    /// This term's byte range in the positions region (positional
-    /// columns; zeros otherwise). The phrase path fetches the range
-    /// and locates per-doc runs via the blocks'
-    /// `positions_block_offset`.
-    positions_offset: u64,
-    positions_length: u32,
-    /// The single position of an inline (df=1, tf=1) term of a
-    /// positional column — the inline FST value's slot carries it
-    /// instead of a tf. `None` on PFOR cursors and on positionless
-    /// columns.
-    inline_position: Option<u32>,
 }
 
 impl TermCursor {
@@ -4431,7 +4487,6 @@ impl TermCursor {
                 block_byte_offset: metadata_offset + block_offset_in_term,
                 block_byte_end: metadata_offset + term_meta.block_end_in_term(postings, i),
                 block_max_bm25,
-                positions_block_offset: term_meta.positions_block_offset(postings, i),
             });
         }
 
@@ -4447,9 +4502,6 @@ impl TermCursor {
             pos: 0,
             inspect_block: 0,
             bytes: term_bytes,
-            positions_offset: term_meta.positions_offset,
-            positions_length: term_meta.positions_length,
-            inline_position: None,
         };
         if !cursor.blocks.is_empty() {
             cursor.decode_current_block();
@@ -4464,13 +4516,7 @@ impl TermCursor {
     /// doc means min_dl = dl and max_tf = tf, so the per-block UB
     /// formula collapses to the score itself). Computed at query time
     /// since there's no skip-table entry stored for inline terms.
-    fn new_inline(
-        doc_id: u32,
-        tf: u32,
-        n_docs: u64,
-        dl_norm_k1: f32,
-        inline_position: Option<u32>,
-    ) -> Self {
+    fn new_inline(doc_id: u32, tf: u32, n_docs: u64, dl_norm_k1: f32) -> Self {
         let idf = bm25::idf(n_docs, 1);
         let idf_x_k1p1 = idf * (bm25::K1 + 1.0);
         let block_max_bm25 = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
@@ -4483,7 +4529,6 @@ impl TermCursor {
             block_byte_offset: 0,
             block_byte_end: 0,
             block_max_bm25,
-            positions_block_offset: 0,
         }];
 
         let mut block_doc_ids = vec![0u32; BLOCK_LEN];
@@ -4503,9 +4548,6 @@ impl TermCursor {
             pos: 0,
             inspect_block: 0,
             bytes: Bytes::new(),
-            positions_offset: 0,
-            positions_length: 0,
-            inline_position,
         }
     }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -898,9 +898,22 @@ impl FtsReader {
         let initial_cap = k.min(self.n_docs as usize).max(1);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
 
+        // Per-atom pruning slack: an atom only needs to contribute
+        // more than the walk's bar minus what every *other* atom could
+        // possibly add. Phrase atoms use it to skip position work on
+        // docs that provably can't matter (`skip_to_pruned`).
+        let atom_slack = |atoms: &[AnyCursor], extra_ub: f32| -> Vec<f32> {
+            let total: f32 = atoms.iter().map(AnyCursor::term_max_bm25).sum();
+            atoms
+                .iter()
+                .map(|a| total - a.term_max_bm25() + extra_ub)
+                .collect()
+        };
+
         if musts.is_empty() {
             // Union of shoulds, doc-at-a-time: score every atom
             // sitting on the frontier doc, then advance them past it.
+            let others_ub = atom_slack(&shoulds, 0.0);
             while let Some(doc) = shoulds
                 .iter()
                 .filter(|a| !a.is_exhausted())
@@ -925,9 +938,13 @@ impl FtsReader {
                 let Some(next) = doc.checked_add(1) else {
                     break;
                 };
-                for a in shoulds.iter_mut() {
+                let bar = match heap.len() >= k {
+                    true => heap.peek().expect("heap len == k").0.max(floor_eff),
+                    false => floor_eff,
+                };
+                for (a, &others) in shoulds.iter_mut().zip(&others_ub) {
                     if !a.is_exhausted() && a.current_doc_id() == doc {
-                        a.skip_to(next)?;
+                        a.skip_to_pruned(next, bar - others, dl_norm_k1)?;
                     }
                 }
             }
@@ -937,13 +954,22 @@ impl FtsReader {
         // Must-driven walk: leapfrog the musts to each common doc,
         // score musts + landing shoulds there.
         let should_ub: f32 = shoulds.iter().map(AnyCursor::term_max_bm25).sum();
+        let must_others_ub = atom_slack(&musts, should_ub);
+        let should_others_ub: Vec<f32> = {
+            let must_ub_total: f32 = musts.iter().map(AnyCursor::term_max_bm25).sum();
+            atom_slack(&shoulds, must_ub_total)
+        };
         let mut target = 0u32;
         'docs: loop {
+            let bar = match heap.len() >= k {
+                true => heap.peek().expect("heap len == k").0.max(floor_eff),
+                false => floor_eff,
+            };
             let mut aligned = target;
             let mut i = 0usize;
             while i < musts.len() {
                 let a = &mut musts[i];
-                a.skip_to(aligned)?;
+                a.skip_to_pruned(aligned, bar - must_others_ub[i], dl_norm_k1)?;
                 if a.is_exhausted() {
                     break 'docs;
                 }
@@ -959,18 +985,16 @@ impl FtsReader {
             // most the shoulds could add bounds what the musts must
             // reach; a candidate whose must-side block bounds can't
             // get there is dead without scoring (and, for phrase
-            // shoulds, without any position work).
-            let bar = match heap.len() >= k {
-                true => heap.peek().expect("heap len == k").0.max(floor_eff),
-                false => floor_eff,
-            };
+            // shoulds, without any position work). `>=`, not `>`: a
+            // doc exactly at the bar can still displace the incumbent
+            // kth-best on the ascending-doc-id tie-break.
             let scoring_needed = match bar > f32::NEG_INFINITY {
                 true => {
                     let must_ub: f32 = musts
                         .iter_mut()
                         .map(|a| a.block_max_in_range(aligned, aligned))
                         .sum();
-                    must_ub + should_ub > bar
+                    must_ub + should_ub >= bar
                 }
                 false => true,
             };
@@ -982,8 +1006,8 @@ impl FtsReader {
             if admitted {
                 let norm = dl_norm_k1[aligned as usize];
                 let mut score: f32 = musts.iter().map(|a| a.score_current(norm)).sum();
-                for sh in shoulds.iter_mut() {
-                    sh.skip_to(aligned)?;
+                for (sh, &others) in shoulds.iter_mut().zip(&should_others_ub) {
+                    sh.skip_to_pruned(aligned, bar - others, dl_norm_k1)?;
                     if !sh.is_exhausted() && sh.current_doc_id() == aligned {
                         score += sh.score_current(norm);
                     }
@@ -3453,7 +3477,7 @@ impl PhraseCursor {
             current_doc: 0,
             current_tf: 0,
         };
-        cursor.seek_match(0)?;
+        cursor.seek_match(0, f32::NEG_INFINITY, &[])?;
         Ok(cursor)
     }
 
@@ -3472,12 +3496,39 @@ impl PhraseCursor {
         if self.is_exhausted() || self.current_doc >= target {
             return Ok(());
         }
-        self.seek_match(target)
+        self.seek_match(target, f32::NEG_INFINITY, &[])
+    }
+
+    /// [`Self::skip_to`] for ranked walks: additionally skips docs
+    /// whose phrase contribution provably can't matter. `bar` is the
+    /// most this atom may need to contribute (the walk's pruning bar
+    /// minus every other atom's upper bound); a doc whose phrase
+    /// score bound falls strictly below it is passed over without any
+    /// position work — sound for top-k because the doc's total score
+    /// then can't reach the bar, but NOT for match/count walks, which
+    /// must keep using [`Self::skip_to`].
+    fn skip_to_pruned(
+        &mut self,
+        target: u32,
+        bar: f32,
+        dl_norm_k1: &[f32],
+    ) -> Result<(), FtsError> {
+        if self.is_exhausted() || self.current_doc >= target {
+            return Ok(());
+        }
+        self.seek_match(target, bar, dl_norm_k1)
     }
 
     /// Leapfrog the members to their next common doc ≥ `from`, verify
-    /// adjacency there, and repeat until a match or exhaustion.
-    fn seek_match(&mut self, mut from: u32) -> Result<(), FtsError> {
+    /// adjacency there, and repeat until a match or exhaustion. When
+    /// `bar` is finite, aligned docs are pre-screened without touching
+    /// positions: the phrase tf can't exceed any member's tf, so the
+    /// BM25 score at the members' minimum tf bounds the phrase's
+    /// contribution, and a doc strictly below `bar` is skipped before
+    /// the run decode. (`<`, not `<=`: a doc exactly at the bar can
+    /// still displace the incumbent kth-best on the ascending-doc-id
+    /// tie-break, so it must be verified.)
+    fn seek_match(&mut self, mut from: u32, bar: f32, dl_norm_k1: &[f32]) -> Result<(), FtsError> {
         'docs: loop {
             // Align every member to the same doc ≥ `from`.
             let mut aligned = from;
@@ -3498,6 +3549,31 @@ impl PhraseCursor {
                     continue;
                 }
                 i += 1;
+            }
+
+            if bar > f32::NEG_INFINITY {
+                let min_tf = self
+                    .members
+                    .iter()
+                    .map(|m| m.cursor.current_tf())
+                    .min()
+                    .expect("members >= 2");
+                let ub = bm25::score_with_dl_norm_k1(
+                    self.idf_x_k1p1,
+                    min_tf,
+                    dl_norm_k1[aligned as usize],
+                );
+                if ub < bar {
+                    from = match aligned.checked_add(1) {
+                        Some(next) => next,
+                        None => {
+                            self.current_doc = u32::MAX;
+                            self.current_tf = 0;
+                            return Ok(());
+                        }
+                    };
+                    continue 'docs;
+                }
             }
 
             // Verify adjacency at the aligned doc.
@@ -3601,6 +3677,26 @@ impl AnyCursor {
                 Ok(())
             }
             AnyCursor::Phrase(c) => c.skip_to(target),
+        }
+    }
+
+    /// [`Self::skip_to`] with the ranked walks' pruning bar: a phrase
+    /// atom skips docs it provably can't lift over the bar without
+    /// doing any position work (see [`PhraseCursor::skip_to_pruned`]).
+    /// Term atoms ignore the bar — their per-doc score costs nothing
+    /// beyond the postings walk itself.
+    fn skip_to_pruned(
+        &mut self,
+        target: u32,
+        bar: f32,
+        dl_norm_k1: &[f32],
+    ) -> Result<(), FtsError> {
+        match self {
+            AnyCursor::Term(c) => {
+                c.skip_to(target);
+                Ok(())
+            }
+            AnyCursor::Phrase(c) => c.skip_to_pruned(target, bar, dl_norm_k1),
         }
     }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -3758,7 +3758,8 @@ mod tests {
         // 3 docs, 1 column.
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register column");
+        b.register_column("body".into(), false)
+            .expect("register column");
         b.add_doc(0, 0, "rust async runtime").expect("add doc");
         b.add_doc(0, 1, "tokio is a rust runtime").expect("add doc");
         b.add_doc(0, 2, "java spring boot").expect("add doc");
@@ -3912,7 +3913,7 @@ mod tests {
         const N_DOCS: u32 = OR_WINDOW * 2 + 500;
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         for i in 0..N_DOCS {
             let mut text = String::from("alpha "); // every doc
             if i % 2 == 0 {
@@ -3990,7 +3991,8 @@ mod tests {
         // score, ascending doc_id tiebreak).
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register column");
+        b.register_column("body".into(), false)
+            .expect("register column");
         // 20 docs sprinkled with mixed term combinations.
         let docs = [
             "alpha",
@@ -4142,7 +4144,8 @@ mod tests {
     fn build_mixed_df_blob() -> (Bytes, String) {
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register column");
+        b.register_column("body".into(), false)
+            .expect("register column");
         // `common`     → df = 3 (PFOR form)
         // `rust`       → df = 2 (PFOR form)
         // `uniqzero`  → df = 1 (inline form)
@@ -4268,7 +4271,7 @@ mod tests {
 
         let mut b_inline = FtsBuilder::new(tok.clone());
         b_inline
-            .register_column("body".into())
+            .register_column("body".into(), false)
             .expect("register column");
         for i in 0..20 {
             b_inline
@@ -4279,7 +4282,7 @@ mod tests {
 
         let mut b_pfor = FtsBuilder::new(tok);
         b_pfor
-            .register_column("body".into())
+            .register_column("body".into(), false)
             .expect("register column");
         // Same 20 terms but all appearing in every doc → df = 20 → PFOR.
         for i in 0..20 {
@@ -4569,8 +4572,8 @@ mod tests {
     async fn search_multi_weights_and_combines_columns() {
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("title".into()).expect("register");
-        b.register_column("body".into()).expect("register");
+        b.register_column("title".into(), false).expect("register");
+        b.register_column("body".into(), false).expect("register");
         // doc 0: title "rust"; doc 1: body "rust"; doc 2: neither.
         b.add_doc(0, 0, "rust").expect("add");
         b.add_doc(1, 0, "systems").expect("add");
@@ -4597,7 +4600,7 @@ mod tests {
         // ranged path actually clips some out.
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         for i in 0..8u32 {
             b.add_doc(0, i, "alpha beta").expect("add");
         }
@@ -4646,7 +4649,7 @@ mod tests {
     async fn search_or_range_with_floor_prunes() {
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         for i in 0..8u32 {
             b.add_doc(0, i, "alpha beta").expect("add");
         }
@@ -4666,7 +4669,7 @@ mod tests {
         // BMM path on the planted corpus.
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         let docs = [
             "alpha beta",
             "alpha",
@@ -4718,7 +4721,7 @@ mod tests {
 
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         for i in 0..N_DOCS {
             let mut text = String::new();
             // `alpha` in ~every doc, `beta` in ~half, `gamma` every
@@ -4773,7 +4776,7 @@ mod tests {
         const N_DOCS: u32 = OR_WINDOW * 2 + 500;
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         for i in 0..N_DOCS {
             let mut text = String::from("alpha zeta eta theta "); // ~every doc
             if i % 2 == 0 {
@@ -4844,7 +4847,7 @@ mod tests {
         const N_DOCS: u32 = OR_WINDOW * 2 + 500;
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         for i in 0..N_DOCS {
             let mut text = String::from("alpha ");
             if i % 2 == 0 {
@@ -4889,7 +4892,7 @@ mod tests {
         const N_DOCS: u32 = 4000;
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         for i in 0..N_DOCS {
             let mut text = String::from("common "); // every doc
             if i % 2 == 0 {
@@ -4936,7 +4939,7 @@ mod tests {
         const N_DOCS: u32 = OR_WINDOW + 1000; // spans more than one window
         let tok = Arc::new(AsciiLowerTokenizer);
         let mut b = FtsBuilder::new(tok);
-        b.register_column("body".into()).expect("register");
+        b.register_column("body".into(), false).expect("register");
         for i in 0..N_DOCS {
             let mut text = String::from("alpha ");
             if i % 2 == 0 {

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -43,6 +43,7 @@ use crate::superfile::{
         },
         dict::{DictReader, make_key},
         fst_value::FstValue,
+        positions::{decode_run, skip_run},
         posting::{BLOCK_LEN, decode_block},
         tokenize::{AsciiLowerTokenizer, Tokenizer as _},
     },
@@ -62,6 +63,42 @@ pub enum BoolMode {
     /// the musts alone define the match set and bare terms become
     /// scoring-only.
     Or,
+}
+
+/// A query's parsed clause lists, borrowed for one search call —
+/// terms and phrases per polarity, with the default operator already
+/// resolved (see `ParsedQuery::into_clauses`). Grouped so the search
+/// entry points don't take nine parallel parameters.
+#[derive(Default)]
+pub(crate) struct ClauseLists<'a> {
+    pub musts: &'a [&'a str],
+    pub shoulds: &'a [&'a str],
+    pub negatives: &'a [&'a str],
+    pub must_phrases: &'a [Vec<String>],
+    pub should_phrases: &'a [Vec<String>],
+    pub negative_phrases: &'a [Vec<String>],
+}
+
+impl ClauseLists<'_> {
+    /// Any phrase atom anywhere routes the query to the atom walks.
+    fn has_phrases(&self) -> bool {
+        !self.must_phrases.is_empty()
+            || !self.should_phrases.is_empty()
+            || !self.negative_phrases.is_empty()
+    }
+
+    /// Nothing to rank or match on the positive side.
+    fn no_positive_atoms(&self) -> bool {
+        self.musts.is_empty()
+            && self.shoulds.is_empty()
+            && self.must_phrases.is_empty()
+            && self.should_phrases.is_empty()
+    }
+
+    /// Nothing negated either.
+    fn no_negative_atoms(&self) -> bool {
+        self.negatives.is_empty() && self.negative_phrases.is_empty()
+    }
 }
 
 impl From<&str> for BoolMode {
@@ -265,9 +302,8 @@ pub struct FtsReader {
     fst_range: Range<usize>,
     postings_range: Range<usize>,
     /// Byte range of the positions region (CRC stripped) — `Some`
-    /// iff the blob is v2 (some column recorded positions). Consumed
-    /// by the phrase read path that follows in this series.
-    #[allow(dead_code)]
+    /// iff the blob is v2. Phrase queries fetch per-term run ranges
+    /// out of it via [`Self::fetch_term_positions`].
     positions_range: Option<Range<usize>>,
     columns: Vec<ColumnMeta>,
     column_id_by_name: HashMap<String, u32>,
@@ -759,6 +795,235 @@ impl FtsReader {
             })
     }
 
+    /// Fetch each requested term's position-run bytes from the
+    /// positions region — the phrase sibling of
+    /// [`fetch_term_postings`](Self::fetch_term_postings): one range
+    /// per term, fanned out in parallel, never the whole region.
+    /// `terms` pairs are `(positions_offset, positions_length)` from
+    /// the terms' metadata; zero-length entries (inline terms) yield
+    /// empty buffers without touching the source.
+    async fn fetch_term_positions(&self, terms: &[(u64, u32)]) -> Result<Vec<Bytes>, FtsError> {
+        if terms.iter().all(|&(_, len)| len == 0) {
+            return Ok(vec![Bytes::new(); terms.len()]);
+        }
+        let region = self.positions_range.as_ref().ok_or_else(|| {
+            FtsError::Read(ReadError::MalformedVersion(
+                "positional term in a blob with no positions region".into(),
+            ))
+        })?;
+        let base = region.start;
+        let region_len = region.len();
+        let mut ranges: Vec<Range<usize>> = Vec::with_capacity(terms.len());
+        for &(off, len) in terms {
+            let off = off as usize;
+            let len = len as usize;
+            if off + len > region_len {
+                return Err(FtsError::Read(ReadError::MalformedVersion(
+                    "term positions range runs past positions region".into(),
+                )));
+            }
+            ranges.push(base + off..base + off + len);
+        }
+        self.source
+            .get_ranges_parallel_async(&ranges)
+            .await
+            .map_err(|e| {
+                FtsError::Read(ReadError::MalformedVersion(format!(
+                    "fts/positions term range fetch failed: {e}"
+                )))
+            })
+    }
+
+    /// Build one [`AnyCursor`] per requested atom, preserving input
+    /// order: first the `terms`, then the `phrases`. An atom whose
+    /// term (or any phrase member) is absent from the column yields
+    /// `None` — the caller applies polarity semantics (a missing must
+    /// empties the result; a missing should or negative is dropped).
+    ///
+    /// Multi-token phrases require the column to be positional;
+    /// otherwise [`FtsError::PositionsUnavailable`].
+    async fn build_atom_cursors(
+        &self,
+        column_id: u32,
+        terms: &[&str],
+        phrases: &[Vec<String>],
+    ) -> Result<Vec<Option<AnyCursor>>, FtsError> {
+        let col_meta = &self.columns[column_id as usize];
+        if !phrases.is_empty() && !col_meta.positions {
+            return Err(FtsError::PositionsUnavailable {
+                column: col_meta.name.clone(),
+            });
+        }
+        let mut out: Vec<Option<AnyCursor>> = Vec::with_capacity(terms.len() + phrases.len());
+        for term in terms {
+            let mut cursors = self.build_term_cursors(column_id, &[term]).await?;
+            out.push(cursors.pop().map(AnyCursor::Term));
+        }
+        for phrase in phrases {
+            let member_refs: Vec<&str> = phrase.iter().map(|t| t.as_str()).collect();
+            let cursors = self.build_term_cursors(column_id, &member_refs).await?;
+            if cursors.len() != member_refs.len() {
+                // A member is absent — the phrase can never match.
+                out.push(None);
+                continue;
+            }
+            let pos_ranges: Vec<(u64, u32)> = cursors
+                .iter()
+                .map(|c| (c.positions_offset, c.positions_length))
+                .collect();
+            let positions = self.fetch_term_positions(&pos_ranges).await?;
+            out.push(Some(AnyCursor::Phrase(PhraseCursor::new(
+                cursors, positions,
+            )?)));
+        }
+        Ok(out)
+    }
+
+    /// Ranked search over heterogeneous atoms — the walk every
+    /// phrase-bearing query takes. With musts, the match set is their
+    /// intersection and shoulds are scoring-only (the clause model);
+    /// with none, the shoulds' union matches. Docs excluded by
+    /// `filter` never reach the heap; docs scoring strictly below
+    /// `floor_eff` are dropped at admission.
+    fn run_atoms_search(
+        &self,
+        column_id: u32,
+        mut musts: Vec<AnyCursor>,
+        mut shoulds: Vec<AnyCursor>,
+        k: usize,
+        mut filter: Option<AtomExcludeFilter>,
+        floor_eff: f32,
+    ) -> Result<Vec<(u32, f32)>, FtsError> {
+        let dl_norm_k1 = self.columns[column_id as usize].dl_norm_k1.as_slice();
+        let initial_cap = k.min(self.n_docs as usize).max(1);
+        let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
+
+        if musts.is_empty() {
+            // Union of shoulds, doc-at-a-time: score every atom
+            // sitting on the frontier doc, then advance them past it.
+            loop {
+                let Some(doc) = shoulds
+                    .iter()
+                    .filter(|a| !a.is_exhausted())
+                    .map(AnyCursor::current_doc_id)
+                    .min()
+                else {
+                    break;
+                };
+                let admitted = match filter.as_mut() {
+                    Some(f) => f.admits(doc)?,
+                    None => true,
+                };
+                if admitted {
+                    let norm = dl_norm_k1[doc as usize];
+                    let score: f32 = shoulds
+                        .iter()
+                        .filter(|a| !a.is_exhausted() && a.current_doc_id() == doc)
+                        .map(|a| a.score_current(norm))
+                        .sum();
+                    if score > floor_eff {
+                        and_heap_push(&mut heap, k, None, score, doc);
+                    }
+                }
+                let Some(next) = doc.checked_add(1) else {
+                    break;
+                };
+                for a in shoulds.iter_mut() {
+                    if !a.is_exhausted() && a.current_doc_id() == doc {
+                        a.skip_to(next)?;
+                    }
+                }
+            }
+            return Ok(drain_top_k_desc(heap));
+        }
+
+        // Must-driven walk: leapfrog the musts to each common doc,
+        // score musts + landing shoulds there.
+        let mut target = 0u32;
+        'docs: loop {
+            let mut aligned = target;
+            let mut i = 0usize;
+            while i < musts.len() {
+                let a = &mut musts[i];
+                a.skip_to(aligned)?;
+                if a.is_exhausted() {
+                    break 'docs;
+                }
+                let here = a.current_doc_id();
+                if here > aligned {
+                    aligned = here;
+                    i = 0;
+                    continue;
+                }
+                i += 1;
+            }
+            let admitted = match filter.as_mut() {
+                Some(f) => f.admits(aligned)?,
+                None => true,
+            };
+            if admitted {
+                let norm = dl_norm_k1[aligned as usize];
+                let mut score: f32 = musts.iter().map(|a| a.score_current(norm)).sum();
+                for sh in shoulds.iter_mut() {
+                    sh.skip_to(aligned)?;
+                    if !sh.is_exhausted() && sh.current_doc_id() == aligned {
+                        score += sh.score_current(norm);
+                    }
+                }
+                if score > floor_eff {
+                    and_heap_push(&mut heap, k, None, score, aligned);
+                }
+            }
+            let Some(next) = aligned.checked_add(1) else {
+                break;
+            };
+            target = next;
+        }
+        Ok(drain_top_k_desc(heap))
+    }
+
+    /// Unranked count over heterogeneous atoms: the cardinality of the
+    /// musts' intersection (minus exclusions) — shoulds have no scores
+    /// to raise here, matching the clause model's unranked semantics.
+    fn count_atoms(
+        &self,
+        mut musts: Vec<AnyCursor>,
+        mut filter: Option<AtomExcludeFilter>,
+    ) -> Result<u64, FtsError> {
+        let mut n = 0u64;
+        let mut target = 0u32;
+        'docs: loop {
+            let mut aligned = target;
+            let mut i = 0usize;
+            while i < musts.len() {
+                let a = &mut musts[i];
+                a.skip_to(aligned)?;
+                if a.is_exhausted() {
+                    break 'docs;
+                }
+                let here = a.current_doc_id();
+                if here > aligned {
+                    aligned = here;
+                    i = 0;
+                    continue;
+                }
+                i += 1;
+            }
+            let admitted = match filter.as_mut() {
+                Some(f) => f.admits(aligned)?,
+                None => true,
+            };
+            if admitted {
+                n += 1;
+            }
+            let Some(next) = aligned.checked_add(1) else {
+                break;
+            };
+            target = next;
+        }
+        Ok(n)
+    }
+
     /// Resolve a column name to its dense column_id, or
     /// `FtsError::UnknownColumn` if the column isn't FTS-indexed in
     /// this superfile. Shared by every public search entry point.
@@ -893,9 +1158,7 @@ impl FtsReader {
     pub(crate) async fn search_excluding(
         &self,
         column: &str,
-        musts: &[&str],
-        shoulds: &[&str],
-        negatives: &[&str],
+        lists: ClauseLists<'_>,
         k: usize,
         floor: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
@@ -903,23 +1166,65 @@ impl FtsReader {
         if k == 0 {
             return Ok(Vec::new());
         }
-        if musts.is_empty() && shoulds.is_empty() {
-            if negatives.is_empty() {
+        if lists.no_positive_atoms() {
+            if lists.no_negative_atoms() {
                 return Ok(Vec::new());
             }
             return Err(FtsError::NegationOnly);
         }
+        let floor_eff = floor.next_down();
 
-        let mut filter = match negatives {
+        if lists.has_phrases() {
+            // Phrase-bearing query: the heterogeneous atom walks.
+            let must_atoms = self
+                .build_atom_cursors(column_id, lists.musts, lists.must_phrases)
+                .await?;
+            if must_atoms.iter().any(Option::is_none) {
+                // A must atom can never match in this superfile.
+                return Ok(Vec::new());
+            }
+            let must_atoms: Vec<AnyCursor> = must_atoms.into_iter().flatten().collect();
+            let should_atoms: Vec<AnyCursor> = self
+                .build_atom_cursors(column_id, lists.shoulds, lists.should_phrases)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect();
+            let negative_atoms: Vec<AnyCursor> = self
+                .build_atom_cursors(column_id, lists.negatives, lists.negative_phrases)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect();
+            let filter = match negative_atoms.is_empty() {
+                true => None,
+                false => Some(AtomExcludeFilter::new(negative_atoms)),
+            };
+            return self.run_atoms_search(
+                column_id,
+                must_atoms,
+                should_atoms,
+                k,
+                filter,
+                floor_eff,
+            );
+        }
+
+        let mut filter = match lists.negatives {
             [] => None,
             _ => Some(ExcludeFilter::new(
-                self.build_term_cursors(column_id, negatives).await?,
+                self.build_term_cursors(column_id, lists.negatives).await?,
             )),
         };
-
-        let floor_eff = floor.next_down();
-        self.search_clauses(column_id, musts, shoulds, k, filter.as_mut(), floor_eff)
-            .await
+        self.search_clauses(
+            column_id,
+            lists.musts,
+            lists.shoulds,
+            k,
+            filter.as_mut(),
+            floor_eff,
+        )
+        .await
     }
 
     /// Shared dispatch for [`Self::search_with_floor`] and
@@ -1387,9 +1692,9 @@ impl FtsReader {
                     // the term's single position, tf implied 1 — the
                     // builder only inlines tf == 1 postings there.
                     // Scoring must use the implied tf, never the slot.
-                    let tf = match col_meta.positions {
-                        true => 1,
-                        false => tf,
+                    let (tf, inline_position) = match col_meta.positions {
+                        true => (1, Some(tf)),
+                        false => (tf, None),
                     };
                     let dl_norm_k1 = col_meta.dl_norm_k1[doc_id as usize];
                     cursors.push(TermCursor::new_inline(
@@ -1397,6 +1702,7 @@ impl FtsReader {
                         tf,
                         self.n_docs as u64,
                         dl_norm_k1,
+                        inline_position,
                     ));
                 }
                 Resolved::Pfor => {
@@ -2918,6 +3224,326 @@ fn drain_top_k_desc(heap: BinaryHeap<TopKEntry>) -> Vec<(u32, f32)> {
     out
 }
 
+/// One member term of a [`PhraseCursor`]: its posting cursor, its
+/// fetched position runs, and a lazily-built per-block cache of each
+/// pair's run offset.
+struct PhraseMember {
+    cursor: TermCursor,
+    /// The term's complete position runs (empty for an inline df=1
+    /// member, whose single position rides on the cursor).
+    positions: Bytes,
+    /// The member's bare idf (the cursor stores only `idf × (K1+1)`).
+    idf: f32,
+    /// Byte offset of each decoded-block pair's run within
+    /// `positions`, valid for `run_offsets_block`. Rebuilt on block
+    /// crossings by one `skip_run` walk over the block's runs.
+    run_offsets: Vec<u32>,
+    /// Which block index `run_offsets` covers (`usize::MAX` = none).
+    run_offsets_block: usize,
+    /// Scratch for the member's decoded positions at the aligned doc.
+    pos_scratch: Vec<u32>,
+}
+
+/// Sentinel for [`PhraseMember::run_offsets_block`]: no block cached.
+const NO_BLOCK_CACHED: usize = usize::MAX;
+
+impl PhraseMember {
+    /// The member's positions at its cursor's current doc, decoded
+    /// into `pos_scratch`. The cursor must be positioned on a doc
+    /// (not exhausted).
+    fn decode_current_positions(&mut self) -> Result<(), FtsError> {
+        self.pos_scratch.clear();
+        if let Some(p) = self.cursor.inline_position {
+            self.pos_scratch.push(p);
+            return Ok(());
+        }
+        let block = self.cursor.current_block;
+        if self.run_offsets_block != block {
+            // One forward walk locates every pair's run in this
+            // block: start at the block's recorded first-run offset,
+            // then skip each pair's `tf` varints.
+            self.run_offsets.clear();
+            let mut at = self.cursor.blocks[block].positions_block_offset as usize;
+            for i in 0..self.cursor.block_n {
+                self.run_offsets.push(at as u32);
+                skip_run(&self.positions, &mut at, self.cursor.block_tfs[i]).ok_or_else(|| {
+                    FtsError::Read(ReadError::MalformedVersion(
+                        "position runs truncated within block".into(),
+                    ))
+                })?;
+            }
+            self.run_offsets_block = block;
+        }
+        let pair = self.cursor.pos;
+        let mut at = self.run_offsets[pair] as usize;
+        decode_run(
+            &self.positions,
+            &mut at,
+            self.cursor.block_tfs[pair],
+            &mut self.pos_scratch,
+        )
+        .ok_or_else(|| {
+            FtsError::Read(ReadError::MalformedVersion(
+                "position run truncated or overflowing".into(),
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+/// Doc-at-a-time cursor over an exact phrase: the members'
+/// intersection drives doc alignment, and a doc matches only when the
+/// members' positions verify adjacency (member `i` at `p + i` for
+/// some anchor `p`). Scores as one BM25 atom with `tf` = the number
+/// of verified anchors and `idf` = Σ member idf. Exposes the same
+/// notion of term- and block-level upper bounds as [`TermCursor`], so
+/// the atom walks can prune with it:
+/// `bound = phrase_idf × min_i(member_bound_i / idf_i)` — sound
+/// because the phrase tf in any doc is ≤ every member's tf there and
+/// the BM25 tf-factor is monotone in tf.
+struct PhraseCursor {
+    members: Vec<PhraseMember>,
+    /// Σ member idf × (K1 + 1) — the phrase's scoring constant.
+    idf_x_k1p1: f32,
+    /// Phrase-scaled term-level upper bound (see type docs).
+    term_max_bm25: f32,
+    /// Aligned-and-verified doc, or `u32::MAX` when exhausted.
+    current_doc: u32,
+    /// Number of verified anchors at `current_doc`.
+    current_tf: u32,
+}
+
+impl PhraseCursor {
+    /// Build from member cursors (query order) and their fetched
+    /// position runs, then seek to the first matching doc.
+    fn new(cursors: Vec<TermCursor>, positions: Vec<Bytes>) -> Result<Self, FtsError> {
+        debug_assert!(cursors.len() >= 2, "single-token phrases degrade to terms");
+        debug_assert_eq!(cursors.len(), positions.len());
+        let mut idf_sum = 0.0f32;
+        let mut min_scaled_bound = f32::INFINITY;
+        let members: Vec<PhraseMember> = cursors
+            .into_iter()
+            .zip(positions)
+            .map(|(cursor, positions)| {
+                let idf = cursor.idf_x_k1p1 / (bm25::K1 + 1.0);
+                min_scaled_bound = min_scaled_bound.min(cursor.term_max_bm25 / idf);
+                idf_sum += idf;
+                PhraseMember {
+                    cursor,
+                    positions,
+                    idf,
+                    run_offsets: Vec::new(),
+                    run_offsets_block: NO_BLOCK_CACHED,
+                    pos_scratch: Vec::new(),
+                }
+            })
+            .collect();
+        let mut cursor = Self {
+            idf_x_k1p1: idf_sum * (bm25::K1 + 1.0),
+            term_max_bm25: idf_sum * min_scaled_bound,
+            members,
+            current_doc: 0,
+            current_tf: 0,
+        };
+        cursor.seek_match(0)?;
+        Ok(cursor)
+    }
+
+    #[inline]
+    fn is_exhausted(&self) -> bool {
+        self.current_doc == u32::MAX
+    }
+
+    #[inline]
+    fn current_doc_id(&self) -> u32 {
+        self.current_doc
+    }
+
+    #[inline]
+    fn current_tf(&self) -> u32 {
+        self.current_tf
+    }
+
+    /// Advance to the first verified phrase match at doc ≥ `target`.
+    fn skip_to(&mut self, target: u32) -> Result<(), FtsError> {
+        if self.is_exhausted() || self.current_doc >= target {
+            return Ok(());
+        }
+        self.seek_match(target)
+    }
+
+    /// Leapfrog the members to their next common doc ≥ `from`, verify
+    /// adjacency there, and repeat until a match or exhaustion.
+    fn seek_match(&mut self, mut from: u32) -> Result<(), FtsError> {
+        'docs: loop {
+            // Align every member to the same doc ≥ `from`.
+            let mut aligned = from;
+            let mut i = 0usize;
+            while i < self.members.len() {
+                let c = &mut self.members[i].cursor;
+                c.skip_to(aligned);
+                if c.is_exhausted() {
+                    self.current_doc = u32::MAX;
+                    self.current_tf = 0;
+                    return Ok(());
+                }
+                let here = c.current_doc_id();
+                if here > aligned {
+                    // Restart alignment at the higher doc.
+                    aligned = here;
+                    i = 0;
+                    continue;
+                }
+                i += 1;
+            }
+
+            // Verify adjacency at the aligned doc.
+            let tf = self.verify_at_aligned()?;
+            if tf > 0 {
+                self.current_doc = aligned;
+                self.current_tf = tf;
+                return Ok(());
+            }
+            from = match aligned.checked_add(1) {
+                Some(next) => next,
+                None => {
+                    self.current_doc = u32::MAX;
+                    self.current_tf = 0;
+                    return Ok(());
+                }
+            };
+            continue 'docs;
+        }
+    }
+
+    /// Count the phrase's anchors at the members' aligned doc: the
+    /// first member's positions `p` where member `i` also has `p + i`
+    /// for every `i`. Member position lists are ascending, so each
+    /// probe is a binary search over a per-doc-tf-sized slice.
+    fn verify_at_aligned(&mut self) -> Result<u32, FtsError> {
+        for m in self.members.iter_mut() {
+            m.decode_current_positions()?;
+        }
+        let (anchor, rest) = self.members.split_first_mut().expect("members >= 2");
+        let mut tf = 0u32;
+        'anchors: for &p in &anchor.pos_scratch {
+            for (i, m) in rest.iter().enumerate() {
+                let want = match p.checked_add(i as u32 + 1) {
+                    Some(w) => w,
+                    None => continue 'anchors,
+                };
+                if m.pos_scratch.binary_search(&want).is_err() {
+                    continue 'anchors;
+                }
+            }
+            tf += 1;
+        }
+        Ok(tf)
+    }
+
+    /// Score the phrase at its current doc with the caller-supplied
+    /// per-doc BM25 normalization.
+    #[inline]
+    fn score_current(&self, dl_norm_k1: f32) -> f32 {
+        bm25::score_with_dl_norm_k1(self.idf_x_k1p1, self.current_tf, dl_norm_k1)
+    }
+
+    /// Phrase-scaled block-level upper bound over `[range_start,
+    /// range_end]` — the block analog of `term_max_bm25`.
+    fn block_max_in_range(&mut self, range_start: u32, range_end: u32) -> f32 {
+        let mut min_scaled = f32::INFINITY;
+        for m in self.members.iter_mut() {
+            let b = m.cursor.block_max_in_range(range_start, range_end);
+            min_scaled = min_scaled.min(b / m.idf);
+        }
+        let idf_sum = self.idf_x_k1p1 / (bm25::K1 + 1.0);
+        idf_sum * min_scaled
+    }
+}
+
+/// A query atom's cursor: a plain term or an exact phrase. The atom
+/// walks below are heterogeneous doc-at-a-time loops over this enum —
+/// deliberately separate from the field-level optimized kernels
+/// (flat-merge AND, MaxScore/BMM, windowed union), which keep serving
+/// term-only queries unchanged. A query containing any phrase routes
+/// here: correctness-first walks whose per-doc cost is dominated by
+/// the phrase verification itself.
+enum AnyCursor {
+    Term(TermCursor),
+    Phrase(PhraseCursor),
+}
+
+impl AnyCursor {
+    #[inline]
+    fn is_exhausted(&self) -> bool {
+        match self {
+            AnyCursor::Term(c) => c.is_exhausted(),
+            AnyCursor::Phrase(c) => c.is_exhausted(),
+        }
+    }
+
+    #[inline]
+    fn current_doc_id(&self) -> u32 {
+        match self {
+            AnyCursor::Term(c) => c.current_doc_id(),
+            AnyCursor::Phrase(c) => c.current_doc_id(),
+        }
+    }
+
+    /// Advance to the first (phrase: first *verified*) doc ≥ `target`.
+    fn skip_to(&mut self, target: u32) -> Result<(), FtsError> {
+        match self {
+            AnyCursor::Term(c) => {
+                c.skip_to(target);
+                Ok(())
+            }
+            AnyCursor::Phrase(c) => c.skip_to(target),
+        }
+    }
+
+    /// BM25 contribution at the cursor's current doc.
+    #[inline]
+    fn score_current(&self, dl_norm_k1: f32) -> f32 {
+        match self {
+            AnyCursor::Term(c) => {
+                bm25::score_with_dl_norm_k1(c.idf_x_k1p1, c.current_tf(), dl_norm_k1)
+            }
+            AnyCursor::Phrase(c) => c.score_current(dl_norm_k1),
+        }
+    }
+}
+
+/// Atom-walk exclusion gate: the heterogeneous sibling of
+/// [`ExcludeFilter`], additionally able to exclude docs containing a
+/// negated *phrase*. Same monotonic-doc contract.
+struct AtomExcludeFilter {
+    atoms: Vec<AnyCursor>,
+    last_doc: u32,
+}
+
+impl AtomExcludeFilter {
+    fn new(atoms: Vec<AnyCursor>) -> Self {
+        Self { atoms, last_doc: 0 }
+    }
+
+    /// `false` iff `doc` matches any negated atom.
+    fn admits(&mut self, doc: u32) -> Result<bool, FtsError> {
+        debug_assert!(
+            doc >= self.last_doc,
+            "AtomExcludeFilter fed non-monotonic doc: {doc} < {}",
+            self.last_doc
+        );
+        self.last_doc = doc;
+        for a in &mut self.atoms {
+            a.skip_to(doc)?;
+            if !a.is_exhausted() && a.current_doc_id() == doc {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+}
+
 /// Exclusion gate for negated (`-term`) clauses: holds one
 /// [`TermCursor`] per negated term, streamed with `skip_to` (a common
 /// negated list is never fully decoded). A doc is rejected if it appears
@@ -3336,6 +3962,12 @@ struct TermMeta {
     /// Absolute offset (within the postings region) of the first
     /// skip-table entry: `metadata_offset + TERM_META_SIZE`.
     skip_start: usize,
+    /// This term's byte offset in the positions region (positional
+    /// columns; zero otherwise).
+    positions_offset: u64,
+    /// Byte length of this term's position runs (positional columns;
+    /// zero otherwise).
+    positions_length: u32,
 }
 
 impl TermMeta {
@@ -3372,6 +4004,20 @@ impl TermMeta {
                 ..metadata_offset + term_meta::NUM_BLOCKS_OFF + U32_BYTES],
         ) as usize;
 
+        let (positions_offset, positions_length) = match positional {
+            true => (
+                read_u64_le(
+                    &postings[metadata_offset + term_meta::POSITIONS_OFFSET_OFF
+                        ..metadata_offset + term_meta::POSITIONS_OFFSET_OFF + U64_BYTES],
+                ),
+                read_u32_le(
+                    &postings[metadata_offset + term_meta::POSITIONS_LENGTH_OFF
+                        ..metadata_offset + term_meta::POSITIONS_LENGTH_OFF + U32_BYTES],
+                ),
+            ),
+            false => (0, 0),
+        };
+
         let skip_start = metadata_offset + term_meta_size;
         let skip_end = skip_start + num_blocks * SKIP_ENTRY_SIZE;
         if skip_end > postings.len() {
@@ -3384,6 +4030,8 @@ impl TermMeta {
             postings_length,
             num_blocks,
             skip_start,
+            positions_offset,
+            positions_length,
         })
     }
 
@@ -3420,6 +4068,19 @@ impl TermMeta {
         )
     }
 
+    /// This block's position-run byte offset within the term's
+    /// positions bytes — the skip entry's fourth field (zero on
+    /// positionless columns, where it is the reserved slot).
+    #[inline]
+    fn positions_block_offset(&self, postings: &[u8], i: usize) -> u32 {
+        debug_assert!(i < self.num_blocks, "skip entry {i} >= {}", self.num_blocks);
+        let entry_off = self.skip_start + i * SKIP_ENTRY_SIZE;
+        read_u32_le(
+            &postings[entry_off + skip_entry::POSITIONS_BLOCK_OFFSET_OFF
+                ..entry_off + skip_entry::POSITIONS_BLOCK_OFFSET_OFF + U32_BYTES],
+        )
+    }
+
     /// End offset (relative to the term's `metadata_offset`) of block
     /// `i`'s bytes. Blocks are concatenated back-to-back, so each
     /// block ends where the next one's `block_offset` begins; the last
@@ -3449,6 +4110,10 @@ struct BlockMeta {
     /// Per-block BM25 upper bound, recovered from the skip table's
     /// fixed-point `max_bm25_x1000` field.
     block_max_bm25: f32,
+    /// Byte offset of this block's first position run within the
+    /// term's positions bytes (positional columns; zero otherwise —
+    /// the field is the skip entry's formerly-reserved slot).
+    positions_block_offset: u32,
 }
 
 /// Per-query-term cursor used by [`FtsReader::run_max_score_bmm`]
@@ -3511,6 +4176,17 @@ struct TermCursor {
     /// search hot loops index only the bytes this term touches, never
     /// the whole postings region.
     bytes: Bytes,
+    /// This term's byte range in the positions region (positional
+    /// columns; zeros otherwise). The phrase path fetches the range
+    /// and locates per-doc runs via the blocks'
+    /// `positions_block_offset`.
+    positions_offset: u64,
+    positions_length: u32,
+    /// The single position of an inline (df=1, tf=1) term of a
+    /// positional column — the inline FST value's slot carries it
+    /// instead of a tf. `None` on PFOR cursors and on positionless
+    /// columns.
+    inline_position: Option<u32>,
 }
 
 impl TermCursor {
@@ -3538,6 +4214,7 @@ impl TermCursor {
                 block_byte_offset: metadata_offset + block_offset_in_term,
                 block_byte_end: metadata_offset + term_meta.block_end_in_term(postings, i),
                 block_max_bm25,
+                positions_block_offset: term_meta.positions_block_offset(postings, i),
             });
         }
 
@@ -3553,6 +4230,9 @@ impl TermCursor {
             pos: 0,
             inspect_block: 0,
             bytes: term_bytes,
+            positions_offset: term_meta.positions_offset,
+            positions_length: term_meta.positions_length,
+            inline_position: None,
         };
         if !cursor.blocks.is_empty() {
             cursor.decode_current_block();
@@ -3567,7 +4247,13 @@ impl TermCursor {
     /// doc means min_dl = dl and max_tf = tf, so the per-block UB
     /// formula collapses to the score itself). Computed at query time
     /// since there's no skip-table entry stored for inline terms.
-    fn new_inline(doc_id: u32, tf: u32, n_docs: u64, dl_norm_k1: f32) -> Self {
+    fn new_inline(
+        doc_id: u32,
+        tf: u32,
+        n_docs: u64,
+        dl_norm_k1: f32,
+        inline_position: Option<u32>,
+    ) -> Self {
         let idf = bm25::idf(n_docs, 1);
         let idf_x_k1p1 = idf * (bm25::K1 + 1.0);
         let block_max_bm25 = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
@@ -3580,6 +4266,7 @@ impl TermCursor {
             block_byte_offset: 0,
             block_byte_end: 0,
             block_max_bm25,
+            positions_block_offset: 0,
         }];
 
         let mut block_doc_ids = vec![0u32; BLOCK_LEN];
@@ -3599,6 +4286,9 @@ impl TermCursor {
             pos: 0,
             inspect_block: 0,
             bytes: Bytes::new(),
+            positions_offset: 0,
+            positions_length: 0,
+            inline_position,
         }
     }
 
@@ -4627,13 +5317,168 @@ mod tests {
         assert!(matches!(err, FtsError::UnknownColumn(_)));
     }
 
+    // ---- phrase atoms ----
+
+    /// Corpus with controlled adjacency for "new york": docs 0, 2
+    /// match (doc 4 twice); docs 1, 3 contain both words but never
+    /// adjacent in order.
+    fn build_phrase_blob() -> (Bytes, &'static str) {
+        use crate::superfile::fts::builder::FtsBuilder;
+        let mut b = FtsBuilder::new(crate::test_helpers::default_tokenizer());
+        b.register_column("title".into(), true).expect("register");
+        let docs = [
+            "new york city",
+            "york new haven",
+            "the new york times",
+            "new haven york",
+            "new york new york",
+        ];
+        for (i, d) in docs.iter().enumerate() {
+            b.add_doc(0, i as u32, d).expect("add doc");
+        }
+        (
+            Bytes::from(b.finish().expect("finish")),
+            r#"[{"name":"title","tokenizer":"ascii_lower","positions":true}]"#,
+        )
+    }
+
+    fn phrase(terms: &[&str]) -> Vec<Vec<String>> {
+        vec![terms.iter().map(|t| t.to_string()).collect()]
+    }
+
+    #[tokio::test]
+    async fn phrase_matches_adjacent_in_order_only() {
+        let (blob, json) = build_phrase_blob();
+        let r = FtsReader::open(blob, json).expect("open");
+        let phrases = phrase(&["new", "york"]);
+        let hits = r
+            .search_excluding(
+                "title",
+                ClauseLists {
+                    should_phrases: &phrases,
+                    ..ClauseLists::default()
+                },
+                10,
+                f32::NEG_INFINITY,
+            )
+            .await
+            .expect("phrase search");
+        let ids: Vec<u32> = hits.iter().map(|(d, _)| *d).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec![0, 2, 4], "adjacency in order only");
+        // Doc 4 has the phrase twice — highest tf, and with uniform
+        // doc lengths in play its score must strictly exceed doc 0's
+        // (same length, tf 1... doc 0 len 3, doc 4 len 4; tf=2 wins).
+        assert_eq!(hits[0].0, 4, "double occurrence ranks first");
+    }
+
+    #[tokio::test]
+    async fn phrase_composes_with_clauses() {
+        let (blob, json) = build_phrase_blob();
+        let r = FtsReader::open(blob, json).expect("open");
+        let ny = phrase(&["new", "york"]);
+
+        // Must-phrase + must-term: "the" only in doc 2.
+        let hits = r
+            .search_excluding(
+                "title",
+                ClauseLists {
+                    musts: &["the"],
+                    must_phrases: &ny,
+                    ..ClauseLists::default()
+                },
+                10,
+                f32::NEG_INFINITY,
+            )
+            .await
+            .expect("must phrase + term");
+        assert_eq!(
+            hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(),
+            vec![2],
+            "+\"new york\" +the"
+        );
+
+        // Negated phrase: haven-docs minus the phrase docs.
+        let hits = r
+            .search_excluding(
+                "title",
+                ClauseLists {
+                    shoulds: &["haven"],
+                    negative_phrases: &ny,
+                    ..ClauseLists::default()
+                },
+                10,
+                f32::NEG_INFINITY,
+            )
+            .await
+            .expect("negated phrase");
+        let mut ids: Vec<u32> = hits.iter().map(|(d, _)| *d).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![1, 3], "haven docs don't contain the phrase");
+    }
+
+    #[tokio::test]
+    async fn phrase_with_absent_member_matches_nothing() {
+        let (blob, json) = build_phrase_blob();
+        let r = FtsReader::open(blob, json).expect("open");
+        let ghost = phrase(&["new", "zealand"]);
+        let hits = r
+            .search_excluding(
+                "title",
+                ClauseLists {
+                    must_phrases: &ghost,
+                    ..ClauseLists::default()
+                },
+                10,
+                f32::NEG_INFINITY,
+            )
+            .await
+            .expect("ghost phrase");
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn phrase_on_positionless_column_is_typed_error() {
+        use crate::superfile::fts::builder::FtsBuilder;
+        let mut b = FtsBuilder::new(crate::test_helpers::default_tokenizer());
+        b.register_column("title".into(), false).expect("register");
+        b.add_doc(0, 0, "new york").expect("add doc");
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let r =
+            FtsReader::open(blob, r#"[{"name":"title","tokenizer":"ascii_lower"}]"#).expect("open");
+        let phrases = phrase(&["new", "york"]);
+        let err = r
+            .search_excluding(
+                "title",
+                ClauseLists {
+                    should_phrases: &phrases,
+                    ..ClauseLists::default()
+                },
+                10,
+                f32::NEG_INFINITY,
+            )
+            .await
+            .expect_err("must be a typed error");
+        assert!(matches!(err, FtsError::PositionsUnavailable { .. }));
+    }
+
     #[tokio::test]
     async fn search_excluding_drops_negated_docs() {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
         // "runtime" hits docs 0 and 1; negate "async" (only in doc 0).
         let hits = r
-            .search_excluding("body", &[], &["runtime"], &["async"], 10, f32::NEG_INFINITY)
+            .search_excluding(
+                "body",
+                ClauseLists {
+                    shoulds: &["runtime"],
+                    negatives: &["async"],
+                    ..ClauseLists::default()
+                },
+                10,
+                f32::NEG_INFINITY,
+            )
             .await
             .expect("search excluding");
         let ids: Vec<u32> = hits.iter().map(|(d, _)| *d).collect();
@@ -4645,7 +5490,15 @@ mod tests {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
         let err = r
-            .search_excluding("body", &[], &[], &["rust"], 10, f32::NEG_INFINITY)
+            .search_excluding(
+                "body",
+                ClauseLists {
+                    negatives: &["rust"],
+                    ..ClauseLists::default()
+                },
+                10,
+                f32::NEG_INFINITY,
+            )
             .await
             .expect_err("negation-only");
         assert!(matches!(err, FtsError::NegationOnly));
@@ -4656,7 +5509,7 @@ mod tests {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
         let hits = r
-            .search_excluding("body", &[], &[], &[], 10, f32::NEG_INFINITY)
+            .search_excluding("body", ClauseLists::default(), 10, f32::NEG_INFINITY)
             .await
             .expect("empty");
         assert!(hits.is_empty());

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -197,6 +197,9 @@ pub struct ColumnMeta {
     /// add + mul vs recomputing on the fly. Computed once per
     /// reader at `open` time.
     pub dl_norm_k1: Vec<f32>,
+    /// Whether this column's index carries token positions (from
+    /// `inf.fts.columns`); phrase queries require it.
+    pub positions: bool,
 }
 
 /// JSON-deserialized form of one entry in `inf.fts.columns`. The KV
@@ -211,6 +214,12 @@ pub struct FtsColumnConfig {
     /// been emitted with it implicitly.
     #[serde(default = "default_tokenizer")]
     pub tokenizer: String,
+    /// Whether this column's index records token positions (phrase
+    /// support). Files written before positions existed lack the
+    /// field, which can only mean no positions — so a missing field
+    /// deserializes to `false`.
+    #[serde(default)]
+    pub positions: bool,
 }
 
 fn default_tokenizer() -> String {
@@ -578,6 +587,7 @@ impl FtsReader {
                 doc_lengths_range: doc_lengths_offset..array_end,
                 avgdl,
                 dl_norm_k1,
+                positions: col_cfg.positions,
             });
             column_id_by_name.insert(col_cfg.name.clone(), i as u32);
         }

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -321,7 +321,7 @@ impl FtsReader {
             }));
         }
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
-        if version != format::fts::VERSION && version != format::fts::VERSION_POSITIONS {
+        if version != format::fts::VERSION_LEGACY && version != format::fts::VERSION_POSITIONS {
             return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
                 "fts section version {version}"
             ))));
@@ -410,7 +410,7 @@ impl FtsReader {
         // region between the postings and the doc-lengths directory.
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
         let positional_blob = match version {
-            v if v == format::fts::VERSION => false,
+            v if v == format::fts::VERSION_LEGACY => false,
             v if v == format::fts::VERSION_POSITIONS => true,
             _ => {
                 return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -32,8 +32,8 @@ use crate::superfile::{
         self, FST_SEPARATOR,
         checksum::crc32c,
         fts::{
-            HEADER_SIZE as FTS_HEADER_SIZE, MAGIC_BYTES, U32_BYTES, U64_BYTES, hdr, skip_entry,
-            term_meta,
+            HEADER_SIZE_V1_LEGACY as FTS_HEADER_SIZE, MAGIC_BYTES, U32_BYTES, U64_BYTES, hdr,
+            skip_entry, term_meta,
         },
     },
     fts::{
@@ -321,7 +321,7 @@ impl FtsReader {
             }));
         }
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
-        if version != format::fts::VERSION_LEGACY && version != format::fts::VERSION_POSITIONS {
+        if version != format::fts::VERSION_V1_LEGACY && version != format::fts::VERSION_V2 {
             return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
                 "fts section version {version}"
             ))));
@@ -331,7 +331,7 @@ impl FtsReader {
         // fetched span (and in the overlay below), so
         // `open_with_source` re-reads them without another GET.
         let header_size = match version {
-            v if v == format::fts::VERSION_POSITIONS => format::fts::HEADER_SIZE_V2,
+            v if v == format::fts::VERSION_V2 => format::fts::HEADER_SIZE_V2,
             _ => FTS_HEADER_SIZE,
         };
         if header.len() < header_size {
@@ -410,8 +410,8 @@ impl FtsReader {
         // region between the postings and the doc-lengths directory.
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
         let positional_blob = match version {
-            v if v == format::fts::VERSION_LEGACY => false,
-            v if v == format::fts::VERSION_POSITIONS => true,
+            v if v == format::fts::VERSION_V1_LEGACY => false,
+            v if v == format::fts::VERSION_V2 => true,
             _ => {
                 return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
                     "fts section version {version}"

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -901,15 +901,12 @@ impl FtsReader {
         if musts.is_empty() {
             // Union of shoulds, doc-at-a-time: score every atom
             // sitting on the frontier doc, then advance them past it.
-            loop {
-                let Some(doc) = shoulds
-                    .iter()
-                    .filter(|a| !a.is_exhausted())
-                    .map(AnyCursor::current_doc_id)
-                    .min()
-                else {
-                    break;
-                };
+            while let Some(doc) = shoulds
+                .iter()
+                .filter(|a| !a.is_exhausted())
+                .map(AnyCursor::current_doc_id)
+                .min()
+            {
                 let admitted = match filter.as_mut() {
                     Some(f) => f.admits(doc)?,
                     None => true,
@@ -939,6 +936,7 @@ impl FtsReader {
 
         // Must-driven walk: leapfrog the musts to each common doc,
         // score musts + landing shoulds there.
+        let should_ub: f32 = shoulds.iter().map(AnyCursor::term_max_bm25).sum();
         let mut target = 0u32;
         'docs: loop {
             let mut aligned = target;
@@ -957,10 +955,30 @@ impl FtsReader {
                 }
                 i += 1;
             }
-            let admitted = match filter.as_mut() {
-                Some(f) => f.admits(aligned)?,
-                None => true,
+            // Bar skip: the kth-best (or the seeded floor) minus the
+            // most the shoulds could add bounds what the musts must
+            // reach; a candidate whose must-side block bounds can't
+            // get there is dead without scoring (and, for phrase
+            // shoulds, without any position work).
+            let bar = match heap.len() >= k {
+                true => heap.peek().expect("heap len == k").0.max(floor_eff),
+                false => floor_eff,
             };
+            let scoring_needed = match bar > f32::NEG_INFINITY {
+                true => {
+                    let must_ub: f32 = musts
+                        .iter_mut()
+                        .map(|a| a.block_max_in_range(aligned, aligned))
+                        .sum();
+                    must_ub + should_ub > bar
+                }
+                false => true,
+            };
+            let admitted = scoring_needed
+                && match filter.as_mut() {
+                    Some(f) => f.admits(aligned)?,
+                    None => true,
+                };
             if admitted {
                 let norm = dl_norm_k1[aligned as usize];
                 let mut score: f32 = musts.iter().map(|a| a.score_current(norm)).sum();
@@ -982,45 +1000,135 @@ impl FtsReader {
         Ok(drain_top_k_desc(heap))
     }
 
-    /// Unranked count over heterogeneous atoms: the cardinality of the
-    /// musts' intersection (minus exclusions) — shoulds have no scores
-    /// to raise here, matching the clause model's unranked semantics.
-    fn count_atoms(
+    /// Unranked doc-at-a-time walk over heterogeneous atoms, calling
+    /// `on_doc` for every matching doc in ascending order. `And` walks
+    /// the atoms' intersection (a phrase atom's own verification is
+    /// part of its cursor); `Or` walks their union. The shared spine
+    /// of the phrase-aware `token_match` / `count` entries.
+    fn walk_atoms_match(
         &self,
-        mut musts: Vec<AnyCursor>,
+        mut atoms: Vec<AnyCursor>,
+        mode: BoolMode,
         mut filter: Option<AtomExcludeFilter>,
-    ) -> Result<u64, FtsError> {
-        let mut n = 0u64;
-        let mut target = 0u32;
-        'docs: loop {
-            let mut aligned = target;
-            let mut i = 0usize;
-            while i < musts.len() {
-                let a = &mut musts[i];
-                a.skip_to(aligned)?;
-                if a.is_exhausted() {
-                    break 'docs;
+        mut on_doc: impl FnMut(u32),
+    ) -> Result<(), FtsError> {
+        match mode {
+            BoolMode::Or => {
+                while let Some(doc) = atoms
+                    .iter()
+                    .filter(|a| !a.is_exhausted())
+                    .map(AnyCursor::current_doc_id)
+                    .min()
+                {
+                    let admitted = match filter.as_mut() {
+                        Some(f) => f.admits(doc)?,
+                        None => true,
+                    };
+                    if admitted {
+                        on_doc(doc);
+                    }
+                    let Some(next) = doc.checked_add(1) else {
+                        break;
+                    };
+                    for a in atoms.iter_mut() {
+                        if !a.is_exhausted() && a.current_doc_id() == doc {
+                            a.skip_to(next)?;
+                        }
+                    }
                 }
-                let here = a.current_doc_id();
-                if here > aligned {
-                    aligned = here;
-                    i = 0;
-                    continue;
+                Ok(())
+            }
+            BoolMode::And => {
+                let mut target = 0u32;
+                'docs: loop {
+                    let mut aligned = target;
+                    let mut i = 0usize;
+                    while i < atoms.len() {
+                        let a = &mut atoms[i];
+                        a.skip_to(aligned)?;
+                        if a.is_exhausted() {
+                            break 'docs;
+                        }
+                        let here = a.current_doc_id();
+                        if here > aligned {
+                            aligned = here;
+                            i = 0;
+                            continue;
+                        }
+                        i += 1;
+                    }
+                    let admitted = match filter.as_mut() {
+                        Some(f) => f.admits(aligned)?,
+                        None => true,
+                    };
+                    if admitted {
+                        on_doc(aligned);
+                    }
+                    let Some(next) = aligned.checked_add(1) else {
+                        break;
+                    };
+                    target = next;
                 }
-                i += 1;
+                Ok(())
             }
-            let admitted = match filter.as_mut() {
-                Some(f) => f.admits(aligned)?,
-                None => true,
-            };
-            if admitted {
-                n += 1;
-            }
-            let Some(next) = aligned.checked_add(1) else {
-                break;
-            };
-            target = next;
         }
+    }
+
+    /// Phrase-aware unranked match: the `local_doc_id`s matching the
+    /// terms + phrases under `mode`, ascending — the atoms sibling of
+    /// [`Self::token_match`], used whenever the match set contains a
+    /// phrase. Under `And`, a missing atom empties the set.
+    pub(crate) async fn atoms_match_ids(
+        &self,
+        column: &str,
+        terms: &[&str],
+        phrases: &[Vec<String>],
+        mode: BoolMode,
+    ) -> Result<Vec<u32>, FtsError> {
+        let column_id = self.resolve_column_id(column)?;
+        let built = self.build_atom_cursors(column_id, terms, phrases).await?;
+        let atoms: Vec<AnyCursor> = match mode {
+            BoolMode::And => {
+                if built.iter().any(Option::is_none) {
+                    return Ok(Vec::new());
+                }
+                built.into_iter().flatten().collect()
+            }
+            BoolMode::Or => built.into_iter().flatten().collect(),
+        };
+        if atoms.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        self.walk_atoms_match(atoms, mode, None, |d| out.push(d))?;
+        Ok(out)
+    }
+
+    /// Phrase-aware unranked match **count** — the atoms sibling of
+    /// [`Self::token_match_count`].
+    pub(crate) async fn atoms_match_count(
+        &self,
+        column: &str,
+        terms: &[&str],
+        phrases: &[Vec<String>],
+        mode: BoolMode,
+    ) -> Result<u64, FtsError> {
+        let column_id = self.resolve_column_id(column)?;
+        let built = self.build_atom_cursors(column_id, terms, phrases).await?;
+        let atoms: Vec<AnyCursor> = match mode {
+            BoolMode::And => {
+                if built.iter().any(Option::is_none) {
+                    return Ok(0);
+                }
+                built.into_iter().flatten().collect()
+            }
+            BoolMode::Or => built.into_iter().flatten().collect(),
+        };
+        if atoms.is_empty() {
+            return Ok(0);
+        }
+        let mut n = 0u64;
+        self.walk_atoms_match(atoms, mode, None, |_| n += 1)?;
         Ok(n)
     }
 
@@ -3359,11 +3467,6 @@ impl PhraseCursor {
         self.current_doc
     }
 
-    #[inline]
-    fn current_tf(&self) -> u32 {
-        self.current_tf
-    }
-
     /// Advance to the first verified phrase match at doc ≥ `target`.
     fn skip_to(&mut self, target: u32) -> Result<(), FtsError> {
         if self.is_exhausted() || self.current_doc >= target {
@@ -3509,6 +3612,24 @@ impl AnyCursor {
                 bm25::score_with_dl_norm_k1(c.idf_x_k1p1, c.current_tf(), dl_norm_k1)
             }
             AnyCursor::Phrase(c) => c.score_current(dl_norm_k1),
+        }
+    }
+
+    /// Atom-level score upper bound (any doc).
+    #[inline]
+    fn term_max_bm25(&self) -> f32 {
+        match self {
+            AnyCursor::Term(c) => c.term_max_bm25,
+            AnyCursor::Phrase(c) => c.term_max_bm25,
+        }
+    }
+
+    /// Score upper bound over the doc range (see the cursors' docs).
+    #[inline]
+    fn block_max_in_range(&mut self, range_start: u32, range_end: u32) -> f32 {
+        match self {
+            AnyCursor::Term(c) => c.block_max_in_range(range_start, range_end),
+            AnyCursor::Phrase(c) => c.block_max_in_range(range_start, range_end),
         }
     }
 }

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -303,7 +303,16 @@ impl FtsReader {
         // Length of the FTS subsection itself (≈ `kv::FTS_LENGTH`), not
         // the whole superfile: `source` is the FTS-scoped sub-source.
         let fts_blob_len = source.size() as usize;
-        let header = fetch_lazy_range(source.as_ref(), 0..FTS_HEADER_SIZE, "fts header").await?;
+        // One GET covers either header size: any real FTS blob is
+        // larger than the 56-byte v2 header (header + FST CRC +
+        // postings CRC + a non-empty doc-lengths directory), so
+        // fetching the v2 span up front costs no extra round-trip on
+        // v1 blobs and saves one on v2.
+        let header_fetch = format::fts::HEADER_SIZE_V2.min(fts_blob_len);
+        let header = fetch_lazy_range(source.as_ref(), 0..header_fetch, "fts header").await?;
+        if header.len() < FTS_HEADER_SIZE {
+            return Err(FtsError::Read(ReadError::MissingKv("fts header")));
+        }
         if &header[0..MAGIC_BYTES] != format::fts::MAGIC {
             return Err(FtsError::Read(ReadError::BadMagic {
                 section: "fts",
@@ -317,25 +326,17 @@ impl FtsReader {
                 "fts section version {version}"
             ))));
         }
-        // A v2 blob's header extension ([48..56], the positions-region
-        // offset) is fetched here and installed in the overlay so
-        // `open_with_source` reads it without another GET. The FST
-        // directory starts right after whichever header applies.
+        // The FST directory starts right after whichever header
+        // applies; a v2 header's extension bytes are already in the
+        // fetched span (and in the overlay below), so
+        // `open_with_source` re-reads them without another GET.
         let header_size = match version {
             v if v == format::fts::VERSION_POSITIONS => format::fts::HEADER_SIZE_V2,
             _ => FTS_HEADER_SIZE,
         };
-        let header_ext = match header_size > FTS_HEADER_SIZE {
-            true => Some(
-                fetch_lazy_range(
-                    source.as_ref(),
-                    FTS_HEADER_SIZE..header_size,
-                    "fts header ext",
-                )
-                .await?,
-            ),
-            false => None,
-        };
+        if header.len() < header_size {
+            return Err(FtsError::Read(ReadError::MissingKv("fts header")));
+        }
 
         let postings_offset =
             read_u64_le(&header[hdr::POSTINGS_OFFSET_OFF..hdr::POSTINGS_OFFSET_OFF + U64_BYTES])
@@ -375,9 +376,6 @@ impl FtsReader {
 
         let mut overlay = PrefetchedSource::new(source);
         overlay.install(0, header);
-        if let Some(ext) = header_ext {
-            overlay.install(FTS_HEADER_SIZE as u64, ext);
-        }
         overlay.install(header_size as u64, fst_region);
         overlay.install(doc_lengths_table_offset as u64, doc_lengths_tail);
 
@@ -4406,24 +4404,26 @@ mod tests {
                 .try_into()
                 .expect("postings_off_i slice is 8 bytes"),
         ) as usize;
-        let dir_off_i = u64::from_le_bytes(
-            blob_inline[40..48]
+        // v2 layout: the postings region ends where the positions
+        // region begins (header bytes [48..56]).
+        let positions_off_i = u64::from_le_bytes(
+            blob_inline[48..56]
                 .try_into()
-                .expect("dir_off_i slice is 8 bytes"),
+                .expect("positions_off_i slice is 8 bytes"),
         ) as usize;
-        let postings_size_inline = dir_off_i - postings_off_i;
+        let postings_size_inline = positions_off_i - postings_off_i;
 
         let postings_off_p = u64::from_le_bytes(
             blob_pfor[32..40]
                 .try_into()
                 .expect("postings_off_p slice is 8 bytes"),
         ) as usize;
-        let dir_off_p = u64::from_le_bytes(
-            blob_pfor[40..48]
+        let positions_off_p = u64::from_le_bytes(
+            blob_pfor[48..56]
                 .try_into()
-                .expect("dir_off_p slice is 8 bytes"),
+                .expect("positions_off_p slice is 8 bytes"),
         ) as usize;
-        let postings_size_pfor = dir_off_p - postings_off_p;
+        let postings_size_pfor = positions_off_p - postings_off_p;
 
         // Inline-only blob's postings region holds just the trailing
         // CRC32 (4 B). PFOR blob holds 20 terms × (20 B metadata +

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -38,7 +38,9 @@ use crate::superfile::{
     },
     fts::{
         bm25,
-        builder::{DOC_LENGTHS_ENTRY_SIZE, SKIP_ENTRY_SIZE, TERM_META_SIZE},
+        builder::{
+            DOC_LENGTHS_ENTRY_SIZE, SKIP_ENTRY_SIZE, TERM_META_POSITIONAL_SIZE, TERM_META_SIZE,
+        },
         dict::{DictReader, make_key},
         fst_value::FstValue,
         posting::{BLOCK_LEN, decode_block},
@@ -262,6 +264,11 @@ pub struct FtsReader {
     n_terms_total: u32,
     fst_range: Range<usize>,
     postings_range: Range<usize>,
+    /// Byte range of the positions region (CRC stripped) — `Some`
+    /// iff the blob is v2 (some column recorded positions). Consumed
+    /// by the phrase read path that follows in this series.
+    #[allow(dead_code)]
+    positions_range: Option<Range<usize>>,
     columns: Vec<ColumnMeta>,
     column_id_by_name: HashMap<String, u32>,
 }
@@ -305,11 +312,30 @@ impl FtsReader {
             }));
         }
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
-        if version != format::fts::VERSION {
+        if version != format::fts::VERSION && version != format::fts::VERSION_POSITIONS {
             return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
                 "fts section version {version}"
             ))));
         }
+        // A v2 blob's header extension ([48..56], the positions-region
+        // offset) is fetched here and installed in the overlay so
+        // `open_with_source` reads it without another GET. The FST
+        // directory starts right after whichever header applies.
+        let header_size = match version {
+            v if v == format::fts::VERSION_POSITIONS => format::fts::HEADER_SIZE_V2,
+            _ => FTS_HEADER_SIZE,
+        };
+        let header_ext = match header_size > FTS_HEADER_SIZE {
+            true => Some(
+                fetch_lazy_range(
+                    source.as_ref(),
+                    FTS_HEADER_SIZE..header_size,
+                    "fts header ext",
+                )
+                .await?,
+            ),
+            false => None,
+        };
 
         let postings_offset =
             read_u64_le(&header[hdr::POSTINGS_OFFSET_OFF..hdr::POSTINGS_OFFSET_OFF + U64_BYTES])
@@ -339,11 +365,7 @@ impl FtsReader {
         // keeping the open-time GET count minimal and avoiding
         // per-column range calls during metadata decode.
         let (fst_region, doc_lengths_tail) = futures::try_join!(
-            fetch_lazy_range(
-                source.as_ref(),
-                FTS_HEADER_SIZE..postings_offset,
-                "fts/dict"
-            ),
+            fetch_lazy_range(source.as_ref(), header_size..postings_offset, "fts/dict"),
             fetch_lazy_range(
                 source.as_ref(),
                 doc_lengths_table_offset..fts_blob_len,
@@ -353,7 +375,10 @@ impl FtsReader {
 
         let mut overlay = PrefetchedSource::new(source);
         overlay.install(0, header);
-        overlay.install(FTS_HEADER_SIZE as u64, fst_region);
+        if let Some(ext) = header_ext {
+            overlay.install(FTS_HEADER_SIZE as u64, ext);
+        }
+        overlay.install(header_size as u64, fst_region);
         overlay.install(doc_lengths_table_offset as u64, doc_lengths_tail);
 
         Self::open_with_source(Source::Lazy(Arc::new(overlay)), columns_json, opts)
@@ -382,12 +407,25 @@ impl FtsReader {
             }));
         }
 
-        // Version check.
+        // Version check. v1 = no positions (48-byte header); v2 adds
+        // the positions-region offset at [48..56] and a positions
+        // region between the postings and the doc-lengths directory.
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
-        if version != format::fts::VERSION {
-            return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
-                "fts section version {version}"
-            ))));
+        let positional_blob = match version {
+            v if v == format::fts::VERSION => false,
+            v if v == format::fts::VERSION_POSITIONS => true,
+            _ => {
+                return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
+                    "fts section version {version}"
+                ))));
+            }
+        };
+        let header_size = match positional_blob {
+            true => format::fts::HEADER_SIZE_V2,
+            false => FTS_HEADER_SIZE,
+        };
+        if source_len < header_size {
+            return Err(FtsError::Read(ReadError::MissingKv("fts header")));
         }
 
         let n_columns =
@@ -402,6 +440,19 @@ impl FtsReader {
         let doc_lengths_table_offset =
             read_u64_le(&header[hdr::DOC_LENGTHS_DIR_OFF..hdr::DOC_LENGTHS_DIR_OFF + U64_BYTES])
                 as usize;
+        // The v2 extension lives past the 48 bytes fetched above; on
+        // the lazy path it resolves from the prefetch overlay.
+        let positions_offset: Option<usize> = match positional_blob {
+            true => {
+                let ext = fetch_source_range(
+                    &source,
+                    FTS_HEADER_SIZE..format::fts::HEADER_SIZE_V2,
+                    "fts header ext",
+                )?;
+                Some(read_u64_le(&ext[0..U64_BYTES]) as usize)
+            }
+            false => None,
+        };
 
         // Bounds-check every offset against the blob length before
         // any slice indexing. A single byte flip in the header can
@@ -414,24 +465,31 @@ impl FtsReader {
         // short-circuit, the postings region body is zero bytes and
         // only the trailing 4-byte CRC32C(empty) sits between
         // `postings_offset` and `doc_lengths_table_offset`.
-        if fst_offset < FTS_HEADER_SIZE
+        let postings_end = positions_offset.unwrap_or(doc_lengths_table_offset);
+        if fst_offset < header_size
             || postings_offset < fst_offset + 4
-            || doc_lengths_table_offset < postings_offset + 4
+            || postings_end < postings_offset + 4
+            || doc_lengths_table_offset < postings_end
             || doc_lengths_table_offset > source_len
+            || positions_offset.is_some_and(|po| doc_lengths_table_offset < po + 4)
         {
             return Err(FtsError::Read(ReadError::MalformedVersion(format!(
                 "fts header offsets out of range: fst={fst_offset}, postings={postings_offset}, \
-                 doc_lengths={doc_lengths_table_offset}, blob_len={}",
+                 positions={positions_offset:?}, doc_lengths={doc_lengths_table_offset}, \
+                 blob_len={}",
                 source_len
             ))));
         }
 
-        // Postings region length: we don't store it explicitly (CRC32C of
-        // the body is at postings_offset + len - 4). Compute from the
-        // surrounding offsets — postings ends where the doc-lengths
+        // Region lengths aren't stored explicitly (each region ends
+        // with its CRC32C). Compute from the surrounding offsets —
+        // postings end where the positions region begins (or the
+        // doc-lengths directory on a v1 blob), positions end where the
         // directory begins.
         let fst_range = fst_offset..postings_offset.saturating_sub(4); // strip CRC
-        let postings_range = postings_offset..doc_lengths_table_offset.saturating_sub(4); // strip CRC
+        let postings_range = postings_offset..postings_end.saturating_sub(4); // strip CRC
+        let positions_range: Option<Range<usize>> =
+            positions_offset.map(|po| po..doc_lengths_table_offset.saturating_sub(4));
 
         // Verify FST CRC32C (4 bytes after fst body).
         if opts.verify_crc {
@@ -453,12 +511,9 @@ impl FtsReader {
 
         // Verify postings region CRC32C.
         if opts.verify_crc {
-            let postings_crc_pos = doc_lengths_table_offset.saturating_sub(4);
-            let postings_crc_bytes = fetch_source_range(
-                &source,
-                postings_crc_pos..doc_lengths_table_offset,
-                "fts/postings crc",
-            )?;
+            let postings_crc_pos = postings_end.saturating_sub(4);
+            let postings_crc_bytes =
+                fetch_source_range(&source, postings_crc_pos..postings_end, "fts/postings crc")?;
             let postings_crc_expected = read_u32_le(&postings_crc_bytes);
             let postings_bytes =
                 fetch_source_range(&source, postings_range.clone(), "fts/postings")?;
@@ -466,6 +521,27 @@ impl FtsReader {
             if postings_crc_expected != postings_crc_actual {
                 return Err(FtsError::Read(ReadError::ChecksumMismatch {
                     section: "fts/postings",
+                    column: String::new(),
+                }));
+            }
+        }
+
+        // Verify positions region CRC32C (v2 blobs only).
+        if opts.verify_crc
+            && let Some(pos_range) = &positions_range
+        {
+            let crc_pos = doc_lengths_table_offset.saturating_sub(4);
+            let crc_bytes = fetch_source_range(
+                &source,
+                crc_pos..doc_lengths_table_offset,
+                "fts/positions crc",
+            )?;
+            let crc_expected = read_u32_le(&crc_bytes);
+            let pos_bytes = fetch_source_range(&source, pos_range.clone(), "fts/positions")?;
+            let crc_actual = crc32c(&pos_bytes);
+            if crc_expected != crc_actual {
+                return Err(FtsError::Read(ReadError::ChecksumMismatch {
+                    section: "fts/positions",
                     column: String::new(),
                 }));
             }
@@ -598,6 +674,7 @@ impl FtsReader {
             n_terms_total,
             fst_range,
             postings_range,
+            positions_range,
             columns,
             column_id_by_name,
         })
@@ -1143,6 +1220,14 @@ impl FtsReader {
                 // skip-table, no PFOR decode. The single doc's score
                 // is the entire result for any k ≥ 1 (unless it sits
                 // strictly below the caller's floor).
+                //
+                // On a positional column the slot carries the term's
+                // single position, tf implied 1 (the builder only
+                // inlines tf == 1 there) — score with the implied tf.
+                let tf = match col_meta.positions {
+                    true => 1,
+                    false => tf,
+                };
                 let idf_t = bm25::idf(self.n_docs as u64, 1);
                 let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);
                 // Drop the lone match if a negated term excludes it.
@@ -1176,7 +1261,7 @@ impl FtsReader {
         let postings = term_bytes.as_ref();
         let metadata_offset = 0usize;
 
-        let term_meta = TermMeta::parse(postings, metadata_offset)?;
+        let term_meta = TermMeta::parse(postings, metadata_offset, col_meta.positions)?;
 
         let idf_t = bm25::idf(self.n_docs as u64, term_meta.df);
         let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);
@@ -1300,6 +1385,14 @@ impl FtsReader {
         for r in resolved {
             match r {
                 Resolved::Inline { doc_id, tf } => {
+                    // On a positional column the inline slot carries
+                    // the term's single position, tf implied 1 — the
+                    // builder only inlines tf == 1 postings there.
+                    // Scoring must use the implied tf, never the slot.
+                    let tf = match col_meta.positions {
+                        true => 1,
+                        false => tf,
+                    };
                     let dl_norm_k1 = col_meta.dl_norm_k1[doc_id as usize];
                     cursors.push(TermCursor::new_inline(
                         doc_id,
@@ -1310,7 +1403,11 @@ impl FtsReader {
                 }
                 Resolved::Pfor => {
                     let term_bytes = pfor_iter.next().expect("one fetched range per PFOR term");
-                    cursors.push(TermCursor::new(term_bytes, self.n_docs as u64)?);
+                    cursors.push(TermCursor::new(
+                        term_bytes,
+                        self.n_docs as u64,
+                        col_meta.positions,
+                    )?);
                 }
             }
         }
@@ -3248,8 +3345,17 @@ impl TermMeta {
     /// Returns `Err` (never panics) on a corrupt or malicious
     /// `metadata_offset` — the crate-wide "untrusted input yields
     /// `Err`, not a slice-index panic" rule.
-    fn parse(postings: &[u8], metadata_offset: usize) -> Result<Self, FtsError> {
-        if metadata_offset + TERM_META_SIZE > postings.len() {
+    fn parse(postings: &[u8], metadata_offset: usize, positional: bool) -> Result<Self, FtsError> {
+        // Positional columns carry the extended 32-byte header (the
+        // term's positions offset + length after `num_blocks`); the
+        // skip table starts after whichever stride applies. The
+        // positions fields themselves are consumed by the phrase read
+        // path, not here.
+        let term_meta_size = match positional {
+            true => TERM_META_POSITIONAL_SIZE,
+            false => TERM_META_SIZE,
+        };
+        if metadata_offset + term_meta_size > postings.len() {
             return Err(FtsError::Read(ReadError::MalformedVersion(
                 "term metadata offset out of postings region".into(),
             )));
@@ -3268,7 +3374,7 @@ impl TermMeta {
                 ..metadata_offset + term_meta::NUM_BLOCKS_OFF + U32_BYTES],
         ) as usize;
 
-        let skip_start = metadata_offset + TERM_META_SIZE;
+        let skip_start = metadata_offset + term_meta_size;
         let skip_end = skip_start + num_blocks * SKIP_ENTRY_SIZE;
         if skip_end > postings.len() {
             return Err(FtsError::Read(ReadError::MalformedVersion(
@@ -3415,11 +3521,11 @@ impl TermCursor {
     /// the term's 20-byte metadata header (offset 0) and runs to the
     /// end of its last block — the contiguous range
     /// [`FtsReader::fetch_term_postings`] fetched for this term.
-    fn new(term_bytes: Bytes, n_docs: u64) -> Result<Self, FtsError> {
+    fn new(term_bytes: Bytes, n_docs: u64, positional: bool) -> Result<Self, FtsError> {
         let postings: &[u8] = term_bytes.as_ref();
         let metadata_offset = 0usize;
 
-        let term_meta = TermMeta::parse(postings, metadata_offset)?;
+        let term_meta = TermMeta::parse(postings, metadata_offset, positional)?;
         let idf = bm25::idf(n_docs, term_meta.df);
 
         let mut blocks: Vec<BlockMeta> = Vec::with_capacity(term_meta.num_blocks);

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -3372,11 +3372,16 @@ impl PartialOrd for TopKEntry {
 }
 impl Ord for TopKEntry {
     fn cmp(&self, other: &Self) -> Ordering {
+        // Score is inverted (lower score = greater) so the max-heap's
+        // peek is the worst kept entry; the doc-id leg must NOT be
+        // inverted, so that among score-tied entries the LARGER doc id
+        // is greater — i.e. peek — and is the one evicted when a
+        // better doc arrives, keeping the smaller id.
         other
             .0
             .partial_cmp(&self.0)
             .unwrap_or(Ordering::Equal)
-            .then_with(|| other.1.cmp(&self.1))
+            .then_with(|| self.1.cmp(&other.1))
     }
 }
 

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -71,6 +71,21 @@ const TOKEN_SCRATCH_INITIAL_CAP: usize = 32;
 pub trait Tokenizer: Send + Sync + 'static {
     /// Yield each token as an owned `String` lower-cased per the
     /// implementation's rules.
+    ///
+    /// ## Phrase positions and dropped tokens
+    ///
+    /// The positional index numbers tokens by the order this trait
+    /// yields them, and exact-phrase matching checks those numbers for
+    /// adjacency. A tokenizer that *drops* an input token (a stopword
+    /// filter, a non-ASCII skip, etc.) without otherwise signalling it
+    /// makes the tokens on either side of the dropped one look
+    /// adjacent — so a phrase can match text that isn't actually
+    /// contiguous. The built-in [`AsciiLowerTokenizer`] avoids this on
+    /// its positional build path by leaving a position gap for each
+    /// dropped run; a custom tokenizer that drops tokens and needs
+    /// exact phrase semantics must not rely on this trait to preserve
+    /// gaps (position increments through the trait are a planned
+    /// extension, not yet available).
     fn tokenize<'a>(&'a self, text: &'a str) -> Box<dyn Iterator<Item = String> + 'a>;
 
     /// Call `f(&token)` for each token. The `&str` passed to `f` is
@@ -248,9 +263,35 @@ impl AsciiLowerTokenizer {
     /// keep it.
     #[inline]
     pub fn tokenize_each_inline<F: FnMut(&str)>(&self, text: &str, mut f: F) {
+        // One scan implementation — delegate and discard the position
+        // ordinal so the positionless / query paths and the positional
+        // index build can never disagree on which tokens are emitted.
+        self.tokenize_each_inline_positioned(text, |tok, _position| f(tok));
+    }
+
+    /// Like [`Self::tokenize_each_inline`], but also hands each emitted
+    /// token its **position ordinal**: the count of token runs scanned
+    /// before it, *including runs this tokenizer drops*.
+    ///
+    /// A run that contains a non-ASCII byte is dropped (no token), but
+    /// it still consumes one ordinal — so a phrase never treats the
+    /// tokens on either side of a dropped word as adjacent. Without
+    /// this, `"new café york"` would tokenize to `new`, `york` at
+    /// positions 0, 1 and the phrase `"new york"` would wrongly match
+    /// it; with the gap they sit at 0 and 2. Used by the positional
+    /// index build. (A run consisting *only* of non-ASCII bytes carries
+    /// no ASCII token byte to anchor the scan and is treated as a
+    /// separator, not a gap — the ASCII tokenizer cannot represent such
+    /// text at all.)
+    ///
+    /// The borrowed/copied `&str` is valid only for that one callback
+    /// call, exactly as in [`Self::tokenize_each_inline`].
+    #[inline]
+    pub fn tokenize_each_inline_positioned<F: FnMut(&str, u64)>(&self, text: &str, mut f: F) {
         let bytes = text.as_bytes();
         let mut buf: Vec<u8> = Vec::new();
         let mut pos = 0;
+        let mut position: u64 = 0;
         while pos < bytes.len() {
             pos = simd_skip_non_token(bytes, pos);
             if pos >= bytes.len() {
@@ -259,7 +300,15 @@ impl AsciiLowerTokenizer {
             let start = pos;
             let (end, had_upper, had_non_ascii) = simd_scan_token_run(bytes, pos);
             pos = end;
-            if had_non_ascii || start == pos {
+            if start == pos {
+                continue;
+            }
+            // Every scanned run occupies one ordinal, dropped or not.
+            let this_position = position;
+            position += 1;
+            if had_non_ascii {
+                // Dropped per the v1 ASCII-only rule — the ordinal it
+                // just consumed is the phrase gap it leaves behind.
                 continue;
             }
             if !had_upper {
@@ -271,7 +320,7 @@ impl AsciiLowerTokenizer {
                 // therefore valid UTF-8 and the original `text`
                 // outlives the callback call.
                 let s = unsafe { from_utf8_unchecked(&bytes[start..end]) };
-                f(s);
+                f(s, this_position);
             } else {
                 // Slow path: copy + lowercase into the reusable buf.
                 buf.clear();
@@ -283,7 +332,7 @@ impl AsciiLowerTokenizer {
                 // ASCII alphanumeric (or its lowercased form, which
                 // is also ASCII).
                 let s = unsafe { from_utf8_unchecked(&buf) };
-                f(s);
+                f(s, this_position);
             }
         }
     }
@@ -607,6 +656,52 @@ mod tests {
 
     fn tokens(text: &str) -> Vec<String> {
         AsciiLowerTokenizer.tokenize(text).collect()
+    }
+
+    /// Collect `(token, position)` pairs from the positional scan.
+    fn positioned(text: &str) -> Vec<(String, u64)> {
+        let mut out = Vec::new();
+        AsciiLowerTokenizer
+            .tokenize_each_inline_positioned(text, |tok, pos| out.push((tok.to_owned(), pos)));
+        out
+    }
+
+    #[test]
+    fn positioned_leaves_a_gap_for_dropped_runs() {
+        // No drops: positions are dense emission ordinals, and the
+        // positioned scan emits exactly the same tokens as the plain
+        // one (delegation guarantees this).
+        assert_eq!(
+            positioned("the quick brown fox"),
+            vec![
+                ("the".into(), 0),
+                ("quick".into(), 1),
+                ("brown".into(), 2),
+                ("fox".into(), 3),
+            ],
+        );
+
+        // A dropped (non-ASCII) run consumes an ordinal but emits no
+        // token, so the neighbours are NOT adjacent: `york` is at 2,
+        // not 1 — this is what stops `"new york"` matching this text.
+        assert_eq!(
+            positioned("new café york"),
+            vec![("new".into(), 0), ("york".into(), 2)],
+        );
+        // Gap whether the dropped word leads, trails, or sits between.
+        assert_eq!(
+            positioned("café new york"),
+            vec![("new".into(), 1), ("york".into(), 2)],
+        );
+        assert_eq!(
+            positioned("new york café"),
+            vec![("new".into(), 0), ("york".into(), 1)],
+        );
+
+        // The plain scan still emits the same tokens (positions dropped).
+        let mut plain = Vec::new();
+        AsciiLowerTokenizer.tokenize_each_inline("new café york", |t| plain.push(t.to_owned()));
+        assert_eq!(plain, vec!["new".to_string(), "york".to_string()]);
     }
 
     #[test]

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -107,7 +107,69 @@ pub trait Tokenizer: Send + Sync + 'static {
     /// positive clause is not an error here; the caller checks.
     fn parse<'q>(&self, query: &'q str) -> ParsedQuery<'q> {
         let mut parsed = ParsedQuery::default();
-        for run in query.split_whitespace() {
+        let bytes = query.as_bytes();
+        let mut i = 0usize;
+        let mut seg_start = 0usize;
+        while i < bytes.len() {
+            if bytes[i] != b'"' {
+                i += 1;
+                continue;
+            }
+            let Some(close_rel) = query[i + 1..].find('"') else {
+                // Unbalanced quote: treat the dangling `"` as
+                // whitespace (lenient, like lucene's parser) — close
+                // the unquoted segment here and keep scanning after it.
+                self.parse_unquoted_segment(&query[seg_start..i], &mut parsed);
+                i += 1;
+                seg_start = i;
+                continue;
+            };
+            let close = i + 1 + close_rel;
+            // A `+` / `-` glued to the opening quote — and itself at a
+            // token boundary — sets the phrase's polarity; the sigil
+            // byte is excluded from the unquoted segment.
+            let sigil = match i > seg_start {
+                true => {
+                    let boundary = i - 1 == seg_start || bytes[i - 2].is_ascii_whitespace();
+                    match (boundary, bytes[i - 1]) {
+                        (true, b'+') => Some(b'+'),
+                        (true, b'-') => Some(b'-'),
+                        _ => None,
+                    }
+                }
+                false => None,
+            };
+            let unquoted_end = match sigil {
+                Some(_) => i - 1,
+                None => i,
+            };
+            self.parse_unquoted_segment(&query[seg_start..unquoted_end], &mut parsed);
+            let mut terms: Vec<Cow<'q, str>> = Vec::new();
+            self.tokenize_each_query(&query[i + 1..close], &mut |t| terms.push(t));
+            match (terms.len(), sigil) {
+                // Empty quotes contribute nothing.
+                (0, _) => {}
+                // A single-token phrase is just that term — degrade to
+                // the term list of the same polarity.
+                (1, Some(b'-')) => parsed.negatives.push(terms.pop().expect("one term")),
+                (1, Some(b'+')) => parsed.musts.push(terms.pop().expect("one term")),
+                (1, _) => parsed.positives.push(terms.pop().expect("one term")),
+                (_, Some(b'-')) => parsed.negative_phrases.push(terms),
+                (_, Some(b'+')) => parsed.must_phrases.push(terms),
+                (_, _) => parsed.positive_phrases.push(terms),
+            }
+            i = close + 1;
+            seg_start = i;
+        }
+        self.parse_unquoted_segment(&query[seg_start..], &mut parsed);
+        parsed
+    }
+
+    /// Parse one stretch of query text containing no quotes — the
+    /// pre-phrase grammar: whitespace runs with optional `+`/`-`
+    /// clause sigils.
+    fn parse_unquoted_segment<'q>(&self, segment: &'q str, parsed: &mut ParsedQuery<'q>) {
+        for run in segment.split_whitespace() {
             match (run.strip_prefix('-'), run.strip_prefix('+')) {
                 (Some(rest), _) if !rest.is_empty() => {
                     self.tokenize_each_query(rest, &mut |t| parsed.negatives.push(t));
@@ -118,7 +180,6 @@ pub trait Tokenizer: Send + Sync + 'static {
                 _ => self.tokenize_each_query(run, &mut |t| parsed.positives.push(t)),
             }
         }
-        parsed
     }
 }
 
@@ -351,6 +412,16 @@ pub struct ParsedQuery<'q> {
     pub positives: Vec<Cow<'q, str>>,
     /// `-`-sigiled tokens: any doc containing one is excluded.
     pub negatives: Vec<Cow<'q, str>>,
+    /// `+"…"`-quoted runs of two or more tokens: the doc must contain
+    /// the exact token sequence. (Single-token phrases degrade into
+    /// `musts`.)
+    pub must_phrases: Vec<Vec<Cow<'q, str>>>,
+    /// Bare-quoted multi-token runs; polarity resolved from the
+    /// default operator like bare terms.
+    pub positive_phrases: Vec<Vec<Cow<'q, str>>>,
+    /// `-"…"`-quoted multi-token runs: any doc containing the exact
+    /// sequence is excluded.
+    pub negative_phrases: Vec<Vec<Cow<'q, str>>>,
 }
 
 /// A query's clause lists with the default operator already applied —
@@ -365,6 +436,13 @@ pub struct QueryClauses<'q> {
     pub shoulds: Vec<Cow<'q, str>>,
     /// Docs containing any of these are excluded.
     pub negatives: Vec<Cow<'q, str>>,
+    /// Multi-token phrases every doc in the result must contain.
+    pub must_phrases: Vec<Vec<Cow<'q, str>>>,
+    /// Scoring-only phrases when `musts`/`must_phrases` is non-empty;
+    /// otherwise part of the union match.
+    pub should_phrases: Vec<Vec<Cow<'q, str>>>,
+    /// Docs containing any of these exact sequences are excluded.
+    pub negative_phrases: Vec<Vec<Cow<'q, str>>>,
 }
 
 impl<'q> ParsedQuery<'q> {
@@ -376,6 +454,9 @@ impl<'q> ParsedQuery<'q> {
             mut musts,
             positives,
             negatives,
+            mut must_phrases,
+            positive_phrases,
+            negative_phrases,
         } = self;
         let shoulds = match mode {
             BoolMode::And => {
@@ -384,10 +465,20 @@ impl<'q> ParsedQuery<'q> {
             }
             BoolMode::Or => positives,
         };
+        let should_phrases = match mode {
+            BoolMode::And => {
+                must_phrases.extend(positive_phrases);
+                Vec::new()
+            }
+            BoolMode::Or => positive_phrases,
+        };
         QueryClauses {
             musts,
             shoulds,
             negatives,
+            must_phrases,
+            should_phrases,
+            negative_phrases,
         }
     }
 }
@@ -795,6 +886,99 @@ mod tests {
         assert_eq!(p.negatives, vec!["x"]);
         let p = parse("+-x");
         assert_eq!(p.musts, vec!["x"]);
+    }
+
+    // ---- parse (quoted phrase atoms) ----
+
+    #[test]
+    fn parse_pure_phrase() {
+        let p = parse(r#""griffith observatory""#);
+        assert_eq!(p.positive_phrases, vec![vec!["griffith", "observatory"]]);
+        assert!(p.positives.is_empty());
+        assert!(p.musts.is_empty());
+    }
+
+    #[test]
+    fn parse_phrase_polarities() {
+        let p = parse(r#"+"the who" -"memory unsafe" "new york""#);
+        assert_eq!(p.must_phrases, vec![vec!["the", "who"]]);
+        assert_eq!(p.negative_phrases, vec![vec!["memory", "unsafe"]]);
+        assert_eq!(p.positive_phrases, vec![vec!["new", "york"]]);
+    }
+
+    #[test]
+    fn parse_phrase_mixes_with_terms() {
+        let p = parse(r#"+"the who" +uk rust -python"#);
+        assert_eq!(p.must_phrases, vec![vec!["the", "who"]]);
+        assert_eq!(p.musts, vec!["uk"]);
+        assert_eq!(p.positives, vec!["rust"]);
+        assert_eq!(p.negatives, vec!["python"]);
+    }
+
+    #[test]
+    fn parse_single_token_phrase_degrades_to_term() {
+        let p = parse(r#""york" +"london" -"paris""#);
+        assert!(p.positive_phrases.is_empty());
+        assert!(p.must_phrases.is_empty());
+        assert!(p.negative_phrases.is_empty());
+        assert_eq!(p.positives, vec!["york"]);
+        assert_eq!(p.musts, vec!["london"]);
+        assert_eq!(p.negatives, vec!["paris"]);
+    }
+
+    #[test]
+    fn parse_empty_quotes_contribute_nothing() {
+        let p = parse(r#"rust "" async"#);
+        assert_eq!(p.positives, vec!["rust", "async"]);
+        assert!(p.positive_phrases.is_empty());
+    }
+
+    #[test]
+    fn parse_unbalanced_quote_is_whitespace() {
+        // The dangling quote splits the text; everything parses as
+        // bare terms (lenient, never an error).
+        let p = parse(r#"rust "new york"#);
+        assert_eq!(p.positives, vec!["rust", "new", "york"]);
+        assert!(p.positive_phrases.is_empty());
+    }
+
+    #[test]
+    fn parse_phrase_tokens_are_normalized() {
+        // Phrase innards run through the same tokenizer: lowercased,
+        // punctuation split.
+        let p = parse(r#""New-York City""#);
+        assert_eq!(p.positive_phrases, vec![vec!["new", "york", "city"]]);
+    }
+
+    #[test]
+    fn parse_interior_sigil_before_quote_is_not_polarity() {
+        // `abc+"x y"`: the `+` is interior to the run, not a phrase
+        // sigil — the phrase is bare and `abc` parses from the
+        // unquoted segment (its trailing `+` strips as punctuation).
+        let p = parse(r#"abc+"x y""#);
+        assert_eq!(p.positives, vec!["abc"]);
+        assert_eq!(p.positive_phrases, vec![vec!["x", "y"]]);
+        assert!(p.must_phrases.is_empty());
+    }
+
+    #[test]
+    fn parse_adjacent_phrases() {
+        let p = parse(r#""a b""c d""#);
+        assert_eq!(p.positive_phrases, vec![vec!["a", "b"], vec!["c", "d"]]);
+    }
+
+    #[test]
+    fn into_clauses_resolves_phrase_polarity_by_mode() {
+        let c = parse(r#""new york" +"the who" -"bad seq" rust"#).into_clauses(BoolMode::Or);
+        assert_eq!(c.should_phrases, vec![vec!["new", "york"]]);
+        assert_eq!(c.must_phrases, vec![vec!["the", "who"]]);
+        assert_eq!(c.negative_phrases, vec![vec!["bad", "seq"]]);
+        assert_eq!(c.shoulds, vec!["rust"]);
+
+        let c = parse(r#""new york" rust"#).into_clauses(BoolMode::And);
+        assert_eq!(c.must_phrases, vec![vec!["new", "york"]]);
+        assert!(c.should_phrases.is_empty());
+        assert_eq!(c.musts, vec!["rust"]);
     }
 
     // ---- into_clauses (default-operator resolution) ----

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -892,7 +892,7 @@ impl SuperfileReader {
     /// ascending. Used by the table layer whenever the match set
     /// contains a phrase; plain-token queries keep
     /// [`token_match`](Self::token_match).
-    pub(crate) async fn atoms_match_ids(
+    pub async fn atoms_match_ids(
         &self,
         column: &str,
         terms: &[&str],
@@ -907,7 +907,7 @@ impl SuperfileReader {
 
     /// Phrase-aware unranked match **count** — the phrase sibling of
     /// [`token_match_count`](Self::token_match_count).
-    pub(crate) async fn atoms_match_count(
+    pub async fn atoms_match_count(
         &self,
         column: &str,
         terms: &[&str],

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -20,7 +20,7 @@
 //! single-superfile SuperfileReader does no I/O after `open()`; a
 //! storage layer can layer cold-fetch heuristics on top.
 
-use std::{fmt, io, str, sync::Arc};
+use std::{borrow::Cow, fmt, io, str, sync::Arc};
 
 use arrow::compute::{concat_batches, take};
 use arrow_array::{
@@ -48,7 +48,7 @@ use crate::{
         BytesLazyByteSource, LazyByteSource, LazySubSource, ReadError,
         format::{self, footer, kv},
         fts::{
-            reader::{self as fts_reader, BoolMode, FtsReader},
+            reader::{self as fts_reader, BoolMode, ClauseLists, FtsReader},
             tokenize::{AsciiLowerTokenizer, Tokenizer},
         },
         vector::reader::{self as vector_reader, VectorReader},
@@ -784,8 +784,29 @@ impl SuperfileReader {
         let musts: Vec<&str> = clauses.musts.iter().map(|t| &**t).collect();
         let shoulds: Vec<&str> = clauses.shoulds.iter().map(|t| &**t).collect();
         let negatives: Vec<&str> = clauses.negatives.iter().map(|t| &**t).collect();
-        self.bm25_search_clauses(column, &musts, &shoulds, &negatives, k, f32::NEG_INFINITY)
-            .await
+        let own = |phrases: Vec<Vec<Cow<'_, str>>>| -> Vec<Vec<String>> {
+            phrases
+                .into_iter()
+                .map(|p| p.into_iter().map(Cow::into_owned).collect())
+                .collect()
+        };
+        let must_phrases = own(clauses.must_phrases);
+        let should_phrases = own(clauses.should_phrases);
+        let negative_phrases = own(clauses.negative_phrases);
+        self.bm25_search_clauses(
+            column,
+            ClauseLists {
+                musts: &musts,
+                shoulds: &shoulds,
+                negatives: &negatives,
+                must_phrases: &must_phrases,
+                should_phrases: &should_phrases,
+                negative_phrases: &negative_phrases,
+            },
+            k,
+            f32::NEG_INFINITY,
+        )
+        .await
     }
 
     /// Pre-tokenized variant of [`Self::bm25_hits_async`] — the caller
@@ -941,18 +962,14 @@ impl SuperfileReader {
     pub(crate) async fn bm25_search_clauses(
         &self,
         column: &str,
-        musts: &[&str],
-        shoulds: &[&str],
-        negatives: &[&str],
+        lists: ClauseLists<'_>,
         k: usize,
         floor: f32,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
-        Ok(fts
-            .search_excluding(column, musts, shoulds, negatives, k, floor)
-            .await?)
+        Ok(fts.search_excluding(column, lists, k, floor).await?)
     }
 
     /// Prefix-expanded BM25 search.

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -887,6 +887,39 @@ impl SuperfileReader {
         Ok(fts.token_match_count(column, tokens, mode).await?)
     }
 
+    /// Phrase-aware unranked match: `local_doc_id`s whose `column`
+    /// matches the `terms` and exact `phrases` under `mode`,
+    /// ascending. Used by the table layer whenever the match set
+    /// contains a phrase; plain-token queries keep
+    /// [`token_match`](Self::token_match).
+    pub(crate) async fn atoms_match_ids(
+        &self,
+        column: &str,
+        terms: &[&str],
+        phrases: &[Vec<String>],
+        mode: BoolMode,
+    ) -> Result<Vec<u32>, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.atoms_match_ids(column, terms, phrases, mode).await?)
+    }
+
+    /// Phrase-aware unranked match **count** — the phrase sibling of
+    /// [`token_match_count`](Self::token_match_count).
+    pub(crate) async fn atoms_match_count(
+        &self,
+        column: &str,
+        terms: &[&str],
+        phrases: &[Vec<String>],
+        mode: BoolMode,
+    ) -> Result<u64, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.atoms_match_count(column, terms, phrases, mode).await?)
+    }
+
     /// Document frequency of `token` in `column` (0 if absent) — a cheap
     /// header-only read used to estimate a predicate's match count
     /// before running `token_match`. Delegates to

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1409,6 +1409,7 @@ mod tests {
             "doc_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -1776,9 +1777,11 @@ mod tests {
             vec![
                 FtsConfig {
                     column: "title".into(),
+                    positions: false,
                 },
                 FtsConfig {
                     column: "body".into(),
+                    positions: false,
                 },
             ],
             vec![],

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1052,6 +1052,7 @@ mod tests {
             schema(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tk),

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -2129,6 +2129,7 @@ mod tests {
                 schema(),
                 vec![FtsConfig {
                     column: "title".into(),
+                    positions: false,
                 }],
                 vec![],
                 Some(tk),

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -83,6 +83,18 @@ pub fn compute_options_hash(opts: &SupertableOptions, strategy: &PartitionStrate
     for c in &opts.fts_columns {
         push_str(&mut buf, &c.column);
     }
+    // 3b. positions flags — appended as a tagged block, and ONLY when
+    //     some column opts in. An all-false table's stream stays
+    //     byte-identical to hashes stamped before positions existed,
+    //     so pre-positions manifests keep verifying; a positional
+    //     table hashes differently from its positionless twin (the
+    //     built superfiles differ, so the options identity must too).
+    if opts.fts_columns.iter().any(|c| c.positions) {
+        push_tag(&mut buf, b"fts_positions");
+        for c in &opts.fts_columns {
+            buf.push(c.positions as u8);
+        }
+    }
 
     // 4. vector_columns (same declared-order rationale).
     push_tag(&mut buf, b"vector_columns");
@@ -235,6 +247,7 @@ mod tests {
             schema_title_only(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -275,6 +288,7 @@ mod tests {
             )])),
             vec![FtsConfig {
                 column: "body".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -299,6 +313,7 @@ mod tests {
             )])),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -325,9 +340,11 @@ mod tests {
             vec![
                 FtsConfig {
                     column: "title".into(),
+                    positions: false,
                 },
                 FtsConfig {
                     column: "subtitle".into(),
+                    positions: false,
                 },
             ],
             vec![],
@@ -354,9 +371,11 @@ mod tests {
             vec![
                 FtsConfig {
                     column: "title".into(),
+                    positions: false,
                 },
                 FtsConfig {
                     column: "subtitle".into(),
+                    positions: false,
                 },
             ],
             vec![],
@@ -368,9 +387,11 @@ mod tests {
             vec![
                 FtsConfig {
                     column: "subtitle".into(),
+                    positions: false,
                 },
                 FtsConfig {
                     column: "title".into(),
+                    positions: false,
                 },
             ],
             vec![],
@@ -382,6 +403,61 @@ mod tests {
         assert_ne!(h_a.0, h_b.0);
     }
 
+    /// The positions flag is hashed via a tagged block appended ONLY
+    /// when some column opts in. Three properties pin the
+    /// compatibility contract:
+    ///   1. all-false hashes stay stable against a golden value, so
+    ///      manifests stamped before positions existed keep
+    ///      verifying (the golden guards future encoding drift);
+    ///   2. flipping a column to positional changes the hash;
+    ///   3. WHICH column is positional matters (per-column bytes,
+    ///      not a single any() bit).
+    #[test]
+    fn compute_options_hash_positions_flag() {
+        let schema_two = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("subtitle", DataType::LargeUtf8, false),
+        ]));
+        let opts = |title_pos: bool, subtitle_pos: bool| {
+            SupertableOptions::new(
+                schema_two.clone(),
+                vec![
+                    FtsConfig {
+                        column: "title".into(),
+                        positions: title_pos,
+                    },
+                    FtsConfig {
+                        column: "subtitle".into(),
+                        positions: subtitle_pos,
+                    },
+                ],
+                vec![],
+                Some(default_tokenizer()),
+            )
+            .expect("opts")
+        };
+        let h_ff = compute_options_hash(&opts(false, false), &time_range());
+        let h_tf = compute_options_hash(&opts(true, false), &time_range());
+        let h_ft = compute_options_hash(&opts(false, true), &time_range());
+        assert_ne!(h_ff.0, h_tf.0, "positional column must change the hash");
+        assert_ne!(h_tf.0, h_ft.0, "which column is positional must matter");
+
+        // Golden: the all-false stream contains no positions block, so
+        // this value equals what pre-positions code produced for the
+        // same options. If this assertion ever fails, the encoding
+        // drifted and every existing table would fail open-validation.
+        let hex: String = h_ff.0.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(hex, ALL_FALSE_GOLDEN_HEX);
+    }
+
+    /// blake3 of the two-fts-column, all-positions-false fixture in
+    /// [`compute_options_hash_positions_flag`], captured from the
+    /// encoding as it existed before the positions flag — the
+    /// all-false stream appends no positions block, so the bytes are
+    /// identical by construction.
+    const ALL_FALSE_GOLDEN_HEX: &str =
+        "a89715d00cba061aed0b06910a2fde77a9b980c1f7a25c1d5eca901790c6f24a";
+
     #[test]
     fn compute_options_hash_changes_with_vector_columns() {
         // Adding a vector column changes the vector_columns
@@ -392,6 +468,7 @@ mod tests {
             schema_title_emb(16),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -1103,6 +1103,7 @@ mod tests {
     fn fc(name: &str) -> FtsConfig {
         FtsConfig {
             column: name.into(),
+            positions: false,
         }
     }
 

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -722,6 +722,7 @@ mod tests {
             schema,
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -445,6 +445,7 @@ mod tests {
             title_schema(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -570,6 +570,7 @@ mod tests {
             schema,
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -1092,6 +1093,7 @@ mod tests {
             schema,
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -418,6 +418,7 @@ mod tests {
             title_schema(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -545,6 +545,7 @@ mod tests {
             schema,
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -89,6 +89,7 @@ use crate::{
     InfinoError,
     superfile::{
         SuperfileReader,
+        error::{FtsError, ReadError},
         fts::{
             reader::ClauseLists,
             tokenize::{AsciiLowerTokenizer, Tokenizer},
@@ -418,7 +419,7 @@ impl SupertableReader {
                             floor,
                         )
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?
+                        .map_err(fts_read_error)?
                     }
                     None => {
                         let must_refs: Vec<&str> = must_arc.iter().map(|s| s.as_str()).collect();
@@ -439,7 +440,7 @@ impl SupertableReader {
                             floor,
                         )
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?
+                        .map_err(fts_read_error)?
                     }
                 };
                 // Raise the global floor with this unit's surviving
@@ -533,11 +534,11 @@ impl SupertableReader {
                     Some((start, end)) => r
                         .bm25_search_prefix_range(&column_arc, &prefix_arc, k, start, end)
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string())),
+                        .map_err(fts_read_error),
                     None => r
                         .bm25_search_prefix(&column_arc, &prefix_arc, k)
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string())),
+                        .map_err(fts_read_error),
                 }
             }
         };
@@ -693,11 +694,11 @@ impl SupertableReader {
                     true => r
                         .atoms_match_ids(&column_arc, &refs, &phrase_arc, match_mode)
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                        .map_err(fts_read_error)?,
                     false => r
                         .token_match(&column_arc, &refs, match_mode)
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                        .map_err(fts_read_error)?,
                 };
                 // Drop any positive match that also carries a negated
                 // atom (union of the negatives). The df / count fast
@@ -709,11 +710,11 @@ impl SupertableReader {
                         true => r
                             .token_match(&column_arc, &neg_refs, BoolMode::Or)
                             .await
-                            .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                            .map_err(fts_read_error)?,
                         false => r
                             .atoms_match_ids(&column_arc, &neg_refs, &neg_ph_arc, BoolMode::Or)
                             .await
-                            .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                            .map_err(fts_read_error)?,
                     }
                     .into_iter()
                     .collect();
@@ -805,11 +806,11 @@ impl SupertableReader {
                             true => r
                                 .atoms_match_ids(&column_arc, &refs, &phrase_arc, match_mode)
                                 .await
-                                .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                                .map_err(fts_read_error)?,
                             false => r
                                 .token_match(&column_arc, &refs, match_mode)
                                 .await
-                                .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                                .map_err(fts_read_error)?,
                         };
                         let excluded: RoaringBitmap = if has_negatives {
                             let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
@@ -817,7 +818,7 @@ impl SupertableReader {
                                 true => r
                                     .token_match(&column_arc, &neg_refs, BoolMode::Or)
                                     .await
-                                    .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                                    .map_err(fts_read_error)?,
                                 false => r
                                     .atoms_match_ids(
                                         &column_arc,
@@ -826,7 +827,7 @@ impl SupertableReader {
                                         BoolMode::Or,
                                     )
                                     .await
-                                    .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                                    .map_err(fts_read_error)?,
                             }
                             .into_iter()
                             .collect()
@@ -849,15 +850,15 @@ impl SupertableReader {
                     let n = if single_term {
                         r.term_df(&column_arc, &term_arc[0])
                             .await
-                            .map_err(|e| QueryError::Parquet(e.to_string()))?
+                            .map_err(fts_read_error)?
                     } else if phrase_involved {
                         r.atoms_match_count(&column_arc, &refs, &phrase_arc, match_mode)
                             .await
-                            .map_err(|e| QueryError::Parquet(e.to_string()))?
+                            .map_err(fts_read_error)?
                     } else {
                         r.token_match_count(&column_arc, &refs, match_mode)
                             .await
-                            .map_err(|e| QueryError::Parquet(e.to_string()))?
+                            .map_err(fts_read_error)?
                     };
                     Ok(n)
                 }
@@ -907,7 +908,7 @@ impl SupertableReader {
                 let docs = r
                     .exact_match(&column_arc, &value_arc)
                     .await
-                    .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                    .map_err(fts_read_error)?;
                 Ok(docs.into_iter().map(|d| (d, 0.0f32)).collect::<Vec<_>>())
             }
         };
@@ -1038,6 +1039,26 @@ struct WorkUnit {
 /// the scales we benchmark (1.25M docs/superfile after 10M × cpus/2
 /// row-shard) are well above this floor.
 const SUBRANGE_MIN_DOCS: u32 = 50_000;
+
+/// Map a per-superfile FTS read error to the query-layer error. A
+/// phrase query against a column indexed without positions, or a query
+/// with no positive clause to rank, is a malformed *request* — surface
+/// it as [`QueryError::InvalidQuery`] so the caller sees a bad-input
+/// error, not a storage/scan failure. Everything else is a genuine
+/// read error and stays [`QueryError::Parquet`].
+fn fts_read_error(e: ReadError) -> QueryError {
+    match &e {
+        ReadError::Fts(fts)
+            if matches!(
+                fts.as_ref(),
+                FtsError::PositionsUnavailable { .. } | FtsError::NegationOnly
+            ) =>
+        {
+            QueryError::InvalidQuery(e.to_string())
+        }
+        _ => QueryError::Parquet(e.to_string()),
+    }
+}
 
 /// Minimum query term count that makes OR sub-range fan-out eligible.
 /// The range-aware Block-Max MaxScore path is only wired up for
@@ -1996,14 +2017,24 @@ mod tests {
         let err = r
             .bm25_hits("title", r#""climate change""#, 10, BoolMode::Or)
             .expect_err("typed error expected");
-        let msg = err.to_string();
+        // A phrase on a positionless column is a bad *request*, not a
+        // read failure — it surfaces as InvalidQuery, and the message
+        // explains the missing positions.
         assert!(
-            msg.contains("positions"),
-            "error should say positions are missing: {msg}"
+            matches!(err, QueryError::InvalidQuery(_)),
+            "phrase on positionless column should be InvalidQuery, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("positions"),
+            "error should say positions are missing: {err}"
         );
         let err = r
             .count("title", r#""climate change""#, BoolMode::Or)
             .expect_err("count errors too");
+        assert!(
+            matches!(err, QueryError::InvalidQuery(_)),
+            "count phrase on positionless column should be InvalidQuery, got {err:?}"
+        );
         assert!(err.to_string().contains("positions"));
     }
 

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1224,6 +1224,7 @@ mod tests {
             schema_id_title(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tok()),
@@ -1258,6 +1259,7 @@ mod tests {
             "_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1179,6 +1179,18 @@ impl Supertable {
     /// the docs containing `climate` and ranks those also mentioning
     /// `policy` higher.
     ///
+    /// A double-quoted run of words is an **exact phrase** atom: the
+    /// words must appear adjacent and in order, verified against
+    /// token positions. A phrase takes any clause polarity —
+    /// `"new york" hotel`, `+"new york" +hotel`, `-"new york"` — and
+    /// scores as one BM25 atom whose `tf` is the number of phrase
+    /// occurrences and whose `idf` is the sum of its members'. Phrase
+    /// queries require the column to be indexed with token positions
+    /// (the `positions` flag on the column's FTS build config, off by
+    /// default); against a positionless column they return a typed
+    /// error rather than silently degrading to a bag-of-words match.
+    /// A single-word phrase (`"york"`) is just that term.
+    ///
     /// `score` is a similarity (higher is better) — the opposite
     /// direction from [`Supertable::vector_search`]'s distance. Fuse the
     /// two with [`Supertable::hybrid_search`], not by raw score.
@@ -1233,7 +1245,10 @@ impl Supertable {
     /// `column` matches `query`'s tokens under `mode` (`Or` = any token,
     /// `And` = every token). With a `+must` clause the match set is
     /// the musts' intersection and bare terms are ignored (no scores
-    /// for a should to raise); `-term` exclusions apply. Returns
+    /// for a should to raise); `-term` exclusions apply. Quoted
+    /// phrases participate as atoms exactly as in
+    /// [`Supertable::bm25_search`]: an exact-adjacency match against
+    /// token positions, requiring a positions-indexed column. Returns
     /// Arrow rows like [`Supertable::bm25_search`], but the `score`
     /// column is `0.0` and row order is unspecified — a candidate
     /// set, not a ranking. `projection` follows the same rules as
@@ -1307,7 +1322,10 @@ impl Supertable {
     /// cardinality — bare (should) terms affect only scores, never
     /// which docs count, so `count("+climate policy")` is the number
     /// of docs containing `climate`. A lone must keeps the O(1) df
-    /// fast path. `-term` exclusions apply as in search.
+    /// fast path. `-term` exclusions apply as in search. Quoted
+    /// phrases count exact-adjacency matches (verified against token
+    /// positions, so the column must be positions-indexed) — every
+    /// match is verified, giving exact phrase counts.
     ///
     /// ```
     /// # use std::sync::Arc;

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -106,6 +106,47 @@ use crate::{
     },
 };
 
+/// An unranked query's match set: the terms and exact phrases every
+/// (`And`) or any (`Or`) of which a doc must contain. Produced by
+/// `parse_and_prune` from the clause model — the must side when any
+/// must exists (shoulds have no scores to raise unranked), the bare
+/// side under the default operator otherwise.
+struct UnrankedMatchSet {
+    terms: Vec<String>,
+    phrases: Vec<Vec<String>>,
+    mode: BoolMode,
+}
+
+impl Default for UnrankedMatchSet {
+    fn default() -> Self {
+        Self {
+            terms: Vec::new(),
+            phrases: Vec::new(),
+            mode: BoolMode::Or,
+        }
+    }
+}
+
+impl UnrankedMatchSet {
+    fn has_phrases(&self) -> bool {
+        !self.phrases.is_empty()
+    }
+}
+
+/// An unranked query's negated atoms (docs containing any are
+/// excluded).
+#[derive(Default)]
+struct UnrankedNegatives {
+    terms: Vec<String>,
+    phrases: Vec<Vec<String>>,
+}
+
+impl UnrankedNegatives {
+    fn is_empty(&self) -> bool {
+        self.terms.is_empty() && self.phrases.is_empty()
+    }
+}
+
 /// Rejection message for a query with negated terms but no positive
 /// anchor (e.g. `-foo`). Shared by the scored and unranked FTS paths so
 /// both reject the case identically.
@@ -530,40 +571,76 @@ impl SupertableReader {
     /// scored search returns. With no musts, the bare terms match
     /// under `mode` exactly as before.
     ///
-    /// Returns `(match_terms, match_mode, negatives, kept)`.
+    /// Returns `(match_set, negatives, kept)`.
     async fn parse_and_prune(
         &self,
         column: &str,
         query: &str,
         mode: BoolMode,
-    ) -> Result<(Vec<String>, BoolMode, Vec<String>, Vec<Arc<SuperfileEntry>>), QueryError> {
+    ) -> Result<
+        (
+            UnrankedMatchSet,
+            UnrankedNegatives,
+            Vec<Arc<SuperfileEntry>>,
+        ),
+        QueryError,
+    > {
         let clauses = AsciiLowerTokenizer.parse(query).into_clauses(mode);
         let musts: Vec<String> = clauses.musts.into_iter().map(Cow::into_owned).collect();
         let shoulds: Vec<String> = clauses.shoulds.into_iter().map(Cow::into_owned).collect();
         let negatives: Vec<String> = clauses.negatives.into_iter().map(Cow::into_owned).collect();
-        if musts.is_empty() && shoulds.is_empty() {
-            if negatives.is_empty() {
+        let own_phrases = |phrases: Vec<Vec<Cow<'_, str>>>| -> Vec<Vec<String>> {
+            phrases
+                .into_iter()
+                .map(|p| p.into_iter().map(Cow::into_owned).collect())
+                .collect()
+        };
+        let must_phrases = own_phrases(clauses.must_phrases);
+        let should_phrases = own_phrases(clauses.should_phrases);
+        let negative_phrases = own_phrases(clauses.negative_phrases);
+        let negs = UnrankedNegatives {
+            terms: negatives,
+            phrases: negative_phrases,
+        };
+        let has_musts = !musts.is_empty() || !must_phrases.is_empty();
+        if !has_musts && shoulds.is_empty() && should_phrases.is_empty() {
+            if negs.terms.is_empty() && negs.phrases.is_empty() {
                 // No tokens at all (empty/whitespace query) — nothing to
                 // match, not an error.
-                return Ok((Vec::new(), mode, negatives, Vec::new()));
+                return Ok((UnrankedMatchSet::default(), negs, Vec::new()));
             }
             // Negation-only (e.g. `-foo`): reject, matching the scored
             // search path, which has no positive anchor to rank or match.
             return Err(QueryError::InvalidQuery(NEGATION_ONLY_QUERY_MSG.to_owned()));
         }
-        let (match_terms, match_mode) = if musts.is_empty() {
-            (shoulds, mode)
-        } else {
-            (musts, BoolMode::And)
+        // Unranked matching has no scores for a should to raise, so
+        // the match set is the must side whenever any must exists.
+        let match_set = match has_musts {
+            true => UnrankedMatchSet {
+                terms: musts,
+                phrases: must_phrases,
+                mode: BoolMode::And,
+            },
+            false => UnrankedMatchSet {
+                terms: shoulds,
+                phrases: should_phrases,
+                mode,
+            },
         };
+        // Prune on the match set's terms plus its phrases' members —
+        // a phrase match requires every member present.
+        let mut prune_terms = match_set.terms.clone();
+        for p in &match_set.phrases {
+            prune_terms.extend(p.iter().cloned());
+        }
         let prune_leaf = PruneLeaf::TermPresence {
             column: column.to_owned(),
-            terms: match_terms.clone(),
-            mode: match_mode,
+            terms: prune_terms,
+            mode: match_set.mode,
         };
         let kept =
             select_superfiles(self.manifest().as_ref(), slice::from_ref(&prune_leaf)).await?;
-        Ok((match_terms, match_mode, negatives, kept))
+        Ok((match_set, negs, kept))
     }
 
     /// Unranked token match across the pinned snapshot. Returns
@@ -588,38 +665,58 @@ impl SupertableReader {
         query: &str,
         mode: BoolMode,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
-        let (match_terms, match_mode, negatives, kept) =
-            self.parse_and_prune(column, query, mode).await?;
+        let (match_set, negatives, kept) = self.parse_and_prune(column, query, mode).await?;
         if kept.is_empty() {
             return Ok(Vec::new());
         }
+        let match_mode = match_set.mode;
         let has_negatives = !negatives.is_empty();
+        let phrase_involved = match_set.has_phrases() || !negatives.phrases.is_empty();
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
         let column_arc = Arc::new(column.to_owned());
-        let term_arc: Arc<Vec<String>> = Arc::new(match_terms);
-        let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
+        let term_arc: Arc<Vec<String>> = Arc::new(match_set.terms);
+        let phrase_arc: Arc<Vec<Vec<String>>> = Arc::new(match_set.phrases);
+        let neg_arc: Arc<Vec<String>> = Arc::new(negatives.terms);
+        let neg_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(negatives.phrases);
         let kernel = move |r: Arc<SuperfileReader>, _: ()| {
             let column_arc = Arc::clone(&column_arc);
             let term_arc = Arc::clone(&term_arc);
+            let phrase_arc = Arc::clone(&phrase_arc);
             let neg_arc = Arc::clone(&neg_arc);
+            let neg_ph_arc = Arc::clone(&neg_ph_arc);
             async move {
                 let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
-                let docs = r
-                    .token_match(&column_arc, &refs, match_mode)
-                    .await
-                    .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                // Any phrase atom (match or negated) takes the
+                // phrase-aware walk; plain-token queries keep the
+                // optimized token_match path unchanged.
+                let docs = match phrase_involved {
+                    true => r
+                        .atoms_match_ids(&column_arc, &refs, &phrase_arc, match_mode)
+                        .await
+                        .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                    false => r
+                        .token_match(&column_arc, &refs, match_mode)
+                        .await
+                        .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                };
                 // Drop any positive match that also carries a negated
-                // term (union of the negatives). The df / count fast
+                // atom (union of the negatives). The df / count fast
                 // paths can't express exclusion, so negation forces a
                 // materialized walk over both sets.
                 let docs = if has_negatives {
                     let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
-                    let excluded: RoaringBitmap = r
-                        .token_match(&column_arc, &neg_refs, BoolMode::Or)
-                        .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?
-                        .into_iter()
-                        .collect();
+                    let excluded: RoaringBitmap = match neg_ph_arc.is_empty() {
+                        true => r
+                            .token_match(&column_arc, &neg_refs, BoolMode::Or)
+                            .await
+                            .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                        false => r
+                            .atoms_match_ids(&column_arc, &neg_refs, &neg_ph_arc, BoolMode::Or)
+                            .await
+                            .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                    }
+                    .into_iter()
+                    .collect();
                     docs.into_iter()
                         .filter(|d| !excluded.contains(*d))
                         .collect::<Vec<_>>()
@@ -657,17 +754,20 @@ impl SupertableReader {
         query: &str,
         mode: BoolMode,
     ) -> Result<u64, QueryError> {
-        let (match_terms, match_mode, negatives, kept) =
-            self.parse_and_prune(column, query, mode).await?;
+        let (match_set, negatives, kept) = self.parse_and_prune(column, query, mode).await?;
         if kept.is_empty() {
             return Ok(0);
         }
 
-        let single_term = match_terms.len() == 1;
+        let match_mode = match_set.mode;
+        let single_term = match_set.terms.len() == 1 && !match_set.has_phrases();
         let has_negatives = !negatives.is_empty();
+        let phrase_involved = match_set.has_phrases() || !negatives.phrases.is_empty();
         let column_arc = Arc::new(column.to_owned());
-        let term_arc: Arc<Vec<String>> = Arc::new(match_terms);
-        let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
+        let term_arc: Arc<Vec<String>> = Arc::new(match_set.terms);
+        let phrase_arc: Arc<Vec<Vec<String>>> = Arc::new(match_set.phrases);
+        let neg_arc: Arc<Vec<String>> = Arc::new(negatives.terms);
+        let neg_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(negatives.phrases);
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
 
         // Shared fan-out (`dispatch::fanout_with`): warms tombstones,
@@ -680,7 +780,9 @@ impl SupertableReader {
             move |r, entry, tombstone_cache, now, _params: ()| {
                 let column_arc = Arc::clone(&column_arc);
                 let term_arc = Arc::clone(&term_arc);
+                let phrase_arc = Arc::clone(&phrase_arc);
                 let neg_arc = Arc::clone(&neg_arc);
+                let neg_ph_arc = Arc::clone(&neg_ph_arc);
                 async move {
                     // Tombstone bitmap for this superfile (None = no deletes).
                     let tomb = match tombstone_cache.as_ref() {
@@ -699,17 +801,35 @@ impl SupertableReader {
                     // matches, then drop any doc carrying a negated term
                     // (union of the negatives) or a tombstone.
                     if has_negatives || tomb.is_some() {
-                        let docs = r
-                            .token_match(&column_arc, &refs, match_mode)
-                            .await
-                            .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                        let docs = match phrase_involved {
+                            true => r
+                                .atoms_match_ids(&column_arc, &refs, &phrase_arc, match_mode)
+                                .await
+                                .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                            false => r
+                                .token_match(&column_arc, &refs, match_mode)
+                                .await
+                                .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                        };
                         let excluded: RoaringBitmap = if has_negatives {
                             let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
-                            r.token_match(&column_arc, &neg_refs, BoolMode::Or)
-                                .await
-                                .map_err(|e| QueryError::Parquet(e.to_string()))?
-                                .into_iter()
-                                .collect()
+                            match neg_ph_arc.is_empty() {
+                                true => r
+                                    .token_match(&column_arc, &neg_refs, BoolMode::Or)
+                                    .await
+                                    .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                                false => r
+                                    .atoms_match_ids(
+                                        &column_arc,
+                                        &neg_refs,
+                                        &neg_ph_arc,
+                                        BoolMode::Or,
+                                    )
+                                    .await
+                                    .map_err(|e| QueryError::Parquet(e.to_string()))?,
+                            }
+                            .into_iter()
+                            .collect()
                         } else {
                             RoaringBitmap::new()
                         };
@@ -728,6 +848,10 @@ impl SupertableReader {
                     // match walk through the counting sink.
                     let n = if single_term {
                         r.term_df(&column_arc, &term_arc[0])
+                            .await
+                            .map_err(|e| QueryError::Parquet(e.to_string()))?
+                    } else if phrase_involved {
+                        r.atoms_match_count(&column_arc, &refs, &phrase_arc, match_mode)
                             .await
                             .map_err(|e| QueryError::Parquet(e.to_string()))?
                     } else {
@@ -1773,6 +1897,96 @@ mod tests {
         .expect("append");
         w.commit().expect("commit");
         st
+    }
+
+    /// Positional twin of the options fixture, for phrase queries.
+    fn options_positional_one_superfile_per_commit() -> SupertableOptions {
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        SupertableOptions::new(
+            schema_id_title(),
+            vec![FtsConfig {
+                column: "title".into(),
+                positions: true,
+            }],
+            vec![],
+            Some(tok()),
+        )
+        .expect("valid options")
+        .with_writer_pool(pool)
+    }
+
+    /// Two superfiles with controlled "new york" adjacency: docs in
+    /// the first commit match (0, 1), the second commit has both
+    /// words non-adjacent plus one more match.
+    fn seeded_phrase_supertable() -> Supertable {
+        let st = Supertable::create(options_positional_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(0, &["new york city", "the new york times"]))
+            .expect("append");
+        w.commit().expect("commit");
+        w.append(&build_batch(10, &["york loves new haven", "big new york"]))
+            .expect("append");
+        w.commit().expect("commit");
+        st
+    }
+
+    #[test]
+    fn phrase_query_end_to_end() {
+        let st = seeded_phrase_supertable();
+        let r = st.reader();
+
+        // Ranked: exactly the adjacent-in-order docs across both
+        // superfiles.
+        let hits = r
+            .bm25_hits("title", r#""new york""#, 10, BoolMode::Or)
+            .expect("phrase hits");
+        assert_eq!(hits.len(), 3, "three docs contain the phrase");
+
+        // Count = the phrase match set.
+        let n = r
+            .count("title", r#""new york""#, BoolMode::Or)
+            .expect("phrase count");
+        assert_eq!(n, 3);
+        // The non-adjacent doc is the difference vs the token AND.
+        let and_count = r
+            .count("title", "+new +york", BoolMode::Or)
+            .expect("token and count");
+        assert_eq!(and_count, 4);
+
+        // Phrase composed with clauses: must-phrase + must-term.
+        let hits = r
+            .bm25_hits("title", r#"+"new york" +the"#, 10, BoolMode::Or)
+            .expect("phrase + term");
+        assert_eq!(hits.len(), 1);
+
+        // Negated phrase: docs with `york` minus the phrase docs.
+        let n = r
+            .count("title", r#"york -"new york""#, BoolMode::Or)
+            .expect("negated phrase count");
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn phrase_on_positionless_table_errors() {
+        let st = seeded_clause_supertable();
+        let r = st.reader();
+        let err = r
+            .bm25_hits("title", r#""climate change""#, 10, BoolMode::Or)
+            .expect_err("typed error expected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("positions"),
+            "error should say positions are missing: {msg}"
+        );
+        let err = r
+            .count("title", r#""climate change""#, BoolMode::Or)
+            .expect_err("count errors too");
+        assert!(err.to_string().contains("positions"));
     }
 
     #[test]

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -89,7 +89,10 @@ use crate::{
     InfinoError,
     superfile::{
         SuperfileReader,
-        fts::tokenize::{AsciiLowerTokenizer, Tokenizer},
+        fts::{
+            reader::ClauseLists,
+            tokenize::{AsciiLowerTokenizer, Tokenizer},
+        },
     },
     supertable::{
         error::QueryError,
@@ -238,15 +241,27 @@ impl SupertableReader {
         let musts: Vec<String> = clauses.musts.into_iter().map(Cow::into_owned).collect();
         let shoulds: Vec<String> = clauses.shoulds.into_iter().map(Cow::into_owned).collect();
         let negatives: Vec<String> = clauses.negatives.into_iter().map(Cow::into_owned).collect();
+        let own_phrases = |phrases: Vec<Vec<Cow<'_, str>>>| -> Vec<Vec<String>> {
+            phrases
+                .into_iter()
+                .map(|p| p.into_iter().map(Cow::into_owned).collect())
+                .collect()
+        };
+        let must_phrases = own_phrases(clauses.must_phrases);
+        let should_phrases = own_phrases(clauses.should_phrases);
+        let negative_phrases = own_phrases(clauses.negative_phrases);
+        let has_musts = !musts.is_empty() || !must_phrases.is_empty();
+        let has_phrases =
+            !must_phrases.is_empty() || !should_phrases.is_empty() || !negative_phrases.is_empty();
 
-        if musts.is_empty() && shoulds.is_empty() {
+        if !has_musts && shoulds.is_empty() && should_phrases.is_empty() {
             // No scorable clause at all. Empty / punctuation-only
             // queries match nothing (not an error); negation-only
             // (e.g. `-foo`) has no anchor to rank — reject up front so
             // the per-superfile kernel never has to, and so the
             // unranked count / token_match path surfaces the identical
             // error (see `parse_and_prune`).
-            if negatives.is_empty() {
+            if negatives.is_empty() && negative_phrases.is_empty() {
                 return Ok(Vec::new());
             }
             return Err(QueryError::InvalidQuery(NEGATION_ONLY_QUERY_MSG.to_owned()));
@@ -254,17 +269,30 @@ impl SupertableReader {
 
         // Pick the superfiles to search, via the shared two-tier bloom
         // prune. Musts prune hardest: every match contains all of
-        // them, so a superfile lacking any must is skipped regardless
-        // of `mode`. A pure should query prunes exactly as the flat
-        // term list did. Negated terms never prune — a superfile
-        // without a negated term is the best case (none of its docs
-        // can be excluded) — and shoulds never prune once a must
-        // exists, since they only affect scores.
-        let (prune_terms, prune_mode) = if musts.is_empty() {
+        // them — a phrase's member terms included, since a phrase
+        // match requires every member present — so a superfile
+        // lacking any is skipped regardless of `mode`. A pure should
+        // query prunes as the flat term list did (phrase members join
+        // the union: a doc matching the phrase contains each member).
+        // Negated atoms never prune, and shoulds never prune once a
+        // must exists, since they only affect scores.
+        let (mut prune_terms, prune_mode) = if !has_musts {
             (shoulds.clone(), mode)
         } else {
             (musts.clone(), BoolMode::And)
         };
+        match has_musts {
+            true => {
+                for p in &must_phrases {
+                    prune_terms.extend(p.iter().cloned());
+                }
+            }
+            false => {
+                for p in &should_phrases {
+                    prune_terms.extend(p.iter().cloned());
+                }
+            }
+        }
         let prune_leaf = PruneLeaf::TermPresence {
             column: column_owned.clone(),
             terms: prune_terms,
@@ -282,7 +310,12 @@ impl SupertableReader {
         // Single-term OR, AND, and any query with a must or negated
         // clause stay on the un-ranged call.
         let kept_refs: Vec<&Arc<SuperfileEntry>> = kept.iter().collect();
-        let fanout = fanout_for(musts.len(), shoulds.len(), !negatives.is_empty());
+        // Phrase-bearing queries stay per-superfile: the ranged
+        // kernel is the pure term-union fast path.
+        let fanout = match has_phrases {
+            true => FanOut::PerSuperfile,
+            false => fanout_for(musts.len(), shoulds.len(), !negatives.is_empty()),
+        };
         let work_units = build_work_units(&kept_refs, fanout, pool_threads);
         let units: Vec<(Arc<SuperfileEntry>, (Option<(u32, u32)>, Uuid))> = work_units
             .into_iter()
@@ -295,6 +328,9 @@ impl SupertableReader {
         let must_arc: Arc<Vec<String>> = Arc::new(musts);
         let should_arc: Arc<Vec<String>> = Arc::new(shoulds);
         let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
+        let must_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(must_phrases);
+        let should_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(should_phrases);
+        let neg_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(negative_phrases);
         let column_arc = Arc::new(column_owned);
 
         // Cross-segment threshold sharing: each unit reads the global
@@ -318,6 +354,9 @@ impl SupertableReader {
             let must_arc = Arc::clone(&must_arc);
             let should_arc = Arc::clone(&should_arc);
             let neg_arc = Arc::clone(&neg_arc);
+            let must_ph_arc = Arc::clone(&must_ph_arc);
+            let should_ph_arc = Arc::clone(&should_ph_arc);
+            let neg_ph_arc = Arc::clone(&neg_ph_arc);
             let shared = Arc::clone(&shared);
             let tombstones = tombstones.clone();
             async move {
@@ -347,9 +386,14 @@ impl SupertableReader {
                         let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
                         r.bm25_search_clauses(
                             &column_arc,
-                            &must_refs,
-                            &should_refs,
-                            &neg_refs,
+                            ClauseLists {
+                                musts: &must_refs,
+                                shoulds: &should_refs,
+                                negatives: &neg_refs,
+                                must_phrases: &must_ph_arc,
+                                should_phrases: &should_ph_arc,
+                                negative_phrases: &neg_ph_arc,
+                            },
                             k,
                             floor,
                         )

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -1883,6 +1883,7 @@ mod tests {
             cat_title_schema(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(default_tokenizer()),

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -454,6 +454,7 @@ mod tests {
                 schema,
                 vec![FtsConfig {
                     column: "title".into(),
+                    positions: false,
                 }],
                 vec![],
                 Some(tk),

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -425,6 +425,7 @@ mod tests {
                 schema,
                 vec![FtsConfig {
                     column: "title".into(),
+                    positions: false,
                 }],
                 vec![],
                 Some(tk),

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -782,6 +782,7 @@ mod tests {
             Arc::clone(&schema),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tok()),
@@ -833,6 +834,7 @@ mod tests {
             Arc::clone(&schema),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -345,6 +345,7 @@ mod tests {
             schema_id_cat_title(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tok()),
@@ -945,6 +946,7 @@ mod tests {
             schema_with_vector(dim),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -932,6 +932,7 @@ mod tests {
             schema_with_vector(dim),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -995,6 +996,7 @@ mod tests {
             "_id",
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/utils/vector_split.rs
+++ b/src/supertable/utils/vector_split.rs
@@ -232,6 +232,7 @@ mod tests {
     fn fc(name: &str) -> FtsConfig {
         FtsConfig {
             column: name.into(),
+            positions: false,
         }
     }
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -2272,6 +2272,7 @@ mod tests {
             schema_id_title(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -105,7 +105,7 @@ use crate::{
         format::{
             CRC_BYTES,
             footer::read_kv_metadata,
-            fts::{HEADER_SIZE as FTS_HEADER_SIZE, U64_BYTES, hdr},
+            fts::{HEADER_SIZE_V1_LEGACY as FTS_HEADER_SIZE, U64_BYTES, hdr},
             kv,
             vec::{
                 CLUSTER_IDX_ENTRY_BYTES, DIR_ENTRY_SIZE, OUTER_HEADER_SIZE, SUB_HEADER_SIZE,

--- a/src/test_helpers/brute_force_bm25.rs
+++ b/src/test_helpers/brute_force_bm25.rs
@@ -33,6 +33,21 @@ use crate::superfile::fts::tokenize::Tokenizer;
 const K1: f32 = 1.2;
 const B: f32 = 0.75;
 
+/// Number of times `phrase` occurs contiguously (in order) in
+/// `tokens` — the brute-force phrase tf.
+fn phrase_tf(tokens: &[String], phrase: &[String]) -> u32 {
+    if phrase.is_empty() || tokens.len() < phrase.len() {
+        return 0;
+    }
+    let mut tf = 0u32;
+    for start in 0..=(tokens.len() - phrase.len()) {
+        if tokens[start..start + phrase.len()] == *phrase {
+            tf += 1;
+        }
+    }
+    tf
+}
+
 /// Per-doc statistics derived from the corpus once and reused
 /// across queries.
 struct DocStats {
@@ -42,6 +57,8 @@ struct DocStats {
     dl: u32,
     /// Term frequencies for this doc: term → count.
     tf: HashMap<String, u32>,
+    /// The doc's token sequence, for phrase adjacency scans.
+    tokens: Vec<String>,
 }
 
 /// Pre-tokenized corpus + per-term df + corpus avgdl. Construct
@@ -68,10 +85,12 @@ impl BruteForceBm25 {
 
         for (doc_id, text) in corpus {
             let mut tf: HashMap<String, u32> = HashMap::new();
+            let mut tokens: Vec<String> = Vec::new();
             let mut dl: u32 = 0;
             tokenizer.tokenize_each(text, &mut |tok| {
                 dl += 1;
                 *tf.entry(tok.to_owned()).or_insert(0) += 1;
+                tokens.push(tok.to_owned());
             });
             for term in tf.keys() {
                 *df.entry(term.clone()).or_insert(0) += 1;
@@ -81,6 +100,7 @@ impl BruteForceBm25 {
                 doc_id: *doc_id,
                 dl,
                 tf,
+                tokens,
             });
         }
 
@@ -206,6 +226,109 @@ impl BruteForceBm25 {
             // idf is always positive); with none, only docs hit by at
             // least one should are in the union.
             if !musts.is_empty() || any_should {
+                scored.push((doc.doc_id, score));
+            }
+        }
+
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(Ordering::Equal)
+                .then(a.0.cmp(&b.0))
+        });
+        scored.truncate(k);
+        scored
+    }
+
+    /// Phrase-aware clause-model top-k: like
+    /// [`Self::top_k_clauses`], with exact phrases in every polarity.
+    /// A phrase matches a doc when its token sequence occurs
+    /// contiguously in order; its per-doc tf is the number of
+    /// occurrence starts, and it scores as one BM25 atom with
+    /// `idf = Σ member idf` — mirroring the production phrase atom.
+    #[allow(clippy::too_many_arguments)]
+    pub fn top_k_atoms(
+        &self,
+        musts: &[String],
+        must_phrases: &[Vec<String>],
+        shoulds: &[String],
+        should_phrases: &[Vec<String>],
+        negatives: &[String],
+        negative_phrases: &[Vec<String>],
+        k: usize,
+    ) -> Vec<(u64, f32)> {
+        let no_positive = musts.is_empty()
+            && must_phrases.is_empty()
+            && shoulds.is_empty()
+            && should_phrases.is_empty();
+        if k == 0 || no_positive || self.n == 0 {
+            return Vec::new();
+        }
+
+        let n = self.n as f32;
+        let idf_of = |term: &String| -> f32 {
+            let df = *self.df.get(term).unwrap_or(&0) as f32;
+            match df > 0.0 {
+                true => (1.0 + (n - df + 0.5) / (df + 0.5)).ln(),
+                false => 0.0,
+            }
+        };
+        let phrase_idf = |p: &Vec<String>| -> f32 { p.iter().map(idf_of).sum() };
+
+        let avgdl = self.avgdl;
+        let mut scored: Vec<(u64, f32)> = Vec::with_capacity(self.docs.len());
+        'docs: for doc in &self.docs {
+            for neg in negatives {
+                if doc.tf.contains_key(neg) {
+                    continue 'docs;
+                }
+            }
+            for p in negative_phrases {
+                if phrase_tf(&doc.tokens, p) > 0 {
+                    continue 'docs;
+                }
+            }
+            for must in musts {
+                if !doc.tf.contains_key(must) {
+                    continue 'docs;
+                }
+            }
+            let mut must_phrase_tfs: Vec<u32> = Vec::with_capacity(must_phrases.len());
+            for p in must_phrases {
+                let tf = phrase_tf(&doc.tokens, p);
+                if tf == 0 {
+                    continue 'docs;
+                }
+                must_phrase_tfs.push(tf);
+            }
+
+            let dl = doc.dl as f32;
+            let dl_norm = K1 * (1.0 - B + B * dl / avgdl.max(f32::MIN_POSITIVE));
+            let tf_factor = |tf: u32| -> f32 { tf as f32 * (K1 + 1.0) / (tf as f32 + dl_norm) };
+
+            let mut score: f32 = 0.0;
+            let mut matched_any_should = false;
+            for term in musts {
+                score += idf_of(term) * tf_factor(doc.tf[term]);
+            }
+            for (p, tf) in must_phrases.iter().zip(&must_phrase_tfs) {
+                score += phrase_idf(p) * tf_factor(*tf);
+            }
+            for term in shoulds {
+                if let Some(&tf) = doc.tf.get(term) {
+                    matched_any_should = true;
+                    score += idf_of(term) * tf_factor(tf);
+                }
+            }
+            for p in should_phrases {
+                let tf = phrase_tf(&doc.tokens, p);
+                if tf > 0 {
+                    matched_any_should = true;
+                    score += phrase_idf(p) * tf_factor(tf);
+                }
+            }
+
+            let has_musts = !musts.is_empty() || !must_phrases.is_empty();
+            if has_musts || matched_any_should {
                 scored.push((doc.doc_id, score));
             }
         }

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -205,6 +205,7 @@ pub fn default_supertable_options() -> SupertableOptions {
         schema_id_title(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -47,6 +47,42 @@ const CRC_TEST_SECONDARY_AXIS_OFFSET: usize = 3;
 /// XOR mask used to flip a byte when corrupting a CRC-protected region.
 const CORRUPTION_FLIP_MASK: u8 = 0xFF;
 
+/// Positional variant of the corruptable superfile: same corpus, the
+/// FTS column records token positions, so the blob is v2 and carries a
+/// CRC-protected positions region.
+fn build_corruptable_positional_superfile() -> Vec<u8> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "doc_id",
+            DataType::Decimal128(ID_DECIMAL_PRECISION, ID_DECIMAL_SCALE),
+            false,
+        ),
+        Field::new("title", DataType::LargeUtf8, false),
+    ]));
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: true,
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let n = CRC_TEST_N_DOCS;
+    let ids = decimal128_ids(0..n as u64);
+    let titles = LargeStringArray::from(
+        (0..n)
+            .map(|i| format!("doc {i} rust async runtime systems"))
+            .collect::<Vec<_>>(),
+    );
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
+        .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    b.finish().expect("finish builder")
+}
+
 fn build_corruptable_superfile() -> Vec<u8> {
     let schema = Arc::new(Schema::new(vec![
         Field::new(
@@ -268,4 +304,53 @@ fn corruption_at_random_interior_positions_rejected() {
         rejected * 4 >= n_samples * 3,
         "expected ≥75% of random interior corruptions to be rejected; got {rejected}/{n_samples}"
     );
+}
+
+#[test]
+fn corrupt_fts_positions_region_rejected() {
+    // v2 blob: the positions-region offset lives at header bytes
+    // [48..56] (relative to the blob). Flip a byte inside the region
+    // body — the multi-doc terms guarantee it is non-empty.
+    let bytes = build_corruptable_positional_superfile();
+    let (fts_off, _) = locate_fts_blob_only(&bytes);
+    let version = u32::from_le_bytes(
+        bytes[fts_off + 8..fts_off + 12]
+            .try_into()
+            .expect("version bytes"),
+    );
+    assert_eq!(version, 2, "positional superfile must embed a v2 FTS blob");
+    let positions_off_rel = u64::from_le_bytes(
+        bytes[fts_off + 48..fts_off + 56]
+            .try_into()
+            .expect("positions offset bytes"),
+    ) as usize;
+    let doc_lengths_off_rel = u64::from_le_bytes(
+        bytes[fts_off + 40..fts_off + 48]
+            .try_into()
+            .expect("doc-lengths offset bytes"),
+    ) as usize;
+    assert!(
+        doc_lengths_off_rel - positions_off_rel > 4,
+        "positions region has a non-empty body"
+    );
+    let target = fts_off + positions_off_rel + 1;
+    assert_corruption_rejected(bytes, target, "fts/positions region");
+}
+
+#[test]
+fn uncorrupted_positional_superfile_opens() {
+    // Sanity twin of the corruption test: the same v2 bytes open
+    // cleanly when untouched.
+    let bytes = build_corruptable_positional_superfile();
+    SuperfileReader::open(Bytes::from(bytes)).expect("clean v2 superfile opens");
+}
+
+/// FTS blob range only (the positional fixture has no vector blob, so
+/// `locate_blobs` — which insists on both — doesn't apply).
+fn locate_fts_blob_only(bytes: &[u8]) -> (usize, usize) {
+    use infino::superfile::format::footer::read_kv_metadata;
+    let kv = read_kv_metadata(bytes).expect("read kv metadata");
+    let fts_off: usize = kv["inf.fts.offset"].parse().expect("parse");
+    let fts_len: usize = kv["inf.fts.length"].parse().expect("parse");
+    (fts_off, fts_len)
 }

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -61,6 +61,7 @@ fn build_corruptable_superfile() -> Vec<u8> {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("emb", CRC_TEST_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/superfile/format/lazy_byte_source.rs
+++ b/tests/superfile/format/lazy_byte_source.rs
@@ -80,6 +80,7 @@ fn build_test_bytes() -> Bytes {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -324,6 +325,7 @@ fn build_vec_plus_fts_bytes() -> Bytes {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("emb", LAZY_VEC_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/superfile/format/lazy_byte_source.rs
+++ b/tests/superfile/format/lazy_byte_source.rs
@@ -129,6 +129,80 @@ async fn open_lazy_via_bytes_source_matches_open() {
     assert_eq!(lazy_terms, eager_terms);
 }
 
+/// v2 (positional) variant of the fixture: same corpus, positions on.
+fn build_positional_test_bytes() -> Bytes {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "doc_id",
+            DataType::Decimal128(ID_DECIMAL_PRECISION, ID_DECIMAL_SCALE),
+            false,
+        ),
+        Field::new("title", DataType::LargeUtf8, false),
+    ]));
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: true,
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("builder");
+    let ids = decimal128_ids(vec![1u64, 2, 3, 4]);
+    let titles = LargeStringArray::from(vec![
+        "alpha bravo special",
+        "charlie delta",
+        "echo special foxtrot",
+        "gamma hotel",
+    ]);
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    Bytes::from(b.finish().expect("finish"))
+}
+
+#[tokio::test]
+async fn open_lazy_reads_positional_v2_blob_like_eager() {
+    // The v2 header extension and the shifted FST prefetch range are
+    // lazy-open-specific code paths; this pins them against the eager
+    // open on the same bytes, including a term resolution (postings
+    // fetch through the lazy source with the positional term-meta
+    // stride).
+    let bytes = build_positional_test_bytes();
+    let eager = SuperfileReader::open(bytes.clone()).expect("eager open");
+
+    let source: Arc<dyn LazyByteSource> = Arc::new(BytesLazyByteSource::new(bytes));
+    let lazy = SuperfileReader::open_lazy(source).await.expect("lazy open");
+
+    assert_eq!(lazy.n_docs(), eager.n_docs());
+    assert_eq!(lazy.fts_columns(), eager.fts_columns());
+    let lazy_terms = lazy
+        .fts()
+        .expect("fts")
+        .iter_column_terms("title")
+        .expect("lazy terms");
+    let eager_terms = eager
+        .fts()
+        .expect("fts")
+        .iter_column_terms("title")
+        .expect("eager terms");
+    assert_eq!(lazy_terms, eager_terms);
+
+    // A multi-doc term ("special", df=2) resolves through the lazy
+    // postings fetch with the 32-byte positional term meta.
+    let lazy_hits = lazy
+        .token_match("title", &["special"], BoolMode::And)
+        .await
+        .expect("lazy match");
+    let eager_hits = eager
+        .token_match("title", &["special"], BoolMode::And)
+        .await
+        .expect("eager match");
+    assert_eq!(lazy_hits, eager_hits);
+    assert_eq!(lazy_hits, vec![0, 2]);
+}
+
 // ============================================================
 // StorageRangeSource — wraps a real storage provider.
 // ============================================================

--- a/tests/superfile/format/parquet_compat.rs
+++ b/tests/superfile/format/parquet_compat.rs
@@ -86,6 +86,7 @@ fn build_planted_superfile() -> Bytes {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("emb", PARQUET_COMPAT_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -120,6 +120,7 @@ pub fn build_infino_superfile(corpus: &[(u64, &str)]) -> SuperfileReader {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -111,6 +111,15 @@ pub fn corpus() -> Vec<(u64, &'static str)> {
 
 /// Build an infino superfile from the corpus.
 pub fn build_infino_superfile(corpus: &[(u64, &str)]) -> SuperfileReader {
+    build_infino_superfile_with(corpus, false)
+}
+
+/// Positional variant for the phrase oracle tests.
+pub fn build_infino_superfile_positional(corpus: &[(u64, &str)]) -> SuperfileReader {
+    build_infino_superfile_with(corpus, true)
+}
+
+fn build_infino_superfile_with(corpus: &[(u64, &str)], positions: bool) -> SuperfileReader {
     let schema = Arc::new(Schema::new(vec![
         Field::new("doc_id", DataType::Decimal128(38, 0), false),
         Field::new("title", DataType::LargeUtf8, false),
@@ -120,7 +129,7 @@ pub fn build_infino_superfile(corpus: &[(u64, &str)]) -> SuperfileReader {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
-            positions: false,
+            positions,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -4,5 +4,6 @@
 pub mod brute_force_oracle;
 pub mod must_should;
 pub mod negation;
+pub mod phrase;
 pub mod pipeline;
 pub mod uses_spill_builder;

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! End-to-end tests for exact phrase queries (`"a b"`), pinning the
+//! semantics against corpus truth and the brute-force phrase oracle:
+//!
+//! * a phrase matches only contiguous, in-order token sequences;
+//! * its per-doc tf is the number of occurrence starts (overlaps
+//!   like "a a a" for "a a" count each start);
+//! * it composes with the clause model in every polarity;
+//! * scores agree with the oracle's sum-idf phrase atom.
+
+use std::collections::{HashMap, HashSet};
+
+use infino::{
+    superfile::{SuperfileReader, fts::reader::BoolMode},
+    test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer},
+};
+
+use crate::fts::brute_force_oracle::{
+    build_infino_superfile_positional, build_multi_block_corpus, corpus,
+};
+
+/// k large enough to capture every match on the 60-doc corpus.
+const K_ALL: usize = 64;
+/// k covering every match in the 1000-doc multi-block corpus.
+const K_ALL_MULTI_BLOCK: usize = 1024;
+/// Score-equality tolerance between the two BM25 implementations.
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+
+async fn search_hits(
+    reader: &SuperfileReader,
+    query: &str,
+    k: usize,
+    mode: BoolMode,
+) -> Vec<(u64, f32)> {
+    reader
+        .bm25_hits_async("title", query, k, mode)
+        .await
+        .expect("phrase query")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect()
+}
+
+/// Compare reader results against the phrase oracle for `query`:
+/// identical match sets, per-doc scores within tolerance.
+async fn assert_matches_oracle(
+    reader: &SuperfileReader,
+    oracle: &BruteForceBm25,
+    query: &str,
+    mode: BoolMode,
+    k: usize,
+) {
+    let tok = default_tokenizer();
+    let clauses = tok.parse(query).into_clauses(mode);
+    let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
+        v.into_iter().map(|t| t.into_owned()).collect()
+    };
+    let own_ph = |v: Vec<Vec<std::borrow::Cow<'_, str>>>| -> Vec<Vec<String>> {
+        v.into_iter()
+            .map(|p| p.into_iter().map(|t| t.into_owned()).collect())
+            .collect()
+    };
+    let want = oracle.top_k_atoms(
+        &own(clauses.musts),
+        &own_ph(clauses.must_phrases),
+        &own(clauses.shoulds),
+        &own_ph(clauses.should_phrases),
+        &own(clauses.negatives),
+        &own_ph(clauses.negative_phrases),
+        k,
+    );
+    let got = search_hits(reader, query, k, mode).await;
+
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();
+    let want_ids: HashSet<u64> = want.iter().map(|(d, _)| *d).collect();
+    assert_eq!(got_ids, want_ids, "query {query:?}: match sets disagree");
+
+    let want_scores: HashMap<u64, f32> = want.into_iter().collect();
+    for (d, s) in &got {
+        let w = want_scores[d];
+        assert!(
+            (s - w).abs() <= SCORE_ABS_TOLERANCE,
+            "query {query:?} doc {d}: reader score {s} vs oracle {w}"
+        );
+    }
+}
+
+// ── planted semantics ─────────────────────────────────────────────────
+
+/// Small corpus with deliberate phrase shapes: boundaries, repeats,
+/// overlapping self-phrases, and near-misses.
+fn phrase_corpus() -> Vec<(u64, &'static str)> {
+    vec![
+        (0, "new york city"),               // match at doc start
+        (1, "i love new york"),             // match at doc end
+        (2, "york new haven"),              // both words, wrong order
+        (3, "new deal in york county"),     // both words, not adjacent
+        (4, "new york new york"),           // phrase twice
+        (5, "buzz buzz buzz"),              // overlapping "buzz buzz"
+        (6, "the new york times daily"),    // interior match
+        (7, "brand new yorkshire pudding"), // prefix-ish near miss
+    ]
+}
+
+#[tokio::test]
+async fn phrase_matches_only_contiguous_in_order() {
+    let corp = phrase_corpus();
+    let r = build_infino_superfile_positional(&corp);
+    let hits = search_hits(&r, r#""new york""#, K_ALL, BoolMode::Or).await;
+    let mut ids: Vec<u64> = hits.iter().map(|(d, _)| *d).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![0, 1, 4, 6], "boundaries + interior + repeats");
+}
+
+#[tokio::test]
+async fn overlapping_occurrences_each_count() {
+    // "buzz buzz" in "buzz buzz buzz": starts at 0 and 1 → tf 2,
+    // which must outscore a doc where... there is only one such doc;
+    // pin via the oracle instead.
+    let corp = phrase_corpus();
+    let r = build_infino_superfile_positional(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    assert_matches_oracle(&r, &oracle, r#""buzz buzz""#, BoolMode::Or, K_ALL).await;
+}
+
+#[tokio::test]
+async fn phrase_oracle_agreement_small_corpus() {
+    let corp = phrase_corpus();
+    let r = build_infino_superfile_positional(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    for query in [
+        r#""new york""#,
+        r#""new york" city"#,
+        r#"+"new york" +times"#,
+        r#"haven -"new york""#,
+        r#""new york city""#,
+        r#""york new""#,
+        r#"+"new york" -times"#,
+    ] {
+        assert_matches_oracle(&r, &oracle, query, BoolMode::Or, K_ALL).await;
+        assert_matches_oracle(&r, &oracle, query, BoolMode::And, K_ALL).await;
+    }
+}
+
+#[tokio::test]
+async fn three_token_phrase_and_absent_member() {
+    let corp = phrase_corpus();
+    let r = build_infino_superfile_positional(&corp);
+    let hits = search_hits(&r, r#""new york city""#, K_ALL, BoolMode::Or).await;
+    assert_eq!(
+        hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(),
+        vec![0],
+        "three-token phrase"
+    );
+    let hits = search_hits(&r, r#""new zealand""#, K_ALL, BoolMode::Or).await;
+    assert!(hits.is_empty(), "absent member matches nothing");
+}
+
+#[tokio::test]
+async fn single_and_repeated_words_on_sixty_doc_corpus() {
+    // The negation-suite corpus, positional: phrase behavior must
+    // agree with the oracle on organic text too.
+    let corp = corpus();
+    let r = build_infino_superfile_positional(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    for query in [
+        r#""rust async""#,
+        r#""web framework""#,
+        r#""search engine" rust"#,
+        r#"+"inverted index""#,
+    ] {
+        assert_matches_oracle(&r, &oracle, query, BoolMode::Or, K_ALL).await;
+    }
+}
+
+// ── multi-block corpus (positions cross skip boundaries) ─────────────
+
+#[tokio::test]
+async fn phrase_oracle_agreement_multi_block() {
+    // "alpha beta" is adjacent in every doc divisible by 12 (~83
+    // docs), with alpha spanning 3 PFOR blocks — the per-block run
+    // offsets and the block-crossing position decode are all
+    // exercised, as is a phrase should over a large union.
+    let owned = build_multi_block_corpus();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile_positional(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+    for query in [
+        r#""alpha beta""#,
+        r#""alpha beta gamma""#,
+        r#"+"alpha beta" epsilon"#,
+        r#"delta -"alpha beta""#,
+        r#""beta gamma" "gamma delta""#,
+    ] {
+        assert_matches_oracle(&r, &oracle, query, BoolMode::Or, K_ALL_MULTI_BLOCK).await;
+    }
+    // Truncated top-k exercises the atom walk's pruning bar.
+    assert_matches_oracle(&r, &oracle, r#""alpha beta" gamma"#, BoolMode::Or, 10).await;
+}

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -293,4 +293,3 @@ async fn unranked_ids_and_count_agree_with_oracle() {
         }
     }
 }
-

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -203,3 +203,94 @@ async fn phrase_oracle_agreement_multi_block() {
     // Truncated top-k exercises the atom walk's pruning bar.
     assert_matches_oracle(&r, &oracle, r#""alpha beta" gamma"#, BoolMode::Or, 10).await;
 }
+
+#[tokio::test]
+async fn truncated_top_k_pruning_agrees_with_oracle() {
+    // Every query shape whose ranked walk can skip phrase
+    // verification once the heap fills — a small k keeps the bar live
+    // for most of the walk, so a pruning bug (skipping a doc that
+    // belongs in the top k, or scoring a skipped doc) diverges from
+    // the oracle. Shapes cover the three prune sites: the union
+    // advance (bare phrase, alone and beside other atoms), the
+    // must-driven leapfrog (phrase musts), and the should drag
+    // (phrase should landing on must-matched docs).
+    let owned = build_multi_block_corpus();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile_positional(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+    for query in [
+        r#""alpha beta""#,
+        r#"+"alpha beta""#,
+        r#"+"alpha beta" +delta"#,
+        r#"+delta "alpha beta""#,
+        r#""alpha beta" "gamma delta""#,
+        r#""alpha beta" epsilon -"gamma delta""#,
+    ] {
+        for k in [3, 10] {
+            assert_matches_oracle(&r, &oracle, query, BoolMode::Or, k).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn unranked_ids_and_count_agree_with_oracle() {
+    // The unranked walk (`token_match` / `count`) is a separate spine
+    // from ranked search and must never prune: every verified match
+    // counts. Pin its ids and count against the oracle's full match
+    // set for both combination modes.
+    let owned = build_multi_block_corpus();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile_positional(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+
+    let alpha_beta = || vec![vec!["alpha".to_string(), "beta".to_string()]];
+    let shapes: Vec<(Vec<&str>, Vec<Vec<String>>)> = vec![
+        (vec![], alpha_beta()),
+        (vec!["gamma"], alpha_beta()),
+        (
+            vec![],
+            vec![
+                vec!["alpha".to_string(), "beta".to_string()],
+                vec!["gamma".to_string(), "delta".to_string()],
+            ],
+        ),
+    ];
+    for (terms, phrases) in shapes {
+        for mode in [BoolMode::And, BoolMode::Or] {
+            let owned_terms: Vec<String> = terms.iter().map(|t| t.to_string()).collect();
+            // Under And the atoms are all musts; under Or all shoulds.
+            let (musts, must_ph, shoulds, should_ph) = match mode {
+                BoolMode::And => (owned_terms.clone(), phrases.clone(), vec![], vec![]),
+                BoolMode::Or => (vec![], vec![], owned_terms.clone(), phrases.clone()),
+            };
+            let want: HashSet<u64> = oracle
+                .top_k_atoms(&musts, &must_ph, &shoulds, &should_ph, &[], &[], refs.len())
+                .into_iter()
+                .map(|(d, _)| d)
+                .collect();
+
+            let ids = r
+                .atoms_match_ids("title", &terms, &phrases, mode)
+                .await
+                .expect("atoms_match_ids");
+            let got: HashSet<u64> = ids.into_iter().map(u64::from).collect();
+            assert_eq!(
+                got, want,
+                "unranked ids disagree ({terms:?} + {phrases:?}, {mode:?})"
+            );
+
+            let count = r
+                .atoms_match_count("title", &terms, &phrases, mode)
+                .await
+                .expect("atoms_match_count");
+            assert_eq!(
+                count as usize,
+                want.len(),
+                "unranked count disagrees ({terms:?} + {phrases:?}, {mode:?})"
+            );
+        }
+    }
+}
+

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -161,6 +161,38 @@ async fn three_token_phrase_and_absent_member() {
 }
 
 #[tokio::test]
+async fn dropped_token_leaves_a_phrase_gap() {
+    // The default tokenizer drops runs containing non-ASCII bytes.
+    // A dropped run must still leave a position gap, or the tokens on
+    // either side of it would look adjacent and a phrase would match
+    // text that isn't contiguous.
+    let corp = vec![
+        (0u64, "new york"),          // genuinely adjacent → must match
+        (1, "new café york"),        // dropped word between → must NOT match
+        (2, "café new york"),        // dropped word before the phrase → matches
+        (3, "new york café"),        // dropped word after the phrase → matches
+        (4, "new naïve fresh york"), // dropped word + real word between → no match
+    ];
+    let r = build_infino_superfile_positional(&corp);
+    let hits = search_hits(&r, r#""new york""#, K_ALL, BoolMode::Or).await;
+    let mut ids: Vec<u64> = hits.iter().map(|(d, _)| *d).collect();
+    ids.sort_unstable();
+    assert_eq!(
+        ids,
+        vec![0, 2, 3],
+        "phrase must span a dropped token as a gap, not treat its neighbours as adjacent"
+    );
+
+    // The single dropped-word doc is not merely absent because `york`
+    // is missing — `york` alone still matches doc 1.
+    let york = search_hits(&r, "york", K_ALL, BoolMode::Or).await;
+    assert!(
+        york.iter().any(|(d, _)| *d == 1),
+        "doc 1 still contains the term `york`"
+    );
+}
+
+#[tokio::test]
 async fn single_and_repeated_words_on_sixty_doc_corpus() {
     // The negation-suite corpus, positional: phrase behavior must
     // agree with the oracle on organic text too.

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -205,6 +205,53 @@ async fn phrase_oracle_agreement_multi_block() {
 }
 
 #[tokio::test]
+async fn phrase_block_crossing_rejection() {
+    // The block-crossing offset logic must reject as well as accept.
+    // `epsilon` fires every 20th doc, and 20 is a multiple of both 4
+    // and 5, so `beta` and `gamma` are ALWAYS planted between `alpha`
+    // and `epsilon`. The pair therefore co-occurs at every 60th doc —
+    // 17 docs spanning all three of `alpha`'s posting blocks — yet is
+    // never adjacent, so `"alpha epsilon"` must match nothing. This
+    // drives the per-block run-offset rebuild across block boundaries
+    // on a genuine rejection, not just on docs that match.
+    let owned = build_multi_block_corpus();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile_positional(&refs);
+
+    let phrase = search_hits(&r, r#""alpha epsilon""#, K_ALL_MULTI_BLOCK, BoolMode::Or).await;
+    assert!(
+        phrase.is_empty(),
+        "alpha and epsilon co-occur but are never adjacent — phrase must not match: {phrase:?}"
+    );
+    // Guard the guard: the members really do co-occur (across blocks),
+    // so the empty phrase result is a rejection, not an empty
+    // intersection. Term-AND matches the 17 multiples of 60.
+    let both = search_hits(&r, "+alpha +epsilon", K_ALL_MULTI_BLOCK, BoolMode::Or).await;
+    assert_eq!(
+        both.len(),
+        17,
+        "alpha ∧ epsilon co-occur at every 60th doc: {}",
+        both.len()
+    );
+
+    // `"alpha gamma"` is the mixed case across blocks: adjacent (and
+    // matching) only where `beta` is absent between them — docs
+    // divisible by 15 but not 4 — and rejected elsewhere. Pinning it
+    // against the oracle checks the offset logic accepts exactly the
+    // true-adjacent occurrences and rejects the rest.
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+    assert_matches_oracle(
+        &r,
+        &oracle,
+        r#""alpha gamma""#,
+        BoolMode::Or,
+        K_ALL_MULTI_BLOCK,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn truncated_top_k_pruning_agrees_with_oracle() {
     // Every query shape whose ranked walk can skip phrase
     // verification once the heap fills — a small k keeps the bar live

--- a/tests/superfile/fts/pipeline.rs
+++ b/tests/superfile/fts/pipeline.rs
@@ -37,8 +37,12 @@ const BMW_SCORE_TOLERANCE: f32 = 1e-5;
 fn build_with_two_columns() -> (Bytes, String) {
     let tok = default_tokenizer();
     let mut b = FtsBuilder::new(tok);
-    let _ = b.register_column("title".into()).expect("register column");
-    let _ = b.register_column("body".into()).expect("register column");
+    let _ = b
+        .register_column("title".into(), false)
+        .expect("register column");
+    let _ = b
+        .register_column("body".into(), false)
+        .expect("register column");
 
     // Doc 0: title="rust runtime", body="tokio fast async"
     b.add_doc(0, 0, "rust runtime").expect("add doc");
@@ -232,7 +236,8 @@ async fn bmw_single_term_matches_brute_force() {
     use infino::superfile::fts::reader::BoolMode;
 
     let mut b = FtsBuilder::new(default_tokenizer());
-    b.register_column("body".into()).expect("register column");
+    b.register_column("body".into(), false)
+        .expect("register column");
 
     // Build ~500 docs with the term "foo" appearing in every other doc
     // with varying tfs (1..=8) — produces multiple posting blocks, plenty

--- a/tests/superfile/fts/uses_spill_builder.rs
+++ b/tests/superfile/fts/uses_spill_builder.rs
@@ -68,9 +68,11 @@ fn build_test_superfile() -> Bytes {
         vec![
             FtsConfig {
                 column: "title".into(),
+                positions: false,
             },
             FtsConfig {
                 column: "body".into(),
+                positions: false,
             },
         ],
         Vec::new(),

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -76,9 +76,11 @@ fn build_pipeline_superfile() -> Bytes {
         vec![
             FtsConfig {
                 column: "title".into(),
+                positions: false,
             },
             FtsConfig {
                 column: "body".into(),
+                positions: false,
             },
         ],
         vec![SfVectorConfig {
@@ -280,6 +282,7 @@ async fn end_to_end_fts_only_blob_offsets_within_file() {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -322,6 +325,7 @@ async fn end_to_end_three_batches_doc_ids_continuous() {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -379,9 +383,11 @@ fn add_batch_from_reader_mergeability_compatible_superfiles() {
         vec![
             FtsConfig {
                 column: "title".into(),
+                positions: false,
             },
             FtsConfig {
                 column: "body".into(),
+                positions: false,
             },
         ],
         vec![SfVectorConfig {
@@ -502,6 +508,7 @@ fn add_batch_from_reader_mergeability_fts_column_count_mismatch() {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -533,9 +540,11 @@ fn add_batch_from_reader_mergeability_fts_column_count_mismatch() {
         vec![
             FtsConfig {
                 column: "title".into(),
+                positions: false,
             },
             FtsConfig {
                 column: "body".into(),
+                positions: false,
             },
         ],
         vec![],
@@ -559,6 +568,7 @@ fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
         "doc_id",
         vec![FtsConfig {
             column: "body".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -589,6 +599,7 @@ fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -866,6 +877,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_fts() {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -900,6 +912,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_fts() {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -1159,6 +1172,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![SfVectorConfig {
             column: "emb".into(),
@@ -1209,6 +1223,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![SfVectorConfig {
             column: "emb".into(),

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -252,6 +252,7 @@ fn open_rejects_mismatched_options_via_options_hash() {
         other_schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(tk),

--- a/tests/supertable/commit/partition_assignment.rs
+++ b/tests/supertable/commit/partition_assignment.rs
@@ -277,6 +277,7 @@ fn time_range_assigns_int64_superfiles_to_bucket_zero() {
         schema.clone(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(tk),
@@ -354,6 +355,7 @@ fn time_range_superfile_spanning_two_buckets_errors() {
         schema.clone(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(tk),

--- a/tests/supertable/disk_cache/basic.rs
+++ b/tests/supertable/disk_cache/basic.rs
@@ -151,6 +151,7 @@ fn build_test_superfile_bytes() -> Bytes {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/disk_cache/hybrid.rs
+++ b/tests/supertable/disk_cache/hybrid.rs
@@ -143,6 +143,7 @@ fn build_test_bytes() -> Bytes {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/disk_cache/lazy_foreground.rs
+++ b/tests/supertable/disk_cache/lazy_foreground.rs
@@ -162,6 +162,7 @@ fn build_fts_only_bytes() -> Bytes {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/disk_cache/sweep.rs
+++ b/tests/supertable/disk_cache/sweep.rs
@@ -81,6 +81,7 @@ fn build_test_bytes() -> Bytes {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -153,6 +153,7 @@ fn build_supertable(corpus: &[(u64, String)], n_superfiles: usize) -> Supertable
         schema_id_title(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(tk),

--- a/tests/supertable/query/fanout_concurrency.rs
+++ b/tests/supertable/query/fanout_concurrency.rs
@@ -102,6 +102,7 @@ fn options_title_emb() -> SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/fanout_floor.rs
+++ b/tests/supertable/query/fanout_floor.rs
@@ -117,6 +117,7 @@ fn options_title_only() -> SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -228,6 +229,7 @@ fn build_one_superfile() -> SuperfileReader {
         "doc_id",
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -562,6 +562,7 @@ fn tag_options() -> SupertableOptions {
         tag_schema(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/query/hybrid_search.rs
+++ b/tests/supertable/query/hybrid_search.rs
@@ -70,6 +70,7 @@ fn options_title_emb() -> SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/id_resolve.rs
+++ b/tests/supertable/query/id_resolve.rs
@@ -54,6 +54,7 @@ fn options_title_only() -> SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -100,6 +100,7 @@ fn options_title_emb() -> SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/query_errors.rs
+++ b/tests/supertable/query/query_errors.rs
@@ -62,6 +62,7 @@ fn options_title_rating_emb() -> SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/query_surface.rs
+++ b/tests/supertable/query/query_surface.rs
@@ -60,6 +60,7 @@ fn options_title_rating_emb() -> SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -127,6 +127,7 @@ fn options_with_counting_store(store: Arc<CountingStore>) -> SupertableOptions {
         schema_id_title(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![],
         Some(tk),

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -288,6 +288,7 @@ async fn vector_query_excludes_tombstoned_row() {
         schema_with_vec(),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![default_vector_config("embedding", VECTOR_ROT_SEED)],
         Some(tk),
@@ -475,6 +476,7 @@ async fn vector_query_backfills_across_superfiles_after_deletes() {
             schema(),
             vec![FtsConfig {
                 column: "title".into(),
+                positions: false,
             }],
             vec![default_vector_config("embedding", VECTOR_ROT_SEED)],
             Some(tk),

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -209,6 +209,7 @@ fn options_title_emb() -> SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![VectorConfig {
             column: "emb".into(),

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -105,6 +105,7 @@ fn real_azure_options(dim: usize) -> infino::supertable::SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![VectorConfig {
             column: "emb".into(),

--- a/tests/supertable/storage/smoke_gcs.rs
+++ b/tests/supertable/storage/smoke_gcs.rs
@@ -78,6 +78,7 @@ fn gcs_options(dim: usize) -> SupertableOptions {
         unified_schema(dim),
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![VectorConfig {
             column: "emb".into(),

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -203,6 +203,7 @@ fn real_s3_options(dim: usize) -> infino::supertable::SupertableOptions {
         schema,
         vec![FtsConfig {
             column: "title".into(),
+            positions: false,
         }],
         vec![VectorConfig {
             column: "emb".into(),


### PR DESCRIPTION
Adds opt-in token positions to the full-text index and makes double-quoted exact phrases first-class query atoms in `bm25_search`, `token_match`, and `count`.

## What

- **Positions are a per-column opt-in** (`FtsConfig { positions: true }`, default off). A positional column stores, per (term, doc), the token ordinals as delta-encoded varint runs in a dedicated, CRC-guarded region addressed from the term dictionary — a query fetches only the runs it touches. Positions roughly double a column's FTS footprint, which is why they're opt-in.
- **Quoted phrases are query atoms** under the existing flat clause model: any polarity works (`"new york" hotel`, `+"new york" +hotel`, `-"memory unsafe"`). A phrase scores as one BM25 atom — `tf` = verified occurrences, `idf` = Σ member idf. A single-word phrase degrades to that term.
- **No silent fallback**: a phrase against a positionless column is a typed error (`PositionsUnavailable`), never a bag-of-words approximation. No public signatures change — the feature rides in the query string and the build config.
- **Counts are exact**: the count path verifies adjacency for every candidate.

## Format

The FTS blob header grows 48 → 56 bytes (version 2) and records the positions-region offset; the region is empty for positionless columns. New code always writes v2 and reads v1; term metadata for positional columns carries the run offset/length (32 bytes vs 20), skip entries address the per-block first run, and a df=1 tf=1 term packs its single position into the existing inline-value fast path. Cold-open GET count is unchanged.

## Query path

Phrase-bearing queries route to heterogeneous atom walks (term + phrase cursors); term-only queries keep the existing optimized kernels byte-for-byte. A phrase cursor leapfrogs its member postings and verifies adjacency via per-block run-offset caches with binary-search probes. Ranked walks hand each atom a pruning bar (kth-best minus the other atoms' score bounds): since a phrase's tf can't exceed any member's tf, candidates whose min-member-tf bound falls below the bar skip position work entirely. That pruning is what makes dense phrases ("secretary of state") competitive: verification only runs for candidates that can still change the top-k.

## Performance

External: the full 962-query standard suite (5M-doc Wikipedia corpus, c7i.2xlarge) on [search-benchmark-game](https://github.com/infino-ai/search-benchmark-game). All 962 queries are now answered — including the 300 phrase queries previously reported UNSUPPORTED — and every phrase count was verified exact, query by query.

Phrase-tag latency (mean / median of per-query best, ms):

| mode | latency |
|---|---|
| TOP_10 | 1.41 / 0.54 |
| COUNT | 1.78 / 0.43 |
| TOP_100 | 1.91 / 0.84 |
| TOP_1000 | 2.44 / 1.02 |
| TOP_100_COUNT | 3.74 / 1.26 (†) |

(†) That mode issues a full top-k search *plus* a separate exhaustive count (3.74 ≈ 1.91 + 1.78); a count-while-ranking walk is a natural follow-up.

Non-phrase tags are unregressed vs current main — term/intersection/union deltas within cross-run noise in every mode (e.g. TOP_10 global mean 0.52 vs 0.51 ms; COUNT intersection 0.29 vs 0.27 ms).

### Internal A/B (branch vs `main`, same host)

Azure A/B runs (Standard_D8s_v7, 1M docs, both arms built and run on one VM) plus a local three-arm A/B at the same scale:

- **Warm/count queries, supertable tier**: every non-phrase row within the ±5% noise threshold (best: `twenty_term_or` p90 −5%). Phrase rows land as new cells (e.g. `phrase_two_mixed` warm min 1.55 ms across 112 segments).
- **Warm queries, superfile tier**: an early A/B caught a real regression — multi-term OR shapes +6–9%, scaling with term count — traced to the positional fields having grown the two structures the OR kernels iterate hottest (`BlockMeta` 24→32 bytes, `TermCursor` +3 fields). Fixed by moving all positional state onto the phrase members, which re-derive it from the term's own bytes; `BlockMeta`/`TermCursor` are back to their pre-positions layout.
- **Re-verification after the fix** (same A/B rig): every non-phrase FTS query row is back under the ±5% gate — `three_similar_or` +2.3%, `five_term_or` +2.1%, `ten_term_or` +0.6%, `twenty_term_or` +3.6%, `forty_term_or` +3.9% (from +6–9% before the fix), with AND rows within noise. The small remaining drift tracks a codegen/layout shift, not a code path: the term-only kernels are source-identical to main, yet the BMM kernel's machine code moved +128 bytes on a 6.6 KB symbol under `codegen-units = 1`. The real-corpus check agrees: non-phrase tags on the external suite are flat vs main in all five modes.
- **Positional build cost (opt-in, per column)**: enabling positions costs roughly +50–70% index build time and +39% stored bytes — positions add about as many encoded bytes as the postings themselves. Positionless columns are unaffected: the default build produces byte-identical output (606.55 MiB at 1M docs) in the same time as main. The superfile bench now reports both configs as separate rows — the historical `1 writer` / `N writers` rows keep measuring the default build (and compare clean vs main on the A/B rig), while new `(positions)` rows track the opt-in cost explicitly.
- **Final A/B state**: no FTS row is flagged by the ±5% gate. The single remaining flag in the last run (`token_match (all rows)` p90 +9%) is run-to-run variance — the library code was identical to the preceding run, where that row was unflagged.

## Tests

- Phrase semantics suite against a brute-force BM25 phrase oracle (set + score agreement), including boundary, wrong-order, non-adjacent, overlapping-occurrence, and multi-block corpora.
- Truncated top-k oracle agreement for every pruning site of the ranked atom walk (bare-phrase union, phrase musts, should drag, multi-phrase union, negated phrase), and ids/count parity of the unranked walk against the oracle's full match set in both combination modes. These caught a pre-existing top-k bug on main — on score ties at the kth-best boundary the heap evicted the smaller doc id, opposite to the documented tie-break — fixed here with the tests as its regression guard.
- Positional build/read round-trips for both the in-RAM and spilled builder paths; a synthesized v1 blob read by new code; positions-region CRC corruption rejected; lazy (range-read) open of a positional blob.
- Parser coverage for quoted runs with all sigil combinations, unbalanced quotes, and single-token degradation.
- End-to-end supertable tests: phrase search/count across segments, and the typed error on a positionless column.
