### PR TITLE
benches: improve cost calcluations

### DIFF
--- a/benches/utils/cost.rs
+++ b/benches/utils/cost.rs
@@ -667,13 +667,22 @@ fn egress_usd(payload_bytes: f64) -> f64 {
     payload_bytes / BYTES_PER_GB * egress_usd_per_gb()
 }
 
-/// Marks a serving family whose result size scales with the match set
-/// (`O(selectivity × corpus)`) rather than with `k`. Such a shape has no
-/// meaningful per-query rate — its cost is per GB returned — so it is kept
-/// out of every per-query monthly average and billed per event instead.
-/// Matched on the family label the runners construct.
+/// Marks a serving family that must stay OUT of the bounded-result
+/// monthly mean and be billed per event instead. Two classes qualify,
+/// matched on the family label the runners construct:
+///
+/// * **Bulk row sets** — result size scales with the match set
+///   (`O(selectivity × corpus)`), so the cost is per GB returned and a
+///   per-query rate is meaningless.
+/// * **Scan-backed aggregates** — whole-corpus CPU per query. Averaged
+///   into the blend at equal weight they dominate it: at 10M a scan
+///   aggregate prices in the $100s/1M while the selective shapes sit at
+///   $1–5/1M, dragging the "SQL COGS" headline to ~$160/1M when the
+///   selective serving mix it is quoted against costs a few dollars.
+///   Scan work is real Infino capability — priced per event, according
+///   to the work, never silently averaged into retrieval pricing.
 fn is_bulk_group(label: &str) -> bool {
-    label.starts_with("Bulk")
+    label.starts_with("Bulk") || label.starts_with("Aggregates — scan-backed")
 }
 
 /// "$X/1M" cell text for one query's egress, from its payload bytes. Battery
@@ -2475,15 +2484,15 @@ pub fn emit(report: &mut Report, anchor: &str, title: String, c: &CellCost) {
             Some(month)
         }
     };
-    // Bulk shapes as per-event rates: the cost of ONE such query, which the
-    // reader multiplies by however many they actually run. Not folded into the
-    // monthly total — the run rate is a workload property, not a bench
-    // constant.
+    // Bulk row sets and scan-backed aggregates as per-event rates: the cost
+    // of ONE such query, which the reader multiplies by however many they
+    // actually run. Not folded into the monthly total — the run rate is a
+    // workload property, not a bench constant.
     for (name, warm_usd, payload) in &monthly_bulk_shapes {
         let per_event = warm_usd + egress_usd(*payload as f64);
         summary_rows.push(vec![
             text(format!(
-                "Bulk (per event, not in Total) — {name} ({} result)",
+                "Per event (not in Total) — {name} ({} result)",
                 fmt_bytes(*payload)
             )),
             text(format!("{}/query", usd(per_event))),

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -715,9 +715,11 @@ enum TextLifecyclePhase {
 const SHARED_CONSUMER_CACHE_INDEX_FACTOR: u64 = 2;
 
 /// What the shared FTS/SQL lifecycle hands back: the compaction window's
-/// stats plus the settled local disk-cache footprint of the lifecycle
-/// consumer, sampled after the post-compact battery (just before the
-/// consumer drops) — the cost model's provisioned-occupancy NVMe basis.
+/// stats plus the serving NVMe working set — the disk-cache footprint of
+/// a FRESH consumer that replayed the caller's default battery against
+/// the settled post-compact layout (the cost model's
+/// provisioned-occupancy NVMe basis; the lifecycle consumer itself
+/// accumulates both generations and would overstate it).
 struct TextLifecycleStats {
     compaction: CompactionStats,
     disk_cache_bytes: Option<u64>,
@@ -736,6 +738,7 @@ fn run_metered_text_lifecycle(
     modality: Modality,
     built: &supertable::IngestResult,
     mut on_phase: impl FnMut(TextLifecyclePhase, &Supertable, &storage_meter::MeteredStorage),
+    serve_for_working_set: impl FnOnce(&Supertable),
 ) -> TextLifecycleStats {
     let meter = storage_meter::wrap(Arc::clone(&built.storage));
     let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
@@ -755,9 +758,20 @@ fn run_metered_text_lifecycle(
     on_phase(TextLifecyclePhase::PreCompact, &consumer, &meter);
     let compaction = run_metered_optimize(label, &consumer, &meter);
     on_phase(TextLifecyclePhase::Compacted, &consumer, &meter);
-    let disk_cache_bytes = consumer_disk_cache_bytes(&consumer);
     drop(consumer);
     drop(cache_dir);
+    // Serving NVMe working set — same basis as the vector battery: what a
+    // QUERY-ONLY node retains. The lifecycle consumer above is the wrong
+    // sample: its cache accumulated BOTH generations (the pre- and
+    // post-compact batteries ran through it — measured FTS-10M: 16 GiB
+    // cached for an 8.35 GiB table). A fresh consumer replays the
+    // caller's default battery against the settled post-compact layout;
+    // its cache is the priced working set.
+    let (serving_cache_dir, serving) = open_consumer(modality, built);
+    serve_for_working_set(&serving);
+    let disk_cache_bytes = consumer_disk_cache_bytes(&serving);
+    drop(serving);
+    drop(serving_cache_dir);
     TextLifecycleStats {
         compaction,
         disk_cache_bytes,
@@ -1776,6 +1790,24 @@ pub mod fts {
                     }
                     warm_post = warm;
                     cold_post = cold;
+                },
+                |serving| {
+                    // Default FTS battery, one pass — the serving
+                    // working set a query-only node retains.
+                    let reader = serving.reader().expect("serving reader");
+                    for q in FTS_BATTERY {
+                        let query = q.terms.join(" ");
+                        let _ = reader
+                            .bm25_search(
+                                supertable::TEXT_COLUMN,
+                                &query,
+                                TOP_K,
+                                exec_fts::to_infino_mode(q.mode),
+                                infino::Bm25Stats::PerSuperfile,
+                                None,
+                            )
+                            .expect("serving working-set bm25_search");
+                    }
                 },
             );
             drop(corpus.take());
@@ -4766,6 +4798,29 @@ pub mod vector {
                         .flatten()
                         .map(routing_cold_to_measurement)
                 };
+                // Serving NVMe working set for the occupancy / keep-warm
+                // policy rows: what a QUERY-ONLY node retains. The
+                // lifecycle consumer's cache is the wrong basis — by this
+                // point it has absorbed drain/compaction traffic and the
+                // all-cells oracle sweeps (whole-index reads no serving
+                // node performs; maintenance runs on separate machines in
+                // production). Replay the default-path battery queries on
+                // a fresh consumer + cache and sample what it kept.
+                let serving_disk_cache_bytes = {
+                    let (_serving_cache_dir, serving) = open_consumer(Modality::Vector, &built);
+                    let serving_reader = serving.reader().expect("serving consumer reader");
+                    for q in q_correct.iter().chain(q_cal.iter()) {
+                        let _ = serving_reader.vector_search(
+                            supertable::VEC_COLUMN,
+                            q,
+                            TOP_K,
+                            exec_vec::default_search_opts(),
+                            None,
+                            None,
+                        );
+                    }
+                    consumer_disk_cache_bytes(&serving)
+                };
                 let store = cost::StorePhases {
                     drain: drain_stats.map(|(_, io, _, _)| io),
                     drain_wall_s: drain_stats.map(|(wall_s, _, _, _)| wall_s),
@@ -4786,7 +4841,7 @@ pub mod vector {
                     query_states: query_state_costs(&routing_states),
                     filtered_query: filtered_stats.map(|(io, _)| io),
                     filtered_query_iters: filtered_stats.map(|(_, n)| n).unwrap_or(0),
-                    disk_cache_bytes: consumer_disk_cache_bytes(&consumer),
+                    disk_cache_bytes: serving_disk_cache_bytes,
                     ..store_phases_from_measurement(cold_measured)
                 };
                 let warm_pre_vec = pre_search_rows
@@ -5045,6 +5100,17 @@ pub mod sql {
                     }
                     warm_sets_post = warm;
                     cold_post = cold;
+                },
+                |serving| {
+                    // Default SQL battery, one pass — the serving
+                    // working set a query-only node retains.
+                    let _ = exec_sql::measure_query_sets(
+                        serving,
+                        &inputs,
+                        1,
+                        "supertable_sql serving-working-set",
+                        &[],
+                    );
                 },
             );
             drop(corpus.take());


### PR DESCRIPTION

**Price the serving NVMe working set, not the lifecycle cache.** The keep-warm policy rows priced `disk_cache_bytes` from each battery's long-lived lifecycle consumer — a cache that absorbs maintenance traffic and the all-cells oracle sweeps (vector), or both pre- and post-compact generations (FTS/SQL). None of that is what a query-only serving node retains; maintenance runs on separate machines in production. Now a fresh consumer replays the modality's default battery against the settled post-compact layout and its cache is the priced working set. Measured at 10M: vector 44.99 → 21.96 GiB (Policy B $18.21 → $10.10), FTS 16.03 → 8.21 GiB (idle floor $4.55 → $2.33).

**Price scan-backed SQL aggregates per event.** The blended monthly read line already excluded Bulk (GB-returned) shapes; scan-backed aggregates stayed in the mean, so whole-corpus-CPU shapes ($100s/1M) averaged at equal weight with $1–5/1M lookups dragged the SQL headline to ~$160/1M. They now get per-event rate rows like Bulk (prefix generalized to "Per event"). Measured at 10M: scan aggregates $0.000006–$0.0029/query, bulk range scan $0.18, all-rows token_match $0.01; the selective blend reads $14.31/mo.

Measured 10M Policy-B set on this branch: vector ≈ $10.10, FTS ≈ $29.84, SQL (selective) ≈ $22.83, with scan SQL per event.