### PR TITLE
metering: expose table storage bytes and ingest byte split

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -559,6 +559,14 @@ impl Connection {
         }
     }
 
+    /// On-storage byte footprint for `name` (user + hidden vector index).
+    ///
+    /// Visible under `metering` for platform billing / Grafana scrapes.
+    #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
+    pub fn table_storage_bytes(&self, name: &str) -> Result<u64, InfinoError> {
+        Ok(self.open_table(name)?.storage_bytes())
+    }
+
     /// List the names of every table registered in this catalog,
     /// alphabetically.
     ///
@@ -568,13 +576,6 @@ impl Connection {
     /// # let _ = names;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    /// On-storage byte footprint for `name` (user + hidden vector index).
-    /// Visible under `metering` for platform billing / Grafana scrapes.
-    #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
-    pub fn table_storage_bytes(&self, name: &str) -> Result<u64, InfinoError> {
-        Ok(self.open_table(name)?.storage_bytes())
-    }
-
     pub fn list_tables(&self) -> Result<Vec<String>, InfinoError> {
         match &self.inner.store {
             CatalogStore::Memory(map) => {

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -561,10 +561,13 @@ impl Connection {
 
     /// On-storage byte footprint for `name` (user + hidden vector index).
     ///
-    /// Visible under `metering` for platform billing / Grafana scrapes.
+    /// Loads lazy manifest parts before summing so cold tables are not
+    /// under-counted. Visible under `metering` for platform billing / Grafana.
     #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
     pub fn table_storage_bytes(&self, name: &str) -> Result<u64, InfinoError> {
-        Ok(self.open_table(name)?.storage_bytes())
+        self.open_table(name)?
+            .storage_bytes()
+            .map_err(|e| InfinoError::from(e).with_context("table_storage_bytes", Some(name)))
     }
 
     /// List the names of every table registered in this catalog,

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -568,6 +568,13 @@ impl Connection {
     /// # let _ = names;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    /// On-storage byte footprint for `name` (user + hidden vector index).
+    /// Visible under `metering` for platform billing / Grafana scrapes.
+    #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
+    pub fn table_storage_bytes(&self, name: &str) -> Result<u64, InfinoError> {
+        Ok(self.open_table(name)?.storage_bytes())
+    }
+
     pub fn list_tables(&self) -> Result<Vec<String>, InfinoError> {
         match &self.inner.store {
             CatalogStore::Memory(map) => {

--- a/src/runtime_metrics/ingest.rs
+++ b/src/runtime_metrics/ingest.rs
@@ -10,16 +10,17 @@
 use arrow_array::{Array, RecordBatch};
 use arrow_schema::DataType;
 
-/// Split `batch`'s in-memory column footprint into `(text_bytes, vector_bytes)`.
+/// Split `batch`'s visible column footprint into `(text_bytes, vector_bytes)`.
 ///
-/// Sizes come from Arrow's `get_array_memory_size` (buffer + null bitmap +
-/// children). This is an attribution of the ingested payload, not the
+/// Sizes use Arrow's slice-aware array-data memory size so sliced arrays are
+/// not billed for unused backing capacity (falls back to full array memory
+/// size if slice sizing fails). This attributes the ingested payload, not the
 /// on-storage superfile footprint after encode.
 pub fn classify_batch_bytes(batch: &RecordBatch) -> (u64, u64) {
     let mut text_bytes = 0u64;
     let mut vector_bytes = 0u64;
     for column in batch.columns() {
-        let size = column.get_array_memory_size() as u64;
+        let size = visible_array_bytes(column.as_ref());
         if matches!(column.data_type(), DataType::FixedSizeList(_, _)) {
             vector_bytes = vector_bytes.saturating_add(size);
         } else {
@@ -27,6 +28,13 @@ pub fn classify_batch_bytes(batch: &RecordBatch) -> (u64, u64) {
         }
     }
     (text_bytes, vector_bytes)
+}
+
+fn visible_array_bytes(column: &dyn Array) -> u64 {
+    column
+        .to_data()
+        .get_slice_memory_size()
+        .unwrap_or_else(|_| column.get_array_memory_size()) as u64
 }
 
 #[cfg(test)]
@@ -53,5 +61,25 @@ mod tests {
         let (text, vector) = classify_batch_bytes(&batch);
         assert!(text > 0, "text columns must contribute bytes");
         assert!(vector > 0, "vector columns must contribute bytes");
+    }
+
+    #[test]
+    fn sliced_column_does_not_bill_full_backing_capacity() {
+        let full = LargeStringArray::from(vec!["aaaa", "bbbb", "cccc", "dddd"]);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "body",
+            DataType::LargeUtf8,
+            false,
+        )]));
+        let full_batch =
+            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(full.clone())]).expect("full");
+        let sliced_batch =
+            RecordBatch::try_new(schema, vec![Arc::new(full.slice(1, 1))]).expect("sliced");
+        let (full_text, _) = classify_batch_bytes(&full_batch);
+        let (sliced_text, _) = classify_batch_bytes(&sliced_batch);
+        assert!(
+            sliced_text < full_text,
+            "slice should bill less than full array ({sliced_text} vs {full_text})"
+        );
     }
 }

--- a/src/runtime_metrics/ingest.rs
+++ b/src/runtime_metrics/ingest.rs
@@ -48,8 +48,8 @@ mod tests {
         let body = LargeStringArray::from(vec!["hello", "world"]);
         let flat = Float32Array::from(vec![1.0_f32, 2.0, 3.0, 4.0]);
         let emb = FixedSizeListArray::new(item, 2, Arc::new(flat), None);
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(body), Arc::new(emb)])
-            .expect("batch");
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(body), Arc::new(emb)]).expect("batch");
         let (text, vector) = classify_batch_bytes(&batch);
         assert!(text > 0, "text columns must contribute bytes");
         assert!(vector > 0, "vector columns must contribute bytes");

--- a/src/runtime_metrics/ingest.rs
+++ b/src/runtime_metrics/ingest.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Classify ingested [`RecordBatch`] bytes into text/scalar vs vector columns.
+//!
+//! Used by the platform worker when attributing write meters for Stripe.
+//! Vector columns are Arrow [`DataType::FixedSizeList`] (the engine's vector
+//! column shape); every other column counts as text/scalar.
+
+use arrow_array::{Array, RecordBatch};
+use arrow_schema::DataType;
+
+/// Split `batch`'s in-memory column footprint into `(text_bytes, vector_bytes)`.
+///
+/// Sizes come from Arrow's `get_array_memory_size` (buffer + null bitmap +
+/// children). This is an attribution of the ingested payload, not the
+/// on-storage superfile footprint after encode.
+pub fn classify_batch_bytes(batch: &RecordBatch) -> (u64, u64) {
+    let mut text_bytes = 0u64;
+    let mut vector_bytes = 0u64;
+    for column in batch.columns() {
+        let size = column.get_array_memory_size() as u64;
+        if matches!(column.data_type(), DataType::FixedSizeList(_, _)) {
+            vector_bytes = vector_bytes.saturating_add(size);
+        } else {
+            text_bytes = text_bytes.saturating_add(size);
+        }
+    }
+    (text_bytes, vector_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+
+    use super::classify_batch_bytes;
+
+    #[test]
+    fn splits_text_and_vector_columns() {
+        let item = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("body", DataType::LargeUtf8, false),
+            Field::new("emb", DataType::FixedSizeList(Arc::clone(&item), 2), false),
+        ]));
+        let body = LargeStringArray::from(vec!["hello", "world"]);
+        let flat = Float32Array::from(vec![1.0_f32, 2.0, 3.0, 4.0]);
+        let emb = FixedSizeListArray::new(item, 2, Arc::new(flat), None);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(body), Arc::new(emb)])
+            .expect("batch");
+        let (text, vector) = classify_batch_bytes(&batch);
+        assert!(text > 0, "text columns must contribute bytes");
+        assert!(vector > 0, "vector columns must contribute bytes");
+    }
+}

--- a/src/runtime_metrics/mod.rs
+++ b/src/runtime_metrics/mod.rs
@@ -13,9 +13,11 @@
 //! `/proc` parsers or parallel I/O counters.
 
 pub mod cpu;
+pub mod ingest;
 pub mod io;
 pub mod rss;
 
+pub use ingest::classify_batch_bytes;
 pub use io::{
     ClassIo, N_URI_CLASSES, TraceEntry, UriClass, UsageMeter, UsageSnapshot, io_is_background,
     scope_background,

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -711,8 +711,7 @@ impl Supertable {
         Ok(entries
             .iter()
             .filter_map(|entry| entry.subsection_offsets.as_ref())
-            .map(|offsets| offsets.total_size)
-            .sum())
+            .fold(0u64, |acc, offsets| acc.saturating_add(offsets.total_size)))
     }
 
     /// Total on-storage bytes of the committed superfiles across the user
@@ -3173,6 +3172,100 @@ mod tests {
             "explicit budgets are warned about, never changed"
         );
         drop(st);
+    }
+
+    /// Cold reopen with lazy manifest parts must not under-report the
+    /// billing footprint. `on_storage_footprint_bytes` reads only the
+    /// resident flat view (safe for raise-only cache reconcile);
+    /// `storage_bytes` forces every part to load first so meters see the
+    /// full user + hidden index footprint.
+    #[test]
+    fn storage_bytes_loads_lazy_parts_on_cold_reopen() {
+        use arrow_array::{Array, FixedSizeListArray, Float32Array};
+
+        use crate::superfile::{
+            builder::VectorConfig,
+            vector::{distance::Metric, rerank_codec::RerankCodec},
+        };
+
+        let dim = 16usize;
+        let n_rows = 32usize;
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let vec_schema = Arc::new(Schema::new(vec![Field::new(
+            "emb",
+            DataType::FixedSizeList(item_field.clone(), dim as i32),
+            false,
+        )]));
+        let storage_dir = TempDir::new().expect("storage tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(storage_dir.path()).expect("provider"));
+        // Threshold 0 ⇒ open never eager-loads parts; threshold 1 byte ⇒
+        // every commit spills into a real manifest part (not an inline flat
+        // view). Together they reproduce the cold undercount that billing
+        // must not see.
+        let make_options = || {
+            SupertableOptions::new(
+                vec_schema.clone(),
+                vec![],
+                vec![VectorConfig {
+                    column: "emb".into(),
+                    dim,
+                    n_cent: 4,
+                    rot_seed: 7,
+                    metric: Metric::Cosine,
+                    rerank_codec: RerankCodec::Sq8Residual,
+                    provided_centroids: None,
+                }],
+                None,
+            )
+            .expect("valid options")
+            .with_storage(Arc::clone(&storage))
+            .with_eager_load_threshold(0)
+            .with_part_size_threshold_bytes(1)
+        };
+
+        let warm_bytes = {
+            let producer = Supertable::create(make_options()).expect("create");
+            let mut flat = Vec::<f32>::with_capacity(n_rows * dim);
+            for i in 0..n_rows {
+                for d in 0..dim {
+                    flat.push(if d == i % dim { 1.0 } else { 0.0 });
+                }
+            }
+            let fsl = FixedSizeListArray::new(
+                item_field,
+                dim as i32,
+                Arc::new(Float32Array::from(flat)),
+                None,
+            );
+            let batch = arrow_array::RecordBatch::try_new(
+                vec_schema.clone(),
+                vec![Arc::new(fsl) as Arc<dyn Array>],
+            )
+            .expect("batch");
+            let mut w = producer.writer().expect("writer");
+            w.append(&batch).expect("append");
+            w.commit().expect("commit");
+            producer.drain_vectors_to_cells_sync().expect("drain");
+            assert!(
+                producer.reader().vector_index_table().is_some(),
+                "drain must leave a hidden vector-index table"
+            );
+            producer.storage_bytes().expect("warm storage_bytes")
+        };
+        assert!(warm_bytes > 0, "committed + drained table has a footprint");
+
+        let cold = Supertable::open(make_options()).expect("cold reopen");
+        let resident = cold.on_storage_footprint_bytes();
+        let loaded = cold.storage_bytes().expect("cold storage_bytes");
+        assert!(
+            resident < loaded,
+            "resident flat view undercounts lazy parts ({resident} vs loaded {loaded})"
+        );
+        assert_eq!(
+            loaded, warm_bytes,
+            "cold storage_bytes must match the warm footprint (user + hidden)"
+        );
     }
 
     /// The hidden IVF superfiles must be made *resident* in the

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -685,14 +685,34 @@ impl Supertable {
     }
 
     /// Total on-storage bytes of the committed superfiles across the user
-    /// table and the hidden vector-index table, from the currently loaded
-    /// manifest views (lazy, not-yet-loaded manifest parts contribute 0 —
-    /// the reconcile below is raise-only, so an undercount is safe).
+    /// table and the hidden vector-index table.
     ///
-    /// Exposed under `metering` for platform billing / Grafana scrapes.
+    /// Loads every lazy manifest part first (user + hidden index) so cold
+    /// handles do not under-report. Prefer this for billing / Grafana scrapes;
+    /// the resident-only footprint helper used for cache-budget reconcile can
+    /// still under-count unloaded parts by design.
     #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
-    pub fn storage_bytes(&self) -> u64 {
-        self.on_storage_footprint_bytes()
+    pub fn storage_bytes(&self) -> Result<u64, OpenError> {
+        let user = self.loaded_storage_footprint_bytes()?;
+        let hidden = match self.inner.vector_index_table.as_ref() {
+            Some(h) => h.loaded_storage_footprint_bytes()?,
+            None => 0,
+        };
+        Ok(user.saturating_add(hidden))
+    }
+
+    /// Sum `subsection_offsets.total_size` after loading all manifest parts.
+    #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
+    fn loaded_storage_footprint_bytes(&self) -> Result<u64, OpenError> {
+        let manifest = self.inner.manifest.load_full();
+        let entries = self
+            .block_on_query(manifest.get_all_superfiles_loaded())
+            .map_err(OpenError::ManifestLoadError)?;
+        Ok(entries
+            .iter()
+            .filter_map(|entry| entry.subsection_offsets.as_ref())
+            .map(|offsets| offsets.total_size)
+            .sum())
     }
 
     /// Total on-storage bytes of the committed superfiles across the user

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -688,6 +688,17 @@ impl Supertable {
     /// table and the hidden vector-index table, from the currently loaded
     /// manifest views (lazy, not-yet-loaded manifest parts contribute 0 —
     /// the reconcile below is raise-only, so an undercount is safe).
+    ///
+    /// Exposed under `metering` for platform billing / Grafana scrapes.
+    #[cfg(any(test, feature = "test-helpers", feature = "metering"))]
+    pub fn storage_bytes(&self) -> u64 {
+        self.on_storage_footprint_bytes()
+    }
+
+    /// Total on-storage bytes of the committed superfiles across the user
+    /// table and the hidden vector-index table, from the currently loaded
+    /// manifest views (lazy, not-yet-loaded manifest parts contribute 0 —
+    /// the reconcile below is raise-only, so an undercount is safe).
     pub(crate) fn on_storage_footprint_bytes(&self) -> u64 {
         let table_bytes = |inner: &SupertableInner| -> u64 {
             inner


### PR DESCRIPTION
Add Supertable/Connection storage footprint helpers and classify RecordBatch columns into text vs vector bytes for platform write meters.