### PR TITLE
ci: never run release, publish, or docs workflows in a fork

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -33,6 +33,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Never run in a fork: only this repo has the Pages site to deploy to.
+    if: github.repository == 'infino-ai/infino'
     steps:
       - name: Python reference (pdoc, from the published package)
         uses: actions/setup-python@v5

--- a/.github/workflows/crate-publish.yml
+++ b/.github/workflows/crate-publish.yml
@@ -50,6 +50,8 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # Never run in a fork: only this repo publishes to the registry.
+    if: github.repository == 'infino-ai/infino'
     timeout-minutes: 60
     # CARGO_REGISTRY_TOKEN is read from a repository secret. To gate real
     # publishes behind required reviewers, move that secret into a GitHub

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -38,7 +38,8 @@ jobs:
     # Coordinated-release gate: on a tag push, run only when the tag is a
     # minor/major (patch == 0, tag ends in `.0`). A crate-only patch tag skips
     # the bindings. A manual run always proceeds (independent Node patch).
-    if: ${{ github.event_name == 'workflow_dispatch' || endsWith(github.ref_name, '.0') }}
+    # Never run in a fork: only this repo publishes to the registry.
+    if: ${{ github.repository == 'infino-ai/infino' && (github.event_name == 'workflow_dispatch' || endsWith(github.ref_name, '.0')) }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -54,7 +54,8 @@ jobs:
     # minor/major (patch == 0, tag ends in `.0`). A crate-only patch tag skips
     # the bindings (build + publish need this job, so they skip too). A manual
     # run always proceeds (independent Python patch).
-    if: ${{ github.event_name == 'workflow_dispatch' || endsWith(github.ref_name, '.0') }}
+    # Never run in a fork: only this repo publishes to the registry.
+    if: ${{ github.repository == 'infino-ai/infino' && (github.event_name == 'workflow_dispatch' || endsWith(github.ref_name, '.0')) }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -47,6 +47,9 @@ jobs:
   release:
     name: Detect release and kick off publish
     runs-on: ubuntu-latest
+    # Never run in a fork: syncing main replays the release commit, which
+    # would re-detect an already-published version.
+    if: github.repository == 'infino-ai/infino'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -52,6 +52,8 @@ jobs:
   prep:
     name: Stamp versions and open the release PR
     runs-on: ubuntu-latest
+    # Never run in a fork: releases are cut from this repo only.
+    if: github.repository == 'infino-ai/infino'
     timeout-minutes: 10
     steps:
       # Fail fast, before touching anything, if the token is missing or


### PR DESCRIPTION
## What

Guard six workflows with `if: github.repository == 'infino-ai/infino'` on their entry job, so they no longer run in forks.

## Why

Each of these fires automatically but can only fail outside this repo, because it needs org-only secrets or infrastructure. All six were observed failing (or are one tag push away from it) on a fork of this repo:

| Workflow | Trigger | Failure in a fork |
| --- | --- | --- |
| API reference | `schedule`, `workflow_run` | `actions/deploy-pages` → `HttpError: Not Found`; a fork has no Pages site |
| Release prep | weekly `schedule` | `RELEASE_PAT secret is not set` |
| Release on merge | `push` to `main` on version-file paths | Syncing a fork replays the release commit, so it re-detects an already-tagged version: `Cargo.toml changed to 0.1.9 but tag v0.1.9 already exists` |
| Publish crate | `push` tag `v[0-9]*` | A fork inherits the release tags, so pushing one attempts a real crates.io publish |
| Node publish | `push` tag `v[0-9]*` | Same, for npm |
| Publish Python package | `push` tag `v[0-9]*` | Same, for PyPI |

The publish trio is the one worth calling out: a fork inherits `v*` tags on sync, so the guard is a safety property, not only noise reduction. Only the `.0` coordinated-release gate stood between a fork tag push and a registry publish attempt.

`bench.yml` and `bench-janitor.yml` already carry this guard — this brings the rest in line with the pattern rather than inventing one.

## Notes for review

- The guard goes on the **entry** job only. Every downstream job (`api-docs` `deploy`, `node-publish` `publish`, `publish-python` `build`/`publish`) reaches the runner solely via a guarded job and none uses `if: always()`, so the skip cascades — no per-job duplication.
- For the two publish workflows that already had an `if`, the repository check is ANDed with the existing `.0` coordinated-release gate; that gate's behavior is unchanged.
- No behavior change in this repo: the condition is always true here.
- `ci.yml` is deliberately untouched — CI *should* run on forks, and its object-store job is already secret-gated.
- `dataset-*.yml` and `supertable-bench-azure.yml` are `workflow_dispatch`/`workflow_call` only, so they never auto-fire; left alone to keep this diff scoped. Happy to guard them in a follow-up if you'd rather a fork couldn't dispatch them against the shared Azure resources.
- Workflows only; no Rust touched, so no bench run applies. `actionlint` is clean (the four `SC2034` warnings it reports in `release-on-merge.yml` are pre-existing — verified they reproduce on `main` unchanged).