### PR TITLE
catalog: reject duplicate column names at create_table

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -2225,6 +2225,16 @@ mod tests {
         assert!(err.to_string().contains("duplicate column name: a"));
     }
 
+    /// A single-column schema whose one column `emb` is a
+    /// `FixedSizeList<Float32, dim>` — the vector-column shape.
+    fn emb_schema(dim: i32) -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new(
+            "emb",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+            false,
+        )]))
+    }
+
     #[test]
     fn vector_index_dim_out_of_range_rejected_at_create() {
         // A vector index's `dim` is validated when the table is created, not
@@ -2232,21 +2242,27 @@ mod tests {
         // rejected up front, so a caller can't create a table whose vector
         // column can never be built.
         let conn = connect("memory://").expect("connect");
-        let vector_col = |dim: i32| {
-            Arc::new(Schema::new(vec![Field::new(
-                "emb",
-                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
-                false,
-            )]))
-        };
 
         // Zero (below the floor) and an oversized dim both fail at create time.
         for dim in [0_i32, 100_000] {
             let spec = IndexSpec::new().vector("emb", dim as usize, 1, Metric::Cosine);
             let err = conn
-                .create_table(&format!("v{dim}"), vector_col(dim), spec)
+                .create_table(&format!("v{dim}"), emb_schema(dim), spec)
                 .expect_err("an out-of-range vector dim is rejected");
             assert!(matches!(err, InfinoError::Schema(_)), "got {err:?}");
+        }
+    }
+
+    #[test]
+    fn vector_index_dim_within_range_accepted_at_create() {
+        // The complement of the rejection test: both inclusive boundaries of
+        // the supported range (16 and 4096) are valid dims, so a table with a
+        // vector index at either bound is created successfully.
+        let conn = connect("memory://").expect("connect");
+        for dim in [16_i32, 4096] {
+            let spec = IndexSpec::new().vector("emb", dim as usize, 1, Metric::Cosine);
+            conn.create_table(&format!("v{dim}"), emb_schema(dim), spec)
+                .expect("an in-range vector dim is accepted");
         }
     }
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -322,6 +322,7 @@ impl Connection {
         indexes: IndexSpec,
     ) -> Result<Supertable, InfinoError> {
         validate_name(name).map_err(|e| e.with_context("create_table", Some(name)))?;
+        validate_schema(&schema).map_err(|e| e.with_context("create_table", Some(name)))?;
         let (fts_cfg, vec_cfg) = indexes.to_configs();
         let tokenizers =
             table_tokenizers(&indexes).map_err(|e| e.with_context("create_table", Some(name)))?;
@@ -1016,6 +1017,24 @@ fn validate_name(name: &str) -> Result<(), InfinoError> {
             "invalid table name {name:?}: use non-empty [A-Za-z0-9_-], not starting with '_'"
         )))
     }
+}
+
+/// Reject a schema that the engine can build but can never query. Arrow
+/// permits a `Schema` with duplicate field names, yet any query against a
+/// table built from one fails on the ambiguous column. Catching it here turns
+/// a table that would otherwise error on every read into a create-time
+/// rejection.
+fn validate_schema(schema: &SchemaRef) -> Result<(), InfinoError> {
+    let mut seen = HashSet::new();
+    for field in schema.fields() {
+        if !seen.insert(field.name().as_str()) {
+            return Err(InfinoError::Schema(format!(
+                "duplicate column name: {}",
+                field.name()
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// A unique-per-creation physical subtree for a table. The catalog name
@@ -2186,6 +2205,49 @@ mod tests {
         let conn = connect("memory://").expect("connect");
         let bad = conn.create_table("has space", schema_id_title(), IndexSpec::new());
         assert!(bad.is_err());
+    }
+
+    #[test]
+    fn duplicate_column_names_rejected() {
+        // Arrow accepts a schema with two fields named `a`, but a table built
+        // from it can never be queried — every query fails on the ambiguous
+        // column. `create_table` rejects it up front rather than yielding a
+        // table that errors on every read.
+        let conn = connect("memory://").expect("connect");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("a", DataType::LargeUtf8, true),
+        ]));
+        let err = conn
+            .create_table("dupcol", schema, IndexSpec::new())
+            .expect_err("a schema with duplicate column names is rejected");
+        assert!(matches!(err, InfinoError::Schema(_)), "got {err:?}");
+        assert!(err.to_string().contains("duplicate column name: a"));
+    }
+
+    #[test]
+    fn vector_index_dim_out_of_range_rejected_at_create() {
+        // A vector index's `dim` is validated when the table is created, not
+        // deferred to the first append: a `dim` outside the supported range is
+        // rejected up front, so a caller can't create a table whose vector
+        // column can never be built.
+        let conn = connect("memory://").expect("connect");
+        let vector_col = |dim: i32| {
+            Arc::new(Schema::new(vec![Field::new(
+                "emb",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            )]))
+        };
+
+        // Zero (below the floor) and an oversized dim both fail at create time.
+        for dim in [0_i32, 100_000] {
+            let spec = IndexSpec::new().vector("emb", dim as usize, 1, Metric::Cosine);
+            let err = conn
+                .create_table(&format!("v{dim}"), vector_col(dim), spec)
+                .expect_err("an out-of-range vector dim is rejected");
+            assert!(matches!(err, InfinoError::Schema(_)), "got {err:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`create_table` accepts an Arrow schema with duplicate field names and returns success, but the resulting table is permanently unqueryable — every query fails with `Schema contains duplicate qualified field name <table>.<col>`. A caller can create a table it can never read, with no error at creation time.

## Fix

Validate the schema in `create_table` (ahead of the backend `match`, so all backends are covered) and reject duplicate column names with `InfinoError::Schema`. This is validation on the create error path only — no query, ingest, or commit surface is touched, so there is no performance or cost impact and no bench delta.

## Tests

- `duplicate_column_names_rejected` — regression test: a two-`a`-column schema now returns `InfinoError::Schema` (`duplicate column name: a`). Fails before this change (create returned `Ok`), passes after.
- `vector_index_dim_out_of_range_rejected_at_create` — pins existing behavior that a vector index `dim` outside the supported range is rejected at create time (via `IndexSpec::vector`), not deferred to the first append. Guards against regressing that validation.

`cargo fmt --check`, `cargo clippy`, and the catalog test suite (68 tests) pass.