### PR TITLE
supertable: tell an unindexed search column from an absent one

### DIFF
--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -1310,6 +1310,30 @@ mod tests {
 
     use crate::test_helpers::default_tokenizer as tok;
 
+    /// Vector width for the `require_*_column` fixtures.
+    const INDEX_DIM: usize = 16;
+
+    /// `[title (FTS), emb (vector)]` — each column indexed for one kind
+    /// only, so it is unindexed from the other kind's point of view.
+    fn indexed_opts() -> SupertableOptions {
+        SupertableOptions::new(
+            schema_with_vector(INDEX_DIM),
+            vec![fc("title")],
+            vec![vc("emb", INDEX_DIM)],
+            Some(tok()),
+        )
+        .expect("valid options")
+    }
+
+    /// The message of an [`QueryError::InvalidQuery`], which is the whole
+    /// contract for a column-naming mistake.
+    fn message(err: QueryError) -> String {
+        match err {
+            QueryError::InvalidQuery(m) => m,
+            other => panic!("expected InvalidQuery, got {other:?}"),
+        }
+    }
+
     #[test]
     fn valid_options_with_fts_and_vector_succeeds() {
         let s = schema_with_vector(16);
@@ -2071,36 +2095,17 @@ supertable:
         assert!(matches!(err, BuildError::Store(_)), "{err:?}");
     }
 
-    fn message(err: QueryError) -> String {
-        match err {
-            QueryError::InvalidQuery(m) => m,
-            other => panic!("expected InvalidQuery, got {other:?}"),
-        }
-    }
-
     #[test]
     fn require_column_resolves_an_indexed_column() {
-        let opts = SupertableOptions::new(
-            schema_with_vector(16),
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = indexed_opts();
         opts.require_fts_column("title").expect("title is indexed");
         let config = opts.require_vector_column("emb").expect("emb is indexed");
-        assert_eq!(config.dim, 16, "resolves the column's own config");
+        assert_eq!(config.dim, INDEX_DIM, "resolves the column's own config");
     }
 
     #[test]
     fn require_column_reports_the_indexed_columns_for_an_unindexed_one() {
-        let opts = SupertableOptions::new(
-            schema_with_vector(16),
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = indexed_opts();
         assert_eq!(
             message(
                 opts.require_fts_column("emb")
@@ -2124,7 +2129,7 @@ supertable:
     /// search.
     #[test]
     fn require_column_reports_an_empty_indexed_set() {
-        let opts = SupertableOptions::new(schema_with_vector(16), vec![], vec![], None)
+        let opts = SupertableOptions::new(schema_with_vector(INDEX_DIM), vec![], vec![], None)
             .expect("valid options");
         assert!(
             message(opts.require_fts_column("title").expect_err("no FTS index"))
@@ -2141,13 +2146,7 @@ supertable:
 
     #[test]
     fn require_column_distinguishes_an_absent_column() {
-        let opts = SupertableOptions::new(
-            schema_with_vector(16),
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = indexed_opts();
         for err in [
             opts.require_fts_column("ghost")
                 .expect_err("no such column"),

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -50,7 +50,7 @@ use rayon::{ThreadPool, ThreadPoolBuilder};
 use tokio::sync::Mutex as TokioMutex;
 
 use super::{
-    error::BuildError,
+    error::{BuildError, QueryError},
     reader_cache::{
         ColdFetchMode, DiskCacheConfig, DiskCacheStore, InMemoryReaderCache, LruPolicy,
         SuperfileReaderCache,
@@ -781,14 +781,61 @@ impl SupertableOptions {
 
     /// Tokenizer configured for `column`, for tokenizing query text so
     /// it matches how the column was indexed. Falls back to the ASCII
-    /// default when `column` is not a registered FTS column (the query
-    /// then fails downstream on the unknown column).
+    /// default when `column` is not a registered FTS column (callers
+    /// reject that case up front via [`Self::require_fts_column`]).
     pub fn fts_tokenizer_for(&self, column: &str) -> Arc<dyn Tokenizer> {
         self.fts_columns
             .iter()
             .position(|c| c.column == column)
             .and_then(|i| self.fts_tokenizers.get(i).cloned())
             .unwrap_or_else(|| Arc::new(AsciiLowerTokenizer))
+    }
+
+    /// Reject `column` unless it carries a full-text index. The search
+    /// paths call this before any fan-out, so an absent and an unindexed
+    /// column are told apart regardless of what the superfiles hold.
+    pub(crate) fn require_fts_column(&self, column: &str) -> Result<(), QueryError> {
+        if self.fts_columns.iter().any(|c| c.column == column) {
+            return Ok(());
+        }
+        Err(self.no_index(
+            column,
+            "full-text",
+            self.fts_columns.iter().map(|c| c.column.as_str()),
+        ))
+    }
+
+    /// Resolve `column`'s vector index — see [`Self::require_fts_column`].
+    pub(crate) fn require_vector_column(&self, column: &str) -> Result<&VectorConfig, QueryError> {
+        self.vector_columns
+            .iter()
+            .find(|c| c.column == column)
+            .ok_or_else(|| {
+                self.no_index(
+                    column,
+                    "vector",
+                    self.vector_columns.iter().map(|c| c.column.as_str()),
+                )
+            })
+    }
+
+    /// The error for a column carrying no `kind` index, distinguishing a
+    /// name absent from the schema from one that is merely unindexed.
+    fn no_index<'a>(
+        &self,
+        column: &str,
+        kind: &str,
+        declared: impl Iterator<Item = &'a str>,
+    ) -> QueryError {
+        if !self.schema.fields().iter().any(|f| f.name() == column) {
+            return QueryError::InvalidQuery(format!("no column `{column}` in this table"));
+        }
+        let declared: Vec<&str> = declared.collect();
+        QueryError::InvalidQuery(format!(
+            "column `{column}` has no {kind} index (indexed: [{}]); \
+             search indexes are declared when the table is created and cannot be added later",
+            declared.join(", ")
+        ))
     }
 
     /// Attach a disk cache for storage-backed reads.
@@ -2022,5 +2069,92 @@ supertable:
             .apply_config(&cfg)
             .expect_err("missing container");
         assert!(matches!(err, BuildError::Store(_)), "{err:?}");
+    }
+
+    fn message(err: QueryError) -> String {
+        match err {
+            QueryError::InvalidQuery(m) => m,
+            other => panic!("expected InvalidQuery, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn require_column_resolves_an_indexed_column() {
+        let opts = SupertableOptions::new(
+            schema_with_vector(16),
+            vec![fc("title")],
+            vec![vc("emb", 16)],
+            Some(tok()),
+        )
+        .expect("valid options");
+        opts.require_fts_column("title").expect("title is indexed");
+        let config = opts.require_vector_column("emb").expect("emb is indexed");
+        assert_eq!(config.dim, 16, "resolves the column's own config");
+    }
+
+    #[test]
+    fn require_column_reports_the_indexed_columns_for_an_unindexed_one() {
+        let opts = SupertableOptions::new(
+            schema_with_vector(16),
+            vec![fc("title")],
+            vec![vc("emb", 16)],
+            Some(tok()),
+        )
+        .expect("valid options");
+        assert_eq!(
+            message(
+                opts.require_fts_column("emb")
+                    .expect_err("emb has no FTS index")
+            ),
+            "column `emb` has no full-text index (indexed: [title]); search indexes are declared \
+             when the table is created and cannot be added later"
+        );
+        assert_eq!(
+            message(
+                opts.require_vector_column("title")
+                    .expect_err("title has no vector index")
+            ),
+            "column `title` has no vector index (indexed: [emb]); search indexes are declared \
+             when the table is created and cannot be added later"
+        );
+    }
+
+    /// A table with no indexes names an empty indexed set rather than
+    /// claiming the column is absent — it isn't, it just has nothing to
+    /// search.
+    #[test]
+    fn require_column_reports_an_empty_indexed_set() {
+        let opts = SupertableOptions::new(schema_with_vector(16), vec![], vec![], None)
+            .expect("valid options");
+        assert!(
+            message(opts.require_fts_column("title").expect_err("no FTS index"))
+                .contains("has no full-text index (indexed: [])")
+        );
+        assert!(
+            message(
+                opts.require_vector_column("emb")
+                    .expect_err("no vector index")
+            )
+            .contains("has no vector index (indexed: [])")
+        );
+    }
+
+    #[test]
+    fn require_column_distinguishes_an_absent_column() {
+        let opts = SupertableOptions::new(
+            schema_with_vector(16),
+            vec![fc("title")],
+            vec![vc("emb", 16)],
+            Some(tok()),
+        )
+        .expect("valid options");
+        for err in [
+            opts.require_fts_column("ghost")
+                .expect_err("no such column"),
+            opts.require_vector_column("ghost")
+                .expect_err("no such column"),
+        ] {
+            assert_eq!(message(err), "no column `ghost` in this table");
+        }
     }
 }

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -266,10 +266,11 @@ impl SupertableReader {
         k: usize,
         mode: BoolMode,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        let manifest = self.manifest();
+        manifest.options.require_fts_column(column)?;
         if k == 0 {
             return Ok(Vec::new());
         }
-        let manifest = self.manifest();
         let pool_threads = manifest.options.reader_pool.current_num_threads();
         let column_owned = column.to_owned();
 
@@ -499,10 +500,11 @@ impl SupertableReader {
         prefix: &str,
         k: usize,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        let manifest = self.manifest();
+        manifest.options.require_fts_column(column)?;
         if k == 0 {
             return Ok(Vec::new());
         }
-        let manifest = self.manifest();
         let pool_threads = manifest.options.reader_pool.current_num_threads();
         let column_owned = column.to_owned();
         let prefix_owned = prefix.to_owned();
@@ -601,8 +603,9 @@ impl SupertableReader {
         ),
         QueryError,
     > {
-        let clauses = self
-            .manifest()
+        let manifest = self.manifest();
+        manifest.options.require_fts_column(column)?;
+        let clauses = manifest
             .options
             .fts_tokenizer_for(column)
             .parse(query)
@@ -912,6 +915,7 @@ impl SupertableReader {
         value: &str,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
         let manifest = self.manifest();
+        manifest.options.require_fts_column(column)?;
         let term_strings: Vec<String> = manifest
             .options
             .fts_tokenizer_for(column)
@@ -1909,7 +1913,12 @@ mod tests {
         let err = r
             .bm25_hits("missing_column", "rust", 5, BoolMode::Or)
             .expect_err("expected error");
-        assert!(matches!(err, QueryError::Parquet(_)), "got {err:?}");
+        // Rejected up front by name, not as a per-superfile scan failure —
+        // a column that isn't in the schema is a caller error, not I/O.
+        assert!(
+            matches!(&err, QueryError::InvalidQuery(m) if m.contains("no column `missing_column`")),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1245,10 +1245,9 @@ impl SupertableReader {
         // fp32 centroids. Rank every (superfile, cluster) with [`distance`]
         // on the resident centroid slices (zero-copy, no dequant), then
         // probe only the globally-closest clusters.
-        // Undeclared column = caller error, rejected here — not a silent
-        // L2Sq default that fails later with a per-superfile decode error.
-        // `rot_seed` feeds the 1-bit admit prefilter (same rotation as the
-        // column's row codes).
+        // The column is already validated at every entry point; this
+        // re-resolves it for its metric and `rot_seed`, which feeds the
+        // 1-bit admit prefilter (same rotation as the column's row codes).
         let (metric, rot_seed) = manifest
             .options
             .require_vector_column(column)
@@ -1902,10 +1901,11 @@ impl SupertableReader {
         options: VectorSearchOptions,
         plan: &CandidatePlan,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        let manifest = self.manifest();
+        manifest.options.require_vector_column(column)?;
         if k == 0 {
             return Ok(Vec::new());
         }
-        let manifest = self.manifest();
         let superfiles = match plan.surviving_superfile_ids(manifest).await? {
             None => manifest
                 .get_all_superfiles_loaded()
@@ -2298,6 +2298,7 @@ impl SupertableReader {
         options: VectorSearchOptions,
         prepared: &PreparedGlobalAllow,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        self.manifest().options.require_vector_column(column)?;
         if k == 0 || prepared.allow_by_uri.is_empty() {
             return Ok(Vec::new());
         }

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1251,11 +1251,8 @@ impl SupertableReader {
         // column's row codes).
         let (metric, rot_seed) = manifest
             .options
-            .vector_columns
-            .iter()
-            .find(|vc| vc.column == column)
-            .map(|vc| (vc.metric, vc.rot_seed))
-            .ok_or_else(|| QueryError::Execute(format!("unknown vector column `{column}`")))?;
+            .require_vector_column(column)
+            .map(|vc| (vc.metric, vc.rot_seed))?;
 
         let grid = manifest
             .global_vector_index()
@@ -1778,10 +1775,11 @@ impl SupertableReader {
         options: VectorSearchOptions,
         filter: VectorFilter<'_>,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        let manifest = self.manifest();
+        manifest.options.require_vector_column(column)?;
         if k == 0 {
             return Ok(Vec::new());
         }
-        let manifest = self.manifest();
         // Tokenize the predicate once with the index tokenizer (the same
         // tokenizer used at build time, so the terms match the postings AND
         // the manifest term blooms). No tokens (empty / punctuation-only) ⇒
@@ -2419,10 +2417,11 @@ impl SupertableReader {
         k: usize,
         options: VectorSearchOptions,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        let manifest = self.manifest();
+        manifest.options.require_vector_column(column)?;
         if k == 0 {
             return Ok(Vec::new());
         }
-        let manifest = self.manifest();
         let superfiles = manifest
             .get_all_superfiles_loaded()
             .await
@@ -2443,6 +2442,7 @@ impl SupertableReader {
         k: usize,
         options: VectorSearchOptions,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        self.manifest().options.require_vector_column(column)?;
         if k == 0 {
             return Ok(Vec::new());
         }
@@ -3490,7 +3490,7 @@ mod tests {
         // not the old shape (silent metric default + blind per-superfile
         // probe, surfacing later as a kernel decode error).
         assert!(
-            matches!(&err, QueryError::Execute(m) if m.contains("unknown vector column")),
+            matches!(&err, QueryError::InvalidQuery(m) if m.contains("no column `nope`")),
             "got {err:?}"
         );
     }

--- a/tests/supertable/query/query_errors.rs
+++ b/tests/supertable/query/query_errors.rs
@@ -169,6 +169,17 @@ fn assert_all_error(st: &Supertable, label: &str, queries: &[String]) {
     }
 }
 
+/// Assert `query` is rejected with a message containing `expected`. For a
+/// column-naming mistake the message *is* the contract — it's the only
+/// thing telling the caller which of the two mistakes they made.
+fn assert_error_contains(st: &Supertable, query: &str, expected: &str) {
+    let err = st.reader().query_sql(query).expect_err(query).to_string();
+    assert!(
+        err.contains(expected),
+        "expected {expected:?} in the error for {query}, got: {err}"
+    );
+}
+
 // ---------------------------------------------------------------------
 // bm25_search — arity + type validators in fts_exec.rs::Bm25SearchFunc.
 // ---------------------------------------------------------------------
@@ -476,6 +487,104 @@ fn empty_result_queries_return_no_rows() {
     ] {
         let b = st.reader().query_sql(&q).expect("empty-result query");
         assert_eq!(row_count(&b), 0, "expected no matches: {q}");
+    }
+}
+
+// ---------------------------------------------------------------------
+// Column naming — an absent column vs an unindexed one.
+// ---------------------------------------------------------------------
+
+/// Expected rejection for a schema column with no FTS index, over the
+/// `[title (FTS), rating, emb (vector)]` fixture.
+const NO_FTS: &str = "has no full-text index (indexed: [title])";
+/// The vector-side counterpart of [`NO_FTS`].
+const NO_VECTOR: &str = "has no vector index (indexed: [emb])";
+
+/// Every search TVF, driven against a schema column that carries no index
+/// of the kind it searches. The message must name the kind and list the
+/// columns that do carry it: the schema reports the column as present, so
+/// "unknown column" would send the caller hunting a typo that isn't there.
+#[test]
+fn unindexed_column_errors_name_the_indexed_columns() {
+    let st = demo_table();
+    let qv = csv_one_hot(0);
+    for (query, expected) in [
+        (
+            format!("SELECT _id FROM bm25_search('rating', 'rust', {SURFACE_TOP_K})"),
+            NO_FTS,
+        ),
+        (
+            format!("SELECT _id FROM bm25_search_prefix('emb', 'rus', {SURFACE_TOP_K})"),
+            NO_FTS,
+        ),
+        (
+            "SELECT _id FROM token_match('rating', 'rust')".into(),
+            NO_FTS,
+        ),
+        (
+            "SELECT _id FROM exact_match('rating', 'rust async')".into(),
+            NO_FTS,
+        ),
+        (
+            format!("SELECT _id FROM vector_search('title', '{qv}', {SURFACE_TOP_K})"),
+            NO_VECTOR,
+        ),
+        // Hybrid fuses both retrievers: a bad column on either side is an
+        // error, never a side that silently contributes nothing.
+        (
+            format!(
+                "SELECT _id FROM hybrid_search('rating', 'rust', 'emb', '{qv}', {SURFACE_TOP_K})"
+            ),
+            NO_FTS,
+        ),
+        (
+            format!(
+                "SELECT _id FROM hybrid_search('title', 'rust', 'title', '{qv}', {SURFACE_TOP_K})"
+            ),
+            NO_VECTOR,
+        ),
+    ] {
+        assert_error_contains(&st, &query, expected);
+    }
+}
+
+/// A name absent from the schema reports exactly that, not the unindexed
+/// message — the two mistakes have different fixes.
+#[test]
+fn absent_column_errors_say_no_such_column() {
+    let st = demo_table();
+    let qv = csv_one_hot(0);
+    for query in [
+        format!("SELECT _id FROM bm25_search('ghost', 'rust', {SURFACE_TOP_K})"),
+        format!("SELECT _id FROM vector_search('ghost', '{qv}', {SURFACE_TOP_K})"),
+        "SELECT _id FROM token_match('ghost', 'rust')".into(),
+    ] {
+        assert_error_contains(&st, &query, "no column `ghost` in this table");
+    }
+}
+
+/// The checks read the table's declared indexes, not the committed
+/// superfiles, so an empty table rejects a bad column instead of answering
+/// it with an empty result set.
+#[test]
+fn column_checks_apply_before_the_first_commit() {
+    let st = Supertable::create(options_title_rating_emb()).expect("create");
+    let qv = csv_one_hot(0);
+    for (query, expected) in [
+        (
+            format!("SELECT _id FROM bm25_search('rating', 'rust', {SURFACE_TOP_K})"),
+            "has no full-text index",
+        ),
+        (
+            format!("SELECT _id FROM vector_search('title', '{qv}', {SURFACE_TOP_K})"),
+            "has no vector index",
+        ),
+        (
+            "SELECT _id FROM token_match('ghost', 'rust')".into(),
+            "no column `ghost`",
+        ),
+    ] {
+        assert_error_contains(&st, &query, expected);
     }
 }
 

--- a/tests/supertable/query/query_errors.rs
+++ b/tests/supertable/query/query_errors.rs
@@ -548,6 +548,36 @@ fn unindexed_column_errors_name_the_indexed_columns() {
     }
 }
 
+/// A predicate that survives no rows must not swallow the column check:
+/// the filtered and allow-set vector paths short-circuit on an empty
+/// candidate set, and that early return sits ahead of the fan-out.
+#[test]
+fn column_checks_survive_a_predicate_that_matches_nothing() {
+    let st = demo_table();
+    let qv = csv_one_hot(0);
+    for query in [
+        // Scalar predicate: not FTS-resolvable, so the kNN runs unbounded.
+        format!(
+            "SELECT _id FROM vector_search('title', '{qv}', {SURFACE_TOP_K}) WHERE rating > 9999"
+        ),
+        // FTS-resolvable predicate matching nothing: lowers to a bounded
+        // candidate plan whose surviving set is empty.
+        format!(
+            "SELECT _id FROM vector_search('title', '{qv}', {SURFACE_TOP_K}) \
+             WHERE title = 'zzzznomatch'"
+        ),
+        format!(
+            "SELECT _id FROM vector_search('ghost', '{qv}', {SURFACE_TOP_K}) \
+             WHERE title = 'zzzznomatch'"
+        ),
+    ] {
+        assert!(
+            st.reader().query_sql(&query).is_err(),
+            "a bad column must error even when the predicate prunes everything: {query}"
+        );
+    }
+}
+
 /// A name absent from the schema reports exactly that, not the unindexed
 /// message — the two mistakes have different fixes.
 #[test]


### PR DESCRIPTION
Searching a column that exists but carries no index of the kind being
searched produced a message indistinguishable from searching a column that
doesn't exist at all:

```
vector_search("emb2", …)  →  unknown vector column `emb2`
vector_search("nope", …)  →  unknown vector column `nope`
```

`emb2` is in the schema — it just has no ANN index, which the schema can't
show. The identical message sends the caller hunting a typo that isn't
there, when the real fix is to declare the index (and the table has to be
recreated to gain one, since index specs are create-time only).

The FTS side was worse: `bm25_search` on an unindexed column surfaced as
`error reading parquet bytes during scan: FTS error: unknown FTS column
"other"` — a config mistake wearing an I/O error's clothing, pointing
debugging at the storage layer.

## What changed

`SupertableOptions::require_fts_column` / `require_vector_column` resolve a
search column's role and, on failure, say which of the two mistakes it is:

```
column `rating` has no full-text index (indexed: [title]); search indexes
are declared when the table is created and cannot be added later

no column `ghost` in this table
```

They sit beside the existing `fts_tokenizer_for`, the other per-column
lookup on that type. Both return `QueryError::InvalidQuery` rather than
`Execute`/`Parquet`, which is what a caller-supplied bad name actually is.

Every search entry point that takes a column now resolves it before any
fan-out — four on the FTS side (`bm25_search`, `bm25_search_prefix`,
`parse_and_prune` covering `token_match`/`count`, `exact_match`) and five
on the vector side, including the filtered and allow-set paths.

## Empty candidate sets no longer swallow the check

Checking inside the fan-out meant every early return ahead of it answered a
bad column with an empty result instead of an error. Two were reachable:

- an empty table (no commits) — nothing to fan out over;
- `vector_hits_filtered_by_plan` with an FTS-bounded predicate matching no
  rows, e.g. `vector_search('title', …) WHERE title = 'zzzznomatch'`,
  which returns before the fan-out on `surviving.is_empty()`.

Both are covered by regression tests that fail without the fix.

## Notes

- Public API unchanged (`make public-api` clean); the new methods are
  `pub(crate)`.
- `QueryError` variants all map to `InfinoError::Query`, so the variant
  change doesn't move any HTTP status a caller sees.
- No bench run: this is an error-path change, adding one name comparison
  over a list that is almost always length 1-2, ahead of any I/O.
