### PR TITLE
bench: fts-diag — split FTS kernel vs supertable resolve/assembly

### DIFF
--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -16,7 +16,7 @@
 //! cargo bench -- supertable vector build cold
 //!
 //! # Diagnostics (standalone programs, same binary):
-//! cargo bench -- diagnostic              # all five
+//! cargo bench -- diagnostic              # all seven
 //! cargo bench -- diagnostic scale        # a subset, grouped
 //! cargo bench -- tombstone               # bare names also work
 //!
@@ -34,9 +34,9 @@
 //!   `all`       : explicit "every tier × modality × phase" (the default).
 //!                 Matrix only — diagnostics are NEVER implied by `all` or
 //!                 by a bare `cargo bench`.
-//!   diagnostic  : `scale` | `tombstone` | `update` | `sql-diag` | `object-store` | `concurrent`,
+//!   diagnostic  : `scale` | `tombstone` | `update` | `sql-diag` | `fts-diag` | `object-store` | `concurrent`,
 //!                 by name, or grouped under the `diagnostic` keyword —
-//!                 `cargo bench -- diagnostic` runs all six,
+//!                 `cargo bench -- diagnostic` runs all seven,
 //!                 `cargo bench -- diagnostic scale tombstone` a subset.
 //!
 //! The matrix tests run = (selected tiers) × (selected modalities).
@@ -67,6 +67,7 @@ enum Diagnostic {
     Tombstone,
     Update,
     SqlDiag,
+    FtsDiag,
     ObjectStore,
     Concurrent,
 }
@@ -78,6 +79,7 @@ impl Diagnostic {
             Diagnostic::Tombstone => "tombstone",
             Diagnostic::Update => "update",
             Diagnostic::SqlDiag => "sql-diag",
+            Diagnostic::FtsDiag => "fts-diag",
             Diagnostic::ObjectStore => "object-store",
             Diagnostic::Concurrent => "concurrent",
         }
@@ -89,6 +91,7 @@ impl Diagnostic {
             Diagnostic::Tombstone => infino_bench_utils::tombstone_overhead::run(),
             Diagnostic::Update => infino_bench_utils::supertable_update::run(),
             Diagnostic::SqlDiag => infino_bench_utils::sql_diag::run(),
+            Diagnostic::FtsDiag => infino_bench_utils::fts_diag::run(),
             Diagnostic::ObjectStore => infino_bench_utils::unified_object_store::run(),
             Diagnostic::Concurrent => infino_bench_utils::concurrent::run(),
         }
@@ -297,7 +300,7 @@ fn print_usage_and_exit(code: i32) -> ! {
          Phase     : build | warm | cold | search  (search = warm+cold; omitted => all)\n\
          all       : every tier x modality x phase (the default for a bare\n\
          \x20           `cargo bench`); matrix only — never implies diagnostics\n\
-         Diagnostic: scale | tombstone | update | sql-diag | object-store | concurrent,\n\
+         Diagnostic: scale | tombstone | update | sql-diag | fts-diag | object-store | concurrent,\n\
          \x20           or `diagnostic` for all six / `diagnostic <names>` for a subset\n\
          \n\
          Examples:\n\
@@ -382,6 +385,7 @@ fn parse_args() -> Selection {
             "tombstone" | "tombstone-overhead" => diagnostics.push(Diagnostic::Tombstone),
             "update" | "supertable-update" => diagnostics.push(Diagnostic::Update),
             "sql-diag" | "sql_diag" => diagnostics.push(Diagnostic::SqlDiag),
+            "fts-diag" | "fts_diag" => diagnostics.push(Diagnostic::FtsDiag),
             "object-store" | "object_store" => diagnostics.push(Diagnostic::ObjectStore),
             "concurrent" => diagnostics.push(Diagnostic::Concurrent),
             "diagnostic" | "diagnostics" => want_diagnostics = true,
@@ -404,6 +408,7 @@ fn parse_args() -> Selection {
             Diagnostic::Tombstone,
             Diagnostic::Update,
             Diagnostic::SqlDiag,
+            Diagnostic::FtsDiag,
             Diagnostic::ObjectStore,
             Diagnostic::Concurrent,
         ];

--- a/benches/utils/diag_common.rs
+++ b/benches/utils/diag_common.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Shared harness for the query-path diagnostics (`sql-diag`,
+//! `fts-diag`).
+//!
+//! Both diagnostics measure per-query paths over the *same* kind of
+//! table, so they build and configure it the same way — one scale knob
+//! (`INFINO_BENCH_SUPERTABLE_DOCS`), one iters knob (`INFINO_DIAG_ITERS`),
+//! one corpus, one supertable build, one set of stat/format helpers.
+//! Each diagnostic then plugs in only its own measurements. Without this
+//! the diagnostics drift into separate config surfaces (different doc-count
+//! knobs, different corpora, different stores), which is exactly what this
+//! module exists to prevent.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use arrow_array::{Int64Array, LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use infino::{
+    superfile::builder::FtsConfig,
+    supertable::{Supertable, SupertableOptions},
+    test_helpers::default_tokenizer,
+};
+
+use crate::corpus::{self, MmapTextCorpus};
+
+/// Rows per commit — matches the headline benches' `WRITE_CHUNK` so the
+/// diagnostic's superfile count mirrors production shapes.
+pub const WRITE_CHUNK: usize = 65_536;
+
+/// Round-robin category labels (matches `superfile::sql::CATEGORIES`).
+pub const CATEGORIES: &[&str] = &["rust", "python", "go", "sql"];
+
+/// Default timed iters per path; override with `INFINO_DIAG_ITERS`.
+const DEFAULT_ITERS: usize = 15;
+
+/// Unified diagnostic config: one scale knob, one iters knob, shared by
+/// every query-path diagnostic.
+pub struct DiagConfig {
+    pub n_docs: usize,
+    pub iters: usize,
+}
+
+/// Read the diagnostic config from the single shared set of knobs.
+pub fn config() -> DiagConfig {
+    let iters = std::env::var("INFINO_DIAG_ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_ITERS);
+    DiagConfig {
+        n_docs: corpus::supertable_docs(),
+        iters,
+    }
+}
+
+/// Scalar schema for the diagnostic table: `title` (FTS) + `category` +
+/// `rating`. No vector index — vectors never touch the scored/scalar
+/// paths these diagnostics measure, so omitting them keeps the build
+/// cheap while leaving the measured paths identical.
+pub fn diag_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("category", DataType::LargeUtf8, false),
+        Field::new("rating", DataType::Int64, false),
+    ]))
+}
+
+/// Supertable options for the diagnostic table (scalar + FTS on `title`).
+pub fn diag_options() -> SupertableOptions {
+    SupertableOptions::new(
+        diag_schema(),
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        vec![],
+        Some(default_tokenizer()),
+    )
+    .expect("diag supertable options")
+}
+
+/// Build one `WRITE_CHUNK`-row batch from `(id, text)` corpus rows.
+pub fn chunk_batch(rows: &[(u64, &str)]) -> RecordBatch {
+    let titles = LargeStringArray::from(rows.iter().map(|&(_, t)| t).collect::<Vec<_>>());
+    let categories = LargeStringArray::from(
+        rows.iter()
+            .map(|&(id, _)| CATEGORIES[(id as usize) % CATEGORIES.len()])
+            .collect::<Vec<_>>(),
+    );
+    let ratings = Int64Array::from(
+        rows.iter()
+            .map(|&(id, _)| (id % 100) as i64)
+            .collect::<Vec<_>>(),
+    );
+    RecordBatch::try_new(
+        diag_schema(),
+        vec![Arc::new(titles), Arc::new(categories), Arc::new(ratings)],
+    )
+    .expect("chunk batch")
+}
+
+/// Build the diagnostic `Supertable` from a Zipfian `termNNNNN` corpus,
+/// committed one `WRITE_CHUNK` superfile at a time (in-memory store, warm
+/// by construction). Returns the table plus the chunk batches — the SQL
+/// diagnostic reuses them for its DataFusion baselines; callers that only
+/// need the table can ignore them (the batches own their data, so the
+/// corpus is dropped here).
+pub fn build_supertable(cfg: &DiagConfig) -> (Supertable, Vec<RecordBatch>) {
+    let corpus = MmapTextCorpus::generate(cfg.n_docs, 1);
+    let batches: Vec<RecordBatch> = corpus.rows().chunks(WRITE_CHUNK).map(chunk_batch).collect();
+    let table = Supertable::create(diag_options()).expect("create diag supertable");
+    {
+        let mut writer = table.writer().expect("writer");
+        for batch in &batches {
+            writer.append(batch).expect("append");
+            writer.commit().expect("commit");
+        }
+    }
+    (table, batches)
+}
+
+/// The `p`-th percentile of `samples` (sorts in place). `Duration::ZERO`
+/// for an empty slice.
+pub fn percentile(samples: &mut [Duration], p: usize) -> Duration {
+    if samples.is_empty() {
+        return Duration::ZERO;
+    }
+    samples.sort_unstable();
+    let rank = ((p as f64 / 100.0) * samples.len() as f64).ceil() as usize;
+    samples[rank.saturating_sub(1).min(samples.len() - 1)]
+}
+
+/// Right-aligned µs/ms formatting, shared across diagnostic tables.
+pub fn fmt(d: Duration) -> String {
+    let us = d.as_secs_f64() * 1e6;
+    if us < 1000.0 {
+        format!("{us:>9.1} µs")
+    } else {
+        format!("{:>9.2} ms", us / 1000.0)
+    }
+}
+
+/// Time `f` once (warm-up) then `iters` times; return (p50, mean, rows).
+pub fn time_path(iters: usize, mut f: impl FnMut() -> usize) -> (Duration, Duration, usize) {
+    let rows = f();
+    let mut samples = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let t = Instant::now();
+        let out = f();
+        samples.push(t.elapsed());
+        std::hint::black_box(out);
+    }
+    let sum: u128 = samples.iter().map(|d| d.as_nanos()).sum();
+    let mean = Duration::from_nanos((sum / samples.len().max(1) as u128) as u64);
+    (percentile(&mut samples, 50), mean, rows)
+}

--- a/benches/utils/fts_diag.rs
+++ b/benches/utils/fts_diag.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! FTS query-path diagnostic — splits the scored top-k path into the FTS
+//! kernel vs the supertable `_id`-resolution + result assembly.
+//!
+//! The serving path (`bm25_search(.., None)`) is *kernel + resolve*: the
+//! kernel scores and returns superfile-local hits; resolution turns each
+//! hit into its stable `_id` and builds the Arrow batch. The kernel alone
+//! is `bm25_hits`. So:
+//!
+//!   resolve/assembly = full (`bm25_search`) − kernel (`bm25_hits`)
+//!
+//! Resolution scales with the number of hits returned (≤ k) and sits
+//! *above* the FTS kernel, so kernel-side scoring changes can't move it.
+//! At large k this diagnostic shows whether the top-k cost lives in the
+//! kernel or in resolution — the split that decides where to optimize.
+//!
+//! Shares the build + config with the SQL diagnostic (see
+//! [`crate::diag_common`]): one corpus, one scale knob
+//! (`INFINO_BENCH_SUPERTABLE_DOCS`), one iters knob (`INFINO_DIAG_ITERS`).
+//!
+//! ```text
+//! cargo bench -- fts-diag
+//! INFINO_BENCH_SUPERTABLE_DOCS=1000000 cargo bench -- fts-diag
+//! INFINO_DIAG_ITERS=30 cargo bench -- fts-diag
+//! ```
+
+use std::time::Instant;
+
+use infino::superfile::fts::reader::BoolMode;
+
+use crate::{diag_common, markdown::fmt_count};
+
+/// Large-k retrieval — the regime where resolution cost, proportional to
+/// hits returned, is most exposed.
+const K: usize = 1000;
+
+/// FTS column planted by [`diag_common::build_supertable`].
+const COLUMN: &str = "title";
+
+/// One query shape measured across the kernel and full paths.
+struct FtsShape {
+    name: &'static str,
+    query: &'static str,
+    mode: BoolMode,
+}
+
+/// Shapes chosen to span the two regimes the split matters for: a small
+/// intersection (matches ≤ k ⇒ no pruning, every match scored *and*
+/// resolved), a large intersection (heavy pruning), and a union.
+const SHAPES: &[FtsShape] = &[
+    FtsShape {
+        name: "single_common",
+        query: "term00001",
+        mode: BoolMode::Or,
+    },
+    FtsShape {
+        name: "small_and",
+        query: "term00500 term01000",
+        mode: BoolMode::And,
+    },
+    FtsShape {
+        name: "large_and",
+        query: "term00001 term00050",
+        mode: BoolMode::And,
+    },
+    FtsShape {
+        name: "union",
+        query: "term00050 term00051 term00052",
+        mode: BoolMode::Or,
+    },
+];
+
+pub fn run() {
+    let cfg = diag_common::config();
+    eprintln!(
+        "[fts-diag] kernel vs resolve/assembly split: n_docs={} iters={} k={K} \
+         (knobs: INFINO_BENCH_SUPERTABLE_DOCS, INFINO_DIAG_ITERS)",
+        fmt_count(cfg.n_docs),
+        cfg.iters,
+    );
+
+    eprintln!("[fts-diag] building supertable...");
+    let build_t0 = Instant::now();
+    let (table, _batches) = diag_common::build_supertable(&cfg);
+    eprintln!(
+        "[fts-diag] built in {:.1}s",
+        build_t0.elapsed().as_secs_f64()
+    );
+    let reader = table.reader();
+
+    // Warm both paths for every shape (cache-hot before timing).
+    for s in SHAPES {
+        let _ = reader
+            .bm25_search(COLUMN, s.query, K, s.mode, None)
+            .expect("warm-up bm25_search");
+    }
+
+    eprintln!();
+    eprintln!(
+        "[fts-diag] {:<15}{:>8}{:>13}{:>13}{:>13}{:>10}",
+        "shape", "hits", "kernel p50", "full p50", "resolve p50", "resolve%"
+    );
+    for s in SHAPES {
+        let hits = reader
+            .bm25_hits(COLUMN, s.query, K, s.mode)
+            .expect("bm25_hits")
+            .len();
+
+        let mut kernel = Vec::with_capacity(cfg.iters);
+        for _ in 0..cfg.iters {
+            let t = Instant::now();
+            let out = reader
+                .bm25_hits(COLUMN, s.query, K, s.mode)
+                .expect("kernel bm25_hits");
+            kernel.push(t.elapsed());
+            std::hint::black_box(out);
+        }
+
+        let mut full = Vec::with_capacity(cfg.iters);
+        for _ in 0..cfg.iters {
+            let t = Instant::now();
+            let out = reader
+                .bm25_search(COLUMN, s.query, K, s.mode, None)
+                .expect("full bm25_search");
+            full.push(t.elapsed());
+            std::hint::black_box(out);
+        }
+
+        let kp = diag_common::percentile(&mut kernel, 50);
+        let fp = diag_common::percentile(&mut full, 50);
+        let resolve = fp.saturating_sub(kp);
+        let pct = if fp.as_nanos() > 0 {
+            resolve.as_nanos() as f64 / fp.as_nanos() as f64 * 100.0
+        } else {
+            0.0
+        };
+        eprintln!(
+            "[fts-diag] {:<15}{:>8}{:>13}{:>13}{:>13}{:>9.0}%",
+            s.name,
+            hits,
+            diag_common::fmt(kp),
+            diag_common::fmt(fp),
+            diag_common::fmt(resolve),
+            pct,
+        );
+    }
+}

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -28,6 +28,8 @@ pub mod superfile;
 pub mod supertable;
 
 pub mod concurrent;
+pub mod diag_common;
+pub mod fts_diag;
 pub mod scale;
 pub mod sql_diag;
 pub mod supertable_update;

--- a/benches/utils/sql_diag.rs
+++ b/benches/utils/sql_diag.rs
@@ -41,8 +41,8 @@
 //!
 //! ```text
 //! cargo bench -- sql-diag
-//! INFINO_BENCH_SUPERFILE_DOCS=1000000 cargo bench -- sql-diag
-//! INFINO_SQL_DIAG_ITERS=20 cargo bench -- sql-diag
+//! INFINO_BENCH_SUPERTABLE_DOCS=1000000 cargo bench -- sql-diag
+//! INFINO_DIAG_ITERS=20 cargo bench -- sql-diag
 //! # delegate to the kernel-vs-query_sql TVF dispatch-tax diagnostic:
 //! INFINO_SQL_DIAG=tvf cargo bench -- sql-diag
 //! ```
@@ -53,32 +53,16 @@ use std::{
 };
 
 use arrow_array::{Int64Array, LargeStringArray, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use datafusion::{
     datasource::MemTable,
     prelude::{ParquetReadOptions, SessionContext},
 };
-use infino::{
-    superfile::builder::FtsConfig,
-    supertable::{Supertable, SupertableOptions},
-    test_helpers::default_tokenizer,
-};
 use parquet::arrow::{ProjectionMask, arrow_reader::ParquetRecordBatchReaderBuilder};
 use rayon::prelude::*;
 use tokio::runtime::Runtime;
 
-use crate::{
-    corpus::{self, MmapTextCorpus},
-    markdown::fmt_count,
-};
-
-/// Rows per commit — mirrors `InfinoSqlEngine`'s `WRITE_CHUNK`, so the
-/// superfile count matches the headline SQL bench.
-const WRITE_CHUNK: usize = 65_536;
-
-/// Round-robin category labels (matches `superfile::sql::CATEGORIES`).
-const CATEGORIES: &[&str] = &["rust", "python", "go", "sql"];
+use crate::{diag_common, markdown::fmt_count};
 
 const TABLE: &str = "supertable";
 
@@ -114,84 +98,8 @@ const SHAPES: &[Shape] = &[
     },
 ];
 
-/// Baseline-table schema (no `_id`; `query_sql` injects its own, but
-/// these shapes never project it). Order matches `raw_cols`.
-fn baseline_schema() -> Arc<Schema> {
-    Arc::new(Schema::new(vec![
-        Field::new("title", DataType::LargeUtf8, false),
-        Field::new("category", DataType::LargeUtf8, false),
-        Field::new("rating", DataType::Int64, false),
-    ]))
-}
-
-/// Supertable schema for the infino path: scalar + FTS only. No vector
-/// index — vectors are stripped to the embedded blob and never touch
-/// the scalar scan path, so omitting them keeps the build cheap while
-/// leaving the measured path identical.
-fn supertable_options() -> SupertableOptions {
-    SupertableOptions::new(
-        baseline_schema(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-        }],
-        vec![],
-        Some(default_tokenizer()),
-    )
-    .expect("supertable sql-diag options")
-}
-
-fn chunk_batch(rows: &[(u64, &str)]) -> RecordBatch {
-    let titles = LargeStringArray::from(rows.iter().map(|&(_, t)| t).collect::<Vec<_>>());
-    let categories = LargeStringArray::from(
-        rows.iter()
-            .map(|&(id, _)| CATEGORIES[(id as usize) % CATEGORIES.len()])
-            .collect::<Vec<_>>(),
-    );
-    let ratings = Int64Array::from(
-        rows.iter()
-            .map(|&(id, _)| (id % 100) as i64)
-            .collect::<Vec<_>>(),
-    );
-    RecordBatch::try_new(
-        baseline_schema(),
-        vec![Arc::new(titles), Arc::new(categories), Arc::new(ratings)],
-    )
-    .expect("chunk batch")
-}
-
-fn percentile(samples: &mut [Duration], p: usize) -> Duration {
-    if samples.is_empty() {
-        return Duration::ZERO;
-    }
-    samples.sort_unstable();
-    let rank = ((p as f64 / 100.0) * samples.len() as f64).ceil() as usize;
-    samples[rank.saturating_sub(1).min(samples.len() - 1)]
-}
-
-fn fmt(d: Duration) -> String {
-    let us = d.as_secs_f64() * 1e6;
-    if us < 1000.0 {
-        format!("{us:>9.1} µs")
-    } else {
-        format!("{:>9.2} ms", us / 1000.0)
-    }
-}
-
-/// Time `f` once (warm) then `iters` times; return (p50, mean, rows).
-fn time_path(iters: usize, mut f: impl FnMut() -> usize) -> (Duration, Duration, usize) {
-    let rows = f();
-    let mut samples = Vec::with_capacity(iters);
-    for _ in 0..iters {
-        let t = Instant::now();
-        let out = f();
-        samples.push(t.elapsed());
-        std::hint::black_box(out);
-    }
-    let sum: u128 = samples.iter().map(|d| d.as_nanos()).sum();
-    let mean = Duration::from_nanos((sum / samples.len().max(1) as u128) as u64);
-    (percentile(&mut samples, 50), mean, rows)
-}
+// Table build, corpus, chunk batching, and the stat/format helpers are
+// shared with the FTS diagnostic — see `crate::diag_common`.
 
 /// Raw parquet-rs decode of `cols` from every superfile, applying `keep`
 /// to each row by hand and counting survivors — the direct-decode
@@ -256,34 +164,20 @@ pub fn run() {
         return;
     }
 
-    let n = corpus::superfile_docs();
-    let iters: usize = std::env::var("INFINO_SQL_DIAG_ITERS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(15);
+    let cfg = diag_common::config();
+    let n = cfg.n_docs;
+    let iters = cfg.iters;
     eprintln!(
         "[sql-diag] scalar scan decomposition: n_docs={} iters={iters} \
-         (knobs: INFINO_BENCH_SUPERFILE_DOCS, INFINO_SQL_DIAG_ITERS)",
+         (knobs: INFINO_BENCH_SUPERTABLE_DOCS, INFINO_DIAG_ITERS)",
         fmt_count(n)
     );
 
-    // ── Shared corpus + per-chunk batches (the "superfiles"). ──────────
-    eprintln!("[sql-diag] generating {}-row corpus...", fmt_count(n));
-    let corpus = MmapTextCorpus::generate(n, 1);
-    let corpus_rows = corpus.rows();
-    let batches: Vec<RecordBatch> = corpus_rows.chunks(WRITE_CHUNK).map(chunk_batch).collect();
-
-    // ── infino Supertable (scalar + FTS), committed per chunk. ───────
+    // ── Shared corpus + supertable build (see `diag_common`); the chunk
+    //    batches come back for the DataFusion MemTable baseline below. ──
     eprintln!("[sql-diag] building infino supertable...");
     let build_t0 = Instant::now();
-    let table = Supertable::create(supertable_options()).expect("create supertable");
-    {
-        let mut writer = table.writer().expect("writer");
-        for batch in &batches {
-            writer.append(batch).expect("append");
-            writer.commit().expect("commit");
-        }
-    }
+    let (table, batches) = diag_common::build_supertable(&cfg);
     eprintln!(
         "[sql-diag] supertable built in {:.1}s",
         build_t0.elapsed().as_secs_f64()
@@ -334,7 +228,7 @@ pub fn run() {
 
     for shape in SHAPES {
         // 1. infino query_sql (full path).
-        let (full_p50, full_mean, full_rows) = time_path(iters, || {
+        let (full_p50, full_mean, full_rows) = diag_common::time_path(iters, || {
             table
                 .reader()
                 .query_sql(shape.sql)
@@ -355,8 +249,8 @@ pub fn run() {
             ex.push(t1.elapsed());
             df_rows = count_rows(&out);
         }
-        let pp_p50 = percentile(&mut pp, 50);
-        let ex_p50 = percentile(&mut ex, 50);
+        let pp_p50 = diag_common::percentile(&mut pp, 50);
+        let ex_p50 = diag_common::percentile(&mut ex, 50);
 
         // 2. vanilla DataFusion over the same parquet files (no infino).
         let (dfq_p50, dfq_mean, dfq_rows) = {
@@ -394,7 +288,7 @@ pub fn run() {
             }
             let sum: u128 = samples.iter().map(|d| d.as_nanos()).sum();
             (
-                percentile(&mut samples, 50),
+                diag_common::percentile(&mut samples, 50),
                 Duration::from_nanos((sum / samples.len().max(1) as u128) as u64),
                 rows,
             )
@@ -402,8 +296,8 @@ pub fn run() {
 
         // 3. DataFusion MemTable over the already-decoded Arrow batches.
         let (mem_p50, mem_mean, mem_rows) = {
-            let provider =
-                MemTable::try_new(baseline_schema(), vec![batches.clone()]).expect("memtable");
+            let provider = MemTable::try_new(diag_common::diag_schema(), vec![batches.clone()])
+                .expect("memtable");
             let provider = Arc::new(provider);
             let mut samples = Vec::with_capacity(iters);
             // warm
@@ -429,14 +323,14 @@ pub fn run() {
             }
             let sum: u128 = samples.iter().map(|d| d.as_nanos()).sum();
             (
-                percentile(&mut samples, 50),
+                diag_common::percentile(&mut samples, 50),
                 Duration::from_nanos((sum / samples.len().max(1) as u128) as u64),
                 rows,
             )
         };
 
         // 4. raw parquet-rs decode floor.
-        let (raw_p50, raw_mean, raw_rows) = time_path(iters, || {
+        let (raw_p50, raw_mean, raw_rows) = diag_common::time_path(iters, || {
             raw_decode(&superfiles, shape.raw_cols, shape.keep)
         });
 
@@ -465,27 +359,27 @@ pub fn run() {
         eprintln!(
             "[sql-diag] {:<16} {} {} {} {} {}   {}",
             shape.name,
-            fmt(full_p50),
-            fmt(pp_p50),
-            fmt(ex_p50),
-            fmt(dfq_p50),
-            fmt(mem_p50),
+            diag_common::fmt(full_p50),
+            diag_common::fmt(pp_p50),
+            diag_common::fmt(ex_p50),
+            diag_common::fmt(dfq_p50),
+            diag_common::fmt(mem_p50),
             fmt_count(full_rows),
         );
         eprintln!(
             "[sql-diag] {:<16} {} {} {} {} {}   (mean; raw-decode floor below)",
             "",
-            fmt(full_mean),
-            fmt(Duration::ZERO),
-            fmt(Duration::ZERO),
-            fmt(dfq_mean),
-            fmt(mem_mean),
+            diag_common::fmt(full_mean),
+            diag_common::fmt(Duration::ZERO),
+            diag_common::fmt(Duration::ZERO),
+            diag_common::fmt(dfq_mean),
+            diag_common::fmt(mem_mean),
         );
         eprintln!(
             "[sql-diag] {:<16} raw parquet-rs decode floor: p50 {} / mean {}",
             "",
-            fmt(raw_p50),
-            fmt(raw_mean),
+            diag_common::fmt(raw_p50),
+            diag_common::fmt(raw_mean),
         );
         eprintln!();
     }


### PR DESCRIPTION
## What

Adds an `fts-diag` diagnostic (`cargo bench -- fts-diag`) that localizes where scored top-k latency goes by splitting the serving path into its two layers:

- **kernel** — `bm25_hits(col, q, k, mode)` (scores, returns superfile-local hits)
- **full** — `bm25_search(col, q, k, mode, None)` (kernel **+** `_id`-resolution + Arrow result assembly)
- **resolve/assembly = full − kernel**

It builds one supertable, warms it, and times both paths at k=1000 across a small-intersection AND (no-prune), a large AND, a union, and a single common term — reporting `hits / kernel p50 / full p50 / resolve p50 / resolve%` per shape. This answers whether large-k scored cost lives in the FTS kernel or in per-hit resolution (which scales with hits returned and sits above the kernel).

Sample (100K docs, local — the split runs; resolution is near-zero at this cache-resident scale and grows with scale/hits):
```
shape              hits   kernel p50     full p50  resolve p50  resolve%
single_common      1000     457.7 µs     468.8 µs      11.0 µs        2%
small_and            75      43.7 µs      44.0 µs       0.3 µs        1%
large_and          1000     392.5 µs     376.7 µs       0.0 µs        0%
union              1000     393.7 µs     390.3 µs       0.0 µs        0%
```

## Unified diagnostic config

Adds `diag_common` — one config surface shared by `sql-diag` and `fts-diag`, so the diagnostics don't each invent their own corpus/scale/store wiring:

- one scale knob `INFINO_BENCH_SUPERTABLE_DOCS`, one iters knob `INFINO_DIAG_ITERS`
- one Zipfian corpus + supertable build (`build_supertable`)
- shared stat/format helpers (`percentile`, `fmt`, `time_path`)

`sql-diag` is refactored onto `diag_common` (numbers unchanged; single config surface). Its knobs are now `INFINO_BENCH_SUPERTABLE_DOCS` / `INFINO_DIAG_ITERS` (were `INFINO_BENCH_SUPERFILE_DOCS` / `INFINO_SQL_DIAG_ITERS`).

## Scope

Bench-harness only (`benches/`), no engine or public-API change. `fmt` (import-grouped) and `clippy --all-targets -D warnings` clean; `fts-diag` smoke-run verified.