### PR TITLE
superfile: stream build/compaction output to scratch to bound peak memory

### DIFF
--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -88,7 +88,7 @@ use crate::superfile::{
     BuildError, SuperfileReader,
     format::{
         self,
-        footer::{encode_parquet_body, splice_index_blobs, splice_index_streams_to},
+        footer::{ParquetLayout, encode_parquet_body, splice_index_streams_to},
         kv,
     },
     fts::{
@@ -1193,9 +1193,28 @@ impl SuperfileBuilder {
     /// If no `add_batch` calls have landed any rows, returns an
     /// empty `Vec<u8>` — there's no Parquet body to write and no
     /// FTS/vector blobs to embed.
-    pub fn finish(mut self) -> Result<Vec<u8>, BuildError> {
+    /// Finish the build, streaming the assembled superfile to `output`.
+    ///
+    /// Streaming counterpart of [`finish`](Self::finish): produces
+    /// byte-identical superfile bytes but writes them to an arbitrary
+    /// [`Write`] sink (e.g. a temp file) instead of returning a `Vec<u8>`,
+    /// so the caller never holds the whole superfile in RAM. Returns the
+    /// [`ParquetLayout`] (total size + blob offsets/lengths) so the caller
+    /// can build manifest metadata without re-parsing the output.
+    ///
+    /// The scalar Parquet body and the FTS/vector blobs are still assembled
+    /// in memory (each smaller than the whole superfile); only the final
+    /// splice — the largest resident value in [`finish`] — is streamed, so
+    /// the combined superfile is never materialized.
+    pub(crate) fn finish_to<W: Write>(mut self, output: W) -> Result<ParquetLayout, BuildError> {
         if self.next_local_doc_id == 0 {
-            return Ok(Vec::new());
+            return Ok(ParquetLayout {
+                total_size: 0,
+                fts_offset: 0,
+                fts_length: 0,
+                vec_offset: 0,
+                vec_length: 0,
+            });
         }
         let n_docs = self.next_local_doc_id as u64;
 
@@ -1263,8 +1282,27 @@ impl SuperfileBuilder {
             (body, fts_blob, vec_blob)
         };
 
-        let parts = splice_index_blobs(body, &fts_blob, &vec_blob, &kvs)?;
-        Ok(parts.bytes)
+        let layout = splice_index_streams_to(
+            body,
+            Cursor::new(fts_blob.as_slice()),
+            fts_blob.len() as u64,
+            Cursor::new(vec_blob.as_slice()),
+            vec_blob.len() as u64,
+            &kvs,
+            output,
+        )?;
+        Ok(layout)
+    }
+
+    /// Finish the build and return the assembled superfile bytes.
+    ///
+    /// Thin wrapper over [`finish_to`](Self::finish_to) that collects the
+    /// stream into a `Vec<u8>`. Prefer `finish_to` on the large-build path
+    /// (commit / compaction) so the whole superfile is never held in RAM.
+    pub fn finish(self) -> Result<Vec<u8>, BuildError> {
+        let mut buf = Vec::new();
+        self.finish_to(&mut buf)?;
+        Ok(buf)
     }
 
     /// Consume an ids-only builder and stream one packed MultiCellIvf

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -81,7 +81,7 @@ use arrow_array::{Array, ArrayRef, Decimal128Array, LargeStringArray, RecordBatc
 use arrow_schema::{DataType, Schema};
 use parquet::basic::{Compression, ZstdLevel};
 use roaring::RoaringBitmap;
-use tempfile::tempfile;
+use tempfile::{NamedTempFile, tempfile};
 
 pub use crate::superfile::vector::builder::VectorConfig;
 use crate::superfile::{
@@ -1300,35 +1300,56 @@ impl SuperfileBuilder {
         let has_vector = vec_builder.is_some()
             || cell_posting_builder.is_some()
             || prebuilt_multi_cell.is_some();
-        let (body, fts_blob, vec_blob) = if has_vector {
-            let (fts_blob, vec_blob) = finish_index_blobs(
+
+        // Stream the FTS and vector blobs to scratch temp files instead of
+        // materializing them as `Vec<u8>`. At corpus scale the positional FTS
+        // blob is multi-GB; holding it, the vector blob, the Parquet body, and
+        // the buffered input all at once is what OOMs a memory-tight build. The
+        // splice below streams the body + on-disk blobs to `output`, so no full
+        // blob is ever resident. `reopen()` gives an independent handle at
+        // offset 0, so the write handle and the later read handle don't share a
+        // cursor.
+        let fts_file = NamedTempFile::new().map_err(BuildError::Io)?;
+        let vec_file = NamedTempFile::new().map_err(BuildError::Io)?;
+        let fts_write = fts_file.reopen().map_err(BuildError::Io)?;
+        let vec_write = vec_file.reopen().map_err(BuildError::Io)?;
+        let stream_blobs = move || -> Result<(), BuildError> {
+            let mut fw = BufWriter::new(fts_write);
+            let mut vw = BufWriter::new(vec_write);
+            finish_index_blobs_streamed(
                 fts_builder,
                 vec_builder,
                 cell_posting_builder,
                 prebuilt_multi_cell,
+                &mut fw,
+                &mut vw,
             )?;
-            let body = encode_body()?;
-            (body, fts_blob, vec_blob)
-        } else {
-            let (body_res, blobs_res) = rayon::join(encode_body, || {
-                finish_index_blobs(
-                    fts_builder,
-                    vec_builder,
-                    cell_posting_builder,
-                    prebuilt_multi_cell,
-                )
-            });
-            let body = body_res?;
-            let (fts_blob, vec_blob) = blobs_res?;
-            (body, fts_blob, vec_blob)
+            fw.flush().map_err(BuildError::Io)?;
+            vw.flush().map_err(BuildError::Io)?;
+            Ok(())
         };
 
+        // Same overlap policy as before: with a vector index present, finalize
+        // blobs first (the vector finalizer already saturates the pool), then
+        // encode the body; otherwise hide the body encode behind the blob
+        // finish.
+        let body = if has_vector {
+            stream_blobs()?;
+            encode_body()?
+        } else {
+            let (body_res, blobs_res) = rayon::join(encode_body, stream_blobs);
+            blobs_res?;
+            body_res?
+        };
+
+        let fts_length = fts_file.as_file().metadata().map_err(BuildError::Io)?.len();
+        let vec_length = vec_file.as_file().metadata().map_err(BuildError::Io)?.len();
         let layout = splice_index_streams_to(
             body,
-            Cursor::new(fts_blob.as_slice()),
-            fts_blob.len() as u64,
-            Cursor::new(vec_blob.as_slice()),
-            vec_blob.len() as u64,
+            BufReader::new(fts_file.reopen().map_err(BuildError::Io)?),
+            fts_length,
+            BufReader::new(vec_file.reopen().map_err(BuildError::Io)?),
+            vec_length,
             &kvs,
             output,
         )?;
@@ -1558,42 +1579,56 @@ fn scalar_batch_in_stable_id_order(
     })
 }
 
-/// Finish the independent embedded index blobs. Once `add_batch` has
-/// routed scalar text and vectors into their builders, FTS and vector
-/// finalization do not share mutable state, so build them as sibling
-/// rayon jobs when both indexes are present.
-fn finish_index_blobs(
+/// Streaming counterpart of [`finish_index_blobs`]: writes the FTS blob to
+/// `fts_out` and the vector blob to `vec_out` instead of returning them as
+/// `Vec<u8>`, so the corpus-sized positional FTS blob (and the vector blob)
+/// never materialize whole in RAM. Same builder-combination semantics; the
+/// `FtsBuilder`/`VectorBuilder` finalizers already stream through a
+/// `Write` sink (spilling to their own scratch when a column overflowed).
+fn finish_index_blobs_streamed<Wf: Write + Send, Wv: Write + Send>(
     fts_builder: Option<FtsBuilder>,
     vec_builder: Option<VectorBuilder>,
     cell_posting_builder: Option<CellPostingBuilder>,
     prebuilt_multi_cell: Option<Vec<(u32, MergedIvfSubsection)>>,
-) -> Result<(Vec<u8>, Vec<u8>), BuildError> {
-    let vec_blob = if let Some(cells) = prebuilt_multi_cell {
-        crate::superfile::vector::builder::finish_multi_cell_blob(&cells)?
-    } else {
-        Vec::new()
-    };
-    match (
-        fts_builder,
-        vec_builder,
-        cell_posting_builder,
-        vec_blob.is_empty(),
-    ) {
-        (Some(fb), Some(vb), None, true) => {
-            let (fts, vec) = rayon::join(|| fb.finish(), || vb.finish());
-            Ok((fts?, vec?))
+    fts_out: &mut Wf,
+    vec_out: &mut Wv,
+) -> Result<(), BuildError> {
+    if let Some(cells) = prebuilt_multi_cell {
+        if vec_builder.is_some() || cell_posting_builder.is_some() {
+            return Err(BuildError::VectorSchemaMismatch(
+                "mixed ivf, cell_posting, and multi-cell builders".into(),
+            ));
         }
-        (Some(fb), None, Some(cb), true) => Ok((fb.finish()?, cb.finish()?)),
-        (Some(fb), None, None, true) => Ok((fb.finish()?, Vec::new())),
-        (None, Some(vb), None, true) => Ok((Vec::new(), vb.finish()?)),
-        (None, None, Some(cb), true) => Ok((Vec::new(), cb.finish()?)),
-        (None, None, None, true) => Ok((Vec::new(), Vec::new())),
-        (Some(fb), None, None, false) => Ok((fb.finish()?, vec_blob)),
-        (None, None, None, false) => Ok((Vec::new(), vec_blob)),
-        _ => Err(BuildError::VectorSchemaMismatch(
-            "mixed ivf, cell_posting, and multi-cell builders".into(),
-        )),
+        let vec_blob = crate::superfile::vector::builder::finish_multi_cell_blob(&cells)?;
+        vec_out.write_all(&vec_blob).map_err(BuildError::Io)?;
+        if let Some(fb) = fts_builder {
+            fb.finish_to(fts_out)?;
+        }
+        return Ok(());
     }
+    match (fts_builder, vec_builder, cell_posting_builder) {
+        (Some(fb), Some(vb), None) => {
+            // Disjoint sinks, so the two finalizers can run concurrently.
+            let (fts_res, vec_res) =
+                rayon::join(|| fb.finish_to(fts_out), || vb.finish_to(vec_out));
+            fts_res?;
+            vec_res?;
+        }
+        (Some(fb), None, Some(cb)) => {
+            fb.finish_to(fts_out)?;
+            vec_out.write_all(&cb.finish()?).map_err(BuildError::Io)?;
+        }
+        (Some(fb), None, None) => fb.finish_to(fts_out)?,
+        (None, Some(vb), None) => vb.finish_to(vec_out)?,
+        (None, None, Some(cb)) => vec_out.write_all(&cb.finish()?).map_err(BuildError::Io)?,
+        (None, None, None) => {}
+        _ => {
+            return Err(BuildError::VectorSchemaMismatch(
+                "mixed ivf, cell_posting, and multi-cell builders".into(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Reject user-supplied column names that would collide with

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -1171,6 +1171,20 @@ impl SuperfileBuilder {
     pub fn build_from_readers(
         readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
     ) -> Result<(Vec<u8>, SuperfileStats), BuildError> {
+        let mut buf = Vec::new();
+        let stats = Self::build_from_readers_to(readers, &mut buf)?;
+        Ok((buf, stats))
+    }
+
+    /// Streaming counterpart of [`build_from_readers`](Self::build_from_readers):
+    /// merges the readers and writes the assembled superfile to `output`
+    /// instead of returning a `Vec<u8>`, so the compaction caller can stream
+    /// to a temp file and never hold the merged superfile in RAM. Returns the
+    /// merged [`SuperfileStats`].
+    pub(crate) fn build_from_readers_to<W: Write>(
+        readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
+        output: W,
+    ) -> Result<SuperfileStats, BuildError> {
         let first = readers.first().ok_or(BuildError::BatchReadError)?;
 
         let builder_opts = BuilderOptions::new_from_reader(&first.0);
@@ -1182,10 +1196,8 @@ impl SuperfileBuilder {
             stats_collector.push(stats);
         }
 
-        let bytes = superfile_builder.finish()?;
-        let stats = SuperfileStats::from_children(stats_collector.as_slice());
-
-        Ok((bytes, stats))
+        superfile_builder.finish_to(output)?;
+        Ok(SuperfileStats::from_children(stats_collector.as_slice()))
     }
 
     /// Consume the builder and emit one self-contained superfile.

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -790,6 +790,19 @@ impl SuperfileBuilder {
     pub fn build_from_sq8_ivf_readers(
         readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
     ) -> Result<(Vec<u8>, SuperfileStats), BuildError> {
+        let mut buf = Vec::new();
+        let stats = Self::build_from_sq8_ivf_readers_to(readers, &mut buf)?;
+        Ok((buf, stats))
+    }
+
+    /// Streaming counterpart of
+    /// [`build_from_sq8_ivf_readers`](Self::build_from_sq8_ivf_readers): writes
+    /// the merged superfile to `output` instead of returning a `Vec<u8>`, so
+    /// the compaction caller can stream to a temp file.
+    pub(crate) fn build_from_sq8_ivf_readers_to<W: Write>(
+        readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
+        output: W,
+    ) -> Result<SuperfileStats, BuildError> {
         let first = readers.first().ok_or(BuildError::BatchReadError)?;
         let builder_opts = BuilderOptions::new_from_reader(&first.0);
         let mut superfile_builder = SuperfileBuilder::new(builder_opts)?;
@@ -837,9 +850,8 @@ impl SuperfileBuilder {
         let merged_sub = merge_sq8_ivf_subsections(&merge_refs)?;
         superfile_builder.set_prebuilt_ivf_subsection(0, merged_sub)?;
 
-        let bytes = superfile_builder.finish()?;
-        let stats = SuperfileStats::from_children(stats_collector.as_slice());
-        Ok((bytes, stats))
+        superfile_builder.finish_to(output)?;
+        Ok(SuperfileStats::from_children(stats_collector.as_slice()))
     }
 
     /// Merge multi-cell (v2) Sq8 IVF superfiles **per global cell id**, then
@@ -852,6 +864,23 @@ impl SuperfileBuilder {
         readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
         superseded_per_reader: &[BTreeSet<u32>],
     ) -> Result<(Vec<u8>, SuperfileStats), BuildError> {
+        let mut buf = Vec::new();
+        let stats = Self::build_from_multi_cell_sq8_ivf_readers_to(
+            readers,
+            superseded_per_reader,
+            &mut buf,
+        )?;
+        Ok((buf, stats))
+    }
+
+    /// Streaming counterpart of
+    /// [`build_from_multi_cell_sq8_ivf_readers`](Self::build_from_multi_cell_sq8_ivf_readers):
+    /// writes the merged superfile to `output` instead of returning a `Vec<u8>`.
+    pub(crate) fn build_from_multi_cell_sq8_ivf_readers_to<W: Write>(
+        readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
+        superseded_per_reader: &[BTreeSet<u32>],
+        output: W,
+    ) -> Result<SuperfileStats, BuildError> {
         let first = readers.first().ok_or(BuildError::BatchReadError)?;
         let builder_opts = BuilderOptions::new_from_reader(&first.0);
         if builder_opts.vector_layout != VectorLayout::MultiCellIvf {
@@ -1044,7 +1073,7 @@ impl SuperfileBuilder {
             // flows through `prepare_superfile` -> None -> NoDocsToBuild and the
             // compaction caller reclaims the dead inputs (removes them, writes no
             // replacement), instead of a hard schema error.
-            return Ok((Vec::new(), SuperfileStats::from_children(&[])));
+            return Ok(SuperfileStats::from_children(&[]));
         }
 
         // Parquet rows must follow the same cell-directory order as the packed
@@ -1059,7 +1088,7 @@ impl SuperfileBuilder {
         )?;
         superfile_builder.add_batch_ids_only(&scalar_batch)?;
         superfile_builder.set_prebuilt_multi_cell_ivfs(packed_cells)?;
-        let bytes = superfile_builder.finish()?;
+        superfile_builder.finish_to(output)?;
         let mut stats = SuperfileStats::from_children(stats_collector.as_slice());
         if scalar_schema.fields().len() == 1 {
             // Hidden id-only index: the merged doc set is exactly `all_stable_ids`
@@ -1071,7 +1100,7 @@ impl SuperfileBuilder {
             stats.id_min = all_stable_ids.iter().copied().min().unwrap_or(0);
             stats.id_max = all_stable_ids.iter().copied().max().unwrap_or(0);
         }
-        Ok((bytes, stats))
+        Ok(stats)
     }
 
     /// Add all data (Parquet + fts + vectors) from another [`SuperfileReader`] to this builder.

--- a/src/superfile/format/footer.rs
+++ b/src/superfile/format/footer.rs
@@ -25,7 +25,7 @@
 
 use std::{
     collections::HashMap,
-    io::{self, Cursor, Read, Write},
+    io::{self, BufReader, Cursor, Read, Seek, SeekFrom, Write},
     sync::Arc,
 };
 
@@ -44,6 +44,7 @@ use parquet::{
     },
     schema::types::ColumnPath,
 };
+use tempfile::NamedTempFile;
 
 use crate::superfile::{LazyByteSource, LazyByteSourceError, format::kv};
 
@@ -135,9 +136,13 @@ pub enum FooterError {
 /// holds everything that the CPU-bound column encode produced, ready for
 /// the cheap blob splice + footer rewrite.
 pub struct EncodedBody {
-    /// Parquet bytes truncated to the end of the last row group (footer
-    /// removed) — blobs and the rewritten footer get appended here.
-    buf: Vec<u8>,
+    /// Parquet body written to a scratch temp file and truncated to the end of
+    /// the last row group (footer removed). Streamed into the superfile at
+    /// splice time so the body — multi-GB at corpus scale — never materializes
+    /// as a whole `Vec`. Blobs and the rewritten footer get appended after it.
+    body_file: NamedTempFile,
+    /// Byte length of the footer-stripped body in `body_file`.
+    body_len: u64,
     /// Footer metadata decoded from the original write, carried through
     /// to the rewrite so row groups + column/offset indexes survive.
     metadata: ParquetMetaData,
@@ -171,40 +176,57 @@ pub fn encode_parquet_body(
             .set_column_data_page_size_limit(ColumnPath::from((*col).to_string()), *limit);
     }
     let props = props_builder.build();
-    let mut buf: Vec<u8> = Vec::new();
+
+    // Encode the Parquet body to a scratch temp file rather than a `Vec`, so
+    // the body — multi-GB at corpus scale — never materializes whole in RAM.
+    // The footer is read back from the file, then the file is truncated to the
+    // end of the last row group; the splice appends the blobs + rewritten
+    // footer.
+    let mut body_file = NamedTempFile::new()?;
     {
-        let mut writer = ArrowWriter::try_new(&mut buf, schema.clone(), Some(props))?;
+        let mut writer =
+            ArrowWriter::try_new(body_file.as_file_mut(), schema.clone(), Some(props))?;
         for batch in batches {
             writer.write(batch)?;
         }
         writer.close()?;
     }
 
-    // Locate the footer and decode it.
-    let n = buf.len();
-    if n < PARQUET_MIN_FILE_BYTES {
+    // Locate the footer and decode it, reading from the file end.
+    let file = body_file.as_file_mut();
+    let n = file.seek(SeekFrom::End(0))?;
+    if n < PARQUET_MIN_FILE_BYTES as u64 {
         return Err(FooterError::Malformed("parquet buffer too short"));
     }
-    if &buf[n - PARQUET_MAGIC_LEN..n] != b"PAR1" {
+    let mut suffix = [0u8; PARQUET_FOOTER_SUFFIX_BYTES];
+    file.seek(SeekFrom::Start(n - PARQUET_FOOTER_SUFFIX_BYTES as u64))?;
+    file.read_exact(&mut suffix)?;
+    if &suffix[PARQUET_FOOTER_LEN_FIELD_BYTES..] != b"PAR1" {
         return Err(FooterError::Malformed("missing trailing PAR1 magic"));
     }
-    let footer_len_bytes: [u8; PARQUET_FOOTER_LEN_FIELD_BYTES] = buf
-        [n - PARQUET_FOOTER_SUFFIX_BYTES..n - PARQUET_MAGIC_LEN]
+    let footer_len_bytes: [u8; PARQUET_FOOTER_LEN_FIELD_BYTES] = suffix
+        [..PARQUET_FOOTER_LEN_FIELD_BYTES]
         .try_into()
         .map_err(|_| FooterError::Malformed("footer length not 4 bytes"))?;
-    let footer_len = u32::from_le_bytes(footer_len_bytes) as usize;
-    if n < PARQUET_FOOTER_SUFFIX_BYTES + footer_len {
+    let footer_len = u32::from_le_bytes(footer_len_bytes) as u64;
+    if n < PARQUET_FOOTER_SUFFIX_BYTES as u64 + footer_len {
         return Err(FooterError::Malformed("footer length out of range"));
     }
-    let footer_start = n - PARQUET_FOOTER_SUFFIX_BYTES - footer_len;
-    let footer_bytes = buf[footer_start..n - PARQUET_FOOTER_SUFFIX_BYTES].to_vec();
+    let footer_start = n - PARQUET_FOOTER_SUFFIX_BYTES as u64 - footer_len;
+    let mut footer_bytes = vec![0u8; footer_len as usize];
+    file.seek(SeekFrom::Start(footer_start))?;
+    file.read_exact(&mut footer_bytes)?;
     let metadata = ParquetMetaDataReader::decode_metadata(&footer_bytes)?;
 
     // Truncate to end of last row group; blobs + the rewritten footer
-    // get appended in `splice_index_blobs`.
-    buf.truncate(footer_start);
+    // get appended by the splice.
+    file.set_len(footer_start)?;
 
-    Ok(EncodedBody { buf, metadata })
+    Ok(EncodedBody {
+        body_file,
+        body_len: footer_start,
+        metadata,
+    })
 }
 
 /// Splice the `fts_blob` and `vec_blob` between an [`EncodedBody`]'s last
@@ -222,8 +244,7 @@ pub fn splice_index_blobs(
     extra_kv: &[(String, String)],
 ) -> Result<ParquetParts, FooterError> {
     let mut bytes = Vec::with_capacity(
-        body.buf
-            .len()
+        (body.body_len as usize)
             .saturating_add(fts_blob.len())
             .saturating_add(vec_blob.len()),
     );
@@ -263,12 +284,22 @@ where
     F: Read,
     V: Read,
 {
-    let EncodedBody { buf, metadata } = body;
+    let EncodedBody {
+        body_file,
+        body_len,
+        metadata,
+    } = body;
     let mut output = CountingWriter {
         output: &mut output,
         written: 0,
     };
-    output.write_all(&buf)?;
+    // Stream the footer-stripped body from its scratch file; `reopen()` reads
+    // from offset 0 independently of the write handle.
+    let mut body_reader = BufReader::new(body_file.reopen()?);
+    let body_copied = io::copy(&mut body_reader, &mut output)?;
+    if body_copied != body_len {
+        return Err(FooterError::Malformed("body stream length mismatch"));
+    }
 
     let fts_offset = if fts_length > 0 {
         let offset = output.written;

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -524,38 +524,38 @@ impl Supertable {
                     .next()
                     .map(|c| c.rerank_codec.is_sq8_residual_family())
             });
-            if multi_cell && sq8_merge == Some(true) {
-                let (bytes, stats) = SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(
-                    &readers_with_tombstones,
-                    &superseded_per_reader,
-                )?;
-                (Bytes::from(bytes), stats)
-            } else if sq8_merge == Some(true) {
-                let (bytes, stats) =
-                    SuperfileBuilder::build_from_sq8_ivf_readers(&readers_with_tombstones)?;
-                (Bytes::from(bytes), stats)
-            } else {
-                // FTS/SQL merge: stream the merged superfile to a temp file and
-                // mmap it back, so the corpus-sized merge output isn't held as an
-                // anon Vec — the allocation that OOMs compaction on a memory-tight
-                // host. Mapped pages are file-backed and reclaimable.
-                let mut output = NamedTempFile::new()
-                    .map_err(|e| BuildError::Store(format!("merge temp create: {e}")))?;
-                let stats = {
-                    let mut writer = BufWriter::new(output.as_file_mut());
-                    let stats = SuperfileBuilder::build_from_readers_to(
+            // Every merge kind streams its output to a temp file and mmaps it
+            // back, so the corpus-sized merge output is never held as an anon
+            // Vec — the allocation that OOMs compaction on a memory-tight host.
+            // Mapped pages are file-backed and reclaimable; downstream publish
+            // takes `Bytes` unchanged (large superfiles already stream via
+            // put_multipart).
+            let mut output = NamedTempFile::new()
+                .map_err(|e| BuildError::Store(format!("merge temp create: {e}")))?;
+            let stats = {
+                let mut writer = BufWriter::new(output.as_file_mut());
+                let stats = if multi_cell && sq8_merge == Some(true) {
+                    SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers_to(
+                        &readers_with_tombstones,
+                        &superseded_per_reader,
+                        &mut writer,
+                    )?
+                } else if sq8_merge == Some(true) {
+                    SuperfileBuilder::build_from_sq8_ivf_readers_to(
                         &readers_with_tombstones,
                         &mut writer,
-                    )?;
-                    writer
-                        .flush()
-                        .map_err(|e| BuildError::Store(format!("merge temp flush: {e}")))?;
-                    stats
+                    )?
+                } else {
+                    SuperfileBuilder::build_from_readers_to(&readers_with_tombstones, &mut writer)?
                 };
-                let bytes = mmap_readonly_bytes(output.path())
-                    .map_err(|e| BuildError::Store(format!("merge mmap: {e}")))?;
-                (bytes, stats)
-            }
+                writer
+                    .flush()
+                    .map_err(|e| BuildError::Store(format!("merge temp flush: {e}")))?;
+                stats
+            };
+            let bytes = mmap_readonly_bytes(output.path())
+                .map_err(|e| BuildError::Store(format!("merge mmap: {e}")))?;
+            (bytes, stats)
         };
 
         let shard = ShardOutput::new_with_params(

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -10,6 +10,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    io::{BufWriter, Write},
     mem,
     sync::{
         Arc,
@@ -25,9 +26,12 @@ use futures::{
     stream::{self, StreamExt},
 };
 use roaring::RoaringBitmap;
+use tempfile::NamedTempFile;
 use tokio::time;
 use tracing::warn;
 use uuid::Uuid;
+
+use crate::supertable::reader_cache::disk::mmap_readonly_bytes;
 
 use crate::{
     config::CompactionSettings,
@@ -510,7 +514,7 @@ impl Supertable {
             readers_with_tombstones.push((reader.clone(), bitmap));
         }
 
-        let (merged_bytes, superfile_stats) = {
+        let (merged_bytes, superfile_stats): (Bytes, _) = {
             let first_vec = readers_with_tombstones
                 .first()
                 .and_then(|(reader, _)| reader.vec());
@@ -521,17 +525,38 @@ impl Supertable {
                     .map(|c| c.rerank_codec.is_sq8_residual_family())
             });
             if multi_cell && sq8_merge == Some(true) {
-                SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(
+                let (bytes, stats) = SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(
                     &readers_with_tombstones,
                     &superseded_per_reader,
-                )?
+                )?;
+                (Bytes::from(bytes), stats)
             } else if sq8_merge == Some(true) {
-                SuperfileBuilder::build_from_sq8_ivf_readers(&readers_with_tombstones)?
+                let (bytes, stats) =
+                    SuperfileBuilder::build_from_sq8_ivf_readers(&readers_with_tombstones)?;
+                (Bytes::from(bytes), stats)
             } else {
-                SuperfileBuilder::build_from_readers(&readers_with_tombstones)?
+                // FTS/SQL merge: stream the merged superfile to a temp file and
+                // mmap it back, so the corpus-sized merge output isn't held as an
+                // anon Vec — the allocation that OOMs compaction on a memory-tight
+                // host. Mapped pages are file-backed and reclaimable.
+                let mut output = NamedTempFile::new()
+                    .map_err(|e| BuildError::Store(format!("merge temp create: {e}")))?;
+                let stats = {
+                    let mut writer = BufWriter::new(output.as_file_mut());
+                    let stats = SuperfileBuilder::build_from_readers_to(
+                        &readers_with_tombstones,
+                        &mut writer,
+                    )?;
+                    writer
+                        .flush()
+                        .map_err(|e| BuildError::Store(format!("merge temp flush: {e}")))?;
+                    stats
+                };
+                let bytes = mmap_readonly_bytes(output.path())
+                    .map_err(|e| BuildError::Store(format!("merge mmap: {e}")))?;
+                (bytes, stats)
             }
         };
-        let merged_bytes = Bytes::from(merged_bytes);
 
         let shard = ShardOutput::new_with_params(
             merged_bytes,

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1931,7 +1931,24 @@ fn build_one_shard_with_layout(
     let scalar_batches: Vec<&RecordBatch> = slice.iter().map(|b| &b.scalar).collect();
     let scalar_stats = ScalarStatsAgg::from_batches(&scalar_schema, &scalar_batches);
 
-    let bytes = Bytes::from(builder.finish()?);
+    // Stream the assembled superfile to a temp file, then mmap it back as
+    // zero-copy `Bytes`, rather than materializing the whole superfile as an
+    // anon `Vec<u8>` (which, on a corpus-sized single-shard build, is the
+    // dominant resident allocation and OOMs a memory-tight host). The mapped
+    // pages are file-backed and reclaimable; the downstream publish path takes
+    // `Bytes` unchanged and streams large superfiles via `put_multipart`. Same
+    // temp-file → mmap idiom the drain packed-shard path uses.
+    let mut output = NamedTempFile::new()
+        .map_err(|error| BuildError::Store(format!("shard temp create: {error}")))?;
+    {
+        let mut writer = BufWriter::new(output.as_file_mut());
+        builder.finish_to(&mut writer)?;
+        writer
+            .flush()
+            .map_err(|error| BuildError::Store(format!("shard temp flush: {error}")))?;
+    }
+    let bytes = mmap_readonly_bytes(output.path())
+        .map_err(|error| BuildError::Store(format!("shard mmap: {error}")))?;
 
     let (id_min, id_max) = if n_docs == 0 {
         (0, 0)
@@ -4993,7 +5010,21 @@ fn build_one_shard_from_packed_cells(
     let id_max = stable_ids.iter().copied().max().unwrap_or(0);
     let n_docs = stable_ids.len() as u64;
     let scalar_stats = ScalarStatsAgg::from_batches(&options.scalar_schema(), &[&scalar]);
-    let bytes = Bytes::from(builder.finish()?);
+    // Stream the compacted superfile to a temp file, then mmap it back as
+    // zero-copy `Bytes` (same idiom as the append-commit build path) instead of
+    // materializing the merged superfile as an anon `Vec<u8>` — the merge
+    // output is corpus-sized and OOMs a memory-tight host during compaction.
+    let mut output = NamedTempFile::new()
+        .map_err(|error| BuildError::Store(format!("compacted shard temp create: {error}")))?;
+    {
+        let mut writer = BufWriter::new(output.as_file_mut());
+        builder.finish_to(&mut writer)?;
+        writer
+            .flush()
+            .map_err(|error| BuildError::Store(format!("compacted shard temp flush: {error}")))?;
+    }
+    let bytes = mmap_readonly_bytes(output.path())
+        .map_err(|error| BuildError::Store(format!("compacted shard mmap: {error}")))?;
 
     Ok(ShardOutput {
         bytes,
@@ -5328,7 +5359,21 @@ fn build_one_packed_shard_via_drain(
         .map(|g| (g.cell_id, g.subsection))
         .collect();
     builder.set_prebuilt_multi_cell_ivfs(subsections)?;
-    let bytes = Bytes::from(builder.finish()?);
+    // Stream the compacted superfile to a temp file, then mmap it back as
+    // zero-copy `Bytes` (same idiom as the append-commit build path) instead of
+    // materializing the merged superfile as an anon `Vec<u8>` — the merge
+    // output is corpus-sized and OOMs a memory-tight host during compaction.
+    let mut output = NamedTempFile::new()
+        .map_err(|error| BuildError::Store(format!("compacted shard temp create: {error}")))?;
+    {
+        let mut writer = BufWriter::new(output.as_file_mut());
+        builder.finish_to(&mut writer)?;
+        writer
+            .flush()
+            .map_err(|error| BuildError::Store(format!("compacted shard temp flush: {error}")))?;
+    }
+    let bytes = mmap_readonly_bytes(output.path())
+        .map_err(|error| BuildError::Store(format!("compacted shard mmap: {error}")))?;
 
     Ok(Some(ShardOutput {
         bytes,


### PR DESCRIPTION
## Problem

Building a superfile — both at append-commit and during a compaction merge — materialized the whole assembled superfile *and* its intermediate build artifacts (the Parquet body, the FTS blob, the vector blob) as in-memory `Vec<u8>`s at the same time. At corpus scale each of these is multiple GiB — the positional FTS blob especially — so peak resident memory for a single large build is several times the output size. On a memory-constrained host that OOMs the build.

## Change

Stream the large build artifacts to scratch temp files instead of holding them whole in RAM:

- **`SuperfileBuilder::finish_to<W: Write>`** streams the final splice to a sink; `finish()` is a thin wrapper over it.
- **`encode_parquet_body`** encodes the Parquet body to a scratch temp file (reads the footer back to decode metadata, truncates to the last row group) instead of a `Vec`; `EncodedBody` carries the file.
- **FTS/vector blobs** stream to scratch via the builders' existing `finish_to<W>` sinks (a new `finish_index_blobs_streamed` replaces the Vec-returning `finish_index_blobs`).
- The **append-commit build** and **all compaction merge paths** write the assembled superfile to a `NamedTempFile` and map it back (`mmap_readonly_bytes`) — the publish path takes `Bytes` unchanged, and large superfiles already stream via `put_multipart`. New streaming `build_from_*_to` variants back the Vec-returning merge methods.

Net effect: no whole build artifact is held in RAM; `finish` peak drops to roughly the buffered input. Reuses the existing mmap boundary in `reader_cache/disk.rs`, so **no new `unsafe`**.

## Correctness

Output is byte-identical — the write sinks change, the produced bytes don't. Unit round-trips green: superfile builder + reader, format footer, supertable writer (commit → read), compaction merge.

## Status — draft, validation pending

- [ ] `benches/` peak-RSS + build-throughput comparison vs `main`
- [ ] recall@10 ≥ 0.99 confirmation (change touches the output sink, not codecs — expected unchanged)
- [ ] `make miri` / `make asan` (no new `unsafe`, but new temp-file/mmap plumbing)

Opening as a draft to validate peak-memory + throughput before marking ready.