### PR TITLE
catalog: make read consistency configurable via ConnectOptions

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -69,6 +69,28 @@ impl core::marker::Unpin for infino::ColdFetchMode
 impl core::marker::UnsafeUnpin for infino::ColdFetchMode
 impl core::panic::unwind_safe::RefUnwindSafe for infino::ColdFetchMode
 impl core::panic::unwind_safe::UnwindSafe for infino::ColdFetchMode
+pub enum infino::Consistency
+pub infino::Consistency::BoundedStaleness(core::time::Duration)
+pub infino::Consistency::Snapshot
+pub infino::Consistency::Strong
+impl core::clone::Clone for infino::Consistency
+pub fn infino::Consistency::clone(&self) -> infino::Consistency
+impl core::cmp::Eq for infino::Consistency
+impl core::cmp::PartialEq for infino::Consistency
+pub fn infino::Consistency::eq(&self, &infino::Consistency) -> bool
+impl core::default::Default for infino::Consistency
+pub fn infino::Consistency::default() -> Self
+impl core::fmt::Debug for infino::Consistency
+pub fn infino::Consistency::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for infino::Consistency
+impl core::marker::StructuralPartialEq for infino::Consistency
+impl core::marker::Freeze for infino::Consistency
+impl core::marker::Send for infino::Consistency
+impl core::marker::Sync for infino::Consistency
+impl core::marker::Unpin for infino::Consistency
+impl core::marker::UnsafeUnpin for infino::Consistency
+impl core::panic::unwind_safe::RefUnwindSafe for infino::Consistency
+impl core::panic::unwind_safe::UnwindSafe for infino::Consistency
 pub enum infino::GcError
 pub infino::GcError::NoStorage
 pub infino::GcError::Storage(infino::storage::StorageError)
@@ -217,6 +239,7 @@ pub fn infino::ConnectOptions::with_cache_budget_bytes(self, u64) -> Self
 pub fn infino::ConnectOptions::with_cache_dir(self, impl core::convert::Into<std::path::PathBuf>) -> Self
 pub fn infino::ConnectOptions::with_cold_fetch_mode(self, infino::ColdFetchMode) -> Self
 pub fn infino::ConnectOptions::with_connection_memory_budget_bytes(self, u64) -> Self
+pub fn infino::ConnectOptions::with_read_consistency(self, infino::Consistency) -> Self
 pub fn infino::ConnectOptions::with_storage_option(self, impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn infino::ConnectOptions::with_validate(self, bool) -> Self
 impl core::clone::Clone for infino::ConnectOptions

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -63,7 +63,7 @@ use crate::{
     },
     supertable::{
         Supertable as SupertableHandle,
-        options::{Consistency, SupertableOptions},
+        options::SupertableOptions,
         reader_cache::{DiskCacheConfig, DiskCacheError, DiskCacheStore},
     },
 };
@@ -410,9 +410,9 @@ impl Connection {
                     opts = opts.with_disk_cache(cache);
                 }
 
-                // Match `open_table`'s memoized handles: Strong keeps every
-                // query re-checking the manifest pointer (see `open_table`).
-                opts = opts.with_read_consistency(Consistency::Strong);
+                // Honor the connection's read-consistency policy (default
+                // BoundedStaleness); `open_table` applies the same.
+                opts = opts.with_read_consistency(self.inner.options.read_consistency);
 
                 // Create the physical table at its unique location, then
                 // register the name. A losing racer that also created a
@@ -546,10 +546,10 @@ impl Connection {
                 if let Some(cache) = disk_cache {
                     opts = opts.with_disk_cache(cache);
                 }
-                // Strong: re-check the manifest pointer per query (cheap,
-                // short-circuits when unchanged), matching the old rebuild's
-                // freshness without its cost.
-                opts = opts.with_read_consistency(Consistency::Strong);
+                // Honor the connection's read-consistency policy. Default is
+                // BoundedStaleness(1s): the per-query pointer re-check is
+                // amortized across the window rather than paid on every query.
+                opts = opts.with_read_consistency(self.inner.options.read_consistency);
                 let handle = SupertableHandle::open(opts)
                     .map_err(|e| InfinoError::from(e).with_context("open_table", Some(name)))?;
                 handles.insert(name.to_string(), handle.clone());
@@ -1093,6 +1093,7 @@ mod tests {
         path::{Path, PathBuf},
         sync::Arc,
         thread,
+        time::Duration,
     };
 
     use arrow_array::{Array, Int64Array, LargeStringArray, StringViewArray};
@@ -1101,7 +1102,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        Bm25SearchOptions, BoolMode,
+        Bm25SearchOptions, BoolMode, Consistency,
         supertable::manifest::commit::POINTER_PATH,
         test_helpers::{build_title_batch, schema_id_title},
     };
@@ -1498,8 +1499,16 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let uri = dir.path().to_str().expect("utf8 path").to_string();
 
-        let writer = connect(&uri).expect("connect writer");
-        let peer = connect(&uri).expect("connect peer");
+        let writer = connect_with(
+            &uri,
+            ConnectOptions::new().with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect writer");
+        let peer = connect_with(
+            &uri,
+            ConnectOptions::new().with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect peer");
 
         writer
             .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
@@ -1558,9 +1567,18 @@ mod tests {
         let cache = tempfile::tempdir().expect("cache dir");
         let uri = dir.path().to_str().expect("utf8 path").to_string();
 
-        let writer = connect(&uri).expect("connect writer");
-        let peer = connect_with(&uri, ConnectOptions::new().with_cache_dir(cache.path()))
-            .expect("connect peer");
+        let writer = connect_with(
+            &uri,
+            ConnectOptions::new().with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect writer");
+        let peer = connect_with(
+            &uri,
+            ConnectOptions::new()
+                .with_cache_dir(cache.path())
+                .with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect peer");
 
         writer
             .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
@@ -1740,8 +1758,16 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let uri = dir.path().to_str().expect("utf8 path").to_string();
 
-        let writer = connect(&uri).expect("connect writer");
-        let peer = connect(&uri).expect("connect peer");
+        let writer = connect_with(
+            &uri,
+            ConnectOptions::new().with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect writer");
+        let peer = connect_with(
+            &uri,
+            ConnectOptions::new().with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect peer");
 
         writer
             .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
@@ -2085,7 +2111,11 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let uri = dir.path().to_str().expect("utf8 path").to_string();
 
-        let writer = connect(&uri).expect("connect writer");
+        let writer = connect_with(
+            &uri,
+            ConnectOptions::new().with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect writer");
         writer
             .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
             .expect("create_table")
@@ -2093,7 +2123,11 @@ mod tests {
             .expect("append 1");
 
         // A separate connection memoizes + warms its own handle for `docs`.
-        let reader = connect(&uri).expect("connect reader");
+        let reader = connect_with(
+            &uri,
+            ConnectOptions::new().with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect reader");
         assert_eq!(count_rows(&reader, "docs"), 1);
 
         // The other connection commits a second row.
@@ -2947,6 +2981,113 @@ mod tests {
     fn connect_with_default_options_yields_empty_memory_catalog() {
         let db = connect_with("memory://", ConnectOptions::new()).expect("connect_with");
         assert!(db.list_tables().expect("list").is_empty());
+    }
+
+    #[test]
+    fn connection_read_consistency_flows_to_table_handles() {
+        let dir = std::env::temp_dir().join(format!("infino-consistency-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let uri = format!("file://{}", dir.display());
+
+        // Default connection → BoundedStaleness(1s), applied to both a created
+        // handle and a freshly opened one.
+        let db = connect_with(&uri, ConnectOptions::new()).expect("connect default");
+        let created = db
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create");
+        assert_eq!(
+            created.local_handle().options().read_consistency,
+            Consistency::BoundedStaleness(Duration::from_secs(1)),
+            "an unset connection defaults to BoundedStaleness(1s)"
+        );
+        assert_eq!(
+            db.open_table("docs")
+                .expect("open")
+                .local_handle()
+                .options()
+                .read_consistency,
+            Consistency::BoundedStaleness(Duration::from_secs(1)),
+            "open_table applies the same policy as create_table"
+        );
+
+        // An explicit policy on the connection flows through unchanged.
+        let dir2 = std::env::temp_dir().join(format!(
+            "infino-consistency-strong-{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&dir2).expect("mkdir");
+        let uri2 = format!("file://{}", dir2.display());
+        let strong = connect_with(
+            &uri2,
+            ConnectOptions::new().with_read_consistency(Consistency::Strong),
+        )
+        .expect("connect strong");
+        let created = strong
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create");
+        assert_eq!(
+            created.local_handle().options().read_consistency,
+            Consistency::Strong,
+            "with_read_consistency(Strong) reaches the table handle"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+        let _ = fs::remove_dir_all(&dir2);
+    }
+
+    #[test]
+    fn bounded_staleness_default_is_stale_within_window_then_converges() {
+        // The default connection is BoundedStaleness(1s): a peer connection's
+        // commit is not visible within the staleness window, and becomes visible
+        // once it elapses. (Strong would show it immediately; that path is
+        // covered by `storage_memoized_handle_sees_another_connections_commit`.)
+        let dir = std::env::temp_dir().join(format!("infino-bs-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let uri = format!("file://{}", dir.display());
+
+        let writer = connect(&uri).expect("connect writer");
+        writer
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create")
+            .append(&build_title_batch(&["fox"]))
+            .expect("append v1");
+
+        // A separate default (BoundedStaleness) connection. Its first read sees
+        // the first commit and stamps the per-window pointer check.
+        let reader = connect(&uri).expect("connect reader");
+        let hits = |r: &Connection| {
+            n_rows(
+                &r.open_table("docs")
+                    .expect("open")
+                    .bm25_search("title", "fox", TOP_K, Bm25SearchOptions::new(), None)
+                    .expect("search"),
+            )
+        };
+        assert_eq!(hits(&reader), 1, "reader sees the first commit");
+
+        // The writer commits a second matching doc.
+        writer
+            .open_table("docs")
+            .expect("open")
+            .append(&build_title_batch(&["fox"]))
+            .expect("append v2");
+
+        // Within the 1s window the reader still serves its pinned snapshot.
+        assert_eq!(
+            hits(&reader),
+            1,
+            "within the bounded-staleness window the peer's commit is not yet visible"
+        );
+
+        // After the window elapses, the next read re-probes and converges.
+        thread::sleep(Duration::from_millis(1_100));
+        assert_eq!(
+            hits(&reader),
+            2,
+            "after the 1s window the reader picks up the peer's commit"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/catalog/options.rs
+++ b/src/catalog/options.rs
@@ -8,7 +8,7 @@
 
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::supertable::reader_cache::ColdFetchMode as InternalColdFetchMode;
+use crate::supertable::{Consistency, reader_cache::ColdFetchMode as InternalColdFetchMode};
 
 /// How a disk-cache miss is serviced when reading cold superfiles from
 /// object storage. The cache-servicing modes need a cache
@@ -68,6 +68,12 @@ pub struct ConnectOptions {
     /// can't exhaust process memory. Applies to the whole connection, shared
     /// across supertables.
     pub(crate) connection_memory_budget_bytes: Option<u64>,
+    /// Read-consistency policy for every table opened or created on this
+    /// connection (see [`Consistency`]). Default:
+    /// [`Consistency::BoundedStaleness`] with a 1s window — the engine default,
+    /// which amortizes the per-query manifest-pointer re-check. Set
+    /// [`Consistency::Strong`] for a pointer re-check on every query.
+    pub(crate) read_consistency: Consistency,
     /// Probe the backend at `connect`. Default `false`; opt in for
     /// fail-fast on bad credentials.
     pub(crate) validate: bool,
@@ -126,6 +132,15 @@ impl ConnectOptions {
         self
     }
 
+    /// Set the read-consistency policy for tables on this connection (see
+    /// [`Consistency`]). Unset defaults to [`Consistency::BoundedStaleness`]
+    /// with a 1s window (the engine default); pass [`Consistency::Strong`] to
+    /// re-check the manifest pointer on every query. Chainable.
+    pub fn with_read_consistency(mut self, consistency: Consistency) -> Self {
+        self.read_consistency = consistency;
+        self
+    }
+
     /// Probe the object store at `connect` (default `false`). `true`
     /// fails fast on bad credentials instead of on first use.
     pub fn with_validate(mut self, validate: bool) -> Self {
@@ -152,7 +167,24 @@ impl ConnectOptions {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
+
+    #[test]
+    fn read_consistency_defaults_to_bounded_staleness() {
+        assert_eq!(
+            ConnectOptions::new().read_consistency,
+            Consistency::BoundedStaleness(Duration::from_secs(1)),
+            "unset read consistency defaults to the engine's BoundedStaleness(1s)"
+        );
+    }
+
+    #[test]
+    fn with_read_consistency_overrides_the_default() {
+        let opts = ConnectOptions::new().with_read_consistency(Consistency::Strong);
+        assert_eq!(opts.read_consistency, Consistency::Strong);
+    }
 
     #[test]
     fn with_storage_option_round_trips() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub use superfile::{
     vector::distance::Metric,
 };
 pub use supertable::{
-    GcError, GcReport, MutationStats, OptimizeError, query::vector::VectorFilter,
+    Consistency, GcError, GcReport, MutationStats, OptimizeError, query::vector::VectorFilter,
 };
 
 /// Convenience builders for test fixtures. Visible to:

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -6665,6 +6665,86 @@ mod tests {
         assert_eq!(bm25_title_hits(&verifier, "keep"), 1, "keep survives");
     }
 
+    /// The update-path companion to the delete regression above. An update
+    /// resolves a 1:1 target set the same way, so under bounded staleness a stale
+    /// resolve would fail to see a row a peer committed after the handle's last
+    /// read — matching zero rows and failing the cardinality check — rather than
+    /// replacing it. With the target resolved against the latest manifest, the
+    /// update matches and swaps the row.
+    #[test]
+    fn an_update_resolves_its_target_against_a_peers_commit_under_bounded_staleness() {
+        use datafusion::prelude::{col, lit};
+
+        let dir = TempDir::new().expect("tempdir");
+        let inner: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+
+        // Producer creates the table and commits a baseline row.
+        let producer = Supertable::create(opts().with_storage(Arc::clone(&inner))).expect("create");
+        let mut w = producer.writer().expect("writer");
+        w.append(&title_batch(&["keep"])).expect("append keep");
+        w.commit().expect("commit keep");
+        drop(w);
+
+        // Consumer opens under BoundedStaleness with a window long enough that a
+        // plain read never re-probes for the rest of the test.
+        let consumer = Supertable::open(
+            opts()
+                .with_storage(Arc::clone(&inner))
+                .with_read_consistency(Consistency::BoundedStaleness(Duration::from_secs(3600))),
+        )
+        .expect("open");
+        // One read pins the snapshot and opens the window.
+        assert_eq!(
+            bm25_title_hits(&consumer, "keep"),
+            1,
+            "sees the initial row"
+        );
+
+        // Producer commits the update target the consumer has NOT yet observed.
+        let mut w = producer.writer().expect("writer");
+        w.append(&title_batch(&["stale-target"]))
+            .expect("append target");
+        w.commit().expect("commit target");
+        drop(w);
+
+        // The consumer updates "stale-target" → "fresh-value" while still inside
+        // its staleness window. A plain reader would resolve against the
+        // pre-commit snapshot, match zero rows, and fail the 1:1 cardinality
+        // check; the mutation path force-refreshes and matches the row.
+        let stats = consumer
+            .update(
+                col("title").eq(lit("stale-target")),
+                &title_batch(&["fresh-value"]),
+            )
+            .expect("update");
+        assert_eq!(
+            stats.matched(),
+            1,
+            "the update must resolve against the peer's commit and match the target row"
+        );
+
+        // A fresh reader sees the replacement, the old version gone, and the
+        // untouched row intact — no pre-update version left live beside it.
+        let verifier = Supertable::open(
+            opts()
+                .with_storage(Arc::clone(&inner))
+                .with_read_consistency(Consistency::Strong),
+        )
+        .expect("open verifier");
+        assert_eq!(
+            bm25_title_hits(&verifier, "fresh-value"),
+            1,
+            "replacement is present"
+        );
+        assert_eq!(
+            bm25_title_hits(&verifier, "stale-target"),
+            0,
+            "old version was tombstoned"
+        );
+        assert_eq!(bm25_title_hits(&verifier, "keep"), 1, "keep survives");
+    }
+
     /// The typed shape of a deleted pointer on the read path, pinned at the
     /// layer that produces it. Both the error and the latch matter: callers
     /// above match the variant, and the catalog keys handle eviction on the

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -690,6 +690,43 @@ impl Supertable {
         Ok(())
     }
 
+    /// Force the in-memory snapshot to the latest committed manifest,
+    /// regardless of `read_consistency`, surfacing a failed pointer probe as
+    /// an error (like [`Consistency::Strong`]) rather than serving the current
+    /// snapshot.
+    ///
+    /// This is the freshness a *mutation* resolves its target set against.
+    /// [`ensure_fresh`](Self::ensure_fresh) honors `read_consistency`, so under
+    /// [`Consistency::BoundedStaleness`] it may leave the snapshot behind a
+    /// peer's commit. Resolving an update/delete predicate against such a
+    /// snapshot would miss a row committed after it and silently drop that
+    /// row's tombstone — a lost delete, or an update that leaves the old
+    /// version live beside the new one. The target set must instead agree with
+    /// the manifest the commit will CAS onto, so mutations always resolve
+    /// against the latest, independent of the read policy. Bounded staleness is
+    /// a read-latency contract for queries; it must never cause a write to lose
+    /// data.
+    pub(crate) fn ensure_fresh_strong(&self) -> Result<(), ManifestLoadError> {
+        if self.inner.options.storage.is_none() {
+            return Ok(());
+        }
+        bridge_sync_to_async(self.refresh())?;
+        Ok(())
+    }
+
+    /// A reader pinned to the latest committed manifest (force-refreshed via
+    /// [`ensure_fresh_strong`](Self::ensure_fresh_strong)), for resolving a
+    /// mutation's target set. Unlike [`reader`](Self::reader) this ignores
+    /// `read_consistency` — see `ensure_fresh_strong` for why mutations must
+    /// resolve against the latest manifest.
+    pub(crate) fn reader_strong(&self) -> Result<SupertableReader, ManifestLoadError> {
+        self.ensure_fresh_strong()?;
+        if self.pointer_vanished() {
+            return Err(ManifestLoadError::PointerVanished);
+        }
+        Ok(self.pinned_reader())
+    }
+
     /// Whether this handle's table was dropped and purged elsewhere, seen as
     /// its pointer disappearing during a freshness check. [`Self::ensure_fresh`]
     /// swallows errors by design, so this latch is how that fact escapes.
@@ -6555,6 +6592,77 @@ mod tests {
             1,
             "bounded staleness serves the last good snapshot when the probe fails"
         );
+    }
+
+    /// Regression: a mutation must resolve its target set against the latest
+    /// committed manifest even under `BoundedStaleness`, where a plain read
+    /// would serve a snapshot behind a peer's commit. Resolving the predicate
+    /// against such a snapshot would miss the peer-committed row and silently
+    /// drop its tombstone — a lost delete, or (for update) the old version left
+    /// live beside its replacement.
+    #[test]
+    fn a_mutation_resolves_its_target_against_a_peers_commit_under_bounded_staleness() {
+        use datafusion::prelude::{col, lit};
+
+        let dir = TempDir::new().expect("tempdir");
+        let inner: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+
+        // Producer creates the table and commits one row.
+        let producer = Supertable::create(opts().with_storage(Arc::clone(&inner))).expect("create");
+        let mut w = producer.writer().expect("writer");
+        w.append(&title_batch(&["keep"])).expect("append keep");
+        w.commit().expect("commit keep");
+        drop(w);
+
+        // Consumer opens under BoundedStaleness with a window long enough that a
+        // plain read never re-probes for the rest of the test.
+        let consumer = Supertable::open(
+            opts()
+                .with_storage(Arc::clone(&inner))
+                .with_read_consistency(Consistency::BoundedStaleness(Duration::from_secs(3600))),
+        )
+        .expect("open");
+        // One read pins the snapshot and stamps the pointer-check timestamp, so
+        // the window is now open — a later plain read would serve this snapshot.
+        assert_eq!(
+            bm25_title_hits(&consumer, "keep"),
+            1,
+            "sees the initial row"
+        );
+
+        // Producer commits a second row the consumer has NOT yet observed.
+        let mut w = producer.writer().expect("writer");
+        w.append(&title_batch(&["target"])).expect("append target");
+        w.commit().expect("commit target");
+        drop(w);
+
+        // The consumer deletes "target" while still inside its staleness window.
+        // A plain reader would resolve against the pre-commit snapshot and match
+        // zero rows; the mutation path force-refreshes, so it sees the peer's
+        // commit and tombstones the row.
+        let stats = consumer
+            .delete(col("title").eq(lit("target")))
+            .expect("delete");
+        assert_eq!(
+            stats.n_tombstoned(),
+            1,
+            "the delete must resolve against the peer's commit and tombstone the row"
+        );
+
+        // The row is gone for a fresh reader, and the untouched row survives.
+        let verifier = Supertable::open(
+            opts()
+                .with_storage(Arc::clone(&inner))
+                .with_read_consistency(Consistency::Strong),
+        )
+        .expect("open verifier");
+        assert_eq!(
+            bm25_title_hits(&verifier, "target"),
+            0,
+            "target was deleted"
+        );
+        assert_eq!(bm25_title_hits(&verifier, "keep"), 1, "keep survives");
     }
 
     /// The typed shape of a deleted pointer on the read path, pinned at the

--- a/src/supertable/mod.rs
+++ b/src/supertable/mod.rs
@@ -53,7 +53,7 @@ pub use manifest::{
     SuperfileEntry, SuperfileList, SuperfileUri, VectorSummary,
 };
 pub use mutations::MutationStats;
-pub use options::SupertableOptions;
+pub use options::{Consistency, SupertableOptions};
 pub use reader_cache::{InMemoryReaderCache, ReaderCacheError, SuperfileReaderCache};
 pub use stats::SupertableStats;
 pub use writer::SupertableWriter;

--- a/src/supertable/mutations.rs
+++ b/src/supertable/mutations.rs
@@ -7,7 +7,9 @@
 //! already uses:
 //!
 //! 1. `update()` / `delete()` resolve the predicate against the
-//!    current manifest snapshot, capture the matching `_id` set,
+//!    latest committed manifest — refreshed regardless of the
+//!    connection's read consistency, so the target set agrees with
+//!    the manifest the commit lands on — capture the matching `_id` set,
 //!    pre-reserve any resources the WAL will need (an `_id`
 //!    range + a fresh superfile UUID for updates), and stash a
 //!    pending entry on the writer.
@@ -44,6 +46,7 @@ use crate::{
     supertable::{
         QueryError,
         error::BuildError,
+        manifest::ManifestLoadError,
         wal::{
             persistence::WalStoreError,
             pipeline::{AppendPhaseError, TombstonePhaseError},
@@ -183,6 +186,14 @@ pub enum MutationError {
     /// per-target bits in the sidecars.
     #[error("tombstone phase failed: {0}")]
     TombstonePhase(#[from] TombstonePhaseError),
+
+    /// Refreshing to the latest committed manifest failed while resolving the
+    /// mutation's target set. The target set must agree with the manifest the
+    /// commit lands on, so a failed refresh is surfaced rather than resolving
+    /// against a stale snapshot (which would drop a tombstone for a row
+    /// committed after that snapshot).
+    #[error("failed to refresh to the latest manifest for target resolution: {0}")]
+    TargetResolve(#[source] ManifestLoadError),
 }
 
 impl MutationError {

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -701,6 +701,20 @@ fn single_outcome(res: CommitResult) -> Result<MutationStats, InfinoError> {
         .ok_or_else(|| InfinoError::Backend("commit produced no mutation outcome".to_string()))
 }
 
+/// Map a manifest-refresh failure hit while resolving a mutation's target set
+/// to a [`MutationError`]. A vanished/absent pointer means the table was
+/// dropped and purged — report it gone, matching the read path; any other
+/// failure is a genuine inability to reach the latest manifest, surfaced rather
+/// than resolving the target set against a stale snapshot.
+fn target_resolve_err(e: ManifestLoadError) -> MutationError {
+    match e {
+        ManifestLoadError::PointerVanished | ManifestLoadError::PointerNotFound => {
+            MutationError::TableGone
+        }
+        other => MutationError::TargetResolve(other),
+    }
+}
+
 impl Supertable {
     /// Append one batch of rows and commit — durable when this returns.
     ///
@@ -1055,16 +1069,17 @@ impl SupertableWriter {
             .as_ref()
             .ok_or(MutationError::NoStorageAttached)?;
 
-        // Resolve the predicate against the current manifest
-        // snapshot. NOTE: the writer's pending-appends buffer
-        // is NOT flushed here. Captured-at-call semantics mean
-        // the delete sees the manifest as it stood at this
-        // call's instant; rows the caller appended in the same
+        // Resolve the predicate against the latest committed manifest, not a
+        // bounded-staleness snapshot: a stale resolve would miss a row
+        // committed after the snapshot and silently drop its tombstone (a lost
+        // delete). NOTE: the writer's pending-appends buffer is NOT flushed
+        // here. Captured-at-call semantics mean the delete sees the manifest as
+        // it stood at this call's instant; rows the caller appended in the same
         // writer session are not yet in the manifest.
         let supertable = Supertable::from_inner(Arc::clone(&self.inner));
         let target_ids = supertable
-            .reader()
-            .map_err(|_| MutationError::TableGone)?
+            .reader_strong()
+            .map_err(target_resolve_err)?
             .scan_ids_matching(predicate)
             .map_err(MutationError::PredicateEval)?;
         let matched = target_ids.len();
@@ -1135,13 +1150,15 @@ impl SupertableWriter {
             )));
         }
 
-        // Resolve predicate against the manifest snapshot.
-        // Captured-at-call semantics: appends still in this
-        // writer's buffer don't count toward the match set.
+        // Resolve the predicate against the latest committed manifest, not a
+        // bounded-staleness snapshot: a stale resolve would miss a row
+        // committed after the snapshot and leave the old version live beside
+        // the replacement. Captured-at-call semantics still hold — appends
+        // still in this writer's buffer don't count toward the match set.
         let supertable = Supertable::from_inner(Arc::clone(&self.inner));
         let target_ids = supertable
-            .reader()
-            .map_err(|_| MutationError::TableGone)?
+            .reader_strong()
+            .map_err(target_resolve_err)?
             .scan_ids_matching(predicate)
             .map_err(MutationError::PredicateEval)?;
         let matched = target_ids.len();


### PR DESCRIPTION
## Problem

The catalog **forced `Consistency::Strong`** on every table handle it built — both `create_table` and `open_table` unconditionally called `with_read_consistency(Consistency::Strong)`, overriding the engine's documented default of `BoundedStaleness(1s)`. So the `BoundedStaleness` default never took effect for any `connect`-based caller, and there was **no way for a connection to choose** its consistency.

`Strong` re-checks the manifest pointer on **every** query (one conditional pointer GET per read). `BoundedStaleness` amortizes that check across the window, which matters for hot read workloads (and per-request GET cost on object stores).

## Change

- Add `ConnectOptions::with_read_consistency(Consistency)` and thread the connection's policy through `create_table` / `open_table` instead of hardcoding `Strong`.
- Re-export `Consistency` at the crate root so callers can name it.
- **Default (unset) is `BoundedStaleness(1s)`** — matching the engine default. A connection opts into `Strong` only when it needs a per-query pointer re-check.

**Backwards compatibility:** purely additive to the public surface (`public-api.txt` diff has zero removals — one new re-exported enum + one new builder). The new struct field is `pub(crate)` and derives `Default`, so existing construction is unchanged. The **only** observable change is the default policy for catalog-built handles; anyone who wants the old behavior calls `.with_read_consistency(Consistency::Strong)`.

## Mutation safety under bounded staleness

Making `BoundedStaleness` the default exposed a latent assumption in the mutation path. An `update` / `delete` resolves its predicate to the set of `_id`s it will tombstone, and that resolution read the writer handle's current snapshot — whose freshness follows the connection's read consistency. Under `Strong` (the old forced default) that snapshot was always re-checked, so it never mattered; under `BoundedStaleness` a mutation could resolve against a snapshot **behind a peer's commit**, miss a row committed after it, and silently drop that row's tombstone — a delete that leaves the row, or an update that leaves the old version live beside its replacement (a duplicate row).

Fix: a mutation's target set must agree with the manifest its commit will land on, so `update` / `delete` now **force the snapshot to the latest committed manifest before resolving, independent of read consistency** (a failed pointer probe is surfaced, not resolved against a stale snapshot). Bounded staleness remains a read-latency contract for *queries*; it must never cause a write to lose data. Added a regression test: under `BoundedStaleness` with a long window, a handle deletes a row a peer committed after the handle's last read — with the fix the delete resolves against the latest manifest and tombstones it; without it the delete matches zero rows.

## Tests

- `ConnectOptions` default is `BoundedStaleness(1s)`; `with_read_consistency` overrides it.
- The connection's policy reaches both created and freshly-opened table handles.
- A default `BoundedStaleness` read is **stale within its 1s window and converges after it elapses**.
- The cross-connection freshness tests that assert *immediate* convergence (peer-commit visibility, purge detection) now opt into `Strong` explicitly — preserving that coverage.
- New: a mutation resolves its target set against a peer's commit under `BoundedStaleness` (fails without the fix).

Full lib suite (1116 supertable unit + rest) + integration suites (superfile/supertable/concurrent-process, 227) + `fmt` (CI config) + `clippy --all-targets --features test-helpers -D warnings` + `make public-api` all green.
