### PR TITLE
bench: scope the high-cardinality GROUP BY guard to the in-memory tier

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1965,16 +1965,20 @@ pub mod sql {
             name: "group_by_category",
             sql: "SELECT category, COUNT(*) AS n FROM supertable GROUP BY category",
         },
-        // High-cardinality GROUP BY: `title` is near-unique per row, so the
-        // group key set is ~n_docs. This is the shape where the aggregate's
-        // per-partition partial phase does almost no dedup yet re-hashes every
-        // key; the ORDER BY / LIMIT keeps the output small while still forcing
-        // the full high-cardinality group-id build.
-        SqlQuery {
-            name: "group_by_title_highcard",
-            sql: "SELECT title, COUNT(*) AS n FROM supertable GROUP BY title ORDER BY n DESC LIMIT 10",
-        },
     ];
+
+    /// High-cardinality GROUP BY guard, run only on the in-memory superfile
+    /// tier (passed as `extra_scalar` to [`measure_query_sets`]). `title` is
+    /// near-unique per row, so the group key set is ~n_docs: the shape where
+    /// the aggregate's partial phase does almost no dedup yet re-hashes every
+    /// key (the case `PARTIAL_AGG_SKIP_PROBE_RATIO` targets). Kept off the
+    /// shared battery because a whole-table scan's working set blows the
+    /// supertable object-store tier's warm-settle window; the in-memory tier
+    /// has no such settle.
+    pub const HIGH_CARD_SQL: &[SqlQuery] = &[SqlQuery {
+        name: "group_by_title_highcard",
+        sql: "SELECT title, COUNT(*) AS n FROM supertable GROUP BY title ORDER BY n DESC LIMIT 10",
+    }];
 
     /// Query literals that depend on the built corpus (sample row values).
     pub struct QueryInputs {
@@ -2116,6 +2120,7 @@ pub mod sql {
         inputs: &QueryInputs,
         iters: usize,
         log_prefix: &str,
+        extra_scalar: &[SqlQuery],
     ) -> QuerySets {
         let qv = inputs.qv.as_str();
         let sample_title = inputs.sample_title.as_str();
@@ -2123,10 +2128,11 @@ pub mod sql {
 
         eprintln!(
             "[{log_prefix}] scalar SQL battery ({} queries)...",
-            SQL_BATTERY.len()
+            SQL_BATTERY.len() + extra_scalar.len()
         );
         let scalar = SQL_BATTERY
             .iter()
+            .chain(extra_scalar)
             .map(|q| timed(reader, q.name, q.sql, iters))
             .collect();
 

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -1898,6 +1898,7 @@ pub mod sql {
                 &query_inputs,
                 exec_sql::ITERS,
                 "superfile_sql",
+                exec_sql::HIGH_CARD_SQL,
             );
             exec_sql::emit_query(
                 &mut report,

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -4002,8 +4002,13 @@ pub mod sql {
         let warm_sets_pre = if phases.warm {
             eprintln!("[supertable_sql] warm (pre-compact): opening consumer...");
             let (cache_dir, consumer) = open_consumer(Modality::Sql, &built);
-            let sets =
-                exec_sql::measure_query_sets(&consumer, &inputs, exec_sql::ITERS, "supertable_sql");
+            let sets = exec_sql::measure_query_sets(
+                &consumer,
+                &inputs,
+                exec_sql::ITERS,
+                "supertable_sql",
+                &[],
+            );
             drop(consumer);
             drop(cache_dir);
             let (anchor, title, note) = if run_optimize {
@@ -4074,6 +4079,7 @@ pub mod sql {
                     &inputs,
                     exec_sql::ITERS,
                     "supertable_sql",
+                    &[],
                 );
                 drop(consumer);
                 drop(cache_dir);


### PR DESCRIPTION
### What does this PR do?
Fixes the `supertable_sql` benchmark that #441 broke, while keeping the high-cardinality GROUP BY guard that #441 added.

### Why do we need this change?
#441 put a `group_by_title_highcard` cell in the shared SQL battery. That battery also runs on the supertable object-store tier, where each query's warm-settle waits for its background cache fills to complete. A whole-table-scan GROUP BY has the whole table as its working set, so the fills exceed the 600s settle ceiling in CI and the benchmark fails. It was green on the commit before #441 and red immediately after; only the `supertable_sql` arm failed.

### How do we do this change?
- **Move the high-cardinality cell out of the shared battery** into a superfile-only `HIGH_CARD_SQL` set.
- **Thread it through `measure_query_sets` as `extra_scalar`**, so the in-memory superfile tier runs it and the supertable tier passes an empty slice.
- The in-memory tier exercises the aggregate knob with no object-store warm-settle, so the guard is preserved where it is stable and the shared battery returns to its pre-#441 shape.

### Testing
Benches only, no engine change. `cargo bench --bench bench -- superfile sql` runs the guard on the in-memory tier; the `supertable_sql` bench no longer runs it and returns to green.
