### PR TITLE
ci(bench): don't route push-to-main bench into the approval-gated env

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -67,5 +67,8 @@ jobs:
       name_suffix: -${{ matrix.suffix }}
       pr_number: ${{ github.event.pull_request.number }}
       # Fork PR ⇒ gate on maintainer approval before secrets are exposed.
-      is_fork_pr: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+      # Guard on the event: a push has no pull_request context, so the bare
+      # inequality would treat every push as a fork and route it to the
+      # approval-gated environment, leaving baseline runs stuck awaiting review.
+      is_fork_pr: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets: inherit


### PR DESCRIPTION
## Problem

Push-to-main runs of the **Benchmark** workflow have been piling up in `waiting` status — some for over a week — instead of running. These are the baseline-refresh runs that the informational bench compares PRs against, so a stale/blocked baseline undermines every PR's A/B comparison.

## Root cause

The reusable Azure bench workflow selects its deployment environment from `is_fork_pr`:

```yaml
environment: ${{ inputs.is_fork_pr && 'bench' || 'ci' }}
```

`bench` requires maintainer approval (a `required_reviewers` rule); `ci` has no protection. In `bench.yml`, `is_fork_pr` was:

```yaml
is_fork_pr: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
```

On a `push` event there is no `pull_request` object, so `github.event.pull_request.head.repo.full_name` is empty and the comparison `'' != 'infino-ai/infino'` is always **true**. Every push-to-main run was therefore misclassified as a fork PR and routed into the approval-gated `bench` environment, where it waited forever — nobody approves a baseline refresh.

## Fix

Guard the flag on the event name so it only evaluates for actual PR events:

```yaml
is_fork_pr: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
```

- **Push to main** → `false` → `ci` environment → runs automatically (baseline refreshes again).
- **Fork PR into upstream** → still `true` → `bench` environment → approval gate preserved.
- **Same-repo PR** → unchanged (already `false` → `ci`).

No behavior change for either PR path; only the push path is corrected.

## Note

The ~10 push-to-main runs already parked in `waiting` won't self-heal — they'll need to be cancelled (or approved) separately; this only fixes future runs.