### PR TITLE
release: each 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "apache-avro",
  "arc-swap",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "infino-node"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-node/Cargo.toml
+++ b/infino-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-node"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.1.7",
-    "infx-darwin-arm64": "0.1.7",
-    "infx-linux-x64-gnu": "0.1.7",
-    "infx-linux-arm64-gnu": "0.1.7",
-    "infx-linux-x64-musl": "0.1.7",
-    "infx-linux-arm64-musl": "0.1.7"
+    "infx-darwin-x64": "0.1.8",
+    "infx-darwin-arm64": "0.1.8",
+    "infx-linux-x64-gnu": "0.1.8",
+    "infx-linux-arm64-gnu": "0.1.8",
+    "infx-linux-x64-musl": "0.1.8",
+    "infx-linux-arm64-musl": "0.1.8"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "apache-avro",
  "arc-swap",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "infino-python"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-python"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Release PR stamped by the `Release prep` workflow (scope: `each`).

| Package | Version |
| ------- | ------- |
| crate   | 0.1.10  |
| node    | 0.1.8   |
| python  | 0.1.9 |

On merge, `Release on merge` tags and publishes whichever of these changed — see docs/versioning.md.