### PR TITLE
bench(fts-diag): single-superfile mode, reader-thread knob, count decomposition

### DIFF
--- a/benches/utils/diag_common.rs
+++ b/benches/utils/diag_common.rs
@@ -26,6 +26,7 @@ use infino::{
     supertable::{Supertable, SupertableOptions},
     test_helpers::default_tokenizer,
 };
+use rayon::ThreadPoolBuilder;
 
 use crate::corpus::{self, MmapTextCorpus};
 
@@ -44,6 +45,17 @@ const DEFAULT_ITERS: usize = 15;
 pub struct DiagConfig {
     pub n_docs: usize,
     pub iters: usize,
+    /// Build the table as a **single superfile** (one writer, one commit)
+    /// instead of the default many-superfile layout (a commit produces
+    /// one superfile per writer thread = cpu/2). Lets a diagnostic
+    /// separate intrinsic single-superfile kernel cost from
+    /// cross-superfile fan-out. Set `INFINO_DIAG_SINGLE_SUPERFILE=1`.
+    pub single_superfile: bool,
+    /// Override the reader pool thread count (`INFINO_DIAG_READER_THREADS`).
+    /// `None` = engine default (num_cpu). Setting it to 1 disables the
+    /// intra-superfile sub-range fan-out (which triggers when
+    /// pool_threads > superfile count), isolating that machinery's cost.
+    pub reader_threads: Option<usize>,
 }
 
 /// Read the diagnostic config from the single shared set of knobs.
@@ -55,6 +67,10 @@ pub fn config() -> DiagConfig {
     DiagConfig {
         n_docs: corpus::supertable_docs(),
         iters,
+        reader_threads: std::env::var("INFINO_DIAG_READER_THREADS")
+            .ok()
+            .and_then(|s| s.parse().ok()),
+        single_superfile: std::env::var("INFINO_DIAG_SINGLE_SUPERFILE").is_ok(),
     }
 }
 
@@ -104,16 +120,55 @@ pub fn chunk_batch(rows: &[(u64, &str)]) -> RecordBatch {
     .expect("chunk batch")
 }
 
-/// Build the diagnostic `Supertable` from a Zipfian `termNNNNN` corpus,
-/// committed one `WRITE_CHUNK` superfile at a time (in-memory store, warm
-/// by construction). Returns the table plus the chunk batches — the SQL
-/// diagnostic reuses them for its DataFusion baselines; callers that only
-/// need the table can ignore them (the batches own their data, so the
-/// corpus is dropped here).
+/// Build the diagnostic `Supertable` from a Zipfian `termNNNNN` corpus
+/// (in-memory store, warm by construction). Returns the table plus the
+/// chunk batches — the SQL diagnostic reuses them for its DataFusion
+/// baselines; callers that only need the table can ignore them (the
+/// batches own their data, so the corpus is dropped here).
+///
+/// Layout depends on [`DiagConfig::single_superfile`]: the default
+/// commits per `WRITE_CHUNK` chunk (one superfile per writer thread each
+/// commit ⇒ many superfiles), then runs default `optimize`; the
+/// single-superfile mode uses a one-thread writer and one commit so the
+/// whole table is one superfile (no cross-superfile fan-out).
 pub fn build_supertable(cfg: &DiagConfig) -> (Supertable, Vec<RecordBatch>) {
     let corpus = MmapTextCorpus::generate(cfg.n_docs, 1);
     let batches: Vec<RecordBatch> = corpus.rows().chunks(WRITE_CHUNK).map(chunk_batch).collect();
-    let table = Supertable::create(diag_options()).expect("create diag supertable");
+
+    // Optional reader-pool override (isolates the sub-range fan-out cost).
+    let with_reader = |o: SupertableOptions| -> SupertableOptions {
+        match cfg.reader_threads {
+            Some(n) => o.with_reader_pool(Arc::new(
+                ThreadPoolBuilder::new()
+                    .num_threads(n)
+                    .build()
+                    .expect("reader pool"),
+            )),
+            None => o,
+        }
+    };
+
+    if cfg.single_superfile {
+        // One writer thread + one commit ⇒ exactly one superfile.
+        let pool = Arc::new(
+            ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("single-thread writer pool"),
+        );
+        let table = Supertable::create(with_reader(diag_options().with_writer_pool(pool)))
+            .expect("create diag supertable");
+        {
+            let mut writer = table.writer().expect("writer");
+            for batch in &batches {
+                writer.append(batch).expect("append");
+            }
+            writer.commit().expect("commit");
+        }
+        return (table, batches);
+    }
+
+    let table = Supertable::create(with_reader(diag_options())).expect("create diag supertable");
     {
         let mut writer = table.writer().expect("writer");
         for batch in &batches {

--- a/benches/utils/diag_common.rs
+++ b/benches/utils/diag_common.rs
@@ -21,6 +21,7 @@ use std::{
 use arrow_array::{Int64Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    OptimizeOptions,
     superfile::builder::FtsConfig,
     supertable::{Supertable, SupertableOptions},
     test_helpers::default_tokenizer,
@@ -120,6 +121,12 @@ pub fn build_supertable(cfg: &DiagConfig) -> (Supertable, Vec<RecordBatch>) {
             writer.commit().expect("commit");
         }
     }
+    // Optimize with defaults — the maintenance step a real deployment runs.
+    // (At small totals this leaves the per-commit superfiles as-is, since
+    // optimize only merges once the total exceeds the target size.)
+    table
+        .optimize(&OptimizeOptions::default())
+        .expect("optimize diag supertable");
     (table, batches)
 }
 

--- a/benches/utils/fts_diag.rs
+++ b/benches/utils/fts_diag.rs
@@ -84,11 +84,12 @@ pub fn run() {
     eprintln!("[fts-diag] building supertable...");
     let build_t0 = Instant::now();
     let (table, _batches) = diag_common::build_supertable(&cfg);
-    eprintln!(
-        "[fts-diag] built in {:.1}s",
-        build_t0.elapsed().as_secs_f64()
-    );
     let reader = table.reader();
+    eprintln!(
+        "[fts-diag] built in {:.1}s ({} superfile(s) after optimize)",
+        build_t0.elapsed().as_secs_f64(),
+        reader.manifest().superfiles.len(),
+    );
 
     // Warm both paths for every shape (cache-hot before timing).
     for s in SHAPES {

--- a/benches/utils/fts_diag.rs
+++ b/benches/utils/fts_diag.rs
@@ -98,16 +98,38 @@ pub fn run() {
             .expect("warm-up bm25_search");
     }
 
+    // Warm the count path too.
+    for s in SHAPES {
+        let _ = reader
+            .count(COLUMN, s.query, s.mode)
+            .expect("warm-up count");
+    }
+
+    // Decompose the scored path into three additive layers:
+    //   count  = posting traversal + block decode (no score, no heap)
+    //   kernel = count + BM25 scoring + top-k heap   (= bm25_hits)
+    //   full   = kernel + _id-resolution + result assembly (= bm25_search)
+    // so score+heap = kernel − count, and resolve = full − kernel. (At
+    // k=1000 over a large superfile the scored path prunes little, so
+    // count is a fair traverse/decode floor for it.)
     eprintln!();
     eprintln!(
-        "[fts-diag] {:<15}{:>8}{:>13}{:>13}{:>13}{:>10}",
-        "shape", "hits", "kernel p50", "full p50", "resolve p50", "resolve%"
+        "[fts-diag] {:<15}{:>8}{:>12}{:>12}{:>12}{:>13}{:>12}",
+        "shape", "hits", "count", "kernel", "full", "score+heap", "resolve"
     );
     for s in SHAPES {
         let hits = reader
             .bm25_hits(COLUMN, s.query, K, s.mode)
             .expect("bm25_hits")
             .len();
+
+        let mut count = Vec::with_capacity(cfg.iters);
+        for _ in 0..cfg.iters {
+            let t = Instant::now();
+            let out = reader.count(COLUMN, s.query, s.mode).expect("count");
+            count.push(t.elapsed());
+            std::hint::black_box(out);
+        }
 
         let mut kernel = Vec::with_capacity(cfg.iters);
         for _ in 0..cfg.iters {
@@ -129,22 +151,20 @@ pub fn run() {
             std::hint::black_box(out);
         }
 
+        let cp = diag_common::percentile(&mut count, 50);
         let kp = diag_common::percentile(&mut kernel, 50);
         let fp = diag_common::percentile(&mut full, 50);
+        let score_heap = kp.saturating_sub(cp);
         let resolve = fp.saturating_sub(kp);
-        let pct = if fp.as_nanos() > 0 {
-            resolve.as_nanos() as f64 / fp.as_nanos() as f64 * 100.0
-        } else {
-            0.0
-        };
         eprintln!(
-            "[fts-diag] {:<15}{:>8}{:>13}{:>13}{:>13}{:>9.0}%",
+            "[fts-diag] {:<15}{:>8}{:>12}{:>12}{:>12}{:>13}{:>12}",
             s.name,
             hits,
+            diag_common::fmt(cp),
             diag_common::fmt(kp),
             diag_common::fmt(fp),
+            diag_common::fmt(score_heap),
             diag_common::fmt(resolve),
-            pct,
         );
     }
 }


### PR DESCRIPTION
Enhances the `fts-diag` query-path diagnostic (added earlier) with three profiling capabilities used to localize where the scored large-k top-k cost actually lives within the FTS kernel. No engine or on-disk format change — benches only.

## What

- **single-superfile build mode** (`INFINO_DIAG_SINGLE_SUPERFILE=1`): one writer thread + one commit, so the table is exactly one superfile. Separates intrinsic single-superfile kernel cost from cross-superfile fan-out.
- **reader-thread override** (`INFINO_DIAG_READER_THREADS`): pins the reader pool size. Setting it to 1 disables the intra-superfile sub-range fan-out (which triggers when pool threads exceed superfile count), isolating that machinery's cost.
- **count decomposition** in `fts-diag`: splits the scored path into additive layers — `count` (traverse + block decode) / `score+heap` (kernel − count) / `resolve` (full − kernel) — so the kernel-vs-resolve split is visible per query shape.
- The diagnostic table now runs default `optimize()` after ingest (the maintenance step a real deployment runs) and prints its superfile count, so the measured layout mirrors production shapes.

## Why

The kernel-vs-resolve split alone couldn't distinguish scan cost from decode cost from cursor-build cost. These knobs let a single in-process run (`cargo bench -- fts-diag`) attribute the large-k scored cost across superfile layout, reader parallelism, and the count/score/resolve layers — the attribution needed before optimizing the scored path.

## Testing

- `cargo build --benches` clean.
- `cargo fmt --check` clean.
- Diagnostic runs at 1M docs across the single/many-superfile and reader-thread configurations.