### PR TITLE
fts: byte-quantize the per-doc length-norm table (4x smaller)

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -406,6 +406,16 @@ pub mod fts {
             terms: &["term00001", "term00050"],
             mode: BoolMode::And,
         },
+        // Small intersection: two mid-rare terms whose overlap is well
+        // under a top-1000 request, so the top-k heap never fills and
+        // the block-max-AND skip cannot fire — every match is scored.
+        // Isolates the raw score-and-collect cost that the large
+        // `two_term_and` overlap hides behind pruning.
+        FtsQuery {
+            name: "two_term_and_small",
+            terms: &["term00500", "term01000"],
+            mode: BoolMode::And,
+        },
         FtsQuery {
             name: "three_wide_and",
             terms: &["term00001", "term00050", "term00100"],

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -185,6 +185,7 @@ pub mod fts {
         "two_term_or",
         "ten_term_or",
         "two_term_and",
+        "two_term_and_small",
     ];
     /// Large-union shapes that exist only to stress the multi-term count
     /// path. Excluded from the cold object-store search tier, where their

--- a/src/superfile/fts/bm25.rs
+++ b/src/superfile/fts/bm25.rs
@@ -40,6 +40,58 @@ const IDF_SMOOTHING: f64 = 0.5;
 /// windowed-union path scores this many docs from one cursor.
 pub(super) const SCORE_SIMD_LANES: usize = 4;
 
+/// Document lengths below this are quantized to one byte with no loss;
+/// at or above it, an 8-bit floating representation kicks in. Equal to
+/// `2^(LEN_QUANT_MANTISSA_BITS + 1)` so the exact region and the
+/// float region join without a monotonicity gap.
+const LEN_QUANT_EXACT_MAX: u32 = 1 << (LEN_QUANT_MANTISSA_BITS + 1);
+
+/// Mantissa bits kept when a length is quantized into the float region.
+/// Three mantissa bits (plus the implicit leading 1) cap the decoded
+/// length's relative error at `2^-MANTISSA_BITS` = 12.5% (the codec
+/// truncates rather than rounds, which is what makes it idempotent) —
+/// and BM25 only feels a fraction of that, since the length enters the
+/// norm as `1 - b + b·dl/avgdl` (the `1 - b` term carries no error). In
+/// exchange the resident length-norm table shrinks 4× (one byte per doc
+/// instead of an `f32`), which is what keeps it cache-resident at scale.
+const LEN_QUANT_MANTISSA_BITS: u32 = 3;
+
+/// Quantize a document length into one byte via an 8-bit float:
+/// lengths `< LEN_QUANT_EXACT_MAX` are stored exactly; larger lengths
+/// keep the top `LEN_QUANT_MANTISSA_BITS` bits below the leading 1 plus
+/// an exponent. Monotonic non-decreasing in `len`, so it never reorders
+/// two docs whose true lengths differ by more than one bucket. Inverse
+/// of [`dequantize_len`].
+#[inline]
+pub(super) fn quantize_len(len: u32) -> u8 {
+    if len < LEN_QUANT_EXACT_MAX {
+        len as u8
+    } else {
+        // floor(log2 len); len >= LEN_QUANT_EXACT_MAX >= 8 ⇒ bits >= 3.
+        let bits = u32::BITS - 1 - len.leading_zeros();
+        let mantissa = (len >> (bits - LEN_QUANT_MANTISSA_BITS)) & 0x07;
+        // Exponent field is offset by 1 so the smallest float-region
+        // code sits just above the exact region (no gap, stays monotone).
+        let exponent = bits - LEN_QUANT_MANTISSA_BITS + 1;
+        ((exponent << LEN_QUANT_MANTISSA_BITS) | mantissa) as u8
+    }
+}
+
+/// Decode a byte produced by [`quantize_len`] back to a representative
+/// document length. The result is the exact length for small docs and a
+/// bucket representative (within ~6.25%) for larger ones.
+#[inline]
+pub(super) fn dequantize_len(b: u8) -> u32 {
+    let i = b as u32;
+    if i < LEN_QUANT_EXACT_MAX {
+        i
+    } else {
+        let mantissa = i & 0x07;
+        let exponent = (i >> LEN_QUANT_MANTISSA_BITS) - 1;
+        (mantissa | 0x08) << exponent
+    }
+}
+
 /// BM25 inverse-document-frequency. Plus-half smoothing keeps the log
 /// argument ≥ 1, so `idf(N, df) >= 0` for all valid `(N, df)`.
 ///
@@ -366,6 +418,60 @@ mod tests {
                 approx(simd[lane], scalar, 1e-6),
                 "lane {lane}: simd={} scalar={scalar}",
                 simd[lane]
+            );
+        }
+    }
+
+    // --- length quantization --------------------------------------------
+
+    #[test]
+    fn len_quant_is_exact_below_threshold() {
+        // Small documents (the common case) round-trip with zero error.
+        for len in 0..LEN_QUANT_EXACT_MAX {
+            let b = quantize_len(len);
+            assert_eq!(dequantize_len(b), len, "len {len} not exact");
+        }
+    }
+
+    #[test]
+    fn len_quant_is_monotonic_non_decreasing() {
+        // A larger true length never encodes to a smaller byte, so
+        // quantization can't invert the length ordering of two docs.
+        let mut prev = 0u8;
+        for len in 0..100_000u32 {
+            let b = quantize_len(len);
+            assert!(b >= prev, "len {len}: byte {b} < previous {prev}");
+            prev = b;
+        }
+    }
+
+    #[test]
+    fn len_quant_round_trip_relative_error_is_bounded() {
+        // Truncating codec: decoded length is within 2^-MANTISSA_BITS
+        // (12.5% at 3 mantissa bits) of the input, always rounding down.
+        let max_rel = 2f64.powi(-(LEN_QUANT_MANTISSA_BITS as i32));
+        for len in LEN_QUANT_EXACT_MAX..1_000_000u32 {
+            let decoded = dequantize_len(quantize_len(len));
+            let rel = (len as f64 - decoded as f64).abs() / len as f64;
+            assert!(
+                rel <= max_rel,
+                "len {len}: decoded {decoded}, rel err {rel} > {max_rel}"
+            );
+        }
+    }
+
+    #[test]
+    fn len_quant_is_idempotent_over_realistic_lengths() {
+        // Decoding a quantized length and re-quantizing it yields the
+        // same byte — the byte↔length map is stable, so a doc's bucket
+        // never drifts across rebuilds. (Checked over lengths a real
+        // corpus can produce; bytes no length maps to are irrelevant.)
+        for len in 0..2_000_000u32 {
+            let b = quantize_len(len);
+            assert_eq!(
+                quantize_len(dequantize_len(b)),
+                b,
+                "len {len} → byte {b} not idempotent"
             );
         }
     }

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -225,6 +225,75 @@ fn two_term_has_rare_anchor(cursors: &[TermCursor]) -> bool {
     lo > 0 && hi >= lo.saturating_mul(WAND_BMW_2TERM_DF_RATIO)
 }
 
+/// Per-doc BM25 length normalizer, quantized to one byte per doc.
+///
+/// The scorer needs `dl_norm_k1[doc] = K1·(1 - B + B·dl/avgdl)` for
+/// every scored doc. Held as an `f32` per doc, that table is 4 bytes ×
+/// n_docs — at multi-million-doc scale too large to stay cache-resident,
+/// so each scored doc pays a scattered load from a table that overflows
+/// cache. Instead the doc length is quantized to one byte
+/// ([`bm25::quantize_len`]) and a 256-entry table decodes each bucket to
+/// its norm value: the per-doc table is 4× smaller (one byte), and the
+/// decode table is 1 KiB (L1-resident). A scored doc reads
+/// `lut[bytes[doc]]` — one load from the small per-doc table plus one L1
+/// lookup — instead of one load from a 4×-larger table.
+#[derive(Debug, Clone)]
+pub struct NormTable {
+    /// Per-doc quantized length bucket. Empty for a column with no docs.
+    bytes: Vec<u8>,
+    /// Bucket → `K1·(1 - B + B·dequantize_len(bucket)/avgdl)`. 256
+    /// entries; empty when the column is empty.
+    lut: Vec<f32>,
+}
+
+impl NormTable {
+    /// Build from a column's per-doc lengths and average length. An
+    /// `avgdl` of `0.0` (empty column) yields an empty table; it is
+    /// never indexed because `search` short-circuits on empty columns.
+    fn new(doc_lengths: impl Iterator<Item = u32>, n_docs: usize, avgdl: f32) -> Self {
+        if avgdl <= 0.0 {
+            return Self {
+                bytes: Vec::new(),
+                lut: Vec::new(),
+            };
+        }
+        let inv_avgdl = 1.0_f32 / avgdl;
+        let lut: Vec<f32> = (0..=u8::MAX)
+            .map(|b| {
+                let dl = bm25::dequantize_len(b) as f32;
+                bm25::K1 * (1.0 - bm25::B + bm25::B * dl * inv_avgdl)
+            })
+            .collect();
+        let mut bytes = Vec::with_capacity(n_docs);
+        for dl in doc_lengths {
+            bytes.push(bm25::quantize_len(dl));
+        }
+        Self { bytes, lut }
+    }
+
+    /// `dl_norm_k1` for a doc (length quantized): one per-doc byte load
+    /// plus one L1 decode-table lookup. Hot path — keep it inlined.
+    #[inline(always)]
+    fn get(&self, doc: u32) -> f32 {
+        self.lut[self.bytes[doc as usize] as usize]
+    }
+
+    /// Number of docs in the table.
+    fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// An empty table (no allocation). For call sites that need a
+    /// `&NormTable` but provably never index it — an unranked
+    /// (`bar == NEG_INFINITY`) phrase seek, which does no scoring.
+    fn empty() -> Self {
+        Self {
+            bytes: Vec::new(),
+            lut: Vec::new(),
+        }
+    }
+}
+
 /// Per-column metadata, indexed by column_id (declaration order).
 #[derive(Debug, Clone)]
 pub struct ColumnMeta {
@@ -235,13 +304,12 @@ pub struct ColumnMeta {
     /// Average doc length across this column. `0.0` if the column has
     /// no docs.
     pub avgdl: f32,
-    /// Precomputed BM25 denominator constant per doc:
-    /// `dl_norm_k1[d] = K1 * (1 - B + B * dl[d] / avgdl)`. The hot
-    /// scoring loop multiplies-out to `idf * tf * (K1+1) / (tf +
-    /// dl_norm_k1[d])`, so each scoring call shaves a load + mul +
-    /// add + mul vs recomputing on the fly. Computed once per
-    /// reader at `open` time.
-    pub dl_norm_k1: Vec<f32>,
+    /// Per-doc BM25 length normalizer, byte-quantized — see
+    /// [`NormTable`]. Computed once per reader at `open` time from the
+    /// column's on-disk doc-lengths array. The hot scoring loop reads
+    /// `dl_norm_k1.get(d)` and multiplies-out to `idf · tf · (K1+1) /
+    /// (tf + dl_norm_k1.get(d))`.
+    pub dl_norm_k1: NormTable,
     /// Whether this column's index carries token positions (from
     /// `inf.fts.columns`); phrase queries require it.
     pub positions: bool,
@@ -685,19 +753,15 @@ impl FtsReader {
             }
 
             let avgdl = (avgdl_x1000 as f32) / format::fts::AVGDL_FIXED_POINT_SCALE;
-            // Precompute per-doc length normalizer:
-            //   dl_norm_k1[d] = K1 * (1 - B + B * dl[d] / avgdl)
-            // For avgdl == 0 (empty column) leave the table empty;
-            // it'll never be indexed since `search` short-circuits.
-            let mut dl_norm_k1 = Vec::with_capacity(n_docs as usize);
-            if avgdl > 0.0 {
-                let inv_avgdl = 1.0_f32 / avgdl;
-                for d in 0..(n_docs as usize) {
-                    let dl = read_u32_le(&array_region[d * 4..d * 4 + 4]) as f32;
-                    let norm = 1.0 - bm25::B + bm25::B * dl * inv_avgdl;
-                    dl_norm_k1.push(bm25::K1 * norm);
-                }
-            }
+            // Per-doc length normalizer, byte-quantized (see `NormTable`).
+            // For avgdl == 0 (empty column) this is an empty table; it'll
+            // never be indexed since `search` short-circuits.
+            let n = n_docs as usize;
+            let dl_norm_k1 = NormTable::new(
+                (0..n).map(|d| read_u32_le(&array_region[d * 4..d * 4 + 4])),
+                n,
+                avgdl,
+            );
             columns.push(ColumnMeta {
                 name: col_cfg.name.clone(),
                 doc_lengths_range: doc_lengths_offset..array_end,
@@ -946,7 +1010,7 @@ impl FtsReader {
         mut filter: Option<AtomExcludeFilter>,
         floor_eff: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
-        let dl_norm_k1 = self.columns[column_id as usize].dl_norm_k1.as_slice();
+        let dl_norm_k1 = &self.columns[column_id as usize].dl_norm_k1;
         let initial_cap = k.min(self.n_docs as usize).max(1);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
 
@@ -977,7 +1041,7 @@ impl FtsReader {
                     None => true,
                 };
                 if admitted {
-                    let norm = dl_norm_k1[doc as usize];
+                    let norm = dl_norm_k1.get(doc);
                     let score: f32 = shoulds
                         .iter()
                         .filter(|a| !a.is_exhausted() && a.current_doc_id() == doc)
@@ -1056,7 +1120,7 @@ impl FtsReader {
                     None => true,
                 };
             if admitted {
-                let norm = dl_norm_k1[aligned as usize];
+                let norm = dl_norm_k1.get(aligned);
                 let mut score: f32 = musts.iter().map(|a| a.score_current(norm)).sum();
                 for (sh, &others) in shoulds.iter_mut().zip(&should_others_ub) {
                     sh.skip_to_pruned(aligned, bar - others, dl_norm_k1)?;
@@ -1723,7 +1787,7 @@ impl FtsReader {
                 {
                     return Ok(Vec::new());
                 }
-                let dl_norm_k1 = col_meta.dl_norm_k1[doc_id as usize];
+                let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
                 let score = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
                 if score <= floor_eff {
                     return Ok(Vec::new());
@@ -1752,7 +1816,7 @@ impl FtsReader {
 
         let idf_t = bm25::idf(self.n_docs as u64, term_meta.df);
         let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
 
         // Top-k min-heap; see `TopKEntry` for the reversed ordering
         // that makes `peek()` the current kth-best score.
@@ -1796,8 +1860,7 @@ impl FtsReader {
                     continue;
                 }
                 let tf = buf_t[j];
-                let score =
-                    bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1[doc_id as usize]);
+                let score = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1.get(doc_id));
                 // Floor gate: strictly-below-floor docs are dead to the
                 // caller; keeping them out also keeps the heap's min
                 // (the BMW skip bar) honest.
@@ -1882,7 +1945,7 @@ impl FtsReader {
                         true => 1,
                         false => tf,
                     };
-                    let dl_norm_k1 = col_meta.dl_norm_k1[doc_id as usize];
+                    let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
                     cursors.push(TermCursor::new_inline(
                         doc_id,
                         tf,
@@ -1939,7 +2002,7 @@ impl FtsReader {
         k: usize,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
         let col_meta = &self.columns[column_id as usize];
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
 
         // `search_multi` passes `k = usize::MAX` to gather every
         // matching doc before weighting across columns; cap initial
@@ -2071,7 +2134,7 @@ impl FtsReader {
             // beyond the prefix may also be at pivot_doc — they
             // contribute too). SIMD-pack up to 4 cursors per scoring
             // call.
-            let norm = dl_norm_k1[pivot_doc as usize];
+            let norm = dl_norm_k1.get(pivot_doc);
             let mut score: f32 = 0.0;
             let mut idfs = [0.0_f32; 4];
             let mut tfs = [0.0_f32; 4];
@@ -2197,7 +2260,7 @@ impl FtsReader {
             return Ok(Vec::new());
         }
         let col_meta = &self.columns[column_id as usize];
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
 
         // Smallest-df cursor at index 0 = leader. The remaining order
         // doesn't matter for correctness but ascending-df reduces the
@@ -2237,7 +2300,7 @@ impl FtsReader {
             "dispatch routes empty-side shapes to the AND/OR kernels"
         );
         let col_meta = &self.columns[column_id as usize];
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
         must_cursors.sort_by_key(|c| c.block_count());
 
         let initial_cap = k.min(self.n_docs as usize).max(1);
@@ -2268,7 +2331,7 @@ impl FtsReader {
             return Vec::new();
         }
         let col_meta = &self.columns[column_id as usize];
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
         cursors.sort_by_key(|c| c.block_count());
         let mut sink = CollectSink { out: Vec::new() };
         self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
@@ -2284,7 +2347,7 @@ impl FtsReader {
             return 0;
         }
         let col_meta = &self.columns[column_id as usize];
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
         cursors.sort_by_key(|c| c.block_count());
         let mut sink = CountSink { n: 0 };
         self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
@@ -2302,7 +2365,7 @@ impl FtsReader {
     fn and_flat_merge<S: AndSink>(
         &self,
         cursors: &mut [TermCursor],
-        dl_norm_k1: &[f32],
+        dl_norm_k1: &NormTable,
         sink: &mut S,
     ) {
         if cursors.len() == 2 {
@@ -2324,7 +2387,7 @@ impl FtsReader {
     fn and_flat_merge_general<S: AndSink>(
         &self,
         cursors: &mut [TermCursor],
-        dl_norm_k1: &[f32],
+        dl_norm_k1: &NormTable,
         sink: &mut S,
     ) {
         'outer: loop {
@@ -2426,7 +2489,7 @@ impl FtsReader {
                 }
                 if all_match {
                     let score = if sink.needs_score() {
-                        let norm = dl_norm_k1[a as usize];
+                        let norm = dl_norm_k1.get(a);
                         let mut score =
                             bm25::score_with_dl_norm_k1(c0.idf_x_k1p1, c0.block_tfs[i], norm);
                         for o in others.iter() {
@@ -2472,7 +2535,7 @@ impl FtsReader {
     fn and_flat_merge_2term<S: AndSink>(
         &self,
         cursors: &mut [TermCursor],
-        dl_norm_k1: &[f32],
+        dl_norm_k1: &NormTable,
         sink: &mut S,
     ) {
         debug_assert_eq!(cursors.len(), 2);
@@ -2547,7 +2610,7 @@ impl FtsReader {
                     j += 1;
                 } else {
                     let score = if sink.needs_score() {
-                        let norm = dl_norm_k1[a as usize];
+                        let norm = dl_norm_k1.get(a);
                         bm25::score_with_dl_norm_k1(c0_idf, c0.block_tfs[i], norm)
                             + bm25::score_with_dl_norm_k1(c1_idf, c1.block_tfs[j], norm)
                     } else {
@@ -2604,7 +2667,7 @@ impl FtsReader {
         floor_eff: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
         let col_meta = &self.columns[column_id as usize];
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
 
         // Sub-range seek: jump every cursor past any doc_id below
         // the lower bound. Cursors already past the bound stay where
@@ -2713,7 +2776,7 @@ impl FtsReader {
                         cursors[0].next();
                         continue;
                     }
-                    let norm = dl_norm_k1[candidate as usize];
+                    let norm = dl_norm_k1.get(candidate);
                     let essential_score = bm25::score_with_dl_norm_k1(
                         cursors[0].idf_x_k1p1,
                         cursors[0].current_tf(),
@@ -2852,7 +2915,7 @@ impl FtsReader {
                 // scoring has no early-bail; non-essential scoring below
                 // does, so it stays scalar to keep `score` always
                 // up-to-date for the bail check.)
-                let norm = dl_norm_k1[candidate as usize];
+                let norm = dl_norm_k1.get(candidate);
                 let mut score: f32 = 0.0;
                 let mut idfs = [0.0_f32; 4];
                 let mut tfs = [0.0_f32; 4];
@@ -2995,7 +3058,7 @@ impl FtsReader {
             return Ok(Vec::new());
         }
         let col_meta = &self.columns[column_id as usize];
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
 
         if doc_id_start > 0 {
             for c in &mut cursors {
@@ -3061,10 +3124,10 @@ impl FtsReader {
                                     c.block_tfs[pos + 3],
                                 ],
                                 [
-                                    dl_norm_k1[doc_ids[0] as usize],
-                                    dl_norm_k1[doc_ids[1] as usize],
-                                    dl_norm_k1[doc_ids[2] as usize],
-                                    dl_norm_k1[doc_ids[3] as usize],
+                                    dl_norm_k1.get(doc_ids[0]),
+                                    dl_norm_k1.get(doc_ids[1]),
+                                    dl_norm_k1.get(doc_ids[2]),
+                                    dl_norm_k1.get(doc_ids[3]),
                                 ],
                             );
                             for lane in 0..bm25::SCORE_SIMD_LANES {
@@ -3080,7 +3143,7 @@ impl FtsReader {
                     scores[local] += bm25::score_with_dl_norm_k1(
                         c.idf_x_k1p1,
                         c.current_tf(),
-                        dl_norm_k1[d as usize],
+                        dl_norm_k1.get(d),
                     );
                     present[local >> 6] |= 1u64 << (local & 63);
                     c.next();
@@ -3183,7 +3246,7 @@ impl FtsReader {
         k: usize,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
         let col_meta = &self.columns[column_id as usize];
-        let dl_norm_k1 = col_meta.dl_norm_k1.as_slice();
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
 
         let initial_cap = k.min(self.n_docs as usize).max(1);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
@@ -3209,7 +3272,7 @@ impl FtsReader {
             // Score: sum BM25 from every cursor positioned at the
             // candidate doc. Pack up to 4 cursors per SIMD scoring
             // call, matching the BMM essential-scoring shape.
-            let norm = dl_norm_k1[candidate as usize];
+            let norm = dl_norm_k1.get(candidate);
             let mut score: f32 = 0.0;
             let mut idfs = [0.0_f32; 4];
             let mut tfs = [0.0_f32; 4];
@@ -3559,7 +3622,7 @@ impl PhraseCursor {
             current_doc: 0,
             current_tf: 0,
         };
-        cursor.seek_match(0, f32::NEG_INFINITY, &[])?;
+        cursor.seek_match(0, f32::NEG_INFINITY, &NormTable::empty())?;
         Ok(cursor)
     }
 
@@ -3578,7 +3641,7 @@ impl PhraseCursor {
         if self.is_exhausted() || self.current_doc >= target {
             return Ok(());
         }
-        self.seek_match(target, f32::NEG_INFINITY, &[])
+        self.seek_match(target, f32::NEG_INFINITY, &NormTable::empty())
     }
 
     /// [`Self::skip_to`] for ranked walks: additionally skips docs
@@ -3593,7 +3656,7 @@ impl PhraseCursor {
         &mut self,
         target: u32,
         bar: f32,
-        dl_norm_k1: &[f32],
+        dl_norm_k1: &NormTable,
     ) -> Result<(), FtsError> {
         if self.is_exhausted() || self.current_doc >= target {
             return Ok(());
@@ -3610,7 +3673,12 @@ impl PhraseCursor {
     /// the run decode. (`<`, not `<=`: a doc exactly at the bar can
     /// still displace the incumbent kth-best on the ascending-doc-id
     /// tie-break, so it must be verified.)
-    fn seek_match(&mut self, mut from: u32, bar: f32, dl_norm_k1: &[f32]) -> Result<(), FtsError> {
+    fn seek_match(
+        &mut self,
+        mut from: u32,
+        bar: f32,
+        dl_norm_k1: &NormTable,
+    ) -> Result<(), FtsError> {
         'docs: loop {
             // Align every member to the same doc ≥ `from`.
             let mut aligned = from;
@@ -3640,11 +3708,8 @@ impl PhraseCursor {
                     .map(|m| m.cursor.current_tf())
                     .min()
                     .expect("members >= 2");
-                let ub = bm25::score_with_dl_norm_k1(
-                    self.idf_x_k1p1,
-                    min_tf,
-                    dl_norm_k1[aligned as usize],
-                );
+                let ub =
+                    bm25::score_with_dl_norm_k1(self.idf_x_k1p1, min_tf, dl_norm_k1.get(aligned));
                 if ub < bar {
                     from = match aligned.checked_add(1) {
                         Some(next) => next,
@@ -3771,7 +3836,7 @@ impl AnyCursor {
         &mut self,
         target: u32,
         bar: f32,
-        dl_norm_k1: &[f32],
+        dl_norm_k1: &NormTable,
     ) -> Result<(), FtsError> {
         match self {
             AnyCursor::Term(c) => {
@@ -3979,7 +4044,7 @@ struct MustShouldSink<'a> {
     should_ub: f32,
     /// Per-doc BM25 length normalization for the column, for scoring
     /// the should terms at emitted docs.
-    dl_norm_k1: &'a [f32],
+    dl_norm_k1: &'a NormTable,
 }
 
 impl AndSink for MustShouldSink<'_> {
@@ -4006,7 +4071,7 @@ impl AndSink for MustShouldSink<'_> {
     }
 
     fn emit(&mut self, doc: u32, must_score: f32) {
-        let norm = self.dl_norm_k1[doc as usize];
+        let norm = self.dl_norm_k1.get(doc);
         let mut score = must_score;
         for c in &mut self.shoulds {
             c.skip_to(doc);

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -5591,6 +5591,49 @@ mod tests {
     }
 
     #[test]
+    fn norm_table_footprint_is_one_byte_per_doc() {
+        // Memory guard: the resident length-norm table must stay at one
+        // byte per doc (plus the fixed 256-entry decode LUT), not the
+        // 4-byte-per-doc `f32` table it replaced. Build enough
+        // varied-length docs that the per-doc term dominates the LUT.
+        const N: u32 = 5_000;
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false)
+            .expect("register column");
+        for d in 0..N {
+            // Lengths cycle 1..=40 tokens so norms span many buckets and
+            // the table isn't a degenerate single value.
+            let words = (d % 40) + 1;
+            let text: String = (0..words).map(|w| format!("t{}x{w} ", d % 97)).collect();
+            b.add_doc(0, d, text.trim()).expect("add doc");
+        }
+        let bytes = b.finish().expect("finish");
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(Bytes::from(bytes), json).expect("open");
+        let nt = &r.columns[0].dl_norm_k1;
+
+        let per_doc = nt.bytes.capacity(); // 1 byte/doc
+        let lut = nt.lut.capacity() * std::mem::size_of::<f32>(); // 256 * 4 = 1 KiB
+        let m2_bytes = per_doc + lut;
+        let f32_baseline = N as usize * std::mem::size_of::<f32>();
+
+        assert_eq!(nt.bytes.len(), N as usize, "one bucket byte per doc");
+        assert_eq!(nt.lut.len(), 256, "fixed 256-entry decode table");
+        // The whole point: strictly smaller than the old f32 table, and
+        // asymptotically 4× smaller (per-doc term is 1 byte vs 4).
+        assert!(
+            m2_bytes < f32_baseline,
+            "norm table {m2_bytes} B not smaller than f32 baseline {f32_baseline} B"
+        );
+        assert_eq!(
+            per_doc * 4,
+            f32_baseline,
+            "per-doc term is exactly 4× smaller"
+        );
+    }
+
+    #[test]
     fn iter_column_terms_lists_every_term_in_lex_order() {
         // build_blob plants the union of tokens across the 3 docs.
         let (blob, json) = build_blob();

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -241,9 +241,12 @@ fn two_term_has_rare_anchor(cursors: &[TermCursor]) -> bool {
 pub struct NormTable {
     /// Per-doc quantized length bucket. Empty for a column with no docs.
     bytes: Vec<u8>,
-    /// Bucket → `K1·(1 - B + B·dequantize_len(bucket)/avgdl)`. 256
-    /// entries; empty when the column is empty.
-    lut: Vec<f32>,
+    /// Bucket → `K1·(1 - B + B·dequantize_len(bucket)/avgdl)`. A fixed
+    /// 256-entry table, boxed so `ColumnMeta` stays pointer-sized (it is
+    /// scanned by non-scoring paths — column lookup, listing) while the
+    /// `u8` bucket index into a fixed-length array lets the compiler drop
+    /// the bounds check in `get`.
+    lut: Box<[f32; 256]>,
 }
 
 impl NormTable {
@@ -252,18 +255,16 @@ impl NormTable {
     /// never indexed because `search` short-circuits on empty columns.
     fn new(doc_lengths: impl Iterator<Item = u32>, n_docs: usize, avgdl: f32) -> Self {
         if avgdl <= 0.0 {
-            return Self {
-                bytes: Vec::new(),
-                lut: Vec::new(),
-            };
+            return Self::empty();
         }
         let inv_avgdl = 1.0_f32 / avgdl;
-        let lut: Vec<f32> = (0..=u8::MAX)
-            .map(|b| {
-                let dl = bm25::dequantize_len(b) as f32;
-                bm25::K1 * (1.0 - bm25::B + bm25::B * dl * inv_avgdl)
-            })
-            .collect();
+        // Fill the boxed table in place so the 256 f32s land on the heap
+        // directly rather than being built on the stack and moved.
+        let mut lut = Box::new([0.0_f32; 256]);
+        for (b, slot) in lut.iter_mut().enumerate() {
+            let dl = bm25::dequantize_len(b as u8) as f32;
+            *slot = bm25::K1 * (1.0 - bm25::B + bm25::B * dl * inv_avgdl);
+        }
         let mut bytes = Vec::with_capacity(n_docs);
         for dl in doc_lengths {
             bytes.push(bm25::quantize_len(dl));
@@ -285,13 +286,15 @@ impl NormTable {
         self.bytes.len()
     }
 
-    /// An empty table (no allocation). For call sites that need a
-    /// `&NormTable` but provably never index it — an unranked
-    /// (`bar == NEG_INFINITY`) phrase seek, which does no scoring.
+    /// An empty table: `bytes` is empty, so `get` must never be called on
+    /// it. For call sites that need a `&NormTable` but provably never index
+    /// it — an unranked (`bar == NEG_INFINITY`) phrase seek, which does no
+    /// scoring. The `lut` is a zeroed 256-entry table, allocated but never
+    /// read.
     fn empty() -> Self {
         Self {
             bytes: Vec::new(),
-            lut: Vec::new(),
+            lut: Box::new([0.0; 256]),
         }
     }
 }
@@ -5616,7 +5619,7 @@ mod tests {
         let nt = &r.columns[0].dl_norm_k1;
 
         let per_doc = nt.bytes.capacity(); // 1 byte/doc
-        let lut = nt.lut.capacity() * std::mem::size_of::<f32>(); // 256 * 4 = 1 KiB
+        let lut = std::mem::size_of_val(&*nt.lut); // 256 * 4 = 1 KiB
         let m2_bytes = per_doc + lut;
         let f32_baseline = N as usize * std::mem::size_of::<f32>();
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -278,7 +278,9 @@ impl NormTable {
         self.lut[self.bytes[doc as usize] as usize]
     }
 
-    /// Number of docs in the table.
+    /// Number of docs in the table. Test-only: the query path indexes
+    /// by doc id and never needs the count.
+    #[cfg(test)]
     fn len(&self) -> usize {
         self.bytes.len()
     }

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -27,7 +27,10 @@
 //! tie differently. We assert "set equality" on the head, not
 //! "ordered equality".
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use arrow_array::{LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
@@ -756,5 +759,139 @@ async fn oracle_and_multi_block_score_matches_brute_force() {
     assert_eq!(
         infino_set, oracle_set,
         "multi-block AND top-10 sets disagree: infino={infino_hits:?} oracle={oracle_hits:?}"
+    );
+}
+
+#[tokio::test]
+async fn oracle_and_multi_block_two_term_score_values_match_brute_force() {
+    // Scores (not just doc-id sets) for a two-term AND whose match set
+    // spans multiple posting blocks — cross-checked against the exact
+    // BM25 oracle so a block-crossing scoring bug (wrong tf index after
+    // a block boundary, stale norm) can't slip through.
+    //
+    // alpha (÷3, spans 3 blocks) ∧ gamma (÷5, spans 2 blocks) →
+    // d ÷ 15 → docs {0, 15, …, 990} = 67 matches, crossing blocks on
+    // both cursors mid-walk.
+    let corp_owned = build_multi_block_corpus();
+    let corp_refs: Vec<(u64, &str)> = corp_owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile(&corp_refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp_refs, tok.as_ref());
+    let mut terms: Vec<String> = Vec::new();
+    tok.tokenize_each("alpha gamma", &mut |t| terms.push(t.to_owned()));
+
+    // Oracle scores for the full intersection, indexed by doc-id and
+    // also as a descending score vector for the top-k comparison.
+    let oracle_full = oracle.top_k_terms_and(&terms, MULTI_BLOCK_N_DOCS as usize);
+    let oracle_by_doc: HashMap<u64, f32> = oracle_full.iter().copied().collect();
+    assert_eq!(
+        oracle_full.len(),
+        67,
+        "corpus assumption changed: alpha∧gamma should be 67 docs"
+    );
+
+    // Regime 1 — no pruning: k >= match count, so the heap never fills,
+    // the block-max bar stays -inf, and every match is batch-scored.
+    // Each returned score must match the oracle for that exact doc.
+    let infino_full = r
+        .bm25_hits_async(
+            "title",
+            "alpha gamma",
+            MULTI_BLOCK_N_DOCS as usize,
+            BoolMode::And,
+        )
+        .await
+        .expect("AND search (full)");
+    assert_eq!(infino_full.len(), 67, "full AND(alpha, gamma) count");
+    for (doc, score) in &infino_full {
+        let expected = oracle_by_doc
+            .get(&(*doc as u64))
+            .expect("returned doc not in oracle intersection");
+        let delta = (score - expected).abs();
+        assert!(
+            delta < BM25_SCORE_ABS_TOLERANCE,
+            "score divergence on doc {doc}: infino={score} oracle={expected} delta={delta}"
+        );
+    }
+
+    // Regime 2 — pruning active: k < match count, so the heap fills and
+    // the block-max-AND skip fires between blocks while the batched
+    // scorer flushes each block's tail before the bar is re-read. The
+    // ten best scores must equal the oracle's ten best (compared by
+    // value, so a score-tie at the boundary can't make this flaky).
+    let mut infino_top: Vec<f32> = r
+        .bm25_hits_async("title", "alpha gamma", 10, BoolMode::And)
+        .await
+        .expect("AND search (top-k)")
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect();
+    assert_eq!(infino_top.len(), 10, "top-k=10 should fill");
+    infino_top.sort_unstable_by(|a, b| b.partial_cmp(a).unwrap());
+    let mut oracle_top: Vec<f32> = oracle_full.iter().map(|(_, s)| *s).collect();
+    oracle_top.sort_unstable_by(|a, b| b.partial_cmp(a).unwrap());
+    oracle_top.truncate(10);
+    for (got, want) in infino_top.iter().zip(&oracle_top) {
+        let delta = (got - want).abs();
+        assert!(
+            delta < BM25_SCORE_ABS_TOLERANCE,
+            "top-10 score divergence: infino={got} oracle={want} delta={delta}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn quantized_norms_preserve_topk_ranking_on_long_docs() {
+    // The length-norm table is byte-quantized, which is lossy for
+    // documents long enough to leave the exact-encoding region. This
+    // guards the ranking-quality claim: on long docs with well-separated
+    // lengths, the quantized top-k must still be the exact BM25 top-k.
+    //
+    // Each candidate doc contains "qterm" once and is padded with
+    // per-doc-unique filler to a length that grows ~1.5× per doc
+    // (20, 30, 45, …). BM25 for "qterm" (tf=1, same idf everywhere)
+    // ranks purely by length-norm — shortest first — and the 1.5× gap
+    // exceeds one quantization bucket, so the exact order is preserved.
+    const N_CANDIDATES: usize = 8;
+    let mut corpus_owned: Vec<(u64, String)> = Vec::new();
+    let mut len = 20usize;
+    for d in 0..N_CANDIDATES {
+        let mut text = String::from("qterm");
+        // Pad with tokens unique to this doc so filler never matches the
+        // query and every doc's length is deliberate.
+        for f in 0..(len - 1) {
+            text.push_str(&format!(" fill{d}x{f}"));
+        }
+        corpus_owned.push((d as u64, text));
+        len = (len * 3) / 2;
+    }
+    // A few long filler-only docs to make avgdl realistic and ensure the
+    // norm table spans multiple quantization buckets.
+    for d in N_CANDIDATES..(N_CANDIDATES + 4) {
+        let mut text = String::new();
+        for f in 0..300 {
+            text.push_str(&format!("noise{d}x{f} "));
+        }
+        corpus_owned.push((d as u64, text));
+    }
+    let corpus: Vec<(u64, &str)> = corpus_owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+
+    let infino = build_infino_superfile(&corpus);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corpus, tok.as_ref());
+
+    let infino_hits = infino_top_k(&infino, "qterm", N_CANDIDATES).await;
+    let oracle_hits: Vec<u64> = oracle
+        .top_k("qterm", N_CANDIDATES, tok.as_ref())
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    // Order preserved: shortest doc (id 0) first, longest last. The 1.5×
+    // length spacing keeps every candidate in its own bucket, so the
+    // quantized ranking matches the exact ranking element-for-element.
+    assert_eq!(
+        infino_hits, oracle_hits,
+        "quantized norms reordered the top-k vs exact BM25"
     );
 }


### PR DESCRIPTION
## What

Quantize the per-doc BM25 length normalizer (`dl_norm_k1`) from an `f32`
table (4 bytes/doc) to one byte per doc plus a 256-entry decode table.

## Why

The length-norm table is indexed once per scored doc. Held as `f32`, it is
`4 × n_docs` bytes — at multi-million-doc scale it no longer stays
cache-resident, so each scored doc pays a scattered load from a table that
overflows cache. Byte-quantizing the doc length cuts the resident table 4×
and keeps the decode table (1 KiB) L1-resident:

| docs | norm table (before) | after | reduction |
|---|---|---|---|
| 1M | 4.0 MB | 1.0 MB | −75% |
| 5M | 20.0 MB | 5.0 MB | −75% |
| 10M | 40.0 MB | 10.0 MB | −75% |

A scored doc now reads `lut[bytes[doc]]` — one load from the small per-doc
table plus one L1 lookup.

## How

- Each doc's length is quantized to one byte via an 8-bit float (3-bit
  mantissa, truncating so the map is monotonic and idempotent). Relative
  length error ≤ 12.5%, and BM25 feels only a fraction of that since the
  length enters the norm as `1 - b + b·dl/avgdl` (the `1 - b` term carries
  no error).
- A 256-entry table decodes each bucket to its `dl_norm_k1` value.
- Built at reader open from the existing on-disk doc-lengths array — **the
  on-disk format is unchanged.**

## Correctness

- Documents up to length 15 quantize exactly, so existing BM25 oracle tests
  are bit-identical.
- New codec unit tests: exactness below threshold, monotonicity, bounded
  relative error, idempotence.
- New long-doc ranking-preservation test: on varied, well-separated lengths
  the quantized top-k equals the exact-BM25 top-k element-for-element.
- New memory-footprint guard test: the resident table stays one byte/doc.
- Full FTS unit + integration suites pass; `fmt`/`clippy` clean.

Localized to the FTS read path; no public API or on-disk format change.