### PR TITLE
supertable: skip past crash-orphaned manifest lists in OCC retries

### DIFF
--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -338,6 +338,15 @@ pub(crate) async fn write_part_bytes(
 /// a given `manifest_id`'s manifest; concurrent attempts surface
 /// `PreconditionFailed` and the caller's commit fails (the
 /// writer's OCC retry loop catches this).
+///
+/// A list object can outlive its writer without ever being
+/// published: a crash between this PUT and the pointer CAS
+/// leaves the id occupied but unreferenced. Retrying the same
+/// id would fail here forever, so the OCC retry loop detects
+/// the case (contention while the list object exists at an id
+/// the pointer never reached) and derives its next successor
+/// past the orphan — see `refresh_and_orphaned_id_floor` in
+/// the writer. The orphan itself ages into the GC sweep.
 pub async fn write_manifest(
     storage: &dyn StorageProvider,
     list: &PersistedManifest,

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -133,9 +133,12 @@ pub(crate) const DEFAULT_VECTOR_INDEX_PREFIX: &str = "_vector_index";
 pub struct SuperfileList {
     /// Monotonic point-in-time identifier. Starts at 0 (empty
     /// initial manifest from `Supertable::create`); each commit
-    /// derives `manifest_id = old.manifest_id + 1`. With a single
-    /// writer at a time, no separate counter or atomic is needed —
-    /// the read-then-store sequence is exclusive by construction.
+    /// derives `manifest_id = old.next_manifest_id()` — normally
+    /// `old.manifest_id + 1`, past that when a crash-orphaned list
+    /// occupies an id (ids may gap; readers follow the pointer, never
+    /// id arithmetic). With a single writer at a time, no separate
+    /// counter or atomic is needed — the read-then-store sequence is
+    /// exclusive by construction.
     pub manifest_id: u64,
     /// Pointer back to the immutable per-supertable configuration.
     /// Same Arc across all manifests of one supertable.
@@ -147,6 +150,13 @@ pub struct SuperfileList {
     /// Hidden vector-index sibling prefix. Set at create before the
     /// first manifest list is persisted; cleared once loaded from list.
     pub(crate) vector_index_storage_prefix: Option<String>,
+    /// In-memory only — never persisted. Minimum id the next successor
+    /// manifest may take. The OCC retry loop raises it past a manifest list
+    /// left orphaned by a writer that crashed between its list PUT and its
+    /// pointer CAS: the orphaned object occupies its id (lists are
+    /// conditional-create and never overwritten), so re-deriving the same
+    /// id can never publish. 0 means unconstrained.
+    pub(crate) next_manifest_id_floor: u64,
 }
 
 impl SuperfileList {
@@ -157,6 +167,7 @@ impl SuperfileList {
             options,
             superfiles: Vec::new(),
             vector_index_storage_prefix: None,
+            next_manifest_id_floor: 0,
         }
     }
 
@@ -169,20 +180,29 @@ impl SuperfileList {
             options,
             superfiles: Vec::new(),
             vector_index_storage_prefix,
+            next_manifest_id_floor: 0,
         }
+    }
+
+    /// The id the next successor manifest takes: one past this manifest,
+    /// unless `next_manifest_id_floor` was raised past a crash-orphaned
+    /// manifest list occupying that id.
+    pub(crate) fn next_manifest_id(&self) -> u64 {
+        (self.manifest_id + 1).max(self.next_manifest_id_floor)
     }
 
     /// Build a successor SuperfileList with `new_entries` appended to
     /// the end of `superfiles`. Original is unchanged. `manifest_id`
-    /// of the result is `self.manifest_id + 1`.
+    /// of the result is `self.next_manifest_id()`.
     pub fn with_appended(&self, new_entries: Vec<Arc<SuperfileEntry>>) -> Self {
         let mut superfiles = self.superfiles.clone();
         superfiles.extend(new_entries);
         Self {
-            manifest_id: self.manifest_id + 1,
+            manifest_id: self.next_manifest_id(),
             options: self.options.clone(),
             superfiles,
             vector_index_storage_prefix: self.vector_index_storage_prefix.clone(),
+            next_manifest_id_floor: self.next_manifest_id_floor,
         }
     }
 
@@ -269,6 +289,7 @@ impl ManifestSnapshot {
             options,
             superfiles: superfile_list,
             vector_index_storage_prefix: None,
+            next_manifest_id_floor: 0,
         };
         if let Some(storage) = storage
             && let Some(list) = list
@@ -442,7 +463,7 @@ impl ManifestSnapshot {
     }
 
     pub fn get_next_manifest_id(&self) -> u64 {
-        self.get_manifest_id() + 1
+        self.superfile_list.next_manifest_id()
     }
 
     pub fn get_opts(&self) -> Arc<SupertableOptions> {
@@ -1188,16 +1209,10 @@ impl ManifestSnapshot {
             list.deleted_user_ids_inline = Some(encoded.clone());
             list
         });
+        let mut superfile_list = self.superfile_list.clone();
+        superfile_list.manifest_id = next_id;
         Self {
-            superfile_list: SuperfileList {
-                manifest_id: next_id,
-                options: Arc::clone(&self.superfile_list.options),
-                superfiles: self.superfile_list.superfiles.clone(),
-                vector_index_storage_prefix: self
-                    .superfile_list
-                    .vector_index_storage_prefix
-                    .clone(),
-            },
+            superfile_list,
             list: new_list,
             parts: self.parts.clone(),
             loader: self.loader.clone(),
@@ -1229,16 +1244,10 @@ impl ManifestSnapshot {
             list.slow_vector_state_centroids = Some(centroids);
             list
         });
+        let mut superfile_list = self.superfile_list.clone();
+        superfile_list.manifest_id = next_id;
         Self {
-            superfile_list: SuperfileList {
-                manifest_id: next_id,
-                options: Arc::clone(&self.superfile_list.options),
-                superfiles: self.superfile_list.superfiles.clone(),
-                vector_index_storage_prefix: self
-                    .superfile_list
-                    .vector_index_storage_prefix
-                    .clone(),
-            },
+            superfile_list,
             list: new_list,
             parts: self.parts.clone(),
             loader: self.loader.clone(),
@@ -1267,15 +1276,7 @@ impl ManifestSnapshot {
             list
         });
         Self {
-            superfile_list: SuperfileList {
-                manifest_id: self.superfile_list.manifest_id,
-                options: Arc::clone(&self.superfile_list.options),
-                superfiles: self.superfile_list.superfiles.clone(),
-                vector_index_storage_prefix: self
-                    .superfile_list
-                    .vector_index_storage_prefix
-                    .clone(),
-            },
+            superfile_list: self.superfile_list.clone(),
             list: new_list,
             parts: self.parts.clone(),
             loader: self.loader.clone(),
@@ -1298,12 +1299,7 @@ impl ManifestSnapshot {
             None => None,
         };
         Self {
-            superfile_list: SuperfileList {
-                manifest_id: self.manifest_id,
-                options: Arc::clone(&self.options),
-                superfiles: self.superfiles.clone(),
-                vector_index_storage_prefix: self.vector_index_storage_prefix.clone(),
-            },
+            superfile_list: self.superfile_list.clone(),
             list: new_list.or_else(|| self.list.clone()),
             parts: self.parts.clone(),
             loader: self.loader.clone(),
@@ -1324,12 +1320,7 @@ impl ManifestSnapshot {
             list
         });
         Self {
-            superfile_list: SuperfileList {
-                manifest_id: self.manifest_id,
-                options: Arc::clone(&self.options),
-                superfiles: self.superfiles.clone(),
-                vector_index_storage_prefix: self.vector_index_storage_prefix.clone(),
-            },
+            superfile_list: self.superfile_list.clone(),
             list: new_list.or_else(|| self.list.clone()),
             parts: self.parts.clone(),
             loader: self.loader.clone(),
@@ -1351,18 +1342,35 @@ impl ManifestSnapshot {
             list
         });
         Self {
-            superfile_list: SuperfileList {
-                manifest_id: self.manifest_id,
-                options: Arc::clone(&self.options),
-                superfiles: self.superfiles.clone(),
-                vector_index_storage_prefix: self.vector_index_storage_prefix.clone(),
-            },
+            superfile_list: self.superfile_list.clone(),
             list: new_list.or_else(|| self.list.clone()),
             parts: self.parts.clone(),
             loader: self.loader.clone(),
             stamped_partition_strategy: self.stamped_partition_strategy.clone(),
             stamped_global_vector_index: self.stamped_global_vector_index.clone(),
             stamped_drained_ranges: Some(ranges),
+        }
+    }
+
+    /// Identity successor whose next derived manifest id is at least
+    /// `floor` (see [`SuperfileList::next_manifest_id`]). The OCC retry
+    /// loop stamps this onto its reloaded base after a commit attempt
+    /// collided with a manifest list no pointer references — a writer
+    /// crashed between its list PUT and its pointer CAS, so the orphaned
+    /// object occupies the id and re-deriving it can never publish.
+    /// `manifest_id` and the persisted list are unchanged; only successor
+    /// derivation is affected.
+    pub(crate) fn with_next_manifest_id_floor(&self, floor: u64) -> Self {
+        let mut superfile_list = self.superfile_list.clone();
+        superfile_list.next_manifest_id_floor = superfile_list.next_manifest_id_floor.max(floor);
+        Self {
+            superfile_list,
+            list: self.list.clone(),
+            parts: self.parts.clone(),
+            loader: self.loader.clone(),
+            stamped_partition_strategy: self.stamped_partition_strategy.clone(),
+            stamped_global_vector_index: self.stamped_global_vector_index.clone(),
+            stamped_drained_ranges: self.stamped_drained_ranges.clone(),
         }
     }
 
@@ -1383,12 +1391,7 @@ impl ManifestSnapshot {
             list
         });
         Self {
-            superfile_list: SuperfileList {
-                manifest_id: self.manifest_id,
-                options: Arc::clone(&self.options),
-                superfiles: self.superfiles.clone(),
-                vector_index_storage_prefix: self.vector_index_storage_prefix.clone(),
-            },
+            superfile_list: self.superfile_list.clone(),
             list: new_list.or_else(|| self.list.clone()),
             parts: self.parts.clone(),
             loader: self.loader.clone(),
@@ -1883,6 +1886,7 @@ impl ManifestSnapshot {
             options: self.get_opts(),
             superfiles: new_superfile_list,
             vector_index_storage_prefix: None,
+            next_manifest_id_floor: self.superfile_list.next_manifest_id_floor,
         };
         let loader = opts.storage.as_ref().map(|storage| {
             Arc::new(ManifestPartLoader::new_with_cache(
@@ -4180,6 +4184,44 @@ mod tests {
     }
 
     #[test]
+    fn with_next_manifest_id_floor_skips_orphaned_ids() {
+        // The floor stamp is the OCC retry loop's escape from a
+        // crash-orphaned manifest list: the base's own id is unchanged
+        // (the pointer-etag fence still validates), but every successor
+        // derives past the occupied id.
+        let m1 = ManifestSnapshot::empty(opts()).with_appended(vec![seg_entry(Uuid::new_v4(), 1)]);
+        assert_eq!(m1.get_next_manifest_id(), 2);
+
+        let floored = m1.with_next_manifest_id_floor(3);
+        assert_eq!(floored.get_manifest_id(), 1, "base id unchanged");
+        assert_eq!(floored.get_next_manifest_id(), 3, "successor skips id 2");
+
+        let m3 = floored.with_appended(vec![seg_entry(Uuid::new_v4(), 1)]);
+        assert_eq!(m3.get_manifest_id(), 3);
+        assert_eq!(
+            m3.get_next_manifest_id(),
+            4,
+            "an inert floor never skips again once passed"
+        );
+    }
+
+    #[test]
+    fn with_next_manifest_id_floor_is_monotonic_and_inert_below_next() {
+        // Stamping a lower floor never lowers an existing one, and a
+        // floor at or below the natural successor id changes nothing.
+        let m1 = ManifestSnapshot::empty(opts()).with_appended(vec![seg_entry(Uuid::new_v4(), 1)]);
+        let floored = m1
+            .with_next_manifest_id_floor(5)
+            .with_next_manifest_id_floor(3);
+        assert_eq!(floored.get_next_manifest_id(), 5, "floor is monotonic");
+        assert_eq!(
+            m1.with_next_manifest_id_floor(2).get_next_manifest_id(),
+            2,
+            "floor at the natural successor is inert"
+        );
+    }
+
+    #[test]
     fn superfile_uri_is_distinct_per_call() {
         let a = SuperfileUri::new_v4();
         let b = SuperfileUri::new_v4();
@@ -5584,6 +5626,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![old_superfile],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts,
@@ -5735,6 +5778,7 @@ mod tests {
                     .cloned()
                     .collect(),
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -5944,6 +5988,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf1, sf2],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts,
@@ -6045,6 +6090,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf1, sf2],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts,
@@ -6175,6 +6221,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf1, sf2],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts,
@@ -6305,6 +6352,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf_old, sf_latest],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts,
@@ -6442,6 +6490,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf_a, sf_b],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -6586,6 +6635,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf_a, sf_b],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -6768,6 +6818,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf_a_old, sf_a_latest, sf_b_old, sf_b_latest],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -6946,6 +6997,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf_keep.clone(), sf_remove.clone()],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -7044,6 +7096,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf_keep.clone(), sf_remove.clone()],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -7176,6 +7229,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf_a_keep.clone(), sf_a_remove.clone(), sf_b.clone()],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -7317,6 +7371,7 @@ mod tests {
                     sf_a_latest_remove.clone(),
                 ],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -7427,6 +7482,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf1.clone(), sf2.clone()],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -7516,6 +7572,7 @@ mod tests {
                 options: opts.clone(),
                 superfiles: vec![sf1.clone(), sf2.clone()],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,
@@ -7645,6 +7702,7 @@ mod tests {
                     sf_a_latest.clone(),
                 ],
                 vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
             },
             list: Some(list),
             parts: parts_map,

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -6485,9 +6485,12 @@ pub(in crate::supertable) async fn refresh_and_orphaned_id_floor(
     // the occupied run starting at `attempted_id` is finite; the floor
     // contract is only that every id below it is occupied, which holds at
     // whatever point the walk stops (first free id, probe cap, or a
-    // failed probe).
+    // failed probe). The saturating bound keeps the arithmetic total even
+    // for ids no real table reaches; below it, the plain increment cannot
+    // wrap.
+    let probe_limit = attempted_id.saturating_add(MAX_ORPHAN_RUN_PROBES);
     let mut next_free_id = attempted_id;
-    while next_free_id < attempted_id + MAX_ORPHAN_RUN_PROBES {
+    while next_free_id < probe_limit {
         match storage.head(&manifest_uri(next_free_id)).await {
             Ok(_) => next_free_id += 1,
             Err(StorageError::NotFound { .. }) => break,

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -158,7 +158,7 @@ use crate::{
         hidden_deleted::{self, encode_deleted_ids},
         manifest::{
             ClusterCentroids, RabitqAdmitContext,
-            commit::get_current_manifest_etag,
+            commit::{get_current_manifest_etag, manifest_uri},
             list::{
                 CellRoutingParams, DrainedVersionRanges, GlobalVectorIndex, PartitionStrategy,
                 WIDTH_LAW_KS,
@@ -5758,8 +5758,16 @@ async fn stamp_slow_vector_state(
         return Ok(());
     };
     let max_retries = inner.options.max_commit_retries.max(1);
+    let mut next_id_floor: u64 = 0;
     for attempt in 0..max_retries {
         let old = inner.manifest.load_full();
+        // A prior attempt found its id occupied by a crash-orphaned
+        // manifest list — derive this attempt's successor past it.
+        let old = if next_id_floor > 0 {
+            Arc::new(old.with_next_manifest_id_floor(next_id_floor))
+        } else {
+            old
+        };
         let entries = old.get_all_superfiles();
         if entries.is_empty() && pending_drain.is_none() {
             // Nothing to describe (pre-drain / empty table); the ref is
@@ -5800,6 +5808,7 @@ async fn stamp_slow_vector_state(
         }
         let new_manifest =
             old.with_slow_vector_state(published.uri, published.content_hash, published.centroids);
+        let attempted_id = new_manifest.get_manifest_id();
         let prev_etag = get_current_manifest_etag(&storage, Arc::clone(&old))
             .await
             .inspect_err(|e| inner.note_commit_error(e))
@@ -5813,9 +5822,11 @@ async fn stamp_slow_vector_state(
                 return Ok(());
             }
             Err(SupertableCommitError::WriteContentionExhausted) if attempt + 1 < max_retries => {
-                refresh_inner_state_async(inner, &storage)
-                    .await
-                    .map_err(|e| BuildError::Store(e.to_string()))?;
+                next_id_floor = next_id_floor.max(
+                    refresh_and_orphaned_id_floor(inner, &storage, attempted_id)
+                        .await
+                        .map_err(|e| BuildError::Store(e.to_string()))?,
+                );
                 sleep(backoff_delay(attempt)).await;
             }
             Err(e) => return Err(BuildError::Store(e.to_string())),
@@ -5837,8 +5848,16 @@ async fn record_hidden_deleted_ids(
         return Ok(());
     };
     let max_retries = inner.options.max_commit_retries.max(1);
+    let mut next_id_floor: u64 = 0;
     for attempt in 0..max_retries {
         let old = inner.manifest.load_full();
+        // A prior attempt found its id occupied by a crash-orphaned
+        // manifest list — derive this attempt's successor past it.
+        let old = if next_id_floor > 0 {
+            Arc::new(old.with_next_manifest_id_floor(next_id_floor))
+        } else {
+            old
+        };
         let mut ids = hidden_deleted::deleted_user_ids(&old)
             .map_err(|e| BuildError::Store(e.to_string()))?
             .as_ref()
@@ -5852,6 +5871,7 @@ async fn record_hidden_deleted_ids(
         }
         let bytes = encode_deleted_ids(&ids);
         let new_manifest = old.with_deleted_user_ids(bytes);
+        let attempted_id = new_manifest.get_manifest_id();
         let prev_etag = get_current_manifest_etag(&storage, Arc::clone(&old))
             .await
             .inspect_err(|e| inner.note_commit_error(e))
@@ -5865,9 +5885,11 @@ async fn record_hidden_deleted_ids(
                 return Ok(());
             }
             Err(SupertableCommitError::WriteContentionExhausted) if attempt + 1 < max_retries => {
-                refresh_inner_state_async(inner, &storage)
-                    .await
-                    .map_err(|e| BuildError::Store(e.to_string()))?;
+                next_id_floor = next_id_floor.max(
+                    refresh_and_orphaned_id_floor(inner, &storage, attempted_id)
+                        .await
+                        .map_err(|e| BuildError::Store(e.to_string()))?,
+                );
                 sleep(backoff_delay(attempt)).await;
             }
             Err(e) => return Err(BuildError::Store(e.to_string())),
@@ -5940,8 +5962,16 @@ pub(in crate::supertable) async fn persist_commit_async(
     let max_retries = opts.max_commit_retries.max(1);
     let drive = async move {
         let mut last_err: Option<SupertableCommitError> = None;
+        let mut next_id_floor: u64 = 0;
         for attempt in 0..max_retries {
             let old = inner.manifest.load_full();
+            // A prior attempt found its id occupied by a crash-orphaned
+            // manifest list — derive this attempt's successor past it.
+            let old = if next_id_floor > 0 {
+                Arc::new(old.with_next_manifest_id_floor(next_id_floor))
+            } else {
+                old
+            };
             // Re-apply call-site stamps on every attempt. A pre-store of these
             // fields is not OCC-safe: contention refresh reloads from storage
             // and would drop them before a successful CAS.
@@ -5950,6 +5980,7 @@ pub(in crate::supertable) async fn persist_commit_async(
             } else {
                 Arc::new(list_metadata.apply(&old))
             };
+            let attempted_id = base.get_next_manifest_id();
             let pending_writes = &mut pending_storage_writes;
             let pending_replaces = &mut pending_storage_replaces;
             match try_commit_attempt(
@@ -5968,7 +5999,9 @@ pub(in crate::supertable) async fn persist_commit_async(
                 Err(SupertableCommitError::WriteContentionExhausted)
                     if attempt + 1 < max_retries =>
                 {
-                    refresh_inner_state_async(inner, &storage_async).await?;
+                    next_id_floor = next_id_floor.max(
+                        refresh_and_orphaned_id_floor(inner, &storage_async, attempted_id).await?,
+                    );
                     last_err = Some(SupertableCommitError::WriteContentionExhausted);
                     sleep(backoff_delay(attempt)).await;
                 }
@@ -6387,6 +6420,47 @@ pub(in crate::supertable) async fn refresh_inner_state_async(
     Ok(())
 }
 
+/// Refresh after a contention-failed publish attempt at `attempted_id` and
+/// compute the manifest-id floor for the next attempt.
+///
+/// `WriteContentionExhausted` from one attempt covers two situations:
+///
+/// - **Real race** — another writer published and moved the pointer. The
+///   refresh advances the in-memory base, the next attempt derives a fresh
+///   id, and no floor is needed (returns 0).
+/// - **Unpublished occupant** — the list object at `attempted_id` exists
+///   while the pointer sits short of it: no pointer references that list.
+///   Its writer either died between its list PUT and its pointer CAS (a
+///   crash orphan), or is mid-commit. Lists are conditional-create and
+///   never overwritten, so re-deriving the same id can never publish;
+///   return `attempted_id + 1` so the retry skips past it. The object is
+///   left untouched — an orphan stays unreferenced and ages into the GC
+///   sweep, while a live mid-commit writer keeps its candidate: its pointer
+///   CAS and ours are fenced on the same prior etag, so exactly one wins
+///   and the loser retries as usual.
+///
+/// Both conditions are required. The pointer sitting short of
+/// `attempted_id` alone is not proof of an occupant: a loser's refresh can
+/// run before the winner's pointer CAS lands, and a floored attempt can
+/// lose its etag pre-check with nothing at its id — hence the existence
+/// probe before skipping.
+pub(in crate::supertable) async fn refresh_and_orphaned_id_floor(
+    inner: &SupertableInner,
+    storage: &Arc<dyn StorageProvider>,
+    attempted_id: u64,
+) -> Result<u64, SupertableCommitError> {
+    refresh_inner_state_async(inner, storage).await?;
+    let refreshed_id = inner.manifest.load_full().get_manifest_id();
+    if refreshed_id >= attempted_id {
+        return Ok(0);
+    }
+    match storage.head(&manifest_uri(attempted_id)).await {
+        Ok(_) => Ok(attempted_id + 1),
+        Err(StorageError::NotFound { .. }) => Ok(0),
+        Err(e) => Err(SupertableCommitError::Storage(e)),
+    }
+}
+
 /// CAS-publish a successor manifest whose tombstone seq for every
 /// superfile in `touched` is bumped to the successor's `manifest_id`.
 ///
@@ -6410,12 +6484,21 @@ pub(in crate::supertable) async fn stamp_tombstone_seqs(
         return Ok(());
     };
     let max_retries = inner.options.max_commit_retries.max(1);
+    let mut next_id_floor: u64 = 0;
     for attempt in 0..max_retries {
         let old = inner.manifest.load_full();
+        // A prior attempt found its id occupied by a crash-orphaned
+        // manifest list — derive this attempt's successor past it.
+        let old = if next_id_floor > 0 {
+            Arc::new(old.with_next_manifest_id_floor(next_id_floor))
+        } else {
+            old
+        };
         let Some(new_manifest) = old.with_tombstone_seqs_bumped(touched) else {
             // No persisted list ⇒ in-process-only ⇒ nothing to stamp.
             return Ok(());
         };
+        let attempted_id = new_manifest.get_manifest_id();
         let prev_etag = match get_current_manifest_etag(&storage, Arc::clone(&old)).await {
             Ok(etag) => etag,
             // Pointer moved past our snapshot — reload and retry.
@@ -6439,7 +6522,8 @@ pub(in crate::supertable) async fn stamp_tombstone_seqs(
                 return Ok(());
             }
             Err(SupertableCommitError::WriteContentionExhausted) if attempt + 1 < max_retries => {
-                refresh_inner_state_async(inner, &storage).await?;
+                next_id_floor = next_id_floor
+                    .max(refresh_and_orphaned_id_floor(inner, &storage, attempted_id).await?);
                 sleep(backoff_delay(attempt)).await;
             }
             Err(e) => return Err(e),

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -6433,11 +6433,13 @@ pub(in crate::supertable) async fn refresh_inner_state_async(
 ///   Its writer either died between its list PUT and its pointer CAS (a
 ///   crash orphan), or is mid-commit. Lists are conditional-create and
 ///   never overwritten, so re-deriving the same id can never publish;
-///   return `attempted_id + 1` so the retry skips past it. The object is
-///   left untouched — an orphan stays unreferenced and ages into the GC
-///   sweep, while a live mid-commit writer keeps its candidate: its pointer
-///   CAS and ours are fenced on the same prior etag, so exactly one wins
-///   and the loser retries as usual.
+///   walk the contiguous occupied run and return the first free id, so a
+///   single retry escapes the whole run (skipping one id per retry would
+///   still exhaust `max_commit_retries` on a run longer than the budget).
+///   The occupants are left untouched — an orphan stays unreferenced and
+///   ages into the GC sweep, while a live mid-commit writer keeps its
+///   candidate: its pointer CAS and ours are fenced on the same prior
+///   etag, so exactly one wins and the loser retries as usual.
 ///
 /// Both conditions are required. The pointer sitting short of
 /// `attempted_id` alone is not proof of an occupant: a loser's refresh can
@@ -6454,11 +6456,23 @@ pub(in crate::supertable) async fn refresh_and_orphaned_id_floor(
     if refreshed_id >= attempted_id {
         return Ok(0);
     }
-    match storage.head(&manifest_uri(attempted_id)).await {
-        Ok(_) => Ok(attempted_id + 1),
-        Err(StorageError::NotFound { .. }) => Ok(0),
-        Err(e) => Err(SupertableCommitError::Storage(e)),
+    // Ids above the pointer are only ever held by unpublished lists, and
+    // every write below the pointer has already happened, so the run of
+    // occupied ids starting at `attempted_id` is finite and the walk
+    // terminates at the first free id.
+    let mut next_free_id = attempted_id;
+    loop {
+        match storage.head(&manifest_uri(next_free_id)).await {
+            Ok(_) => next_free_id += 1,
+            Err(StorageError::NotFound { .. }) => break,
+            Err(e) => return Err(SupertableCommitError::Storage(e)),
+        }
     }
+    Ok(if next_free_id > attempted_id {
+        next_free_id
+    } else {
+        0
+    })
 }
 
 /// CAS-publish a successor manifest whose tombstone seq for every

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -82,7 +82,7 @@ use rayon::{ThreadPool, ThreadPoolBuilder, prelude::*};
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 use tokio::time::sleep;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use super::{
@@ -6433,39 +6433,72 @@ pub(in crate::supertable) async fn refresh_inner_state_async(
 ///   Its writer either died between its list PUT and its pointer CAS (a
 ///   crash orphan), or is mid-commit. Lists are conditional-create and
 ///   never overwritten, so re-deriving the same id can never publish;
-///   walk the contiguous occupied run and return the first free id, so a
-///   single retry escapes the whole run (skipping one id per retry would
-///   still exhaust `max_commit_retries` on a run longer than the budget).
-///   The occupants are left untouched — an orphan stays unreferenced and
-///   ages into the GC sweep, while a live mid-commit writer keeps its
-///   candidate: its pointer CAS and ours are fenced on the same prior
-///   etag, so exactly one wins and the loser retries as usual.
+///   walk the occupied run (bounded per retry) and return the first free
+///   id, so a retry escapes a whole run in chunks instead of one id per
+///   retry, which would exhaust `max_commit_retries` on a run longer than
+///   the budget. The occupants are left untouched — an orphan stays
+///   unreferenced and ages into the GC sweep, while a live mid-commit
+///   writer keeps its candidate: its pointer CAS and ours are fenced on
+///   the same prior etag, so exactly one wins and the loser retries as
+///   usual.
 ///
 /// Both conditions are required. The pointer sitting short of
 /// `attempted_id` alone is not proof of an occupant: a loser's refresh can
 /// run before the winner's pointer CAS lands, and a floored attempt can
 /// lose its etag pre-check with nothing at its id — hence the existence
 /// probe before skipping.
+///
+/// The two conditions still cannot tell a crash orphan from a live winner
+/// that has PUT its list but not yet CAS'd its pointer. Skipping past a
+/// live winner is safe (the etag fence elects exactly one CAS) but leaves
+/// the loser's own earlier list as an orphan, so a hot-contention table
+/// trades some steady-state orphan production — reclaimed by the GC sweep
+/// like any other orphan — for the guarantee that the first commit after a
+/// crash publishes. The `refreshed_id >= attempted_id` pre-check keeps the
+/// common lost-race shape (winner already published) on the dense-id path
+/// with no probe at all.
+///
+/// The floor is advisory: failing to compute it must never fail the
+/// caller's commit. A transient probe error ends the walk at what it has
+/// established so far — a real orphan re-detects on the next contention,
+/// and a persistent storage fault still surfaces through the retry's own
+/// I/O.
 pub(in crate::supertable) async fn refresh_and_orphaned_id_floor(
     inner: &SupertableInner,
     storage: &Arc<dyn StorageProvider>,
     attempted_id: u64,
 ) -> Result<u64, SupertableCommitError> {
+    /// Cap on sequential HEAD probes per retry. A contiguous orphan run
+    /// longer than this escapes in chunks — each retry's floor lands on
+    /// the first unprobed id and the next collision resumes the walk from
+    /// there — instead of one unbounded serial probe-per-orphan walk
+    /// delaying the commit (on LocalFS a `head` of a small object reads
+    /// its body, so probes are not free).
+    const MAX_ORPHAN_RUN_PROBES: u64 = 32;
+
     refresh_inner_state_async(inner, storage).await?;
     let refreshed_id = inner.manifest.load_full().get_manifest_id();
     if refreshed_id >= attempted_id {
         return Ok(0);
     }
-    // Ids above the pointer are only ever held by unpublished lists, and
-    // every write below the pointer has already happened, so the run of
-    // occupied ids starting at `attempted_id` is finite and the walk
-    // terminates at the first free id.
+    // Ids above the pointer are only ever held by unpublished lists, so
+    // the occupied run starting at `attempted_id` is finite; the floor
+    // contract is only that every id below it is occupied, which holds at
+    // whatever point the walk stops (first free id, probe cap, or a
+    // failed probe).
     let mut next_free_id = attempted_id;
-    loop {
+    while next_free_id < attempted_id + MAX_ORPHAN_RUN_PROBES {
         match storage.head(&manifest_uri(next_free_id)).await {
             Ok(_) => next_free_id += 1,
             Err(StorageError::NotFound { .. }) => break,
-            Err(e) => return Err(SupertableCommitError::Storage(e)),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    manifest_id = next_free_id,
+                    "orphaned-list probe failed; retrying at the last established id"
+                );
+                break;
+            }
         }
     }
     Ok(if next_free_id > attempted_id {

--- a/tests/supertable/commit/mod.rs
+++ b/tests/supertable/commit/mod.rs
@@ -4,6 +4,7 @@
 pub mod concurrent_threads;
 pub mod id_uniqueness;
 pub mod open_refresh;
+pub mod orphaned_list_recovery;
 pub mod partition_assignment;
 pub mod persistence;
 pub mod pointer_atomic;

--- a/tests/supertable/commit/orphaned_list_recovery.rs
+++ b/tests/supertable/commit/orphaned_list_recovery.rs
@@ -20,18 +20,29 @@
 
 #![deny(clippy::unwrap_used)]
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    ops::Range,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{SyncSender, sync_channel},
+    },
+    thread,
+    time::Duration,
+};
 
+use async_trait::async_trait;
 use bytes::Bytes;
 use infino::{
     supertable::{
         Supertable,
-        manifest::commit::{manifest_uri, read_pointer},
-        storage::{LocalFsStorageProvider, StorageProvider},
+        manifest::commit::{POINTER_PATH, manifest_uri, read_pointer},
+        storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
     test_helpers::{build_title_batch, default_supertable_options},
 };
 use tempfile::TempDir;
+use tokio::sync::Notify;
 
 /// Manifest id of the orphaned list a crashed writer left behind: `create`
 /// publishes id 0, the first commit id 1, so the crashed commit was id 2.
@@ -52,6 +63,13 @@ const N_CONSECUTIVE_ORPHANS: u64 = 4;
 /// Commit-retry budget for the consecutive-orphans test — smaller than the
 /// orphan run so per-id skipping cannot pass.
 const TIGHT_COMMIT_RETRIES: u32 = 2;
+
+/// Safety gap far longer than any orphan's age within a test run, so a
+/// guarded sweep must classify the fresh orphan as too new to reclaim.
+const ORPHAN_PROTECTION_GAP: Duration = Duration::from_secs(3600);
+
+/// Rounds of alternating stale-handle commits in the dense-ids tripwire.
+const STALE_ALTERNATION_ROUNDS: usize = 3;
 
 fn commit_titles(st: &Supertable, titles: &[&str]) {
     let mut w = st.writer().expect("writer");
@@ -102,6 +120,18 @@ fn commit_skips_past_orphaned_manifest_list() {
         futures::executor::block_on(storage.get(&manifest_uri(ORPHANED_MANIFEST_ID)))
             .expect("orphan still present");
     assert_eq!(&orphan_bytes[..], ORPHANED_LIST_BYTES);
+
+    // A safety gap longer than the orphan's age must protect it — to a
+    // sweeper, a young orphan is indistinguishable from a live writer's
+    // just-PUT, not-yet-published list.
+    let guarded = st.gc(ORPHAN_PROTECTION_GAP).expect("guarded gc");
+    assert!(
+        guarded.objects_skipped_too_new >= 1,
+        "the young orphan must be among the too-new skips"
+    );
+    futures::executor::block_on(storage.get(&manifest_uri(ORPHANED_MANIFEST_ID)))
+        .expect("young orphan survives a guarded sweep");
+
     st.gc(Duration::ZERO).expect("gc");
     let gone = futures::executor::block_on(storage.get(&manifest_uri(ORPHANED_MANIFEST_ID)));
     assert!(gone.is_err(), "gc sweeps the unreferenced orphan list");
@@ -136,6 +166,165 @@ fn commit_skips_past_consecutive_orphaned_manifest_lists() {
         "commit publishes at the first id past the whole orphan run"
     );
     assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
+}
+
+/// Pass-through storage that pauses its handle's FIRST pointer CAS. The
+/// wrapper signals `reached` from inside `put_if_match` — i.e. after the
+/// commit's manifest-list PUT already landed — then holds the CAS until
+/// `release` fires: the deterministic reproduction of a live winner frozen
+/// inside the list-PUT → pointer-CAS window.
+#[derive(Debug)]
+struct PauseFirstPointerCas {
+    inner: Arc<dyn StorageProvider>,
+    armed: AtomicBool,
+    reached: SyncSender<()>,
+    release: Arc<Notify>,
+}
+
+#[async_trait]
+impl StorageProvider for PauseFirstPointerCas {
+    async fn head(&self, uri: &str) -> Result<ObjectMeta, StorageError> {
+        self.inner.head(uri).await
+    }
+    async fn get(&self, uri: &str) -> Result<(Bytes, ObjectMeta), StorageError> {
+        self.inner.get(uri).await
+    }
+    async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
+        self.inner.get_range(uri, range).await
+    }
+    async fn put_atomic(&self, uri: &str, bytes: Bytes) -> Result<Option<String>, StorageError> {
+        self.inner.put_atomic(uri, bytes).await
+    }
+    async fn put_if_match(
+        &self,
+        uri: &str,
+        bytes: Bytes,
+        expected_etag: Option<&str>,
+    ) -> Result<Option<String>, StorageError> {
+        if uri == POINTER_PATH && self.armed.swap(false, Ordering::SeqCst) {
+            self.reached.send(()).expect("test main alive");
+            self.release.notified().await;
+        }
+        self.inner.put_if_match(uri, bytes, expected_etag).await
+    }
+    async fn put_multipart(
+        &self,
+        uri: &str,
+    ) -> Result<Box<dyn object_store::MultipartUpload>, StorageError> {
+        self.inner.put_multipart(uri).await
+    }
+    async fn delete(&self, uri: &str) -> Result<(), StorageError> {
+        self.inner.delete(uri).await
+    }
+}
+
+/// The hazardous interleaving behind the orphan-skip gate: winner W has
+/// PUT its manifest list and stands before its pointer CAS while loser L
+/// collides, HEAD-finds W's list, and floors past it. The etag fence must
+/// elect exactly one winner per id — W's frozen CAS loses, its OCC retry
+/// republishes, and every batch's rows land exactly once.
+#[test]
+fn loser_skips_a_live_winner_and_both_commits_land_exactly_once() {
+    let dir = TempDir::new().expect("tempdir");
+    let plain: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st_l = Supertable::create(default_supertable_options().with_storage(Arc::clone(&plain)))
+        .expect("create");
+    commit_titles(&st_l, &["first commit alpha"]);
+
+    let (reached_tx, reached_rx) = sync_channel(1);
+    let release = Arc::new(Notify::new());
+    let wrapped: Arc<dyn StorageProvider> = Arc::new(PauseFirstPointerCas {
+        inner: Arc::clone(&plain),
+        armed: AtomicBool::new(true),
+        reached: reached_tx,
+        release: Arc::clone(&release),
+    });
+    let st_w = Supertable::open(default_supertable_options().with_storage(wrapped))
+        .expect("open winner handle");
+
+    let winner = thread::spawn(move || {
+        let mut w = st_w.writer().expect("winner writer");
+        w.append(&build_title_batch(&["winner bravo"]))
+            .expect("append winner");
+        w.commit()
+            .expect("the frozen winner's commit must still publish");
+        st_w.manifest_id()
+    });
+    reached_rx
+        .recv()
+        .expect("winner reached its pointer CAS with its list durable");
+
+    // W is frozen with list id 2 durable and the pointer at 1. L's commit
+    // collides at id 2, HEAD-finds the in-flight list, floors past it, and
+    // publishes at id 3.
+    commit_titles(&st_l, &["loser charlie"]);
+    assert_eq!(
+        st_l.manifest_id(),
+        3,
+        "loser skips the live winner's in-flight id"
+    );
+
+    // Released, W's fenced CAS at id 2 must LOSE (the pointer moved), and
+    // its OCC retry republishes everything at id 4.
+    release.notify_one();
+    let winner_view = winner.join().expect("winner thread");
+    assert_eq!(winner_view, 4, "winner republishes after losing the fence");
+
+    // Exactly-once across the whole interleaving: three commits, three
+    // superfiles, no double-publish of the winner's rows.
+    let fresh = Supertable::open(default_supertable_options().with_storage(Arc::clone(&plain)))
+        .expect("fresh open");
+    assert_eq!(fresh.manifest_id(), 4);
+    assert_eq!(fresh.reader().expect("reader").n_superfiles(), 3);
+
+    // The winner's superseded first list is exactly the steady-state
+    // orphan this mechanism trades for crash recovery — present,
+    // unreferenced, and left for GC.
+    futures::executor::block_on(plain.get(&manifest_uri(2)))
+        .expect("the skipped in-flight list remains for GC");
+}
+
+/// False-positive tripwire: ordinary staleness (a handle that last
+/// refreshed before another handle's commits) must never trip the orphan
+/// gate. Every id stays dense — a skip here would turn plain alternating
+/// writers into steady orphan production.
+#[test]
+fn stale_handle_contention_keeps_manifest_ids_dense() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st_a = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("create");
+    let st_b = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("open second handle");
+
+    for round in 0..STALE_ALTERNATION_ROUNDS {
+        let title_a = format!("round {round} from a");
+        let title_b = format!("round {round} from b");
+        commit_titles(&st_a, &[&title_a]);
+        commit_titles(&st_b, &[&title_b]);
+    }
+
+    let expected_commits = 2 * STALE_ALTERNATION_ROUNDS as u64;
+    let (pointer, _) = futures::executor::block_on(read_pointer(&*storage))
+        .expect("read pointer")
+        .expect("pointer present");
+    assert_eq!(
+        pointer.get_manifest_id(),
+        expected_commits,
+        "every commit takes the next id — no skips under plain staleness"
+    );
+    // Dense ids ⇔ exactly one list object per id 0..=N: any extra object
+    // in manifest/ would be an orphan a false-positive skip left behind.
+    let n_lists = std::fs::read_dir(dir.path().join("manifest"))
+        .expect("manifest dir")
+        .count();
+    assert_eq!(
+        n_lists as u64,
+        expected_commits + 1,
+        "create's id-0 list plus one list per commit, nothing else"
+    );
 }
 
 #[test]

--- a/tests/supertable/commit/orphaned_list_recovery.rs
+++ b/tests/supertable/commit/orphaned_list_recovery.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Commit recovery past a crash-orphaned manifest list.
+//!
+//! A writer that dies between its manifest-list PUT and its pointer CAS
+//! leaves the list object durably occupying the next manifest id while the
+//! pointer still names the prior commit. Lists are conditional-create and
+//! never overwritten, so the next writer's natural attempt at that id can
+//! only surface `PreconditionFailed` — and, before the orphan-skip fix, its
+//! OCC retry loop refreshed from the (unmoved) pointer, re-derived the same
+//! id, and exhausted as `WriteContentionExhausted` until a GC sweep
+//! reclaimed the orphan.
+//!
+//! These tests inject the crash residue directly (a PUT to the next
+//! manifest id, no pointer advance) and assert the next commit publishes by
+//! skipping past the occupied id, leaving the orphan for GC. The
+//! process-level version of the same scenario (a real SIGABRT between the
+//! two PUTs) lives in `tests/supertable_commit_crash_localfs.rs`.
+
+#![deny(clippy::unwrap_used)]
+
+use std::{sync::Arc, time::Duration};
+
+use bytes::Bytes;
+use infino::{
+    supertable::{
+        Supertable,
+        manifest::commit::{manifest_uri, read_pointer},
+        storage::{LocalFsStorageProvider, StorageProvider},
+    },
+    test_helpers::{build_title_batch, default_supertable_options},
+};
+use tempfile::TempDir;
+
+/// Manifest id of the orphaned list a crashed writer left behind: `create`
+/// publishes id 0, the first commit id 1, so the crashed commit was id 2.
+const ORPHANED_MANIFEST_ID: u64 = 2;
+
+/// Bytes standing in for the crashed writer's encoded manifest list. Never
+/// parsed: no pointer references the object, and the recovery path skips
+/// the id without reading it.
+const ORPHANED_LIST_BYTES: &[u8] =
+    b"manifest list left by a writer that died before its pointer CAS";
+
+fn commit_titles(st: &Supertable, titles: &[&str]) {
+    let mut w = st.writer().expect("writer");
+    w.append(&build_title_batch(titles)).expect("append");
+    w.commit().expect("commit");
+}
+
+fn put_orphan(storage: &Arc<dyn StorageProvider>, manifest_id: u64) {
+    futures::executor::block_on(storage.put_atomic(
+        &manifest_uri(manifest_id),
+        Bytes::from_static(ORPHANED_LIST_BYTES),
+    ))
+    .expect("orphan PUT");
+}
+
+#[test]
+fn commit_skips_past_orphaned_manifest_list() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("create");
+    commit_titles(&st, &["first commit alpha"]);
+    assert_eq!(st.manifest_id(), 1);
+
+    // Crash residue: the list object occupies id 2, the pointer stays at 1.
+    put_orphan(&storage, ORPHANED_MANIFEST_ID);
+
+    // The next commit must publish rather than retry id 2 into
+    // WriteContentionExhausted — it skips to id 3.
+    commit_titles(&st, &["second commit beta"]);
+    assert_eq!(
+        st.manifest_id(),
+        ORPHANED_MANIFEST_ID + 1,
+        "commit publishes at the first id past the orphan"
+    );
+    let (pointer, _) = futures::executor::block_on(read_pointer(&*storage))
+        .expect("read pointer")
+        .expect("pointer present");
+    assert_eq!(pointer.get_manifest_id(), ORPHANED_MANIFEST_ID + 1);
+
+    // Both commits' rows are visible through the published manifest.
+    assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
+
+    // Recovery never touches the orphan: it stays on disk, unreferenced,
+    // until a GC sweep past the safety gap reclaims it.
+    let (orphan_bytes, _) =
+        futures::executor::block_on(storage.get(&manifest_uri(ORPHANED_MANIFEST_ID)))
+            .expect("orphan still present");
+    assert_eq!(&orphan_bytes[..], ORPHANED_LIST_BYTES);
+    st.gc(Duration::ZERO).expect("gc");
+    let gone = futures::executor::block_on(storage.get(&manifest_uri(ORPHANED_MANIFEST_ID)));
+    assert!(gone.is_err(), "gc sweeps the unreferenced orphan list");
+}
+
+#[test]
+fn commit_skips_past_consecutive_orphaned_manifest_lists() {
+    // Two writers crashing back-to-back (the second recovered past the
+    // first, then died the same way) occupy two consecutive ids. Each
+    // occupied id costs one OCC retry; the commit still publishes.
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("create");
+    commit_titles(&st, &["first commit alpha"]);
+
+    put_orphan(&storage, ORPHANED_MANIFEST_ID);
+    put_orphan(&storage, ORPHANED_MANIFEST_ID + 1);
+
+    commit_titles(&st, &["second commit beta"]);
+    assert_eq!(
+        st.manifest_id(),
+        ORPHANED_MANIFEST_ID + 2,
+        "commit publishes at the first id past both orphans"
+    );
+    assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
+}
+
+#[test]
+fn fresh_handle_commits_past_orphaned_manifest_list() {
+    // The wild-world shape of the hazard: the crashed writer's process is
+    // gone, and a NEW handle (fresh open, no in-memory state carried over)
+    // is the one that must commit past the residue.
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    {
+        let st =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+                .expect("create");
+        commit_titles(&st, &["first commit alpha"]);
+    }
+    put_orphan(&storage, ORPHANED_MANIFEST_ID);
+
+    let st = Supertable::open(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("open");
+    assert_eq!(st.manifest_id(), 1, "opens at the last published commit");
+    commit_titles(&st, &["second commit beta"]);
+    assert_eq!(st.manifest_id(), ORPHANED_MANIFEST_ID + 1);
+    assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
+}

--- a/tests/supertable/commit/orphaned_list_recovery.rs
+++ b/tests/supertable/commit/orphaned_list_recovery.rs
@@ -43,6 +43,16 @@ const ORPHANED_MANIFEST_ID: u64 = 2;
 const ORPHANED_LIST_BYTES: &[u8] =
     b"manifest list left by a writer that died before its pointer CAS";
 
+/// Length of the contiguous orphan run in the consecutive-orphans test.
+/// Deliberately longer than [`TIGHT_COMMIT_RETRIES`]: recovery must escape
+/// the whole run in a single retry (one forward probe to the first free
+/// id), not one id per retry — the latter would exhaust the budget here.
+const N_CONSECUTIVE_ORPHANS: u64 = 4;
+
+/// Commit-retry budget for the consecutive-orphans test — smaller than the
+/// orphan run so per-id skipping cannot pass.
+const TIGHT_COMMIT_RETRIES: u32 = 2;
+
 fn commit_titles(st: &Supertable, titles: &[&str]) {
     let mut w = st.writer().expect("writer");
     w.append(&build_title_batch(titles)).expect("append");
@@ -99,24 +109,31 @@ fn commit_skips_past_orphaned_manifest_list() {
 
 #[test]
 fn commit_skips_past_consecutive_orphaned_manifest_lists() {
-    // Two writers crashing back-to-back (the second recovered past the
-    // first, then died the same way) occupy two consecutive ids. Each
-    // occupied id costs one OCC retry; the commit still publishes.
+    // Writers crashing back-to-back (each recovered past the previous run,
+    // then died the same way) leave a contiguous run of occupied ids. The
+    // run is longer than the retry budget, so recovery must escape it in a
+    // single retry — one forward probe to the first free id — rather than
+    // skipping one id per retry.
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
-        .expect("create");
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_max_commit_retries(TIGHT_COMMIT_RETRIES)
+            .with_storage(Arc::clone(&storage)),
+    )
+    .expect("create");
     commit_titles(&st, &["first commit alpha"]);
 
-    put_orphan(&storage, ORPHANED_MANIFEST_ID);
-    put_orphan(&storage, ORPHANED_MANIFEST_ID + 1);
+    for i in 0..N_CONSECUTIVE_ORPHANS {
+        put_orphan(&storage, ORPHANED_MANIFEST_ID + i);
+    }
 
     commit_titles(&st, &["second commit beta"]);
     assert_eq!(
         st.manifest_id(),
-        ORPHANED_MANIFEST_ID + 2,
-        "commit publishes at the first id past both orphans"
+        ORPHANED_MANIFEST_ID + N_CONSECUTIVE_ORPHANS,
+        "commit publishes at the first id past the whole orphan run"
     );
     assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
 }

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -48,6 +48,7 @@
 //! | `crash_post_list_no_prior_commit_yields_pointer_unreadable`    | After create's list PUT, before its pointer | `OpenError::PointerUnreadable`                     |
 //! | `crash_post_superfile_on_second_commit_yields_v1`                | First commit succeeds; 2nd commit's superfile PUT triggers | `manifest_id == 1` (v_prev), orphan v2 superfile    |
 //! | `crash_post_list_on_second_commit_yields_v1`                   | First commit succeeds; 2nd commit's list PUT triggers   | `manifest_id == 1`, orphan v2 list + part         |
+//! | `crash_post_list_on_second_commit_recovers_next_commit`        | Same crash point as above                    | v1 recovered; the FIRST post-crash commit publishes at id 3, skipping the orphaned id 2 |
 //! | `crash_post_pointer_on_second_commit_yields_v2`                | First commit succeeds; 2nd commit's pointer PUT triggers AFTER it lands | `manifest_id == 2` (commit was durable)           |
 //!
 //! LocalFS-only. The atomic-rename semantics hinge on local
@@ -404,6 +405,47 @@ fn crash_post_list_on_second_commit_yields_v1() {
     assert!(
         n_lists >= 2,
         "v1 list + orphan v2 list both on disk; found {n_lists}"
+    );
+}
+
+#[test]
+fn crash_post_list_on_second_commit_recovers_next_commit() {
+    if dispatch_child_if_set().is_some() {
+        return;
+    }
+    let dir = spawn_crash_child(
+        "crash_post_list_on_second_commit_recovers_next_commit",
+        KP_LIST_SECOND,
+    );
+
+    // Recovery opens at v1: the crashed second commit never published, but
+    // its manifest list survives on disk, occupying id 2 (lists are
+    // conditional-create and never overwritten).
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(&dir).expect("provider"));
+    let recovered =
+        Supertable::open(default_supertable_options().with_storage(storage)).expect("open at v1");
+    assert_eq!(recovered.manifest_id(), 1);
+
+    // The FIRST post-crash commit must publish. Regression: the OCC retry
+    // loop used to refresh from the (unmoved) pointer, re-derive the same
+    // occupied id 2, and exhaust as WriteContentionExhausted until a GC
+    // sweep past the safety gap reclaimed the orphan. It now skips to id 3
+    // and leaves the orphan for GC.
+    let mut w = recovered.writer().expect("writer");
+    w.append(&build_title_batch(&["post crash gamma"]))
+        .expect("append");
+    w.commit()
+        .expect("first post-crash commit must publish past the orphaned list");
+    assert_eq!(
+        recovered.manifest_id(),
+        3,
+        "commit skips the orphaned id 2 and publishes at id 3"
+    );
+    assert_eq!(
+        recovered.reader().expect("reader").n_superfiles(),
+        2,
+        "first commit's superfile + the post-crash commit's superfile"
     );
 }
 


### PR DESCRIPTION
**Problem:** A writer that dies between its manifest list PUT and its pointer CAS leaves the list object occupying the next manifest id while the pointer still names the prior commit. Lists are conditional-create and never overwritten, so every retry at that id surfaced PreconditionFailed, the refresh saw no pointer movement, and the first commit after the crash exhausted as WriteContentionExhausted until a GC sweep past the safety gap reclaimed the orphan.

Teach the OCC retry loops to detect the case and derive their next successor past the occupied id: after a contention-failed attempt, if the refreshed pointer sits short of the attempted id AND a HEAD probe finds a list object there, raise an in-memory next-manifest-id floor (never persisted) consulted by successor derivation. Both conditions are required — pointer lag alone also occurs when a loser refreshes before the winner's pointer CAS lands, and skipping there would gap ids on ordinary contention.

Recovery never deletes, overwrites, or reads the orphan: it stays unreferenced and ages into the existing GC sweep, and a slow-but-alive writer keeps its candidate (its pointer CAS and ours are fenced on the same prior etag, so exactly one wins). Manifest ids may gap after a crash; readers follow the pointer and GC's live set names only the current id, so nothing assumes density.

**Regression tests:** direct orphan-injection commit tests (same handle, fresh handle, consecutive orphans, GC of the skipped orphan) and a crash-harness test that commits after a SIGABRT between the list PUT and pointer CAS — both fail before the fix with "write contention exhausted retries".