### PR TITLE
fts: improve post-compaction OR latencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,6 +2376,7 @@ dependencies = [
  "rayon",
  "rcgen",
  "reqwest",
+ "rustix",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -16,7 +16,7 @@
 //! cargo bench -- supertable vector build cold
 //!
 //! # Diagnostics (standalone programs, same binary):
-//! cargo bench -- diagnostic              # all seven
+//! cargo bench -- diagnostic              # all eight
 //! cargo bench -- diagnostic scale        # a subset, grouped
 //! cargo bench -- tombstone               # bare names also work
 //!
@@ -34,9 +34,9 @@
 //!   `all`       : explicit "every tier × modality × phase" (the default).
 //!                 Matrix only — diagnostics are NEVER implied by `all` or
 //!                 by a bare `cargo bench`.
-//!   diagnostic  : `scale` | `tombstone` | `update` | `sql-diag` | `fts-diag` | `object-store` | `concurrent`,
+//!   diagnostic  : `scale` | `tombstone` | `update` | `sql-diag` | `fts-diag` | `object-store` | `concurrent` | `disk-warm`,
 //!                 by name, or grouped under the `diagnostic` keyword —
-//!                 `cargo bench -- diagnostic` runs all seven,
+//!                 `cargo bench -- diagnostic` runs all eight,
 //!                 `cargo bench -- diagnostic scale tombstone` a subset.
 //!
 //! The matrix tests run = (selected tiers) × (selected modalities).
@@ -70,6 +70,7 @@ enum Diagnostic {
     FtsDiag,
     ObjectStore,
     Concurrent,
+    DiskWarm,
 }
 
 impl Diagnostic {
@@ -82,6 +83,7 @@ impl Diagnostic {
             Diagnostic::FtsDiag => "fts-diag",
             Diagnostic::ObjectStore => "object-store",
             Diagnostic::Concurrent => "concurrent",
+            Diagnostic::DiskWarm => "disk-warm",
         }
     }
 
@@ -94,6 +96,7 @@ impl Diagnostic {
             Diagnostic::FtsDiag => infino_bench_utils::fts_diag::run(),
             Diagnostic::ObjectStore => infino_bench_utils::unified_object_store::run(),
             Diagnostic::Concurrent => infino_bench_utils::concurrent::run(),
+            Diagnostic::DiskWarm => infino_bench_utils::disk_warm::run(),
         }
     }
 }
@@ -300,8 +303,8 @@ fn print_usage_and_exit(code: i32) -> ! {
          Phase     : build | warm | cold | search  (search = warm+cold; omitted => all)\n\
          all       : every tier x modality x phase (the default for a bare\n\
          \x20           `cargo bench`); matrix only — never implies diagnostics\n\
-         Diagnostic: scale | tombstone | update | sql-diag | fts-diag | object-store | concurrent,\n\
-         \x20           or `diagnostic` for all six / `diagnostic <names>` for a subset\n\
+         Diagnostic: scale | tombstone | update | sql-diag | fts-diag | object-store | concurrent | disk-warm,\n\
+         \x20           or `diagnostic` for all eight / `diagnostic <names>` for a subset\n\
          \n\
          Examples:\n\
          \x20 cargo bench\n\
@@ -388,6 +391,7 @@ fn parse_args() -> Selection {
             "fts-diag" | "fts_diag" => diagnostics.push(Diagnostic::FtsDiag),
             "object-store" | "object_store" => diagnostics.push(Diagnostic::ObjectStore),
             "concurrent" => diagnostics.push(Diagnostic::Concurrent),
+            "disk-warm" | "disk_warm" => diagnostics.push(Diagnostic::DiskWarm),
             "diagnostic" | "diagnostics" => want_diagnostics = true,
             other => unknown.push(other.to_string()),
         }
@@ -411,6 +415,7 @@ fn parse_args() -> Selection {
             Diagnostic::FtsDiag,
             Diagnostic::ObjectStore,
             Diagnostic::Concurrent,
+            Diagnostic::DiskWarm,
         ];
     }
 

--- a/benches/utils/Cargo.toml
+++ b/benches/utils/Cargo.toml
@@ -32,6 +32,11 @@ parquet = "58"
 rand = "0.10"
 rand_distr = "0.6"
 rayon = "1"
+# rustix — safe posix_fadvise(DONTNEED) + sync for the disk-warm serving-state
+# diagnostic (`disk_warm.rs`): drop the OS page cache under the local disk
+# cache without unsafe libc calls. Already in the dependency tree
+# transitively (tokio/tempfile).
+rustix = { version = "1", features = ["fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/benches/utils/cost.rs
+++ b/benches/utils/cost.rs
@@ -601,6 +601,15 @@ fn occupancy_replicas() -> u32 {
         .get_or_init(|| parse_replicas(std::env::var("INFINO_BENCH_COST_REPLICAS").ok().as_deref()))
 }
 
+/// The tenant's composed serving cost per month: marginal work (storage +
+/// blended reads + writes + maintenance, egress excluded as pass-through)
+/// plus the keep-warm floor (idle-retained NVMe × R) that buys the blend's
+/// warm-hit rate. `None` floor (NVMe cache unmeasured) yields `None` — the
+/// composed number is withheld rather than silently missing its floor.
+fn serving_cogs_month(marginal_ex_egress: f64, idle_floor_total: Option<f64>) -> Option<f64> {
+    idle_floor_total.map(|floor| marginal_ex_egress + floor)
+}
+
 /// Network egress rate ($/GB out), env-overridable like [`storage_months`]
 /// (it is a rate-card rate, not an instance attribute, so it is read here and
 /// not in `Instance::from_env`). Set `INFINO_BENCH_COST_EGRESS_USD_PER_GB=0`
@@ -2600,6 +2609,67 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
         rows: occupancy_rows,
     });
 
+    // ---- Block 7: serving COGS (the composed per-tenant number) ----
+    // The one number the two blocks above only imply: what serving this
+    // tenant costs per month. Marginal work (storage + blended reads +
+    // writes + maintenance) PLUS the keep-warm floor that buys the blend's
+    // warm-hit rate (idle-retained NVMe × R). Egress is excluded — it is
+    // passed through to the customer, so it is revenue-neutral, not COGS.
+    // The floor requires a measured NVMe cache size; when unmeasured the
+    // total is withheld, never guessed low.
+    let marginal_ex_egress = storage_month
+        + blended_read_q
+            .map(|q| q * SUMMARY_QUERIES_PER_MONTH)
+            .unwrap_or(0.0)
+        + writes_month
+        + maintenance_month.unwrap_or(0.0);
+    let idle_floor_total = nvme_sh.map(|s| s * node_month * f64::from(replicas));
+    let serving_cogs = {
+        let warm_pct = SUMMARY_READ_WARM_FRACTION * 100.0;
+        let mut rows = vec![vec![
+            text(format!(
+                "Marginal work — storage + blended reads ({warm_pct:.0}/{:.0}) + writes + maintenance",
+                100.0 - warm_pct,
+            )),
+            text("summary lines above, egress excluded (passed through to the customer)"),
+            context(marginal_ex_egress, usd(marginal_ex_egress), Better::Lower),
+        ]];
+        match idle_floor_total {
+            Some(floor) => {
+                rows.push(vec![
+                    text(format!(
+                        "Keep-warm floor — idle-retained NVMe × R={replicas}"
+                    )),
+                    text("the occupancy row that buys the blend's warm-hit rate"),
+                    context(floor, usd(floor), Better::Lower),
+                ]);
+                let total = serving_cogs_month(marginal_ex_egress, idle_floor_total)
+                    .expect("floor is Some in this branch");
+                rows.push(vec![
+                    text("Serving COGS (marginal + keep-warm floor, ex-egress)"),
+                    text("—"),
+                    metric(total, usd(total), Better::Lower),
+                ]);
+            }
+            None => rows.push(vec![
+                text("Serving COGS (marginal + keep-warm floor, ex-egress)"),
+                text("NVMe cache unmeasured this run — total withheld, never guessed"),
+                text("—"),
+            ]),
+        }
+        Block {
+            subtitle: format!(
+                "Serving COGS — per tenant-month at {} queries/mo, {:.0}% warm blend, \
+                 keep-warm-NVMe policy. The composed number the marginal summary and the \
+                 occupancy view each show one half of.",
+                fmt_count(SUMMARY_QUERIES_PER_MONTH as usize),
+                SUMMARY_READ_WARM_FRACTION * 100.0,
+            ),
+            headers: vec!["Line".into(), "Basis".into(), "$/month".into()],
+            rows,
+        }
+    };
+
     let mut blocks = vec![rate_card];
     if let Some(io_ledger) = io_ledger {
         blocks.push(io_ledger);
@@ -2610,6 +2680,7 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
     if let Some(occupancy) = occupancy {
         blocks.push(occupancy);
     }
+    blocks.push(serving_cogs);
 
     report.emit(&Section {
         anchor: anchor.into(),
@@ -2924,6 +2995,17 @@ mod tests {
         assert!((inst.usd_per_month() - 0.3629 * HOURS_PER_MONTH).abs() < 1e-9);
         let billed = 0.5 * inst.usd_per_month() * 2.0;
         assert!((billed - inst.usd_per_month()).abs() < 1e-9);
+    }
+
+    /// The composed serving-COGS number: marginal-ex-egress plus the
+    /// keep-warm floor, and withheld (not guessed at marginal-only) when
+    /// the floor is unmeasured. Values mirror the 100K FTS reference run:
+    /// $4.18 marginal + $0.78 idle-NVMe floor = $4.96/mo.
+    #[test]
+    fn serving_cogs_composes_marginal_plus_floor_or_withholds() {
+        let composed = serving_cogs_month(4.18, Some(0.78)).expect("floor measured");
+        assert!((composed - 4.96).abs() < 1e-9);
+        assert_eq!(serving_cogs_month(4.18, None), None);
     }
 
     #[test]

--- a/benches/utils/cost.rs
+++ b/benches/utils/cost.rs
@@ -32,7 +32,7 @@ use std::{collections::HashMap, sync::OnceLock};
 use crate::{
     executors::{ColdTiming, fts::FtsQueryStat, sql::QuerySets, vector::RecallRow},
     markdown::{fmt_count, fmt_time},
-    report::{Better, Block, Cell, Report, Section, metric, text},
+    report::{Better, Block, Cell, Report, Section, context, metric, text},
     rss::fmt_bytes,
     storage_meter::{ObjectStoreMeter, background_fill_meter, merge_background_fill},
 };
@@ -78,6 +78,18 @@ const SUMMARY_READ_WARM_FRACTION: f64 = 0.95;
 /// metering must record the exact measured hold time and put any padding
 /// in the PRICE, never in the reported quantity.
 const QUERY_RAM_HOLD_FUDGE: f64 = 2.0;
+/// Average hours in a calendar month (365.25 days × 24 h ÷ 12). Used only by
+/// the provisioned-occupancy block to price a whole reserved node per month —
+/// the marginal model never bills calendar hours (residency stays inside each
+/// query's RAM-hold leg).
+const HOURS_PER_MONTH: f64 = 730.5;
+/// Default replication factor for the provisioned-occupancy framing: an
+/// R-way HA placement where each replica keeps its own independent local
+/// cache, so NVMe and RAM occupancy multiply by R rather than being shared.
+/// The bench itself measures ONE node — the per-replica column is the
+/// measured basis and the ×R column applies this multiplier visibly.
+/// Override via `INFINO_BENCH_COST_REPLICAS`.
+const DEFAULT_OCCUPANCY_REPLICAS: u32 = 2;
 
 /// The instance the model prices against. Default is a portable cloud SKU
 /// with local NVMe; override via `INFINO_BENCH_COST_*` env vars.
@@ -144,6 +156,28 @@ impl Instance {
     /// Fraction of the instance's RAM a resident set occupies.
     fn ram_share(&self, resident_bytes: u64) -> f64 {
         resident_bytes as f64 / BYTES_PER_GIB / self.ram_gib
+    }
+
+    /// Whole-node dollars for one calendar month — the reserved-capacity
+    /// rate the provisioned-occupancy block prices shares against.
+    fn usd_per_month(&self) -> f64 {
+        self.usd_per_hour * HOURS_PER_MONTH
+    }
+
+    /// Fraction of the instance's local NVMe a cache footprint occupies.
+    /// NVMe capacity is quoted in decimal GB (matching cloud SKU listings).
+    fn nvme_share(&self, bytes: u64) -> f64 {
+        bytes as f64 / BYTES_PER_GB / self.nvme_gb
+    }
+
+    /// Fraction of the node's CPU an assumed monthly query load keeps busy:
+    /// queries/month × billed vCPU·s per query ÷ the node's total vCPU·s in
+    /// a month. "Billed" vCPU·s is `per_query_vcpu_seconds` — the binding of
+    /// measured CPU and the RAM-hold leg — so the occupancy view and the
+    /// marginal model reconcile on the same per-query quantity.
+    fn cpu_share_at_load(&self, billed_vcpu_s_per_query: f64, queries_per_month: f64) -> f64 {
+        queries_per_month * billed_vcpu_s_per_query
+            / (f64::from(self.vcpu.max(1)) * HOURS_PER_MONTH * SECS_PER_HOUR)
     }
 
     /// RAM-hold leg for a one-time phase, in aggregate vCPU-seconds: `wall ×
@@ -387,6 +421,13 @@ pub struct StorePhases {
     /// on the same shared consumer — filtered vs unfiltered GET/query.
     pub filtered_query: Option<ObjectStoreMeter>,
     pub filtered_query_iters: u64,
+    /// Settled local NVMe disk-cache footprint (`DiskCacheStore` current
+    /// bytes) sampled on the shared consumer after the steady-state serving
+    /// battery. Includes the hidden vector-index table — it shares the same
+    /// cache root and budget. Feeds the provisioned-occupancy NVMe rows;
+    /// `None` (e.g. an in-memory cell with no disk cache) omits them,
+    /// never guesses.
+    pub disk_cache_bytes: Option<u64>,
 }
 
 /// Everything one cell (one tier × modality) needs to be priced.
@@ -466,6 +507,32 @@ fn usd_per_million(per_unit: f64) -> String {
     format!("{}/1M", usd(per_unit * PER_MILLION))
 }
 
+/// A capacity share as a percentage, with adaptive precision below 0.1% so
+/// a tiny CPU share (e.g. 0.06%) never collapses to a meaningless "0.0%" —
+/// same rationale as [`usd`].
+fn fmt_share(share: f64) -> String {
+    let pct = share * 100.0;
+    if pct == 0.0 {
+        return "0%".into();
+    }
+    if pct >= 0.1 {
+        return format!("{pct:.1}%");
+    }
+    let decimals = ((-pct.log10()).ceil() as usize + 1).min(9);
+    format!("{pct:.decimals$}%")
+}
+
+/// The binding provisioned resource: the largest MEASURED share with its
+/// label. Unmeasured shares are skipped, never treated as 0 (a missing
+/// measurement must not "lose" the max and misname the binding resource);
+/// `None` only when nothing was measured.
+fn binding_share(shares: &[(&'static str, Option<f64>)]) -> Option<(&'static str, f64)> {
+    shares
+        .iter()
+        .filter_map(|(label, share)| share.map(|s| (*label, s)))
+        .max_by(|(_, a), (_, b)| a.total_cmp(b))
+}
+
 /// Per-query cost with both scales visible — prevents comparing $/open to $/1M.
 fn usd_per_query_both_scales(per_query: f64) -> String {
     format!("{}/query ({})", usd(per_query), usd_per_million(per_query))
@@ -514,6 +581,24 @@ fn storage_months() -> f64 {
             .and_then(|x| x.parse().ok())
             .unwrap_or(DEFAULT_STORAGE_MONTHS)
     })
+}
+
+/// Replication factor for the provisioned-occupancy block. Zero or garbage
+/// falls back to the default — R=0 would print a $0 keep-warm bill, which is
+/// never a measurement.
+fn parse_replicas(raw: Option<&str>) -> u32 {
+    raw.and_then(|s| s.parse::<u32>().ok())
+        .filter(|&r| r > 0)
+        .unwrap_or(DEFAULT_OCCUPANCY_REPLICAS)
+}
+
+/// R for the occupancy block, env-overridable like [`storage_months`] (a
+/// deployment-topology knob, not an instance attribute, so it is read here
+/// and not in `Instance::from_env`).
+fn occupancy_replicas() -> u32 {
+    static REPLICAS: OnceLock<u32> = OnceLock::new();
+    *REPLICAS
+        .get_or_init(|| parse_replicas(std::env::var("INFINO_BENCH_COST_REPLICAS").ok().as_deref()))
 }
 
 /// Network egress rate ($/GB out), env-overridable like [`storage_months`]
@@ -812,8 +897,17 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
     // first-cold latency, which must be labeled "first-cold", never "steady").
     let cold_second_io = c.store.cold_second_query;
     enum SteadyColdPrice {
-        Full { per_q: f64, wall_s: f64 },
-        RequestsOnly { usd: f64 },
+        Full {
+            per_q: f64,
+            wall_s: f64,
+            /// Billed compute of the steady cold query (max of measured CPU
+            /// and the RAM-hold leg, no request dollars) — the quantity the
+            /// occupancy block's CPU share is built from.
+            vcpu_s: f64,
+        },
+        RequestsOnly {
+            usd: f64,
+        },
         None,
     }
     let steady_cold_price = match (
@@ -826,6 +920,7 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
         (Some(io), Some(cpu), Some(window)) => SteadyColdPrice::Full {
             per_q: inst.per_query_usd(cpu, window, c.resident_anon_bytes) + request_usd(&io),
             wall_s: window,
+            vcpu_s: inst.per_query_vcpu_seconds(cpu, window, c.resident_anon_bytes),
         },
         (Some(io), _, _) => SteadyColdPrice::RequestsOnly {
             usd: request_usd(&io),
@@ -919,7 +1014,7 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
         && let Some(q) = anchor_cold
     {
         match &steady_cold_price {
-            SteadyColdPrice::Full { per_q, wall_s } => {
+            SteadyColdPrice::Full { per_q, wall_s, .. } => {
                 let io = cold_second_io.expect("Full variant implies cold_second_io");
                 rate_rows.push(vec![
                     text("Cold query (CPU + requests, steady)"),
@@ -1612,6 +1707,13 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
     let mut monthly_bulk_shapes: Vec<(String, f64, u64)> = Vec::new();
     let mut steady_warm: Option<(String, f64)> = None;
     let mut steady_cold: Option<(String, f64)> = None;
+    // Billed compute (vCPU·s) of the same steady warm/cold queries the dollar
+    // figures above are built from — set at the same branches, blended the
+    // same way — so the occupancy block's CPU share prices exactly the load
+    // the monthly read line bills (the dollar figures can't stand in: the
+    // cold side folds in GET request dollars, which are not compute).
+    let mut steady_warm_vcpu_s: Option<f64> = None;
+    let mut steady_cold_vcpu_s: Option<f64> = None;
     if let Some(groups) = c.serving_groups {
         // Per-group serving priced from the full query battery — the SAME
         // measurement the per-shape search table reports, so the two tables
@@ -1630,20 +1732,23 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
             .last()
             .map(|s| s.serving_resident_bytes(c.resident_anon_bytes))
             .unwrap_or(c.resident_anon_bytes);
-        // Each returns (p50_seconds, per_query_usd, payload_bytes). Payload
-        // is the returned result size (cache-independent), the egress quantity.
-        let warm_per_q = |name: &str| -> Option<(f64, f64, u64)> {
+        // Each returns (p50_seconds, per_query_usd, billed_vcpu_s,
+        // payload_bytes). Payload is the returned result size
+        // (cache-independent), the egress quantity; billed vCPU·s is the
+        // compute-only quantity behind the dollars (no request leg).
+        let warm_per_q = |name: &str| -> Option<(f64, f64, f64, u64)> {
             c.warm.iter().find(|w| w.name == name).and_then(|w| {
                 w.cpu_s.map(|cpu| {
                     (
                         w.p50_s,
                         inst.per_query_usd(cpu, w.p50_s, resident),
+                        inst.per_query_vcpu_seconds(cpu, w.p50_s, resident),
                         w.payload_bytes,
                     )
                 })
             })
         };
-        let cold_per_q = |name: &str| -> Option<(f64, f64, u64)> {
+        let cold_per_q = |name: &str| -> Option<(f64, f64, f64, u64)> {
             let cq = c.cold?.iter().find(|q| q.name == name)?;
             let cpu = cq.search_cpu_s?;
             // Cold holds the resident set for ~its warm window (bytes local);
@@ -1656,42 +1761,53 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
             let warm = c.warm.iter().find(|w| w.name == name)?;
             let per_q = inst.per_query_usd(cpu, warm.p50_s, resident)
                 + cq.search_get_count as f64 * USD_PER_GET;
-            Some((cq.search_s, per_q, warm.payload_bytes))
+            Some((
+                cq.search_s,
+                per_q,
+                inst.per_query_vcpu_seconds(cpu, warm.p50_s, resident),
+                warm.payload_bytes,
+            ))
         };
         let mut all_warm_usd: Vec<f64> = Vec::new();
         let mut all_cold_usd: Vec<f64> = Vec::new();
+        let mut all_warm_vcpu_s: Vec<f64> = Vec::new();
+        let mut all_cold_vcpu_s: Vec<f64> = Vec::new();
         // Family row: p50 / payload / egress are the family means; the final
         // per-query dollars are the FULL serve cost — compute + requests +
         // egress on the returned bytes — so the row is the complete unit cost
         // of that query class.
-        let group_row =
-            |rows: &mut Vec<Vec<Cell>>, label: &str, kind: &str, samples: &[(f64, f64, u64)]| {
-                if samples.is_empty() {
-                    return;
-                }
-                let n = samples.len() as f64;
-                let mean_p50 = samples.iter().map(|(p, _, _)| p).sum::<f64>() / n;
-                let mean_usd = samples.iter().map(|(_, u, _)| u).sum::<f64>() / n;
-                let mean_payload = samples.iter().map(|(_, _, b)| *b).sum::<u64>() as f64 / n;
-                let egress = egress_usd(mean_payload);
-                let total = mean_usd + egress;
-                let qpu = 1.0 / total.max(f64::MIN_POSITIVE);
-                rows.push(vec![
-                    text(format!(
-                        "{label} — {kind} (mean of {} shapes)",
-                        samples.len()
-                    )),
-                    text(fmt_time(mean_p50 * 1e9)),
-                    text(fmt_bytes(mean_payload as u64)),
-                    text(usd(egress * PER_MILLION)),
-                    metric(qpu, format!("{qpu:.0}"), Better::Higher),
-                    speed_per_usd_cell(total, mean_p50),
-                    metric(total * PER_MILLION, usd(total * PER_MILLION), Better::Lower),
-                ]);
-            };
+        let group_row = |rows: &mut Vec<Vec<Cell>>,
+                         label: &str,
+                         kind: &str,
+                         samples: &[(f64, f64, f64, u64)]| {
+            if samples.is_empty() {
+                return;
+            }
+            let n = samples.len() as f64;
+            let mean_p50 = samples.iter().map(|(p, _, _, _)| p).sum::<f64>() / n;
+            let mean_usd = samples.iter().map(|(_, u, _, _)| u).sum::<f64>() / n;
+            let mean_payload = samples.iter().map(|(_, _, _, b)| *b).sum::<u64>() as f64 / n;
+            let egress = egress_usd(mean_payload);
+            let total = mean_usd + egress;
+            let qpu = 1.0 / total.max(f64::MIN_POSITIVE);
+            rows.push(vec![
+                text(format!(
+                    "{label} — {kind} (mean of {} shapes)",
+                    samples.len()
+                )),
+                text(fmt_time(mean_p50 * 1e9)),
+                text(fmt_bytes(mean_payload as u64)),
+                text(usd(egress * PER_MILLION)),
+                metric(qpu, format!("{qpu:.0}"), Better::Higher),
+                speed_per_usd_cell(total, mean_p50),
+                metric(total * PER_MILLION, usd(total * PER_MILLION), Better::Lower),
+            ]);
+        };
         for (label, names) in groups {
-            let warms: Vec<(f64, f64, u64)> = names.iter().filter_map(|n| warm_per_q(n)).collect();
-            let colds: Vec<(f64, f64, u64)> = names.iter().filter_map(|n| cold_per_q(n)).collect();
+            let warms: Vec<(f64, f64, f64, u64)> =
+                names.iter().filter_map(|n| warm_per_q(n)).collect();
+            let colds: Vec<(f64, f64, f64, u64)> =
+                names.iter().filter_map(|n| cold_per_q(n)).collect();
             // BOUNDED shapes only feed the per-query monthly rates. A bulk
             // shape's result scales with the match set, so averaging it into a
             // per-query rate asserts that every query returns a full-corpus
@@ -1700,13 +1816,15 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
             // (see the bulk rate lines in the monthly summary).
             if is_bulk_group(label) {
                 monthly_bulk_shapes.extend(names.iter().filter_map(|n| {
-                    let (_, warm_usd, payload) = warm_per_q(n)?;
+                    let (_, warm_usd, _, payload) = warm_per_q(n)?;
                     Some((n.to_string(), warm_usd, payload))
                 }));
             } else {
-                all_warm_usd.extend(warms.iter().map(|(_, u, _)| *u));
-                all_cold_usd.extend(colds.iter().map(|(_, u, _)| *u));
-                monthly_bounded_payloads.extend(warms.iter().map(|(_, _, b)| *b));
+                all_warm_usd.extend(warms.iter().map(|(_, u, _, _)| *u));
+                all_cold_usd.extend(colds.iter().map(|(_, u, _, _)| *u));
+                all_warm_vcpu_s.extend(warms.iter().map(|(_, _, v, _)| *v));
+                all_cold_vcpu_s.extend(colds.iter().map(|(_, _, v, _)| *v));
+                monthly_bounded_payloads.extend(warms.iter().map(|(_, _, _, b)| *b));
             }
             group_row(&mut serving_rows, label, "warm", &warms);
             group_row(&mut serving_rows, label, "cold", &colds);
@@ -1718,6 +1836,14 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
         if !all_cold_usd.is_empty() {
             let mean = all_cold_usd.iter().sum::<f64>() / all_cold_usd.len() as f64;
             steady_cold = Some(("cold (bounded-result mean)".to_string(), mean));
+        }
+        if !all_warm_vcpu_s.is_empty() {
+            steady_warm_vcpu_s =
+                Some(all_warm_vcpu_s.iter().sum::<f64>() / all_warm_vcpu_s.len() as f64);
+        }
+        if !all_cold_vcpu_s.is_empty() {
+            steady_cold_vcpu_s =
+                Some(all_cold_vcpu_s.iter().sum::<f64>() / all_cold_vcpu_s.len() as f64);
         }
     } else if query_states.is_empty() {
         serving_rows.extend(c.warm.iter().filter_map(|w| {
@@ -1752,6 +1878,8 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
         {
             let per_q = inst.per_query_usd(*cpu, *p50_s, c.resident_anon_bytes);
             steady_warm = Some((format!("warm ({name})"), per_q));
+            steady_warm_vcpu_s =
+                Some(inst.per_query_vcpu_seconds(*cpu, *p50_s, c.resident_anon_bytes));
         }
         if let Some(q) = anchor_cold {
             let payload = c
@@ -1762,7 +1890,11 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
                 .unwrap_or(0);
             let egress = egress_usd(payload as f64);
             match &steady_cold_price {
-                SteadyColdPrice::Full { per_q, wall_s } => {
+                SteadyColdPrice::Full {
+                    per_q,
+                    wall_s,
+                    vcpu_s,
+                } => {
                     let total = per_q + egress;
                     let queries_per_usd = 1.0 / total.max(f64::MIN_POSITIVE);
                     serving_rows.push(vec![
@@ -1779,6 +1911,7 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
                         metric(total * PER_MILLION, usd(total * PER_MILLION), Better::Lower),
                     ]);
                     steady_cold = Some((format!("cold ({})", q.name), *per_q));
+                    steady_cold_vcpu_s = Some(*vcpu_s);
                 }
                 SteadyColdPrice::RequestsOnly { usd: req_usd } => {
                     // No steady wall-clock sample exists here — the first-cold
@@ -1864,6 +1997,7 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
                     row.push(metric(p50_s * 1e9, fmt_time(p50_s * 1e9), Better::Lower));
                     row.push(text(format!("{}/1M", usd(total * PER_MILLION))));
                     steady_warm = Some((format!("warm — {label}"), per_q));
+                    steady_warm_vcpu_s = Some(inst.per_query_vcpu_seconds(cpu_s, p50_s, ram_bytes));
                 }
                 _ => row.extend([text("—"), text("—")]),
             }
@@ -1886,6 +2020,8 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
                     if state.io.cold_second.is_none() {
                         steady_cold =
                             Some((format!("cold — {label} ({} GET)", io.get_count), per_q));
+                        steady_cold_vcpu_s =
+                            Some(inst.per_query_vcpu_seconds(cpu_s, warm_window, ram_bytes));
                     }
                 }
                 _ => row.push(text("—")),
@@ -1913,6 +2049,8 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
                         format!("cold steady — {label} ({} GET)", io.get_count),
                         per_q,
                     ));
+                    steady_cold_vcpu_s =
+                        Some(inst.per_query_vcpu_seconds(cpu_s, warm_window, ram_bytes));
                 }
                 _ => row.extend([text("—"), text("—")]),
             }
@@ -2331,6 +2469,137 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
         rows: summary_rows,
     };
 
+    // ---- Block 6: provisioned occupancy (informational) ----
+    // The keep-warm framing the marginal summary above deliberately excludes:
+    // what holding this tenant's capacity costs when it is RESERVED between
+    // queries rather than billed per query served. Models a process-per-
+    // database serving platform with scale-to-zero — an idle tenant keeps
+    // only its local NVMe cache (worker reaped: no RAM, no CPU); an active
+    // tenant's node share is bounded by its largest resource share. Never
+    // added to the marginal Total: the two framings answer different
+    // questions (cost of work performed vs cost of capacity held), and which
+    // applies is the operator's keep-warm policy. Every row is measured — an
+    // unmeasured resource is omitted, never guessed at 0.
+    let replicas = occupancy_replicas();
+    let node_month = inst.usd_per_month();
+    // Same resident-set basis the serving table and the per-query RAM-hold
+    // leg use: the LAST populated query state (post-compact when the
+    // lifecycle ran) is the shape a long-lived table serves.
+    let occupancy_resident = query_states
+        .last()
+        .map(|s| s.serving_resident_bytes(c.resident_anon_bytes))
+        .unwrap_or(c.resident_anon_bytes);
+    let occupancy_ram_label = query_states
+        .last()
+        .map(|s| s.serving_ram_label(c.resident_anon_bytes))
+        .unwrap_or_else(|| fmt_bytes(occupancy_resident));
+    // Billed compute per query at the same 95/5 blend (and the same
+    // single-sided fallback) as the monthly read line.
+    let blended_vcpu_q = match (steady_warm_vcpu_s, steady_cold_vcpu_s) {
+        (Some(warm_v), Some(cold_v)) => {
+            Some(warm_v * SUMMARY_READ_WARM_FRACTION + cold_v * (1.0 - SUMMARY_READ_WARM_FRACTION))
+        }
+        (Some(warm_v), None) => Some(warm_v),
+        (None, Some(cold_v)) => Some(cold_v),
+        (None, None) => None,
+    };
+    let cpu_sh = blended_vcpu_q.map(|v| inst.cpu_share_at_load(v, SUMMARY_QUERIES_PER_MONTH));
+    let ram_sh = (occupancy_resident > 0).then(|| inst.ram_share(occupancy_resident));
+    let nvme_sh = c.store.disk_cache_bytes.map(|b| inst.nvme_share(b));
+    let mut occupancy_rows: Vec<Vec<Cell>> = Vec::new();
+    if let (Some(share), Some(vcpu_q)) = (cpu_sh, blended_vcpu_q) {
+        occupancy_rows.push(vec![
+            text("CPU at assumed load"),
+            text(format!(
+                "{} queries/mo × {} billed vCPU·s/query on {} vCPU",
+                fmt_count(SUMMARY_QUERIES_PER_MONTH as usize),
+                fmt_vcpu_seconds(vcpu_q),
+                inst.vcpu,
+            )),
+            context(share, fmt_share(share), Better::Lower),
+            text(""),
+            text(""),
+        ]);
+    }
+    if let Some(share) = ram_sh {
+        occupancy_rows.push(vec![
+            text("RAM-resident (while worker live)"),
+            text(format!(
+                "{occupancy_ram_label} of {:.0} GiB — page cache is node-global and \
+                 reclaimable, not a standing per-tenant reservation",
+                inst.ram_gib,
+            )),
+            context(share, fmt_share(share), Better::Lower),
+            text(""),
+            text(""),
+        ]);
+    }
+    if let (Some(share), Some(bytes)) = (nvme_sh, c.store.disk_cache_bytes) {
+        occupancy_rows.push(vec![
+            text("NVMe disk cache"),
+            text(format!(
+                "{} local cache (user + hidden index, shared root) of {:.0} GB",
+                fmt_bytes(bytes),
+                inst.nvme_gb,
+            )),
+            context(share, fmt_share(share), Better::Lower),
+            text(""),
+            text(""),
+        ]);
+    }
+    if let Some((binding, share)) =
+        binding_share(&[("CPU", cpu_sh), ("RAM", ram_sh), ("NVMe", nvme_sh)])
+    {
+        let per_replica = share * node_month;
+        let total = per_replica * f64::from(replicas);
+        occupancy_rows.push(vec![
+            text(format!("Active occupancy (binding: {binding})")),
+            text(format!(
+                "largest share × {}/node-mo, held while the worker process is live",
+                usd(node_month),
+            )),
+            context(share, fmt_share(share), Better::Lower),
+            context(per_replica, usd(per_replica), Better::Lower),
+            context(total, usd(total), Better::Lower),
+        ]);
+    }
+    if let Some(share) = nvme_sh {
+        let per_replica = share * node_month;
+        let total = per_replica * f64::from(replicas);
+        occupancy_rows.push(vec![
+            text("Idle-retained occupancy (NVMe only)"),
+            text("cache kept on local disk between activations; worker reaped — zero RAM/CPU"),
+            context(share, fmt_share(share), Better::Lower),
+            context(per_replica, usd(per_replica), Better::Lower),
+            context(total, usd(total), Better::Lower),
+        ]);
+    }
+    let occupancy = (!occupancy_rows.is_empty()).then(|| Block {
+        subtitle: format!(
+            "Provisioned occupancy — keep-warm framing (informational, NOT in the Total \
+             above): what holding this tenant's capacity costs when it is reserved between \
+             queries instead of billed per query served. Share of one {} ({} vCPU / {:.0} GiB \
+             RAM / {:.0} GB NVMe at ${:.4}/h = {}/node-mo) × R={replicas} replicas (R-way HA, \
+             each replica keeps an independent local cache; INFINO_BENCH_COST_REPLICAS \
+             overrides). Shares are of raw instance capacity — apply any usable-capacity \
+             headroom policy as your own divisor.",
+            inst.name,
+            inst.vcpu,
+            inst.ram_gib,
+            inst.nvme_gb,
+            inst.usd_per_hour,
+            usd(node_month),
+        ),
+        headers: vec![
+            "Line".into(),
+            "Measured basis".into(),
+            "Share of node".into(),
+            "$/mo — 1 replica".into(),
+            format!("$/mo — ×{replicas} replicas"),
+        ],
+        rows: occupancy_rows,
+    });
+
     let mut blocks = vec![rate_card];
     if let Some(io_ledger) = io_ledger {
         blocks.push(io_ledger);
@@ -2338,6 +2607,9 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
     blocks.push(compute_ledger);
     blocks.push(serving);
     blocks.push(monthly_summary);
+    if let Some(occupancy) = occupancy {
+        blocks.push(occupancy);
+    }
 
     report.emit(&Section {
         anchor: anchor.into(),
@@ -2611,5 +2883,67 @@ mod tests {
         // (1000 PUT + 50 LIST) × $5e-6 + 100 reads × $4e-7; DELETE unpriced.
         let expected = 1050.0 * 5.0e-6 + 100.0 * 4.0e-7;
         assert!((request_usd(&io) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn nvme_share_is_decimal_gb_fraction() {
+        let inst = test_instance();
+        // NVMe capacity is quoted in decimal GB, so 47.4e9 bytes on a 237 GB
+        // device is exactly a 20% share — a GiB divisor would misstate it.
+        assert!((inst.nvme_share(47_400_000_000) - 0.2).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cpu_share_at_load_reconciles_with_month_seconds() {
+        let inst = test_instance();
+        // An 8-vCPU node holds 8 × 730.5 h × 3600 s = 21,038,400 vCPU·s per
+        // month; a load consuming exactly that many is a share of 1.0, and
+        // half the load is half the share.
+        let node_vcpu_s = 8.0 * HOURS_PER_MONTH * SECS_PER_HOUR;
+        assert!((inst.cpu_share_at_load(node_vcpu_s / 1e6, 1e6) - 1.0).abs() < 1e-12);
+        assert!((inst.cpu_share_at_load(node_vcpu_s / 2e6, 1e6) - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn binding_share_picks_largest_measured_and_skips_unmeasured() {
+        let picked = binding_share(&[("CPU", Some(0.1)), ("RAM", Some(0.6)), ("NVMe", Some(0.2))]);
+        assert_eq!(picked, Some(("RAM", 0.6)));
+        // An unmeasured share is skipped, never treated as a 0 that "loses"
+        // the max — with RAM absent, NVMe binds.
+        let picked = binding_share(&[("CPU", Some(0.1)), ("RAM", None), ("NVMe", Some(0.2))]);
+        assert_eq!(picked, Some(("NVMe", 0.2)));
+        // Nothing measured ⇒ no binding row, not a fabricated $0 one.
+        assert_eq!(binding_share(&[("CPU", None), ("RAM", None)]), None);
+    }
+
+    #[test]
+    fn occupancy_dollars_multiply_share_node_price_and_replicas() {
+        let inst = test_instance();
+        // usd_per_month is the plain hourly rate over the calendar month, and
+        // a 50% share on 2 replicas bills exactly one full node-month.
+        assert!((inst.usd_per_month() - 0.3629 * HOURS_PER_MONTH).abs() < 1e-9);
+        let billed = 0.5 * inst.usd_per_month() * 2.0;
+        assert!((billed - inst.usd_per_month()).abs() < 1e-9);
+    }
+
+    #[test]
+    fn replicas_parse_defaults_and_rejects_zero() {
+        // Pure parser (no env mutation): unset and garbage fall back to the
+        // default, and R=0 is rejected — it would print a $0 keep-warm bill,
+        // which is never a measurement.
+        assert_eq!(parse_replicas(None), DEFAULT_OCCUPANCY_REPLICAS);
+        assert_eq!(parse_replicas(Some("1")), 1);
+        assert_eq!(parse_replicas(Some("3")), 3);
+        assert_eq!(parse_replicas(Some("0")), DEFAULT_OCCUPANCY_REPLICAS);
+        assert_eq!(parse_replicas(Some("x")), DEFAULT_OCCUPANCY_REPLICAS);
+    }
+
+    #[test]
+    fn fmt_share_keeps_tiny_shares_visible() {
+        // The CPU share at 1M queries/mo is often well below 0.1% — it must
+        // print with significant digits, never collapse to "0.0%".
+        assert_eq!(fmt_share(0.593), "59.3%");
+        assert_eq!(fmt_share(0.0006), "0.060%");
+        assert_eq!(fmt_share(0.0), "0%");
     }
 }

--- a/benches/utils/disk_warm.rs
+++ b/benches/utils/disk_warm.rs
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Disk-warm serving-state diagnostic: local NVMe cache fully populated,
+//! OS page cache deliberately dropped.
+//!
+//! The main bench measures two serving states: **warm** (cache files local
+//! AND their pages resident in the OS page cache) and **cold** (nothing
+//! local — the full object-store fetch). This diagnostic measures the state
+//! between them — every byte on local disk, no byte in RAM — which is the
+//! latency a query pays after another tenant's traffic evicts this table's
+//! page-cache working set. That number decides how far RAM can be
+//! oversubscribed on a multi-tenant node: if a disk re-fault is cheap, the
+//! per-tenant serving cost sits near the NVMe-occupancy floor; if it is
+//! expensive, capacity must be provisioned near the RAM-resident ceiling
+//! (see the cost model's provisioned-occupancy block).
+//!
+//! Dropping the page cache leaves the query code path IDENTICAL to warm —
+//! the only variable is where the pages come from. The drop is a
+//! three-step pass (see `drop_page_cache`): `sweep_once()` to unmap
+//! mmap-promoted cache entries (`fadvise` skips pages a mapping still
+//! references), `sync()` so dirty fill pages become droppable, then
+//! `posix_fadvise(DONTNEED)` over every file under the cache root plus
+//! every regular file the process holds open (centroid spill, manifest
+//! parts).
+//!
+//! Three batteries over the same shared consumer, post-drain:
+//! - **RAM-warm**: the ordinary warm battery (baseline).
+//! - **disk-warm**: the page cache is dropped before EVERY query, so each
+//!   sample faults its working set from local disk.
+//! - **re-warmed**: the same battery again with no drops — proves the
+//!   working set re-promoted to page cache and recovers the baseline.
+//!
+//! Validity evidence, printed per battery: object-store GETs (must be 0 —
+//! disk-warm, not accidentally cold), physical bytes read from storage
+//! (`/proc/self/io` `read_bytes` — near zero when RAM-warm, the working
+//! set when disk-warm), and the settled file-backed RSS after the battery.
+//!
+//! Scale follows `INFINO_BENCH_SUPERTABLE_DOCS`. Invoked as
+//! `cargo bench -- disk-warm`.
+
+use std::{
+    fs::{self, File},
+    hint::black_box,
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use infino::{
+    VectorSearchOptions,
+    supertable::{Supertable, reader_cache::DiskCacheStore},
+};
+use rustix::fs::{Advice, fadvise, sync};
+
+use crate::{
+    corpus::{self, DIM},
+    diag_common::percentile,
+    ingest::supertable::{self as ingest, Modality, VEC_COLUMN},
+    markdown::{fmt_count, fmt_time},
+    report::{Better, Block, Cell, Report, Section, context, metric, text},
+    rss,
+    storage_meter::{self, MeteredStorage, ObjectStoreMeter},
+    tiers,
+};
+
+/// Result set size per query — matches the vector cell's battery.
+const TOP_K: usize = 10;
+/// Queries per battery. Same count as the vector cell's correctness battery,
+/// so per-query cell coverage matches the reference warm numbers.
+const N_QUERIES: usize = 100;
+/// Query-vector generation seed/sigma — mirror the vector cell's
+/// correctness battery (`QUERY_CORRECTNESS_SEED` / `QUERY_SIGMA`) so the
+/// probes route like the reference battery's.
+const QUERY_SEED: u64 = 17;
+const QUERY_SIGMA: f32 = 0.05;
+/// Iterations of the RAM-warm and re-warmed batteries (p50 over
+/// `WARM_ITERS × N_QUERIES` samples). The disk-warm battery runs each query
+/// once — every sample is preceded by a full page-cache drop, so iterations
+/// are independent by construction.
+const WARM_ITERS: usize = 3;
+/// Cache budget = this multiple of the built index, mirroring the main
+/// bench's shared-consumer sizing (the hidden index roughly doubles a
+/// vector table's working set after the drain).
+const CACHE_INDEX_FACTOR: u64 = 2;
+/// Ceiling on waiting for background cache fills to settle after the fill
+/// pass, so "disk-warm" starts from a complete local cache.
+const WARM_SETTLE_TIMEOUT: Duration = Duration::from_secs(600);
+/// Nanoseconds per second, for report metric cells.
+const SEC_TO_NANOS: f64 = 1e9;
+
+/// One battery's samples plus its validity evidence.
+struct BatteryResult {
+    label: &'static str,
+    samples: Vec<Duration>,
+    /// Object-store window over the battery — 0 GETs proves disk-warm
+    /// rather than accidentally cold.
+    io: ObjectStoreMeter,
+    /// Physical bytes read from the storage layer (`/proc/self/io`
+    /// `read_bytes` delta) — proves disk-warm queries actually hit the
+    /// device rather than lingering page cache.
+    physical_read_bytes: u64,
+    /// Settled file-backed RSS after the battery (page-cache working set).
+    file_rss_after: Option<u64>,
+}
+
+pub fn run() {
+    let n_docs = ingest::n_docs();
+    eprintln!(
+        "[disk-warm] building vector supertable ({} docs) and draining the hidden index...",
+        fmt_count(n_docs)
+    );
+    let prepared = ingest::prepare_corpus(Modality::Vector);
+    let built = ingest::build_on_storage(Modality::Vector, &prepared);
+    let queries = {
+        let vectors = prepared.vectors().expect("vector corpus");
+        let base = &vectors.as_slice()[..n_docs * DIM];
+        corpus::generate_realistic_queries(base, n_docs, N_QUERIES, QUERY_SEED, true, QUERY_SIGMA)
+    };
+    drop(prepared);
+
+    let meter = storage_meter::wrap(Arc::clone(&built.storage));
+    let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
+        meter.provider(),
+        Some(built.total_index_bytes.saturating_mul(CACHE_INDEX_FACTOR)),
+    );
+    // Kept for the page-cache drop: mmap-promoted entries must be
+    // `sweep_once()`-advised (PTEs dropped) before `fadvise` can evict
+    // their pages — see `drop_page_cache`.
+    let cache_for_drop = Arc::clone(&cache);
+    let consumer = tiers::open_consumer(tiers::consumer_options(
+        ingest::options_for(Modality::Vector, None),
+        meter.provider(),
+        cache,
+    ));
+    consumer
+        .drain_vectors_to_cells_sync()
+        .expect("hidden cell drain");
+
+    // Fill: run the full battery once so every probed cell's blocks land in
+    // the local disk cache, settle background fills, then once more so the
+    // page cache is hot for the RAM-warm baseline.
+    eprintln!("[disk-warm] filling the local disk cache (2 battery passes)...");
+    for query in &queries {
+        black_box(search(&consumer, query));
+    }
+    consumer
+        .wait_until_warm(WARM_SETTLE_TIMEOUT)
+        .expect("cache fills settled");
+    for query in &queries {
+        black_box(search(&consumer, query));
+    }
+    rss::log_rss_breakdown("disk-warm: after fill");
+
+    let warm = run_battery("RAM-warm", &consumer, &meter, &queries, WARM_ITERS, None);
+    let disk = run_battery(
+        "disk-warm",
+        &consumer,
+        &meter,
+        &queries,
+        1,
+        Some((cache_dir.path(), cache_for_drop.as_ref())),
+    );
+    let rewarmed = run_battery("re-warmed", &consumer, &meter, &queries, WARM_ITERS, None);
+
+    if disk.io.get_count > 0 {
+        eprintln!(
+            "[disk-warm] WARNING: {} object-store GET(s) during the disk-warm battery — the \
+             local cache did not fully absorb the working set (undersized budget or eviction); \
+             the disk-warm latency above includes object-store fetches and overstates the \
+             NVMe re-fault cost",
+            disk.io.get_count
+        );
+    }
+
+    let batteries = [warm, disk, rewarmed];
+    let mut report = Report::load("disk-warm");
+    report.emit(&Section {
+        anchor: "bench/vector/supertable/disk-warm".into(),
+        title: format!(
+            "Disk-warm serving state — supertable vector ({} docs × dim={DIM})",
+            fmt_count(n_docs)
+        ),
+        note: "The serving state between warm and cold: local disk cache fully populated, OS \
+               page cache dropped (`fadvise(DONTNEED)` before every disk-warm query). Same \
+               consumer and code path as the warm battery — only the page residency differs. \
+               Valid only when the disk-warm battery shows 0 GETs (else it is partially \
+               object-store cold). `phys read` is the /proc/self/io read_bytes delta — the \
+               bytes actually faulted from the device. Δ is vs the previous run."
+            .into(),
+        blocks: vec![Block {
+            subtitle: String::new(),
+            headers: vec![
+                "State".into(),
+                "p50".into(),
+                "p90".into(),
+                "p99".into(),
+                "GET (battery)".into(),
+                "phys read".into(),
+                "file RSS after".into(),
+            ],
+            rows: batteries.iter().map(battery_row).collect(),
+        }],
+    });
+    report.save();
+}
+
+fn battery_row(battery: &BatteryResult) -> Vec<Cell> {
+    let mut samples = battery.samples.clone();
+    let p50 = percentile(&mut samples, 50);
+    let p90 = percentile(&mut samples, 90);
+    let p99 = percentile(&mut samples, 99);
+    vec![
+        text(battery.label),
+        metric(
+            p50.as_secs_f64() * SEC_TO_NANOS,
+            fmt_time(p50.as_secs_f64() * SEC_TO_NANOS),
+            Better::Lower,
+        ),
+        context(
+            p90.as_secs_f64() * SEC_TO_NANOS,
+            fmt_time(p90.as_secs_f64() * SEC_TO_NANOS),
+            Better::Lower,
+        ),
+        context(
+            p99.as_secs_f64() * SEC_TO_NANOS,
+            fmt_time(p99.as_secs_f64() * SEC_TO_NANOS),
+            Better::Lower,
+        ),
+        context(
+            battery.io.get_count as f64,
+            format!("{}", battery.io.get_count),
+            Better::Lower,
+        ),
+        text(rss::fmt_bytes(battery.physical_read_bytes)),
+        text(
+            battery
+                .file_rss_after
+                .map(rss::fmt_bytes)
+                .unwrap_or_else(|| "—".into()),
+        ),
+    ]
+}
+
+/// Run one battery. With `drop_state` set (cache root + cache store), the
+/// page cache under that root (plus every open regular file) is dropped
+/// before EVERY query; the drop itself is excluded from the timed sample.
+fn run_battery(
+    label: &'static str,
+    consumer: &Supertable,
+    meter: &MeteredStorage,
+    queries: &[Vec<f32>],
+    iters: usize,
+    drop_state: Option<(&Path, &DiskCacheStore)>,
+) -> BatteryResult {
+    let io_before = meter.snapshot();
+    let physical_before = proc_read_bytes();
+    let mut samples = Vec::with_capacity(iters * queries.len());
+    let mut dropped_files = 0usize;
+    let mut dropped_bytes = 0u64;
+    let mut swept_mmaps = 0u64;
+    for _ in 0..iters {
+        for query in queries {
+            if let Some((root, cache)) = drop_state {
+                let (files, bytes, swept) = drop_page_cache(root, cache);
+                dropped_files = files;
+                dropped_bytes = bytes;
+                swept_mmaps = swept;
+            }
+            let t0 = Instant::now();
+            black_box(search(consumer, query));
+            samples.push(t0.elapsed());
+        }
+    }
+    let io = meter.snapshot().since(&io_before);
+    let physical_read_bytes = proc_read_bytes().saturating_sub(physical_before);
+    let file_rss_after = rss::settled_rss_breakdown().map(|(_, _, file, _)| file);
+    let mut sorted = samples.clone();
+    let p50 = percentile(&mut sorted, 50);
+    eprintln!(
+        "[disk-warm] {label}: p50 {} over {} samples; {} GET / {} down; phys read {}{}",
+        fmt_time(p50.as_secs_f64() * SEC_TO_NANOS),
+        samples.len(),
+        io.get_count,
+        rss::fmt_bytes(io.get_bytes),
+        rss::fmt_bytes(physical_read_bytes),
+        if drop_state.is_some() {
+            format!(
+                "; per-query drop swept {swept_mmaps} mmap(s), advised {dropped_files} file(s) / {}",
+                rss::fmt_bytes(dropped_bytes)
+            )
+        } else {
+            String::new()
+        },
+    );
+    BatteryResult {
+        label,
+        samples,
+        io,
+        physical_read_bytes,
+        file_rss_after,
+    }
+}
+
+/// One default-config vector query on the shared consumer — the same call
+/// shape the vector cell's warm battery times.
+fn search(consumer: &Supertable, query: &[f32]) -> usize {
+    let batches = consumer
+        .reader()
+        .expect("reader")
+        .vector_search(
+            VEC_COLUMN,
+            query,
+            TOP_K,
+            VectorSearchOptions::default(),
+            None,
+            None,
+        )
+        .expect("vector_search");
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+/// Evict the disk cache's pages (and every regular file this process holds
+/// open — centroid spill, manifest parts) from the OS page cache. Three
+/// steps, each necessary:
+/// 1. `sweep_once()` — `MADV_DONTNEED` on every mmap-promoted cache entry
+///    (the bench cache config disables the idle threshold, so the sweep
+///    covers all of them). `fadvise` skips pages a mapping still
+///    references; the sweep drops the PTEs so the pages become plain
+///    unmapped page cache. Without this step the whole drop is a measured
+///    no-op for mmap'd entries.
+/// 2. `sync()` — `fadvise(DONTNEED)` also skips dirty pages, and freshly
+///    filled cache blocks may still be in writeback.
+/// 3. `fadvise(DONTNEED)` by path under `root` and over every open fd.
+///
+/// Returns (files, bytes advised under `root`, mmaps swept).
+fn drop_page_cache(root: &Path, cache: &DiskCacheStore) -> (usize, u64, u64) {
+    let swept = cache.sweep_once();
+    sync();
+    let mut files = 0usize;
+    let mut bytes = 0u64;
+    advise_tree(root, &mut files, &mut bytes);
+    advise_open_fds();
+    (files, bytes, swept)
+}
+
+/// `fadvise(DONTNEED)` every regular file under `dir`, recursively.
+fn advise_tree(dir: &Path, files: &mut usize, bytes: &mut u64) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if meta.is_dir() {
+            advise_tree(&path, files, bytes);
+        } else if meta.is_file()
+            && let Ok(file) = File::open(&path)
+        {
+            let _ = fadvise(&file, 0, None, Advice::DontNeed);
+            *files += 1;
+            *bytes += meta.len();
+        }
+    }
+}
+
+/// `fadvise(DONTNEED)` every regular file this process holds open, by
+/// re-opening its `/proc/self/fd` target — fadvise acts on the inode's page
+/// cache, so a fresh fd to the same file evicts the original's pages. This
+/// reaches page-cache-backed files that live outside the cache root (the
+/// slow-CAS centroid spill in TMPDIR). Non-file targets (pipes, sockets,
+/// devices, deleted temp files) resolve to non-file or missing paths and
+/// are skipped.
+fn advise_open_fds() {
+    let Ok(entries) = fs::read_dir("/proc/self/fd") else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(target) = fs::read_link(entry.path()) else {
+            continue;
+        };
+        if !target.is_absolute() || target.starts_with("/proc") || target.starts_with("/dev") {
+            continue;
+        }
+        if fs::metadata(&target).map(|m| m.is_file()).unwrap_or(false)
+            && let Ok(file) = File::open(&target)
+        {
+            let _ = fadvise(&file, 0, None, Advice::DontNeed);
+        }
+    }
+}
+
+/// Bytes this process has caused to be fetched from the storage layer
+/// (`/proc/self/io` `read_bytes`) — page-cache hits don't count, so the
+/// delta over a battery is the physically faulted volume.
+fn proc_read_bytes() -> u64 {
+    fs::read_to_string("/proc/self/io")
+        .ok()
+        .and_then(|s| {
+            s.lines().find_map(|line| {
+                line.strip_prefix("read_bytes:")
+                    .and_then(|v| v.trim().parse().ok())
+            })
+        })
+        .unwrap_or(0)
+}

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1139,7 +1139,7 @@ pub mod fts {
         note: &str,
         warm: Option<&[FtsQueryStat]>,
         cold: Option<&HashMap<&'static str, FtsColdStat>>,
-        probes: Option<&[(&'static str, Duration, Duration)]>,
+        probes: Option<&[(&'static str, Duration, Duration, Duration)]>,
     ) {
         let warm_map: Option<HashMap<&'static str, FtsQueryStat>> =
             warm.map(|w| w.iter().map(|q| (q.name, q.clone())).collect());
@@ -1197,17 +1197,25 @@ pub mod fts {
         let mut blocks = vec![or_block, and_block, clause_block, phrase_block];
         if let Some(probes) = probes {
             blocks.push(Block {
-                subtitle: "Per-algorithm probes (WAND+BMW vs MaxScore+BMM)".into(),
-                headers: vec!["Shape".into(), "WAND+BMW".into(), "MaxScore+BMM".into()],
+                subtitle: "Per-algorithm probes (WAND+BMW vs MaxScore+BMM vs windowed union)"
+                    .into(),
+                headers: vec![
+                    "Shape".into(),
+                    "WAND+BMW".into(),
+                    "MaxScore+BMM".into(),
+                    "Windowed union".into(),
+                ],
                 rows: probes
                     .iter()
-                    .map(|(shape, wand, bmm)| {
+                    .map(|(shape, wand, bmm, windowed)| {
                         let w = wand.as_secs_f64() * NS_PER_SEC;
                         let b = bmm.as_secs_f64() * NS_PER_SEC;
+                        let u = windowed.as_secs_f64() * NS_PER_SEC;
                         vec![
                             text(*shape),
                             context(w, fmt_time(w), Better::Lower),
                             context(b, fmt_time(b), Better::Lower),
+                            context(u, fmt_time(u), Better::Lower),
                         ]
                     })
                     .collect(),

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -31,6 +31,7 @@ pub mod supertable;
 
 pub mod concurrent;
 pub mod diag_common;
+pub mod disk_warm;
 pub mod fts_diag;
 pub mod scale;
 pub mod sql_diag;

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -234,8 +234,13 @@ pub mod fts {
         ),
     ];
 
-    /// Per-algorithm probe shapes (OR-only; WAND+BMW vs MaxScore+BMM). This
-    /// is an infino-internal hook with no cross-engine analogue.
+    /// Per-algorithm probe shapes (OR-only; WAND+BMW vs MaxScore+BMM vs
+    /// windowed union). This is an infino-internal hook with no
+    /// cross-engine analogue. The shapes deliberately span both sides of
+    /// the dispatcher's dominance threshold (`OR_WINDOW_DOMINANCE_MULT`):
+    /// `wide_3_or` carries a dominant rare term (MaxScore side), the
+    /// `similar_*` shapes are uniform (windowed side) — so every run
+    /// re-measures the routing heuristic where it actually decides.
     const PROBE_SHAPES: &[(&str, &[&str])] = &[
         ("wide_3_or", &["term00001", "term00050", "term00100"]),
         ("similar_3_or", &["term00050", "term00051", "term00052"]),
@@ -736,18 +741,21 @@ pub mod fts {
     }
 
     /// Infino-only warm probes on the measured in-memory artifact.
-    fn measure_warm_probes(index: &InfinoFtsIndex) -> Vec<(&'static str, Duration, Duration)> {
+    fn measure_warm_probes(
+        index: &InfinoFtsIndex,
+    ) -> Vec<(&'static str, Duration, Duration, Duration)> {
         eprintln!(
-            "[superfile_fts] per-algorithm probes: {} OR shapes × {WARM_ITERS} iters (WAND+BMW vs MaxScore+BMM)...",
+            "[superfile_fts] per-algorithm probes: {} OR shapes × {WARM_ITERS} iters (WAND+BMW vs MaxScore+BMM vs windowed union)...",
             PROBE_SHAPES.len(),
         );
         let reader = index.reader();
-        let mut probes: Vec<(&'static str, Duration, Duration)> = Vec::new();
+        let mut probes: Vec<(&'static str, Duration, Duration, Duration)> = Vec::new();
         for (shape, terms) in PROBE_SHAPES {
             eprintln!("[superfile_fts] probe: {shape}...");
             let wand = probe_algo_p50(reader, terms, OrAlgo::WandBmw);
             let bmm = probe_algo_p50(reader, terms, OrAlgo::Bmm);
-            probes.push((shape, wand, bmm));
+            let windowed = probe_algo_p50(reader, terms, OrAlgo::Windowed);
+            probes.push((shape, wand, bmm, windowed));
         }
         probes
     }

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -669,6 +669,7 @@ fn run_metered_optimize(
 fn store_phases_lifecycle(
     measured: Option<ColdStoreMeasurement>,
     compaction: Option<CompactionStats>,
+    disk_cache_bytes: Option<u64>,
     routing_states: &[RoutingStateStat],
 ) -> cost::StorePhases {
     let mut store = store_phases_from_measurement(measured);
@@ -678,8 +679,21 @@ fn store_phases_lifecycle(
         store.compaction_cpu_s = cpu_s;
         store.compaction_peak_rss_bytes = Some(peak_rss);
     }
+    store.disk_cache_bytes = disk_cache_bytes;
     store.query_states = query_state_costs(routing_states);
     store
+}
+
+/// Settled local disk-cache footprint of a consumer's cache store (user +
+/// hidden index — they share one root), for the cost model's
+/// provisioned-occupancy NVMe rows. `None` when the consumer has no disk
+/// cache attached (in-memory configs).
+fn consumer_disk_cache_bytes(consumer: &Supertable) -> Option<u64> {
+    consumer
+        .options()
+        .disk_cache
+        .as_ref()
+        .map(|cache| cache.stats().current_bytes)
 }
 
 /// Measure/emit hook points around the shared FTS/SQL compaction.
@@ -699,6 +713,15 @@ enum TextLifecyclePhase {
 /// "warm" batteries at serving scale.
 const SHARED_CONSUMER_CACHE_INDEX_FACTOR: u64 = 2;
 
+/// What the shared FTS/SQL lifecycle hands back: the compaction window's
+/// stats plus the settled local disk-cache footprint of the lifecycle
+/// consumer, sampled after the post-compact battery (just before the
+/// consumer drops) — the cost model's provisioned-occupancy NVMe basis.
+struct TextLifecycleStats {
+    compaction: CompactionStats,
+    disk_cache_bytes: Option<u64>,
+}
+
 /// Shared FTS/SQL mutation sequence: open a metered consumer, measure
 /// the pre-compact state, run `optimize`, then measure post-compact —
 /// invoking `on_phase` with the SAME consumer + meter so the
@@ -712,7 +735,7 @@ fn run_metered_text_lifecycle(
     modality: Modality,
     built: &supertable::IngestResult,
     mut on_phase: impl FnMut(TextLifecyclePhase, &Supertable, &storage_meter::MeteredStorage),
-) -> CompactionStats {
+) -> TextLifecycleStats {
     let meter = storage_meter::wrap(Arc::clone(&built.storage));
     let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
         meter.provider(),
@@ -731,9 +754,13 @@ fn run_metered_text_lifecycle(
     on_phase(TextLifecyclePhase::PreCompact, &consumer, &meter);
     let compaction = run_metered_optimize(label, &consumer, &meter);
     on_phase(TextLifecyclePhase::Compacted, &consumer, &meter);
+    let disk_cache_bytes = consumer_disk_cache_bytes(&consumer);
     drop(consumer);
     drop(cache_dir);
-    compaction
+    TextLifecycleStats {
+        compaction,
+        disk_cache_bytes,
+    }
 }
 
 /// Pre-drain (transient-shape) latency rows: the warm battery and the
@@ -1676,6 +1703,7 @@ pub mod fts {
         }
 
         let mut compaction_stats = None;
+        let mut lifecycle_disk_cache_bytes: Option<u64> = None;
         let mut routing_states: Vec<RoutingStateStat> = Vec::new();
         let (warm_post, cold_post) = if run_lifecycle {
             let mut warm_post = None;
@@ -1684,7 +1712,7 @@ pub mod fts {
             // no undrained-delta commit, so the lifecycle measures just
             // two states — pre-compact and post-compact — and emits only
             // the post-compact search battery (pre-compact already ran).
-            let compaction = run_metered_text_lifecycle(
+            let lifecycle = run_metered_text_lifecycle(
                 "supertable_fts",
                 Modality::Fts,
                 &built,
@@ -1729,7 +1757,8 @@ pub mod fts {
                 },
             );
             drop(corpus.take());
-            compaction_stats = Some(compaction);
+            compaction_stats = Some(lifecycle.compaction);
+            lifecycle_disk_cache_bytes = lifecycle.disk_cache_bytes;
             (warm_post, cold_post)
         } else {
             drop(corpus.take());
@@ -1833,7 +1862,12 @@ pub mod fts {
                     // Compaction-only text lifecycle: not a full-maintenance
                     // (drain/delta) cell, so drain/delta ledger rows never render.
                     false,
-                    store_phases_lifecycle(cold_measured, compaction_stats, &routing_states),
+                    store_phases_lifecycle(
+                        cold_measured,
+                        compaction_stats,
+                        lifecycle_disk_cache_bytes,
+                        &routing_states,
+                    ),
                     None,
                     // Serving/monthly priced per query-family from the same
                     // battery the search table reports (reconciles by
@@ -4526,6 +4560,7 @@ pub mod vector {
                     query_states: query_state_costs(&routing_states),
                     filtered_query: filtered_stats.map(|(io, _)| io),
                     filtered_query_iters: filtered_stats.map(|(_, n)| n).unwrap_or(0),
+                    disk_cache_bytes: consumer_disk_cache_bytes(&consumer),
                     ..store_phases_from_measurement(cold_measured)
                 };
                 let warm_pre_vec = pre_search_rows
@@ -4718,6 +4753,7 @@ pub mod sql {
         }
 
         let mut compaction_stats = None;
+        let mut lifecycle_disk_cache_bytes: Option<u64> = None;
         let mut routing_states: Vec<RoutingStateStat> = Vec::new();
         let (warm_sets_post, cold_post) = if run_lifecycle {
             let mut warm_sets_post = None;
@@ -4726,7 +4762,7 @@ pub mod sql {
             // has no drain; the lifecycle is compaction-only, measuring just
             // pre-compact and post-compact and emitting only the post-compact
             // query battery (pre-compact already ran).
-            let compaction = run_metered_text_lifecycle(
+            let lifecycle = run_metered_text_lifecycle(
                 "supertable_sql",
                 Modality::Sql,
                 &built,
@@ -4786,7 +4822,8 @@ pub mod sql {
                 },
             );
             drop(corpus.take());
-            compaction_stats = Some(compaction);
+            compaction_stats = Some(lifecycle.compaction);
+            lifecycle_disk_cache_bytes = lifecycle.disk_cache_bytes;
             (warm_sets_post, cold_post)
         } else {
             drop(corpus.take());
@@ -4901,7 +4938,12 @@ pub mod sql {
                 // Compaction-only text lifecycle: not a full-maintenance
                 // (drain/delta) cell, so drain/delta ledger rows never render.
                 false,
-                store_phases_lifecycle(cold_measured, compaction_stats, &routing_states),
+                store_phases_lifecycle(
+                    cold_measured,
+                    compaction_stats,
+                    lifecycle_disk_cache_bytes,
+                    &routing_states,
+                ),
                 None,
                 // Serving/monthly priced per query-family from the full warm
                 // battery the search table reports (all shapes, not one).

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1717,15 +1717,37 @@ impl FtsReader {
             return Ok(Vec::new());
         }
         // The ranged (sub-range fan-out) path carries no negation in v1.
-        self.run_max_score_bmm_range(
-            column_id,
-            cursors,
-            k,
-            doc_id_start,
-            doc_id_end,
-            None,
-            floor.next_down(),
-        )
+        //
+        // Mirror `dispatch_multi_term_or`'s kernel choice instead of
+        // hardcoding MaxScore+BMM: on a broad OR over uniform-upper-bound
+        // terms BMM cannot prune (every block max ties), so it degrades to
+        // per-doc min-scan bookkeeping over ~the whole union — the exact
+        // shape `run_windowed_union` exists for, and it is natively ranged.
+        // Hardcoding BMM here made the SAME query run a different kernel
+        // depending on whether the fan-out sliced (few large superfiles,
+        // i.e. post-compaction) or not (many small ones, pre-compaction) —
+        // measured at 1M as the 11-24x post-compact broad-OR regression.
+        if prefer_windowed_union(&cursors) {
+            self.run_windowed_union(
+                column_id,
+                cursors,
+                k,
+                None,
+                floor.next_down(),
+                doc_id_start,
+                doc_id_end,
+            )
+        } else {
+            self.run_max_score_bmm_range(
+                column_id,
+                cursors,
+                k,
+                doc_id_start,
+                doc_id_end,
+                None,
+                floor.next_down(),
+            )
+        }
     }
 
     /// Multi-column BM25 search (most_fields semantics): each
@@ -5997,6 +6019,133 @@ mod tests {
             [2u32, 3, 4].into_iter().collect(),
             "only docs in [2,5) returned"
         );
+    }
+
+    /// Regression: the ranged OR entry must produce the same results as
+    /// the un-ranged path for ANY partition of the doc space, on BOTH of
+    /// the kernels its dispatch can now pick. Before the fix it hardcoded
+    /// MaxScore+BMM, so a query sliced into sub-ranges (the fan-out shape
+    /// a compacted table takes) ran a different kernel than the same query
+    /// un-ranged — uniform broad ORs degraded 11-24x post-compaction.
+    #[tokio::test]
+    async fn search_or_range_partitions_agree_with_unranged() {
+        /// Docs in the planted corpus — spans several 4096-doc OR windows
+        /// and many 128-doc posting blocks.
+        const N_DOCS: u32 = 6_000;
+        /// Ask for every match so partition union == full result set.
+        const K_ALL: usize = N_DOCS as usize;
+        /// Top-k size for the truncated comparison.
+        const K_TOP: usize = 10;
+
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false).expect("register");
+        for i in 0..N_DOCS {
+            // Deterministic mixed-df corpus: four uniform terms with
+            // varying tf (windowed-union shape), plus one rare term
+            // (dominant-UB / BMM shape when queried with two commons).
+            let mut text = String::new();
+            for (t, name) in ["alpha", "beta", "gamma", "delta"].iter().enumerate() {
+                let h = i.wrapping_mul(31).wrapping_add(t as u32 * 17) % 5;
+                for _ in 0..h {
+                    text.push_str(name);
+                    text.push(' ');
+                }
+            }
+            if i % 2000 == 7 {
+                text.push_str("rareterm ");
+            }
+            if text.is_empty() {
+                text.push_str("filler");
+            }
+            b.add_doc(0, i, &text).expect("add");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+
+        // Uniform 4-term OR routes to the windowed union; the
+        // rare+common mix keeps a dominant term UB and stays on BMM.
+        // Assert the routing rather than assume it — a corpus tweak that
+        // silently stopped exercising one branch would otherwise turn
+        // this into a test of the other branch twice.
+        let shapes: [&[&str]; 2] = [
+            &["alpha", "beta", "gamma", "delta"],
+            &["rareterm", "alpha", "beta"],
+        ];
+        let column_id = r.resolve_column_id("body").expect("column");
+        let uniform_cursors = r
+            .build_term_cursors(column_id, shapes[0])
+            .await
+            .expect("cursors");
+        assert!(
+            prefer_windowed_union(&uniform_cursors),
+            "uniform shape must route to the windowed ranged branch"
+        );
+        let dominant_cursors = r
+            .build_term_cursors(column_id, shapes[1])
+            .await
+            .expect("cursors");
+        assert!(
+            !prefer_windowed_union(&dominant_cursors),
+            "dominant-UB shape must route to the BMM ranged branch"
+        );
+        // Uneven partitions, including window-boundary-crossing cuts.
+        let partitions: [&[(u32, u32)]; 3] = [
+            &[(0, N_DOCS)],
+            &[(0, 3_000), (3_000, N_DOCS)],
+            &[(0, 100), (100, 4_097), (4_097, 5_000), (5_000, N_DOCS)],
+        ];
+
+        for terms in shapes {
+            let full = r
+                .search("body", terms, K_ALL, BoolMode::Or)
+                .await
+                .expect("un-ranged search");
+            let mut full_sorted: Vec<(u32, u32)> =
+                full.iter().map(|&(d, s)| (d, s.to_bits())).collect();
+            full_sorted.sort_unstable();
+
+            for cuts in partitions {
+                let mut merged: Vec<(u32, f32)> = Vec::new();
+                for &(lo, hi) in cuts {
+                    merged.extend(
+                        r.search_or_range_pretokenized("body", terms, K_ALL, lo, hi)
+                            .await
+                            .expect("ranged search"),
+                    );
+                }
+                let mut merged_sorted: Vec<(u32, u32)> =
+                    merged.iter().map(|&(d, s)| (d, s.to_bits())).collect();
+                merged_sorted.sort_unstable();
+                assert_eq!(
+                    merged_sorted, full_sorted,
+                    "partition union must equal the un-ranged result \
+                     (terms={terms:?}, cuts={cuts:?})"
+                );
+
+                // Top-k contract: resorting the merged pool by
+                // (score desc, doc asc) reproduces the un-ranged top-k.
+                let mut pool = merged.clone();
+                pool.sort_unstable_by(|a, b| {
+                    b.1.partial_cmp(&a.1)
+                        .expect("BM25 scores are finite")
+                        .then(a.0.cmp(&b.0))
+                });
+                pool.truncate(K_TOP);
+                let top: Vec<(u32, u32)> = pool.iter().map(|&(d, s)| (d, s.to_bits())).collect();
+                let full_top: Vec<(u32, u32)> = full
+                    .iter()
+                    .take(K_TOP)
+                    .map(|&(d, s)| (d, s.to_bits()))
+                    .collect();
+                assert_eq!(
+                    top, full_top,
+                    "merged top-{K_TOP} must equal un-ranged top-{K_TOP} \
+                     (terms={terms:?}, cuts={cuts:?})"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1708,28 +1708,60 @@ impl FtsReader {
         doc_id_end: u32,
         floor: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
+        let set = self.build_or_cursor_set(column, terms).await?;
+        self.search_or_range_prebuilt(&set, k, doc_id_start, doc_id_end, floor)
+    }
+
+    /// Build the OR cursors for `terms` once — the postings fetch and
+    /// skip-table parse — for reuse across doc-id sub-ranges via
+    /// [`Self::search_or_range_prebuilt`]. An intra-superfile fan-out
+    /// that builds per slice re-fetches every term's full posting bytes
+    /// and re-parses its skip table per slice (measured at 1M as 2.5x
+    /// cold bytes when slicing widened); clones of these cursors share
+    /// `bytes` and the `Arc` skip table instead.
+    pub(crate) async fn build_or_cursor_set(
+        &self,
+        column: &str,
+        terms: &[&str],
+    ) -> Result<OrCursorSet, FtsError> {
         let column_id = self.resolve_column_id(column)?;
-        if terms.is_empty() || k == 0 || doc_id_start >= doc_id_end {
+        let cursors = if terms.is_empty() {
+            Vec::new()
+        } else {
+            self.build_term_cursors(column_id, terms).await?
+        };
+        Ok(OrCursorSet { column_id, cursors })
+    }
+
+    /// Multi-term OR over `[doc_id_start, doc_id_end)` against prebuilt
+    /// cursors — the ranged fan-out's per-slice call;
+    /// [`Self::search_or_range_pretokenized_with_floor`] delegates here.
+    /// The ranged path carries no negation in v1.
+    ///
+    /// Kernel choice mirrors `dispatch_multi_term_or` instead of
+    /// hardcoding MaxScore+BMM: on a broad OR over uniform-upper-bound
+    /// terms BMM cannot prune (every block max ties), so it degrades to
+    /// per-doc min-scan bookkeeping over ~the whole union — the exact
+    /// shape `run_windowed_union` exists for, and it is natively ranged.
+    /// Hardcoding BMM here made the SAME query run a different kernel
+    /// depending on whether the fan-out sliced (few large superfiles,
+    /// i.e. post-compaction) or not (many small ones, pre-compaction) —
+    /// measured at 1M as the 11-24x post-compact broad-OR regression.
+    pub(crate) fn search_or_range_prebuilt(
+        &self,
+        set: &OrCursorSet,
+        k: usize,
+        doc_id_start: u32,
+        doc_id_end: u32,
+        floor: f32,
+    ) -> Result<Vec<(u32, f32)>, FtsError> {
+        if set.cursors.is_empty() || k == 0 || doc_id_start >= doc_id_end {
             return Ok(Vec::new());
         }
-        let cursors = self.build_term_cursors(column_id, terms).await?;
-        if cursors.is_empty() {
-            return Ok(Vec::new());
-        }
-        // The ranged (sub-range fan-out) path carries no negation in v1.
-        //
-        // Mirror `dispatch_multi_term_or`'s kernel choice instead of
-        // hardcoding MaxScore+BMM: on a broad OR over uniform-upper-bound
-        // terms BMM cannot prune (every block max ties), so it degrades to
-        // per-doc min-scan bookkeeping over ~the whole union — the exact
-        // shape `run_windowed_union` exists for, and it is natively ranged.
-        // Hardcoding BMM here made the SAME query run a different kernel
-        // depending on whether the fan-out sliced (few large superfiles,
-        // i.e. post-compaction) or not (many small ones, pre-compaction) —
-        // measured at 1M as the 11-24x post-compact broad-OR regression.
+        let cursors = set.cursors.clone();
         if prefer_windowed_union(&cursors) {
             self.run_windowed_union(
-                column_id,
+                set.column_id,
                 cursors,
                 k,
                 None,
@@ -1739,7 +1771,7 @@ impl FtsReader {
             )
         } else {
             self.run_max_score_bmm_range(
-                column_id,
+                set.column_id,
                 cursors,
                 k,
                 doc_id_start,
@@ -3469,6 +3501,15 @@ impl FtsReader {
     }
 }
 
+/// One query's built OR cursors for one superfile: the postings fetch
+/// and skip-table parse done once, cheaply cloneable per doc-id
+/// sub-range. Produced by [`FtsReader::build_or_cursor_set`], consumed
+/// by [`FtsReader::search_or_range_prebuilt`].
+pub(crate) struct OrCursorSet {
+    column_id: u32,
+    cursors: Vec<TermCursor>,
+}
+
 /// Top-k min-heap entry `(score, doc_id)`, shared by every search
 /// path (single-term BMW, WAND+BMW, MaxScore+BMM, exhaustive union,
 /// AND intersection, and the `search_multi` combiner).
@@ -4544,6 +4585,7 @@ struct BlockMeta {
 /// `current_doc_id() == u32::MAX` is the "exhausted" sentinel; the
 /// WAND loop drops cursors that are exhausted at the top of each
 /// iteration.
+#[derive(Clone)]
 struct TermCursor {
     /// Precomputed `idf * (K1 + 1)` — the score numerator's
     /// per-cursor constant. Computed once at cursor build so the
@@ -4559,8 +4601,10 @@ struct TermCursor {
     /// the 2-term OR router to detect a rare anchor term (short list),
     /// where WAND+BMW can skip the other term's long list.
     df: u64,
-    /// Per-block metadata.
-    blocks: Vec<BlockMeta>,
+    /// Per-block metadata (the parsed skip table). Read-only after
+    /// build and `Arc`-shared, so cloning a cursor for another doc-id
+    /// sub-range costs the ~1 KiB decode buffers, never a re-parse.
+    blocks: Arc<[BlockMeta]>,
     /// Decoded buffers for the current block. Reused across decodes.
     block_doc_ids: Vec<u32>,
     block_tfs: Vec<u32>,
@@ -4631,7 +4675,7 @@ impl TermCursor {
             idf_x_k1p1: idf * (bm25::K1 + 1.0),
             term_max_bm25,
             df: term_meta.df,
-            blocks,
+            blocks: blocks.into(),
             block_doc_ids: vec![0u32; BLOCK_LEN],
             block_tfs: vec![0u32; BLOCK_LEN],
             block_n: 0,
@@ -4658,7 +4702,7 @@ impl TermCursor {
         let idf_x_k1p1 = idf * (bm25::K1 + 1.0);
         let block_max_bm25 = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
 
-        let blocks = vec![BlockMeta {
+        let blocks: Arc<[BlockMeta]> = Arc::from(vec![BlockMeta {
             last_doc_id: doc_id,
             // No postings-region bytes back this cursor; the decoded
             // buffer is pre-filled below so `decode_current_block` is
@@ -4666,7 +4710,7 @@ impl TermCursor {
             block_byte_offset: 0,
             block_byte_end: 0,
             block_max_bm25,
-        }];
+        }]);
 
         let mut block_doc_ids = vec![0u32; BLOCK_LEN];
         let mut block_tfs = vec![0u32; BLOCK_LEN];
@@ -6145,6 +6189,63 @@ mod tests {
                      (terms={terms:?}, cuts={cuts:?})"
                 );
             }
+        }
+    }
+
+    /// The prebuilt-cursor ranged path must be byte-identical to fresh
+    /// per-call builds — it is the same search minus the redundant fetch
+    /// and parse, so any divergence is a sharing bug (walk state leaking
+    /// between clones, stale first-block decode, ...). One set serves
+    /// overlapping windows and a repeated window to force reuse.
+    #[tokio::test]
+    async fn search_or_range_prebuilt_matches_fresh_calls() {
+        /// Docs in the planted corpus (multiple OR windows and blocks).
+        const N_DOCS: u32 = 6_000;
+        /// Ask for every match so whole result sets are compared.
+        const K_ALL: usize = N_DOCS as usize;
+
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false).expect("register");
+        for i in 0..N_DOCS {
+            let mut text = String::new();
+            for (t, name) in ["alpha", "beta", "gamma", "delta"].iter().enumerate() {
+                let h = i.wrapping_mul(31).wrapping_add(t as u32 * 17) % 5;
+                for _ in 0..h {
+                    text.push_str(name);
+                    text.push(' ');
+                }
+            }
+            if text.is_empty() {
+                text.push_str("filler");
+            }
+            b.add_doc(0, i, &text).expect("add");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+
+        let terms: &[&str] = &["alpha", "beta", "gamma", "delta"];
+        let set = r.build_or_cursor_set("body", terms).await.expect("set");
+        let windows = [
+            (0u32, N_DOCS),
+            (0, 3_000),
+            (2_000, 4_097),
+            (3_000, N_DOCS),
+            (0, N_DOCS),
+        ];
+        for (lo, hi) in windows {
+            let fresh = r
+                .search_or_range_pretokenized("body", terms, K_ALL, lo, hi)
+                .await
+                .expect("fresh ranged search");
+            let pre = r
+                .search_or_range_prebuilt(&set, K_ALL, lo, hi, f32::NEG_INFINITY)
+                .expect("prebuilt ranged search");
+            let fresh_bits: Vec<(u32, u32)> =
+                fresh.iter().map(|&(d, s)| (d, s.to_bits())).collect();
+            let pre_bits: Vec<(u32, u32)> = pre.iter().map(|&(d, s)| (d, s.to_bits())).collect();
+            assert_eq!(pre_bits, fresh_bits, "window ({lo},{hi})");
         }
     }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -4892,30 +4892,37 @@ impl TermCursor {
             _ => None,
         };
 
-        let mut blocks: Vec<BlockMeta> = Vec::with_capacity(term_meta.num_blocks);
+        // Collect straight into the `Arc` allocation: `0..num_blocks` is
+        // an exact-size iterator, so this writes each entry in place —
+        // one allocation, no intermediate `Vec` + copy. The skip table
+        // is ~a quarter of a long term's cursor-build bytes (one 32-byte
+        // entry per 128-doc block), so the doubled write showed up on
+        // common-term queries.
         let mut term_max_bm25: f32 = 0.0;
-        for i in 0..term_meta.num_blocks {
-            let (last_doc_id, block_offset_in_term, raw_block_max) =
-                term_meta.skip_entry(postings, i);
-            let block_max_bm25 = match idf_rescale {
-                Some(ratio) => raw_block_max * ratio,
-                None => raw_block_max,
-            };
-            term_max_bm25 = term_max_bm25.max(block_max_bm25);
+        let blocks: Arc<[BlockMeta]> = (0..term_meta.num_blocks)
+            .map(|i| {
+                let (last_doc_id, block_offset_in_term, raw_block_max) =
+                    term_meta.skip_entry(postings, i);
+                let block_max_bm25 = match idf_rescale {
+                    Some(ratio) => raw_block_max * ratio,
+                    None => raw_block_max,
+                };
+                term_max_bm25 = term_max_bm25.max(block_max_bm25);
 
-            blocks.push(BlockMeta {
-                last_doc_id,
-                block_byte_offset: metadata_offset + block_offset_in_term,
-                block_byte_end: metadata_offset + term_meta.block_end_in_term(postings, i),
-                block_max_bm25,
-            });
-        }
+                BlockMeta {
+                    last_doc_id,
+                    block_byte_offset: metadata_offset + block_offset_in_term,
+                    block_byte_end: metadata_offset + term_meta.block_end_in_term(postings, i),
+                    block_max_bm25,
+                }
+            })
+            .collect();
 
         let mut cursor = Self {
             idf_x_k1p1: idf * (bm25::K1 + 1.0),
             term_max_bm25,
             df: term_meta.df,
-            blocks: blocks.into(),
+            blocks,
             block_doc_ids: vec![0u32; BLOCK_LEN],
             block_tfs: vec![0u32; BLOCK_LEN],
             block_n: 0,
@@ -4948,7 +4955,7 @@ impl TermCursor {
         let idf_x_k1p1 = idf * (bm25::K1 + 1.0);
         let block_max_bm25 = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
 
-        let blocks: Arc<[BlockMeta]> = Arc::from(vec![BlockMeta {
+        let blocks: Arc<[BlockMeta]> = Arc::from([BlockMeta {
             last_doc_id: doc_id,
             // No postings-region bytes back this cursor; the decoded
             // buffer is pre-filled below so `decode_current_block` is

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -154,8 +154,10 @@ const OR_WINDOW_WORDS: usize = (OR_WINDOW as usize).div_ceil(64);
 
 /// Multi-term OR dispatch floor. A 2-term OR is already sub-millisecond
 /// on MaxScore, so the window's per-window bookkeeping isn't worth it
-/// below this many terms.
-const OR_WINDOW_MIN_TERMS: usize = 3;
+/// below this many terms. `pub(crate)`: the supertable fan-out reuses
+/// this same boundary to decide when a ranged kernel is heavy enough to
+/// ship to the reader pool (see `RANGED_KERNEL_POOL_MIN_TERMS`).
+pub(crate) const OR_WINDOW_MIN_TERMS: usize = 3;
 /// Route a multi-term OR to the windowed union scorer only when the top
 /// term's score upper bound is at most this multiple of the *average*
 /// term upper bound — i.e. no single term dominates. Uniform terms sit at

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -163,7 +163,10 @@ pub(crate) const OR_WINDOW_MIN_TERMS: usize = 3;
 /// term upper bound — i.e. no single term dominates. Uniform terms sit at
 /// ~1.0× the average (MaxScore can't prune them → windowed wins); a
 /// dominant rare term sits well above it (MaxScore prunes hard → it stays
-/// on MaxScore). Calibrated on the 1M tier.
+/// on MaxScore). Calibrated on the 1M tier; re-measured on every bench
+/// run by the superfile tier's per-algorithm probes
+/// (`benches/utils/superfile.rs`), whose shapes sit on both sides of
+/// this threshold.
 const OR_WINDOW_DOMINANCE_MULT: f32 = 1.5;
 
 /// Largest `k` for which a 2-term OR routes to WAND+BMW instead of
@@ -3268,9 +3271,9 @@ impl FtsReader {
     /// block skipping — every doc in the union of the cursor postings
     /// is scored and offered to the top-K heap.
     ///
-    /// **Not on the production path.** `dispatch_multi_term_or` always
-    /// routes to MaxScore+BMM; this function is reachable only via
-    /// `search_with_algo_for_bench(OrAlgo::Exhaustive)`. It exists
+    /// **Not on the production path.** `dispatch_multi_term_or` routes
+    /// to MaxScore+BMM or the windowed union; this function is reachable
+    /// only via `search_with_algo_for_bench(OrAlgo::Exhaustive)`. It exists
     /// because the supertable bench surfaced one specific shape where
     /// it narrowly wins, and we want the option available for future
     /// re-routing work without re-implementing it.
@@ -3468,10 +3471,11 @@ impl FtsReader {
     }
 
     /// Bench/dev helper: force the multi-term OR path to use a specific
-    /// algorithm regardless of the dispatcher's heuristic. Used by
-    /// `benches/fts_search.rs` to compare WAND+BMW, MaxScore+BMM, and
-    /// exhaustive-union under identical inputs so the heuristic
-    /// threshold can be validated against measured numbers.
+    /// algorithm regardless of the dispatcher's heuristic. Used by the
+    /// superfile tier's per-algorithm probes
+    /// (`benches/utils/superfile.rs`) to compare WAND+BMW, MaxScore+BMM,
+    /// and the windowed union under identical inputs so the dispatch
+    /// thresholds are validated against measured numbers every run.
     ///
     /// **Not part of the stable API** — production code should use
     /// `search`, which routes through `dispatch_multi_term_or`.

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -294,6 +294,36 @@ fn prefer_windowed_union(cursors: &[TermCursor]) -> bool {
     cursors.len() >= OR_WINDOW_MIN_TERMS && no_dominant_term_ub(cursors)
 }
 
+/// Initial capacity for a scan's top-k heap, in [`TopKEntry`] slots.
+///
+/// `docs_in_scope` bounds the distinct doc_ids that can ever enter the
+/// heap. It exists because callers may pass `k = usize::MAX`
+/// (`search_multi` gathers every match before weighting across
+/// columns), and `usize::MAX * size_of::<TopKEntry>()` is not an
+/// allocation any machine will serve; the heap still grows on demand.
+///
+/// `range` is the doc-id window the scan will visit; `None` is a
+/// whole-superfile scan, whose scope is `n_docs`. **Every ranged kernel
+/// must pass its own `Some((start, end))`** — a slice can only rank the
+/// docs inside its window, so sizing it by `n_docs` instead makes a
+/// sliced fan-out preallocate `slices × min(k, n_docs)` slots for a doc
+/// space its slices collectively walk exactly once. That is a
+/// pool-sized multiple on a compacted table, where doc-mass allocation
+/// hands one merged superfile the entire reader pool: measured at 1M
+/// docs × 8 threads as 61 MiB requested against 7.6 MiB rankable.
+/// Guarded by `ranged_slice_heaps_are_sized_by_their_own_range`.
+///
+/// An un-ranged caller that still has a window handy may pass it — the
+/// `min` against `n_docs` makes `Some((0, u32::MAX))` and `None`
+/// equivalent.
+pub(crate) fn top_k_initial_capacity(k: usize, n_docs: u64, range: Option<(u32, u32)>) -> usize {
+    let docs_in_scope = match range {
+        Some((start, end)) => (end.saturating_sub(start) as usize).min(n_docs as usize),
+        None => n_docs as usize,
+    };
+    k.min(docs_in_scope).max(1)
+}
+
 /// True for a 2-term cursor set where one term's posting list is at least
 /// [`WAND_BMW_2TERM_DF_RATIO`]× shorter than the other's — a rare anchor
 /// WAND+BMW can pivot on to skip the common term's long list. The whole
@@ -1126,7 +1156,7 @@ impl FtsReader {
         floor_eff: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
         let dl_norm_k1 = &self.columns[column_id as usize].dl_norm_k1;
-        let initial_cap = k.min(self.n_docs as usize).max(1);
+        let initial_cap = top_k_initial_capacity(k, u64::from(self.n_docs), None);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
 
         // Per-atom pruning slack: an atom only needs to contribute
@@ -2262,7 +2292,7 @@ impl FtsReader {
         // capacity at n_docs (the upper bound on distinct doc_ids in
         // the heap) so we don't try to allocate `usize::MAX * size_of::<TopKEntry>()`.
         // The BinaryHeap grows on demand if needed.
-        let initial_cap = k.min(self.n_docs as usize).max(1);
+        let initial_cap = top_k_initial_capacity(k, u64::from(self.n_docs), None);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
         let mut threshold: f32 = 0.0;
 
@@ -2520,7 +2550,7 @@ impl FtsReader {
         // expected number of leapfrog bumps per candidate.
         cursors.sort_by_key(|c| c.block_count());
 
-        let initial_cap = k.min(self.n_docs as usize).max(1);
+        let initial_cap = top_k_initial_capacity(k, u64::from(self.n_docs), None);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
         let mut sink = ScoreSink {
             heap: &mut heap,
@@ -2556,7 +2586,7 @@ impl FtsReader {
         let dl_norm_k1 = &col_meta.dl_norm_k1;
         must_cursors.sort_by_key(|c| c.block_count());
 
-        let initial_cap = k.min(self.n_docs as usize).max(1);
+        let initial_cap = top_k_initial_capacity(k, u64::from(self.n_docs), None);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
         let should_ub = should_cursors.iter().map(|c| c.term_max_bm25).sum();
         let mut sink = MustShouldSink {
@@ -2952,7 +2982,11 @@ impl FtsReader {
             partial_max[i] = partial_max[i + 1] + cursors[i].term_max_bm25;
         }
 
-        let initial_cap = k.min(self.n_docs as usize).max(1);
+        // Sized by this slice's own window: only docs inside it can be
+        // ranked here, and a sliced fan-out would otherwise preallocate
+        // one whole-superfile heap per slice.
+        let initial_cap =
+            top_k_initial_capacity(k, u64::from(self.n_docs), Some((doc_id_start, doc_id_end)));
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
         // Seed the pruning threshold with the caller's floor: docs
         // strictly below it can never matter, so the MaxScore
@@ -3319,7 +3353,11 @@ impl FtsReader {
             }
         }
 
-        let initial_cap = k.min(self.n_docs as usize).max(1);
+        // This scan's own window, as in the MaxScore path. Un-ranged
+        // callers pass `[0, u32::MAX)`, which the `n_docs` cap collapses
+        // back to a whole-superfile scope.
+        let initial_cap =
+            top_k_initial_capacity(k, u64::from(self.n_docs), Some((doc_id_start, doc_id_end)));
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
         // Floor-seeded threshold, identical to the MaxScore path.
         let mut threshold: f32 = floor_eff.max(0.0);
@@ -3501,7 +3539,7 @@ impl FtsReader {
         let col_meta = &self.columns[column_id as usize];
         let dl_norm_k1 = &col_meta.dl_norm_k1;
 
-        let initial_cap = k.min(self.n_docs as usize).max(1);
+        let initial_cap = top_k_initial_capacity(k, u64::from(self.n_docs), None);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
         let mut threshold: f32 = 0.0;
 
@@ -6296,6 +6334,50 @@ mod tests {
             ids,
             [2u32, 3, 4].into_iter().collect(),
             "only docs in [2,5) returned"
+        );
+    }
+
+    /// A scan's top-k heap is preallocated for the docs it can actually
+    /// rank: the whole superfile un-ranged, the window's width when
+    /// ranged. Sizing a ranged scan by `n_docs` is what made a sliced
+    /// fan-out preallocate one whole-superfile heap per slice.
+    #[test]
+    fn top_k_capacity_is_scoped_to_the_range_the_scan_visits() {
+        /// Docs in the notional superfile.
+        const N_DOCS: u64 = 1_000_000;
+        /// Result size large enough that the scope, not `k`, is the cap.
+        const BIG_K: usize = N_DOCS as usize;
+
+        // Un-ranged: scope is the whole superfile.
+        assert_eq!(top_k_initial_capacity(BIG_K, N_DOCS, None), N_DOCS as usize);
+        // Ranged: scope is the window, not the file — an eighth of the
+        // doc space preallocates an eighth of the slots.
+        let eighth = (N_DOCS / 8) as u32;
+        assert_eq!(
+            top_k_initial_capacity(BIG_K, N_DOCS, Some((0, eighth))),
+            eighth as usize
+        );
+        assert_eq!(
+            top_k_initial_capacity(BIG_K, N_DOCS, Some((eighth, 2 * eighth))),
+            eighth as usize
+        );
+        // A window wider than the file (un-ranged callers pass
+        // `[0, u32::MAX)`) collapses back to the whole-superfile scope.
+        assert_eq!(
+            top_k_initial_capacity(BIG_K, N_DOCS, Some((0, u32::MAX))),
+            N_DOCS as usize
+        );
+        // Small `k` still wins over the scope, and the floor is 1 slot so
+        // a `k = 0` or empty-range caller never asks for a zero-capacity
+        // heap.
+        assert_eq!(top_k_initial_capacity(10, N_DOCS, Some((0, eighth))), 10);
+        assert_eq!(top_k_initial_capacity(0, N_DOCS, None), 1);
+        assert_eq!(top_k_initial_capacity(BIG_K, N_DOCS, Some((5, 5))), 1);
+        // `k = usize::MAX` (`search_multi`) is capped by the scope, never
+        // turned into an unservable allocation.
+        assert_eq!(
+            top_k_initial_capacity(usize::MAX, N_DOCS, None),
+            N_DOCS as usize
         );
     }
 

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -52,7 +52,7 @@ use crate::{
         BytesLazyByteSource, LazyByteSource, LazySubSource, ReadError,
         format::{self, footer, kv},
         fts::{
-            reader::{self as fts_reader, BoolMode, ClauseLists, FtsReader},
+            reader::{self as fts_reader, BoolMode, ClauseLists, FtsReader, OrCursorSet},
             tokenize::{AsciiLowerTokenizer, Tokenizer},
         },
         vector::{
@@ -1260,6 +1260,37 @@ impl SuperfileReader {
                 floor,
             )
             .await?)
+    }
+
+    /// Build the OR cursor set for `terms` once, for reuse across this
+    /// superfile's doc-id sub-ranges via
+    /// [`Self::bm25_search_or_range_prebuilt`].
+    pub(crate) async fn bm25_or_cursor_set(
+        &self,
+        column: &str,
+        terms: &[&str],
+    ) -> Result<OrCursorSet, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.build_or_cursor_set(column, terms).await?)
+    }
+
+    /// Ranged multi-term OR against prebuilt cursors — see
+    /// [`Self::bm25_search_or_range_pretokenized_with_floor`] for the
+    /// range and floor contract.
+    pub(crate) fn bm25_search_or_range_prebuilt(
+        &self,
+        set: &OrCursorSet,
+        k: usize,
+        doc_id_start: u32,
+        doc_id_end: u32,
+        floor: f32,
+    ) -> Result<Vec<(u32, f32)>, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.search_or_range_prebuilt(set, k, doc_id_start, doc_id_end, floor)?)
     }
 
     /// Prefix-expanded BM25 search restricted to a doc_id sub-range.

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -543,8 +543,19 @@ impl SupertableReader {
                                     floor,
                                 ));
                             });
+                            // A dropped `tx` means the pool task died before
+                            // sending (it can't happen short of a kernel
+                            // panic, which the shared pool's default rayon
+                            // handler turns into an abort first) — but
+                            // surface it as an error rather than a second
+                            // panic, matching the resolve-decode bridge in
+                            // `exec::common`.
                             rx.await
-                                .expect("reader-pool ranged kernel dropped its result channel")
+                                .map_err(|_| {
+                                    QueryError::Execute(
+                                        "ranged fts kernel: reader pool dropped result".into(),
+                                    )
+                                })?
                                 .map_err(fts_read_error)?
                         } else {
                             r.bm25_search_or_range_prebuilt(set, k, start, end, floor)
@@ -1367,6 +1378,12 @@ fn fanout_for(n_musts: usize, n_shoulds: usize, has_negatives: bool) -> FanOut {
 /// couple of threads walk nearly the whole corpus. Slices share one
 /// cursor build per superfile (see the fan-out's cursor-set cache), so
 /// extra units cost decode buffers, not postings fetches.
+///
+/// `pool_threads` is a target, not a budget: per-file round-half-up
+/// plus the ≥ 1-unit clamp can emit up to `kept − 1` units more than
+/// there are threads (e.g. three equal files on an 8-thread pool yield
+/// 3 × 3 = 9). Excess units queue on the pool — scheduling slop, never
+/// extra concurrency.
 ///
 /// Two limits still apply:
 ///   1. `FanOut::PerSuperfile` (no range-aware kernel for the shape)
@@ -3036,6 +3053,48 @@ mod tests {
             top_k_initial_capacity(K, MERGED_DOCS, None),
             "un-sliced scan allocates exactly the docs it can rank"
         );
+    }
+
+    /// Pins the documented "target, not a budget" slop: per-file
+    /// round-half-up with the ≥ 1 clamp may emit up to `kept − 1` units
+    /// beyond the pool. Three equal files on an 8-thread pool round to
+    /// 3 slices each; the excess unit queues, it never adds concurrency.
+    #[test]
+    fn build_work_units_may_oversubscribe_pool_by_kept_minus_one() {
+        /// Threads in the simulated reader pool.
+        const POOL: usize = 8;
+        /// Docs per superfile — equal thirds, each well above the
+        /// `SUBRANGE_MIN_DOCS` floor so rounding alone decides.
+        const DOCS_EACH: u64 = 400_000;
+
+        let files = [
+            manifest_entry(DOCS_EACH),
+            manifest_entry(DOCS_EACH),
+            manifest_entry(DOCS_EACH),
+        ];
+        let kept: Vec<_> = files.iter().collect();
+        let units = build_work_units(&kept, FanOut::SubRanges, POOL);
+        // round(1/3 × 8) = 3 slices per file.
+        assert_eq!(units.len(), 9, "3 equal files each round to 3 slices");
+        assert!(
+            units.len() <= POOL + (kept.len() - 1),
+            "oversubscription is bounded by kept − 1"
+        );
+        // Every file's slices still tile its own doc space exactly.
+        for f in &files {
+            let mut ranges: Vec<(u32, u32)> = units
+                .iter()
+                .filter(|u| u.entry.superfile_id == f.superfile_id)
+                .map(|u| u.range.expect("equal thirds are sliced"))
+                .collect();
+            ranges.sort_unstable();
+            let mut cursor = 0u32;
+            for (start, end) in ranges {
+                assert_eq!(start, cursor, "sub-ranges tile without gaps");
+                cursor = end;
+            }
+            assert_eq!(cursor, DOCS_EACH as u32, "sub-ranges cover every doc");
+        }
     }
 
     #[test]

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1657,13 +1657,18 @@ impl Supertable {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, future::Future, sync::Arc};
+    use std::{
+        collections::{HashMap, HashSet},
+        future::Future,
+        sync::Arc,
+    };
 
     use arrow_array::{Decimal128Array, LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use bytes::Bytes;
     use datafusion::prelude::{col, lit};
     use tokio::runtime::Builder;
+    use uuid::Uuid;
 
     use super::{Bm25Stats, BoolMode, FanOut, build_work_units, fanout_for};
     use crate::{
@@ -1671,15 +1676,38 @@ mod tests {
         superfile::{
             SuperfileReader,
             builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
+            fts::reader::top_k_initial_capacity,
             vector::layout::VectorLayout,
         },
         supertable::{
             Supertable, SupertableOptions,
             error::QueryError,
+            manifest::{SuperfileEntry, SuperfileUri},
             options::{DECIMAL128_PRECISION, DECIMAL128_SCALE},
         },
         test_helpers::default_tokenizer as tok,
     };
+
+    /// Manifest entry fixture for the work-unit tests. `n_docs` is the
+    /// only field the fan-out's slicing reads; everything else is inert.
+    fn manifest_entry(n_docs: u64) -> Arc<SuperfileEntry> {
+        let id = Uuid::new_v4();
+        Arc::new(SuperfileEntry {
+            birth_version: 0,
+            superfile_id: id,
+            uri: SuperfileUri(id),
+            n_docs,
+            id_min: 0,
+            id_max: n_docs.saturating_sub(1) as i128,
+            scalar_stats: HashMap::new(),
+            fts_summary: HashMap::new(),
+            vector_summary: HashMap::new(),
+            partition_key: Vec::new(),
+            partition_hint: None,
+            vector_layout: VectorLayout::Ivf,
+            subsection_offsets: None,
+        })
+    }
 
     /// Drive an async future to completion on a throwaway current-thread
     /// runtime. Used only for the single-superfile `SuperfileReader`
@@ -2837,33 +2865,8 @@ mod tests {
 
     #[test]
     fn build_work_units_per_superfile_is_one_unranged_unit_each() {
-        use std::collections::HashMap;
-
-        use uuid::Uuid;
-
-        use crate::supertable::manifest::{SuperfileEntry, SuperfileUri};
-
-        fn entry(n_docs: u64) -> Arc<SuperfileEntry> {
-            let id = Uuid::new_v4();
-            Arc::new(SuperfileEntry {
-                birth_version: 0,
-                superfile_id: id,
-                uri: SuperfileUri(id),
-                n_docs,
-                id_min: 0,
-                id_max: n_docs.saturating_sub(1) as i128,
-                scalar_stats: HashMap::new(),
-                fts_summary: HashMap::new(),
-                vector_summary: HashMap::new(),
-                partition_key: Vec::new(),
-                partition_hint: None,
-                vector_layout: VectorLayout::Ivf,
-                subsection_offsets: None,
-            })
-        }
-
-        let e0 = entry(100);
-        let e1 = entry(200);
+        let e0 = manifest_entry(100);
+        let e1 = manifest_entry(200);
         let kept = vec![&e0, &e1];
 
         // PerSuperfile always yields exactly one un-ranged unit per kept
@@ -2893,12 +2896,6 @@ mod tests {
     /// hand the merged file the pool and leave remnants whole.
     #[test]
     fn build_work_units_allocates_by_doc_mass_not_file_count() {
-        use std::collections::HashMap;
-
-        use uuid::Uuid;
-
-        use crate::supertable::manifest::{SuperfileEntry, SuperfileUri};
-
         /// Threads in the simulated reader pool.
         const POOL: usize = 8;
         /// Docs in the merged superfile (compaction output).
@@ -2906,30 +2903,12 @@ mod tests {
         /// Docs in each post-merge remnant — below `SUBRANGE_MIN_DOCS`.
         const REMNANT_DOCS: u64 = 10_000;
 
-        let entry = |n_docs: u64| {
-            let id = Uuid::new_v4();
-            Arc::new(SuperfileEntry {
-                birth_version: 0,
-                superfile_id: id,
-                uri: SuperfileUri(id),
-                n_docs,
-                id_min: 0,
-                id_max: n_docs as i128 - 1,
-                scalar_stats: HashMap::new(),
-                fts_summary: HashMap::new(),
-                vector_summary: HashMap::new(),
-                partition_key: Vec::new(),
-                partition_hint: None,
-                vector_layout: VectorLayout::Ivf,
-                subsection_offsets: None,
-            })
-        };
-        let merged = entry(MERGED_DOCS);
+        let merged = manifest_entry(MERGED_DOCS);
         let remnants = [
-            entry(REMNANT_DOCS),
-            entry(REMNANT_DOCS),
-            entry(REMNANT_DOCS),
-            entry(REMNANT_DOCS),
+            manifest_entry(REMNANT_DOCS),
+            manifest_entry(REMNANT_DOCS),
+            manifest_entry(REMNANT_DOCS),
+            manifest_entry(REMNANT_DOCS),
         ];
         let mut kept = vec![&merged];
         kept.extend(remnants.iter());
@@ -2965,6 +2944,98 @@ mod tests {
             cursor = end;
         }
         assert_eq!(cursor, MERGED_DOCS as u32, "sub-ranges cover every doc");
+    }
+
+    /// Regression: a sliced fan-out must preallocate top-k heap slots for
+    /// the docs it can actually rank, not one whole-superfile heap **per
+    /// slice**. Before the fix the slices requested
+    /// `slices × min(k, superfile docs)` — 61 MiB against 7.6 MiB
+    /// rankable at the 1M × 8-thread shape below, and a pool-sized
+    /// multiple (GBs) on a compacted table with a wide reader pool.
+    ///
+    /// All three trigger conditions are just what a compacted table under
+    /// an everyday query looks like:
+    ///   1. a bare two-or-more-term OR — `fanout_for(0, >= 2, false)` is
+    ///      `SubRanges`, so any two-word query slices;
+    ///   2. one merged superfile holding ~all the doc mass, which
+    ///      doc-mass allocation hands the entire pool (see
+    ///      `build_work_units_allocates_by_doc_mass_not_file_count`) —
+    ///      i.e. the shape `optimize` produces;
+    ///   3. a large `k`, which the fan-out passes to every slice
+    ///      unchanged.
+    ///
+    /// The slices tile the doc space exactly once, so the slots the query
+    /// needs is bounded by `min(k, docs)`. Capacity is computed through
+    /// the same `top_k_initial_capacity` both ranged kernels call
+    /// (`run_max_score_bmm_range`, `run_windowed_union`), each passing
+    /// its own `[start, end)`.
+    #[test]
+    fn ranged_slice_heaps_are_sized_by_their_own_range() {
+        /// Threads in the reader pool = slices the merged file takes.
+        const POOL: usize = 8;
+        /// Docs in the merged superfile a full optimize produces.
+        const MERGED_DOCS: u64 = 1_000_000;
+        /// Result size. Large `k` is what makes the over-allocation bite:
+        /// at small `k` the cap is `k` and the waste is negligible.
+        const K: usize = MERGED_DOCS as usize;
+        /// Bytes per heap slot — `TopKEntry` is `(f32, u32)`.
+        const SLOT_BYTES: usize = 8;
+
+        let merged = manifest_entry(MERGED_DOCS);
+        let kept = vec![&merged];
+        let units = build_work_units(&kept, FanOut::SubRanges, POOL);
+        assert_eq!(units.len(), POOL, "merged superfile takes the whole pool");
+
+        // What the slices collectively ask for, computed exactly as the
+        // ranged kernels do — each scoped to its own sub-range.
+        let requested: usize = units
+            .iter()
+            .map(|u| top_k_initial_capacity(K, u.entry.n_docs, u.range))
+            .sum();
+        // What the query can possibly need: the slices tile the doc space
+        // once, so no more than `min(k, docs)` distinct docs are rankable.
+        let needed = top_k_initial_capacity(K, MERGED_DOCS, None);
+
+        let mib = |slots: usize| (slots * SLOT_BYTES) as f64 / (1024.0 * 1024.0);
+        assert_eq!(
+            requested,
+            needed,
+            "sliced fan-out requested {requested} top-k slots ({:.1} MiB) for \
+             a doc space needing {needed} ({:.1} MiB): a slice must be sized \
+             by its own range, not by the whole superfile",
+            mib(requested),
+            mib(needed),
+        );
+    }
+
+    /// Control for the regression above: the same corpus and the same `k`
+    /// on the un-sliced path allocate exactly once. This pinned the
+    /// blow-up to slicing rather than to large `k` on its own, and now
+    /// pins the fixed sliced case to the same total.
+    #[test]
+    fn unsliced_fanout_preallocates_one_top_k_heap_per_superfile() {
+        /// Docs in the merged superfile a full optimize produces.
+        const MERGED_DOCS: u64 = 1_000_000;
+        /// Same large `k` as the sliced repro.
+        const K: usize = MERGED_DOCS as usize;
+        /// Reader-pool threads; irrelevant under `PerSuperfile`.
+        const POOL: usize = 8;
+
+        let merged = manifest_entry(MERGED_DOCS);
+        let kept = vec![&merged];
+        // A query carrying a must or a negation stays whole-superfile.
+        let units = build_work_units(&kept, FanOut::PerSuperfile, POOL);
+        assert_eq!(units.len(), 1, "un-ranged fan-out is one unit per file");
+
+        let requested: usize = units
+            .iter()
+            .map(|u| top_k_initial_capacity(K, u.entry.n_docs, u.range))
+            .sum();
+        assert_eq!(
+            requested,
+            top_k_initial_capacity(K, MERGED_DOCS, None),
+            "un-sliced scan allocates exactly the docs it can rank"
+        );
     }
 
     #[test]

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -82,9 +82,21 @@ use std::{
 use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, LargeStringArray};
 use roaring::RoaringBitmap;
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, oneshot};
 use tracing::debug;
 use uuid::Uuid;
+
+/// Fewest should-terms for which a ranged kernel is shipped to the
+/// reader pool (oneshot bridge) instead of running inline on the tokio
+/// worker. Multi-term kernels are multi-millisecond sync blocks — run
+/// inline they starve woken tasks (one slice per query measured waiting
+/// ~6 ms for a worker at 1M post-compaction). Below this many terms the
+/// kernel is sub-millisecond and the bridge round-trip costs more than
+/// it saves (`two_term_or` measured +~0.1 ms when bridged). Reuses
+/// [`OR_WINDOW_MIN_TERMS`]: the same boundary below which the windowed
+/// union kernel isn't worth its bookkeeping, so the two thresholds
+/// cannot drift apart.
+const RANGED_KERNEL_POOL_MIN_TERMS: usize = OR_WINDOW_MIN_TERMS;
 
 pub use crate::superfile::fts::reader::BoolMode;
 use crate::{
@@ -92,7 +104,7 @@ use crate::{
     superfile::{
         SuperfileReader,
         error::{FtsError, ReadError},
-        fts::reader::{ClauseLists, OrCursorSet},
+        fts::reader::{ClauseLists, OR_WINDOW_MIN_TERMS, OrCursorSet},
     },
     supertable::{
         error::QueryError,
@@ -397,6 +409,14 @@ impl SupertableReader {
         type SharedCursorCell = Arc<OnceCell<Arc<OrCursorSet>>>;
         let cursor_sets: Arc<Mutex<HashMap<Uuid, SharedCursorCell>>> =
             Arc::new(Mutex::new(HashMap::new()));
+        // Ranged kernels are multi-millisecond SYNC scans; run them as a
+        // rayon wave on the reader pool, bridged with a oneshot, per the
+        // concurrency contract. Inline on tokio workers they block the
+        // runtime: with 8 slices the OnceCell wake of one waiter reliably
+        // lost the worker race and sat a full kernel duration in a run
+        // queue — measured at 1M post-compact as one ~6 ms-starved slice
+        // per query gating a 9.6 ms wall over ~6 ms of actual work.
+        let reader_pool = Arc::clone(&manifest.options.reader_pool);
 
         // One shared fan-out (`query::dispatch::fanout`) — the same
         // orchestrator the vector path uses. It warms the tombstone
@@ -415,6 +435,7 @@ impl SupertableReader {
             let neg_ph_arc = Arc::clone(&neg_ph_arc);
             let shared = Arc::clone(&shared);
             let cursor_sets = Arc::clone(&cursor_sets);
+            let reader_pool = Arc::clone(&reader_pool);
             let tombstones = tombstones.clone();
             async move {
                 // Share the global kth-best floor with every superfile —
@@ -449,8 +470,29 @@ impl SupertableReader {
                                     .map_err(fts_read_error)
                             })
                             .await?;
-                        r.bm25_search_or_range_prebuilt(set, k, start, end, floor)
-                            .map_err(fts_read_error)?
+                        // Heavy kernels go to the reader pool; trivial ones
+                        // run inline where the oneshot round-trip would cost
+                        // more than the scan — see the gate's doc comment.
+                        if should_arc.len() >= RANGED_KERNEL_POOL_MIN_TERMS {
+                            let (tx, rx) = oneshot::channel();
+                            let kernel_reader = Arc::clone(&r);
+                            let kernel_set = Arc::clone(set);
+                            reader_pool.spawn(move || {
+                                let _ = tx.send(kernel_reader.bm25_search_or_range_prebuilt(
+                                    &kernel_set,
+                                    k,
+                                    start,
+                                    end,
+                                    floor,
+                                ));
+                            });
+                            rx.await
+                                .expect("reader-pool ranged kernel dropped its result channel")
+                                .map_err(fts_read_error)?
+                        } else {
+                            r.bm25_search_or_range_prebuilt(set, k, start, end, floor)
+                                .map_err(fts_read_error)?
+                        }
                     }
                     None => {
                         let must_refs: Vec<&str> = must_arc.iter().map(|s| s.as_str()).collect();

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -70,7 +70,7 @@
 use std::{
     borrow::Cow,
     cmp::{Ordering, Reverse},
-    collections::BinaryHeap,
+    collections::{BinaryHeap, HashMap},
     slice,
     sync::{
         Arc, Mutex,
@@ -82,6 +82,7 @@ use std::{
 use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, LargeStringArray};
 use roaring::RoaringBitmap;
+use tokio::sync::OnceCell;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -91,7 +92,7 @@ use crate::{
     superfile::{
         SuperfileReader,
         error::{FtsError, ReadError},
-        fts::reader::ClauseLists,
+        fts::reader::{ClauseLists, OrCursorSet},
     },
     supertable::{
         error::QueryError,
@@ -388,6 +389,15 @@ impl SupertableReader {
         let tombstones = self.tombstone_cache.clone();
         let now = Instant::now();
 
+        // Ranged units are slices of ONE superfile: share its cursor build
+        // across them (keyed by superfile id) instead of re-fetching and
+        // re-parsing every term's postings per slice — measured at 1M as
+        // 2.5x cold bytes when slicing widened. The OnceCell coalesces
+        // concurrent slices of a file; un-ranged units never touch this.
+        type SharedCursorCell = Arc<OnceCell<Arc<OrCursorSet>>>;
+        let cursor_sets: Arc<Mutex<HashMap<Uuid, SharedCursorCell>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
         // One shared fan-out (`query::dispatch::fanout`) — the same
         // orchestrator the vector path uses. It warms the tombstone
         // sidecars in one batch, opens each superfile reader and runs the
@@ -404,6 +414,7 @@ impl SupertableReader {
             let should_ph_arc = Arc::clone(&should_ph_arc);
             let neg_ph_arc = Arc::clone(&neg_ph_arc);
             let shared = Arc::clone(&shared);
+            let cursor_sets = Arc::clone(&cursor_sets);
             let tombstones = tombstones.clone();
             async move {
                 // Share the global kth-best floor with every superfile —
@@ -423,18 +434,23 @@ impl SupertableReader {
                     // queries (`fanout_for` never slices when a must
                     // or negated clause exists).
                     Some((start, end)) => {
-                        let should_refs: Vec<&str> =
-                            should_arc.iter().map(|s| s.as_str()).collect();
-                        r.bm25_search_or_range_pretokenized_with_floor(
-                            &column_arc,
-                            &should_refs,
-                            k,
-                            start,
-                            end,
-                            floor,
-                        )
-                        .await
-                        .map_err(fts_read_error)?
+                        let cell = {
+                            let mut sets =
+                                cursor_sets.lock().expect("cursor-set map lock poisoned");
+                            Arc::clone(sets.entry(suid).or_default())
+                        };
+                        let set = cell
+                            .get_or_try_init(|| async {
+                                let should_refs: Vec<&str> =
+                                    should_arc.iter().map(|s| s.as_str()).collect();
+                                r.bm25_or_cursor_set(&column_arc, &should_refs)
+                                    .await
+                                    .map(Arc::new)
+                                    .map_err(fts_read_error)
+                            })
+                            .await?;
+                        r.bm25_search_or_range_prebuilt(set, k, start, end, floor)
+                            .map_err(fts_read_error)?
                     }
                     None => {
                         let must_refs: Vec<&str> = must_arc.iter().map(|s| s.as_str()).collect();
@@ -1176,51 +1192,52 @@ fn fanout_for(n_musts: usize, n_shoulds: usize, has_negatives: bool) -> FanOut {
 /// Slice the kept superfiles into parallel work units — one
 /// [`WorkUnit`] per (superfile, doc_id sub-range) tuple.
 ///
-/// `FanOut::SubRanges` slices only when:
-///   1. The reader pool has more threads than kept superfiles —
-///      otherwise every thread is already saturated by one superfile
-///      and splitting just adds overhead.
-///   2. The candidate sub-range width is at least
-///      `SUBRANGE_MIN_DOCS` — below that, BMM bookkeeping +
-///      cross-sub-range top-K merge dominate the parallel win.
+/// Sub-range count is allocated by **doc mass**: a superfile holding
+/// `f` of the surviving docs gets `round(f × pool_threads)` slices.
+/// Splitting the pool evenly per *file* instead leaves a compacted
+/// table — one large merged superfile plus small remnants — with the
+/// same one-or-two units the merged file had when it was dozens of
+/// balanced files, so most of the pool idles on remnants while a
+/// couple of threads walk nearly the whole corpus. Slices share one
+/// cursor build per superfile (see the fan-out's cursor-set cache), so
+/// extra units cost decode buffers, not postings fetches.
 ///
-/// Otherwise each kept superfile becomes a single un-ranged work unit
-/// — identical to the original `par_iter` over superfiles shape.
+/// Two limits still apply:
+///   1. `FanOut::PerSuperfile` (no range-aware kernel for the shape)
+///      and a single-threaded pool both collapse to one un-ranged unit
+///      per superfile — the original `par_iter` over superfiles shape.
+///   2. No slice is narrower than `SUBRANGE_MIN_DOCS`; below that, BMM
+///      bookkeeping + the cross-sub-range top-K merge dominate the
+///      parallel win.
 fn build_work_units(
     kept: &[&Arc<SuperfileEntry>],
     fanout: FanOut,
     pool_threads: usize,
 ) -> Vec<WorkUnit> {
-    let want_subranges = pool_threads.div_ceil(kept.len().max(1)).max(1);
-    if matches!(fanout, FanOut::PerSuperfile) || want_subranges <= 1 {
-        return kept
-            .iter()
-            .map(|e| WorkUnit {
-                entry: Arc::clone(e),
-                range: None,
-            })
-            .collect();
+    let un_ranged = |entry: &Arc<SuperfileEntry>| WorkUnit {
+        entry: Arc::clone(entry),
+        range: None,
+    };
+    let total_docs: u64 = kept.iter().map(|e| e.n_docs).sum();
+    if matches!(fanout, FanOut::PerSuperfile) || pool_threads <= 1 || total_docs == 0 {
+        return kept.iter().map(|e| un_ranged(e)).collect();
     }
 
-    let mut units: Vec<WorkUnit> = Vec::with_capacity(kept.len() * want_subranges);
+    let mut units: Vec<WorkUnit> = Vec::with_capacity(kept.len() + pool_threads);
     for entry in kept {
         let n_docs = entry.n_docs as u32;
         if n_docs == 0 {
             continue;
         }
-        // Round the sub-range count down to avoid producing
-        // narrower-than-floor slices. With `want_subranges = 2` on
-        // a 1.25M-doc superfile, stride = 625K (well above floor) so
-        // both sub-ranges fire. With a tiny superfile (e.g., 10K
-        // docs, well below `SUBRANGE_MIN_DOCS`), the division
-        // collapses to 1 sub-range = full superfile.
+        // Integer round-half-up of `n_docs / total_docs × pool_threads`.
+        // A file holding ~all the docs asks for the whole pool; a
+        // remnant holding ~none rounds to 0 and is clamped to one
+        // whole-file unit.
+        let by_mass = ((entry.n_docs * pool_threads as u64 + total_docs / 2) / total_docs) as usize;
         let cap_by_floor = (n_docs / SUBRANGE_MIN_DOCS).max(1) as usize;
-        let n_sub = want_subranges.min(cap_by_floor);
+        let n_sub = by_mass.clamp(1, cap_by_floor);
         if n_sub <= 1 {
-            units.push(WorkUnit {
-                entry: Arc::clone(entry),
-                range: None,
-            });
+            units.push(un_ranged(entry));
             continue;
         }
         let stride = n_docs.div_ceil(n_sub as u32);
@@ -2285,6 +2302,88 @@ mod tests {
         let units = build_work_units(&kept, FanOut::SubRanges, 16);
         assert_eq!(units.len(), 2);
         assert!(units.iter().all(|u| u.range.is_none()));
+    }
+
+    /// The compacted shape: one merged superfile holding essentially the
+    /// whole corpus plus small remnants. Even-per-file allocation gave
+    /// the merged file `ceil(threads / n_files)` slices — 2 of 8 on the
+    /// 5-superfile table the 1M bench produces post-compaction — while
+    /// remnants took units they could not fill. Doc-mass allocation must
+    /// hand the merged file the pool and leave remnants whole.
+    #[test]
+    fn build_work_units_allocates_by_doc_mass_not_file_count() {
+        use std::collections::HashMap;
+
+        use uuid::Uuid;
+
+        use crate::supertable::manifest::{SuperfileEntry, SuperfileUri};
+
+        /// Threads in the simulated reader pool.
+        const POOL: usize = 8;
+        /// Docs in the merged superfile (compaction output).
+        const MERGED_DOCS: u64 = 1_000_000;
+        /// Docs in each post-merge remnant — below `SUBRANGE_MIN_DOCS`.
+        const REMNANT_DOCS: u64 = 10_000;
+
+        let entry = |n_docs: u64| {
+            let id = Uuid::new_v4();
+            Arc::new(SuperfileEntry {
+                birth_version: 0,
+                superfile_id: id,
+                uri: SuperfileUri(id),
+                n_docs,
+                id_min: 0,
+                id_max: n_docs as i128 - 1,
+                scalar_stats: HashMap::new(),
+                fts_summary: HashMap::new(),
+                vector_summary: HashMap::new(),
+                partition_key: Vec::new(),
+                partition_hint: None,
+                vector_layout: VectorLayout::Ivf,
+                subsection_offsets: None,
+            })
+        };
+        let merged = entry(MERGED_DOCS);
+        let remnants = [
+            entry(REMNANT_DOCS),
+            entry(REMNANT_DOCS),
+            entry(REMNANT_DOCS),
+            entry(REMNANT_DOCS),
+        ];
+        let mut kept = vec![&merged];
+        kept.extend(remnants.iter());
+
+        let units = build_work_units(&kept, FanOut::SubRanges, POOL);
+        let merged_units: Vec<_> = units
+            .iter()
+            .filter(|u| u.entry.superfile_id == merged.superfile_id)
+            .collect();
+        assert_eq!(
+            merged_units.len(),
+            POOL,
+            "merged superfile holds ~all docs so it must take the whole pool"
+        );
+        for remnant in &remnants {
+            let n: Vec<_> = units
+                .iter()
+                .filter(|u| u.entry.superfile_id == remnant.superfile_id)
+                .collect();
+            assert_eq!(n.len(), 1, "sub-floor remnant stays one unit");
+            assert!(n[0].range.is_none(), "remnant unit must be un-ranged");
+        }
+        // The merged file's slices tile [0, MERGED_DOCS) without gaps.
+        let mut ranges: Vec<(u32, u32)> = merged_units
+            .iter()
+            .map(|u| u.range.expect("merged units are ranged"))
+            .collect();
+        ranges.sort_unstable();
+        let mut cursor = 0u32;
+        for (start, end) in ranges {
+            assert_eq!(start, cursor, "sub-ranges tile without gaps");
+            assert!(end > start, "sub-range is non-empty");
+            cursor = end;
+        }
+        assert_eq!(cursor, MERGED_DOCS as u32, "sub-ranges cover every doc");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

After `optimize` compacts a table (128 superfiles → 5 at the 1M bench scale),
warm multi-term OR queries regress by an amount that grows with term count —
measured at 1M docs on Azure, post-compact vs pre-compact warm p50:

| shape          | pre-compact | post-compact (before) | ratio |
|----------------|-------------|----------------------|-------|
| ten_term_or    | 2.2 ms      | 25.5 ms              | 11.5x |
| twenty_term_or | 3.7 ms      | 67.8 ms              | 18.2x |
| forty_term_or  | 6.3 ms      | 151.9 ms             | 24.3x |

## Root causes (three, layered)

1. **The ranged OR entry point hardcoded MaxScore+BMM.** The un-ranged path
   picks its kernel via `dispatch_multi_term_or`, which routes uniform
   broad ORs to the windowed union scorer precisely because BMM cannot
   prune when block maxima tie. Ranged work units only exist when the
   reader pool has more threads than surviving superfiles — i.e. only
   after compaction — so the same query silently switched to the wrong
   kernel exactly and only post-compact.

2. **Each ranged slice rebuilt its cursors.** Every slice of one superfile
   independently re-fetched every term's full posting bytes and re-parsed
   its skip table (measured as 2.5x cold read amplification when slicing
   widened), and the work-unit allocator split the pool evenly per *file*
   (`ceil(threads/files)`), starving the one merged superfile that holds
   ~all the docs.

3. **Ranged kernels ran as multi-millisecond sync blocks on tokio
   workers.** Schedule reconstruction (per-unit start/end stamps) showed
   every query lost one slice to worker starvation: 7 slices finish at
   ~6 ms, one waits ~6 ms for a thread and lands at ~9.6 ms. This is the
   concurrency-contract violation CLAUDE.md warns about (CPU waves belong
   on the reader pool, bridged with a oneshot).

## Changes

- `search_or_range_pretokenized_with_floor` now mirrors the un-ranged
  kernel dispatch (windowed union when no term's upper bound dominates,
  BMM otherwise).
- `TermCursor` is `Clone` with the parsed skip table behind an `Arc`;
  `FtsReader::build_or_cursor_set` / `search_or_range_prebuilt` let one
  build serve every slice of a superfile. The supertable fan-out coalesces
  one build per (query, superfile) behind a `tokio::sync::OnceCell`.
- `build_work_units` allocates sub-ranges by doc mass
  (`round(docs_share x pool_threads)`, floored by `SUBRANGE_MIN_DOCS`)
  instead of evenly per file.
- Ranged kernels run as a rayon wave on `options.reader_pool`, bridged
  with a oneshot, keeping tokio workers free for wakeups.

All items are `pub(crate)`; the crate-root public surface is unchanged.

## Measured (1M docs, Azure, supertable FTS, warm p50 post-compact)

| shape          | before   | after fix 1 | after fix 2 | after fix 3 | pre-compact |
|----------------|----------|-------------|-------------|-------------|-------------|
| ten_term_or    | 25.5 ms  | 5.0 ms      | 3.3 ms      | 3.0 ms      | 2.2 ms      |
| twenty_term_or | 67.8 ms  | 8.7 ms      | 5.7 ms      | 5.1 ms      | 3.7 ms      |
| forty_term_or  | 151.9 ms | 17.3 ms     | 9.5 ms      | 8.5 ms      | 6.3 ms      |

Fix-3 columns were measured with temporary schedule instrumentation
enabled, which printed one line per work unit and so taxed pre-compact
(128 units/query) far more than post-compact (12): pre-compact appeared
inflated by ~0.5-3 ms in those runs. The pre-compact column above is
from instrumentation-free runs; fix-3 post-compact numbers carry ~0.2 ms
of print overhead and are, if anything, slightly pessimistic. The
instrumentation is not part of this change.
Fix 3 eliminates the measured one-starved-slice-per-query pattern (all
slice waits uniform at ~0.65 ms = the shared build) at the price of ~+20%
CPU-seconds per broad-OR query: with all eight kernels truly concurrent,
SMT contention on the 4C/8T box raises per-slice scan time (5.4->7.4 ms
spread), and the wall lands at the hardware's effective-thread ceiling.
Latency-vs-CPU-cost trade-off; the cost model prices the CPU side.

Cold I/O is unchanged or better throughout (post-compact cold-1st
16-17 GET / 8.5-11.5 MiB; steady 1-2 GET). `two_term_or` (the slicing-
overhead canary) is flat through fix 2; fix 3's oneshot round-trip adds
~0.1 ms to it (0.46 -> 0.55 ms with diagnostics on) — gating the bridge
on >= 3 should-terms would exempt trivial shapes if that matters.

## Tests

- Partition-equivalence: ranged results equal un-ranged results for any
  cut of the doc space, on BOTH dispatch branches, with assertions that
  each planted shape actually routes to the branch it covers.
- Prebuilt-vs-fresh equivalence over overlapping and repeated windows
  (guards walk-state leaks between cursor clones).
- Doc-mass allocation: merged file takes the whole pool, sub-floor
  remnants stay un-ranged, slices tile the doc space.
- Full FTS lib suite: 368 tests green; fmt + clippy -D warnings clean.

## Bench / verification status

- [x] 1M supertable-FTS A/B on Azure per change (numbers above)
- [x] Full `make bench` A/B against main (all tiers x modalities)
- [ ] Vector suite + recall@10 >= 0.99 gate (drain/query code shared paths)
- [ ] 10M FTS validation (<20 ms broad-OR target at scale)
- [ ] miri/asan: not required (no new `unsafe`)

## Notes for reviewers

- No env vars or diagnostics are added; the schedule attribution above
  was measured with temporary instrumentation that is not part of this
  change.
- The superfile tier's per-algorithm probes now exercise the windowed
  union alongside WAND+BMW and MaxScore+BMM (the shapes span both sides
  of `OR_WINDOW_DOMINANCE_MULT`), restoring the routing-heuristic
  validation the deleted `benches/fts_search.rs` used to provide; the
  stale references in the kernel doc comments are corrected.
- Kernels bridge to the reader pool only at >= RANGED_KERNEL_POOL_MIN_TERMS
  (= `OR_WINDOW_MIN_TERMS`, a shared constant so the two thresholds
  cannot drift): below it kernels are sub-millisecond and the oneshot
  round-trip costs more than it saves.