### PR TITLE
fix: query side reader pool

### DIFF
--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -32,13 +32,16 @@
 //! actix, etc.).
 
 use std::{
+    fmt,
     future::Future,
     sync::{Arc, OnceLock},
     thread,
 };
 
+use rayon::ThreadPool;
 use tokio::{
     runtime::{self, Handle, Runtime},
+    sync::oneshot,
     task::block_in_place,
 };
 
@@ -114,6 +117,47 @@ where
             .expect("sync→async bridge worker thread panicked"),
         Err(_) => build_current_thread_runtime().block_on(fut),
     }
+}
+
+/// Async→rayon bridge: dispatch CPU work onto the configured reader pool
+pub(crate) fn spawn_on<F: FnOnce() + Send + 'static>(pool: Option<&ThreadPool>, f: F) {
+    match pool {
+        Some(pool) => pool.spawn(f),
+        None => rayon::spawn(f),
+    }
+}
+
+/// The pool task's sender was dropped before sending a result surfaced as
+/// an error rather than a second panic.
+#[derive(Debug)]
+pub(crate) struct PoolDropped(pub(crate) &'static str);
+
+impl fmt::Display for PoolDropped {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl std::error::Error for PoolDropped {}
+
+/// Run `f` on `pool` (or the global rayon pool if `None`) and bridge the
+/// result back to the awaiting async task via a oneshot, so no tokio worker
+/// blocks under the compute. `what` becomes the [`PoolDropped`] message if
+/// the pool task dies before sending
+pub(crate) async fn run_on_pool<R, F>(
+    pool: Option<&ThreadPool>,
+    what: &'static str,
+    f: F,
+) -> Result<R, PoolDropped>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let (tx, rx) = oneshot::channel();
+    spawn_on(pool, move || {
+        let _ = tx.send(f());
+    });
+    rx.await.map_err(|_| PoolDropped(what))
 }
 
 /// Process-wide query runtime, shared by every `Connection` and

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -220,22 +220,18 @@ pub(crate) enum PreparedClauses {
 }
 
 impl PreparedClauses {
-    /// Sum of term document frequencies across the held cursors — the
-    /// scan-cost proxy callers gate reader-pool dispatch on. `Done` has
-    /// nothing left to scan, so it's zero.
+    /// Scan-cost proxy callers gate reader-pool dispatch on: the driving
+    /// (smallest) posting list for the AND-intersect shapes, the full
+    /// union for OR. `Done` has nothing left to scan, so it's zero.
     pub(crate) fn posting_mass(&self) -> u64 {
         match self {
             PreparedClauses::Done(_) => 0,
-            PreparedClauses::Must { must_cursors, .. } => must_cursors.iter().map(|c| c.df).sum(),
-            PreparedClauses::MustShould {
-                must_cursors,
-                should_cursors,
-                ..
-            } => must_cursors
-                .iter()
-                .chain(should_cursors)
-                .map(|c| c.df)
-                .sum(),
+            PreparedClauses::Must { must_cursors, .. } => {
+                must_cursors.iter().map(|c| c.df).min().unwrap_or(0)
+            }
+            PreparedClauses::MustShould { must_cursors, .. } => {
+                must_cursors.iter().map(|c| c.df).min().unwrap_or(0)
+            }
             PreparedClauses::Or { cursors, .. } => cursors.iter().map(|c| c.df).sum(),
         }
     }
@@ -1630,9 +1626,10 @@ impl FtsReader {
 
     /// I/O half of an un-ranged clause search: resolve the column,
     /// classify the query shape, and fetch every cursor
-    /// [`Self::run_prepared`] needs to score. The single-atom and
-    /// phrase-atom shapes finish here instead, since each is cheap
-    /// enough that handing it off isn't worth it.
+    /// [`Self::run_prepared`] needs to score. The single-atom shape
+    /// finishes here since it's cheap; the phrase-atom shape also
+    /// finishes here, but only because it isn't wired to the reader
+    /// pool yet, not because it's cheap.
     pub(crate) async fn prepare_clauses(
         &self,
         column: &str,

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -184,6 +184,63 @@ impl ClauseLists<'_> {
     }
 }
 
+/// Output of [`FtsReader::prepare_clauses`], consumed by
+/// [`FtsReader::run_prepared`]. Either an already-final result or the
+/// cursors for one clause shape still to score. Owns its `ExcludeFilter`
+/// rather than borrowing it, so it can move into a `'static` closure.
+pub(crate) enum PreparedClauses {
+    /// Already final — nothing left for `run_prepared` to do.
+    Done(Vec<(u32, f32)>),
+    /// AND-only: intersect `must_cursors`.
+    Must {
+        column_id: u32,
+        must_cursors: Vec<TermCursor>,
+        filter: Option<ExcludeFilter>,
+        k: usize,
+        floor_eff: f32,
+    },
+    /// AND with should-boosted scoring.
+    MustShould {
+        column_id: u32,
+        must_cursors: Vec<TermCursor>,
+        should_cursors: Vec<TermCursor>,
+        filter: Option<ExcludeFilter>,
+        k: usize,
+        floor_eff: f32,
+    },
+    /// Plain multi-term OR (no musts) — algorithm choice resolved in
+    /// `run_prepared`.
+    Or {
+        column_id: u32,
+        cursors: Vec<TermCursor>,
+        filter: Option<ExcludeFilter>,
+        k: usize,
+        floor_eff: f32,
+    },
+}
+
+impl PreparedClauses {
+    /// Sum of term document frequencies across the held cursors — the
+    /// scan-cost proxy callers gate reader-pool dispatch on. `Done` has
+    /// nothing left to scan, so it's zero.
+    pub(crate) fn posting_mass(&self) -> u64 {
+        match self {
+            PreparedClauses::Done(_) => 0,
+            PreparedClauses::Must { must_cursors, .. } => must_cursors.iter().map(|c| c.df).sum(),
+            PreparedClauses::MustShould {
+                must_cursors,
+                should_cursors,
+                ..
+            } => must_cursors
+                .iter()
+                .chain(should_cursors)
+                .map(|c| c.df)
+                .sum(),
+            PreparedClauses::Or { cursors, .. } => cursors.iter().map(|c| c.df).sum(),
+        }
+    }
+}
+
 impl From<&str> for BoolMode {
     fn from(s: &str) -> Self {
         match s {
@@ -196,7 +253,7 @@ impl From<&str> for BoolMode {
 
 /// Multi-term OR algorithm selector for the bench harness's
 /// `search_with_algo_for_bench` entry point. Production code routes
-/// through `FtsReader::dispatch_multi_term_or`, which picks
+/// through `FtsReader::dispatch_or_algo`, which picks
 /// automatically; this enum exists so head-to-head bench runs can
 /// compare all three under identical inputs.
 #[doc(hidden)]
@@ -1521,23 +1578,29 @@ impl FtsReader {
         mode: BoolMode,
         floor: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
-        let column_id = self.resolve_column_id(column)?;
-        if terms.is_empty() || k == 0 {
-            return Ok(Vec::new());
-        }
-        // Every kernel prunes with `<= threshold` / `> threshold`
-        // comparisons; seeding them with the largest f32 strictly
-        // below `floor` makes those comparisons exactly "strictly
-        // below floor is dead, equal-to-floor survives".
-        let floor_eff = floor.next_down();
         // A flat term list under one mode is the degenerate clause
         // shape: `And` makes every term a must, `Or` a should.
+        // `prepare_clauses` resolves the column and, on the `<= threshold`
+        // pruning comparisons every kernel uses, seeds them with the
+        // largest f32 strictly below `floor` ("strictly below floor is
+        // dead, equal-to-floor survives") via `floor.next_down()`.
         let (musts, shoulds): (&[&str], &[&str]) = match mode {
             BoolMode::And => (terms, &[]),
             BoolMode::Or => (&[], terms),
         };
-        self.search_clauses(column_id, musts, shoulds, k, None, floor_eff, None)
-            .await
+        let prep = self
+            .prepare_clauses(
+                column,
+                ClauseLists {
+                    musts,
+                    shoulds,
+                    ..ClauseLists::default()
+                },
+                k,
+                floor,
+            )
+            .await?;
+        self.run_prepared(prep)
     }
 
     /// BM25 search over explicit clause lists, with negated terms
@@ -1561,13 +1624,29 @@ impl FtsReader {
         k: usize,
         floor: f32,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
+        let prep = self.prepare_clauses(column, lists, k, floor).await?;
+        self.run_prepared(prep)
+    }
+
+    /// I/O half of an un-ranged clause search: resolve the column,
+    /// classify the query shape, and fetch every cursor
+    /// [`Self::run_prepared`] needs to score. The single-atom and
+    /// phrase-atom shapes finish here instead, since each is cheap
+    /// enough that handing it off isn't worth it.
+    pub(crate) async fn prepare_clauses(
+        &self,
+        column: &str,
+        lists: ClauseLists<'_>,
+        k: usize,
+        floor: f32,
+    ) -> Result<PreparedClauses, FtsError> {
         let column_id = self.resolve_column_id(column)?;
         if k == 0 {
-            return Ok(Vec::new());
+            return Ok(PreparedClauses::Done(Vec::new()));
         }
         if lists.no_positive_atoms() {
             if lists.no_negative_atoms() {
-                return Ok(Vec::new());
+                return Ok(PreparedClauses::Done(Vec::new()));
             }
             return Err(FtsError::NegationOnly);
         }
@@ -1580,7 +1659,7 @@ impl FtsReader {
                 .await?;
             if must_atoms.iter().any(Option::is_none) {
                 // A must atom can never match in this superfile.
-                return Ok(Vec::new());
+                return Ok(PreparedClauses::Done(Vec::new()));
             }
             let must_atoms: Vec<AnyCursor> = must_atoms.into_iter().flatten().collect();
             let should_atoms: Vec<AnyCursor> = self
@@ -1606,17 +1685,12 @@ impl FtsReader {
                 true => None,
                 false => Some(AtomExcludeFilter::new(negative_atoms)),
             };
-            return self.run_atoms_search(
-                column_id,
-                must_atoms,
-                should_atoms,
-                k,
-                filter,
-                floor_eff,
-            );
+            let result =
+                self.run_atoms_search(column_id, must_atoms, should_atoms, k, filter, floor_eff)?;
+            return Ok(PreparedClauses::Done(result));
         }
 
-        let mut filter = match lists.negatives {
+        let neg_filter = match lists.negatives {
             [] => None,
             // Negatives are a hard exclusion filter, not scored, so their
             // idf is irrelevant — always build them with local stats.
@@ -1625,33 +1699,7 @@ impl FtsReader {
                     .await?,
             )),
         };
-        self.search_clauses(
-            column_id,
-            lists.musts,
-            lists.shoulds,
-            k,
-            filter.as_mut(),
-            floor_eff,
-            lists.global_idf,
-        )
-        .await
-    }
 
-    /// Shared dispatch for [`Self::search_with_floor`] and
-    /// [`Self::search_excluding`]: routes the clause lists to the
-    /// single-term / OR / AND / must+should kernel, threading `filter`
-    /// to the heap-admission sites and `floor_eff` (already
-    /// `next_down`-adjusted) to every pruning structure.
-    async fn search_clauses(
-        &self,
-        column_id: u32,
-        musts: &[&str],
-        shoulds: &[&str],
-        k: usize,
-        filter: Option<&mut ExcludeFilter>,
-        floor_eff: f32,
-        global_idf: Option<&GlobalTermIdf>,
-    ) -> Result<Vec<(u32, f32)>, FtsError> {
         // Single-atom fast path: BlockMaxWAND-driven block skipping.
         // One term scores identically whichever clause list it sits
         // in (a lone must and a lone should both rank that term's
@@ -1659,44 +1707,111 @@ impl FtsReader {
         // — the bespoke single-term BMW does not take an idf override,
         // so route a lone term through the general cursor path (which
         // does) instead; correctness over the single-term micro-opt.
-        if global_idf.is_none() && musts.len() + shoulds.len() == 1 {
-            let term = musts.iter().chain(shoulds).next().expect("one atom");
-            return self
-                .search_single_term_bmw(column_id, term, k, filter, floor_eff)
-                .await;
+        if lists.global_idf.is_none() && lists.musts.len() + lists.shoulds.len() == 1 {
+            let term = lists
+                .musts
+                .iter()
+                .chain(lists.shoulds)
+                .next()
+                .expect("one atom");
+            let mut filter = neg_filter;
+            let result = self
+                .search_single_term_bmw(column_id, term, k, filter.as_mut(), floor_eff)
+                .await?;
+            return Ok(PreparedClauses::Done(result));
         }
-        if musts.is_empty() {
-            return self
-                .dispatch_multi_term_or(column_id, shoulds, k, filter, floor_eff, global_idf)
-                .await;
+
+        if lists.musts.is_empty() {
+            let cursors = self
+                .build_term_cursors(column_id, lists.shoulds, lists.global_idf)
+                .await?;
+            if cursors.is_empty() {
+                return Ok(PreparedClauses::Done(Vec::new()));
+            }
+            return Ok(PreparedClauses::Or {
+                column_id,
+                cursors,
+                filter: neg_filter,
+                k,
+                floor_eff,
+            });
         }
         // Build must cursors; if any must is missing, the
         // intersection is empty.
         let must_cursors = self
-            .build_term_cursors(column_id, musts, global_idf)
+            .build_term_cursors(column_id, lists.musts, lists.global_idf)
             .await?;
-        if must_cursors.len() != musts.len() {
-            return Ok(Vec::new());
+        if must_cursors.len() != lists.musts.len() {
+            return Ok(PreparedClauses::Done(Vec::new()));
         }
-        if shoulds.is_empty() {
-            return self.run_and_intersect(column_id, must_cursors, k, filter, floor_eff);
+        if lists.shoulds.is_empty() {
+            return Ok(PreparedClauses::Must {
+                column_id,
+                must_cursors,
+                filter: neg_filter,
+                k,
+                floor_eff,
+            });
         }
         // Shoulds absent from this superfile contribute nothing;
         // when none survive, the walk is a plain must intersection.
         let should_cursors = self
-            .build_term_cursors(column_id, shoulds, global_idf)
+            .build_term_cursors(column_id, lists.shoulds, lists.global_idf)
             .await?;
         if should_cursors.is_empty() {
-            return self.run_and_intersect(column_id, must_cursors, k, filter, floor_eff);
+            return Ok(PreparedClauses::Must {
+                column_id,
+                must_cursors,
+                filter: neg_filter,
+                k,
+                floor_eff,
+            });
         }
-        self.run_must_should(
+        Ok(PreparedClauses::MustShould {
             column_id,
             must_cursors,
             should_cursors,
+            filter: neg_filter,
             k,
-            filter,
             floor_eff,
-        )
+        })
+    }
+
+    /// CPU half paired with [`Self::prepare_clauses`] — scores the
+    /// cursors it fetched. No I/O, so it can run on the reader pool.
+    pub(crate) fn run_prepared(&self, prep: PreparedClauses) -> Result<Vec<(u32, f32)>, FtsError> {
+        match prep {
+            PreparedClauses::Done(result) => Ok(result),
+            PreparedClauses::Must {
+                column_id,
+                must_cursors,
+                mut filter,
+                k,
+                floor_eff,
+            } => self.run_and_intersect(column_id, must_cursors, k, filter.as_mut(), floor_eff),
+            PreparedClauses::MustShould {
+                column_id,
+                must_cursors,
+                should_cursors,
+                mut filter,
+                k,
+                floor_eff,
+            } => self.run_must_should(
+                column_id,
+                must_cursors,
+                should_cursors,
+                k,
+                filter.as_mut(),
+                floor_eff,
+            ),
+            PreparedClauses::Or {
+                column_id,
+                cursors,
+                mut filter,
+                k,
+                floor_eff,
+            } => self.dispatch_or_algo(column_id, cursors, k, filter.as_mut(), floor_eff),
+        }
     }
 
     /// Unranked token match over a **token list** — the no-scoring
@@ -1930,7 +2045,7 @@ impl FtsReader {
     /// [`Self::search_or_range_pretokenized_with_floor`] delegates here.
     /// The ranged path carries no negation in v1.
     ///
-    /// Kernel choice mirrors `dispatch_multi_term_or` instead of
+    /// Kernel choice mirrors `dispatch_or_algo` instead of
     /// hardcoding MaxScore+BMM: on a broad OR over uniform-upper-bound
     /// terms BMM cannot prune (every block max ties), so it degrades to
     /// per-doc min-scan bookkeeping over ~the whole union — the exact
@@ -2268,7 +2383,7 @@ impl FtsReader {
     /// by ascending doc_id.
     ///
     /// Production path for small-`k`, **floor-free** 2-term ORs (see
-    /// `dispatch_multi_term_or`), and the `search_with_algo_for_bench`
+    /// `dispatch_or_algo`), and the `search_with_algo_for_bench`
     /// entry point. Cursor construction is shared with the BMM path.
     ///
     /// Carries **no cross-segment floor and no exclude filter** — the
@@ -2497,7 +2612,7 @@ impl FtsReader {
     /// (rare + common); the partition collapses to a single
     /// essential cursor anyway and WAND's pivot is tighter.
     ///
-    /// The router [`Self::dispatch_multi_term_or`] picks between
+    /// The router [`Self::dispatch_or_algo`] picks between
     /// the two using a UB-spread heuristic. Both algorithms share
     /// cursor construction via [`Self::build_term_cursors`] so the
     /// router doesn't pay for cursor work twice.
@@ -3479,7 +3594,7 @@ impl FtsReader {
     /// block skipping — every doc in the union of the cursor postings
     /// is scored and offered to the top-K heap.
     ///
-    /// **Not on the production path.** `dispatch_multi_term_or` routes
+    /// **Not on the production path.** `dispatch_or_algo` routes
     /// to MaxScore+BMM or the windowed union; this function is reachable
     /// only via `search_with_algo_for_bench(OrAlgo::Exhaustive)`. It exists
     /// because the supertable bench surfaced one specific shape where
@@ -3630,21 +3745,14 @@ impl FtsReader {
     /// the one shape (prefix-of-very-rare-terms in parallel mode)
     /// where it narrowly wins. WAND+BMW remains in the codebase
     /// for the same reason — bench-harness comparison only.
-    async fn dispatch_multi_term_or(
+    fn dispatch_or_algo(
         &self,
         column_id: u32,
-        terms: &[&str],
+        cursors: Vec<TermCursor>,
         k: usize,
         filter: Option<&mut ExcludeFilter>,
         floor_eff: f32,
-        global_idf: Option<&GlobalTermIdf>,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
-        let cursors = self
-            .build_term_cursors(column_id, terms, global_idf)
-            .await?;
-        if cursors.is_empty() {
-            return Ok(Vec::new());
-        }
         // Route on upper-bound *spread*, not term count: when no single
         // term dominates, MaxScore's essential set never shrinks and it
         // degrades to scoring the whole union with per-doc f-way merge
@@ -3689,7 +3797,7 @@ impl FtsReader {
     /// thresholds are validated against measured numbers every run.
     ///
     /// **Not part of the stable API** — production code should use
-    /// `search`, which routes through `dispatch_multi_term_or`.
+    /// `search`, which routes through `dispatch_or_algo`.
     #[doc(hidden)]
     pub async fn search_with_algo_for_bench(
         &self,
@@ -3725,6 +3833,15 @@ impl FtsReader {
 pub(crate) struct OrCursorSet {
     column_id: u32,
     cursors: Vec<TermCursor>,
+}
+
+impl OrCursorSet {
+    /// Number of expanded terms this set was built from — used to gate
+    /// ranged-kernel pool dispatch by scan cost, the same signal the
+    /// plain multi-should path gates on.
+    pub(crate) fn len(&self) -> usize {
+        self.cursors.len()
+    }
 }
 
 /// Top-k min-heap entry `(score, doc_id)`, shared by every search
@@ -4221,7 +4338,7 @@ impl AtomExcludeFilter {
 /// rather than a generic filter parameter: monomorphizing the OR kernel
 /// measured 25-30% slower even with a no-op filter, while the `None`
 /// branch is constant per query, perfectly predicted, and free.
-struct ExcludeFilter {
+pub(crate) struct ExcludeFilter {
     cursors: Vec<TermCursor>,
     /// Last doc-id passed to `admits`; guards the monotonic call order.
     last_doc: u32,
@@ -4803,7 +4920,7 @@ struct BlockMeta {
 /// WAND loop drops cursors that are exhausted at the top of each
 /// iteration.
 #[derive(Clone)]
-struct TermCursor {
+pub(crate) struct TermCursor {
     /// Precomputed `idf * (K1 + 1)` — the score numerator's
     /// per-cursor constant. Computed once at cursor build so the
     /// hot inner loop fits one multiply + add + divide per call.

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -52,7 +52,9 @@ use crate::{
         BytesLazyByteSource, LazyByteSource, LazySubSource, ReadError,
         format::{self, footer, kv},
         fts::{
-            reader::{self as fts_reader, BoolMode, ClauseLists, FtsReader, OrCursorSet},
+            reader::{
+                self as fts_reader, BoolMode, ClauseLists, FtsReader, OrCursorSet, PreparedClauses,
+            },
             tokenize::{AsciiLowerTokenizer, Tokenizer},
         },
         vector::{
@@ -1175,6 +1177,30 @@ impl SuperfileReader {
         Ok(fts.search_excluding(column, lists, k, floor).await?)
     }
 
+    /// I/O half of [`Self::bm25_search_clauses`] — resolves the column
+    /// and fetches every cursor [`Self::run_prepared`] needs to score.
+    pub(crate) async fn prepare_clauses(
+        &self,
+        column: &str,
+        lists: ClauseLists<'_>,
+        k: usize,
+        floor: f32,
+    ) -> Result<PreparedClauses, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.prepare_clauses(column, lists, k, floor).await?)
+    }
+
+    /// CPU half paired with [`Self::prepare_clauses`] — scores the
+    /// cursors it fetched.
+    pub(crate) fn run_prepared(&self, prep: PreparedClauses) -> Result<Vec<(u32, f32)>, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.run_prepared(prep)?)
+    }
+
     /// Prefix-expanded BM25 search.
     ///
     /// Expands `prefix` to the lex-ordered list of indexed terms
@@ -1292,6 +1318,29 @@ impl SuperfileReader {
         Ok(fts.build_or_cursor_set(column, terms, global_idf).await?)
     }
 
+    /// Expand `prefix` via the FST and build its OR cursor set, for
+    /// reuse across this superfile's doc-id sub-ranges via
+    /// [`Self::bm25_search_or_range_prebuilt`].
+    pub(crate) async fn bm25_prefix_cursor_set(
+        &self,
+        column: &str,
+        prefix: &str,
+    ) -> Result<OrCursorSet, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        let lowered = prefix.to_ascii_lowercase();
+        let term_bytes = fts.iter_terms_with_prefix(column, lowered.as_bytes())?;
+        // FST keys are valid UTF-8 by construction (AsciiLower
+        // tokenizer only emits ASCII bytes); the from_utf8 below
+        // is a typed pass-through, not a re-validation cost.
+        let term_strings: Vec<&str> = term_bytes
+            .iter()
+            .filter_map(|b| str::from_utf8(b).ok())
+            .collect();
+        Ok(fts.build_or_cursor_set(column, &term_strings, None).await?)
+    }
+
     /// Ranged multi-term OR against prebuilt cursors — see
     /// [`Self::bm25_search_or_range_pretokenized_with_floor`] for the
     /// range and floor contract.
@@ -1314,11 +1363,9 @@ impl SuperfileReader {
     /// Same expansion logic as [`Self::bm25_search_prefix`] —
     /// AsciiLower the prefix, walk the FST for matching terms, run
     /// BM25 OR over the term set — but only docs in
-    /// `[doc_id_start, doc_id_end)` are eligible. Used by the
-    /// supertable layer's intra-superfile parallel fan-out on prefix
-    /// queries; the per-sub-range expansion is identical (same FST,
-    /// same column) so each sub-range expands locally rather than
-    /// passing pre-expanded terms across the task boundary.
+    /// `[doc_id_start, doc_id_end)` are eligible. A single-call wrapper
+    /// around [`Self::bm25_prefix_cursor_set`] +
+    /// [`Self::bm25_search_or_range_prebuilt`].
     pub async fn bm25_search_prefix_range(
         &self,
         column: &str,
@@ -1327,24 +1374,11 @@ impl SuperfileReader {
         doc_id_start: u32,
         doc_id_end: u32,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        let fts = self
-            .fts()
-            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
         if k == 0 || doc_id_start >= doc_id_end {
             return Ok(Vec::new());
         }
-        let lowered = prefix.to_ascii_lowercase();
-        let term_bytes = fts.iter_terms_with_prefix(column, lowered.as_bytes())?;
-        if term_bytes.is_empty() {
-            return Ok(Vec::new());
-        }
-        let term_strings: Vec<&str> = term_bytes
-            .iter()
-            .filter_map(|b| str::from_utf8(b).ok())
-            .collect();
-        Ok(fts
-            .search_or_range_pretokenized(column, &term_strings, k, doc_id_start, doc_id_end)
-            .await?)
+        let set = self.bm25_prefix_cursor_set(column, prefix).await?;
+        self.bm25_search_or_range_prebuilt(&set, k, doc_id_start, doc_id_end, f32::NEG_INFINITY)
     }
 
     /// Multi-column BM25 search with per-column weights ("most

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -32,6 +32,7 @@ use tokio::sync::oneshot;
 pub(crate) use crate::superfile::lazy_source::Source;
 use crate::{
     memory::{ConnectionMemoryBudget, Reservation},
+    runtime_bridge::{run_on_pool, spawn_on},
     storage::io_counters,
     superfile::{
         BuildError, ReadError,
@@ -4530,14 +4531,6 @@ fn parallel_chunks(n_items: usize) -> usize {
         .max(1)
 }
 
-/// Dispatch `f` onto `pool` if provided, or the global rayon pool otherwise.
-fn spawn_on<F: FnOnce() + Send + 'static>(pool: Option<&ThreadPool>, f: F) {
-    match pool {
-        Some(pool) => pool.spawn(f),
-        None => rayon::spawn(f),
-    }
-}
-
 /// Map `f` over `items` on the configured rayon pool, preserving input
 /// order. The order-independent vector scans (rerank) use this; the
 /// compute runs on rayon (`par_iter().map().collect()`) bridged back to
@@ -4556,12 +4549,13 @@ where
     if parallel_chunks(items.len()) <= 1 {
         return Ok(items.iter().map(&f).collect());
     }
-    let (tx, rx) = oneshot::channel();
-    spawn_on(pool.as_deref(), move || {
-        let out: Vec<R> = items.par_iter().map(f).collect();
-        let _ = tx.send(out);
-    });
-    rx.await.map_err(|_| VectorError::TaskDropped("rerank"))
+    run_on_pool(
+        pool.as_deref(),
+        "rerank rayon task dropped result",
+        move || items.par_iter().map(f).collect(),
+    )
+    .await
+    .map_err(|_| VectorError::TaskDropped("rerank"))
 }
 
 /// The 1-bit scan loop over one cluster's codes, generic over the

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -15,18 +15,25 @@
 //! orchestrator instead of each re-implementing the fan-out. The
 //! division of labor is the project-wide model:
 //!
-//!   * **tokio owns the fan-out and I/O.** One `tokio::spawn` task per
-//!     work unit: each opens its superfile reader and runs the kernel,
-//!     so superfile opens and cold object-store range GETs across
-//!     hundreds of superfiles are all in flight at once on the shared
-//!     multi-thread query runtime.
-//!   * **CPU model is per-kernel, not uniform.** The vector kernel
-//!     parallelizes its own scoring + rerank with `par_iter` (see
-//!     `superfile/vector/reader.rs`). The FTS BMW/MaxScore kernel
-//!     scores **serially inside its tokio task** — there is no rayon in
-//!     the FTS scoring path. Intra-superfile FTS parallelism is instead
-//!     expressed as additional tokio work units (doc-id sub-ranges; see
-//!     `query/fts.rs`).
+//!   * **tokio bounds I/O concurrency — stays wide.** One `tokio::spawn`
+//!     task per work unit: each opens its superfile reader and runs the
+//!     kernel, so superfile opens and cold object-store range GETs
+//!     across hundreds of superfiles are all in flight at once on the
+//!     shared multi-thread query runtime. Never cap the fan-out's task
+//!     count at the reader pool's width — `tokio::spawn` dispatches a
+//!     task, not an OS thread, and object-store GETs are latency-bound,
+//!     so narrowing their concurrency only hurts cold latency.
+//!   * **The reader pool bounds CPU concurrency — the configured knob.**
+//!     Both vector and FTS scoring run their scan/scoring kernel on the
+//!     configured reader pool, bridged back to the awaiting tokio task
+//!     via a oneshot (`runtime_bridge::run_on_pool`) so no tokio worker
+//!     blocks under the compute. The vector kernel parallelizes its own
+//!     scoring + rerank with `par_iter` (see `superfile/vector/reader.rs`);
+//!     FTS kernels are scored on one reader-pool thread per work unit,
+//!     with intra-superfile parallelism expressed as additional tokio
+//!     work units (doc-id sub-ranges; see `query/fts.rs`). Cheap
+//!     shapes stay inline where the pool round trip would cost more
+//!     than the scan.
 //!
 //! The per-superfile merge (top-k ascending for vector distance,
 //! descending for BM25 relevance) stays with each caller; this layer

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -41,9 +41,9 @@ use parquet::{
     file::metadata::ParquetMetaData,
 };
 use rayon::prelude::*;
-use tokio::sync::oneshot;
 
 use crate::{
+    runtime_bridge::run_on_pool,
     superfile::{
         SuperfileReader,
         lazy_source::Source,
@@ -517,23 +517,24 @@ async fn resolve_columns(
         let owned_names: Vec<String> = names.iter().map(|s| (*s).to_string()).collect();
         let pool = Arc::clone(&manifest.options.reader_pool);
         let inputs = warm_inputs;
-        let (tx, rx) = oneshot::channel();
-        pool.spawn(move || {
-            let name_refs: Vec<&str> = owned_names.iter().map(String::as_str).collect();
-            let result: Result<Vec<(usize, RecordBatch)>, _> = inputs
-                .into_par_iter()
-                .map(|(i, sf, locals)| {
-                    sf.take_by_local_doc_ids(&locals, &name_refs)
-                        .map(|batch| (i, batch))
-                })
-                .collect();
-            let _ = tx.send(result);
-        });
-        rx.await
-            .map_err(|_| {
-                DataFusionError::Execution("resolve decode: reader pool dropped result".into())
-            })?
-            .map_err(|e| DataFusionError::Execution(e.to_string()))
+        run_on_pool(
+            Some(&pool),
+            "resolve decode: reader pool dropped result",
+            move || {
+                let name_refs: Vec<&str> = owned_names.iter().map(String::as_str).collect();
+                let result: Result<Vec<(usize, RecordBatch)>, _> = inputs
+                    .into_par_iter()
+                    .map(|(i, sf, locals)| {
+                        sf.take_by_local_doc_ids(&locals, &name_refs)
+                            .map(|batch| (i, batch))
+                    })
+                    .collect();
+                result
+            },
+        )
+        .await
+        .map_err(|e| DataFusionError::Execution(e.to_string()))?
+        .map_err(|e| DataFusionError::Execution(e.to_string()))
     };
 
     let cold_wave = try_join_all(

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -91,7 +91,7 @@ use std::{
 use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, LargeStringArray};
 use roaring::RoaringBitmap;
-use tokio::sync::{OnceCell, oneshot};
+use tokio::sync::OnceCell;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -107,9 +107,16 @@ use uuid::Uuid;
 /// cannot drift apart.
 const RANGED_KERNEL_POOL_MIN_TERMS: usize = OR_WINDOW_MIN_TERMS;
 
+/// Fewest summed term document frequencies for which the un-ranged
+/// clause kernel runs on the reader pool instead of inline. Measured
+/// masses split bimodal — cheap matches stay under 4,000, real scans
+/// start past 60,000 — so this sits in the gap.
+const UNRANGED_KERNEL_POOL_MIN_MASS: u64 = 20_000;
+
 pub use crate::superfile::fts::reader::BoolMode;
 use crate::{
     InfinoError,
+    runtime_bridge::run_on_pool,
     superfile::{
         SuperfileReader,
         error::{FtsError, ReadError},
@@ -531,32 +538,24 @@ impl SupertableReader {
                         // run inline where the oneshot round-trip would cost
                         // more than the scan — see the gate's doc comment.
                         if should_arc.len() >= RANGED_KERNEL_POOL_MIN_TERMS {
-                            let (tx, rx) = oneshot::channel();
                             let kernel_reader = Arc::clone(&r);
                             let kernel_set = Arc::clone(set);
-                            reader_pool.spawn(move || {
-                                let _ = tx.send(kernel_reader.bm25_search_or_range_prebuilt(
-                                    &kernel_set,
-                                    k,
-                                    start,
-                                    end,
-                                    floor,
-                                ));
-                            });
-                            // A dropped `tx` means the pool task died before
-                            // sending (it can't happen short of a kernel
-                            // panic, which the shared pool's default rayon
-                            // handler turns into an abort first) — but
-                            // surface it as an error rather than a second
-                            // panic, matching the resolve-decode bridge in
-                            // `exec::common`.
-                            rx.await
-                                .map_err(|_| {
-                                    QueryError::Execute(
-                                        "ranged fts kernel: reader pool dropped result".into(),
+                            run_on_pool(
+                                Some(&reader_pool),
+                                "ranged fts kernel: reader pool dropped result",
+                                move || {
+                                    kernel_reader.bm25_search_or_range_prebuilt(
+                                        &kernel_set,
+                                        k,
+                                        start,
+                                        end,
+                                        floor,
                                     )
-                                })?
-                                .map_err(fts_read_error)?
+                                },
+                            )
+                            .await
+                            .map_err(|e| QueryError::Execute(e.to_string()))?
+                            .map_err(fts_read_error)?
                         } else {
                             r.bm25_search_or_range_prebuilt(set, k, start, end, floor)
                                 .map_err(fts_read_error)?
@@ -567,22 +566,39 @@ impl SupertableReader {
                         let should_refs: Vec<&str> =
                             should_arc.iter().map(|s| s.as_str()).collect();
                         let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
-                        r.bm25_search_clauses(
-                            &column_arc,
-                            ClauseLists {
-                                musts: &must_refs,
-                                shoulds: &should_refs,
-                                negatives: &neg_refs,
-                                must_phrases: &must_ph_arc,
-                                should_phrases: &should_ph_arc,
-                                negative_phrases: &neg_ph_arc,
-                                global_idf: global_idf.as_deref(),
-                            },
-                            k,
-                            floor,
-                        )
-                        .await
-                        .map_err(fts_read_error)?
+                        let prep = r
+                            .prepare_clauses(
+                                &column_arc,
+                                ClauseLists {
+                                    musts: &must_refs,
+                                    shoulds: &should_refs,
+                                    negatives: &neg_refs,
+                                    must_phrases: &must_ph_arc,
+                                    should_phrases: &should_ph_arc,
+                                    negative_phrases: &neg_ph_arc,
+                                    global_idf: global_idf.as_deref(),
+                                },
+                                k,
+                                floor,
+                            )
+                            .await
+                            .map_err(fts_read_error)?;
+                        // Gate on posting mass, not term count: this scan
+                        // isn't sliced, so a rare-term query with many
+                        // terms can be cheaper than a common-term pair.
+                        if prep.posting_mass() >= UNRANGED_KERNEL_POOL_MIN_MASS {
+                            let kernel_reader = Arc::clone(&r);
+                            run_on_pool(
+                                Some(&reader_pool),
+                                "un-ranged fts kernel: reader pool dropped result",
+                                move || kernel_reader.run_prepared(prep),
+                            )
+                            .await
+                            .map_err(|e| QueryError::Execute(e.to_string()))?
+                            .map_err(fts_read_error)?
+                        } else {
+                            r.run_prepared(prep).map_err(fts_read_error)?
+                        }
                     }
                 };
                 // Raise the global floor with this unit's surviving
@@ -723,23 +739,71 @@ impl SupertableReader {
         // Prefix expansion is always multi-term OR with no negation, so
         // it is directly sub-range eligible.
         let work_units = build_work_units(&kept_refs, FanOut::SubRanges, pool_threads);
-        let units: Vec<(Arc<SuperfileEntry>, Option<(u32, u32)>)> =
-            work_units.into_iter().map(|u| (u.entry, u.range)).collect();
+        let units: Vec<(Arc<SuperfileEntry>, (Option<(u32, u32)>, Uuid))> = work_units
+            .into_iter()
+            .map(|u| {
+                let suid = u.entry.superfile_id;
+                (u.entry, (u.range, suid))
+            })
+            .collect();
 
         let column_arc = Arc::new(column_owned);
         let prefix_arc = Arc::new(prefix_owned);
+        let reader_pool = Arc::clone(&manifest.options.reader_pool);
+
+        // Share one FST expansion + cursor build per superfile across its
+        // slices, keyed by superfile id.
+        type SharedCursorCell = Arc<OnceCell<Arc<OrCursorSet>>>;
+        let cursor_sets: Arc<Mutex<HashMap<Uuid, SharedCursorCell>>> =
+            Arc::new(Mutex::new(HashMap::new()));
 
         // Shared fan-out — see `bm25_search` for the rationale; the
         // kernel differs only in calling the prefix search variants.
-        let kernel = move |r: Arc<SuperfileReader>, range: Option<(u32, u32)>| {
+        let kernel = move |r: Arc<SuperfileReader>, (range, suid): (Option<(u32, u32)>, Uuid)| {
             let column_arc = Arc::clone(&column_arc);
             let prefix_arc = Arc::clone(&prefix_arc);
+            let cursor_sets = Arc::clone(&cursor_sets);
+            let reader_pool = Arc::clone(&reader_pool);
             async move {
                 match range {
-                    Some((start, end)) => r
-                        .bm25_search_prefix_range(&column_arc, &prefix_arc, k, start, end)
-                        .await
-                        .map_err(fts_read_error),
+                    Some((start, end)) => {
+                        let cell = {
+                            let mut sets =
+                                cursor_sets.lock().expect("cursor-set map lock poisoned");
+                            Arc::clone(sets.entry(suid).or_default())
+                        };
+                        let set = cell
+                            .get_or_try_init(|| async {
+                                r.bm25_prefix_cursor_set(&column_arc, &prefix_arc)
+                                    .await
+                                    .map(Arc::new)
+                                    .map_err(fts_read_error)
+                            })
+                            .await?;
+                        if set.len() >= RANGED_KERNEL_POOL_MIN_TERMS {
+                            let kernel_reader = Arc::clone(&r);
+                            let kernel_set = Arc::clone(set);
+                            run_on_pool(
+                                Some(&reader_pool),
+                                "ranged prefix kernel: reader pool dropped result",
+                                move || {
+                                    kernel_reader.bm25_search_or_range_prebuilt(
+                                        &kernel_set,
+                                        k,
+                                        start,
+                                        end,
+                                        f32::NEG_INFINITY,
+                                    )
+                                },
+                            )
+                            .await
+                            .map_err(|e| QueryError::Execute(e.to_string()))?
+                            .map_err(fts_read_error)
+                        } else {
+                            r.bm25_search_or_range_prebuilt(set, k, start, end, f32::NEG_INFINITY)
+                                .map_err(fts_read_error)
+                        }
+                    }
                     None => r
                         .bm25_search_prefix(&column_arc, &prefix_arc, k)
                         .await


### PR DESCRIPTION
## Route FTS query CPU through the configured reader pool

reader_threads only bounded CPU concurrency for the ranged multi-term OR path. Everything else (prefix, AND/must-should queries) scored inline on tokio workers, so reader_threads: 1 didn't work as intended

### how did we change this ? 

- One shared async→rayon bridge helper instead of three copies.
- Prefix queries share FST expansion + cursor build per superfile instead of redoing it per doc-id slice.
- Un-ranged AND/must-should queries bridge to the reader pool when the scan is heavy (gated on term document frequency, since this path isn't sliced and can't gate on term count alone)