### PR TITLE
bench: load vector ground truth from the oracle bin on reopen

### DIFF
--- a/benches/utils/corpus/grading.rs
+++ b/benches/utils/corpus/grading.rs
@@ -187,6 +187,9 @@ pub fn load_oracle(path: &Path) -> Result<CachedOracle> {
     let top_k = key.top_k as usize;
     let base = pull_ground_truth(&mut cursor, key.query_count as usize, top_k)?;
     let correctness = key.correctness_query_count as usize;
+    if correctness > queries.len() {
+        return invalid_data("lifecycle ground-truth cache correctness count exceeds query count");
+    }
     let filtered = pull_ground_truth(&mut cursor, correctness, top_k)?;
     let augmented = pull_ground_truth(&mut cursor, correctness, top_k)?;
     if !cursor.is_empty() {
@@ -381,6 +384,16 @@ fn pull_queries(cursor: &mut &[u8]) -> Result<Vec<Vec<f32>>> {
     let dim = read_u64(cursor)? as usize;
     if dim != DIM {
         return invalid_data("lifecycle ground-truth cache query dim mismatch");
+    }
+    // Bound the claimed count by the bytes actually present before allocating,
+    // so a corrupt count can't drive a huge Vec::with_capacity (mirrors the
+    // validate-before-allocate guard in pull_ground_truth).
+    if count
+        .checked_mul(dim)
+        .and_then(|n| n.checked_mul(4))
+        .is_none_or(|need| need > cursor.len())
+    {
+        return invalid_data("lifecycle ground-truth cache query count exceeds buffer");
     }
     let mut queries = Vec::with_capacity(count);
     for _ in 0..count {

--- a/benches/utils/corpus/grading.rs
+++ b/benches/utils/corpus/grading.rs
@@ -142,6 +142,69 @@ pub fn lifecycle_ground_truth_cached(options: LifecycleGradingOptions<'_>) -> Li
     labels
 }
 
+/// Held-out queries + exact labels loaded straight from a persisted oracle
+/// bin, without the corpus. Both the full-corpus vector bench (reopen /
+/// read-sweep) and the streaming recall bench (keep-table read-sweep) use this
+/// to skip their own ground-truth construction — the on-disk corpus brute
+/// force and the inline running heaps respectively — since the bin already
+/// holds both the queries and the labels.
+pub struct CachedOracle {
+    pub queries: Vec<Vec<f32>>,
+    pub labels: LifecycleGroundTruth,
+    pub n_docs: usize,
+    pub top_k: usize,
+    /// `queries[..correctness_query_count]` are the correctness queries; the
+    /// remainder (if any) are calibration queries. `labels.base` splits at the
+    /// same index.
+    pub correctness_query_count: usize,
+}
+
+/// The explicit oracle-bin path (`INFINO_BENCH_VECTOR_GROUND_TRUTH_PATH`), if set.
+pub fn oracle_path() -> Option<PathBuf> {
+    env::var_os(GROUND_TRUTH_PATH_ENV).map(PathBuf::from)
+}
+
+/// Read queries + exact labels from a persisted oracle bin (`INFLGT02`) without
+/// preparing the corpus. Row counts come from the embedded key, so no expected
+/// query set is needed (that is the whole point — the caller has no corpus to
+/// regenerate the queries from).
+pub fn load_oracle(path: &Path) -> Result<CachedOracle> {
+    let bytes = fs::read(path)?;
+    let mut cursor = bytes.as_slice();
+    let mut magic = [0u8; CACHE_MAGIC.len()];
+    read_exact(&mut cursor, &mut magic)?;
+    if &magic != CACHE_MAGIC {
+        return invalid_data("bad lifecycle ground-truth cache magic");
+    }
+    if read_u32(&mut cursor)? != CACHE_VERSION {
+        return invalid_data("lifecycle ground-truth cache version mismatch");
+    }
+    let key = pull_key(&mut cursor)?;
+    let queries = pull_queries(&mut cursor)?;
+    if queries.len() as u64 != key.query_count {
+        return invalid_data("lifecycle ground-truth cache query count mismatch");
+    }
+    let top_k = key.top_k as usize;
+    let base = pull_ground_truth(&mut cursor, key.query_count as usize, top_k)?;
+    let correctness = key.correctness_query_count as usize;
+    let filtered = pull_ground_truth(&mut cursor, correctness, top_k)?;
+    let augmented = pull_ground_truth(&mut cursor, correctness, top_k)?;
+    if !cursor.is_empty() {
+        return invalid_data("lifecycle ground-truth cache has trailing bytes");
+    }
+    Ok(CachedOracle {
+        queries,
+        labels: LifecycleGroundTruth {
+            base,
+            filtered,
+            augmented,
+        },
+        n_docs: key.n_docs as usize,
+        top_k,
+        correctness_query_count: correctness,
+    })
+}
+
 fn validate_options(options: &LifecycleGradingOptions<'_>) {
     assert!(options.n_docs > 0);
     assert!(options.n_docs <= options.augmented_docs);
@@ -313,6 +376,23 @@ fn validate_queries(cursor: &mut &[u8], expected: &[Vec<f32>]) -> Result<()> {
     Ok(())
 }
 
+fn pull_queries(cursor: &mut &[u8]) -> Result<Vec<Vec<f32>>> {
+    let count = read_u64(cursor)? as usize;
+    let dim = read_u64(cursor)? as usize;
+    if dim != DIM {
+        return invalid_data("lifecycle ground-truth cache query dim mismatch");
+    }
+    let mut queries = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut query = Vec::with_capacity(dim);
+        for _ in 0..dim {
+            query.push(f32::from_bits(read_u32(cursor)?));
+        }
+        queries.push(query);
+    }
+    Ok(queries)
+}
+
 fn push_ground_truth(bytes: &mut Vec<u8>, labels: &[Vec<u32>], top_k: usize) {
     bytes.extend_from_slice(&(labels.len() as u64).to_le_bytes());
     for row in labels {
@@ -467,5 +547,38 @@ mod tests {
                 .kind(),
             ErrorKind::InvalidData
         );
+    }
+
+    #[test]
+    fn load_oracle_recovers_queries_and_labels_without_corpus() {
+        let directory = tempdir().expect("tempdir");
+        let path = directory.path().join("grading.bin");
+        let (_vectors, queries, key, labels) = fixture();
+        write_cache(&path, key, &queries, &labels).expect("write");
+
+        // No expected query set, no corpus — everything comes from the bin.
+        let oracle = load_oracle(&path).expect("load");
+        assert_eq!(oracle.queries, queries);
+        assert_eq!(oracle.labels.base, labels.base);
+        assert_eq!(oracle.labels.filtered, labels.filtered);
+        assert_eq!(oracle.labels.augmented, labels.augmented);
+        assert_eq!(oracle.n_docs, TEST_N_DOCS);
+        assert_eq!(oracle.top_k, TEST_TOP_K);
+        assert_eq!(oracle.correctness_query_count, TEST_N_CORRECTNESS_QUERIES);
+
+        // The correctness split matches how the reopen path reconstructs
+        // q_correct / q_cal and their labels.
+        assert_eq!(
+            &oracle.queries[..oracle.correctness_query_count],
+            &queries[..TEST_N_CORRECTNESS_QUERIES]
+        );
+        assert_eq!(
+            oracle.queries.len() - oracle.correctness_query_count,
+            TEST_N_QUERIES - TEST_N_CORRECTNESS_QUERIES
+        );
+
+        let truncated = fs::read(&path).expect("bytes");
+        fs::write(&path, &truncated[..truncated.len() - 1]).expect("truncate");
+        assert!(load_oracle(&path).is_err(), "truncated bin must error");
     }
 }

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1742,7 +1742,14 @@ pub mod vector {
         title: String,
         note: &str,
     ) -> Vec<RecallRow> {
-        let q0 = &q_cal[0];
+        // Representative query for the latency probes below. Prefer a
+        // calibration query; fall back to the correctness set, which a
+        // skip-calibration reopen loads from the oracle bin without any
+        // calibration queries (so `q_cal` is legitimately empty there).
+        let q0 = q_cal
+            .first()
+            .or_else(|| q_correct.first())
+            .expect("run_search needs at least one held-out query");
         let mut rows: Vec<RecallRow> = Vec::new();
         let default_recall: Option<f32>;
         if skip_calibration {

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -4056,7 +4056,12 @@ pub mod vector {
                                             &q_cal[..]
                                         },
                                     ),
-                                    None => (&q_correct[0], &q_correct[1..]),
+                                    None => (
+                                        q_correct
+                                            .first()
+                                            .expect("correctness query set is non-empty"),
+                                        &q_correct[1..],
+                                    ),
                                 };
                             measure_cold_store(
                                 "steady-state",

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -3120,10 +3120,36 @@ pub mod vector {
         // gate are forced off below and queries are corpus-free.
         let existing = tiers::block_on(tiers::existing_supertable_storage_fixture());
 
-        // Always prepare the corpus for vector benches so recall is always
-        // measurable (including existing-prefix runs).
+        // On a reopen (existing prefix) with a persisted oracle bin, load the
+        // held-out queries + exact labels straight from the bin and skip the
+        // corpus entirely: the bin already holds both, so regenerating the
+        // (potentially ~400 GB) corpus solely to rebuild the query vectors is
+        // pure waste. Fresh ingest / dataset / bin-less reopen still prepare it.
+        let reopen_oracle = if existing.is_some() && (phases.warm || phases.cold) {
+            corpus::grading::oracle_path()
+                .filter(|path| path.exists())
+                .map(|path| {
+                    let oracle = corpus::grading::load_oracle(&path).unwrap_or_else(|error| {
+                        panic!("failed to load oracle bin {}: {error}", path.display())
+                    });
+                    eprintln!(
+                        "[vector reopen] loaded {} queries + labels from oracle bin {}; \
+                         skipping corpus regeneration",
+                        oracle.queries.len(),
+                        path.display()
+                    );
+                    oracle
+                })
+        } else {
+            None
+        };
+
         crate::rss::log_rss_breakdown("supertable_vector before corpus prepare");
-        let mut corpus = Some(supertable::prepare_corpus(Modality::Vector));
+        let mut corpus = if reopen_oracle.is_some() {
+            None
+        } else {
+            Some(supertable::prepare_corpus(Modality::Vector))
+        };
         crate::rss::log_rss_breakdown("supertable_vector after corpus prepare");
 
         let (built, ingest_metrics) = if let Some(fixture) = existing {
@@ -3168,69 +3194,97 @@ pub mod vector {
             let nprobe = fixed_nprobe();
             let rerank = fixed_rerank_mult();
 
-            let (q_correct, q_cal, gt_correct, gt_cal, filtered_gt, augmented_gt) = {
-                let corpus = corpus
-                    .as_ref()
-                    .expect("vector benches always prepare a corpus");
-                // The ingested vectors are still mmapped from the prepared
-                // corpus — queries and ground truth come from them instead
-                // of a regeneration. Skip-calibration still computes
-                // correctness/default recall (and filtered recall); it only
-                // skips the recall-target calibration sweep.
-                let vslice = corpus
-                    .vectors()
-                    .expect("vector modality prepared a vector corpus")
-                    .as_slice();
-                let base_vectors = &vslice[..n_docs * DIM];
-                let q_correct = corpus::generate_realistic_queries(
-                    base_vectors,
-                    n_docs,
-                    N_CORRECTNESS_QUERIES,
-                    QUERY_CORRECTNESS_SEED,
-                    true,
-                    QUERY_SIGMA,
-                );
-                let q_cal = corpus::generate_realistic_queries(
-                    base_vectors,
-                    n_docs,
-                    N_CALIBRATION_QUERIES,
-                    QUERY_CALIBRATION_SEED,
-                    true,
-                    QUERY_SIGMA,
-                );
-                let augmented_docs = n_docs + supertable::docs_per_commit();
-                let all_queries: Vec<Vec<f32>> = if skip_cal {
-                    q_correct.clone()
+            let (q_correct, q_cal, gt_correct, gt_cal, filtered_gt, augmented_gt) =
+                if let Some(oracle) = reopen_oracle {
+                    // Reopen: queries + exact labels came straight from the
+                    // persisted oracle bin, so no corpus was prepared. Split the
+                    // combined query/label sets at the correctness boundary exactly
+                    // as the corpus path does below.
+                    let corpus::grading::CachedOracle {
+                        mut queries,
+                        mut labels,
+                        n_docs: oracle_docs,
+                        top_k: oracle_top_k,
+                        correctness_query_count,
+                    } = oracle;
+                    assert_eq!(
+                        oracle_docs, n_docs,
+                        "oracle bin n_docs does not match the reopened table"
+                    );
+                    assert_eq!(oracle_top_k, TOP_K, "oracle bin top_k mismatch");
+                    let q_cal = queries.split_off(correctness_query_count);
+                    let gt_cal = labels.base.split_off(correctness_query_count);
+                    (
+                        queries,
+                        q_cal,
+                        labels.base,
+                        gt_cal,
+                        Some(labels.filtered),
+                        labels.augmented,
+                    )
                 } else {
-                    q_correct.iter().chain(&q_cal).cloned().collect()
-                };
-                let mut labels = corpus::grading::lifecycle_ground_truth_cached(
-                    corpus::grading::LifecycleGradingOptions {
-                        vectors: vslice,
+                    let corpus = corpus
+                        .as_ref()
+                        .expect("vector benches always prepare a corpus");
+                    // The ingested vectors are still mmapped from the prepared
+                    // corpus — queries and ground truth come from them instead
+                    // of a regeneration. Skip-calibration still computes
+                    // correctness/default recall (and filtered recall); it only
+                    // skips the recall-target calibration sweep.
+                    let vslice = corpus
+                        .vectors()
+                        .expect("vector modality prepared a vector corpus")
+                        .as_slice();
+                    let base_vectors = &vslice[..n_docs * DIM];
+                    let q_correct = corpus::generate_realistic_queries(
+                        base_vectors,
                         n_docs,
-                        augmented_docs,
-                        corpus_seed: supertable::CORPUS_VEC_SEED,
-                        normalized_vectors: true,
-                        filter_keep_every: FILTER_KEEP_EVERY,
-                        top_k: TOP_K,
-                        correctness_query_count: q_correct.len(),
-                        queries: &all_queries,
-                    },
-                );
-                let gt_cal = if skip_cal {
-                    Vec::new()
-                } else {
-                    labels.base.split_off(q_correct.len())
+                        N_CORRECTNESS_QUERIES,
+                        QUERY_CORRECTNESS_SEED,
+                        true,
+                        QUERY_SIGMA,
+                    );
+                    let q_cal = corpus::generate_realistic_queries(
+                        base_vectors,
+                        n_docs,
+                        N_CALIBRATION_QUERIES,
+                        QUERY_CALIBRATION_SEED,
+                        true,
+                        QUERY_SIGMA,
+                    );
+                    let augmented_docs = n_docs + supertable::docs_per_commit();
+                    let all_queries: Vec<Vec<f32>> = if skip_cal {
+                        q_correct.clone()
+                    } else {
+                        q_correct.iter().chain(&q_cal).cloned().collect()
+                    };
+                    let mut labels = corpus::grading::lifecycle_ground_truth_cached(
+                        corpus::grading::LifecycleGradingOptions {
+                            vectors: vslice,
+                            n_docs,
+                            augmented_docs,
+                            corpus_seed: supertable::CORPUS_VEC_SEED,
+                            normalized_vectors: true,
+                            filter_keep_every: FILTER_KEEP_EVERY,
+                            top_k: TOP_K,
+                            correctness_query_count: q_correct.len(),
+                            queries: &all_queries,
+                        },
+                    );
+                    let gt_cal = if skip_cal {
+                        Vec::new()
+                    } else {
+                        labels.base.split_off(q_correct.len())
+                    };
+                    (
+                        q_correct,
+                        q_cal,
+                        labels.base,
+                        gt_cal,
+                        Some(labels.filtered),
+                        labels.augmented,
+                    )
                 };
-                (
-                    q_correct,
-                    q_cal,
-                    labels.base,
-                    gt_cal,
-                    Some(labels.filtered),
-                    labels.augmented,
-                )
-            };
             // Queries + ground truth extracted. Keep the mapping for the
             // normal follow-up commit, but evict its pages while measuring
             // pre/post-drain search.
@@ -3989,15 +4043,26 @@ pub mod vector {
                     phases
                         .cold
                         .then(|| {
+                            // Latency probe only (not graded); a skip-calibration
+                            // reopen loads no calibration queries, so q_cal is
+                            // empty there -- fall back to the correctness set.
+                            let (cold_probe, cold_rest): (&Vec<f32>, &[Vec<f32>]) =
+                                match q_cal.first() {
+                                    Some(first) => (
+                                        first,
+                                        if q_cal.len() > 1 {
+                                            &q_cal[1..]
+                                        } else {
+                                            &q_cal[..]
+                                        },
+                                    ),
+                                    None => (&q_correct[0], &q_correct[1..]),
+                                };
                             measure_cold_store(
                                 "steady-state",
                                 &built,
-                                &q_cal[0],
-                                if q_cal.len() > 1 {
-                                    &q_cal[1..]
-                                } else {
-                                    &q_cal[..]
-                                },
+                                cold_probe,
+                                cold_rest,
                                 nprobe,
                                 rerank,
                                 post_drain_stored,


### PR DESCRIPTION
## What

On a reopen of an already-built vector supertable (`INFINO_BENCH_EXISTING_PREFIX`), load the held-out queries **and** their exact labels straight from the persisted oracle bin and skip corpus preparation entirely.

## Why — the reopen win

The vector bench grades against a full-corpus brute-force oracle: it mmaps the whole corpus (~400 GB at 100M × 1024) and brute-forces top-k, caching the queries + labels in a bin. But a **reopen** never needs the corpus for the *table* — it opens the persisted one — it only regenerated the corpus to rebuild the *query vectors* for grading. The bin already stores those queries. So the reopen was paying a ~400 GB disk write + a multi-minute brute-force pass for data it already had on disk.

Measured on a reopened 100M table:

| | before (regenerate corpus) | after (load bin) |
|---|---|---|
| corpus prepared | ~400 GB mmap + brute-force | **none** — RSS flat ~22 MiB across corpus-prepare |
| oracle build | **1084.6 s (~18 min)** exact pass over the 103M-row corpus (705–1900 s across 100M runs) | **412 KB bin, sub-second read** |
| path to first query | corpus build → oracle pass → open | **straight to table open** (cold open 2.19 s) |
| `recall@10` (nprobe=1) | 0.986 | **0.986** — identical |

**Before → after:** an ~18-minute exact oracle build plus a ~400 GB corpus regeneration on every reopen → a sub-second 412 KB bin read with no corpus. The recall matching to the digit is the correctness proof: the bin-loaded queries + labels are the *same* oracle, so the only thing that changed is not regenerating the corpus. This also makes read-only recall sweeps on retained large tables cheap — previously they were gated on regenerating the corpus just to grade.

## How

- **`grading::load_oracle(path) -> CachedOracle`** in the **shared** grading module (sibling to the existing `write_cache`): reads the magic + key + queries + all three label sets. Every row count comes from the embedded key, so it needs no expected query set — which is the whole point: the caller has no corpus to regenerate the queries from.
- **`vector::run`**: when an existing prefix is reopened and a matching oracle bin is present, load queries + labels from it and gate `prepare_corpus` to `None`. The combined query/label sets are split at the correctness boundary exactly as the corpus path does. **The corpus path is unchanged** — `git diff -w` shows only the added branch + the gate; the old block is byte-identical, just indented into the `else` arm.
- **Latent-panic fix (two sites)**: `run_search` **and** the steady-state `measure_cold_store` both hard-indexed `q_cal[0]` for their latency probes; a skip-calibration reopen loads no calibration queries (the bin stores none), so `q_cal` is legitimately empty → both fall back to the correctness set. (Without the second fix, the cold-store measurement panics after grading — silently dropping the cold GET/cost accounting on every reopen.)

## Correctness for both calibration modes

`skip_calibration` is a pure function of `n_docs`, so the bin's contents and the reopen's flag can never disagree (it's the same table, same `n_docs`):

- **non-skip** (small tables): bin persists correctness **+** calibration queries → `load_oracle` splits into non-empty `q_cal`/`gt_cal` → calibration path runs, `q0 = q_cal[0]` unchanged.
- **skip** (large tables, e.g. 100M): bin persists correctness only → `q_cal` empty → `q0` falls back to the correctness set → recall graded from `gt_correct`.

## Tests

- **Unit**: `load_oracle` round-trips the queries + all three label sets and rejects a truncated bin (exercises the non-skip split shape).
- **End-to-end**: the reopened 100M table reproduces the corpus-based reopen's 0.986 with no corpus (table above). The `q0` fallback is exercised by this skip-calibration reopen (bench-harness code, so runtime-validated rather than unit-tested).

## Scope / follow-ups

This is the **read** side only. The remaining #467 items — persisting `recall_while_ingest`'s inline ground truth in this same bin format (the `save_oracle` counterpart) and dropping the corpus from the vector bench's own GT — **will be taken up after #466 (`recall_while_ingest`) is merged**, since they build on that tool. `load_oracle` is placed in the shared grading module precisely so those items reuse it verbatim.

Refs #467.
