### PR TITLE
tests/vector: fix flaky test -- resolve filter-hit identity via an exact_match oracle

### DIFF
--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -3264,7 +3264,9 @@ mod tests {
     };
 
     use arrow::array::Array;
-    use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+    use arrow_array::{
+        Decimal128Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch,
+    };
     use arrow_schema::{DataType, Field, Schema};
 
     use super::{
@@ -4971,8 +4973,18 @@ mod tests {
     /// First unit coverage of the public filter entry — the bench battery
     /// exercises it, but benches don't gate. Fixture titles repeat "doc
     /// {0..31}" per commit, so the token "5" matches exactly one row in
-    /// each of the four commits (stable ids 5 + 32k), and a matching-all
-    /// token ("doc") must reproduce a full top-k.
+    /// each of the four commits, and a matching-all token ("doc") must
+    /// reproduce a full top-k.
+    ///
+    /// Hit identity is checked against an `exact_match("doc 5")` oracle,
+    /// never via arithmetic on the generated `_id`s: the fixture has no
+    /// explicit id column, and a minted snowflake id's low sequence bits
+    /// track row position only while each 32-row batch mints with the
+    /// generator's per-millisecond sequence on a multiple of 32 and no
+    /// millisecond tick lands mid-batch. The open-time handle-id mint
+    /// sharing a millisecond with the first commit's batch is enough to
+    /// shift every sequence by one, and parallel test load makes exactly
+    /// that timing likely.
     #[test]
     fn vector_filter_restricts_hits_to_predicate_matches() {
         let (_dir, st, q, _k) = drained_three_direction_fixture();
@@ -4995,10 +5007,28 @@ mod tests {
             FIXTURE_COMMITS as usize,
             "the predicate matches one row per commit — nothing more"
         );
+        // Identity oracle: resolve the predicate rows' stable ids through
+        // the stored-text-verified exact-match surface — a different path
+        // from the token_match fan the filter itself resolves through.
+        let predicate_rows: HashSet<i128> = st
+            .exact_match("title", "doc 5", Some(&["_id"]))
+            .expect("exact-match oracle")
+            .iter()
+            .filter_map(|b| {
+                b.column_by_name("_id")
+                    .and_then(|c| c.as_any().downcast_ref::<Decimal128Array>())
+            })
+            .flat_map(|c| c.values().iter().copied())
+            .collect();
+        assert_eq!(
+            predicate_rows.len(),
+            FIXTURE_COMMITS as usize,
+            "oracle sanity: exactly one \"doc 5\" row per commit"
+        );
         assert!(
             matched
                 .iter()
-                .all(|h| h.stable_id.is_some_and(|id| id % 32 == 5)),
+                .all(|h| h.stable_id.is_some_and(|id| predicate_rows.contains(&id))),
             "every hit is a predicate row, not a nearest neighbor: {matched:?}"
         );
 


### PR DESCRIPTION
## Problem

`supertable::query::vector::tests::vector_filter_restricts_hits_to_predicate_matches`
is flaky under suite parallelism: `cargo test --lib supertable::query::vector::`
fails ~30–60% of runs (reproduced at 1-in-8 to 1-in-3 locally), while the test
passes 100% in isolation. Failing runs report the "every hit is a predicate row"
assertion with four hits scoring 1.0.

## Root cause

The engine returns the correct rows in every failing run. The fixture's schema
has no `_id` column, so ids are auto-minted snowflakes
(`[64-bit ms timestamp | 40-bit worker | 24-bit sequence]`), and the sequence
resets each millisecond. The test asserted `stable_id % 32 == 5`, which holds
only while each 32-row commit batch mints with the sequence on a multiple
of 32. That alignment is a timing accident: the handle mints one open-time
handle id from the same generator, and when that mint shares a millisecond
with the first commit's batch, every sequence shifts by one.

Captured from a failing run (ids decomposed): same 40-bit worker on all four
hits (one generator — no cross-test contamination), one timestamp per commit,
and commit 0's "doc 5" row carried sequence 6 instead of 5 — exactly the +1
handle-id shift. The hits' 1.0 scores are correct: every predicate row is
orthogonal to the query. Parallel suite load only perturbs which millisecond
each mint lands in.

## Fix

Resolve the expected rows' `_id`s through the public
`exact_match("title", "doc 5", Some(&["_id"]))` surface — stored-text-verified,
a different path from the `token_match` fan the filter resolves through — and
assert set identity (count + containment). This is strictly stronger than the
old mod-32 check and independent of id-generation timing. Doc comment records
why arithmetic on generated ids is forbidden here.

## Verification

- Before: 1-in-8 to 1-in-3 module runs failed; after: **45/45 clean**
  module-parallel runs, 15 of them with a full clippy build competing for CPU
  (the trigger condition). 8/8 in isolation.
- `cargo fmt --check` clean; `cargo clippy --all-targets --features
  test-helpers -- -D warnings` green.

## Performance / recall

Not applicable: the diff is confined to the `#[cfg(test)]` module of
`src/supertable/query/vector.rs` — no engine, bench, or config code changed,
so nothing measured by the bench suite is affected and the recall bar is
untouched.