### PR TITLE
release: each 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "apache-avro",
  "arc-swap",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "infino-node"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-node/Cargo.toml
+++ b/infino-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-node"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.1.5",
-    "infx-darwin-arm64": "0.1.5",
-    "infx-linux-x64-gnu": "0.1.5",
-    "infx-linux-arm64-gnu": "0.1.5",
-    "infx-linux-x64-musl": "0.1.5",
-    "infx-linux-arm64-musl": "0.1.5"
+    "infx-darwin-x64": "0.1.6",
+    "infx-darwin-arm64": "0.1.6",
+    "infx-linux-x64-gnu": "0.1.6",
+    "infx-linux-arm64-gnu": "0.1.6",
+    "infx-linux-x64-musl": "0.1.6",
+    "infx-linux-arm64-musl": "0.1.6"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "apache-avro",
  "arc-swap",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "infino-python"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-python"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Release PR stamped by the `Release prep` workflow (scope: `each`); the workflow's own PR creation failed on a token permission, so this PR was opened by hand from the stamped branch.

| Package | Version |
| ------- | ------- |
| crate   | 0.1.6   |
| node    | 0.1.6   |
| python  | 0.1.7   |

On merge, `Release on merge` tags and publishes whichever of these changed — see docs/versioning.md.