### PR TITLE
supertable/query: cache-backed _id resolution for scored top-k

### DIFF
--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -53,7 +53,7 @@ use crate::{
         handle::SupertableReader,
         manifest::SuperfileEntry,
         query::{
-            exec::common::{take_rows_byte_source, take_rows_object_store},
+            exec::common::{stamp_stable_ids, take_rows_byte_source, take_rows_object_store},
             superfile_reader::superfile_reader,
             vector::row_id_from_manifest_entry,
         },
@@ -308,44 +308,21 @@ pub(crate) async fn attach_stable_ids_to_hits(
     hits: &mut [SuperfileHit],
 ) -> Result<(), QueryError> {
     // Arithmetic-capable files were stamped at tag time ([`tag_hits`]);
-    // only hits from cell-packed / gapped-span files arrive unresolved. On
-    // such tables that is EVERY hit, so this must not copy hits: process
-    // contiguous same-file runs in place (unranked hits arrive file-grouped
-    // from the fan-out; ranked top-k interleaves, but is top-k-sized). Per
-    // run: one manifest lookup, one reader open, one in-place stamp.
-    let manifest = Arc::clone(table_reader.manifest());
-    let store = Arc::clone(&manifest.options.store);
-    let disk_cache = manifest.options.disk_cache.clone();
-    let storage = manifest.options.storage.clone();
-    let mut start = 0usize;
-    while start < hits.len() {
-        if hits[start].stable_id.is_some() {
-            start += 1;
-            continue;
-        }
-        let uri = hits[start].superfile;
-        let mut end = start + 1;
-        while end < hits.len() && hits[end].superfile == uri && hits[end].stable_id.is_none() {
-            end += 1;
-        }
-        let entry = manifest
-            .lookup_superfile_entry(uri)
-            .await
-            .map_err(QueryError::ManifestLoad)?
-            .ok_or_else(|| {
-                QueryError::Execute(format!("hit superfile {uri:?} missing from manifest"))
-            })?;
-        // FTS post-topk id stamp — allow fill (same modality as the search).
-        let reader =
-            open_reader(&store, disk_cache.as_ref(), storage.as_ref(), &entry, true).await?;
-        attach_stable_ids(&reader, &entry, &mut hits[start..end], true).await?;
-        if let Some(missing) = hits[start..end].iter().find(|h| h.stable_id.is_none()) {
-            return Err(QueryError::Execute(format!(
-                "hit {uri:?}/{} missing stable _id after search-wave stamping",
-                missing.local_doc_id
-            )));
-        }
-        start = end;
+    // only hits from cell-packed / gapped-span files arrive unresolved. Fill
+    // them through the shared, cache-backed id resolution: inline id / span
+    // arithmetic where possible, else a `_id`-column read via the decoded
+    // scalar cache (so a warm reader decodes each superfile's `_id` column
+    // once, not once per query). This replaces a per-superfile
+    // `take_by_local_doc_ids`, whose scattered per-query Parquet page reads
+    // dominated large-k scored latency on real corpora.
+    stamp_stable_ids(table_reader, hits)
+        .await
+        .map_err(|e| QueryError::Execute(e.to_string()))?;
+    if let Some(missing) = hits.iter().find(|h| h.stable_id.is_none()) {
+        return Err(QueryError::Execute(format!(
+            "hit {:?}/{} missing stable _id after search-wave stamping",
+            missing.superfile, missing.local_doc_id
+        )));
     }
     Ok(())
 }

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -333,6 +333,45 @@ fn resolve_ids_arithmetic(
     )
 }
 
+/// Fill each hit's `stable_id` in place using the cheap, cache-backed
+/// resolution path: inline id / contiguous-span arithmetic where they
+/// apply, else a `_id`-column read routed through `resolve_columns` (and
+/// thus `decoded_scalar_cache`), so a warm reader decodes each superfile's
+/// `_id` column at most once and later queries hit the cache.
+///
+/// This is the resolution `resolve_hits` already uses for an id-only
+/// projection. The scored fan-out uses it to stamp its final top-k instead
+/// of a per-superfile `take_by_local_doc_ids`, which re-runs a scattered
+/// Parquet page read (~one page + decompress per hit) on *every* query and
+/// dominates large-k scored latency on real corpora (it is ~free only on a
+/// tiny table with few pages, which is why synthetic benches never saw it).
+pub(crate) async fn stamp_stable_ids(
+    reader: &SupertableReader,
+    hits: &mut [SuperfileHit],
+) -> DfResult<()> {
+    if hits.is_empty() || hits.iter().all(|h| h.stable_id.is_some()) {
+        return Ok(());
+    }
+    let id_batch = match resolve_ids_arithmetic(reader, hits) {
+        Some(batch) => batch?,
+        None => {
+            let id_column = reader.options().id_column.clone();
+            resolve_columns(reader, hits, &[id_column.as_str()]).await?
+        }
+    };
+    let ids = id_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Decimal128Array>()
+        .ok_or_else(|| {
+            DataFusionError::Execution("stamp_stable_ids: _id column not Decimal128".into())
+        })?;
+    for (hit, id) in hits.iter_mut().zip(ids.values()) {
+        hit.stable_id = Some(*id);
+    }
+    Ok(())
+}
+
 /// Build the engine-native `_id` + `score` batch directly from already-resolved
 /// stable ids and per-hit scores — the same two-column shape `resolve_hits_named`
 /// returns for a `None` projection, but synthesized without opening any


### PR DESCRIPTION
## Problem

The scored full-text fan-out stamps each result's stable `_id` after
top-k selection. That stamping went through a per-superfile
`take_by_local_doc_ids`, which re-runs a scattered Parquet page read
(roughly one page fetch + decompress per hit) on **every** query. On a
real corpus with many pages this dominates large-k scored latency; it is
near-free only on a tiny table with few pages, which is why the in-repo
synthetic benches never surfaced it.

## Fix

Route the stamp through the shared, cache-backed resolution already used
for an id-only projection:

- inline id / contiguous-span arithmetic where they apply (unchanged, cheap);
- otherwise a `_id`-column read via the decoded scalar cache, so a warm
  reader decodes each superfile's `_id` column at most once and later
  queries hit the cache.

New helper `stamp_stable_ids` in `exec/common.rs`;
`attach_stable_ids_to_hits` in `dispatch.rs` now calls it instead of the
per-superfile page-read loop. The per-superfile `attach_stable_ids` is
retained for the vector path.

## Results

5M-document full-text corpus, scored top-k, mean latency per query:

| command | before | after | Δ |
|---|---:|---:|---:|
| TOP_10 | 1,323µs | 722µs | −45% |
| TOP_100 | 4,992µs | 939µs | −81% |
| TOP_1000 | 27,792µs | 1,534µs | −94% |
| COUNT | 980µs | 870µs | −11% |

Median-of-min is sharper still (TOP_1000 37,470µs → 816µs, −98%), so the
shift is distribution-wide, not driven by a few outliers. The gain scales
with `k` because the old path paid the per-hit page read for every one of
the top-k results.

## Correctness

All 298 tests pass, including the brute-force BM25 top-k oracle and both
fan-out determinism gates. `cargo fmt --check` + clippy clean, no new
warnings. No format or public-API change.