### PR TITLE
compaction: key the hidden split phase on the manifest strategy

### DIFF
--- a/benches/utils/cost.rs
+++ b/benches/utils/cost.rs
@@ -67,9 +67,13 @@ const PER_MILLION: f64 = 1.0e6;
 /// the cell's own corpus size (`n_docs`/month) so the summary prices writing
 /// THIS table, not a synthetic volume.
 const SUMMARY_QUERIES_PER_MONTH: f64 = 1.0e6;
-/// Warm fraction of the blended monthly read line (the rest pay the cold
-/// per-query cost).
-const SUMMARY_READ_WARM_FRACTION: f64 = 0.95;
+/// Default warm fraction of the blended monthly read line (the rest pay
+/// the cold per-query cost). Env-overridable via
+/// `INFINO_BENCH_COST_WARM_FRACTION` (0 < f ≤ 1) so pricing scenarios can
+/// flex the assumed hit rate without recompiling — the frequency knob;
+/// the warm/cold rate gap the summary prints is the magnitude it
+/// multiplies against.
+const DEFAULT_SUMMARY_READ_WARM_FRACTION: f64 = 0.95;
 /// Padding on the per-query RAM-hold window: a query holds the resident set
 /// a little longer than its own p50 (dispatch, response write, scheduler
 /// slack between overlapped queries), so the hold is billed at fudge × p50.
@@ -599,6 +603,30 @@ fn occupancy_replicas() -> u32 {
     static REPLICAS: OnceLock<u32> = OnceLock::new();
     *REPLICAS
         .get_or_init(|| parse_replicas(std::env::var("INFINO_BENCH_COST_REPLICAS").ok().as_deref()))
+}
+
+/// Parse an `INFINO_BENCH_COST_WARM_FRACTION` override. Accepts only
+/// 0 < f ≤ 1; anything else (unset, garbage, 0, negative, >1, NaN) falls
+/// back to the default — a nonsense hit rate must never silently shape
+/// the blend.
+fn parse_warm_fraction(raw: Option<&str>) -> f64 {
+    raw.and_then(|s| s.parse::<f64>().ok())
+        .filter(|f| f.is_finite() && *f > 0.0 && *f <= 1.0)
+        .unwrap_or(DEFAULT_SUMMARY_READ_WARM_FRACTION)
+}
+
+/// Warm fraction for the blended read line, env-overridable like
+/// [`occupancy_replicas`] (a workload assumption, not an instance
+/// attribute).
+fn summary_warm_fraction() -> f64 {
+    static FRACTION: OnceLock<f64> = OnceLock::new();
+    *FRACTION.get_or_init(|| {
+        parse_warm_fraction(
+            std::env::var("INFINO_BENCH_COST_WARM_FRACTION")
+                .ok()
+                .as_deref(),
+        )
+    })
 }
 
 /// The tenant's composed serving cost per month: marginal work (storage +
@@ -2138,7 +2166,7 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
     // set.
     let blended_read_q = match (&steady_warm, &steady_cold) {
         (Some((_, warm_q)), Some((_, cold_q))) => {
-            Some(warm_q * SUMMARY_READ_WARM_FRACTION + cold_q * (1.0 - SUMMARY_READ_WARM_FRACTION))
+            Some(warm_q * summary_warm_fraction() + cold_q * (1.0 - summary_warm_fraction()))
         }
         (Some((_, warm_q)), None) => Some(*warm_q),
         (None, Some((_, cold_q))) => Some(*cold_q),
@@ -2206,8 +2234,8 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
             text(format!(
                 "Reads — {} queries/mo, {:.0}% warm / {:.0}% cold blend",
                 fmt_count(SUMMARY_QUERIES_PER_MONTH as usize),
-                SUMMARY_READ_WARM_FRACTION * 100.0,
-                (1.0 - SUMMARY_READ_WARM_FRACTION) * 100.0,
+                summary_warm_fraction() * 100.0,
+                (1.0 - summary_warm_fraction()) * 100.0,
             )),
             text(usd_per_million(blended_q)),
             metric(month, usd(month), Better::Lower),
@@ -2506,7 +2534,7 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
     // single-sided fallback) as the monthly read line.
     let blended_vcpu_q = match (steady_warm_vcpu_s, steady_cold_vcpu_s) {
         (Some(warm_v), Some(cold_v)) => {
-            Some(warm_v * SUMMARY_READ_WARM_FRACTION + cold_v * (1.0 - SUMMARY_READ_WARM_FRACTION))
+            Some(warm_v * summary_warm_fraction() + cold_v * (1.0 - summary_warm_fraction()))
         }
         (Some(warm_v), None) => Some(warm_v),
         (None, Some(cold_v)) => Some(cold_v),
@@ -2556,9 +2584,8 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
             text(""),
         ]);
     }
-    if let Some((binding, share)) =
-        binding_share(&[("CPU", cpu_sh), ("RAM", ram_sh), ("NVMe", nvme_sh)])
-    {
+    let active_binding = binding_share(&[("CPU", cpu_sh), ("RAM", ram_sh), ("NVMe", nvme_sh)]);
+    if let Some((binding, share)) = active_binding {
         let per_replica = share * node_month;
         let total = per_replica * f64::from(replicas);
         occupancy_rows.push(vec![
@@ -2609,14 +2636,15 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
         rows: occupancy_rows,
     });
 
-    // ---- Block 7: serving COGS (the composed per-tenant number) ----
-    // The one number the two blocks above only imply: what serving this
-    // tenant costs per month. Marginal work (storage + blended reads +
-    // writes + maintenance) PLUS the keep-warm floor that buys the blend's
-    // warm-hit rate (idle-retained NVMe × R). Egress is excluded — it is
-    // passed through to the customer, so it is revenue-neutral, not COGS.
-    // The floor requires a measured NVMe cache size; when unmeasured the
-    // total is withheld, never guessed low.
+    // ---- Block 7: serving COGS per keep-warm policy ----
+    // The number the marginal summary and the occupancy view each show one
+    // half of: what serving this tenant costs per month, one row per
+    // keep-warm policy. Egress is excluded throughout — passed through to
+    // the customer at cost, revenue-neutral, not COGS. These rows are the
+    // COGS basis for pricing; the assumptions are the knobs printed in the
+    // subtitle, all env-overridable, so scenarios re-run without a code
+    // change. Unmeasured components withhold their row, never guess.
+    let warm_frac = summary_warm_fraction();
     let marginal_ex_egress = storage_month
         + blended_read_q
             .map(|q| q * SUMMARY_QUERIES_PER_MONTH)
@@ -2624,46 +2652,80 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
         + writes_month
         + maintenance_month.unwrap_or(0.0);
     let idle_floor_total = nvme_sh.map(|s| s * node_month * f64::from(replicas));
+    let active_floor_total = active_binding.map(|(_, s)| s * node_month * f64::from(replicas));
+    let warm_reads_month = steady_warm
+        .as_ref()
+        .map(|(_, q)| q * SUMMARY_QUERIES_PER_MONTH);
     let serving_cogs = {
-        let warm_pct = SUMMARY_READ_WARM_FRACTION * 100.0;
+        let warm_pct = warm_frac * 100.0;
+        let cold_pct = 100.0 - warm_pct;
         let mut rows = vec![vec![
+            text("Policy A — scale-to-zero (nothing retained between queries)"),
             text(format!(
-                "Marginal work — storage + blended reads ({warm_pct:.0}/{:.0}) + writes + maintenance",
-                100.0 - warm_pct,
+                "storage {} + reads {} ({warm_pct:.0}% warm / {cold_pct:.0}% at Azure-cold) \
+                 + writes {} + maintenance {}",
+                usd(storage_month),
+                usd(blended_read_q
+                    .map(|q| q * SUMMARY_QUERIES_PER_MONTH)
+                    .unwrap_or(0.0)),
+                usd(writes_month),
+                usd(maintenance_month.unwrap_or(0.0)),
             )),
-            text("summary lines above, egress excluded (passed through to the customer)"),
-            context(marginal_ex_egress, usd(marginal_ex_egress), Better::Lower),
+            metric(marginal_ex_egress, usd(marginal_ex_egress), Better::Lower),
         ]];
-        match idle_floor_total {
-            Some(floor) => {
+        match serving_cogs_month(marginal_ex_egress, idle_floor_total) {
+            Some(total) => rows.push(vec![
+                text("Policy B — keep-warm NVMe (worker reaped between queries)"),
+                text(format!(
+                    "policy A {} + idle-NVMe floor {} (×R={replicas}). Conservative: the \
+                     {cold_pct:.0}% misses are still priced at Azure-cold, but with NVMe \
+                     retained a miss costs near the warm rate — true B is at most this",
+                    usd(marginal_ex_egress),
+                    usd(idle_floor_total.unwrap_or(0.0)),
+                )),
+                metric(total, usd(total), Better::Lower),
+            ]),
+            None => rows.push(vec![
+                text("Policy B — keep-warm NVMe (worker reaped between queries)"),
+                text("NVMe cache unmeasured this run — row withheld, never guessed"),
+                text("—"),
+            ]),
+        }
+        match (active_floor_total, warm_reads_month) {
+            (Some(active), Some(warm_reads)) => {
+                let total = storage_month
+                    + warm_reads
+                    + writes_month
+                    + maintenance_month.unwrap_or(0.0)
+                    + active;
                 rows.push(vec![
+                    text("Policy C — reserved (worker held live, 100% warm)"),
                     text(format!(
-                        "Keep-warm floor — idle-retained NVMe × R={replicas}"
+                        "storage {} + reads at 100% warm {} + writes {} + maintenance {} + \
+                         active occupancy {} (binding share × node-mo × R={replicas})",
+                        usd(storage_month),
+                        usd(warm_reads),
+                        usd(writes_month),
+                        usd(maintenance_month.unwrap_or(0.0)),
+                        usd(active),
                     )),
-                    text("the occupancy row that buys the blend's warm-hit rate"),
-                    context(floor, usd(floor), Better::Lower),
-                ]);
-                let total = serving_cogs_month(marginal_ex_egress, idle_floor_total)
-                    .expect("floor is Some in this branch");
-                rows.push(vec![
-                    text("Serving COGS (marginal + keep-warm floor, ex-egress)"),
-                    text("—"),
                     metric(total, usd(total), Better::Lower),
                 ]);
             }
-            None => rows.push(vec![
-                text("Serving COGS (marginal + keep-warm floor, ex-egress)"),
-                text("NVMe cache unmeasured this run — total withheld, never guessed"),
+            _ => rows.push(vec![
+                text("Policy C — reserved (worker held live, 100% warm)"),
+                text("needs a measured warm read class and an occupancy share — row withheld"),
                 text("—"),
             ]),
         }
         Block {
             subtitle: format!(
-                "Serving COGS — per tenant-month at {} queries/mo, {:.0}% warm blend, \
-                 keep-warm-NVMe policy. The composed number the marginal summary and the \
-                 occupancy view each show one half of.",
+                "Serving COGS per keep-warm policy — one tenant-month at {} queries/mo, \
+                 egress excluded (passed through at cost). Pick the policy you sell; \
+                 assumptions are knobs: warm-hit rate {warm_pct:.0}% \
+                 (INFINO_BENCH_COST_WARM_FRACTION), R={replicas} \
+                 (INFINO_BENCH_COST_REPLICAS), instance rates (INFINO_BENCH_COST_*).",
                 fmt_count(SUMMARY_QUERIES_PER_MONTH as usize),
-                SUMMARY_READ_WARM_FRACTION * 100.0,
             ),
             headers: vec!["Line".into(), "Basis".into(), "$/month".into()],
             rows,
@@ -2995,6 +3057,26 @@ mod tests {
         assert!((inst.usd_per_month() - 0.3629 * HOURS_PER_MONTH).abs() < 1e-9);
         let billed = 0.5 * inst.usd_per_month() * 2.0;
         assert!((billed - inst.usd_per_month()).abs() < 1e-9);
+    }
+
+    /// The warm-fraction knob accepts only a real hit rate: 0 < f ≤ 1.
+    /// Unset, garbage, zero, negative, >1 and NaN all fall back to the
+    /// default rather than silently shaping the blend.
+    #[test]
+    fn warm_fraction_parse_accepts_only_a_real_hit_rate() {
+        assert_eq!(
+            parse_warm_fraction(None),
+            DEFAULT_SUMMARY_READ_WARM_FRACTION
+        );
+        assert_eq!(parse_warm_fraction(Some("0.5")), 0.5);
+        assert_eq!(parse_warm_fraction(Some("1")), 1.0);
+        for bad in ["0", "-0.2", "1.5", "NaN", "warm"] {
+            assert_eq!(
+                parse_warm_fraction(Some(bad)),
+                DEFAULT_SUMMARY_READ_WARM_FRACTION,
+                "{bad} must fall back"
+            );
+        }
     }
 
     /// The composed serving-COGS number: marginal-ex-egress plus the

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     supertable::{
         BuildError, CommitError, ManifestSnapshot, SuperfileEntry, SuperfileUri, Supertable,
         error::CompactionError,
-        handle::{hidden_vector_index_compaction_settings, is_hidden_vector_index_table},
+        handle::hidden_vector_index_compaction_settings,
         manifest::list::{DrainedVersionRanges, PartitionStrategy},
         query::dispatch::open_compaction_input,
         wal::{
@@ -276,7 +276,18 @@ impl Supertable {
         // merged just to be re-split (the merge output would be discarded), and
         // the split runs as its own snapshot-consistent phase, so it can't remove
         // a superfile a later merge job in this pass planned to use.
-        if is_hidden_vector_index_table(&inner.options) {
+        //
+        // Keyed on the manifest's LOCKED strategy, not the handle options: a
+        // hidden handle built at table create time has no user manifest to
+        // train a grid from, so its options never carry VectorCell — only the
+        // first drain locks the strategy into the manifest. An options-keyed
+        // gate silently skips every split until the table is reopened.
+        // `split_overflow_cells` re-checks the manifest strategy itself, so
+        // user tables (never VectorCell-locked) cannot reach the split.
+        if matches!(
+            inner.manifest.load().partition_strategy(),
+            Some(PartitionStrategy::VectorCell { .. })
+        ) {
             split_overflow_cells(Arc::clone(inner))
                 .await
                 .map_err(|e| CompactionError::Build(e.to_string()))?;

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1216,6 +1216,15 @@ const CACHE_BUDGET_HEADROOM_DIVISOR: u64 = 10;
 /// ~one compact packed shard object per partition key instead of many
 /// small delta files.
 /// True for the derived hidden vector-index sibling (VectorCell routing, no FTS).
+///
+/// Options-keyed, so it is STALE for a hidden handle built at table create
+/// time: with no user manifest to train a grid from,
+/// [`build_vector_index_options`] leaves `partition_strategy: None`, and the
+/// options never catch up after the first drain locks VectorCell into the
+/// manifest. Gates deciding whether hidden maintenance must run should key on
+/// the manifest's locked strategy (`ManifestSnapshot::partition_strategy`)
+/// instead; this predicate answers "was this handle BUILT as the hidden
+/// sibling", which is only true for open-era handles.
 pub(crate) fn is_hidden_vector_index_table(opts: &SupertableOptions) -> bool {
     !opts.vector_columns.is_empty()
         && opts.fts_columns.is_empty()
@@ -1844,6 +1853,7 @@ mod tests {
         sync::Arc,
     };
 
+    use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use tempfile::TempDir;
     use uuid::Uuid;
@@ -1852,12 +1862,17 @@ mod tests {
     use crate::{
         config::OptimizeOptions,
         storage::{LocalFsStorageProvider, StorageProvider},
-        superfile::{builder::FtsConfig, vector::layout::VectorLayout},
+        superfile::{
+            builder::{FtsConfig, VectorConfig},
+            vector::{distance::Metric, layout::VectorLayout, rerank_codec::RerankCodec},
+        },
         supertable::{
             manifest::{
                 SuperfileEntry, SuperfileUri,
                 commit::{POINTER_PATH, get_current_manifest_etag},
+                list::PartitionStrategy,
             },
+            opann::MODALITY_MIN_CELL_DOCS,
             options::Consistency,
             query::dispatch::open_reader,
         },
@@ -4605,6 +4620,146 @@ mod tests {
             N,
             "all docs retrievable after the merge — no loss, no half-recall"
         );
+    }
+
+    /// Regression: `optimize` must run the hidden cell-split phase on a handle
+    /// built at table CREATE time, in the same process, with no reopen. The
+    /// split gate in `compact_one_table` once keyed on the handle's options —
+    /// but a create-era hidden handle has no user manifest to train a grid
+    /// from, so its options never carry a VectorCell strategy (only the first
+    /// drain locks it into the manifest), and the options-keyed gate silently
+    /// skipped every split until the table was reopened elsewhere. This pins
+    /// the manifest-keyed gate through the public `optimize()` entry.
+    #[test]
+    fn optimize_runs_split_phase_on_create_era_handle() {
+        // The 500k `cell_split_doc_cap` is out of unit-test reach and config is
+        // process-global, so the fixture leans on the default modality trigger
+        // instead: a cell holding >= MODALITY_MIN_CELL_DOCS rows in MORE than
+        // the whole-mode grouping factor (4 modes, `opann::cell_split_plan`)
+        // of well-separated modes splits under `optimize`.
+        const DIM: usize = 16;
+        /// One-hot modes e_0..e_7 — more than the 4-modes-per-cell grouping
+        /// stop, so the modality plan must split the cell.
+        const MODES: usize = 8;
+        const DOCS_PER_MODE: usize = 64;
+        const N: usize = MODES * DOCS_PER_MODE;
+        assert!(
+            N as u64 >= MODALITY_MIN_CELL_DOCS,
+            "fixture must reach the modality trigger's minimum cell size"
+        );
+
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new(
+                "emb",
+                DataType::FixedSizeList(item_field.clone(), DIM as i32),
+                false,
+            ),
+        ]));
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let options = SupertableOptions::new(
+            schema.clone(),
+            vec![FtsConfig {
+                column: "title".into(),
+                positions: false,
+            }],
+            vec![VectorConfig {
+                column: "emb".into(),
+                dim: DIM,
+                n_cent: 4,
+                rot_seed: 7,
+                metric: Metric::Cosine,
+                rerank_codec: RerankCodec::Sq8Residual,
+                provided_centroids: None,
+            }],
+            Some(default_tokenizer()),
+        )
+        .expect("valid options")
+        .with_storage(storage)
+        .with_writer_pool(pool)
+        // A single hidden cell: every mode drains into cell 0, making it the
+        // one over-populated multimodal cell the split phase must act on.
+        .with_vector_cell_counts(1, 1);
+        // The handle under test comes from CREATE and is never reopened.
+        let st = Supertable::create(options).expect("create");
+
+        let titles = LargeStringArray::from((0..N).map(|i| format!("doc-{i}")).collect::<Vec<_>>());
+        let mut flat = vec![0.0f32; N * DIM];
+        for r in 0..N {
+            let mode = r / DOCS_PER_MODE;
+            flat[r * DIM + mode] = 1.0;
+            // Tiny deterministic jitter on a component no mode occupies keeps
+            // within-mode variance non-zero (no 0/0 Ashman-D corner) while the
+            // modes stay maximally separated.
+            flat[r * DIM + MODES + mode] = ((r % 5) as f32 - 2.0) * 1e-3;
+        }
+        let fsl = FixedSizeListArray::new(
+            item_field,
+            DIM as i32,
+            Arc::new(Float32Array::from(flat)),
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(titles) as Arc<dyn Array>,
+                Arc::new(fsl) as Arc<dyn Array>,
+            ],
+        )
+        .expect("batch");
+        let mut w = st.writer().expect("writer");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+        st.drain_vectors_to_cells_sync().expect("drain to cells");
+
+        let hidden = st
+            .reader()
+            .expect("reader")
+            .vector_index_table()
+            .expect("hidden index")
+            .clone();
+        match hidden
+            .reader()
+            .expect("reader")
+            .manifest()
+            .get_partition_strategy()
+        {
+            PartitionStrategy::VectorCell { clusters, .. } => {
+                assert_eq!(clusters.n_cent, 1, "single-cell grid before optimize");
+                // Grid counts are maintenance bookkeeping (they tally the
+                // incoming region as well as the drained cells), so only the
+                // populated/empty distinction is asserted here.
+                assert!(clusters.counts[0] > 0, "the one cell is populated");
+            }
+            other => panic!("hidden must be VectorCell after drain, got {other:?}"),
+        }
+
+        st.optimize(&OptimizeOptions::default()).expect("optimize");
+
+        // No reopen: the same create-era handles observe the split. The grid
+        // must have grown past one cell (doc preservation across a split is
+        // pinned by the dedicated `split_overflow_cell_*` tests).
+        let reader = hidden.reader().expect("reader");
+        match reader.manifest().get_partition_strategy() {
+            PartitionStrategy::VectorCell { clusters, .. } => {
+                assert!(
+                    clusters.n_cent > 1,
+                    "optimize on a create-era handle must run the split phase; \
+                     grid stayed at {} cell(s)",
+                    clusters.n_cent
+                );
+            }
+            other => panic!("hidden stays VectorCell after optimize, got {other:?}"),
+        }
     }
 
     /// With writer_pool=N>1 and multiple touched cells, drain publishes at most


### PR DESCRIPTION
Fixes #499 

Related PR: #498 

## Problem

A process that creates a vector table and keeps using the same handle —
`create_table` → append → drain → `optimize()`, the normal single-process
ingest lifecycle — never runs the hidden index's cell-split phase. Over-cap
and multimodal cells grow without bound until some other process reopens the
table and optimizes there. Same table, same data: open-era handles split,
create-era handles silently don't.

## Root cause

`compact_one_table` gated `split_overflow_cells` on the handle's options
(`is_hidden_vector_index_table`), which requires `opts.partition_strategy ==
Some(VectorCell)`. A hidden handle built at table create has no user manifest
to train a grid from, so `build_vector_index_options` leaves its options with
no VectorCell strategy — and options are immutable, so they never catch up
after the first drain locks the strategy into the manifest. The gate read the
options; the truth lives in the manifest.

## Fix

Key the gate on the manifest's locked partition strategy — the same signal
`split_overflow_cells` already self-guards on, and the same form the sibling
gate in `compact_async` uses. User tables never lock VectorCell into their
manifests, so the phase still cannot run on them; the change only makes the
split run where it was wrongly skipped.

The one remaining `is_hidden_vector_index_table` call site (the
`try_commit_attempt` step-2b slow-state restamp) has the same staleness
hazard; that is the separately tracked durably-empty-membership bug with its
own fix and regression test in flight. This PR documents the hazard on the
helper's doc-comment; once both fixes land the helper has no callers and
should be deleted.

## Regression test

`supertable::handle::tests::optimize_runs_split_phase_on_create_era_handle`:
create (never reopened) → append one batch that drains into a single hidden
cell holding 8 well-separated modes → drain → public `optimize()` → assert
the grid grew past one cell, all in one process. Rides the default modality
split trigger (>4 modes, ≥ `MODALITY_MIN_CELL_DOCS` rows) because the 500k
`cell_split_doc_cap` is out of unit-test reach and config is process-global.
Fails on the options-keyed gate (grid stays at 1 cell), passes with the
manifest-keyed gate.

## Testing

- New regression test verified fail-before / pass-after the gate change
- `cargo test --lib`: 2085 passed, 0 failed
- Integration subsets: `compact` (6), `commit::` (56), `query::` incl. the
  brute-force oracles (92), `supertable_commit_crash_localfs` crash-safety
  contract (5) — all green
- `cargo fmt --check` and `cargo clippy --all-targets --features
  test-helpers,remote -- -D warnings` clean
- No public-API change (`public-api.txt` untouched)

## Benchmarks

The gate is evaluated once per `optimize()` call and is off every query and
ingest hot path, so steady-state latency, throughput, and fetch/request
counts are unaffected by construction. `optimize` in create-era processes now
performs split work it previously (wrongly) skipped — that is the intended
behavioral fix, not an overhead. 