### PR TITLE
vectors: enforce limit on cluster size and implement better performance metering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,11 @@ mimalloc = ["dep:mimalloc", "dep:libmimalloc-sys"]
 # `test-helpers` across the whole dev-target graph (tests, benches,
 # AND examples), so no in-package example can build with it off.
 test-helpers = []
+# Exposes `infino::runtime_metrics` (`io` / `cpu` / `rss`) plus
+# `Connection::usage_snapshot` / `usage_meter` for dependents
+# (e.g. infino-platform Prometheus) without `test-helpers`.
+# Off the curated `public-api.txt` snapshot (default features only).
+metering = []
 # Opt-in diagnostic benches that are useful for storage/request-shape
 # work or release-profile recall gates, but should not run as part of a
 # plain `cargo bench`.

--- a/benches/utils/cost.rs
+++ b/benches/utils/cost.rs
@@ -398,11 +398,14 @@ pub struct CellCost<'a> {
     pub cold_pre: Option<&'a [ColdQuery]>,
     /// Measured object-store I/O per phase.
     pub store: StorePhases,
-    /// Whether this cell has the vector maintenance lifecycle (drain,
-    /// compaction, filtered search, pre/post-drain split). Those ledger
-    /// rows always render on such a cell — as "NOT METERED" when the
-    /// harness failed to measure them — and never render elsewhere
-    /// (an FTS cell has no drain to meter).
+    /// Whether this cell runs the full maintenance lifecycle (pre-drain →
+    /// drain → post-drain → delta → post-delta → compact → post-compact).
+    /// Ledger rows for drain / delta / optimize / pre-drain cold always
+    /// render on such a cell — as "NOT METERED" when the harness failed
+    /// to measure them — and never render elsewhere. Named for the
+    /// vector cell that introduced the shape; FTS/SQL set this too when
+    /// they run the same phase sequence (drain is a no-op without a
+    /// hidden vector index).
     pub vector_cell: bool,
     /// Assumed retention for the capacity line (GB-months). Default 1 month.
     pub storage_months: Option<f64>,

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -360,12 +360,20 @@ pub fn prepare_corpus(modality: Modality) -> PreparedCorpus {
     } else {
         n_docs
     };
+    // FTS/SQL carry a one-commit delta tail (same shape as the vector
+    // modality's undrained follow-up) so the post-drain → delta →
+    // post-delta → compact lifecycle can append without regenerating.
+    let text_docs = if matches!(modality, Modality::Fts | Modality::Sql) {
+        n_docs + docs_per_commit()
+    } else {
+        n_docs
+    };
     let text = modality.has_text().then(|| {
         eprintln!(
             "[supertable_ingest] generating {} -doc text corpus (mmap-backed)...",
-            fmt_count(n_docs)
+            fmt_count(text_docs)
         );
-        MmapTextCorpus::generate(n_docs, CORPUS_TEXT_SEED)
+        MmapTextCorpus::generate(text_docs, CORPUS_TEXT_SEED)
     });
     let vectors = modality.has_vector().then(|| {
         if let Some(path) = explicit_vector_path.as_deref() {
@@ -420,6 +428,41 @@ pub fn vector_delta_batch(corpus: &PreparedCorpus) -> RecordBatch {
         MmapVectorCorpus::generate_range(start, len, corpus::n_cent(start), CORPUS_VEC_SEED, true);
     RecordBatch::try_new(schema, vec![vector_array(tail.as_slice())])
         .expect("vector delta RecordBatch")
+}
+
+/// The next normal FTS commit after the measured base ingest.
+pub fn fts_delta_batch(corpus: &PreparedCorpus) -> RecordBatch {
+    text_delta_batch(Modality::Fts, corpus)
+}
+
+/// The next normal SQL commit after the measured base ingest.
+pub fn sql_delta_batch(corpus: &PreparedCorpus) -> RecordBatch {
+    text_delta_batch(Modality::Sql, corpus)
+}
+
+fn text_delta_batch(modality: Modality, corpus: &PreparedCorpus) -> RecordBatch {
+    assert!(
+        matches!(modality, Modality::Fts | Modality::Sql),
+        "text delta is FTS/SQL only"
+    );
+    let start = n_docs();
+    let len = docs_per_commit();
+    let end = start + len;
+    let text = corpus
+        .text
+        .as_ref()
+        .expect("FTS/SQL delta requires a prepared text corpus");
+    assert!(
+        text.n_docs() >= end,
+        "text corpus must include the delta tail ({} docs, need {end})",
+        text.n_docs()
+    );
+    let schema = if modality.has_sql() {
+        sql_schema()
+    } else {
+        schema_for(modality)
+    };
+    chunk_batch(modality, corpus, &schema, start, end, len)
 }
 
 /// Stream the prepared on-disk corpus → append → commit → object

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -355,53 +355,44 @@ impl PreparedCorpus {
 pub fn prepare_corpus(modality: Modality) -> PreparedCorpus {
     let n_docs = n_docs();
     let explicit_vector_path = env::var_os(VECTOR_CORPUS_PATH_ENV).map(PathBuf::from);
-    let vector_docs = if modality == Modality::Vector {
-        n_docs + docs_per_commit()
-    } else {
-        n_docs
-    };
-    // FTS/SQL carry a one-commit delta tail (same shape as the vector
-    // modality's undrained follow-up) so the post-drain → delta →
-    // post-delta → compact lifecycle can append without regenerating.
-    let text_docs = if matches!(modality, Modality::Fts | Modality::Sql) {
-        n_docs + docs_per_commit()
-    } else {
-        n_docs
-    };
+    // Every modality's lifecycle appends one undrained follow-up commit
+    // after the measured base ingest (vector: post-drain delta; FTS/SQL:
+    // post-drain → delta → compact). Generate base + that tail once so
+    // the delta batch does not regenerate.
+    let corpus_docs = n_docs + docs_per_commit();
     let text = modality.has_text().then(|| {
         eprintln!(
             "[supertable_ingest] generating {} -doc text corpus (mmap-backed)...",
-            fmt_count(text_docs)
+            fmt_count(corpus_docs)
         );
-        MmapTextCorpus::generate(text_docs, CORPUS_TEXT_SEED)
+        MmapTextCorpus::generate(corpus_docs, CORPUS_TEXT_SEED)
     });
     let vectors = modality.has_vector().then(|| {
         if let Some(path) = explicit_vector_path.as_deref() {
-            // A persisted corpus is either base-only (`n_docs` rows) or —
-            // for the vector modality — carries the undrained delta tail
-            // (`vector_docs` rows, the shape `generate` writes). Accept
-            // both; `vector_delta_batch` regenerates the tail when only
-            // the base rows are present.
+            // A persisted corpus is either base-only (`n_docs` rows) or
+            // carries the undrained delta tail (`corpus_docs` rows, the
+            // shape `generate` writes). Accept both; `vector_delta_batch`
+            // regenerates the tail when only the base rows are present.
             eprintln!(
                 "[supertable_ingest] opening persisted {} ×{DIM} vector corpus from {}...",
                 fmt_count(n_docs),
                 path.display()
             );
-            MmapVectorCorpus::open(path, vector_docs)
+            MmapVectorCorpus::open(path, corpus_docs)
                 .or_else(|_| MmapVectorCorpus::open(path, n_docs))
                 .unwrap_or_else(|error| {
                     panic!(
                         "failed to open {VECTOR_CORPUS_PATH_ENV}={} with either \
-                         {vector_docs} (base + delta) or {n_docs} (base-only) rows: {error}",
+                         {corpus_docs} (base + delta) or {n_docs} (base-only) rows: {error}",
                         path.display()
                     )
                 })
         } else {
             eprintln!(
                 "[supertable_ingest] generating {} ×{DIM} vector corpus (mmap-backed)...",
-                fmt_count(vector_docs)
+                fmt_count(corpus_docs)
             );
-            MmapVectorCorpus::generate(vector_docs, corpus::n_cent(n_docs), CORPUS_VEC_SEED, true)
+            MmapVectorCorpus::generate(corpus_docs, corpus::n_cent(n_docs), CORPUS_VEC_SEED, true)
         }
     });
     PreparedCorpus { text, vectors }

--- a/benches/utils/storage_meter.rs
+++ b/benches/utils/storage_meter.rs
@@ -9,8 +9,9 @@
 
 use std::sync::Arc;
 
-pub use infino::storage::{ClassIo, N_URI_CLASSES, TraceEntry, UriClass};
-use infino::storage::{StorageProvider, UsageMeter, UsageSnapshot};
+pub use infino::runtime_metrics::{ClassIo, N_URI_CLASSES, TraceEntry, UriClass};
+use infino::runtime_metrics::{UsageMeter, UsageSnapshot};
+use infino::storage::StorageProvider;
 
 use crate::rss;
 

--- a/benches/utils/storage_meter.rs
+++ b/benches/utils/storage_meter.rs
@@ -10,8 +10,10 @@
 use std::sync::Arc;
 
 pub use infino::runtime_metrics::{ClassIo, N_URI_CLASSES, TraceEntry, UriClass};
-use infino::runtime_metrics::{UsageMeter, UsageSnapshot};
-use infino::storage::StorageProvider;
+use infino::{
+    runtime_metrics::{UsageMeter, UsageSnapshot},
+    storage::StorageProvider,
+};
 
 use crate::rss;
 

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -46,6 +46,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use arrow_array::RecordBatch;
 use infino::{
     OptimizeOptions,
     supertable::{
@@ -647,11 +648,26 @@ fn run_metered_optimize(
     (wall_s, io, peak_rss, cpu_s)
 }
 
-fn store_phases_with_compaction(
+/// Fill cold + drain + delta + compaction slots on [`cost::StorePhases`].
+fn store_phases_lifecycle(
     measured: Option<ColdStoreMeasurement>,
+    drain: Option<CompactionStats>,
+    delta: Option<CompactionStats>,
     compaction: Option<CompactionStats>,
 ) -> cost::StorePhases {
     let mut store = store_phases_from_measurement(measured);
+    if let Some((wall_s, io, peak_rss, cpu_s)) = drain {
+        store.drain = Some(io);
+        store.drain_wall_s = Some(wall_s);
+        store.drain_cpu_s = cpu_s;
+        store.drain_peak_rss_bytes = Some(peak_rss);
+    }
+    if let Some((wall_s, io, peak_rss, cpu_s)) = delta {
+        store.delta_commit = Some(io);
+        store.delta_commit_wall_s = Some(wall_s);
+        store.delta_commit_cpu_s = cpu_s;
+        store.delta_commit_peak_rss_bytes = Some(peak_rss);
+    }
     if let Some((wall_s, io, peak_rss, cpu_s)) = compaction {
         store.compaction = Some(io);
         store.compaction_wall_s = Some(wall_s);
@@ -661,13 +677,86 @@ fn store_phases_with_compaction(
     store
 }
 
-/// Open a metered consumer, run [`run_metered_optimize`], return stats.
-/// The table on `built.storage` is left in the compacted layout.
-fn optimize_built_table(
+/// Metered [`Supertable::drain_vectors_to_cells_sync`]. On FTS/SQL tables
+/// this is a no-op (no hidden vector index) but still brackets a real
+/// drain window so the lifecycle matches the vector cell.
+fn run_metered_drain(
+    label: &str,
+    consumer: &Supertable,
+    meter: &storage_meter::MeteredStorage,
+) -> CompactionStats {
+    eprintln!("[{label}] draining (hidden vector cells; no-op when absent)...");
+    let before = meter.snapshot();
+    let sampler = PeakSampler::start_default();
+    let (result, wall, cpu_s) = cpu::timed(|| consumer.drain_vectors_to_cells_sync());
+    result.expect("drain");
+    let wall_s = wall.as_secs_f64();
+    let rss_stats = sampler.stop_stats();
+    let peak_rss = rss_stats.peak_rss_bytes;
+    let io = meter.snapshot().since(&before);
+    eprintln!(
+        "[{label}] drain object-store I/O: {} PUT ({} up), {} GET ({} down) in {wall_s:.1}s \
+         (peak RSS {} / anon {} / file {})",
+        io.put_count,
+        rss::fmt_bytes(io.put_bytes),
+        io.get_count,
+        rss::fmt_bytes(io.get_bytes),
+        rss::fmt_bytes(peak_rss),
+        rss::fmt_bytes(rss_stats.peak_anon_rss_bytes),
+        rss::fmt_bytes(rss_stats.peak_file_rss_bytes),
+    );
+    (wall_s, io, peak_rss, cpu_s)
+}
+
+/// Metered follow-up `append` of one normal commit (the undrained delta).
+fn run_metered_delta_append(
+    label: &str,
+    consumer: &Supertable,
+    meter: &storage_meter::MeteredStorage,
+    batch: &RecordBatch,
+) -> CompactionStats {
+    let n_rows = batch.num_rows();
+    eprintln!("[{label}] committing {n_rows} undrained delta rows...");
+    let before = meter.snapshot();
+    let sampler = PeakSampler::start_default();
+    let (result, wall, cpu_s) = cpu::timed(|| consumer.append(batch));
+    result.expect("delta append");
+    let wall_s = wall.as_secs_f64();
+    let rss_stats = sampler.stop_stats();
+    let peak_rss = rss_stats.peak_rss_bytes;
+    let io = meter.snapshot().since(&before);
+    eprintln!(
+        "[{label}] delta commit: {n_rows} rows, {} PUT ({} up), {} GET ({} down) in {wall_s:.1}s \
+         (peak RSS {})",
+        io.put_count,
+        rss::fmt_bytes(io.put_bytes),
+        io.get_count,
+        rss::fmt_bytes(io.get_bytes),
+        rss::fmt_bytes(peak_rss),
+    );
+    (wall_s, io, peak_rss, cpu_s)
+}
+
+/// Measure/emit hook points between the shared FTS/SQL mutations.
+#[derive(Clone, Copy)]
+enum TextLifecyclePhase {
+    AfterDrain,
+    AfterDelta,
+    AfterCompact,
+}
+
+/// Shared FTS/SQL mutation sequence: open a metered consumer, then
+/// drain → delta append → optimize, invoking `on_phase` after each
+/// step (and after the consumer is dropped post-optimize). Vector
+/// keeps its own OPANN-aware path. Drain is a no-op without a hidden
+/// vector index but is still metered for phase parity across modalities.
+fn run_metered_text_lifecycle(
     label: &str,
     modality: Modality,
     built: &supertable::IngestResult,
-) -> CompactionStats {
+    delta: &RecordBatch,
+    mut on_phase: impl FnMut(TextLifecyclePhase),
+) -> (CompactionStats, CompactionStats, CompactionStats) {
     let meter = storage_meter::wrap(Arc::clone(&built.storage));
     let (cache_dir, cache) =
         tiers::fresh_supertable_search_cache(meter.provider(), Some(built.total_index_bytes));
@@ -677,10 +766,15 @@ fn optimize_built_table(
         cache,
     );
     let consumer = tiers::open_consumer(opts);
-    let stats = run_metered_optimize(label, &consumer, &meter);
+    let drain = run_metered_drain(label, &consumer, &meter);
+    on_phase(TextLifecyclePhase::AfterDrain);
+    let delta_stats = run_metered_delta_append(label, &consumer, &meter, delta);
+    on_phase(TextLifecyclePhase::AfterDelta);
+    let compaction = run_metered_optimize(label, &consumer, &meter);
     drop(consumer);
     drop(cache_dir);
-    stats
+    on_phase(TextLifecyclePhase::AfterCompact);
+    (drain, delta_stats, compaction)
 }
 
 /// Pre-drain (transient-shape) latency rows: the warm battery and the
@@ -857,25 +951,6 @@ fn build_measured(
     (built, metrics)
 }
 
-/// Obtain the search artifact for modalities that don't need the corpus after
-/// build (FTS, SQL): in dataset mode open the pre-uploaded dataset (no corpus,
-/// no ingest); otherwise generate the corpus and ingest it. Vector keeps its
-/// corpus for recall ground truth and calls [`build_measured`] directly.
-fn build_or_open(
-    modality: Modality,
-    phases: Phases,
-) -> (supertable::IngestResult, Option<ShapeMetrics>) {
-    // Dataset mode opens the pre-uploaded dataset only for read phases; a
-    // build phase is the prepare step, which still ingests (to the fixed
-    // prefix).
-    if crate::dataset::dataset_mode() && !phases.build {
-        return (supertable::open_dataset(modality), None);
-    }
-    // Corpus to disk + mmap BEFORE the sampler — engine-only window.
-    let corpus = supertable::prepare_corpus(modality);
-    build_measured(modality, &corpus, phases)
-}
-
 fn open_consumer(modality: Modality, built: &supertable::IngestResult) -> (TempDir, Supertable) {
     let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
         Arc::clone(&built.storage),
@@ -937,14 +1012,24 @@ pub mod fts {
             return;
         }
 
-        let (built, ingest_metrics) = build_or_open(Modality::Fts, phases);
+        // Fresh ingest retains the text corpus for the undrained delta commit.
+        let (built, ingest_metrics, mut corpus) = if crate::dataset::dataset_mode() && !phases.build
+        {
+            (supertable::open_dataset(Modality::Fts), None, None)
+        } else {
+            let corpus = supertable::prepare_corpus(Modality::Fts);
+            let (built, metrics) = build_measured(Modality::Fts, &corpus, phases);
+            (built, metrics, Some(corpus))
+        };
         if let Some(metrics) = &ingest_metrics {
             emit_ingest(&mut report, n_docs, metrics);
         }
 
-        // Optimize + post-compact only on a fresh ingest in this process —
-        // without drain/delta/OPANN.
-        let run_optimize = ingest_metrics.is_some() && (phases.warm || phases.cold);
+        // Full lifecycle (pre-drain → drain → post-drain → delta → post-delta
+        // → compact → post-compact) on a fresh ingest in this process —
+        // same gate as the vector cell. Drain is a no-op without a hidden
+        // vector index but is still metered for phase parity.
+        let run_lifecycle = ingest_metrics.is_some() && (phases.warm || phases.cold);
 
         if phases.warm || phases.cold {
             let (cache_dir, consumer) = open_consumer(Modality::Fts, &built);
@@ -954,21 +1039,21 @@ pub mod fts {
             drop(cache_dir);
         }
 
-        // Pre-compact (or sole) search: fragmented post-ingest layout.
+        // Pre-drain (or sole) search: fragmented post-ingest layout.
         let (warm_pre, counts, large_k) = match phases.warm.then(|| measure_warm(&built)) {
             Some((w, c, l)) => (Some(w), Some(c), Some(l)),
             None => (None, None, None),
         };
         let cold_pre = phases.cold.then(|| measure_cold(&built));
         if phases.warm || phases.cold {
-            let (anchor, title, note) = if run_optimize {
+            let (anchor, title, note) = if run_lifecycle {
                 (
-                    "bench/fts/supertable/search-pre-compact",
+                    "bench/fts/supertable/search/pre-drain",
                     format!(
-                        "Supertable FTS — search pre-compact, multi-superfile / object-store ({} docs)",
+                        "Supertable FTS — search pre-drain, multi-superfile / object-store ({} docs)",
                         fmt_count(n_docs)
                     ),
-                    "Pre-compact (post-ingest fanout): warm = shared consumer + disk cache; \
+                    "Pre-drain (post-ingest fanout): warm = shared consumer + disk cache; \
                      cold open = construct only; cold search = first bm25_search. Δ vs previous run."
                         .to_string(),
                 )
@@ -1040,38 +1125,78 @@ pub mod fts {
             );
         }
 
-        let compaction_stats =
-            run_optimize.then(|| optimize_built_table("supertable_fts", Modality::Fts, &built));
-
-        // Post-compact search + cost-cold (steady serving layout).
-        let (warm_post, cold_post) = if run_optimize {
-            let warm_post = phases.warm.then(|| {
-                let (w, _, _) = measure_warm(&built);
-                w
-            });
-            let cold_post = phases.cold.then(|| measure_cold(&built));
-            if phases.warm || phases.cold {
-                exec_fts::emit_search(
-                    &mut report,
-                    "bench/fts/supertable/search-post-compact",
-                    format!(
-                        "Supertable FTS — search post-compact, multi-superfile / object-store ({} docs)",
-                        fmt_count(n_docs)
-                    ),
-                    "Post-compact (after optimize): fewer superfiles; warm/cold recipe unchanged. \
-                     This is the steady-state layout the cost model prices. Δ vs previous run.",
-                    warm_post.as_deref(),
-                    cold_post.as_ref(),
-                    None,
-                );
-            }
+        let mut drain_stats = None;
+        let mut delta_stats = None;
+        let mut compaction_stats = None;
+        let (warm_post, cold_post) = if run_lifecycle {
+            let delta_batch = supertable::fts_delta_batch(
+                corpus
+                    .as_ref()
+                    .expect("FTS lifecycle retains text corpus for delta"),
+            );
+            let mut warm_post = None;
+            let mut cold_post = None;
+            let (drain, delta, compaction) = run_metered_text_lifecycle(
+                "supertable_fts",
+                Modality::Fts,
+                &built,
+                &delta_batch,
+                |phase| {
+                    let (anchor_suffix, note) = match phase {
+                        TextLifecyclePhase::AfterDrain => (
+                            "post-drain",
+                            "Post-drain (after drain_vectors_to_cells; no-op without a hidden vector index). \
+                             Same warm/cold recipe as pre-drain. Δ vs previous run.",
+                        ),
+                        TextLifecyclePhase::AfterDelta => (
+                            "post-delta",
+                            "Post-delta (base commits + one undrained follow-up commit). Warm/cold recipe \
+                             unchanged. Δ vs previous run.",
+                        ),
+                        TextLifecyclePhase::AfterCompact => (
+                            "post-compact",
+                            "Post-compact (after optimize): fewer superfiles; warm/cold recipe unchanged. \
+                             Steady-state layout the cost model prices. Δ vs previous run.",
+                        ),
+                    };
+                    let warm = phases.warm.then(|| {
+                        let (w, _, _) = measure_warm(&built);
+                        w
+                    });
+                    let cold = phases.cold.then(|| measure_cold(&built));
+                    if phases.warm || phases.cold {
+                        exec_fts::emit_search(
+                            &mut report,
+                            &format!("bench/fts/supertable/search/{anchor_suffix}"),
+                            format!(
+                                "Supertable FTS — search {anchor_suffix}, multi-superfile / object-store ({} docs)",
+                                fmt_count(n_docs)
+                            ),
+                            note,
+                            warm.as_deref(),
+                            cold.as_ref(),
+                            None,
+                        );
+                    }
+                    if matches!(phase, TextLifecyclePhase::AfterCompact) {
+                        warm_post = warm;
+                        cold_post = cold;
+                    }
+                },
+            );
+            drop(delta_batch);
+            drop(corpus.take());
+            drain_stats = Some(drain);
+            delta_stats = Some(delta);
+            compaction_stats = Some(compaction);
             (warm_post, cold_post)
         } else {
+            drop(corpus.take());
             (None, None)
         };
 
         if phases.warm || phases.cold {
-            let (warm_for_cost, cold_for_cost, pre_latencies) = if run_optimize {
+            let (warm_for_cost, cold_for_cost, pre_latencies) = if run_lifecycle {
                 (
                     warm_post.as_deref().unwrap_or(&[]),
                     cold_post.as_ref(),
@@ -1112,8 +1237,13 @@ pub mod fts {
                         Some(&cold_vec)
                     },
                     pre_refs,
-                    false,
-                    store_phases_with_compaction(cold_measured, compaction_stats),
+                    run_lifecycle,
+                    store_phases_lifecycle(
+                        cold_measured,
+                        drain_stats,
+                        delta_stats,
+                        compaction_stats,
+                    ),
                     None,
                 );
             }
@@ -3956,7 +4086,16 @@ pub mod sql {
 
         let n_docs = supertable::n_docs();
         let mut report = Report::load("supertable_sql");
-        let (built, ingest_metrics) = build_or_open(Modality::Sql, phases);
+
+        // Fresh ingest retains the text corpus for the undrained delta commit.
+        let (built, ingest_metrics, mut corpus) = if crate::dataset::dataset_mode() && !phases.build
+        {
+            (supertable::open_dataset(Modality::Sql), None, None)
+        } else {
+            let corpus = supertable::prepare_corpus(Modality::Sql);
+            let (built, metrics) = build_measured(Modality::Sql, &corpus, phases);
+            (built, metrics, Some(corpus))
+        };
         if let Some(metrics) = &ingest_metrics {
             report.emit(&Section {
                 anchor: "bench/sql/supertable/ingest".into(),
@@ -3987,9 +4126,11 @@ pub mod sql {
                 .expect("sql ingest sets sample_key"),
         };
 
-        // Optimize + post-compact only on a fresh ingest in this process —
-        // same gate as FTS.
-        let run_optimize = ingest_metrics.is_some() && (phases.warm || phases.cold);
+        // Full lifecycle (pre-drain → drain → post-drain → delta → post-delta
+        // → compact → post-compact) on a fresh ingest in this process —
+        // same gate as FTS/vector. Drain is a no-op without a hidden
+        // vector index but is still metered for phase parity.
+        let run_lifecycle = ingest_metrics.is_some() && (phases.warm || phases.cold);
 
         if phases.warm || phases.cold {
             let (cache_dir, consumer) = open_consumer(Modality::Sql, &built);
@@ -3998,22 +4139,22 @@ pub mod sql {
             drop(cache_dir);
         }
 
-        // Pre-compact (or sole) warm/cold on the post-ingest layout.
+        // Pre-drain (or sole) warm/cold on the post-ingest layout.
         let warm_sets_pre = if phases.warm {
-            eprintln!("[supertable_sql] warm (pre-compact): opening consumer...");
+            eprintln!("[supertable_sql] warm (pre-drain): opening consumer...");
             let (cache_dir, consumer) = open_consumer(Modality::Sql, &built);
             let sets =
                 exec_sql::measure_query_sets(&consumer, &inputs, exec_sql::ITERS, "supertable_sql");
             drop(consumer);
             drop(cache_dir);
-            let (anchor, title, note) = if run_optimize {
+            let (anchor, title, note) = if run_lifecycle {
                 (
-                    "bench/sql/supertable/warm-pre-compact",
+                    "bench/sql/supertable/warm/pre-drain",
                     format!(
-                        "Supertable SQL — warm queries pre-compact, warm cache / object-store ({} rows)",
+                        "Supertable SQL — warm queries pre-drain, warm cache / object-store ({} rows)",
                         fmt_count(n_docs)
                     ),
-                    "Pre-compact (post-ingest fanout): each query once untimed (cache fill), then p50 / p90 / p99. Δ vs previous run.",
+                    "Pre-drain (post-ingest fanout): each query once untimed (cache fill), then p50 / p90 / p99. Δ vs previous run.",
                 )
             } else {
                 (
@@ -4037,14 +4178,14 @@ pub mod sql {
                 COLD_ITERS,
                 "supertable_sql",
             );
-            let (anchor, title, note) = if run_optimize {
+            let (anchor, title, note) = if run_lifecycle {
                 (
-                    "bench/sql/supertable/cold-pre-compact",
+                    "bench/sql/supertable/cold/pre-drain",
                     format!(
-                        "Supertable SQL — cold queries pre-compact, fresh cache / object-store ({} rows)",
+                        "Supertable SQL — cold queries pre-drain, fresh cache / object-store ({} rows)",
                         fmt_count(n_docs)
                     ),
-                    "Pre-compact cold: open = construct only; search is the first query on that cold consumer. Δ vs previous run.",
+                    "Pre-drain cold: open = construct only; search is the first query on that cold consumer. Δ vs previous run.",
                 )
             } else {
                 (
@@ -4062,57 +4203,99 @@ pub mod sql {
             None
         };
 
-        let compaction_stats =
-            run_optimize.then(|| optimize_built_table("supertable_sql", Modality::Sql, &built));
-
-        let (warm_sets_post, cold_post) = if run_optimize {
-            let warm_sets_post = if phases.warm {
-                eprintln!("[supertable_sql] warm (post-compact): opening consumer...");
-                let (cache_dir, consumer) = open_consumer(Modality::Sql, &built);
-                let sets = exec_sql::measure_query_sets(
-                    &consumer,
-                    &inputs,
-                    exec_sql::ITERS,
-                    "supertable_sql",
-                );
-                drop(consumer);
-                drop(cache_dir);
-                exec_sql::emit_query(
-                    &mut report,
-                    "bench/sql/supertable/warm-post-compact",
-                    format!(
-                        "Supertable SQL — warm queries post-compact, warm cache / object-store ({} rows)",
-                        fmt_count(n_docs)
-                    ),
-                    "Post-compact (after optimize): fewer superfiles; same warm recipe. Steady-state layout for the cost model. Δ vs previous run.",
-                    &sets,
-                );
-                Some(sets)
-            } else {
-                None
-            };
-            let cold_post = if phases.cold {
-                let cold = exec_sql::measure_cold(
-                    || SupertableSqlColdGuard::open(&built),
-                    COLD_ITERS,
-                    "supertable_sql",
-                );
-                exec_sql::emit_cold(
-                    &mut report,
-                    "bench/sql/supertable/cold-post-compact",
-                    format!(
-                        "Supertable SQL — cold queries post-compact, fresh cache / object-store ({} rows)",
-                        fmt_count(n_docs)
-                    ),
-                    "Post-compact cold: open = construct only; search is the first query on the merged layout. Δ vs previous run.",
-                    &cold,
-                );
-                Some(cold)
-            } else {
-                None
-            };
+        let mut drain_stats = None;
+        let mut delta_stats = None;
+        let mut compaction_stats = None;
+        let (warm_sets_post, cold_post) = if run_lifecycle {
+            let delta_batch = supertable::sql_delta_batch(
+                corpus
+                    .as_ref()
+                    .expect("SQL lifecycle retains text corpus for delta"),
+            );
+            let mut warm_sets_post = None;
+            let mut cold_post = None;
+            let (drain, delta, compaction) = run_metered_text_lifecycle(
+                "supertable_sql",
+                Modality::Sql,
+                &built,
+                &delta_batch,
+                |phase| {
+                    let (suffix, warm_note, cold_note) = match phase {
+                        TextLifecyclePhase::AfterDrain => (
+                            "post-drain",
+                            "Post-drain (after drain_vectors_to_cells; no-op without a hidden vector index). Same warm recipe as pre-drain. Δ vs previous run.",
+                            "Post-drain cold: open = construct only; search is the first query. Δ vs previous run.",
+                        ),
+                        TextLifecyclePhase::AfterDelta => (
+                            "post-delta",
+                            "Post-delta (base commits + one undrained follow-up commit). Same warm recipe. Δ vs previous run.",
+                            "Post-delta cold: open = construct only; search is the first query. Δ vs previous run.",
+                        ),
+                        TextLifecyclePhase::AfterCompact => (
+                            "post-compact",
+                            "Post-compact (after optimize): fewer superfiles; same warm recipe. Steady-state layout for the cost model. Δ vs previous run.",
+                            "Post-compact cold: open = construct only; search is the first query on the merged layout. Δ vs previous run.",
+                        ),
+                    };
+                    let warm = if phases.warm {
+                        eprintln!("[supertable_sql] warm ({suffix}): opening consumer...");
+                        let (cache_dir, c) = open_consumer(Modality::Sql, &built);
+                        let sets = exec_sql::measure_query_sets(
+                            &c,
+                            &inputs,
+                            exec_sql::ITERS,
+                            "supertable_sql",
+                        );
+                        drop(c);
+                        drop(cache_dir);
+                        exec_sql::emit_query(
+                            &mut report,
+                            &format!("bench/sql/supertable/warm/{suffix}"),
+                            format!(
+                                "Supertable SQL — warm queries {suffix}, warm cache / object-store ({} rows)",
+                                fmt_count(n_docs)
+                            ),
+                            warm_note,
+                            &sets,
+                        );
+                        Some(sets)
+                    } else {
+                        None
+                    };
+                    let cold = if phases.cold {
+                        let cold = exec_sql::measure_cold(
+                            || SupertableSqlColdGuard::open(&built),
+                            COLD_ITERS,
+                            "supertable_sql",
+                        );
+                        exec_sql::emit_cold(
+                            &mut report,
+                            &format!("bench/sql/supertable/cold/{suffix}"),
+                            format!(
+                                "Supertable SQL — cold queries {suffix}, fresh cache / object-store ({} rows)",
+                                fmt_count(n_docs)
+                            ),
+                            cold_note,
+                            &cold,
+                        );
+                        Some(cold)
+                    } else {
+                        None
+                    };
+                    if matches!(phase, TextLifecyclePhase::AfterCompact) {
+                        warm_sets_post = warm;
+                        cold_post = cold;
+                    }
+                },
+            );
+            drop(delta_batch);
+            drop(corpus.take());
+            drain_stats = Some(drain);
+            delta_stats = Some(delta);
+            compaction_stats = Some(compaction);
             (warm_sets_post, cold_post)
         } else {
+            drop(corpus.take());
             (None, None)
         };
 
@@ -4132,7 +4315,7 @@ pub mod sql {
             .as_ref()
             .map(cost::cold_from_timings)
             .unwrap_or_default();
-        let (warm_vec, cold_vec, pre_latencies) = if run_optimize {
+        let (warm_vec, cold_vec, pre_latencies) = if run_lifecycle {
             (
                 warm_post_vec.as_slice(),
                 cold_post_vec.as_slice(),
@@ -4153,8 +4336,8 @@ pub mod sql {
                 warm_vec,
                 (!cold_vec.is_empty()).then_some(cold_vec),
                 pre_latencies,
-                false,
-                store_phases_with_compaction(cold_measured, compaction_stats),
+                run_lifecycle,
+                store_phases_lifecycle(cold_measured, drain_stats, delta_stats, compaction_stats),
                 None,
             );
         }

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -1664,24 +1664,24 @@ pub mod vector {
     ];
     /// Per-state `(label, <5M ceiling, 5M–20M ceiling)` on the SECOND
     /// (steady) cold query's data GETs. <5M: a probed cell spans ~6 MiB,
-    /// the whole probe coalesces to ONE GET on post-drain / post-compact
-    /// (measured 1 / 3 / 1 at 1M). Post-delta adds the undrained user
-    /// tail: measured 2 user data GETs + 1 hidden = 3 (the tail no
-    /// longer always coalesces to a single user GET). 5–20M: a probed
-    /// cell spans ~60 MiB and the selected runs occupy 2–4
+    /// the whole probe coalesces to ONE GET (measured 1 / 2 / 1 at 1M —
+    /// post-delta's extra GET is the undrained user tail). 5–20M: a
+    /// probed cell spans ~60 MiB and the selected runs occupy 2–4
     /// geometric-chain islands with 10–18 MiB gaps that are cheaper to
     /// fetch in parallel than to bridge (median 3–4 measured at 10M
-    /// under the 8 MiB cold windows). Post-compact matches post-delta at
-    /// mid scale — a budgeted optimize leaves the hidden table two shard
+    /// under the 8 MiB cold windows). Invariant across tiers:
+    /// post-delta = post-drain + 1 (the undrained user tail is exactly
+    /// one extra coalesced GET). Post-compact matches post-delta at mid
+    /// scale — a budgeted optimize leaves the hidden table two shard
     /// generations deep, so a probed cell's runs span two files
     /// (measured 5 at 10M: 3–4 islands in the old shard + 1 in the
     /// new); a full per-cell consolidation pass would earn post-drain's
-    /// ceiling back. The old 2-GET mid-tier value was calibrated against
-    /// the fat-open era (727 MiB opens staging all cell metadata) and is
-    /// not reachable on the v1-open architecture.
+    /// ceiling back. The old 2-GET value at this tier was calibrated
+    /// against the fat-open era (727 MiB opens staging all cell
+    /// metadata) and is not reachable on the v1-open architecture.
     const COLD_GET_CEILINGS_SECOND: &[(&str, u64, u64)] = &[
         ("post-drain", 1, 4),
-        ("post-delta", 3, 5),
+        ("post-delta", 2, 5),
         ("post-compact", 1, 5),
     ];
     /// Ceiling for `label` + `n_docs` out of one of the two gate tables,

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -1664,24 +1664,24 @@ pub mod vector {
     ];
     /// Per-state `(label, <5M ceiling, 5M–20M ceiling)` on the SECOND
     /// (steady) cold query's data GETs. <5M: a probed cell spans ~6 MiB,
-    /// the whole probe coalesces to ONE GET (measured 1 / 2 / 1 at 1M —
-    /// post-delta's extra GET is the undrained user tail). 5–20M: a
-    /// probed cell spans ~60 MiB and the selected runs occupy 2–4
+    /// the whole probe coalesces to ONE GET on post-drain / post-compact
+    /// (measured 1 / 3 / 1 at 1M). Post-delta adds the undrained user
+    /// tail: measured 2 user data GETs + 1 hidden = 3 (the tail no
+    /// longer always coalesces to a single user GET). 5–20M: a probed
+    /// cell spans ~60 MiB and the selected runs occupy 2–4
     /// geometric-chain islands with 10–18 MiB gaps that are cheaper to
     /// fetch in parallel than to bridge (median 3–4 measured at 10M
-    /// under the 8 MiB cold windows). Invariant across tiers:
-    /// post-delta = post-drain + 1 (the undrained user tail is exactly
-    /// one extra coalesced GET). Post-compact matches post-delta at mid
-    /// scale — a budgeted optimize leaves the hidden table two shard
+    /// under the 8 MiB cold windows). Post-compact matches post-delta at
+    /// mid scale — a budgeted optimize leaves the hidden table two shard
     /// generations deep, so a probed cell's runs span two files
     /// (measured 5 at 10M: 3–4 islands in the old shard + 1 in the
     /// new); a full per-cell consolidation pass would earn post-drain's
-    /// ceiling back. The old 2-GET value at this tier was calibrated
-    /// against the fat-open era (727 MiB opens staging all cell
-    /// metadata) and is not reachable on the v1-open architecture.
+    /// ceiling back. The old 2-GET mid-tier value was calibrated against
+    /// the fat-open era (727 MiB opens staging all cell metadata) and is
+    /// not reachable on the v1-open architecture.
     const COLD_GET_CEILINGS_SECOND: &[(&str, u64, u64)] = &[
         ("post-drain", 1, 4),
-        ("post-delta", 2, 5),
+        ("post-delta", 3, 5),
         ("post-compact", 1, 5),
     ];
     /// Ceiling for `label` + `n_docs` out of one of the two gate tables,

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -740,9 +740,9 @@ fn run_metered_delta_append(
 /// Measure/emit hook points between the shared FTS/SQL mutations.
 #[derive(Clone, Copy)]
 enum TextLifecyclePhase {
-    AfterDrain,
-    AfterDelta,
-    AfterCompact,
+    Drain,
+    Delta,
+    Compact,
 }
 
 /// Shared FTS/SQL mutation sequence: open a metered consumer, then
@@ -767,13 +767,13 @@ fn run_metered_text_lifecycle(
     );
     let consumer = tiers::open_consumer(opts);
     let drain = run_metered_drain(label, &consumer, &meter);
-    on_phase(TextLifecyclePhase::AfterDrain);
+    on_phase(TextLifecyclePhase::Drain);
     let delta_stats = run_metered_delta_append(label, &consumer, &meter, delta);
-    on_phase(TextLifecyclePhase::AfterDelta);
+    on_phase(TextLifecyclePhase::Delta);
     let compaction = run_metered_optimize(label, &consumer, &meter);
     drop(consumer);
     drop(cache_dir);
-    on_phase(TextLifecyclePhase::AfterCompact);
+    on_phase(TextLifecyclePhase::Compact);
     (drain, delta_stats, compaction)
 }
 
@@ -1143,17 +1143,17 @@ pub mod fts {
                 &delta_batch,
                 |phase| {
                     let (anchor_suffix, note) = match phase {
-                        TextLifecyclePhase::AfterDrain => (
+                        TextLifecyclePhase::Drain => (
                             "post-drain",
                             "Post-drain (after drain_vectors_to_cells; no-op without a hidden vector index). \
                              Same warm/cold recipe as pre-drain. Δ vs previous run.",
                         ),
-                        TextLifecyclePhase::AfterDelta => (
+                        TextLifecyclePhase::Delta => (
                             "post-delta",
                             "Post-delta (base commits + one undrained follow-up commit). Warm/cold recipe \
                              unchanged. Δ vs previous run.",
                         ),
-                        TextLifecyclePhase::AfterCompact => (
+                        TextLifecyclePhase::Compact => (
                             "post-compact",
                             "Post-compact (after optimize): fewer superfiles; warm/cold recipe unchanged. \
                              Steady-state layout the cost model prices. Δ vs previous run.",
@@ -1178,7 +1178,7 @@ pub mod fts {
                             None,
                         );
                     }
-                    if matches!(phase, TextLifecyclePhase::AfterCompact) {
+                    if matches!(phase, TextLifecyclePhase::Compact) {
                         warm_post = warm;
                         cold_post = cold;
                     }
@@ -4226,17 +4226,17 @@ pub mod sql {
                 &delta_batch,
                 |phase| {
                     let (suffix, warm_note, cold_note) = match phase {
-                        TextLifecyclePhase::AfterDrain => (
+                        TextLifecyclePhase::Drain => (
                             "post-drain",
                             "Post-drain (after drain_vectors_to_cells; no-op without a hidden vector index). Same warm recipe as pre-drain. Δ vs previous run.",
                             "Post-drain cold: open = construct only; search is the first query. Δ vs previous run.",
                         ),
-                        TextLifecyclePhase::AfterDelta => (
+                        TextLifecyclePhase::Delta => (
                             "post-delta",
                             "Post-delta (base commits + one undrained follow-up commit). Same warm recipe. Δ vs previous run.",
                             "Post-delta cold: open = construct only; search is the first query. Δ vs previous run.",
                         ),
-                        TextLifecyclePhase::AfterCompact => (
+                        TextLifecyclePhase::Compact => (
                             "post-compact",
                             "Post-compact (after optimize): fewer superfiles; same warm recipe. Steady-state layout for the cost model. Δ vs previous run.",
                             "Post-compact cold: open = construct only; search is the first query on the merged layout. Δ vs previous run.",
@@ -4288,7 +4288,7 @@ pub mod sql {
                     } else {
                         None
                     };
-                    if matches!(phase, TextLifecyclePhase::AfterCompact) {
+                    if matches!(phase, TextLifecyclePhase::Compact) {
                         warm_sets_post = warm;
                         cold_post = cold;
                     }

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -101,6 +101,7 @@ use infino::{
         CompactionSettings, Config, StorageBackend, StorageColdFetchMode, StorageSettings,
         SupertableSettings,
     },
+    runtime_metrics::UsageMeter,
     superfile::{
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder, VectorConfig},
         fts::reader::BoolMode,
@@ -957,7 +958,7 @@ pub(crate) mod diag {
             self.inner.object_store_handle(uri)
         }
 
-        fn usage_meter(&self) -> Arc<infino::storage::UsageMeter> {
+        fn usage_meter(&self) -> Arc<UsageMeter> {
             self.inner.usage_meter()
         }
     }

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -47,9 +47,10 @@ use crate::{
     config::DEFAULT_CONNECTION_BUDGET_BYTES,
     memory::{ConnectionMemoryBudget, budgeted_session_context},
     runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
+    runtime_metrics::io::{UsageMeter, UsageSnapshot},
     storage::{
         AzureStorageProvider, GcsStorageProvider, LocalFsStorageProvider, S3StorageProvider,
-        StorageError, StorageProvider, UsageMeter, UsageSnapshot,
+        StorageError, StorageProvider,
     },
     superfile::{
         builder::FtsConfig,
@@ -199,15 +200,18 @@ impl Connection {
     /// Cumulative object-store usage for this connection (read-only snapshot).
     /// Shared by every table provider created through this connection; take
     /// two snapshots and call [`UsageSnapshot::since`] for a window delta.
-    /// Not part of the curated public API — unit tests / `test-helpers` only.
-    #[cfg(any(test, feature = "test-helpers"))]
+    /// Visible under `test-helpers`, `metering`, or `cfg(test)` — not part
+    /// of the curated default public API.
+    #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
     pub fn usage_snapshot(&self) -> UsageSnapshot {
         self.inner.usage_meter.snapshot()
     }
 
     /// Object-store usage ledger for this connection. Shared by every table
     /// provider; benches and diagnostics hold the `Arc` across phases.
-    #[cfg(any(test, feature = "test-helpers"))]
+    /// Visible under `test-helpers`, `metering`, or `cfg(test)` — not part
+    /// of the curated default public API.
+    #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
     pub fn usage_meter(&self) -> Arc<UsageMeter> {
         Arc::clone(&self.inner.usage_meter)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,9 +146,11 @@ pub use roaring;
 mod catalog;
 mod error;
 mod runtime_bridge;
-#[cfg(feature = "test-helpers")]
+// Process CPU / RSS samplers: benches use `test-helpers`; platform
+// Prometheus uses `metering`. Same module either way — no second copy.
+#[cfg(any(feature = "test-helpers", feature = "metering"))]
 pub mod runtime_metrics;
-#[cfg(not(feature = "test-helpers"))]
+#[cfg(not(any(feature = "test-helpers", feature = "metering")))]
 pub(crate) mod runtime_metrics;
 mod utils;
 

--- a/src/runtime_metrics/io.rs
+++ b/src/runtime_metrics/io.rs
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Connection-scoped object-store usage meter — the **sole** I/O ledger.
+//! Object-store I/O metering — the **sole** connection-scoped I/O ledger,
+//! plus background vs foreground attribution for that ledger.
 //!
-//! Providers and [`super::counting`] wrappers record here. Benches and the
-//! usage flush read [`UsageMeter::snapshot`]; they must not keep a parallel
-//! counter implementation.
+//! Parallel to [`super::cpu`] and [`super::rss`]: one resource family per
+//! module (`io` / `cpu` / `rss`).
+//!
+//! Storage providers and counting wrappers `record_*` here. Benches and
+//! `features = ["metering"]` consumers read [`UsageMeter::snapshot`];
+//! they must not keep a parallel counter implementation.
 
 use std::{
     array, fmt,
+    future::Future,
     sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicU64, Ordering},
@@ -17,7 +22,30 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::io_counters::io_is_background;
+tokio::task_local! {
+    /// Set to `true` inside a background cache-fill task so its
+    /// object-store reads are distinguishable from foreground
+    /// query reads. Absent (→ foreground) on the query path.
+    static IO_BACKGROUND: bool;
+}
+
+/// Whether the current task is a background cache-fill
+/// (`false` unless the task-local flag is set).
+pub fn io_is_background() -> bool {
+    IO_BACKGROUND.try_with(|b| *b).unwrap_or(false)
+}
+
+/// Run `fut` with [`io_is_background`] true for the current task.
+///
+/// Background cache-fill GETs wrap their object-store calls in this
+/// so meters and timelines can attribute them separately from
+/// foreground query reads.
+pub async fn scope_background<F>(fut: F) -> F::Output
+where
+    F: Future,
+{
+    IO_BACKGROUND.scope(true, fut).await
+}
 
 /// Path token of the hidden vector-index sibling's storage prefix
 /// (`_infino_<uuid>_vector_index/...` under the table root).
@@ -179,7 +207,7 @@ fn process_default_meter() -> Arc<UsageMeter> {
     Arc::clone(METER.get_or_init(UsageMeter::new))
 }
 
-/// Connection-scoped (or process-default) usage ledger.
+/// Connection-scoped (or process-default) object-store I/O ledger.
 pub struct UsageMeter {
     head_count: AtomicU64,
     get_count: AtomicU64,
@@ -257,7 +285,7 @@ impl UsageMeter {
     }
 
     /// Record a successful GET / range / tail. `uri` drives [`UriClass`];
-    /// background tasks (`io_counters::scope_background`) land in `bg_get_*`.
+    /// background tasks ([`scope_background`]) land in `bg_get_*`.
     pub fn record_get(&self, uri: &str, range: Option<(u64, u64)>, bytes: u64) {
         if io_is_background() {
             self.bg_get_count.fetch_add(1, Ordering::Relaxed);
@@ -333,7 +361,6 @@ impl UsageMeter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::io_counters::scope_background;
 
     #[test]
     fn uri_class_covers_user_and_hidden() {

--- a/src/runtime_metrics/mod.rs
+++ b/src/runtime_metrics/mod.rs
@@ -1,10 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Process CPU and RSS sampling used by benches and optional usage flush.
+//! In-engine metering signals for benches and `features = ["metering"]`.
 //!
-//! Process-wide attribution only — not a Stripe dimension. Benches must call
-//! these APIs rather than reimplement `/proc` parsers.
+//! Three resource families — parallel names, one ownership home:
+//! - [`io`] — object-store request/byte ledger (+ background attribution)
+//! - [`cpu`] — process on-CPU time
+//! - [`rss`] — process resident set / peak sampler
+//!
+//! Storage providers `record_*` into [`UsageMeter`]; they do not own it.
+//! Benches and platform must use these APIs rather than reimplement
+//! `/proc` parsers or parallel I/O counters.
 
 pub mod cpu;
+pub mod io;
 pub mod rss;
+
+pub use io::{
+    ClassIo, N_URI_CLASSES, TraceEntry, UriClass, UsageMeter, UsageSnapshot, io_is_background,
+    scope_background,
+};

--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -21,9 +21,11 @@ use object_store::{
     path::Path as ObjPath,
 };
 
+use crate::runtime_metrics::io::UsageMeter;
+
 use super::{
     ObjectMeta, StorageError, StorageOptions, StorageProvider, counting, io_counters,
-    logical_list_key, options::apply, retry, usage::UsageMeter,
+    logical_list_key, options::apply, retry,
 };
 
 /// Azure Blob-backed `StorageProvider`. Cheap to clone; the inner

--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -21,12 +21,11 @@ use object_store::{
     path::Path as ObjPath,
 };
 
-use crate::runtime_metrics::io::UsageMeter;
-
 use super::{
     ObjectMeta, StorageError, StorageOptions, StorageProvider, counting, io_counters,
     logical_list_key, options::apply, retry,
 };
+use crate::runtime_metrics::io::UsageMeter;
 
 /// Azure Blob-backed `StorageProvider`. Cheap to clone; the inner
 /// `MicrosoftAzure` shares its HTTP client across clones.

--- a/src/storage/counting.rs
+++ b/src/storage/counting.rs
@@ -3,7 +3,7 @@
 
 //! Meters for the raw [`ObjectStore`] handle and multipart uploads.
 //!
-//! Records into the same [`UsageMeter`] as [`super::StorageProvider`] methods
+//! Records into the same [`UsageMeter`] as [`crate::storage::StorageProvider`] methods
 //! so parquet range GETs and multipart parts share one ledger.
 
 use std::{fmt, ops::Range, sync::Arc};
@@ -17,7 +17,7 @@ use object_store::{
     Result as ObjectStoreResult, UploadPart, path::Path as ObjPath,
 };
 
-use super::usage::UsageMeter;
+use crate::runtime_metrics::io::UsageMeter;
 
 /// Wrap an [`ObjectStore`] so every successful read increments `meter`.
 pub(crate) fn wrap_object_store(

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -24,9 +24,11 @@ use object_store::{
     path::Path as ObjPath,
 };
 
+use crate::runtime_metrics::io::UsageMeter;
+
 use super::{
     ObjectMeta, StorageError, StorageOptions, StorageProvider, counting, io_counters,
-    logical_list_key, options::apply, retry, usage::UsageMeter,
+    logical_list_key, options::apply, retry,
 };
 
 /// Warm idle connections per host, so a wide range-GET fan-out reuses TLS

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -24,12 +24,11 @@ use object_store::{
     path::Path as ObjPath,
 };
 
-use crate::runtime_metrics::io::UsageMeter;
-
 use super::{
     ObjectMeta, StorageError, StorageOptions, StorageProvider, counting, io_counters,
     logical_list_key, options::apply, retry,
 };
+use crate::runtime_metrics::io::UsageMeter;
 
 /// Warm idle connections per host, so a wide range-GET fan-out reuses TLS
 /// sessions instead of re-handshaking on the cold tail.

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -28,7 +28,9 @@ use object_store::{
     PutPayload, local::LocalFileSystem, path::Path as ObjPath,
 };
 
-use super::{ObjectMeta, StorageError, StorageProvider, counting, usage::UsageMeter};
+use crate::runtime_metrics::io::UsageMeter;
+
+use super::{ObjectMeta, StorageError, StorageProvider, counting};
 
 #[derive(Debug)]
 pub struct LocalFsStorageProvider {

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -28,9 +28,8 @@ use object_store::{
     PutPayload, local::LocalFileSystem, path::Path as ObjPath,
 };
 
-use crate::runtime_metrics::io::UsageMeter;
-
 use super::{ObjectMeta, StorageError, StorageProvider, counting};
+use crate::runtime_metrics::io::UsageMeter;
 
 #[derive(Debug)]
 pub struct LocalFsStorageProvider {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -43,14 +43,14 @@ pub mod local_fs;
 pub(crate) mod options;
 mod retry;
 pub mod s3;
-pub mod usage;
 
 pub use azure::AzureStorageProvider;
 pub use gcs::GcsStorageProvider;
 pub use local_fs::LocalFsStorageProvider;
 pub(crate) use options::StorageOptions;
 pub use s3::S3StorageProvider;
-pub use usage::{ClassIo, N_URI_CLASSES, TraceEntry, UriClass, UsageMeter, UsageSnapshot};
+
+use crate::runtime_metrics::io::UsageMeter;
 
 /// Object metadata returned by HEAD, GET, and list operations.
 ///
@@ -110,17 +110,18 @@ pub enum StorageError {
     },
 }
 
-/// I/O diagnostics that are not the usage ledger: timeline, phase spans,
-/// and background-task tagging. Request/byte counts live only on
-/// [`usage::UsageMeter`] (per connection / provider).
+/// I/O diagnostics that are not the usage ledger: timeline and phase spans.
+/// Request/byte counts and background tagging live in
+/// [`crate::runtime_metrics::io`] — import that module, not here.
 ///
 /// [`take`] / [`snapshot`] read the **process-default** meter (providers
 /// built outside a [`crate::catalog::Connection`]). Prefer
 /// `provider.usage_meter().snapshot()` for connection-scoped windows.
 pub mod io_counters {
-    use std::future::Future;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Instant;
 
-    use super::usage::{UsageMeter, UsageSnapshot};
+    use crate::runtime_metrics::io::{UsageMeter, UsageSnapshot, io_is_background};
 
     /// `(fetches, bytes, hidden_fetches, hidden_bytes)` since the last call on
     /// the process-default meter; resets those get-family counters.
@@ -143,8 +144,6 @@ pub mod io_counters {
     /// post-hoc dump shows overlap (parallel) vs back-to-back (serial) and the
     /// implied concurrency `Σdur / wall`. Gated on `INFINO_IO_TIMELINE`; a
     /// no-op (one relaxed env check) otherwise so the hot path is unaffected.
-    use std::sync::{Mutex, OnceLock};
-    use std::time::Instant;
 
     /// One recorded object-store fetch on the timeline.
     #[derive(Clone)]
@@ -159,31 +158,6 @@ pub mod io_counters {
         /// `true` if issued by a background cache-fill task (off the
         /// query-critical path), `false` for foreground query reads.
         pub background: bool,
-    }
-
-    tokio::task_local! {
-        /// Set to `true` inside a background cache-fill task so its
-        /// object-store reads are distinguishable from foreground
-        /// query reads. Absent (→ foreground) on the query path.
-        static IO_BACKGROUND: bool;
-    }
-
-    /// Whether the current task is a background cache-fill
-    /// (`false` unless the task-local flag is set).
-    pub fn io_is_background() -> bool {
-        IO_BACKGROUND.try_with(|b| *b).unwrap_or(false)
-    }
-
-    /// Run `fut` with [`io_is_background`] true for the current task.
-    ///
-    /// Background cache-fill GETs wrap their object-store calls in this
-    /// so meters and timelines can attribute them separately from
-    /// foreground query reads.
-    pub async fn scope_background<F>(fut: F) -> F::Output
-    where
-        F: Future,
-    {
-        IO_BACKGROUND.scope(true, fut).await
     }
 
     static TIMELINE_ON: OnceLock<bool> = OnceLock::new();
@@ -548,8 +522,8 @@ pub trait StorageProvider: Send + Sync + fmt::Debug {
     /// records into. Benches and billing snapshot this meter — there is no
     /// second counter wrapper. Default is the process-default meter (mocks /
     /// ad-hoc providers); durable providers override with their injected Arc.
-    fn usage_meter(&self) -> Arc<usage::UsageMeter> {
-        usage::UsageMeter::process_default()
+    fn usage_meter(&self) -> Arc<UsageMeter> {
+        UsageMeter::process_default()
     }
 }
 
@@ -691,7 +665,7 @@ impl StorageProvider for PrefixedStorageProvider {
         self.inner.object_store_handle(&self.prefixed(uri))
     }
 
-    fn usage_meter(&self) -> Arc<usage::UsageMeter> {
+    fn usage_meter(&self) -> Arc<UsageMeter> {
         self.inner.usage_meter()
     }
 }
@@ -823,8 +797,8 @@ mod tests {
             Ok(())
         }
 
-        fn usage_meter(&self) -> Arc<usage::UsageMeter> {
-            usage::UsageMeter::process_default()
+        fn usage_meter(&self) -> Arc<UsageMeter> {
+            UsageMeter::process_default()
         }
     }
 
@@ -1010,7 +984,7 @@ mod tests {
     /// counters are process-global and other tests may increment concurrently.
     #[test]
     fn usage_meter_record_and_snapshot_are_monotonic() {
-        let meter = usage::UsageMeter::new();
+        let meter = UsageMeter::new();
         let before = meter.snapshot();
         meter.record_get("seg/x", None, 100);
         meter.record_head();
@@ -1037,7 +1011,7 @@ mod tests {
 
         // Prefix must contain `_vector_index` so UriClass classifies as Hidden*.
         let dir = tempfile::TempDir::new().expect("tempdir");
-        let meter = usage::UsageMeter::new();
+        let meter = UsageMeter::new();
         let inner = Arc::new(
             LocalFsStorageProvider::new_with_meter(dir.path(), Arc::clone(&meter))
                 .expect("localfs"),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -118,8 +118,10 @@ pub enum StorageError {
 /// built outside a [`crate::catalog::Connection`]). Prefer
 /// `provider.usage_meter().snapshot()` for connection-scoped windows.
 pub mod io_counters {
-    use std::sync::{Mutex, OnceLock};
-    use std::time::Instant;
+    use std::{
+        sync::{Mutex, OnceLock},
+        time::Instant,
+    };
 
     use crate::runtime_metrics::io::{UsageMeter, UsageSnapshot, io_is_background};
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -136,16 +136,15 @@ pub mod io_counters {
         UsageMeter::process_default().snapshot()
     }
 
-    /// Per-fetch *timeline* — diagnostic for the cold-search critical path.
-    ///
-    /// Fetch counts/bytes tell us breadth; they can't tell us whether the cold
-    /// floor is a *serial dependent chain* (each read gated on the prior's
-    /// offsets — gaps = network RTT) or *parallel breadth* (many overlapping
-    /// reads — wall-time = slowest single chain). This records each
-    /// object-store op's `[start, end)` relative to a shared epoch, so a
-    /// post-hoc dump shows overlap (parallel) vs back-to-back (serial) and the
-    /// implied concurrency `Σdur / wall`. Gated on `INFINO_IO_TIMELINE`; a
-    /// no-op (one relaxed env check) otherwise so the hot path is unaffected.
+    // Per-fetch *timeline* — diagnostic for the cold-search critical path.
+    // Fetch counts/bytes tell us breadth; they can't tell us whether the cold
+    // floor is a *serial dependent chain* (each read gated on the prior's
+    // offsets — gaps = network RTT) or *parallel breadth* (many overlapping
+    // reads — wall-time = slowest single chain). This records each
+    // object-store op's `[start, end)` relative to a shared epoch, so a
+    // post-hoc dump shows overlap (parallel) vs back-to-back (serial) and the
+    // implied concurrency `Σdur / wall`. Gated on `INFINO_IO_TIMELINE`; a
+    // no-op (one relaxed env check) otherwise so the hot path is unaffected.
 
     /// One recorded object-store fetch on the timeline.
     #[derive(Clone)]

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -34,9 +34,11 @@ use object_store::{
     path::Path as ObjPath,
 };
 
+use crate::runtime_metrics::io::UsageMeter;
+
 use super::{
     ObjectMeta, StorageError, StorageOptions, StorageProvider, counting, io_counters,
-    logical_list_key, options::apply, retry, usage::UsageMeter,
+    logical_list_key, options::apply, retry,
 };
 
 /// Config key written by [`S3StorageProvider::new_with_endpoint`] to point

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -34,12 +34,11 @@ use object_store::{
     path::Path as ObjPath,
 };
 
-use crate::runtime_metrics::io::UsageMeter;
-
 use super::{
     ObjectMeta, StorageError, StorageOptions, StorageProvider, counting, io_counters,
     logical_list_key, options::apply, retry,
 };
+use crate::runtime_metrics::io::UsageMeter;
 
 /// Config key written by [`S3StorageProvider::new_with_endpoint`] to point
 /// at a custom endpoint. Detection accepts any object_store alias (see

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -3573,14 +3573,8 @@ mod tests {
             before.iter().max().expect("nonempty")
         );
 
-        let n_cent = split_oversized_fine_runs(
-            &mut centroids,
-            &sample,
-            SPLIT_DIM,
-            SPLIT_REQUESTED,
-            7,
-            None,
-        );
+        let n_cent =
+            split_oversized_fine_runs(&mut centroids, &sample, SPLIT_DIM, SPLIT_REQUESTED, 7, None);
         assert_eq!(centroids.len(), n_cent * SPLIT_DIM);
         assert!(n_cent > 5, "split must add sub-centroids");
         let after = run_counts(&sample, &centroids, n_cent);
@@ -3734,15 +3728,14 @@ mod tests {
                     centroids[c * SPLIT_DIM + d] = 1_000.0 + c as f32;
                 }
             }
-            let n =
-                split_oversized_fine_runs(
-                    &mut centroids,
-                    &sample,
-                    SPLIT_DIM,
-                    SPLIT_REQUESTED,
-                    7,
-                    None,
-                );
+            let n = split_oversized_fine_runs(
+                &mut centroids,
+                &sample,
+                SPLIT_DIM,
+                SPLIT_REQUESTED,
+                7,
+                None,
+            );
             (n, centroids)
         };
         assert_eq!(make(), make());

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -104,18 +104,20 @@ const FINE_RUN_SPLIT_MAX_ROUNDS: usize = 4;
 const FINE_RUN_SPLIT_SEED_OFFSET: u64 = 101;
 
 /// Cell row count marking the consolidated-cell regime where the drain's
-/// per-cell k-means degenerates and the cell pack switches build policy:
-/// above it the byte-target `n_cent` goes uncapped and oversized runs are
-/// split; at or below it the legacy build ships byte-identical (row-count
-/// cap applied, no split). The value is bracketed by measurement: 10M's
-/// largest cell (65,918 rows) must keep the legacy layout — the armed
-/// 2-GET cold-probe gate was measured on it, and letting the new policy
-/// leak in moved the probe to 4 GETs — while 100M's median cell (95,801
-/// rows) trains 48×-imbalanced mega-runs under the legacy build (flat
-/// 0.81 fine-coverage curve) and needs both fixes. 80,000 sits strictly
-/// between the two design points. Distinct from the drain-sample boost
-/// threshold (65,536 in `reservoir.rs`), which is part of the measured
-/// 10M baseline and must keep covering its biggest cells.
+/// per-cell k-means degenerates and the cell pack drops the legacy
+/// row-count `n_cent` cap (byte-target count goes uncapped). Oversized
+/// fine-run splitting always runs — under fine-first `cells 1..1`, a
+/// 2×-skewed run parks its summary centroid at the blob center and
+/// caps post-drain recall (measured 0.985 vs 0.995 at 1M / 256 cells
+/// with identical cell membership). The value is bracketed by
+/// measurement: 10M's largest cell (65,918 rows) must keep the capped
+/// `n_cent` — the armed 2-GET cold-probe gate was measured on it, and
+/// uncapping alone moved the probe to 4 GETs — while 100M's median
+/// cell (95,801 rows) needs the uncapped byte-target count. 80,000
+/// sits strictly between the two design points. Distinct from the
+/// drain-sample boost threshold (65,536 in `reservoir.rs`), which is
+/// part of the measured 10M baseline and must keep covering its
+/// biggest cells.
 const CONSOLIDATED_CELL_ROWS_THRESHOLD: usize = 80_000;
 
 /// Target memory budget (~128 MiB) for one pass-2 rotated chunk
@@ -1134,12 +1136,13 @@ fn materialized_centroids(cfg: &VectorConfig, n_docs: usize, sample: &[f32]) -> 
         let n_cent = global.len() / dim.max(1);
         return (n_cent, global.to_vec());
     }
-    // Build policy switches at the consolidated-cell boundary (see
+    // `n_cent` cap switches at the consolidated-cell boundary (see
     // `CONSOLIDATED_CELL_ROWS_THRESHOLD`): consolidated cells take the
-    // row-derived byte-target `n_cent` uncapped and get oversized runs
-    // split; everything below ships the legacy build byte-identical —
-    // row-count cap applied, no split — because the 1M/10M layouts (and
-    // their armed cold-probe gates) were measured on exactly that build.
+    // row-derived byte-target uncapped; everything below keeps the
+    // legacy row-count cap so the 1M/10M cold-GET layout stays on the
+    // measured shape. Oversized fine-run splitting always runs — the
+    // cap alone does not stop Lloyd from parking 2×-skewed runs that
+    // flatten fine-first p=1 recall below 0.99.
     let consolidated = n_docs > CONSOLIDATED_CELL_ROWS_THRESHOLD;
     let requested = if consolidated {
         cfg.n_cent.max(1).min(n_docs.max(1))
@@ -1150,11 +1153,7 @@ fn materialized_centroids(cfg: &VectorConfig, n_docs: usize, sample: &[f32]) -> 
             .min(n_docs.max(1))
     };
     let mut centroids = kmeans(sample, dim, requested, KMEANS_ITERS, cfg.rot_seed);
-    let n_cent = if consolidated {
-        split_oversized_fine_runs(&mut centroids, sample, dim, requested, cfg.rot_seed)
-    } else {
-        requested
-    };
+    let n_cent = split_oversized_fine_runs(&mut centroids, sample, dim, requested, cfg.rot_seed);
     order_centroids_geometrically(&mut centroids, dim, n_cent);
     (n_cent, centroids)
 }
@@ -1966,9 +1965,9 @@ pub(crate) fn build_cell_subsection_from_source(
             }
         }
     }
-    // Mirrors the `materialized_centroids` policy switch so the sample is
-    // sized for the runs actually trained: consolidated cells uncapped,
-    // sub-threshold cells under the legacy row-count cap.
+    // Mirrors the `materialized_centroids` `n_cent` cap switch so the
+    // sample is sized for the runs actually trained: consolidated cells
+    // uncapped, sub-threshold cells under the legacy row-count cap.
     let requested_n_cent = if n_docs > CONSOLIDATED_CELL_ROWS_THRESHOLD {
         cfg.n_cent.max(1).min(n_docs)
     } else {
@@ -3619,10 +3618,11 @@ mod tests {
         assert_eq!(centroids, original);
     }
 
-    /// The cell-pack build policy switches at the consolidated-cell
-    /// boundary: at or below it the legacy row-count cap binds `n_cent`
-    /// (the measured 1M/10M layout); above it the byte-target count is
-    /// taken uncapped.
+    /// The cell-pack `n_cent` policy switches at the consolidated-cell
+    /// boundary: at or below it the legacy row-count cap binds the
+    /// *requested* count (the measured 1M/10M layout); above it the
+    /// byte-target count is taken uncapped. Run-split may grow past the
+    /// request on either side when Lloyd leaves an oversized run.
     #[test]
     fn materialized_centroids_caps_only_below_consolidated_threshold() {
         let dim = 8;
@@ -3641,16 +3641,49 @@ mod tests {
             };
             materialized_centroids(&cfg, n_docs, &sample).0
         };
-        assert_eq!(
-            mk(CONSOLIDATED_CELL_ROWS_THRESHOLD),
-            N_CENT_SMALL,
-            "sub-threshold cell keeps the legacy cap"
-        );
-        // Uncapped: at least the byte-target count (the run split may add
-        // sub-centroids on top; with the cap this would read exactly 64).
+        let below = mk(CONSOLIDATED_CELL_ROWS_THRESHOLD);
+        let above = mk(CONSOLIDATED_CELL_ROWS_THRESHOLD + 1);
+        // Sub-threshold trains from the legacy cap; run-split may grow a
+        // few sub-centroids on top, but must not jump to the uncapped
+        // byte-target request.
         assert!(
-            mk(CONSOLIDATED_CELL_ROWS_THRESHOLD + 1) >= requested,
+            below >= N_CENT_SMALL && below < requested,
+            "sub-threshold cell stays near the legacy cap (got {below}, cap {N_CENT_SMALL}, byte-target {requested})"
+        );
+        assert!(
+            above >= requested,
             "consolidated cell takes the byte-target count uncapped"
+        );
+    }
+
+    /// Sub-threshold cells still split oversized fine runs. Without this,
+    /// fine-first p=1 post-drain recall flaps 0.985↔0.995 at 1M/256c when
+    /// Lloyd parks a 2×-skewed run (same cell membership both ways).
+    #[test]
+    fn materialized_centroids_splits_oversized_runs_below_threshold() {
+        let sample = two_blob_sample();
+        let sample_n = sample.len() / SPLIT_DIM;
+        let target = sample_n.div_ceil(SPLIT_REQUESTED);
+        let bound = target * FINE_RUN_SPLIT_BOUND_FACTOR;
+        let cfg = VectorConfig {
+            column: "emb".into(),
+            dim: SPLIT_DIM,
+            n_cent: SPLIT_REQUESTED,
+            rot_seed: 7,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Sq8Residual,
+            provided_centroids: None,
+        };
+        let (n_cent, centroids) =
+            materialized_centroids(&cfg, CONSOLIDATED_CELL_ROWS_THRESHOLD, &sample);
+        assert!(
+            n_cent >= SPLIT_REQUESTED,
+            "split may grow past the request, never shrink it"
+        );
+        let after = run_counts(&sample, &centroids, n_cent);
+        assert!(
+            after.iter().all(|&n| n <= bound),
+            "sub-threshold cell must still bound every fine run at {bound}: {after:?}"
         );
     }
 

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -1207,7 +1207,9 @@ fn split_oversized_fine_runs(
     // sample row; any later round (or a missing/mismatched labeling)
     // re-assigns against the current centroids.
     let (mut assignments, mut need_assign) = match initial_assignments {
-        Some(a) if a.len() == sample_n => (a, false),
+        Some(a) if a.len() == sample_n && a.iter().all(|&idx| (idx as usize) < n_cent) => {
+            (a, false)
+        }
         _ => (vec![0u32; sample_n], true),
     };
     for round in 0..FINE_RUN_SPLIT_MAX_ROUNDS {

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -39,7 +39,7 @@ use crate::{
             cell_posting::{MaterializedIvfRow, sq8_residual_norm_sq},
             distance::{Metric, dequantize_sq8_residual_into, distance, mean_f32_cluster_major},
             ivf_merge::MergedIvfSubsection,
-            kmeans::{assign_to_centroids, kmeans},
+            kmeans::{assign_to_centroids, kmeans, kmeans_with_assignments},
             quant::BitQuantizer,
             rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
             reservoir::{Reservoir, default_kmeans_sample_size, partition_kmeans_sample_size},
@@ -1152,8 +1152,21 @@ fn materialized_centroids(cfg: &VectorConfig, n_docs: usize, sample: &[f32]) -> 
             .min(n_cent_row_count_cap(n_docs))
             .min(n_docs.max(1))
     };
-    let mut centroids = kmeans(sample, dim, requested, KMEANS_ITERS, cfg.rot_seed);
-    let n_cent = split_oversized_fine_runs(&mut centroids, sample, dim, requested, cfg.rot_seed);
+    // Keep the final Lloyd assignments — `split_oversized_fine_runs`
+    // consumes them for the first bound check so a balanced pack (the
+    // common commit-cell case) does not pay a redundant full sample
+    // assign on top of the train. `kmeans` alone would drop them and
+    // force that duplicate pass (see `kmeans_with_assignments`).
+    let (mut centroids, assignments) =
+        kmeans_with_assignments(sample, dim, requested, KMEANS_ITERS, cfg.rot_seed);
+    let n_cent = split_oversized_fine_runs(
+        &mut centroids,
+        sample,
+        dim,
+        requested,
+        cfg.rot_seed,
+        Some(assignments),
+    );
     order_centroids_geometrically(&mut centroids, dim, n_cent);
     (n_cent, centroids)
 }
@@ -1166,6 +1179,13 @@ fn materialized_centroids(cfg: &VectorConfig, n_docs: usize, sample: &[f32]) -> 
 /// in place). Single-run packs (the commit-time cell delta shape,
 /// `requested == 1`) can never exceed the bound and pass through untouched.
 ///
+/// When `initial_assignments` matches the current `centroids` (the final
+/// Lloyd labeling from [`kmeans_with_assignments`]), the first round
+/// skips `assign_to_centroids` and only scans counts — balanced packs
+/// return without another distance pass. Pass `None` when the caller
+/// has no labeling (tests / synthetic centroid fixtures); the first
+/// round then assigns normally.
+///
 /// Deterministic: assignment and sub-k-means are seeded from `seed` plus a
 /// fixed offset mixed with the round and run index.
 fn split_oversized_fine_runs(
@@ -1174,6 +1194,7 @@ fn split_oversized_fine_runs(
     dim: usize,
     requested: usize,
     seed: u64,
+    initial_assignments: Option<Vec<u32>>,
 ) -> usize {
     let mut n_cent = centroids.len() / dim.max(1);
     let sample_n = sample.len() / dim.max(1);
@@ -1182,9 +1203,18 @@ fn split_oversized_fine_runs(
     }
     let target = sample_n.div_ceil(requested.max(1)).max(1);
     let bound = target.saturating_mul(FINE_RUN_SPLIT_BOUND_FACTOR);
-    let mut assignments = vec![0u32; sample_n];
+    // Reuse the caller's Lloyd labeling on round 0 when it covers every
+    // sample row; any later round (or a missing/mismatched labeling)
+    // re-assigns against the current centroids.
+    let (mut assignments, mut need_assign) = match initial_assignments {
+        Some(a) if a.len() == sample_n => (a, false),
+        _ => (vec![0u32; sample_n], true),
+    };
     for round in 0..FINE_RUN_SPLIT_MAX_ROUNDS {
-        assign_to_centroids(sample, centroids, dim, n_cent, &mut assignments);
+        if need_assign {
+            assign_to_centroids(sample, centroids, dim, n_cent, &mut assignments);
+        }
+        need_assign = true;
         let mut counts = vec![0usize; n_cent];
         for &a in &assignments {
             counts[a as usize] += 1;
@@ -3543,8 +3573,14 @@ mod tests {
             before.iter().max().expect("nonempty")
         );
 
-        let n_cent =
-            split_oversized_fine_runs(&mut centroids, &sample, SPLIT_DIM, SPLIT_REQUESTED, 7);
+        let n_cent = split_oversized_fine_runs(
+            &mut centroids,
+            &sample,
+            SPLIT_DIM,
+            SPLIT_REQUESTED,
+            7,
+            None,
+        );
         assert_eq!(centroids.len(), n_cent * SPLIT_DIM);
         assert!(n_cent > 5, "split must add sub-centroids");
         let after = run_counts(&sample, &centroids, n_cent);
@@ -3613,7 +3649,7 @@ mod tests {
         let sample = two_blob_sample();
         let mut centroids = vec![0.5f32; SPLIT_DIM];
         let original = centroids.clone();
-        let n_cent = split_oversized_fine_runs(&mut centroids, &sample, SPLIT_DIM, 1, 7);
+        let n_cent = split_oversized_fine_runs(&mut centroids, &sample, SPLIT_DIM, 1, 7, None);
         assert_eq!(n_cent, 1);
         assert_eq!(centroids, original);
     }
@@ -3699,7 +3735,14 @@ mod tests {
                 }
             }
             let n =
-                split_oversized_fine_runs(&mut centroids, &sample, SPLIT_DIM, SPLIT_REQUESTED, 7);
+                split_oversized_fine_runs(
+                    &mut centroids,
+                    &sample,
+                    SPLIT_DIM,
+                    SPLIT_REQUESTED,
+                    7,
+                    None,
+                );
             (n, centroids)
         };
         assert_eq!(make(), make());

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -460,11 +460,14 @@ fn eligible_summary<'e>(
 /// With `admit` set (`(prefilter query, must-include cells)`), a 1-bit
 /// XOR+popcount pass first ranks tagged cells by their best estimated
 /// fine-centroid score and keeps the [`admit_shortlist_window`] top
-/// slice plus the caller's grid picks; the exact fp32 scan below then
-/// skips instances outside that set. Every *emitted* score is exact
-/// fp32, so routing and near-tie logic never see 1-bit noise — the
-/// estimates only bound which cells get exact-scored. Untagged
-/// (`cell_id: None`) summaries are always exact-scored.
+/// slice plus any caller force-includes; the exact fp32 scan below then
+/// skips instances outside that set. Unfiltered callers leave
+/// must-include empty (1-bit is the sole cell filter). Filtered callers
+/// may exact-score the cell grid first and pass the probe-cutoff picks
+/// as must-include so the wide filtered beam cannot lose cells to 1-bit
+/// noise. Every *emitted* score is exact fp32, so selection never sees
+/// 1-bit estimates; they only bound which cells get exact-scored.
+/// Untagged (`cell_id: None`) summaries are always exact-scored.
 fn score_fine_candidates(
     superfiles: &[Arc<SuperfileEntry>],
     column: &str,
@@ -553,47 +556,14 @@ fn score_fine_candidates(
     Ok((candidates, deferred))
 }
 
-/// Default-path cell selection, shared by the hidden (post-drain) and user
-/// (pre-drain) branches: probe the fine-ranked top cell, adding the grid's
-/// top cell only when its own fine score is a genuine near-tie of the fine
-/// winner (same relative window replica closure uses at drain time, so
-/// probing and replication agree on what counts as a boundary). At the
-/// shipped grid shapes (256/1024 cells) fine p1 coverage measures 1.000
-/// (drain-diag, 1M–100M), so a second unconditional pick only multiplies
-/// the probed-cell fan without recall to show for it.
-fn fine_first_cell_selection(fine_ranked: &[(u32, f32)], grid_top: Option<u32>) -> Vec<u32> {
-    let Some(&(fine_top, fine_top_score)) = fine_ranked.first() else {
-        return grid_top.into_iter().collect();
-    };
-    let mut cells = vec![fine_top];
-    if let Some(grid_top) = grid_top
-        && grid_top != fine_top
-    {
-        let tie_threshold =
-            relative_score_window(fine_top_score, REPLICA_CLOSURE_DISTANCE_RATIO - 1.0);
-        let grid_top_fine_score = fine_ranked
-            .iter()
-            .find(|(cell, _)| *cell == grid_top)
-            .map(|(_, score)| *score);
-        if grid_top_fine_score.is_some_and(|score| score <= tie_threshold) {
-            cells.push(grid_top);
-        }
-    }
-    cells
-}
-
 /// Union of the grid-ranked and fine-ranked cell selections, in probe
 /// priority order: grid picks first, then fine picks not already selected.
 ///
-/// The two rankings fail in opposite regimes, so probing their union holds
-/// the coverage floor at every measured scale. Small cells (100K/64c: ~1.5K
-/// rows, ~3 fine runs each) make fine centroids noisy — grid ranking wins
-/// (measured neighbor coverage 0.950 grid vs 0.700 fine). Large cells
-/// (10M/64c: ~230K rows, ~250 fine runs each) make the single grid centroid
-/// a poor proxy for the cell's extent — fine ranking wins (0.919 fine vs
-/// 0.629 grid; fine p2 = 0.997). Grid-only p=1 routing pinned 10M recall to
-/// the 0.63 ceiling; the union restores the better ranking at each scale for
-/// at most one extra probed cell per pick.
+/// Used only on the filtered path, which exact-scores the cell grid before
+/// admit and probes a wide cell set — the two rankings fail in opposite
+/// regimes, so their union holds the coverage floor. Unfiltered search
+/// stays fine-first after the global 1-bit admit and never builds this
+/// union.
 fn union_cell_selection(grid: &[u32], fine: &[u32]) -> Vec<u32> {
     let mut selected: Vec<u32> = Vec::with_capacity(grid.len() + fine.len());
     for &cell in grid.iter().chain(fine) {
@@ -602,6 +572,37 @@ fn union_cell_selection(grid: &[u32], fine: &[u32]) -> Vec<u32> {
         }
     }
     selected
+}
+
+/// Default-path (unfiltered) cell selection, shared by the hidden
+/// (post-drain) and user (pre-drain) branches: probe the fine-ranked top
+/// cell, optionally adding `tie_cell` when its fine score is a genuine
+/// near-tie of the fine winner (same relative window replica closure
+/// uses at drain time). `tie_cell` is the fine runner-up after the
+/// global 1-bit admit — unfiltered search does not exact-score cell
+/// centroids before that filter. At the shipped grid shapes (256/1024
+/// cells) fine p1 coverage measures 1.000 (drain-diag, 1M–100M), so a
+/// second unconditional pick only multiplies the probed-cell fan without
+/// recall to show for it.
+fn fine_first_cell_selection(fine_ranked: &[(u32, f32)], tie_cell: Option<u32>) -> Vec<u32> {
+    let Some(&(fine_top, fine_top_score)) = fine_ranked.first() else {
+        return tie_cell.into_iter().collect();
+    };
+    let mut cells = vec![fine_top];
+    if let Some(tie_cell) = tie_cell
+        && tie_cell != fine_top
+    {
+        let tie_threshold =
+            relative_score_window(fine_top_score, REPLICA_CLOSURE_DISTANCE_RATIO - 1.0);
+        let tie_fine_score = fine_ranked
+            .iter()
+            .find(|(cell, _)| *cell == tie_cell)
+            .map(|(_, score)| *score);
+        if tie_fine_score.is_some_and(|score| score <= tie_threshold) {
+            cells.push(tie_cell);
+        }
+    }
+    cells
 }
 
 /// Map a per-superfile vector-search error to a query error. A budget refusal
@@ -1248,40 +1249,22 @@ impl SupertableReader {
             .map(|vc| (vc.metric, vc.rot_seed))
             .ok_or_else(|| QueryError::Execute(format!("unknown vector column `{column}`")))?;
 
-        // Borrow grids only. Cloning `GlobalVectorIndex` / `ClusterCentroids`
-        // on this path cleared the lazily-built transposed cache every query
-        // and rebuilt it with the scalar `transpose_centroids_cluster_major`
-        // loop (~ms at dim=1024) before any SIMD scoring ran.
-        let grid = manifest
-            .global_vector_index()
-            .filter(|g| g.column == column)
-            // Route on the same grid commit packing stamped cell tags from:
-            // the finer user grid when trained, else the drain grid. (Hidden
-            // manifests carry no `global_vector_index` and take the
-            // `VectorCell` branch below.)
-            .map(|g| g.user_grid())
-            .filter(|grid| grid.n_cent > 0 && grid.dim as usize == query.len())
-            .or_else(|| {
-                manifest
-                    .vector_cell_clusters(column)
-                    .filter(|clusters| clusters.n_cent > 0 && clusters.dim as usize == query.len())
-            });
-        // Admit: rank the coarse grid, score every fine IVF centroid in
-        // eligible summaries, then fine/grid cell selection + per-fragment
-        // gate. Phase timers (INFINO_TRACE_VECTOR_WARM_PHASES): admit covers
+        // Admit:
+        //   * Unfiltered — global fine 1-bit first, exact-score fines only
+        //     on that shortlist, then fine-first cell selection. No exact
+        //     cell-centroid scan (the 1-bit stage replaces it).
+        //   * Filtered — pay the O(k) exact cell-centroid scan; those
+        //     probe-cutoff picks are must-include so 1-bit cannot drop
+        //     cells the wide filtered probe needs. Matching neighbors sit
+        //     deeper than unfiltered top cells (~rank k/selectivity).
+        // Phase timers (INFINO_TRACE_VECTOR_WARM_PHASES): admit covers
         // that work; fanout_wall is probe+rerank+remap wall.
         let admit_t0 = io_counters::phase_start();
-        let ranked_cells_scored: Option<Vec<(u32, f32)>> =
-            grid.map(|grid| grid.rank_cells(metric, query));
-        let ranked_cells: Option<Vec<u32>> = ranked_cells_scored
-            .as_ref()
-            .map(|cells| cells.iter().map(|(cell, _)| *cell).collect());
 
-        // Cell cutoff shared by the hidden and user branches: probe the
-        // `nprobe_min` nearest cells under GRID ranking, widening toward
-        // `nprobe_max` while a cell's score stays within the slack threshold
-        // of the nearest cell.
-        let grid_cell_cutoff = |ranked: &[(u32, f32)], routing: &CellRoutingParams| -> usize {
+        // Probe-width cutoff over a scored cell ranking: `nprobe_min`
+        // nearest, widening toward `nprobe_max` while a cell's score stays
+        // within the slack threshold of the nearest.
+        let cell_probe_cutoff = |ranked: &[(u32, f32)], routing: &CellRoutingParams| -> usize {
             if ranked.is_empty() {
                 return 0;
             }
@@ -1309,7 +1292,7 @@ impl SupertableReader {
         // Assigned in both admit arms; used below for the posting-aware
         // budget expand (keep scoring until we cover ≥ k postings).
         let candidate_counts: HashMap<(usize, u32), u64>;
-        if let (Some(ranked_scored), true) = (&ranked_cells_scored, any_tagged) {
+        if any_tagged {
             let cell_routing = if hidden_vector_index {
                 let base = hidden_routing.expect("hidden manifest carries routing");
                 if filtered && options.nprobe.is_some() {
@@ -1358,38 +1341,46 @@ impl SupertableReader {
             } else {
                 CellRoutingParams::default()
             };
-            let ranked_for_beam: Vec<(u32, f32)> = ranked_scored
-                .iter()
-                .filter(|(cell, _)| postings_by_cell.contains_key(cell))
-                .copied()
-                .collect();
-            if ranked_for_beam.is_empty() {
-                return Err(QueryError::Execute(
-                    "vector candidates name no cell present in the grid — \
-                     malformed cell tags"
-                        .into(),
-                ));
-            }
-            let cutoff = grid_cell_cutoff(&ranked_for_beam, &cell_routing);
-            // 1-bit prefilter for the exact fine scan: the grid's cutoff
-            // picks are must-include so every cell the beam can select has
-            // exact candidate scores (near-tie checks included). Filtered
-            // queries use the same prefilter — same code, same budgets;
-            // the allow-set only decides which rows may take shortlist
-            // slots inside the probed runs.
+            // Filtered: exact-score the resident cell grid (user grid on
+            // the global index, else VectorCell clusters). Unfiltered
+            // skips this scan — 1-bit admit ranks cells instead.
+            let grid_ranked: Option<Vec<(u32, f32)>> = if filtered {
+                let grid = manifest
+                    .global_vector_index()
+                    .map(|g| g.user_grid())
+                    .filter(|grid| grid.n_cent > 0 && grid.dim as usize == query.len())
+                    .or_else(|| {
+                        manifest.vector_cell_clusters(column).filter(|clusters| {
+                            clusters.n_cent > 0 && clusters.dim as usize == query.len()
+                        })
+                    });
+                grid.map(|grid| {
+                    grid.rank_cells(metric, query)
+                        .into_iter()
+                        .filter(|(cell, _)| postings_by_cell.contains_key(cell))
+                        .collect()
+                })
+            } else {
+                None
+            };
             let admit_q = RabitqAdmitQuery::new(query.len(), rot_seed, query);
-            let must_include: Vec<u32> = ranked_for_beam[..cutoff]
-                .iter()
-                .map(|(cell, _)| *cell)
-                .collect();
-            let (mut candidates, deferred) = score_fine_candidates(
-                &superfiles,
-                column,
-                query,
-                metric,
-                Some((&admit_q, must_include.as_slice())),
-                allow_ref,
-            )?;
+            let filtered_must_include: Vec<u32> = match &grid_ranked {
+                Some(ranked) if !ranked.is_empty() => {
+                    let cutoff = cell_probe_cutoff(ranked, &cell_routing);
+                    ranked[..cutoff].iter().map(|(cell, _)| *cell).collect()
+                }
+                _ => Vec::new(),
+            };
+            // Filtered with a grid: 1-bit + must-include the cell-scan
+            // cutoff. Filtered without a grid: exact-score every fine
+            // (no admit). Unfiltered: 1-bit with empty must-include.
+            let admit = if filtered && grid_ranked.is_none() {
+                None
+            } else {
+                Some((&admit_q, filtered_must_include.as_slice()))
+            };
+            let (mut candidates, deferred) =
+                score_fine_candidates(&superfiles, column, query, metric, admit, allow_ref)?;
             if !deferred.is_empty() {
                 self.rescore_deferred_cells(
                     &superfiles,
@@ -1405,31 +1396,45 @@ impl SupertableReader {
                 .iter()
                 .map(|(si, cluster, _, _, count)| ((*si, *cluster), *count))
                 .collect();
-            let ranked = ranked_cells
-                .as_ref()
-                .expect("ranked cell ids exist with scored ranking");
+            let fine_ranked = cells_ranked_by_fine_score(&candidates);
+            let fine_for_beam: Vec<(u32, f32)> = fine_ranked
+                .iter()
+                .filter(|(cell, _)| postings_by_cell.contains_key(cell))
+                .copied()
+                .collect();
+            if fine_for_beam.is_empty() {
+                return Err(QueryError::Execute(
+                    "vector candidates name no cell present in the grid — \
+                     malformed cell tags"
+                        .into(),
+                ));
+            }
+            // Unfiltered default: fine-first p=1. Filtered (and explicit
+            // nprobe): grid∪fine over the probe cutoff — the cell scan
+            // paid above supplies the grid half.
+            let default_p1 = !filtered && options.nprobe.is_none();
+            let fine_cutoff = cell_probe_cutoff(&fine_for_beam, &cell_routing);
+            let tie_cell = fine_for_beam.get(1).map(|(cell, _)| *cell);
             if hidden_vector_index {
-                let fine_ranked = cells_ranked_by_fine_score(&candidates);
-                // Default path: fine-first p=1, the same selection the user
-                // (pre-drain) branch ships. Filtered search and explicit
-                // caller nprobe keep the wider grid/fine union.
-                let default_p1 = !filtered && options.nprobe.is_none() && cutoff == 1;
-                let selected_cells_ordered: Vec<u32> = if default_p1 {
-                    fine_first_cell_selection(
-                        &fine_ranked,
-                        ranked_for_beam.first().map(|(cell, _)| *cell),
-                    )
-                } else {
-                    let grid_cells: Vec<u32> = ranked_for_beam[..cutoff]
+                let selected_cells_ordered: Vec<u32> = if default_p1 && fine_cutoff == 1 {
+                    fine_first_cell_selection(&fine_for_beam, tie_cell)
+                } else if let Some(grid_ranked) = &grid_ranked {
+                    let grid_cutoff = cell_probe_cutoff(grid_ranked, &cell_routing);
+                    let grid_cells: Vec<u32> = grid_ranked[..grid_cutoff]
                         .iter()
                         .map(|(cell, _)| *cell)
                         .collect();
-                    let fine_cells: Vec<u32> = fine_ranked
-                        .iter()
-                        .take(cutoff.max(UNION_FINE_PICKS_MIN))
-                        .map(|(cell, _)| *cell)
-                        .collect();
+                    let n = grid_cutoff
+                        .max(UNION_FINE_PICKS_MIN)
+                        .min(fine_for_beam.len());
+                    let fine_cells: Vec<u32> =
+                        fine_for_beam[..n].iter().map(|(cell, _)| *cell).collect();
                     union_cell_selection(&grid_cells, &fine_cells)
+                } else {
+                    let n = fine_cutoff
+                        .max(UNION_FINE_PICKS_MIN)
+                        .min(fine_for_beam.len());
+                    fine_for_beam[..n].iter().map(|(cell, _)| *cell).collect()
                 };
                 let selected_cells: HashSet<u32> = selected_cells_ordered.iter().copied().collect();
                 gated = gate_fine_candidates_by_fragment(
@@ -1443,26 +1448,38 @@ impl SupertableReader {
                     Some(&birth_versions),
                 );
             } else {
-                // Fine-first p=1 over all scored fines. Explicit nprobe /
-                // filtered search keep the grid/fine union.
-                let fine_ranked = cells_ranked_by_fine_score(&candidates);
-                let default_p1 = !filtered && options.nprobe.is_none() && cutoff == 1;
-                let mut selected_cells: Vec<u32> = if default_p1 && !fine_ranked.is_empty() {
-                    fine_first_cell_selection(&fine_ranked, ranked.first().copied())
-                } else {
-                    let grid_cells: Vec<u32> = ranked[..cutoff].to_vec();
-                    let fine_cells: Vec<u32> = fine_ranked
-                        .iter()
-                        .take(cutoff)
-                        .map(|(cell, _)| *cell)
-                        .collect();
-                    union_cell_selection(&grid_cells, &fine_cells)
-                };
+                let mut selected_cells: Vec<u32> =
+                    if default_p1 && fine_cutoff == 1 && !fine_for_beam.is_empty() {
+                        fine_first_cell_selection(&fine_for_beam, tie_cell)
+                    } else if let Some(grid_ranked) = &grid_ranked {
+                        let grid_cutoff = cell_probe_cutoff(grid_ranked, &cell_routing);
+                        let grid_cells: Vec<u32> = grid_ranked[..grid_cutoff]
+                            .iter()
+                            .map(|(cell, _)| *cell)
+                            .collect();
+                        let fine_cells: Vec<u32> = fine_for_beam
+                            [..fine_cutoff.min(fine_for_beam.len())]
+                            .iter()
+                            .map(|(cell, _)| *cell)
+                            .collect();
+                        union_cell_selection(&grid_cells, &fine_cells)
+                    } else {
+                        fine_for_beam[..fine_cutoff]
+                            .iter()
+                            .map(|(cell, _)| *cell)
+                            .collect()
+                    };
+                let expand_order: Vec<u32> = grid_ranked
+                    .as_ref()
+                    .map(|ranked| ranked.iter().map(|(cell, _)| *cell).collect())
+                    .unwrap_or_else(|| fine_for_beam.iter().map(|(cell, _)| *cell).collect());
                 let mut covered: u64 = selected_cells
                     .iter()
                     .map(|cell| postings_by_cell.get(cell).copied().unwrap_or(0))
                     .sum();
-                for cell in ranked.iter().copied() {
+                // Expand toward the gated posting target in grid-rank
+                // order when filtered paid for a cell scan; else fine-rank.
+                for cell in expand_order {
                     if covered >= gated_target {
                         break;
                     }
@@ -1485,10 +1502,10 @@ impl SupertableReader {
                 );
             }
         } else {
-            // No grid, or untagged summaries: score every fine centroid
-            // (legacy flat path, no prefilter). Stripped summaries defer to
-            // the exact rescore — untagged legacy tables have no per-cell
-            // gating to absorb estimate noise.
+            // Untagged summaries: score every fine centroid (legacy flat
+            // path, no prefilter). Stripped summaries defer to the exact
+            // rescore — untagged legacy tables have no per-cell gating to
+            // absorb estimate noise.
             let (mut candidates, deferred) =
                 score_fine_candidates(&superfiles, column, query, metric, None, allow_ref)?;
             if !deferred.is_empty() {
@@ -2866,6 +2883,17 @@ mod tests {
         assert_eq!(admit_shortlist_window(241), 49);
     }
 
+    /// Union keeps grid picks first (probe priority), appends fine picks
+    /// not already selected, and collapses to one cell when both rankings
+    /// agree. Filtered search uses this after the exact cell scan.
+    #[test]
+    fn union_cell_selection_dedups_with_grid_priority() {
+        assert_eq!(union_cell_selection(&[4], &[9]), vec![4, 9]);
+        assert_eq!(union_cell_selection(&[4], &[4]), vec![4]);
+        assert_eq!(union_cell_selection(&[4, 9], &[9, 1]), vec![4, 9, 1]);
+        assert_eq!(union_cell_selection(&[], &[2]), vec![2]);
+    }
+
     #[test]
     fn cells_ranked_by_fine_score_takes_min_per_cell_in_order() {
         let candidates: Vec<(usize, u32, f32, Option<u32>, u64)> = vec![
@@ -2880,17 +2908,6 @@ mod tests {
         assert_eq!(ranked[0], (7, 0.2));
         assert_eq!(ranked[1].0, 2, "score tie broken by lower cell id");
         assert_eq!(ranked[2].0, 3);
-    }
-
-    /// Union keeps grid picks first (probe priority), appends fine picks
-    /// not already selected, and collapses to one cell when both rankings
-    /// agree.
-    #[test]
-    fn union_cell_selection_dedups_with_grid_priority() {
-        assert_eq!(union_cell_selection(&[4], &[9]), vec![4, 9]);
-        assert_eq!(union_cell_selection(&[4], &[4]), vec![4]);
-        assert_eq!(union_cell_selection(&[4, 9], &[9, 1]), vec![4, 9, 1]);
-        assert_eq!(union_cell_selection(&[], &[2]), vec![2]);
     }
 
     /// The inline stable-id fast path: hits carrying `stable_id` are resolved

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -460,14 +460,11 @@ fn eligible_summary<'e>(
 /// With `admit` set (`(prefilter query, must-include cells)`), a 1-bit
 /// XOR+popcount pass first ranks tagged cells by their best estimated
 /// fine-centroid score and keeps the [`admit_shortlist_window`] top
-/// slice plus any caller force-includes; the exact fp32 scan below then
-/// skips instances outside that set. Unfiltered callers leave
-/// must-include empty (1-bit is the sole cell filter). Filtered callers
-/// may exact-score the cell grid first and pass the probe-cutoff picks
-/// as must-include so the wide filtered beam cannot lose cells to 1-bit
-/// noise. Every *emitted* score is exact fp32, so selection never sees
-/// 1-bit estimates; they only bound which cells get exact-scored.
-/// Untagged (`cell_id: None`) summaries are always exact-scored.
+/// slice plus the caller's grid picks; the exact fp32 scan below then
+/// skips instances outside that set. Every *emitted* score is exact
+/// fp32, so routing and near-tie logic never see 1-bit noise — the
+/// estimates only bound which cells get exact-scored. Untagged
+/// (`cell_id: None`) summaries are always exact-scored.
 fn score_fine_candidates(
     superfiles: &[Arc<SuperfileEntry>],
     column: &str,
@@ -559,11 +556,11 @@ fn score_fine_candidates(
 /// Union of the grid-ranked and fine-ranked cell selections, in probe
 /// priority order: grid picks first, then fine picks not already selected.
 ///
-/// Used only on the filtered path, which exact-scores the cell grid before
-/// admit and probes a wide cell set — the two rankings fail in opposite
-/// regimes, so their union holds the coverage floor. Unfiltered search
-/// stays fine-first after the global 1-bit admit and never builds this
-/// union.
+/// The two rankings fail in opposite regimes, so probing their union holds
+/// the coverage floor at every measured scale. Small cells make fine
+/// centroids noisy — grid ranking wins. Large cells make the single grid
+/// centroid a poor proxy — fine ranking wins. Used for filtered search and
+/// explicit caller `nprobe`; default unfiltered stays fine-first.
 fn union_cell_selection(grid: &[u32], fine: &[u32]) -> Vec<u32> {
     let mut selected: Vec<u32> = Vec::with_capacity(grid.len() + fine.len());
     for &cell in grid.iter().chain(fine) {
@@ -574,32 +571,30 @@ fn union_cell_selection(grid: &[u32], fine: &[u32]) -> Vec<u32> {
     selected
 }
 
-/// Default-path (unfiltered) cell selection, shared by the hidden
-/// (post-drain) and user (pre-drain) branches: probe the fine-ranked top
-/// cell, optionally adding `tie_cell` when its fine score is a genuine
-/// near-tie of the fine winner (same relative window replica closure
-/// uses at drain time). `tie_cell` is the fine runner-up after the
-/// global 1-bit admit — unfiltered search does not exact-score cell
-/// centroids before that filter. At the shipped grid shapes (256/1024
-/// cells) fine p1 coverage measures 1.000 (drain-diag, 1M–100M), so a
-/// second unconditional pick only multiplies the probed-cell fan without
-/// recall to show for it.
-fn fine_first_cell_selection(fine_ranked: &[(u32, f32)], tie_cell: Option<u32>) -> Vec<u32> {
+/// Default-path cell selection, shared by the hidden (post-drain) and user
+/// (pre-drain) branches: probe the fine-ranked top cell, adding the grid's
+/// top cell only when its own fine score is a genuine near-tie of the fine
+/// winner (same relative window replica closure uses at drain time, so
+/// probing and replication agree on what counts as a boundary). At the
+/// shipped grid shapes (256/1024 cells) fine p1 coverage measures 1.000
+/// (drain-diag, 1M–100M), so a second unconditional pick only multiplies
+/// the probed-cell fan without recall to show for it.
+fn fine_first_cell_selection(fine_ranked: &[(u32, f32)], grid_top: Option<u32>) -> Vec<u32> {
     let Some(&(fine_top, fine_top_score)) = fine_ranked.first() else {
-        return tie_cell.into_iter().collect();
+        return grid_top.into_iter().collect();
     };
     let mut cells = vec![fine_top];
-    if let Some(tie_cell) = tie_cell
-        && tie_cell != fine_top
+    if let Some(grid_top) = grid_top
+        && grid_top != fine_top
     {
         let tie_threshold =
             relative_score_window(fine_top_score, REPLICA_CLOSURE_DISTANCE_RATIO - 1.0);
-        let tie_fine_score = fine_ranked
+        let grid_top_fine_score = fine_ranked
             .iter()
-            .find(|(cell, _)| *cell == tie_cell)
+            .find(|(cell, _)| *cell == grid_top)
             .map(|(_, score)| *score);
-        if tie_fine_score.is_some_and(|score| score <= tie_threshold) {
-            cells.push(tie_cell);
+        if grid_top_fine_score.is_some_and(|score| score <= tie_threshold) {
+            cells.push(grid_top);
         }
     }
     cells
@@ -1249,25 +1244,36 @@ impl SupertableReader {
             .map(|vc| (vc.metric, vc.rot_seed))
             .ok_or_else(|| QueryError::Execute(format!("unknown vector column `{column}`")))?;
 
-        // Admit:
-        //   * Unfiltered default — global fine 1-bit first, exact-score
-        //     fines only on that shortlist, then fine-first cell
-        //     selection. No exact cell-centroid scan.
-        //   * Unfiltered + explicit `nprobe` — pay the O(k) cell scan for
-        //     the grid half of grid∪fine (legacy widened-beam path); 1-bit
-        //     still gates exact fine scoring with empty must-include.
-        //   * Filtered — pay the O(k) exact cell-centroid scan; those
-        //     probe-cutoff picks are must-include so 1-bit cannot drop
-        //     cells the wide filtered probe needs. Matching neighbors sit
-        //     deeper than unfiltered top cells (~rank k/selectivity).
-        // Phase timers (INFINO_TRACE_VECTOR_WARM_PHASES): admit covers
+        let grid = manifest
+            .global_vector_index()
+            .filter(|g| g.column == column)
+            // Route on the same grid commit packing stamped cell tags from:
+            // the finer user grid when trained, else the drain grid. (Hidden
+            // manifests carry no `global_vector_index` and take the
+            // `VectorCell` branch below.)
+            .map(|g| g.user_grid())
+            .filter(|grid| grid.n_cent > 0 && grid.dim as usize == query.len())
+            .or_else(|| {
+                manifest
+                    .vector_cell_clusters(column)
+                    .filter(|clusters| clusters.n_cent > 0 && clusters.dim as usize == query.len())
+            });
+        // Admit: rank the coarse grid, score every fine IVF centroid in
+        // eligible summaries, then fine/grid cell selection + per-fragment
+        // gate. Phase timers (INFINO_TRACE_VECTOR_WARM_PHASES): admit covers
         // that work; fanout_wall is probe+rerank+remap wall.
         let admit_t0 = io_counters::phase_start();
+        let ranked_cells_scored: Option<Vec<(u32, f32)>> =
+            grid.map(|grid| grid.rank_cells(metric, query));
+        let ranked_cells: Option<Vec<u32>> = ranked_cells_scored
+            .as_ref()
+            .map(|cells| cells.iter().map(|(cell, _)| *cell).collect());
 
-        // Probe-width cutoff over a scored cell ranking: `nprobe_min`
-        // nearest, widening toward `nprobe_max` while a cell's score stays
-        // within the slack threshold of the nearest.
-        let cell_probe_cutoff = |ranked: &[(u32, f32)], routing: &CellRoutingParams| -> usize {
+        // Cell cutoff shared by the hidden and user branches: probe the
+        // `nprobe_min` nearest cells under GRID ranking, widening toward
+        // `nprobe_max` while a cell's score stays within the slack threshold
+        // of the nearest cell.
+        let grid_cell_cutoff = |ranked: &[(u32, f32)], routing: &CellRoutingParams| -> usize {
             if ranked.is_empty() {
                 return 0;
             }
@@ -1295,7 +1301,7 @@ impl SupertableReader {
         // Assigned in both admit arms; used below for the posting-aware
         // budget expand (keep scoring until we cover ≥ k postings).
         let candidate_counts: HashMap<(usize, u32), u64>;
-        if any_tagged {
+        if let (Some(ranked_scored), true) = (&ranked_cells_scored, any_tagged) {
             let cell_routing = if hidden_vector_index {
                 let base = hidden_routing.expect("hidden manifest carries routing");
                 if filtered && options.nprobe.is_some() {
@@ -1344,65 +1350,38 @@ impl SupertableReader {
             } else {
                 CellRoutingParams::default()
             };
-            // Exact cell-centroid ranking for paths that still need the
-            // grid half of grid∪fine: filtered search, and unfiltered
-            // with an explicit caller `nprobe` (the old widened-beam
-            // path). Default unfiltered skips this — 1-bit admit ranks
-            // cells instead.
-            let need_grid_ranking = filtered || options.nprobe.is_some();
-            let grid_ranked: Option<Vec<(u32, f32)>> = if need_grid_ranking {
-                let grid = manifest
-                    .global_vector_index()
-                    .filter(|g| g.column == column)
-                    .map(|g| g.user_grid())
-                    .filter(|grid| grid.n_cent > 0 && grid.dim as usize == query.len())
-                    .or_else(|| {
-                        manifest.vector_cell_clusters(column).filter(|clusters| {
-                            clusters.n_cent > 0 && clusters.dim as usize == query.len()
-                        })
-                    });
-                grid.map(|grid| {
-                    grid.rank_cells(metric, query)
-                        .into_iter()
-                        .filter(|(cell, _)| postings_by_cell.contains_key(cell))
-                        .collect()
-                })
-            } else {
-                None
-            };
-            if filtered && matches!(grid_ranked.as_ref(), Some(ranked) if ranked.is_empty()) {
+            let ranked_for_beam: Vec<(u32, f32)> = ranked_scored
+                .iter()
+                .filter(|(cell, _)| postings_by_cell.contains_key(cell))
+                .copied()
+                .collect();
+            if ranked_for_beam.is_empty() {
                 return Err(QueryError::Execute(
                     "vector candidates name no cell present in the grid — \
                      malformed cell tags"
                         .into(),
                 ));
             }
+            let cutoff = grid_cell_cutoff(&ranked_for_beam, &cell_routing);
+            // 1-bit prefilter for the exact fine scan: the grid's cutoff
+            // picks are must-include so every cell the beam can select has
+            // exact candidate scores (near-tie checks included). Filtered
+            // queries use the same prefilter — same code, same budgets;
+            // the allow-set only decides which rows may take shortlist
+            // slots inside the probed runs.
             let admit_q = RabitqAdmitQuery::new(query.len(), rot_seed, query);
-            // Only filtered force-includes the cell-scan cutoff into the
-            // 1-bit shortlist. Unfiltered + explicit nprobe still uses
-            // grid_ranked for selection below, but keeps must-include
-            // empty so 1-bit alone gates exact fine scoring.
-            let filtered_must_include: Vec<u32> = if filtered {
-                match &grid_ranked {
-                    Some(ranked) => {
-                        let cutoff = cell_probe_cutoff(ranked, &cell_routing);
-                        ranked[..cutoff].iter().map(|(cell, _)| *cell).collect()
-                    }
-                    None => Vec::new(),
-                }
-            } else {
-                Vec::new()
-            };
-            // Filtered with a grid: 1-bit + must-include the cell-scan
-            // cutoff. Filtered without a grid: exact-score every fine
-            // (no admit). Unfiltered: 1-bit with empty must-include.
-            let admit = if filtered && grid_ranked.is_none() {
-                None
-            } else {
-                Some((&admit_q, filtered_must_include.as_slice()))
-            };
-            let (mut candidates, deferred) =
-                score_fine_candidates(&superfiles, column, query, metric, admit, allow_ref)?;
+            let must_include: Vec<u32> = ranked_for_beam[..cutoff]
+                .iter()
+                .map(|(cell, _)| *cell)
+                .collect();
+            let (mut candidates, deferred) = score_fine_candidates(
+                &superfiles,
+                column,
+                query,
+                metric,
+                Some((&admit_q, must_include.as_slice())),
+                allow_ref,
+            )?;
             if !deferred.is_empty() {
                 self.rescore_deferred_cells(
                     &superfiles,
@@ -1418,45 +1397,31 @@ impl SupertableReader {
                 .iter()
                 .map(|(si, cluster, _, _, count)| ((*si, *cluster), *count))
                 .collect();
-            let fine_ranked = cells_ranked_by_fine_score(&candidates);
-            let fine_for_beam: Vec<(u32, f32)> = fine_ranked
-                .iter()
-                .filter(|(cell, _)| postings_by_cell.contains_key(cell))
-                .copied()
-                .collect();
-            if fine_for_beam.is_empty() {
-                return Err(QueryError::Execute(
-                    "vector candidates name no cell present in the grid — \
-                     malformed cell tags"
-                        .into(),
-                ));
-            }
-            // Unfiltered default: fine-first p=1. Filtered (and explicit
-            // nprobe): grid∪fine over the probe cutoff — the cell scan
-            // paid above supplies the grid half.
-            let default_p1 = !filtered && options.nprobe.is_none();
-            let fine_cutoff = cell_probe_cutoff(&fine_for_beam, &cell_routing);
-            let tie_cell = fine_for_beam.get(1).map(|(cell, _)| *cell);
+            let ranked = ranked_cells
+                .as_ref()
+                .expect("ranked cell ids exist with scored ranking");
             if hidden_vector_index {
-                let selected_cells_ordered: Vec<u32> = if default_p1 && fine_cutoff == 1 {
-                    fine_first_cell_selection(&fine_for_beam, tie_cell)
-                } else if let Some(grid_ranked) = &grid_ranked {
-                    let grid_cutoff = cell_probe_cutoff(grid_ranked, &cell_routing);
-                    let grid_cells: Vec<u32> = grid_ranked[..grid_cutoff]
+                let fine_ranked = cells_ranked_by_fine_score(&candidates);
+                // Default path: fine-first p=1, the same selection the user
+                // (pre-drain) branch ships. Filtered search and explicit
+                // caller nprobe keep the wider grid/fine union.
+                let default_p1 = !filtered && options.nprobe.is_none() && cutoff == 1;
+                let selected_cells_ordered: Vec<u32> = if default_p1 {
+                    fine_first_cell_selection(
+                        &fine_ranked,
+                        ranked_for_beam.first().map(|(cell, _)| *cell),
+                    )
+                } else {
+                    let grid_cells: Vec<u32> = ranked_for_beam[..cutoff]
                         .iter()
                         .map(|(cell, _)| *cell)
                         .collect();
-                    let n = grid_cutoff
-                        .max(UNION_FINE_PICKS_MIN)
-                        .min(fine_for_beam.len());
-                    let fine_cells: Vec<u32> =
-                        fine_for_beam[..n].iter().map(|(cell, _)| *cell).collect();
+                    let fine_cells: Vec<u32> = fine_ranked
+                        .iter()
+                        .take(cutoff.max(UNION_FINE_PICKS_MIN))
+                        .map(|(cell, _)| *cell)
+                        .collect();
                     union_cell_selection(&grid_cells, &fine_cells)
-                } else {
-                    let n = fine_cutoff
-                        .max(UNION_FINE_PICKS_MIN)
-                        .min(fine_for_beam.len());
-                    fine_for_beam[..n].iter().map(|(cell, _)| *cell).collect()
                 };
                 let selected_cells: HashSet<u32> = selected_cells_ordered.iter().copied().collect();
                 gated = gate_fine_candidates_by_fragment(
@@ -1470,38 +1435,26 @@ impl SupertableReader {
                     Some(&birth_versions),
                 );
             } else {
-                let mut selected_cells: Vec<u32> =
-                    if default_p1 && fine_cutoff == 1 && !fine_for_beam.is_empty() {
-                        fine_first_cell_selection(&fine_for_beam, tie_cell)
-                    } else if let Some(grid_ranked) = &grid_ranked {
-                        let grid_cutoff = cell_probe_cutoff(grid_ranked, &cell_routing);
-                        let grid_cells: Vec<u32> = grid_ranked[..grid_cutoff]
-                            .iter()
-                            .map(|(cell, _)| *cell)
-                            .collect();
-                        let fine_cells: Vec<u32> = fine_for_beam
-                            [..fine_cutoff.min(fine_for_beam.len())]
-                            .iter()
-                            .map(|(cell, _)| *cell)
-                            .collect();
-                        union_cell_selection(&grid_cells, &fine_cells)
-                    } else {
-                        fine_for_beam[..fine_cutoff]
-                            .iter()
-                            .map(|(cell, _)| *cell)
-                            .collect()
-                    };
-                let expand_order: Vec<u32> = grid_ranked
-                    .as_ref()
-                    .map(|ranked| ranked.iter().map(|(cell, _)| *cell).collect())
-                    .unwrap_or_else(|| fine_for_beam.iter().map(|(cell, _)| *cell).collect());
+                // Fine-first p=1 over all scored fines. Explicit nprobe /
+                // filtered search keep the grid/fine union.
+                let fine_ranked = cells_ranked_by_fine_score(&candidates);
+                let default_p1 = !filtered && options.nprobe.is_none() && cutoff == 1;
+                let mut selected_cells: Vec<u32> = if default_p1 && !fine_ranked.is_empty() {
+                    fine_first_cell_selection(&fine_ranked, ranked.first().copied())
+                } else {
+                    let grid_cells: Vec<u32> = ranked[..cutoff].to_vec();
+                    let fine_cells: Vec<u32> = fine_ranked
+                        .iter()
+                        .take(cutoff)
+                        .map(|(cell, _)| *cell)
+                        .collect();
+                    union_cell_selection(&grid_cells, &fine_cells)
+                };
                 let mut covered: u64 = selected_cells
                     .iter()
                     .map(|cell| postings_by_cell.get(cell).copied().unwrap_or(0))
                     .sum();
-                // Expand toward the gated posting target in grid-rank
-                // order when filtered paid for a cell scan; else fine-rank.
-                for cell in expand_order {
+                for cell in ranked.iter().copied() {
                     if covered >= gated_target {
                         break;
                     }
@@ -1524,10 +1477,10 @@ impl SupertableReader {
                 );
             }
         } else {
-            // Untagged summaries: score every fine centroid (legacy flat
-            // path, no prefilter). Stripped summaries defer to the exact
-            // rescore — untagged legacy tables have no per-cell gating to
-            // absorb estimate noise.
+            // No grid, or untagged summaries: score every fine centroid
+            // (legacy flat path, no prefilter). Stripped summaries defer to
+            // the exact rescore — untagged legacy tables have no per-cell
+            // gating to absorb estimate noise.
             let (mut candidates, deferred) =
                 score_fine_candidates(&superfiles, column, query, metric, None, allow_ref)?;
             if !deferred.is_empty() {

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1250,9 +1250,12 @@ impl SupertableReader {
             .ok_or_else(|| QueryError::Execute(format!("unknown vector column `{column}`")))?;
 
         // Admit:
-        //   * Unfiltered — global fine 1-bit first, exact-score fines only
-        //     on that shortlist, then fine-first cell selection. No exact
-        //     cell-centroid scan (the 1-bit stage replaces it).
+        //   * Unfiltered default — global fine 1-bit first, exact-score
+        //     fines only on that shortlist, then fine-first cell
+        //     selection. No exact cell-centroid scan.
+        //   * Unfiltered + explicit `nprobe` — pay the O(k) cell scan for
+        //     the grid half of grid∪fine (legacy widened-beam path); 1-bit
+        //     still gates exact fine scoring with empty must-include.
         //   * Filtered — pay the O(k) exact cell-centroid scan; those
         //     probe-cutoff picks are must-include so 1-bit cannot drop
         //     cells the wide filtered probe needs. Matching neighbors sit
@@ -1341,10 +1344,13 @@ impl SupertableReader {
             } else {
                 CellRoutingParams::default()
             };
-            // Filtered: exact-score the resident cell grid (user grid on
-            // the global index, else VectorCell clusters). Unfiltered
-            // skips this scan — 1-bit admit ranks cells instead.
-            let grid_ranked: Option<Vec<(u32, f32)>> = if filtered {
+            // Exact cell-centroid ranking for paths that still need the
+            // grid half of grid∪fine: filtered search, and unfiltered
+            // with an explicit caller `nprobe` (the old widened-beam
+            // path). Default unfiltered skips this — 1-bit admit ranks
+            // cells instead.
+            let need_grid_ranking = filtered || options.nprobe.is_some();
+            let grid_ranked: Option<Vec<(u32, f32)>> = if need_grid_ranking {
                 let grid = manifest
                     .global_vector_index()
                     .filter(|g| g.column == column)
@@ -1364,13 +1370,28 @@ impl SupertableReader {
             } else {
                 None
             };
+            if filtered && matches!(grid_ranked.as_ref(), Some(ranked) if ranked.is_empty()) {
+                return Err(QueryError::Execute(
+                    "vector candidates name no cell present in the grid — \
+                     malformed cell tags"
+                        .into(),
+                ));
+            }
             let admit_q = RabitqAdmitQuery::new(query.len(), rot_seed, query);
-            let filtered_must_include: Vec<u32> = match &grid_ranked {
-                Some(ranked) if !ranked.is_empty() => {
-                    let cutoff = cell_probe_cutoff(ranked, &cell_routing);
-                    ranked[..cutoff].iter().map(|(cell, _)| *cell).collect()
+            // Only filtered force-includes the cell-scan cutoff into the
+            // 1-bit shortlist. Unfiltered + explicit nprobe still uses
+            // grid_ranked for selection below, but keeps must-include
+            // empty so 1-bit alone gates exact fine scoring.
+            let filtered_must_include: Vec<u32> = if filtered {
+                match &grid_ranked {
+                    Some(ranked) => {
+                        let cutoff = cell_probe_cutoff(ranked, &cell_routing);
+                        ranked[..cutoff].iter().map(|(cell, _)| *cell).collect()
+                    }
+                    None => Vec::new(),
                 }
-                _ => Vec::new(),
+            } else {
+                Vec::new()
             };
             // Filtered with a grid: 1-bit + must-include the cell-scan
             // cutoff. Filtered without a grid: exact-score every fine

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1347,6 +1347,7 @@ impl SupertableReader {
             let grid_ranked: Option<Vec<(u32, f32)>> = if filtered {
                 let grid = manifest
                     .global_vector_index()
+                    .filter(|g| g.column == column)
                     .map(|g| g.user_grid())
                     .filter(|grid| grid.n_cent > 0 && grid.dim as usize == query.len())
                     .or_else(|| {

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -40,7 +40,8 @@ use super::{
 };
 use crate::{
     config::global as global_config,
-    storage::{StorageError, StorageProvider, io_counters::scope_background},
+    runtime_metrics::io::scope_background,
+    storage::{StorageError, StorageProvider},
     superfile::{
         BytesLazyByteSource, LazyByteSource, LazyByteSourceError, PrefetchedSource,
         format::{footer, kv},


### PR DESCRIPTION
## Summary

Post-drain vector recall@10 was 0.985 on the pinned 1M / 256-cell grid under fine-first `cells 1..1`. Cell membership was identical across good/bad runs; fine-run balance was not (bad: fine p90≈1952; good: ≈977). Oversized fine-run split was gated behind the 80K-row consolidated threshold, so 1M cells never split.

**Fix:** always run `split_oversized_fine_runs` after fine k-means; keep the legacy `n_cent` cap below 80K so the measured cold-GET layout is unchanged.

Also extend supertable FTS/SQL benches through the same lifecycle as vector: pre-drain → drain → post-drain → delta → post-delta → compact → post-compact (drain is a no-op without a hidden index; still metered for phase parity). Shared via `run_metered_text_lifecycle` + `text_delta_batch`.

## Verify (1M S3, 256 hidden cells)

| | Before | After |
|---|---|---|
| Post-drain recall@10 | 0.985 | **0.995** |
| Fine rows p50/p90/max | 960 / 1952 / 4882 | 958 / 977 / 977 |
| Cold steady | 1 GET | 1 GET |
| Filtered (~10%) recall@10 | 0.884 | **0.998** |

`cargo fmt --check` clean.