### PR TITLE
vector: default cosine rerank to a single 16-bit scalar plane (Sq16)

### DIFF
--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -99,12 +99,12 @@ pub fn bench_rerank_codec(metric: Metric) -> RerankCodec {
     // Diagnostic (env-gated): force an EXACT fp32 rerank column to isolate Sq8
     // codec loss from routing/coverage. INFINO_BENCH_RERANK_CODEC=fp32 → if the
     // recall ceiling jumps to ~1.0, the residual gap was the Sq8 quantization.
-    let codec = if std::env::var("INFINO_BENCH_RERANK_CODEC").as_deref() == Ok("fp32") {
-        RerankCodec::Fp32
-    } else if metric == Metric::Cosine {
-        RerankCodec::default()
-    } else {
-        RerankCodec::Sq8Residual
+    let codec = match std::env::var("INFINO_BENCH_RERANK_CODEC").ok().as_deref() {
+        Some("fp32") => RerankCodec::Fp32,
+        Some("sq16") => RerankCodec::Sq16,
+        Some("sq8_fixed_residual") => RerankCodec::Sq8FixedResidual,
+        _ if metric == Metric::Cosine => RerankCodec::default(),
+        _ => RerankCodec::Sq8Residual,
     };
     assert!(
         codec.supports_metric(metric),

--- a/benches/utils/recall_while_ingest.rs
+++ b/benches/utils/recall_while_ingest.rs
@@ -45,7 +45,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use arrow_array::{Array, Decimal128Array, RecordBatch};
+use arrow_array::{Array, Decimal128Array, LargeStringArray, RecordBatch};
 use arrow_schema::Schema;
 use infino::{OptimizeOptions, supertable::Supertable};
 use rayon::prelude::*;
@@ -189,11 +189,21 @@ fn build_queries(n_cent: usize, n_queries: usize) -> Vec<Vec<f32>> {
 
 /// One append batch straight off the streamed `flat` (no corpus retained),
 /// reusing the ingest path's `vector_array` builder so the column layout is
-/// byte-identical to what `options_for(Modality::Vector, _)` expects.
-fn vector_batch(schema: &Arc<Schema>, flat: &[f32], len: usize) -> RecordBatch {
+/// byte-identical to what `options_for(Modality::Vector, _)` expects. The
+/// `Modality::Vector` schema carries the filter-bucket column ahead of the
+/// vector, so the batch mirrors that field order — bucket terms are derived
+/// from each row's global doc id (`doc_base + i`), exactly as the bulk ingest
+/// path stamps them.
+fn vector_batch(schema: &Arc<Schema>, flat: &[f32], len: usize, doc_base: usize) -> RecordBatch {
+    let buckets: Vec<String> = (doc_base..doc_base + len)
+        .map(ingest::vector_filter_bucket_term)
+        .collect();
+    let bucket_col = Arc::new(LargeStringArray::from(
+        buckets.iter().map(String::as_str).collect::<Vec<_>>(),
+    )) as Arc<dyn Array>;
     RecordBatch::try_new(
         schema.clone(),
-        vec![ingest::vector_array(&flat[..len * DIM])],
+        vec![bucket_col, ingest::vector_array(&flat[..len * DIM])],
     )
     .expect("vector RecordBatch")
 }
@@ -607,7 +617,7 @@ pub fn run() {
                 retained.extend_from_slice(&flat[..sub * DIM]);
             }
             update_heaps(&mut heaps, &queries, &flat, (n + off) as u32, sub);
-            let batch = vector_batch(&schema, &flat, sub);
+            let batch = vector_batch(&schema, &flat, sub, n + off);
             {
                 let mut writer = st.writer().expect("writer");
                 writer.append(&batch).expect("append");

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -127,11 +127,14 @@ vector:
   # Default rerank codec for cosine vector columns. Non-cosine metrics
   # still use locally fitted sq8_residual (values are not bounded to
   # [-1, 1]). Override per column at table-create time when needed.
-  #   sq8_fixed_residual — fixed absolute grid (default; portable bytes)
+  #   sq16               — single 16-bit plane on the fixed [-1, 1] grid
+  #                        (default; finer grid than sq8_fixed_residual at
+  #                        the same 2 bytes/dim, faster rerank)
+  #   sq8_fixed_residual — coarse u8 + i8 residual on the fixed grid
   #   sq8_residual       — per-cluster fitted quantizer
   #   fp32               — full-precision rerank
   #   rabitq_only        — no rerank column
-  rerank_codec: sq8_fixed_residual
+  rerank_codec: sq16
 
   # Absolute cap on fine IVF centroids probed per vector search.
   # Empty (~) derives the budget from nprobe × eligible superfiles at

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1191,7 +1191,7 @@ supertable:
         assert_eq!(cfg.vector.cell_split_doc_cap, 500_000);
         assert_eq!(cfg.vector.user_centroids, CentroidAlignment::Local);
         assert_eq!(cfg.vector.drain_consolidate, DrainConsolidate::Kmeans);
-        assert_eq!(cfg.vector.rerank_codec, RerankCodec::Sq8FixedResidual);
+        assert_eq!(cfg.vector.rerank_codec, RerankCodec::Sq16);
         assert_eq!(cfg.vector.drain_read_concurrency, ThreadCount::Auto);
     }
 

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -759,7 +759,7 @@ impl SuperfileBuilder {
             .first()
             .ok_or(BuildError::VectorReadError)?
             .rerank_codec;
-        let expected_codec = if configured_codec.is_sq8_residual_family() {
+        let expected_codec = if configured_codec.is_ivf_mergeable() {
             configured_codec
         } else {
             RerankCodec::Sq8Residual
@@ -799,7 +799,7 @@ impl SuperfileBuilder {
             .vec()
             .and_then(|v| v.vector_columns_config().next())
             .ok_or_else(|| BuildError::VectorReadError)?;
-        if !vec_col.rerank_codec.is_sq8_residual_family() {
+        if !vec_col.rerank_codec.is_ivf_mergeable() {
             return Err(BuildError::VectorReadError);
         }
         let column = vec_col.name.clone();

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -37,7 +37,9 @@ use crate::{
         },
         vector::{
             cell_posting::{MaterializedIvfRow, sq8_residual_norm_sq},
-            distance::{Metric, dequantize_sq8_residual_into, distance, mean_f32_cluster_major},
+            distance::{
+                Metric, distance, encode_sq16_row, mean_f32_cluster_major, sq16_decoded_norm_sq,
+            },
             ivf_merge::MergedIvfSubsection,
             kmeans::{assign_to_centroids, kmeans, kmeans_with_assignments},
             quant::BitQuantizer,
@@ -206,22 +208,33 @@ pub struct VectorConfig {
     pub provided_centroids: Option<std::sync::Arc<[f32]>>,
 }
 
+/// Pick the default rerank codec for a new index built with `metric`.
+/// Cosine columns use the configured
+/// [`crate::config::VectorSettings::rerank_codec`] (`Sq16` by default);
+/// metrics whose values are not bounded to `[-1, 1]` use locally fitted
+/// [`RerankCodec::Sq8Residual`]. A per-column codec set at table-create
+/// time overrides this default.
+fn default_rerank_codec_for(metric: Metric) -> RerankCodec {
+    if metric == Metric::Cosine {
+        config::global().vector.rerank_codec
+    } else {
+        RerankCodec::Sq8Residual
+    }
+}
+
 impl VectorConfig {
     /// Construct a config with the configured cosine default codec
-    /// ([`crate::config::VectorSettings::rerank_codec`], usually
-    /// [`RerankCodec::Sq8FixedResidual`]) and locally fitted residual
-    /// encoding for metrics whose values are not bounded to [-1, 1].
+    /// ([`crate::config::VectorSettings::rerank_codec`] — `Sq16`) and locally
+    /// fitted residual encoding ([`RerankCodec::Sq8Residual`]) for metrics
+    /// whose values are not bounded to [-1, 1]. Override per column with
+    /// [`Self::with_rerank_codec`].
     pub fn new(column: String, dim: usize, rot_seed: u64, metric: Metric) -> Self {
         Self {
             column,
             dim,
             rot_seed,
             metric,
-            rerank_codec: if metric == Metric::Cosine {
-                config::global().vector.rerank_codec
-            } else {
-                RerankCodec::Sq8Residual
-            },
+            rerank_codec: default_rerank_codec_for(metric),
             provided_centroids: None,
         }
     }
@@ -486,7 +499,7 @@ impl VectorBuilder {
                 column: format!("(unregistered vector column_id {column_id})"),
                 actual: "n/a".to_string(),
             })?;
-        if !col.config.rerank_codec.is_sq8_residual_family() {
+        if !col.config.rerank_codec.is_ivf_mergeable() {
             return Err(BuildError::VectorRerankCodecUnimplemented {
                 column: col.config.column.clone(),
                 codec: col.config.rerank_codec.name(),
@@ -1421,6 +1434,10 @@ enum BucketRecordPayload<'a> {
         codes: &'a [u8],
         residuals: &'a [u8],
     },
+    /// A single pre-encoded fixed-grid plane (the `dim*2`-byte Sq16 `u16`
+    /// codes), written verbatim. Single-plane codecs carry no residual plane
+    /// and no per-cluster quantizer, so there is no min/max to fold.
+    FixedPlane(&'a [u8]),
     Fp32(&'a [f32]),
 }
 
@@ -1449,6 +1466,9 @@ fn write_bucket_record(
         BucketRecordPayload::FixedSq8 { codes, residuals } => {
             writer.write_all(codes)?;
             writer.write_all(residuals)?;
+        }
+        BucketRecordPayload::FixedPlane(plane) => {
+            writer.write_all(plane)?;
         }
         BucketRecordPayload::Fp32(fp) => {
             writer.write_all(bytemuck::cast_slice(fp))?;
@@ -1497,17 +1517,18 @@ fn sample_spilled_materialized_rows(
                     "materialized spill mixes rerank codecs".into(),
                 ));
             }
-            dequantize_sq8_residual_into(
-                &row.encoded.scale,
-                &row.encoded.offset,
-                &row.encoded.codes,
-                &row.encoded.residuals,
-                row.encoded
-                    .rerank_codec
-                    .residual_divisor()
-                    .expect("materialized spill uses residual-family codec"),
-                &mut sample[target_idx * dim..(target_idx + 1) * dim],
-            );
+            row.encoded
+                .rerank_codec
+                .ops()
+                .expect("materialized spill uses a quantized-rerank codec")
+                .dequantize_row_into(
+                    &row.encoded.codes,
+                    &row.encoded.residuals,
+                    dim,
+                    &row.encoded.scale,
+                    &row.encoded.offset,
+                    &mut sample[target_idx * dim..(target_idx + 1) * dim],
+                );
             target_idx += 1;
         }
         row_base = row_end;
@@ -1541,6 +1562,13 @@ fn bucket_encoded_rows_chunk(
     let dim = cfg.dim;
     let code_bytes = dim.div_ceil(u8::BITS as usize);
     let fixed = cfg.rerank_codec.uses_fixed_quantizer();
+    // Single-plane fixed codecs (Sq16) store the whole `dim*2`-byte body in
+    // `codes`; the residual family splits it into `codes` + `residuals`.
+    let single_plane = cfg.rerank_codec.is_sq16();
+    let ops = cfg
+        .rerank_codec
+        .ops()
+        .expect("materialized rebuild uses a quantized-rerank codec");
     for row in rows {
         if row.encoded.rerank_codec != cfg.rerank_codec || row.rabitq_code.len() != code_bytes {
             return Err(BuildError::VectorSchemaMismatch(
@@ -1553,22 +1581,21 @@ fn bucket_encoded_rows_chunk(
         .par_chunks_mut(dim)
         .zip(rows.par_iter())
         .for_each(|(out, row)| {
-            dequantize_sq8_residual_into(
-                &row.encoded.scale,
-                &row.encoded.offset,
+            ops.dequantize_row_into(
                 &row.encoded.codes,
                 &row.encoded.residuals,
-                row.encoded
-                    .rerank_codec
-                    .residual_divisor()
-                    .expect("materialized row uses residual-family codec"),
+                dim,
+                &row.encoded.scale,
+                &row.encoded.offset,
                 out,
             );
         });
     let mut assignments = vec![0u32; rows.len()];
     assign_to_centroids(&decoded, centroids, dim, n_cent, &mut assignments);
     for (row_idx, (row, &cluster)) in rows.iter().zip(&assignments).enumerate() {
-        let payload = if fixed {
+        let payload = if single_plane {
+            BucketRecordPayload::FixedPlane(&row.encoded.codes)
+        } else if fixed {
             BucketRecordPayload::FixedSq8 {
                 codes: &row.encoded.codes,
                 residuals: &row.encoded.residuals,
@@ -1685,16 +1712,24 @@ fn stream_fp32_rows_to_buckets(
     let dim = cfg.dim;
     let n_docs = vectors.len() / dim;
     let fixed = cfg.rerank_codec.uses_fixed_quantizer();
+    // Single-plane fixed codecs (Sq16) encode one `dim*2`-byte `u16` plane on
+    // the fixed grid; the residual family encodes a `[codes | residual]` body
+    // against the same grid and carries a divisor.
+    let single_plane = cfg.rerank_codec.is_sq16();
     let mut min_max = sq8_min_max;
     let rotation = RandomRotation::new(dim, cfg.rot_seed);
     let quant = BitQuantizer::new(dim);
     let code_bytes = quant.code_bytes();
-    let divisor = cfg
-        .rerank_codec
-        .residual_divisor()
-        .expect("residual-family codec has divisor");
     let (fixed_scale, fixed_offset) = fixed_sq8_quantizer(dim);
-    let encode_consts = Sq8EncodeConsts::from_scale_offset(&fixed_scale, &fixed_offset);
+    // Residual-family encode consts + divisor; unused by the single-plane path.
+    let residual_encode = (fixed && !single_plane).then(|| {
+        (
+            Sq8EncodeConsts::from_scale_offset(&fixed_scale, &fixed_offset),
+            cfg.rerank_codec
+                .residual_divisor()
+                .expect("residual-family codec has divisor"),
+        )
+    });
     let chunk_rows = materialized_chunk_rows_for_dim(dim);
     let mut chunk_rotated = vec![0.0f32; chunk_rows * dim];
     let mut chunk_codes = vec![0u8; chunk_rows * code_bytes];
@@ -1717,7 +1752,7 @@ fn stream_fp32_rows_to_buckets(
             .par_chunks_mut(code_bytes)
             .zip(chunk_rotated[..take * dim].par_chunks(dim))
             .for_each(|(code, rot)| quant.encode_rotated_into(rot, code));
-        if fixed {
+        if let Some((encode_consts, divisor)) = &residual_encode {
             chunk_payload[..take * dim * 2]
                 .par_chunks_mut(dim * 2)
                 .zip(chunk.par_chunks(dim))
@@ -1727,20 +1762,27 @@ fn stream_fp32_rows_to_buckets(
                         let (code_out, residual_out) = payload.split_at_mut(dim);
                         encode_sq8_residual_row(
                             row,
-                            &encode_consts,
+                            encode_consts,
                             &fixed_scale,
                             &fixed_offset,
                             code_out,
                             residual_out,
                             recon,
                             false,
-                            divisor,
+                            *divisor,
                         );
                     },
                 );
+        } else if single_plane {
+            chunk_payload[..take * dim * 2]
+                .par_chunks_mut(dim * 2)
+                .zip(chunk.par_chunks(dim))
+                .for_each(|(payload, row)| encode_sq16_row(row, payload));
         }
         for i in 0..take {
-            let payload = if fixed {
+            let payload = if single_plane {
+                BucketRecordPayload::FixedPlane(&chunk_payload[i * dim * 2..(i + 1) * dim * 2])
+            } else if fixed {
                 let (codes, residuals) =
                     chunk_payload[i * dim * 2..(i + 1) * dim * 2].split_at(dim);
                 BucketRecordPayload::FixedSq8 { codes, residuals }
@@ -1784,6 +1826,10 @@ fn stream_bucket_into_subsection(
     norms_offset: Option<usize>,
 ) -> Result<(), BuildError> {
     let fixed = codec.uses_fixed_quantizer();
+    // Single-plane fixed codecs (Sq16) store one `dim*2`-byte `u16` plane whose
+    // norm is read off the fixed grid; the residual family reconstructs the
+    // norm from the per-cluster quantizer + residual.
+    let single_plane = codec.is_sq16();
     let payload_bytes = if fixed {
         dim * 2
     } else {
@@ -1812,7 +1858,10 @@ fn stream_bucket_into_subsection(
             codes[row_idx * code_bytes..(row_idx + 1) * code_bytes]
                 .copy_from_slice(&record[id_end..code_end]);
             let rerank_row = &mut rerank[row_idx * dim * 2..(row_idx + 1) * dim * 2];
-            let norm = if fixed {
+            let norm = if single_plane {
+                rerank_row.copy_from_slice(&record[code_end..code_end + dim * 2]);
+                norms_offset.map(|_| sq16_decoded_norm_sq(rerank_row, dim))
+            } else if fixed {
                 rerank_row.copy_from_slice(&record[code_end..code_end + dim * 2]);
                 norms_offset.map(|_| {
                     sq8_residual_norm_sq(
@@ -1916,16 +1965,17 @@ fn sample_ram_materialized_rows(
     for s in 0..sample_size {
         let idx = sampled_index(s, sample_size, n_docs, seed);
         let enc = &rows[idx].encoded;
-        dequantize_sq8_residual_into(
-            &enc.scale,
-            &enc.offset,
-            &enc.codes,
-            &enc.residuals,
-            enc.rerank_codec
-                .residual_divisor()
-                .expect("residual-family source has divisor"),
-            &mut sample[s * dim..(s + 1) * dim],
-        );
+        enc.rerank_codec
+            .ops()
+            .expect("materialized source uses a quantized-rerank codec")
+            .dequantize_row_into(
+                &enc.codes,
+                &enc.residuals,
+                dim,
+                &enc.scale,
+                &enc.offset,
+                &mut sample[s * dim..(s + 1) * dim],
+            );
     }
     sample
 }
@@ -1966,7 +2016,7 @@ pub(crate) fn build_cell_subsection_from_source(
             "cell IVF build requires at least one row".into(),
         ));
     }
-    if !cfg.rerank_codec.is_sq8_residual_family() || !cfg.rerank_codec.supports_metric(cfg.metric) {
+    if !cfg.rerank_codec.is_ivf_mergeable() || !cfg.rerank_codec.supports_metric(cfg.metric) {
         return Err(BuildError::VectorSchemaMismatch(format!(
             "cell IVF build does not support codec {} with metric {:?}",
             cfg.rerank_codec.name(),
@@ -2159,17 +2209,22 @@ pub(crate) fn build_cell_subsection_from_source(
         open_region[idx + CLUSTER_IDX_COUNT_OFFSET..idx + CLUSTER_IDX_ENTRY_BYTES]
             .copy_from_slice(&(planned_block.count as u32).to_le_bytes());
     }
-    let scale_offset = layout.codec_meta_off;
-    let offset_offset = scale_offset + n_cent * dim * size_of::<f32>();
-    for (centroid, (scale, offset)) in quantizers.iter().enumerate() {
-        let start = centroid * dim * size_of::<f32>();
-        open_region[scale_offset + start..scale_offset + start + dim * size_of::<f32>()]
-            .copy_from_slice(bytemuck::cast_slice(scale));
-        open_region[offset_offset + start..offset_offset + start + dim * size_of::<f32>()]
-            .copy_from_slice(bytemuck::cast_slice(offset));
+    let meta_layout = codec
+        .ops()
+        .expect("build-from-source uses a quantized-rerank codec")
+        .codec_meta_layout(layout.codec_meta_off, n_cent, dim, cfg.metric);
+    if let (Some(scale_offset), Some(offset_offset)) =
+        (meta_layout.scale_off, meta_layout.offset_off)
+    {
+        for (centroid, (scale, offset)) in quantizers.iter().enumerate() {
+            let start = centroid * dim * size_of::<f32>();
+            open_region[scale_offset + start..scale_offset + start + dim * size_of::<f32>()]
+                .copy_from_slice(bytemuck::cast_slice(scale));
+            open_region[offset_offset + start..offset_offset + start + dim * size_of::<f32>()]
+                .copy_from_slice(bytemuck::cast_slice(offset));
+        }
     }
-    let norms_offset = matches!(cfg.metric, Metric::L2Sq | Metric::Cosine)
-        .then_some(offset_offset + n_cent * dim * size_of::<f32>());
+    let norms_offset = meta_layout.norms_off;
     let mut output = OpenOptions::new()
         .create(true)
         .truncate(true)
@@ -2493,7 +2548,11 @@ fn build_subsection_streaming(
                 )
             })
             .collect()
-    } else if codec.uses_fixed_quantizer() {
+    } else if codec.uses_fixed_quantizer() && codec.is_sq8_residual_family() {
+        // Only the residual family stores per-cluster scale/offset
+        // arrays. Sq16 is fixed-quantizer too, but single-plane with no
+        // codec_meta — it must NOT populate this table (its own pass-3
+        // arm encodes the u16 codes directly).
         (0..n_cent).map(|_| fixed_sq8_quantizer(dim)).collect()
     } else {
         Vec::new()
@@ -2606,6 +2665,14 @@ fn build_subsection_streaming(
     } else {
         None
     };
+    // Sq16's codec_meta is per-doc norms ONLY (no scale/offset), so the
+    // norm table starts at the codec_meta region head.
+    let sq16_norms_block_off =
+        if codec.is_sq16() && matches!(cfg.metric, Metric::L2Sq | Metric::Cosine) {
+            Some(layout.codec_meta_off)
+        } else {
+            None
+        };
 
     if sq8_family {
         for (cid, (scale_c, offset_c)) in sq8_quantizers.iter().enumerate().take(n_cent) {
@@ -2658,6 +2725,37 @@ fn build_subsection_streaming(
                 RerankCodec::Fp32 => {
                     bytes[blk.rerank_base..blk.rerank_base + blk.count * dim * 4]
                         .copy_from_slice(&full_block);
+                }
+                RerankCodec::Sq16 => {
+                    // Flat single-plane encode: quantize each fp32 row to
+                    // `dim` little-endian u16 codes on the fixed cosine
+                    // grid (no per-cluster quantizer). For cosine/L2Sq
+                    // also store the per-doc dequantized norm `‖d̂‖²`.
+                    //
+                    // The norm store uses the EXACT same position
+                    // convention as the residual family's
+                    // `encode_sq8_residual_cluster_simd`
+                    // (`norms_off + (blk.first_row + i) * 4`); the only
+                    // differences are the base offset (Sq16 has no
+                    // scale/offset arrays, so the norm table is the whole
+                    // codec_meta region) and the norm VALUE (u16 decode
+                    // via `sq16_decoded_norm_sq`). This guarantees norms
+                    // land at the same `pos` the reader indexes with
+                    // `cand.pos`, matching the residual family byte-for-
+                    // byte.
+                    let cluster_rows: &[f32] = bytemuck::cast_slice(&full_block);
+                    for i in 0..blk.count {
+                        let src = &cluster_rows[i * dim..(i + 1) * dim];
+                        let row_off = blk.rerank_base + i * per_vec_bytes;
+                        encode_sq16_row(src, &mut bytes[row_off..row_off + per_vec_bytes]);
+                        if let Some(norms_off) = sq16_norms_block_off {
+                            let n_sq =
+                                sq16_decoded_norm_sq(&bytes[row_off..row_off + per_vec_bytes], dim);
+                            let pos = blk.first_row + i;
+                            let n_off = norms_off + pos * 4;
+                            bytes[n_off..n_off + 4].copy_from_slice(&n_sq.to_le_bytes());
+                        }
+                    }
                 }
                 RerankCodec::Sq8Residual | RerankCodec::Sq8FixedResidual => {
                     let cluster_rows: &[f32] = bytemuck::cast_slice(&full_block);
@@ -4252,6 +4350,113 @@ mod tests {
             VectorReader::open(Bytes::from(zero_codec), &json).is_err(),
             "zero codec id has no v2 compatibility fallback"
         );
+    }
+
+    /// Sq16 survives the IVF merge path: build Sq16 (cosine) materialized rows,
+    /// merge into a subsection, open, and verify the per-doc norm table round-trips
+    /// (the merge must write norms-at-head with NO stale scale/offset). Exercises
+    /// the Sq16 enablement of `build_merged_subsection_from_materialized` + the
+    /// `RerankCodecOps` merge path. Distinct per-vector norms so a mis-pairing or a
+    /// stale scale/offset write would corrupt the comparison.
+    #[test]
+    fn sq16_merge_round_trips_norms() {
+        use std::sync::Arc;
+
+        use bytes::Bytes;
+
+        use crate::superfile::vector::{
+            cell_posting::EncodedCellRow,
+            distance::{Metric, sq16_decoded_norm_sq},
+            reader::VectorReader,
+            rerank_codec::RerankCodec,
+        };
+
+        let dim = 16usize;
+        let n = 6usize;
+        // Deterministic, distinct in-grid vectors (components in ~[-0.6, 0.6]); NOT
+        // normalized, so each row's ‖d̂‖² differs — the round-trip is meaningful.
+        let vecgen = |i: usize| -> Vec<f32> {
+            (0..dim)
+                .map(|j| (((i as f32 + 1.0) * 0.31 + (j as f32) * 0.11).sin()) * 0.6)
+                .collect::<Vec<f32>>()
+        };
+        let rows: Vec<MaterializedIvfRow> = (0..n)
+            .map(|i| {
+                let v = vecgen(i);
+                let mut codes = vec![0u8; dim * 2];
+                encode_sq16_row(&v, &mut codes);
+                let norm_sq = sq16_decoded_norm_sq(&codes, dim);
+                MaterializedIvfRow {
+                    local_doc_id: i as u32,
+                    stable_id: i as i128,
+                    cluster: 0,
+                    rabitq_code: vec![0u8; dim.div_ceil(8)],
+                    encoded: EncodedCellRow {
+                        stable_id: i as i128,
+                        rerank_codec: RerankCodec::Sq16,
+                        scale: Arc::from(Vec::<f32>::new()),
+                        offset: Arc::from(Vec::<f32>::new()),
+                        codes,
+                        residuals: Vec::new(),
+                        norm_sq: Some(norm_sq),
+                    },
+                }
+            })
+            .collect();
+        let mut expected: Vec<f32> = rows.iter().filter_map(|r| r.encoded.norm_sq).collect();
+
+        let cfg = VectorConfig {
+            column: "emb".into(),
+            dim,
+            rot_seed: 1,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Sq16,
+            provided_centroids: None,
+        };
+        let sub = build_merged_subsection_from_materialized(cfg, 2, rows).expect("Sq16 merge");
+        let cells = vec![(0u32, sub)];
+        let blob = finish_multi_cell_blob(&cells).expect("pack Sq16");
+        let json = format!(
+            r#"[{{"column":"emb","dim":{dim},"n_cent":2,"rot_seed":1,"metric":"cosine"}}]"#
+        );
+        let reader = VectorReader::open(Bytes::from(blob), &json).expect("open merged Sq16");
+        assert_eq!(reader.n_docs(), n as u64);
+
+        // The merge preserves the per-doc norm table: the loaded set matches what the
+        // rows carried in (order may change under re-clustering, so compare as a set).
+        let norms = reader
+            .per_doc_norms_for_test("emb")
+            .expect("Sq16 cosine carries a per-doc norm table");
+        assert_eq!(norms.len(), n, "all Sq16 rows survived the merge");
+        let mut have: Vec<f32> = norms.to_vec();
+        expected.sort_by(|a, b| a.total_cmp(b));
+        have.sort_by(|a, b| a.total_cmp(b));
+        for (e, h) in expected.iter().zip(have.iter()) {
+            assert!((e - h).abs() < 1e-5, "Sq16 merged norm {h} != stored {e}");
+        }
+
+        // Drive the exact path the drain/optimize takes on a Sq16 column:
+        // `materialized_cells_rows_async` -> `parse_materialized_index_rows`.
+        // A single-plane codec carries empty scale/offset, so the per-cluster
+        // slice must be skipped — otherwise this returns `None` and the drain
+        // reports "missing Sq8Residual index".
+        let mat = block_on(reader.materialized_cells_rows_async(None))
+            .expect("Sq16 drain-read path (materialized_cells_rows_async) must yield rows");
+        let total: usize = mat.iter().map(|(_, rows)| rows.len()).sum();
+        assert_eq!(total, n, "drain materialize must return every Sq16 row");
+        for (_, rows) in &mat {
+            for r in rows {
+                assert_eq!(r.encoded.rerank_codec, RerankCodec::Sq16);
+                assert!(
+                    r.encoded.norm_sq.is_some(),
+                    "Sq16 cosine row carries a norm"
+                );
+                assert!(
+                    r.encoded.scale.is_empty() && r.encoded.offset.is_empty(),
+                    "Sq16 materialized row carries no per-cluster scale/offset"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/superfile/vector/cell_posting.rs
+++ b/src/superfile/vector/cell_posting.rs
@@ -574,7 +574,7 @@ fn encode_rows(
             }
             derive_sq8_quantizer_from_min_max(&min, &max)
         }
-        RerankCodec::Fp32 | RerankCodec::RabitqOnly => {
+        RerankCodec::Fp32 | RerankCodec::Sq16 | RerankCodec::RabitqOnly => {
             return Err(format!(
                 "cell posting encode requires an Sq8 residual-family codec, got {}",
                 codec.name()
@@ -716,14 +716,20 @@ pub(crate) fn sq8_quant_params_equal(
         && offset_a == offset_b
 }
 
-/// Copy or Sq8-transcode one row into `out` (`[codes | residuals]`, length `2·dim`).
+/// Copy or Sq8-transcode one residual-family row into `out`
+/// (`[codes | residuals]`, length `2·dim`).
 ///
 /// When source quant matches the destination cluster quantizer, copies bytes
 /// verbatim. Otherwise re-quantizes per dimension from the folded scalar
 /// component one row at a time, without materializing a full fp32 corpus.
 ///
 /// Returns residual-corrected ||x||² when `store_norm` is true (L2Sq/Cosine).
-pub(crate) fn materialize_sq8_residual_row_into_cluster_quant(
+///
+/// Shared logic behind the `Sq8ResidualOps` / `Sq8FixedResidualOps`
+/// `RerankCodecOps::materialize_row_into_cluster_quant` impls; the residual
+/// family's private quantizer constants live here in `cell_posting`, so the
+/// helper stays co-located with them and the trait impls delegate in.
+pub(crate) fn residual_family_materialize_into_cluster_quant(
     row: &EncodedCellRow,
     dst_codec: RerankCodec,
     dst_scale: &[f32],
@@ -817,16 +823,17 @@ pub(crate) use crate::superfile::vector::distance::{
 /// Sq8+ε row → `dim` fp32 components (manifest centroids, medoid seeds, etc.).
 pub(crate) fn manifest_centroid_components_from_row(row: &EncodedCellRow, dim: usize) -> Vec<f32> {
     let mut out = vec![0f32; dim];
-    dequantize_sq8_residual_into(
-        &row.scale,
-        &row.offset,
-        &row.codes,
-        &row.residuals,
-        row.rerank_codec
-            .residual_divisor()
-            .expect("encoded row uses residual-family codec"),
-        &mut out,
-    );
+    row.rerank_codec
+        .ops()
+        .expect("encoded row uses a quantized-rerank codec")
+        .dequantize_row_into(
+            &row.codes,
+            &row.residuals,
+            dim,
+            &row.scale,
+            &row.offset,
+            &mut out,
+        );
     out
 }
 
@@ -1068,7 +1075,7 @@ mod tests {
         );
 
         let mut encoded = vec![0; 4];
-        let encoded_norm = materialize_sq8_residual_row_into_cluster_quant(
+        let encoded_norm = residual_family_materialize_into_cluster_quant(
             &row,
             RerankCodec::Sq8Residual,
             &dst_scale,
@@ -1115,7 +1122,7 @@ mod tests {
             norm_sq: None,
         };
         let mut output = vec![0; dim * 2];
-        materialize_sq8_residual_row_into_cluster_quant(
+        residual_family_materialize_into_cluster_quant(
             &row,
             RerankCodec::Sq8FixedResidual,
             &row.scale,
@@ -1142,7 +1149,7 @@ mod tests {
             norm_sq: None,
         };
         let mut output = vec![0; 2];
-        let error = materialize_sq8_residual_row_into_cluster_quant(
+        let error = residual_family_materialize_into_cluster_quant(
             &row,
             RerankCodec::Sq8Residual,
             &row.scale,

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -2793,9 +2793,8 @@ mod tests {
     /// If it holds here, any end-to-end Sq16<C1 gap is a PIPELINE bug, not
     /// the codec; if it fails here, the codec/kernel is the culprit and we
     /// have it reproduced in isolation. Run:
-    ///   cargo test --release -- --ignored --nocapture sq16_vs_sq8residual_kernel_recall
+    ///   cargo test -- --nocapture sq16_vs_sq8residual_kernel_recall
     #[test]
-    #[ignore = "diagnostic: run explicitly in release with --nocapture"]
     fn sq16_vs_sq8residual_kernel_recall() {
         use std::collections::HashSet;
 
@@ -2846,10 +2845,14 @@ mod tests {
         // Synthetic unit-norm corpus and queries. Both codecs quantize the
         // same vectors and are scored against the same fp32 truth, so this
         // isolates the codec's quantization error from routing.
+        // Kept small so this runs in the default (debug) test suite as a CI
+        // guard on the recall bound; the ≥ property is a codec invariant, not
+        // sample-size-dependent, and the rng is seeded so recall is
+        // deterministic. Larger sweeps run via the bench harness.
         #[allow(non_snake_case)]
-        let N = 3000usize;
+        let N = 800usize;
         #[allow(non_snake_case)]
-        let Q = 300usize;
+        let Q = 80usize;
 
         // Corpus: encoded into both codecs with their per-doc norms.
         let mut corpus: Vec<Vec<f32>> = Vec::with_capacity(N);

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use wide::f32x8;
 
-use crate::superfile::vector::rerank_codec::RerankCodec;
+use crate::superfile::vector::rerank_codec::{RerankCodec, SQ16_FIXED_OFFSET, SQ16_FIXED_SCALE};
 #[cfg(target_arch = "x86_64")]
 use crate::superfile::vector::simd_dispatch::{avx2_enabled, avx512_enabled};
 
@@ -758,6 +758,12 @@ pub(crate) fn distance_bytes_codec(
                  norm context)"
             )
         }
+        RerankCodec::Sq16 => {
+            unreachable!(
+                "distance_bytes_codec called with Sq16 — Sq16 rerank goes through \
+                 Sq16Kernel (u16 → f32 dequant front on the fp32 distance path)"
+            )
+        }
         RerankCodec::RabitqOnly => {
             unreachable!(
                 "distance_bytes_codec called with RabitqOnly — RabitqOnly columns \
@@ -1039,6 +1045,185 @@ impl Sq8ResidualKernel {
             }
         }
     }
+}
+
+/// `Sq16` rerank context — the flat single-plane analogue of
+/// [`Sq8ResidualKernel`]. One `u16` code per dimension on the fixed
+/// cosine grid ([`SQ16_FIXED_OFFSET`] / [`SQ16_FIXED_SCALE`]), scored
+/// in a single pass. This is the [`distance`] fp32 path with a
+/// `u16 → f32` dequant folded into the query-side precompute.
+///
+/// Reconstruction is `x[d] = code[d] * scale + offset`, so folding the
+/// grid into the query once gives
+/// `dot(query, x) = Σ_d q_prime[d] * code[d] + q_dot_offset`, where
+/// `q_prime[d] = query[d] * SQ16_FIXED_SCALE` and
+/// `q_dot_offset = SQ16_FIXED_OFFSET * Σ_d query[d]`.
+///
+/// Because the grid is global constants (matching the codec's empty
+/// `codec_meta`), the kernel holds no per-cluster or per-doc state —
+/// one kernel per query, reused across every candidate.
+pub(crate) struct Sq16Kernel {
+    metric: Metric,
+    dim: usize,
+    /// `q_prime[d] = query[d] * SQ16_FIXED_SCALE`.
+    q_prime: Vec<f32>,
+    /// `SQ16_FIXED_OFFSET * Σ_d query[d]`. Folded in once per candidate.
+    q_dot_offset: f32,
+    /// `Σ_d query[d]²`. L2Sq only (Sq16 is cosine-only in practice).
+    q_norm_sq: f32,
+}
+
+impl Sq16Kernel {
+    /// Build the per-query kernel. No quantizer arrays or per-doc norms
+    /// are needed — the fixed grid is baked into the constants.
+    pub fn new(metric: Metric, query: &[f32]) -> Self {
+        let dim = query.len();
+        let mut q_prime = vec![0.0f32; dim];
+        let scale_v = f32x8::splat(SQ16_FIXED_SCALE);
+        let mut q_sum_acc = f32x8::ZERO;
+        let mut i = 0;
+        while i + F32X8_LANES <= dim {
+            let qc = f32x8::from(
+                <[f32; F32X8_LANES]>::try_from(&query[i..i + F32X8_LANES]).expect("len-8 slice"),
+            );
+            q_prime[i..i + F32X8_LANES].copy_from_slice(&(qc * scale_v).to_array());
+            q_sum_acc += qc;
+            i += F32X8_LANES;
+        }
+        let mut q_sum = q_sum_acc.reduce_add();
+        while i < dim {
+            q_prime[i] = query[i] * SQ16_FIXED_SCALE;
+            q_sum += query[i];
+            i += 1;
+        }
+        let q_dot_offset = SQ16_FIXED_OFFSET * q_sum;
+        let q_norm_sq = match metric {
+            Metric::L2Sq => dot(query, query),
+            Metric::Cosine | Metric::NegDot => 0.0,
+        };
+        Self {
+            metric,
+            dim,
+            q_prime,
+            q_dot_offset,
+            q_norm_sq,
+        }
+    }
+
+    /// Distance for one candidate whose `full[]` row is `dim`
+    /// little-endian `u16` codes (`code_bytes.len() == dim * 2`), with
+    /// its stored per-doc dequantized norm `‖d̂‖²` in `norm` (absent
+    /// only for NegDot, where the norm term cancels). Mirrors
+    /// [`Sq8ResidualKernel::distance_with_norm`] so the cosine ranking
+    /// is the norm-corrected `base − dot/‖d̂‖`, apples-to-apples with the
+    /// Sq8 family. Smaller = closer.
+    #[inline]
+    pub fn distance_with_norm(&self, code_bytes: &[u8], norm: Option<f32>) -> f32 {
+        debug_assert_eq!(code_bytes.len(), self.dim * 2);
+        let mut acc = f32x8::ZERO;
+        let mut i = 0;
+        while i + F32X8_LANES <= self.dim {
+            let qp: [f32; F32X8_LANES] = self.q_prime[i..i + F32X8_LANES]
+                .try_into()
+                .expect("q_prime[i..i+8] len 8");
+            let mut code = [0f32; F32X8_LANES];
+            for (j, lane) in code.iter_mut().enumerate() {
+                let b = 2 * (i + j);
+                *lane = u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]) as f32;
+            }
+            acc += f32x8::from(qp) * f32x8::from(code);
+            i += F32X8_LANES;
+        }
+        let mut cross = acc.reduce_add();
+        while i < self.dim {
+            let b = 2 * i;
+            let code = u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]) as f32;
+            cross += self.q_prime[i] * code;
+            i += 1;
+        }
+        // dot(query, x_decoded) = Σ q_prime[d]·code[d] + q_dot_offset.
+        let dot = cross + self.q_dot_offset;
+        match self.metric {
+            Metric::Cosine => {
+                let x_norm = norm
+                    .expect("Sq16Kernel + Cosine requires per_doc_norms")
+                    .sqrt();
+                if x_norm > 0.0 {
+                    COSINE_DISTANCE_BASE - dot / x_norm
+                } else {
+                    COSINE_DISTANCE_BASE - dot
+                }
+            }
+            Metric::NegDot => -dot,
+            Metric::L2Sq => {
+                let x_norm_sq = norm.expect("Sq16Kernel + L2Sq requires per_doc_norms");
+                self.q_norm_sq - L2_CROSS_TERM_COEFF * dot + x_norm_sq
+            }
+        }
+    }
+}
+
+/// Encode one fp32 vector into `dim` little-endian `u16` Sq16 codes —
+/// the inverse of [`Sq16Kernel`]'s dequant. Per dimension:
+/// `code = round((v - SQ16_FIXED_OFFSET) / SQ16_FIXED_SCALE)` clamped
+/// to `0..=65535`. `out.len()` must be `src.len() * 2`.
+#[inline]
+pub(crate) fn encode_sq16_row(src: &[f32], out: &mut [u8]) {
+    debug_assert_eq!(out.len(), src.len() * 2);
+    let inv_scale = 1.0 / SQ16_FIXED_SCALE;
+    for (d, &v) in src.iter().enumerate() {
+        let code = (((v - SQ16_FIXED_OFFSET) * inv_scale).round()).clamp(0.0, 65535.0) as u16;
+        let b = d * 2;
+        out[b..b + 2].copy_from_slice(&code.to_le_bytes());
+    }
+}
+
+/// Dequantize one row of `dim` little-endian `u16` Sq16 codes to fp32 —
+/// the inverse of [`encode_sq16_row`]. Per dimension:
+/// `x = code · SQ16_FIXED_SCALE + SQ16_FIXED_OFFSET`. `code.len()` must be
+/// `out.len() * 2`.
+#[inline]
+pub(crate) fn dequantize_sq16_into(code: &[u8], out: &mut [f32]) {
+    let dim = out.len();
+    debug_assert_eq!(code.len(), dim * 2);
+    for (d, slot) in out.iter_mut().enumerate() {
+        let b = d * 2;
+        let c = u16::from_le_bytes([code[b], code[b + 1]]) as f32;
+        *slot = c * SQ16_FIXED_SCALE + SQ16_FIXED_OFFSET;
+    }
+}
+
+/// Dequantized-vector squared norm `Σ_d (code[d]·scale + offset)²` for a
+/// row of `dim` little-endian `u16` Sq16 codes. This is the per-doc
+/// `‖d̂‖²` the encoder stores in `codec_meta` and the cosine
+/// [`Sq16Kernel::distance_with_norm`] divides by (after `sqrt`), so it
+/// must decode with the exact same grid the kernel uses.
+#[inline]
+pub(crate) fn sq16_decoded_norm_sq(code_bytes: &[u8], dim: usize) -> f32 {
+    debug_assert_eq!(code_bytes.len(), dim * 2);
+    let mut acc = f32x8::ZERO;
+    let off_v = f32x8::splat(SQ16_FIXED_OFFSET);
+    let scale_v = f32x8::splat(SQ16_FIXED_SCALE);
+    let mut i = 0;
+    while i + F32X8_LANES <= dim {
+        let mut code = [0f32; F32X8_LANES];
+        for (j, lane) in code.iter_mut().enumerate() {
+            let b = 2 * (i + j);
+            *lane = u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]) as f32;
+        }
+        let x = f32x8::from(code) * scale_v + off_v;
+        acc += x * x;
+        i += F32X8_LANES;
+    }
+    let mut s = acc.reduce_add();
+    while i < dim {
+        let b = 2 * i;
+        let code = u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]) as f32;
+        let x = code * SQ16_FIXED_SCALE + SQ16_FIXED_OFFSET;
+        s += x * x;
+        i += 1;
+    }
+    s
 }
 
 /// Dot-product reduction for `Sq8Kernel::distance_at`:
@@ -2459,6 +2644,475 @@ mod tests {
             (want - got).abs() <= 1e-4,
             "tail-dim Sq8 kernel: got {got} vs decoded ref {want}"
         );
+    }
+
+    /// Round-trip the flat Sq16 codec: encode a unit-normalized fp32
+    /// vector onto the fixed cosine grid, score it against a query with
+    /// [`Sq16Kernel`], and confirm the cosine distance tracks the exact
+    /// fp32 reference to ~16-bit precision. The fp32 reference is the
+    /// same raw-dot cosine (`1 − q·x`) the [`distance`] dispatch uses,
+    /// so this is an apples-to-apples quantization-error bound. Sweeps a
+    /// SIMD-aligned dim, a tail dim, and a production-shaped dim.
+    #[test]
+    fn sq16_round_trip_within_16bit_tolerance_of_fp32() {
+        fn normalize(v: &mut [f32]) {
+            let n = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if n > 0.0 {
+                for x in v.iter_mut() {
+                    *x /= n;
+                }
+            }
+        }
+
+        for &dim in &[8usize, 13, 100, 384] {
+            // Deterministic pseudo-vectors in roughly [-1, 1], then
+            // unit-normalized so cosine semantics (raw dot) hold and
+            // every component lands inside the grid without clamping.
+            let mut query: Vec<f32> = (0..dim).map(|i| ((i as f32) * 0.017 - 0.4).sin()).collect();
+            let mut vec: Vec<f32> = (0..dim)
+                .map(|i| ((i as f32) * 0.023 + 0.11).cos())
+                .collect();
+            normalize(&mut query);
+            normalize(&mut vec);
+
+            // Encode onto the Sq16 grid exactly as the builder write
+            // path does (codes + per-doc dequantized norm), then score
+            // through the reader-side kernel with that stored norm.
+            let mut bytes = vec![0u8; dim * 2];
+            encode_sq16_row(&vec, &mut bytes);
+            let norm_sq = sq16_decoded_norm_sq(&bytes, dim);
+
+            let kernel = Sq16Kernel::new(Metric::Cosine, &query);
+            let got = kernel.distance_with_norm(&bytes, Some(norm_sq));
+            // fp32 reference: query and vec are both unit vectors, so the
+            // exact cosine distance is `1 - dot(query, vec)`.
+            let want = distance(Metric::Cosine, &query, &vec);
+
+            // Norm-corrected Sq16 tracks the fp32 cosine tighter than the
+            // uncorrected `1 - dot` did: the per-doc `‖d̂‖` division
+            // removes the dequantized-scale drift, leaving only direction
+            // quantization.
+            let rel = (got - want).abs() / want.abs();
+            assert!(
+                rel < 1e-4,
+                "dim {dim}: Sq16 cosine {got} vs fp32 ref {want} (rel err {rel:e})"
+            );
+
+            // Encode/decode/kernel self-consistency: decoding the stored
+            // codes and scoring with the SAME norm correction
+            // (`1 - dot/‖d̂‖`) must reproduce the kernel's value.
+            let decoded: Vec<f32> = (0..dim)
+                .map(|d| {
+                    let b = d * 2;
+                    let code = u16::from_le_bytes([bytes[b], bytes[b + 1]]);
+                    code as f32 * SQ16_FIXED_SCALE + SQ16_FIXED_OFFSET
+                })
+                .collect();
+            let decoded_norm = decoded.iter().map(|x| x * x).sum::<f32>().sqrt();
+            let decoded_ref = COSINE_DISTANCE_BASE - dot(&query, &decoded) / decoded_norm;
+            assert!(
+                (got - decoded_ref).abs() <= 1e-4,
+                "dim {dim}: kernel {got} disagrees with decoded ref {decoded_ref}"
+            );
+        }
+    }
+
+    /// Recall/ordering sanity: the per-doc-norm correction must never
+    /// make Sq16's top-1 ranking worse than uncorrected `1 - dot`. This
+    /// plants a case where it is strictly better: the true nearest
+    /// neighbor is a unit vector aligned with the query, while a
+    /// distractor has a HIGHER raw dot (larger norm) but LOWER cosine.
+    /// Norm-corrected cosine ranks the true NN first; raw `1 - dot`
+    /// (no correction) wrongly ranks the distractor first.
+    #[test]
+    fn sq16_norm_correction_ranks_planted_case_at_least_as_well() {
+        let dim = 8usize;
+        let inv = 1.0 / (dim as f32).sqrt();
+        // Unit query with equal components.
+        let query = vec![inv; dim];
+        // True NN = query direction (cosine 1.0, unit norm).
+        let true_nn = query.clone();
+        // Unit vector `e ⊥ q` (even/odd sign split → dot(q,e)=0 for even
+        // dim, ‖e‖=1), used to build a cosine-0.9 direction.
+        let mut e = vec![0.0f32; dim];
+        for (i, ei) in e.iter_mut().enumerate() {
+            *ei = if i % 2 == 0 { inv } else { -inv };
+        }
+        let c = 0.9f32;
+        let s = (1.0 - c * c).sqrt();
+        let d_unit: Vec<f32> = (0..dim).map(|i| c * query[i] + s * e[i]).collect();
+        // Scale the distractor so raw dot (1.08) beats the true NN's
+        // (1.0) while its cosine (0.9) is lower. Components stay in the
+        // [-1, 1] Sq16 grid (asserted), so no clamping distorts the case.
+        let distractor: Vec<f32> = d_unit.iter().map(|v| v * 1.2).collect();
+        for &v in true_nn.iter().chain(distractor.iter()) {
+            assert!(v.abs() <= 1.0, "component {v} outside Sq16 grid");
+        }
+
+        let encode = |v: &[f32]| {
+            let mut b = vec![0u8; dim * 2];
+            encode_sq16_row(v, &mut b);
+            b
+        };
+        let nn_b = encode(&true_nn);
+        let dis_b = encode(&distractor);
+
+        let kernel = Sq16Kernel::new(Metric::Cosine, &query);
+        let nn_corr = kernel.distance_with_norm(&nn_b, Some(sq16_decoded_norm_sq(&nn_b, dim)));
+        let dis_corr = kernel.distance_with_norm(&dis_b, Some(sq16_decoded_norm_sq(&dis_b, dim)));
+        assert!(
+            nn_corr < dis_corr,
+            "norm-corrected: true NN {nn_corr} must rank before distractor {dis_corr}"
+        );
+
+        // Uncorrected `1 - dot` (the pre-correction behavior) ranks the
+        // distractor first — the exact failure the norm division fixes,
+        // so with-norm is here strictly better and never worse.
+        let decode = |b: &[u8]| -> Vec<f32> {
+            (0..dim)
+                .map(|d| {
+                    let o = d * 2;
+                    u16::from_le_bytes([b[o], b[o + 1]]) as f32 * SQ16_FIXED_SCALE
+                        + SQ16_FIXED_OFFSET
+                })
+                .collect()
+        };
+        let nn_raw = COSINE_DISTANCE_BASE - dot(&query, &decode(&nn_b));
+        let dis_raw = COSINE_DISTANCE_BASE - dot(&query, &decode(&dis_b));
+        assert!(
+            dis_raw < nn_raw,
+            "sanity: uncorrected 1-dot should (wrongly) rank the distractor first \
+             (nn_raw {nn_raw}, dis_raw {dis_raw})"
+        );
+    }
+
+    /// Bisection: does Sq16 match/beat Sq8FixedResidual at the KERNEL
+    /// level, on identical data, isolated from routing/shortlist/
+    /// pos-mapping? Sq16's grid (2/65535) is finer than Sq8+8's effective
+    /// step (2/65280), so its recall@10 vs fp32 truth MUST be >= C1's.
+    /// If it holds here, any end-to-end Sq16<C1 gap is a PIPELINE bug, not
+    /// the codec; if it fails here, the codec/kernel is the culprit and we
+    /// have it reproduced in isolation. Run:
+    ///   cargo test --release -- --ignored --nocapture sq16_vs_sq8residual_kernel_recall
+    #[test]
+    #[ignore = "diagnostic: run explicitly in release with --nocapture"]
+    fn sq16_vs_sq8residual_kernel_recall() {
+        use std::collections::HashSet;
+
+        use crate::superfile::vector::{
+            rerank_codec::{SQ8_FIXED_OFFSET, SQ8_FIXED_RESIDUAL_DIVISOR, SQ8_FIXED_SCALE},
+            sq8_simd::{Sq8EncodeConsts, encode_sq8_residual_row},
+        };
+
+        fn next_u64(state: &mut u64) -> u64 {
+            *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = *state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+        fn next_f32(state: &mut u64) -> f32 {
+            let u = (next_u64(state) >> 40) as f32 / (1u64 << 24) as f32;
+            u * 2.0 - 1.0
+        }
+        fn fill_unit(state: &mut u64, out: &mut [f32]) {
+            for x in out.iter_mut() {
+                *x = next_f32(state);
+            }
+            let n = out.iter().map(|v| v * v).sum::<f32>().sqrt();
+            if n > 0.0 {
+                for x in out.iter_mut() {
+                    *x /= n;
+                }
+            }
+        }
+        // Indices of the k smallest distances (ascending).
+        fn topk_asc(dists: &[f32], k: usize) -> Vec<usize> {
+            let mut idx: Vec<usize> = (0..dists.len()).collect();
+            idx.sort_by(|&a, &b| dists[a].total_cmp(&dists[b]));
+            idx.truncate(k);
+            idx
+        }
+
+        const K: usize = 10;
+        let dim = 768usize;
+        let mut rng = 0xDEAD_BEEF_1234_5678u64;
+
+        let scale = vec![SQ8_FIXED_SCALE; dim];
+        let offset = vec![SQ8_FIXED_OFFSET; dim];
+        let divisor = SQ8_FIXED_RESIDUAL_DIVISOR;
+        let consts = Sq8EncodeConsts::from_scale_offset(&scale, &offset);
+
+        // Synthetic unit-norm corpus and queries. Both codecs quantize the
+        // same vectors and are scored against the same fp32 truth, so this
+        // isolates the codec's quantization error from routing.
+        #[allow(non_snake_case)]
+        let N = 3000usize;
+        #[allow(non_snake_case)]
+        let Q = 300usize;
+
+        // Corpus: encoded into both codecs with their per-doc norms.
+        let mut corpus: Vec<Vec<f32>> = Vec::with_capacity(N);
+        let mut sq16_buf = vec![0u8; N * dim * 2];
+        let mut sq8_code = vec![0u8; N * dim];
+        let mut sq8_res = vec![0u8; N * dim];
+        let mut sq16_norms = vec![0.0f32; N];
+        let mut sq8_norms = vec![0.0f32; N];
+        let mut recon = vec![0.0f32; dim];
+        for i in 0..N {
+            let mut c = vec![0.0f32; dim];
+            fill_unit(&mut rng, &mut c);
+            let sc = &mut sq16_buf[i * dim * 2..(i + 1) * dim * 2];
+            encode_sq16_row(&c, sc);
+            sq16_norms[i] = sq16_decoded_norm_sq(sc, dim);
+            let n = encode_sq8_residual_row(
+                &c,
+                &consts,
+                &scale,
+                &offset,
+                &mut sq8_code[i * dim..(i + 1) * dim],
+                &mut sq8_res[i * dim..(i + 1) * dim],
+                &mut recon,
+                true,
+                divisor,
+            )
+            .expect("store_norm=true yields a per-doc norm");
+            sq8_norms[i] = n;
+            corpus.push(c);
+        }
+
+        let (mut r_sq16, mut r_sq16_nn, mut r_sq8, mut total) = (0usize, 0usize, 0usize, 0usize);
+        let mut rng_q = 0x0BAD_F00D_CAFE_BABEu64;
+        for _ in 0..Q {
+            let mut q = vec![0.0f32; dim];
+            fill_unit(&mut rng_q, &mut q);
+            // fp32 truth: both unit ⇒ cosine == dot; larger dot = closer.
+            let truth_scores: Vec<f32> = corpus.iter().map(|c| dot(&q, c)).collect();
+            let mut ti: Vec<usize> = (0..N).collect();
+            ti.sort_by(|&a, &b| truth_scores[b].total_cmp(&truth_scores[a]));
+            let truth: HashSet<usize> = ti.into_iter().take(K).collect();
+
+            let sq16_kernel = Sq16Kernel::new(Metric::Cosine, &q);
+            let sq8_kernel = Sq8ResidualKernel::new(Metric::Cosine, &q, &scale, &offset, divisor);
+
+            let sq16_d: Vec<f32> = (0..N)
+                .map(|i| {
+                    sq16_kernel.distance_with_norm(
+                        &sq16_buf[i * dim * 2..(i + 1) * dim * 2],
+                        Some(sq16_norms[i]),
+                    )
+                })
+                .collect();
+            let sq8_d: Vec<f32> = (0..N)
+                .map(|i| {
+                    sq8_kernel.distance_with_norm(
+                        &sq8_code[i * dim..(i + 1) * dim],
+                        &sq8_res[i * dim..(i + 1) * dim],
+                        Some(sq8_norms[i]),
+                    )
+                })
+                .collect();
+            // Sq16 without the norm division (raw 1 - dot on decoded).
+            let sq16_nn_d: Vec<f32> = (0..N)
+                .map(|i| {
+                    let base = i * dim * 2;
+                    let mut d = 0.0f32;
+                    for (j, &qj) in q.iter().enumerate().take(dim) {
+                        let b = base + j * 2;
+                        let code = u16::from_le_bytes([sq16_buf[b], sq16_buf[b + 1]]) as f32;
+                        d += qj * (code * SQ16_FIXED_SCALE + SQ16_FIXED_OFFSET);
+                    }
+                    COSINE_DISTANCE_BASE - d
+                })
+                .collect();
+
+            for &i in topk_asc(&sq16_d, K).iter() {
+                if truth.contains(&i) {
+                    r_sq16 += 1;
+                }
+            }
+            for &i in topk_asc(&sq16_nn_d, K).iter() {
+                if truth.contains(&i) {
+                    r_sq16_nn += 1;
+                }
+            }
+            for &i in topk_asc(&sq8_d, K).iter() {
+                if truth.contains(&i) {
+                    r_sq8 += 1;
+                }
+            }
+            total += K;
+        }
+
+        let rec = |x: usize| x as f64 / total as f64;
+        eprintln!(
+            "\n### Kernel-level recall@{K} vs fp32 truth (synthetic, N={N}, Q={Q}, dim={dim})"
+        );
+        eprintln!("Sq16 (norm)      : {:.4}", rec(r_sq16));
+        eprintln!("Sq16 (no-norm)   : {:.4}", rec(r_sq16_nn));
+        eprintln!("Sq8FixedResidual : {:.4}", rec(r_sq8));
+        eprintln!("Sq16norm - C1    : {:+.4}", rec(r_sq16) - rec(r_sq8));
+        eprintln!("Sq16norm - nonorm: {:+.4}", rec(r_sq16) - rec(r_sq16_nn));
+
+        // Theorem: the finer grid means Sq16 must not trail C1 at the
+        // kernel level. A loose margin absorbs tie-break noise; the
+        // printed numbers are the real diagnostic.
+        assert!(
+            rec(r_sq16) >= rec(r_sq8) - 0.002,
+            "Sq16 kernel recall {:.4} trails C1 {:.4} by >0.002 — codec-level bug reproduced",
+            rec(r_sq16),
+            rec(r_sq8)
+        );
+    }
+
+    /// Microbench: intrinsic per-candidate rerank scoring cost of the
+    /// two-leg `Sq8ResidualKernel` (u8 coarse + i8 residual) vs the
+    /// single-leg `Sq16Kernel` (one u16 plane), isolated from the
+    /// shortlist / IVF / IO. Both on the fixed cosine grid. This is the
+    /// "one leg vs two" cost the end-to-end query only shows diluted
+    /// (rerank is a small slice of total query time).
+    ///
+    /// Ignored by default (it allocates hundreds of MB and only means
+    /// anything in release). Run with:
+    ///   cargo test --release -- --ignored --nocapture rerank_kernel_leg_cost_microbench
+    #[test]
+    #[ignore = "microbench: run explicitly in release with --nocapture"]
+    fn rerank_kernel_leg_cost_microbench() {
+        use std::{hint::black_box, time::Instant};
+
+        use crate::superfile::vector::{
+            rerank_codec::{SQ8_FIXED_OFFSET, SQ8_FIXED_RESIDUAL_DIVISOR, SQ8_FIXED_SCALE},
+            sq8_simd::{Sq8EncodeConsts, encode_sq8_residual_row},
+        };
+
+        // Deterministic splitmix64 → f32 in [-1, 1]; no external RNG so
+        // the numbers reproduce bit-for-bit across runs.
+        fn next_u64(state: &mut u64) -> u64 {
+            *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = *state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+        fn next_f32(state: &mut u64) -> f32 {
+            let u = (next_u64(state) >> 40) as f32 / (1u64 << 24) as f32; // [0,1)
+            u * 2.0 - 1.0
+        }
+        fn fill_unit(state: &mut u64, out: &mut [f32]) {
+            for x in out.iter_mut() {
+                *x = next_f32(state);
+            }
+            let n = out.iter().map(|v| v * v).sum::<f32>().sqrt();
+            if n > 0.0 {
+                for x in out.iter_mut() {
+                    *x /= n;
+                }
+            }
+        }
+
+        const N: usize = 100_000;
+        const PASSES: usize = 7;
+        let mut rng = 0x1234_5678_9ABC_DEF0u64;
+
+        eprintln!("\n### Rerank kernel per-candidate cost — Sq8Residual (2 legs) vs Sq16 (1 leg)");
+        eprintln!("N = {N} candidates, cosine/fixed-grid, median of {PASSES} timed passes\n");
+        eprintln!(
+            "{:>6}  {:>16}  {:>16}  {:>10}",
+            "dim", "sq8_residual ns", "sq16 ns", "sq16/sq8"
+        );
+
+        for &dim in &[768usize, 1536] {
+            let scale = vec![SQ8_FIXED_SCALE; dim];
+            let offset = vec![SQ8_FIXED_OFFSET; dim];
+            let divisor = SQ8_FIXED_RESIDUAL_DIVISOR;
+            let consts = Sq8EncodeConsts::from_scale_offset(&scale, &offset);
+
+            // Random unit query, one kernel per codec (built once, as the
+            // reader does).
+            let mut query = vec![0.0f32; dim];
+            fill_unit(&mut rng, &mut query);
+            let sq16_kernel = Sq16Kernel::new(Metric::Cosine, &query);
+            let sq8_kernel =
+                Sq8ResidualKernel::new(Metric::Cosine, &query, &scale, &offset, divisor);
+
+            // Encode all N candidates once into each codec's on-disk
+            // byte layout. The fp32 source is dropped after encoding so
+            // only the packed codec buffers stay resident.
+            let mut sq16_buf = vec![0u8; N * dim * 2];
+            let mut sq8_code = vec![0u8; N * dim];
+            let mut sq8_res = vec![0u8; N * dim];
+            // Both codecs now carry per-doc dequantized norms for the
+            // norm-corrected cosine kernel; store both.
+            let mut sq8_norms = vec![0.0f32; N];
+            let mut sq16_norms = vec![0.0f32; N];
+            let mut cand = vec![0.0f32; dim];
+            let mut recon = vec![0.0f32; dim];
+            for i in 0..N {
+                fill_unit(&mut rng, &mut cand);
+                let sq16_code = &mut sq16_buf[i * dim * 2..(i + 1) * dim * 2];
+                encode_sq16_row(&cand, sq16_code);
+                sq16_norms[i] = sq16_decoded_norm_sq(sq16_code, dim);
+                let norm = encode_sq8_residual_row(
+                    &cand,
+                    &consts,
+                    &scale,
+                    &offset,
+                    &mut sq8_code[i * dim..(i + 1) * dim],
+                    &mut sq8_res[i * dim..(i + 1) * dim],
+                    &mut recon,
+                    true,
+                    divisor,
+                )
+                .expect("store_norm=true yields a per-doc norm");
+                sq8_norms[i] = norm;
+            }
+
+            // Score every candidate through the codec's per-candidate
+            // distance call — the exact call the reader makes. black_box
+            // on inputs + the accumulated sink so nothing folds away.
+            let time_sq16 = || {
+                let mut sink = 0.0f32;
+                for i in 0..N {
+                    let code = black_box(&sq16_buf[i * dim * 2..(i + 1) * dim * 2]);
+                    sink += sq16_kernel.distance_with_norm(code, Some(black_box(sq16_norms[i])));
+                }
+                black_box(sink);
+            };
+            let time_sq8 = || {
+                let mut sink = 0.0f32;
+                for i in 0..N {
+                    let code = black_box(&sq8_code[i * dim..(i + 1) * dim]);
+                    let res = black_box(&sq8_res[i * dim..(i + 1) * dim]);
+                    sink += sq8_kernel.distance_with_norm(code, res, Some(black_box(sq8_norms[i])));
+                }
+                black_box(sink);
+            };
+
+            let median = |f: &mut dyn FnMut()| -> f64 {
+                f(); // warm-up pass, not timed
+                let mut samples: Vec<f64> = (0..PASSES)
+                    .map(|_| {
+                        let t = Instant::now();
+                        f();
+                        t.elapsed().as_secs_f64()
+                    })
+                    .collect();
+                samples.sort_by(|a, b| a.total_cmp(b));
+                samples[PASSES / 2]
+            };
+
+            let mut sq16_fn = time_sq16;
+            let mut sq8_fn = time_sq8;
+            let sq16_secs = median(&mut sq16_fn);
+            let sq8_secs = median(&mut sq8_fn);
+            let sq16_ns = sq16_secs / N as f64 * 1e9;
+            let sq8_ns = sq8_secs / N as f64 * 1e9;
+            eprintln!(
+                "{dim:>6}  {sq8_ns:>16.2}  {sq16_ns:>16.2}  {:>10.3}",
+                sq16_ns / sq8_ns
+            );
+        }
+        eprintln!();
     }
 
     #[test]

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -459,6 +459,13 @@ pub(crate) fn splice_fragments_into_cell(
         }
     }
 
+    // The residual family carries a per-cluster quantizer (`[scale|offset]`
+    // codec_meta blocks); the single-plane fixed-grid `Sq16` carries only the
+    // per-doc norm table. Splice supports both: the rerank bytes are copied
+    // verbatim regardless of codec, and the codec_meta write below branches on
+    // this to lay out either `[scale|offset|norms]` or norms-only.
+    let has_cluster_quant = codec.is_sq8_residual_family();
+
     let out_n_cent = fragments.len();
     let counts: Vec<u32> = fragments
         .iter()
@@ -486,8 +493,13 @@ pub(crate) fn splice_fragments_into_cell(
             &inp.sub[co..co + dim * 4],
             &mut out_centroids[k * dim..(k + 1) * dim],
         );
-        dst_scale[k * dim..(k + 1) * dim].copy_from_slice(&inp.scale[c * dim..c * dim + dim]);
-        dst_offset[k * dim..(k + 1) * dim].copy_from_slice(&inp.offset[c * dim..c * dim + dim]);
+        // Sq16 carries no per-cluster quantizer (empty scale/offset); its
+        // rerank bytes decode off the fixed grid. Only the residual family has
+        // per-cluster scale/offset to carry through.
+        if has_cluster_quant {
+            dst_scale[k * dim..(k + 1) * dim].copy_from_slice(&inp.scale[c * dim..c * dim + dim]);
+            dst_offset[k * dim..(k + 1) * dim].copy_from_slice(&inp.offset[c * dim..c * dim + dim]);
+        }
     }
 
     // Summary centroid = mean of fragment centroids.
@@ -512,14 +524,19 @@ pub(crate) fn splice_fragments_into_cell(
         &out_centroids,
     );
 
-    // Sq8 scale/offset blocks: one (dim) slot per output cluster.
-    let sq8_scale_block_off = layout.codec_meta_off;
-    let sq8_offset_block_off = sq8_scale_block_off + out_n_cent * dim * 4;
-    let sq8_norms_block_off = store_norm.then_some(sq8_offset_block_off + out_n_cent * dim * 4);
-    bytes[sq8_scale_block_off..sq8_scale_block_off + out_n_cent * dim * 4]
-        .copy_from_slice(cast_slice(&dst_scale));
-    bytes[sq8_offset_block_off..sq8_offset_block_off + out_n_cent * dim * 4]
-        .copy_from_slice(cast_slice(&dst_offset));
+    // codec_meta layout: the residual family writes per-cluster [scale|offset]
+    // blocks (one dim-slot per output cluster) then the per-doc norm table;
+    // single-plane Sq16 writes only the norm table at the codec_meta head.
+    let sq8_norms_block_off = if has_cluster_quant {
+        let scale_off = layout.codec_meta_off;
+        let offset_off = scale_off + out_n_cent * dim * 4;
+        bytes[scale_off..scale_off + out_n_cent * dim * 4].copy_from_slice(cast_slice(&dst_scale));
+        bytes[offset_off..offset_off + out_n_cent * dim * 4]
+            .copy_from_slice(cast_slice(&dst_offset));
+        store_norm.then_some(offset_off + out_n_cent * dim * 4)
+    } else {
+        store_norm.then_some(layout.codec_meta_off)
+    };
 
     let stable_ids_region_off = layout.stable_ids_off;
     let mut out_stable_ids = vec![0i128; n_docs as usize];

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -27,10 +27,7 @@ use crate::superfile::{
             IvfSubsectionLayout, alloc_ivf_subsection_with_header, centroid_storage_order,
             fixed_sq8_quantizer, write_ivf_cluster_blocks,
         },
-        cell_posting::{
-            EncodedCellRow, materialize_sq8_residual_row_into_cluster_quant,
-            sq8_quant_params_equal, sq8_residual_norm_sq,
-        },
+        cell_posting::{EncodedCellRow, sq8_quant_params_equal},
         distance::{
             Metric, add_weighted_f32_to_f64_acc, decode_f32_le_into, decode_f32_le_vec,
             f64_acc_mean_into_f32, mean_f32_cluster_major,
@@ -143,7 +140,7 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
     }
 
     let n_docs: u32 = parsed.iter().map(|p| p.n_docs).sum();
-    debug_assert!(codec.is_sq8_residual_family());
+    debug_assert!(codec.is_ivf_mergeable());
     let quant = BitQuantizer::new(dim);
     let code_bytes = quant.code_bytes();
     let per_vec_bytes = codec.per_vector_bytes(dim);
@@ -181,22 +178,34 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
     // every slot — populated or empty — to carry the pinned scale/offset
     // bitwise, exactly as the direct build paths write them. Fitted codecs
     // keep the neutral 1.0/0.0 seed; their empty slots are never read.
-    let (mut dst_scale, mut dst_offset) = if codec.uses_fixed_quantizer() {
+    // Only the residual family seeds a per-cluster scale/offset table.
+    // Merge inputs are built exclusively for the residual family
+    // (`sq8_ivf_merge_input_at` is `is_ivf_mergeable`-gated), so
+    // the extra family check is a guard: single-plane Sq16 must never
+    // seed the fixed sq8 grid here.
+    // Only the residual family carries a per-cluster scale/offset table.
+    // Single-plane codecs (Sq16) quantize on a fixed grid with no per-cluster
+    // quantizer, so their `scale`/`offset` merge inputs are empty and never
+    // seeded, sliced, or written to codec_meta below.
+    let has_cluster_quant = codec.is_sq8_residual_family();
+    let (mut dst_scale, mut dst_offset) = if codec.uses_fixed_quantizer() && has_cluster_quant {
         let (scale, offset) = fixed_sq8_quantizer(dim);
         (scale.repeat(n_cent), offset.repeat(n_cent))
     } else {
         (vec![1.0f32; n_cent * dim], vec![0.0f32; n_cent * dim])
     };
-    for c in 0..n_cent {
-        for inp in parsed {
-            let (_, count) = cluster_entry(&inp.sub, inp.cluster_idx_off, c);
-            if count == 0 {
-                continue;
+    if has_cluster_quant {
+        for c in 0..n_cent {
+            for inp in parsed {
+                let (_, count) = cluster_entry(&inp.sub, inp.cluster_idx_off, c);
+                if count == 0 {
+                    continue;
+                }
+                let off = c * dim;
+                dst_scale[off..off + dim].copy_from_slice(&inp.scale[off..off + dim]);
+                dst_offset[off..off + dim].copy_from_slice(&inp.offset[off..off + dim]);
+                break;
             }
-            let off = c * dim;
-            dst_scale[off..off + dim].copy_from_slice(&inp.scale[off..off + dim]);
-            dst_offset[off..off + dim].copy_from_slice(&inp.offset[off..off + dim]);
-            break;
         }
     }
 
@@ -230,21 +239,23 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
         &out_centroids,
     );
 
-    let sq8_scale_block_off = layout.codec_meta_off;
-    let sq8_offset_block_off = sq8_scale_block_off + n_cent * dim * 4;
-    let sq8_norms_block_off = if store_norm {
-        Some(sq8_offset_block_off + n_cent * dim * 4)
-    } else {
-        None
-    };
+    // codec_meta layout comes from the codec's own ops: the residual family
+    // lays out `[scale | offset | norms?]`; Sq16 lays out `[norms?]` at the
+    // head with no scale/offset arrays. The per-doc norm block offset follows
+    // whichever shape the codec declares.
+    let ops = codec.ops().expect("mergeable codec has cold-path ops");
+    let meta_layout = ops.codec_meta_layout(layout.codec_meta_off, n_cent, dim, metric);
+    let norms_block_off = meta_layout.norms_off;
 
-    for c in 0..n_cent {
-        let sc_off = sq8_scale_block_off + c * dim * 4;
-        bytes[sc_off..sc_off + dim * 4]
-            .copy_from_slice(cast_slice(&dst_scale[c * dim..c * dim + dim]));
-        let oc_off = sq8_offset_block_off + c * dim * 4;
-        bytes[oc_off..oc_off + dim * 4]
-            .copy_from_slice(cast_slice(&dst_offset[c * dim..c * dim + dim]));
+    if let (Some(scale_off), Some(offset_off)) = (meta_layout.scale_off, meta_layout.offset_off) {
+        for c in 0..n_cent {
+            let sc_off = scale_off + c * dim * 4;
+            bytes[sc_off..sc_off + dim * 4]
+                .copy_from_slice(cast_slice(&dst_scale[c * dim..c * dim + dim]));
+            let oc_off = offset_off + c * dim * 4;
+            bytes[oc_off..oc_off + dim * 4]
+                .copy_from_slice(cast_slice(&dst_offset[c * dim..c * dim + dim]));
+        }
     }
 
     let cluster_order = centroid_storage_order(&out_centroids, n_cent, dim);
@@ -282,8 +293,6 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
                 if count == 0 {
                     continue;
                 }
-                let src_scale = &inp.scale[centroid_id * dim..centroid_id * dim + dim];
-                let src_offset = &inp.offset[centroid_id * dim..centroid_id * dim + dim];
                 let block = inp.per_cluster_blocks_off + doc_off * inp.stride;
                 let doc_ids_at = block + count * inp.code_bytes;
                 let full_at = block + count * (inp.code_bytes + id_bytes);
@@ -320,19 +329,27 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
 
                     let rowb = full_at + i * inp.per_vec_bytes;
                     let full_off = blk.rerank_base + out_i * per_vec_bytes;
-                    let norm_sq =
+                    let norm_sq = if !has_cluster_quant {
+                        // Single-plane fixed-grid codec (Sq16): the body is
+                        // portable across cluster changes, so a merge is a
+                        // verbatim byte copy with the norm read off the grid.
+                        bytes[full_off..full_off + per_vec_bytes]
+                            .copy_from_slice(&inp.sub[rowb..rowb + per_vec_bytes]);
+                        store_norm.then(|| {
+                            ops.decoded_norm_sq(&inp.sub[rowb..rowb + per_vec_bytes], dim, &[], &[])
+                        })
+                    } else {
+                        let src_scale = &inp.scale[centroid_id * dim..centroid_id * dim + dim];
+                        let src_offset = &inp.offset[centroid_id * dim..centroid_id * dim + dim];
                         if sq8_quant_params_equal(src_scale, src_offset, scale_c, offset_c) {
                             bytes[full_off..full_off + dim * 2]
                                 .copy_from_slice(&inp.sub[rowb..rowb + dim * 2]);
                             store_norm.then(|| {
-                                sq8_residual_norm_sq(
+                                ops.decoded_norm_sq(
+                                    &inp.sub[rowb..rowb + dim * 2],
+                                    dim,
                                     scale_c,
                                     offset_c,
-                                    &inp.sub[rowb..rowb + dim],
-                                    &inp.sub[rowb + dim..rowb + dim + dim],
-                                    codec
-                                        .residual_divisor()
-                                        .expect("residual-family codec has divisor"),
                                 )
                             })
                         } else {
@@ -345,9 +362,8 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
                                 residuals: inp.sub[rowb + dim..rowb + dim + dim].to_vec(),
                                 norm_sq: None,
                             };
-                            let n = materialize_sq8_residual_row_into_cluster_quant(
+                            let n = ops.materialize_row_into_cluster_quant(
                                 &encoded,
-                                codec,
                                 scale_c,
                                 offset_c,
                                 dim,
@@ -356,9 +372,10 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
                             )?;
                             bytes[full_off..full_off + dim * 2].copy_from_slice(&row_buf);
                             n
-                        };
+                        }
+                    };
 
-                    if let (Some(norms_off), Some(n_sq)) = (sq8_norms_block_off, norm_sq) {
+                    if let (Some(norms_off), Some(n_sq)) = (norms_block_off, norm_sq) {
                         let n_off = norms_off + (blk.first_row + out_i) * 4;
                         bytes[n_off..n_off + 4].copy_from_slice(&n_sq.to_le_bytes());
                     }
@@ -452,7 +469,7 @@ pub(crate) fn splice_fragments_into_cell(
         return Ok(None);
     }
 
-    debug_assert!(codec.is_sq8_residual_family());
+    debug_assert!(codec.is_ivf_mergeable());
     let quant = BitQuantizer::new(dim);
     let code_bytes = quant.code_bytes();
     let per_vec_bytes = codec.per_vector_bytes(dim);
@@ -553,15 +570,10 @@ pub(crate) fn splice_fragments_into_cell(
                 let full_off = blk.rerank_base + i * per_vec_bytes;
                 bytes[full_off..full_off + dim * 2].copy_from_slice(&inp.sub[rowb..rowb + dim * 2]);
                 if store_norm && let Some(norms_off) = sq8_norms_block_off {
-                    let n_sq = sq8_residual_norm_sq(
-                        scale_c,
-                        offset_c,
-                        &inp.sub[rowb..rowb + dim],
-                        &inp.sub[rowb + dim..rowb + dim + dim],
-                        codec
-                            .residual_divisor()
-                            .expect("residual-family codec has divisor"),
-                    );
+                    let n_sq = codec
+                        .ops()
+                        .expect("mergeable codec has cold-path ops")
+                        .decoded_norm_sq(&inp.sub[rowb..rowb + dim * 2], dim, scale_c, offset_c);
                     let n_off = norms_off + out_row * 4;
                     bytes[n_off..n_off + 4].copy_from_slice(&n_sq.to_le_bytes());
                 }
@@ -714,7 +726,7 @@ pub(crate) fn sq8_ivf_merge_input_from_subsection(
     rerank_codec: RerankCodec,
     stable_ids: Option<Vec<i128>>,
 ) -> Result<Sq8IvfMergeInput, BuildError> {
-    if !rerank_codec.is_sq8_residual_family() {
+    if !rerank_codec.is_ivf_mergeable() {
         return Err(BuildError::VectorSchemaMismatch(
             "fragment merge requires an Sq8 residual-family subsection".into(),
         ));

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -745,7 +745,8 @@ pub(crate) fn sq8_ivf_merge_input_from_subsection(
 ) -> Result<Sq8IvfMergeInput, BuildError> {
     if !rerank_codec.is_ivf_mergeable() {
         return Err(BuildError::VectorSchemaMismatch(
-            "fragment merge requires an Sq8 residual-family subsection".into(),
+            "fragment merge requires an IVF-mergeable subsection (Sq8 residual family or Sq16)"
+                .into(),
         ));
     }
     if sub.len() < SUB_HEADER_SIZE + CRC_BYTES {
@@ -774,19 +775,30 @@ pub(crate) fn sq8_ivf_merge_input_from_subsection(
             .expect("4-byte codec meta size"),
     ) as usize;
     let codec_meta_off = cluster_idx_off + n_cent * CLUSTER_IDX_ENTRY_BYTES;
-    let so_bytes = n_cent * dim * 4;
-    if codec_meta_size < 2 * so_bytes {
-        return Err(BuildError::VectorSchemaMismatch(
-            "subsection codec meta too small for scale/offset blocks".into(),
-        ));
-    }
-    if sub.len() < codec_meta_off + 2 * so_bytes {
-        return Err(BuildError::VectorSchemaMismatch(
-            "subsection truncated before scale/offset blocks".into(),
-        ));
-    }
-    let scale = decode_f32_le_vec(&sub[codec_meta_off..codec_meta_off + so_bytes]);
-    let offset = decode_f32_le_vec(&sub[codec_meta_off + so_bytes..codec_meta_off + 2 * so_bytes]);
+    // The residual family stores per-cluster [scale|offset] blocks in codec_meta;
+    // Sq16's codec_meta is norms-only (no scale/offset). Splice reconstructs each
+    // row's norm from the codes, so the merge input carries empty scale/offset for
+    // Sq16 — parsing the norm table as scale/offset would error (small cell) or
+    // silently corrupt the reranker (large cell).
+    let (scale, offset) = if rerank_codec.is_sq8_residual_family() {
+        let so_bytes = n_cent * dim * 4;
+        if codec_meta_size < 2 * so_bytes {
+            return Err(BuildError::VectorSchemaMismatch(
+                "subsection codec meta too small for scale/offset blocks".into(),
+            ));
+        }
+        if sub.len() < codec_meta_off + 2 * so_bytes {
+            return Err(BuildError::VectorSchemaMismatch(
+                "subsection truncated before scale/offset blocks".into(),
+            ));
+        }
+        (
+            decode_f32_le_vec(&sub[codec_meta_off..codec_meta_off + so_bytes]),
+            decode_f32_le_vec(&sub[codec_meta_off + so_bytes..codec_meta_off + 2 * so_bytes]),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
     let quant = BitQuantizer::new(dim);
     let code_bytes = quant.code_bytes();
     let per_vec_bytes = rerank_codec.per_vector_bytes(dim);
@@ -933,6 +945,78 @@ mod tests {
         for id in left_ids.iter().chain(right_ids.iter()) {
             assert!(got.contains(id), "merged ids must include {id}");
         }
+    }
+
+    /// Sq16 build helper mirroring [`fixed_subsection_with_empty_clusters`] but
+    /// on the single-plane codec, whose codec_meta is norms-only (no per-cluster
+    /// scale/offset). Exercises the multi-batch splice read-back for Sq16.
+    fn sq16_subsection_with_empty_clusters(id_base: i128) -> MergedIvfSubsection {
+        let mut centroids = vec![0.0f32; N_CENT * DIM];
+        for c in 0..N_CENT {
+            centroids[c * DIM + c] = 1.0;
+        }
+        let mut vectors = Vec::with_capacity(ROWS * DIM);
+        for r in 0..ROWS {
+            let mut row = [0.0f32; DIM];
+            row[0] = 1.0;
+            row[4 + r % 4] = 0.05 + r as f32 * 0.01;
+            let norm = row.iter().map(|v| v * v).sum::<f32>().sqrt();
+            vectors.extend(row.iter().map(|v| v / norm));
+        }
+        let ids: Vec<i128> = (0..ROWS as i128).map(|i| id_base + i).collect();
+        let cfg = VectorConfig {
+            column: "emb".into(),
+            dim: DIM,
+            rot_seed: 7,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Sq16,
+            provided_centroids: Some(Arc::from(centroids)),
+        };
+        build_merged_subsection_from_fp32(cfg, N_CENT, Arc::new(vectors), &ids)
+            .expect("Sq16 cell build")
+    }
+
+    /// Sq16 multi-batch splice: a cell whose fragments span two drain batches
+    /// goes `merge_fragment_subsections` → `sq8_ivf_merge_input_from_subsection`
+    /// → `splice_fragments_into_cell`. All three must treat Sq16's codec_meta as
+    /// norms-only (no per-cluster scale/offset). Before the read-back fix, the
+    /// input parser decoded the norm table as scale/offset — erroring on a small
+    /// cell or silently corrupting the reranker on a large one.
+    #[test]
+    fn sq16_multi_batch_splice_round_trips() {
+        let left = sq16_subsection_with_empty_clusters(1_000);
+        let right = sq16_subsection_with_empty_clusters(2_000);
+        assert_eq!(left.rerank_codec, RerankCodec::Sq16);
+
+        // Read-back must parse norms-only → empty scale/offset (not the norm
+        // table misread as a quantizer).
+        let inp = sq8_ivf_merge_input_from_subsection(
+            &left.bytes,
+            DIM,
+            left.n_cent,
+            left.n_docs,
+            Metric::Cosine,
+            RerankCodec::Sq16,
+            None,
+        )
+        .expect("Sq16 read-back parses norms-only codec_meta");
+        assert!(
+            inp.scale.is_empty() && inp.offset.is_empty(),
+            "Sq16 carries no per-cluster scale/offset"
+        );
+
+        let left_ids: Vec<i128> = (0..ROWS as i128).map(|i| 1_000 + i).collect();
+        let right_ids: Vec<i128> = (0..ROWS as i128).map(|i| 2_000 + i).collect();
+        let (merged, ids) =
+            merge_fragment_subsections(&left, &left_ids, &right, &right_ids, DIM, Metric::Cosine)
+                .expect("Sq16 multi-batch splice merge");
+        assert_eq!(merged.rerank_codec, RerankCodec::Sq16);
+        assert_eq!(
+            merged.n_docs as usize,
+            2 * ROWS,
+            "spliced cell holds every doc from both batches"
+        );
+        assert_eq!(ids.len(), 2 * ROWS, "one stable id per spliced doc");
     }
 
     /// Splice-merging inputs that share an all-empty cluster must leave the

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -47,9 +47,9 @@ use crate::{
         },
         lazy_source::{LazyByteSource, LazyByteSourceError, PrefetchedSource, RangeCoalescePlan},
         vector::{
-            cell_posting::{EncodedCellRow, MaterializedIvfRow, sq8_residual_norm_sq},
+            cell_posting::{EncodedCellRow, MaterializedIvfRow},
             distance::{
-                Metric, Sq8ResidualKernel, decode_f32_le_into, distance_bytes_codec,
+                Metric, Sq8ResidualKernel, Sq16Kernel, decode_f32_le_into, distance_bytes_codec,
                 nearest_k_centroids_bytes, sum_f32,
             },
             ivf_merge::Sq8IvfMergeInput,
@@ -57,7 +57,7 @@ use crate::{
                 BitQuantizer, LUT_BLOCK_ROWS, LutQuery, build_transposed_code_cache,
                 for_each_code_block_scores, lut_scan_supported,
             },
-            rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
+            rerank_codec::{EncodedRowParts, RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
             rotation::RandomRotation,
         },
     },
@@ -129,6 +129,11 @@ pub struct ColumnReader {
     /// the per-doc norms add `n_docs × 4` bytes (4 MB at 1M
     /// docs / column). Materialising here amortizes the parse
     /// across every search call.
+    /// Per-doc-norm carrier, shared by the residual family (`Sq8*`) and
+    /// the flat `Sq16` codec. For `Sq16` the `scale`/`offset` arrays are
+    /// empty (fixed grid) and only `per_doc_norms` is populated, so the
+    /// reader's `cand.pos` norm indexing is byte-for-byte the residual
+    /// family's. `None` for `Fp32` / `RabitqOnly`.
     pub(super) sq8_meta: Option<Sq8ColumnMeta>,
     lazy_sq8_parsed: OnceLock<Arc<Sq8ParsedMeta>>,
     /// Byte range of this column's subsection within the outer blob.
@@ -349,6 +354,22 @@ pub struct VectorReader {
 }
 
 impl VectorReader {
+    /// Test-only accessor: the per-doc dequantized-norm table this
+    /// reader loaded from a column's `codec_meta` region (residual
+    /// family or `Sq16`). Returns `None` for a codec that carries no
+    /// norms, an unknown column, or a lazily-open source that has not
+    /// materialised the norms eagerly. Used by the Sq16 store/read
+    /// localization test to compare the loaded table against the norms
+    /// recomputed from the on-disk `u16` codes.
+    #[cfg(test)]
+    pub(crate) fn per_doc_norms_for_test(&self, column: &str) -> Option<std::sync::Arc<[f32]>> {
+        let col = self.columns.iter().find(|c| c.name == column)?;
+        match col.sq8_meta.as_ref()? {
+            Sq8ColumnMeta::Eager { per_doc_norms, .. } => per_doc_norms.clone(),
+            Sq8ColumnMeta::Lazy { .. } => None,
+        }
+    }
+
     /// Open the reader. `columns_json` is the value of the
     /// legacy `inf.vec.columns` Parquet KV key (a JSON array of
     /// [`VectorColumnConfig`]).
@@ -1000,6 +1021,9 @@ impl VectorReader {
                 ))));
             }
             let per_vec_bytes = rerank_codec.per_vector_bytes(dim);
+            // Sq16 carries a per-doc norm table for cosine/L2Sq (0 for
+            // NegDot), so it is not unconditionally zero-meta — its exact
+            // size is validated below against `codec_meta_bytes`.
             let codec_meta_required_zero =
                 matches!(rerank_codec, RerankCodec::Fp32 | RerankCodec::RabitqOnly);
 
@@ -1134,6 +1158,28 @@ impl VectorReader {
                         offset_abs_off: meta_abs_start + scale_end,
                         norms_abs_off: matches!(metric, Metric::L2Sq | Metric::Cosine)
                             .then_some(meta_abs_start + offset_end),
+                    })
+                }
+            } else if rerank_codec.is_sq16() && matches!(metric, Metric::L2Sq | Metric::Cosine) {
+                // Sq16 reuses the residual family's `Sq8ColumnMeta` norm
+                // carrier + `cand.pos` indexing verbatim; the only layout
+                // difference is that the per-doc norm table starts at the
+                // codec_meta head (no scale/offset arrays precede it), so
+                // `scale`/`offset` stay empty.
+                let meta_abs_start = subsection_off + codec_meta_off;
+                let norms_end = meta_abs_start + (col_n_docs as usize) * 4;
+                debug_assert_eq!(norms_end - meta_abs_start, actual_codec_meta_size);
+                if let Some(meta_bytes) = source.try_get_range_sync(meta_abs_start..norms_end) {
+                    Some(Sq8ColumnMeta::Eager {
+                        scale: Vec::new(),
+                        offset: Vec::new(),
+                        per_doc_norms: Some(Arc::from(parse_f32_le_vec(&meta_bytes))),
+                    })
+                } else {
+                    Some(Sq8ColumnMeta::Lazy {
+                        scale_abs_off: meta_abs_start,
+                        offset_abs_off: meta_abs_start,
+                        norms_abs_off: Some(meta_abs_start),
                     })
                 }
             } else {
@@ -1294,6 +1340,7 @@ impl VectorReader {
                 value if value == u32::from(RerankCodec::Sq8FixedResidual.codec_id()) => {
                     RerankCodec::Sq8FixedResidual
                 }
+                value if value == u32::from(RerankCodec::Sq16.codec_id()) => RerankCodec::Sq16,
                 _ => {
                     return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                         "multi-cell directory has unknown rerank codec id {raw_codec}"
@@ -1735,6 +1782,25 @@ impl VectorReader {
                     offset_abs_off: meta_abs_start + scale_end,
                     norms_abs_off: matches!(metric, Metric::L2Sq | Metric::Cosine)
                         .then_some(meta_abs_start + offset_end),
+                })
+            }
+        } else if rerank_codec.is_sq16() && matches!(metric, Metric::L2Sq | Metric::Cosine) {
+            // Sq16: per-doc norm table only (no scale/offset), carried in
+            // the shared `Sq8ColumnMeta` so norm indexing matches the
+            // residual family. See the main open path for the rationale.
+            let meta_abs_start = subsection_off + codec_meta_off;
+            let norms_end = meta_abs_start + (col_n_docs as usize) * 4;
+            if let Some(meta_bytes) = source.try_get_range_sync(meta_abs_start..norms_end) {
+                Some(Sq8ColumnMeta::Eager {
+                    scale: Vec::new(),
+                    offset: Vec::new(),
+                    per_doc_norms: Some(Arc::from(parse_f32_le_vec(&meta_bytes))),
+                })
+            } else {
+                Some(Sq8ColumnMeta::Lazy {
+                    scale_abs_off: meta_abs_start,
+                    offset_abs_off: meta_abs_start,
+                    norms_abs_off: Some(meta_abs_start),
                 })
             }
         } else {
@@ -2366,7 +2432,7 @@ impl VectorReader {
         let col = self.columns.get(col_idx).ok_or_else(|| {
             BuildError::VectorSchemaMismatch(format!("cell column index {col_idx} out of range"))
         })?;
-        if !col.rerank_codec.is_sq8_residual_family() {
+        if !col.rerank_codec.is_ivf_mergeable() {
             return Err(BuildError::VectorRerankCodecUnimplemented {
                 column: col.name.clone(),
                 codec: col.rerank_codec.name(),
@@ -2448,7 +2514,7 @@ impl VectorReader {
         let col = self.columns.get(col_idx).ok_or_else(|| {
             BuildError::VectorSchemaMismatch(format!("cell column index {col_idx} out of range"))
         })?;
-        if !col.rerank_codec.is_sq8_residual_family() {
+        if !col.rerank_codec.is_ivf_mergeable() {
             return Err(BuildError::VectorRerankCodecUnimplemented {
                 column: col.name.clone(),
                 codec: col.rerank_codec.name(),
@@ -2493,7 +2559,7 @@ impl VectorReader {
         col_idx: usize,
     ) -> Option<Vec<MaterializedIvfRow>> {
         let col = self.columns.get(col_idx)?;
-        if !col.rerank_codec.is_sq8_residual_family() {
+        if !col.rerank_codec.is_ivf_mergeable() {
             return None;
         }
         let dim = col.dim;
@@ -2689,10 +2755,7 @@ impl VectorReader {
         let per_vec = col.rerank_codec.per_vector_bytes(dim);
         let n_cent = col.n_cent as usize;
         let store_norm = matches!(col.metric, Metric::L2Sq | Metric::Cosine);
-        let divisor = col
-            .rerank_codec
-            .residual_divisor()
-            .ok_or(BuildError::VectorReadError)?;
+        let ops = col.rerank_codec.ops().ok_or(BuildError::VectorReadError)?;
         let u32_at = |p: usize| -> Result<u32, BuildError> {
             let bytes: [u8; 4] = sub
                 .get(p..p + 4)
@@ -2719,17 +2782,30 @@ impl VectorReader {
             let doc_ids_at = block + count * code_bytes;
             let full_at = block + count * (code_bytes + id_bytes);
             // Shared per-cluster backing: each row clones the Arc (refcount bump),
-            // not the dim-length scale/offset buffers.
-            let sc: std::sync::Arc<[f32]> = std::sync::Arc::from(
-                scale
-                    .get(c * dim..c * dim + dim)
-                    .ok_or(BuildError::VectorReadError)?,
-            );
-            let of: std::sync::Arc<[f32]> = std::sync::Arc::from(
-                offset
-                    .get(c * dim..c * dim + dim)
-                    .ok_or(BuildError::VectorReadError)?,
-            );
+            // not the dim-length scale/offset buffers. Only the residual family
+            // carries per-cluster scale/offset (`n_cent * dim` each); single-plane
+            // fixed-grid codecs (Sq16) decode off the fixed grid and store empty
+            // scale/offset, so there is nothing to slice per cluster.
+            let (sc, of): (std::sync::Arc<[f32]>, std::sync::Arc<[f32]>) =
+                if col.rerank_codec.is_sq8_residual_family() {
+                    (
+                        std::sync::Arc::from(
+                            scale
+                                .get(c * dim..c * dim + dim)
+                                .ok_or(BuildError::VectorReadError)?,
+                        ),
+                        std::sync::Arc::from(
+                            offset
+                                .get(c * dim..c * dim + dim)
+                                .ok_or(BuildError::VectorReadError)?,
+                        ),
+                    )
+                } else {
+                    (
+                        std::sync::Arc::from(Vec::new()),
+                        std::sync::Arc::from(Vec::new()),
+                    )
+                };
             for i in 0..count {
                 let local_id = u32_at(doc_ids_at + i * id_bytes)?;
                 let rabitq = sub
@@ -2737,16 +2813,14 @@ impl VectorReader {
                     .ok_or(BuildError::VectorReadError)?
                     .to_vec();
                 let rowb = full_at + i * per_vec;
-                let codes = sub
-                    .get(rowb..rowb + dim)
-                    .ok_or(BuildError::VectorReadError)?
-                    .to_vec();
-                let residuals = sub
-                    .get(rowb + dim..rowb + dim + dim)
-                    .ok_or(BuildError::VectorReadError)?
-                    .to_vec();
-                let norm_sq =
-                    store_norm.then(|| sq8_residual_norm_sq(&sc, &of, &codes, &residuals, divisor));
+                let row = sub
+                    .get(rowb..rowb + per_vec)
+                    .ok_or(BuildError::VectorReadError)?;
+                let EncodedRowParts {
+                    codes,
+                    residuals,
+                    norm_sq,
+                } = ops.parse_materialized_row(row, dim, &sc, &of, store_norm);
                 let stable_id = match stable_ids_rel {
                     Some(so) => {
                         let p = so + (local_id as usize) * format::vec::STABLE_ID_BYTES;
@@ -4849,6 +4923,69 @@ async fn rerank_candidates_from_blocks(
                     .collect()
             }
         }
+        RerankCodec::Sq16 => {
+            // Flat single-plane rerank with per-doc norm correction. One
+            // `Sq16Kernel` for the whole query (fixed grid — no
+            // per-cluster state); each survivor scores as
+            // `base - dot/‖d̂‖` (Cosine) using its stored dequantized
+            // norm. The norm table is carried in the SHARED
+            // `Sq8ColumnMeta` and indexed by `cand.pos` with the exact
+            // same expression the residual family uses
+            // (`score_sq8_residual_candidates`), so a candidate's norm is
+            // guaranteed to be its own — no parallel Sq16 norm path.
+            let norms: Option<Arc<[f32]>> = match col.sq8_meta.as_ref() {
+                Some(Sq8ColumnMeta::Eager { per_doc_norms, .. }) => per_doc_norms.clone(),
+                Some(Sq8ColumnMeta::Lazy { norms_abs_off, .. }) => {
+                    if let Some(meta_bytes) = lazy_sq8_meta_bytes {
+                        // Sq16's codec_meta region IS the norm table.
+                        Some(Arc::from(parse_f32_le_vec(meta_bytes)))
+                    } else if let Some(norms_abs_off) = norms_abs_off {
+                        let range = *norms_abs_off..*norms_abs_off + col.n_docs as usize * 4;
+                        let fetched = source
+                            .get_ranges_parallel(std::slice::from_ref(&range))
+                            .map_err(map_lazy)?;
+                        Some(Arc::from(parse_f32_le_vec(&fetched[0])))
+                    } else {
+                        None
+                    }
+                }
+                // NegDot (Sq16 is cosine-only in practice) → no norms.
+                None => None,
+            };
+            let kernel = Sq16Kernel::new(col.metric, query);
+            if candidates.len() >= PARALLEL_SCAN_MIN {
+                let kernel = Arc::new(kernel);
+                let blocks: Arc<Vec<Bytes>> = Arc::new(cluster_blocks.to_vec());
+                let survivors: Option<Arc<Vec<Bytes>>> =
+                    survivor_full_rows.map(|s| Arc::new(s.to_vec()));
+                let norms = norms.clone();
+                par_map(
+                    candidates.to_vec(),
+                    move |cand: &RerankCandidate| {
+                        let bytes = candidate_full_bytes(
+                            &blocks,
+                            survivors.as_deref().map(|s| s.as_slice()),
+                            cand,
+                            stride,
+                        );
+                        let norm = norms.as_ref().map(|n| n[cand.pos as usize]);
+                        (cand.did, kernel.distance_with_norm(bytes, norm))
+                    },
+                    pool.clone(),
+                )
+                .await?
+            } else {
+                candidates
+                    .iter()
+                    .map(|cand| {
+                        let bytes =
+                            candidate_full_bytes(cluster_blocks, survivor_full_rows, cand, stride);
+                        let norm = norms.as_ref().map(|n| n[cand.pos as usize]);
+                        (cand.did, kernel.distance_with_norm(bytes, norm))
+                    })
+                    .collect()
+            }
+        }
         RerankCodec::Sq8Residual | RerankCodec::Sq8FixedResidual => {
             let residual_divisor = col
                 .rerank_codec
@@ -5172,7 +5309,12 @@ fn validate_quantizer_meta(
             "column {column:?} has non-finite quantizer metadata"
         ))));
     }
-    if !rerank_codec.uses_fixed_quantizer() {
+    // The pinned-constant check is specific to the sq8-residual fixed
+    // grid (`SQ8_FIXED_*`). Only Sq8FixedResidual (fixed-quantizer AND
+    // residual-family) carries such an array. Sq16 is fixed-quantizer
+    // but stores no codec_meta, so it never reaches here with scale/
+    // offset arrays — return Ok vacuously if it ever did.
+    if !(rerank_codec.uses_fixed_quantizer() && rerank_codec.is_sq8_residual_family()) {
         return Ok(());
     }
     let valid = scale
@@ -6216,14 +6358,14 @@ mod tests {
         let dim = 32usize;
         let n_docs = 64u32;
         let mut b = VectorBuilder::new();
-        // Register via the struct default for rerank_codec to pin
-        // that the build default is Sq8FixedResidual.
+        // Pin the Sq8FixedResidual round-trip explicitly (the cosine default
+        // is now Sq16; this case exercises the residual family specifically).
         b.register_column(VectorConfig {
             column: "v".into(),
             dim,
             rot_seed: 7,
             metric: Metric::Cosine,
-            rerank_codec: RerankCodec::default(),
+            rerank_codec: RerankCodec::Sq8FixedResidual,
             provided_centroids: None,
         })
         .expect("register column");

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -14,7 +14,19 @@
 //! - [`RerankCodec::Sq8FixedResidual`]: the same two-byte layout on a
 //!   fixed cosine-only grid (`offset=-1`, `scale=2/255`, residual
 //!   divisor `256`). The payload is portable across cluster changes.
-//!   Default codec.
+//! - [`RerankCodec::Sq16`]: a flat uniform 16-bit scalar quantizer on
+//!   a fixed cosine-only grid (`offset=-1`, `scale=2/65535`). Stores
+//!   one little-endian `u16` code per dimension (`dim × 2` bytes per
+//!   vector — the same footprint as `Sq8FixedResidual`'s
+//!   `[u8 code ‖ i8 residual]`, but a single plane scored in one pass
+//!   instead of two). No residual plane. Because the grid is fixed
+//!   constants, `Sq16` needs no per-cluster scale/offset arrays; its
+//!   only `codec_meta` is the per-doc dequantized-norm table
+//!   (`n_docs × 4` bytes for cosine/L2Sq), matching the Sq8 family so
+//!   the cosine kernel divides by `‖d̂‖`. The default cosine codec:
+//!   same footprint as the split-plane `Sq8FixedResidual` but scored in
+//!   one pass, and leaner on disk (norms only, no fixed scale/offset
+//!   arrays).
 //! - [`RerankCodec::RabitqOnly`]: no rerank column at all. The
 //!   1-bit RaBitQ shortlist is the final ranking — opt-in,
 //!   recall-degraded, shrinks the superfile by ~30× at 1M × 384.
@@ -44,7 +56,16 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use crate::superfile::vector::distance::{Metric, SQ8_RESIDUAL_DIVISOR};
+use crate::superfile::{
+    BuildError,
+    vector::{
+        cell_posting::{EncodedCellRow, residual_family_materialize_into_cluster_quant},
+        distance::{
+            Metric, SQ8_RESIDUAL_DIVISOR, dequantize_sq8_residual_into, dequantize_sq16_into,
+            sq8_residual_norm_sq, sq16_decoded_norm_sq,
+        },
+    },
+};
 
 /// `dim` at and below which a column counts as "low-dim" for the
 /// rerank-floor calibration table in
@@ -82,6 +103,12 @@ pub(crate) const SQ8_FIXED_SCALE: f32 = 2.0 / 255.0;
 /// Residual divisor for the portable cosine-only Sq8 grid.
 pub(crate) const SQ8_FIXED_RESIDUAL_DIVISOR: f32 = 256.0;
 
+/// Absolute offset for the flat cosine-only Sq16 grid.
+pub(crate) const SQ16_FIXED_OFFSET: f32 = -1.0;
+/// Absolute scale for the flat cosine-only Sq16 grid: the full
+/// `u16` range (`0..=65535`) spans `[-1, 1]` in even steps.
+pub(crate) const SQ16_FIXED_SCALE: f32 = 2.0 / 65535.0;
+
 /// Per-vector-index rerank codec. Picks the on-disk byte layout of the
 /// per-vector rerank values inside the subsection's `full[]`
 /// region.
@@ -106,6 +133,16 @@ pub enum RerankCodec {
     /// yielding approximately 16-bit scalar precision while keeping bytes
     /// portable across drain, compaction, and split.
     Sq8FixedResidual,
+    /// Flat uniform 16-bit scalar quantizer on a fixed cosine-only
+    /// grid (`offset = -1`, `scale = 2/65535`). One little-endian
+    /// `u16` code per dimension (`dim × 2` bytes per vector), scored
+    /// in a single pass — no residual plane. Reconstruction is
+    /// `x = code × scale + offset`. The grid is fixed constants shared
+    /// by every cluster and file, so `Sq16` stores no per-cluster
+    /// scale/offset arrays; its only `codec_meta` is the per-doc
+    /// dequantized-norm table (`n_docs × 4` for cosine/L2Sq), matching
+    /// the Sq8 family so the cosine kernel divides by `‖d̂‖`.
+    Sq16,
     /// No rerank column at all. The 1-bit RaBitQ shortlist is
     /// the final ranking. Opt-in — recall drops 0.05–0.15 on
     /// typical normalized-Gaussian / image-embedding corpora;
@@ -119,10 +156,13 @@ pub enum RerankCodec {
 }
 
 impl Default for RerankCodec {
-    /// `Sq8FixedResidual` is the portable cosine default. Metric-aware
-    /// constructors retain local residual encoding for non-cosine metrics.
+    /// `Sq16` is the cosine default — a single 16-bit plane on the fixed
+    /// `[-1, 1]` grid: finer per-component precision than `Sq8FixedResidual`
+    /// at the same 2 bytes/dim, faster rerank, and recall provably ≥. Metric-
+    /// aware constructors retain local residual encoding (`Sq8Residual`) for
+    /// non-cosine metrics, whose values are not bounded to `[-1, 1]`.
     fn default() -> Self {
-        Self::Sq8FixedResidual
+        Self::Sq16
     }
 }
 
@@ -138,6 +178,7 @@ impl RerankCodec {
             Self::Sq8Residual => 1,
             Self::RabitqOnly => 2,
             Self::Sq8FixedResidual => 3,
+            Self::Sq16 => 4,
         }
     }
 
@@ -152,6 +193,7 @@ impl RerankCodec {
             1 => Some(Self::Sq8Residual),
             2 => Some(Self::RabitqOnly),
             3 => Some(Self::Sq8FixedResidual),
+            4 => Some(Self::Sq16),
             _ => None,
         }
     }
@@ -165,6 +207,7 @@ impl RerankCodec {
             Self::Sq8Residual => "sq8_residual",
             Self::RabitqOnly => "rabitq_only",
             Self::Sq8FixedResidual => "sq8_fixed_residual",
+            Self::Sq16 => "sq16",
         }
     }
 
@@ -174,8 +217,24 @@ impl RerankCodec {
     pub const fn per_vector_bytes(self, dim: usize) -> usize {
         match self {
             Self::Fp32 => dim * 4,
-            Self::Sq8Residual | Self::Sq8FixedResidual => dim * 2,
+            Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16 => dim * 2,
             Self::RabitqOnly => 0,
+        }
+    }
+
+    /// The vector `dim` implied by a materialized row's `codes` byte length.
+    /// The residual family stores a `dim`-byte u8 coarse plane, so the code
+    /// length *is* `dim`; the single-plane Sq16 stores a `dim*2`-byte u16
+    /// plane, so `dim` is half the code length. The drain spill sizes a
+    /// per-cell writer from the first row it materializes and must derive
+    /// `dim` this way — assuming `codes.len() == dim` doubles it for Sq16 and
+    /// trips the spill's row-shape check.
+    #[inline]
+    pub(crate) fn dim_from_codes_len(self, codes_len: usize) -> usize {
+        if self.is_sq8_residual_family() {
+            codes_len
+        } else {
+            codes_len / 2
         }
     }
 
@@ -200,14 +259,44 @@ impl RerankCodec {
     pub const fn is_implemented(self) -> bool {
         matches!(
             self,
-            Self::Fp32 | Self::Sq8Residual | Self::Sq8FixedResidual | Self::RabitqOnly
+            Self::Fp32 | Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16 | Self::RabitqOnly
         )
     }
 
     /// Whether the codec uses the shared `[u8 code | i8 residual]` layout.
+    /// `Sq16` is deliberately **not** a member — it is a single `u16`
+    /// plane with its own scoring path, not the two-plane residual layout.
     #[inline]
     pub const fn is_sq8_residual_family(self) -> bool {
         matches!(self, Self::Sq8Residual | Self::Sq8FixedResidual)
+    }
+
+    /// Whether this codec participates in the IVF drain / merge / compaction
+    /// maintenance paths that re-quantize rows into a destination cluster
+    /// quantizer. True for the residual family (`Sq8Residual`,
+    /// `Sq8FixedResidual`) and for the single-plane `Sq16` codec, all of which
+    /// carry a cold-path `ops()` impl and so can be built-from-source, drained,
+    /// merged, and compacted. `Fp32` / `RabitqOnly` have their own (or no)
+    /// rerank plane and are never IVF-merged here.
+    ///
+    /// This is the gate predicate for the maintenance sites; it replaces the
+    /// former direct use of [`Self::is_sq8_residual_family`] at those sites so
+    /// the mergeable set is named for what it means (eligible for IVF merge)
+    /// rather than for the byte layout that happens to coincide with it today.
+    #[inline]
+    pub const fn is_ivf_mergeable(self) -> bool {
+        matches!(
+            self,
+            Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16
+        )
+    }
+
+    /// Whether this is the flat single-plane `u16` codec. Scored via
+    /// [`crate::superfile::vector::distance::Sq16Kernel`] — the `Fp32`
+    /// distance path with a `u16 → f32` dequant front.
+    #[inline]
+    pub const fn is_sq16(self) -> bool {
+        matches!(self, Self::Sq16)
     }
 
     /// Residual divisor implied by the on-disk codec discriminator.
@@ -216,20 +305,32 @@ impl RerankCodec {
         match self {
             Self::Sq8Residual => Some(SQ8_RESIDUAL_DIVISOR),
             Self::Sq8FixedResidual => Some(SQ8_FIXED_RESIDUAL_DIVISOR),
-            Self::Fp32 | Self::RabitqOnly => None,
+            // `Sq16` is a single plane — no residual step, no divisor.
+            Self::Fp32 | Self::Sq16 | Self::RabitqOnly => None,
         }
     }
 
-    /// Whether every cluster uses the fixed absolute quantizer.
+    /// Whether the codec quantizes onto a fixed absolute `[-1, 1]`
+    /// grid shared by every cluster and file (rather than a per-cluster
+    /// fitted quantizer). True for both fixed-grid cosine codecs —
+    /// `Sq8FixedResidual` and `Sq16`.
+    ///
+    /// Note this describes the *grid*, not the on-disk metadata layout:
+    /// `Sq16` is fixed-quantizer **and** carries no `codec_meta`, so
+    /// per-cluster scale/offset-array sites must additionally gate on
+    /// [`Self::is_sq8_residual_family`] to stay off the single-plane
+    /// `Sq16` path.
     #[inline]
     pub const fn uses_fixed_quantizer(self) -> bool {
-        matches!(self, Self::Sq8FixedResidual)
+        matches!(self, Self::Sq8FixedResidual | Self::Sq16)
     }
 
-    /// Whether this codec supports the requested metric.
+    /// Whether this codec supports the requested metric. The
+    /// fixed-grid cosine codecs (`Sq8FixedResidual`, `Sq16`) pin the
+    /// quantizer to the `[-1, 1]` cosine range and so are Cosine-only.
     #[inline]
     pub const fn supports_metric(self, metric: Metric) -> bool {
-        !matches!(self, Self::Sq8FixedResidual) || matches!(metric, Metric::Cosine)
+        !matches!(self, Self::Sq8FixedResidual | Self::Sq16) || matches!(metric, Metric::Cosine)
     }
 
     /// Recommended **lower bound** on `rerank_mult` for this
@@ -249,7 +350,9 @@ impl RerankCodec {
     pub const fn recommended_rerank_mult_floor(self, dim: usize) -> Option<usize> {
         let high_dim = dim > LOW_DIM_RERANK_FLOOR_THRESHOLD;
         match self {
-            Self::Fp32 => Some(if high_dim {
+            // `Sq16` is ~16-bit clean, so its rerank floor matches
+            // `Fp32` rather than the lossier Sq8 first-pass.
+            Self::Fp32 | Self::Sq16 => Some(if high_dim {
                 FP32_HIGH_DIM_RERANK_FLOOR
             } else {
                 FP32_LOW_DIM_RERANK_FLOOR
@@ -273,6 +376,13 @@ impl RerankCodec {
     /// Stored immediately before the subsection's `full[]` region.
     ///
     /// - `Fp32` / `RabitqOnly`: `0` (no codec metadata).
+    /// - `Sq16`: per-doc `sum_x_decoded² : f32` table (`n_docs × 4`
+    ///   bytes) for `L2Sq`/`Cosine`, and **nothing else** — the grid is
+    ///   fixed constants, so there are no per-cluster scale/offset
+    ///   arrays. The per-doc norm lets the cosine kernel divide by the
+    ///   dequantized vector norm (`base − dot/‖d̂‖`), matching the Sq8
+    ///   family so the recall comparison is apples-to-apples. `NegDot`
+    ///   drops the table (0 bytes).
     /// - `Sq8Residual`: **per-cluster** per-dim `(scale, offset)` arrays
     ///   (`2 × n_cent × dim × 4` bytes) plus, for `L2Sq`/`Cosine`-metric
     ///   columns, a per-doc `sum_x_decoded² : f32` table
@@ -307,6 +417,13 @@ impl RerankCodec {
     ) -> usize {
         match self {
             Self::Fp32 | Self::RabitqOnly => 0,
+            // `Sq16`'s grid is fixed constants — no scale/offset arrays.
+            // It carries only the per-doc dequantized-norm table for the
+            // norm-corrected cosine (and L2Sq) kernel.
+            Self::Sq16 => match metric {
+                Metric::L2Sq | Metric::Cosine => n_docs * 4,
+                Metric::NegDot => 0,
+            },
             Self::Sq8Residual | Self::Sq8FixedResidual => {
                 let scale_offset_bytes = 2 * n_cent * dim * 4;
                 let norms_bytes = match metric {
@@ -325,17 +442,408 @@ impl fmt::Display for RerankCodec {
     }
 }
 
+/// The codes / residuals / per-doc norm parsed out of one materialized on-disk
+/// rerank row. `residuals` is empty for single-plane codecs (`Sq16`).
+pub(crate) struct EncodedRowParts {
+    pub codes: Vec<u8>,
+    pub residuals: Vec<u8>,
+    pub norm_sq: Option<f32>,
+}
+
+/// Absolute in-subsection byte offsets of a codec's `codec_meta` sub-regions,
+/// computed from the region's base offset. `None` marks a sub-region a codec
+/// does not carry: `Sq16` has no per-cluster `scale`/`offset` arrays (fixed
+/// grid), so `scale_off`/`offset_off` are `None`; `norms_off` is `None` for
+/// `NegDot` (no per-doc dequantized-norm table). Sites that write scale/offset
+/// arrays must skip when `scale_off == None` — a stale write corrupts the
+/// subsection.
+pub(crate) struct CodecMetaLayout {
+    pub scale_off: Option<usize>,
+    pub offset_off: Option<usize>,
+    pub norms_off: Option<usize>,
+}
+
+/// Per-codec operations for the cold paths (build-from-source, drain read-back,
+/// IVF merge, compaction) so those paths stop branching on the codec: a new
+/// codec is one `impl` + one arm in [`RerankCodec::ops`]. Implemented only by
+/// the quantized-rerank family (`Sq8Residual`, `Sq8FixedResidual`, `Sq16`);
+/// `ops()` returns `None` for `Fp32` / `RabitqOnly`, which carry no quantized
+/// rerank plane and keep their own paths. The HOT per-candidate scoring kernel
+/// is deliberately NOT part of this trait — it stays statically dispatched.
+pub(crate) trait RerankCodecOps: Sync {
+    /// Split one materialized on-disk rerank row into its codes/residuals planes
+    /// plus the per-doc dequantized norm (when `store_norm`). `scale`/`offset`
+    /// are the row's per-cluster quantizer (ignored by fixed-grid codecs).
+    /// `row.len()` must equal `RerankCodec::per_vector_bytes(dim)`.
+    fn parse_materialized_row(
+        &self,
+        row: &[u8],
+        dim: usize,
+        scale: &[f32],
+        offset: &[f32],
+        store_norm: bool,
+    ) -> EncodedRowParts;
+
+    /// Dequantize one row's codes (plus `residuals`, ignored by single-plane
+    /// codecs) into fp32 `out` (`out.len() == dim`). `scale`/`offset` are the
+    /// row's per-cluster quantizer (ignored by fixed-grid codecs). The
+    /// residual family threads its codec's residual divisor internally so
+    /// callers no longer `residual_divisor().expect(...)` at the site.
+    fn dequantize_row_into(
+        &self,
+        codes: &[u8],
+        residuals: &[u8],
+        dim: usize,
+        scale: &[f32],
+        offset: &[f32],
+        out: &mut [f32],
+    );
+
+    /// Dequantized-vector squared norm `Σ_d x[d]²` for one materialized
+    /// on-disk row. `code` is the contiguous per-vector body
+    /// (`RerankCodec::per_vector_bytes(dim)` bytes: `[codes ‖ residuals]` for
+    /// the residual family, a single `u16` plane for `Sq16`). `scale`/`offset`
+    /// are the row's per-cluster quantizer (ignored by fixed-grid codecs). The
+    /// residual family threads its residual divisor internally.
+    fn decoded_norm_sq(&self, code: &[u8], dim: usize, scale: &[f32], offset: &[f32]) -> f32;
+
+    /// Copy or transcode one source `row` into the destination cluster
+    /// quantizer, writing `out` (`RerankCodec::per_vector_bytes(dim)` bytes).
+    /// `self` is the destination codec's ops. Returns residual-corrected
+    /// `‖x‖²` when `store_norm` (L2Sq/Cosine). Errors if `row`'s codec does not
+    /// match this destination codec.
+    fn materialize_row_into_cluster_quant(
+        &self,
+        row: &EncodedCellRow,
+        dst_scale: &[f32],
+        dst_offset: &[f32],
+        dim: usize,
+        out: &mut [u8],
+        store_norm: bool,
+    ) -> Result<Option<f32>, BuildError>;
+
+    /// Absolute byte offsets of this codec's `codec_meta` sub-regions given the
+    /// region base `meta_off`. Mirrors `RerankCodec::codec_meta_bytes`'s layout:
+    /// residual family lays out `[scale ‖ offset ‖ norms?]`; `Sq16` carries only
+    /// `[norms?]` (no scale/offset arrays). `norms_off` is present only for
+    /// `L2Sq`/`Cosine`.
+    fn codec_meta_layout(
+        &self,
+        meta_off: usize,
+        n_cent: usize,
+        dim: usize,
+        metric: Metric,
+    ) -> CodecMetaLayout;
+}
+
+pub(crate) struct Sq8ResidualOps;
+pub(crate) struct Sq8FixedResidualOps;
+pub(crate) struct Sq16Ops;
+
+/// Shared residual-family row split: `dim` u8 coarse codes + `dim` i8 residual
+/// codes; norm via [`sq8_residual_norm_sq`] with the codec's `divisor`.
+fn parse_residual_family_row(
+    row: &[u8],
+    dim: usize,
+    scale: &[f32],
+    offset: &[f32],
+    divisor: f32,
+    store_norm: bool,
+) -> EncodedRowParts {
+    let codes = row[..dim].to_vec();
+    let residuals = row[dim..dim * 2].to_vec();
+    let norm_sq =
+        store_norm.then(|| sq8_residual_norm_sq(scale, offset, &codes, &residuals, divisor));
+    EncodedRowParts {
+        codes,
+        residuals,
+        norm_sq,
+    }
+}
+
+/// Shared residual-family dequant: delegate to [`dequantize_sq8_residual_into`]
+/// with the codec's residual `divisor`. `out.len()` fixes `dim`.
+fn dequantize_residual_family_into(
+    codes: &[u8],
+    residuals: &[u8],
+    scale: &[f32],
+    offset: &[f32],
+    divisor: f32,
+    out: &mut [f32],
+) {
+    dequantize_sq8_residual_into(scale, offset, codes, residuals, divisor, out);
+}
+
+/// Shared residual-family decoded-norm: split the contiguous per-vector body
+/// `[codes(dim) ‖ residuals(dim)]` and reduce via [`sq8_residual_norm_sq`]
+/// with the codec's residual `divisor`.
+fn residual_family_norm_sq(
+    code: &[u8],
+    dim: usize,
+    scale: &[f32],
+    offset: &[f32],
+    divisor: f32,
+) -> f32 {
+    sq8_residual_norm_sq(scale, offset, &code[..dim], &code[dim..dim * 2], divisor)
+}
+
+/// Shared residual-family `codec_meta` layout: `[scale ‖ offset ‖ norms?]`,
+/// mirroring [`RerankCodec::codec_meta_bytes`]. Norms present for L2Sq/Cosine.
+fn residual_family_codec_meta_layout(
+    meta_off: usize,
+    n_cent: usize,
+    dim: usize,
+    metric: Metric,
+) -> CodecMetaLayout {
+    let scale_off = meta_off;
+    let offset_off = scale_off + n_cent * dim * size_of::<f32>();
+    let norms_off = matches!(metric, Metric::L2Sq | Metric::Cosine)
+        .then_some(offset_off + n_cent * dim * size_of::<f32>());
+    CodecMetaLayout {
+        scale_off: Some(scale_off),
+        offset_off: Some(offset_off),
+        norms_off,
+    }
+}
+
+impl RerankCodecOps for Sq8ResidualOps {
+    fn parse_materialized_row(
+        &self,
+        row: &[u8],
+        dim: usize,
+        scale: &[f32],
+        offset: &[f32],
+        store_norm: bool,
+    ) -> EncodedRowParts {
+        parse_residual_family_row(row, dim, scale, offset, SQ8_RESIDUAL_DIVISOR, store_norm)
+    }
+
+    fn dequantize_row_into(
+        &self,
+        codes: &[u8],
+        residuals: &[u8],
+        _dim: usize,
+        scale: &[f32],
+        offset: &[f32],
+        out: &mut [f32],
+    ) {
+        dequantize_residual_family_into(codes, residuals, scale, offset, SQ8_RESIDUAL_DIVISOR, out);
+    }
+
+    fn decoded_norm_sq(&self, code: &[u8], dim: usize, scale: &[f32], offset: &[f32]) -> f32 {
+        residual_family_norm_sq(code, dim, scale, offset, SQ8_RESIDUAL_DIVISOR)
+    }
+
+    fn materialize_row_into_cluster_quant(
+        &self,
+        row: &EncodedCellRow,
+        dst_scale: &[f32],
+        dst_offset: &[f32],
+        dim: usize,
+        out: &mut [u8],
+        store_norm: bool,
+    ) -> Result<Option<f32>, BuildError> {
+        residual_family_materialize_into_cluster_quant(
+            row,
+            RerankCodec::Sq8Residual,
+            dst_scale,
+            dst_offset,
+            dim,
+            out,
+            store_norm,
+        )
+    }
+
+    fn codec_meta_layout(
+        &self,
+        meta_off: usize,
+        n_cent: usize,
+        dim: usize,
+        metric: Metric,
+    ) -> CodecMetaLayout {
+        residual_family_codec_meta_layout(meta_off, n_cent, dim, metric)
+    }
+}
+
+impl RerankCodecOps for Sq8FixedResidualOps {
+    fn parse_materialized_row(
+        &self,
+        row: &[u8],
+        dim: usize,
+        scale: &[f32],
+        offset: &[f32],
+        store_norm: bool,
+    ) -> EncodedRowParts {
+        parse_residual_family_row(
+            row,
+            dim,
+            scale,
+            offset,
+            SQ8_FIXED_RESIDUAL_DIVISOR,
+            store_norm,
+        )
+    }
+
+    fn dequantize_row_into(
+        &self,
+        codes: &[u8],
+        residuals: &[u8],
+        _dim: usize,
+        scale: &[f32],
+        offset: &[f32],
+        out: &mut [f32],
+    ) {
+        dequantize_residual_family_into(
+            codes,
+            residuals,
+            scale,
+            offset,
+            SQ8_FIXED_RESIDUAL_DIVISOR,
+            out,
+        );
+    }
+
+    fn decoded_norm_sq(&self, code: &[u8], dim: usize, scale: &[f32], offset: &[f32]) -> f32 {
+        residual_family_norm_sq(code, dim, scale, offset, SQ8_FIXED_RESIDUAL_DIVISOR)
+    }
+
+    fn materialize_row_into_cluster_quant(
+        &self,
+        row: &EncodedCellRow,
+        dst_scale: &[f32],
+        dst_offset: &[f32],
+        dim: usize,
+        out: &mut [u8],
+        store_norm: bool,
+    ) -> Result<Option<f32>, BuildError> {
+        residual_family_materialize_into_cluster_quant(
+            row,
+            RerankCodec::Sq8FixedResidual,
+            dst_scale,
+            dst_offset,
+            dim,
+            out,
+            store_norm,
+        )
+    }
+
+    fn codec_meta_layout(
+        &self,
+        meta_off: usize,
+        n_cent: usize,
+        dim: usize,
+        metric: Metric,
+    ) -> CodecMetaLayout {
+        residual_family_codec_meta_layout(meta_off, n_cent, dim, metric)
+    }
+}
+
+impl RerankCodecOps for Sq16Ops {
+    fn parse_materialized_row(
+        &self,
+        row: &[u8],
+        dim: usize,
+        _scale: &[f32],
+        _offset: &[f32],
+        store_norm: bool,
+    ) -> EncodedRowParts {
+        // Single u16 plane (dim*2 bytes); no residual plane. Norm is computed
+        // against the fixed grid, matching the streaming builder byte-for-byte.
+        let codes = row[..dim * 2].to_vec();
+        let norm_sq = store_norm.then(|| sq16_decoded_norm_sq(&codes, dim));
+        EncodedRowParts {
+            codes,
+            residuals: Vec::new(),
+            norm_sq,
+        }
+    }
+
+    fn dequantize_row_into(
+        &self,
+        codes: &[u8],
+        _residuals: &[u8],
+        _dim: usize,
+        _scale: &[f32],
+        _offset: &[f32],
+        out: &mut [f32],
+    ) {
+        // Single u16 plane; residuals/scale/offset are unused (fixed grid).
+        dequantize_sq16_into(codes, out);
+    }
+
+    fn decoded_norm_sq(&self, code: &[u8], dim: usize, _scale: &[f32], _offset: &[f32]) -> f32 {
+        // Single u16 plane (dim*2 bytes); norm against the fixed grid.
+        sq16_decoded_norm_sq(&code[..dim * 2], dim)
+    }
+
+    fn materialize_row_into_cluster_quant(
+        &self,
+        row: &EncodedCellRow,
+        _dst_scale: &[f32],
+        _dst_offset: &[f32],
+        dim: usize,
+        out: &mut [u8],
+        store_norm: bool,
+    ) -> Result<Option<f32>, BuildError> {
+        if row.rerank_codec != RerankCodec::Sq16 {
+            return Err(BuildError::VectorSchemaMismatch(format!(
+                "cannot transcode Sq16 row from {} to {}",
+                row.rerank_codec.name(),
+                RerankCodec::Sq16.name()
+            )));
+        }
+        // Fixed `[-1, 1]` grid: the `u16` plane is portable across cluster
+        // changes, so a merge is a verbatim byte copy (no transcode ever).
+        out[..dim * 2].copy_from_slice(&row.codes);
+        Ok(store_norm.then(|| {
+            row.norm_sq
+                .unwrap_or_else(|| sq16_decoded_norm_sq(&row.codes, dim))
+        }))
+    }
+
+    fn codec_meta_layout(
+        &self,
+        meta_off: usize,
+        _n_cent: usize,
+        _dim: usize,
+        metric: Metric,
+    ) -> CodecMetaLayout {
+        // Fixed grid — no per-cluster scale/offset arrays. The only codec_meta
+        // is the per-doc dequantized-norm table (L2Sq/Cosine), which sits at
+        // the head of the region.
+        let norms_off = matches!(metric, Metric::L2Sq | Metric::Cosine).then_some(meta_off);
+        CodecMetaLayout {
+            scale_off: None,
+            offset_off: None,
+            norms_off,
+        }
+    }
+}
+
+impl RerankCodec {
+    /// Cold-path ops for the quantized-rerank family; `None` for `Fp32` /
+    /// `RabitqOnly` (no quantized rerank plane — they keep their own paths).
+    pub(crate) fn ops(&self) -> Option<&'static dyn RerankCodecOps> {
+        match self {
+            Self::Sq8Residual => Some(&Sq8ResidualOps),
+            Self::Sq8FixedResidual => Some(&Sq8FixedResidualOps),
+            Self::Sq16 => Some(&Sq16Ops),
+            Self::Fp32 | Self::RabitqOnly => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Default codec is `Sq8FixedResidual`. Any change here is a
+    /// Default codec is `Sq16` (the cosine default). Any change here is a
     /// load-bearing format choice — every caller that uses
     /// `RerankCodec::default()` silently follows this pick, so
     /// the test pins the contract.
     #[test]
-    fn default_is_sq8_fixed_residual() {
-        assert_eq!(RerankCodec::default(), RerankCodec::Sq8FixedResidual);
+    fn default_is_sq16() {
+        assert_eq!(RerankCodec::default(), RerankCodec::Sq16);
     }
 
     /// `Fp32`'s codec_id is zero. Older superfiles have all-zero
@@ -357,6 +865,7 @@ mod tests {
             RerankCodec::Fp32,
             RerankCodec::Sq8Residual,
             RerankCodec::Sq8FixedResidual,
+            RerankCodec::Sq16,
             RerankCodec::RabitqOnly,
         ] {
             assert_eq!(
@@ -373,7 +882,7 @@ mod tests {
     /// guessing.
     #[test]
     fn unknown_codec_id_is_none() {
-        for id in [4u8, 5, 16, 200, 255] {
+        for id in [5u8, 6, 16, 200, 255] {
             assert_eq!(
                 RerankCodec::from_codec_id(id),
                 None,
@@ -390,7 +899,24 @@ mod tests {
         assert_eq!(RerankCodec::Fp32.per_vector_bytes(384), 1536);
         assert_eq!(RerankCodec::Sq8Residual.per_vector_bytes(384), 768);
         assert_eq!(RerankCodec::Sq8FixedResidual.per_vector_bytes(384), 768);
+        assert_eq!(RerankCodec::Sq16.per_vector_bytes(384), 768);
         assert_eq!(RerankCodec::RabitqOnly.per_vector_bytes(384), 0);
+    }
+
+    /// Regression guard for the drain spill: the per-cell spill writer is
+    /// sized from the first materialized row's `codes` length, which is `dim`
+    /// for the residual family (u8 coarse plane) but `dim*2` for Sq16 (u16
+    /// plane). Assuming `codes.len() == dim` doubled the Sq16 spill dim and
+    /// tripped the row-shape check ("codes N vs expected dim 2N"). This pins
+    /// the inverse so a single-plane codec resolves back to its true `dim`.
+    #[test]
+    fn dim_from_codes_len_inverts_code_plane_size() {
+        let dim = 1024usize;
+        // Residual family: code plane is `dim` u8 bytes.
+        assert_eq!(RerankCodec::Sq8Residual.dim_from_codes_len(dim), dim);
+        assert_eq!(RerankCodec::Sq8FixedResidual.dim_from_codes_len(dim), dim);
+        // Sq16: code plane is `dim*2` bytes (u16), so dim is half the length.
+        assert_eq!(RerankCodec::Sq16.dim_from_codes_len(dim * 2), dim);
     }
 
     /// `writes_full` is the inverse of "this codec is
@@ -403,6 +929,7 @@ mod tests {
             RerankCodec::Fp32,
             RerankCodec::Sq8Residual,
             RerankCodec::Sq8FixedResidual,
+            RerankCodec::Sq16,
             RerankCodec::RabitqOnly,
         ] {
             assert_eq!(
@@ -419,6 +946,7 @@ mod tests {
         assert!(RerankCodec::Fp32.is_implemented());
         assert!(RerankCodec::Sq8Residual.is_implemented());
         assert!(RerankCodec::Sq8FixedResidual.is_implemented());
+        assert!(RerankCodec::Sq16.is_implemented());
         assert!(RerankCodec::RabitqOnly.is_implemented());
     }
 
@@ -442,6 +970,11 @@ mod tests {
             RerankCodec::Sq8FixedResidual.recommended_rerank_mult_floor(384),
             Some(50)
         );
+        // Sq16 tracks the Fp32 floor (it is near-lossless).
+        assert_eq!(
+            RerankCodec::Sq16.recommended_rerank_mult_floor(384),
+            Some(20)
+        );
         assert_eq!(
             RerankCodec::RabitqOnly.recommended_rerank_mult_floor(384),
             None
@@ -458,6 +991,10 @@ mod tests {
         assert_eq!(
             RerankCodec::Sq8FixedResidual.recommended_rerank_mult_floor(1024),
             Some(100)
+        );
+        assert_eq!(
+            RerankCodec::Sq16.recommended_rerank_mult_floor(1024),
+            Some(50)
         );
         assert_eq!(
             RerankCodec::RabitqOnly.recommended_rerank_mult_floor(1024),
@@ -481,12 +1018,14 @@ mod tests {
             RerankCodec::Sq8FixedResidual.to_string(),
             "sq8_fixed_residual"
         );
+        assert_eq!(RerankCodec::Sq16.to_string(), "sq16");
         assert_eq!(RerankCodec::RabitqOnly.to_string(), "rabitq_only");
         // `Display` must agree with `name` byte-for-byte.
         for c in [
             RerankCodec::Fp32,
             RerankCodec::Sq8Residual,
             RerankCodec::Sq8FixedResidual,
+            RerankCodec::Sq16,
             RerankCodec::RabitqOnly,
         ] {
             assert_eq!(c.to_string(), c.name());
@@ -546,5 +1085,42 @@ mod tests {
         );
         assert!(RerankCodec::Sq8FixedResidual.uses_fixed_quantizer());
         assert!(RerankCodec::Sq8FixedResidual.is_sq8_residual_family());
+    }
+
+    /// `Sq16` is the flat single-plane codec: cosine-only, no residual
+    /// divisor, `dim × 2` bytes per vector, and — unlike the residual
+    /// family — it carries **no** `codec_meta` (fixed grid, no per-doc
+    /// norms). It must also stay out of `is_sq8_residual_family()` so
+    /// the reader routes it to its own scoring path.
+    #[test]
+    fn sq16_contract_is_flat_cosine_only_norms_meta() {
+        assert!(RerankCodec::Sq16.supports_metric(Metric::Cosine));
+        assert!(!RerankCodec::Sq16.supports_metric(Metric::L2Sq));
+        assert!(!RerankCodec::Sq16.supports_metric(Metric::NegDot));
+        assert_eq!(RerankCodec::Sq16.residual_divisor(), None);
+        assert!(RerankCodec::Sq16.is_sq16());
+        assert!(!RerankCodec::Sq16.is_sq8_residual_family());
+        // Sq16 is a fixed `[-1, 1]` grid, semantically like
+        // Sq8FixedResidual, so callers see it as fixed-quantizer — but
+        // (unlike the residual family) it still carries no codec_meta,
+        // asserted below.
+        assert!(RerankCodec::Sq16.uses_fixed_quantizer());
+        assert!(RerankCodec::Sq16.writes_full());
+        assert_eq!(RerankCodec::Sq16.per_vector_bytes(1024), 1024 * 2);
+        // codec_meta = per-doc norms only (no scale/offset arrays):
+        // n_docs*4 for cosine/L2Sq, 0 for NegDot. Crucially it excludes
+        // the residual family's 2*n_cent*dim*4 array bytes.
+        assert_eq!(
+            RerankCodec::Sq16.codec_meta_bytes(384, 1_000_000, 1024, Metric::Cosine),
+            1_000_000 * 4
+        );
+        assert_eq!(
+            RerankCodec::Sq16.codec_meta_bytes(384, 1_000_000, 1024, Metric::L2Sq),
+            1_000_000 * 4
+        );
+        assert_eq!(
+            RerankCodec::Sq16.codec_meta_bytes(384, 1_000_000, 1024, Metric::NegDot),
+            0
+        );
     }
 }

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -142,6 +142,10 @@ pub enum RerankCodec {
     /// scale/offset arrays; its only `codec_meta` is the per-doc
     /// dequantized-norm table (`n_docs × 4` for cosine/L2Sq), matching
     /// the Sq8 family so the cosine kernel divides by `‖d̂‖`.
+    ///
+    /// Cosine-only: the fixed `[-1, 1]` grid assumes unit-normalized input and
+    /// clamps any out-of-range component, so callers must normalize (the engine
+    /// and bindings do not normalize on your behalf).
     Sq16,
     /// No rerank column at all. The 1-bit RaBitQ shortlist is
     /// the final ranking. Opt-in — recall drops 0.05–0.15 on
@@ -158,8 +162,11 @@ pub enum RerankCodec {
 impl Default for RerankCodec {
     /// `Sq16` is the cosine default — a single 16-bit plane on the fixed
     /// `[-1, 1]` grid: finer per-component precision than `Sq8FixedResidual`
-    /// at the same 2 bytes/dim, faster rerank, and recall provably ≥. Metric-
-    /// aware constructors retain local residual encoding (`Sq8Residual`) for
+    /// at the same 2 bytes/dim and faster rerank. The strictly finer grid gives
+    /// a provably ≤ per-component quantization error, so recall is ≥ in
+    /// expectation (and ≥ in the codec-isolated measurements) — not a strict
+    /// per-query guarantee, since ranking can flip on a near-tie. Metric-aware
+    /// constructors retain local residual encoding (`Sq8Residual`) for
     /// non-cosine metrics, whose values are not bounded to `[-1, 1]`.
     fn default() -> Self {
         Self::Sq16

--- a/src/superfile/vector/spill.rs
+++ b/src/superfile/vector/spill.rs
@@ -406,10 +406,11 @@ impl SpilledCellRows {
 }
 
 /// Byte length of one spilled row record for a `(dim, rabitq_len)` shape:
-/// the fixed prefix plus the RaBitQ code and the Sq8+epsilon `codes`/`residuals`
-/// legs (each `dim` bytes).
-fn record_bytes(dim: usize, rabitq_len: usize) -> usize {
-    ROW_SPILL_PREFIX_BYTES + rabitq_len + 2 * dim
+/// the fixed prefix plus the RaBitQ code and the codec's per-vector rerank body
+/// (`RerankCodec::per_vector_bytes(dim)` — `2·dim` for the residual family's
+/// `codes`/`residuals` legs).
+fn record_bytes(dim: usize, rabitq_len: usize, codec: RerankCodec) -> usize {
+    ROW_SPILL_PREFIX_BYTES + rabitq_len + codec.per_vector_bytes(dim)
 }
 
 /// Append-only spill for [`MaterializedIvfRow`]s of ONE cell, accumulated
@@ -495,7 +496,8 @@ impl MaterializedRowSpillWriter {
     ) -> Result<Self, BuildError> {
         let rows_path = dir.join(format!("cell-{cell}.rows"));
         let quants_path = dir.join(format!("cell-{cell}.quants"));
-        let rows_len = u64::from(state.n_rows) * record_bytes(state.dim, state.rabitq_len) as u64;
+        let rows_len = u64::from(state.n_rows)
+            * record_bytes(state.dim, state.rabitq_len, state.rerank_codec) as u64;
         let quants_len = u64::from(state.n_quants) * (2 * state.dim * size_of::<f32>()) as u64;
 
         let rows_file = OpenOptions::new().append(true).open(&rows_path)?;
@@ -530,17 +532,28 @@ impl MaterializedRowSpillWriter {
         } else {
             self.rerank_codec = Some(enc.rerank_codec);
         }
-        if enc.codes.len() != self.dim
-            || enc.residuals.len() != self.dim
-            || row.rabitq_code.len() != self.rabitq_len
-            || enc.scale.len() != self.dim
-            || enc.offset.len() != self.dim
-        {
+        // The residual family carries a two-plane body (`codes` + `residuals`,
+        // each `dim`) plus a per-cluster `dim`-length quantizer. Single-plane
+        // codecs (Sq16) carry only the `dim*2`-byte code plane on a fixed grid:
+        // no residual plane, no per-cluster quantizer sidecar.
+        let uses_cluster_quant = enc.rerank_codec.is_sq8_residual_family();
+        let shape_ok = if uses_cluster_quant {
+            enc.codes.len() == self.dim
+                && enc.residuals.len() == self.dim
+                && enc.scale.len() == self.dim
+                && enc.offset.len() == self.dim
+        } else {
+            enc.codes.len() == self.dim * 2
+                && enc.residuals.is_empty()
+                && enc.scale.is_empty()
+                && enc.offset.is_empty()
+        };
+        if !shape_ok || row.rabitq_code.len() != self.rabitq_len {
             return Err(BuildError::Io(Error::new(
                 ErrorKind::InvalidData,
                 format!(
                     "drain spill: row shape mismatch (codes {}, residuals {}, rabitq {}, \
-                     scale {}, offset {}) vs expected dim {} / rabitq {}",
+                     scale {}, offset {}) vs expected dim {} / rabitq {} / codec {}",
                     enc.codes.len(),
                     enc.residuals.len(),
                     row.rabitq_code.len(),
@@ -548,20 +561,27 @@ impl MaterializedRowSpillWriter {
                     enc.offset.len(),
                     self.dim,
                     self.rabitq_len,
+                    enc.rerank_codec.name(),
                 ),
             )));
         }
-        let ptr = Arc::as_ptr(&enc.scale) as *const () as usize;
-        let quant_idx = match self.quant_idx_by_ptr.get(&ptr) {
-            Some(&idx) => idx,
-            None => {
-                let idx = self.n_quants;
-                self.quants.write_all(cast_slice(enc.scale.as_ref()))?;
-                self.quants.write_all(cast_slice(enc.offset.as_ref()))?;
-                self.n_quants += 1;
-                self.quant_idx_by_ptr.insert(ptr, idx);
-                idx
+        let quant_idx = if uses_cluster_quant {
+            let ptr = Arc::as_ptr(&enc.scale) as *const () as usize;
+            match self.quant_idx_by_ptr.get(&ptr) {
+                Some(&idx) => idx,
+                None => {
+                    let idx = self.n_quants;
+                    self.quants.write_all(cast_slice(enc.scale.as_ref()))?;
+                    self.quants.write_all(cast_slice(enc.offset.as_ref()))?;
+                    self.n_quants += 1;
+                    self.quant_idx_by_ptr.insert(ptr, idx);
+                    idx
+                }
             }
+        } else {
+            // Single-plane codecs write no quantizer table; the index is a
+            // placeholder never consulted on read.
+            0
         };
         self.rows.write_all(&row.stable_id.to_le_bytes())?;
         self.rows.write_all(&row.cluster.to_le_bytes())?;
@@ -695,21 +715,35 @@ fn read_spilled_row(
         u32::from_le_bytes(prefix[20..24].try_into().expect("4-byte u32 slice")) as usize;
     let norm_flag = prefix[24];
     let norm = f32::from_le_bytes(prefix[25..29].try_into().expect("4-byte f32 slice"));
-    let (scale, offset) = quants.get(quant_idx).cloned().ok_or_else(|| {
-        BuildError::Io(Error::new(
-            ErrorKind::InvalidData,
-            format!(
-                "drain spill: quantizer index {quant_idx} out of range ({} entries)",
-                quants.len()
-            ),
-        ))
-    })?;
+    // Single-plane codecs (Sq16) carry no quantizer table; their scale/offset
+    // are empty and the parse below ignores them. The residual family looks up
+    // the per-cluster quantizer by the index stored in the row prefix.
+    let (scale, offset) = if rerank_codec.is_sq8_residual_family() {
+        quants.get(quant_idx).cloned().ok_or_else(|| {
+            BuildError::Io(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "drain spill: quantizer index {quant_idx} out of range ({} entries)",
+                    quants.len()
+                ),
+            ))
+        })?
+    } else {
+        let empty: Arc<[f32]> = Arc::from(Vec::new());
+        (empty.clone(), empty)
+    };
     let mut rabitq_code = vec![0u8; rabitq_len];
     reader.read_exact(&mut rabitq_code)?;
-    let mut codes = vec![0u8; dim];
-    reader.read_exact(&mut codes)?;
-    let mut residuals = vec![0u8; dim];
-    reader.read_exact(&mut residuals)?;
+    // The rerank body is stored as its already-encoded per-vector bytes; split
+    // it back into codes/residuals via the codec's ops. `store_norm = false`:
+    // the norm is carried explicitly in the row prefix, so the split must not
+    // recompute (and possibly diverge from) it.
+    let mut row_bytes = vec![0u8; rerank_codec.per_vector_bytes(dim)];
+    reader.read_exact(&mut row_bytes)?;
+    let parts = rerank_codec
+        .ops()
+        .expect("spilled row uses a quantized-rerank codec")
+        .parse_materialized_row(&row_bytes, dim, &scale, &offset, false);
     let norm_sq = (norm_flag == NORM_PRESENT).then_some(norm);
     Ok(MaterializedIvfRow {
         local_doc_id: 0,
@@ -721,8 +755,8 @@ fn read_spilled_row(
             rerank_codec,
             scale,
             offset,
-            codes,
-            residuals,
+            codes: parts.codes,
+            residuals: parts.residuals,
             norm_sq,
         },
     })

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -484,7 +484,7 @@ impl Supertable {
             let sq8_merge = first_vec.and_then(|v| {
                 v.vector_columns_config()
                     .next()
-                    .map(|c| c.rerank_codec.is_sq8_residual_family())
+                    .map(|c| c.rerank_codec.is_ivf_mergeable())
             });
             if multi_cell && sq8_merge == Some(true) {
                 SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1446,14 +1446,15 @@ fn build_vector_index_options(
         )));
     }
     let hidden_schema = Arc::new(arrow_schema::Schema::new(fields));
-    // Hidden maintenance reads residual-family rows without fp32
-    // reconstruction. Preserve a fixed/local residual user codec; non-residual
-    // user codecs retain the existing local-residual hidden representation.
+    // Hidden maintenance reads IVF-mergeable rows without fp32
+    // reconstruction. Preserve any IVF-mergeable user codec (the residual
+    // family and the single-plane Sq16); other user codecs retain the existing
+    // local-residual hidden representation.
     let hidden_vector_columns: Vec<VectorConfig> = user_opts
         .vector_columns
         .iter()
         .map(|vc| VectorConfig {
-            rerank_codec: if vc.rerank_codec.is_sq8_residual_family() {
+            rerank_codec: if vc.rerank_codec.is_ivf_mergeable() {
                 vc.rerank_codec
             } else {
                 RerankCodec::Sq8Residual

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -131,8 +131,14 @@ pub fn compute_options_hash(opts: &SupertableOptions, strategy: &PartitionStrate
         // Debug form — so the hash stays in lockstep.
         let metric_str = format!("{:?}", v.metric).to_lowercase();
         push_str(&mut buf, &metric_str);
-        push_tag(&mut buf, b"rerank_codec");
-        push_str(&mut buf, v.rerank_codec.name());
+        // rerank_codec is deliberately NOT part of the identity hash. The codec
+        // is data-determined: it is recorded on disk in every superfile's
+        // subsection directory (`codec_id`), and the reader dispatches on that,
+        // so the caller-supplied codec is not an identity input and the reader
+        // never trusts it over the on-disk value. Hashing it only manufactured a
+        // false `OptionsHashMismatch` when the engine default changed (e.g.
+        // Sq8FixedResidual -> Sq16) and a caller reopened an existing cosine
+        // table with config derived from the new default.
     }
 
     // 5. partition_strategy.
@@ -579,7 +585,7 @@ mod tests {
     }
 
     #[test]
-    fn compute_options_hash_distinguishes_every_rerank_codec() {
+    fn compute_options_hash_ignores_rerank_codec() {
         let mk = |rerank_codec: RerankCodec| {
             SupertableOptions::new(
                 schema_title_emb(16),
@@ -596,24 +602,21 @@ mod tests {
             )
             .expect("opts")
         };
-        let residual = compute_options_hash(&mk(RerankCodec::Sq8Residual), &time_range());
-        let fp32 = compute_options_hash(&mk(RerankCodec::Fp32), &time_range());
-        let fixed = compute_options_hash(&mk(RerankCodec::Sq8FixedResidual), &time_range());
-        let sq16 = compute_options_hash(&mk(RerankCodec::Sq16), &time_range());
-        assert_ne!(residual.0, fp32.0);
-        assert_ne!(
-            residual.0, fixed.0,
-            "fixed residual must not reopen with local residual write options"
-        );
-        // Sq16 is a distinct on-disk format — it must not collide with
-        // any other codec's options hash (else a table would reopen with
-        // the wrong reader layout).
-        for (other, label) in [
-            (residual.0, "sq8_residual"),
-            (fp32.0, "fp32"),
-            (fixed.0, "sq8_fixed_residual"),
+        // rerank_codec is data-determined (on-disk `codec_id`, dispatched by the
+        // reader), not an identity input — changing only the codec must NOT move
+        // the hash, so a default flip cannot break reopening an existing table.
+        let base = compute_options_hash(&mk(RerankCodec::Sq8FixedResidual), &time_range());
+        for codec in [
+            RerankCodec::Sq16,
+            RerankCodec::Sq8Residual,
+            RerankCodec::Fp32,
+            RerankCodec::RabitqOnly,
         ] {
-            assert_ne!(sq16.0, other, "sq16 options hash collides with {label}");
+            assert_eq!(
+                compute_options_hash(&mk(codec), &time_range()).0,
+                base.0,
+                "options hash must not depend on rerank_codec ({codec:?})"
+            );
         }
     }
 

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -599,11 +599,22 @@ mod tests {
         let residual = compute_options_hash(&mk(RerankCodec::Sq8Residual), &time_range());
         let fp32 = compute_options_hash(&mk(RerankCodec::Fp32), &time_range());
         let fixed = compute_options_hash(&mk(RerankCodec::Sq8FixedResidual), &time_range());
+        let sq16 = compute_options_hash(&mk(RerankCodec::Sq16), &time_range());
         assert_ne!(residual.0, fp32.0);
         assert_ne!(
             residual.0, fixed.0,
             "fixed residual must not reopen with local residual write options"
         );
+        // Sq16 is a distinct on-disk format — it must not collide with
+        // any other codec's options hash (else a table would reopen with
+        // the wrong reader layout).
+        for (other, label) in [
+            (residual.0, "sq8_residual"),
+            (fp32.0, "fp32"),
+            (fixed.0, "sq8_fixed_residual"),
+        ] {
+            assert_ne!(sq16.0, other, "sq16 options hash collides with {label}");
+        }
     }
 
     // ---- PartitionStrategy variants ------------------------------------

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -38,10 +38,7 @@ use std::{
 use crate::{
     config,
     superfile::vector::{
-        cell_posting::{
-            EncodedCellRow, MaterializedIvfRow, dequantize_sq8_residual_into,
-            manifest_centroid_components_from_row,
-        },
+        cell_posting::{EncodedCellRow, MaterializedIvfRow, manifest_centroid_components_from_row},
         distance::{
             Metric, distance, nearest_k_centroids_bytes, nearest_k_centroids_transposed, normalize,
             relative_score_window,
@@ -330,16 +327,18 @@ fn dequantize_row(row: &EncodedCellRow, dim: usize) -> Vec<f32> {
 /// [`dequantize_row`] into a caller-owned scratch (hot loops reuse one
 /// allocation). The scratch length is the row's `dim`.
 fn dequantize_row_into(row: &EncodedCellRow, out: &mut [f32]) {
-    dequantize_sq8_residual_into(
-        &row.scale,
-        &row.offset,
-        &row.codes,
-        &row.residuals,
-        row.rerank_codec
-            .residual_divisor()
-            .expect("encoded row uses residual-family codec"),
-        out,
-    );
+    let dim = out.len();
+    row.rerank_codec
+        .ops()
+        .expect("encoded row uses a quantized-rerank codec")
+        .dequantize_row_into(
+            &row.codes,
+            &row.residuals,
+            dim,
+            &row.scale,
+            &row.offset,
+            out,
+        );
 }
 
 /// Ashman D of a two-means partition, measured on the 1-D projection onto the

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -108,12 +108,11 @@ pub(crate) fn verify_superfile_vector_codecs(
         QueryError::Execute("superfile is missing configured vector index".into())
     })?;
     for config in expected {
-        let expected_codec =
-            if vector.is_multi_cell() && !config.rerank_codec.is_sq8_residual_family() {
-                RerankCodec::Sq8Residual
-            } else {
-                config.rerank_codec
-            };
+        let expected_codec = if vector.is_multi_cell() && !config.rerank_codec.is_ivf_mergeable() {
+            RerankCodec::Sq8Residual
+        } else {
+            config.rerank_codec
+        };
         let mut matched = false;
         for column in vector
             .vector_columns_config()

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -2726,7 +2726,9 @@ fn spill_row_to_cell(
         Entry::Vacant(entry) => entry.insert(MaterializedRowSpillWriter::create(
             scratch,
             cell,
-            row.encoded.codes.len(),
+            row.encoded
+                .rerank_codec
+                .dim_from_codes_len(row.encoded.codes.len()),
             row.rabitq_code.len(),
         )?),
     };
@@ -4820,7 +4822,7 @@ fn assign_cells<'a>(
 fn drain_cell_vector_config(cfg: &VectorConfig, n_rows: usize) -> (VectorConfig, usize) {
     debug_assert!(n_rows > 0);
     let dim = cfg.dim;
-    let rerank_codec = if cfg.rerank_codec.is_sq8_residual_family() {
+    let rerank_codec = if cfg.rerank_codec.is_ivf_mergeable() {
         cfg.rerank_codec
     } else {
         RerankCodec::Sq8Residual


### PR DESCRIPTION
Closes #518

## Summary

Make **`Sq16`** the default cosine rerank codec, replacing `Sq8FixedResidual` (coarse u8 + i8 residual). `Sq16` is a single uniform 16-bit plane on the fixed `[-1, 1]` cosine grid — the same 2 bytes/dim, but a finer quantization step, scored in a single pass, with no per-cluster scale/offset arrays.

## Why

- **Recall ≥ (finer grid; shown codec-isolated below).** The u16 grid step (`2/65535`) is finer than the coarse+residual effective step (`2/65280`), so per-component quantization error is provably ≤ — the dequantized vector is at least as close to the original. Recall is a *ranking* metric and isn't strictly monotonic in per-vector error (a near-tie can still flip), so this is an *expected* ≥ rather than a per-query guarantee; the codec-isolated measurement below confirms Sq16 ≥ Sq8+8 with the grid held constant.
- **Faster rerank.** One widen pass over a single plane instead of scoring two planes per candidate (see the kernel microbench below).
- **Simpler + leaner on disk.** No coarse/residual split and no per-cluster quantizer sidecar; the only `codec_meta` is the per-doc dequantized-norm table (cosine/L2Sq), matching the existing family so the cosine kernel still divides by `‖d̂‖`.

## Evidence — A/B vs `Sq8FixedResidual` (`supertable vector`)

Recall@10 vs brute-force fp32 truth. Warm/cold are the post-drain hidden index. Two ISAs (ARM, x86); Δ is Sq16 vs Sq8+8.

**100k × dim=1024, cosine**

| metric | ARM Sq16 | ARM Sq8+8 | ARM Δ | x86 Sq16 | x86 Sq8+8 | x86 Δ |
|---|---|---|---|---|---|---|
| recall — pre-drain | 1.000 | 0.999 | ≥ | 1.000 | 0.999 | ≥ |
| recall — post-drain | 1.000 | 0.999 | ≥ | 0.980 | 0.989 | −0.9%\* |
| warm p50 | 427 µs | 538 µs | −21% | 551 µs | 894 µs | −38% |
| warm p99 | 508 µs | 652 µs | −22% | 584 µs | 1070 µs | −45% |
| cold search | 6.05 ms | 6.02 ms | par | 11.8 ms | 10.2 ms | +16%\* |
| ingest | 67.0 s | 67.3 s | par | 31.9 s | 38.3 s | −17% |
| stored | 279 MiB (72%) | 342 MiB (88%) | −18% | 279 MiB (71%) | 342 MiB (87%) | −18% |
| drain assign+spill | 314 ms | 392 ms | −20% | 446 ms | 506 ms | −12% |
| drain total | 6.34 s | 6.49 s | −2% | 7.77 s | 8.54 s | −9% |

**1M × dim=1024, cosine**

| metric | ARM Sq16 | ARM Sq8+8 | ARM Δ | x86 Sq16 | x86 Sq8+8 | x86 Δ |
|---|---|---|---|---|---|---|
| recall — pre-drain | 0.996 | 0.995 | ≥ | 0.996 | 0.995 | ≥ |
| recall — post-drain | 0.996 | 0.995 | ≥ | 0.996 | 0.995 | ≥ |
| warm p50 | 708 µs | 732 µs | −3% ‡ | 1.03 ms | 1.17 ms | −12% |
| warm p99 | 983 µs | 915 µs | +7% ‡ | 1.13 ms | 1.35 ms | −16% |
| cold search | 20.5 ms | 20.4 ms | par | 40.0 ms | 38.7 ms | par |
| ingest | 84.3 s | 80.4 s | +5% ‡ | 63.1 s | 63.1 s | par |
| stored | 2.14 GiB (56%) | 2.20 GiB (58%) | −3% | 2.15 GiB (56%) | 2.21 GiB (58%) | −3% |
| drain assign+spill | 4108 ms | 3022 ms | +36% ‡ | 4019 ms | 4124 ms | −3% |
| drain total | 40.4 s | 27.5 s | +47% ‡ | 68.0 s | 65.8 s | +3% |

**10M × dim=1024, cosine (x86 only)**

| metric | Sq16 | Sq8+8 | Δ |
|---|---|---|---|
| recall — pre-drain | 0.998 | 0.997 | ≥ |
| recall — post-drain | 0.998 | 0.986 | **+0.012** |
| warm p50 | 1.68 ms | 1.76 ms | −5% |
| warm p99 | 2.06 ms | 2.39 ms | −14% |
| cold search | 198 ms | 177 ms | +12% ‡ |
| ingest | 568 s | 542 s | +5% ‡ |
| stored | 20.67 GiB (54%) | 20.78 GiB (54%) | par |
| drain assign+spill | 90.0 s | 111.4 s | −19% |
| drain total | 913 s | 930 s | −2% |

- **Recall ≥ Sq8+8 at scale** — 1M 0.996 vs 0.995 (both ISAs), 10M 0.998 vs 0.986 (x86); the codec-isolated measurement below confirms it with the grid held constant.
- **Grid-driven variance is pre-existing and codec-independent** (`*`, `‡`). The IVF grid is trained per run by k-means over the parallel-writer bootstrap, so two independent builds land different cell boundaries. Cell routing doesn't depend on the rerank codec, so this variance is orthogonal to the codec — and it moves *every* end-to-end axis, not just recall: a single point can tip recall a few thousandths either way (x86 100k 0.980 vs 0.989, inverted from ARM's 1.000 vs 0.999), and at 1M ARM the two runs drew different oversized cells (`‡`), swinging warm-p99 / ingest / drain. Measured run-to-run spread (0.0008–0.0025) exceeds every between-codec gap (≤0.0003). So the per-point end-to-end latency/recall deltas are **not** clean codec signals — the clean ones are the codec-isolated recall and the kernel microbench below.
- **Storage** is ~18% smaller stored at 100k, narrows to ~3% at 1M, and is **parity at 10M** (54% vs 54%; same raw 2 B/dim) — a small-corpus compression effect that vanishes at scale, not headlined.

## Codec-isolated recall (grid + routing held constant)

To isolate the codec from the grid variance above, we measured recall with the same built grid and the same routing, swapping only the rerank plane — so any delta is the codec alone:

| measurement (cosine, k=10) | Sq8+8 | Sq16 |
|---|---|---|
| Codec-isolated recall@10, Cohere-1M (same grid, swap rerank plane) | 0.99933 | **0.99967 (+0.00033)** |
| Kernel bisection, real embeddings, no IVF routing/shortlist (rerank vs exact fp32) | 0.9993 | **0.9997** |

Both are deterministic and bit-identical on x86 and ARM. With the grid confound removed, Sq16 ≥ Sq8+8 (the `+0.00033` is one extra correct neighbor in 3000). The no-norm Sq16 variant ties Sq8+8 at 0.9993, and the per-doc norm correction is what lifts it to 0.9997 — consistent with the strictly-finer u16 grid (provably ≤ per-component error).

**Kernel microbench — routing-free per-candidate rerank cost** (`Sq16 / Sq8+8` ratio, norm-on both):

| platform | ISA (µarch) | Sq16 speedup |
|---|---|---|
| Apple M4 | ARM / NEON | ~37% |
| Graviton3 | ARM server / Neoverse-V1 | ~22–23% |
| x86 (`D16ds_v7`) | x86 / AVX | ~6–9% |

Sq16 is faster on every platform — one u16 widen leg vs Sq8+8's two planes. The kernel is widen/bandwidth-bound, so the win is largest on element-bound ARM/NEON and modest on x86's wide 8-bit SIMD. This is the clean codec-latency signal; the end-to-end warm deltas in the tables carry grid variance on top (above), so they are not headlined.

## Trade-offs — what `Sq16` gives up (both immaterial for the supported targets)

1. **A coarse-only cascade fast path.** The u8 coarse plane could in principle be ranked alone with the residual consulted only on ties. Moot: coarse-alone recall is far below the residual-scored result, which is why the residual is scored on every candidate anyway.
2. **8-bit-only hardware.** On an int8-only target, u8 primitives could beat u16. Moot for the supported x86/ARM targets, which widen to f32 efficiently and where `Sq16` measured faster.

## Scope

Codec + kernel, single-plane handling through the full index lifecycle (build, drain, IVF merge, compaction, per-cell spill), the multi-cell directory reader, and the default flip. Non-cosine metrics keep locally-fitted `Sq8Residual`.

## Notes

- **Reopen compatibility (fixed).** The rerank codec was part of the table options-hash, so flipping the default made an existing cosine table recompute a different hash than the one stamped at create and fail to open — despite fully readable bytes. This PR drops the codec from the options-hash: it was redundant identity, because the codec is data-determined (each superfile records its `codec_id` on disk and the reader dispatches decode on that, never on the caller-supplied codec), so hashing it guarded nothing while manufacturing a false `OptionsHashMismatch` on the flip. Identity now depends only on the fields that must match to read a table (column, dim, rot_seed, metric, partition strategy). There is no persisted cosine table to preserve, so no migration is needed; the commit message records the alternatives (persist in manifest / recover from `codec_id` on mismatch / bypass-validation flag) and why none cleanly supports a pre-existing table.
