### PR TITLE
ci(bench): gate on repo owner instead of an exact repo name

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   bench:
     # Skip on forks (no Azure secrets); fork PRs into upstream still run.
-    if: github.repository == 'infino-ai/infino'
+    if: github.repository_owner == 'infino-ai'
     strategy:
       fail-fast: false # one member failing must not cancel the other
       matrix:


### PR DESCRIPTION
The bench job's guard was pinned to one exact repo path. Its purpose is to keep the job out of forks — they lack the Azure secrets, and `pull_request_target` + secrets must not run in an untrusted fork. Ownership is the actual trust boundary: a fork is always owned by the forker, never by `infino-ai`, so gate on `github.repository_owner`.

**No behavior change** for the canonical repo or for fork PRs into upstream (which still run in the base context; `is_fork_pr` continues to flag them). Personal/org forks stay excluded because their owner isn't `infino-ai`.