### PR TITLE
supertable/vector: manifest-calibrated probe-width + configurable nprobe for improved recall on real-world corpus

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1417,11 +1417,7 @@ pub mod vector {
     pub fn search_opts(nprobe: usize, rerank_mult: usize) -> VectorSearchOptions {
         let mut opts = VectorSearchOptions::default();
         if nprobe != ENGINE_DEFAULT {
-            // Bench diagnostic: also let the explicit nprobe widen the coarse
-            // cell probe on unfiltered hidden-indexed queries (the breadth
-            // sweep). No-op for filtered queries / production (setter is
-            // test-helpers-gated).
-            opts = opts.with_nprobe(nprobe).widen_unfiltered_hidden_cells();
+            opts = opts.with_nprobe(nprobe);
         }
         if rerank_mult != ENGINE_DEFAULT {
             opts = opts.with_rerank_mult(rerank_mult);

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -234,6 +234,13 @@ pub enum VectorError {
     /// `InfinoError::OverBudget` via [`VectorError::over_budget`].
     #[error("{0}")]
     OverBudget(String),
+
+    /// A rayon-bridged compute task dropped its result channel without
+    /// sending — the worker panicked or was cancelled mid-query. Surfaced
+    /// as an error so a lost scan/rerank fails the one query instead of
+    /// panicking the process.
+    #[error("vector compute task dropped its result during {0}")]
+    TaskDropped(&'static str),
 }
 
 impl VectorError {

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -57,7 +57,7 @@ use crate::{
         },
         vector::{
             layout::VectorLayout,
-            reader::{self as vector_reader, VectorReader},
+            reader::{self as vector_reader, ScanCandidate, ScanOutcome, VectorReader},
         },
     },
     supertable::query::provider::tombstone_access_plan,
@@ -1483,6 +1483,63 @@ impl SuperfileReader {
             budget,
         )
         .await?)
+    }
+
+    /// Deferred-rerank sibling of [`Self::vector_search_clusters_filtered`]
+    /// for the supertable's global-shortlist width sweeps: warm cells
+    /// return 1-bit estimate survivors (scanned at the undivided
+    /// `k × rerank_mult`), cold cells rerank immediately under
+    /// `cold_rerank_mult`.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn vector_scan_clusters_filtered(
+        &self,
+        column: &str,
+        query: &[f32],
+        k: usize,
+        clusters: &[u32],
+        options: VectorSearchOptions,
+        cold_rerank_mult: usize,
+        allow: Option<Arc<RoaringBitmap>>,
+        deny: Option<Arc<RoaringBitmap>>,
+        pool: Option<Arc<ThreadPool>>,
+        budget: Option<Arc<ConnectionMemoryBudget>>,
+    ) -> Result<ScanOutcome, ReadError> {
+        let filtered = allow.is_some();
+        let (_, rerank_mult) = options.resolve(filtered);
+        let v = self
+            .vec()
+            .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
+        let rerank_mult = v.public_rerank_mult(column, rerank_mult);
+        Ok(v.search_clusters_scan_async(
+            column,
+            query,
+            k,
+            clusters,
+            rerank_mult,
+            cold_rerank_mult,
+            allow,
+            deny,
+            pool,
+            budget,
+        )
+        .await?)
+    }
+
+    /// Rerank this superfile's share of the globally selected shortlist —
+    /// phase C of the deferred-rerank width sweep.
+    pub(crate) async fn vector_rerank_selected(
+        &self,
+        column: &str,
+        query: &[f32],
+        k: usize,
+        selected: Vec<ScanCandidate>,
+        pool: Option<Arc<ThreadPool>>,
+    ) -> Result<Vec<(u32, f32)>, ReadError> {
+        let v = self
+            .vec()
+            .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
+        Ok(v.rerank_selected_async(column, query, k, selected, pool)
+            .await?)
     }
 }
 

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1502,12 +1502,6 @@ pub struct VectorSearchOptions {
     /// IVF probe override. `None` → engine default for the query path.
     pub nprobe: Option<usize>,
     rerank_mult: Option<usize>,
-    /// Diagnostic, bench/test builds only: when set, an explicit `nprobe`
-    /// widens the coarse cell probe on UNFILTERED hidden-indexed queries too.
-    /// Always `false` in production — the setter is `#[cfg(feature =
-    /// "test-helpers")]`, so it cannot be reached from the public API and the
-    /// serving path never sees it.
-    pub(crate) widen_unfiltered_hidden_cells: bool,
 }
 
 impl VectorSearchOptions {
@@ -1529,16 +1523,6 @@ impl VectorSearchOptions {
     /// the cost of more work.
     pub fn with_nprobe(mut self, n: usize) -> Self {
         self.nprobe = Some(n);
-        self
-    }
-
-    /// Diagnostic, bench/test builds only: let an explicit `nprobe` widen the
-    /// coarse cell probe on UNFILTERED hidden-indexed queries (used by the
-    /// recall breadth-sweep). Absent from production builds, so it never
-    /// affects the serving path.
-    #[cfg(feature = "test-helpers")]
-    pub fn widen_unfiltered_hidden_cells(mut self) -> Self {
-        self.widen_unfiltered_hidden_cells = true;
         self
     }
 

--- a/src/superfile/vector/quant.rs
+++ b/src/superfile/vector/quant.rs
@@ -41,13 +41,29 @@ use wide::f32x8;
 
 use crate::superfile::vector::distance::sum_f32;
 #[cfg(target_arch = "x86_64")]
-use crate::superfile::vector::simd_dispatch::avx512_enabled;
+use crate::superfile::vector::simd_dispatch::{avx2_enabled, avx512_enabled, has_vbmi};
 
 /// Number of sign bits packed into one code byte (1-bit RaBitQ packs
 /// one sign per dimension, eight per byte). One `f32x8` SIMD block
 /// also covers exactly this many dimensions, so the same constant
 /// drives both the bit-packing and the per-block SIMD stride.
 const BITS_PER_CODE_BYTE: usize = 8;
+
+/// Rows per packed FastScan block: one AVX-512 byte register's worth of
+/// lanes. The packed layout groups the same code-byte position of
+/// [`LUT_BLOCK_ROWS`] consecutive rows so one register load feeds one
+/// table lookup for all of them.
+pub(crate) const LUT_BLOCK_ROWS: usize = 64;
+
+/// Dimensions folded into one nibble group: each 4 query dims collapse
+/// into a 16-entry signed-i8 lookup table indexed by 4 code bits.
+const LUT_GROUP_DIMS: usize = 4;
+
+/// Entries per nibble table (2^[`LUT_GROUP_DIMS`]).
+const LUT_ENTRIES_PER_GROUP: usize = 16;
+
+/// The i8 quantization ceiling for LUT entries.
+const LUT_I8_MAX: f32 = 127.0;
 
 /// Number of distinct byte values a code byte can take (`2^8`). The
 /// sign table holds one [`BITS_PER_CODE_BYTE`]-wide `±1` expansion
@@ -199,6 +215,427 @@ impl BitQuantizer {
         estimate_dot_rotated_wide(&self.sign_table, q_rot, code, self.dim)
     }
 }
+
+// ---------------- FastScan LUT transposed code scan ----------------
+//
+// The warm 1-bit scan's fast path: the codes equivalent of the routing
+// layer's transposed centroid cache (`build_transposed_centroid_cache`
+// + `for_each_centroid_block_scores` in `distance`). The query folds
+// once into per-group nibble tables (4 dims -> 16 signed-i8 entries);
+// cluster codes — transposed position-major in [`LUT_BLOCK_ROWS`]-row
+// blocks — are then scored 64 rows per table permute. Estimates come
+// back i8-quantized (bounded by [`LutQuery::quantization_bound`]); the
+// exact rerank downstream consumes them exactly as it consumes the
+// full-precision estimator's output.
+
+/// A query folded into FastScan nibble tables. Build once per query
+/// per column (pure function of the rotated query); share across every
+/// cluster scanned with it.
+pub(crate) struct LutQuery {
+    /// `groups * `[`LUT_ENTRIES_PER_GROUP`] signed entries; group `g`
+    /// covers query dims `[g*4, g*4+4)`.
+    luts: Vec<i8>,
+    /// Undoes the i8 quantization: multiply summed table entries by
+    /// this to get back to estimate scale.
+    inv_scale: f32,
+    pub(crate) groups: usize,
+    /// Exact worst-case |accumulator| for THIS query: the sum over
+    /// groups of each group's max |entry|. The i16 kernels are safe
+    /// iff this fits i16 — see [`LutQuery::fits_i16`].
+    worst_abs: u32,
+}
+
+impl LutQuery {
+    pub(crate) fn new(q_rot: &[f32]) -> LutQuery {
+        let dim = q_rot.len();
+        let groups = dim.div_ceil(LUT_GROUP_DIMS);
+        // Scale so the largest-magnitude group sum maps to i8 range.
+        let mut max_abs = 1e-12f32;
+        for g in 0..groups {
+            let d0 = g * LUT_GROUP_DIMS;
+            let s: f32 = q_rot[d0..(d0 + LUT_GROUP_DIMS).min(dim)]
+                .iter()
+                .map(|v| v.abs())
+                .sum();
+            max_abs = max_abs.max(s);
+        }
+        let scale = LUT_I8_MAX / max_abs;
+        let mut luts = vec![0i8; groups * LUT_ENTRIES_PER_GROUP];
+        let mut worst_abs = 0u32;
+        for g in 0..groups {
+            let d0 = g * LUT_GROUP_DIMS;
+            let mut group_max = 0u32;
+            for nib in 0..LUT_ENTRIES_PER_GROUP as u32 {
+                let mut s = 0f32;
+                for (bit, d) in (d0..(d0 + LUT_GROUP_DIMS).min(dim)).enumerate() {
+                    let sign = if (nib >> bit) & 1 == 1 { 1.0 } else { -1.0 };
+                    s += sign * q_rot[d];
+                }
+                let entry = (s * scale).round().clamp(-LUT_I8_MAX, LUT_I8_MAX) as i8;
+                luts[g * LUT_ENTRIES_PER_GROUP + nib as usize] = entry;
+                group_max = group_max.max(entry.unsigned_abs() as u32);
+            }
+            worst_abs += group_max;
+        }
+        LutQuery {
+            luts,
+            inv_scale: 1.0 / scale,
+            groups,
+            worst_abs,
+        }
+    }
+
+    /// Whether the i16 block accumulators can represent every possible
+    /// row sum for this query — the exact per-query bound, not a dim
+    /// heuristic (768d always fits; 1536d fits for real queries; only
+    /// pathological shapes fall back). When false the caller keeps the
+    /// exact row-major estimator, which is the MORE precise path — the
+    /// fallback costs speed, never correctness.
+    #[inline]
+    pub(crate) fn fits_i16(&self) -> bool {
+        let fits = self.worst_abs <= i16::MAX as u32;
+        if !fits {
+            lut_overflow_fallback_warn_once(self.groups);
+        }
+        fits
+    }
+
+    /// Worst-case absolute error of the LUT estimate vs the exact
+    /// estimator: one rounding half-step per group.
+    #[cfg(test)]
+    pub(crate) fn quantization_bound(&self) -> f32 {
+        self.groups as f32 * 0.5 * self.inv_scale
+    }
+}
+
+/// One-time visibility for the (rare) i16-bound fallback, so a corpus
+/// running on the exact estimator is diagnosable rather than silent.
+fn lut_overflow_fallback_warn_once(groups: usize) {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        tracing::warn!(
+            groups,
+            "vector scan: FastScan LUT path disabled for this query shape \
+             (i16 accumulator bound); using the exact row-major estimator"
+        );
+    });
+}
+
+/// Whether the transposed LUT scan path exists on this host. ISA gate
+/// only — the per-query accumulator bound is [`LutQuery::fits_i16`].
+#[inline]
+pub(crate) fn lut_scan_supported() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        has_vbmi() || avx2_enabled()
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        false
+    }
+}
+
+/// Build the block-transposed code cache for one cluster: `cnt`
+/// row-major rows of `cb` code bytes become position-major
+/// [`LUT_BLOCK_ROWS`]-row blocks —
+/// `out[block*cb*64 + pos*64 + lane] = codes[(block*64+lane)*cb + pos]`.
+/// The tail block zero-pads missing rows (a zero code scores the
+/// constant `sum(-|q|)` per group; callers slice results to `cnt`).
+///
+/// Same role as [`distance`]'s `build_transposed_centroid_cache`, but
+/// byte-granular and hot at first touch (once per cluster per cache
+/// lifetime), so the interior is a word-parallel 8x8 byte-tile
+/// transpose (three shift/mask exchange rounds per tile, Hacker's
+/// Delight 7-3) with scalar edges; safe Rust throughout.
+pub(crate) fn build_transposed_code_cache(codes: &[u8], cnt: usize, cb: usize) -> Vec<u8> {
+    /// One 8x8 byte tile held in 8 little-endian u64 rows.
+    #[inline]
+    fn transpose_8x8(rows: &mut [u64; 8]) {
+        /// Byte lanes exchanged in round 1 (adjacent bytes).
+        const M1: u64 = 0x00FF_00FF_00FF_00FF;
+        /// Byte lanes exchanged in round 2 (byte pairs).
+        const M2: u64 = 0x0000_FFFF_0000_FFFF;
+        /// Byte lanes exchanged in round 3 (byte quads).
+        const M4: u64 = 0x0000_0000_FFFF_FFFF;
+        for i in [0usize, 2, 4, 6] {
+            let t = ((rows[i] >> 8) ^ rows[i + 1]) & M1;
+            rows[i + 1] ^= t;
+            rows[i] ^= t << 8;
+        }
+        for i in [0usize, 1, 4, 5] {
+            let t = ((rows[i] >> 16) ^ rows[i + 2]) & M2;
+            rows[i + 2] ^= t;
+            rows[i] ^= t << 16;
+        }
+        for i in [0usize, 1, 2, 3] {
+            let t = ((rows[i] >> 32) ^ rows[i + 4]) & M4;
+            rows[i + 4] ^= t;
+            rows[i] ^= t << 32;
+        }
+    }
+    /// Square byte-tile edge for the word-parallel transpose.
+    const TILE: usize = 8;
+    let blocks = cnt.div_ceil(LUT_BLOCK_ROWS);
+    let mut out = vec![0u8; blocks * cb * LUT_BLOCK_ROWS];
+    let full_row_tiles = cnt / TILE;
+    let full_col_tiles = cb / TILE;
+    for rt in 0..full_row_tiles {
+        let r0 = rt * TILE;
+        let block = r0 / LUT_BLOCK_ROWS;
+        let lane0 = r0 % LUT_BLOCK_ROWS;
+        let base = block * cb * LUT_BLOCK_ROWS;
+        for ct in 0..full_col_tiles {
+            let p0 = ct * TILE;
+            let mut tile = [0u64; TILE];
+            for (i, row) in tile.iter_mut().enumerate() {
+                let src = (r0 + i) * cb + p0;
+                *row = u64::from_le_bytes(
+                    codes[src..src + TILE].try_into().expect("8-byte row slice"),
+                );
+            }
+            transpose_8x8(&mut tile);
+            for (j, row) in tile.iter().enumerate() {
+                let dst = base + (p0 + j) * LUT_BLOCK_ROWS + lane0;
+                out[dst..dst + TILE].copy_from_slice(&row.to_le_bytes());
+            }
+        }
+        // Column tail (cb not a multiple of 8).
+        for p in full_col_tiles * TILE..cb {
+            for i in 0..TILE {
+                out[base + p * LUT_BLOCK_ROWS + lane0 + i] = codes[(r0 + i) * cb + p];
+            }
+        }
+    }
+    // Row tail (cnt not a multiple of 8).
+    for r in full_row_tiles * TILE..cnt {
+        let block = r / LUT_BLOCK_ROWS;
+        let lane = r % LUT_BLOCK_ROWS;
+        let base = block * cb * LUT_BLOCK_ROWS;
+        for p in 0..cb {
+            out[base + p * LUT_BLOCK_ROWS + lane] = codes[r * cb + p];
+        }
+    }
+    out
+}
+
+/// Drive the block scorers over every [`LUT_BLOCK_ROWS`]-row block of
+/// a transposed code cache, handing each block's 64 estimates to
+/// `reduce(base_row, scores)`. Tier dispatch is hoisted outside the
+/// block loop (same shape as [`distance`]'s
+/// `for_each_centroid_block_scores`); all tiers produce bit-identical
+/// scores (integer accumulation in one order, one f32 scale at the
+/// end). Callers gate the *path* on [`lut_scan_supported`] +
+/// [`LutQuery::fits_i16`]; the scalar tier closes the dispatch.
+pub(crate) fn for_each_code_block_scores(
+    cache: &[u8],
+    cb: usize,
+    lut: &LutQuery,
+    mut reduce: impl FnMut(usize, &[f32; LUT_BLOCK_ROWS]),
+) {
+    debug_assert_eq!(cache.len() % (cb * LUT_BLOCK_ROWS), 0);
+    debug_assert!(lut.worst_abs <= i16::MAX as u32);
+    let n_blocks = cache.len() / (cb * LUT_BLOCK_ROWS);
+    let mut scores = [0f32; LUT_BLOCK_ROWS];
+    #[cfg(target_arch = "x86_64")]
+    {
+        if has_vbmi() {
+            for block in 0..n_blocks {
+                let span = &cache[block * cb * LUT_BLOCK_ROWS..(block + 1) * cb * LUT_BLOCK_ROWS];
+                // SAFETY: gated on `has_vbmi()` which implies `avx512f` +
+                // `avx512bw` and checks `avx512vbmi`.
+                unsafe { score_code_block64_transposed_avx512(span, cb, lut, &mut scores) };
+                reduce(block * LUT_BLOCK_ROWS, &scores);
+            }
+            return;
+        }
+        if avx2_enabled() {
+            for block in 0..n_blocks {
+                let span = &cache[block * cb * LUT_BLOCK_ROWS..(block + 1) * cb * LUT_BLOCK_ROWS];
+                // SAFETY: gated on `avx2_enabled()` which requires `avx2`.
+                unsafe { score_code_block64_transposed_avx2(span, cb, lut, &mut scores) };
+                reduce(block * LUT_BLOCK_ROWS, &scores);
+            }
+            return;
+        }
+    }
+    for block in 0..n_blocks {
+        let span = &cache[block * cb * LUT_BLOCK_ROWS..(block + 1) * cb * LUT_BLOCK_ROWS];
+        score_code_block64_transposed_scalar(span, cb, lut, &mut scores);
+        reduce(block * LUT_BLOCK_ROWS, &scores);
+    }
+}
+
+/// Portable reference tier: same i16 accumulation as the SIMD kernels,
+/// lane by lane. `wide` offers no byte-table permute, so the portable
+/// form stays scalar — reachable only when both x86 tiers are disabled
+/// (or off-x86, where [`lut_scan_supported`] never selects this path).
+fn score_code_block64_transposed_scalar(
+    block: &[u8],
+    cb: usize,
+    lut: &LutQuery,
+    est_out: &mut [f32; LUT_BLOCK_ROWS],
+) {
+    let mut acc = [0i16; LUT_BLOCK_ROWS];
+    for p in 0..cb {
+        let g_lo = 2 * p;
+        let g_hi = 2 * p + 1;
+        let bytes = &block[p * LUT_BLOCK_ROWS..(p + 1) * LUT_BLOCK_ROWS];
+        for (lane, &b) in bytes.iter().enumerate() {
+            let lo = (b & 0x0F) as usize;
+            acc[lane] += i16::from(lut.luts[g_lo * LUT_ENTRIES_PER_GROUP + lo]);
+            if g_hi < lut.groups {
+                let hi = (b >> 4) as usize;
+                acc[lane] += i16::from(lut.luts[g_hi * LUT_ENTRIES_PER_GROUP + hi]);
+            }
+        }
+    }
+    for (lane, &a) in acc.iter().enumerate() {
+        est_out[lane] = f32::from(a) * lut.inv_scale;
+    }
+}
+
+/// # Safety
+///
+/// Callers must ensure the target supports `avx512f`, `avx512bw`, and
+/// `avx512vbmi`. [`has_vbmi`] guarantees this at the dispatch site.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f,avx512bw,avx512vbmi")]
+unsafe fn score_code_block64_transposed_avx512(
+    block: &[u8],
+    cb: usize,
+    lut: &LutQuery,
+    est_out: &mut [f32; LUT_BLOCK_ROWS],
+) {
+    use std::arch::x86_64::*;
+    // SAFETY: `block.len() == cb * 64` (the driver slices exactly that
+    // span), so every 64-byte load at `p * 64` for `p < cb` is in
+    // bounds. Each 16-byte LUT load at `g * 16` is in bounds because
+    // `g_lo, g_hi < lut.groups` are checked and
+    // `luts.len() == groups * 16`. `_mm512_permutexvar_epi8` requires
+    // `avx512vbmi`, guaranteed by the caller per the `# Safety`
+    // contract. i16 accumulators cannot overflow: the driver
+    // debug-asserts `lut.worst_abs <= i16::MAX` (exact per-query bound).
+    unsafe {
+        let mut acc_lo = _mm512_setzero_si512();
+        let mut acc_hi = _mm512_setzero_si512();
+        let nib_mask = _mm512_set1_epi8(0x0F);
+        for p in 0..cb {
+            let bytes = _mm512_loadu_si512(block.as_ptr().add(p * LUT_BLOCK_ROWS) as *const _);
+            let g_lo = 2 * p;
+            let g_hi = 2 * p + 1;
+            let lut_lo = _mm512_broadcast_i32x4(_mm_loadu_si128(
+                lut.luts.as_ptr().add(g_lo * LUT_ENTRIES_PER_GROUP) as *const _,
+            ));
+            let idx_lo = _mm512_and_si512(bytes, nib_mask);
+            let val_lo = _mm512_permutexvar_epi8(idx_lo, lut_lo);
+            acc_lo = _mm512_add_epi16(acc_lo, _mm512_cvtepi8_epi16(_mm512_castsi512_si256(val_lo)));
+            acc_hi = _mm512_add_epi16(
+                acc_hi,
+                _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(val_lo, 1)),
+            );
+            if g_hi < lut.groups {
+                let lut_hi = _mm512_broadcast_i32x4(_mm_loadu_si128(
+                    lut.luts.as_ptr().add(g_hi * LUT_ENTRIES_PER_GROUP) as *const _,
+                ));
+                let idx_hi = _mm512_and_si512(_mm512_srli_epi16(bytes, 4), nib_mask);
+                let val_hi = _mm512_permutexvar_epi8(idx_hi, lut_hi);
+                acc_lo =
+                    _mm512_add_epi16(acc_lo, _mm512_cvtepi8_epi16(_mm512_castsi512_si256(val_hi)));
+                acc_hi = _mm512_add_epi16(
+                    acc_hi,
+                    _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(val_hi, 1)),
+                );
+            }
+        }
+        let mut tmp = [0i16; LUT_BLOCK_ROWS];
+        _mm512_storeu_si512(tmp.as_mut_ptr() as *mut _, acc_lo);
+        _mm512_storeu_si512(tmp.as_mut_ptr().add(32) as *mut _, acc_hi);
+        for r in 0..LUT_BLOCK_ROWS {
+            est_out[r] = f32::from(tmp[r]) * lut.inv_scale;
+        }
+    }
+}
+
+/// # Safety
+///
+/// Callers must ensure the target supports `avx2`. [`avx2_enabled`]
+/// guarantees this at the dispatch site.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn score_code_block64_transposed_avx2(
+    block: &[u8],
+    cb: usize,
+    lut: &LutQuery,
+    est_out: &mut [f32; LUT_BLOCK_ROWS],
+) {
+    use std::arch::x86_64::*;
+    // SAFETY: `block.len() == cb * 64` (the driver slices exactly that
+    // span), so the two 32-byte loads at `p * 64` and `p * 64 + 32` are
+    // in bounds for `p < cb`. Each 16-byte LUT load at `g * 16` is in
+    // bounds because `g_lo, g_hi < lut.groups` and
+    // `luts.len() == groups * 16`. `_mm256_shuffle_epi8` looks up
+    // within 128-bit halves; the table is broadcast to both halves and
+    // indices are masked to 0..15 with the high bit clear, so both
+    // halves index the same 16-entry table. i16 accumulators cannot
+    // overflow: the driver debug-asserts `lut.worst_abs <= i16::MAX`.
+    unsafe {
+        // 64 i16 lanes = four 256-bit accumulators: [0..16), [16..32)
+        // for the low 32 rows, [32..48), [48..64) for the high 32.
+        let mut acc = [_mm256_setzero_si256(); 4];
+        let nib_mask = _mm256_set1_epi8(0x0F);
+        for p in 0..cb {
+            let lo32 = _mm256_loadu_si256(block.as_ptr().add(p * LUT_BLOCK_ROWS) as *const _);
+            let hi32 = _mm256_loadu_si256(block.as_ptr().add(p * LUT_BLOCK_ROWS + 32) as *const _);
+            let g_lo = 2 * p;
+            let g_hi = 2 * p + 1;
+            let lut_lo = _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                lut.luts.as_ptr().add(g_lo * LUT_ENTRIES_PER_GROUP) as *const _,
+            ));
+            let val_a = _mm256_shuffle_epi8(lut_lo, _mm256_and_si256(lo32, nib_mask));
+            acc[0] = _mm256_add_epi16(acc[0], _mm256_cvtepi8_epi16(_mm256_castsi256_si128(val_a)));
+            acc[1] = _mm256_add_epi16(
+                acc[1],
+                _mm256_cvtepi8_epi16(_mm256_extracti128_si256(val_a, 1)),
+            );
+            let val_b = _mm256_shuffle_epi8(lut_lo, _mm256_and_si256(hi32, nib_mask));
+            acc[2] = _mm256_add_epi16(acc[2], _mm256_cvtepi8_epi16(_mm256_castsi256_si128(val_b)));
+            acc[3] = _mm256_add_epi16(
+                acc[3],
+                _mm256_cvtepi8_epi16(_mm256_extracti128_si256(val_b, 1)),
+            );
+            if g_hi < lut.groups {
+                let lut_hi = _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    lut.luts.as_ptr().add(g_hi * LUT_ENTRIES_PER_GROUP) as *const _,
+                ));
+                let idx_a = _mm256_and_si256(_mm256_srli_epi16(lo32, 4), nib_mask);
+                let val_a = _mm256_shuffle_epi8(lut_hi, idx_a);
+                acc[0] =
+                    _mm256_add_epi16(acc[0], _mm256_cvtepi8_epi16(_mm256_castsi256_si128(val_a)));
+                acc[1] = _mm256_add_epi16(
+                    acc[1],
+                    _mm256_cvtepi8_epi16(_mm256_extracti128_si256(val_a, 1)),
+                );
+                let idx_b = _mm256_and_si256(_mm256_srli_epi16(hi32, 4), nib_mask);
+                let val_b = _mm256_shuffle_epi8(lut_hi, idx_b);
+                acc[2] =
+                    _mm256_add_epi16(acc[2], _mm256_cvtepi8_epi16(_mm256_castsi256_si128(val_b)));
+                acc[3] = _mm256_add_epi16(
+                    acc[3],
+                    _mm256_cvtepi8_epi16(_mm256_extracti128_si256(val_b, 1)),
+                );
+            }
+        }
+        let mut tmp = [0i16; LUT_BLOCK_ROWS];
+        for (i, a) in acc.iter().enumerate() {
+            _mm256_storeu_si256(tmp.as_mut_ptr().add(i * 16) as *mut _, *a);
+        }
+        for r in 0..LUT_BLOCK_ROWS {
+            est_out[r] = f32::from(tmp[r]) * lut.inv_scale;
+        }
+    }
+}
+// -------------- END FastScan LUT transposed code scan --------------
 
 /// Portable `wide::f32x8` (256-bit) RaBitQ estimator via the 8KB
 /// sign-table lookup. The kernel that has shipped since the
@@ -516,6 +953,157 @@ mod tests {
         let mut code = vec![0u8; quant.code_bytes()];
         quant.encode_rotated_into(&d_vec, &mut code);
         code
+    }
+
+    /// The word-parallel transposed code cache builder vs a plain
+    /// nested-loop reference, across row counts that cross the 64-row
+    /// block boundary and code widths that exercise the 8-byte tile
+    /// edges (odd `cb` = column tail; odd `cnt` = row tail).
+    #[test]
+    fn build_transposed_code_cache_matches_reference() {
+        for &(cnt, cb) in &[
+            (1usize, 12usize),
+            (7, 12),
+            (8, 12),
+            (63, 96),
+            (64, 96),
+            (65, 96),
+            (100, 13),
+            (129, 96),
+            (200, 8),
+        ] {
+            let codes: Vec<u8> = (0..cnt * cb)
+                .map(|i| ((i as u32).wrapping_mul(2654435761) >> 24) as u8)
+                .collect();
+            let blocks = cnt.div_ceil(LUT_BLOCK_ROWS);
+            let mut want = vec![0u8; blocks * cb * LUT_BLOCK_ROWS];
+            for r in 0..cnt {
+                let block = r / LUT_BLOCK_ROWS;
+                let lane = r % LUT_BLOCK_ROWS;
+                for p in 0..cb {
+                    want[block * cb * LUT_BLOCK_ROWS + p * LUT_BLOCK_ROWS + lane] =
+                        codes[r * cb + p];
+                }
+            }
+            let got = build_transposed_code_cache(&codes, cnt, cb);
+            assert_eq!(got, want, "cnt {cnt} cb {cb}");
+        }
+    }
+
+    /// Every LUT scan tier must produce bit-identical scores: the
+    /// accumulation is integer (order-free) and the only float op is
+    /// one final scale. Mirrors `sq8_simd`'s exact-equality tier
+    /// tests, including the raw feature probes that bypass the config
+    /// gates so a diagnostics toggle cannot skip a tier here.
+    #[test]
+    fn code_block_scores_transposed_match_scalar_reference() {
+        for &dim in &[12usize, 60, 764, 768, 1024] {
+            let quant = BitQuantizer::new(dim);
+            let cb = quant.code_bytes();
+            let cnt = 130;
+            let mut codes = Vec::with_capacity(cnt * cb);
+            for row in 0..cnt {
+                codes.extend_from_slice(&fake_code(&quant, 0x1234 + row as u32));
+            }
+            let cache = build_transposed_code_cache(&codes, cnt, cb);
+            let lut = LutQuery::new(&fake_vec(dim, 0xBEEF));
+            assert!(lut.fits_i16(), "dim {dim} must fit i16");
+            let n_blocks = cache.len() / (cb * LUT_BLOCK_ROWS);
+            let mut want = vec![[0f32; LUT_BLOCK_ROWS]; n_blocks];
+            for (block, out) in want.iter_mut().enumerate() {
+                score_code_block64_transposed_scalar(
+                    &cache[block * cb * LUT_BLOCK_ROWS..(block + 1) * cb * LUT_BLOCK_ROWS],
+                    cb,
+                    &lut,
+                    out,
+                );
+            }
+            #[cfg(target_arch = "x86_64")]
+            for tier in ["avx2", "avx512"] {
+                let mut got = [0f32; LUT_BLOCK_ROWS];
+                for (block, want_block) in want.iter().enumerate() {
+                    let span =
+                        &cache[block * cb * LUT_BLOCK_ROWS..(block + 1) * cb * LUT_BLOCK_ROWS];
+                    match tier {
+                        "avx2" if std::arch::is_x86_feature_detected!("avx2") => {
+                            // SAFETY: gated on the raw avx2 probe above.
+                            unsafe { score_code_block64_transposed_avx2(span, cb, &lut, &mut got) }
+                        }
+                        "avx512"
+                            if std::arch::is_x86_feature_detected!("avx512f")
+                                && std::arch::is_x86_feature_detected!("avx512bw")
+                                && std::arch::is_x86_feature_detected!("avx512vbmi") =>
+                        {
+                            // SAFETY: gated on the raw avx512f/bw/vbmi probes above.
+                            unsafe {
+                                score_code_block64_transposed_avx512(span, cb, &lut, &mut got)
+                            }
+                        }
+                        _ => continue,
+                    }
+                    assert_eq!(
+                        &got[..],
+                        &want_block[..],
+                        "tier {tier} dim {dim} block {block}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The i8-quantized LUT estimate must sit within its analytic
+    /// rounding bound of the exact estimator on every row: half a
+    /// quantization step per nibble group.
+    #[test]
+    fn lut_estimate_within_quantization_bound() {
+        for &dim in &[60usize, 768, 1024] {
+            let quant = BitQuantizer::new(dim);
+            let cb = quant.code_bytes();
+            let q_rot = fake_vec(dim, 0xC0FFEE);
+            let lut = LutQuery::new(&q_rot);
+            let bound = lut.quantization_bound() + 1e-3;
+            let cnt = 96;
+            let mut codes = Vec::with_capacity(cnt * cb);
+            for row in 0..cnt {
+                codes.extend_from_slice(&fake_code(&quant, 0x77 + row as u32));
+            }
+            let cache = build_transposed_code_cache(&codes, cnt, cb);
+            let mut checked = 0usize;
+            for_each_code_block_scores(&cache, cb, &lut, |base_r, scores| {
+                for (lane, &est) in scores.iter().enumerate() {
+                    let r = base_r + lane;
+                    if r >= cnt {
+                        continue;
+                    }
+                    let exact = quant.estimate_dot_rotated(&q_rot, &codes[r * cb..(r + 1) * cb]);
+                    assert!(
+                        (est - exact).abs() <= bound,
+                        "dim {dim} row {r}: lut {est} vs exact {exact} (bound {bound})"
+                    );
+                    checked += 1;
+                }
+            });
+            assert_eq!(checked, cnt);
+        }
+    }
+
+    /// `fits_i16` is the exact per-query accumulator bound: an
+    /// adversarial equal-magnitude query saturates every group to the
+    /// i8 ceiling, so past 258 groups (1,032 dims) it must decline —
+    /// and a realistic 768-dim query must pass.
+    #[test]
+    fn lut_query_i16_bound_is_exact_per_query() {
+        assert!(LutQuery::new(&fake_vec(768, 0xAB)).fits_i16());
+        // Equal |q| per dim -> every group's max entry is 127 ->
+        // worst_abs = groups * 127 = 512 * 127 > i16::MAX.
+        let adversarial = vec![1.0f32; 2048];
+        assert!(!LutQuery::new(&adversarial).fits_i16());
+        // The same 2048 dims with mass concentrated in one group keeps
+        // the other groups' entries tiny: the exact bound admits it
+        // where a dim heuristic would have declined.
+        let mut concentrated = vec![1e-4f32; 2048];
+        concentrated[0] = 1.0;
+        assert!(LutQuery::new(&concentrated).fits_i16());
     }
 
     /// AVX-512 RaBitQ estimator vs the wide sign-table kernel

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3103,49 +3103,66 @@ impl VectorReader {
             running = running.saturating_add(col.n_docs);
         }
 
-        let mut merged: Vec<(u32, f32)> = Vec::new();
-        for (cell_idx, locals) in by_cell {
+        // Probe the selected cells CONCURRENTLY — the same wave shape the
+        // supertable's cross-superfile fan-out (and FTS) already uses, one
+        // level down. A width sweep selects many cells inside one packed
+        // shard; awaiting them serially stacked their fetch+scan+rerank
+        // walls (measured ~1.2 ms x width per query at w=54 on Cohere-1M).
+        // Each cell's probe is independent: own ProbeCtx, own blocks, own
+        // rerank; the merge below is order-independent (re-sorted).
+        let cell_probes = by_cell.into_iter().filter_map(|(cell_idx, locals)| {
             let col = &self.columns[cell_idx];
             if col.n_docs == 0 {
-                continue;
+                return None;
             }
             let base = doc_base[cell_idx];
             // Allow/deny are file-local; each cell IVF checks cell-local ids.
             let cell_allow = self.cell_local_filter_bitmap(allow.as_deref(), cell_idx, base);
             let cell_deny = self.cell_local_filter_bitmap(deny.as_deref(), cell_idx, base);
-            let sub_start = col.subsection_range.start;
-            let idx_start = sub_start + col.cluster_idx_off;
-            let idx_end = idx_start + (col.n_cent as usize) * CLUSTER_IDX_ENTRY_BYTES;
-            let cluster_idx = self
-                .source
-                .range_async(idx_start..idx_end)
-                .await
-                .map_err(|e| VectorError::LazySource(e.to_string()))?;
-            let mut q_rot = vec![0f32; col.dim];
-            col.rot.apply(query, &mut q_rot);
             // No inverse-selectivity rerank inflation — same reasoning as
             // [`Self::search_clusters_async`]: the shortlist is allow-first
             // (matching rows only), so the standard `k × rerank_mult`
             // contract holds unchanged under a filter.
             if cell_allow.as_ref().is_some_and(|bm| bm.is_empty()) {
-                continue;
+                return None;
             }
-            let ctx = ProbeCtx {
-                q_rot: &q_rot,
-                k,
-                rerank_mult,
-                allow: cell_allow,
-                deny: cell_deny,
-                pool: pool.clone(),
-                budget: budget.clone(),
-            };
-            let hits = self
-                .probe_clusters_async(col, query, &ctx, &cluster_idx, &locals)
-                .await?;
-            for (local_id, score) in hits {
-                merged.push((base.saturating_add(local_id), score));
-            }
-        }
+            let pool = pool.clone();
+            let budget = budget.clone();
+            Some(async move {
+                let sub_start = col.subsection_range.start;
+                let idx_start = sub_start + col.cluster_idx_off;
+                let idx_end = idx_start + (col.n_cent as usize) * CLUSTER_IDX_ENTRY_BYTES;
+                let cluster_idx = self
+                    .source
+                    .range_async(idx_start..idx_end)
+                    .await
+                    .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                let mut q_rot = vec![0f32; col.dim];
+                col.rot.apply(query, &mut q_rot);
+                let ctx = ProbeCtx {
+                    q_rot: &q_rot,
+                    k,
+                    rerank_mult,
+                    allow: cell_allow,
+                    deny: cell_deny,
+                    pool,
+                    budget,
+                };
+                let hits = self
+                    .probe_clusters_async(col, query, &ctx, &cluster_idx, &locals)
+                    .await?;
+                Ok::<Vec<(u32, f32)>, VectorError>(
+                    hits.into_iter()
+                        .map(|(local_id, score)| (base.saturating_add(local_id), score))
+                        .collect(),
+                )
+            })
+        });
+        let mut merged: Vec<(u32, f32)> = try_join_all(cell_probes)
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
         // Distance ascending (smaller = closer), matching every other vector
         // search path. Descending here kept the farthest k hits and collapsed
         // packed-shard recall to ~0.

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -2856,7 +2856,7 @@ impl VectorReader {
             survivor_only_rerank_fetch,
             &ctx,
         )
-        .await
+        .await?
         {
             ShortlistOutcome::Done(out) => return Ok(out),
             ShortlistOutcome::Rerank {
@@ -3058,6 +3058,33 @@ impl VectorReader {
             .await
     }
 
+    /// Map flat cluster ids to per-cell probe work on a multi-cell
+    /// reader: `(cell index, doc-id base, cell-local cluster ids)`.
+    /// Doc-id bases follow parquet row order (cells concatenated in
+    /// directory order). The single shared resolution step of the
+    /// immediate probe ([`Self::search_clusters_async_multi_cell`]) and
+    /// the deferred scan ([`Self::search_clusters_scan_async`]), so the
+    /// two paths cannot drift.
+    fn resolve_cells_for_clusters(&self, clusters: &[u32]) -> Vec<(usize, u32, Vec<usize>)> {
+        let mut by_cell: HashMap<usize, Vec<usize>> = HashMap::new();
+        for &flat in clusters {
+            let Some((cell_idx, local)) = self.resolve_flat_cluster(flat) else {
+                continue;
+            };
+            by_cell.entry(cell_idx).or_default().push(local as usize);
+        }
+        let mut doc_base = vec![0u32; self.columns.len()];
+        let mut running = 0u32;
+        for (i, col) in self.columns.iter().enumerate() {
+            doc_base[i] = running;
+            running = running.saturating_add(col.n_docs);
+        }
+        by_cell
+            .into_iter()
+            .map(|(cell_idx, locals)| (cell_idx, doc_base[cell_idx], locals))
+            .collect()
+    }
+
     /// Multi-cell probe: map flat cluster ids → (cell, local), probe each
     /// touched cell, merge hits. Local doc ids are unique within a cell
     /// subsection; across cells they may collide, so hits are tagged with
@@ -3095,24 +3122,9 @@ impl VectorReader {
             return Ok(Vec::new());
         }
 
-        // Group flat cluster ids by cell index.
-        let mut by_cell: HashMap<usize, Vec<usize>> = HashMap::new();
-        for &flat in clusters {
-            let Some((cell_idx, local)) = self.resolve_flat_cluster(flat) else {
-                continue;
-            };
-            by_cell.entry(cell_idx).or_default().push(local as usize);
-        }
-        if by_cell.is_empty() {
+        let per_cell = self.resolve_cells_for_clusters(clusters);
+        if per_cell.is_empty() {
             return Ok(Vec::new());
-        }
-
-        // Doc-id bases: parquet rows are concatenated in cell-directory order.
-        let mut doc_base = vec![0u32; self.columns.len()];
-        let mut running = 0u32;
-        for (i, col) in self.columns.iter().enumerate() {
-            doc_base[i] = running;
-            running = running.saturating_add(col.n_docs);
         }
 
         // Probe the selected cells CONCURRENTLY — the same wave shape the
@@ -3122,12 +3134,11 @@ impl VectorReader {
         // walls (measured ~1.2 ms x width per query at w=54 on Cohere-1M).
         // Each cell's probe is independent: own ProbeCtx, own blocks, own
         // rerank; the merge below is order-independent (re-sorted).
-        let cell_probes = by_cell.into_iter().filter_map(|(cell_idx, locals)| {
+        let cell_probes = per_cell.into_iter().filter_map(|(cell_idx, base, locals)| {
             let col = &self.columns[cell_idx];
             if col.n_docs == 0 {
                 return None;
             }
-            let base = doc_base[cell_idx];
             // Allow/deny are file-local; each cell IVF checks cell-local ids.
             let cell_allow = self.cell_local_filter_bitmap(allow.as_deref(), cell_idx, base);
             let cell_deny = self.cell_local_filter_bitmap(deny.as_deref(), cell_idx, base);
@@ -3248,23 +3259,7 @@ impl VectorReader {
                     got: query.len(),
                 });
             }
-            let mut by_cell: HashMap<usize, Vec<usize>> = HashMap::new();
-            for &flat in clusters {
-                let Some((cell_idx, local)) = self.resolve_flat_cluster(flat) else {
-                    continue;
-                };
-                by_cell.entry(cell_idx).or_default().push(local as usize);
-            }
-            let mut doc_base = vec![0u32; self.columns.len()];
-            let mut running = 0u32;
-            for (i, col) in self.columns.iter().enumerate() {
-                doc_base[i] = running;
-                running = running.saturating_add(col.n_docs);
-            }
-            per_cell = by_cell
-                .into_iter()
-                .map(|(cell_idx, locals)| (cell_idx, doc_base[cell_idx], locals))
-                .collect();
+            per_cell = self.resolve_cells_for_clusters(clusters);
         } else {
             let (_, validated) = self.resolve_column(column, query, k)?;
             if !validated {
@@ -3342,7 +3337,7 @@ impl VectorReader {
                     let coarse_limit = k.saturating_mul(rerank_mult);
                     let shortlist =
                         scan_shortlist(col, cb, &cluster_meta, &blocks, true, coarse_limit, &ctx)
-                            .await;
+                            .await?;
                     let cands = shortlist
                         .into_iter()
                         .map(|(did, estimate, pos, cluster_id)| ScanCandidate {
@@ -3655,7 +3650,7 @@ impl VectorReader {
             survivor_only_rerank_fetch,
             ctx,
         )
-        .await
+        .await?
         {
             ShortlistOutcome::Done(out) => {
                 if let Some(t0) = shortlist_t0 {
@@ -4076,7 +4071,7 @@ async fn scan_shortlist(
     survivor_only_rerank_fetch: bool,
     coarse_limit: usize,
     ctx: &ProbeCtx<'_>,
-) -> Vec<(u32, f32, u32, u32)> {
+) -> Result<Vec<(u32, f32, u32, u32)>, VectorError> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
     let total_candidates: usize = cluster_meta.iter().map(|&(_, _, cnt)| cnt as usize).sum();
     // Collect every scored row, then keep the top `coarse_limit` with one
@@ -4224,7 +4219,7 @@ async fn scan_shortlist(
                 });
             let _ = tx.send(acc);
         });
-        rx.await.expect("vector scan rayon task dropped result")
+        rx.await.map_err(|_| VectorError::TaskDropped("scan"))?
     } else {
         let cap = coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK);
         let mut acc = Vec::with_capacity(total_candidates.min(cap));
@@ -4237,7 +4232,7 @@ async fn scan_shortlist(
         acc
     };
     truncate_to_top_estimates(&mut acc, coarse_limit);
-    acc
+    Ok(acc)
 }
 
 /// Keep the `limit` highest-estimate survivors of one cell scan via a
@@ -4299,7 +4294,7 @@ async fn build_shortlist(
     cluster_blocks: &[Bytes],
     survivor_only_rerank_fetch: bool,
     ctx: &ProbeCtx<'_>,
-) -> ShortlistOutcome {
+) -> Result<ShortlistOutcome, VectorError> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
     // Score each probed cluster's 1-bit codes into the shortlist.
     // The per-cluster slices are zero-copy `Bytes` views; the actual
@@ -4314,7 +4309,7 @@ async fn build_shortlist(
         ctx.k.saturating_mul(ctx.rerank_mult)
     };
     if coarse_limit == 0 {
-        return ShortlistOutcome::Done(Vec::new());
+        return Ok(ShortlistOutcome::Done(Vec::new()));
     }
     let mut shortlist = scan_shortlist(
         col,
@@ -4325,10 +4320,10 @@ async fn build_shortlist(
         coarse_limit,
         ctx,
     )
-    .await;
+    .await?;
 
     if shortlist.is_empty() {
-        return ShortlistOutcome::Done(Vec::new());
+        return Ok(ShortlistOutcome::Done(Vec::new()));
     }
 
     // `RabitqOnly` short-circuit: the 1-bit shortlist *is* the final
@@ -4346,12 +4341,12 @@ async fn build_shortlist(
         // merge path — otherwise the two paths diverge on top-k for a
         // corrupt/degenerate score.
         shortlist.sort_unstable_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-        return ShortlistOutcome::Done(
+        return Ok(ShortlistOutcome::Done(
             shortlist
                 .into_iter()
                 .map(|(did, est, _pos, _c)| (did, -est))
                 .collect(),
-        );
+        ));
     }
 
     // Build lightweight rerank references into the cluster blocks
@@ -4391,10 +4386,10 @@ async fn build_shortlist(
             full_idx,
         });
     }
-    ShortlistOutcome::Rerank {
+    Ok(ShortlistOutcome::Rerank {
         candidates,
         survivor_full_ranges,
-    }
+    })
 }
 
 /// Maximum multiplier applied to filtered-search probe breadth and
@@ -4548,21 +4543,25 @@ fn spawn_on<F: FnOnce() + Send + 'static>(pool: Option<&ThreadPool>, f: F) {
 /// compute runs on rayon (`par_iter().map().collect()`) bridged back to
 /// the async caller via a oneshot, so no tokio worker blocks under it.
 /// `f` and the items must be `'static` so the work can move onto rayon.
-async fn par_map<T, R, F>(items: Vec<T>, f: F, pool: Option<Arc<ThreadPool>>) -> Vec<R>
+async fn par_map<T, R, F>(
+    items: Vec<T>,
+    f: F,
+    pool: Option<Arc<ThreadPool>>,
+) -> Result<Vec<R>, VectorError>
 where
     T: Send + Sync + 'static,
     R: Send + 'static,
     F: Fn(&T) -> R + Send + Sync + 'static,
 {
     if parallel_chunks(items.len()) <= 1 {
-        return items.iter().map(&f).collect();
+        return Ok(items.iter().map(&f).collect());
     }
     let (tx, rx) = oneshot::channel();
     spawn_on(pool.as_deref(), move || {
         let out: Vec<R> = items.par_iter().map(f).collect();
         let _ = tx.send(out);
     });
-    rx.await.expect("rerank rayon task dropped result")
+    rx.await.map_err(|_| VectorError::TaskDropped("rerank"))
 }
 
 /// The 1-bit scan loop over one cluster's codes, generic over the
@@ -4723,7 +4722,7 @@ async fn rerank_candidates_from_blocks(
                     },
                     pool.clone(),
                 )
-                .await
+                .await?
             } else {
                 candidates
                     .iter()
@@ -4771,7 +4770,7 @@ async fn rerank_candidates_from_blocks(
                         pool.clone(),
                         stride,
                     )
-                    .await
+                    .await?
                 }
                 Sq8ColumnMeta::Lazy {
                     scale_abs_off,
@@ -4810,7 +4809,7 @@ async fn rerank_candidates_from_blocks(
                                 pool.clone(),
                                 stride,
                             )
-                            .await,
+                            .await?,
                             k,
                         ));
                     }
@@ -4957,7 +4956,7 @@ async fn score_sq8_residual_candidates(
     residual_divisor: f32,
     pool: Option<Arc<ThreadPool>>,
     stride: usize,
-) -> Vec<(u32, f32)> {
+) -> Result<Vec<(u32, f32)>, VectorError> {
     let mut cids: Vec<u32> = candidates.iter().map(|c| c.cluster_id).collect();
     cids.sort_unstable();
     cids.dedup();
@@ -5014,7 +5013,7 @@ async fn score_sq8_residual_candidates(
         )
         .await
     } else {
-        candidates.iter().map(score_one).collect()
+        Ok(candidates.iter().map(score_one).collect())
     }
 }
 
@@ -5497,7 +5496,8 @@ mod tests {
             None,
             2,
         )
-        .await;
+        .await
+        .expect("sq8 scorer");
         assert_eq!(scored.len(), candidates.len());
         scored.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         assert_eq!(
@@ -9070,6 +9070,66 @@ mod tests {
         assert!(hits[0].1 < 1e-4, "self distance ~0, got {}", hits[0].1);
     }
 
+    /// Deferred-vs-immediate parity (review follow-up): nothing else
+    /// asserts the deferred pipeline (1-bit scan -> selection ->
+    /// selected-candidate rerank) agrees with the proven immediate
+    /// probe. Same reader, same clusters, untruncated budget
+    /// (`k * rerank_mult >= corpus`, so selection drops nothing and
+    /// both paths exact-rerank identical candidate sets): the top-k
+    /// must match exactly — ids and scores — since both ends run the
+    /// same rerank kernel over the same bytes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deferred_scan_rerank_matches_immediate_probe_top_k() {
+        let (blob, json, all) =
+            build_large_corpus(16, 4, 2600, RerankCodec::Sq8Residual, Metric::L2Sq);
+        let r = VectorReader::open(blob, &json).expect("open");
+        let clusters: Vec<u32> = (0..4).collect();
+        let k = 25usize;
+        let rerank_mult = 128usize; // 25 * 128 = 3200 >= 2600 rows
+        let immediate = r
+            .search_clusters_async(
+                "v",
+                &all[7],
+                k,
+                &clusters,
+                rerank_mult,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("immediate probe");
+        let scan = r
+            .search_clusters_scan_async(
+                "v",
+                &all[7],
+                k,
+                &clusters,
+                rerank_mult,
+                rerank_mult,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("deferred scan");
+        assert!(
+            scan.hits.is_empty(),
+            "a fully-resident reader defers every cell (no cold hits)"
+        );
+        assert!(!scan.candidates.is_empty(), "deferred candidates surface");
+        let deferred = r
+            .rerank_selected_async("v", &all[7], k, scan.candidates, None)
+            .await
+            .expect("selected rerank");
+        assert_eq!(
+            immediate, deferred,
+            "deferred scan+select+rerank must equal the immediate probe's top-k"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn parallel_scan_untruncated_pool_matches_brute_force() {
         // 2600 docs across 4 clusters puts the probed scan over
@@ -9141,7 +9201,9 @@ mod tests {
     #[tokio::test]
     async fn par_map_serial_fallback_for_small_input() {
         // parallel_chunks(items) <= 1 takes the serial map arm.
-        let out = par_map(vec![1u32, 2, 3], |x| x * 10, None).await;
+        let out = par_map(vec![1u32, 2, 3], |x| x * 10, None)
+            .await
+            .expect("serial par_map cannot drop");
         assert_eq!(out, vec![10, 20, 30]);
     }
 

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3283,6 +3283,11 @@ impl VectorReader {
         if per_cell.is_empty() {
             return Ok(outcome);
         }
+        // Estimates pool cross-superfile keyed by this seed; report the
+        // REQUESTED column's seed (every cell of one column shares it),
+        // not `columns[0]`'s — a multi-column file's first column can be
+        // a different column with a different rotation.
+        outcome.rot_seed = self.columns[per_cell[0].0].rot_seed;
         // Rotate the query once per superfile: every cell of a column
         // shares the table-wide rotation seed (cross-cell estimate pooling
         // depends on it), so per-cell re-rotation is duplicate work — at a
@@ -3442,6 +3447,15 @@ impl VectorReader {
                 let mut rerank_cands = Vec::with_capacity(cands.len());
                 for cand in &cands {
                     let (off, cnt) = extent_by_cid[&cand.cluster_id];
+                    // `pos = off + i` was captured from the same immutable
+                    // superfile this rerank reads, so the subtraction cannot
+                    // wrap — make any future layout drift loud instead of a
+                    // ~4e9 "local" and an out-of-range byte range.
+                    debug_assert!(
+                        cand.pos >= off && cand.pos - off < cnt,
+                        "candidate pos {} outside cluster extent (off {off}, cnt {cnt})",
+                        cand.pos
+                    );
                     let local = (cand.pos - off) as usize;
                     let full_idx = Some(ranges.len());
                     ranges.push(col.cluster_rerank_row_range(off, cnt, local));
@@ -4152,9 +4166,10 @@ async fn scan_shortlist(
                 .par_chunks(chunk)
                 .zip(blocks_owned.par_chunks(chunk))
                 .map(|(meta_chunk, block_chunk)| {
-                    let mut acc = Vec::with_capacity(
-                        meta_chunk.iter().map(|&(_, _, cnt)| cnt as usize).sum(),
-                    );
+                    let chunk_rows: usize =
+                        meta_chunk.iter().map(|&(_, _, cnt)| cnt as usize).sum();
+                    let cap = coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK);
+                    let mut acc = Vec::with_capacity(chunk_rows.min(cap));
                     for (&(c, off, cnt), block) in meta_chunk.iter().zip(block_chunk.iter()) {
                         let codes_len = (cnt as usize) * cb;
                         let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
@@ -4194,20 +4209,30 @@ async fn scan_shortlist(
                                 acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id))
                             },
                         );
+                        if acc.len() >= cap {
+                            truncate_to_top_estimates(&mut acc, coarse_limit);
+                        }
                     }
                     acc
                 })
                 .reduce(Vec::new, |mut a, mut b| {
                     a.append(&mut b);
+                    if a.len() >= coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK) {
+                        truncate_to_top_estimates(&mut a, coarse_limit);
+                    }
                     a
                 });
             let _ = tx.send(acc);
         });
         rx.await.expect("vector scan rayon task dropped result")
     } else {
-        let mut acc = Vec::with_capacity(total_candidates);
+        let cap = coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK);
+        let mut acc = Vec::with_capacity(total_candidates.min(cap));
         for item in cluster_meta.iter().zip(cluster_blocks.iter()) {
             scan_vec(&mut acc, item);
+            if acc.len() >= cap {
+                truncate_to_top_estimates(&mut acc, coarse_limit);
+            }
         }
         acc
     };
@@ -4488,6 +4513,16 @@ fn score_centroids(
 /// superfile nprobe=1 hot path — stay serial, while the 10M
 /// supertable's `nprobe × superfiles` fan-out goes parallel.
 const PARALLEL_SCAN_MIN: usize = 2048;
+
+/// Amortized shortlist-truncation slack: scan accumulators may grow to
+/// this multiple of `coarse_limit` before being partitioned back down.
+/// At real cell shapes (~9K rows vs a 6.4K cap) the guard never fires;
+/// at the 500K-row cell backstop it bounds per-task growth to
+/// `2 x coarse_limit` entries instead of every scanned row. Early
+/// truncation keeps the final set exact: the kept set is the top
+/// `coarse_limit` under a total order, so any row dropped early is
+/// dominated by rows that stay until the final partition.
+const SHORTLIST_TRUNCATE_SLACK: usize = 2;
 
 /// Number of chunks to split a parallel rayon scan into — the machine's
 /// logical parallelism, capped by the item count so we never make more

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -13,8 +13,12 @@
 
 use std::{
     collections::HashMap,
+    fmt,
     ops::Range,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, Mutex, OnceLock, PoisonError,
+        atomic::{AtomicBool, Ordering as AtomicOrdering},
+    },
     thread,
 };
 
@@ -48,7 +52,10 @@ use crate::{
                 nearest_k_centroids_bytes, sum_f32,
             },
             ivf_merge::Sq8IvfMergeInput,
-            quant::BitQuantizer,
+            quant::{
+                BitQuantizer, LUT_BLOCK_ROWS, LutQuery, build_transposed_code_cache,
+                for_each_code_block_scores, lut_scan_supported,
+            },
             rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
             rotation::RandomRotation,
         },
@@ -95,6 +102,10 @@ struct Sq8ParsedMeta {
 /// Per-column reader state; cached at open time.
 #[derive(Debug)]
 pub struct ColumnReader {
+    /// Lazily built transposed code blocks for the FastScan LUT scan
+    /// (shared `Arc` so rayon scan tasks can hold it past the reader
+    /// borrow). See [`TransposedCodeCache`].
+    transposed_codes: Arc<TransposedCodeCache>,
     pub name: String,
     pub dim: usize,
     pub n_cent: u32,
@@ -1156,6 +1167,7 @@ impl VectorReader {
             }
 
             columns.push(ColumnReader {
+                transposed_codes: Arc::new(TransposedCodeCache::default()),
                 name: cfg.column.clone(),
                 dim,
                 n_cent,
@@ -1726,6 +1738,7 @@ impl VectorReader {
         };
 
         Ok(ColumnReader {
+            transposed_codes: Arc::new(TransposedCodeCache::default()),
             name: cfg.column.clone(),
             dim,
             n_cent: n_cent_u32,
@@ -3914,7 +3927,128 @@ fn pool_wave_cap(pool: Option<&ThreadPool>) -> usize {
         .max(1)
 }
 
-/// The pure-CPU half of [`build_shortlist`]: score every probed cluster's
+/// Per-cell cache of cluster codes in transposed (position-major)
+/// layout for the FastScan LUT scan — the codes counterpart of the
+/// routing layer's transposed centroid cache. Built lazily per cluster
+/// on the first scan that touches it (every later query reuses the
+/// blocks) and dropped with the reader, so its lifetime and footprint
+/// ride the reader cache. Each entry holds the RAII budget reservation
+/// that admitted it; a denied reservation keeps that cluster on the
+/// row-major estimator instead of evicting anything.
+#[derive(Default)]
+pub(super) struct TransposedCodeCache {
+    clusters: Mutex<HashMap<u32, TransposedCluster>>,
+    /// Sticky once the budget declines a build: warm queries must not
+    /// keep knocking on the gate (the budget's denial counter is an
+    /// operator diagnostic, and warm search's contract is to reserve
+    /// nothing at steady state). Already-built entries keep serving;
+    /// a reader-cache reopen retries naturally.
+    budget_denied: AtomicBool,
+}
+
+impl fmt::Debug for TransposedCodeCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let clusters = self
+            .clusters
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .len();
+        f.debug_struct("TransposedCodeCache")
+            .field("clusters", &clusters)
+            .finish()
+    }
+}
+
+struct TransposedCluster {
+    bytes: Arc<Vec<u8>>,
+    /// Held for the entry's lifetime; releases when the reader drops.
+    _reservation: Option<Reservation>,
+}
+
+impl TransposedCodeCache {
+    /// Return the cluster's transposed code blocks, building them on
+    /// first touch. `None` = the memory budget declined the bytes; the
+    /// caller falls back to the row-major scan for this cluster.
+    fn get_or_build(
+        &self,
+        off: u32,
+        codes: &[u8],
+        cnt: usize,
+        cb: usize,
+        budget: Option<&Arc<ConnectionMemoryBudget>>,
+    ) -> Option<Arc<Vec<u8>>> {
+        {
+            let map = self.clusters.lock().unwrap_or_else(PoisonError::into_inner);
+            if let Some(hit) = map.get(&off) {
+                return Some(Arc::clone(&hit.bytes));
+            }
+        }
+        if self.budget_denied.load(AtomicOrdering::Relaxed) {
+            return None;
+        }
+        // Build outside the lock: concurrent chunks of one cell may race
+        // to build the same cluster; the first insert wins and the
+        // loser's work (and reservation) is discarded — bounded waste,
+        // no lock held across the transpose.
+        let transposed_len = cnt.div_ceil(LUT_BLOCK_ROWS) * cb * LUT_BLOCK_ROWS;
+        let reservation = match budget {
+            Some(b) => match b.try_reserve(transposed_len) {
+                Ok(r) => Some(r),
+                Err(_) => {
+                    self.budget_denied.store(true, AtomicOrdering::Relaxed);
+                    tracing::warn!(
+                        transposed_len,
+                        "vector scan: connection memory budget declined the \
+                         transposed-code cache; this reader keeps the exact \
+                         row-major estimator"
+                    );
+                    return None;
+                }
+            },
+            // No budget attached: measure-only, same as the cold path.
+            None => None,
+        };
+        let bytes = Arc::new(build_transposed_code_cache(codes, cnt, cb));
+        let mut map = self.clusters.lock().unwrap_or_else(PoisonError::into_inner);
+        let entry = map.entry(off).or_insert(TransposedCluster {
+            bytes,
+            _reservation: reservation,
+        });
+        Some(Arc::clone(&entry.bytes))
+    }
+}
+
+/// Scan one cluster through the transposed LUT kernels, pushing
+/// `(did, estimate, pos, cluster_id)` for every row — the fast-path
+/// body of [`scan_shortlist`]'s per-cluster loop (unfiltered scans
+/// only; filtered scans keep the row-major estimator, whose per-row
+/// allow/deny checks precede scoring).
+#[allow(clippy::too_many_arguments)]
+fn scan_cluster_transposed(
+    transposed: &[u8],
+    doc_ids: &[u8],
+    cnt: usize,
+    off: u32,
+    cluster_id: u32,
+    cb: usize,
+    lut: &LutQuery,
+    acc: &mut Vec<(u32, f32, u32, u32)>,
+) {
+    for_each_code_block_scores(transposed, cb, lut, |base_r, scores| {
+        let live = cnt.saturating_sub(base_r).min(LUT_BLOCK_ROWS);
+        for (lane, &est) in scores.iter().enumerate().take(live) {
+            let rr = base_r + lane;
+            let did = u32::from_le_bytes(
+                doc_ids[rr * 4..rr * 4 + 4]
+                    .try_into()
+                    .expect("4-byte doc id"),
+            );
+            acc.push((did, est, off + rr as u32, cluster_id));
+        }
+    });
+}
+
+/// The pure-CPU half of [`build_shortlist`]/// The pure-CPU half of [`build_shortlist`]: score every probed cluster's
 /// 1-bit codes into one bounded heap of `coarse_limit` survivors, rayon-
 /// parallel when the candidate pool amortizes the hand-off. Shared by the
 /// immediate-rerank path ([`build_shortlist`]) and the deferred-rerank
@@ -3936,6 +4070,15 @@ async fn scan_shortlist(
     // to retain the same set `select_nth` finds in a single pass — at the
     // 1M width-sweep shape (~9K-row cells against a k*rerank_mult cap)
     // the heap admission machinery alone measured ~15% of scan CPU.
+    // FastScan LUT fast path: unfiltered scans score whole cells, so
+    // the transposed-block kernels apply. The per-query i16 bound
+    // (`fits_i16`) closes the accumulator-overflow hole exactly; when
+    // it declines, the exact row-major estimator below is the (more
+    // precise) fallback.
+    let lut_query = (ctx.allow.is_none() && ctx.deny.is_none() && lut_scan_supported())
+        .then(|| LutQuery::new(ctx.q_rot))
+        .filter(|lut| lut.fits_i16())
+        .map(Arc::new);
     let scan_vec = |acc: &mut Vec<(u32, f32, u32, u32)>,
                     (&(c, off, cnt), block): (&(usize, u32, u32), &Bytes)| {
         let codes_len = (cnt as usize) * cb;
@@ -3950,6 +4093,27 @@ async fn scan_shortlist(
         );
         let codes = block.slice(0..codes_len);
         let doc_ids = block.slice(codes_len..codes_len + doc_ids_len);
+        if let Some(lut) = lut_query.as_deref()
+            && let Some(transposed) = col.transposed_codes.get_or_build(
+                off,
+                &codes,
+                cnt as usize,
+                cb,
+                ctx.budget.as_ref(),
+            )
+        {
+            scan_cluster_transposed(
+                &transposed,
+                &doc_ids,
+                cnt as usize,
+                off,
+                c as u32,
+                cb,
+                lut,
+                acc,
+            );
+            return;
+        }
         score_cluster_codes_with(
             &codes,
             &doc_ids,
@@ -3972,6 +4136,9 @@ async fn scan_shortlist(
         let n_tasks = parallel_chunks(cluster_meta.len());
         let chunk = cluster_meta.len().div_ceil(n_tasks).max(1);
         let quant = col.quant.clone();
+        let transposed_cache = Arc::clone(&col.transposed_codes);
+        let budget_owned = ctx.budget.clone();
+        let lut_owned = lut_query.clone();
         let q_rot_v: Vec<f32> = ctx.q_rot.to_vec();
         let meta_owned: Vec<(usize, u32, u32)> = cluster_meta.to_vec();
         let blocks_owned: Vec<Bytes> = cluster_blocks.to_vec();
@@ -3992,6 +4159,27 @@ async fn scan_shortlist(
                         let codes_len = (cnt as usize) * cb;
                         let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
                         let codes = block.slice(0..codes_len);
+                        if let Some(lut) = lut_owned.as_deref()
+                            && let Some(transposed) = transposed_cache.get_or_build(
+                                off,
+                                &codes,
+                                cnt as usize,
+                                cb,
+                                budget_owned.as_ref(),
+                            )
+                        {
+                            scan_cluster_transposed(
+                                &transposed,
+                                &doc_ids,
+                                cnt as usize,
+                                off,
+                                c as u32,
+                                cb,
+                                lut,
+                                &mut acc,
+                            );
+                            continue;
+                        }
                         score_cluster_codes_with(
                             &codes,
                             &doc_ids,
@@ -9204,10 +9392,39 @@ mod tests {
             "warm search returns hits under a tiny budget"
         );
 
-        // Resident slices reserve nothing: no denial, and peak stays 0 even
-        // under a 0-byte gate. This is what keeps warm queries off the gate.
-        assert_eq!(budget.denials(), 0, "warm search reserves nothing");
+        // Resident slices reserve nothing for the scan itself. The one
+        // permitted knock on the gate is the transposed-code cache's
+        // single opportunistic reservation attempt: denied here (sticky
+        // per reader), after which warm search reserves nothing again —
+        // peak stays 0 under the tiny gate either way.
+        assert!(
+            budget.denials() <= 1,
+            "at most the cache's one sticky attempt, got {}",
+            budget.denials()
+        );
         assert_eq!(budget.peak(), 0, "warm search commits no bytes");
+        let denials_after_first = budget.denials();
+        let hits = r_eager
+            .search_async(
+                "v",
+                &all[0],
+                5,
+                4,
+                20,
+                None,
+                None,
+                None,
+                Some(budget.clone()),
+            )
+            .await
+            .expect("second warm search");
+        assert!(!hits.is_empty());
+        assert_eq!(
+            budget.denials(),
+            denials_after_first,
+            "denied cache stays off the gate on later queries"
+        );
+        assert_eq!(budget.peak(), 0);
     }
 
     #[tokio::test]
@@ -9607,6 +9824,60 @@ mod tests {
     // -----------------------------------------------------------------
     // truncate_to_top_estimates (per-cell shortlist truncation)
     // -----------------------------------------------------------------
+
+    /// The transposed code cache builds a cluster once (later scans get
+    /// the same shared buffer), and a budget denial falls back cleanly
+    /// (`None`) instead of evicting or failing the scan.
+    #[test]
+    fn transposed_code_cache_reuses_entries_and_respects_budget() {
+        let cache = TransposedCodeCache::default();
+        let cnt = 70usize;
+        let cb = 12usize;
+        let codes: Vec<u8> = (0..cnt * cb).map(|i| i as u8).collect();
+
+        let unbudgeted = cache
+            .get_or_build(3, &codes, cnt, cb, None)
+            .expect("no budget attached never declines");
+        let again = cache.get_or_build(3, &codes, cnt, cb, None).expect("hit");
+        assert!(
+            Arc::ptr_eq(&unbudgeted, &again),
+            "second touch reuses the built buffer"
+        );
+
+        // A budget too small for the transposed buffer declines the
+        // build — and the denial is sticky for the cache's lifetime:
+        // even a roomier budget on a later query is not consulted (a
+        // reader keeps one budget in production; the reopen cycle is
+        // the retry). A separate cache with room admits the build and
+        // holds the reservation for the entry's lifetime.
+        let denied = TransposedCodeCache::default();
+        let tiny = ConnectionMemoryBudget::with_limit(64);
+        assert!(
+            denied
+                .get_or_build(9, &codes, cnt, cb, Some(&tiny))
+                .is_none()
+        );
+        assert_eq!(tiny.denials(), 1);
+        let roomy = ConnectionMemoryBudget::with_limit(1 << 20);
+        assert!(
+            denied
+                .get_or_build(9, &codes, cnt, cb, Some(&roomy))
+                .is_none(),
+            "denial is sticky per cache"
+        );
+        assert_eq!(roomy.denials(), 0, "sticky path never touches the gate");
+
+        let admitted = TransposedCodeCache::default();
+        assert!(
+            admitted
+                .get_or_build(9, &codes, cnt, cb, Some(&roomy))
+                .is_some()
+        );
+        assert!(
+            roomy.used() > 0,
+            "admitted bytes stay reserved by the entry"
+        );
+    }
 
     /// Keeps the `limit` highest-estimate rows; the survivor set matches
     /// what the old bounded-heap admission retained.

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3906,6 +3906,84 @@ async fn scan_shortlist(
 ) -> Vec<(u32, f32, u32, u32)> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
     let total_candidates: usize = cluster_meta.iter().map(|&(_, _, cnt)| cnt as usize).sum();
+    // Fits-path: when every scanned row fits the cap, admission can never
+    // evict — the bounded heap (sift per push, heap-merge per rayon
+    // chunk) is pure overhead. Score straight into a vec; parallel chunks
+    // append instead of re-pushing through a merge. The deferred-rerank
+    // scan lives here almost always (cell rows < k x undivided mult).
+    if total_candidates <= coarse_limit {
+        let scan_vec =
+            |acc: &mut Vec<(u32, f32, u32, u32)>,
+             (&(c, off, cnt), block): (&(usize, u32, u32), &Bytes)| {
+                let codes_len = (cnt as usize) * cb;
+                let codes = block.slice(0..codes_len);
+                let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
+                score_cluster_codes_with(
+                    &codes,
+                    &doc_ids,
+                    cnt,
+                    off,
+                    c as u32,
+                    &col.quant,
+                    ctx.q_rot,
+                    ctx.allow.as_deref(),
+                    ctx.deny.as_deref(),
+                    &mut |cand| acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id)),
+                );
+            };
+        if total_candidates >= PARALLEL_SCAN_MIN && cluster_meta.len() > 1 {
+            let n_tasks = parallel_chunks(cluster_meta.len());
+            let chunk = cluster_meta.len().div_ceil(n_tasks).max(1);
+            let quant = col.quant.clone();
+            let q_rot_v: Vec<f32> = ctx.q_rot.to_vec();
+            let meta_owned: Vec<(usize, u32, u32)> = cluster_meta.to_vec();
+            let blocks_owned: Vec<Bytes> = cluster_blocks.to_vec();
+            let allow_owned = ctx.allow.clone();
+            let deny_owned = ctx.deny.clone();
+            let (tx, rx) = oneshot::channel();
+            spawn_on(ctx.pool.as_deref(), move || {
+                let acc = meta_owned
+                    .par_chunks(chunk)
+                    .zip(blocks_owned.par_chunks(chunk))
+                    .map(|(meta_chunk, block_chunk)| {
+                        let mut acc = Vec::with_capacity(
+                            meta_chunk.iter().map(|&(_, _, cnt)| cnt as usize).sum(),
+                        );
+                        for (&(c, off, cnt), block) in meta_chunk.iter().zip(block_chunk.iter()) {
+                            let codes_len = (cnt as usize) * cb;
+                            let codes = block.slice(0..codes_len);
+                            let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
+                            score_cluster_codes_with(
+                                &codes,
+                                &doc_ids,
+                                cnt,
+                                off,
+                                c as u32,
+                                &quant,
+                                &q_rot_v,
+                                allow_owned.as_deref(),
+                                deny_owned.as_deref(),
+                                &mut |cand| {
+                                    acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id))
+                                },
+                            );
+                        }
+                        acc
+                    })
+                    .reduce(Vec::new, |mut a, mut b| {
+                        a.append(&mut b);
+                        a
+                    });
+                let _ = tx.send(acc);
+            });
+            return rx.await.expect("vector scan rayon task dropped result");
+        }
+        let mut acc = Vec::with_capacity(total_candidates);
+        for item in cluster_meta.iter().zip(cluster_blocks.iter()) {
+            scan_vec(&mut acc, item);
+        }
+        return acc;
+    }
     let score_block =
         |heap: &mut BoundedCoarseHeap, (&(c, off, cnt), block): (&(usize, u32, u32), &Bytes)| {
             let codes_len = (cnt as usize) * cb;
@@ -4308,6 +4386,39 @@ fn score_cluster_codes_into_heap(
     deny: Option<&roaring::RoaringBitmap>,
     out: &mut BoundedCoarseHeap,
 ) {
+    score_cluster_codes_with(
+        cluster_codes,
+        cluster_doc_ids,
+        cnt,
+        off,
+        cluster_id,
+        quant,
+        q_rot,
+        allow,
+        deny,
+        &mut |cand| out.push(cand),
+    );
+}
+
+/// The 1-bit scan loop over one cluster's codes, generic over the
+/// candidate sink: the bounded heap when admission must evict
+/// ([`score_cluster_codes_into_heap`]), a plain vec when every scanned
+/// row fits the cap anyway and heap maintenance is pure overhead
+/// ([`scan_shortlist`]'s fits-path).
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn score_cluster_codes_with(
+    cluster_codes: &[u8],
+    cluster_doc_ids: &[u8],
+    cnt: u32,
+    off: u32,
+    cluster_id: u32,
+    quant: &BitQuantizer,
+    q_rot: &[f32],
+    allow: Option<&roaring::RoaringBitmap>,
+    deny: Option<&roaring::RoaringBitmap>,
+    sink: &mut impl FnMut(CoarseCandidate),
+) {
     let cb = quant.code_bytes();
     let q_total: f32 = sum_f32(q_rot);
     for i in 0..cnt as usize {
@@ -4334,7 +4445,7 @@ fn score_cluster_codes_into_heap(
         }
         let code = &cluster_codes[i * cb..(i + 1) * cb];
         let est = quant.estimate_dot_rotated_with_total(q_rot, code, q_total);
-        out.push(CoarseCandidate {
+        sink(CoarseCandidate {
             did,
             estimate: est,
             pos: off + i as u32,

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3445,9 +3445,25 @@ impl VectorReader {
                     None
                 };
                 let survivor_t0 = io_counters::phase_start();
-                let survivor_rows = get_survivor_ranges_coalesced_async(&self.source, &ranges)
-                    .await
-                    .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                // Residency-aware gather: the globally selected winners are
+                // FEW and SCATTERED (~k x rerank_mult / width per cell), so
+                // the coalesce plan's gap window — correct for remote
+                // fetches, where round trips dominate — merges them into
+                // ~whole-cell spans that a resident cache then materializes
+                // (measured: ~300 MB touched per query to deliver ~10 MB of
+                // rows, 60% of warm query wall). When every row resolves
+                // synchronously from resident bytes, read the exact ranges
+                // instead; fall back to the coalesced remote plan otherwise.
+                let sync_rows: Option<Vec<Bytes>> = ranges
+                    .iter()
+                    .map(|range| self.source.try_get_range_sync(range.clone()))
+                    .collect();
+                let survivor_rows = match sync_rows {
+                    Some(rows) => rows,
+                    None => get_survivor_ranges_coalesced_async(&self.source, &ranges)
+                        .await
+                        .map_err(|e| VectorError::LazySource(e.to_string()))?,
+                };
                 if let Some(t0) = survivor_t0 {
                     io_counters::phase_record(
                         "vec.survivor_fetch",

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::future::try_join_all;
+use futures::{StreamExt, TryStreamExt, future::try_join_all, stream};
 use rayon::{ThreadPool, prelude::*};
 use roaring::RoaringBitmap;
 use serde::Deserialize;
@@ -3158,11 +3158,20 @@ impl VectorReader {
                 )
             })
         });
-        let mut merged: Vec<(u32, f32)> = try_join_all(cell_probes)
-            .await?
-            .into_iter()
-            .flatten()
-            .collect();
+        // Wave-cap the concurrent probes to the pool width (the same
+        // bound every other fan-out here uses): a wide sweep over a
+        // many-celled shard must not open unbounded simultaneous
+        // range reads / cold fetches.
+        let max_in_flight = pool
+            .as_deref()
+            .map(ThreadPool::current_num_threads)
+            .unwrap_or_else(rayon::current_num_threads)
+            .max(1);
+        let per_cell: Vec<Vec<(u32, f32)>> = stream::iter(cell_probes)
+            .buffer_unordered(max_in_flight)
+            .try_collect()
+            .await?;
+        let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flatten().collect();
         // Distance ascending (smaller = closer), matching every other vector
         // search path. Descending here kept the farthest k hits and collapsed
         // packed-shard recall to ~0.

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3162,11 +3162,7 @@ impl VectorReader {
         // bound every other fan-out here uses): a wide sweep over a
         // many-celled shard must not open unbounded simultaneous
         // range reads / cold fetches.
-        let max_in_flight = pool
-            .as_deref()
-            .map(ThreadPool::current_num_threads)
-            .unwrap_or_else(rayon::current_num_threads)
-            .max(1);
+        let max_in_flight = pool_wave_cap(pool.as_deref());
         let per_cell: Vec<Vec<(u32, f32)>> = stream::iter(cell_probes)
             .buffer_unordered(max_in_flight)
             .try_collect()
@@ -3175,6 +3171,312 @@ impl VectorReader {
         // Distance ascending (smaller = closer), matching every other vector
         // search path. Descending here kept the farthest k hits and collapsed
         // packed-shard recall to ~0.
+        merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+        merged.truncate(k);
+        Ok(merged)
+    }
+
+    /// Deferred-rerank scan for the supertable's GLOBAL shortlist selection
+    /// (unfiltered width sweeps). Per probed cell:
+    ///
+    /// - WARM (every `[codes][doc_ids]` prefix resident): run only the
+    ///   1-bit scan, heap-capped at the UNDIVIDED `k × rerank_mult`, and
+    ///   surface the survivors with their estimates — the supertable pools
+    ///   them across cells and superfiles, selects the global top
+    ///   `k × rerank_mult`, and calls [`Self::rerank_selected_async`] with
+    ///   the winners. No survivor fetch, no rerank here.
+    /// - COLD (or `RabitqOnly`, which has no rerank stage): probe exactly
+    ///   as [`Self::search_clusters_async`] does, under the width-divided
+    ///   `cold_rerank_mult` — deferring a cold cell would hold its fetched
+    ///   blocks and budget reservation across the whole fan-out.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn search_clusters_scan_async(
+        &self,
+        column: &str,
+        query: &[f32],
+        k: usize,
+        clusters: &[u32],
+        rerank_mult: usize,
+        cold_rerank_mult: usize,
+        allow: Option<Arc<RoaringBitmap>>,
+        deny: Option<Arc<RoaringBitmap>>,
+        pool: Option<Arc<ThreadPool>>,
+        budget: Option<Arc<ConnectionMemoryBudget>>,
+    ) -> Result<ScanOutcome, VectorError> {
+        let rot_seed = self
+            .columns
+            .first()
+            .map(|c| c.rot_seed)
+            .ok_or_else(|| VectorError::UnknownColumn(column.to_string()))?;
+        let mut outcome = ScanOutcome {
+            hits: Vec::new(),
+            candidates: Vec::new(),
+            rot_seed,
+        };
+        if k == 0 || self.n_docs == 0 {
+            return Ok(outcome);
+        }
+
+        // (cell_idx, base, cell-local chosen clusters): multi-cell files
+        // resolve flat ids per cell; single-subsection files are the
+        // degenerate one-cell case.
+        let mut per_cell: Vec<(usize, u32, Vec<usize>)> = Vec::new();
+        if self.is_multi_cell() {
+            if !self.column_id_by_name.contains_key(column) {
+                return Err(VectorError::UnknownColumn(column.to_string()));
+            }
+            let dim = self
+                .columns
+                .first()
+                .map(|c| c.dim)
+                .ok_or_else(|| VectorError::UnknownColumn(column.to_string()))?;
+            if query.len() != dim {
+                return Err(VectorError::DimensionMismatch {
+                    expected: dim,
+                    got: query.len(),
+                });
+            }
+            let mut by_cell: HashMap<usize, Vec<usize>> = HashMap::new();
+            for &flat in clusters {
+                let Some((cell_idx, local)) = self.resolve_flat_cluster(flat) else {
+                    continue;
+                };
+                by_cell.entry(cell_idx).or_default().push(local as usize);
+            }
+            let mut doc_base = vec![0u32; self.columns.len()];
+            let mut running = 0u32;
+            for (i, col) in self.columns.iter().enumerate() {
+                doc_base[i] = running;
+                running = running.saturating_add(col.n_docs);
+            }
+            per_cell = by_cell
+                .into_iter()
+                .map(|(cell_idx, locals)| (cell_idx, doc_base[cell_idx], locals))
+                .collect();
+        } else {
+            let (_, validated) = self.resolve_column(column, query, k)?;
+            if !validated {
+                return Ok(outcome);
+            }
+            // v1 layout: `column_id_by_name` indexes straight into `columns`.
+            let cell_idx = self
+                .column_id_by_name
+                .get(column)
+                .copied()
+                .ok_or_else(|| VectorError::UnknownColumn(column.to_string()))?
+                as usize;
+            per_cell.push((cell_idx, 0, clusters.iter().map(|&c| c as usize).collect()));
+        }
+
+        let cell_scans = per_cell.into_iter().filter_map(|(cell_idx, base, locals)| {
+            let col = &self.columns[cell_idx];
+            if col.n_docs == 0 {
+                return None;
+            }
+            let cell_allow = self.cell_local_filter_bitmap(allow.as_deref(), cell_idx, base);
+            let cell_deny = self.cell_local_filter_bitmap(deny.as_deref(), cell_idx, base);
+            if cell_allow.as_ref().is_some_and(|bm| bm.is_empty()) {
+                return None;
+            }
+            let pool = pool.clone();
+            let budget = budget.clone();
+            Some(async move {
+                let sub_start = col.subsection_range.start;
+                let idx_start = sub_start + col.cluster_idx_off;
+                let idx_end = idx_start + (col.n_cent as usize) * CLUSTER_IDX_ENTRY_BYTES;
+                let cluster_idx = self
+                    .source
+                    .range_async(idx_start..idx_end)
+                    .await
+                    .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                let mut q_rot = vec![0f32; col.dim];
+                col.rot.apply(query, &mut q_rot);
+                let cb = col.quant.code_bytes();
+                let (cluster_meta, prefix_ranges) = chosen_cluster_meta(col, &cluster_idx, &locals);
+                if cluster_meta.is_empty() {
+                    return Ok((Vec::new(), Vec::new()));
+                }
+                // Warm fast path: every prefix resident -> defer rerank.
+                let prefix_blocks: Option<Vec<Bytes>> = prefix_ranges
+                    .iter()
+                    .map(|range| self.source.try_get_range_sync(range.clone()))
+                    .collect();
+                let rabitq_only = matches!(col.rerank_codec, RerankCodec::RabitqOnly);
+                if let (Some(blocks), false) = (prefix_blocks, rabitq_only) {
+                    let ctx = ProbeCtx {
+                        q_rot: &q_rot,
+                        k,
+                        rerank_mult,
+                        allow: cell_allow,
+                        deny: cell_deny,
+                        pool,
+                        budget,
+                    };
+                    let coarse_limit = k.saturating_mul(rerank_mult);
+                    let shortlist =
+                        scan_shortlist(col, cb, &cluster_meta, &blocks, true, coarse_limit, &ctx)
+                            .await;
+                    let cands = shortlist
+                        .into_iter()
+                        .map(|(did, estimate, pos, cluster_id)| ScanCandidate {
+                            did: base.saturating_add(did),
+                            estimate,
+                            pos,
+                            cluster_id,
+                            cell_idx,
+                        })
+                        .collect();
+                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>), VectorError>((
+                        Vec::new(),
+                        cands,
+                    ));
+                }
+                // Cold (or RabitqOnly): probe-and-rerank now, width-divided.
+                let ctx = ProbeCtx {
+                    q_rot: &q_rot,
+                    k,
+                    rerank_mult: cold_rerank_mult,
+                    allow: cell_allow,
+                    deny: cell_deny,
+                    pool,
+                    budget,
+                };
+                let hits = self
+                    .probe_clusters_async(col, query, &ctx, &cluster_idx, &locals)
+                    .await?;
+                Ok((
+                    hits.into_iter()
+                        .map(|(local_id, score)| (base.saturating_add(local_id), score))
+                        .collect(),
+                    Vec::new(),
+                ))
+            })
+        });
+        let max_in_flight = pool_wave_cap(pool.as_deref());
+        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>)> = stream::iter(cell_scans)
+            .buffer_unordered(max_in_flight)
+            .try_collect()
+            .await?;
+        for (hits, cands) in per_cell_results {
+            outcome.hits.extend(hits);
+            outcome.candidates.extend(cands);
+        }
+        // Cold hits merge to this file's top-k exactly as the immediate
+        // path does; candidates stay unbounded here (per-cell heaps
+        // already cap them) — the supertable's global selection truncates.
+        outcome
+            .hits
+            .sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+        outcome.hits.truncate(k);
+        Ok(outcome)
+    }
+
+    /// Rerank the GLOBAL shortlist winners that live in this superfile —
+    /// phase C of the deferred-rerank path. Every selected candidate came
+    /// from a WARM cell scan ([`Self::search_clusters_scan_async`]), so the
+    /// survivor rows and Sq8 meta resolve from resident bytes; per cell the
+    /// flow is exactly the warm arm of the immediate probe (survivor-only
+    /// gather -> exact rerank -> ascending top-k), minus the 1-bit scan
+    /// already done.
+    pub(crate) async fn rerank_selected_async(
+        &self,
+        column: &str,
+        query: &[f32],
+        k: usize,
+        selected: Vec<ScanCandidate>,
+        pool: Option<Arc<ThreadPool>>,
+    ) -> Result<Vec<(u32, f32)>, VectorError> {
+        if selected.is_empty() || k == 0 {
+            return Ok(Vec::new());
+        }
+        if !self.column_id_by_name.contains_key(column) {
+            return Err(VectorError::UnknownColumn(column.to_string()));
+        }
+        let mut by_cell: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
+        for cand in selected {
+            by_cell.entry(cand.cell_idx).or_default().push(cand);
+        }
+        let cell_reranks = by_cell.into_iter().filter_map(|(cell_idx, cands)| {
+            let col = self.columns.get(cell_idx)?;
+            let pool = pool.clone();
+            Some(async move {
+                let sub_start = col.subsection_range.start;
+                let idx_start = sub_start + col.cluster_idx_off;
+                let idx_end = idx_start + (col.n_cent as usize) * CLUSTER_IDX_ENTRY_BYTES;
+                let cluster_idx = self
+                    .source
+                    .range_async(idx_start..idx_end)
+                    .await
+                    .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                // Distinct probed clusters -> (off, cnt), for survivor
+                // row addressing.
+                let mut extent_by_cid: HashMap<u32, (u32, u32)> = HashMap::new();
+                for cand in &cands {
+                    extent_by_cid.entry(cand.cluster_id).or_insert_with(|| {
+                        read_cluster_entry(&cluster_idx, cand.cluster_id as usize)
+                    });
+                }
+                let mut ranges = Vec::with_capacity(cands.len());
+                let mut rerank_cands = Vec::with_capacity(cands.len());
+                for cand in &cands {
+                    let (off, cnt) = extent_by_cid[&cand.cluster_id];
+                    let local = (cand.pos - off) as usize;
+                    let full_idx = Some(ranges.len());
+                    ranges.push(col.cluster_rerank_row_range(off, cnt, local));
+                    // `did` passes through rerank untouched (norms are keyed
+                    // by `pos`), so the file-local id stays as selected.
+                    rerank_cands.push(RerankCandidate {
+                        did: cand.did,
+                        pos: cand.pos,
+                        cluster_id: cand.cluster_id,
+                        block_idx: 0,
+                        full_off: 0,
+                        full_idx,
+                    });
+                }
+                let meta_bytes = if let Some(range) = lazy_sq8_meta_range(col) {
+                    let mut fetched = self
+                        .source
+                        .get_ranges_parallel_async(&[range])
+                        .await
+                        .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                    fetched.pop()
+                } else {
+                    None
+                };
+                let survivor_t0 = io_counters::phase_start();
+                let survivor_rows = get_survivor_ranges_coalesced_async(&self.source, &ranges)
+                    .await
+                    .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                if let Some(t0) = survivor_t0 {
+                    io_counters::phase_record(
+                        "vec.survivor_fetch",
+                        t0.elapsed().as_micros() as u64,
+                    );
+                }
+                io_counters::phase_timed_async("vec.rerank", async {
+                    rerank_candidates_from_blocks(
+                        &self.source,
+                        meta_bytes.as_ref(),
+                        &[],
+                        Some(&survivor_rows),
+                        &rerank_cands,
+                        col,
+                        query,
+                        pool,
+                        k,
+                    )
+                    .await
+                })
+                .await
+            })
+        });
+        let max_in_flight = pool_wave_cap(pool.as_deref());
+        let per_cell: Vec<Vec<(u32, f32)>> = stream::iter(cell_reranks)
+            .buffer_unordered(max_in_flight)
+            .try_collect()
+            .await?;
+        let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flatten().collect();
         merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         merged.truncate(k);
         Ok(merged)
@@ -3195,19 +3497,7 @@ impl VectorReader {
         chosen: &[usize],
     ) -> Result<Vec<(u32, f32)>, VectorError> {
         let cb = col.quant.code_bytes();
-        let mut cluster_meta: Vec<(usize, u32, u32)> = Vec::with_capacity(chosen.len());
-        let mut cluster_prefix_ranges: Vec<Range<usize>> = Vec::with_capacity(chosen.len());
-        for &c in chosen {
-            if c >= col.n_cent as usize {
-                continue;
-            }
-            let (off, cnt) = read_cluster_entry(cluster_idx, c);
-            if cnt == 0 {
-                continue;
-            }
-            cluster_prefix_ranges.push(col.cluster_codes_doc_ids_range(off, cnt));
-            cluster_meta.push((c, off, cnt));
-        }
+        let (cluster_meta, cluster_prefix_ranges) = chosen_cluster_meta(col, cluster_idx, chosen);
         if cluster_meta.is_empty() {
             return Ok(Vec::new());
         }
@@ -3566,31 +3856,56 @@ enum ShortlistOutcome {
 /// then runs [`rerank_candidates_from_blocks`]. Factoring this out
 /// keeps `search` / `search_async` down to their fetch waves around a
 /// single shared kernel, so the two can't drift in scoring/recall.
-async fn build_shortlist(
+/// Resolve the chosen cluster ids against a cell's cluster index:
+/// `(cluster_id, doc_off, count)` for every non-empty in-range cluster,
+/// plus each cluster's `[codes][doc_ids]` prefix range.
+fn chosen_cluster_meta(
+    col: &ColumnReader,
+    cluster_idx: &[u8],
+    chosen: &[usize],
+) -> (Vec<(usize, u32, u32)>, Vec<Range<usize>>) {
+    let mut cluster_meta = Vec::with_capacity(chosen.len());
+    let mut prefix_ranges = Vec::with_capacity(chosen.len());
+    for &c in chosen {
+        if c >= col.n_cent as usize {
+            continue;
+        }
+        let (off, cnt) = read_cluster_entry(cluster_idx, c);
+        if cnt == 0 {
+            continue;
+        }
+        prefix_ranges.push(col.cluster_codes_doc_ids_range(off, cnt));
+        cluster_meta.push((c, off, cnt));
+    }
+    (cluster_meta, prefix_ranges)
+}
+
+/// Wave cap for concurrent per-cell probes: the pool's width — the same
+/// bound every fan-out here uses, so a wide sweep cannot open unbounded
+/// simultaneous range reads / cold fetches.
+fn pool_wave_cap(pool: Option<&ThreadPool>) -> usize {
+    pool.map(ThreadPool::current_num_threads)
+        .unwrap_or_else(rayon::current_num_threads)
+        .max(1)
+}
+
+/// The pure-CPU half of [`build_shortlist`]: score every probed cluster's
+/// 1-bit codes into one bounded heap of `coarse_limit` survivors, rayon-
+/// parallel when the candidate pool amortizes the hand-off. Shared by the
+/// immediate-rerank path ([`build_shortlist`]) and the deferred-rerank
+/// scan ([`VectorReader::search_clusters_scan_async`]). Returns unsorted
+/// `(did, estimate, pos, cluster_id)` survivors.
+async fn scan_shortlist(
     col: &ColumnReader,
     cb: usize,
     cluster_meta: &[(usize, u32, u32)],
     cluster_blocks: &[Bytes],
     survivor_only_rerank_fetch: bool,
+    coarse_limit: usize,
     ctx: &ProbeCtx<'_>,
-) -> ShortlistOutcome {
+) -> Vec<(u32, f32, u32, u32)> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
-    // Score each probed cluster's 1-bit codes into the shortlist.
-    // The per-cluster slices are zero-copy `Bytes` views; the actual
-    // estimate scan is the hot CPU work, parallelized across clusters
-    // once the candidate pool is large enough to amortize the rayon
-    // hand-off. Cluster scoring is order-independent: every survivor
-    // is re-sorted by estimate below, so parallel and serial
-    // shortlists rank identically.
     let total_candidates: usize = cluster_meta.iter().map(|&(_, _, cnt)| cnt as usize).sum();
-    let coarse_limit = if matches!(col.rerank_codec, RerankCodec::RabitqOnly) {
-        ctx.k
-    } else {
-        ctx.k.saturating_mul(ctx.rerank_mult)
-    };
-    if coarse_limit == 0 {
-        return ShortlistOutcome::Done(Vec::new());
-    }
     let score_block =
         |heap: &mut BoundedCoarseHeap, (&(c, off, cnt), block): (&(usize, u32, u32), &Bytes)| {
             let codes_len = (cnt as usize) * cb;
@@ -3679,7 +3994,78 @@ async fn build_shortlist(
         }
         heap
     };
-    let mut shortlist = shortlist_heap.into_vec();
+    shortlist_heap.into_vec()
+}
+
+/// One 1-bit-scan survivor surfaced to the supertable's GLOBAL shortlist
+/// selection (unfiltered width sweeps): the estimate that admitted it plus
+/// everything the deferred rerank needs to find its bytes again. Estimates
+/// are comparable across cells and superfiles of one column — the rotation
+/// is seeded once per column, table-wide, and the estimator is a pure
+/// function of the rotated query and the stored code.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ScanCandidate {
+    /// File-local doc id (cell base already applied on packed files).
+    pub(crate) did: u32,
+    /// 1-bit RaBitQ estimate; higher = better.
+    pub(crate) estimate: f32,
+    /// Row position within the cell's cluster ordering (`cluster off + i`).
+    pub(crate) pos: u32,
+    pub(crate) cluster_id: u32,
+    /// Cell directory index within this superfile.
+    pub(crate) cell_idx: usize,
+}
+
+/// Result of a deferred-rerank scan over one superfile
+/// ([`VectorReader::search_clusters_scan_async`]).
+pub(crate) struct ScanOutcome {
+    /// Exact hits from cells that probed COLD (whole blocks fetched and
+    /// reranked immediately under the width-divided budget — deferring
+    /// them would hold the fetched blocks and their budget reservation
+    /// across the whole fan-out) plus RabitqOnly short-circuits.
+    pub(crate) hits: Vec<(u32, f32)>,
+    /// Estimate survivors from warm cells, deferred to the supertable's
+    /// global selection.
+    pub(crate) candidates: Vec<ScanCandidate>,
+    /// The column's rotation seed — the supertable asserts every pooled
+    /// unit agrees before comparing estimates across superfiles.
+    pub(crate) rot_seed: u64,
+}
+
+async fn build_shortlist(
+    col: &ColumnReader,
+    cb: usize,
+    cluster_meta: &[(usize, u32, u32)],
+    cluster_blocks: &[Bytes],
+    survivor_only_rerank_fetch: bool,
+    ctx: &ProbeCtx<'_>,
+) -> ShortlistOutcome {
+    let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
+    // Score each probed cluster's 1-bit codes into the shortlist.
+    // The per-cluster slices are zero-copy `Bytes` views; the actual
+    // estimate scan is the hot CPU work, parallelized across clusters
+    // once the candidate pool is large enough to amortize the rayon
+    // hand-off. Cluster scoring is order-independent: every survivor
+    // is re-sorted by estimate below, so parallel and serial
+    // shortlists rank identically.
+    let coarse_limit = if matches!(col.rerank_codec, RerankCodec::RabitqOnly) {
+        ctx.k
+    } else {
+        ctx.k.saturating_mul(ctx.rerank_mult)
+    };
+    if coarse_limit == 0 {
+        return ShortlistOutcome::Done(Vec::new());
+    }
+    let mut shortlist = scan_shortlist(
+        col,
+        cb,
+        cluster_meta,
+        cluster_blocks,
+        survivor_only_rerank_fetch,
+        coarse_limit,
+        ctx,
+    )
+    .await;
 
     if shortlist.is_empty() {
         return ShortlistOutcome::Done(Vec::new());

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -12,8 +12,7 @@
 //! eagerly at `open()`; per-query work happens on demand.
 
 use std::{
-    cmp::Ordering,
-    collections::{BinaryHeap, HashMap},
+    collections::HashMap,
     ops::Range,
     sync::{Arc, OnceLock},
     thread,
@@ -3268,6 +3267,18 @@ impl VectorReader {
             per_cell.push((cell_idx, 0, clusters.iter().map(|&c| c as usize).collect()));
         }
 
+        if per_cell.is_empty() {
+            return Ok(outcome);
+        }
+        // Rotate the query once per superfile: every cell of a column
+        // shares the table-wide rotation seed (cross-cell estimate pooling
+        // depends on it), so per-cell re-rotation is duplicate work — at a
+        // ~60-cell width sweep the repeated 768x768 applies measured
+        // ~1.3ms of wall per query.
+        let first_col = &self.columns[per_cell[0].0];
+        let mut q_rot_shared = vec![0f32; first_col.dim];
+        first_col.rot.apply(query, &mut q_rot_shared);
+        let q_rot_shared = &q_rot_shared;
         let cell_scans = per_cell.into_iter().filter_map(|(cell_idx, base, locals)| {
             let col = &self.columns[cell_idx];
             if col.n_docs == 0 {
@@ -3289,8 +3300,6 @@ impl VectorReader {
                     .range_async(idx_start..idx_end)
                     .await
                     .map_err(|e| VectorError::LazySource(e.to_string()))?;
-                let mut q_rot = vec![0f32; col.dim];
-                col.rot.apply(query, &mut q_rot);
                 let cb = col.quant.code_bytes();
                 let (cluster_meta, prefix_ranges) = chosen_cluster_meta(col, &cluster_idx, &locals);
                 if cluster_meta.is_empty() {
@@ -3304,7 +3313,7 @@ impl VectorReader {
                 let rabitq_only = matches!(col.rerank_codec, RerankCodec::RabitqOnly);
                 if let (Some(blocks), false) = (prefix_blocks, rabitq_only) {
                     let ctx = ProbeCtx {
-                        q_rot: &q_rot,
+                        q_rot: q_rot_shared,
                         k,
                         rerank_mult,
                         allow: cell_allow,
@@ -3333,7 +3342,7 @@ impl VectorReader {
                 }
                 // Cold (or RabitqOnly): probe-and-rerank now, width-divided.
                 let ctx = ProbeCtx {
-                    q_rot: &q_rot,
+                    q_rot: q_rot_shared,
                     k,
                     rerank_mult: cold_rerank_mult,
                     allow: cell_allow,
@@ -3922,125 +3931,52 @@ async fn scan_shortlist(
 ) -> Vec<(u32, f32, u32, u32)> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
     let total_candidates: usize = cluster_meta.iter().map(|&(_, _, cnt)| cnt as usize).sum();
-    // Fits-path: when every scanned row fits the cap, admission can never
-    // evict — the bounded heap (sift per push, heap-merge per rayon
-    // chunk) is pure overhead. Score straight into a vec; parallel chunks
-    // append instead of re-pushing through a merge. The deferred-rerank
-    // scan lives here almost always (cell rows < k x undivided mult).
-    if total_candidates <= coarse_limit {
-        let scan_vec =
-            |acc: &mut Vec<(u32, f32, u32, u32)>,
-             (&(c, off, cnt), block): (&(usize, u32, u32), &Bytes)| {
-                let codes_len = (cnt as usize) * cb;
-                let codes = block.slice(0..codes_len);
-                let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
-                score_cluster_codes_with(
-                    &codes,
-                    &doc_ids,
-                    cnt,
-                    off,
-                    c as u32,
-                    &col.quant,
-                    ctx.q_rot,
-                    ctx.allow.as_deref(),
-                    ctx.deny.as_deref(),
-                    &mut |cand| acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id)),
-                );
-            };
-        if total_candidates >= PARALLEL_SCAN_MIN && cluster_meta.len() > 1 {
-            let n_tasks = parallel_chunks(cluster_meta.len());
-            let chunk = cluster_meta.len().div_ceil(n_tasks).max(1);
-            let quant = col.quant.clone();
-            let q_rot_v: Vec<f32> = ctx.q_rot.to_vec();
-            let meta_owned: Vec<(usize, u32, u32)> = cluster_meta.to_vec();
-            let blocks_owned: Vec<Bytes> = cluster_blocks.to_vec();
-            let allow_owned = ctx.allow.clone();
-            let deny_owned = ctx.deny.clone();
-            let (tx, rx) = oneshot::channel();
-            spawn_on(ctx.pool.as_deref(), move || {
-                let acc = meta_owned
-                    .par_chunks(chunk)
-                    .zip(blocks_owned.par_chunks(chunk))
-                    .map(|(meta_chunk, block_chunk)| {
-                        let mut acc = Vec::with_capacity(
-                            meta_chunk.iter().map(|&(_, _, cnt)| cnt as usize).sum(),
-                        );
-                        for (&(c, off, cnt), block) in meta_chunk.iter().zip(block_chunk.iter()) {
-                            let codes_len = (cnt as usize) * cb;
-                            let codes = block.slice(0..codes_len);
-                            let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
-                            score_cluster_codes_with(
-                                &codes,
-                                &doc_ids,
-                                cnt,
-                                off,
-                                c as u32,
-                                &quant,
-                                &q_rot_v,
-                                allow_owned.as_deref(),
-                                deny_owned.as_deref(),
-                                &mut |cand| {
-                                    acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id))
-                                },
-                            );
-                        }
-                        acc
-                    })
-                    .reduce(Vec::new, |mut a, mut b| {
-                        a.append(&mut b);
-                        a
-                    });
-                let _ = tx.send(acc);
-            });
-            return rx.await.expect("vector scan rayon task dropped result");
-        }
-        let mut acc = Vec::with_capacity(total_candidates);
-        for item in cluster_meta.iter().zip(cluster_blocks.iter()) {
-            scan_vec(&mut acc, item);
-        }
-        return acc;
-    }
-    let score_block =
-        |heap: &mut BoundedCoarseHeap, (&(c, off, cnt), block): (&(usize, u32, u32), &Bytes)| {
-            let codes_len = (cnt as usize) * cb;
-            let doc_ids_len = (cnt as usize) * 4;
-            debug_assert_eq!(
-                block.len(),
-                if survivor_only_rerank_fetch {
-                    codes_len + doc_ids_len
-                } else {
-                    codes_len + doc_ids_len + (cnt as usize) * full_vec_bytes
-                }
-            );
-            let codes = block.slice(0..codes_len);
-            let doc_ids = block.slice(codes_len..codes_len + doc_ids_len);
-            score_cluster_codes_into_heap(
-                &codes,
-                &doc_ids,
-                cnt,
-                off,
-                c as u32,
-                &col.quant,
-                ctx.q_rot,
-                ctx.allow.as_deref(),
-                ctx.deny.as_deref(),
-                heap,
-            );
-        };
-    let shortlist_heap = if total_candidates >= PARALLEL_SCAN_MIN && cluster_meta.len() > 1 {
-        // Parallelize the coarse 1-bit scan across the configured rayon pool,
-        // bridged back via a oneshot so no tokio worker blocks under the
-        // compute. Cluster scoring is order-independent — every survivor
-        // is re-sorted below — so chunked-parallel and serial shortlists
-        // rank identically. Partial heaps merge after.
+    // Collect every scored row, then keep the top `coarse_limit` with one
+    // O(n) partition. A bounded heap pays a sift on (nearly) every push
+    // to retain the same set `select_nth` finds in a single pass — at the
+    // 1M width-sweep shape (~9K-row cells against a k*rerank_mult cap)
+    // the heap admission machinery alone measured ~15% of scan CPU.
+    let scan_vec = |acc: &mut Vec<(u32, f32, u32, u32)>,
+                    (&(c, off, cnt), block): (&(usize, u32, u32), &Bytes)| {
+        let codes_len = (cnt as usize) * cb;
+        let doc_ids_len = (cnt as usize) * 4;
+        debug_assert_eq!(
+            block.len(),
+            if survivor_only_rerank_fetch {
+                codes_len + doc_ids_len
+            } else {
+                codes_len + doc_ids_len + (cnt as usize) * full_vec_bytes
+            }
+        );
+        let codes = block.slice(0..codes_len);
+        let doc_ids = block.slice(codes_len..codes_len + doc_ids_len);
+        score_cluster_codes_with(
+            &codes,
+            &doc_ids,
+            cnt,
+            off,
+            c as u32,
+            &col.quant,
+            ctx.q_rot,
+            ctx.allow.as_deref(),
+            ctx.deny.as_deref(),
+            &mut |cand| acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id)),
+        );
+    };
+    let mut acc = if total_candidates >= PARALLEL_SCAN_MIN && cluster_meta.len() > 1 {
+        // Parallelize the coarse 1-bit scan across the configured rayon
+        // pool, bridged back via a oneshot so no tokio worker blocks under
+        // the compute. Cluster scoring is order-independent — the partition
+        // below and every caller re-sort survivors — so chunked-parallel
+        // and serial shortlists rank identically.
         let n_tasks = parallel_chunks(cluster_meta.len());
         let chunk = cluster_meta.len().div_ceil(n_tasks).max(1);
         let quant = col.quant.clone();
         let q_rot_v: Vec<f32> = ctx.q_rot.to_vec();
         let meta_owned: Vec<(usize, u32, u32)> = cluster_meta.to_vec();
         let blocks_owned: Vec<Bytes> = cluster_blocks.to_vec();
-        // Move an `Arc` clone of the allow-set + deny-set into the rayon task;
-        // each chunk borrows them as `Option<&RoaringBitmap>` via `as_deref`.
+        // Move an `Arc` clone of the allow-set + deny-set into the rayon
+        // task; each chunk borrows them as `Option<&RoaringBitmap>`.
         let allow_owned = ctx.allow.clone();
         let deny_owned = ctx.deny.clone();
         let (tx, rx) = oneshot::channel();
@@ -4049,13 +3985,14 @@ async fn scan_shortlist(
                 .par_chunks(chunk)
                 .zip(blocks_owned.par_chunks(chunk))
                 .map(|(meta_chunk, block_chunk)| {
-                    let mut heap = BoundedCoarseHeap::new(coarse_limit);
+                    let mut acc = Vec::with_capacity(
+                        meta_chunk.iter().map(|&(_, _, cnt)| cnt as usize).sum(),
+                    );
                     for (&(c, off, cnt), block) in meta_chunk.iter().zip(block_chunk.iter()) {
                         let codes_len = (cnt as usize) * cb;
-                        let doc_ids_len = (cnt as usize) * 4;
+                        let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
                         let codes = block.slice(0..codes_len);
-                        let doc_ids = block.slice(codes_len..codes_len + doc_ids_len);
-                        score_cluster_codes_into_heap(
+                        score_cluster_codes_with(
                             &codes,
                             &doc_ids,
                             cnt,
@@ -4065,30 +4002,46 @@ async fn scan_shortlist(
                             &q_rot_v,
                             allow_owned.as_deref(),
                             deny_owned.as_deref(),
-                            &mut heap,
+                            &mut |cand| {
+                                acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id))
+                            },
                         );
                     }
-                    heap
+                    acc
                 })
-                .reduce(
-                    || BoundedCoarseHeap::new(coarse_limit),
-                    |mut a, b| {
-                        a.merge(b);
-                        a
-                    },
-                );
+                .reduce(Vec::new, |mut a, mut b| {
+                    a.append(&mut b);
+                    a
+                });
             let _ = tx.send(acc);
         });
-        rx.await
-            .expect("vector shortlist rayon task dropped result")
+        rx.await.expect("vector scan rayon task dropped result")
     } else {
-        let mut heap = BoundedCoarseHeap::new(coarse_limit);
+        let mut acc = Vec::with_capacity(total_candidates);
         for item in cluster_meta.iter().zip(cluster_blocks.iter()) {
-            score_block(&mut heap, item);
+            scan_vec(&mut acc, item);
         }
-        heap
+        acc
     };
-    shortlist_heap.into_vec()
+    truncate_to_top_estimates(&mut acc, coarse_limit);
+    acc
+}
+
+/// Keep the `limit` highest-estimate survivors of one cell scan via a
+/// single O(n) partition (`select_nth_unstable`), deterministic doc-id
+/// tie-break. Output order is unspecified — every caller re-sorts or
+/// re-selects downstream.
+fn truncate_to_top_estimates(acc: &mut Vec<(u32, f32, u32, u32)>, limit: usize) {
+    if limit == 0 {
+        acc.clear();
+        return;
+    }
+    if acc.len() > limit {
+        acc.select_nth_unstable_by(limit - 1, |a, b| {
+            b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0))
+        });
+        acc.truncate(limit);
+    }
 }
 
 /// One 1-bit-scan survivor surfaced to the supertable's GLOBAL shortlist
@@ -4389,38 +4342,9 @@ where
     rx.await.expect("rerank rayon task dropped result")
 }
 
-#[inline]
-fn score_cluster_codes_into_heap(
-    cluster_codes: &[u8],
-    cluster_doc_ids: &[u8],
-    cnt: u32,
-    off: u32,
-    cluster_id: u32,
-    quant: &BitQuantizer,
-    q_rot: &[f32],
-    allow: Option<&roaring::RoaringBitmap>,
-    deny: Option<&roaring::RoaringBitmap>,
-    out: &mut BoundedCoarseHeap,
-) {
-    score_cluster_codes_with(
-        cluster_codes,
-        cluster_doc_ids,
-        cnt,
-        off,
-        cluster_id,
-        quant,
-        q_rot,
-        allow,
-        deny,
-        &mut |cand| out.push(cand),
-    );
-}
-
 /// The 1-bit scan loop over one cluster's codes, generic over the
-/// candidate sink: the bounded heap when admission must evict
-/// ([`score_cluster_codes_into_heap`]), a plain vec when every scanned
-/// row fits the cap anyway and heap maintenance is pure overhead
-/// ([`scan_shortlist`]'s fits-path).
+/// candidate sink ([`scan_shortlist`] appends to a plain vec and keeps
+/// the top `coarse_limit` with one O(n) partition afterwards).
 #[inline]
 #[allow(clippy::too_many_arguments)]
 fn score_cluster_codes_with(
@@ -4446,16 +4370,15 @@ fn score_cluster_codes_with(
         ]);
         // Filtered search: the predicate's per-superfile allow-set is a
         // hard constraint applied *before* the candidate enters the
-        // coarse heap. The heap therefore ranks distance only among
-        // matching doc-ids, so the top-k is the true k-nearest among
-        // matching rows with no underflow — no over-fetch, no
-        // post-filter. Decode the code (the hot work) only for an
-        // allowed candidate.
+        // shortlist, which therefore ranks distance only among matching
+        // doc-ids — the top-k is the true k-nearest among matching rows
+        // with no underflow, no over-fetch, no post-filter. Decode the
+        // code (the hot work) only for an allowed candidate.
         if allow.is_some_and(|bm| !bm.contains(did)) {
             continue;
         }
-        // Tombstone deny-set: exclude deleted rows here, before they can take a
-        // coarse-heap slot, so the per-cell top-k is selected from live rows.
+        // Tombstone deny-set: exclude deleted rows here, before they can
+        // take a shortlist slot, so the per-cell top-k is from live rows.
         if deny.is_some_and(|bm| bm.contains(did)) {
             continue;
         }
@@ -4476,93 +4399,6 @@ struct CoarseCandidate {
     estimate: f32,
     pos: u32,
     cluster_id: u32,
-}
-
-impl PartialEq for CoarseCandidate {
-    fn eq(&self, other: &Self) -> bool {
-        self.estimate == other.estimate
-            && self.did == other.did
-            && self.pos == other.pos
-            && self.cluster_id == other.cluster_id
-    }
-}
-
-impl Eq for CoarseCandidate {}
-
-impl PartialOrd for CoarseCandidate {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for CoarseCandidate {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // BinaryHeap is a max-heap. Reverse estimate ordering so `peek()`
-        // is the worst retained candidate; higher estimates are better.
-        other
-            .estimate
-            .partial_cmp(&self.estimate)
-            .unwrap_or(Ordering::Equal)
-            .then_with(|| other.did.cmp(&self.did))
-            .then_with(|| other.pos.cmp(&self.pos))
-            .then_with(|| other.cluster_id.cmp(&self.cluster_id))
-    }
-}
-
-struct BoundedCoarseHeap {
-    limit: usize,
-    heap: BinaryHeap<CoarseCandidate>,
-}
-
-impl BoundedCoarseHeap {
-    fn new(limit: usize) -> Self {
-        Self {
-            limit,
-            heap: BinaryHeap::with_capacity(limit.max(1)),
-        }
-    }
-
-    #[inline]
-    fn push(&mut self, candidate: CoarseCandidate) {
-        if self.limit == 0 {
-            return;
-        }
-        if self.heap.len() < self.limit {
-            self.heap.push(candidate);
-            return;
-        }
-        if self
-            .heap
-            .peek()
-            .is_some_and(|worst| candidate.estimate > worst.estimate)
-        {
-            let mut worst = self
-                .heap
-                .peek_mut()
-                .expect("heap is non-empty because len == limit");
-            *worst = candidate;
-        }
-    }
-
-    fn merge(&mut self, other: BoundedCoarseHeap) {
-        for candidate in other.heap {
-            self.push(candidate);
-        }
-    }
-
-    fn into_vec(self) -> Vec<(u32, f32, u32, u32)> {
-        self.heap
-            .into_iter()
-            .map(|candidate| {
-                (
-                    candidate.did,
-                    candidate.estimate,
-                    candidate.pos,
-                    candidate.cluster_id,
-                )
-            })
-            .collect()
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -5267,6 +5103,7 @@ fn fetch_sync(source: &Source, range: Range<usize>, what: &str) -> Result<Bytes,
 #[cfg(test)]
 mod tests {
     use std::{
+        cmp::Ordering,
         collections::HashSet,
         fs::File,
         hint::black_box,
@@ -8913,8 +8750,8 @@ mod tests {
     // -----------------------------------------------------------------
     //
     // The coarse 1-bit scan in `build_shortlist`, the fp32 / Sq8 rerank
-    // scans, and the `par_map` / `parallel_chunks` / `BoundedCoarseHeap::merge`
-    // helpers all switch from a serial loop to a chunked rayon scan once
+    // scans, and the `par_map` / `parallel_chunks` helpers all switch
+    // from a serial loop to a chunked rayon scan once
     // the candidate pool crosses `PARALLEL_SCAN_MIN` (2048) with more
     // than one probed cluster. The default test corpora are far below
     // that threshold, so these tests build a deliberately large corpus
@@ -9011,30 +8848,33 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn parallel_scan_matches_serial_scan_results() {
-        // The parallel and serial coarse/rerank paths must rank
-        // identically (chunked-parallel scoring is order-independent).
-        // Run the same query through a large corpus (parallel) and pin
-        // that a smaller-k path on the same reader is internally
-        // consistent — both recover the planted self vector.
+    async fn parallel_scan_untruncated_pool_matches_brute_force() {
+        // 2600 docs across 4 clusters puts the probed scan over
+        // PARALLEL_SCAN_MIN, driving the chunked-parallel arm. With an
+        // untruncated shortlist (k * rerank_mult >= corpus, so
+        // `truncate_to_top_estimates` drops nothing) and fp32 rerank,
+        // the returned top-k must equal brute-force L2 over the corpus
+        // exactly — a stronger pin than ranking-consistency heuristics.
         use std::collections::HashSet;
         let (blob, json, all) = build_large_corpus(16, 4, 2600, RerankCodec::Fp32, Metric::L2Sq);
         let r = VectorReader::open(blob, &json).expect("open");
-        // Large shortlist → parallel.
-        let parallel = r.search("v", &all[42], 64, 4, 40).await.expect("parallel");
-        // Small shortlist → serial (coarse_limit = 50 < 2048).
-        let serial = r.search("v", &all[42], 10, 4, 5).await.expect("serial");
-        assert_eq!(parallel[0].0, 42, "parallel recovers self");
-        assert_eq!(serial[0].0, 42, "serial recovers self");
-        // The serial top-10 set must be a subset of the parallel top-64
-        // set (same scoring, parallel just keeps more).
-        let par_ids: HashSet<u32> = parallel.iter().map(|(id, _)| *id).collect();
-        for (id, _) in &serial {
-            assert!(
-                par_ids.contains(id),
-                "serial top-10 id {id} must appear in parallel top-64"
-            );
-        }
+        // k * rerank_mult = 64 * 41 = 2624 >= 2600: nothing truncated.
+        let hits = r.search("v", &all[42], 64, 4, 41).await.expect("search");
+        assert_eq!(hits[0].0, 42, "recovers planted self");
+        let l2sq =
+            |a: &[f32], b: &[f32]| -> f32 { a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum() };
+        let mut exact: Vec<(u32, f32)> = all
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i as u32, l2sq(v, &all[42])))
+            .collect();
+        exact.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+        let want: HashSet<u32> = exact[..64].iter().map(|&(i, _)| i).collect();
+        let got: HashSet<u32> = hits.iter().map(|&(i, _)| i).collect();
+        assert_eq!(
+            got, want,
+            "untruncated parallel scan + fp32 rerank == brute force"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -9080,79 +8920,6 @@ mod tests {
         // parallel_chunks(items) <= 1 takes the serial map arm.
         let out = par_map(vec![1u32, 2, 3], |x| x * 10, None).await;
         assert_eq!(out, vec![10, 20, 30]);
-    }
-
-    #[test]
-    fn bounded_coarse_heap_merge_keeps_top_by_estimate() {
-        // Direct unit test of `BoundedCoarseHeap::merge` (otherwise only
-        // reached on the parallel reduce path). Two bounded heaps merged
-        // must retain the globally-highest `estimate` candidates up to
-        // the limit.
-        let mk = |did: u32, est: f32| CoarseCandidate {
-            did,
-            estimate: est,
-            pos: did,
-            cluster_id: 0,
-        };
-        let mut a = BoundedCoarseHeap::new(3);
-        for c in [mk(0, 1.0), mk(1, 2.0), mk(2, 3.0)] {
-            a.push(c);
-        }
-        let mut b = BoundedCoarseHeap::new(3);
-        for c in [mk(3, 0.5), mk(4, 5.0), mk(5, 4.0)] {
-            b.push(c);
-        }
-        a.merge(b);
-        let mut ests: Vec<f32> = a.into_vec().into_iter().map(|(_, est, _, _)| est).collect();
-        ests.sort_by(|x, y| y.partial_cmp(x).expect("finite estimates"));
-        // Top-3 by estimate across both heaps: 5.0, 4.0, 3.0.
-        assert_eq!(ests, vec![5.0, 4.0, 3.0]);
-    }
-
-    #[test]
-    fn coarse_candidate_ordering_and_equality_tie_breaks() {
-        // The Ord impl reverses estimate (max-heap "worst" peek) and
-        // tie-breaks on did, then pos, then cluster_id. PartialEq tests
-        // every field.
-        let base = CoarseCandidate {
-            did: 5,
-            estimate: 1.0,
-            pos: 10,
-            cluster_id: 2,
-        };
-        let same = CoarseCandidate { ..base };
-        assert_eq!(base, same, "identical fields compare equal");
-        assert_eq!(base.cmp(&same), Ordering::Equal, "identical → Equal");
-
-        // Higher estimate is "better" → reversed → Less in the heap order.
-        let higher_est = CoarseCandidate {
-            estimate: 2.0,
-            ..base
-        };
-        assert_eq!(
-            base.cmp(&higher_est),
-            Ordering::Greater,
-            "lower estimate sorts as the worse (Greater) candidate"
-        );
-        assert_ne!(base, higher_est);
-
-        // Equal estimate, differing did → did tie-break (reversed).
-        let other_did = CoarseCandidate { did: 6, ..base };
-        assert_eq!(base.cmp(&other_did), Ordering::Greater);
-        assert_ne!(base, other_did);
-
-        // Equal estimate + did, differing pos → pos tie-break.
-        let other_pos = CoarseCandidate { pos: 11, ..base };
-        assert_eq!(base.cmp(&other_pos), Ordering::Greater);
-        assert_ne!(base, other_pos);
-
-        // Equal estimate + did + pos, differing cluster_id.
-        let other_cluster = CoarseCandidate {
-            cluster_id: 3,
-            ..base
-        };
-        assert_eq!(base.cmp(&other_cluster), Ordering::Greater);
-        assert_ne!(base, other_cluster);
     }
 
     // -----------------------------------------------------------------
@@ -9838,86 +9605,49 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // CoarseCandidate ordering + BoundedCoarseHeap
+    // truncate_to_top_estimates (per-cell shortlist truncation)
     // -----------------------------------------------------------------
 
-    fn coarse(did: u32, estimate: f32) -> CoarseCandidate {
-        CoarseCandidate {
-            did,
-            estimate,
-            pos: did,
-            cluster_id: 0,
-        }
-    }
-
-    /// `CoarseCandidate` is reverse-ordered on `estimate` so a max-heap
-    /// `peek()` yields the *worst* (lowest-estimate) retained candidate.
-    /// Also exercises `PartialEq`/`Eq` (identical fields compare equal,
-    /// differing fields do not).
+    /// Keeps the `limit` highest-estimate rows; the survivor set matches
+    /// what the old bounded-heap admission retained.
     #[test]
-    fn coarse_candidate_reverse_orders_on_estimate() {
-        let lo = coarse(1, 0.1);
-        let hi = coarse(2, 0.9);
-        // Higher estimate is "better" → compares as Less under the
-        // reversed Ord (so it sinks to the bottom of a max-heap's worst).
-        assert_eq!(hi.cmp(&lo), Ordering::Less);
-        assert_eq!(lo.cmp(&hi), Ordering::Greater);
-        assert_eq!(lo.partial_cmp(&hi), Some(Ordering::Greater));
-
-        // PartialEq / Eq.
-        assert_eq!(coarse(5, 0.5), coarse(5, 0.5));
-        assert_ne!(coarse(5, 0.5), coarse(6, 0.5));
-        assert_ne!(coarse(5, 0.5), coarse(5, 0.6));
-
-        // The max-heap's peek is the worst (lowest-estimate) candidate.
-        let mut heap = BinaryHeap::new();
-        heap.push(coarse(1, 0.1));
-        heap.push(coarse(2, 0.9));
-        heap.push(coarse(3, 0.5));
-        assert_eq!(heap.peek().expect("non-empty").estimate, 0.1);
-    }
-
-    /// `BoundedCoarseHeap` retains the `limit` highest-estimate
-    /// candidates; pushes beyond the limit evict the current worst.
-    #[test]
-    fn bounded_coarse_heap_retains_top_by_estimate() {
-        let mut h = BoundedCoarseHeap::new(3);
-        for (did, est) in [(0u32, 0.1f32), (1, 0.9), (2, 0.5), (3, 0.7), (4, 0.2)] {
-            h.push(coarse(did, est));
-        }
-        let mut kept: Vec<u32> = h.into_vec().into_iter().map(|(did, ..)| did).collect();
+    fn truncate_keeps_top_by_estimate() {
+        let mut acc: Vec<(u32, f32, u32, u32)> =
+            [(0u32, 0.1f32), (1, 0.9), (2, 0.5), (3, 0.7), (4, 0.2)]
+                .into_iter()
+                .map(|(did, est)| (did, est, did, 0))
+                .collect();
+        truncate_to_top_estimates(&mut acc, 3);
+        let mut kept: Vec<u32> = acc.into_iter().map(|(did, ..)| did).collect();
         kept.sort_unstable();
         // The three highest estimates are 0.9 (did 1), 0.7 (did 3),
         // 0.5 (did 2).
         assert_eq!(kept, vec![1, 2, 3]);
     }
 
-    /// A zero-limit `BoundedCoarseHeap` drops every push and yields an
-    /// empty result.
+    /// Zero limit clears the shortlist; a limit at or above the length
+    /// leaves it untouched.
     #[test]
-    fn bounded_coarse_heap_zero_limit_keeps_nothing() {
-        let mut h = BoundedCoarseHeap::new(0);
-        h.push(coarse(0, 0.5));
-        h.push(coarse(1, 0.9));
-        assert!(h.into_vec().is_empty());
+    fn truncate_limit_edges() {
+        let rows: Vec<(u32, f32, u32, u32)> = vec![(0, 0.5, 0, 0), (1, 0.9, 1, 0)];
+        let mut zero = rows.clone();
+        truncate_to_top_estimates(&mut zero, 0);
+        assert!(zero.is_empty());
+        let mut fits = rows.clone();
+        truncate_to_top_estimates(&mut fits, 2);
+        assert_eq!(fits, rows);
     }
 
-    /// `merge` folds another heap's candidates in under the receiver's
-    /// limit, preserving the global top-by-estimate set.
+    /// Ties on the estimate break deterministically toward the lower
+    /// doc id, so equal-estimate boundaries cannot flap between runs.
     #[test]
-    fn bounded_coarse_heap_merge_preserves_global_top() {
-        let mut a = BoundedCoarseHeap::new(2);
-        a.push(coarse(0, 0.1));
-        a.push(coarse(1, 0.4));
-        let mut b = BoundedCoarseHeap::new(2);
-        b.push(coarse(2, 0.9));
-        b.push(coarse(3, 0.2));
-        a.merge(b);
-        let mut kept: Vec<u32> = a.into_vec().into_iter().map(|(did, ..)| did).collect();
+    fn truncate_tie_breaks_on_doc_id() {
+        let mut acc: Vec<(u32, f32, u32, u32)> =
+            (0u32..6).rev().map(|did| (did, 0.5f32, did, 0)).collect();
+        truncate_to_top_estimates(&mut acc, 3);
+        let mut kept: Vec<u32> = acc.into_iter().map(|(did, ..)| did).collect();
         kept.sort_unstable();
-        // Across both heaps the two best estimates are 0.9 (did 2) and
-        // 0.4 (did 1).
-        assert_eq!(kept, vec![1, 2]);
+        assert_eq!(kept, vec![0, 1, 2]);
     }
 
     // -----------------------------------------------------------------

--- a/src/superfile/vector/reservoir.rs
+++ b/src/superfile/vector/reservoir.rs
@@ -198,6 +198,14 @@ impl Reservoir {
     ///
     /// Panics if `vec.len() != self.dim`.
     pub fn update(&mut self, vec: &[f32]) {
+        let _ = self.update_traced(vec);
+    }
+
+    /// [`Self::update`], reporting where the vector landed: `Some(slot)`
+    /// when it was appended (fill phase) or replaced an existing sample,
+    /// `None` when it passed by. Lets a caller keep per-sample metadata
+    /// (e.g. row ids) in lockstep with the reservoir.
+    pub(crate) fn update_traced(&mut self, vec: &[f32]) -> Option<usize> {
         assert_eq!(
             vec.len(),
             self.dim,
@@ -218,7 +226,7 @@ impl Reservoir {
                 self.w = (Self::nonzero_uniform(&mut self.rng).ln() / k as f64).exp();
                 self.next_replace_at = i + 1 + Self::skip(&mut self.rng, self.w);
             }
-            return;
+            return Some(i as usize);
         }
 
         // Full phase. Replace at the precomputed skip
@@ -228,7 +236,9 @@ impl Reservoir {
             self.buf[slot * self.dim..(slot + 1) * self.dim].copy_from_slice(vec);
             self.w *= (Self::nonzero_uniform(&mut self.rng).ln() / k as f64).exp();
             self.next_replace_at = i + 1 + Self::skip(&mut self.rng, self.w);
+            return Some(slot);
         }
+        None
     }
 
     /// Number of vectors observed via [`Self::update`].

--- a/src/superfile/vector/simd_dispatch.rs
+++ b/src/superfile/vector/simd_dispatch.rs
@@ -93,6 +93,33 @@ pub(crate) fn has_vpopcntdq() -> bool {
     })
 }
 
+/// True iff the host supports AVX-512 VBMI (byte-granular
+/// `_mm512_permutexvar_epi8`). Required by `quant`'s FastScan LUT
+/// block scanner: its nibble lookups permute a register-resident
+/// 16-entry i8 table across all 64 byte lanes in one instruction.
+///
+/// Also implies [`avx512_enabled`] (we never enable a specialized
+/// kernel on a host without the foundation), so callers should
+/// check this gate alone.
+#[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
+#[inline]
+pub(crate) fn has_vbmi() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        if !avx512_enabled() {
+            return false;
+        }
+        #[cfg(target_arch = "x86_64")]
+        {
+            std::arch::is_x86_feature_detected!("avx512vbmi")
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            false
+        }
+    })
+}
+
 /// True iff this binary should use AVX2 fast-path kernels in the
 /// "wide" tier. Checks `is_x86_feature_detected!("avx2")` at
 /// runtime; near-universally true on production x86_64 hosts (Intel
@@ -165,6 +192,12 @@ mod tests {
             assert!(
                 avx512_enabled(),
                 "has_vpopcntdq() returned true but avx512_enabled() is false"
+            );
+        }
+        if has_vbmi() {
+            assert!(
+                avx512_enabled(),
+                "has_vbmi() returned true but avx512_enabled() is false"
             );
         }
     }

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -341,6 +341,11 @@ pub struct VectorColumnInfo {
     pub metric: String,
 }
 
+/// Canonical `k` points the drain calibrates the probe-width law at.
+/// Chosen log-spaced so query-time log-interpolation between neighbors
+/// stays within one decade of a measured point.
+pub(crate) const WIDTH_LAW_KS: [usize; 4] = [1, 10, 100, 1000];
+
 /// Adaptive cell-probe tuning for the hidden VectorCell index.
 /// Calibrated per table; persisted in the manifest list.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -354,6 +359,16 @@ pub struct CellRoutingParams {
     /// Floor on fine IVF centroids probed per selected hidden cell. The
     /// actual probe is `max(this, floor(pct × the cell's fine-cluster count))`.
     pub fine_nprobe: usize,
+    /// Per-table probe-width law: cells (in grid-nearest order) needed for
+    /// mean 0.99 coverage of the exact top-k, measured by the drain at each
+    /// [`WIDTH_LAW_KS`] point on a held-out row sample. `0` = uncalibrated
+    /// point; all zeros = no law (pre-law manifests, or drain calibration
+    /// skipped). How many cells the true top-k spreads over is a property
+    /// of the data — synthetic clustered corpora calibrate narrow, real
+    /// text embeddings wide (measured on Cohere-1M/768d: ~30 cells of 256
+    /// at k=100 under a converged grid, ~1 at k=1) — so the default cannot
+    /// be a constant; it has to be measured per table.
+    pub width_for_k: [u32; WIDTH_LAW_KS.len()],
 }
 
 impl Default for CellRoutingParams {
@@ -363,7 +378,41 @@ impl Default for CellRoutingParams {
             nprobe_max: DEFAULT_CELL_NPROBE_MAX,
             slack: DEFAULT_CELL_SLACK,
             fine_nprobe: crate::config::global().vector.fine_nprobe_floor,
+            width_for_k: [0; WIDTH_LAW_KS.len()],
         }
+    }
+}
+
+impl CellRoutingParams {
+    /// Resolve the calibrated probe width for a query's `k`, or `None`
+    /// when no usable law is persisted (all-zero, or every point at or
+    /// around `k` is uncalibrated).
+    ///
+    /// Interpolates log-linearly in `k` between the two calibrated
+    /// [`WIDTH_LAW_KS`] points bracketing the query's `k` (zero entries
+    /// are skipped), clamping to the nearest calibrated point outside
+    /// the calibrated range. Width is rounded up: under-probing costs
+    /// recall, over-probing costs one cell's read.
+    pub(crate) fn width_for_k_at(&self, k: usize) -> Option<usize> {
+        let pts: Vec<(f64, f64)> = WIDTH_LAW_KS
+            .iter()
+            .zip(self.width_for_k.iter())
+            .filter(|(_, w)| **w > 0)
+            .map(|(k_pt, w)| ((*k_pt as f64).ln(), f64::from(*w)))
+            .collect();
+        let (first, last) = (pts.first()?, pts.last()?);
+        let x = (k.max(1) as f64).ln();
+        if x <= first.0 {
+            return Some(first.1.ceil() as usize);
+        }
+        if x >= last.0 {
+            return Some(last.1.ceil() as usize);
+        }
+        let hi = pts.iter().position(|(px, _)| *px >= x)?;
+        let (x0, w0) = pts[hi - 1];
+        let (x1, w1) = pts[hi];
+        let t = (x - x0) / (x1 - x0);
+        Some((w0 + t * (w1 - w0)).ceil() as usize)
     }
 }
 
@@ -1159,6 +1208,11 @@ struct CellRoutingParamsDto {
     slack: Option<f32>,
     #[serde(default)]
     fine_nprobe: usize,
+    /// Probe-width law measured at the [`WIDTH_LAW_KS`] points; zero
+    /// entries are uncalibrated. Absent on pre-law manifests (defaults
+    /// to all-zero = no law).
+    #[serde(default)]
+    width_for_k: [u32; WIDTH_LAW_KS.len()],
 }
 
 impl From<CellRoutingParams> for CellRoutingParamsDto {
@@ -1168,6 +1222,7 @@ impl From<CellRoutingParams> for CellRoutingParamsDto {
             nprobe_max: r.nprobe_max,
             slack: Some(r.slack),
             fine_nprobe: r.fine_nprobe,
+            width_for_k: r.width_for_k,
         }
     }
 }
@@ -1187,6 +1242,7 @@ impl From<CellRoutingParamsDto> for CellRoutingParams {
         if d.fine_nprobe > 0 {
             r.fine_nprobe = d.fine_nprobe;
         }
+        r.width_for_k = d.width_for_k;
         r.nprobe_max = r.nprobe_max.max(r.nprobe_min);
         r
     }
@@ -2549,6 +2605,84 @@ mod tests {
             CellRoutingParams::default().slack,
             "absent slack keeps the default"
         );
+    }
+
+    /// The probe-width law round-trips through the list encoding, and a
+    /// JSON body without the field (pre-law manifests) decodes to no law.
+    #[test]
+    fn cell_routing_width_law_roundtrip_and_legacy_default() {
+        let mut list = empty_list();
+        list.partition_strategy = PartitionStrategy::VectorCell {
+            column: "emb".into(),
+            clusters: ClusterCentroids::from_fp32(1, 4, &[0.5, 0.5, 0.5, 0.5], vec![1]),
+            routing: CellRoutingParams {
+                width_for_k: [1, 2, 30, 48],
+                ..CellRoutingParams::default()
+            },
+        };
+        let bytes = encode(&list).expect("encode");
+        let decoded = decode(&bytes).expect("decode");
+        let PartitionStrategy::VectorCell { routing, .. } = &decoded.partition_strategy else {
+            panic!("VectorCell strategy must survive the round-trip");
+        };
+        assert_eq!(routing.width_for_k, [1, 2, 30, 48]);
+
+        // Strip the whole `"width_for_k": [...]` member (the encoder
+        // pretty-prints, so cut structurally: from the comma preceding the
+        // key through the closing bracket).
+        let s = from_utf8(&bytes).expect("utf8");
+        let key = s
+            .find("\"width_for_k\"")
+            .expect("field present in encoding");
+        let comma = s[..key].rfind(',').expect("preceding member comma");
+        let close = key + s[key..].find(']').expect("array close") + 1;
+        let stripped = format!("{}{}", &s[..comma], &s[close..]);
+        assert_ne!(stripped, s, "fixture must actually strip the field");
+        let legacy = decode(stripped.as_bytes()).expect("decode without width law");
+        let PartitionStrategy::VectorCell { routing, .. } = &legacy.partition_strategy else {
+            panic!("VectorCell strategy must survive the stripped decode");
+        };
+        assert_eq!(
+            routing.width_for_k,
+            [0; WIDTH_LAW_KS.len()],
+            "absent law decodes to all-zero (no law)"
+        );
+        assert_eq!(routing.width_for_k_at(100), None, "no law resolves None");
+    }
+
+    /// Width-law resolution: log-interpolation between calibrated points,
+    /// clamping outside the calibrated range, skipping zero entries, and
+    /// `None` for an absent law.
+    #[test]
+    fn width_for_k_at_interpolates_clamps_and_skips_zeros() {
+        let law = |w: [u32; WIDTH_LAW_KS.len()]| CellRoutingParams {
+            width_for_k: w,
+            ..CellRoutingParams::default()
+        };
+        // Calibrated at all four points: k = 1, 10, 100, 1000.
+        let full = law([1, 2, 30, 48]);
+        assert_eq!(full.width_for_k_at(1), Some(1));
+        assert_eq!(full.width_for_k_at(10), Some(2));
+        assert_eq!(full.width_for_k_at(100), Some(30));
+        assert_eq!(full.width_for_k_at(1000), Some(48));
+        // Clamped outside the calibrated range (k=0 treated as 1).
+        assert_eq!(full.width_for_k_at(0), Some(1));
+        assert_eq!(full.width_for_k_at(100_000), Some(48));
+        // Interpolated between points, rounded up (under-probing costs
+        // recall): halfway in log-k between 10 and 100.
+        let mid = full.width_for_k_at(32).expect("interpolated");
+        assert!(
+            (2..=30).contains(&mid) && mid > 2,
+            "k=32 interpolates strictly between the k=10 and k=100 widths, got {mid}"
+        );
+        // Zero (uncalibrated) points are skipped: with only the k=100
+        // point calibrated, every k clamps to it.
+        let single = law([0, 0, 30, 0]);
+        assert_eq!(single.width_for_k_at(1), Some(30));
+        assert_eq!(single.width_for_k_at(100), Some(30));
+        assert_eq!(single.width_for_k_at(5000), Some(30));
+        // All-zero = no law.
+        assert_eq!(law([0; WIDTH_LAW_KS.len()]).width_for_k_at(10), None);
     }
 
     #[test]

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -394,12 +394,18 @@ impl CellRoutingParams {
     /// the calibrated range. Width is rounded up: under-probing costs
     /// recall, over-probing costs one cell's read.
     pub(crate) fn width_for_k_at(&self, k: usize) -> Option<usize> {
-        let pts: Vec<(f64, f64)> = WIDTH_LAW_KS
-            .iter()
-            .zip(self.width_for_k.iter())
-            .filter(|(_, w)| **w > 0)
-            .map(|(k_pt, w)| ((*k_pt as f64).ln(), f64::from(*w)))
-            .collect();
+        // Calibrated (ln k, width) points, gathered on the stack — at most
+        // `WIDTH_LAW_KS.len()` of them, resolved once per query, so no
+        // per-query heap allocation.
+        let mut pts = [(0f64, 0f64); WIDTH_LAW_KS.len()];
+        let mut n = 0;
+        for (k_pt, w) in WIDTH_LAW_KS.iter().zip(self.width_for_k.iter()) {
+            if *w > 0 {
+                pts[n] = ((*k_pt as f64).ln(), f64::from(*w));
+                n += 1;
+            }
+        }
+        let pts = &pts[..n];
         let (first, last) = (pts.first()?, pts.last()?);
         let x = (k.max(1) as f64).ln();
         if x <= first.0 {

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -759,15 +759,14 @@ pub(crate) struct WidthLawCalibration {
     slot_ids: Vec<i128>,
     dequant_scratch: Vec<f32>,
     frozen: Option<WidthLawQueries>,
-    /// Per-query `(score, cell)` candidates, truncated to the largest law
-    /// `k` as cells merge in. Lock poisoning is recovered, not propagated:
-    /// each merge is an atomic append+truncate, so a panicked pack worker
-    /// leaves the held data usable. NOTE: candidates are not deduplicated
-    /// by stable id — boundary replicas (drain replica factor > 1.0) could
-    /// let one neighbor occupy several top-k slots and narrow the law;
-    /// inert while replication is off, to be resolved with the replication
-    /// repair.
-    tops: Mutex<Vec<Vec<(f32, u32)>>>,
+    /// Per-query `(score, cell, stable id)` candidates, truncated to the
+    /// largest law `k` as cells merge in. The stable id lets [`Self::finish`]
+    /// deduplicate boundary replicas (drain replica factor > 1.0) to their
+    /// best-scored copy, so one neighbor can never occupy several top-k
+    /// slots and narrow the law. Lock poisoning is recovered, not
+    /// propagated: each merge is an atomic append+truncate, so a panicked
+    /// pack worker leaves the held data usable.
+    tops: Mutex<Vec<Vec<(f32, u32, i128)>>>,
 }
 
 impl WidthLawCalibration {
@@ -819,7 +818,7 @@ impl WidthLawCalibration {
             return Ok(());
         }
         let k_max = *WIDTH_LAW_KS.last().expect("law has k points");
-        let mut partial: Vec<Vec<(f32, u32)>> = vec![Vec::new(); n_queries];
+        let mut partial: Vec<Vec<(f32, u32, i128)>> = vec![Vec::new(); n_queries];
         let mut reader = spill.reader()?;
         let mut remaining = spill.n_rows();
         let mut scratch = vec![0f32; self.dim];
@@ -841,7 +840,7 @@ impl WidthLawCalibration {
                     if row.stable_id == frozen.ids[qi] {
                         continue;
                     }
-                    partial[qi].push((distance(self.metric, q, &scratch), cell));
+                    partial[qi].push((distance(self.metric, q, &scratch), cell, row.stable_id));
                 }
             }
             // Bound the per-cell partials the same way the merge does.
@@ -888,7 +887,12 @@ impl WidthLawCalibration {
                     *slot = rank as u32;
                 }
             }
+            // Best-scored copy per stable id first: boundary replicas of
+            // one row must count as ONE neighbor, or replicated tables
+            // would measure narrower coverage than a query experiences.
             let mut sorted = cand.clone();
+            sorted.sort_unstable_by(|a, b| a.2.cmp(&b.2).then_with(|| a.0.total_cmp(&b.0)));
+            sorted.dedup_by_key(|c| c.2);
             sorted.sort_unstable_by(|a, b| a.0.total_cmp(&b.0));
             for (ki, &k) in WIDTH_LAW_KS.iter().enumerate() {
                 if sorted.len() < k {
@@ -898,7 +902,7 @@ impl WidthLawCalibration {
                 // Per-rank counts of this query's top-k, then a prefix walk
                 // accumulates the mean coverage curve.
                 let mut per_rank = vec![0u32; n_cells];
-                for (_, cell) in &sorted[..k] {
+                for (_, cell, _) in &sorted[..k] {
                     per_rank[rank_of_cell[*cell as usize] as usize] += 1;
                 }
                 let mut covered = 0u32;
@@ -922,7 +926,7 @@ impl WidthLawCalibration {
 }
 
 /// Keep the ascending-best `cap` candidates in place.
-fn truncate_ascending(cand: &mut Vec<(f32, u32)>, cap: usize) {
+fn truncate_ascending(cand: &mut Vec<(f32, u32, i128)>, cap: usize) {
     if cand.len() > cap {
         cand.sort_unstable_by(|a, b| a.0.total_cmp(&b.0));
         cand.truncate(cap);
@@ -1004,6 +1008,58 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+
+    /// Boundary replicas must count as ONE neighbor in the width law:
+    /// [`WidthLawCalibration::finish`] dedups candidates to the
+    /// best-scored copy per stable id before measuring coverage. The
+    /// fixture plants one id three times in the two query-nearest cells;
+    /// without the dedup those copies pad the top-10 and the law would
+    /// stop at width 2, hiding the two real neighbors in the 4th-ranked
+    /// cell.
+    #[test]
+    fn width_law_finish_dedups_replicated_rows() {
+        const DIM: usize = 4;
+        // Grid ranked against the e0 query: cells 0, 1, 2, 3 in order.
+        let grid = ClusterCentroids::from_fp32(
+            4,
+            DIM as u32,
+            &[
+                1.0, 0.0, 0.0, 0.0, //
+                0.9, 0.1, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            vec![1; 4],
+        );
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut query = vec![0.0f32; DIM];
+        query[0] = 1.0;
+        cal.frozen = Some(WidthLawQueries {
+            queries: query,
+            ids: vec![999],
+        });
+        // (score, cell, stable id): id 1 replicated across cells 0 and 1;
+        // ids 2..=8 fill the near cells; ids 9 and 10 sit in cell 3 and
+        // only enter the top-10 once the replicas collapse to one slot.
+        let mut cands = vec![(0.01, 0, 1), (0.02, 1, 1), (0.03, 1, 1)];
+        cands.extend((2..=8).map(|id| (0.03 + id as f32 * 0.01, (id % 2) as u32, id as i128)));
+        cands.push((0.5, 3, 9));
+        cands.push((0.6, 3, 10));
+        *cal.tops.lock().unwrap_or_else(PoisonError::into_inner) = vec![cands];
+
+        let law = cal.finish(&grid).expect("law from planted candidates");
+        // k=1: the best copy of id 1 sits in the top-ranked cell.
+        assert_eq!(law[0], 1, "top-1 coverage is the nearest cell");
+        // k=10: deduped top-10 = ids 1..=10, whose coverage needs the
+        // 4th-ranked cell. Replica padding would have stopped at 2.
+        assert_eq!(
+            law[1], 4,
+            "replicated copies must not pad top-k coverage (got width {})",
+            law[1]
+        );
+        // 10 deduped candidates cannot support the k=100/1000 points.
+        assert_eq!(&law[2..], &[0, 0], "unsupported points stay uncalibrated");
+    }
     use crate::superfile::vector::{
         cell_posting::{encode_blob, load_encoded_rows_from_blob},
         rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -26,7 +26,11 @@
 //! manifest centroids and rows to fp32 before [`distance`]; rows are
 //! re-spliced with [`encode_encoded_rows`], never decoded to full fp32 corpora.
 
-use std::{cmp::Ordering, collections::HashMap, sync::Mutex};
+use std::{
+    cmp::Ordering,
+    collections::HashMap,
+    sync::{Mutex, PoisonError},
+};
 
 use crate::{
     config,
@@ -756,7 +760,13 @@ pub(crate) struct WidthLawCalibration {
     dequant_scratch: Vec<f32>,
     frozen: Option<WidthLawQueries>,
     /// Per-query `(score, cell)` candidates, truncated to the largest law
-    /// `k` as cells merge in.
+    /// `k` as cells merge in. Lock poisoning is recovered, not propagated:
+    /// each merge is an atomic append+truncate, so a panicked pack worker
+    /// leaves the held data usable. NOTE: candidates are not deduplicated
+    /// by stable id — boundary replicas (drain replica factor > 1.0) could
+    /// let one neighbor occupy several top-k slots and narrow the law;
+    /// inert while replication is off, to be resolved with the replication
+    /// repair.
     tops: Mutex<Vec<Vec<(f32, u32)>>>,
 }
 
@@ -791,7 +801,7 @@ impl WidthLawCalibration {
     pub(crate) fn freeze(&mut self) {
         let queries = self.reservoir.sample().to_vec();
         let ids = self.slot_ids.clone();
-        *self.tops.lock().expect("width-law tops lock") = vec![Vec::new(); ids.len()];
+        *self.tops.lock().unwrap_or_else(PoisonError::into_inner) = vec![Vec::new(); ids.len()];
         self.frozen = Some(WidthLawQueries { queries, ids });
     }
 
@@ -839,7 +849,7 @@ impl WidthLawCalibration {
                 truncate_ascending(cand, k_max);
             }
         }
-        let mut tops = self.tops.lock().expect("width-law tops lock");
+        let mut tops = self.tops.lock().unwrap_or_else(PoisonError::into_inner);
         for (qi, mut cand) in partial.into_iter().enumerate() {
             tops[qi].append(&mut cand);
             truncate_ascending(&mut tops[qi], k_max);
@@ -859,7 +869,10 @@ impl WidthLawCalibration {
             return None;
         }
         let n_cells = grid.n_cent as usize;
-        let tops = self.tops.into_inner().expect("width-law tops lock");
+        let tops = self
+            .tops
+            .into_inner()
+            .unwrap_or_else(PoisonError::into_inner);
         // Superseded or empty cells inflate ranks slightly (routing skips
         // them, this count does not) — an over-probe, never an under-probe;
         // fresh drains, the normal calibration moment, have neither.

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -849,18 +849,19 @@ impl WidthLawCalibration {
             }
         }
         let mut tops = self.tops.lock().unwrap_or_else(PoisonError::into_inner);
-        for (qi, mut cand) in partial.into_iter().enumerate() {
-            tops[qi].append(&mut cand);
-            truncate_ascending(&mut tops[qi], k_max);
+        for (qi, cand) in partial.into_iter().enumerate() {
+            merge_candidates(&mut tops[qi], cand, k_max);
         }
         Ok(())
     }
 
     /// Extract the width law: cells (in the grid's routing order) needed
     /// for mean [`WIDTH_LAW_TARGET_COVERAGE`] coverage of the exact top-k
-    /// at each [`WIDTH_LAW_KS`] point. Points the sample cannot support
-    /// (k exceeding any query's candidate count) stay `0` (uncalibrated).
-    /// `None` when nothing was sampled.
+    /// at each [`WIDTH_LAW_KS`] point. Each point is measured over the
+    /// queries whose candidate count reaches its `k` — one boundary-starved
+    /// query excludes itself, not the whole sample. Points NO query can
+    /// support stay `0` (uncalibrated). Measured points are floored to be
+    /// monotone in `k`. `None` when nothing was sampled.
     pub(crate) fn finish(self, grid: &ClusterCentroids) -> Option<[u32; WIDTH_LAW_KS.len()]> {
         let frozen = self.frozen?;
         let n_queries = frozen.ids.len();
@@ -877,7 +878,7 @@ impl WidthLawCalibration {
         // fresh drains, the normal calibration moment, have neither.
         let mut law = [0u32; WIDTH_LAW_KS.len()];
         let mut coverage_sums: Vec<Vec<f64>> = vec![vec![0f64; n_cells]; WIDTH_LAW_KS.len()];
-        let mut supported = [true; WIDTH_LAW_KS.len()];
+        let mut support = [0usize; WIDTH_LAW_KS.len()];
         let mut rank_of_cell = vec![0u32; n_cells];
         for (qi, cand) in tops.iter().enumerate() {
             let q = &frozen.queries[qi * self.dim..(qi + 1) * self.dim];
@@ -887,18 +888,17 @@ impl WidthLawCalibration {
                     *slot = rank as u32;
                 }
             }
-            // Best-scored copy per stable id first: boundary replicas of
-            // one row must count as ONE neighbor, or replicated tables
-            // would measure narrower coverage than a query experiences.
+            // [`merge_candidates`] keeps one entry per stable id, so the
+            // accumulator only needs ranking by score for the prefix walk.
             let mut sorted = cand.clone();
-            sorted.sort_unstable_by(|a, b| a.2.cmp(&b.2).then_with(|| a.0.total_cmp(&b.0)));
-            sorted.dedup_by_key(|c| c.2);
             sorted.sort_unstable_by(|a, b| a.0.total_cmp(&b.0));
             for (ki, &k) in WIDTH_LAW_KS.iter().enumerate() {
                 if sorted.len() < k {
-                    supported[ki] = false;
+                    // Below this point's k: the query measures the smaller
+                    // points and sits out this one.
                     continue;
                 }
+                support[ki] += 1;
                 // Per-rank counts of this query's top-k, then a prefix walk
                 // accumulates the mean coverage curve.
                 let mut per_rank = vec![0u32; n_cells];
@@ -913,16 +913,39 @@ impl WidthLawCalibration {
             }
         }
         for (ki, sums) in coverage_sums.iter().enumerate() {
-            if !supported[ki] {
+            if support[ki] == 0 {
                 continue;
             }
-            let target = WIDTH_LAW_TARGET_COVERAGE * n_queries as f64;
+            let target = WIDTH_LAW_TARGET_COVERAGE * support[ki] as f64;
             if let Some(rank) = sums.iter().position(|&s| s >= target) {
                 law[ki] = (rank + 1) as u32;
             }
         }
+        // Coverage need only grows with k, so each measured point is floored
+        // by the measured points below it — sampling noise near the target
+        // must never let a larger k probe FEWER cells than a smaller one (a
+        // recall inversion at query time). Unmeasured points (0) stay 0; the
+        // interpolator skips them.
+        let mut floor = 0u32;
+        for w in law.iter_mut().filter(|w| **w > 0) {
+            *w = (*w).max(floor);
+            floor = *w;
+        }
         (law.iter().any(|&w| w > 0)).then_some(law)
     }
+}
+
+/// Merge one cell's candidates into a query's accumulator: collapse to the
+/// best-scored copy per stable id FIRST (boundary replicas of one row are
+/// one neighbor), then keep the ascending-best `cap`. The dedup must
+/// precede the truncate — replicated copies of near rows filling raw slots
+/// would evict distinct farther neighbors and stamp a narrower law than a
+/// real query experiences.
+fn merge_candidates(acc: &mut Vec<(f32, u32, i128)>, mut cand: Vec<(f32, u32, i128)>, cap: usize) {
+    acc.append(&mut cand);
+    acc.sort_unstable_by(|a, b| a.2.cmp(&b.2).then_with(|| a.0.total_cmp(&b.0)));
+    acc.dedup_by_key(|c| c.2);
+    truncate_ascending(acc, cap);
 }
 
 /// Keep the ascending-best `cap` candidates in place.
@@ -1045,7 +1068,11 @@ mod tests {
         cands.extend((2..=8).map(|id| (0.03 + id as f32 * 0.01, (id % 2) as u32, id as i128)));
         cands.push((0.5, 3, 9));
         cands.push((0.6, 3, 10));
-        *cal.tops.lock().unwrap_or_else(PoisonError::into_inner) = vec![cands];
+        // Plant through the same merge the scorer uses — dedup happens
+        // there, BEFORE the truncate, so replicas can never occupy slots.
+        let mut acc = Vec::new();
+        merge_candidates(&mut acc, cands, *WIDTH_LAW_KS.last().expect("knots"));
+        *cal.tops.lock().unwrap_or_else(PoisonError::into_inner) = vec![acc];
 
         let law = cal.finish(&grid).expect("law from planted candidates");
         // k=1: the best copy of id 1 sits in the top-ranked cell.
@@ -1059,6 +1086,72 @@ mod tests {
         );
         // 10 deduped candidates cannot support the k=100/1000 points.
         assert_eq!(&law[2..], &[0, 0], "unsupported points stay uncalibrated");
+    }
+
+    /// Per-query point support and the monotone floor. Query A (10
+    /// candidates spread over four cells) cannot support k=100 — it must
+    /// sit that point out rather than zero it for the whole sample. Query B
+    /// (100 candidates in one cell) then measures k=100 alone at width 1,
+    /// NARROWER than the two-query k=10 point (width 4) — the monotone
+    /// floor lifts it, because a larger k probing fewer cells would invert
+    /// recall at query time.
+    #[test]
+    fn width_law_supports_points_per_query_and_stays_monotone() {
+        const DIM: usize = 4;
+        let grid = ClusterCentroids::from_fp32(
+            4,
+            DIM as u32,
+            &[
+                1.0, 0.0, 0.0, 0.0, //
+                0.9, 0.1, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            vec![1; 4],
+        );
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut queries = vec![0.0f32; 2 * DIM];
+        queries[0] = 1.0;
+        queries[DIM] = 1.0;
+        cal.frozen = Some(WidthLawQueries {
+            queries,
+            ids: vec![998, 999],
+        });
+        let k_max = *WIDTH_LAW_KS.last().expect("knots");
+        // A: distinct ids 1..=10 spread 2/2/3/3 over cells 0..=3, so its
+        // 0.99 top-10 coverage needs the 4th-ranked cell.
+        let a: Vec<(f32, u32, i128)> = (1..=10)
+            .map(|id| {
+                let cell = match id {
+                    1 | 2 => 0u32,
+                    3 | 4 => 1,
+                    5..=7 => 2,
+                    _ => 3,
+                };
+                (id as f32 * 0.01, cell, id as i128)
+            })
+            .collect();
+        // B: distinct ids 100..=199, every one in the top-ranked cell.
+        let b: Vec<(f32, u32, i128)> = (100..200)
+            .map(|id| (id as f32 * 0.001, 0u32, id as i128))
+            .collect();
+        let (mut acc_a, mut acc_b) = (Vec::new(), Vec::new());
+        merge_candidates(&mut acc_a, a, k_max);
+        merge_candidates(&mut acc_b, b, k_max);
+        *cal.tops.lock().unwrap_or_else(PoisonError::into_inner) = vec![acc_a, acc_b];
+
+        let law = cal.finish(&grid).expect("law from planted candidates");
+        assert_eq!(law[0], 1, "top-1: both queries covered by the nearest cell");
+        assert_eq!(
+            law[1], 4,
+            "k=10 measured over both queries needs A's spread"
+        );
+        assert_eq!(
+            law[2], 4,
+            "k=100: B alone measures width 1; the monotone floor lifts it \
+             to the k=10 width instead of stamping a recall inversion"
+        );
+        assert_eq!(law[3], 0, "k=1000 has no supporting query and stays 0");
     }
     use crate::superfile::vector::{
         cell_posting::{encode_blob, load_encoded_rows_from_blob},

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -903,7 +903,14 @@ impl WidthLawCalibration {
                 // accumulates the mean coverage curve.
                 let mut per_rank = vec![0u32; n_cells];
                 for (_, cell, _) in &sorted[..k] {
-                    per_rank[rank_of_cell[*cell as usize] as usize] += 1;
+                    // Candidate cell ids come from the same drain that built
+                    // `grid` and split parents keep their slot when
+                    // superseded, so an out-of-range id is unreachable today
+                    // — but calibration is best-effort diagnostics: an
+                    // inconsistent input abandons the law (unstamped ⇒
+                    // default routing) rather than panicking the drain.
+                    let &rank = rank_of_cell.get(*cell as usize)?;
+                    per_rank[rank as usize] += 1;
                 }
                 let mut covered = 0u32;
                 for (rank, count) in per_rank.iter().enumerate() {
@@ -1152,6 +1159,42 @@ mod tests {
              to the k=10 width instead of stamping a recall inversion"
         );
         assert_eq!(law[3], 0, "k=1000 has no supporting query and stays 0");
+    }
+
+    /// An out-of-range cell id in the candidates (impossible in the current
+    /// drain flow, by construction) abandons the law instead of panicking —
+    /// calibration is diagnostics riding a drain and must never abort one.
+    #[test]
+    fn width_law_bails_on_out_of_range_cell_id() {
+        const DIM: usize = 4;
+        let grid = ClusterCentroids::from_fp32(
+            2,
+            DIM as u32,
+            &[
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0,
+            ],
+            vec![1; 2],
+        );
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut query = vec![0.0f32; DIM];
+        query[0] = 1.0;
+        cal.frozen = Some(WidthLawQueries {
+            queries: query,
+            ids: vec![999],
+        });
+        // Cell 7 does not exist in the two-cell grid.
+        let mut acc = Vec::new();
+        merge_candidates(
+            &mut acc,
+            vec![(0.01, 7, 1)],
+            *WIDTH_LAW_KS.last().expect("knots"),
+        );
+        *cal.tops.lock().unwrap_or_else(PoisonError::into_inner) = vec![acc];
+        assert!(
+            cal.finish(&grid).is_none(),
+            "inconsistent calibration input must abandon the law, not panic"
+        );
     }
     use crate::superfile::vector::{
         cell_posting::{encode_blob, load_encoded_rows_from_blob},

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -26,20 +26,28 @@
 //! manifest centroids and rows to fp32 before [`distance`]; rows are
 //! re-spliced with [`encode_encoded_rows`], never decoded to full fp32 corpora.
 
-use std::{cmp::Ordering, collections::HashMap};
+use std::{cmp::Ordering, collections::HashMap, sync::Mutex};
 
 use crate::{
     config,
     superfile::vector::{
         cell_posting::{
-            EncodedCellRow, dequantize_sq8_residual_into, manifest_centroid_components_from_row,
+            EncodedCellRow, MaterializedIvfRow, dequantize_sq8_residual_into,
+            manifest_centroid_components_from_row,
         },
-        distance::{Metric, distance, nearest_k_centroids_transposed, relative_score_window},
+        distance::{
+            Metric, distance, nearest_k_centroids_transposed, normalize, relative_score_window,
+        },
         kmeans::{kmeans, kmeans_pp},
+        reservoir::Reservoir,
+        spill::SpilledCellRows,
     },
-    supertable::manifest::{
-        ClusterCentroids, RABITQ_ADMIT_CELL_SHORTLIST_FRACTION, RABITQ_ADMIT_CELL_SHORTLIST_MIN,
-        RabitqAdmitContext,
+    supertable::{
+        error::BuildError,
+        manifest::{
+            ClusterCentroids, RABITQ_ADMIT_CELL_SHORTLIST_FRACTION,
+            RABITQ_ADMIT_CELL_SHORTLIST_MIN, RabitqAdmitContext, list::WIDTH_LAW_KS,
+        },
     },
 };
 
@@ -221,18 +229,7 @@ pub(crate) fn boundary_assignment_encoded(
     admit_ctx: &RabitqAdmitContext,
     window: usize,
 ) -> BoundaryAssignment {
-    let dim = clusters.dim as usize;
-    let mut row_fp = vec![0f32; dim];
-    dequantize_sq8_residual_into(
-        &row.scale,
-        &row.offset,
-        &row.codes,
-        &row.residuals,
-        row.rerank_codec
-            .residual_divisor()
-            .expect("encoded row uses residual-family codec"),
-        &mut row_fp,
-    );
+    let row_fp = dequantize_row(row, clusters.dim as usize);
     boundary_assignment_fp32(clusters, metric, &row_fp, admit_ctx, window)
 }
 
@@ -314,6 +311,13 @@ fn boundary_from_ranked(
 /// Dequantize one Sq8+ε residual row to fp32.
 fn dequantize_row(row: &EncodedCellRow, dim: usize) -> Vec<f32> {
     let mut out = vec![0f32; dim];
+    dequantize_row_into(row, &mut out);
+    out
+}
+
+/// [`dequantize_row`] into a caller-owned scratch (hot loops reuse one
+/// allocation). The scratch length is the row's `dim`.
+fn dequantize_row_into(row: &EncodedCellRow, out: &mut [f32]) {
     dequantize_sq8_residual_into(
         &row.scale,
         &row.offset,
@@ -322,9 +326,8 @@ fn dequantize_row(row: &EncodedCellRow, dim: usize) -> Vec<f32> {
         row.rerank_codec
             .residual_divisor()
             .expect("encoded row uses residual-family codec"),
-        &mut out,
+        out,
     );
-    out
 }
 
 /// Ashman D of a two-means partition, measured on the 1-D projection onto the
@@ -692,6 +695,225 @@ pub(crate) fn plan_sq8_split_kway(
         );
     }
     (cents, cand)
+}
+
+// ---------- Drain-time probe-width calibration ----------
+
+/// Rows reservoir-sampled as stand-in queries for probe-width calibration.
+/// Corpus rows are the right calibration distribution — on Cohere-1M/768d,
+/// stored-row queries and the dataset's held-out test queries measured the
+/// same top-k cell spread.
+const WIDTH_LAW_QUERY_SAMPLE: usize = 256;
+/// Mean top-k coverage a probe width must reach to be recorded in the law —
+/// the engine's recall@k acceptance bar.
+const WIDTH_LAW_TARGET_COVERAGE: f64 = 0.99;
+/// Fixed seed for the calibration reservoir, so a re-drained identical
+/// corpus stamps an identical law.
+const WIDTH_LAW_SAMPLE_SEED: u64 = 0x51ED_CA1B;
+/// Rows decoded per chunk while scoring a spilled cell.
+const WIDTH_LAW_SCORE_CHUNK: usize = 1024;
+
+/// Frozen query sample: dequantized fp32 vectors + their stable ids
+/// (self-hit exclusion while scoring).
+struct WidthLawQueries {
+    queries: Vec<f32>,
+    ids: Vec<i128>,
+}
+
+/// Drain-time probe-width calibration: measures, on this table's own data,
+/// how many grid cells (in routing order) cover the exact top-k, and stamps
+/// the result into the manifest's [`CellRoutingParams::width_for_k`] law.
+///
+/// How far the true top-k spreads over cells is a property of the corpus —
+/// synthetic clustered data concentrates (1 cell at k = 10), real text
+/// embeddings spray (Cohere-1M/768d measured ~30 of 256 cells at k = 100,
+/// identical under a converged reference clustering, so it is the data and
+/// not grid quality) — which is why the default probe width must be
+/// measured per table rather than hardcoded.
+///
+/// Lifecycle inside one clean (non-resumed) drain:
+///   1. [`Self::offer`] on every spilled row — [`Reservoir`]-samples the
+///      stand-in queries (sequential; the spill loop holds `&mut`).
+///   2. [`Self::freeze`] once all batches have spilled.
+///   3. [`Self::score_cell`] per cell during the pack fan-out — re-reads
+///      the cell's spill (the pack pass reads it anyway), scores every row
+///      with the shared [`distance`] kernel (rows unit-normalized for
+///      cosine, matching the rerank kernels' norm division), and merges
+///      that cell's per-query top-k under one lock per cell.
+///   4. [`Self::finish`] before the drain's manifest stamp — ranks cells
+///      with the same [`ClusterCentroids::rank_cells`] routing order
+///      queries use and extracts the width law.
+///
+/// Resumed drains skip calibration entirely (checkpointed batches never
+/// re-stream), keeping whatever law the manifest already carries.
+pub(crate) struct WidthLawCalibration {
+    dim: usize,
+    metric: Metric,
+    reservoir: Reservoir,
+    /// Stable id of each reservoir slot, kept in lockstep through
+    /// [`Reservoir::update_traced`].
+    slot_ids: Vec<i128>,
+    dequant_scratch: Vec<f32>,
+    frozen: Option<WidthLawQueries>,
+    /// Per-query `(score, cell)` candidates, truncated to the largest law
+    /// `k` as cells merge in.
+    tops: Mutex<Vec<Vec<(f32, u32)>>>,
+}
+
+impl WidthLawCalibration {
+    pub(crate) fn new(dim: usize, metric: Metric) -> Self {
+        Self {
+            dim,
+            metric,
+            reservoir: Reservoir::new(WIDTH_LAW_QUERY_SAMPLE, dim, WIDTH_LAW_SAMPLE_SEED),
+            slot_ids: Vec::with_capacity(WIDTH_LAW_QUERY_SAMPLE),
+            dequant_scratch: vec![0f32; dim],
+            frozen: None,
+            tops: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Offer one spilled row as a calibration-query candidate.
+    pub(crate) fn offer(&mut self, row: &MaterializedIvfRow) {
+        debug_assert!(self.frozen.is_none(), "offer after freeze");
+        dequantize_row_into(&row.encoded, &mut self.dequant_scratch);
+        if let Some(slot) = self.reservoir.update_traced(&self.dequant_scratch) {
+            if slot == self.slot_ids.len() {
+                self.slot_ids.push(row.stable_id);
+            } else {
+                self.slot_ids[slot] = row.stable_id;
+            }
+        }
+    }
+
+    /// Freeze the sampled queries. Called once, after the last batch
+    /// spilled and before cell packing scores.
+    pub(crate) fn freeze(&mut self) {
+        let queries = self.reservoir.sample().to_vec();
+        let ids = self.slot_ids.clone();
+        *self.tops.lock().expect("width-law tops lock") = vec![Vec::new(); ids.len()];
+        self.frozen = Some(WidthLawQueries { queries, ids });
+    }
+
+    /// Score every row of one spilled cell against the frozen queries and
+    /// merge into the per-query candidate lists. Safe to call from the
+    /// pack fan-out workers; the merge takes one lock per cell.
+    pub(crate) fn score_cell(&self, cell: u32, spill: &SpilledCellRows) -> Result<(), BuildError> {
+        let Some(frozen) = self.frozen.as_ref() else {
+            return Err(BuildError::Store(
+                "width-law score_cell before freeze".into(),
+            ));
+        };
+        let n_queries = frozen.ids.len();
+        if n_queries == 0 {
+            return Ok(());
+        }
+        let k_max = *WIDTH_LAW_KS.last().expect("law has k points");
+        let mut partial: Vec<Vec<(f32, u32)>> = vec![Vec::new(); n_queries];
+        let mut reader = spill.reader()?;
+        let mut remaining = spill.n_rows();
+        let mut scratch = vec![0f32; self.dim];
+        while remaining > 0 {
+            let chunk = reader.next_chunk(WIDTH_LAW_SCORE_CHUNK.min(remaining))?;
+            remaining -= chunk.len();
+            for row in &chunk {
+                dequantize_row_into(&row.encoded, &mut scratch);
+                if self.metric == Metric::Cosine {
+                    // The rerank kernels divide by the stored row norm;
+                    // unit-normalizing the row lets the shared [`distance`]
+                    // kernel (which assumes unit inputs for cosine) score
+                    // with the same ranking. Query scaling is per-query
+                    // monotone and cannot reorder its candidates.
+                    normalize(&mut scratch);
+                }
+                for (qi, q) in frozen.queries.chunks_exact(self.dim).enumerate() {
+                    // Self-hit: a sampled query trivially covers itself.
+                    if row.stable_id == frozen.ids[qi] {
+                        continue;
+                    }
+                    partial[qi].push((distance(self.metric, q, &scratch), cell));
+                }
+            }
+            // Bound the per-cell partials the same way the merge does.
+            for cand in &mut partial {
+                truncate_ascending(cand, k_max);
+            }
+        }
+        let mut tops = self.tops.lock().expect("width-law tops lock");
+        for (qi, mut cand) in partial.into_iter().enumerate() {
+            tops[qi].append(&mut cand);
+            truncate_ascending(&mut tops[qi], k_max);
+        }
+        Ok(())
+    }
+
+    /// Extract the width law: cells (in the grid's routing order) needed
+    /// for mean [`WIDTH_LAW_TARGET_COVERAGE`] coverage of the exact top-k
+    /// at each [`WIDTH_LAW_KS`] point. Points the sample cannot support
+    /// (k exceeding any query's candidate count) stay `0` (uncalibrated).
+    /// `None` when nothing was sampled.
+    pub(crate) fn finish(self, grid: &ClusterCentroids) -> Option<[u32; WIDTH_LAW_KS.len()]> {
+        let frozen = self.frozen?;
+        let n_queries = frozen.ids.len();
+        if n_queries == 0 || grid.n_cent == 0 {
+            return None;
+        }
+        let n_cells = grid.n_cent as usize;
+        let tops = self.tops.into_inner().expect("width-law tops lock");
+        // Superseded or empty cells inflate ranks slightly (routing skips
+        // them, this count does not) — an over-probe, never an under-probe;
+        // fresh drains, the normal calibration moment, have neither.
+        let mut law = [0u32; WIDTH_LAW_KS.len()];
+        let mut coverage_sums: Vec<Vec<f64>> = vec![vec![0f64; n_cells]; WIDTH_LAW_KS.len()];
+        let mut supported = [true; WIDTH_LAW_KS.len()];
+        let mut rank_of_cell = vec![0u32; n_cells];
+        for (qi, cand) in tops.iter().enumerate() {
+            let q = &frozen.queries[qi * self.dim..(qi + 1) * self.dim];
+            let ranked = grid.rank_cells(self.metric, q);
+            for (rank, (cell, _)) in ranked.iter().enumerate() {
+                if let Some(slot) = rank_of_cell.get_mut(*cell as usize) {
+                    *slot = rank as u32;
+                }
+            }
+            let mut sorted = cand.clone();
+            sorted.sort_unstable_by(|a, b| a.0.total_cmp(&b.0));
+            for (ki, &k) in WIDTH_LAW_KS.iter().enumerate() {
+                if sorted.len() < k {
+                    supported[ki] = false;
+                    continue;
+                }
+                // Per-rank counts of this query's top-k, then a prefix walk
+                // accumulates the mean coverage curve.
+                let mut per_rank = vec![0u32; n_cells];
+                for (_, cell) in &sorted[..k] {
+                    per_rank[rank_of_cell[*cell as usize] as usize] += 1;
+                }
+                let mut covered = 0u32;
+                for (rank, count) in per_rank.iter().enumerate() {
+                    covered += count;
+                    coverage_sums[ki][rank] += f64::from(covered) / k as f64;
+                }
+            }
+        }
+        for (ki, sums) in coverage_sums.iter().enumerate() {
+            if !supported[ki] {
+                continue;
+            }
+            let target = WIDTH_LAW_TARGET_COVERAGE * n_queries as f64;
+            if let Some(rank) = sums.iter().position(|&s| s >= target) {
+                law[ki] = (rank + 1) as u32;
+            }
+        }
+        (law.iter().any(|&w| w > 0)).then_some(law)
+    }
+}
+
+/// Keep the ascending-best `cap` candidates in place.
+fn truncate_ascending(cand: &mut Vec<(f32, u32)>, cap: usize) {
+    if cand.len() > cap {
+        cand.sort_unstable_by(|a, b| a.0.total_cmp(&b.0));
+        cand.truncate(cap);
+    }
 }
 
 /// Two-centroid (`k = 2`) test-only wrapper over [`plan_sq8_split_kway`],

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1411,41 +1411,14 @@ impl SupertableReader {
                 } else {
                     None
                 };
-            // Explicit caller `nprobe` pins the cell sweep width on every
-            // branch — an override is honored, never discarded. The
-            // persisted hidden routing (fine-first p=1) stays the
-            // no-override default, but measured on Cohere-1M/768d at k=100
-            // the single probed cell caps recall at 0.61 even scanned in
-            // full, so callers need the width dial to buy recall past that
-            // ceiling. Fine depth is untouched by the pin: the filtered
-            // floors above still apply, unfiltered keeps its branch's depth.
-            //
-            // `sweep_width` — the per-sweep rerank-budget divide and the
-            // per-fragment fine gating downstream — engages on UNFILTERED
-            // sweeps only: a filtered query keeps its pre-width budget and
-            // wave-pooled gating even under an explicit `nprobe`, because a
-            // sparse allow-set's shortlist divided across cells starves.
-            // The width is clamped to the cells that actually carry
-            // postings: the budget divide must split by what the sweep can
-            // read, not by an override larger than the populated grid.
             let populated_cells = postings_by_cell.len().max(1);
-            if options.nprobe.is_some() {
-                cell_routing.nprobe_min = nprobe.max(1);
-                cell_routing.nprobe_max = nprobe.max(1);
-                if !filtered {
-                    sweep_width = Some(nprobe.clamp(1, populated_cells));
-                }
-            } else if let Some(width) = law_width {
-                cell_routing.nprobe_min = width;
-                cell_routing.nprobe_max = width;
-                sweep_width = Some(width.min(populated_cells));
-                // The law was calibrated against exact top-k, so its
-                // coverage numbers assume a probed cell is read in full
-                // (measured: half-depth caps recall at 0.964 where full
-                // depth reaches 0.995). Depth rides with the law; the
-                // per-fragment gate clamps to each fragment's run count.
-                cell_routing.fine_nprobe = usize::MAX;
-            }
+            sweep_width = apply_width_pin(
+                &mut cell_routing,
+                options.nprobe.map(|n| n.max(1)),
+                law_width,
+                filtered,
+                populated_cells,
+            );
             // Per-cell fine probe = max(floor, floor(pct × cell fine-cluster
             // count)), so depth scales with cell size. Filtered queries keep
             // their own fixed fine floor (pct = 0); the proportional depth
@@ -2789,6 +2762,50 @@ fn subtract_tombstones(
 /// distance (smallest = closest). Uses a max-heap of size k so
 /// we never sort more than k elements — O(S·k·log k) instead of
 /// O(S·k·log(S·k)) for the full-sort approach.
+/// One shared width override on top of the per-branch base routing:
+/// explicit caller `nprobe` pins the cell sweep width on every branch —
+/// an override is honored, never discarded — and with no override a
+/// drain-calibrated law width pins the same way. Returns the engaged
+/// `sweep_width` (drives the per-sweep rerank-budget divide and the
+/// per-fragment fine gating downstream), `None` when nothing pinned.
+///
+/// Depth rides the width on the UNFILTERED path, for the pin exactly as
+/// for the law: the law's coverage numbers assume a probed cell is read
+/// in full (measured: half-depth caps recall at 0.964 where full depth
+/// reaches 0.995), and a caller-widened sweep at the persisted
+/// fine-first depth contributes only each cell's first runs — measured
+/// ~0.83 recall@100 on Cohere-1M REGARDLESS of width, a dial that
+/// widened without deepening. The per-fragment gate still clamps to
+/// each fragment's real run count. FILTERED queries keep their own fine
+/// floors (already applied to `routing` by the base branch) and never
+/// engage `sweep_width`: a sparse allow-set's shortlist divided across
+/// cells starves. `populated_cells` clamps the width the budget divide
+/// splits by — never more than the cells that actually carry postings.
+fn apply_width_pin(
+    routing: &mut CellRoutingParams,
+    caller_nprobe: Option<usize>,
+    law_width: Option<usize>,
+    filtered: bool,
+    populated_cells: usize,
+) -> Option<usize> {
+    if let Some(nprobe) = caller_nprobe {
+        routing.nprobe_min = nprobe;
+        routing.nprobe_max = nprobe;
+        if filtered {
+            return None;
+        }
+        routing.fine_nprobe = usize::MAX;
+        Some(nprobe.clamp(1, populated_cells))
+    } else if let Some(width) = law_width {
+        routing.nprobe_min = width;
+        routing.nprobe_max = width;
+        routing.fine_nprobe = usize::MAX;
+        Some(width.min(populated_cells))
+    } else {
+        None
+    }
+}
+
 fn top_k_ascending(per_superfile: Vec<Vec<SuperfileHit>>, k: usize) -> Vec<SuperfileHit> {
     // Total order over hits: distance ascending, then the unique
     // `(superfile, local_doc_id)` key. The tie-break makes the kept set
@@ -2947,10 +2964,10 @@ mod tests {
 
     use super::{
         RABITQ_ADMIT_CELL_SHORTLIST_MIN, SCORE_COLUMN, VectorFilter, VectorSearchOptions,
-        admit_shortlist_window, cells_ranked_by_fine_score, gate_fine_candidates_by_fragment,
-        hidden_hits_user_ids, is_hidden_vector_manifest, postings_by_cell_from_summaries,
-        projection_is_id_score_only, score_fine_candidates, union_cell_selection,
-        vector_read_query_error,
+        admit_shortlist_window, apply_width_pin, cells_ranked_by_fine_score,
+        gate_fine_candidates_by_fragment, hidden_hits_user_ids, is_hidden_vector_manifest,
+        postings_by_cell_from_summaries, projection_is_id_score_only, score_fine_candidates,
+        union_cell_selection, vector_read_query_error,
     };
     use crate::{
         InfinoError,
@@ -2963,7 +2980,10 @@ mod tests {
         supertable::{
             Supertable, SupertableOptions,
             error::QueryError,
-            manifest::{ClusterCentroids, list::PartitionStrategy},
+            manifest::{
+                ClusterCentroids,
+                list::{CellRoutingParams, PartitionStrategy},
+            },
         },
         test_helpers::default_tokenizer as tok,
     };
@@ -4245,6 +4265,50 @@ mod tests {
              {k} exact neighbors across three cells — caller nprobe is an \
              override, never discarded"
         );
+    }
+
+    /// [`apply_width_pin`] semantics, all four arms. Depth MUST ride the
+    /// width on unfiltered pins — a widened sweep at the persisted
+    /// fine-first depth reads only each cell's first runs and caps recall
+    /// regardless of width (measured ~0.83 on Cohere-1M at any nprobe).
+    #[test]
+    fn width_pin_lifts_fine_depth_on_unfiltered_overrides() {
+        let base = CellRoutingParams {
+            nprobe_min: 1,
+            nprobe_max: 1,
+            fine_nprobe: 6,
+            ..CellRoutingParams::default()
+        };
+
+        // Unfiltered caller nprobe: width pinned, depth lifted, sweep
+        // engaged (clamped to populated cells).
+        let mut r = base;
+        let sweep = apply_width_pin(&mut r, Some(64), None, false, 40);
+        assert_eq!((r.nprobe_min, r.nprobe_max), (64, 64));
+        assert_eq!(r.fine_nprobe, usize::MAX, "depth rides the pin");
+        assert_eq!(sweep, Some(40), "sweep width clamps to populated cells");
+
+        // Filtered caller nprobe: width pinned, but the filtered fine
+        // floor is preserved and the width machinery stays disengaged.
+        let mut r = base;
+        let sweep = apply_width_pin(&mut r, Some(64), None, true, 40);
+        assert_eq!((r.nprobe_min, r.nprobe_max), (64, 64));
+        assert_eq!(r.fine_nprobe, 6, "filtered floors untouched by the pin");
+        assert_eq!(sweep, None, "filtered sweeps keep pre-width budget");
+
+        // Law width (no caller override): same pin + depth as an explicit
+        // unfiltered nprobe.
+        let mut r = base;
+        let sweep = apply_width_pin(&mut r, None, Some(45), false, 256);
+        assert_eq!((r.nprobe_min, r.nprobe_max), (45, 45));
+        assert_eq!(r.fine_nprobe, usize::MAX, "depth rides the law");
+        assert_eq!(sweep, Some(45));
+
+        // Nothing pinned: routing untouched.
+        let mut r = base;
+        let sweep = apply_width_pin(&mut r, None, None, false, 256);
+        assert_eq!(r, base);
+        assert_eq!(sweep, None);
     }
 
     /// A clean drain calibrates the probe-width law from the table's own

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -4237,6 +4237,40 @@ mod tests {
         );
     }
 
+    /// An incremental drain calibrates only the newly spilled tail; its
+    /// measurement must never NARROW the stamped law (element-wise max
+    /// merge), or a small tightly-clustered append would under-probe all
+    /// older data. The delta here spans few directions, so its own law is
+    /// far narrower than the fixture's — the default search must still
+    /// recover the full three-cell top-k afterward.
+    #[test]
+    fn incremental_drain_never_narrows_the_width_law() {
+        let (_dir, st, q, k) = drained_three_direction_fixture();
+        let mut w = st.writer().expect("writer");
+        w.append(&build_vector_batch(
+            (FIXTURE_COMMITS * FIXTURE_ROWS_PER_COMMIT as u64) + 1,
+            DOCS_PER_DIRECTION,
+            FIXTURE_DIM,
+            schema_with_vector(FIXTURE_DIM),
+        ))
+        .expect("append delta");
+        w.commit().expect("commit delta");
+        st.drain_vectors_to_cells_sync().expect("incremental drain");
+
+        let hits = st
+            .reader()
+            .vector_hits("emb", &q, k, VectorSearchOptions::new(), None)
+            .expect("default search after incremental drain");
+        let near = near_count(&hits);
+        assert_eq!(
+            near,
+            k,
+            "the delta-only calibration must not narrow the stamped law: \
+             default search lost {} of {k} planted neighbors",
+            k - near
+        );
+    }
+
     /// The `Supertable::vector_search` handle wrapper (tests normally call
     /// `reader().vector_search`) delegates to the reader and returns rows.
     #[test]

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -114,6 +114,15 @@ use crate::{
     },
 };
 
+/// Oversample factor on the per-sweep rerank budget. Dividing
+/// `k x rerank_mult` evenly across the sweep under-serves the nearest
+/// cells (they hold most true neighbors, and the 1-bit estimate ranks
+/// some of them deep within their cell): an even split measured
+/// 0.9695 recall@100 on Cohere-1M vs 0.9937 for undivided caps, and 2x
+/// headroom still only 0.9865. 4x holds the bar while keeping the total
+/// survivor budget well below the undivided width sweep.
+const WIDTH_BUDGET_OVERSAMPLE: usize = 4;
+
 /// Candidate growth when a deleted row occupies a current top-k slot.
 const DELETE_REFILL_GROWTH_FACTOR: usize = 2;
 
@@ -1341,6 +1350,9 @@ impl SupertableReader {
 
         let mut gated = Vec::new();
         let mut scored = Vec::new();
+        // Width the sweep was pinned to (caller nprobe or the width law);
+        // `None` on the fine-first default and legacy paths.
+        let mut sweep_width: Option<usize> = None;
         // Assigned in both admit arms; used below for the posting-aware
         // budget expand (keep scoring until we cover ≥ k postings).
         let candidate_counts: HashMap<(usize, u32), u64>;
@@ -1405,9 +1417,11 @@ impl SupertableReader {
             if options.nprobe.is_some() {
                 cell_routing.nprobe_min = nprobe.max(1);
                 cell_routing.nprobe_max = nprobe.max(1);
+                sweep_width = Some(nprobe.max(1));
             } else if let Some(width) = law_width {
                 cell_routing.nprobe_min = width;
                 cell_routing.nprobe_max = width;
+                sweep_width = Some(width);
                 // The law was calibrated against exact top-k, so its
                 // coverage numbers assume a probed cell is read in full
                 // (measured: half-depth caps recall at 0.964 where full
@@ -1722,6 +1736,24 @@ impl SupertableReader {
         // capping the number of concurrent superfiles keeps that transient
         // memory bounded by instance configuration instead of table size.
         // Skipped superfiles issue zero GETs.
+        // Per-sweep rerank budget. The `k x rerank_mult` shortlist cap was
+        // sized for the fine-first p=1 read: applied per probed cell it
+        // exceeds any cell's row count, so at width every row of every
+        // probed cell "survives" the 1-bit prune and the survivor-only
+        // rerank fetch degenerates into fetching whole cells (measured:
+        // ~6.5 MB x 54 cells per query at w=54). Divide the cap across the
+        // sweep so the TOTAL survivor budget stays ~k x rerank_mult —
+        // measured sufficient at that total: 0.9957 recall@100 on
+        // Cohere-1M with ~25.6K survivors.
+        let options = match sweep_width {
+            Some(w) if w > 1 => {
+                let (_, rerank_mult) = options.resolve(filtered);
+                options.with_rerank_mult(
+                    (rerank_mult * WIDTH_BUDGET_OVERSAMPLE).div_ceil(w).max(1),
+                )
+            }
+            _ => options,
+        };
         let column_arc = Arc::new(column.to_owned());
         let query_arc = Arc::new(query.to_vec());
         let reader_pool = Arc::clone(&manifest.options.reader_pool);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1419,14 +1419,26 @@ impl SupertableReader {
             // full, so callers need the width dial to buy recall past that
             // ceiling. Fine depth is untouched by the pin: the filtered
             // floors above still apply, unfiltered keeps its branch's depth.
+            //
+            // `sweep_width` — the per-sweep rerank-budget divide and the
+            // per-fragment fine gating downstream — engages on UNFILTERED
+            // sweeps only: a filtered query keeps its pre-width budget and
+            // wave-pooled gating even under an explicit `nprobe`, because a
+            // sparse allow-set's shortlist divided across cells starves.
+            // The width is clamped to the cells that actually carry
+            // postings: the budget divide must split by what the sweep can
+            // read, not by an override larger than the populated grid.
+            let populated_cells = postings_by_cell.len().max(1);
             if options.nprobe.is_some() {
                 cell_routing.nprobe_min = nprobe.max(1);
                 cell_routing.nprobe_max = nprobe.max(1);
-                sweep_width = Some(nprobe.max(1));
+                if !filtered {
+                    sweep_width = Some(nprobe.clamp(1, populated_cells));
+                }
             } else if let Some(width) = law_width {
                 cell_routing.nprobe_min = width;
                 cell_routing.nprobe_max = width;
-                sweep_width = Some(width);
+                sweep_width = Some(width.min(populated_cells));
                 // The law was calibrated against exact top-k, so its
                 // coverage numbers assume a probed cell is read in full
                 // (measured: half-depth caps recall at 0.964 where full
@@ -1532,7 +1544,7 @@ impl SupertableReader {
                 // depth follows width, read amplification is what was asked
                 // for (explicitly by the caller, or measured as necessary
                 // by the drain's calibration).
-                let generation_of = if options.nprobe.is_some() || law_width.is_some() {
+                let generation_of = if sweep_width.is_some() {
                     None
                 } else {
                     Some(birth_versions.as_slice())
@@ -1753,7 +1765,12 @@ impl SupertableReader {
         let options = match sweep_width {
             Some(w) if w > 1 => {
                 let (_, rerank_mult) = options.resolve(filtered);
-                options.with_rerank_mult((rerank_mult * WIDTH_BUDGET_OVERSAMPLE).div_ceil(w).max(1))
+                options.with_rerank_mult(
+                    rerank_mult
+                        .saturating_mul(WIDTH_BUDGET_OVERSAMPLE)
+                        .div_ceil(w)
+                        .max(1),
+                )
             }
             _ => options,
         };
@@ -4081,13 +4098,21 @@ mod tests {
                 None,
             )
             .expect("wide search");
+        let unfiltered_exact = near_count(&hits);
         assert!(
-            hits.len() >= 8,
-            "e_0 has 8 exact matches across commits; wide search must find them, got {}",
-            hits.len()
+            unfiltered_exact >= 8,
+            "e_0 has 8 exact matches across commits; wide search must find \
+             them, got {unfiltered_exact}"
         );
 
-        // Filtered variant over the same corpus.
+        // Filtered variant over the same corpus. The title predicate
+        // matches every row, so the allow-set machinery runs with full
+        // coverage and must recover the SAME exact matches as the
+        // unfiltered sweep — pinning that a filtered query with an explicit
+        // `nprobe` keeps its full per-cell shortlist (the width-era
+        // rerank-budget divide and per-fragment gating are unfiltered-only
+        // semantics; a filtered sweep that picked them up would starve a
+        // sparse allow-set).
         let filtered = st
             .reader()
             .expect("reader")
@@ -4103,7 +4128,12 @@ mod tests {
                 }),
             )
             .expect("filtered wide search");
-        assert!(!filtered.is_empty(), "filtered wide search returns hits");
+        assert_eq!(
+            near_count(&filtered),
+            unfiltered_exact,
+            "filtered+nprobe must find the same exact matches as the \
+             unfiltered sweep"
+        );
     }
 
     /// Score bound separating planted neighbors from orthogonal docs in the

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1345,32 +1345,11 @@ impl SupertableReader {
         // budget expand (keep scoring until we cover ≥ k postings).
         let candidate_counts: HashMap<(usize, u32), u64>;
         if let (Some(ranked_scored), true) = (&ranked_cells_scored, any_tagged) {
-            let cell_routing = if hidden_vector_index {
+            // Base routing shape first (per branch), then one shared caller
+            // override on top.
+            let mut cell_routing = if hidden_vector_index {
                 let base = hidden_routing.expect("hidden manifest carries routing");
-                if options.nprobe.is_some() && (filtered || options.widen_unfiltered_hidden_cells) {
-                    // Explicit caller `nprobe` pins the hidden cell sweep. FILTERED
-                    // queries always honor it (the width-dial calibration and the
-                    // filtered sweep). UNFILTERED hidden queries honor it only when
-                    // `widen_unfiltered_hidden_cells` is set — a diagnostic whose
-                    // setter is `#[cfg(feature = "test-helpers")]`, so it is
-                    // unreachable from the production public API and used only by
-                    // the recall breadth-sweep bench. In production the flag is
-                    // always `false`, so an explicit `nprobe` on an unfiltered
-                    // hidden query keeps the persisted p=1 routing (the `else` arms
-                    // below) — `with_nprobe` does not change serving behavior.
-                    // Filtered queries additionally lift per-cell fine depth to the
-                    // filtered floor; unfiltered keeps the persisted fine depth.
-                    CellRoutingParams {
-                        nprobe_min: nprobe.max(1),
-                        nprobe_max: nprobe.max(1),
-                        fine_nprobe: if filtered {
-                            base.fine_nprobe.max(FILTERED_HIDDEN_FINE_NPROBE)
-                        } else {
-                            base.fine_nprobe
-                        },
-                        ..base
-                    }
-                } else if filtered {
+                if filtered {
                     // Allow-set queries widen to the filtered floor and
                     // probe DEEPER fine runs per cell — the matching
                     // neighbors sit past the unfiltered top runs; the
@@ -1383,12 +1362,6 @@ impl SupertableReader {
                     }
                 } else {
                     base
-                }
-            } else if options.nprobe.is_some() {
-                CellRoutingParams {
-                    nprobe_min: nprobe.max(1),
-                    nprobe_max: nprobe.max(1),
-                    ..CellRoutingParams::default()
                 }
             } else if filtered {
                 // Filtered UNDRAINED-tail fan: the default user-table
@@ -1403,6 +1376,45 @@ impl SupertableReader {
             } else {
                 CellRoutingParams::default()
             };
+            // Per-table probe-width law: when the drain calibrated one and
+            // the caller passed nothing, the law's width for this `k` acts
+            // exactly like an explicit caller `nprobe` — same pin, same
+            // per-fragment gating downstream. How far the true top-k
+            // spreads over cells is a property of the corpus (synthetic
+            // clustered data calibrates to 1 cell at k=10; Cohere-1M/768d
+            // measured ~30 of 256 cells at k=100), so the default width
+            // must be per-table and per-k, never a constant. A law width
+            // of 1 resolves to `None` and keeps the fine-first p=1 path
+            // byte-for-byte.
+            let law_width: Option<usize> =
+                if hidden_vector_index && !filtered && options.nprobe.is_none() {
+                    hidden_routing
+                        .and_then(|r| r.width_for_k_at(k))
+                        .filter(|w| *w > 1)
+                } else {
+                    None
+                };
+            // Explicit caller `nprobe` pins the cell sweep width on every
+            // branch — an override is honored, never discarded. The
+            // persisted hidden routing (fine-first p=1) stays the
+            // no-override default, but measured on Cohere-1M/768d at k=100
+            // the single probed cell caps recall at 0.61 even scanned in
+            // full, so callers need the width dial to buy recall past that
+            // ceiling. Fine depth is untouched by the pin: the filtered
+            // floors above still apply, unfiltered keeps its branch's depth.
+            if options.nprobe.is_some() {
+                cell_routing.nprobe_min = nprobe.max(1);
+                cell_routing.nprobe_max = nprobe.max(1);
+            } else if let Some(width) = law_width {
+                cell_routing.nprobe_min = width;
+                cell_routing.nprobe_max = width;
+                // The law was calibrated against exact top-k, so its
+                // coverage numbers assume a probed cell is read in full
+                // (measured: half-depth caps recall at 0.964 where full
+                // depth reaches 0.995). Depth rides with the law; the
+                // per-fragment gate clamps to each fragment's run count.
+                cell_routing.fine_nprobe = usize::MAX;
+            }
             // Per-cell fine probe = max(floor, floor(pct × cell fine-cluster
             // count)), so depth scales with cell size. Filtered queries keep
             // their own fixed fine floor (pct = 0); the proportional depth
@@ -1490,6 +1502,22 @@ impl SupertableReader {
                     union_cell_selection(&grid_cells, &fine_cells)
                 };
                 let selected_cells: HashSet<u32> = selected_cells_ordered.iter().copied().collect();
+                // Wave-pooled depth is the p=1 read-volume model: keep runs
+                // per drain wave so reads track wave count, not probed-cell
+                // count — which also means widening the cell sweep alone
+                // cannot deepen the read (measured flat 0.443 recall@100
+                // from nprobe=4 through 256 on Cohere-1M). An explicit
+                // caller `nprobe` — or the calibrated width law standing in
+                // for one — is a request to actually read N cells, so gate
+                // per (cell, fragment) exactly like the pre-drain user path:
+                // depth follows width, read amplification is what was asked
+                // for (explicitly by the caller, or measured as necessary
+                // by the drain's calibration).
+                let generation_of = if options.nprobe.is_some() || law_width.is_some() {
+                    None
+                } else {
+                    Some(birth_versions.as_slice())
+                };
                 gated = gate_fine_candidates_by_fragment(
                     candidates,
                     &selected_cells,
@@ -1499,7 +1527,7 @@ impl SupertableReader {
                     gated_target,
                     &candidate_counts,
                     &mut scored,
-                    Some(&birth_versions),
+                    generation_of,
                 );
             } else {
                 // Fine-first p=1 over all scored fines. Explicit nprobe /
@@ -4041,6 +4069,124 @@ mod tests {
             )
             .expect("filtered wide search");
         assert!(!filtered.is_empty(), "filtered wide search returns hits");
+    }
+
+    /// Score bound separating planted neighbors from orthogonal docs in the
+    /// drained one-hot fixture: query-aligned directions score well below
+    /// it, every other direction scores exactly 1.0 (cos = 0).
+    const ORTHOGONAL_SCORE: f32 = 0.9;
+    /// Docs planted per one-hot direction (128 docs mod 16 dims).
+    const DOCS_PER_DIRECTION: usize = 8;
+
+    /// Drained planted fixture shared by the probe-width tests: 128 one-hot
+    /// docs over 16 directions in 4 commits, drained into per-direction
+    /// cells, plus a query leaning on three directions — its exact top-24
+    /// spans three cells. Returns `(tempdir, table, query, k)`; the tempdir
+    /// must outlive the table.
+    fn drained_three_direction_fixture() -> (tempfile::TempDir, Supertable, Vec<f32>, usize) {
+        let dim = 16usize;
+        let schema = schema_with_vector(dim);
+        let opts = options_one_superfile_per_commit(dim);
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(crate::storage::LocalFsStorageProvider::new(dir.path()).expect("storage"));
+        let st = Supertable::create(opts.with_storage(storage)).expect("create");
+        for c in 0..4u64 {
+            let mut w = st.writer().expect("writer");
+            w.append(&build_vector_batch(c * 32, 32, dim, schema.clone()))
+                .expect("append");
+            w.commit().expect("commit");
+        }
+        st.drain_vectors_to_cells_sync().expect("drain");
+        let mut q = vec![0.0f32; dim];
+        q[0] = 1.0;
+        q[1] = 0.9;
+        q[2] = 0.8;
+        (dir, st, q, 3 * DOCS_PER_DIRECTION)
+    }
+
+    /// Planted neighbors among `hits` (orthogonal docs score exactly 1.0).
+    fn near_count(hits: &[SuperfileHit]) -> usize {
+        hits.iter().filter(|h| h.score < ORTHOGONAL_SCORE).count()
+    }
+
+    /// Explicit caller `nprobe` widens the post-drain UNFILTERED cell sweep.
+    ///
+    /// Regression test for the discarded-override bug: unfiltered hidden
+    /// routing used to keep the persisted p=1 params and ignore
+    /// `with_nprobe`, so a query whose true top-k spans several cells could
+    /// never recover the neighbors outside the single probed cell (measured
+    /// on Cohere-1M/768d at k=100: recall capped at 0.61 with the probed
+    /// cell scanned in full). The corpus below plants the top-k across
+    /// THREE cells — two would pass even without the fix, because the
+    /// no-override union selection already admits `UNION_FINE_PICKS_MIN = 2`
+    /// fine-ranked cells.
+    #[test]
+    fn caller_nprobe_widens_unfiltered_post_drain_sweep() {
+        let (_dir, st, q, k) = drained_three_direction_fixture();
+
+        // Narrow override: the drain calibrated a wide width law for this
+        // corpus, but `with_nprobe(1)` pulls the sweep back below it — the
+        // override wins in both directions, it is never merely a floor.
+        // (nprobe=1 still reads the grid∪fine union's UNION_FINE_PICKS_MIN
+        // fine picks, so "narrow" means fewer cells than the law, not one.)
+        let narrow_hits = st
+            .reader()
+            .vector_hits(
+                "emb",
+                &q,
+                k,
+                VectorSearchOptions::new().with_nprobe(1),
+                None,
+            )
+            .expect("narrow search");
+        let narrow = near_count(&narrow_hits);
+        assert!(
+            narrow >= DOCS_PER_DIRECTION && narrow < k,
+            "with_nprobe(1) must narrow the sweep below the law-widened \
+             default (got {narrow} of {k})"
+        );
+
+        // Wide override: recovers the full exact top-k across three cells.
+        let wide_hits = st
+            .reader()
+            .vector_hits(
+                "emb",
+                &q,
+                k,
+                VectorSearchOptions::new().with_nprobe(DOCS_PER_DIRECTION),
+                None,
+            )
+            .expect("wide search");
+        assert_eq!(
+            near_count(&wide_hits),
+            k,
+            "with_nprobe must widen the unfiltered post-drain sweep to all \
+             {k} exact neighbors across three cells — caller nprobe is an \
+             override, never discarded"
+        );
+    }
+
+    /// A clean drain calibrates the probe-width law from the table's own
+    /// rows and stamps it into the manifest routing; a DEFAULT search (no
+    /// nprobe, no config) then widens to the calibrated width. On this
+    /// planted corpus the exact top-24 spans three cells, which the old
+    /// fixed p=1 default could never recover (it returned one direction's
+    /// 8 docs); the law measures the spread and buys the coverage without
+    /// the caller knowing any knob exists.
+    #[test]
+    fn drain_calibrated_width_law_widens_default_search() {
+        let (_dir, st, q, k) = drained_three_direction_fixture();
+        let hits = st
+            .reader()
+            .vector_hits("emb", &q, k, VectorSearchOptions::new(), None)
+            .expect("default search");
+        let near = near_count(&hits);
+        assert_eq!(
+            near, k,
+            "drain-calibrated width law must widen the default sweep to all \
+             {k} exact neighbors across three cells, got {near}"
+        );
     }
 
     /// The `Supertable::vector_search` handle wrapper (tests normally call

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -4260,6 +4260,87 @@ mod tests {
         );
     }
 
+    /// Warm-vs-cold parity for the width sweep — the review's "cold
+    /// fixture". The warm arm defers survivors to the global shortlist;
+    /// a cell with non-resident prefixes reranks in-probe under the
+    /// divided cold budget and never enters global selection. At an
+    /// untruncated budget both arms exact-rerank every candidate, so
+    /// the same query on the same committed table must return identical
+    /// hits regardless of cache state. (The replica variant stays
+    /// blocked on the drain_replica_target_factor crash filed
+    /// separately.)
+    #[test]
+    fn vector_cold_arm_matches_warm_top_k() {
+        use crate::test_helpers::lazy_foreground_disk_cache;
+
+        let dim = 16usize;
+        let schema = schema_with_vector(dim);
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(crate::storage::LocalFsStorageProvider::new(dir.path()).expect("storage"));
+        let mut q = vec![0.0f32; dim];
+        q[0] = 1.0;
+
+        // Warm: default in-memory reader cache — every prefix resident,
+        // the sweep defers to the global shortlist.
+        let warm_hits = {
+            let st = Supertable::create(
+                options_one_superfile_per_commit(dim).with_storage(Arc::clone(&storage)),
+            )
+            .expect("create");
+            for c in 0..4u64 {
+                let mut w = st.writer().expect("writer");
+                w.append(&build_vector_batch(c * 32, 32, dim, schema.clone()))
+                    .expect("append");
+                w.commit().expect("commit");
+            }
+            st.drain_vectors_to_cells_sync().expect("drain");
+            st.reader()
+                .expect("reader")
+                .vector_hits(
+                    "emb",
+                    &q,
+                    20,
+                    VectorSearchOptions::new().with_nprobe(4),
+                    None,
+                )
+                .expect("warm search")
+        };
+
+        // Cold: a fresh handle reading through a lazy disk-cache source —
+        // nothing resident, every probed cell takes the cold arm.
+        let cache_dir = tempfile::TempDir::new().expect("cache dir");
+        let cache = lazy_foreground_disk_cache(Arc::clone(&storage), cache_dir.path());
+        let st_cold = Supertable::open(
+            options_one_superfile_per_commit(dim)
+                .with_storage(Arc::clone(&storage))
+                .with_disk_cache(Arc::clone(&cache)),
+        )
+        .expect("open cold");
+        let cold_hits = st_cold
+            .reader()
+            .expect("reader")
+            .vector_hits(
+                "emb",
+                &q,
+                20,
+                VectorSearchOptions::new().with_nprobe(4),
+                None,
+            )
+            .expect("cold search");
+        assert!(
+            cache.stats().n_cold_fetches >= 1,
+            "the cold handle must actually read through the lazy cache \
+             (otherwise this fixture proves nothing)"
+        );
+
+        assert_eq!(
+            warm_hits, cold_hits,
+            "cache state must not change the top-k (warm deferred-global vs \
+             cold divided in-probe, both exact at an untruncated budget)"
+        );
+    }
+
     /// A larger post-drain corpus (many docs across several commits, drained
     /// into multiple cells) searched with a wider `k` and `nprobe`, so the
     /// query reranks candidates spanning multiple clusters — the multi-cluster

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -68,7 +68,8 @@ use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet},
     future::Future,
-    sync::Arc,
+    mem,
+    sync::{Arc, Mutex, PoisonError},
     time::Instant,
 };
 
@@ -97,6 +98,7 @@ use crate::{
         vector::{
             distance::{Metric, distance, relative_score_window},
             layout::VectorLayout,
+            reader::ScanCandidate,
         },
     },
     supertable::{
@@ -1694,8 +1696,10 @@ impl SupertableReader {
         // for every entry would `expect`-panic on exactly those
         // filtered-out superfiles; gating it behind the selection guard
         // keeps the lookup on the path where presence is invariant.
-        let mut units: Vec<(Arc<SuperfileEntry>, (Vec<u32>, Option<Arc<RoaringBitmap>>))> =
-            Vec::new();
+        let mut units: Vec<(
+            Arc<SuperfileEntry>,
+            (usize, Vec<u32>, Option<Arc<RoaringBitmap>>),
+        )> = Vec::new();
         for (si, entry) in superfiles.iter().enumerate() {
             let Some(ids) = per_seg.remove(&si) else {
                 continue;
@@ -1707,7 +1711,7 @@ impl SupertableReader {
                 },
                 None => None,
             };
-            units.push((Arc::clone(entry), (ids, bitmap)));
+            units.push((Arc::clone(entry), (si, ids, bitmap)));
         }
         if units.is_empty() {
             if let Some(t0) = admit_t0 {
@@ -1735,20 +1739,40 @@ impl SupertableReader {
         // sweep so the TOTAL survivor budget stays ~k x rerank_mult —
         // measured sufficient at that total: 0.9957 recall@100 on
         // Cohere-1M with ~25.6K survivors.
+        // On the hidden width sweep the divide is superseded by GLOBAL
+        // shortlist selection: warm cells scan at the undivided cap and the
+        // supertable keeps the best `k x rerank_mult` estimates across the
+        // whole sweep — exact, no even-split heuristic (measured 0.9937
+        // undivided vs 0.9914 divided recall@100 on Cohere-1M). Cold cells
+        // still rerank inside their own probe under the divided budget:
+        // deferring them would hold their fetched blocks and their budget
+        // reservation across the entire fan-out.
+        let global_shortlist_width = if hidden_vector_index {
+            sweep_width.filter(|w| *w > 1)
+        } else {
+            None
+        };
+        let mut cold_rerank_mult = 0;
         let options = match sweep_width {
             Some(w) if w > 1 => {
                 let (_, rerank_mult) = options.resolve(filtered);
-                options.with_rerank_mult(
-                    rerank_mult
-                        .saturating_mul(WIDTH_BUDGET_OVERSAMPLE)
-                        .div_ceil(w)
-                        .max(1),
-                )
+                let divided = rerank_mult
+                    .saturating_mul(WIDTH_BUDGET_OVERSAMPLE)
+                    .div_ceil(w)
+                    .max(1);
+                if global_shortlist_width.is_some() {
+                    cold_rerank_mult = divided;
+                    options
+                } else {
+                    options.with_rerank_mult(divided)
+                }
             }
             _ => options,
         };
         let column_arc = Arc::new(column.to_owned());
         let query_arc = Arc::new(query.to_vec());
+        let column_arc2 = Arc::clone(&column_arc);
+        let query_arc2 = Arc::clone(&query_arc);
         let reader_pool = Arc::clone(&manifest.options.reader_pool);
         // Per-connection memory budget: gates each superfile's cold cluster-block fetch.
         let budget = Some(Arc::clone(&manifest.options.connection_memory_budget));
@@ -1762,76 +1786,112 @@ impl SupertableReader {
         // dropped after ranking by identity instead. The hidden path skips
         // sidecars entirely: its deletes ride inline in the hidden manifest
         // and are applied after remapping to user `_id`s.
-        let body = move |reader: Arc<SuperfileReader>,
-                         entry: Arc<SuperfileEntry>,
-                         tombstone_cache: Option<Arc<SidecarCache>>,
-                         now: Instant,
-                         (ids, bitmap): (Vec<u32>, Option<Arc<RoaringBitmap>>)| {
-            let column = Arc::clone(&column_arc);
-            let query = Arc::clone(&query_arc);
-            let reader_pool = Arc::clone(&reader_pool);
-            let budget = budget.clone();
-            let storage = storage.clone();
-            async move {
-                // Unfiltered user path on row-addressable locals: resolve the
-                // bitmap once (warm after the orchestrator's prefetch) and
-                // push it down. Filtered search leaves it `None` — its
-                // allow-set already excludes tombstones.
-                let deny_pushdown = !hidden_vector_index
-                    && bitmap.is_none()
-                    && entry.vector_layout != VectorLayout::MultiCellIvf;
-                let deny = match tombstone_cache.as_ref() {
-                    Some(cache) if deny_pushdown => {
-                        dispatch::tombstone_deny_set(cache, entry.superfile_id, now)?
-                    }
-                    _ => None,
-                };
-                let pool = Some(Arc::clone(&reader_pool));
-                // Replicated hidden cells store boundary duplicates; fetch
-                // enough extra slots that the post-merge stable-id dedup
-                // still leaves k distinct rows.
-                let replica_overhead = reader
-                    .vec()
-                    .map(|v| (v.n_docs() as usize).saturating_sub(reader.n_docs() as usize))
-                    .unwrap_or(0);
-                let k_fetch = k.saturating_add(replica_overhead);
-                let reader_for_ids = Arc::clone(&reader);
-                let hits = reader
-                    .vector_search_clusters_filtered(
-                        &column, &query, k_fetch, &ids, options, bitmap, deny, pool, budget,
-                    )
-                    .await
-                    .map_err(vector_read_query_error)?;
-                let mut tagged = dispatch::tag_hits(&entry, hits);
-                // Prefer manifest span arithmetic; only touch `_id` pages /
-                // inline IVF regions when the layout is cell-packed or gapped.
-                io_counters::phase_timed_async("vec.stable_id", async {
-                    dispatch::attach_stable_ids(&reader_for_ids, &entry, &mut tagged, false).await
-                })
-                .await?;
-                if !hidden_vector_index && !deny_pushdown {
-                    // MultiCell user files (and any path that skipped the
-                    // push-down): drop deleted rows by identity post-rank.
-                    dispatch::apply_resolved_tombstone_filter(
-                        &reader_for_ids,
-                        storage.as_ref(),
-                        tombstone_cache.as_ref(),
-                        &entry,
-                        &mut tagged,
-                        now,
-                    )
+        // Warm-cell estimate survivors from every scanned unit, pooled for
+        // the global selection: (unit index, rot seed, candidates).
+        let scan_pool: Arc<Mutex<Vec<(usize, u64, Vec<ScanCandidate>)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let scan_pool_body = Arc::clone(&scan_pool);
+        let body =
+            move |reader: Arc<SuperfileReader>,
+                  entry: Arc<SuperfileEntry>,
+                  tombstone_cache: Option<Arc<SidecarCache>>,
+                  now: Instant,
+                  (si, ids, bitmap): (usize, Vec<u32>, Option<Arc<RoaringBitmap>>)| {
+                let column = Arc::clone(&column_arc);
+                let query = Arc::clone(&query_arc);
+                let reader_pool = Arc::clone(&reader_pool);
+                let budget = budget.clone();
+                let storage = storage.clone();
+                let scan_pool = Arc::clone(&scan_pool_body);
+                async move {
+                    // Unfiltered user path on row-addressable locals: resolve the
+                    // bitmap once (warm after the orchestrator's prefetch) and
+                    // push it down. Filtered search leaves it `None` — its
+                    // allow-set already excludes tombstones.
+                    let deny_pushdown = !hidden_vector_index
+                        && bitmap.is_none()
+                        && entry.vector_layout != VectorLayout::MultiCellIvf;
+                    let deny = match tombstone_cache.as_ref() {
+                        Some(cache) if deny_pushdown => {
+                            dispatch::tombstone_deny_set(cache, entry.superfile_id, now)?
+                        }
+                        _ => None,
+                    };
+                    let pool = Some(Arc::clone(&reader_pool));
+                    // Replicated hidden cells store boundary duplicates; fetch
+                    // enough extra slots that the post-merge stable-id dedup
+                    // still leaves k distinct rows.
+                    let replica_overhead = reader
+                        .vec()
+                        .map(|v| (v.n_docs() as usize).saturating_sub(reader.n_docs() as usize))
+                        .unwrap_or(0);
+                    let k_fetch = k.saturating_add(replica_overhead);
+                    let reader_for_ids = Arc::clone(&reader);
+                    let hits = if global_shortlist_width.is_some() {
+                        // Deferred-rerank scan: exact hits from cold cells now;
+                        // warm-cell estimate survivors pooled for the global
+                        // selection (phase C reranks the winners).
+                        let scan = reader
+                            .vector_scan_clusters_filtered(
+                                &column,
+                                &query,
+                                k_fetch,
+                                &ids,
+                                options,
+                                cold_rerank_mult,
+                                bitmap,
+                                deny,
+                                pool,
+                                budget,
+                            )
+                            .await
+                            .map_err(vector_read_query_error)?;
+                        if !scan.candidates.is_empty() {
+                            scan_pool
+                                .lock()
+                                .unwrap_or_else(PoisonError::into_inner)
+                                .push((si, scan.rot_seed, scan.candidates));
+                        }
+                        scan.hits
+                    } else {
+                        reader
+                            .vector_search_clusters_filtered(
+                                &column, &query, k_fetch, &ids, options, bitmap, deny, pool, budget,
+                            )
+                            .await
+                            .map_err(vector_read_query_error)?
+                    };
+                    let mut tagged = dispatch::tag_hits(&entry, hits);
+                    // Prefer manifest span arithmetic; only touch `_id` pages /
+                    // inline IVF regions when the layout is cell-packed or gapped.
+                    io_counters::phase_timed_async("vec.stable_id", async {
+                        dispatch::attach_stable_ids(&reader_for_ids, &entry, &mut tagged, false)
+                            .await
+                    })
                     .await?;
+                    if !hidden_vector_index && !deny_pushdown {
+                        // MultiCell user files (and any path that skipped the
+                        // push-down): drop deleted rows by identity post-rank.
+                        dispatch::apply_resolved_tombstone_filter(
+                            &reader_for_ids,
+                            storage.as_ref(),
+                            tombstone_cache.as_ref(),
+                            &entry,
+                            &mut tagged,
+                            now,
+                        )
+                        .await?;
+                    }
+                    Ok::<Vec<SuperfileHit>, QueryError>(tagged)
                 }
-                Ok::<Vec<SuperfileHit>, QueryError>(tagged)
-            }
-        };
+            };
         // Filtered search holds a per-superfile RoaringBitmap while the
         // kernel builds its shortlist; wave-cap the fan-out by reader-pool
         // width so transient memory stays bounded. The unfiltered path
         // carries no bitmaps and fans out all units at once (matching
         // main's concurrency — every superfile GET overlaps on tokio).
         let fanout_t0 = io_counters::phase_start();
-        let per_superfile = if allow.is_some() {
+        let mut per_superfile = if allow.is_some() {
             let fanout_width = manifest.options.reader_pool.current_num_threads().max(1);
             let mut collected = Vec::new();
             while !units.is_empty() {
@@ -1846,6 +1906,86 @@ impl SupertableReader {
         } else {
             dispatch::fanout_with(self, units, !hidden_vector_index, false, body).await?
         };
+
+        // Phase C of the deferred-rerank width sweep: select the best
+        // `k x rerank_mult` estimates ACROSS every warm-scanned cell and
+        // superfile, then rerank only those winners where they live. The
+        // estimates are comparable across units — one rotation seed per
+        // column, table-wide — asserted here at the only place different
+        // units' estimates ever meet.
+        if global_shortlist_width.is_some() {
+            let pooled = {
+                let mut guard = scan_pool.lock().unwrap_or_else(PoisonError::into_inner);
+                mem::take(&mut *guard)
+            };
+            if !pooled.is_empty() {
+                debug_assert!(
+                    pooled.windows(2).all(|w| w[0].1 == w[1].1),
+                    "pooled 1-bit estimates require one rotation seed per column"
+                );
+                let (_, rerank_mult) = options.resolve(filtered);
+                let mut flat: Vec<(usize, ScanCandidate)> = pooled
+                    .into_iter()
+                    .flat_map(|(si, _, cands)| cands.into_iter().map(move |c| (si, c)))
+                    .collect();
+                flat = select_global_shortlist(flat, k.saturating_mul(rerank_mult));
+                let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
+                for (si, cand) in flat {
+                    winners_by_seg.entry(si).or_default().push(cand);
+                }
+                let rerank_units: Vec<(Arc<SuperfileEntry>, Vec<ScanCandidate>)> = superfiles
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(si, entry)| {
+                        winners_by_seg
+                            .remove(&si)
+                            .map(|sel| (Arc::clone(entry), sel))
+                    })
+                    .collect();
+                let column = Arc::clone(&column_arc2);
+                let query = Arc::clone(&query_arc2);
+                let reader_pool = Arc::clone(&manifest.options.reader_pool);
+                let body_c = move |reader: Arc<SuperfileReader>,
+                                   entry: Arc<SuperfileEntry>,
+                                   _tombstone_cache: Option<Arc<SidecarCache>>,
+                                   _now: Instant,
+                                   selected: Vec<ScanCandidate>| {
+                    let column = Arc::clone(&column);
+                    let query = Arc::clone(&query);
+                    let reader_pool = Arc::clone(&reader_pool);
+                    async move {
+                        // Hidden-path invariants: no tombstone sidecars (the
+                        // manifest's deletes apply after the stable-id
+                        // remap upstream), replica slack mirrors phase A.
+                        let replica_overhead = reader
+                            .vec()
+                            .map(|v| (v.n_docs() as usize).saturating_sub(reader.n_docs() as usize))
+                            .unwrap_or(0);
+                        let k_fetch = k.saturating_add(replica_overhead);
+                        let reader_for_ids = Arc::clone(&reader);
+                        let hits = reader
+                            .vector_rerank_selected(
+                                &column,
+                                &query,
+                                k_fetch,
+                                selected,
+                                Some(reader_pool),
+                            )
+                            .await
+                            .map_err(vector_read_query_error)?;
+                        let mut tagged = dispatch::tag_hits(&entry, hits);
+                        io_counters::phase_timed_async("vec.stable_id", async {
+                            dispatch::attach_stable_ids(&reader_for_ids, &entry, &mut tagged, false)
+                                .await
+                        })
+                        .await?;
+                        Ok::<Vec<SuperfileHit>, QueryError>(tagged)
+                    }
+                };
+                per_superfile
+                    .extend(dispatch::fanout_with(self, rerank_units, false, false, body_c).await?);
+            }
+        }
         if let Some(t0) = fanout_t0 {
             io_counters::phase_record("vec.fanout_wall", t0.elapsed().as_micros() as u64);
         }
@@ -2806,6 +2946,29 @@ fn apply_width_pin(
     }
 }
 
+/// Deterministic global shortlist selection for deferred-rerank width
+/// sweeps: keep the `limit` best 1-bit estimates pooled across every
+/// scanned unit. Higher estimate = better; ties break on
+/// (unit, cell, pos, did), a total order, so the KEPT SET is
+/// insertion-order independent across concurrent scans. O(n) partition,
+/// not a sort — the winners need no internal order (phase C regroups by
+/// unit and the rerank is exact).
+fn select_global_shortlist(
+    mut pooled: Vec<(usize, ScanCandidate)>,
+    limit: usize,
+) -> Vec<(usize, ScanCandidate)> {
+    let cmp = |a: &(usize, ScanCandidate), b: &(usize, ScanCandidate)| {
+        b.1.estimate.total_cmp(&a.1.estimate).then_with(|| {
+            (a.0, a.1.cell_idx, a.1.pos, a.1.did).cmp(&(b.0, b.1.cell_idx, b.1.pos, b.1.did))
+        })
+    };
+    if pooled.len() > limit {
+        pooled.select_nth_unstable_by(limit, cmp);
+        pooled.truncate(limit);
+    }
+    pooled
+}
+
 fn top_k_ascending(per_superfile: Vec<Vec<SuperfileHit>>, k: usize) -> Vec<SuperfileHit> {
     // Total order over hits: distance ascending, then the unique
     // `(superfile, local_doc_id)` key. The tie-break makes the kept set
@@ -2963,11 +3126,11 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
 
     use super::{
-        RABITQ_ADMIT_CELL_SHORTLIST_MIN, SCORE_COLUMN, VectorFilter, VectorSearchOptions,
-        admit_shortlist_window, apply_width_pin, cells_ranked_by_fine_score,
+        RABITQ_ADMIT_CELL_SHORTLIST_MIN, SCORE_COLUMN, ScanCandidate, VectorFilter,
+        VectorSearchOptions, admit_shortlist_window, apply_width_pin, cells_ranked_by_fine_score,
         gate_fine_candidates_by_fragment, hidden_hits_user_ids, is_hidden_vector_manifest,
         postings_by_cell_from_summaries, projection_is_id_score_only, score_fine_candidates,
-        union_cell_selection, vector_read_query_error,
+        select_global_shortlist, union_cell_selection, vector_read_query_error,
     };
     use crate::{
         InfinoError,
@@ -4309,6 +4472,79 @@ mod tests {
         let sweep = apply_width_pin(&mut r, None, None, false, 256);
         assert_eq!(r, base);
         assert_eq!(sweep, None);
+    }
+
+    /// The deferred-rerank width sweep under the tightest possible rerank
+    /// budget: `rerank_mult = 1` leaves the global selection exactly `k`
+    /// slots across ALL probed cells — the even-split divide would hand
+    /// each cell a starved slice, but the global pool ranks every cell's
+    /// estimates together, so the planted neighbors (whose one-hot
+    /// estimates dominate the orthogonal rest) all survive selection and
+    /// rerank to the exact top-k.
+    #[test]
+    fn global_shortlist_survives_minimal_rerank_budget() {
+        let (_dir, st, q, k) = drained_three_direction_fixture();
+        let hits = st
+            .reader()
+            .expect("reader")
+            .vector_hits(
+                "emb",
+                &q,
+                k,
+                VectorSearchOptions::new()
+                    .with_nprobe(DOCS_PER_DIRECTION)
+                    .with_rerank_mult(1),
+                None,
+            )
+            .expect("wide search, minimal budget");
+        assert_eq!(
+            near_count(&hits),
+            k,
+            "global shortlist selection at k x 1 must keep every planted \
+             neighbor across three cells"
+        );
+    }
+
+    /// [`select_global_shortlist`] is deterministic and order-independent:
+    /// the same candidates in any arrival order produce the same cut, ties
+    /// on estimate break on (unit, cell, pos, did), and the limit is a
+    /// hard truncation.
+    #[test]
+    fn select_global_shortlist_is_deterministic() {
+        let cand = |est: f32, cell: usize, pos: u32, did: u32| ScanCandidate {
+            did,
+            estimate: est,
+            pos,
+            cluster_id: 0,
+            cell_idx: cell,
+        };
+        let a = vec![
+            (0usize, cand(0.9, 0, 1, 1)),
+            (1usize, cand(0.9, 0, 1, 1)),
+            (0usize, cand(0.5, 1, 2, 2)),
+            (1usize, cand(0.7, 0, 3, 3)),
+        ];
+        let mut b = a.clone();
+        b.reverse();
+        let pick = |v: Vec<(usize, ScanCandidate)>| {
+            select_global_shortlist(v, 3)
+                .into_iter()
+                .map(|(si, c)| (si, c.cell_idx, c.pos, c.did))
+                .collect::<Vec<_>>()
+        };
+        let mut from_a = pick(a);
+        let mut from_b = pick(b);
+        from_a.sort_unstable();
+        from_b.sort_unstable();
+        assert_eq!(
+            from_a, from_b,
+            "the kept SET must be arrival-order independent (its internal \
+             order is unspecified — the partition does not sort)"
+        );
+        assert_eq!(from_a.len(), 3, "limit is a hard truncation");
+        // Tie on estimate 0.9 breaks by unit, so both 0.9 copies stay and
+        // the 0.7 candidate takes the last slot; 0.5 falls off the cut.
+        assert_eq!(from_a, vec![(0, 0, 1, 1), (1, 0, 1, 1), (1, 0, 3, 3)]);
     }
 
     /// A clean drain calibrates the probe-width law from the table's own

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -4180,6 +4180,7 @@ mod tests {
         // fine picks, so "narrow" means fewer cells than the law, not one.)
         let narrow_hits = st
             .reader()
+            .expect("reader")
             .vector_hits(
                 "emb",
                 &q,
@@ -4198,6 +4199,7 @@ mod tests {
         // Wide override: recovers the full exact top-k across three cells.
         let wide_hits = st
             .reader()
+            .expect("reader")
             .vector_hits(
                 "emb",
                 &q,
@@ -4227,6 +4229,7 @@ mod tests {
         let (_dir, st, q, k) = drained_three_direction_fixture();
         let hits = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, k, VectorSearchOptions::new(), None)
             .expect("default search");
         let near = near_count(&hits);
@@ -4259,6 +4262,7 @@ mod tests {
 
         let hits = st
             .reader()
+            .expect("reader")
             .vector_hits("emb", &q, k, VectorSearchOptions::new(), None)
             .expect("default search after incremental drain");
         let near = near_count(&hits);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -114,6 +114,11 @@ use crate::{
     },
 };
 
+/// A calibrated law width at or below this resolves to `None`: one cell
+/// is exactly the fine-first default's sweep, so the law only engages
+/// when it demands a WIDER read than the default already performs.
+const LAW_WIDTH_WITHIN_DEFAULT: usize = 1;
+
 /// Oversample factor on the per-sweep rerank budget. Dividing
 /// `k x rerank_mult` evenly across the sweep under-serves the nearest
 /// cells (they hold most true neighbors, and the 1-bit estimate ranks
@@ -1402,7 +1407,7 @@ impl SupertableReader {
                 if hidden_vector_index && !filtered && options.nprobe.is_none() {
                     hidden_routing
                         .and_then(|r| r.width_for_k_at(k))
-                        .filter(|w| *w > 1)
+                        .filter(|w| *w > LAW_WIDTH_WITHIN_DEFAULT)
                 } else {
                     None
                 };
@@ -1748,9 +1753,7 @@ impl SupertableReader {
         let options = match sweep_width {
             Some(w) if w > 1 => {
                 let (_, rerank_mult) = options.resolve(filtered);
-                options.with_rerank_mult(
-                    (rerank_mult * WIDTH_BUDGET_OVERSAMPLE).div_ceil(w).max(1),
-                )
+                options.with_rerank_mult((rerank_mult * WIDTH_BUDGET_OVERSAMPLE).div_ceil(w).max(1))
             }
             _ => options,
         };
@@ -4107,8 +4110,16 @@ mod tests {
     /// drained one-hot fixture: query-aligned directions score well below
     /// it, every other direction scores exactly 1.0 (cos = 0).
     const ORTHOGONAL_SCORE: f32 = 0.9;
+    /// Fixture dimensionality — one one-hot direction per dim.
+    const FIXTURE_DIM: usize = 16;
+    /// Commits in the drained fixture (each its own user superfile).
+    const FIXTURE_COMMITS: u64 = 4;
+    /// Rows per fixture commit; `FIXTURE_COMMITS x this / FIXTURE_DIM`
+    /// docs land on each one-hot direction.
+    const FIXTURE_ROWS_PER_COMMIT: usize = 32;
     /// Docs planted per one-hot direction (128 docs mod 16 dims).
-    const DOCS_PER_DIRECTION: usize = 8;
+    const DOCS_PER_DIRECTION: usize =
+        FIXTURE_COMMITS as usize * FIXTURE_ROWS_PER_COMMIT / FIXTURE_DIM;
 
     /// Drained planted fixture shared by the probe-width tests: 128 one-hot
     /// docs over 16 directions in 4 commits, drained into per-direction
@@ -4116,17 +4127,22 @@ mod tests {
     /// spans three cells. Returns `(tempdir, table, query, k)`; the tempdir
     /// must outlive the table.
     fn drained_three_direction_fixture() -> (tempfile::TempDir, Supertable, Vec<f32>, usize) {
-        let dim = 16usize;
+        let dim = FIXTURE_DIM;
         let schema = schema_with_vector(dim);
         let opts = options_one_superfile_per_commit(dim);
         let dir = tempfile::TempDir::new().expect("tempdir");
         let storage: Arc<dyn StorageProvider> =
             Arc::new(crate::storage::LocalFsStorageProvider::new(dir.path()).expect("storage"));
         let st = Supertable::create(opts.with_storage(storage)).expect("create");
-        for c in 0..4u64 {
+        for c in 0..FIXTURE_COMMITS {
             let mut w = st.writer().expect("writer");
-            w.append(&build_vector_batch(c * 32, 32, dim, schema.clone()))
-                .expect("append");
+            w.append(&build_vector_batch(
+                c * FIXTURE_ROWS_PER_COMMIT as u64,
+                FIXTURE_ROWS_PER_COMMIT,
+                dim,
+                schema.clone(),
+            ))
+            .expect("append");
             w.commit().expect("commit");
         }
         st.drain_vectors_to_cells_sync().expect("drain");

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1367,7 +1367,9 @@ impl SupertableReader {
             // Base routing shape first (per branch), then one shared caller
             // override on top.
             let mut cell_routing = if hidden_vector_index {
-                let base = hidden_routing.expect("hidden manifest carries routing");
+                let base = hidden_routing.ok_or_else(|| {
+                    QueryError::Execute("hidden manifest missing cell routing".into())
+                })?;
                 if filtered {
                     // Allow-set queries widen to the filtered floor and
                     // probe DEEPER fine runs per cell — the matching
@@ -1788,7 +1790,7 @@ impl SupertableReader {
         // and are applied after remapping to user `_id`s.
         // Warm-cell estimate survivors from every scanned unit, pooled for
         // the global selection: (unit index, rot seed, candidates).
-        let scan_pool: Arc<Mutex<Vec<(usize, u64, Vec<ScanCandidate>)>>> =
+        let scan_pool: Arc<Mutex<Vec<(usize, u64, usize, Vec<ScanCandidate>)>>> =
             Arc::new(Mutex::new(Vec::new()));
         let scan_pool_body = Arc::clone(&scan_pool);
         let body =
@@ -1850,7 +1852,7 @@ impl SupertableReader {
                             scan_pool
                                 .lock()
                                 .unwrap_or_else(PoisonError::into_inner)
-                                .push((si, scan.rot_seed, scan.candidates));
+                                .push((si, scan.rot_seed, replica_overhead, scan.candidates));
                         }
                         scan.hits
                     } else {
@@ -1919,16 +1921,32 @@ impl SupertableReader {
                 mem::take(&mut *guard)
             };
             if !pooled.is_empty() {
-                debug_assert!(
-                    pooled.windows(2).all(|w| w[0].1 == w[1].1),
-                    "pooled 1-bit estimates require one rotation seed per column"
-                );
+                // Hard error, not debug_assert: this is the one site where
+                // estimates from different superfiles are pooled and ranked
+                // against each other. Backstopped by the open-time seed
+                // check today, but if a future path ever admits a
+                // differently-seeded unit, fail the query loudly instead of
+                // silently ranking incomparable estimates.
+                if pooled.windows(2).any(|w| w[0].1 != w[1].1) {
+                    return Err(QueryError::Execute(
+                        "pooled 1-bit estimates require one rotation seed per column".into(),
+                    ));
+                }
                 let (_, rerank_mult) = options.resolve(filtered);
+                // Mirror phase A/C's `k_fetch = k + replica_overhead` in the
+                // global cut so boundary replicas (dormant today: overhead
+                // is 0 with replication off) cannot take shortlist slots
+                // from distinct rows before the stable-id dedup.
+                let replica_overhead = pooled.iter().map(|(_, _, o, _)| *o).max().unwrap_or(0);
                 let mut flat: Vec<(usize, ScanCandidate)> = pooled
                     .into_iter()
-                    .flat_map(|(si, _, cands)| cands.into_iter().map(move |c| (si, c)))
+                    .flat_map(|(si, _, _, cands)| cands.into_iter().map(move |c| (si, c)))
                     .collect();
-                flat = select_global_shortlist(flat, k.saturating_mul(rerank_mult));
+                flat = select_global_shortlist(
+                    flat,
+                    k.saturating_add(replica_overhead)
+                        .saturating_mul(rerank_mult),
+                );
                 let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
                 for (si, cand) in flat {
                     winners_by_seg.entry(si).or_default().push(cand);

--- a/src/supertable/reader_cache/block_source.rs
+++ b/src/supertable/reader_cache/block_source.rs
@@ -41,9 +41,10 @@ use std::{
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use memmap2::Mmap;
 use roaring::RoaringBitmap;
 
-use super::disk::DiskCacheStore;
+use super::disk::{ArcMmapOwner, DiskCacheStore};
 use crate::{
     superfile::{LazyByteSource, LazyByteSourceError},
     supertable::manifest::SuperfileUri,
@@ -65,6 +66,9 @@ const CACHE_BLOCK_BYTES: u64 = 512 * 1024;
 struct BlockFile {
     file: fs::File,
     size: u64,
+    /// Lazily-created read-only mapping for zero-copy hit service.
+    /// Inner `None` = mapping failed once; keep serving via pread.
+    mmap: OnceLock<Option<Arc<Mmap>>>,
 }
 
 /// Block-caching wrapper around a network-backed [`LazyByteSource`].
@@ -180,7 +184,11 @@ impl BlockCachedSource {
                     .open(&self.path)
                     .ok()?;
                 file.set_len(size).ok()?;
-                Some(BlockFile { file, size })
+                Some(BlockFile {
+                    file,
+                    size,
+                    mmap: OnceLock::new(),
+                })
             })
             .as_ref()
     }
@@ -239,6 +247,31 @@ impl BlockCachedSource {
     /// Serve `[start, start+len)` from the sparse file. `None` on a read
     /// error (caller degrades to passthrough).
     fn read_local(&self, bf: &BlockFile, start: u64, len: u64) -> Option<Bytes> {
+        // Zero-copy hit service: filled ranges are handed out as slices of
+        // one shared read-only mapping instead of alloc+pread per range. At
+        // law width a warm vector query reads ~20 MB through here; the
+        // per-range alloc+zero+pread copies were the measured ~6-7 ms
+        // prefix-service floor of phase A (and the residual copy cost in
+        // the deferred rerank's exact-range gather). Slices keep the
+        // mapping alive after eviction, exactly like the promoted
+        // parquet/FTS mmaps.
+        let mapped = bf.mmap.get_or_init(|| {
+            // SAFETY: the blocks file is pre-sized at creation
+            // (`file.set_len(size)`) and only ever written through
+            // `write_all_at` within that size, so a mapping of the full
+            // file never outruns it (no SIGBUS); the read-only shared
+            // mapping stays page-cache-coherent with those writes, and
+            // reads of not-yet-filled blocks are gated by `all_filled`
+            // before this method runs.
+            unsafe { Mmap::map(&bf.file) }.ok().map(Arc::new)
+        });
+        if let Some(m) = mapped.as_ref() {
+            let s = usize::try_from(start).ok()?;
+            let e = s.checked_add(usize::try_from(len).ok()?)?;
+            if e <= m.len() {
+                return Some(Bytes::from_owner(ArcMmapOwner(Arc::clone(m))).slice(s..e));
+            }
+        }
         let mut out = vec![0u8; len as usize];
         bf.file.read_exact_at(&mut out, start).ok()?;
         Some(Bytes::from(out))

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -2551,7 +2551,7 @@ impl LazyByteSource for HoleFallbackSource {
 /// same `Arc<Mmap>` — both refer to the same OS mapping, so
 /// `madvise` on the cache's handle affects the reader's
 /// resident pages (the idle-threshold sweep relies on this).
-struct ArcMmapOwner(Arc<Mmap>);
+pub(crate) struct ArcMmapOwner(pub(crate) Arc<Mmap>);
 
 impl AsRef<[u8]> for ArcMmapOwner {
     fn as_ref(&self) -> &[u8] {

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -82,7 +82,7 @@ use rayon::{ThreadPool, ThreadPoolBuilder, prelude::*};
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 use tokio::time::sleep;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 use uuid::Uuid;
 
 use super::{
@@ -3982,8 +3982,8 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             for (slot, measured) in routing.width_for_k.iter_mut().zip(law) {
                 *slot = (*slot).max(measured);
             }
-            eprintln!(
-                "[supertable drain] probe-width law (cells for 0.99 top-k coverage at k={WIDTH_LAW_KS:?}): measured {law:?}, stamped {:?}",
+            info!(
+                "supertable drain: probe-width law (cells for 0.99 top-k coverage at k={WIDTH_LAW_KS:?}): measured {law:?}, stamped {:?}",
                 routing.width_for_k
             );
         }

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -159,7 +159,10 @@ use crate::{
         manifest::{
             ClusterCentroids, RabitqAdmitContext,
             commit::get_current_manifest_etag,
-            list::{CellRoutingParams, DrainedVersionRanges, GlobalVectorIndex, PartitionStrategy},
+            list::{
+                CellRoutingParams, DrainedVersionRanges, GlobalVectorIndex, PartitionStrategy,
+                WIDTH_LAW_KS,
+            },
             options_hash,
             part::{self as part_mod, PartId},
         },
@@ -3050,7 +3053,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
     // `routing` (query tuning) is preserved from the hidden grid either way.
     let hidden_manifest = hidden_inner.manifest.load_full();
     let hidden_bootstrapped = !hidden_manifest.get_drained_ranges().is_empty();
-    let (clusters, routing) = match hidden_manifest.get_partition_strategy() {
+    let (clusters, mut routing) = match hidden_manifest.get_partition_strategy() {
         PartitionStrategy::VectorCell {
             clusters, routing, ..
         } if hidden_bootstrapped => (clusters, routing),
@@ -3060,7 +3063,6 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
     if clusters.n_cent == 0 || clusters.dim == 0 {
         return Ok(());
     }
-
     // Source: every user-table vector superfile, processed in BOUNDED BATCHES so
     // drain working-set RAM stays O(batch) instead of O(corpus) (the >3M memory
     // wall). Each batch opens its readers, builds its cell superfiles, publishes
@@ -3320,6 +3322,13 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         }
         new_entries.push(entry);
     }
+
+    // Probe-width calibration rides only CLEAN drains: a resumed drain's
+    // checkpointed batches never re-stream, so its sample would be partial
+    // and the law would under-count. A resumed drain keeps whatever law
+    // the manifest already carries.
+    let mut width_law = (local_checkpoint.batches_done == 0 && completed_shards.is_empty())
+        .then(|| opann::WidthLawCalibration::new(running_clusters.dim as usize, metric));
 
     let mut cell_spills = HashMap::new();
     for (&cell, spill) in &local_checkpoint.spills {
@@ -3581,6 +3590,12 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                             row.cluster,
                             row,
                         )?;
+                        // Each distinct row is a calibration-query candidate
+                        // exactly once (replica spills excluded: sampling
+                        // replicas would bias queries toward boundary rows).
+                        if let Some(cal) = width_law.as_mut() {
+                            cal.offer(row);
+                        }
                     }
                 } else {
                     let replica_extra_budget =
@@ -3642,6 +3657,10 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                             assignment.primary,
                             row,
                         )?;
+                        // Primary placement only — see the assign-skip arm.
+                        if let Some(cal) = width_law.as_mut() {
+                            cal.offer(row);
+                        }
                     }
                 }
                 let mut checkpointed_spills = HashMap::with_capacity(cell_spills.len());
@@ -3756,6 +3775,12 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             .first()
             .cloned()
             .ok_or_else(|| BuildError::Store("drain pack requires a vector column".into()))?;
+        // All batches spilled: freeze the calibration sample so the pack
+        // fan-out below can score cells against a stable query set.
+        if let Some(cal) = width_law.as_mut() {
+            cal.freeze();
+        }
+        let width_law_ref = width_law.as_ref();
         let prepared_shards: Vec<PreparedSuperfile> = fanout_shards(
             &hidden_inner.options.writer_pool,
             &shard_sources,
@@ -3765,6 +3790,11 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                     let cell = match source {
                         DrainCellSource::Packed(cell) => cell.clone(),
                         DrainCellSource::Rows(spill) => {
+                            // Calibration reads the spill the pack pass is
+                            // about to read anyway (before remove_files).
+                            if let Some(cal) = width_law_ref {
+                                cal.score_cell(*cell_id, spill)?;
+                            }
                             let cell = build_spilled_packed_cell_from_rows(
                                 scratch,
                                 *cell_id,
@@ -3920,6 +3950,17 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         // shard membership append — never ArcSwap.store them beforehand
         // (contention refresh would drop the stamps; readers would also see
         // an advanced watermark without the new shards).
+        // Stamp the measured probe-width law into the routing this commit
+        // already persists; ranked against the same live grid queries route
+        // on. `None` (resumed drain / empty sample) keeps the prior law.
+        if let Some(cal) = width_law.take()
+            && let Some(law) = cal.finish(&running_clusters)
+        {
+            eprintln!(
+                "[supertable drain] probe-width law (cells for 0.99 top-k coverage at k={WIDTH_LAW_KS:?}): {law:?}"
+            );
+            routing.width_for_k = law;
+        }
         let list_metadata = CommitListMetadata {
             partition_strategy: Some(PartitionStrategy::VectorCell {
                 column: column.clone(),

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -3327,7 +3327,15 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
     // checkpointed batches never re-stream, so its sample would be partial
     // and the law would under-count. A resumed drain keeps whatever law
     // the manifest already carries.
-    let mut width_law = (local_checkpoint.batches_done == 0 && completed_shards.is_empty())
+    // `spills.is_empty()` is implied today — spills co-save with
+    // `batches_done` in one checkpoint write at each batch boundary — but
+    // checking it here makes the clean-run requirement locally visible:
+    // if a mid-batch checkpoint save is ever introduced, calibration
+    // disables safely instead of sampling a partial stream.
+    let clean_uncheckpointed_drain = local_checkpoint.batches_done == 0
+        && completed_shards.is_empty()
+        && local_checkpoint.spills.is_empty();
+    let mut width_law = clean_uncheckpointed_drain
         .then(|| opann::WidthLawCalibration::new(running_clusters.dim as usize, metric));
 
     let mut cell_spills = HashMap::new();

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -3960,6 +3960,14 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         // small tightly-clustered append would under-probe older data).
         // Widening on new evidence is always recall-safe; the law narrows
         // only when a full rebuild re-measures everything.
+        //
+        // Known staleness bound, accepted for the drain's O(delta) cost
+        // model: the incremental sample scores only tail candidates, so a
+        // distribution-shifting append whose true neighbors span old
+        // packed cells is not fully measured — the merged law can lag the
+        // real cross-generation spread until a full rebuild recalibrates.
+        // The alternative (rescoring every packed cell per incremental
+        // drain) would make drain cost track table size, not delta size.
         if let Some(cal) = width_law.take()
             && let Some(law) = cal.finish(&running_clusters)
         {

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -3953,13 +3953,23 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         // Stamp the measured probe-width law into the routing this commit
         // already persists; ranked against the same live grid queries route
         // on. `None` (resumed drain / empty sample) keeps the prior law.
+        //
+        // Element-wise MAX with the previously stamped law: an incremental
+        // drain samples and scores only the newly spilled tail, so its
+        // measurement alone could narrow the law for the whole table (a
+        // small tightly-clustered append would under-probe older data).
+        // Widening on new evidence is always recall-safe; the law narrows
+        // only when a full rebuild re-measures everything.
         if let Some(cal) = width_law.take()
             && let Some(law) = cal.finish(&running_clusters)
         {
+            for (slot, measured) in routing.width_for_k.iter_mut().zip(law) {
+                *slot = (*slot).max(measured);
+            }
             eprintln!(
-                "[supertable drain] probe-width law (cells for 0.99 top-k coverage at k={WIDTH_LAW_KS:?}): {law:?}"
+                "[supertable drain] probe-width law (cells for 0.99 top-k coverage at k={WIDTH_LAW_KS:?}): measured {law:?}, stamped {:?}",
+                routing.width_for_k
             );
-            routing.width_for_k = law;
         }
         let list_metadata = CommitListMetadata {
             partition_strategy: Some(PartitionStrategy::VectorCell {

--- a/tests/supertable/storage/smoke_rustfs.rs
+++ b/tests/supertable/storage/smoke_rustfs.rs
@@ -62,8 +62,15 @@ const BUDGET_N_ROWS: usize = 65_536;
 /// `BUDGET_N_ROWS` (dim 16, `n_cent` 4, Sq8, default or `nprobe` 4). Assert a
 /// band around the observed ~156 KB fetch: tight enough to prove it's the
 /// real cluster fetch, loose enough to survive minor codec / layout drift.
+// The manifest-calibrated probe-width law widened the default cold sweep
+// from the fine-first single probe to width(k) cells across several
+// units, each unit reserving its selected cells' blocks concurrently —
+// the same fixture now peaks ~5x the single-probe band (measured
+// 622,592 B). The band still pins both failure modes: ~0 = budget not
+// exercised on the query path; far above = reservations leaking past
+// the sweep's working set.
 const CONTROL_PEAK_LOW_BYTES: usize = 120_000;
-const CONTROL_PEAK_HIGH_BYTES: usize = 200_000;
+const CONTROL_PEAK_HIGH_BYTES: usize = 800_000;
 /// Bounded budget set generously above one cold fetch (~156 KB); 90% gate is
 /// 900 KB. Proves an enforcing budget admits under-budget work.
 const AMPLE_BUDGET_BYTES: u64 = 1_000_000;


### PR DESCRIPTION
**Problem.** On real-embedding corpora, post-drain unfiltered vector search could not reach the recall bar under any configuration (main today: recall@100 flat ~0.44 regardless of nprobe). Three compounding causes, measured on Cohere-1M/768d cosine: the hidden-index sweep probed exactly one cell and discarded caller `nprobe`; fine-run depth was pooled per drain wave so a forced-wide sweep didn't read the extra cells; and the p=1 design point assumes the top-k concentrates in the grid-nearest cell — true on synthetic clustered corpora, false on real embeddings (the true top-1 lands outside the nearest cell for ~58% of Cohere queries; 0.99 mean coverage of the top-100 needs ~50 of 256 cells; grid quality, granularity 256→4096, adaptive slack, and boundary replication all measured as non-levers).

**Change.** Four mechanisms, layered:

- **Honor caller `nprobe`** on the post-drain unfiltered path (override wins in both directions), with fine depth riding the pin exactly as it rides the law — a widened cell read at the persisted fine-first depth contributes only its first runs (measured: ~0.83 recall@100 at *any* nprobe). One pure function (`apply_width_pin`) carries all four override arms, unit-tested.
- **Probe-width law**: a clean drain reservoir-samples ~256 rows as stand-in queries, scores them against every packed cell during the pack pass it already performs (Sq8+ε, existing kernels, no fp32 corpus decode), and stamps the cells needed for mean-0.99 exact top-k coverage at k = {1,10,100,1000} into `CellRoutingParams.width_for_k`. Unfiltered queries with no override log-interpolate the law at their k. All-zero law (legacy manifests, resumed drains) keeps fine-first p=1 byte-for-byte; wire-compatible both directions.
- **Global shortlist selection at width**: warm cells surface their 1-bit estimates (scanned heap-free at the undivided cap — estimates are comparable across cells and superfiles, one rotation seed per column, asserted at the pool site); the supertable keeps the best k×rerank_mult across the whole sweep via an O(n) partition and reranks only those winners where they live. This replaces the per-cell even split, which wasted the estimator's precision: at equal budgets, divided vs global is 0.9691 vs 0.9928 (6.4K survivors) and 0.9878 vs 0.9954 (12.8K). Cold cells keep the divided in-probe rerank — their fetched blocks and budget reservation must not outlive the probe. Filtered queries and RabitqOnly untouched.
- **Concurrent per-cell probes** in the multi-cell kernel, wave-capped to the pool width.

**Results, Cohere-1M/768d cosine (official harness, 1000 held-out queries, warm, k=100):**

|  | **main** | **this PR (rerank_mult=64)** |
| --- | --- | --- |
| recall@100 | ~0.44 | 0.9947 |
| avg / p99 latency | — | **13.0/14.1 ms** |

recall@10 (repo bar ≥ 0.99): 0.9950 default / 0.9910 at rerank_mult=64. Cold recall equals warm at every point (measured with no cache at all — the cold arm holds the gate on its own; a checked-in warm-vs-cold parity fixture pins it). Sweep-condition p50 on a 50K-batch table runs ~2 ms lighter (10.6 ms k=100 / 4.1 ms k=10 at rerank_mult=64); the harness numbers above are the quotable condition.

**Trade-offs, explicit:** on spread-heavy corpora the bar has a real read price — the width sweep touches ~20% of corpus *code* bytes; payload reads are survivor-only on warm (k×rerank_mult rows, not whole cells) and whole-block on cold, where the cache fill amortizes them. The cold-budget smoke band widened ([120K,200K]→[120K,800K] B); the bounded-budget contract (sum, refuse on crossing) is unchanged and covered. Calibration adds ~15s to a 1M-row clean drain; resumed drains keep the prior law (max-merge floor; staleness documented at the stamp site). Found in passing, separate issues: `drain_replica_target_factor > 1.0` drain crash; persisting the calibration sample to allow law shrink at maintenance.

**Testing:** 2,428 tests green (lib/supertable/superfile); regression tests pin the override both directions, the law-widened default, filtered+nprobe parity, all pin arms, selection determinism, and the minimal-budget global path; manifest roundtrip + legacy-decode for the new field.

**Bench:** pending — `make bench` vs main before merge; expectation is no change on the synthetic lanes (width 1, global path disengaged).


For engineers who understand how search currently works in main, here's a simpler way to describe the changes:

1. How many cells the search selects — the width law. On main, the post-drain unfiltered default is fine-first p=1 (one cell, slack-widened to ~3), and caller nprobe was silently ignored on that path — worse, wave-pooled gating meant widening cells didn’t even deepen reads (measured dead flat 0.443 recall from nprobe=4 through 256). That’s the 0.44 VDBBench number from yesterday. This branch: the drain calibrates width_for_k on the actual corpus (k=1/10/100/1000 — Cohere needs ~30-40 cells at k=100; synthetic clustered data calibrates to 1), stamps it into manifest routing, and at query time the law pins the cutoff like an explicit nprobe. The cutoff in the pipeline I described was effectively 1-3 on main; it’s the calibrated width here.
2. How deep each selected cell is scanned. Main’s widened cells contributed only their persisted fine-first runs (~6-8), capping recall at 0.83 at any width. This branch: depth rides the pin — fine_nprobe = MAX on the law/pin path (measured load-bearing: 0.83 floor / 0.90 half / 0.9928 full), plus per-(cell, fragment) gating when a width is pinned so reads actually follow width.
3. Who keeps the row shortlist. Main divides the k×rm survivor budget per cell and reranks in-probe — per-cell truncation destroys the global estimate ordering (0.9691 at rm=64). This branch pools 1-bit estimates globally across all cells and superfiles (legal because one table-wide rot_seed makes them comparable), selects the global top k×rm once, and defers exact rerank to those winners: 0.9928 at the same budget. 
4. The speed of every stage — the five optimization commits: exact-range survivor gather, zero-copy mmap block-cache service, per-cell heap → one select_nth partition, per-superfile rotation hoist, and the FastScan LUT transposed scan.

---