### PR TITLE
sql: skip partial aggregation sooner on high-cardinality GROUP BY

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1955,6 +1955,15 @@ pub mod sql {
             name: "group_by_category",
             sql: "SELECT category, COUNT(*) AS n FROM supertable GROUP BY category",
         },
+        // High-cardinality GROUP BY: `title` is near-unique per row, so the
+        // group key set is ~n_docs. This is the shape where the aggregate's
+        // per-partition partial phase does almost no dedup yet re-hashes every
+        // key; the ORDER BY / LIMIT keeps the output small while still forcing
+        // the full high-cardinality group-id build.
+        SqlQuery {
+            name: "group_by_title_highcard",
+            sql: "SELECT title, COUNT(*) AS n FROM supertable GROUP BY title ORDER BY n DESC LIMIT 10",
+        },
     ];
 
     /// Query literals that depend on the built corpus (sample row values).

--- a/src/memory/datafusion_pool.rs
+++ b/src/memory/datafusion_pool.rs
@@ -53,6 +53,14 @@ struct ConnectionBudgetPool {
 /// used only in its diagnostics). The budget has no extra state worth printing.
 const POOL_NAME: &str = "ConnectionBudgetPool";
 
+/// Unique-key fraction above which DataFusion abandons the partial
+/// (per-partition) pre-aggregation phase of a grouped aggregate. DataFusion's
+/// default is 0.8; 0.5 abandons it sooner. On a high-cardinality `GROUP BY` the
+/// partial phase barely reduces the row count yet re-hashes every key, so
+/// skipping it and letting the final aggregate hash once is faster. Low-
+/// cardinality groupings, which still dedup below this fraction, keep it.
+const PARTIAL_AGG_SKIP_PROBE_RATIO: f64 = 0.5;
+
 impl fmt::Display for ConnectionBudgetPool {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(POOL_NAME)
@@ -123,6 +131,15 @@ pub(crate) fn budgeted_session_context(
     // One consequence: a column the user themselves declared `Utf8View` is also
     // converted, so SQL string results are always `LargeUtf8`, never a view.
     config.options_mut().optimizer.expand_views_at_output = true;
+
+    // Skip DataFusion's partial (pre-)aggregation sooner on high-cardinality
+    // GROUP BY (see PARTIAL_AGG_SKIP_PROBE_RATIO). Execution strategy only;
+    // results are identical.
+    config
+        .options_mut()
+        .execution
+        .skip_partial_aggregation_probe_ratio_threshold = PARTIAL_AGG_SKIP_PROBE_RATIO;
+
     Ok(SessionContext::new_with_config_rt(
         config,
         budgeted_runtime(budget)?,


### PR DESCRIPTION
### What does this PR do?
Speeds up grouped aggregations over columns with very many distinct values (high-cardinality `GROUP BY`).

### Why do we need this change?
On a `GROUP BY` with many distinct groups, the partial (per-partition) pre-aggregation does almost no useful work: nearly every input row is its own group, so it hashes every row without meaningfully shrinking the data before the final aggregate. That is wasted CPU on exactly the queries where grouping already dominates the cost. DataFusion can abandon the partial phase once it samples too many unique keys, but its default only does so past 80% unique, so these high-cardinality groupings still pay for a phase that buys them nothing.

### How do we do this change?
- **Lower the partial-aggregation skip threshold to 0.5.** DataFusion samples group keys early in a grouped aggregate and abandons the partial phase once the unique-key fraction crosses `skip_partial_aggregation_probe_ratio_threshold`; the default is 0.8. At 0.5 it drops the partial phase for high-cardinality groupings while keeping it for low-cardinality ones that still dedup below that fraction.
- **Set it where every SQL session is built** (`budgeted_session_context`), so both query paths inherit it, next to the existing `expand_views_at_output` setting, as a documented constant (`PARTIAL_AGG_SKIP_PROBE_RATIO`).
- **Add a high-cardinality GROUP BY cell to the SQL bench battery** (`group_by_title_highcard`), a shape the suite did not previously cover.

### Performance
This changes only the aggregate's execution strategy, not its output, so query results are identical (the existing SQL aggregate tests cover it). The gain is on large-scale, high-cardinality grouping, where the partial phase re-hashes every key without meaningfully shrinking the data; it does not surface at the in-repo SQL suite's 1M in-memory scale, so the new `group_by_title_highcard` cell stands as a guard for the shape and the at-scale before/after will be recorded in `benches/README.md` from an object-store run. Fail-safe: low- and mid-cardinality groupings keep the partial phase and non-grouped aggregates are untouched, so the worst case is unchanged execution, never a wrong result.
