### PR TITLE
python: expose rerank_mult in vector_search and hybrid_search bindings

### DIFF
--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -66,6 +66,7 @@ class Table:
         query: Sequence[float],
         k: int,
         nprobe: int | None = ...,
+        rerank_mult: int | None = ...,
         filter_column: str | None = ...,
         filter_query: str | None = ...,
         filter_mode: BoolMode | None = ...,

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -100,6 +100,7 @@ class Table:
         k: int,
         mode: BoolMode | None = ...,
         nprobe: int | None = ...,
+        rerank_mult: int | None = ...,
         projection: Sequence[str] | None = ...,
     ) -> ArrowTable: ...
     def delete(self, predicate: str) -> MutationStats: ...

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -459,7 +459,11 @@ impl Table {
     /// query terms — a pushdown pre-filter, so kNN ranks only among the
     /// matching rows rather than post-filtering the global top-`k`.
     /// `filter_mode` is `"or"` (default) or `"and"`.
-    #[pyo3(signature = (column, query, k, nprobe=None, filter_column=None, filter_query=None, filter_mode=None, projection=None))]
+    ///
+    /// `rerank_mult` sets how many coarse candidates are re-scored
+    /// exactly (`k * rerank_mult`) — the primary recall/latency lever.
+    /// Omitting it keeps the engine default.
+    #[pyo3(signature = (column, query, k, nprobe=None, rerank_mult=None, filter_column=None, filter_query=None, filter_mode=None, projection=None))]
     #[allow(clippy::too_many_arguments)]
     fn vector_search<'py>(
         &self,
@@ -468,6 +472,7 @@ impl Table {
         query: Vec<f32>,
         k: usize,
         nprobe: Option<usize>,
+        rerank_mult: Option<usize>,
         filter_column: Option<String>,
         filter_query: Option<String>,
         filter_mode: Option<&str>,
@@ -476,6 +481,9 @@ impl Table {
         let mut opts = VectorSearchOptions::new();
         if let Some(n) = nprobe {
             opts = opts.with_nprobe(n);
+        }
+        if let Some(n) = rerank_mult {
+            opts = opts.with_rerank_mult(n);
         }
         // Optional text-predicate filter (pushdown). `filter_column` and
         // `filter_query` must be supplied together; `filter_mode` is only

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -583,12 +583,12 @@ impl Table {
 
     /// Hybrid BM25 + vector search fused with reciprocal-rank fusion.
     /// `text_column` / `text_query` (under `mode`) drive BM25;
-    /// `vector_column` / `vector_query` (with optional `nprobe`) drive
-    /// vector kNN. `k` bounds each retriever and the fused result.
-    /// Returns a pyarrow `Table` like `bm25_search`, with `score` the
-    /// fused RRF score (higher is better); `projection` follows the same
-    /// rules.
-    #[pyo3(signature = (text_column, text_query, vector_column, vector_query, k, mode=None, nprobe=None, projection=None))]
+    /// `vector_column` / `vector_query` (with optional `nprobe` and
+    /// `rerank_mult`) drive vector kNN. `k` bounds each retriever and the
+    /// fused result. Returns a pyarrow `Table` like `bm25_search`, with
+    /// `score` the fused RRF score (higher is better); `projection`
+    /// follows the same rules.
+    #[pyo3(signature = (text_column, text_query, vector_column, vector_query, k, mode=None, nprobe=None, rerank_mult=None, projection=None))]
     #[allow(clippy::too_many_arguments)]
     fn hybrid_search<'py>(
         &self,
@@ -600,12 +600,16 @@ impl Table {
         k: usize,
         mode: Option<&str>,
         nprobe: Option<usize>,
+        rerank_mult: Option<usize>,
         projection: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let mode = parse_mode(mode)?;
         let mut opts = VectorSearchOptions::new();
         if let Some(n) = nprobe {
             opts = opts.with_nprobe(n);
+        }
+        if let Some(n) = rerank_mult {
+            opts = opts.with_rerank_mult(n);
         }
         let batches = py
             .detach(|| {

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -394,6 +394,10 @@ def test_vector_search_end_to_end():
     assert hits.num_rows >= 1
     assert "_id" in hits.column_names and "score" in hits.column_names
 
+    # rerank_mult tunes recall/latency without breaking the search.
+    tuned = t.vector_search("emb", onehot(0), 10, nprobe=8, rerank_mult=32)
+    assert tuned.num_rows >= 1
+
 
 def test_filtered_vector_search():
     db = infino.connect("memory://")

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -491,6 +491,11 @@ def test_hybrid_search_fuses_text_and_vector():
     hits = t.hybrid_search("title", "rust", "emb", onehot(0), 10)
     assert hits.num_rows >= 1
     assert "_id" in hits.column_names and "score" in hits.column_names
+
+    # nprobe/rerank_mult tune the vector leg without breaking the search.
+    assert t.hybrid_search(
+        "title", "rust", "emb", onehot(0), 10, nprobe=8, rerank_mult=32
+    ).num_rows >= 1
     # RRF score is higher-is-better, so rows come back descending.
     scores = hits["score"].to_pylist()
     assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## What

Adds the `rerank_mult` kwarg to the pyo3 `vector_search` and `hybrid_search` bindings, threading it into `VectorSearchOptions`. Documents it in `_infino.pyi`.

Closes #453.

## Why

The Rust vector API exposes `rerank_mult` (the coarse-candidates-re-scored-exactly knob, default 256) — the primary recall/latency lever for IVF search. Python callers could set `nprobe` but never `rerank_mult`, so they couldn't fully tune the recall–latency tradeoff or reproduce non-default Rust results.

While fixing #453 I audited the whole Python binding for param parity against the Rust public surface. `hybrid_search` had the same gap: Rust threads the full `VectorSearchOptions` into its vector leg, but Python forwarded only `nprobe`. Fixed here too. Everything else (connect/ConnectOptions, IndexSpec, optimize/CompactionSettings, bm25/token/exact/count) is at parity.

Node bindings already expose `rerankMult` — no change needed there.

## Changes

- `infino-python/src/lib.rs` — `rerank_mult: Option<usize>` on both `vector_search` and `hybrid_search`, applied via `with_rerank_mult`. Default behavior unchanged when omitted.
- `infino-python/python/infino/_infino.pyi` — stub updated for both methods.
- `infino-python/tests/test_smoke.py` — coverage for both.

## Verification

`maturin develop` builds clean, `cargo clippy -p infino-python` clean, vector + hybrid smoke tests pass.