### PR TITLE
release: node 0.1.9

### DIFF
--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "infino-node"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-node/Cargo.toml
+++ b/infino-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-node"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.1.8",
-    "infx-darwin-arm64": "0.1.8",
-    "infx-linux-x64-gnu": "0.1.8",
-    "infx-linux-arm64-gnu": "0.1.8",
-    "infx-linux-x64-musl": "0.1.8",
-    "infx-linux-arm64-musl": "0.1.8"
+    "infx-darwin-x64": "0.1.9",
+    "infx-darwin-arm64": "0.1.9",
+    "infx-linux-x64-gnu": "0.1.9",
+    "infx-linux-arm64-gnu": "0.1.9",
+    "infx-linux-x64-musl": "0.1.9",
+    "infx-linux-arm64-musl": "0.1.9"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",


### PR DESCRIPTION
Release PR stamped by the `Release prep` workflow (scope: `node`).

| Package | Version |
| ------- | ------- |
| crate   | 0.1.10  |
| node    | 0.1.9   |
| python  | 0.1.9 |

On merge, `Release on merge` tags and publishes whichever of these changed — see docs/versioning.md.