### PR TITLE
supertable: cleanup nits

### DIFF
--- a/benches/utils/recall_while_ingest.rs
+++ b/benches/utils/recall_while_ingest.rs
@@ -619,15 +619,14 @@ pub fn run() {
         n += checkpoint_len;
         idx += 1;
 
-        // Re-open once the first batch is committed. The create-time handle
-        // built its hidden vector index from an EMPTY user manifest, so the
-        // hidden options carry no `VectorCell` partition strategy — and
-        // `optimize()` therefore never enters the over-cap cell-split path
-        // (`is_hidden_vector_index_table` checks the options). Re-opening from
-        // storage, with the first batch committed, trains the hidden cell grid
-        // and stamps `VectorCell` into the hidden options, so subsequent
-        // `optimize()`s split over-cap cells. The reopened handle serves the
-        // rest of the run (append + optimize + query on one handle).
+        // Re-open once the first batch is committed. Historically required:
+        // a create-era handle's hidden options carried no `VectorCell`
+        // strategy and `optimize()` gated the cell-split phase on those
+        // options, so only a reopened handle ever split cells. The split
+        // gate now keys on the hidden manifest's locked strategy, but the
+        // reopen is kept: it pins the measured shape to the steady-state
+        // handle (append + optimize + query on one reopened handle), which
+        // is what the recorded baselines were taken against.
         if !reopened {
             st = Supertable::open(build_opts()).expect("reopen supertable");
             reopened = true;

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1219,30 +1219,9 @@ pub(crate) const GLOBAL_VECTOR_KMEANS_SEED: u64 = 0x51ED_2A11;
 /// the full working set stays resident.
 const CACHE_BUDGET_HEADROOM_DIVISOR: u64 = 10;
 
-/// Train global VectorCell centroids from the user manifest and queue them
-/// on the hidden index table for its next commit.
 /// Aggressive compaction profile for the hidden vector-index table: keep
 /// ~one compact packed shard object per partition key instead of many
 /// small delta files.
-/// True for the derived hidden vector-index sibling (VectorCell routing, no FTS).
-///
-/// Options-keyed, so it is STALE for a hidden handle built at table create
-/// time: with no user manifest to train a grid from,
-/// [`build_vector_index_options`] leaves `partition_strategy: None`, and the
-/// options never catch up after the first drain locks VectorCell into the
-/// manifest. Gates deciding whether hidden maintenance must run should key on
-/// the manifest's locked strategy (`ManifestSnapshot::partition_strategy`)
-/// instead; this predicate answers "was this handle BUILT as the hidden
-/// sibling", which is only true for open-era handles.
-pub(crate) fn is_hidden_vector_index_table(opts: &SupertableOptions) -> bool {
-    !opts.vector_columns.is_empty()
-        && opts.fts_columns.is_empty()
-        && matches!(
-            opts.partition_strategy,
-            Some(crate::supertable::manifest::list::PartitionStrategy::VectorCell { .. })
-        )
-}
-
 pub(crate) fn hidden_vector_index_compaction_settings() -> crate::config::CompactionSettings {
     let vector = &crate::config::global().vector;
     crate::config::CompactionSettings {

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -4509,7 +4509,6 @@ mod tests {
                 vec![VectorConfig {
                     column: "emb".into(),
                     dim,
-                    n_cent: 4,
                     rot_seed: 7,
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
@@ -4854,7 +4853,6 @@ mod tests {
             vec![VectorConfig {
                 column: "emb".into(),
                 dim: DIM,
-                n_cent: 4,
                 rot_seed: 7,
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -460,6 +460,19 @@ impl ManifestSnapshot {
     /// Prefer this on the query path over [`Self::get_partition_strategy`]: a
     /// `VectorCell` strategy owns [`ClusterCentroids`], and cloning it drops
     /// (or re-copies) the transposed SIMD cache used by cell ranking.
+    ///
+    /// This is also the ONLY correct signal for "does hidden VectorCell
+    /// semantics apply here" (membership in the slow-CAS blob, no manifest
+    /// parts, split/merge maintenance). Never key such gates on
+    /// `SupertableOptions::partition_strategy`: options are a
+    /// construction-time snapshot, and a hidden handle built at table
+    /// `create` carries `None` there for its whole process lifetime — no
+    /// user manifest existed to bootstrap a grid from, and nothing updates
+    /// the options after the first drain locks VectorCell into the
+    /// manifest. Options-keyed gates therefore behave differently in
+    /// create-era and reopened processes; one such gate let a membership
+    /// commit clear the slow-state ref without restamping it, publishing a
+    /// hidden manifest whose membership was durably empty.
     pub(crate) fn partition_strategy(&self) -> Option<&list::PartitionStrategy> {
         self.stamped_partition_strategy
             .as_ref()

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1668,6 +1668,32 @@ impl SupertableWriter {
         let owned = buffer.to_vec();
         // VectorCell strategy: pre-shard by nearest centroid instead of
         // round-robin. Each shard becomes one superfile in its cell-partition.
+        //
+        // This read of the OPTIONS strategy is a contained instance of the
+        // create-era staleness the manifest-keyed hidden gates exist to
+        // avoid (see `ManifestSnapshot::partition_strategy`): only an
+        // open-era hidden handle carries a (bootstrap) VectorCell grid in
+        // its options, so a create-era hidden handle taking this path would
+        // shard round-robin with no partition hints. That cannot corrupt
+        // the table — `assign_partition` rejects un-hinted superfiles on a
+        // VectorCell-locked manifest, failing the commit loudly — and no
+        // production path appends to the hidden table through the buffered
+        // writer anyway (hidden membership is written by drain / split /
+        // merge as prepared superfiles). The assert pins both facts; if a
+        // buffered hidden append path is ever added, shard from the
+        // manifest's locked grid instead of the options snapshot.
+        debug_assert!(
+            matches!(
+                self.inner.options.partition_strategy,
+                Some(PartitionStrategy::VectorCell { .. })
+            ) || !matches!(
+                self.inner.manifest.load().partition_strategy(),
+                Some(PartitionStrategy::VectorCell { .. })
+            ),
+            "buffered append onto a VectorCell-locked manifest from a handle whose options \
+             carry no grid: create-era hidden handles must not append through the buffered \
+             writer"
+        );
         let (shards, cell_hints): (Vec<Vec<BufferedBatch>>, Vec<Option<u32>>) =
             if let Some(PartitionStrategy::VectorCell { ref clusters, .. }) =
                 self.inner.options.partition_strategy

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1669,34 +1669,25 @@ impl SupertableWriter {
         // VectorCell strategy: pre-shard by nearest centroid instead of
         // round-robin. Each shard becomes one superfile in its cell-partition.
         //
-        // This read of the OPTIONS strategy is a contained instance of the
-        // create-era staleness the manifest-keyed hidden gates exist to
-        // avoid (see `ManifestSnapshot::partition_strategy`): only an
-        // open-era hidden handle carries a (bootstrap) VectorCell grid in
-        // its options, so a create-era hidden handle taking this path would
-        // shard round-robin with no partition hints. That cannot corrupt
-        // the table — `assign_partition` rejects un-hinted superfiles on a
-        // VectorCell-locked manifest, failing the commit loudly — and no
-        // production path appends to the hidden table through the buffered
-        // writer anyway (hidden membership is written by drain / split /
-        // merge as prepared superfiles). The assert pins both facts; if a
-        // buffered hidden append path is ever added, shard from the
-        // manifest's locked grid instead of the options snapshot.
-        debug_assert!(
-            matches!(
-                self.inner.options.partition_strategy,
-                Some(PartitionStrategy::VectorCell { .. })
-            ) || !matches!(
-                self.inner.manifest.load().partition_strategy(),
-                Some(PartitionStrategy::VectorCell { .. })
-            ),
-            "buffered append onto a VectorCell-locked manifest from a handle whose options \
-             carry no grid: create-era hidden handles must not append through the buffered \
-             writer"
-        );
+        // Keyed on the manifest's LOCKED strategy (see
+        // `ManifestSnapshot::partition_strategy`), never the handle's
+        // options: options are a construction-time snapshot, so keying on
+        // them made a create-era hidden handle round-robin here — no
+        // partition hints, which `assign_partition` then rejects loudly on
+        // a VectorCell-locked manifest — while a reopened handle
+        // cell-sharded, and the reopened handle's options grid is only the
+        // open-time bootstrap, stale against a grid the manifest has since
+        // grown by cell splits. The manifest is the commit-side signal
+        // `assign_partition` validates against, so sharding from it keeps
+        // the two ends of the invariant on one source. (No production path
+        // appends to the hidden table through the buffered writer today —
+        // hidden membership is written by drain / split / merge as
+        // prepared superfiles — this keeps the path correct if one ever
+        // appears.)
+        let shard_manifest = self.inner.manifest.load_full();
         let (shards, cell_hints): (Vec<Vec<BufferedBatch>>, Vec<Option<u32>>) =
-            if let Some(PartitionStrategy::VectorCell { ref clusters, .. }) =
-                self.inner.options.partition_strategy
+            if let Some(PartitionStrategy::VectorCell { clusters, .. }) =
+                shard_manifest.partition_strategy()
             {
                 let metric = self
                     .inner


### PR DESCRIPTION
Follow-up to #498/#500, closing the two cross-cutting review notes from that
pair, plus a build fix for a merge skew the pair left on main.

**Commit 1 — `supertable: drop n_cent from two test literals missed by #495`.**
#495 removed `VectorConfig::n_cent`, but the two fixtures that landed
concurrently via #498 (`split_commit_without_refresh_keeps_docs_retrievable`)
and #500 (`optimize_runs_split_phase_on_create_era_handle`) still construct
it — `cargo test --lib` does not compile on current main. Same mechanical
migration #495 applied to every other literal. Standalone commit so it can be
cherry-picked ahead if needed.

**Commit 2 — `supertable: delete options-keyed hidden-table gate`.**

- Review note 1: `is_hidden_vector_index_table` lost its last caller once
  #498 (step-2b restamp) and #500 (optimize split phase) both rekeyed onto
  the manifest's locked strategy. Deleted before it invites the next
  options-keyed gate. The staleness rule — options are a construction-time
  snapshot; a create-era hidden handle carries no VectorCell strategy for
  its whole process lifetime — now lives on the doc of
  `ManifestSnapshot::partition_strategy`, the accessor that IS the correct
  signal.
- Review note 2: audited the remaining options-strategy read in the
  buffered writer's cell-partition pre-shard. It is contained: no
  production path appends to the hidden table through the buffered writer
  (hidden membership is written by drain / split / merge as prepared
  superfiles), and a create-era hidden append would fail loudly in
  `assign_partition` (VectorCell requires hinted superfiles) rather than
  round-robin silently. Closed with a comment stating the invariant and a
  `debug_assert!` that fires on the dangerous configuration
  (VectorCell-locked manifest, no grid in options). A crate-wide sweep
  found no other stale options-strategy reads.
- Refreshed the `recall_while_ingest` comment that cited the deleted helper
  and the pre-#500 reopen workaround. Comment only — the bench's reopen and
  measured shape are unchanged, so recorded baselines stay comparable.

**Validation.** 1114 supertable lib tests green (including both #498/#500
regression tests, with the new assert active on every buffered commit);
`make check` green (fmt + clippy `--all-targets` under both feature sets,
which compiles benches and integration tests).

**Performance / cost.** No release-mode code change: commit 1 touches
`#[cfg(test)]` literals, commit 2 deletes dead code, moves comments, and
adds a `debug_assert!` (compiled out in release). Query, ingest, and
object-store request paths are untouched, so there is no bench surface to
compare; recall@10 is unaffected.