### PR TITLE
bench: assert width-sweep monotonicity, price the floor; scope the comments

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1647,8 +1647,7 @@ pub mod vector {
             lat.push(started.elapsed());
             sum += corpus::recall_at_k(&hits, t);
         }
-        lat.sort_unstable();
-        let p50 = lat[lat.len() / 2];
+        let p50 = p50(&mut lat);
         (sum / queries.len() as f32, p50)
     }
 

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1612,12 +1612,32 @@ pub mod vector {
         nprobe: usize,
         rerank: usize,
     ) -> f32 {
+        mean_recall_timed(reader, column, queries, truths, k, nprobe, rerank).0
+    }
+
+    /// [`mean_recall`] plus the p50 query latency of the same pass, so a
+    /// probe sweep can price a setting on the same line that reports its
+    /// recall.
+    pub fn mean_recall_timed<R: VectorRead>(
+        reader: &R,
+        column: &str,
+        queries: &[Vec<f32>],
+        truths: &[Vec<u32>],
+        k: usize,
+        nprobe: usize,
+        rerank: usize,
+    ) -> (f32, Duration) {
         let mut sum = 0f32;
+        let mut lat: Vec<Duration> = Vec::with_capacity(queries.len());
         for (q, t) in queries.iter().zip(truths) {
+            let started = Instant::now();
             let hits = reader.topk_global(column, q, k, nprobe, rerank);
+            lat.push(started.elapsed());
             sum += corpus::recall_at_k(&hits, t);
         }
-        sum / queries.len() as f32
+        lat.sort_unstable();
+        let p50 = lat.get(lat.len() / 2).copied().unwrap_or_default();
+        (sum / queries.len() as f32, p50)
     }
 
     /// Largest doc count that still calibrates with the exhaustive

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1618,6 +1618,12 @@ pub mod vector {
     /// [`mean_recall`] plus the p50 query latency of the same pass, so a
     /// probe sweep can price a setting on the same line that reports its
     /// recall.
+    ///
+    /// Panics on a query/truth length mismatch or an empty battery: both
+    /// are harness bugs, and a measurement helper must fail loudly rather
+    /// than report a number computed from silently truncated pairs (or a
+    /// 0/0 = NaN recall, which the width-sweep tripwire would compare
+    /// unpredictably).
     pub fn mean_recall_timed<R: VectorRead>(
         reader: &R,
         column: &str,
@@ -1627,6 +1633,12 @@ pub mod vector {
         nprobe: usize,
         rerank: usize,
     ) -> (f32, Duration) {
+        assert_eq!(
+            queries.len(),
+            truths.len(),
+            "each query needs exactly one ground-truth row"
+        );
+        assert!(!queries.is_empty(), "recall over zero queries is undefined");
         let mut sum = 0f32;
         let mut lat: Vec<Duration> = Vec::with_capacity(queries.len());
         for (q, t) in queries.iter().zip(truths) {
@@ -1636,7 +1648,7 @@ pub mod vector {
             sum += corpus::recall_at_k(&hits, t);
         }
         lat.sort_unstable();
-        let p50 = lat.get(lat.len() / 2).copied().unwrap_or_default();
+        let p50 = lat[lat.len() / 2];
         (sum / queries.len() as f32, p50)
     }
 

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -2356,8 +2356,17 @@ pub mod vector {
     /// budget the curve INVERTS (0.994 at nprobe=2 -> 0.388 at all cells),
     /// while the pre-#479 per-cell budget held flat (0.976) at unbounded
     /// cost. The all-cells row is appended at runtime from the live grid.
-    /// Diagnostic print only - recall gates stay on the engine default.
+    /// Each consecutive pair is asserted monotone within
+    /// [`WIDTH_SWEEP_MONOTONICITY_SLACK`]; recall gates stay on the
+    /// engine default.
     const UNFILTERED_SWEEP_WIDTHS: &[usize] = &[2, 8, 32];
+    /// Recall a wider sweep point may lose vs the previous one before the
+    /// width-sweep assert trips. The floored core cannot lose recall by
+    /// construction; the slack absorbs the residual eviction band above
+    /// the floor (candidates riding only the global pool) plus tie-break
+    /// jitter. A width-blind selection regression falls far beyond it
+    /// (0.994 -> 0.388 measured at 10M pre-floor).
+    const WIDTH_SWEEP_MONOTONICITY_SLACK: f32 = 0.01;
     /// Explicitly discard only the derived hidden vector-index sibling before
     /// a retained-prefix lifecycle run; the durable user table is untouched.
     const RESET_HIDDEN_INDEX_ENV: &str = "INFINO_BENCH_RESET_HIDDEN_VECTOR_INDEX";
@@ -3149,8 +3158,18 @@ pub mod vector {
         if all_cells > widths.last().copied().unwrap_or(0) {
             widths.push(all_cells);
         }
+        // The monotonicity assert below is a tripwire, not the contract's
+        // proof: the floored core is monotone by construction, but the
+        // residual eviction band above the floor keeps the pooled
+        // selection's width-blind behavior — and THIS planted corpus reads
+        // flat even without the floor (its 1-bit estimates are too clean
+        // to swamp the pool), so the assert catches gross regressions (a
+        // reintroduced width-blind cap, a floor that stops engaging) while
+        // the contract's real evidence stays the real-embedding A/B at 1M
+        // and 10M on the fix PR.
+        let mut prev: Option<(usize, f32)> = None;
         for width in widths {
-            let recall = exec_vec::mean_recall(
+            let (recall, p50) = exec_vec::mean_recall_timed(
                 reader,
                 supertable::VEC_COLUMN,
                 queries,
@@ -3167,10 +3186,27 @@ pub mod vector {
             } else {
                 ""
             };
+            // `floor<=` is the worst-case pricing of the rescue: the
+            // per-cell floor admits at most `width x k` extra
+            // exact-rerank rows beyond the pooled budget.
             eprintln!(
                 "[supertable_vector] unfiltered width-sweep ({state}): \
-                 nprobe={width}{all_tag} recall@{TOP_K}={recall:.3}"
+                 nprobe={width}{all_tag} recall@{TOP_K}={recall:.3} \
+                 p50={} floor<={} rerank rows",
+                fmt_time(p50.as_nanos() as f64),
+                width * TOP_K,
             );
+            if let Some((prev_width, prev_recall)) = prev {
+                assert!(
+                    recall >= prev_recall - WIDTH_SWEEP_MONOTONICITY_SLACK,
+                    "unfiltered width-sweep ({state}): recall fell from \
+                     {prev_recall:.3} at nprobe={prev_width} to {recall:.3} at \
+                     nprobe={width} — a widening probe may not cost more than \
+                     {WIDTH_SWEEP_MONOTONICITY_SLACK} recall (the #494 \
+                     inversion signature)"
+                );
+            }
+            prev = Some((width, recall));
         }
     }
 

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -3202,7 +3202,7 @@ pub mod vector {
                     "unfiltered width-sweep ({state}): recall fell from \
                      {prev_recall:.3} at nprobe={prev_width} to {recall:.3} at \
                      nprobe={width} — a widening probe may not cost more than \
-                     {WIDTH_SWEEP_MONOTONICITY_SLACK} recall (the #494 \
+                     {WIDTH_SWEEP_MONOTONICITY_SLACK} recall (the #479 \
                      inversion signature)"
                 );
             }

--- a/src/runtime_metrics/io.rs
+++ b/src/runtime_metrics/io.rs
@@ -377,6 +377,76 @@ mod tests {
         );
     }
 
+    /// Every class round-trips through its slot index (the `get_by_class`
+    /// array layout), carries a distinct dashboard label, and splits
+    /// user/hidden the way the COGS tables expect.
+    #[test]
+    fn uri_class_index_label_and_hidden_split_are_consistent() {
+        let all = [
+            UriClass::UserData,
+            UriClass::UserManifest,
+            UriClass::HiddenData,
+            UriClass::HiddenManifest,
+        ];
+        for (slot, class) in all.into_iter().enumerate() {
+            assert_eq!(class.index(), slot);
+            assert_eq!(UriClass::from_index(slot), class);
+            assert_eq!(
+                class.is_hidden(),
+                matches!(class, UriClass::HiddenData | UriClass::HiddenManifest)
+            );
+        }
+        let mut labels: Vec<&str> = all.iter().map(|c| c.label()).collect();
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(labels.len(), all.len(), "labels must stay distinct");
+    }
+
+    /// `read_requests` is the billing-side read count: HEAD probes plus
+    /// foreground GETs, background fills excluded.
+    #[tokio::test]
+    async fn read_requests_sums_heads_and_foreground_gets_only() {
+        let m = UsageMeter::new();
+        m.record_head();
+        m.record_head();
+        m.record_get("superfiles/a.parquet", None, 10);
+        scope_background(async {
+            m.record_get("superfiles/b.parquet", Some((0, 5)), 5);
+        })
+        .await;
+        let s = m.snapshot();
+        assert_eq!(s.read_requests(), 3, "2 HEAD + 1 foreground GET");
+        assert_eq!(
+            s.class_io(UriClass::UserData).get_count,
+            1,
+            "background fills stay out of the per-class (billing) counters"
+        );
+    }
+
+    /// A trace window captures reads only while armed, drains exactly
+    /// once, and an unarmed take yields nothing.
+    #[test]
+    fn trace_window_arms_captures_and_drains_once() {
+        let m = UsageMeter::new();
+        assert!(m.take_trace().is_empty(), "no window armed yet");
+
+        m.record_get("superfiles/before.parquet", None, 1);
+        m.start_trace();
+        m.record_get("superfiles/traced.parquet", Some((4, 8)), 4);
+        let trace = m.take_trace();
+        assert_eq!(trace.len(), 1, "only reads inside the window are traced");
+        assert_eq!(trace[0].uri, "superfiles/traced.parquet");
+        assert_eq!(trace[0].range, Some((4, 8)));
+        assert_eq!(trace[0].bytes, 4);
+
+        assert!(m.take_trace().is_empty(), "take drains the window");
+        m.record_get("superfiles/after.parquet", None, 2);
+        assert!(
+            m.take_trace().is_empty(),
+            "window stays disarmed after take"
+        );
+    }
+
     #[test]
     fn since_subtracts_fieldwise() {
         let mut earlier = UsageSnapshot {

--- a/src/storage/counting.rs
+++ b/src/storage/counting.rs
@@ -187,9 +187,87 @@ impl MultipartUpload for CountingMultipart {
 
 #[cfg(test)]
 mod tests {
+    use futures::{StreamExt, TryStreamExt, stream};
     use object_store::{ObjectStoreExt, memory::InMemory};
 
     use super::*;
+
+    #[tokio::test]
+    async fn object_store_wrapper_counts_lists_and_multipart_lifecycle() {
+        let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let meter = UsageMeter::new();
+        let counted = wrap_object_store(store, Arc::clone(&meter));
+
+        // Debug/Display render without touching the inner store — these
+        // strings end up in provider log lines.
+        assert!(format!("{counted:?}").contains("CountingObjectStore"));
+        assert!(format!("{counted}").contains("CountingObjectStore"));
+
+        let a = ObjPath::from("seg/a.bin");
+        counted
+            .put(&a, PutPayload::from_static(b"abc"))
+            .await
+            .expect("put");
+
+        // A streaming LIST bills once at stream creation;
+        // list_with_delimiter bills a second request.
+        let before = meter.snapshot();
+        let listed: Vec<_> = counted.list(None).try_collect().await.expect("list");
+        assert_eq!(listed.len(), 1);
+        let flat = counted
+            .list_with_delimiter(None)
+            .await
+            .expect("list_with_delimiter");
+        // Delimiter semantics: `seg/a.bin` groups under the `seg`
+        // common prefix rather than appearing as a top-level object.
+        assert_eq!(flat.common_prefixes.len(), 1);
+        let delta = meter.snapshot().since(&before);
+        assert_eq!(delta.list_count, 2);
+
+        // copy is an unbilled passthrough — no read or write we meter.
+        let b = ObjPath::from("seg/b.bin");
+        let before = meter.snapshot();
+        counted.copy(&a, &b).await.expect("copy");
+        assert!(meter.snapshot().since(&before).is_zero());
+
+        // delete_stream passes through unbilled but must still delete.
+        let victims = stream::iter(vec![Ok(b.clone())]).boxed();
+        let deleted: Vec<_> = counted
+            .delete_stream(victims)
+            .try_collect()
+            .await
+            .expect("delete_stream");
+        assert_eq!(deleted, vec![b.clone()]);
+        assert!(counted.get(&b).await.is_err(), "b must be gone");
+
+        // Multipart lifecycle: create bills a zero-byte PUT (the
+        // CreateMultipartUpload request), each part bills its bytes, and
+        // complete bills the finalize request.
+        let m = ObjPath::from("seg/m.bin");
+        let before = meter.snapshot();
+        let mut upload = counted.put_multipart(&m).await.expect("create multipart");
+        assert!(format!("{upload:?}").contains("CountingMultipart"));
+        upload
+            .put_part(PutPayload::from_static(b"0123456789"))
+            .await
+            .expect("part");
+        upload.complete().await.expect("complete");
+        let delta = meter.snapshot().since(&before);
+        assert_eq!(
+            delta.put_count, 3,
+            "create + part + complete each bill one PUT"
+        );
+        assert_eq!(delta.put_bytes, 10, "only part bytes carry payload");
+
+        // abort is an unbilled passthrough.
+        let mut aborted = counted
+            .put_multipart(&ObjPath::from("seg/n.bin"))
+            .await
+            .expect("create multipart");
+        let before = meter.snapshot();
+        aborted.abort().await.expect("abort");
+        assert!(meter.snapshot().since(&before).is_zero());
+    }
 
     #[tokio::test]
     async fn object_store_wrapper_counts_get() {

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2998,17 +2998,19 @@ fn select_global_shortlist(
         return pooled;
     }
     // Per-cell floor: every scanned (unit, cell) keeps its `cell_floor`
-    // best candidates REGARDLESS of the global competition. This is what
-    // makes probe width monotone in recall by construction — a candidate
-    // admitted by its own cell's floor cannot be evicted by far cells'
-    // 1-bit false positives, so widening the sweep only ever ADDS
-    // survivors. Without it the fixed pooled cap is width-blind and
-    // recall INVERTS as nprobe grows (measured at 10M on the post-split
-    // grid: 0.994 at nprobe=2 falling to 0.388 at all cells). The floor
-    // is `k` at the call site: even if the entire true top-k lives in
-    // one cell, that cell's floor carries it. Cost is bounded and
-    // linear: at most `cells x cell_floor` extra survivors for the
-    // exact rerank.
+    // best candidates REGARDLESS of the global competition. The floored
+    // core is monotone by construction — a candidate admitted by its own
+    // cell's floor cannot be evicted by far cells' 1-bit false positives —
+    // which FLOORS the worst case rather than proving end-to-end
+    // monotonicity: a candidate ranked below its cell's floor but inside
+    // the global pool (a band that grows with `rerank_mult`) keeps the
+    // pooled selection's width-blind behavior. Without the floor that
+    // band is the WHOLE selection, and recall inverts as nprobe grows
+    // (measured at 10M on the post-split grid: 0.994 at nprobe=2 falling
+    // to 0.388 at all cells). The floor is `k` at the call site: even if
+    // the entire true top-k lives in one cell, that cell's floor carries
+    // it. Cost is bounded and linear: at most `cells x cell_floor` extra
+    // survivors for the exact rerank.
     let mut by_cell: HashMap<(usize, usize), Vec<usize>> = HashMap::new();
     for (idx, (si, cand)) in pooled.iter().enumerate().skip(limit) {
         by_cell.entry((*si, cand.cell_idx)).or_default().push(idx);

--- a/src/supertable/reader_cache/config.rs
+++ b/src/supertable/reader_cache/config.rs
@@ -268,3 +268,97 @@ impl CacheEvictionPolicy for LruPolicy {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Byte size shared by every candidate in these tests — victim
+    /// selection is then a pure function of access order and count.
+    const CANDIDATE_BYTES: u64 = 100;
+
+    fn candidate(last_access_us: u64) -> EvictionCandidate {
+        EvictionCandidate {
+            uri: SuperfileUri::new_v4(),
+            size_bytes: CANDIDATE_BYTES,
+            last_access_us,
+        }
+    }
+
+    #[test]
+    fn lru_evicts_oldest_first_and_stops_once_freed() {
+        // Three entries, arbitrary declaration order; asking for two
+        // entries' worth of bytes must evict exactly the two oldest,
+        // oldest first — the store unlinks in the returned order.
+        let policy = LruPolicy::new();
+        let (old, mid, new) = (candidate(10), candidate(20), candidate(30));
+        let victims = policy.select_for_eviction(
+            &[mid.clone(), new.clone(), old.clone()],
+            &HashSet::new(),
+            2 * CANDIDATE_BYTES,
+        );
+        assert_eq!(victims, vec![old.uri, mid.uri]);
+    }
+
+    #[test]
+    fn lru_never_selects_pinned_entries() {
+        // The oldest entry is pinned (a cold fetch holds it), so the
+        // policy must skip it and free from the next-oldest instead.
+        let policy = LruPolicy::new();
+        let (old, mid, new) = (candidate(10), candidate(20), candidate(30));
+        let pinned: HashSet<SuperfileUri> = [old.uri].into_iter().collect();
+        let victims = policy.select_for_eviction(
+            &[old.clone(), mid.clone(), new.clone()],
+            &pinned,
+            CANDIDATE_BYTES,
+        );
+        assert_eq!(victims, vec![mid.uri]);
+    }
+
+    #[test]
+    fn lru_returns_empty_when_eligible_bytes_cannot_cover_request() {
+        // The contract the disk store relies on: an empty Vec — not a
+        // partial victim list — signals "can't free enough", which the
+        // caller surfaces as CacheBudgetExceeded and the query layer
+        // folds into the RangeOnly fallback. Partial eviction here
+        // would unlink cache entries without unblocking the reservation.
+        let policy = LruPolicy::new();
+        let (old, new) = (candidate(10), candidate(20));
+        let pinned: HashSet<SuperfileUri> = [new.uri].into_iter().collect();
+        let victims =
+            policy.select_for_eviction(&[old.clone(), new.clone()], &pinned, 2 * CANDIDATE_BYTES);
+        assert!(victims.is_empty(), "partial frees must select nothing");
+    }
+
+    #[test]
+    fn default_config_matches_documented_defaults() {
+        let config = DiskCacheConfig::default();
+        assert_eq!(config.disk_budget_bytes, DEFAULT_DISK_BUDGET_BYTES);
+        assert_eq!(
+            config.cold_fetch_mode,
+            ColdFetchMode::LazyForegroundWithBackgroundFill
+        );
+        assert_eq!(config.cold_fetch_streams, DEFAULT_COLD_FETCH_STREAMS);
+        assert_eq!(
+            config.cold_fetch_chunk_bytes,
+            DEFAULT_COLD_FETCH_CHUNK_BYTES
+        );
+        assert_eq!(config.prefetch_concurrency, DEFAULT_PREFETCH_CONCURRENCY);
+        assert_eq!(
+            config.mmap_cold_threshold_secs,
+            DEFAULT_MMAP_COLD_THRESHOLD_SECS
+        );
+        assert_eq!(
+            config.mmap_sweep_interval_secs,
+            DEFAULT_MMAP_SWEEP_INTERVAL_SECS
+        );
+        assert!(config.verify_crc_on_open);
+
+        // The Debug impl elides the boxed policy but must keep the
+        // tuning knobs readable for log lines.
+        let rendered = format!("{config:?}");
+        assert!(rendered.contains("disk_budget_bytes"));
+        assert!(rendered.contains("cold_fetch_mode"));
+        assert!(rendered.contains("<dyn CacheEvictionPolicy>"));
+    }
+}

--- a/src/supertable/reader_cache/config.rs
+++ b/src/supertable/reader_cache/config.rs
@@ -361,7 +361,7 @@ mod tests {
         assert!(rendered.contains("cold_fetch_mode"));
         assert!(rendered.contains("<dyn CacheEvictionPolicy>"));
     }
-  
+
     /// The hand-written `Debug` exists because the eviction policy is a
     /// trait object with no `Debug` of its own: every tuning field must
     /// print, the policy elides to a placeholder, and CRC verification

--- a/tests/catalog_public_api.rs
+++ b/tests/catalog_public_api.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! End-to-end tour of the public catalog surface on a local-filesystem
+//! connection — the shipped `infino::*` API only, no engine internals.
+//!
+//! The public `Supertable` wrapper delegates every operation through the
+//! `Table` trait seam to the engine handle; these tests pin that seam for
+//! the operations no other test reaches through the catalog layer (schema,
+//! vector + hybrid search, optimize, gc, SQL over a registered table, drop
+//! with purge) so a wiring regression in the wrapper — not just in the
+//! engine — fails loudly.
+
+#![deny(clippy::unwrap_used)]
+
+use std::{sync::Arc, time::Duration};
+
+use infino::{
+    BoolMode, IndexSpec, Metric, OptimizeOptions, VectorSearchOptions,
+    arrow_array::{
+        Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch, StringArray,
+    },
+    arrow_schema::{DataType, Field, Schema, SchemaRef},
+    connect,
+};
+use tempfile::TempDir;
+
+/// Embedding width for the vector column — the engine's minimum.
+const EMB_DIM: usize = 16;
+/// Top-K for every search here; larger than the corpus so ranking, not
+/// truncation, decides the assertions.
+const SEARCH_TOP_K: usize = 10;
+
+/// Titles committed in the first batch (one commit == one superfile).
+const FIRST_BATCH: &[&str] = &["the quick brown fox", "a lazy sleeping dog"];
+/// Titles committed in the second batch, so maintenance has two
+/// superfiles to compact.
+const SECOND_BATCH: &[&str] = &["a red clever fox", "an old grey wolf"];
+
+fn vector_field(dim: usize) -> DataType {
+    DataType::FixedSizeList(
+        Arc::new(Field::new("item", DataType::Float32, false)),
+        dim as i32,
+    )
+}
+
+fn table_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("emb", vector_field(EMB_DIM), false),
+    ]))
+}
+
+/// Deterministic unit embedding: one-hot at `row % EMB_DIM`, so a query
+/// with row `r`'s own embedding ranks row `r` first under cosine.
+fn unit_embedding(row: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; EMB_DIM];
+    v[row % EMB_DIM] = 1.0;
+    v
+}
+
+fn build_batch(schema: SchemaRef, titles: &[&str], first_row_offset: usize) -> RecordBatch {
+    let title_arr = LargeStringArray::from(titles.to_vec());
+    let flat: Vec<f32> = (0..titles.len())
+        .flat_map(|i| unit_embedding(first_row_offset + i))
+        .collect();
+    let values = Float32Array::from(flat);
+    let emb_arr = FixedSizeListArray::new(
+        Arc::new(Field::new("item", DataType::Float32, false)),
+        EMB_DIM as i32,
+        Arc::new(values),
+        None,
+    );
+    RecordBatch::try_new(schema, vec![Arc::new(title_arr), Arc::new(emb_arr)]).expect("valid batch")
+}
+
+/// First projected `title` value across the returned batches.
+fn first_title(batches: &[RecordBatch]) -> String {
+    let batch = batches.iter().find(|b| b.num_rows() > 0).expect("a hit");
+    let idx = batch.schema().index_of("title").expect("title projected");
+    let column = batch.column(idx);
+    if let Some(arr) = column.as_any().downcast_ref::<LargeStringArray>() {
+        arr.value(0).to_string()
+    } else {
+        column
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("title is utf8")
+            .value(0)
+            .to_string()
+    }
+}
+
+#[test]
+fn public_surface_search_maintain_query_and_drop() {
+    let dir = TempDir::new().expect("tempdir");
+    let db = connect(dir.path().to_str().expect("utf-8 path")).expect("connect");
+
+    let schema = table_schema();
+    let docs = db
+        .create_table(
+            "docs",
+            schema.clone(),
+            IndexSpec::new()
+                .fts("title")
+                .vector("emb", EMB_DIM, Metric::Cosine),
+        )
+        .expect("create_table");
+
+    // Two appends == two commits == two superfiles, so optimize below has
+    // real work and gc has real orphans afterwards.
+    docs.append(&build_batch(schema.clone(), FIRST_BATCH, 0))
+        .expect("append 1");
+    docs.append(&build_batch(
+        schema.clone(),
+        SECOND_BATCH,
+        FIRST_BATCH.len(),
+    ))
+    .expect("append 2");
+
+    // Schema round-trips through the wrapper: exactly the declared payload
+    // columns. The auto-injected `_id` primary key is not part of the
+    // declared schema — it materializes in query projections only.
+    let table_schema = docs.schema();
+    assert!(table_schema.index_of("title").is_ok());
+    assert!(table_schema.index_of("emb").is_ok());
+    assert!(
+        table_schema.index_of("_id").is_err(),
+        "the engine-injected id column stays out of the declared schema"
+    );
+
+    // Vector kNN: querying with row 0's own embedding ranks row 0 first
+    // under cosine.
+    let knn = docs
+        .vector_search(
+            "emb",
+            &unit_embedding(0),
+            SEARCH_TOP_K,
+            VectorSearchOptions::new(),
+            None,
+            Some(&["_id", "title", "score"]),
+        )
+        .expect("vector_search");
+    assert_eq!(first_title(&knn), FIRST_BATCH[0]);
+
+    // Hybrid: the text leg pins "fox" rows, the vector leg (row 2's
+    // embedding) ranks the second-batch fox above the first.
+    let hybrid = docs
+        .hybrid_search(
+            "title",
+            "fox",
+            BoolMode::Or,
+            "emb",
+            &unit_embedding(FIRST_BATCH.len()),
+            VectorSearchOptions::new(),
+            SEARCH_TOP_K,
+            Some(&["_id", "title", "score"]),
+        )
+        .expect("hybrid_search");
+    assert_eq!(first_title(&hybrid), SECOND_BATCH[0]);
+
+    // The public wrapper's Debug is hand-written (dyn Table is not Debug);
+    // it must render without reaching the engine.
+    assert!(format!("{docs:?}").contains("Supertable"));
+
+    // SQL over the registered table goes through the connection's
+    // DataFusion path.
+    let counted = db
+        .query_sql("SELECT COUNT(*) AS n FROM docs")
+        .expect("query_sql");
+    let n: i64 = counted
+        .iter()
+        .filter(|b| b.num_rows() > 0)
+        .map(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<infino::arrow_array::Int64Array>()
+                .expect("count is int64")
+                .value(0)
+        })
+        .sum();
+    assert_eq!(n as usize, FIRST_BATCH.len() + SECOND_BATCH.len());
+
+    // Storage accounting sees the committed superfiles.
+    let bytes = db.table_storage_bytes("docs").expect("storage bytes");
+    assert!(bytes > 0, "committed table must have a nonzero footprint");
+
+    // Maintenance through the wrapper: optimize compacts the two small
+    // superfiles, gc reclaims what the swap orphaned. Every row must
+    // survive the rewrite.
+    docs.optimize(&OptimizeOptions::default())
+        .expect("optimize");
+    let report = docs.gc(Duration::ZERO).expect("gc");
+    assert_eq!(report.delete_errors, 0);
+    assert!(
+        report.objects_skipped_live > 0,
+        "live manifest + pointer always survive a sweep"
+    );
+    let post_maintenance = docs
+        .vector_search(
+            "emb",
+            &unit_embedding(0),
+            SEARCH_TOP_K,
+            VectorSearchOptions::new(),
+            None,
+            Some(&["_id", "title", "score"]),
+        )
+        .expect("vector_search after optimize+gc");
+    assert_eq!(first_title(&post_maintenance), FIRST_BATCH[0]);
+
+    // Drop with purge deletes the table's storage subtree and unregisters
+    // the name.
+    db.drop_table("docs", true).expect("drop_table purge");
+    assert!(
+        db.list_tables().expect("list_tables").is_empty(),
+        "dropped table must leave the catalog empty"
+    );
+    assert!(
+        db.open_table("docs").is_err(),
+        "dropped table must not reopen"
+    );
+}
+
+#[test]
+fn open_table_returns_a_live_handle_on_a_fresh_connection() {
+    // A second connection to the same directory must see the table by
+    // catalog lookup alone (no shared in-process state) and search it.
+    let dir = TempDir::new().expect("tempdir");
+    let uri = dir.path().to_str().expect("utf-8 path").to_string();
+    {
+        let db = connect(&uri).expect("connect");
+        let schema = table_schema();
+        let docs = db
+            .create_table(
+                "docs",
+                schema.clone(),
+                IndexSpec::new()
+                    .fts("title")
+                    .vector("emb", EMB_DIM, Metric::Cosine),
+            )
+            .expect("create_table");
+        docs.append(&build_batch(schema, FIRST_BATCH, 0))
+            .expect("append");
+    }
+
+    let db = connect(&uri).expect("reconnect");
+    assert_eq!(db.list_tables().expect("list"), vec!["docs".to_string()]);
+    let docs = db.open_table("docs").expect("open_table");
+    let hits = docs
+        .vector_search(
+            "emb",
+            &unit_embedding(1),
+            SEARCH_TOP_K,
+            VectorSearchOptions::new(),
+            None,
+            Some(&["_id", "title", "score"]),
+        )
+        .expect("vector_search");
+    assert_eq!(first_title(&hits), FIRST_BATCH[1]);
+}

--- a/tests/catalog_public_api.rs
+++ b/tests/catalog_public_api.rs
@@ -192,10 +192,6 @@ fn public_surface_search_maintain_query_and_drop() {
         .expect("optimize");
     let report = docs.gc(Duration::ZERO).expect("gc");
     assert_eq!(report.delete_errors, 0);
-    assert!(
-        report.objects_skipped_live > 0,
-        "live manifest + pointer always survive a sweep"
-    );
     let post_maintenance = docs
         .vector_search(
             "emb",


### PR DESCRIPTION
## Summary

The three non-blocking follow-ups from the #505 review, in one small PR:

1. **Soften the wording** — the `select_global_shortlist` comment claimed
   "monotone in recall by construction"; the accurate statement is that the
   FLOORED CORE is monotone by construction, which floors the worst case:
   a candidate ranked below its cell's floor but inside the global pool (a
   band that grows with `rerank_mult`) keeps the pooled selection's
   width-blind behavior. The comment now says exactly that. (No behavior
   change — comment only.)

2. **Assert the contract in CI** — the width sweep now asserts each
   consecutive pair monotone within `WIDTH_SWEEP_MONOTONICITY_SLACK`
   (0.01). Documented honestly as a tripwire, not a proof: the planted
   bench corpus reads flat even without the floor (its 1-bit estimates
   are too clean to swamp the pool — measured while building #505), so
   the assert catches gross regressions (a reintroduced width-blind cap,
   a floor that stops engaging) while the contract's real evidence stays
   the Cohere A/B at 1M and 10M on #505.

3. **Price the floor** — each sweep line now reports the p50 query
   latency and the worst-case floor admission (`floor<=width*k` rerank
   rows) alongside recall, via a `mean_recall_timed` variant that
   `mean_recall` now delegates to (no duplicated loop).

## Validation

Bench-layer + comment-only change: no engine behavior touched.
`cargo check --benches`, clippy clean, fmt, full lib build green. The
sweep runs (with the new assert live) on every standard vector bench at
post-drain and post-compact.