### PR TITLE
fix: benches build on mac

### DIFF
--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -98,7 +98,15 @@ impl Diagnostic {
             Diagnostic::FtsDiag => infino_bench_utils::fts_diag::run(),
             Diagnostic::ObjectStore => infino_bench_utils::unified_object_store::run(),
             Diagnostic::Concurrent => infino_bench_utils::concurrent::run(),
-            Diagnostic::DiskWarm => infino_bench_utils::disk_warm::run(),
+            Diagnostic::DiskWarm => {
+                #[cfg(target_os = "linux")]
+                infino_bench_utils::disk_warm::run();
+                #[cfg(not(target_os = "linux"))]
+                eprintln!(
+                    "disk-warm diagnostic needs /proc/self/io and posix_fadvise \
+                     (Linux-only); skipping on this platform"
+                );
+            }
             Diagnostic::RecallWhileIngest => infino_bench_utils::recall_while_ingest::run(),
         }
     }

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -31,6 +31,8 @@ pub mod supertable;
 
 pub mod concurrent;
 pub mod diag_common;
+/// Linux-only relies on `/proc/self/io` and `posix_fadvise`
+#[cfg(target_os = "linux")]
 pub mod disk_warm;
 pub mod fts_diag;
 pub mod recall_while_ingest;


### PR DESCRIPTION
### what is the change

latest change #470 introduces a linux only change in benches, which led to running the benches on mac to fail
This PR fixes it