### PR TITLE
fix supertable drop_table: handle table deletion by another worker process

### DIFF
--- a/benches/utils/bench/supertable/query.rs
+++ b/benches/utils/bench/supertable/query.rs
@@ -16,7 +16,7 @@ pub fn vector_topk_global(
     options: VectorSearchOptions,
 ) -> Vec<i128> {
     let batches = st
-        .reader()
+        .reader().expect("reader")
         .vector_search(VEC_COLUMN, query, k, options, None, None)
         .expect("vector_search");
     corpus::id_scores_from_vector_search(&batches)

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -329,6 +329,7 @@ async fn reader_loop(
         let t0 = Instant::now();
         let _ = black_box(
             st.reader()
+                .expect("reader")
                 .bm25_search(QUERY_FIELD, QUERY_TERM, TOP_K, BoolMode::Or, None)
                 .expect("bm25_search"),
         );

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -1264,6 +1264,7 @@ pub fn engine_id_to_dense(
 
     let batches = table
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable ORDER BY _id")
         .expect("SELECT _id FROM supertable ORDER BY _id");
     let mut ids = Vec::with_capacity(n_docs);

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1529,6 +1529,7 @@ pub mod vector {
             let batches = self
                 .table
                 .reader()
+                .expect("reader")
                 .vector_search(column, query, k, search_opts(nprobe, rerank), None, None)
                 .expect("supertable vector_search");
             corpus::id_scores_from_vector_search(&batches)
@@ -1554,6 +1555,7 @@ pub mod vector {
             let batches = self
                 .table
                 .reader()
+                .expect("reader")
                 .vector_search(column, query, k, search_opts(nprobe, rerank), None, None)
                 .expect("supertable vector_search payload");
             super::payload_bytes(&batches)
@@ -2553,6 +2555,7 @@ pub mod sql {
                 &self
                     .table()
                     .reader()
+                    .expect("reader")
                     .query_sql(sql)
                     .expect("query_sql payload"),
             )
@@ -2562,6 +2565,7 @@ pub mod sql {
                 &self
                     .table()
                     .reader()
+                    .expect("reader")
                     .query_sql(sql)
                     .expect("query_sql count"),
             )
@@ -2571,6 +2575,7 @@ pub mod sql {
     impl SqlRead for Supertable {
         fn query_rows(&self, sql: &str) -> usize {
             self.reader()
+                .expect("reader")
                 .query_sql(sql)
                 .expect("query_sql")
                 .iter()
@@ -2578,10 +2583,22 @@ pub mod sql {
                 .sum()
         }
         fn query_payload(&self, sql: &str) -> (u64, u64) {
-            payload_bytes(&self.reader().query_sql(sql).expect("query_sql payload"))
+            payload_bytes(
+                &self
+                    .reader()
+                    .expect("reader")
+                    .query_sql(sql)
+                    .expect("query_sql payload"),
+            )
         }
         fn query_count(&self, sql: &str) -> i64 {
-            scalar_i64(&self.reader().query_sql(sql).expect("query_sql count"))
+            scalar_i64(
+                &self
+                    .reader()
+                    .expect("reader")
+                    .query_sql(sql)
+                    .expect("query_sql count"),
+            )
         }
         fn settle_warm(&self) {
             self.wait_until_warm(WARM_SETTLE_TIMEOUT)

--- a/benches/utils/fts_diag.rs
+++ b/benches/utils/fts_diag.rs
@@ -84,7 +84,7 @@ pub fn run() {
     eprintln!("[fts-diag] building supertable...");
     let build_t0 = Instant::now();
     let (table, _batches) = diag_common::build_supertable(&cfg);
-    let reader = table.reader();
+    let reader = table.reader().expect("reader");
     eprintln!(
         "[fts-diag] built in {:.1}s ({} superfile(s) after optimize)",
         build_t0.elapsed().as_secs_f64(),

--- a/benches/utils/harness/infino_sql_engine.rs
+++ b/benches/utils/harness/infino_sql_engine.rs
@@ -272,7 +272,12 @@ impl SqlEngine for InfinoSqlEngine {
     }
 
     fn read(index: &Self::Index, sql: &str) -> SqlOutput {
-        let batches = index.table().reader().query_sql(sql).expect("query_sql");
+        let batches = index
+            .table()
+            .reader()
+            .expect("reader")
+            .query_sql(sql)
+            .expect("query_sql");
         SqlOutput {
             rows: batches.iter().map(RecordBatch::num_rows).sum(),
         }

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -563,7 +563,7 @@ pub fn build_on_storage(modality: Modality, corpus: &PreparedCorpus) -> IngestRe
     }
     drop(w);
     crate::rss::log_rss_breakdown("ingest writer dropped");
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     let n_superfiles = reader.n_superfiles();
     let total_index_bytes: u64 = reader
         .manifest()
@@ -699,7 +699,7 @@ pub(crate) fn open_existing(modality: Modality, fixture: tiers::StorageFixture) 
     let opts = options_for(modality, Some(Arc::clone(&fixture.storage))).with_disk_cache(cache);
     let st =
         Supertable::open(opts).expect("open existing supertable at INFINO_BENCH_EXISTING_PREFIX");
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     let (n_superfiles, total_index_bytes) = reader
         .load_superfile_storage_stats()
         .expect("load existing supertable manifest entries");

--- a/benches/utils/sql_diag.rs
+++ b/benches/utils/sql_diag.rs
@@ -182,7 +182,7 @@ pub fn run() {
         "[sql-diag] supertable built in {:.1}s",
         build_t0.elapsed().as_secs_f64()
     );
-    let reader = table.reader();
+    let reader = table.reader().expect("reader");
     let manifest = reader.manifest();
     let superfiles: Vec<Bytes> = manifest
         .superfiles
@@ -231,6 +231,7 @@ pub fn run() {
         let (full_p50, full_mean, full_rows) = diag_common::time_path(iters, || {
             table
                 .reader()
+                .expect("reader")
                 .query_sql(shape.sql)
                 .map(|b| count_rows(&b))
                 .expect("query_sql")

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -2016,7 +2016,7 @@ pub mod sql {
             .with_disk_cache(cache.clone())
             .with_cache_prepopulation(false);
         let table = build_supertable_with_options(rows, opts, rows.len().max(1));
-        let reader = table.reader();
+        let reader = table.reader().expect("reader");
         let total_index_bytes: u64 = reader
             .manifest()
             .superfiles
@@ -2136,6 +2136,7 @@ pub mod sql {
         index
             .table()
             .reader()
+            .expect("reader")
             .manifest()
             .superfiles
             .iter()

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -393,7 +393,7 @@ pub fn ingest_row(n_docs: usize, label: &str, m: &ShapeMetrics) -> Vec<Cell> {
 /// Visit committed superfiles through the flat eager view, or through manifest
 /// parts when the manifest is lazy and the flat view is empty.
 fn visit_manifest_superfiles(table: &Supertable, mut visit: impl FnMut(&SuperfileEntry)) {
-    let reader = table.reader();
+    let reader = table.reader().expect("reader");
     let manifest = reader.manifest();
     let flat_superfiles = manifest.get_all_superfiles();
     if !flat_superfiles.is_empty() {
@@ -452,7 +452,7 @@ fn slow_state_stored_bytes(table: &Supertable) -> Option<u64> {
 fn live_stored_bytes(consumer: &Supertable) -> Option<u64> {
     /// Relative prefix of superfile data objects under a table root.
     const DATA_PREFIX: &str = "data/";
-    let user_reader = consumer.reader();
+    let user_reader = consumer.reader().expect("reader");
     let user_manifest = user_reader.manifest();
     let listing = listed_objects_under(consumer, "")?;
     let bucket_total: u64 = listing.iter().map(|(_, size)| *size).sum();
@@ -500,7 +500,15 @@ fn listed_bytes_under(table: &Supertable, prefix: &str) -> Option<u64> {
 /// table's provider. Keys are provider-root-relative — the same
 /// convention as `SuperfileUri::storage_path`.
 fn listed_objects_under(table: &Supertable, prefix: &str) -> Option<Vec<(String, u64)>> {
-    let storage = Arc::clone(table.reader().manifest().options.storage.as_ref()?);
+    let storage = Arc::clone(
+        table
+            .reader()
+            .expect("reader")
+            .manifest()
+            .options
+            .storage
+            .as_ref()?,
+    );
     let prefix = prefix.to_owned();
     let objects = tiers::block_on(async move {
         storage
@@ -625,7 +633,7 @@ fn run_metered_optimize(
 ) -> CompactionStats {
     eprintln!(
         "[{label}] before optimize: {} superfiles",
-        consumer.reader().n_superfiles()
+        consumer.reader().expect("reader").n_superfiles()
     );
     eprintln!("[{label}] compacting (optimize)...");
     let before = meter.snapshot();
@@ -646,7 +654,7 @@ fn run_metered_optimize(
         rss::fmt_bytes(peak_rss),
         rss::fmt_bytes(rss_stats.peak_anon_rss_bytes),
         rss::fmt_bytes(rss_stats.peak_file_rss_bytes),
-        consumer.reader().n_superfiles(),
+        consumer.reader().expect("reader").n_superfiles(),
     );
     (wall_s, io, peak_rss, cpu_s)
 }
@@ -1573,7 +1581,7 @@ pub mod fts {
 
         if phases.warm || phases.cold {
             let (cache_dir, consumer) = open_consumer(Modality::Fts, &built);
-            let reader = consumer.reader();
+            let reader = consumer.reader().expect("reader");
             exec_fts::assert_correct(&reader, supertable::TEXT_COLUMN, n_docs, "supertable_fts");
             drop(consumer);
             drop(cache_dir);
@@ -1880,7 +1888,7 @@ pub mod fts {
             .expect("battery keeps its broad-OR representative");
         let query = rep.terms.join(" ");
         let mode = exec_fts::to_infino_mode(rep.mode);
-        let reader = consumer.reader();
+        let reader = consumer.reader().expect("reader");
         let hidden_uris: HashSet<_> = consumer
             .vector_index_table()
             .map(|hidden| {
@@ -1948,7 +1956,7 @@ pub mod fts {
         // up as anonymous ≈ file_backed after warm-up.
         crate::rss::log_rss_breakdown("supertable_fts before consumer open");
         let (cache_dir, consumer) = open_consumer(Modality::Fts, built);
-        let reader = consumer.reader();
+        let reader = consumer.reader().expect("reader");
         // Prewarm + wait: run EVERY battery shape once so each opens its
         // pruned-in superfiles and spawns their background fills, then
         // wait_until_warm blocks until all are mmap-promoted. A single-shape
@@ -2076,6 +2084,7 @@ pub mod fts {
                 let mode = exec_fts::to_infino_mode(query.mode);
                 let _ = consumer
                     .reader()
+                    .expect("reader")
                     .bm25_search(supertable::TEXT_COLUMN, &terms, TOP_K, mode, None)
                     .expect("metered cold bm25_search");
             },
@@ -2085,6 +2094,7 @@ pub mod fts {
                 let mode = exec_fts::to_infino_mode(q.mode);
                 let _ = consumer
                     .reader()
+                    .expect("reader")
                     .bm25_search(supertable::TEXT_COLUMN, &terms, TOP_K, mode, None)
                     .expect("metered steady cold bm25_search");
             },
@@ -2094,6 +2104,7 @@ pub mod fts {
                 let mode = exec_fts::to_infino_mode(query.mode);
                 let _ = consumer
                     .reader()
+                    .expect("reader")
                     .bm25_search(supertable::TEXT_COLUMN, &terms, TOP_K, mode, None)
                     .expect("metered repeat cold bm25_search");
             },
@@ -2131,6 +2142,7 @@ pub mod fts {
         ) -> usize {
             self.consumer
                 .reader()
+                .expect("reader")
                 .bm25_search(column, query, k, mode, None)
                 .expect("cold bm25_search")
                 .iter()
@@ -2147,6 +2159,7 @@ pub mod fts {
         ) -> usize {
             self.consumer
                 .reader()
+                .expect("reader")
                 .bm25_search(column, query, k, mode, Some(&["_id", column, "score"]))
                 .expect("cold bm25_search fetched")
                 .iter()
@@ -2161,7 +2174,10 @@ pub mod fts {
             k: usize,
             mode: infino::superfile::fts::reader::BoolMode,
         ) -> ((u64, u64), (u64, u64)) {
-            self.consumer.reader().bm25_payloads(column, query, k, mode)
+            self.consumer
+                .reader()
+                .expect("reader")
+                .bm25_payloads(column, query, k, mode)
         }
 
         fn count_matching(
@@ -2170,7 +2186,10 @@ pub mod fts {
             query: &str,
             mode: infino::superfile::fts::reader::BoolMode,
         ) -> u64 {
-            self.consumer.reader().count_matching(column, query, mode)
+            self.consumer
+                .reader()
+                .expect("reader")
+                .count_matching(column, query, mode)
         }
     }
 }
@@ -2314,7 +2333,7 @@ pub mod vector {
         nprobe: usize,
         rerank: usize,
     ) -> HitTierStats {
-        let reader = table.reader();
+        let reader = table.reader().expect("reader");
         let hidden_uris: HashSet<_> = table
             .vector_index_table()
             .map(|hidden| {
@@ -2398,7 +2417,7 @@ pub mod vector {
         id_to_dense: &HashMap<i128, u32>,
         hits: &[infino::supertable::query::SuperfileHit],
     ) -> Vec<(u32, f32)> {
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let manifest = reader.manifest();
         let mut contiguous_min_by_uri: HashMap<_, i128> = HashMap::new();
         for entry in manifest.get_all_superfiles() {
@@ -2898,6 +2917,7 @@ pub mod vector {
             sampled += 1;
             let batches = consumer
                 .reader()
+                .expect("reader")
                 .vector_search(
                     supertable::VEC_COLUMN,
                     &vectors[start..start + DIM],
@@ -2995,7 +3015,7 @@ pub mod vector {
             return "pre-drain";
         }
         let drained = hidden_manifest.get_drained_ranges();
-        let user_reader = consumer.reader();
+        let user_reader = consumer.reader().expect("reader");
         let user_manifest = user_reader.manifest();
         if user_manifest
             .get_all_superfiles()
@@ -3101,7 +3121,7 @@ pub mod vector {
             .vector_index_table()
             .expect("reset must recreate the hidden vector index");
         assert_eq!(
-            hidden.reader().n_superfiles(),
+            hidden.reader().expect("reader").n_superfiles(),
             0,
             "reset hidden index must reopen empty"
         );
@@ -3147,6 +3167,7 @@ pub mod vector {
                 }
                 let _ = consumer
                     .reader()
+                    .expect("reader")
                     .vector_search(
                         supertable::VEC_COLUMN,
                         query,
@@ -3167,6 +3188,7 @@ pub mod vector {
                 }
                 let _ = consumer
                     .reader()
+                    .expect("reader")
                     .vector_search(
                         supertable::VEC_COLUMN,
                         q,
@@ -3184,6 +3206,7 @@ pub mod vector {
             |(_cache, consumer)| {
                 let _ = consumer
                     .reader()
+                    .expect("reader")
                     .vector_search(
                         supertable::VEC_COLUMN,
                         query,
@@ -3229,7 +3252,7 @@ pub mod vector {
         include_warm: bool,
         include_cold: bool,
     ) -> RoutingStateStat {
-        let reader = consumer.reader();
+        let reader = consumer.reader().expect("reader");
         super::measure_routing_state_with(
             "supertable_vector",
             label,
@@ -3752,7 +3775,7 @@ pub mod vector {
             if phases.warm
                 && let Some(filtered_gt) = filtered_gt.as_ref()
             {
-                let consumer_reader = consumer.reader();
+                let consumer_reader = consumer.reader().expect("reader");
                 let mut allow_stable_ids: Vec<i128> = id_to_dense
                     .iter()
                     .filter_map(|(stable_id, dense_id)| {
@@ -3948,7 +3971,7 @@ pub mod vector {
                 // Post-drain, matching every other search number in this file.
                 drain_hidden_incoming(&combined_consumer);
                 let combined_ids = corpus::engine_id_to_dense(&combined_consumer, n_docs);
-                let combined_reader = combined_consumer.reader();
+                let combined_reader = combined_consumer.reader().expect("reader");
 
                 // Allow-set = the ENGINE's own `token_match` over the same
                 // column/term/mode the filter carries — the identical
@@ -4075,7 +4098,7 @@ pub mod vector {
                 // warm latency battery timed — so the ledger's warm GET/query
                 // and the compute ledger's warm CPU describe one path.
                 let warm_io = (phases.warm && !q_correct.is_empty()).then(|| {
-                    let reader = consumer.reader();
+                    let reader = consumer.reader().expect("reader");
                     // Untimed prewarm: fault each query's routed cells into the
                     // resident cache first, so the metered pass below reflects
                     // steady-state warm I/O (0 GET when the working set fits the
@@ -4797,7 +4820,7 @@ pub mod sql {
             .iter()
             .find(|q| q.name == "filter_category_count")
             .expect("battery keeps its filtered-count representative");
-        let reader = consumer.reader();
+        let reader = consumer.reader().expect("reader");
         super::measure_routing_state_with(
             "supertable_sql",
             label,

--- a/benches/utils/supertable_update.rs
+++ b/benches/utils/supertable_update.rs
@@ -115,6 +115,7 @@ fn rss_cells(stats: RssStats) -> Vec<Cell> {
 fn count_rows(st: &Supertable) -> i64 {
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("sql");
     batches[0]

--- a/benches/utils/tombstone_overhead.rs
+++ b/benches/utils/tombstone_overhead.rs
@@ -178,7 +178,7 @@ impl WorkloadState {
 /// sidecar bitmap is hit twice (idempotent union; bitmap stays
 /// the same shape but the cache's last-written etag advances).
 fn drive_tombstones(st: &Supertable, ws: &WalStore, fraction: f64, churn: bool) {
-    let manifest = st.reader().manifest().clone();
+    let manifest = st.reader().expect("reader").manifest().clone();
     let mut targets: Vec<i128> = Vec::new();
     for entry in manifest.get_all_superfiles().iter() {
         let n = (entry.n_docs as f64 * fraction).ceil() as i64;
@@ -244,6 +244,7 @@ fn p50(samples: &mut [Duration]) -> Duration {
 fn measure_fts(st: &Supertable) -> Duration {
     let warm = st
         .reader()
+        .expect("reader")
         .bm25_search("title", QUERY_TERM, TOP_K, BoolMode::Or, None)
         .expect("fts");
     black_box(warm);
@@ -252,6 +253,7 @@ fn measure_fts(st: &Supertable) -> Duration {
         let t0 = Instant::now();
         let hits = st
             .reader()
+            .expect("reader")
             .bm25_search(
                 black_box("title"),
                 black_box(QUERY_TERM),
@@ -270,6 +272,7 @@ fn measure_fts(st: &Supertable) -> Duration {
 fn measure_sql(st: &Supertable) -> Duration {
     let warm = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) FROM supertable")
         .expect("sql");
     black_box(warm);
@@ -278,6 +281,7 @@ fn measure_sql(st: &Supertable) -> Duration {
         let t0 = Instant::now();
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(black_box("SELECT COUNT(*) FROM supertable"))
             .expect("sql");
         samples.push(t0.elapsed());

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -1712,7 +1712,7 @@ pub(crate) mod diag {
             )
             .expect("open unified supertable from real S3");
             let cold_open = open_t0.elapsed();
-            let reader = consumer.reader();
+            let reader = consumer.reader().expect("reader");
             eprintln!(
                 "[diag-real-s3-supertable] cold_open wall={:.1} ms manifest_id={} n_superfiles={} n_docs_total={}",
                 cold_open.as_secs_f64() * MS_PER_SEC,
@@ -1741,7 +1741,7 @@ pub(crate) mod diag {
             let query = query_vector().to_vec();
             let vec_t0 = Instant::now();
             let vec_hits = consumer
-                .reader()
+                .reader().expect("reader")
                 .vector_search(
                     VEC_COLUMN,
                     &query,
@@ -1760,7 +1760,7 @@ pub(crate) mod diag {
 
             let bm25_t0 = Instant::now();
             let bm25_hits = consumer
-                .reader()
+                .reader().expect("reader")
                 .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, BoolMode::Or)
                 .expect("cold BM25 over real S3 supertable");
             let cold_bm25 = bm25_t0.elapsed();
@@ -1774,7 +1774,7 @@ pub(crate) mod diag {
 
             let warm_vec_t0 = Instant::now();
             let warm_vec_hits = consumer
-                .reader()
+                .reader().expect("reader")
                 .vector_search(
                     VEC_COLUMN,
                     &query,
@@ -1787,7 +1787,7 @@ pub(crate) mod diag {
             let warm_vec = warm_vec_t0.elapsed();
             let warm_bm25_t0 = Instant::now();
             let warm_bm25_hits = consumer
-                .reader()
+                .reader().expect("reader")
                 .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, BoolMode::Or)
                 .expect("warm BM25 over real S3 supertable");
             let warm_bm25 = warm_bm25_t0.elapsed();
@@ -2104,7 +2104,7 @@ pub(crate) mod diag {
     }
 
     /// Times warm `reader.bm25_search` / `reader.vector_search`
-    /// (kernel-direct) vs `consumer.reader().query_sql("SELECT _id FROM
+    /// (kernel-direct) vs `consumer.reader().expect("reader").query_sql("SELECT _id FROM
     /// bm25_search(...)")` / `query_sql("... vector_search ...")`
     /// (DataFusion path) side-by-side on the same warm Supertable
     /// over an in-process `RustFS`. Prints min / p50 / p95 / mean
@@ -2190,10 +2190,12 @@ pub(crate) mod diag {
         let q = query_vector().to_vec();
         let _ = consumer
             .reader()
+            .expect("reader")
             .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, BoolMode::Or)
             .expect("warm-up bm25");
         let _ = consumer
             .reader()
+            .expect("reader")
             .vector_search(
                 VEC_COLUMN,
                 &q,
@@ -2226,10 +2228,12 @@ pub(crate) mod diag {
             format!("SELECT score FROM vector_search('{VEC_COLUMN}', '{q_csv}', {TOP_K})");
         let _ = consumer
             .reader()
+            .expect("reader")
             .query_sql(&bm25_sql)
             .expect("warm-up query_sql bm25");
         let _ = consumer
             .reader()
+            .expect("reader")
             .query_sql(&vec_sql)
             .expect("warm-up query_sql vector");
 
@@ -2241,6 +2245,7 @@ pub(crate) mod diag {
             let t = Instant::now();
             let _ = consumer
                 .reader()
+                .expect("reader")
                 .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, BoolMode::Or)
                 .expect("kernel bm25");
             kernel_bm25.push(t.elapsed());
@@ -2250,6 +2255,7 @@ pub(crate) mod diag {
             let t = Instant::now();
             let _ = consumer
                 .reader()
+                .expect("reader")
                 .query_sql(&bm25_sql)
                 .expect("query_sql bm25");
             qsql_bm25.push(t.elapsed());
@@ -2259,6 +2265,7 @@ pub(crate) mod diag {
             let t = Instant::now();
             let _ = consumer
                 .reader()
+                .expect("reader")
                 .vector_search(VEC_COLUMN, &q, TOP_K, opts, None, None)
                 .expect("kernel vector");
             kernel_vec.push(t.elapsed());
@@ -2268,6 +2275,7 @@ pub(crate) mod diag {
             let t = Instant::now();
             let _ = consumer
                 .reader()
+                .expect("reader")
                 .query_sql(&vec_sql)
                 .expect("query_sql vector");
             qsql_vec.push(t.elapsed());
@@ -2308,6 +2316,7 @@ pub(crate) mod diag {
             let t = Instant::now();
             let _ = consumer
                 .reader()
+                .expect("reader")
                 .query_sql(&bm25_score_sql)
                 .expect("query_sql bm25 score");
             bm25_score_total.push(t.elapsed());
@@ -2317,6 +2326,7 @@ pub(crate) mod diag {
             let t = Instant::now();
             let _ = consumer
                 .reader()
+                .expect("reader")
                 .query_sql(&vec_score_sql)
                 .expect("query_sql vector score");
             vec_score_total.push(t.elapsed());

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -205,6 +205,7 @@ fn demo_supertable() {
     // the public, row-returning path is `Supertable::bm25_search`.
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "fox", SEARCH_TOP_K, BoolMode::Or)
         .expect("bm25 fan-out");
     println!("  bm25 \"fox\" across superfiles -> {} hit(s)", hits.len());
@@ -215,6 +216,7 @@ fn demo_supertable() {
     // SQL surfaces the real auto-injected `_id` alongside the payload.
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id, title FROM supertable ORDER BY _id")
         .expect("query_sql");
     let table = pretty_format_batches(&batches).expect("format");

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1071,7 +1071,12 @@ fn now_unix() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path, sync::Arc, thread};
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::Arc,
+        thread,
+    };
 
     use arrow_array::{Array, Int64Array, LargeStringArray, StringViewArray};
     use arrow_schema::{DataType, Field, Schema};
@@ -1451,7 +1456,7 @@ mod tests {
 
     /// Every `_supertable/current` pointer file under `root`, recursively — the
     /// on-storage evidence that a supertable exists.
-    fn pointer_files(root: &Path) -> Vec<std::path::PathBuf> {
+    fn pointer_files(root: &Path) -> Vec<PathBuf> {
         let mut found = Vec::new();
         let Ok(entries) = fs::read_dir(root) else {
             return found;
@@ -1502,12 +1507,20 @@ mod tests {
             matches!(err, InfinoError::NotFound(_)),
             "expected NotFound, got {err:?}"
         );
+        // `query_sql` reports the planner's failure to resolve the relation,
+        // not our typed `NotFound` — an unregistrable name is skipped during
+        // registration (it may be a CTE or a TVF argument), so the refusal
+        // surfaces one layer up. The typed assertion is on `open_table` above;
+        // what matters here is that the message is a missing *table* and not a
+        // fetch of a purged superfile off the stale manifest, which is exactly
+        // how this failed before.
         let err = peer
             .query_sql("SELECT COUNT(*) FROM docs")
             .expect_err("the purged table must not be queryable");
+        let msg = err.to_string();
         assert!(
-            err.to_string().contains("docs"),
-            "the error should name the missing table, got {err:?}"
+            msg.contains("docs") && !msg.contains(".sf.parquet"),
+            "expected a missing-table error naming docs, got {err:?}"
         );
     }
 
@@ -1628,6 +1641,14 @@ mod tests {
         let err = peer_table
             .append(&build_title_batch(&["after the drop"]))
             .expect_err("appending to a purged table must fail");
+        // The same answer the read path gives. It has to survive the commit →
+        // build → mutation-commit error hops the append path takes, or a caller
+        // sees an indistinguishable backend fault and retries — and every retry
+        // uploads another superfile before reaching the fence that refuses it.
+        assert!(
+            matches!(err, InfinoError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
 
         assert!(
             pointer_files(dir.path()).is_empty(),

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1075,6 +1075,7 @@ mod tests {
 
     use arrow_array::{Array, Int64Array, LargeStringArray, StringViewArray};
     use arrow_schema::{DataType, Field, Schema};
+    use datafusion::prelude::{col, lit};
 
     use super::*;
     use crate::{
@@ -1507,6 +1508,89 @@ mod tests {
         assert!(
             err.to_string().contains("docs"),
             "the error should name the missing table, got {err:?}"
+        );
+    }
+
+    /// The purge seen from a table handle the caller is *holding*, rather than
+    /// re-resolving by name — and with a disk cache, which is what makes this
+    /// the sharpest case.
+    ///
+    /// Re-resolving recovers, because the catalog drops the dead handle and
+    /// rebuilds. A held handle has no name to re-resolve, and the freshness
+    /// probe inside it swallows errors by design, so nothing stops the read:
+    /// the pinned manifest still names the purged superfiles and the cache
+    /// still holds their bytes, so every search answers — correctly shaped,
+    /// from a table that no longer exists — for as long as the handle lives.
+    /// Storage never gets asked, so the deletion cannot surface on its own.
+    #[test]
+    fn storage_reads_on_a_purged_handle_refuse_instead_of_serving_cached_rows() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = tempfile::tempdir().expect("cache dir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let writer = connect(&uri).expect("connect writer");
+        let peer = connect_with(&uri, ConnectOptions::new().with_cache_dir(cache.path()))
+            .expect("connect peer");
+
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["the quick brown fox"]))
+            .expect("append");
+
+        // Read once through the held handle so the superfile bytes are resident
+        // in the peer's disk cache — the state that lets a purged table keep
+        // answering without ever touching storage again.
+        let peer_table = peer.open_table("docs").expect("peer opens the table");
+        assert_eq!(
+            n_rows(
+                &peer_table
+                    .bm25_search("title", "quick", TOP_K, BoolMode::Or, None)
+                    .expect("warm read")
+            ),
+            1,
+            "peer reads the seeded row, warming its cache"
+        );
+
+        writer.drop_table("docs", true).expect("drop_table");
+
+        // Every read verb, twice: the first trips the probe that discovers the
+        // purge, and the second proves the refusal is latched rather than a
+        // one-shot side effect of that discovery.
+        for attempt in 0..2 {
+            let err = peer_table
+                .bm25_search("title", "quick", TOP_K, BoolMode::Or, None)
+                .expect_err("bm25_search on a purged table must not return rows");
+            assert!(
+                matches!(err, InfinoError::NotFound(_)),
+                "attempt {attempt}: expected NotFound, got {err:?}"
+            );
+            for err in [
+                peer_table
+                    .token_match("title", "quick", BoolMode::Or, None)
+                    .expect_err("token_match must refuse"),
+                peer_table
+                    .exact_match("title", "the quick brown fox", None)
+                    .expect_err("exact_match must refuse"),
+                peer_table
+                    .count("title", "quick", BoolMode::Or)
+                    .expect_err("count must refuse"),
+            ] {
+                assert!(
+                    matches!(err, InfinoError::NotFound(_)),
+                    "attempt {attempt}: expected NotFound, got {err:?}"
+                );
+            }
+        }
+
+        // Mutations refuse at predicate resolution, before writing any WAL
+        // state, and report the same missing table rather than a backend fault.
+        let err = peer_table
+            .delete(col("_id").eq(lit(1_i64)))
+            .expect_err("delete on a purged table must refuse");
+        assert!(
+            matches!(err, InfinoError::NotFound(_)),
+            "expected NotFound, got {err:?}"
         );
     }
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1661,6 +1661,61 @@ mod tests {
         );
     }
 
+    /// The write-only twin of the read-path recovery. A handle that has never
+    /// served a read has never run a freshness probe, so the commit's pointer
+    /// fence is the only thing that can notice the purge — and unless that
+    /// observation latches, the catalog goes on serving the dead handle from
+    /// cache and every later append fences against a location a re-create has
+    /// already replaced. Correctly refusing forever is still broken.
+    #[test]
+    fn storage_appends_recover_after_a_peer_drop_and_recreate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let writer = connect(&uri).expect("connect writer");
+        let peer = connect(&uri).expect("connect peer");
+
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["seeded"]))
+            .expect("append");
+
+        // The peer only ever writes — no query, so no freshness probe.
+        let peer_table = peer.open_table("docs").expect("peer opens the table");
+        peer_table
+            .append(&build_title_batch(&["peer row"]))
+            .expect("peer append before the drop");
+
+        writer.drop_table("docs", true).expect("drop_table");
+
+        let err = peer_table
+            .append(&build_title_batch(&["after the drop"]))
+            .expect_err("appending to a purged table must refuse");
+        assert!(
+            matches!(err, InfinoError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+
+        // The name comes back at a fresh location. Re-resolving through the
+        // connection must rebuild rather than hand back the dead handle.
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("re-create")
+            .append(&build_title_batch(&["new one"]))
+            .expect("append to the new generation");
+
+        peer.open_table("docs")
+            .expect("peer re-opens the re-created table")
+            .append(&build_title_batch(&["peer writes again"]))
+            .expect("a write-only peer must recover after the re-create");
+        assert_eq!(
+            count_rows(&writer, "docs"),
+            2,
+            "the new generation holds its own row plus the peer's"
+        );
+    }
+
     /// Drop-then-recreate through different connections: the name is back, but at
     /// a fresh location, so the peer must rebuild rather than serve the old rows.
     #[test]

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -469,9 +469,11 @@ impl Connection {
                 handles,
                 building,
             } => {
-                // Warm path: lock-free sharded lookup, no serialization.
-                if let Some(handle) = handles.get(name) {
-                    return Ok(handle.clone());
+                // Warm path: lock-free sharded lookup, no serialization. A
+                // handle purged elsewhere is dropped here, so the cold path
+                // re-resolves it against the catalog.
+                if let Some(handle) = live_handle(handles, name) {
+                    return Ok(handle);
                 }
 
                 // Cold path: build once under the gate. Blocks here if a
@@ -481,8 +483,8 @@ impl Connection {
                 let _built = gate.lock().expect("catalog build gate poisoned");
 
                 // A peer may have built it while we waited on the gate.
-                if let Some(handle) = handles.get(name) {
-                    return Ok(handle.clone());
+                if let Some(handle) = live_handle(handles, name) {
+                    return Ok(handle);
                 }
 
                 let (body, _etag) = bridge_sync_to_async(read_catalog(root.as_ref()))
@@ -971,6 +973,22 @@ fn build_disk_cache(
     Ok(Some(cache))
 }
 
+/// The cached handle for `name`, or `None` (after evicting it) if its table was
+/// dropped and purged elsewhere — `handles` is per-process, so such a drop never
+/// reaches it. The `Ref` is dropped before `remove`, which would else deadlock.
+fn live_handle(
+    handles: &DashMap<String, SupertableHandle>,
+    name: &str,
+) -> Option<SupertableHandle> {
+    let entry = handles.get(name)?;
+    if !entry.pointer_vanished() {
+        return Some(entry.clone());
+    }
+    drop(entry);
+    handles.remove(name);
+    None
+}
+
 /// The per-name single-flight gate, created on first use. Returned as an owned
 /// `Arc` (not a `DashMap` reference) so the caller locks it *after* the map
 /// access returns, never holding a shard across the build's blocking I/O.
@@ -1061,6 +1079,7 @@ mod tests {
     use super::*;
     use crate::{
         BoolMode,
+        supertable::manifest::commit::POINTER_PATH,
         test_helpers::{build_title_batch, schema_id_title},
     };
 
@@ -1427,6 +1446,232 @@ mod tests {
             cold_after_q2, cold_after_q1,
             "second query must reuse the warm disk cache, not cold-fetch again"
         );
+    }
+
+    /// Every `_supertable/current` pointer file under `root`, recursively — the
+    /// on-storage evidence that a supertable exists.
+    fn pointer_files(root: &Path) -> Vec<std::path::PathBuf> {
+        let mut found = Vec::new();
+        let Ok(entries) = fs::read_dir(root) else {
+            return found;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                found.extend(pointer_files(&path));
+            } else if path.ends_with(POINTER_PATH) {
+                found.push(path);
+            }
+        }
+        found
+    }
+
+    /// Two connections over one storage root, the shape of a database served by
+    /// more than one process. One drops and purges a table; the other has it warm
+    /// in its per-process handle cache, which the drop never reaches, and must
+    /// stop serving it rather than answer from deleted superfiles forever.
+    #[test]
+    fn storage_purged_table_is_not_served_from_a_peer_connections_warm_handle() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let writer = connect(&uri).expect("connect writer");
+        let peer = connect(&uri).expect("connect peer");
+
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["the quick brown fox"]))
+            .expect("append");
+
+        // Warm the peer's handle cache, and confirm it really is serving.
+        assert_eq!(count_rows(&peer, "docs"), 1, "peer reads the seeded row");
+
+        writer.drop_table("docs", true).expect("drop_table");
+
+        // The next freshness probe discovers the deletion, and it runs inside
+        // the query path after the cached handle was taken — so this call is the
+        // trigger and recovery lands on the one after it.
+        let _ = peer.query_sql("SELECT COUNT(*) FROM docs");
+
+        let err = peer
+            .open_table("docs")
+            .expect_err("the purged table must not open");
+        assert!(
+            matches!(err, InfinoError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+        let err = peer
+            .query_sql("SELECT COUNT(*) FROM docs")
+            .expect_err("the purged table must not be queryable");
+        assert!(
+            err.to_string().contains("docs"),
+            "the error should name the missing table, got {err:?}"
+        );
+    }
+
+    /// The same stale handle, written to rather than read from. A commit fences
+    /// on the pointer's etag, and an absent pointer used to mean "initial
+    /// commit" — republishing one from the stale manifest and resurrecting the
+    /// table under a name the catalog no longer lists. Hence the assertion on
+    /// storage state, not just on the error.
+    #[test]
+    fn storage_append_on_a_purged_handle_refuses_and_republishes_no_pointer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let writer = connect(&uri).expect("connect writer");
+        let peer = connect(&uri).expect("connect peer");
+
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["the quick brown fox"]))
+            .expect("append");
+
+        // Write once through the peer, so its handle carries real manifest state.
+        let peer_table = peer.open_table("docs").expect("peer opens the table");
+        peer_table
+            .append(&build_title_batch(&["peer row"]))
+            .expect("peer append before the drop");
+
+        writer.drop_table("docs", true).expect("drop_table");
+        assert!(
+            pointer_files(dir.path()).is_empty(),
+            "the purge should leave no pointer behind"
+        );
+
+        let err = peer_table
+            .append(&build_title_batch(&["after the drop"]))
+            .expect_err("appending to a purged table must fail");
+
+        assert!(
+            pointer_files(dir.path()).is_empty(),
+            "the refused append must not republish a pointer (resurrecting the \
+             dropped table as unreachable, unreclaimable data): {err:?}"
+        );
+        assert!(
+            writer.list_tables().expect("list").is_empty(),
+            "the table stays dropped"
+        );
+    }
+
+    /// Drop-then-recreate through different connections: the name is back, but at
+    /// a fresh location, so the peer must rebuild rather than serve the old rows.
+    #[test]
+    fn storage_recreated_table_after_a_peer_drop_reads_the_new_generation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let writer = connect(&uri).expect("connect writer");
+        let peer = connect(&uri).expect("connect peer");
+
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["old one", "old two", "old three"]))
+            .expect("append");
+        assert_eq!(count_rows(&peer, "docs"), 3, "peer warms on the old table");
+
+        writer.drop_table("docs", true).expect("drop_table");
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("re-create")
+            .append(&build_title_batch(&["new one"]))
+            .expect("append to the new generation");
+
+        // Trip the peer's freshness probe (see the read-path test above).
+        let _ = peer.query_sql("SELECT COUNT(*) FROM docs");
+        assert_eq!(
+            count_rows(&peer, "docs"),
+            1,
+            "peer must rebuild against the re-created table, not serve the \
+             dropped generation's rows"
+        );
+    }
+
+    /// The same purge, against a peer handle that has never served a read.
+    ///
+    /// Freshness is discovered by re-probing the pointer, and the probe carries
+    /// the etag of the last one read — which only a previous probe sets. So a
+    /// handle built but not yet queried has no etag, and neither does one on a
+    /// backend that omits them. Keying "did we have a pointer?" on that etag
+    /// therefore reads this deletion as "nothing newer to load", and since the
+    /// miss also leaves the etag unset, every later probe repeats it: the
+    /// handle serves the purged table off its in-memory manifest for as long
+    /// as the process lives, and a re-create never reaches it either. The
+    /// pointer's absence is what makes it fatal — not our record of it.
+    #[test]
+    fn storage_purged_table_is_not_served_from_a_handle_that_never_read() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let writer = connect(&uri).expect("connect writer");
+        let peer = connect(&uri).expect("connect peer");
+
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table")
+            .append(&build_title_batch(&["old one", "old two", "old three"]))
+            .expect("append");
+
+        // Warm the peer's handle cache *without* querying through it, so no
+        // freshness probe has run and no pointer etag has been recorded.
+        peer.open_table("docs").expect("peer opens the table");
+
+        writer.drop_table("docs", true).expect("drop_table");
+
+        // Trip the probe (it runs inside the query path, after the cached
+        // handle has been taken — so recovery lands on the call after it).
+        let _ = peer.query_sql("SELECT COUNT(*) FROM docs");
+
+        let err = peer
+            .query_sql("SELECT COUNT(*) FROM docs")
+            .expect_err("the purged table must not be queryable");
+        assert!(
+            !err.to_string().contains(".sf.parquet"),
+            "the peer must report the table gone, not fail fetching a purged \
+             superfile off its stale manifest: {err:?}"
+        );
+
+        // And the handle is genuinely replaced, not just poisoned: a re-create
+        // under the same name is visible to this connection.
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("re-create")
+            .append(&build_title_batch(&["new one"]))
+            .expect("append to the new generation");
+        assert_eq!(
+            count_rows(&peer, "docs"),
+            1,
+            "peer must rebuild against the re-created table"
+        );
+    }
+
+    /// The premise the read-path check rests on: `create` publishes a pointer
+    /// before any writer runs, so a table with nothing appended to it still has
+    /// one and reads as empty. That is what makes an *absent* pointer
+    /// unambiguous — never "not committed yet", always "deleted under us".
+    #[test]
+    fn storage_table_with_no_appends_still_reads_as_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+
+        let conn = connect(&uri).expect("connect");
+        conn.create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table");
+
+        assert_eq!(
+            count_rows(&conn, "docs"),
+            0,
+            "an unwritten table reads empty"
+        );
+        conn.open_table("docs")
+            .expect("an unwritten table still opens");
+
+        // And from a second connection, which builds its handle from scratch.
+        let peer = connect(&uri).expect("connect peer");
+        assert_eq!(count_rows(&peer, "docs"), 0);
     }
 
     /// A server holds one `Connection` and fans out concurrent queries. Many

--- a/src/catalog/search_tvf.rs
+++ b/src/catalog/search_tvf.rs
@@ -89,7 +89,9 @@ impl TableResolver {
         })?;
         table.ensure_fresh();
         let resolved = ResolvedTable {
-            reader: Arc::new(table.reader()),
+            reader: Arc::new(table.reader().map_err(|e| {
+                DataFusionError::Plan(format!("search over unknown table {name:?}: {e}"))
+            })?),
             scalar_schema: table.options().scalar_schema(),
         };
         self.cache

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,7 @@ use crate::{
             BuildError as SupertableBuildError, CommitError as SupertableCommitError, OpenError,
             QueryError,
         },
+        manifest::ManifestLoadError,
         mutations::{CommitError as MutationCommitError, MutationError},
     },
 };
@@ -134,6 +135,19 @@ impl From<QueryError> for InfinoError {
     }
 }
 
+impl From<ManifestLoadError> for InfinoError {
+    fn from(e: ManifestLoadError) -> Self {
+        let msg = e.to_string();
+        match e {
+            // The table this handle was reading has been dropped and purged, so
+            // the name it was opened under no longer resolves to anything —
+            // `NotFound`, not a backend fault, is what a caller must react to.
+            ManifestLoadError::PointerVanished => InfinoError::NotFound(msg),
+            _ => InfinoError::Backend(msg),
+        }
+    }
+}
+
 impl From<SuperfileReadError> for InfinoError {
     fn from(e: SuperfileReadError) -> Self {
         if let Some(msg) = e.over_budget() {
@@ -181,6 +195,8 @@ impl From<MutationError> for InfinoError {
             MutationError::CardinalityMismatch { .. }
             | MutationError::MatchCountExceedsCap { .. } => InfinoError::Cardinality(msg),
             MutationError::SchemaMismatch(_) => InfinoError::Schema(msg),
+            // Matches the read path: a purged table's name resolves to nothing.
+            MutationError::TableGone => InfinoError::NotFound(msg),
             _ => InfinoError::Backend(msg),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -168,13 +168,25 @@ impl From<SupertableBuildError> for InfinoError {
         if let Some(msg) = e.over_budget() {
             return InfinoError::OverBudget(msg.to_string());
         }
+        // A commit that found its table dropped and purged is not a schema
+        // problem; it is the name no longer resolving. Same answer the read
+        // path gives, so a caller can match one condition, not three.
+        if matches!(e, SupertableBuildError::TableGone) {
+            return InfinoError::NotFound(e.to_string());
+        }
         InfinoError::Schema(e.to_string())
     }
 }
 
 impl From<SupertableCommitError> for InfinoError {
     fn from(e: SupertableCommitError) -> Self {
-        InfinoError::Backend(e.to_string())
+        let msg = e.to_string();
+        match e {
+            // Reached by commit paths that surface the typed error directly
+            // (the append path converts to `BuildError::TableGone` first).
+            SupertableCommitError::PointerVanished => InfinoError::NotFound(msg),
+            _ => InfinoError::Backend(msg),
+        }
     }
 }
 
@@ -206,6 +218,15 @@ impl From<MutationCommitError> for InfinoError {
     fn from(e: MutationCommitError) -> Self {
         if let Some(msg) = e.over_budget() {
             return InfinoError::OverBudget(msg.to_string());
+        }
+        // `Supertable::append` lands here, so this is the arm that decides what
+        // appending to a purged table reports. Narrow on purpose: every other
+        // append-flush failure keeps its existing `Backend` shape.
+        if matches!(
+            &e,
+            MutationCommitError::AppendFlush(SupertableBuildError::TableGone)
+        ) {
+            return InfinoError::NotFound(e.to_string());
         }
         InfinoError::Backend(e.to_string())
     }

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -1058,7 +1058,7 @@ mod tests {
         commit_titles(&st, &["alpha first", "alpha second"]);
         commit_titles(&st, &["bravo first", "bravo second"]);
 
-        let entries = st.reader().manifest().superfiles.clone();
+        let entries = st.reader().expect("reader").manifest().superfiles.clone();
         assert_eq!(entries.len(), 2);
         let (entry_a, entry_b) = (&entries[0], &entries[1]);
 
@@ -1135,7 +1135,7 @@ mod tests {
         commit_titles(&st, &["india first", "india second"]);
         commit_titles(&st, &["juliet first", "juliet second"]);
 
-        let entries = st.reader().manifest().superfiles.clone();
+        let entries = st.reader().expect("reader").manifest().superfiles.clone();
         let crashed_entry = &entries[0];
 
         // Simulate a compactor that sealed this file and then died
@@ -1172,6 +1172,7 @@ mod tests {
         // 9 unsealed siblings merged around it.
         let still_stuck = st
             .reader()
+            .expect("reader")
             .manifest()
             .superfiles
             .iter()
@@ -1326,7 +1327,7 @@ mod tests {
         }
 
         // Get the superfiles to merge
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let superfiles: Vec<Arc<SuperfileEntry>> = reader
             .manifest()
             .get_all_superfiles()
@@ -1369,7 +1370,7 @@ mod tests {
             w.commit().expect("commit");
         }
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let superfiles: Vec<Arc<SuperfileEntry>> = reader
             .manifest()
             .get_all_superfiles()
@@ -1460,7 +1461,7 @@ mod tests {
             w.commit().expect("commit");
         }
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let superfiles: Vec<Arc<SuperfileEntry>> = reader
             .manifest()
             .get_all_superfiles()
@@ -1545,7 +1546,7 @@ mod tests {
         opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
         let st = Supertable::create(opts).expect("reopen supertable");
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let superfiles: Vec<Arc<SuperfileEntry>> = reader.manifest().get_all_superfiles().to_vec();
 
         match st.merge_superfiles(&superfiles).await {
@@ -1572,7 +1573,7 @@ mod tests {
             w.commit().expect("commit");
         }
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let superfiles: Vec<Arc<SuperfileEntry>> = reader
             .manifest()
             .get_all_superfiles()
@@ -1755,7 +1756,7 @@ mod tests {
             commit_titles(&st, title);
         }
 
-        let before_docs = st.reader().n_docs_total();
+        let before_docs = st.reader().expect("reader").n_docs_total();
         let st2 = st.clone();
 
         // Race a writer commit against compaction. The compactor will
@@ -1773,7 +1774,7 @@ mod tests {
 
         // All docs from both paths must be visible after refresh.
         st.refresh().await.expect("refresh");
-        let after_docs = st.reader().n_docs_total();
+        let after_docs = st.reader().expect("reader").n_docs_total();
         assert_eq!(
             after_docs,
             before_docs + 2,
@@ -1801,7 +1802,7 @@ mod tests {
         commit_titles(&st, &["romeo first", "romeo second"]);
         commit_titles(&st, &["sierra first", "sierra second"]);
 
-        let before = st.reader();
+        let before = st.reader().expect("reader");
         let before_manifest_id = before.manifest_id();
         let before_n_superfiles = before.n_superfiles();
         let input_ids: HashSet<Uuid> = before
@@ -1837,7 +1838,7 @@ mod tests {
             .await
             .expect("compact");
 
-        let after = st.reader();
+        let after = st.reader().expect("reader");
         let sfs = &after.manifest().superfiles;
 
         assert!(
@@ -1914,7 +1915,7 @@ mod tests {
         commit_titles(&st, &["only doc", "second doc"]);
 
         let before_manifest_id = st.manifest_id();
-        let before_n = st.reader().n_superfiles();
+        let before_n = st.reader().expect("reader").n_superfiles();
 
         st.compact_async(&small_compact_cfg())
             .await
@@ -1925,7 +1926,7 @@ mod tests {
             before_manifest_id,
             "manifest_id must not change: a single superfile cannot form a merge job"
         );
-        assert_eq!(st.reader().n_superfiles(), before_n);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), before_n);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1953,7 +1954,7 @@ mod tests {
             before_manifest_id,
             "manifest must not change when combined size is below the fill floor"
         );
-        assert_eq!(st.reader().n_superfiles(), 2);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1973,7 +1974,7 @@ mod tests {
         commit_titles(&st, &["juliet first", "juliet second"]);
 
         // Pin a snapshot before compaction.
-        let reader_before = st.reader();
+        let reader_before = st.reader().expect("reader");
         let before_n = reader_before.n_superfiles();
         let before_manifest_id = reader_before.manifest_id();
 
@@ -1981,7 +1982,7 @@ mod tests {
             .await
             .expect("compact");
 
-        let reader_after = st.reader();
+        let reader_after = st.reader().expect("reader");
 
         // The pinned snapshot must be frozen — it still sees the original superfiles.
         assert_eq!(reader_before.n_superfiles(), before_n);
@@ -2072,7 +2073,7 @@ mod tests {
             "compact must have run; adjust small_compact_cfg() if needed"
         );
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let sfs = &r.manifest().superfiles;
         assert!(sfs.len() < 10, "superfile count should have decreased");
 
@@ -2128,7 +2129,7 @@ mod tests {
         assert_eq!(st.inner().manifest.load_full().superfiles.len(), 1);
 
         let after_first_manifest_id = st.manifest_id();
-        let after_first_n = st.reader().n_superfiles();
+        let after_first_n = st.reader().expect("reader").n_superfiles();
 
         // Second compact on the same data: the merged superfile is the only
         // file in its partition, so pack_partition emits no job (needs ≥ 2 inputs).
@@ -2141,7 +2142,7 @@ mod tests {
             after_first_manifest_id,
             "second compact should produce no jobs"
         );
-        assert_eq!(st.reader().n_superfiles(), after_first_n);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), after_first_n);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2171,7 +2172,7 @@ mod tests {
         let manifest_id_after_first_compact = st.manifest_id();
         assert_eq!(manifest_id_after_first_compact, before_first_compact + 1);
         assert_eq!(
-            st.reader().n_docs_total(),
+            st.reader().expect("reader").n_docs_total(),
             20,
             "batch A should have 20 docs"
         );
@@ -2202,7 +2203,7 @@ mod tests {
         );
 
         // All 40 docs must be visible after both compaction rounds.
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.n_docs_total(), 40, "all docs must be preserved");
         assert!(
             r.n_superfiles() < 8,
@@ -2259,6 +2260,7 @@ mod tests {
 
         let old_uris: Vec<_> = st
             .reader()
+            .expect("reader")
             .manifest()
             .superfiles
             .iter()
@@ -2277,7 +2279,7 @@ mod tests {
             .await
             .expect("compact");
 
-        let merged_uri = st.reader().manifest().superfiles[0].uri;
+        let merged_uri = st.reader().expect("reader").manifest().superfiles[0].uri;
         assert!(
             st.inner().options.store.reader(&merged_uri).is_ok(),
             "merged superfile must be warmed into the in-memory cache right after compact"
@@ -2485,8 +2487,8 @@ mod tests {
             w.commit().expect("commit");
         }
 
-        let n_before = st.reader().n_superfiles();
-        let docs_before = st.reader().n_docs_total();
+        let n_before = st.reader().expect("reader").n_superfiles();
+        let docs_before = st.reader().expect("reader").n_docs_total();
         let narrow_hits_before = latency_bench_count_hits(&st, &narrow_term);
         let broad_hits_before = latency_bench_count_hits(&st, BROAD_TERM);
         let narrow_before =
@@ -2501,11 +2503,11 @@ mod tests {
         .await
         .expect("compact");
 
-        let n_after = st.reader().n_superfiles();
+        let n_after = st.reader().expect("reader").n_superfiles();
         assert!(n_after < n_before, "compact should reduce superfile count");
 
         // No old-file double-counting: doc/hit counts must be identical.
-        assert_eq!(st.reader().n_docs_total(), docs_before);
+        assert_eq!(st.reader().expect("reader").n_docs_total(), docs_before);
         assert_eq!(
             latency_bench_count_hits(&st, &narrow_term),
             narrow_hits_before
@@ -2563,7 +2565,7 @@ mod tests {
             commit_titles(&st, &titles);
         }
 
-        let before_n_superfiles = st.reader().n_superfiles();
+        let before_n_superfiles = st.reader().expect("reader").n_superfiles();
         let before_data_objects = storage
             .list_with_prefix_metadata("data")
             .await
@@ -2575,7 +2577,7 @@ mod tests {
             .await
             .expect("compact");
 
-        let after_n_superfiles = st.reader().n_superfiles();
+        let after_n_superfiles = st.reader().expect("reader").n_superfiles();
         assert!(
             after_n_superfiles < before_n_superfiles,
             "manifest superfile count must drop right after compact"
@@ -2635,6 +2637,7 @@ mod tests {
 
         let stranded_ids: Vec<Uuid> = st
             .reader()
+            .expect("reader")
             .manifest()
             .superfiles
             .iter()
@@ -2684,6 +2687,7 @@ mod tests {
         // they can never be merged, so they leak permanently.
         let remaining_ids: HashSet<Uuid> = st
             .reader()
+            .expect("reader")
             .manifest()
             .superfiles
             .iter()
@@ -2749,7 +2753,7 @@ mod tests {
         );
 
         // All 245760 docs must be visible after compaction.
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.n_docs_total(), 245760, "all docs must be preserved");
         assert!(
             r.n_superfiles() == 2,

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -194,6 +194,11 @@ pub enum CommitError {
     /// loop later is non-breaking.
     #[error("write contention exhausted retries")]
     WriteContentionExhausted,
+
+    /// The pointer this commit would have fenced against is gone: the table
+    /// was dropped and purged while this handle stayed open. Not retryable.
+    #[error("manifest pointer was deleted while this handle was open")]
+    PointerVanished,
 }
 
 #[derive(Debug, Error)]

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -115,6 +115,14 @@ pub enum BuildError {
     #[error("superfile store: {0}")]
     Store(String),
 
+    /// The table was dropped and purged while this handle was open, so the
+    /// commit had no pointer to fence against. Carried as its own variant
+    /// rather than folded into [`Self::Store`] so the public mapping can
+    /// report a missing table instead of a backend fault — see
+    /// [`CommitError::PointerVanished`] and `From<BuildError> for InfinoError`.
+    #[error("table was dropped and purged while this handle was open")]
+    TableGone,
+
     #[error("merge needs more memory than the connection budget allows: {0}")]
     MemoryBudgetExceeded(String),
 
@@ -152,6 +160,20 @@ impl BuildError {
         match self {
             BuildError::OverBudget(m) => Some(m),
             _ => None,
+        }
+    }
+}
+
+impl From<CommitError> for BuildError {
+    /// Commit failures reach the build path as `Store` carrying the message —
+    /// except a vanished pointer, which keeps its own variant so the public
+    /// mapping can report the table missing rather than a backend fault. A
+    /// stringified error cannot be matched on, and the append path converts
+    /// here before any caller sees it.
+    fn from(e: CommitError) -> Self {
+        match e {
+            CommitError::PointerVanished => BuildError::TableGone,
+            other => BuildError::Store(other.to_string()),
         }
     }
 }

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -542,9 +542,21 @@ impl Supertable {
     /// the configured
     /// [`Consistency`](crate::supertable::options::Consistency) allows.
     /// No-op for an in-memory supertable and under `Snapshot`.
-    fn reader(&self) -> SupertableReader {
+    ///
+    /// Fails with [`ManifestLoadError::PointerVanished`] once the freshness
+    /// check above finds this handle's table dropped and purged. Pinning past
+    /// that point serves rows of a table that no longer exists: the snapshot
+    /// still names the deleted superfiles, and a warm disk cache answers from
+    /// bytes the purge removed, so the reads succeed silently for as long as
+    /// the handle is held. Callers that resolve by name recover on their next
+    /// lookup; one holding this handle has nothing to re-resolve, so refusing
+    /// is the only correct answer.
+    fn reader(&self) -> Result<SupertableReader, ManifestLoadError> {
         self.ensure_fresh();
-        self.pinned_reader()
+        if self.pointer_vanished() {
+            return Err(ManifestLoadError::PointerVanished);
+        }
+        Ok(self.pinned_reader())
     }
     }
 
@@ -913,7 +925,7 @@ impl Supertable {
     /// pinned snapshot — the cold-open phase before a timed search.
     /// Hidden IVF superfiles use their prefixed storage provider.
     fn open_all_superfiles(&self) {
-        let reader = self.reader();
+        let reader = self.reader().expect("reader");
         let manifest = reader.manifest();
         let store = manifest.options.store.clone();
         let disk_cache = manifest.options.disk_cache.clone();
@@ -1043,7 +1055,7 @@ impl Supertable {
     /// Used by benches to observe how compacted the hidden cell index is.
     fn hidden_vector_superfile_stats(&self) -> Option<(usize, usize)> {
         let hidden = self.inner.vector_index_table.as_ref()?;
-        let reader = hidden.reader();
+        let reader = hidden.reader().expect("reader");
         let manifest = reader.manifest();
         // Parts are table-level size buckets; per-cell identity lives on each
         // superfile entry's partition key.
@@ -1096,7 +1108,10 @@ impl Supertable {
     pub fn __debug_cached_session(&self) -> SessionContext {
         // Reuses the same fast path as `query_sql` — see the
         // doc-comment on `sql_session_cache` for invalidation.
-        self.reader().query_sql("SELECT 1 WHERE 1=0").ok();
+        self.reader()
+            .expect("reader")
+            .query_sql("SELECT 1 WHERE 1=0")
+            .ok();
         let guard = self
             .sql_session_cache()
             .lock()
@@ -1830,7 +1845,7 @@ mod tests {
     };
 
     fn rerank_payloads_by_stable_id(table: &Supertable) -> HashMap<i128, Vec<u8>> {
-        let table_reader = table.reader();
+        let table_reader = table.reader().expect("reader");
         let manifest = table_reader.manifest();
         let entries = bridge_sync_to_async(manifest.get_all_superfiles_loaded())
             .expect("load superfile entries");
@@ -1914,7 +1929,7 @@ mod tests {
     fn create_returns_handle_with_empty_initial_manifest() {
         let st = Supertable::create(opts()).expect("create");
         assert_eq!(st.manifest_id(), 0);
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.manifest_id(), 0);
         assert_eq!(r.n_superfiles(), 0);
         assert_eq!(r.n_docs_total(), 0);
@@ -1947,7 +1962,7 @@ mod tests {
         let st = Supertable::create(opts()).expect("create");
 
         // Pin reader at manifest_id = 0.
-        let pinned = st.reader();
+        let pinned = st.reader().expect("reader");
         assert_eq!(pinned.manifest_id(), 0);
         assert_eq!(pinned.n_superfiles(), 0);
 
@@ -1960,7 +1975,7 @@ mod tests {
         assert_eq!(pinned.n_superfiles(), 0);
 
         // Fresh reader sees the NEW manifest.
-        let fresh = st.reader();
+        let fresh = st.reader().expect("reader");
         assert_eq!(fresh.manifest_id(), 1);
         assert_eq!(fresh.n_superfiles(), 2);
         assert_eq!(fresh.n_docs_total(), 30);
@@ -1974,13 +1989,13 @@ mod tests {
         // construction-time state, not the latest.
         let st = Supertable::create(opts()).expect("create");
 
-        let r0 = st.reader();
+        let r0 = st.reader().expect("reader");
         publish_appended(&st, vec![entry(1)]);
-        let r1 = st.reader();
+        let r1 = st.reader().expect("reader");
         publish_appended(&st, vec![entry(2)]);
-        let r2 = st.reader();
+        let r2 = st.reader().expect("reader");
         publish_appended(&st, vec![entry(3)]);
-        let r3 = st.reader();
+        let r3 = st.reader().expect("reader");
 
         // Each reader's manifest_id matches the one published at
         // its capture time.
@@ -2011,7 +2026,7 @@ mod tests {
         let r = {
             let st = Supertable::create(opts()).expect("create");
             publish_appended(&st, vec![entry(5)]);
-            st.reader()
+            st.reader().expect("reader")
             // st dropped here; reader survives.
         };
         assert_eq!(r.manifest_id(), 1);
@@ -2026,8 +2041,8 @@ mod tests {
         // concurrent readers" cheap: one allocation, N+1 ref count.
         let st = Supertable::create(opts()).expect("create");
         publish_appended(&st, vec![entry(7)]);
-        let r1 = st.reader();
-        let r2 = st.reader();
+        let r1 = st.reader().expect("reader");
+        let r2 = st.reader().expect("reader");
         assert!(Arc::ptr_eq(r1.manifest(), r2.manifest()));
     }
 
@@ -2037,7 +2052,7 @@ mod tests {
         let s = format!("{:?}", st);
         assert!(s.contains("Supertable"));
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let s = format!("{:?}", r);
         assert!(s.contains("SupertableReader"));
     }
@@ -2060,7 +2075,7 @@ mod tests {
         // The handle-level `manifest_id` advances with the swap, and a
         // fresh reader pins the same value.
         assert_eq!(st.manifest_id(), 1);
-        assert_eq!(st.reader().manifest_id(), 1);
+        assert_eq!(st.reader().expect("reader").manifest_id(), 1);
     }
 
     #[test]
@@ -2128,7 +2143,7 @@ mod tests {
     fn weak_reader_round_trips_and_debug() {
         let st = Supertable::create(opts()).expect("create");
         publish_appended(&st, vec![entry(4)]);
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let weak = WeakReader::from_reader(&reader);
         // Debug is non-exhaustive but must not explode.
         assert!(format!("{weak:?}").contains("WeakReader"));
@@ -2143,7 +2158,7 @@ mod tests {
     fn weak_reader_upgrade_fails_after_inner_dropped() {
         let weak = {
             let st = Supertable::create(opts()).expect("create");
-            let reader = st.reader();
+            let reader = st.reader().expect("reader");
             let weak = WeakReader::from_reader(&reader);
             drop(reader);
             drop(st);
@@ -2156,7 +2171,7 @@ mod tests {
     #[test]
     fn reader_options_match_handle_options() {
         let st = Supertable::create(opts()).expect("create");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         // The reader's options accessor reaches the same validated
         // options the handle exposes.
         assert_eq!(r.options().id_column, st.options().id_column);
@@ -2219,7 +2234,7 @@ mod tests {
         };
         let st = Supertable::create(make_options()).expect("create");
         assert!(
-            st.reader().vector_index_table().is_some(),
+            st.reader().expect("reader").vector_index_table().is_some(),
             "vector columns + storage must create hidden index sibling"
         );
 
@@ -2239,10 +2254,11 @@ mod tests {
         w.append(&batch).expect("append");
         w.commit().expect("commit");
 
-        assert!(st.reader().n_superfiles() > 0);
+        assert!(st.reader().expect("reader").n_superfiles() > 0);
         let user_payloads = rerank_payloads_by_stable_id(&st);
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
@@ -2255,12 +2271,13 @@ mod tests {
         // bootstraps the global cell grid into the hidden manifest; the cell
         // superfiles are drained from the user superfiles on demand.
         assert_eq!(
-            hidden.reader().n_superfiles(),
+            hidden.reader().expect("reader").n_superfiles(),
             0,
             "commit must not dual-write into the hidden table"
         );
         assert!(
             st.reader()
+                .expect("reader")
                 .manifest()
                 .get_global_vector_index()
                 .is_some_and(|g| g.grid.n_cent > 0 && g.grid.dim > 0),
@@ -2272,6 +2289,7 @@ mod tests {
         // to `grid` via `into_user_grid`.
         let user_grid_trained = st
             .reader()
+            .expect("reader")
             .manifest()
             .get_global_vector_index()
             .is_some_and(|g| {
@@ -2285,7 +2303,7 @@ mod tests {
             "user-side grid must be trained exactly when the cell counts differ"
         );
         assert_eq!(
-            st.reader().manifest().superfiles[0].vector_layout,
+            st.reader().expect("reader").manifest().superfiles[0].vector_layout,
             VectorLayout::MultiCellIvf,
             "grid commit must emit packed user MultiCellIvf superfiles"
         );
@@ -2295,6 +2313,7 @@ mod tests {
         // Pre-drain: with empty cells the query falls back to the user superfiles.
         let hits = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 3, VectorSearchOptions::new(), None)
             .expect("vector search");
         assert!(
@@ -2311,6 +2330,7 @@ mod tests {
         let st = Supertable::open(make_options()).expect("reopen before drain");
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index after reopen")
             .clone();
@@ -2324,11 +2344,12 @@ mod tests {
             "fixed residual payloads must survive default k-means drain"
         );
         assert!(
-            hidden.reader().n_superfiles() > 0,
+            hidden.reader().expect("reader").n_superfiles() > 0,
             "drain must populate the hidden cell index"
         );
         let hits2 = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 3, VectorSearchOptions::new(), None)
             .expect("post-drain vector search");
         assert!(
@@ -2338,14 +2359,20 @@ mod tests {
 
         let user_uris: HashSet<_> = st
             .reader()
+            .expect("reader")
             .manifest()
             .superfiles
             .iter()
             .map(|entry| entry.uri)
             .collect();
-        let in_process_drained = hidden.reader().manifest().get_drained_ranges();
+        let in_process_drained = hidden
+            .reader()
+            .expect("reader")
+            .manifest()
+            .get_drained_ranges();
         assert!(
             st.reader()
+                .expect("reader")
                 .manifest()
                 .superfiles
                 .iter()
@@ -2361,13 +2388,19 @@ mod tests {
         let reopened = Supertable::open(make_options()).expect("reopen after drain");
         let reopened_hidden = reopened
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index after drained reopen")
             .clone();
-        let reopened_drained = reopened_hidden.reader().manifest().get_drained_ranges();
+        let reopened_drained = reopened_hidden
+            .reader()
+            .expect("reader")
+            .manifest()
+            .get_drained_ranges();
         assert!(
             reopened
                 .reader()
+                .expect("reader")
                 .manifest()
                 .superfiles
                 .iter()
@@ -2376,6 +2409,7 @@ mod tests {
         );
         let cold_hits = reopened
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 3, VectorSearchOptions::new(), None)
             .expect("cold post-drain vector search");
         assert!(
@@ -2391,6 +2425,7 @@ mod tests {
             .expect("drain fixed delta");
         let hidden = reopened
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden after second drain")
             .clone();
@@ -2537,12 +2572,13 @@ mod tests {
         let pre_baseline = Supertable::open(make_options(false)).expect("pre-drain mode-off");
         let pre_base_hits = pre_baseline
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, TOP_K, VectorSearchOptions::new(), None)
             .expect("pre-drain baseline hits");
         assert!(!pre_base_hits.is_empty(), "pre-drain baseline returns hits");
         drop(pre_baseline);
         let pre_stripped = Supertable::open(make_options(true)).expect("pre-drain mode-on");
-        let pre_stripped_reader = pre_stripped.reader();
+        let pre_stripped_reader = pre_stripped.reader().expect("reader");
         let user_manifest = pre_stripped_reader.manifest();
         let user_part_entries = user_manifest.get_all_list_entries();
         assert!(
@@ -2570,6 +2606,7 @@ mod tests {
         );
         let pre_stripped_hits = pre_stripped
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, TOP_K, VectorSearchOptions::new(), None)
             .expect("pre-drain stripped hits");
         assert_eq!(
@@ -2585,6 +2622,7 @@ mod tests {
         let baseline = Supertable::open(make_options(false)).expect("reopen mode-off");
         let base_hits = baseline
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, TOP_K, VectorSearchOptions::new(), None)
             .expect("baseline hits");
         assert!(!base_hits.is_empty(), "baseline must return hits");
@@ -2593,10 +2631,11 @@ mod tests {
         let stripped = Supertable::open(make_options(true)).expect("reopen mode-on");
         let hidden = stripped
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
-        let hidden_reader = hidden.reader();
+        let hidden_reader = hidden.reader().expect("reader");
         let hidden_manifest = hidden_reader.manifest();
         assert!(
             hidden_manifest.slow_vector_state_blob().is_some(),
@@ -2627,6 +2666,7 @@ mod tests {
 
         let stripped_hits = stripped
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, TOP_K, VectorSearchOptions::new(), None)
             .expect("stripped-mode hits");
         assert_eq!(
@@ -2731,11 +2771,12 @@ mod tests {
         st.drain_vectors_to_cells_sync().expect("splice drain");
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
         assert!(
-            hidden.reader().n_superfiles() > 0,
+            hidden.reader().expect("reader").n_superfiles() > 0,
             "splice drain must populate hidden cells"
         );
         let hidden_payloads = rerank_payloads_by_stable_id(&hidden);
@@ -2833,11 +2874,12 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
         assert!(
-            hidden.reader().n_superfiles() > 0,
+            hidden.reader().expect("reader").n_superfiles() > 0,
             "kmeans drain must populate hidden cells"
         );
         let hidden_payloads = rerank_payloads_by_stable_id(&hidden);
@@ -3060,6 +3102,7 @@ mod tests {
         // The user superfiles load and report real per-superfile index bytes.
         let (n_superfiles, index_bytes) = st
             .reader()
+            .expect("reader")
             .load_superfile_storage_stats()
             .expect("load superfile storage stats");
         assert!(n_superfiles > 0, "user table has committed superfiles");
@@ -3272,7 +3315,11 @@ mod tests {
             w.commit().expect("commit");
             producer.drain_vectors_to_cells_sync().expect("drain");
             assert!(
-                producer.reader().vector_index_table().is_some(),
+                producer
+                    .reader()
+                    .expect("reader")
+                    .vector_index_table()
+                    .is_some(),
                 "drain must leave a hidden vector-index table"
             );
             producer.storage_bytes().expect("warm storage_bytes")
@@ -3433,10 +3480,11 @@ mod tests {
             Supertable::open(make_options().with_disk_cache(Arc::clone(&cache))).expect("open");
 
         // Collect the hidden IVF superfile URIs.
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let hidden = reader.vector_index_table().expect("hidden index");
         let hidden_uris: Vec<SuperfileUri> = hidden
             .reader()
+            .expect("reader")
             .manifest()
             .superfiles
             .iter()
@@ -3460,6 +3508,7 @@ mod tests {
         q[0] = 1.0;
         let hits = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 5, VectorSearchOptions::new(), None)
             .expect("vector search");
         assert!(!hits.is_empty(), "search should find committed vectors");
@@ -3486,6 +3535,7 @@ mod tests {
         let cold_before = cache.stats().n_cold_fetches;
         let hits2 = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 5, VectorSearchOptions::new(), None)
             .expect("warm vector search");
         assert!(!hits2.is_empty());
@@ -3621,11 +3671,12 @@ mod tests {
 
         let hidden = consumer
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
         let mut per_cell: HashMap<Vec<u8>, usize> = HashMap::new();
-        for entry in &hidden.reader().manifest().superfiles {
+        for entry in &hidden.reader().expect("reader").manifest().superfiles {
             *per_cell.entry(entry.partition_key.clone()).or_insert(0) += 1;
         }
         assert!(
@@ -3637,6 +3688,7 @@ mod tests {
         let query = vec![1.0f32; DIM];
         let hits = consumer
             .reader()
+            .expect("reader")
             .vector_hits("emb", &query, 10, VectorSearchOptions::new(), None)
             .expect("vector search");
         assert!(!hits.is_empty(), "hidden index should return vector hits");
@@ -3661,6 +3713,7 @@ mod tests {
         let query = vec![1.0f32; DIM];
         let hits = consumer
             .reader()
+            .expect("reader")
             .vector_hits("emb", &query, 10, VectorSearchOptions::new(), None)
             .expect("vector search");
         assert!(!hits.is_empty(), "pre-drain user search should return hits");
@@ -3913,10 +3966,11 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden vector index")
             .clone();
-        let hidden_reader = hidden.reader();
+        let hidden_reader = hidden.reader().expect("reader");
         let hidden_manifest = hidden_reader.manifest();
         let mut by_cell = HashMap::<Vec<u8>, usize>::new();
         for entry in hidden_manifest.superfiles.iter() {
@@ -4105,34 +4159,39 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
         // Two populated cells (the two directions). Split the busiest; the
         // other populated cell is the neighbour whose count must survive.
-        let (busiest, neighbour, neighbour_count, n_cent_before) =
-            match hidden.reader().manifest().get_partition_strategy() {
-                PartitionStrategy::VectorCell { clusters, .. } => {
-                    let mut populated: Vec<u32> = (0..clusters.n_cent)
-                        .filter(|&c| clusters.counts[c as usize] > 0)
-                        .collect();
-                    assert!(
-                        populated.len() >= 2,
-                        "two directions must drain into two cells, got {:?}",
-                        clusters.counts
-                    );
-                    populated.sort_by_key(|&c| std::cmp::Reverse(clusters.counts[c as usize]));
-                    let busiest = populated[0];
-                    let neighbour = populated[1];
-                    (
-                        busiest,
-                        neighbour,
-                        clusters.counts[neighbour as usize],
-                        clusters.n_cent,
-                    )
-                }
-                other => panic!("hidden must be VectorCell after drain, got {other:?}"),
-            };
+        let (busiest, neighbour, neighbour_count, n_cent_before) = match hidden
+            .reader()
+            .expect("reader")
+            .manifest()
+            .get_partition_strategy()
+        {
+            PartitionStrategy::VectorCell { clusters, .. } => {
+                let mut populated: Vec<u32> = (0..clusters.n_cent)
+                    .filter(|&c| clusters.counts[c as usize] > 0)
+                    .collect();
+                assert!(
+                    populated.len() >= 2,
+                    "two directions must drain into two cells, got {:?}",
+                    clusters.counts
+                );
+                populated.sort_by_key(|&c| std::cmp::Reverse(clusters.counts[c as usize]));
+                let busiest = populated[0];
+                let neighbour = populated[1];
+                (
+                    busiest,
+                    neighbour,
+                    clusters.counts[neighbour as usize],
+                    clusters.n_cent,
+                )
+            }
+            other => panic!("hidden must be VectorCell after drain, got {other:?}"),
+        };
 
         hidden
             .block_on_query(split_overflow_cell(hidden.inner().clone(), busiest))
@@ -4140,7 +4199,12 @@ mod tests {
 
         // The split grows the grid by one sub-cell and republishes the
         // neighbour cell untouched — its doc count is unchanged.
-        match hidden.reader().manifest().get_partition_strategy() {
+        match hidden
+            .reader()
+            .expect("reader")
+            .manifest()
+            .get_partition_strategy()
+        {
             PartitionStrategy::VectorCell { clusters, .. } => {
                 assert_eq!(
                     clusters.n_cent,
@@ -4239,27 +4303,33 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
 
         // The most-populated cell in the hidden grid holds all N docs.
-        let (split_cell, n_cent_before, docs_in_cell) =
-            match hidden.reader().manifest().get_partition_strategy() {
-                PartitionStrategy::VectorCell { clusters, .. } => {
-                    let cell = (0..clusters.n_cent)
-                        .max_by_key(|&c| clusters.counts.get(c as usize).copied().unwrap_or(0))
-                        .expect("at least one cell");
-                    (cell, clusters.n_cent, clusters.counts[cell as usize])
-                }
-                other => panic!("hidden index must be VectorCell after drain, got {other:?}"),
-            };
+        let (split_cell, n_cent_before, docs_in_cell) = match hidden
+            .reader()
+            .expect("reader")
+            .manifest()
+            .get_partition_strategy()
+        {
+            PartitionStrategy::VectorCell { clusters, .. } => {
+                let cell = (0..clusters.n_cent)
+                    .max_by_key(|&c| clusters.counts.get(c as usize).copied().unwrap_or(0))
+                    .expect("at least one cell");
+                (cell, clusters.n_cent, clusters.counts[cell as usize])
+            }
+            other => panic!("hidden index must be VectorCell after drain, got {other:?}"),
+        };
         assert!(docs_in_cell >= 2, "the split cell needs at least two docs");
 
         // Sanity: the drained docs are retrievable before the split.
         let q = vec![1.0f32; dim];
         let hits_before = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, N, VectorSearchOptions::new(), None)
             .expect("pre-split search");
         assert!(!hits_before.is_empty(), "docs retrievable before split");
@@ -4278,7 +4348,12 @@ mod tests {
         // appended at the old `n_cent`). Routing-independent — it reads the
         // counts the split re-derives from the actual live rows, which also
         // corrects the pre-split grid count (that count can lag the true total).
-        match hidden.reader().manifest().get_partition_strategy() {
+        match hidden
+            .reader()
+            .expect("reader")
+            .manifest()
+            .get_partition_strategy()
+        {
             PartitionStrategy::VectorCell { clusters, .. } => {
                 assert_eq!(
                     clusters.n_cent,
@@ -4378,13 +4453,18 @@ mod tests {
         w.commit().expect("commit");
         st.drain_vectors_to_cells_sync().expect("drain");
 
-        let hidden = st.reader().vector_index_table().expect("hidden").clone();
+        let hidden = st
+            .reader()
+            .expect("reader")
+            .vector_index_table()
+            .expect("hidden")
+            .clone();
         assert_eq!(
             hidden.options().writer_pool.current_num_threads(),
             POOL,
             "hidden drain must inherit the user table's configured writer pool"
         );
-        let hidden_reader = hidden.reader();
+        let hidden_reader = hidden.reader().expect("reader");
         let manifest = hidden_reader.manifest();
         let n_objects = manifest.superfiles.len();
         assert_eq!(
@@ -4496,16 +4576,19 @@ mod tests {
             }
             // ONE drain call — the batching happens inside it.
             st.drain_vectors_to_cells_sync().expect("drain");
-            st
+            // Hand the TempDir back: it owns the storage root, and dropping it
+            // here would delete the table out from under the returned handle.
+            (st, dir)
         };
 
         let max_files_per_cell = |st: &Supertable| -> usize {
             let hidden = st
                 .reader()
+                .expect("reader")
                 .vector_index_table()
                 .expect("hidden index")
                 .clone();
-            let reader = hidden.reader();
+            let reader = hidden.reader().expect("reader");
             let manifest = reader.manifest();
             let mut by_cell = HashMap::<Vec<u8>, usize>::new();
             for entry in manifest.superfiles.iter() {
@@ -4516,7 +4599,7 @@ mod tests {
 
         // batch=1: 3 user superfiles -> 3 memory batches, but still one packed
         // shard object (writer_pool=1 ⇒ N=1; identical vectors ⇒ one cell).
-        let st1 = make(1);
+        let (st1, _dir) = make(1);
         assert_eq!(
             max_files_per_cell(&st1),
             1,
@@ -4524,7 +4607,7 @@ mod tests {
         );
 
         // batch=-1 (unbounded): all 3 in one merge -> identical layout.
-        let st_unb = make(-1);
+        let (st_unb, _dir) = make(-1);
         assert_eq!(
             max_files_per_cell(&st_unb),
             1,
@@ -4532,12 +4615,14 @@ mod tests {
         );
 
         // batch=0: drain skipped → hidden index stays empty.
-        let st0 = make(0);
+        let (st0, _dir) = make(0);
         assert_eq!(
             st0.reader()
+                .expect("reader")
                 .vector_index_table()
                 .expect("hidden index")
                 .reader()
+                .expect("reader")
                 .n_superfiles(),
             0,
             "batch=0 must skip the drain"
@@ -4622,10 +4707,11 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
-        let reader = hidden.reader();
+        let reader = hidden.reader().expect("reader");
         let manifest = reader.manifest();
         let mut per_cell = HashMap::<Vec<u8>, usize>::new();
         let mut total_rows = 0u64;
@@ -4666,10 +4752,11 @@ mod tests {
         st.drain_vectors_to_cells_sync().expect("re-drain no-op");
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
-        let n_after = hidden.reader().manifest().superfiles.len();
+        let n_after = hidden.reader().expect("reader").manifest().superfiles.len();
         assert_eq!(
             n_after,
             per_cell.len(),
@@ -4759,10 +4846,11 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden vector index")
             .clone();
-        let manifest_a = Arc::clone(hidden.reader().manifest());
+        let manifest_a = Arc::clone(hidden.reader().expect("reader").manifest());
         let (uri_a, _) = manifest_a
             .slow_vector_state_blob()
             .expect("drain must publish + stamp the slow-CAS ref");
@@ -4773,7 +4861,7 @@ mod tests {
         // on the HIDDEN manifest (linked manifests). Ref + entries survive.
         let stats = st.delete(col("title").eq(lit("alpha"))).expect("delete");
         assert_eq!(stats.n_tombstoned(), 1, "delete must tombstone one row");
-        let manifest_b = Arc::clone(hidden.reader().manifest());
+        let manifest_b = Arc::clone(hidden.reader().expect("reader").manifest());
         assert!(
             manifest_b.get_manifest_id() > manifest_a.get_manifest_id(),
             "user delete must bump the hidden manifest (deleted-ids stamp)"
@@ -4802,7 +4890,7 @@ mod tests {
         // the ONLY invalidation the slow state accepts.
         append_one("gamma");
         st.drain_vectors_to_cells_sync().expect("second drain");
-        let manifest_c = Arc::clone(hidden.reader().manifest());
+        let manifest_c = Arc::clone(hidden.reader().expect("reader").manifest());
         let (uri_c, _) = manifest_c
             .slow_vector_state_blob()
             .expect("drain must restamp the ref");
@@ -4891,14 +4979,23 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden vector index")
             .clone();
 
         // No deletes yet: the resident set is empty, and two reads on the
         // same manifest version return the SAME cached `Arc` (decoded once).
-        let empty_a = hidden.reader().hidden_deleted_ids().expect("decode");
-        let empty_b = hidden.reader().hidden_deleted_ids().expect("cached");
+        let empty_a = hidden
+            .reader()
+            .expect("reader")
+            .hidden_deleted_ids()
+            .expect("decode");
+        let empty_b = hidden
+            .reader()
+            .expect("reader")
+            .hidden_deleted_ids()
+            .expect("cached");
         assert!(empty_a.is_empty(), "no deletes ⇒ empty resident set");
         assert!(
             Arc::ptr_eq(&empty_a, &empty_b),
@@ -4912,10 +5009,12 @@ mod tests {
         // New manifest version ⇒ re-decode the updated set; then cached again.
         let ids_a = hidden
             .reader()
+            .expect("reader")
             .hidden_deleted_ids()
             .expect("decode after delete");
         let ids_b = hidden
             .reader()
+            .expect("reader")
             .hidden_deleted_ids()
             .expect("cached after delete");
         assert_eq!(ids_a.len(), 1, "one deleted id resident after delete");
@@ -5010,10 +5109,11 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden vector index")
             .clone();
-        let manifest = Arc::clone(hidden.reader().manifest());
+        let manifest = Arc::clone(hidden.reader().expect("reader").manifest());
         assert!(!manifest.superfiles.is_empty(), "drain built cell files");
         for entry in manifest.superfiles.iter() {
             let vs = entry.vector_summary.get("emb").unwrap_or_else(|| {
@@ -5132,11 +5232,13 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden vector index")
             .clone();
         let hidden_storage = hidden
             .reader()
+            .expect("reader")
             .manifest()
             .options
             .storage
@@ -5148,6 +5250,7 @@ mod tests {
         // non-empty.
         let (uri_a, _) = hidden
             .reader()
+            .expect("reader")
             .manifest()
             .slow_vector_state_blob()
             .map(|(u, h)| (u.to_owned(), h))
@@ -5168,7 +5271,7 @@ mod tests {
         // (2) optimize (drain no-op + compaction membership updates clear the
         // ref) must END re-stamped, thin-pointered, with a durable blob.
         st.optimize(&OptimizeOptions::default()).expect("optimize");
-        let manifest_after = Arc::clone(hidden.reader().manifest());
+        let manifest_after = Arc::clone(hidden.reader().expect("reader").manifest());
         let (uri_b, _) = manifest_after
             .slow_vector_state_blob()
             .map(|(u, h)| (u.to_owned(), h))
@@ -5203,11 +5306,17 @@ mod tests {
         let st2 = Supertable::open(make_options()).expect("reopen");
         let hidden2 = st2
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden vector index on reopen")
             .clone();
         assert_eq!(
-            hidden2.reader().manifest().superfiles.len(),
+            hidden2
+                .reader()
+                .expect("reader")
+                .manifest()
+                .superfiles
+                .len(),
             n_entries,
             "fresh open hydrated the flat view from the blob (parts deleted)"
         );
@@ -5215,6 +5324,7 @@ mod tests {
         q[0] = 1.0;
         let hits = st2
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 2, VectorSearchOptions::new(), None)
             .expect("vector search on blob-hydrated manifest");
         assert!(!hits.is_empty(), "search serves from the hydrated view");
@@ -5297,10 +5407,11 @@ mod tests {
         let cell_files = || -> usize {
             let hidden = st
                 .reader()
+                .expect("reader")
                 .vector_index_table()
                 .expect("hidden index")
                 .clone();
-            let reader = hidden.reader();
+            let reader = hidden.reader().expect("reader");
             let manifest = reader.manifest();
             let mut by_cell = HashMap::<Vec<u8>, usize>::new();
             for e in manifest.superfiles.iter() {
@@ -5315,11 +5426,17 @@ mod tests {
         assert_eq!(cell_files(), 1, "first drain populates the cell");
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
         assert!(
-            !hidden.reader().manifest().get_drained_ranges().is_empty(),
+            !hidden
+                .reader()
+                .expect("reader")
+                .manifest()
+                .get_drained_ranges()
+                .is_empty(),
             "drain must record progress in drained_ranges"
         );
 
@@ -5338,12 +5455,14 @@ mod tests {
         // Watermark stays a single genesis-anchored interval (contiguous commits).
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden index")
             .clone();
         assert_eq!(
             hidden
                 .reader()
+                .expect("reader")
                 .manifest()
                 .get_drained_ranges()
                 .intervals()
@@ -5437,6 +5556,7 @@ mod tests {
 
         let hidden = st
             .reader()
+            .expect("reader")
             .vector_index_table()
             .expect("hidden vector index")
             .clone();
@@ -5452,7 +5572,7 @@ mod tests {
             }
             by_shard.values().copied().max().unwrap_or(0)
         };
-        let before = count_by_shard(hidden.reader().manifest());
+        let before = count_by_shard(hidden.reader().expect("reader").manifest());
         assert!(
             before >= 2,
             "need multiple drained packed shards before compaction, got {before}"
@@ -5465,7 +5585,7 @@ mod tests {
         };
         hidden.compact(&cfg).expect("hidden compact");
 
-        let after_reader = hidden.reader();
+        let after_reader = hidden.reader().expect("reader");
         let after_manifest = after_reader.manifest();
         let after = count_by_shard(after_manifest);
         assert!(
@@ -5491,6 +5611,7 @@ mod tests {
         }
         let hits = st
             .reader()
+            .expect("reader")
             .vector_hits(
                 "emb",
                 &vec![1.0f32; dim],
@@ -5518,7 +5639,7 @@ mod tests {
         // blocking `refresh` against the storage pointer. No pointer is
         // published yet, so the pinned snapshot remains the empty
         // manifest.
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.n_superfiles(), 0);
         // A direct refresh likewise reports no newer manifest.
         let advanced = bridge_sync_to_async(st.refresh()).expect("refresh against empty store");

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1837,7 +1837,10 @@ mod tests {
         storage::{LocalFsStorageProvider, StorageProvider},
         superfile::{builder::FtsConfig, vector::layout::VectorLayout},
         supertable::{
-            manifest::{SuperfileEntry, SuperfileUri},
+            manifest::{
+                SuperfileEntry, SuperfileUri,
+                commit::{POINTER_PATH, get_current_manifest_etag},
+            },
             options::Consistency,
             query::dispatch::open_reader,
         },
@@ -5644,5 +5647,75 @@ mod tests {
         // A direct refresh likewise reports no newer manifest.
         let advanced = bridge_sync_to_async(st.refresh()).expect("refresh against empty store");
         assert!(!advanced, "no commit yet ⇒ refresh finds nothing newer");
+    }
+
+    /// The typed shape of a deleted pointer on the read path, pinned at the
+    /// layer that produces it. Both the error and the latch matter: callers
+    /// above match the variant, and the catalog keys handle eviction on the
+    /// latch, so a refactor that reclassified either would break recovery
+    /// while every end-to-end assertion still passed.
+    #[test]
+    fn refresh_reports_pointer_vanished_once_the_pointer_is_deleted() {
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let options = opts()
+            .with_storage(Arc::clone(&storage))
+            .with_read_consistency(Consistency::Strong);
+        let st = Supertable::create(options).expect("create storage-backed handle");
+        assert!(!st.pointer_vanished(), "a live table has its pointer");
+
+        // Exactly what a purge leaves behind for a handle that stays open.
+        bridge_sync_to_async(storage.delete(POINTER_PATH)).expect("delete pointer");
+
+        let err = bridge_sync_to_async(st.refresh()).expect_err("refresh must refuse");
+        assert!(
+            matches!(
+                err,
+                OpenError::ManifestLoadError(ManifestLoadError::PointerVanished)
+            ),
+            "expected PointerVanished, got {err:?}"
+        );
+        assert!(
+            st.pointer_vanished(),
+            "the observation must latch, so the catalog can evict this handle"
+        );
+        // And it stays refused rather than being a one-shot side effect of the
+        // probe that discovered it.
+        for attempt in 0..2 {
+            let err = st.reader().expect_err("reader must refuse");
+            assert!(
+                matches!(err, ManifestLoadError::PointerVanished),
+                "attempt {attempt}: expected PointerVanished, got {err:?}"
+            );
+        }
+    }
+
+    /// The same condition on the commit path. `Ok(None)` here would read as
+    /// "initial commit" and republish a pointer from this handle's stale
+    /// manifest, so the variant — not just the failure — is the contract.
+    #[test]
+    fn get_current_manifest_etag_refuses_a_deleted_pointer() {
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let options = opts().with_storage(Arc::clone(&storage));
+        let st = Supertable::create(options).expect("create storage-backed handle");
+
+        // Capture the snapshot while the table is still whole: this is the
+        // stale state a commit would otherwise republish from.
+        let manifest = Arc::clone(st.reader().expect("reader").manifest());
+        let etag = bridge_sync_to_async(get_current_manifest_etag(&storage, Arc::clone(&manifest)))
+            .expect("a live pointer yields its etag");
+        assert!(etag.is_some(), "localfs reports etags");
+
+        bridge_sync_to_async(storage.delete(POINTER_PATH)).expect("delete pointer");
+
+        let err = bridge_sync_to_async(get_current_manifest_etag(&storage, manifest))
+            .expect_err("an absent pointer must not read as an initial commit");
+        assert!(
+            matches!(err, CommitError::PointerVanished),
+            "expected PointerVanished, got {err:?}"
+        );
     }
 }

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -173,6 +173,10 @@ pub(super) struct SupertableInner {
     /// (which rewrite the pointer without capturing its new etag) —
     /// the next probe then takes the full-read path and re-seeds it.
     pub(super) last_pointer_etag: Mutex<Option<String>>,
+    /// Set once this handle's pointer is seen deleted — its table was dropped
+    /// and purged elsewhere. Latched: the handle can only be discarded, and
+    /// `Connection::open_table` checks this before serving it from cache.
+    pub(super) pointer_vanished: OnceLock<()>,
     /// Cached SQL schemas, built once from the immutable `options` (lock-free
     /// lazy init). A pure function of the schema, so no snapshot invalidation
     /// (unlike `sql_session_cache`). See [`SqlSchemas`].
@@ -473,7 +477,19 @@ impl Supertable {
             .await
             .map_err(OpenError::ManifestLoadError)?;
         let (pointer, meta) = match probe {
-            PointerProbe::Absent | PointerProbe::NotModified => return Ok(false),
+            // Absent means the pointer was deleted — the table was
+            // dropped and purged. It is never "not committed yet": this handle
+            // exists, and every path that builds one over storage has a
+            // pointer by then (`open` fails with `PointerNotFound` without
+            // one; `create` publishes an empty manifest first). A handle with
+            // no storage never reaches here — `refresh` requires it above.
+            PointerProbe::Absent => {
+                let _ = self.inner.pointer_vanished.set(());
+                return Err(OpenError::ManifestLoadError(
+                    ManifestLoadError::PointerVanished,
+                ));
+            }
+            PointerProbe::NotModified => return Ok(false),
             PointerProbe::Read(pointer, meta) => (pointer, meta),
         };
         *self
@@ -619,6 +635,13 @@ impl Supertable {
         {
             debug!(error = %e, "manifest refresh failed; serving current snapshot");
         }
+    }
+
+    /// Whether this handle's table was dropped and purged elsewhere, seen as
+    /// its pointer disappearing during a freshness check. [`Self::ensure_fresh`]
+    /// swallows errors by design, so this latch is how that fact escapes.
+    pub(crate) fn pointer_vanished(&self) -> bool {
+        self.inner.pointer_vanished.get().is_some()
     }
 
     test_visible! {
@@ -1365,6 +1388,7 @@ async fn build_handle(
         hidden_index_open_error: std::sync::OnceLock::new(),
         last_pointer_check: Mutex::new(None),
         last_pointer_etag: Mutex::new(None),
+        pointer_vanished: OnceLock::new(),
         hidden_deleted_cache: Mutex::new(None),
         sql_schemas: OnceLock::new(),
     });

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -199,6 +199,23 @@ impl SupertableInner {
         shared_io_runtime()
     }
 
+    /// Latch the purged observation when a commit's pointer fence finds the
+    /// pointer gone, so this handle reads as dead to
+    /// [`Supertable::pointer_vanished`] no matter which path noticed first.
+    ///
+    /// The read path's freshness probe is otherwise the only writer of that
+    /// latch, which leaves a handle that has only ever *written* permanently
+    /// stuck: the commit refuses correctly, but nothing marks the handle, so
+    /// the catalog keeps serving it from cache and every later commit fences
+    /// against a location a re-create has already replaced. Non-vanish errors
+    /// are left alone — contention and storage faults are recoverable, and
+    /// this latch never clears.
+    pub(super) fn note_commit_error(&self, err: &CommitError) {
+        if matches!(err, CommitError::PointerVanished) {
+            let _ = self.pointer_vanished.set(());
+        }
+    }
+
     /// The table's cached SQL schemas, built once from the immutable options.
     /// Cheap `Arc` clone on every call after the first.
     pub(super) fn sql_schemas(&self) -> Arc<SqlSchemas> {
@@ -5638,10 +5655,6 @@ mod tests {
             .with_storage(storage)
             .with_read_consistency(Consistency::Strong);
         let st = Supertable::create(options).expect("create storage-backed handle");
-        // `reader()` calls `ensure_fresh`, which under Strong drives a
-        // blocking `refresh` against the storage pointer. No pointer is
-        // published yet, so the pinned snapshot remains the empty
-        // manifest.
         let r = st.reader().expect("reader");
         assert_eq!(r.n_superfiles(), 0);
         // A direct refresh likewise reports no newer manifest.

--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -420,7 +420,9 @@ pub async fn get_current_manifest_etag(
         .await
         .map_err(|e| CommitError::PointerParse(e.to_string()))?
     else {
-        return Ok(None);
+        // An absent pointer means the table was dropped and purged. ( because
+        // create_table publishes a pointer before any writer runs )
+        return Err(CommitError::PointerVanished);
     };
     let Some(meta_list) = current.list.as_ref() else {
         // no manifest list for in-memory supertables

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -2167,6 +2167,11 @@ pub enum ManifestLoadError {
     /// Pointer not found in storage.
     #[error("pointer not found in storage")]
     PointerNotFound,
+    /// The pointer this handle had been reading has since been deleted, i.e.
+    /// the table was dropped and purged. Unlike [`Self::PointerNotFound`]
+    /// ("never had one"), the handle must be discarded, not refreshed.
+    #[error("manifest pointer was deleted while this handle was open")]
+    PointerVanished,
     #[error("already loaded")]
     AlreadyLoaded,
     /// Pointer parse error.

--- a/src/supertable/mutations.rs
+++ b/src/supertable/mutations.rs
@@ -135,6 +135,13 @@ pub enum MutationError {
     #[error("predicate evaluation failed: {0}")]
     PredicateEval(#[from] QueryError),
 
+    /// The table was dropped and purged while this handle was open, so the
+    /// predicate has no manifest left to resolve against. Refused here rather
+    /// than at the closing commit, which would else write WAL sidecars for a
+    /// table that no longer exists.
+    #[error("table was dropped and purged while this handle was open")]
+    TableGone,
+
     /// Predicate matched more rows than [`MAX_TARGETS_PER_MUTATION`].
     /// Caller narrows the predicate and reissues.
     #[error("predicate matched {matched} rows; mutation cap is {cap}")]

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -969,6 +969,7 @@ mod tests {
         let st = demo(16);
         let batches = st
             .reader()
+            .expect("reader")
             .bm25_search("title", "rust", 10, BoolMode::Or, Some(&["_id"]))
             .expect("bm25_search _id");
         let b = &batches[0];
@@ -983,6 +984,7 @@ mod tests {
         let st = demo(16);
         let batches = st
             .reader()
+            .expect("reader")
             .bm25_search("title", "rust", 10, BoolMode::Or, None)
             .expect("bm25_search default");
         let b = &batches[0];
@@ -998,6 +1000,7 @@ mod tests {
         let st = demo(16);
         let batches = st
             .reader()
+            .expect("reader")
             .bm25_search(
                 "title",
                 "rust",
@@ -1021,9 +1024,13 @@ mod tests {
     #[test]
     fn resolve_hits_named_unknown_column_errors() {
         let st = demo(16);
-        let res = st
-            .reader()
-            .bm25_search("title", "rust", 10, BoolMode::Or, Some(&["nope"]));
+        let res = st.reader().expect("reader").bm25_search(
+            "title",
+            "rust",
+            10,
+            BoolMode::Or,
+            Some(&["nope"]),
+        );
         assert!(res.is_err(), "unknown projected column must error");
     }
 
@@ -1032,6 +1039,7 @@ mod tests {
         let st = demo(16);
         let batches = st
             .reader()
+            .expect("reader")
             .bm25_search("title", "nonexistentterm", 10, BoolMode::Or, Some(&["_id"]))
             .expect("bm25_search empty");
         let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
@@ -1067,7 +1075,7 @@ mod tests {
         // columns (the cost-first "open no readers" branch): `needed`
         // is empty, `score` is synthesized straight from the hits.
         let st = demo(16);
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let hits = two_hits(&reader);
         let scalar_schema = reader.options().scalar_schema();
         let output_schema = output_schema_with_score(&scalar_schema);
@@ -1101,7 +1109,7 @@ mod tests {
         // `_id`+`score` default) materializes every scalar column plus
         // the trailing synthesized `score`, in schema order.
         let st = demo(16);
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let mut hits = two_hits(&reader);
         reader
             .block_on(
@@ -1134,7 +1142,7 @@ mod tests {
         // columns but must still report `hits.len()` rows — the
         // `with_row_count` path.
         let st = demo(16);
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let hits = two_hits(&reader);
         let scalar_schema = reader.options().scalar_schema();
         let output_schema = output_schema_with_score(&scalar_schema);
@@ -1204,7 +1212,7 @@ mod tests {
         // n_docs`, so row `local` resolves to `id_min + local` with no file
         // read.
         let st = demo_fts_only();
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let entry = Arc::clone(&reader.manifest().superfiles[0]);
         let last = (entry.n_docs - 1) as u32;
         let hits = vec![
@@ -1242,7 +1250,7 @@ mod tests {
         // rows are cell-ordered, not id-ordered — span arithmetic must bail
         // to the id-page read even though the id span looks contiguous.
         let st = demo(16);
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let entry = Arc::clone(&reader.manifest().superfiles[0]);
         assert_eq!(entry.vector_layout, VectorLayout::MultiCellIvf);
         let hits = vec![SuperfileHit {
@@ -1263,7 +1271,7 @@ mod tests {
         // lookup, so arithmetic bails to `None` and the caller falls
         // back to the id-page read.
         let st = demo(16);
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let hits = vec![SuperfileHit {
             superfile: SuperfileUri::new_v4(),
             local_doc_id: 0,
@@ -1490,7 +1498,7 @@ mod tests {
         w.append(&build_title_batch(&["rust systems", "go routines"]))
             .expect("second append");
         w.commit().expect("commit");
-        let reader = producer.reader();
+        let reader = producer.reader().expect("reader");
         let entry = reader
             .manifest()
             .superfiles
@@ -1550,6 +1558,7 @@ mod tests {
 
         let batches = consumer
             .reader()
+            .expect("reader")
             .bm25_search("title", "rust", 10, BoolMode::Or, Some(&["title", "score"]))
             .expect("cold bm25 with scalar projection");
 
@@ -1582,6 +1591,7 @@ mod tests {
 
         let batches = consumer
             .reader()
+            .expect("reader")
             .bm25_search(
                 "title",
                 "rust",
@@ -1607,6 +1617,7 @@ mod tests {
 
         let batches = consumer
             .reader()
+            .expect("reader")
             .bm25_search(
                 "title",
                 "nonexistentterm",

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -527,6 +527,7 @@ mod tests {
         let st = demo_corpus();
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title, score FROM bm25_search('title', 'rust', 10)")
             .expect("query_sql");
         let titles = titles_of(&batches);
@@ -544,6 +545,7 @@ mod tests {
         // AND: only doc 4 has both `rust` and `systems`.
         let and_rows = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title FROM bm25_search('title', 'rust systems', 10, 'and')")
             .expect("query_sql");
         let and_titles = titles_of(&and_rows);
@@ -552,6 +554,7 @@ mod tests {
         // OR (default): docs 0 + 4 (union of `rust` and `systems`).
         let or_rows = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title FROM bm25_search('title', 'rust systems', 10)")
             .expect("query_sql");
         assert_eq!(titles_of(&or_rows).len(), 2);
@@ -563,6 +566,7 @@ mod tests {
         // `-systems` drops doc 4; only doc 0 matches `rust` without it.
         let rows = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title FROM bm25_search('title', 'rust -systems', 10)")
             .expect("query_sql");
         assert_eq!(titles_of(&rows), vec!["rust async runtime".to_string()]);
@@ -570,6 +574,7 @@ mod tests {
         // A negation-only query has nothing to rank → error.
         let res = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title FROM bm25_search('title', '-rust', 10)");
         assert!(res.is_err(), "negation-only must error; got {res:?}");
     }
@@ -580,6 +585,7 @@ mod tests {
         // `rus` expands to `rust` → docs 0 + 4.
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title FROM bm25_search_prefix('title', 'rus', 10)")
             .expect("query_sql");
         let titles = titles_of(&batches);
@@ -592,6 +598,7 @@ mod tests {
         let st = demo_corpus();
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT * FROM bm25_search('title', 'rust', 10)")
             .expect("query_sql");
         let b = &batches[0];
@@ -607,6 +614,7 @@ mod tests {
         let st = Supertable::create(options_title_fts()).expect("create");
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title, score FROM bm25_search('title', 'rust', 5)")
             .expect("query_sql");
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -619,6 +627,7 @@ mod tests {
         // 2 args (missing k) → planning error, surfaced as QueryError::Plan.
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT title FROM bm25_search('title', 'rust')")
                 .is_err()
         );
@@ -630,6 +639,7 @@ mod tests {
         // prefix wants exactly 3 args; 2 → planning error.
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT title FROM bm25_search_prefix('title', 'rus')")
                 .is_err()
         );
@@ -641,6 +651,7 @@ mod tests {
         // Non-integer k.
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT title FROM bm25_search('title', 'rust', 'ten')")
                 .is_err(),
             "non-integer k must error"
@@ -648,6 +659,7 @@ mod tests {
         // Invalid mode literal.
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT title FROM bm25_search('title', 'rust', 10, 'nand')")
                 .is_err(),
             "invalid mode must error"
@@ -659,6 +671,7 @@ mod tests {
     fn explain(st: &Supertable, sql: &str) -> String {
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(&format!("EXPLAIN {sql}"))
             .expect("explain");
         let mut out = String::new();
@@ -685,7 +698,7 @@ mod tests {
     async fn bm25_table_and_exec_trait_methods() {
         use crate::supertable::query::exec::common::test_support::call_tvf;
         let st = demo_corpus();
-        let reader = Arc::new(st.reader());
+        let reader = Arc::new(st.reader().expect("reader"));
         let scalar_schema = reader.options().scalar_schema();
         let func = Bm25SearchFunc::new(reader, scalar_schema);
         let table = call_tvf(&func, &[lit("title"), lit("rust"), lit(10_i64)]).expect("bm25 table");

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -192,7 +192,7 @@ impl Supertable {
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
         debug!(text_col, vec_col, k, "hybrid_search");
-        let reader = self.reader();
+        let reader = self.reader()?;
         let hits = reader
             .hybrid_search(text_col, q_text, mode, vec_col, q_vec, options, k)
             .map_err(|e| InfinoError::from(e).with_context("hybrid_search", None))?;
@@ -808,6 +808,7 @@ mod tests {
 
         let hybrid = id_set(
             &st.reader()
+                .expect("reader")
                 .query_sql(&format!(
                     "SELECT _id FROM hybrid_search('title', 'rust', 'emb', '{qv}', {k})"
                 ))
@@ -815,6 +816,7 @@ mod tests {
         );
         let bm25 = id_set(
             &st.reader()
+                .expect("reader")
                 .query_sql(&format!(
                     "SELECT _id FROM bm25_search('title', 'rust', {k})"
                 ))
@@ -822,6 +824,7 @@ mod tests {
         );
         let vector = id_set(
             &st.reader()
+                .expect("reader")
                 .query_sql(&format!(
                     "SELECT _id FROM vector_search('emb', '{qv}', {k})"
                 ))
@@ -841,6 +844,7 @@ mod tests {
         let st = demo(dim);
         let res = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT title, score FROM hybrid_search('title', 'async', 'emb', '{}', 8)",
                 csv_one_hot(dim, 0)
@@ -864,6 +868,7 @@ mod tests {
         let st = demo(dim);
         let res = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT title FROM hybrid_search('title', 'async', 'emb', '{}', 8)",
                 csv_one_hot(dim, 7)
@@ -890,6 +895,7 @@ mod tests {
         let st = demo(dim);
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT * FROM hybrid_search('title', 'rust', 'emb', '{}', 3)",
                 csv_one_hot(dim, 0)
@@ -909,6 +915,7 @@ mod tests {
         let st = Supertable::create(options_title_emb(dim)).expect("create");
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT _id, score FROM hybrid_search('title', 'rust', 'emb', '{}', 5)",
                 csv_one_hot(dim, 0)
@@ -925,6 +932,7 @@ mod tests {
         // 4 args (missing k) → planning error.
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM hybrid_search('title', 'rust', 'emb', '1,0')")
                 .is_err()
         );
@@ -937,6 +945,7 @@ mod tests {
         // Non-integer k (5th arg).
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM hybrid_search('title', 'rust', 'emb', '1,0', 'five')")
                 .is_err(),
             "non-integer k must error"
@@ -944,6 +953,7 @@ mod tests {
         // Unparseable query vector (4th arg).
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM hybrid_search('title', 'rust', 'emb', 'a,b', 3)")
                 .is_err(),
             "bad query vector must error"
@@ -960,6 +970,7 @@ mod tests {
         qv[0] = 1.0; // one-hot at dim 0 → doc 0 exact vector match.
         let hits = st
             .reader()
+            .expect("reader")
             .hybrid_search(
                 "title",
                 "async",
@@ -1019,6 +1030,7 @@ mod tests {
 
         let via_sql = id_set(
             &st.reader()
+                .expect("reader")
                 .query_sql(&format!(
                     "SELECT _id FROM hybrid_search('title', 'async', 'emb', '{}', 8)",
                     csv_one_hot(dim, 0)
@@ -1033,6 +1045,7 @@ mod tests {
     fn explain(st: &Supertable, sql: &str) -> String {
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(&format!("EXPLAIN {sql}"))
             .expect("explain");
         let mut out = String::new();
@@ -1061,7 +1074,7 @@ mod tests {
 
         let dim = 16;
         let st = demo(dim);
-        let reader = Arc::new(st.reader());
+        let reader = Arc::new(st.reader().expect("reader"));
         let scalar_schema = reader.options().scalar_schema();
         use crate::supertable::query::exec::common::test_support::call_tvf;
         let func = HybridSearchFunc::new(reader, scalar_schema);
@@ -1270,16 +1283,19 @@ mod tests {
         // The three single-retriever result sets — the oracle inputs.
         let fts = id_set(
             &st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM bm25_search('title', 'rust', 8)")
                 .expect("bm25 query_sql"),
         );
         let vector = id_set(
             &st.reader()
+                .expect("reader")
                 .query_sql(&format!("SELECT _id FROM vector_search('emb', '{qv}', 5)"))
                 .expect("vector query_sql"),
         );
         let scalar = id_set(
             &st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM supertable WHERE category = 'systems'")
                 .expect("scalar query_sql"),
         );
@@ -1294,6 +1310,7 @@ mod tests {
         // spanning two superfiles.
         let combined_batches = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT b._id, b.title AS title, b.category AS category, b.score AS score \
                  FROM bm25_search('title', 'rust', 8) AS b \

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -439,6 +439,7 @@ mod tests {
 
     fn rows(st: &Supertable, sql: &str) -> usize {
         st.reader()
+            .expect("reader")
             .query_sql(sql)
             .expect("query_sql")
             .iter()
@@ -496,6 +497,7 @@ mod tests {
         let st = demo();
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT * FROM token_match('title', 'rust')")
             .expect("query_sql");
         let b = &batches[0];
@@ -509,12 +511,14 @@ mod tests {
         let st = demo();
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM token_match('title')")
                 .is_err(),
             "token_match needs >= 2 args"
         );
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM exact_match('title')")
                 .is_err(),
             "exact_match needs 2 args"
@@ -524,7 +528,7 @@ mod tests {
     #[test]
     fn public_methods_agree_with_tvfs() {
         let st = demo();
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let method = reader
             .token_match("title", "rust systems", BoolMode::And)
             .expect("token_match");
@@ -540,6 +544,7 @@ mod tests {
     fn explain(st: &Supertable, sql: &str) -> String {
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(&format!("EXPLAIN {sql}"))
             .expect("explain");
         let mut out = String::new();
@@ -580,7 +585,7 @@ mod tests {
     /// schemas a `MatchExec` needs, from a committed demo table.
     fn reader_and_schemas() -> (Arc<SupertableReader>, Arc<Schema>, Arc<Schema>) {
         let st = demo();
-        let reader = Arc::new(st.reader());
+        let reader = Arc::new(st.reader().expect("reader"));
         let scalar_schema = reader.options().scalar_schema();
         let output_schema = output_schema_with_score(&scalar_schema);
         (reader, scalar_schema, output_schema)
@@ -703,7 +708,7 @@ mod tests {
         // SQL layer. A live reader keeps the WeakReader upgrade-able.
         use crate::supertable::query::exec::common::test_support::call_tvf;
         let st = demo();
-        let reader = Arc::new(st.reader());
+        let reader = Arc::new(st.reader().expect("reader"));
         let scalar_schema = reader.options().scalar_schema();
         let tf = TokenMatchFunc::new(Arc::clone(&reader), Arc::clone(&scalar_schema));
         // 1 arg → error; 2 args → ok.
@@ -724,7 +729,7 @@ mod tests {
         use crate::supertable::query::exec::common::test_support::call_tvf;
 
         let st = demo();
-        let reader = Arc::new(st.reader());
+        let reader = Arc::new(st.reader().expect("reader"));
         let scalar_schema = reader.options().scalar_schema();
         let func = TokenMatchFunc::new(reader, scalar_schema);
         let table = call_tvf(&func, &[lit("title"), lit("rust")]).expect("match table");
@@ -744,6 +749,7 @@ mod tests {
         // Non-string column literal.
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM token_match(5, 'rust')")
                 .is_err(),
             "non-string column must error"
@@ -751,6 +757,7 @@ mod tests {
         // Bad mode value (third arg).
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql("SELECT _id FROM token_match('title', 'rust', 'xor')")
                 .is_err(),
             "invalid bool mode must error"

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -752,7 +752,11 @@ mod tests {
             "SELECT _id, title, score FROM vector_search('emb', '{}', {n})",
             csv_one_hot(dim, 0)
         );
-        let batches = st.reader().query_sql(&sql).expect("query_sql");
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(&sql)
+            .expect("query_sql");
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, n, "single superfile, k=n → all docs resolved");
 
@@ -786,6 +790,7 @@ mod tests {
         let query = csv_one_hot(dim, 0);
         let resolved = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT _id, title FROM vector_search('emb', '{query}', {n})"
             ))
@@ -825,6 +830,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT _id FROM vector_search('emb', '{query}', {n})"
             ))
@@ -848,6 +854,7 @@ mod tests {
         // the condition the pushdown exists to fix.
         let unfiltered = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT title, score FROM vector_search('emb', '{q}', {k})"
             ))
@@ -863,6 +870,7 @@ mod tests {
         // exactly the k nearest rare docs — no underflow, every row matches.
         let filtered = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT title, score FROM vector_search('emb', '{q}', {k}) WHERE title = 'rare'"
             ))
@@ -897,6 +905,7 @@ mod tests {
         // unbounded path still returns correct results end-to-end.
         let rows = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT title, score FROM vector_search('emb', '{q}', {k}) WHERE score >= 0.0"
             ))
@@ -913,7 +922,11 @@ mod tests {
             "SELECT * FROM vector_search('emb', '{}', 3)",
             csv_one_hot(dim, 0)
         );
-        let batches = st.reader().query_sql(&sql).expect("query_sql");
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(&sql)
+            .expect("query_sql");
         let b = &batches[0];
         // Scalar schema (_id, title) + score.
         assert_eq!(b.num_columns(), 3);
@@ -931,7 +944,11 @@ mod tests {
             "SELECT score FROM vector_search('emb', '{}', 2)",
             csv_one_hot(dim, 0)
         );
-        let batches = st.reader().query_sql(&sql).expect("query_sql");
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(&sql)
+            .expect("query_sql");
         let b = &batches[0];
         assert_eq!(b.num_columns(), 1);
         assert_eq!(b.schema().field(0).name(), "score");
@@ -948,12 +965,14 @@ mod tests {
         let q = csv_one_hot(dim, 0);
         let full = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT _id, title, score FROM vector_search('emb', '{q}', 5)"
             ))
             .expect("query_sql");
         let only = st
             .reader()
+            .expect("reader")
             .query_sql(&format!("SELECT score FROM vector_search('emb', '{q}', 5)"))
             .expect("query_sql");
 
@@ -983,7 +1002,11 @@ mod tests {
             .collect::<Vec<_>>()
             .join(",");
         let sql = format!("SELECT title FROM vector_search('emb', [{arr}], 1)");
-        let batches = st.reader().query_sql(&sql).expect("query_sql");
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(&sql)
+            .expect("query_sql");
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 1);
         assert_eq!(col_str(&batches[0], "title").value(0), "doc 0");
@@ -997,7 +1020,11 @@ mod tests {
             "SELECT _id, score FROM vector_search('emb', '{}', 5)",
             csv_one_hot(dim, 0)
         );
-        let batches = st.reader().query_sql(&sql).expect("query_sql");
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(&sql)
+            .expect("query_sql");
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 0);
     }
@@ -1099,6 +1126,7 @@ mod tests {
         // 2 args (missing k) → planning error.
         assert!(
             st.reader()
+                .expect("reader")
                 .query_sql(&format!(
                     "SELECT _id FROM vector_search('emb', '{}')",
                     csv_one_hot(dim, 0)
@@ -1115,7 +1143,7 @@ mod tests {
     async fn vector_table_and_exec_trait_methods() {
         let dim = 16;
         let st = supertable_one_superfile(dim, 8);
-        let reader = Arc::new(st.reader());
+        let reader = Arc::new(st.reader().expect("reader"));
         let scalar_schema = reader.options().scalar_schema();
         use crate::supertable::query::exec::common::test_support::call_tvf;
         let func = VectorSearchFunc::new(reader, scalar_schema);
@@ -1148,6 +1176,7 @@ mod tests {
         let st = supertable_one_superfile(dim, 8);
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(&format!(
                 "EXPLAIN SELECT _id FROM vector_search('emb', '{}', 5)",
                 csv_one_hot(dim, 0)

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1352,7 +1352,7 @@ impl Supertable {
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
         debug!(column, k, mode = ?mode, "bm25_search");
-        self.reader()
+        self.reader()?
             .bm25_search(column, query, k, mode, projection)
             .map_err(InfinoError::from)
             .map_err(|e| e.with_context("bm25_search", None))
@@ -1382,7 +1382,7 @@ impl Supertable {
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
         debug!(column, mode = ?mode, "token_match");
-        let reader = self.reader();
+        let reader = self.reader()?;
         let hits = reader
             .token_match(column, query, mode)
             .map_err(|e| InfinoError::from(e).with_context("token_match", None))?;
@@ -1413,7 +1413,7 @@ impl Supertable {
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
         debug!(column, "exact_match");
-        let reader = self.reader();
+        let reader = self.reader()?;
         let hits = reader
             .exact_match(column, value)
             .map_err(|e| InfinoError::from(e).with_context("exact_match", None))?;
@@ -1464,7 +1464,7 @@ impl Supertable {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn count(&self, column: &str, query: &str, mode: BoolMode) -> Result<u64, InfinoError> {
-        self.reader()
+        self.reader()?
             .count(column, query, mode)
             .map_err(InfinoError::from)
             .map_err(|e| e.with_context("count", None))
@@ -1595,7 +1595,7 @@ mod tests {
         w.append(&build_batch(3, &["beta gamma"])).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r
             .bm25_hits("title", "alpha -beta", 10, BoolMode::Or)
             .expect("negation search");
@@ -1624,7 +1624,7 @@ mod tests {
         w.append(&build_batch(3, &["gamma three"])).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r
             .bm25_hits("title", "alpha -delta", 10, BoolMode::And)
             .expect("negation search");
@@ -1638,7 +1638,7 @@ mod tests {
         w.append(&build_batch(0, &["alpha beta"])).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let res = r.bm25_hits("title", "-alpha", 10, BoolMode::Or);
         assert!(res.is_err(), "negation-only must error; got {res:?}");
     }
@@ -1653,7 +1653,7 @@ mod tests {
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["alpha beta"])).expect("append");
         w.commit().expect("commit");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
 
         for mode in [BoolMode::Or, BoolMode::And] {
             assert!(
@@ -1679,7 +1679,7 @@ mod tests {
     #[test]
     fn bm25_search_empty_supertable_returns_empty_without_store_calls() {
         let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r
             .bm25_hits("title", "rust", 5, BoolMode::Or)
             .expect("query");
@@ -1692,7 +1692,7 @@ mod tests {
         let mut w = st.writer().expect("writer");
         w.append(&build_batch(0, &["rust async"])).expect("append");
         w.commit().expect("commit");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r
             .bm25_hits("title", "rust", 0, BoolMode::Or)
             .expect("query");
@@ -1714,7 +1714,7 @@ mod tests {
         ))
         .expect("append");
         w.commit().expect("commit");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r
             .bm25_hits("title", "rust", 4, BoolMode::Or)
             .expect("query");
@@ -1735,7 +1735,7 @@ mod tests {
         w.append(&build_batch(10, &["rust runtime"])).expect("a2");
         w.commit().expect("c2");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.n_superfiles(), 2);
         let hits = r
             .bm25_hits("title", "rust", 5, BoolMode::Or)
@@ -1786,7 +1786,7 @@ mod tests {
                 .expect("append");
             w.commit().expect("commit");
         }
-        assert_eq!(st.reader().n_superfiles(), 3);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 3);
 
         let oracle = build_oracle_superfile(&titles);
         // Single-superfile `SuperfileReader` oracle: async-only search,
@@ -1799,7 +1799,7 @@ mod tests {
         let oracle_set: HashSet<u32> = oracle_hits.iter().map(|(d, _)| *d).collect();
         assert_eq!(oracle_set, [0u32, 4, 8].iter().copied().collect());
 
-        let st_reader = st.reader();
+        let st_reader = st.reader().expect("reader");
         let st_hits = st_reader
             .bm25_hits("title", "nimblefox", 5, BoolMode::Or)
             .expect("supertable query");
@@ -1847,7 +1847,7 @@ mod tests {
         let oracle_hits = block_on(oracle.bm25_search_prefix("title", "rust", 5)).expect("oracle");
         let oracle_globals: HashSet<u32> = oracle_hits.iter().map(|(d, _)| *d).collect();
 
-        let st_reader = st.reader();
+        let st_reader = st.reader().expect("reader");
         let st_hits = st_reader
             .bm25_search_prefix("title", "rust", 5)
             .expect("supertable query");
@@ -1877,7 +1877,7 @@ mod tests {
         w.append(&build_batch(0, &["rust async"])).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r.bm25_search_prefix("title", "zzzz", 10).expect("query");
         assert!(hits.is_empty());
     }
@@ -1893,7 +1893,7 @@ mod tests {
             .expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r.bm25_search_prefix("title", "RUST", 5).expect("query");
         assert_eq!(hits.len(), 1);
     }
@@ -1905,7 +1905,7 @@ mod tests {
         w.append(&build_batch(0, &["rust"])).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let err = r
             .bm25_hits("missing_column", "rust", 5, BoolMode::Or)
             .expect_err("expected error");
@@ -1922,7 +1922,7 @@ mod tests {
                 .expect("a");
             w.commit().expect("c");
         }
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r
             .bm25_hits("title", "rust", 2, BoolMode::Or)
             .expect("query");
@@ -1986,7 +1986,7 @@ mod tests {
     #[test]
     fn reader_token_match_and_exact_match_hits() {
         let st = seeded_three_doc_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
 
         // token_match And requires every token to be present.
         let any = r.token_match("title", "quick", BoolMode::And).expect("tm");
@@ -2005,7 +2005,7 @@ mod tests {
     #[test]
     fn token_match_empty_query_short_circuits() {
         let st = seeded_three_doc_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         // A query that tokenizes to nothing returns empty without
         // touching the store.
         let hits = r
@@ -2074,7 +2074,7 @@ mod tests {
     #[test]
     fn phrase_query_end_to_end() {
         let st = seeded_phrase_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
 
         // Ranked: exactly the adjacent-in-order docs across both
         // superfiles.
@@ -2110,7 +2110,7 @@ mod tests {
     #[test]
     fn phrase_on_positionless_table_errors() {
         let st = seeded_clause_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let err = r
             .bm25_hits("title", r#""climate change""#, 10, BoolMode::Or)
             .expect_err("typed error expected");
@@ -2138,7 +2138,7 @@ mod tests {
     #[test]
     fn must_should_match_set_and_count_across_superfiles() {
         let st = seeded_clause_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
 
         // 3 docs contain `climate`; `policy` is scoring-only and must
         // not pull in "policy analysis quarterly".
@@ -2171,7 +2171,7 @@ mod tests {
     #[test]
     fn must_should_token_match_matches_musts_only() {
         let st = seeded_clause_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         // Unranked matching has no scores for the should to raise —
         // the match set is exactly the must set.
         let tm = r
@@ -2183,7 +2183,7 @@ mod tests {
     #[test]
     fn must_should_with_negation_across_superfiles() {
         let st = seeded_clause_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         // Negation still excludes: drop the summit doc from the
         // climate must set.
         let hits = r
@@ -2199,7 +2199,7 @@ mod tests {
     #[test]
     fn absent_must_prunes_every_superfile() {
         let st = seeded_clause_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         // The must term exists nowhere: bloom-prune (or the empty
         // intersection) yields no hits despite the common should.
         let hits = r
@@ -2215,7 +2215,7 @@ mod tests {
     #[test]
     fn token_match_no_match_returns_empty() {
         let st = seeded_three_doc_supertable();
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let hits = r
             .token_match("title", "nonexistentterm", BoolMode::Or)
             .expect("tm");
@@ -2386,7 +2386,7 @@ mod tests {
         );
 
         // Cross-check every shape against token_match cardinality.
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         for (q, mode) in [
             ("alpha beta", BoolMode::Or),
             ("gamma delta", BoolMode::Or),
@@ -2437,7 +2437,7 @@ mod tests {
         ))
         .expect("append");
         w.commit().expect("commit");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         for (q, mode) in [
             ("alpha", BoolMode::Or),
             ("alpha delta", BoolMode::Or),
@@ -2539,7 +2539,7 @@ mod tests {
         ))
         .expect("append");
         w.commit().expect("commit");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         for (q, mode) in [
             ("alpha -beta", BoolMode::Or),
             ("alpha gamma -delta", BoolMode::Or),

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -2206,9 +2206,9 @@ mod tests {
         w.append(&cat_title_batch(&["lang", "lang"], &["delta", "sigma"]))
             .expect("a3");
         w.commit().expect("c3");
-        assert_eq!(st.reader().n_superfiles(), 3);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 3);
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let provider = SupertableProvider::new(
             st.options().scalar_schema(),
             reader.manifest().clone(),
@@ -2258,7 +2258,7 @@ mod tests {
         w.append(&cat_title_batch(&["b"], &["delta"])).expect("a2");
         w.commit().expect("c2");
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let provider = SupertableProvider::new(
             st.options().scalar_schema(),
             reader.manifest().clone(),
@@ -2435,7 +2435,7 @@ mod tests {
         w.append(&num_batch(&[Some(10), Some(20)])).expect("a2");
         w.commit().expect("c2");
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let provider = SupertableProvider::new(
             st.options().scalar_schema(),
             reader.manifest().clone(),

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -6,7 +6,7 @@
 //! ## Public API
 //!
 //! ```ignore
-//! let reader = supertable.reader();
+//! let reader = supertable.reader().expect("reader");
 //! let batches: Vec<RecordBatch> =
 //!     reader.query_sql("SELECT category, COUNT(*) FROM supertable GROUP BY category")?;
 //! ```
@@ -402,7 +402,7 @@ impl Supertable {
         name: &str,
     ) -> Result<Arc<SupertableReader>, QueryError> {
         self.ensure_fresh();
-        let reader = Arc::new(self.reader());
+        let reader = Arc::new(self.reader().map_err(QueryError::ManifestLoad)?);
         let manifest = Arc::clone(reader.manifest());
         let store = Arc::clone(&self.options().store);
         let disk_cache = self.options().disk_cache.as_ref().map(Arc::clone);
@@ -582,7 +582,11 @@ mod tests {
     /// Convenience: run a query and pull a single `Int64` aggregate
     /// value from cell (0,0).
     fn run_count(st: &Supertable, sql: &str) -> i64 {
-        let batches = st.reader().query_sql(sql).expect("query_sql ok");
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(sql)
+            .expect("query_sql ok");
         assert!(!batches.is_empty(), "expected at least one result batch");
         let n = batches[0]
             .column(0)
@@ -658,7 +662,7 @@ mod tests {
             .append(&build_cat_batch(0, &["rust"], &["searchable"]))
             .expect("append");
         writer.commit().expect("commit");
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let scalar_sql = "SELECT COUNT(*) FROM supertable";
 
         reader.query_sql(scalar_sql).expect("first scalar query");
@@ -792,6 +796,7 @@ mod tests {
 
         let err = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT category, COUNT(*) FROM supertable GROUP BY category")
             .expect_err("0-byte gate refuses the aggregate");
 
@@ -807,6 +812,7 @@ mod tests {
 
         let rows: usize = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title FROM supertable")
             .expect("a streaming scan is not gated")
             .iter()
@@ -830,6 +836,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(
                 "SELECT category, COUNT(*) AS n FROM supertable \
                  GROUP BY category ORDER BY category",
@@ -882,6 +889,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT category FROM supertable GROUP BY category")
             .expect("group-by");
         let col = batches[0].column(0);
@@ -907,6 +915,7 @@ mod tests {
         let st = seeded(&["rust", "go", "python"], &["a", "b", "c"]);
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT category FROM supertable ORDER BY category")
             .expect("order-by");
         let col = batches[0]
@@ -925,6 +934,7 @@ mod tests {
         let st = seeded(&["rust", "rust", "go", "go"], &["b", "a", "d", "c"]);
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(
                 "SELECT category, MIN(title) AS m FROM supertable \
                  GROUP BY category ORDER BY category",
@@ -953,6 +963,7 @@ mod tests {
         let st = seeded(&["rust", "go", "python"], &["a", "b", "c"]);
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT MIN(category) AS m FROM supertable")
             .expect("ungrouped min");
         let col = batches[0]
@@ -1048,6 +1059,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT category FROM supertable")
             .expect("select");
         let col = batches[0]
@@ -1100,6 +1112,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT category FROM supertable GROUP BY category")
             .expect("group-by");
         assert_eq!(
@@ -1117,6 +1130,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT category AS c FROM supertable GROUP BY c ORDER BY c")
             .expect("alias");
         let col = batches[0]
@@ -1136,6 +1150,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(
                 "WITH t AS (SELECT category FROM supertable) \
                  SELECT category FROM t GROUP BY category ORDER BY category",
@@ -1157,6 +1172,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(
                 "SELECT category FROM (SELECT category FROM supertable) sub \
                  GROUP BY category ORDER BY category",
@@ -1192,6 +1208,7 @@ mod tests {
         let st = seeded(&vals, &titles);
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT category FROM supertable GROUP BY category ORDER BY category")
             .expect("group-by over layout-stressing values");
         let col = batches[0]
@@ -1224,6 +1241,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT DISTINCT category FROM supertable ORDER BY category")
             .expect("distinct");
         let col = batches[0]
@@ -1243,6 +1261,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql(
                 "SELECT a.category AS cat FROM supertable a \
                  JOIN supertable b ON a.category = b.category \
@@ -1276,6 +1295,7 @@ mod tests {
 
         let batches = table
             .reader()
+            .expect("reader")
             .query_sql(
                 "SELECT category, COUNT(*) AS n FROM supertable \
                  GROUP BY category ORDER BY category NULLS FIRST",
@@ -1313,7 +1333,7 @@ mod tests {
             .expect("a3");
         w.commit().expect("c3");
 
-        assert_eq!(st.reader().n_superfiles(), 3);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 3);
 
         let n_total = run_count(&st, "SELECT COUNT(*) FROM supertable");
         assert_eq!(n_total, 5);
@@ -1343,7 +1363,7 @@ mod tests {
         w.append(&build_cat_batch(20, &["z"], &["charlie"]))
             .expect("a3");
         w.commit().expect("c3");
-        assert_eq!(st.reader().n_superfiles(), 3);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 3);
 
         assert_eq!(
             run_count(&st, "SELECT COUNT(*) FROM supertable WHERE title = 'bravo'"),
@@ -1372,7 +1392,7 @@ mod tests {
         w.append(&build_cat_batch(10, &["lang"], &["python data science"]))
             .expect("a2");
         w.commit().expect("c2");
-        assert_eq!(st.reader().n_superfiles(), 2);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
 
         assert_eq!(
             run_count(
@@ -1419,6 +1439,7 @@ mod tests {
         );
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT title FROM supertable WHERE title = 'rust async'")
             .expect("query");
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -1571,6 +1592,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT _id FROM supertable ORDER BY _id")
             .expect("query");
         let ids: Vec<i128> = batches
@@ -1602,6 +1624,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT * FROM supertable LIMIT 1")
             .expect("query");
         let schema = batches[0].schema();
@@ -1634,6 +1657,7 @@ mod tests {
         let st = Supertable::create(options_id_cat_title()).expect("create");
         let err = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT NOT_A_REAL_FN(*) FROM supertable")
             .expect_err("expected a plan error");
         assert!(
@@ -1724,6 +1748,7 @@ mod tests {
 
         let batches = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT * FROM supertable LIMIT 1")
             .expect("query");
         let schema = batches[0].schema();
@@ -1743,6 +1768,7 @@ mod tests {
 
         let err = st
             .reader()
+            .expect("reader")
             .query_sql("SELECT emb FROM supertable")
             .expect_err("vector column should not be in the SQL schema");
         assert!(

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2799,7 +2799,7 @@ impl Supertable {
         filter: Option<VectorFilter<'_>>,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, crate::InfinoError> {
-        self.reader()
+        self.reader()?
             .vector_search(column, query, k, options, filter, projection)
             .map_err(crate::InfinoError::from)
             .map_err(|e| e.with_context("vector_search", None))
@@ -2920,7 +2920,7 @@ mod tests {
     fn hidden_hits_user_ids_uses_inline_stable_id_fast_path() {
         let dim = 16;
         let table = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
-        let reader = table.reader();
+        let reader = table.reader().expect("reader");
         let manifest = reader.manifest();
 
         let mk = |sid: i128| SuperfileHit {
@@ -2946,15 +2946,15 @@ mod tests {
         assert!(table.options().partition_strategy.is_none());
         let mut centroid = vec![0.0; dim];
         centroid[0] = 1.0;
-        let manifest =
-            table
-                .reader()
-                .manifest()
-                .with_partition_strategy(PartitionStrategy::VectorCell {
-                    column: "emb".into(),
-                    clusters: ClusterCentroids::from_fp32(1, dim as u32, &centroid, vec![1]),
-                    routing: Default::default(),
-                });
+        let manifest = table
+            .reader()
+            .expect("reader")
+            .manifest()
+            .with_partition_strategy(PartitionStrategy::VectorCell {
+                column: "emb".into(),
+                clusters: ClusterCentroids::from_fp32(1, dim as u32, &centroid, vec![1]),
+                routing: Default::default(),
+            });
         assert!(is_hidden_vector_manifest(&manifest));
     }
 
@@ -3286,7 +3286,7 @@ mod tests {
     #[test]
     fn vector_search_empty_supertable_returns_empty() {
         let st = Supertable::create(options_one_superfile_per_commit(16)).expect("create");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let q = vec![0.1f32; 16];
         let hits = r
             .vector_hits("emb", &q, 5, VectorSearchOptions::new(), None)
@@ -3301,7 +3301,7 @@ mod tests {
         let schema = st.options().schema.clone();
         w.append(&build_vector_batch(0, 8, 16, schema)).expect("a");
         w.commit().expect("c");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let q = vec![0.1f32; 16];
         let hits = r
             .vector_hits("emb", &q, 0, VectorSearchOptions::new(), None)
@@ -3317,7 +3317,7 @@ mod tests {
         let schema = st.options().schema.clone();
         w.append(&build_vector_batch(0, 8, dim, schema)).expect("a");
         w.commit().expect("c");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         // Query vector resembling row 0's pattern.
         let mut q = vec![0.0f32; dim];
         for (d, x) in q.iter_mut().enumerate() {
@@ -3349,7 +3349,7 @@ mod tests {
                 .expect("a");
             w.commit().expect("c");
         }
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let q = vec![0.1f32; dim];
         let hits = r
             .vector_hits("emb", &q, 7, VectorSearchOptions::new(), None)
@@ -3376,13 +3376,14 @@ mod tests {
                 .expect("append");
             w.commit().expect("commit");
         }
-        assert_eq!(st.reader().n_superfiles(), n_seg as usize);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), n_seg as usize);
 
         let mut q = vec![0f32; dim];
         q[0] = 1.0;
         let opts = VectorSearchOptions::new().with_nprobe(1);
         let hits = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 10, opts, None)
             .expect("query");
 
@@ -3405,7 +3406,7 @@ mod tests {
                 .expect("a");
             w.commit().expect("c");
         }
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let q = vec![0.1f32; dim];
         let hits = r
             .vector_hits("emb", &q, 24, VectorSearchOptions::new(), None)
@@ -3453,7 +3454,7 @@ mod tests {
         let oracle_globals: HashSet<u32> = oracle_hits.iter().map(|(d, _)| *d).collect();
         assert_eq!(oracle_globals, [0u32, 16].iter().copied().collect());
 
-        let st_reader = st.reader();
+        let st_reader = st.reader().expect("reader");
         let st_hits = st_reader
             .vector_hits("emb", &q, 2, opts, None)
             .expect("supertable query");
@@ -3481,7 +3482,7 @@ mod tests {
         let schema = st.options().schema.clone();
         w.append(&build_vector_batch(0, 8, dim, schema)).expect("a");
         w.commit().expect("c");
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let q = vec![0.1f32; dim];
         let err = r
             .vector_hits("nope", &q, 5, VectorSearchOptions::new(), None)
@@ -3656,7 +3657,7 @@ mod tests {
             .expect("append");
         w.commit().expect("commit");
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let user_uris: HashSet<_> = reader.manifest().superfiles.iter().map(|e| e.uri).collect();
         assert!(
             reader.vector_index_table().is_some(),
@@ -3705,6 +3706,7 @@ mod tests {
         q[0] = 1.0;
         let batches = st
             .reader()
+            .expect("reader")
             .vector_search(
                 "emb",
                 &q,
@@ -3750,6 +3752,7 @@ mod tests {
         q[0] = 1.0;
         let search = |st: &Supertable| {
             st.reader()
+                .expect("reader")
                 .vector_hits(
                     "emb",
                     &q,
@@ -3778,6 +3781,7 @@ mod tests {
             .expect("optimize after delete");
         assert!(
             !st.reader()
+                .expect("reader")
                 .vector_hits(
                     "emb",
                     &q,
@@ -3821,6 +3825,7 @@ mod tests {
         // Wide k + nprobe: rerank spans several probed cells.
         let hits = st
             .reader()
+            .expect("reader")
             .vector_hits(
                 "emb",
                 &q,
@@ -3838,6 +3843,7 @@ mod tests {
         // Filtered variant over the same corpus.
         let filtered = st
             .reader()
+            .expect("reader")
             .vector_hits(
                 "emb",
                 &q,
@@ -3915,7 +3921,7 @@ mod tests {
         let allow: Arc<RoaringBitmap> = Arc::new([0u32, 1, 2].into_iter().collect());
         let mut q = vec![0.0f32; dim];
         q[0] = 1.0;
-        let hits = block_on(st.reader().vector_hits_global_allow_async(
+        let hits = block_on(st.reader().expect("reader").vector_hits_global_allow_async(
             "emb",
             &q,
             16,
@@ -3958,6 +3964,7 @@ mod tests {
         q[0] = 1.0;
         let batches = st
             .reader()
+            .expect("reader")
             .vector_search(
                 "emb",
                 &q,
@@ -3979,6 +3986,7 @@ mod tests {
 
         let prepared = block_on(
             st.reader()
+                .expect("reader")
                 .prepare_vector_stable_allow_async(Arc::new(vec![id])),
         )
         .expect("valid drained id must map");
@@ -4018,6 +4026,7 @@ mod tests {
         q[0] = 1.0;
         let batches = st
             .reader()
+            .expect("reader")
             .vector_search(
                 "emb",
                 &q,
@@ -4078,6 +4087,7 @@ mod tests {
         q[0] = 1.0;
         let batches = st
             .reader()
+            .expect("reader")
             .vector_search(
                 "emb",
                 &q,
@@ -4151,7 +4161,7 @@ mod tests {
         drop(w);
         st.drain_vectors_to_cells_sync().expect("drain");
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let manifest = reader.manifest();
         let fts_cols: HashSet<&str> = HashSet::from(["title"]);
         let filters = [col("title").eq(lit("doc"))];
@@ -4219,13 +4229,14 @@ mod tests {
         w.commit().expect("commit");
         st.drain_vectors_to_cells_sync().expect("drain");
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let user_uris: HashSet<_> = reader.manifest().superfiles.iter().map(|e| e.uri).collect();
         let hidden = reader
             .vector_index_table()
             .expect("hidden index must exist");
         let hidden_uris: HashSet<_> = hidden
             .reader()
+            .expect("reader")
             .manifest()
             .superfiles
             .iter()
@@ -4331,6 +4342,7 @@ mod tests {
         q[0] = 1.0;
         let hits_before = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 32, VectorSearchOptions::new(), None)
             .expect("pre-delete search");
         assert!(!hits_before.is_empty(), "docs retrievable pre-delete");
@@ -4341,6 +4353,7 @@ mod tests {
 
         let hits_after = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, 32, VectorSearchOptions::new(), None)
             .expect("post-delete search");
         assert_eq!(
@@ -4368,7 +4381,7 @@ mod tests {
             .expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let manifest = r.manifest();
         assert!(
             !manifest.superfiles.is_empty(),
@@ -4439,7 +4452,7 @@ mod tests {
             .expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let mut q = vec![0.0f32; dim];
         q[0] = 1.0;
         let k = 20usize;
@@ -4508,7 +4521,7 @@ mod tests {
             .expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let manifest = r.manifest();
         let mut checked_files = 0usize;
         for entry in manifest.superfiles.iter() {
@@ -4577,9 +4590,13 @@ mod tests {
         writer.commit().expect("commit delta");
         drop(writer);
 
-        let reader = st.reader();
+        let reader = st.reader().expect("reader");
         let hidden = reader.vector_index_table().expect("hidden index");
-        let drained = hidden.reader().manifest().get_drained_ranges();
+        let drained = hidden
+            .reader()
+            .expect("reader")
+            .manifest()
+            .get_drained_ranges();
         let undrained: Vec<_> = reader
             .manifest()
             .superfiles

--- a/src/supertable/wal/recovery_sweep_tests.rs
+++ b/src/supertable/wal/recovery_sweep_tests.rs
@@ -97,7 +97,7 @@ async fn open_time_sweep_drives_pre_seeded_intent_walls_to_complete() {
     {
         let st = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
             .expect("open");
-        let manifest = st.reader().manifest().clone();
+        let manifest = st.reader().expect("reader").manifest().clone();
         target_id = manifest
             .get_all_superfiles()
             .first()
@@ -129,6 +129,7 @@ async fn open_time_sweep_drives_pre_seeded_intent_walls_to_complete() {
     // against the same handle excludes the row.
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "alpha", 10, BoolMode::Or)
         .expect("fts");
     // The "alpha" row is local doc_id 0 — verify it's filtered.
@@ -173,13 +174,14 @@ fn create_with_existing_pointer_delegates_to_open() {
             .with_disk_cache(disk_cache),
     )
     .expect("create with existing pointer");
-    let manifest = st.reader().manifest().clone();
+    let manifest = st.reader().expect("reader").manifest().clone();
     assert!(
         !manifest.get_all_superfiles().is_empty(),
         "create against existing pointer must load the committed manifest"
     );
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("sql");
     let total = batches[0]
@@ -223,7 +225,7 @@ async fn sweep_preempts_expired_lease_and_completes_wal() {
     {
         let st = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
             .expect("open for manifest");
-        let manifest = st.reader().manifest().clone();
+        let manifest = st.reader().expect("reader").manifest().clone();
         target_id = manifest
             .get_all_superfiles()
             .first()
@@ -271,6 +273,7 @@ async fn sweep_preempts_expired_lease_and_completes_wal() {
     // FTS query no longer returns the tombstoned row.
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "foo", 10, BoolMode::Or)
         .expect("fts");
     for hit in &hits {

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -2588,7 +2588,7 @@ async fn persist_superfile_publish_batch_async(
             list_metadata,
         )
         .await
-        .map_err(|e| BuildError::Store(e.to_string()))?;
+        .map_err(BuildError::from)?;
         inner.manifest.store(Arc::new(new_manifest));
         apply_pending_store_inserts(inner, batch.pending_store_inserts);
         // Already async — await the warm-cache fill directly. Do NOT call
@@ -3924,7 +3924,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             list_metadata,
         )
         .await
-        .map_err(|e| BuildError::Store(e.to_string()))?;
+        .map_err(BuildError::from)?;
         hidden_inner.manifest.store(Arc::new(new_manifest));
         apply_pending_store_inserts(&hidden_inner, pending_store_inserts);
         if !pending_cache_inserts.is_empty()
@@ -5409,7 +5409,7 @@ pub(in crate::supertable) async fn split_overflow_cell(
         list_metadata,
     )
     .await
-    .map_err(|e| BuildError::Store(e.to_string()))?;
+    .map_err(BuildError::from)?;
     inner.manifest.store(Arc::new(new_manifest));
     apply_pending_store_inserts(&inner, batch.pending_store_inserts);
 
@@ -6163,9 +6163,11 @@ pub(crate) async fn try_commit_attempt(
         }
     }
 
-    // 3. Read the prior pointer's etag for the CAS. Fresh
-    //    supertable → no pointer yet → None etag (initial
-    //    commit).
+    // 3. Read the prior pointer's etag for the CAS. Every storage-backed
+    //    table has a pointer by now — `create` publishes one before any
+    //    writer runs — so an absent pointer is not an initial commit but a
+    //    table dropped and purged under this handle, and the read refuses
+    //    rather than republishing one from stale state.
     let prev_etag = get_current_manifest_etag(&storage, current_manifest).await?;
 
     // 4. Parallel-issue (touched parts) + list PUTs, then

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1061,6 +1061,7 @@ impl SupertableWriter {
         let supertable = Supertable::from_inner(Arc::clone(&self.inner));
         let target_ids = supertable
             .reader()
+            .map_err(|_| MutationError::TableGone)?
             .scan_ids_matching(predicate)
             .map_err(MutationError::PredicateEval)?;
         let matched = target_ids.len();
@@ -1137,6 +1138,7 @@ impl SupertableWriter {
         let supertable = Supertable::from_inner(Arc::clone(&self.inner));
         let target_ids = supertable
             .reader()
+            .map_err(|_| MutationError::TableGone)?
             .scan_ids_matching(predicate)
             .map_err(MutationError::PredicateEval)?;
         let matched = target_ids.len();
@@ -6624,7 +6626,7 @@ mod tests {
             .expect("append visible entry");
         writer.commit().expect("commit visible entry");
         drop(writer);
-        let pending_entry = Arc::clone(&table.reader().manifest().superfiles[0]);
+        let pending_entry = Arc::clone(&table.reader().expect("reader").manifest().superfiles[0]);
         let sources = vec![DrainCheckpointSource {
             superfile_id: "source-id".into(),
             uri: "source-uri".into(),
@@ -6795,6 +6797,7 @@ mod tests {
         assert!(
             hidden
                 .reader()
+                .expect("reader")
                 .manifest()
                 .superfiles
                 .iter()
@@ -6909,7 +6912,7 @@ mod tests {
         .await
         .expect("splice drain across batches");
         assert!(
-            hidden.reader().n_superfiles() > 0,
+            hidden.reader().expect("reader").n_superfiles() > 0,
             "splice drain must populate the hidden cell index"
         );
         // The e_0 direction (one doc per batch) still resolves through the
@@ -6918,6 +6921,7 @@ mod tests {
         q[0] = 1.0;
         let hits = table
             .reader()
+            .expect("reader")
             .vector_hits(
                 "emb",
                 &q,
@@ -7096,7 +7100,7 @@ mod tests {
     }
 
     fn committed_reader(st: &Supertable) -> (Arc<SuperfileEntry>, Arc<SuperfileReader>) {
-        let entry = Arc::clone(&st.reader().manifest().superfiles[0]);
+        let entry = Arc::clone(&st.reader().expect("reader").manifest().superfiles[0]);
         let reader = st
             .options()
             .store
@@ -7169,7 +7173,7 @@ mod tests {
         );
 
         // Nothing was published, and a refused reservation commits nothing.
-        assert_eq!(st.reader().n_docs_total(), 0);
+        assert_eq!(st.reader().expect("reader").n_docs_total(), 0);
         assert!(st.options().connection_memory_budget.denials() >= 1);
         assert_eq!(st.options().connection_memory_budget.peak(), 0);
     }
@@ -7184,7 +7188,7 @@ mod tests {
 
         st.append(&build_simple_batch(0, 8))
             .expect("measured budget never refuses");
-        assert_eq!(st.reader().n_docs_total(), 8);
+        assert_eq!(st.reader().expect("reader").n_docs_total(), 8);
 
         let budget = &st.options().connection_memory_budget;
         assert_eq!(budget.denials(), 0);
@@ -7205,7 +7209,7 @@ mod tests {
 
         st.append(&build_simple_batch(0, 8))
             .expect("under-budget append runs under a bounded budget");
-        assert_eq!(st.reader().n_docs_total(), 8);
+        assert_eq!(st.reader().expect("reader").n_docs_total(), 8);
 
         let budget = &st.options().connection_memory_budget;
         assert_eq!(budget.denials(), 0);
@@ -7266,7 +7270,7 @@ mod tests {
             .append(&build_vector_batch(0, 8, dim))
             .expect_err("vector build over a 0-byte gate is refused");
         assert!(matches!(err, InfinoError::OverBudget(_)), "got {err:?}");
-        assert_eq!(st.reader().n_docs_total(), 0);
+        assert_eq!(st.reader().expect("reader").n_docs_total(), 0);
     }
 
     #[test]
@@ -7280,7 +7284,7 @@ mod tests {
 
         st.append(&build_vector_batch(0, 8, dim))
             .expect("measured vector ingest runs");
-        assert_eq!(st.reader().n_docs_total(), 8);
+        assert_eq!(st.reader().expect("reader").n_docs_total(), 8);
 
         let budget = &st.options().connection_memory_budget;
         assert_eq!(budget.denials(), 0);
@@ -7337,7 +7341,7 @@ mod tests {
         w.append(&build_simple_batch(0, 4)).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.manifest_id(), 1);
         assert_eq!(r.n_superfiles(), 1);
         assert_eq!(r.n_docs_total(), 4);
@@ -7349,7 +7353,7 @@ mod tests {
         let mut w = st.writer().expect("writer");
         w.commit().expect("commit-empty");
         assert_eq!(st.manifest_id(), 0, "no manifest swap on empty commit");
-        assert_eq!(st.reader().n_superfiles(), 0);
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -7362,7 +7366,7 @@ mod tests {
         w.append(&build_simple_batch(0, 4)).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let superfile = &r.manifest().superfiles[0];
         let store = &st.options().store;
         let sf_reader = store.reader(&superfile.uri).expect("reader");
@@ -7384,7 +7388,7 @@ mod tests {
         w.append(&build_simple_batch(50, 2)).expect("b");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let seg = &r.manifest().superfiles[0];
         assert_eq!(seg.n_docs, 5);
         // _id values are auto-injected via the supertable's
@@ -7404,7 +7408,7 @@ mod tests {
         w.append(&build_simple_batch(0, 4)).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let seg = &r.manifest().superfiles[0];
         let fts = seg
             .fts_summary
@@ -7485,7 +7489,7 @@ mod tests {
         w.append(&build_vector_batch(0, 8, dim)).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let seg = &r.manifest().superfiles[0];
         let vs = seg
             .vector_summary
@@ -7534,7 +7538,11 @@ mod tests {
         )
         .expect("create");
         assert!(
-            !st.reader().options().vector_columns.is_empty(),
+            !st.reader()
+                .expect("reader")
+                .options()
+                .vector_columns
+                .is_empty(),
             "fixture must declare vector columns so commit takes the assign-pack path"
         );
         let mut w = st.writer().expect("writer");
@@ -7687,7 +7695,7 @@ mod tests {
             }
             w.commit().expect("commit");
 
-            let r = st.reader();
+            let r = st.reader().expect("reader");
             assert_eq!(
                 r.n_superfiles(),
                 n_threads,
@@ -7709,7 +7717,7 @@ mod tests {
         w.append(&build_simple_batch(1, 1)).expect("b");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.n_superfiles(), 2);
         assert_eq!(r.n_docs_total(), 2);
     }
@@ -7736,7 +7744,7 @@ supertable:
         }
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(
             r.n_superfiles(),
             4,
@@ -7831,7 +7839,7 @@ supertable:
         w.append(&build_simple_batch(20, 1)).expect("a3");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.manifest_id(), 3);
         assert_eq!(r.n_superfiles(), 3);
         assert_eq!(r.n_docs_total(), 6);
@@ -7873,7 +7881,7 @@ supertable:
         w.append(&build_simple_batch(0, 8)).expect("append");
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         let seg = &r.manifest().superfiles[0];
         let store = &st.options().store;
         // Fetch the bytes back from the in-memory store.
@@ -7921,7 +7929,7 @@ supertable:
         );
         w.commit().expect("commit");
 
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         assert_eq!(r.n_superfiles(), 1);
         assert_eq!(r.n_docs_total(), 8);
     }

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -5670,7 +5670,8 @@ async fn stamp_slow_vector_state(
             old.with_slow_vector_state(published.uri, published.content_hash, published.centroids);
         let prev_etag = get_current_manifest_etag(&storage, Arc::clone(&old))
             .await
-            .map_err(|e| BuildError::Store(e.to_string()))?;
+            .inspect_err(|e| inner.note_commit_error(e))
+            .map_err(BuildError::from)?;
         match new_manifest
             .write(storage.as_ref(), prev_etag.as_deref(), &[])
             .await
@@ -5721,7 +5722,8 @@ async fn record_hidden_deleted_ids(
         let new_manifest = old.with_deleted_user_ids(bytes);
         let prev_etag = get_current_manifest_etag(&storage, Arc::clone(&old))
             .await
-            .map_err(|e| BuildError::Store(e.to_string()))?;
+            .inspect_err(|e| inner.note_commit_error(e))
+            .map_err(BuildError::from)?;
         match new_manifest
             .write(storage.as_ref(), prev_etag.as_deref(), &[])
             .await
@@ -5829,7 +5831,10 @@ pub(in crate::supertable) async fn persist_commit_async(
                     last_err = Some(SupertableCommitError::WriteContentionExhausted);
                     sleep(backoff_delay(attempt)).await;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    inner.note_commit_error(&e);
+                    return Err(e);
+                }
             }
         }
         Err(last_err.unwrap_or(SupertableCommitError::WriteContentionExhausted))
@@ -6263,7 +6268,10 @@ pub(in crate::supertable) async fn stamp_tombstone_seqs(
                 sleep(backoff_delay(attempt)).await;
                 continue;
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                inner.note_commit_error(&e);
+                return Err(e);
+            }
         };
         match new_manifest
             .write(storage.as_ref(), prev_etag.as_deref(), &[])

--- a/tests/supertable/commit/concurrent_threads.rs
+++ b/tests/supertable/commit/concurrent_threads.rs
@@ -91,7 +91,7 @@ fn build_batch(start: u64, n: usize) -> RecordBatch {
 fn reader_pinned_before_writer_starts_never_sees_commits() {
     let st = Supertable::create(options()).expect("create");
     // Pin BEFORE any commit; capture the snapshot.
-    let pinned = st.reader();
+    let pinned = st.reader().expect("reader");
     assert_eq!(pinned.manifest_id(), 0);
     assert_eq!(pinned.n_superfiles(), 0);
 
@@ -132,7 +132,7 @@ fn reader_pinned_before_writer_starts_never_sees_commits() {
     assert_eq!(pinned.n_superfiles(), 0);
 
     // A FRESH reader sees the post-commit state.
-    let fresh = st.reader();
+    let fresh = st.reader().expect("reader");
     assert_eq!(fresh.manifest_id(), 5);
     assert_eq!(fresh.n_superfiles(), 5);
     assert_eq!(fresh.n_docs_total(), 5 * 3);
@@ -148,7 +148,7 @@ fn reader_obtained_after_writer_finishes_sees_full_state() {
     }
     drop(w);
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(r.manifest_id(), 3);
     assert_eq!(r.n_superfiles(), 3);
     assert_eq!(r.n_docs_total(), 12);
@@ -162,7 +162,7 @@ fn pinned_reader_holds_arc_across_subsequent_commits() {
     w.commit().expect("c1");
 
     // Pin reader at manifest_id=1.
-    let r1 = st.reader();
+    let r1 = st.reader().expect("reader");
     let r1_arc = Arc::clone(r1.manifest());
     assert_eq!(r1.manifest_id(), 1);
 
@@ -179,7 +179,7 @@ fn pinned_reader_holds_arc_across_subsequent_commits() {
     );
 
     // Fresh reader sees the new state.
-    let r2 = st.reader();
+    let r2 = st.reader().expect("reader");
     assert_eq!(r2.manifest_id(), 3);
     assert!(!Arc::ptr_eq(r1.manifest(), r2.manifest()));
 }
@@ -203,7 +203,7 @@ fn concurrent_readers_at_same_commit_share_arc_pointer() {
         let bar = Arc::clone(&barrier);
         handles.push(thread::spawn(move || {
             bar.wait();
-            let r = st.reader();
+            let r = st.reader().expect("reader");
             Arc::clone(r.manifest())
         }));
     }
@@ -228,11 +228,11 @@ fn manifest_id_monotonic_across_serially_pinned_readers() {
     let st = Supertable::create(options()).expect("create");
     let mut w = st.writer().expect("writer");
     let mut observed: Vec<u64> = Vec::new();
-    observed.push(st.reader().manifest_id());
+    observed.push(st.reader().expect("reader").manifest_id());
     for i in 0..5u64 {
         w.append(&build_batch(i * 10, 2)).expect("append");
         w.commit().expect("commit");
-        observed.push(st.reader().manifest_id());
+        observed.push(st.reader().expect("reader").manifest_id());
     }
     drop(w);
 
@@ -272,7 +272,7 @@ fn many_concurrent_readers_during_writer_commits_no_inconsistencies() {
         reader_handles.push(thread::spawn(move || {
             let mut max_seen: u64 = 0;
             for _ in 0..pins_per_reader {
-                let r = st.reader();
+                let r = st.reader().expect("reader");
                 let id_before = r.manifest_id();
                 let n_before = r.n_superfiles();
                 // Brief hold so we straddle a commit boundary
@@ -303,7 +303,7 @@ fn many_concurrent_readers_during_writer_commits_no_inconsistencies() {
     // After the writer is done, the FINAL fresh reader must show
     // exactly n_commits — independent of how reader threads
     // observed intermediate state.
-    let final_r = st_arc.reader();
+    let final_r = st_arc.reader().expect("reader");
     assert_eq!(final_r.manifest_id(), n_commits);
     assert_eq!(final_r.n_superfiles(), n_commits as usize);
 
@@ -342,14 +342,14 @@ fn fresh_reader_sequence_taken_during_concurrent_commits_is_monotonic() {
     let mut samples: Vec<u64> = Vec::new();
     let deadline = Instant::now() + Duration::from_millis(500);
     while Instant::now() < deadline {
-        samples.push(st.reader().manifest_id());
+        samples.push(st.reader().expect("reader").manifest_id());
         if samples.last() == Some(&n_commits) {
             break;
         }
     }
     writer.join().expect("writer joined");
     // Final sample after writer fully finished.
-    samples.push(st.reader().manifest_id());
+    samples.push(st.reader().expect("reader").manifest_id());
 
     for w in samples.windows(2) {
         assert!(

--- a/tests/supertable/commit/id_uniqueness.rs
+++ b/tests/supertable/commit/id_uniqueness.rs
@@ -202,7 +202,7 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
             .with_disk_cache(Arc::clone(&cache)),
     )
     .expect("open");
-    let reader = consumer.reader();
+    let reader = consumer.reader().expect("reader");
     let segs = reader.manifest().get_all_superfiles();
     assert_eq!(
         segs.len(),
@@ -213,6 +213,7 @@ async fn four_handles_to_shared_storage_produce_globally_unique_ids() {
 
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable")
         .expect("query _id");
     let mut all: HashSet<i128> = HashSet::with_capacity(N_HANDLES * ROWS_PER_HANDLE as usize);

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -64,7 +64,7 @@ fn open_sees_writes_made_by_a_different_handle() {
         Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
             .expect("open");
     assert_eq!(consumer.manifest_id(), 1);
-    assert_eq!(consumer.reader().n_superfiles(), 1);
+    assert_eq!(consumer.reader().expect("reader").n_superfiles(), 1);
     // Note: full query parity post-open requires the deferred
     // query-path integration through `DiskCacheStore` —
     // the reader sees the manifest's superfile list but
@@ -129,7 +129,7 @@ fn strong_consistency_query_sees_another_writers_new_commit() {
     )
     .expect("open");
     assert_eq!(consumer.manifest_id(), 1);
-    let pinned_reader = consumer.reader(); // snapshot pinned at v1
+    let pinned_reader = consumer.reader().expect("reader"); // snapshot pinned at v1
 
     // Producer commits v2.
     let mut w = producer.writer().expect("w2");
@@ -141,12 +141,13 @@ fn strong_consistency_query_sees_another_writers_new_commit() {
     // against the latest manifest — picking up the new commit.
     let hits = consumer
         .reader()
+        .expect("reader")
         .bm25_hits("title", "added", BM25_TOP_K, BoolMode::Or)
         .expect("query under strong consistency");
     assert!(!hits.is_empty(), "strong query must see the v2 row");
     assert_eq!(consumer.manifest_id(), 2);
     assert_eq!(
-        consumer.reader().n_superfiles(),
+        consumer.reader().expect("reader").n_superfiles(),
         2,
         "post-query reader sees both commits"
     );
@@ -185,6 +186,7 @@ fn strong_consistency_query_is_stable_when_pointer_unchanged() {
     // advanced, so the strongly-consistent query stays at v1.
     let _ = consumer
         .reader()
+        .expect("reader")
         .bm25_hits("title", "only", BM25_TOP_K, BoolMode::Or)
         .expect("query");
     assert_eq!(consumer.manifest_id(), 1);
@@ -207,6 +209,7 @@ fn strong_consistency_query_on_uncommitted_table_stays_at_zero() {
     .expect("create");
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "anything", BM25_TOP_K, BoolMode::Or)
         .expect("query on uncommitted table");
     assert!(hits.is_empty());

--- a/tests/supertable/commit/partition_assignment.rs
+++ b/tests/supertable/commit/partition_assignment.rs
@@ -86,7 +86,7 @@ fn default_strategy_is_ingestion_time_with_one_day_granularity() {
         w.commit().expect("commit");
     }
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     assert_eq!(
@@ -126,7 +126,7 @@ fn rewrite_path_produces_fresh_part_id_per_commit() {
         w.append(&build_title_batch(&["x"])).expect("append");
         w.commit().expect("commit");
         let m_id = {
-            let r = st.reader();
+            let r = st.reader().expect("reader");
             let m = r.manifest();
             let list_entries = m.get_all_list_entries();
             list_entries[0].part_id
@@ -161,7 +161,7 @@ fn target_superfiles_per_partition_triggers_part_split() {
         w.commit().expect("commit");
     }
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     assert_eq!(
@@ -307,7 +307,7 @@ fn time_range_assigns_int64_superfiles_to_bucket_zero() {
         w.commit()
             .expect("TimeRange commit must succeed for a single-bucket batch");
     }
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     assert_eq!(

--- a/tests/supertable/commit/persistence.rs
+++ b/tests/supertable/commit/persistence.rs
@@ -88,7 +88,7 @@ fn commit_persists_pointer_list_part_and_superfile() {
     );
 
     // In-memory manifest reflects the commit.
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(r.manifest_id(), 1);
     assert_eq!(r.n_superfiles(), 1);
 }
@@ -144,7 +144,7 @@ fn two_successive_commits_both_publish() {
     assert_eq!(n_parts, 2);
 
     // In-memory manifest reflects both commits.
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(r.manifest_id(), 2);
     assert_eq!(
         r.n_superfiles(),
@@ -202,7 +202,7 @@ fn multipart_threshold_forces_superfile_through_put_multipart() {
     let consumer =
         Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
             .expect("open after multipart commit");
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     assert_eq!(r.manifest_id(), 1);
     assert_eq!(r.n_superfiles(), 1);
 }
@@ -231,7 +231,7 @@ fn no_storage_attached_takes_in_memory_path() {
     );
 
     // In-memory manifest still updates.
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(r.manifest_id(), 1);
     assert_eq!(r.n_superfiles(), 1);
 }
@@ -258,6 +258,7 @@ fn committed_supertable_remains_in_memory_queryable_for_now() {
 
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits(
             "title",
             "nimblefox",

--- a/tests/supertable/commit/same_handle_query.rs
+++ b/tests/supertable/commit/same_handle_query.rs
@@ -78,6 +78,7 @@ fn query_after_first_commit_on_same_handle_succeeds() {
 
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
         .expect("same-handle query after first commit must resolve parts");
     assert_eq!(hits.len(), 1, "expected the one matching row");
@@ -113,6 +114,7 @@ fn query_after_second_commit_on_same_handle_succeeds() {
     // A term from the first commit (survives the part rewrite)...
     let old_hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
         .expect("query for first-commit term");
     assert_eq!(
@@ -124,6 +126,7 @@ fn query_after_second_commit_on_same_handle_succeeds() {
     // ...and a term from the second commit.
     let new_hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "echo", BM25_TOP_K, BoolMode::Or)
         .expect("query for second-commit term");
     assert_eq!(new_hits.len(), 1, "second-commit row must be queryable");
@@ -155,6 +158,7 @@ fn same_handle_query_after_commit_refetches_no_manifest_parts() {
     let before = counter.part_gets();
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
         .expect("query");
     let after = counter.part_gets();
@@ -271,6 +275,7 @@ fn open_metadata_cost_is_fixed_and_reads_check_pointer_once_per_window() {
     for _ in 0..3 {
         let hits = st
             .reader()
+            .expect("reader")
             .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
             .expect("query");
         assert_eq!(hits.len(), 1);

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -117,7 +117,7 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
         "one manifest per commit, plus create's empty manifest, before compact"
     );
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(r.n_superfiles(), n_commits);
     assert_eq!(r.n_docs_total(), (n_commits * 3) as u64);
 
@@ -138,7 +138,7 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
     // Compact: all 10 superfiles merge into one (or a small number).
     st.optimize(&small_optimize_opts()).expect("optimize");
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     let n_after_compact = r.n_superfiles();
     assert!(
         n_after_compact < n_commits,
@@ -175,7 +175,7 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
     );
 
     // All markers still queryable after GC.
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     for m in &markers {
         assert_eq!(
             r.bm25_hits("title", m, TOP_K, BoolMode::Or)
@@ -250,7 +250,7 @@ fn gc_reaps_tombstone_sidecar_for_merged_away_superfile() {
         "orphaned tombstone sidecars reaped once their superfiles are gone from the manifest"
     );
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(
         r.bm25_hits("title", "alphatoken", TOP_K, BoolMode::Or)
             .expect("query alpha after gc")
@@ -350,7 +350,7 @@ fn optimize_honors_overridden_gc_safety_gap() {
     // them, even though compaction ran and left them orphaned.
     st.optimize(&small_optimize_opts())
         .expect("optimize with default gc_safety_gap");
-    let n_after_compact = st.reader().n_superfiles();
+    let n_after_compact = st.reader().expect("reader").n_superfiles();
     assert!(
         n_after_compact < n_commits,
         "compaction must have merged the ten commits into fewer superfiles"
@@ -372,7 +372,7 @@ fn optimize_honors_overridden_gc_safety_gap() {
     .with_gc(GcSettings::default().with_safety_gap(Duration::ZERO));
     st.optimize(&opts).expect("optimize with gc safety_gap=0");
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(
         count_dir(&data_dir),
         r.n_superfiles(),

--- a/tests/supertable/disk_cache/end_to_end.rs
+++ b/tests/supertable/disk_cache/end_to_end.rs
@@ -84,6 +84,7 @@ fn cross_process_consumer_routes_reads_through_disk_cache() {
     // disk cache → cold-fetch from storage.
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT title FROM supertable ORDER BY _id")
         .expect("first query");
     assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
@@ -108,6 +109,7 @@ fn cross_process_consumer_routes_reads_through_disk_cache() {
     // Second query against the same superfile — warm hit.
     let _batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT title FROM supertable ORDER BY _id")
         .expect("second query");
     let post_stats = cache.stats();
@@ -153,6 +155,7 @@ fn producer_with_cache_reads_through_cache_path() {
 
     let batches = producer
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("query");
     assert_eq!(batches.len(), 1);
@@ -213,6 +216,7 @@ fn writer_warms_cache_on_commit_so_producer_query_skips_cold_fetch() {
     // Producer's query hits the warm cache — no cold-fetch.
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("query");
     assert_eq!(batches.len(), 1);
@@ -296,7 +300,7 @@ fn manifest_superfiles_are_not_pinned_by_supertable_create() {
     // manifest set.
     let post = cache.current_pinned_uris();
     assert!(post.is_empty(), "expected empty pinned set; got {post:?}");
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     assert_eq!(reader.manifest().get_all_superfiles().len(), 1);
 }
 
@@ -336,7 +340,12 @@ fn manifest_superfiles_are_not_pinned_by_supertable_open() {
         pinned.is_empty(),
         "expected empty pinned set; got {pinned:?}"
     );
-    let n_superfiles = consumer.reader().manifest().get_all_superfiles().len();
+    let n_superfiles = consumer
+        .reader()
+        .expect("reader")
+        .manifest()
+        .get_all_superfiles()
+        .len();
     assert_eq!(n_superfiles, 1);
 }
 
@@ -471,6 +480,7 @@ fn no_cache_path_still_uses_in_memory_store() {
 
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("query");
     assert_eq!(batches.len(), 1);

--- a/tests/supertable/manifest/lazy_open.rs
+++ b/tests/supertable/manifest/lazy_open.rs
@@ -71,7 +71,7 @@ fn one_part_eager_fetches_under_default_threshold() {
         Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
             .expect("open");
 
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     assert_eq!(list_entries.len(), 1);
@@ -117,7 +117,7 @@ fn many_parts_skip_eager_fetch() {
             .with_eager_load_threshold(EAGER_LOAD_THRESHOLD_BELOW_PARTS),
     )
     .expect("open");
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     assert_eq!(list_entries.len(), 5);
@@ -167,7 +167,7 @@ async fn manifest_part_lazy_loads_on_first_access() {
             .with_eager_load_threshold(EAGER_LOAD_THRESHOLD_BELOW_PARTS),
     )
     .expect("open");
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     let target_pid = list_entries[LAZY_LOAD_TARGET_PART_INDEX].part_id;
@@ -239,7 +239,7 @@ fn with_eager_load_threshold_zero_forces_lazy_on_tiny_manifest() {
             .with_eager_load_threshold(EAGER_LOAD_THRESHOLD_FORCE_LAZY),
     )
     .expect("open");
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     assert_eq!(list_entries.len(), 1);

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -182,7 +182,7 @@ fn supertable_to_global_ids(
     hits: Vec<SuperfileHit>,
     chunk_size: usize,
 ) -> Vec<u64> {
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     let manifest = r.manifest();
     hits.into_iter()
         .map(|h| {
@@ -199,6 +199,7 @@ fn supertable_to_global_ids(
 fn supertable_search_global(st: &Supertable, query: &str, k: usize, chunk_size: usize) -> Vec<u64> {
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", query, k, BoolMode::Or)
         .expect("supertable bm25");
     supertable_to_global_ids(st, hits, chunk_size)
@@ -212,6 +213,7 @@ fn supertable_search_and_global(
 ) -> Vec<u64> {
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", query, k, BoolMode::And)
         .expect("supertable bm25 AND");
     supertable_to_global_ids(st, hits, chunk_size)
@@ -225,6 +227,7 @@ fn supertable_prefix_global(
 ) -> Vec<u64> {
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_search_prefix("title", prefix, k)
         .expect("supertable bm25_prefix");
     supertable_to_global_ids(st, hits, chunk_size)
@@ -519,7 +522,7 @@ fn prefix_skip_prunes_superfiles_without_matching_lex_range() {
         .collect();
     corp[0].1.push_str(" quokka_unique");
     let infino = build_supertable(&corp, SUPERFILES);
-    let r = infino.reader();
+    let r = infino.reader().expect("reader");
     let hits = r
         .bm25_search_prefix("title", "quokka", ORACLE_TOP_K_SMALL)
         .expect("prefix");

--- a/tests/supertable/query/covered_agg.rs
+++ b/tests/supertable/query/covered_agg.rs
@@ -80,6 +80,7 @@ fn build_table() -> Supertable {
 fn explain(st: &Supertable, sql: &str) -> String {
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql(&format!("EXPLAIN {sql}"))
         .expect("explain");
     let mut out = String::new();
@@ -99,7 +100,7 @@ fn explain(st: &Supertable, sql: &str) -> String {
 }
 
 fn scalar_i64(st: &Supertable, sql: &str) -> i64 {
-    let batches = st.reader().query_sql(sql).expect("sql");
+    let batches = st.reader().expect("reader").query_sql(sql).expect("sql");
     let batch = batches.iter().find(|b| b.num_rows() > 0).expect("one row");
     batch
         .column(0)
@@ -110,7 +111,7 @@ fn scalar_i64(st: &Supertable, sql: &str) -> i64 {
 }
 
 fn scalar_f64(st: &Supertable, sql: &str) -> f64 {
-    let batches = st.reader().query_sql(sql).expect("sql");
+    let batches = st.reader().expect("reader").query_sql(sql).expect("sql");
     let batch = batches.iter().find(|b| b.num_rows() > 0).expect("one row");
     batch
         .column(0)

--- a/tests/supertable/query/fanout_concurrency.rs
+++ b/tests/supertable/query/fanout_concurrency.rs
@@ -202,6 +202,7 @@ const K: usize = 10;
 fn run_bm25(st: &Supertable) -> Vec<(String, u32)> {
     hit_key(
         &st.reader()
+            .expect("reader")
             .bm25_hits("title", "rust", K, BoolMode::Or)
             .expect("bm25"),
     )
@@ -212,6 +213,7 @@ fn run_vector(st: &Supertable) -> Vec<(String, u32)> {
     q[0] = 1.0;
     hit_key(
         &st.reader()
+            .expect("reader")
             .vector_hits("emb", &q, K, VectorSearchOptions::new(), None)
             .expect("vector"),
     )
@@ -220,6 +222,7 @@ fn run_vector(st: &Supertable) -> Vec<(String, u32)> {
 fn run_hybrid(st: &Supertable) -> Vec<i128> {
     id_vec(
         &st.reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT _id FROM hybrid_search('title', 'rust', 'emb', '{}', {K})",
                 csv_one_hot(0)
@@ -231,6 +234,7 @@ fn run_hybrid(st: &Supertable) -> Vec<i128> {
 fn run_count(st: &Supertable) -> i64 {
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("count query_sql");
     batches[0]

--- a/tests/supertable/query/fanout_floor.rs
+++ b/tests/supertable/query/fanout_floor.rs
@@ -206,6 +206,7 @@ fn build_supertable() -> (Supertable, Vec<TempDir>) {
     .expect("open consumer");
     let _ = consumer
         .reader()
+        .expect("reader")
         .bm25_hits("title", "common", K, BoolMode::Or)
         .expect("prewarm");
     consumer
@@ -309,7 +310,7 @@ fn time_p50(mut f: impl FnMut()) -> (Duration, u64) {
 #[ignore = "perf microbench, not a correctness gate"]
 fn fanout_floor_decomposition() {
     let (st, _guards) = build_supertable();
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     // The writer row-shards each commit (cpus/2 shards), so the real
     // segment count is a multiple of the commit count — report it.
     let n_segments = reader.n_superfiles();

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -111,7 +111,7 @@ fn bm25_exact_term_loads_only_the_matching_part() {
 
     // Pre-condition: nothing loaded.
     {
-        let r = consumer.reader();
+        let r = consumer.reader().expect("reader");
         let m = r.manifest();
         let list_entries = m.get_all_list_entries();
         assert_eq!(list_entries.len(), HIERARCHICAL_PART_COUNT);
@@ -128,6 +128,7 @@ fn bm25_exact_term_loads_only_the_matching_part() {
     // query.
     let hits = consumer
         .reader()
+        .expect("reader")
         .bm25_search("title", "echo", BM25_TOP_K, BoolMode::Or, None)
         .expect("bm25");
     assert!(
@@ -136,7 +137,7 @@ fn bm25_exact_term_loads_only_the_matching_part() {
     );
 
     // Post-condition: exactly one OnceCell populated.
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     let n_loaded = list_entries
@@ -172,6 +173,7 @@ fn bm25_term_in_no_part_loads_nothing() {
     // already rejected without needing the part bytes).
     let hits = consumer
         .reader()
+        .expect("reader")
         .bm25_search("title", "zoo", BM25_TOP_K, BoolMode::Or, None)
         .expect("bm25");
     // False positives are tolerated. So `hits` might end
@@ -180,7 +182,7 @@ fn bm25_term_in_no_part_loads_nothing() {
     // is selective. The load-bearing assertion is the
     // n_loaded count: if the union pruned everything, no
     // part was ever loaded.
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     let n_loaded = list_entries
@@ -219,6 +221,7 @@ fn bm25_prefix_with_narrow_prefix_loads_one_part() {
     // union should route the prefix to one part.
     let hits = consumer
         .reader()
+        .expect("reader")
         .bm25_search_prefix("title", "ech", BM25_TOP_K)
         .expect("prefix");
     assert!(
@@ -226,7 +229,7 @@ fn bm25_prefix_with_narrow_prefix_loads_one_part() {
         "prefix search must find 'echo'-rooted terms"
     );
 
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     let n_loaded = list_entries
@@ -270,6 +273,7 @@ fn sql_loads_all_parts_returns_correct_count() {
     // 5 commits × 2 rows/commit = 10 rows total.
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("query");
     assert_eq!(batches.len(), 1);
@@ -282,7 +286,7 @@ fn sql_loads_all_parts_returns_correct_count() {
     assert_eq!(arr.value(0), HIERARCHICAL_PART_COUNT as i64 * ROWS_PER_PART);
 
     // Post: all 5 parts loaded (SQL doesn't list-prune).
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     let n_loaded = list_entries
@@ -330,7 +334,7 @@ fn open_lazy_consumer(storage_dir: &std::path::Path, cache_dir: &std::path::Path
 /// How many parts are currently resident (loaded) in the consumer's
 /// manifest — the observable behind "did the prune skip parts?".
 fn parts_loaded(consumer: &Supertable) -> (usize, usize) {
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let entries = m.get_all_list_entries();
     let loaded = entries
@@ -363,6 +367,7 @@ fn sql_single_value_in_prunes_parts_via_equality_rewrite() {
 
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE title IN ('Fig Roll')")
         .expect("query");
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -400,6 +405,7 @@ fn sql_multi_value_in_returns_exact_rows_across_parts() {
 
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE title IN ('Straw Berry', 'Orange Juice')")
         .expect("query");
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -416,6 +422,7 @@ fn sql_multi_value_in_returns_exact_rows_across_parts() {
     // exact title; the other literal exists nowhere.
     let none = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE title IN ('Straw', 'Iced Coffee Blend')")
         .expect("query");
     assert_eq!(
@@ -450,6 +457,7 @@ fn sql_between_returns_exact_rows_across_parts() {
 
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE title BETWEEN 'C' AND 'G'")
         .expect("query");
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -490,6 +498,7 @@ fn fts_in_bloom_prunes_parts_min_max_cannot() {
     // the other three exist nowhere.
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE title IN ('bravo', 'qx', 'qy', 'qz')")
         .expect("query");
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -528,6 +537,7 @@ fn sql_or_on_fts_column_bloom_prunes_parts_min_max_cannot() {
     // 2 values → arrives as `title = 'bravo' OR title = 'qx'`.
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE title = 'bravo' OR title = 'qx'")
         .expect("query");
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -634,6 +644,7 @@ fn sql_is_null_prunes_no_null_parts() {
 
     let rows: usize = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE tag IS NULL")
         .expect("query")
         .iter()
@@ -658,6 +669,7 @@ fn sql_is_not_null_prunes_all_null_parts() {
 
     let rows: usize = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE tag IS NOT NULL")
         .expect("query")
         .iter()
@@ -695,6 +707,7 @@ fn fts_in_multitoken_bloom_spans_parts_and_skips_the_unmatched() {
 
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql(
             "SELECT _id FROM supertable \
              WHERE title IN ('new york', 'los angeles', 'qx', 'qy')",
@@ -731,6 +744,7 @@ fn fts_in_all_values_absent_prunes_every_part() {
 
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT _id FROM supertable WHERE title IN ('qx', 'qy', 'qz', 'qw')")
         .expect("query");
     assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
@@ -766,6 +780,7 @@ fn fts_in_multiword_mixedcase_value_bloom_and_exact_filter() {
     //  - FilterExec keeps only the exact "lives in Mumbai" row.
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql(
             "SELECT _id FROM supertable \
              WHERE title IN ('lives in Mumbai', 'qx', 'qy', 'qz')",
@@ -789,6 +804,7 @@ fn fts_in_multiword_mixedcase_value_bloom_and_exact_filter() {
     // So the bloom is a presence superset; the exact filter is correctness.
     let none = consumer
         .reader()
+        .expect("reader")
         .query_sql(
             "SELECT _id FROM supertable \
              WHERE title IN ('lives in MUMBAI', 'qx', 'qy', 'qz')",
@@ -830,7 +846,7 @@ fn eager_mode_query_paths_observationally_unchanged() {
     .expect("open");
 
     // Eager: 1 part loaded at open.
-    let r = consumer.reader();
+    let r = consumer.reader().expect("reader");
     let m = r.manifest();
     let list_entries = m.get_all_list_entries();
     assert_eq!(list_entries.len(), 1);
@@ -843,6 +859,7 @@ fn eager_mode_query_paths_observationally_unchanged() {
     // BM25 hits.
     let hits = consumer
         .reader()
+        .expect("reader")
         .bm25_search("title", "alpha", BM25_TOP_K, BoolMode::Or, None)
         .expect("bm25");
     assert!(!hits.is_empty());
@@ -850,6 +867,7 @@ fn eager_mode_query_paths_observationally_unchanged() {
     // SQL.
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("sql");
     assert_eq!(batches.len(), 1);

--- a/tests/supertable/query/hybrid_search.rs
+++ b/tests/supertable/query/hybrid_search.rs
@@ -196,6 +196,7 @@ fn hybrid_search_star_projection_exposes_scalar_schema_plus_score() {
     let st = demo_two_superfiles();
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql(&format!(
             "SELECT * FROM hybrid_search('title', 'rust', 'emb', '{}', {HYBRID_SCHEMA_TOP_K})",
             csv_one_hot(0)
@@ -223,6 +224,7 @@ fn hybrid_search_identity_set_is_union_of_subsearches_across_superfiles() {
 
     let hybrid = id_set(
         &st.reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT _id FROM hybrid_search('title', 'rust', 'emb', '{qv}', {k})"
             ))
@@ -230,6 +232,7 @@ fn hybrid_search_identity_set_is_union_of_subsearches_across_superfiles() {
     );
     let bm25 = id_set(
         &st.reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT _id FROM bm25_search('title', 'rust', {k})"
             ))
@@ -237,6 +240,7 @@ fn hybrid_search_identity_set_is_union_of_subsearches_across_superfiles() {
     );
     let vector = id_set(
         &st.reader()
+            .expect("reader")
             .query_sql(&format!(
                 "SELECT _id FROM vector_search('emb', '{qv}', {k})"
             ))
@@ -265,7 +269,7 @@ fn hybrid_search_doc_top_in_both_retrievers_ranks_first() {
     // 0 makes doc 0 the exact vector match (rank 1). Top in both →
     // highest RRF → emitted first.
     let res = st
-        .reader().query_sql(&format!(
+        .reader().expect("reader").query_sql(&format!(
             "SELECT title, score FROM hybrid_search('title', 'async', 'emb', '{}', {HYBRID_SCORE_TOP_K})",
             csv_one_hot(0)
         ))

--- a/tests/supertable/query/id_resolve.rs
+++ b/tests/supertable/query/id_resolve.rs
@@ -105,7 +105,7 @@ fn bare_projection_ids_match_id_page_read_path() {
         w.commit().expect("commit");
     }
     drop(w);
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
 
     // `common` is in every doc → hits span segments; per-doc unique
     // tokens keep scores distinct so rank order is meaningful.

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -9,7 +9,7 @@
 //! SQL table-valued functions and the RRF math on a single superfile.
 //! This file exercises the published
 //! `SupertableReader::{token_match, exact_match, hybrid_search}` surface
-//! the way a Rust consumer calls it — `st.reader().token_match(..)` —
+//! the way a Rust consumer calls it — `st.reader().expect("reader").token_match(..)` —
 //! over a committed **multi-superfile** corpus so the per-superfile work
 //! fans out and merges across superfiles.
 //!
@@ -171,7 +171,7 @@ fn stable_ids(hits: &[SuperfileHit]) -> HashSet<i128> {
 #[test]
 fn token_match_or_is_the_unranked_bm25_candidate_set() {
     let st = demo_two_superfiles();
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     let token = reader
         .token_match("title", "rust", BoolMode::Or)
         .expect("token_match OR");
@@ -197,7 +197,7 @@ fn token_match_or_is_the_unranked_bm25_candidate_set() {
 #[test]
 fn token_match_and_intersects_tokens() {
     let st = demo_two_superfiles();
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     // Only "rust systems" carries both tokens.
     let token = reader
         .token_match("title", "rust systems", BoolMode::And)
@@ -217,7 +217,7 @@ fn token_match_and_intersects_tokens() {
 #[test]
 fn exact_match_is_raw_value_equality_not_token() {
     let st = demo_two_superfiles();
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     // The raw title "rust async" equals exactly the docs that the
     // token-AND prune leaves (only doc 0 has both `rust` and `async`).
     let exact = reader
@@ -252,7 +252,7 @@ fn exact_match_is_raw_value_equality_not_token() {
 #[test]
 fn hybrid_search_unions_bm25_and_vector_and_orders_by_score() {
     let st = demo_two_superfiles();
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     let q = one_hot(QUERY_DIM);
 
     let hybrid = reader
@@ -300,7 +300,7 @@ fn hybrid_search_unions_bm25_and_vector_and_orders_by_score() {
 #[test]
 fn hybrid_search_doc_top_in_both_retrievers_ranks_first() {
     let st = demo_two_superfiles();
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     let q = one_hot(QUERY_DIM);
 
     // `async` is unique to doc 0 (BM25 #1); the one-hot query at

--- a/tests/supertable/query/query_errors.rs
+++ b/tests/supertable/query/query_errors.rs
@@ -161,7 +161,7 @@ fn row_count(batches: &[RecordBatch]) -> usize {
 /// failure message.
 fn assert_all_error(st: &Supertable, label: &str, queries: &[String]) {
     for q in queries {
-        let result = st.reader().query_sql(q);
+        let result = st.reader().expect("reader").query_sql(q);
         assert!(
             result.is_err(),
             "[{label}] expected an error, query unexpectedly succeeded: {q}"
@@ -411,7 +411,11 @@ fn varied_projections_succeed_for_ranked_tvfs() {
         format!("SELECT _id FROM bm25_search('title', 'rust', {SURFACE_TOP_K})"),
         format!("SELECT _id FROM vector_search('emb', '{qv}', {SURFACE_TOP_K})"),
     ] {
-        let b = st.reader().query_sql(&q).expect("id-only query");
+        let b = st
+            .reader()
+            .expect("reader")
+            .query_sql(&q)
+            .expect("id-only query");
         assert_eq!(b[0].schema().field(0).name(), "_id", "{q}");
         assert_eq!(
             b[0].num_columns(),
@@ -423,6 +427,7 @@ fn varied_projections_succeed_for_ranked_tvfs() {
     // Mixed scalar + score projection drives the scalar-decode path.
     let mixed = st
         .reader()
+        .expect("reader")
         .query_sql(&format!(
             "SELECT rating, score FROM bm25_search('title', 'rust', {SURFACE_TOP_K})"
         ))
@@ -433,6 +438,7 @@ fn varied_projections_succeed_for_ranked_tvfs() {
     // `SELECT *` materializes every scalar column plus score.
     let star = st
         .reader()
+        .expect("reader")
         .query_sql(&format!(
             "SELECT * FROM vector_search('emb', '{qv}', {SURFACE_TOP_K})"
         ))
@@ -457,7 +463,11 @@ fn zero_k_yields_empty_result() {
         format!("SELECT _id, score FROM vector_search('emb', '{qv}', 0)"),
         format!("SELECT * FROM hybrid_search('title', 'rust', 'emb', '{qv}', 0)"),
     ] {
-        let b = st.reader().query_sql(&q).expect("k=0 query");
+        let b = st
+            .reader()
+            .expect("reader")
+            .query_sql(&q)
+            .expect("k=0 query");
         assert_eq!(row_count(&b), 0, "k=0 must produce no rows: {q}");
     }
 }
@@ -474,7 +484,11 @@ fn empty_result_queries_return_no_rows() {
         // No title equals this exact value.
         "SELECT _id FROM exact_match('title', 'no such exact title')".to_string(),
     ] {
-        let b = st.reader().query_sql(&q).expect("empty-result query");
+        let b = st
+            .reader()
+            .expect("reader")
+            .query_sql(&q)
+            .expect("empty-result query");
         assert_eq!(row_count(&b), 0, "expected no matches: {q}");
     }
 }

--- a/tests/supertable/query/query_surface.rs
+++ b/tests/supertable/query/query_surface.rs
@@ -154,6 +154,7 @@ fn csv_one_hot(active: usize) -> String {
 fn explain_text(st: &Supertable, sql: &str) -> String {
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql(&format!("EXPLAIN {sql}"))
         .expect("explain");
     let mut out = String::new();
@@ -232,7 +233,11 @@ fn star_projection_materializes_scalar_columns_for_every_tvf() {
         format!("SELECT * FROM hybrid_search('title', 'rust', 'emb', '{qv}', {SURFACE_TOP_K})"),
     ];
     for q in &queries {
-        let batches = st.reader().query_sql(q).expect("star query");
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(q)
+            .expect("star query");
         let b = &batches[0];
         // _id, title, rating, score — the vector column is never exposed.
         assert_eq!(b.schema().field(0).name(), "_id", "{q}");
@@ -254,6 +259,7 @@ fn order_by_and_limit_wrap_the_tvf_scan() {
     let st = demo_table();
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql(&format!(
             "SELECT _id, score FROM bm25_search('title', 'rust', {SURFACE_TOP_K}) \
              ORDER BY score DESC LIMIT 3"
@@ -270,6 +276,7 @@ fn filter_on_materialized_scalar_above_tvf() {
     let st = demo_table();
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql(&format!(
             "SELECT _id, rating FROM bm25_search('title', 'rust', {SURFACE_TOP_K}) \
              WHERE rating >= 8"
@@ -297,6 +304,7 @@ fn base_table_scan_supports_aggregates_and_projection() {
     let st = demo_table();
     let total = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("count");
     let n = total[0]
@@ -310,6 +318,7 @@ fn base_table_scan_supports_aggregates_and_projection() {
     // SUM over the full table equals the closed form 0+1+..+15.
     let sum = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT SUM(rating) AS s FROM supertable")
         .expect("sum");
     let s = sum[0]
@@ -324,6 +333,7 @@ fn base_table_scan_supports_aggregates_and_projection() {
     // Projection + ORDER BY + LIMIT over the base table.
     let top = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT title, rating FROM supertable ORDER BY rating DESC LIMIT 2")
         .expect("ordered projection");
     assert!(row_count(&top) <= 2, "LIMIT 2 caps the projection");

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -171,7 +171,7 @@ fn bm25_exact_term_skip_opens_only_matching_superfile() {
     w.commit().expect("commit");
     drop(w);
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(r.n_superfiles(), EXACT_TERM_SUPERFILE_COUNT);
 
     // Identify the URI of superfile 0 (the planted superfile).
@@ -235,7 +235,7 @@ fn bm25_prefix_skip_opens_only_superfiles_overlapping_prefix_range() {
     w.commit().expect("commit");
     drop(w);
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     assert_eq!(r.n_superfiles(), EXACT_TERM_SUPERFILE_COUNT);
 
     let manifest = r.manifest();
@@ -280,6 +280,7 @@ fn bm25_search_with_no_matching_superfiles_opens_no_superfiles_at_all() {
     let before = store.snapshot();
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits(
             "title",
             "definitelynotpresent",
@@ -317,7 +318,7 @@ fn bm25_and_mode_skip_requires_all_terms_present_in_superfile() {
     w.commit().expect("commit");
     drop(w);
 
-    let r = st.reader();
+    let r = st.reader().expect("reader");
     let manifest = r.manifest();
     let kept_uri = manifest.superfiles[0].uri;
 

--- a/tests/supertable/query/stats_fold.rs
+++ b/tests/supertable/query/stats_fold.rs
@@ -72,6 +72,7 @@ fn build_batch(idx: usize, schema: Arc<Schema>) -> RecordBatch {
 fn explain(st: &Supertable, sql: &str) -> String {
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql(&format!("EXPLAIN {sql}"))
         .expect("explain");
     let mut out = String::new();
@@ -92,7 +93,7 @@ fn explain(st: &Supertable, sql: &str) -> String {
 
 /// Single-cell i64 result of an aggregate query.
 fn scalar_i64(st: &Supertable, sql: &str) -> i64 {
-    let batches = st.reader().query_sql(sql).expect("sql");
+    let batches = st.reader().expect("reader").query_sql(sql).expect("sql");
     let batch = batches.iter().find(|b| b.num_rows() > 0).expect("one row");
     batch
         .column(0)
@@ -104,7 +105,7 @@ fn scalar_i64(st: &Supertable, sql: &str) -> i64 {
 
 /// Single-cell string result of an aggregate query.
 fn scalar_string(st: &Supertable, sql: &str) -> String {
-    let batches = st.reader().query_sql(sql).expect("sql");
+    let batches = st.reader().expect("reader").query_sql(sql).expect("sql");
     let batch = batches.iter().find(|b| b.num_rows() > 0).expect("one row");
     let column = batch.column(0);
     if let Some(s) = column.as_any().downcast_ref::<LargeStringArray>() {
@@ -272,7 +273,7 @@ fn build_day_batch(idx: usize, schema: Arc<Schema>) -> RecordBatch {
 
 /// Single-cell Date32 (days-since-epoch) result of an aggregate query.
 fn scalar_date32(st: &Supertable, sql: &str) -> i32 {
-    let batches = st.reader().query_sql(sql).expect("sql");
+    let batches = st.reader().expect("reader").query_sql(sql).expect("sql");
     let batch = batches.iter().find(|b| b.num_rows() > 0).expect("one row");
     batch
         .column(0)

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -107,7 +107,7 @@ async fn fts_query_excludes_tombstoned_row() {
 
     // Resolve the middle row's `_id`. The producer assigned ids
     // contiguously starting at `id_min`, so middle = id_min + 1.
-    let manifest = st.reader().manifest().clone();
+    let manifest = st.reader().expect("reader").manifest().clone();
     let entry = manifest
         .get_all_superfiles()
         .first()
@@ -127,6 +127,7 @@ async fn fts_query_excludes_tombstoned_row() {
     // middle row.
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
         .expect("fts");
     assert_eq!(hits.len(), 2, "tombstoned row must be excluded");
@@ -152,7 +153,7 @@ async fn sql_query_excludes_tombstoned_row() {
     w.commit().expect("commit");
     drop(w);
 
-    let manifest = st.reader().manifest().clone();
+    let manifest = st.reader().expect("reader").manifest().clone();
     let entry = manifest
         .get_all_superfiles()
         .first()
@@ -178,6 +179,7 @@ async fn sql_query_excludes_tombstoned_row() {
     // tombstoned rows).
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("sql");
     assert_eq!(batches.len(), 1);
@@ -191,6 +193,7 @@ async fn sql_query_excludes_tombstoned_row() {
     // `SELECT title` should return only the un-tombstoned rows.
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT title FROM supertable ORDER BY title")
         .expect("sql");
     let titles: Vec<&str> = batches
@@ -326,7 +329,7 @@ async fn vector_query_excludes_tombstoned_row() {
     w.commit().expect("commit");
     drop(w);
 
-    let manifest = st.reader().manifest().clone();
+    let manifest = st.reader().expect("reader").manifest().clone();
     let entry = manifest
         .get_all_superfiles()
         .first()
@@ -346,6 +349,7 @@ async fn vector_query_excludes_tombstoned_row() {
     // so a no-backfill filter returns empty. It must return row 1.
     let top1 = st
         .reader()
+        .expect("reader")
         .vector_hits("embedding", &q, 1, VectorSearchOptions::new(), None)
         .expect("vector k=1");
     assert_eq!(
@@ -362,6 +366,7 @@ async fn vector_query_excludes_tombstoned_row() {
     // A wider k must never surface the tombstoned row either.
     let hits = st
         .reader()
+        .expect("reader")
         .vector_hits(
             "embedding",
             &q,
@@ -500,7 +505,7 @@ async fn vector_query_backfills_across_superfiles_after_deletes() {
         }
     }
     assert!(
-        st.reader().n_superfiles() > 1,
+        st.reader().expect("reader").n_superfiles() > 1,
         "fixture must span multiple superfiles to exercise the merge backfill"
     );
 
@@ -512,6 +517,7 @@ async fn vector_query_backfills_across_superfiles_after_deletes() {
 
     let before = st
         .reader()
+        .expect("reader")
         .vector_search("embedding", &q, K, opts, None, Some(&proj))
         .expect("search before");
     let deleted: Vec<String> = titles_of(&before);
@@ -528,6 +534,7 @@ async fn vector_query_backfills_across_superfiles_after_deletes() {
     // ranks across superfiles, none of them the deleted ones.
     let after = st
         .reader()
+        .expect("reader")
         .vector_search("embedding", &q, K, opts, None, Some(&proj))
         .expect("search after");
     let survivors = titles_of(&after);

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -287,7 +287,7 @@ fn vec_to_csv(v: &[f32]) -> String {
 /// Run every query in `QUERIES` against a pinned snapshot of `st`.
 /// Returns one sorted `Vec<i128>` of `_id` values per query.
 fn run_bm25_queries(st: &Supertable) -> Vec<Vec<i128>> {
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     QUERIES
         .iter()
         .map(|q| {
@@ -302,7 +302,7 @@ fn run_bm25_queries(st: &Supertable) -> Vec<Vec<i128>> {
 /// Run one `vector_search` call per entry in `VECTOR_PROBE_DOCS`.
 /// Returns sorted `_id` sets per query.
 fn run_vector_queries(st: &Supertable) -> Vec<Vec<i128>> {
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     VECTOR_PROBE_DOCS
         .iter()
         .map(|&idx| {
@@ -327,7 +327,7 @@ fn run_vector_queries(st: &Supertable) -> Vec<Vec<i128>> {
 /// vector queries), in the order of `SQL_FTS_QUERIES` followed by
 /// `SQL_VECTOR_PROBE_DOCS`.
 fn run_sql_queries(st: &Supertable) -> Vec<Vec<i128>> {
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     let mut results = Vec::new();
     for q in SQL_FTS_QUERIES {
         let sql = format!("SELECT _id FROM bm25_search('title', '{q}', 1)");
@@ -424,7 +424,7 @@ async fn compact_azure_two_jobs_results_preserved() {
         w.commit().expect("commit");
     }
 
-    let reader_pre = st.reader();
+    let reader_pre = st.reader().expect("reader");
     assert_eq!(
         reader_pre.n_superfiles(),
         N_COMMITS,
@@ -500,7 +500,7 @@ async fn compact_azure_two_jobs_results_preserved() {
     st.optimize(&cfg).expect("optimize");
     eprintln!("[compact_azure] compact() done");
 
-    let reader_post = st.reader();
+    let reader_post = st.reader().expect("reader");
     assert_eq!(
         reader_post.n_superfiles(),
         N_COMPACTED_FILES,
@@ -623,7 +623,7 @@ async fn compact_real_azure_two_jobs_results_preserved() {
             w.commit().map_err(|e| format!("commit: {e}"))?;
         }
 
-        let reader_pre = st.reader();
+        let reader_pre = st.reader().expect("reader");
         if reader_pre.n_superfiles() != N_COMMITS {
             return Err(format!(
                 "expected {N_COMMITS} superfiles before compaction, got {}",
@@ -686,7 +686,7 @@ async fn compact_real_azure_two_jobs_results_preserved() {
             .map_err(|e| format!("optimize: {e}"))?;
         eprintln!("[real-azure-compact] compact() done");
 
-        let reader_post = st.reader();
+        let reader_post = st.reader().expect("reader");
         if reader_post.n_superfiles() != N_COMPACTED_FILES {
             return Err(format!(
                 "expected {N_COMPACTED_FILES} superfiles after compaction, got {}",

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -246,21 +246,22 @@ async fn supertable_smoke_via_azure_wire_protocol() {
 
     assert_eq!(consumer.manifest_id(), 1, "recovered manifest_id mismatch");
     assert_eq!(
-        consumer.reader().n_docs_total(),
+        consumer.reader().expect("reader").n_docs_total(),
         2,
         "recovered n_docs_total mismatch"
     );
     eprintln!(
         "[azure] consumer open OK; manifest_id={} n_superfiles={} n_docs_total={}",
         consumer.manifest_id(),
-        consumer.reader().n_superfiles(),
-        consumer.reader().n_docs_total()
+        consumer.reader().expect("reader").n_superfiles(),
+        consumer.reader().expect("reader").n_docs_total()
     );
 
     let pre = cache.stats();
     assert_eq!(pre.n_cold_fetches, 0);
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("query_sql via Azure");
     assert_eq!(batches.len(), 1);
@@ -498,15 +499,16 @@ async fn supertable_real_azure_round_trip() {
                 consumer.manifest_id()
             ));
         }
-        if consumer.reader().n_docs_total() != EXPECTED_N_DOCS {
+        if consumer.reader().expect("reader").n_docs_total() != EXPECTED_N_DOCS {
             return Err(format!(
                 "recovered doc count mismatch: got {}",
-                consumer.reader().n_docs_total()
+                consumer.reader().expect("reader").n_docs_total()
             ));
         }
 
         let bm25_hits = consumer
             .reader()
+            .expect("reader")
             .bm25_search(
                 "title",
                 "alpha",
@@ -523,6 +525,7 @@ async fn supertable_real_azure_round_trip() {
         query[0] = 1.0;
         let vector_hits = consumer
             .reader()
+            .expect("reader")
             .vector_search(
                 "emb",
                 &query,
@@ -552,7 +555,7 @@ async fn supertable_real_azure_round_trip() {
             stats.n_cold_fetches, stats.current_bytes
         );
 
-        let reader = consumer.reader();
+        let reader = consumer.reader().expect("reader");
         let manifest = reader.manifest();
         let mut cleanup_keys = vec![
             "_supertable/current".to_string(),
@@ -772,10 +775,10 @@ async fn manifest_disk_cache_serves_parts_without_azure_refetch() {
             )
             .map_err(|e| format!("cold open: {e}"))?;
 
-            if consumer.reader().n_docs_total() != EXPECTED_N_DOCS {
+            if consumer.reader().expect("reader").n_docs_total() != EXPECTED_N_DOCS {
                 return Err(format!(
                     "cold n_docs_total mismatch: {}",
-                    consumer.reader().n_docs_total()
+                    consumer.reader().expect("reader").n_docs_total()
                 ));
             }
             let cold_part_gets = counting.part_gets();
@@ -821,10 +824,10 @@ async fn manifest_disk_cache_serves_parts_without_azure_refetch() {
             )
             .map_err(|e| format!("warm open: {e}"))?;
 
-            if consumer.reader().n_docs_total() != EXPECTED_N_DOCS {
+            if consumer.reader().expect("reader").n_docs_total() != EXPECTED_N_DOCS {
                 return Err(format!(
                     "warm n_docs_total mismatch: {}",
-                    consumer.reader().n_docs_total()
+                    consumer.reader().expect("reader").n_docs_total()
                 ));
             }
             let warm_part_gets = counting.part_gets();
@@ -845,7 +848,7 @@ async fn manifest_disk_cache_serves_parts_without_azure_refetch() {
             );
 
             // Collect cleanup keys from the warm consumer's manifest.
-            let reader = consumer.reader();
+            let reader = consumer.reader().expect("reader");
             let manifest = reader.manifest();
             let mut keys = vec![
                 "_supertable/current".to_string(),

--- a/tests/supertable/storage/smoke_gcs.rs
+++ b/tests/supertable/storage/smoke_gcs.rs
@@ -189,10 +189,14 @@ async fn supertable_real_gcs_round_trip() {
     )
     .expect("open real gcs supertable");
     assert_eq!(consumer.manifest_id(), 1);
-    assert_eq!(consumer.reader().n_docs_total(), EXPECTED_N_DOCS);
+    assert_eq!(
+        consumer.reader().expect("reader").n_docs_total(),
+        EXPECTED_N_DOCS
+    );
 
     let bm25 = consumer
         .reader()
+        .expect("reader")
         .bm25_search("title", "alpha", 10, BoolMode::Or, None)
         .expect("bm25 over real gcs");
     assert!(!bm25.is_empty(), "cold BM25 must find the alpha docs");
@@ -201,6 +205,7 @@ async fn supertable_real_gcs_round_trip() {
     query[0] = 1.0;
     let vectors = consumer
         .reader()
+        .expect("reader")
         .vector_search(
             "emb",
             &query,
@@ -214,6 +219,7 @@ async fn supertable_real_gcs_round_trip() {
 
     let batches = consumer
         .reader()
+        .expect("reader")
         .query_sql("SELECT COUNT(*) AS n FROM supertable")
         .expect("query real gcs");
     assert_eq!(batches.len(), 1);

--- a/tests/supertable/storage/smoke_rustfs.rs
+++ b/tests/supertable/storage/smoke_rustfs.rs
@@ -133,7 +133,7 @@ async fn supertable_smoke_via_rustfs_https() {
     let consumer = Supertable::open(default_supertable_options().with_storage(storage))
         .expect("open from RustFS");
     assert_eq!(consumer.manifest_id(), 2);
-    assert_eq!(consumer.reader().n_docs_total(), 3);
+    assert_eq!(consumer.reader().expect("reader").n_docs_total(), 3);
 
     eprintln!("[rustfs-smoke] smoke done bucket={}", fixture.bucket);
 }
@@ -380,7 +380,10 @@ async fn supertable_tvfs_through_query_sql_via_rustfs() {
     )
     .expect("Supertable::open via RustFS (tvf consumer)");
     assert_eq!(consumer.manifest_id(), 1);
-    assert_eq!(consumer.reader().n_docs_total(), EXPECTED_N_DOCS);
+    assert_eq!(
+        consumer.reader().expect("reader").n_docs_total(),
+        EXPECTED_N_DOCS
+    );
 
     let pre = cache.stats();
 
@@ -399,6 +402,7 @@ async fn supertable_tvfs_through_query_sql_via_rustfs() {
 
     let bm25 = consumer
         .reader()
+        .expect("reader")
         .query_sql(&format!(
             "SELECT _id FROM bm25_search('title', 'alpha', {BM25_TOP_K})"
         ))
@@ -412,6 +416,7 @@ async fn supertable_tvfs_through_query_sql_via_rustfs() {
     let vec_sql = format!("SELECT _id FROM vector_search('emb', '{q_csv}', 3)");
     let vector = consumer
         .reader()
+        .expect("reader")
         .query_sql(&vec_sql)
         .expect("vector_search via query_sql over RustFS");
     assert!(
@@ -423,6 +428,7 @@ async fn supertable_tvfs_through_query_sql_via_rustfs() {
         format!("SELECT _id FROM hybrid_search('title', 'alpha', 'emb', '{q_csv}', 5)");
     let hybrid = consumer
         .reader()
+        .expect("reader")
         .query_sql(&hybrid_sql)
         .expect("hybrid_search via query_sql over RustFS");
     let hyb_rows = count_rows(&hybrid);
@@ -539,7 +545,10 @@ async fn supertable_cold_vector_search_over_budget_via_rustfs() {
 
     let (consumer, _cache_guard) = open_budget_consumer(dim, &storage, TINY_BUDGET_BYTES);
     assert_eq!(consumer.manifest_id(), 1);
-    assert_eq!(consumer.reader().n_docs_total(), BUDGET_N_ROWS as u64);
+    assert_eq!(
+        consumer.reader().expect("reader").n_docs_total(),
+        BUDGET_N_ROWS as u64
+    );
 
     let mut q = vec![0.0f32; dim];
     q[0] = 1.0;
@@ -690,7 +699,11 @@ async fn supertable_cold_vector_search_over_budget_via_sql_rustfs() {
     let sql = format!("SELECT _id FROM vector_search('emb', '{q_csv}', {VECTOR_SEARCH_K})");
 
     let (consumer, _cache_guard) = open_budget_consumer(dim, &storage, TINY_BUDGET_BYTES);
-    let result = consumer.reader().query_sql(&sql).map_err(InfinoError::from);
+    let result = consumer
+        .reader()
+        .expect("reader")
+        .query_sql(&sql)
+        .map_err(InfinoError::from);
     match result {
         Err(InfinoError::OverBudget(msg)) => {
             eprintln!("[rustfs-budget-sql] cold vector search in SQL refused as OverBudget: {msg}");
@@ -712,6 +725,7 @@ async fn supertable_cold_vector_search_over_budget_via_sql_rustfs() {
     let (control, _control_cache_guard) = open_budget_consumer(dim, &storage, 0);
     let control_rows: usize = control
         .reader()
+        .expect("reader")
         .query_sql(&sql)
         .expect("measured cold vector search in SQL should run to completion")
         .iter()
@@ -764,7 +778,12 @@ async fn supertable_cold_hybrid_search_over_budget_via_sql_rustfs() {
     );
 
     let (consumer, _cache_guard) = open_budget_consumer(dim, &storage, TINY_BUDGET_BYTES);
-    match consumer.reader().query_sql(&sql).map_err(InfinoError::from) {
+    match consumer
+        .reader()
+        .expect("reader")
+        .query_sql(&sql)
+        .map_err(InfinoError::from)
+    {
         Err(InfinoError::OverBudget(msg)) => {
             eprintln!("[rustfs-budget-sql] cold hybrid search refused as OverBudget: {msg}");
         }
@@ -783,6 +802,7 @@ async fn supertable_cold_hybrid_search_over_budget_via_sql_rustfs() {
     let (control, _control_cache_guard) = open_budget_consumer(dim, &storage, 0);
     let control_rows: usize = control
         .reader()
+        .expect("reader")
         .query_sql(&sql)
         .expect("measured cold hybrid search should run to completion")
         .iter()
@@ -845,8 +865,11 @@ async fn supertable_vector_budget_is_shared_across_superfiles_via_rustfs() {
     };
 
     let (measured, _measured_guard) = open_budget_consumer(dim, &storage, 0);
-    assert_eq!(measured.reader().n_superfiles(), 2);
-    assert_eq!(measured.reader().n_docs_total(), (BUDGET_N_ROWS as u64) * 2);
+    assert_eq!(measured.reader().expect("reader").n_superfiles(), 2);
+    assert_eq!(
+        measured.reader().expect("reader").n_docs_total(),
+        (BUDGET_N_ROWS as u64) * 2
+    );
     let measured_hits = search(&measured).expect("measured search over two superfiles runs");
     let measured_rows: usize = measured_hits.iter().map(|b| b.num_rows()).sum();
     let measured_peak = measured.options().connection_budget().peak();

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -238,15 +238,16 @@ async fn supertable_real_s3_lazy_vector_and_fts_round_trip() {
                 consumer.manifest_id()
             ));
         }
-        if consumer.reader().n_docs_total() != EXPECTED_N_DOCS {
+        if consumer.reader().expect("reader").n_docs_total() != EXPECTED_N_DOCS {
             return Err(format!(
                 "recovered doc count mismatch: got {}",
-                consumer.reader().n_docs_total()
+                consumer.reader().expect("reader").n_docs_total()
             ));
         }
 
         let bm25_hits = consumer
             .reader()
+            .expect("reader")
             .bm25_search(
                 "title",
                 "alpha",
@@ -263,6 +264,7 @@ async fn supertable_real_s3_lazy_vector_and_fts_round_trip() {
         query[0] = 1.0;
         let vector_hits = consumer
             .reader()
+            .expect("reader")
             .vector_search(
                 "emb",
                 &query,
@@ -292,7 +294,7 @@ async fn supertable_real_s3_lazy_vector_and_fts_round_trip() {
             stats.n_cold_fetches, stats.current_bytes
         );
 
-        let reader = consumer.reader();
+        let reader = consumer.reader().expect("reader");
         let manifest = reader.manifest();
         let mut cleanup_keys = vec![
             "_supertable/current".to_string(),

--- a/tests/supertable/update_crash_property.rs
+++ b/tests/supertable/update_crash_property.rs
@@ -94,7 +94,7 @@ async fn seed_partial_state(
     let ws = WalStore::new(Arc::clone(&storage));
     let st = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
         .expect("open for ids");
-    let manifest = st.reader().manifest().clone();
+    let manifest = st.reader().expect("reader").manifest().clone();
     let id_min = manifest
         .get_all_superfiles()
         .first()

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -100,6 +100,7 @@ async fn writer_delete_tombstones_matching_rows() {
     // Follow-up SQL query no longer returns the row.
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT title FROM supertable ORDER BY title")
         .expect("sql");
     let titles: Vec<String> = batches
@@ -123,6 +124,7 @@ async fn writer_delete_tombstones_matching_rows() {
     // batch, so assert on the row count, not the batch count.
     let hits = st
         .reader()
+        .expect("reader")
         .bm25_search("title", "bravo", FTS_TOP_K, BoolMode::Or, None)
         .expect("fts");
     let n_rows: usize = hits.iter().map(|b| b.num_rows()).sum();
@@ -198,6 +200,7 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
     // later assertion exercises invalidation, not a cold read.
     let n_rows: usize = reader_handle
         .reader()
+        .expect("reader")
         .bm25_search("title", "bravo", FTS_TOP_K, BoolMode::Or, None)
         .expect("pre-delete fts")
         .iter()
@@ -219,6 +222,7 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
     // The very next query on the other worker must drop the row.
     let n_rows: usize = reader_handle
         .reader()
+        .expect("reader")
         .bm25_search("title", "bravo", FTS_TOP_K, BoolMode::Or, None)
         .expect("post-delete fts")
         .iter()
@@ -228,6 +232,7 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
 
     let batches = reader_handle
         .reader()
+        .expect("reader")
         .query_sql("SELECT title FROM supertable ORDER BY title")
         .expect("post-delete sql");
     let titles: Vec<String> = batches
@@ -294,6 +299,7 @@ async fn writer_update_replaces_matching_rows() {
 
     let batches = st
         .reader()
+        .expect("reader")
         .query_sql("SELECT title FROM supertable ORDER BY title")
         .expect("sql");
     let titles: Vec<String> = batches
@@ -373,7 +379,7 @@ async fn update_emitted_superfile_carries_subsection_offsets() {
     w.commit().expect("commit update");
     drop(w);
 
-    let reader = st.reader();
+    let reader = st.reader().expect("reader");
     let manifest = reader.manifest();
     let emitted = manifest
         .get_all_superfiles()

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -311,7 +311,7 @@ fn crash_post_superfile_no_prior_commit_yields_empty_table() {
         "no commit landed → recover create's empty id-0 manifest"
     );
     assert_eq!(
-        recovered.reader().n_superfiles(),
+        recovered.reader().expect("reader").n_superfiles(),
         0,
         "the orphan superfile is invisible without a committed manifest list"
     );
@@ -375,7 +375,7 @@ fn crash_post_superfile_on_second_commit_yields_v1() {
         Supertable::open(default_supertable_options().with_storage(storage)).expect("open at v1");
     assert_eq!(consumer.manifest_id(), 1, "must recover at v1");
     assert_eq!(
-        consumer.reader().n_superfiles(),
+        consumer.reader().expect("reader").n_superfiles(),
         1,
         "v1 has exactly the first commit's superfile; v2's orphan superfile is invisible"
     );
@@ -393,7 +393,7 @@ fn crash_post_list_on_second_commit_yields_v1() {
     let consumer =
         Supertable::open(default_supertable_options().with_storage(storage)).expect("open at v1");
     assert_eq!(consumer.manifest_id(), 1);
-    assert_eq!(consumer.reader().n_superfiles(), 1);
+    assert_eq!(consumer.reader().expect("reader").n_superfiles(), 1);
 
     // Orphan v2 manifest list and v2 part are on disk —
     // tolerated here; compaction GCs them later.
@@ -427,7 +427,7 @@ fn crash_post_pointer_on_second_commit_yields_v2() {
         "pointer rename completed before crash → commit is durable"
     );
     assert_eq!(
-        consumer.reader().n_superfiles(),
+        consumer.reader().expect("reader").n_superfiles(),
         2,
         "v2 sees both commits' superfiles"
     );

--- a/tests/supertable_concurrent_processes.rs
+++ b/tests/supertable_concurrent_processes.rs
@@ -105,7 +105,7 @@ async fn two_handles_concurrent_commits_both_succeed_via_occ_retry() {
             .expect("open");
     assert_eq!(consumer.manifest_id(), 2);
     assert_eq!(
-        consumer.reader().n_superfiles(),
+        consumer.reader().expect("reader").n_superfiles(),
         2,
         "post-open consumer sees both writers' superfiles"
     );
@@ -167,14 +167,14 @@ async fn three_handles_concurrent_commits_all_succeed() {
         3,
         "three concurrent commits must result in manifest_id = 3"
     );
-    assert_eq!(consumer.reader().n_superfiles(), 3);
+    assert_eq!(consumer.reader().expect("reader").n_superfiles(), 3);
 
     // Verify all three writers' superfiles are present by
     // counting distinct superfile URIs — the supertable injects
     // `_id` values via its monotonic generator, so we can't
     // assert specific id values across writer processes (each
     // gets its own random worker_id).
-    let reader = consumer.reader();
+    let reader = consumer.reader().expect("reader");
     let segs = reader.manifest().get_all_superfiles();
     let uris: std::collections::HashSet<_> = segs.iter().map(|s| s.uri.0).collect();
     assert_eq!(
@@ -232,7 +232,7 @@ async fn retry_winner_sees_loser_superfiles_in_final_manifest() {
     // at manifest_id = 1 only sees its own superfile (pre-retry
     // state, never refreshed).
     for st in [&st_a, &st_b] {
-        let r = st.reader();
+        let r = st.reader().expect("reader");
         if r.manifest_id() == 2 {
             assert_eq!(
                 r.n_superfiles(),
@@ -285,7 +285,7 @@ fn sequential_commits_across_handles_no_retry_needed() {
     }
     assert_eq!(st_b.manifest_id(), 2);
     assert_eq!(
-        st_b.reader().n_superfiles(),
+        st_b.reader().expect("reader").n_superfiles(),
         2,
         "B sees both A's and B's superfiles"
     );


### PR DESCRIPTION
### What does this PR do?
- Prevents appends, updates, sql queries, fts queries and vector queries on a table that has been dropped by another infino engine process active on it.
- Fixes #468 

### Why do we need this change?
- To prevent race conditions during delete + commit when a user has multiple infino engines active on the same data

### How do we do this change?
- For catalog operations ( sql queries ), the reason we encounter this error is because we cache the table handles which are never invalidated.
- Now, we invalidate this table handle cache when the current manifest pointer is no longer present ( table deletion )
- This is done by setting a `pointer_vanished` as a latch on the table handle when we find the manifest pointer missing either during reads or writes ( commit ).
- Similarly for reader operations ( bm25_search, token_match, exact_match, count, vector_search, hybrid_search ), the reader initialization should fail when trying to open a reader on an already deleted table. This also requires the reader signature to change ( return a `Result` now ). This is 90% of the changes in this PR ( review commit by commit to make the process easier ).
- For writes/commits, previously, an write on a stale handle could rebuild the table. This PR fixes this by propagating the NotFound error when trying to write on a deleted table.

### How has this been tested?
- Unit tests added
- E2E tests
- Benchmarks - attached in comments

### Next steps
- The original issue still persists if a user deletes the index with `purge=false`. The fix for this is deferred for now and will be part of a separate PR