### PR TITLE
Hosted SDK reference docs + remote-transport API drift check

### DIFF
--- a/.github/workflows/hosted-api-drift.yml
+++ b/.github/workflows/hosted-api-drift.yml
@@ -1,0 +1,36 @@
+name: Hosted API drift
+
+# Checks that the remote transport still conforms to the published hosted API
+# spec (`tests/fixtures/hosted-openapi.json`). Runs ONLY when the vendored spec
+# or the remote transport changes — never on unrelated engine work — and is
+# deliberately NOT part of `make ci`, so a hosted-service change can't gate an
+# OSS engine release. The drift test is `#[ignore]`d for that reason and run
+# explicitly here.
+#
+# This surfaces on the refresh PR (which the refresh-hosted-openapi workflow
+# opens when the spec changes): red means the client no longer matches the API —
+# update the transport in `src/catalog/remote/` (the node and python bindings
+# call through it, so fixing the Rust core covers all three).
+
+on:
+  pull_request:
+    paths:
+      - "tests/fixtures/hosted-openapi.json"
+      - "src/catalog/remote/**"
+      - "tests/remote.rs"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  drift:
+    name: Remote transport ⇄ hosted API spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # `--ignored` runs exactly the ignored drift test (kept out of `make ci`).
+      - run: cargo test --features remote --test remote -- --ignored

--- a/.github/workflows/refresh-hosted-openapi.yml
+++ b/.github/workflows/refresh-hosted-openapi.yml
@@ -1,0 +1,61 @@
+name: Refresh hosted API spec
+
+# Keeps the vendored hosted API spec (`tests/fixtures/hosted-openapi.json`) in
+# step with what the service actually publishes at `/openapi.json`. The
+# remote-transport drift test (`tests/remote.rs`) validates the client's wire
+# calls against this fixture, so refreshing it is how a hosted API change turns
+# into a failing test that says "the client needs updating".
+#
+# It fetches the published spec and, if it changed, opens a PR — the drift test
+# runs on that PR, so any incompatibility surfaces in review rather than at
+# runtime. A human merges the refresh.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # weekly safety net
+  workflow_dispatch:
+    inputs:
+      spec_url:
+        description: "OpenAPI spec URL to fetch"
+        default: "https://api.platform.infino.ai/openapi.json"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-hosted-openapi
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    # Only on the canonical repo — forks have no reason to refresh.
+    if: github.repository == 'infino-ai/infino'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch the published spec
+        run: |
+          URL="${{ github.event.inputs.spec_url || 'https://api.platform.infino.ai/openapi.json' }}"
+          echo "fetching $URL"
+          curl -fsS "$URL" -o tests/fixtures/hosted-openapi.json
+          # Fail loudly if it isn't valid JSON, rather than committing garbage.
+          python3 -m json.tool tests/fixtures/hosted-openapi.json > /dev/null
+
+      - name: Open a refresh PR if the spec changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths: tests/fixtures/hosted-openapi.json
+          branch: bot/refresh-hosted-openapi
+          commit-message: "test: refresh the vendored hosted API spec"
+          title: "Refresh the vendored hosted API spec"
+          body: |
+            Automated refresh of `tests/fixtures/hosted-openapi.json` from the
+            published hosted API spec.
+
+            If the remote-transport drift test fails on this PR, the client's
+            wire calls no longer match the API — update the remote transport in
+            `src/catalog/remote/` (the node and python bindings call through it,
+            so fixing the Rust core covers all three). No-op if the spec is
+            unchanged.

--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -31,7 +31,15 @@ export type SchemaDescriptor = Record<string, string | { vector: number }>;
 /** Accepted shapes for `Table.append`. */
 export type AppendData = RowRecord[] | arrow.Table | arrow.RecordBatch | Buffer | Uint8Array;
 
-/** Storage and cache config the `connect` URI can't carry. All optional. */
+/**
+ * Storage and cache config the `connect` URI can't carry. All optional.
+ *
+ * Which options apply depends on the backend: `apiKey` is for a hosted
+ * (Infino Cloud) connection, while the storage/cache options — `storageOptions`,
+ * `cacheDir`, `cacheBudgetBytes`, `coldFetchMode`, `validate` — apply to **local
+ * connections only**; Infino Cloud manages storage, so it ignores them.
+ * `connectionMemoryBudgetBytes` applies to both.
+ */
 export interface ConnectOptions {
   /**
    * Credentials/tuning for the URI-selected backend, keyed by `object_store`
@@ -59,6 +67,12 @@ export interface ConnectOptions {
    * on bad credentials instead of on the first table operation.
    */
   validate?: boolean;
+  /**
+   * API key for a hosted (`https://<host>/<database>`) connection, sent as a
+   * bearer credential. Ignored by local backends. Falls back to the
+   * `INFINO_API_KEY` environment variable when omitted.
+   */
+  apiKey?: string;
 }
 
 /** Row counts returned by `update` / `delete`. */
@@ -301,8 +315,10 @@ function decode(buf: Buffer, asArrow?: boolean): RowRecord[] | arrow.Table {
 
 // --- friendly handles ---
 
+/** A table handle. Obtain one from {@link Connection.createTable} or {@link Connection.openTable}. */
 export class Table {
   private inner: any;
+  /** @hidden */
   constructor(inner: any) {
     this.inner = inner;
   }
@@ -388,22 +404,34 @@ export class Table {
     return this.inner.delete(predicate);
   }
 
-  /** Merge small / underfilled superfiles into larger ones (omit `settings`
-   * for engine defaults). */
+  /**
+   * Merge small / underfilled superfiles into larger ones (omit `settings`
+   * for engine defaults).
+   *
+   * **Local connections only.** On Infino Cloud, compaction is managed for you,
+   * so calling this on a hosted (`https://…`) connection throws.
+   */
   optimize(settings?: OptimizeOptions): void {
     this.inner.optimize(settings);
   }
 
-  /** Delete orphaned storage objects left by compaction or interrupted writes.
+  /**
+   * Delete orphaned storage objects left by compaction or interrupted writes.
    * Only objects older than `graceSecs` (a safety window against racing
-   * readers/writers) are removed. Requires durable storage (not `memory://`). */
+   * readers/writers) are removed. Requires durable storage (not `memory://`).
+   *
+   * **Local connections only.** On Infino Cloud, cleanup is managed for you, so
+   * calling this on a hosted connection throws.
+   */
   gc(graceSecs: number): GcReport {
     return this.inner.gc(graceSecs);
   }
 }
 
+/** A catalog connection. Create one with {@link connect}. */
 export class Connection {
   private inner: any;
+  /** @hidden */
   constructor(inner: any) {
     this.inner = inner;
   }
@@ -442,7 +470,26 @@ export class Connection {
   }
 }
 
-/** Open (or create) a catalog rooted at `uri`. */
+/**
+ * Open a connection to Infino. The `uri` selects the backend:
+ *
+ * - a local path (`"./data"`) or `"memory://"` — embedded, in-process;
+ * - an object-store URI (`"s3://…"`, `"gs://…"`, `"az://…"`) — embedded over
+ *   your own bucket;
+ * - `"https://<host>/<database>"` — Infino Cloud, the hosted service.
+ *
+ * For a hosted (`https://`) target, authenticate with an API key: pass
+ * {@link ConnectOptions.apiKey}, or set the `INFINO_API_KEY` environment
+ * variable. Storage and cache tuning the URI can't carry also goes in
+ * `options` (see {@link ConnectOptions}).
+ *
+ * ```ts
+ * // local
+ * const db = connect("./data");
+ * // Infino Cloud
+ * const cloud = connect("https://api.platform.infino.ai/my-app", { apiKey: "inf_…" });
+ * ```
+ */
 export function connect(uri: string, options?: ConnectOptions): Connection {
   return new Connection(nativeConnect(uri, options as any));
 }

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -28,6 +28,7 @@ def connect(
     connection_memory_budget_bytes: int | None = ...,
     cold_fetch_mode: ColdFetchMode | None = ...,
     validate: bool | None = ...,
+    api_key: str | None = ...,
 ) -> Connection: ...
 
 class InfinoError(Exception):

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -112,12 +112,20 @@ fn cold_fetch_from_str(s: &str) -> PyResult<ColdFetchMode> {
     }
 }
 
-/// Open (or create) a catalog rooted at `uri`. Storage config the URI
-/// can't carry is passed as keyword arguments: `storage_options` (a map
-/// of `object_store` config keys — `aws_*` / `azure_*` / `google_*`) and the optional
-/// local disk cache. Pass `validate=True` to probe the object store at
-/// connect (off by default) so bad credentials fail there. Omit all for
-/// local / `memory://` / ambient-credential object storage.
+/// Open a connection to Infino. The `uri` selects the backend: a local path
+/// (`"./data"`) or `"memory://"` (embedded), an object-store URI (`"s3://…"` /
+/// `"gs://…"` / `"az://…"`, embedded over your bucket), or
+/// `"https://<host>/<database>"` for Infino Cloud, the hosted service.
+///
+/// For a hosted (`https://`) target, authenticate with an API key: pass
+/// `api_key=`, or set the `INFINO_API_KEY` environment variable. The
+/// storage/cache keyword arguments — `storage_options` (a map of `object_store`
+/// config keys, `aws_*` / `azure_*` / `google_*`), `cache_dir`,
+/// `cache_budget_bytes`, `cold_fetch_mode`, and `validate` — apply to **local
+/// connections only**; Infino Cloud manages storage and ignores them. Pass
+/// `validate=True` to probe the object store at connect (off by default) so bad
+/// credentials fail there. Omit all for local / `memory://` /
+/// ambient-credential object storage.
 ///
 /// `connection_memory_budget_bytes` caps this connection's heap: the memory
 /// used to ingest data and run queries over it (keyword, vector, hybrid, or
@@ -702,6 +710,9 @@ impl Table {
 
     /// Merge small / underfilled superfiles into larger ones. Omit
     /// `settings` for engine defaults.
+    ///
+    /// Local connections only — on Infino Cloud, compaction is managed for you
+    /// and this raises `InfinoError`.
     #[pyo3(signature = (settings=None))]
     fn optimize(&self, py: Python<'_>, settings: Option<&CompactOptions>) -> PyResult<()> {
         let mut s = CompactionSettings::default();
@@ -727,6 +738,9 @@ impl Table {
     /// Delete orphaned storage objects left by compaction or interrupted
     /// writes. Only objects older than `grace_secs` (a safety window against
     /// racing readers/writers) are removed. Requires durable storage.
+    ///
+    /// Local connections only — on Infino Cloud, cleanup is managed for you
+    /// and this raises `InfinoError`.
     fn gc(&self, py: Python<'_>, grace_secs: f64) -> PyResult<GcReport> {
         let grace = Duration::from_secs_f64(grace_secs.max(0.0));
         let report = py.detach(|| self.inner.gc(grace)).map_err(gc_err)?;

--- a/tests/fixtures/hosted-openapi.json
+++ b/tests/fixtures/hosted-openapi.json
@@ -1,0 +1,1367 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Infino API",
+    "description": "The Infino hosted data-plane API: per-database table operations — create, ingest, search, and SQL.",
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.platform.infino.ai",
+      "description": "Infino Enterprise"
+    }
+  ],
+  "paths": {
+    "/v1/append/{database}": {
+      "post": {
+        "tags": [
+          "Rows"
+        ],
+        "summary": "Append rows",
+        "description": "Append rows to a table. The body is an Arrow IPC stream, or a JSON `{\"data\": [...]}` envelope.",
+        "operationId": "append",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "description": "Target table.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rows appended. Body is an Arrow IPC row stream (application/vnd.apache.arrow.stream), or a JSON `{\"data\": [...]}` envelope."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/bm25_search/{database}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "BM25 full-text search",
+        "description": "Ranked BM25 full-text search over a full-text-indexed column.",
+        "operationId": "bm25_search",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Bm25SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Matching rows as an Arrow IPC stream (application/vnd.apache.arrow.stream), or JSON when the request sends `Accept: application/json`."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/count/{database}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Count matches",
+        "description": "Count the rows matching a full-text query.",
+        "operationId": "count",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Match count as JSON `{\"count\": <n>}`."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/create_table/{database}": {
+      "post": {
+        "tags": [
+          "Tables"
+        ],
+        "summary": "Create a table",
+        "description": "Create a table with an Arrow schema and optional full-text and vector indexes.",
+        "operationId": "create_table",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTableRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Table created."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/databases": {
+      "get": {
+        "tags": [
+          "Databases"
+        ],
+        "summary": "List databases",
+        "description": "List your account's databases and their state.",
+        "operationId": "list_databases",
+        "responses": {
+          "200": {
+            "description": "The account's databases.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDatabasesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No valid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Databases"
+        ],
+        "summary": "Create a database",
+        "description": "Register a new database for your account.",
+        "operationId": "create_database",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDatabaseRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Database registered."
+          },
+          "401": {
+            "description": "No valid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Database already exists.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/databases/{name}": {
+      "delete": {
+        "tags": [
+          "Databases"
+        ],
+        "summary": "Delete a database",
+        "description": "Begin deleting a database. Idempotent.",
+        "operationId": "delete_database",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The database name to delete.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Database deletion begun (idempotent)."
+          },
+          "401": {
+            "description": "No valid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/delete/{database}": {
+      "post": {
+        "tags": [
+          "Rows"
+        ],
+        "summary": "Delete rows",
+        "description": "Delete rows matching a predicate. `table` and `predicate` are query parameters; no body.",
+        "operationId": "delete",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "table",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "predicate",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Row counts as JSON `{matched, n_tombstoned, n_not_found}`."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/drop_table/{database}": {
+      "post": {
+        "tags": [
+          "Tables"
+        ],
+        "summary": "Drop a table",
+        "description": "Drop a table from the database.",
+        "operationId": "drop_table",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DropTableRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Table dropped."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/exact_match/{database}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Exact match",
+        "description": "Exact-value match over a column.",
+        "operationId": "exact_match",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExactMatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Matching rows as an Arrow IPC stream (application/vnd.apache.arrow.stream), or JSON when the request sends `Accept: application/json`."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/hybrid_search/{database}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Hybrid search",
+        "description": "Hybrid BM25 and vector search, fused with reciprocal-rank fusion.",
+        "operationId": "hybrid_search",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HybridSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Matching rows as an Arrow IPC stream (application/vnd.apache.arrow.stream), or JSON when the request sends `Accept: application/json`."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/list_tables/{database}": {
+      "post": {
+        "tags": [
+          "Tables"
+        ],
+        "summary": "List tables",
+        "description": "List the tables in the database.",
+        "operationId": "list_tables",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON array of table names."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/query_sql/{database}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Run a SQL query",
+        "description": "Run a read-only SQL query across the database's tables.",
+        "operationId": "sql_query",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SqlQueryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Matching rows as an Arrow IPC stream (application/vnd.apache.arrow.stream), or JSON when the request sends `Accept: application/json`."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/schema/{database}": {
+      "post": {
+        "tags": [
+          "Tables"
+        ],
+        "summary": "Describe a table's schema",
+        "description": "Return a table's column schema.",
+        "operationId": "schema",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SchemaRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "JSON array of column descriptors."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/token_match/{database}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Token match",
+        "description": "Unranked token match over a full-text-indexed column.",
+        "operationId": "token_match",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenMatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Matching rows as an Arrow IPC stream (application/vnd.apache.arrow.stream), or JSON when the request sends `Accept: application/json`."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/update/{database}": {
+      "post": {
+        "tags": [
+          "Rows"
+        ],
+        "summary": "Update rows",
+        "description": "Replace rows matching a predicate. `table` and `predicate` are query parameters; the body carries the replacement rows (Arrow IPC or JSON).",
+        "operationId": "update",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "table",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "predicate",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Row counts as JSON `{matched, n_tombstoned, n_not_found}`. Body is the replacement rows as an Arrow IPC stream."
+          },
+          "400": {
+            "description": "Invalid request."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/vector_search/{database}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Vector search",
+        "description": "Vector (kNN) search over a vector column, with an optional full-text pre-filter.",
+        "operationId": "vector_search",
+        "parameters": [
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Target database.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VectorSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Matching rows as an Arrow IPC stream (application/vnd.apache.arrow.stream), or JSON when the request sends `Accept: application/json`."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Bm25SearchRequest": {
+        "type": "object",
+        "description": "`POST /v1/bm25_search/{database}`. Projection is optional (absent ⇒ the\nengine-native `_id` + `score`).",
+        "required": [
+          "table_name",
+          "field_name",
+          "query",
+          "k",
+          "mode"
+        ],
+        "properties": {
+          "field_name": {
+            "type": "string"
+          },
+          "k": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "mode": {
+            "$ref": "#/components/schemas/Mode"
+          },
+          "projection": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "query": {
+            "type": "string"
+          },
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CountRequest": {
+        "type": "object",
+        "description": "`POST /v1/count/{database}`. Count of rows matching a keyword query.",
+        "required": [
+          "table_name",
+          "field_name",
+          "query",
+          "mode"
+        ],
+        "properties": {
+          "field_name": {
+            "type": "string"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/Mode"
+          },
+          "query": {
+            "type": "string"
+          },
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDatabaseRequest": {
+        "type": "object",
+        "description": "Create-database request.",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The database name, unique within the account."
+          }
+        }
+      },
+      "CreateTableRequest": {
+        "type": "object",
+        "description": "`POST /v1/create_table/{database}`.",
+        "required": [
+          "table_name",
+          "schema"
+        ],
+        "properties": {
+          "indexes": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Indexes"
+              }
+            ]
+          },
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SchemaField"
+            }
+          },
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DatabaseSummary": {
+        "type": "object",
+        "description": "One database in the account's list, with its lifecycle state.",
+        "required": [
+          "name",
+          "state",
+          "created_ms"
+        ],
+        "properties": {
+          "created_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix epoch milliseconds when the database was created, or `0` if unknown\n(a database registered before creation time was tracked).",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string",
+            "description": "The database name, unique within the account."
+          },
+          "state": {
+            "type": "string",
+            "description": "Lifecycle state: `registered` (usable) or `purging` (being deleted)."
+          }
+        }
+      },
+      "DropTableRequest": {
+        "type": "object",
+        "description": "`POST /v1/drop_table/{database}`.",
+        "required": [
+          "table_name",
+          "purge"
+        ],
+        "properties": {
+          "purge": {
+            "type": "boolean"
+          },
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ErrorBody": {
+        "type": "object",
+        "description": "A JSON error body.",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          }
+        }
+      },
+      "ExactMatchRequest": {
+        "type": "object",
+        "description": "`POST /v1/exact_match/{database}`. Unranked; projection required.",
+        "required": [
+          "table_name",
+          "field_name",
+          "value",
+          "projection"
+        ],
+        "properties": {
+          "field_name": {
+            "type": "string"
+          },
+          "projection": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "table_name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HybridSearchRequest": {
+        "type": "object",
+        "description": "`POST /v1/hybrid_search/{database}`. BM25 + vector fused with RRF.\nProjection is optional; `nprobe` / `rerank_mult` tune the vector leg.",
+        "required": [
+          "table_name",
+          "text_field",
+          "text_query",
+          "mode",
+          "vector_field",
+          "vector_query",
+          "k"
+        ],
+        "properties": {
+          "k": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "mode": {
+            "$ref": "#/components/schemas/Mode"
+          },
+          "nprobe": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "projection": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "rerank_mult": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "table_name": {
+            "type": "string"
+          },
+          "text_field": {
+            "type": "string"
+          },
+          "text_query": {
+            "type": "string"
+          },
+          "vector_field": {
+            "type": "string"
+          },
+          "vector_query": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Indexes": {
+        "type": "object",
+        "description": "Index declarations for `create_table`.",
+        "properties": {
+          "fts": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "FTS-indexed column names."
+          },
+          "vector": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/VectorIndex"
+            },
+            "description": "Vector index declarations."
+          }
+        },
+        "additionalProperties": false
+      },
+      "ListDatabasesResponse": {
+        "type": "object",
+        "description": "The databases in your account.",
+        "required": [
+          "databases"
+        ],
+        "properties": {
+          "databases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatabaseSummary"
+            },
+            "description": "The account's databases, order unspecified."
+          }
+        }
+      },
+      "Metric": {
+        "type": "string",
+        "description": "Vector distance metric. Accepted case-insensitively, with the aliases\n`l2` → `l2sq` and `dot` → `negdot`; serialized canonically.",
+        "enum": [
+          "cosine",
+          "l2sq",
+          "negdot"
+        ]
+      },
+      "Mode": {
+        "type": "string",
+        "description": "Boolean mode for a multi-term FTS query. Accepted case-insensitively on the\nwire (`\"or\"`, `\"Or\"`, `\"OR\"`); serialized canonically lowercase.",
+        "enum": [
+          "or",
+          "and"
+        ]
+      },
+      "SchemaField": {
+        "type": "object",
+        "description": "One column in a `create_table` schema. A scalar column is `{name, type}` where `type` is a scalar spelling (`\"i32\"`, `\"large_utf8\"`, …); a vector column is `{name, type: \"vector\", dim}`; a list column is `{name, type: \"list\", item}`. `dim` is required for `\"vector\"` and `item` for `\"list\"`.",
+        "required": [
+          "name",
+          "type"
+        ],
+        "properties": {
+          "dim": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Fixed length, required for `type: \"vector\"`.",
+            "minimum": 0
+          },
+          "item": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Element scalar type, required for `type: \"list\"`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Column name."
+          },
+          "nullable": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Defaults to `true` when omitted."
+          },
+          "type": {
+            "type": "string",
+            "description": "Scalar spelling, or `\"vector\"` / `\"list\"`."
+          }
+        },
+        "additionalProperties": false
+      },
+      "SchemaRequest": {
+        "type": "object",
+        "description": "`POST /v1/schema/{database}`.",
+        "required": [
+          "table_name"
+        ],
+        "properties": {
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SqlQueryRequest": {
+        "type": "object",
+        "description": "`POST /v1/sql_query/{database}`.",
+        "required": [
+          "query"
+        ],
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TokenMatchRequest": {
+        "type": "object",
+        "description": "`POST /v1/token_match/{database}`. Unranked; projection required.",
+        "required": [
+          "table_name",
+          "field_name",
+          "query",
+          "mode",
+          "projection"
+        ],
+        "properties": {
+          "field_name": {
+            "type": "string"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/Mode"
+          },
+          "projection": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "query": {
+            "type": "string"
+          },
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VectorFilter": {
+        "type": "object",
+        "description": "Optional text pre-filter for `vector_search`: kNN ranks only among rows\nwhose FTS-indexed `field_name` matches `query`.",
+        "required": [
+          "field_name",
+          "query",
+          "mode"
+        ],
+        "properties": {
+          "field_name": {
+            "type": "string"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/Mode"
+          },
+          "query": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VectorIndex": {
+        "type": "object",
+        "description": "One vector index declaration under `indexes.vector`.",
+        "required": [
+          "column",
+          "metric"
+        ],
+        "properties": {
+          "column": {
+            "type": "string"
+          },
+          "dim": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Redundant with the schema column's declared width; the server resolves\nthe dimension from the schema, so this is optional and, if given, must\nagree.",
+            "minimum": 0
+          },
+          "metric": {
+            "$ref": "#/components/schemas/Metric"
+          },
+          "n_centroids": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "IVF centroid count. Optional; the server applies a default when omitted.",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "VectorSearchRequest": {
+        "type": "object",
+        "description": "`POST /v1/vector_search/{database}`. Projection required; `nprobe` /\n`rerank_mult` / `filter` are optional tuning knobs.",
+        "required": [
+          "table_name",
+          "field_name",
+          "query",
+          "k",
+          "projection"
+        ],
+        "properties": {
+          "field_name": {
+            "type": "string"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VectorFilter"
+              }
+            ]
+          },
+          "k": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "nprobe": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "projection": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "query": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "rerank_mult": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "session_cookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "infino_session"
+      },
+      "session_token": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Session-Token"
+      }
+    }
+  },
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Databases",
+      "description": "Create, list, and delete the databases in your account."
+    },
+    {
+      "name": "Tables",
+      "description": "Create, drop, and list tables, and describe a table's schema."
+    },
+    {
+      "name": "Rows",
+      "description": "Append, update, and delete rows."
+    },
+    {
+      "name": "Search",
+      "description": "BM25, vector, and hybrid search, token and exact match, count, and SQL."
+    }
+  ]
+}

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -11,7 +11,7 @@
 
 #![cfg(feature = "remote")]
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use arrow::ipc::writer::StreamWriter;
 use arrow_array::{Int32Array, RecordBatch};
@@ -483,4 +483,173 @@ async fn create_database_conflict_maps_to_already_exists() {
     })
     .await;
     assert!(matches!(err, InfinoError::AlreadyExists(_)), "got {err:?}");
+}
+
+/// Collect the sorted, deduped `<op>` segment from each `/v1/<op>/…` path.
+fn path_segments(paths: impl Iterator<Item = String>) -> Vec<String> {
+    let mut segs: Vec<String> = paths
+        .filter_map(|p| {
+            p.strip_prefix("/v1/")
+                .map(|rest| rest.split('/').next().unwrap_or_default().to_string())
+        })
+        .collect();
+    segs.sort();
+    segs.dedup();
+    segs
+}
+
+/// The request-body schema name the spec defines for `(method, <op>)`, if the
+/// operation carries a JSON body. `None` for bodyless ops (binary/query-param).
+fn request_schema_name(spec: &serde_json::Value, method: &str, seg: &str) -> Option<String> {
+    for (path, methods) in spec["paths"].as_object()? {
+        if path.split('/').nth(2) != Some(seg) {
+            continue;
+        }
+        let Some(op) = methods.get(method) else {
+            continue;
+        };
+        if let Some(r) = op
+            .pointer("/requestBody/content/application~1json/schema/$ref")
+            .and_then(serde_json::Value::as_str)
+        {
+            return Some(r.rsplit('/').next().unwrap_or_default().to_string());
+        }
+    }
+    None
+}
+
+/// The remote client's wire calls must match the published data-plane API spec.
+///
+/// The spec (`fixtures/hosted-openapi.json`) is the source of truth, refreshed
+/// from the deployed `/openapi.json` by the `refresh-hosted-openapi` workflow.
+/// This drives every public method against a mock server, captures the requests
+/// the client emits, and checks them against the spec at two levels:
+///
+/// 1. **Operations** — the set of `/v1/<op>` paths called equals the spec's
+///    paths. A hosted operation added or removed fails here.
+/// 2. **Request signatures** — for each operation with a JSON body, the fields
+///    the client sends conform to the spec's request schema: every required
+///    field is present, and no field is undefined (the server's
+///    `deny_unknown_fields` would 400 an undefined one). A renamed, newly
+///    required, or removed field fails here.
+///
+/// The Rust remote transport is the single place these requests are built; the
+/// node and python bindings call through it, so this one check covers all three
+/// bindings. A failure means: the hosted API changed — update the transport.
+///
+/// `#[ignore]`d on purpose: this checks conformance to an external, moving
+/// contract (the hosted API), so it is deliberately kept out of `make ci` — a
+/// hosted-service change must never gate an OSS engine release. It is run
+/// explicitly by the `hosted-api-drift` workflow (on spec/transport changes)
+/// via `cargo test … -- --ignored`.
+#[tokio::test]
+#[ignore = "hosted-API conformance; run by the hosted-api-drift workflow, not make ci"]
+async fn remote_client_matches_the_published_api_spec() {
+    let server = MockServer::start().await;
+    mount_schema(&server).await;
+
+    // Drive every operation. Only `open_table` needs a parseable response; the
+    // rest go unmatched (404) but their requests are still recorded — we assert
+    // on what the client sends, not on the responses. Searches pass a projection
+    // so the required field is present (the projection-optionality question is
+    // tracked separately). `optimize`/`gc` short-circuit and send nothing.
+    with_connection(server.uri(), |db| {
+        let _ = db.create_database();
+        let _ = db.create_table("posts", id_schema(), IndexSpec::new());
+        let _ = db.list_tables();
+        let _ = db.drop_table("posts", false);
+        let _ = db.query_sql("SELECT id FROM posts");
+        if let Ok(table) = db.open_table("posts") {
+            let _ = table.append(&id_batch(vec![1]));
+            let _ = table.update(col("id").gt(lit(0_i32)), &id_batch(vec![1]));
+            let _ = table.delete(col("id").lt(lit(0_i32)));
+            let _ = table.bm25_search("id", "x", 1, Bm25SearchOptions::new(), Some(&["_id"]));
+            let _ = table.token_match("id", "x", BoolMode::Or, Some(&["_id"]));
+            let _ = table.exact_match("id", "x", Some(&["_id"]));
+            let _ = table.count("id", "x", BoolMode::Or);
+            let _ = table.vector_search(
+                "id",
+                &[1.0],
+                1,
+                VectorSearchOptions::new(),
+                None,
+                Some(&["_id"]),
+            );
+            let _ = table.hybrid_search(
+                "id",
+                "x",
+                BoolMode::Or,
+                "id",
+                &[1.0],
+                VectorSearchOptions::new(),
+                1,
+                Some(&["_id"]),
+            );
+            let _ = table.optimize(&OptimizeOptions::default());
+            let _ = table.gc(Duration::from_secs(0));
+        }
+    })
+    .await;
+
+    let spec: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/hosted-openapi.json"))
+            .expect("valid hosted API spec fixture");
+    let requests = server
+        .received_requests()
+        .await
+        .expect("request recording is enabled");
+
+    // Tier 1: operation-set parity.
+    let client_ops = path_segments(requests.iter().map(|r| r.url.path().to_string()));
+    let spec_ops = path_segments(spec["paths"].as_object().expect("paths").keys().cloned());
+    assert_eq!(
+        client_ops, spec_ops,
+        "the remote client's operations drifted from the published API spec \
+         (a hosted operation was added or removed); reconcile the transport"
+    );
+
+    // Tier 2: request-signature conformance for JSON-body operations.
+    for req in &requests {
+        let method = req.method.to_string().to_lowercase();
+        let Some(seg) = req
+            .url
+            .path()
+            .strip_prefix("/v1/")
+            .map(|rest| rest.split('/').next().unwrap_or_default())
+        else {
+            continue;
+        };
+        let Some(schema_name) = request_schema_name(&spec, &method, seg) else {
+            continue; // bodyless op (binary/query-param) — nothing to conform.
+        };
+        let schema = &spec["components"]["schemas"][&schema_name];
+        let required: BTreeSet<&str> = schema["required"]
+            .as_array()
+            .map(|a| a.iter().filter_map(serde_json::Value::as_str).collect())
+            .unwrap_or_default();
+        let properties: BTreeSet<&str> = schema["properties"]
+            .as_object()
+            .map(|o| o.keys().map(String::as_str).collect())
+            .unwrap_or_default();
+
+        let body: serde_json::Value =
+            serde_json::from_slice(&req.body).unwrap_or(serde_json::Value::Null);
+        let Some(obj) = body.as_object() else {
+            continue; // non-JSON body — not a schema-typed request.
+        };
+        let sent: BTreeSet<&str> = obj.keys().map(String::as_str).collect();
+
+        let missing: Vec<&&str> = required.difference(&sent).collect();
+        assert!(
+            missing.is_empty(),
+            "{method} /v1/{seg}: client omits required field(s) {missing:?} that \
+             {schema_name} requires — the request signature drifted from the spec"
+        );
+        let unknown: Vec<&&str> = sent.difference(&properties).collect();
+        assert!(
+            unknown.is_empty(),
+            "{method} /v1/{seg}: client sends field(s) {unknown:?} not defined by \
+             {schema_name} — the request signature drifted (the server would reject these)"
+        );
+    }
 }


### PR DESCRIPTION
Two related pieces of the hosted (`connect("https://…")`) surface.

## 1. Binding reference docs

Makes the generated node/python references (TypeDoc / pdoc) self-explanatory for hosted use, and marks per-option/per-method what applies where:

- Add the `apiKey` / `api_key` connect option, with docs.
- Give `connect` a real doc-comment: the URI forms (local path, object store, and the hosted `https://<host>/<database>` target) and how to authenticate (`apiKey` option or `INFINO_API_KEY`).
- Hide the internal `Connection` / `Table` constructors so the reference points readers at `connect`.
- Note local-vs-hosted: `optimize` / `gc` are local-only (maintenance is managed for you when hosted), and the storage/cache connect options don't apply to a hosted connection.

## 2. Remote-transport drift check

Vendor the published hosted API spec (`tests/fixtures/hosted-openapi.json`, refreshed from the deployed `/openapi.json` by a scheduled workflow) and add a test that drives every remote operation against a mock and asserts, against the spec: the set of operations called, and — per JSON body — that the fields sent conform to the request schema. The Rust transport is the single request builder the node/python bindings call through, so one check covers all three.

The drift test is `#[ignore]`d and run only by a `pull_request`-scoped `hosted-api-drift` workflow, deliberately kept out of the default build and `make ci` — a hosted-service change must never gate an engine release.

### Expected: the drift check is red on this PR

It immediately caught a real mismatch, which is the point: released **0.2.0**'s `bm25_search` sends a `stats` field (from the global-BM25-stats change) that the deployed hosted API's `Bm25SearchRequest` doesn't accept — so a bm25 query from a 0.2.0 client against the hosted service is rejected. `make ci` is green (the drift test is ignored); the drift check is the signal. The `stats` reconciliation is tracked separately.