### PR TITLE
fts: cheaper windowed union + route non-dominant large-k ORs to it

### DIFF
--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -16,8 +16,10 @@
 //! then it's a borrowed view).
 
 use std::{
+    cell::RefCell,
     cmp::Ordering,
     collections::{BinaryHeap, HashMap},
+    mem,
     ops::Range,
     sync::Arc,
 };
@@ -1698,6 +1700,23 @@ impl FtsReader {
             return Ok(Vec::new());
         }
         // The ranged (sub-range fan-out) path carries no negation in v1.
+        //
+        // Route non-dominant unions (no single term's upper bound dominates)
+        // to the windowed scorer: there MaxScore can't prune and degrades to
+        // scoring the whole union with per-doc f-way merge overhead, while
+        // the windowed scan is O(f) per window. A dominant-term union stays
+        // on MaxScore, whose block-skip pruning is the win there.
+        if prefer_windowed_union(&cursors) {
+            return self.run_windowed_union(
+                column_id,
+                cursors,
+                k,
+                None,
+                floor.next_down(),
+                doc_id_start,
+                doc_id_end,
+            );
+        }
         self.run_max_score_bmm_range(
             column_id,
             cursors,
@@ -3076,11 +3095,27 @@ impl FtsReader {
         // Floor-seeded threshold, identical to the MaxScore path.
         let mut threshold: f32 = floor_eff.max(0.0);
 
-        // Per-window state, allocated once and reused across windows.
-        // Cleared lazily during the drain (only touched slots), so reset
-        // cost is proportional to matches, not to OR_WINDOW.
-        let mut scores = vec![0.0f32; OR_WINDOW as usize];
-        let mut present = [0u64; OR_WINDOW_WORDS];
+        // Per-window state, reused across windows AND across calls. The
+        // fan-out invokes this once per (superfile, sub-range) — many calls
+        // per query — so a per-call `scores` allocation (`OR_WINDOW` f32s)
+        // dominates small/sparse unions where the scan itself is cheap.
+        // Keep the buffers in a thread-local (each reader-pool worker its
+        // own) and take / restore them; the drain leaves both fully zeroed,
+        // so reuse needs no re-zero. `touched` records which presence words
+        // a window sets, so the drain visits only those rather than scanning
+        // all `OR_WINDOW_WORDS` every window.
+        thread_local! {
+            static WINDOWED_SCRATCH: RefCell<(Vec<f32>, Vec<u64>, Vec<usize>)> =
+                const { RefCell::new((Vec::new(), Vec::new(), Vec::new())) };
+        }
+        let (mut scores, mut present, mut touched) =
+            WINDOWED_SCRATCH.with(|c| mem::take(&mut *c.borrow_mut()));
+        if scores.len() != OR_WINDOW as usize {
+            scores.resize(OR_WINDOW as usize, 0.0);
+        }
+        if present.len() != OR_WINDOW_WORDS {
+            present.resize(OR_WINDOW_WORDS, 0);
+        }
 
         loop {
             // Next non-empty window: smallest current doc among live
@@ -3138,7 +3173,11 @@ impl FtsReader {
                             for lane in 0..bm25::SCORE_SIMD_LANES {
                                 let local = (doc_ids[lane] - base) as usize;
                                 scores[local] += contributions[lane];
-                                present[local >> 6] |= 1u64 << (local & 63);
+                                let w = local >> 6;
+                                if present[w] == 0 {
+                                    touched.push(w);
+                                }
+                                present[w] |= 1u64 << (local & 63);
                             }
                             c.advance_by(bm25::SCORE_SIMD_LANES);
                             continue;
@@ -3150,16 +3189,24 @@ impl FtsReader {
                         c.current_tf(),
                         dl_norm_k1.get(d),
                     );
-                    present[local >> 6] |= 1u64 << (local & 63);
+                    let w = local >> 6;
+                    if present[w] == 0 {
+                        touched.push(w);
+                    }
+                    present[w] |= 1u64 << (local & 63);
                     c.next();
                 }
             }
 
             // Drain ascending; clear touched slots for reuse; apply
-            // negation; offer to the heap.
-            for (word_idx, word) in present.iter_mut().enumerate() {
-                let mut bits = *word;
-                *word = 0;
+            // negation; offer to the heap. Only the words this window set are
+            // visited (sorted for ascending doc order), so a sparse/spread
+            // window costs O(touched words) instead of a fixed
+            // O(OR_WINDOW_WORDS) full-bitset scan.
+            touched.sort_unstable();
+            for &word_idx in &touched {
+                let mut bits = present[word_idx];
+                present[word_idx] = 0;
                 while bits != 0 {
                     let b = bits.trailing_zeros() as usize;
                     bits &= bits - 1;
@@ -3184,8 +3231,17 @@ impl FtsReader {
                     }
                 }
             }
+            touched.clear();
         }
 
+        // Restore the (drained, zeroed) buffers for the next call on this
+        // thread.
+        WINDOWED_SCRATCH.with(|c| {
+            let mut g = c.borrow_mut();
+            g.0 = scores;
+            g.1 = present;
+            g.2 = touched;
+        });
         Ok(drain_top_k_desc(heap))
     }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -165,6 +165,13 @@ const OR_WINDOW_MIN_TERMS: usize = 3;
 /// dominant rare term sits well above it (MaxScore prunes hard → it stays
 /// on MaxScore). Calibrated on the 1M tier.
 const OR_WINDOW_DOMINANCE_MULT: f32 = 1.5;
+/// Minimum `k` for routing a non-dominant union to the windowed scorer.
+/// At small `k` MaxScore's top-k threshold rises fast and its block-skip
+/// pruning is effective even on a non-dominant union, so windowed (which
+/// scores the whole union) loses; the windowed win only appears at large
+/// `k`, where the k-th-best threshold is too low to prune. Conservative —
+/// below this, keep the union on MaxScore.
+const OR_WINDOW_MIN_K: usize = 256;
 
 /// Largest `k` for which a 2-term OR routes to WAND+BMW instead of
 /// MaxScore. WAND's pivot pruning needs a high top-k threshold to skip
@@ -1702,11 +1709,12 @@ impl FtsReader {
         // The ranged (sub-range fan-out) path carries no negation in v1.
         //
         // Route non-dominant unions (no single term's upper bound dominates)
-        // to the windowed scorer: there MaxScore can't prune and degrades to
-        // scoring the whole union with per-doc f-way merge overhead, while
-        // the windowed scan is O(f) per window. A dominant-term union stays
-        // on MaxScore, whose block-skip pruning is the win there.
-        if prefer_windowed_union(&cursors) {
+        // to the windowed scorer at large k: there MaxScore can't prune and
+        // degrades to scoring the whole union with per-doc f-way merge
+        // overhead, while the windowed scan is O(f) per window. At small k,
+        // or when a term dominates, MaxScore's block-skip pruning wins, so
+        // those stay on MaxScore.
+        if k >= OR_WINDOW_MIN_K && prefer_windowed_union(&cursors) {
             return self.run_windowed_union(
                 column_id,
                 cursors,


### PR DESCRIPTION
## Problem

On the sub-range fan-out path, every multi-term OR is scored by MaxScore.
For a **non-dominant** union at large `k` (no single term's score upper
bound dominates), MaxScore can't prune — its essential set never shrinks —
so it scores the whole union with per-doc f-way merge overhead. The
windowed union scorer is the right structure there (O(f) per window), but
two things kept it from being usable as the default:

1. it allocated its per-window scratch (`scores`/`present`) **per call**,
   and the fan-out calls the scorer once per (superfile, sub-range) — many
   calls per query — so small/sparse unions paid allocation they couldn't
   amortize;
2. its drain scanned the **full** presence bitset every window regardless
   of how many docs the window held, so spread unions paid a fixed
   per-window cost.

## Change

- **Reuse the windowed scratch across calls** via a thread-local (each
  reader-pool worker its own; the drain leaves the buffers zeroed, so reuse
  needs no re-zero).
- **Drain only the presence words a window actually set** (tracked in a
  small reused list, sorted for ascending order) — O(touched) per window
  instead of O(window size).
- With the scorer no longer penalizing small/sparse unions, **route
  non-dominant unions to it at large `k`**. A `k`-gate keeps small-`k`
  queries on MaxScore, where its top-k threshold rises fast and block-skip
  pruning stays effective even without a dominant term; dominant unions
  stay on MaxScore at every `k`.

## Correctness

Results are exact — same top-k, same `(score desc, doc asc)` order —
verified against the brute-force BM25 oracle and the fan-out determinism
tests (both pass). The scratch changes are bit-identical; `fmt` + clippy
clean; no format or public-API change.

## Results (5M-document corpus, multi-term OR queries, warm, min-of-runs)

`k`-gate makes TOP_10/TOP_100 run the unchanged MaxScore path — a built-in
control that came out flat (±2%, the measurement floor), confirming small-`k`
and dominant queries are unaffected:

| command | before | after | median Δ |
|---|---:|---:|---:|
| TOP_10 (control) | 183µs | 186µs | +0.8% |
| TOP_100 (control) | 338µs | 343µs | +1.7% |
| TOP_1000 | 1508µs | 1416µs | **−21% median** (−6% mean) |

**Trade-off, called out:** at large `k`, a minority of unions the
upper-bound heuristic classifies as non-dominant are actually prunable and
regress when routed to windowed (worst observed +231%); the scratch/drain
fixes keep that tail bounded. Net is a clear median win at TOP_1000 with no
change at TOP_10/100. Tightening the routing predicate is a follow-up.
Cross-validation at larger scale is pending.