### PR TITLE
ci(bench): don't check out fork code on the trusted runner

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: "main"
         type: string
+      is_fork_pr:
+        description: "Simulate a fork PR (runner checks out base tooling, not the ref; routes to the approval-gated env). For verifying fork-safe checkout."
+        required: false
+        default: false
+        type: boolean
       keep_table:
         description: "Keep the bench blob prefix after the run (debug)."
         required: false
@@ -153,13 +158,22 @@ jobs:
     # Auto-stop ceiling on VM billing; teardown runs on timeout.
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     steps:
-      # The bench itself builds/runs on the VM, but the runner needs the repo
-      # for the AI-summary script. Match the ref under test so the summarizer
-      # tracks the PR. Cleans the workdir, so it must precede baseline staging.
+      # Runner-side checkout is TRUSTED context (base GITHUB_TOKEN + secrets)
+      # and only runs infino's own tooling (bench_summary.py) over metrics
+      # scp'd back from the VM — it never needs the code under test. So it must
+      # NOT fetch fork code: a fork PR could swap the helper script and run
+      # arbitrary code here with secrets (a "pwn request"). actions/checkout
+      # now refuses fork code under pull_request_target for exactly this reason,
+      # and an environment approval does not make it safe (a reviewer won't
+      # reliably catch a malicious helper-script edit). So fork PRs check out
+      # the base default branch's trusted tooling; same-repo PRs (already
+      # trusted) may use the ref under test. The fork's code-under-test is
+      # cloned/built/run only on the isolated, approval-gated VM below.
+      # Cleans the workdir, so it must precede baseline staging.
       - name: Checkout (runner-side tooling)
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.is_fork_pr && github.event.repository.default_branch || inputs.ref }}
 
       - name: Resolve bench selection
         id: resolve
@@ -310,9 +324,24 @@ jobs:
           git clone --filter=blob:none \
             "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$HOME/infino-src"
           cd "$HOME/infino-src"
-          git checkout "$REF" 2>/dev/null \
-            || { git fetch --depth 1 origin "$REF" && git checkout FETCH_HEAD; }
-          echo "Checked out: $(git rev-parse --short HEAD)"
+          # The VM is the isolated, approval-gated place where the code under
+          # test actually runs, so it may hold fork code. It clones the BASE
+          # repo, so the ref resolves directly for a same-repo PR. For a FORK
+          # PR the sha lives in the fork; it resolves here only if the base repo
+          # exposes it via refs/pull/*. Diagnose which path fires so we know
+          # whether the VM clone must instead target the fork repo directly
+          # (thread head_repo through) — rather than silently benchmarking the
+          # wrong code.
+          echo "[vm-clone] REPO=$REPO REF=$REF"
+          if git checkout "$REF" 2>/dev/null; then
+            echo "[vm-clone] resolved directly from clone (same-repo ref)"
+          elif git fetch --depth 1 origin "$REF" && git checkout FETCH_HEAD; then
+            echo "[vm-clone] resolved via 'fetch origin $REF' (base-repo PR-head object) — fork code IS reachable from the base repo; head_repo threading NOT required"
+          else
+            echo "::error::[vm-clone] ref $REF is not obtainable from $REPO — the fork's code is not reachable from the base repo. The VM clone must target the fork repo directly (thread head_repo through bench.yml). Benchmarking base code here would be misleading, so failing."
+            exit 1
+          fi
+          echo "[vm-clone] HEAD=$(git rev-parse HEAD) (requested $REF)"
           REMOTE
 
       - name: Build (sccache, on VM)


### PR DESCRIPTION
## Problem

The Azure bench started failing on **fork PRs** (e.g. any external / fork-based PR). Root cause is a recent GitHub-side change: **`actions/checkout` now refuses to check out fork-PR code under `pull_request_target`** (hardening against "pwn requests"). The runner-side `Checkout (runner-side tooling)` step fails, every later step is skipped, and it surfaces confusingly downstream as `python3: can't open .github/scripts/bench_summary.py` (exit 2).

This is not caused by any product change — the same `@v4` tag changed behavior underneath us, which is why the bench "worked hours ago" and then broke. (Same-repo PRs are unaffected; their vector-arm failures are a separate recall-floor issue.)

## Why not just `allow-unsafe-pr-checkout: true`

The runner is the **trusted** context (base `GITHUB_TOKEN` + secrets) and only runs our own `bench_summary.py` over metrics `scp`'d back from the VM — it never needs the code under test. Checking out fork code there and running a helper script from that checkout is exactly the pwn-request surface the guardrail blocks, and an **environment approval does not make it safe** (a reviewer won't reliably catch a malicious helper-script edit). So re-enabling the unsafe checkout would reopen a real hole.

## Fix

- **Runner-side checkout uses base tooling for fork PRs** (`ref: is_fork_pr ? default_branch : ref`); same-repo PRs keep using the ref under test. No fork code on the trusted runner.
- The fork's **code-under-test still runs** — on the isolated, approval-gated **VM** (the correct boundary for untrusted code), unchanged.
- **Instrument the VM clone** to report whether the ref resolves from the base repo (directly, or via the base repo's PR-head object) and **fail loudly** if not — so we can tell whether the VM clone must target the fork repo directly (thread `head_repo`) instead of silently benchmarking base code.
- Add an `is_fork_pr` `workflow_dispatch` input so the fork-safe path can be smoke-tested by manual dispatch before merge.

## Note on verifying

`pull_request_target` always runs the **base** repo's copy of the workflow, so this change can't take effect on PR bench runs until it's on `main`. After merge, re-running a fork PR's bench will confirm the runner checkout passes and the `[vm-clone]` diagnostic line will tell us whether a `head_repo` follow-up is needed.