### PR TITLE
superfile: stream build outputs to disk; k-way FTS merge for compaction

### DIFF
--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -88,7 +88,7 @@ use crate::superfile::{
     BuildError, SuperfileReader,
     format::{
         self,
-        footer::{encode_parquet_body, splice_index_blobs, splice_index_streams_to},
+        footer::{ParquetLayout, encode_parquet_body, splice_index_streams_to},
         kv,
     },
     fts::{
@@ -1193,9 +1193,28 @@ impl SuperfileBuilder {
     /// If no `add_batch` calls have landed any rows, returns an
     /// empty `Vec<u8>` — there's no Parquet body to write and no
     /// FTS/vector blobs to embed.
-    pub fn finish(mut self) -> Result<Vec<u8>, BuildError> {
+    /// Finish the build, streaming the assembled superfile to `output`.
+    ///
+    /// Streaming counterpart of [`finish`](Self::finish): produces
+    /// byte-identical superfile bytes but writes them to an arbitrary
+    /// [`Write`] sink (e.g. a temp file) instead of returning a `Vec<u8>`,
+    /// so the caller never holds the whole superfile in RAM. Returns the
+    /// [`ParquetLayout`] (total size + blob offsets/lengths) so the caller
+    /// can build manifest metadata without re-parsing the output.
+    ///
+    /// The scalar Parquet body and the FTS/vector blobs are still assembled
+    /// in memory (each smaller than the whole superfile); only the final
+    /// splice — the largest resident value in [`finish`] — is streamed, so
+    /// the combined superfile is never materialized.
+    pub(crate) fn finish_to<W: Write>(mut self, output: W) -> Result<ParquetLayout, BuildError> {
         if self.next_local_doc_id == 0 {
-            return Ok(Vec::new());
+            return Ok(ParquetLayout {
+                total_size: 0,
+                fts_offset: 0,
+                fts_length: 0,
+                vec_offset: 0,
+                vec_length: 0,
+            });
         }
         let n_docs = self.next_local_doc_id as u64;
 
@@ -1263,8 +1282,27 @@ impl SuperfileBuilder {
             (body, fts_blob, vec_blob)
         };
 
-        let parts = splice_index_blobs(body, &fts_blob, &vec_blob, &kvs)?;
-        Ok(parts.bytes)
+        let layout = splice_index_streams_to(
+            body,
+            Cursor::new(fts_blob.as_slice()),
+            fts_blob.len() as u64,
+            Cursor::new(vec_blob.as_slice()),
+            vec_blob.len() as u64,
+            &kvs,
+            output,
+        )?;
+        Ok(layout)
+    }
+
+    /// Finish the build and return the assembled superfile bytes.
+    ///
+    /// Thin wrapper over [`finish_to`](Self::finish_to) that collects the
+    /// stream into a `Vec<u8>`. Prefer `finish_to` on the large-build path
+    /// (commit / compaction) so the whole superfile is never held in RAM.
+    pub fn finish(self) -> Result<Vec<u8>, BuildError> {
+        let mut buf = Vec::new();
+        self.finish_to(&mut buf)?;
+        Ok(buf)
     }
 
     /// Consume an ids-only builder and stream one packed MultiCellIvf

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -81,7 +81,7 @@ use arrow_array::{Array, ArrayRef, Decimal128Array, LargeStringArray, RecordBatc
 use arrow_schema::{DataType, Schema};
 use parquet::basic::{Compression, ZstdLevel};
 use roaring::RoaringBitmap;
-use tempfile::tempfile;
+use tempfile::{NamedTempFile, tempfile};
 
 pub use crate::superfile::vector::builder::VectorConfig;
 use crate::superfile::{
@@ -1300,35 +1300,56 @@ impl SuperfileBuilder {
         let has_vector = vec_builder.is_some()
             || cell_posting_builder.is_some()
             || prebuilt_multi_cell.is_some();
-        let (body, fts_blob, vec_blob) = if has_vector {
-            let (fts_blob, vec_blob) = finish_index_blobs(
+
+        // Stream the FTS and vector blobs to scratch temp files instead of
+        // materializing them as `Vec<u8>`. At corpus scale the positional FTS
+        // blob is multi-GB; holding it, the vector blob, the Parquet body, and
+        // the buffered input all at once is what OOMs a memory-tight build. The
+        // splice below streams the body + on-disk blobs to `output`, so no full
+        // blob is ever resident. `reopen()` gives an independent handle at
+        // offset 0, so the write handle and the later read handle don't share a
+        // cursor.
+        let fts_file = NamedTempFile::new().map_err(BuildError::Io)?;
+        let vec_file = NamedTempFile::new().map_err(BuildError::Io)?;
+        let fts_write = fts_file.reopen().map_err(BuildError::Io)?;
+        let vec_write = vec_file.reopen().map_err(BuildError::Io)?;
+        let stream_blobs = move || -> Result<(), BuildError> {
+            let mut fw = BufWriter::new(fts_write);
+            let mut vw = BufWriter::new(vec_write);
+            finish_index_blobs_streamed(
                 fts_builder,
                 vec_builder,
                 cell_posting_builder,
                 prebuilt_multi_cell,
+                &mut fw,
+                &mut vw,
             )?;
-            let body = encode_body()?;
-            (body, fts_blob, vec_blob)
-        } else {
-            let (body_res, blobs_res) = rayon::join(encode_body, || {
-                finish_index_blobs(
-                    fts_builder,
-                    vec_builder,
-                    cell_posting_builder,
-                    prebuilt_multi_cell,
-                )
-            });
-            let body = body_res?;
-            let (fts_blob, vec_blob) = blobs_res?;
-            (body, fts_blob, vec_blob)
+            fw.flush().map_err(BuildError::Io)?;
+            vw.flush().map_err(BuildError::Io)?;
+            Ok(())
         };
 
+        // Same overlap policy as before: with a vector index present, finalize
+        // blobs first (the vector finalizer already saturates the pool), then
+        // encode the body; otherwise hide the body encode behind the blob
+        // finish.
+        let body = if has_vector {
+            stream_blobs()?;
+            encode_body()?
+        } else {
+            let (body_res, blobs_res) = rayon::join(encode_body, stream_blobs);
+            blobs_res?;
+            body_res?
+        };
+
+        let fts_length = fts_file.as_file().metadata().map_err(BuildError::Io)?.len();
+        let vec_length = vec_file.as_file().metadata().map_err(BuildError::Io)?.len();
         let layout = splice_index_streams_to(
             body,
-            Cursor::new(fts_blob.as_slice()),
-            fts_blob.len() as u64,
-            Cursor::new(vec_blob.as_slice()),
-            vec_blob.len() as u64,
+            BufReader::new(fts_file.reopen().map_err(BuildError::Io)?),
+            fts_length,
+            BufReader::new(vec_file.reopen().map_err(BuildError::Io)?),
+            vec_length,
             &kvs,
             output,
         )?;
@@ -1558,42 +1579,56 @@ fn scalar_batch_in_stable_id_order(
     })
 }
 
-/// Finish the independent embedded index blobs. Once `add_batch` has
-/// routed scalar text and vectors into their builders, FTS and vector
-/// finalization do not share mutable state, so build them as sibling
-/// rayon jobs when both indexes are present.
-fn finish_index_blobs(
+/// Streaming counterpart of [`finish_index_blobs`]: writes the FTS blob to
+/// `fts_out` and the vector blob to `vec_out` instead of returning them as
+/// `Vec<u8>`, so the corpus-sized positional FTS blob (and the vector blob)
+/// never materialize whole in RAM. Same builder-combination semantics; the
+/// `FtsBuilder`/`VectorBuilder` finalizers already stream through a
+/// `Write` sink (spilling to their own scratch when a column overflowed).
+fn finish_index_blobs_streamed<Wf: Write + Send, Wv: Write + Send>(
     fts_builder: Option<FtsBuilder>,
     vec_builder: Option<VectorBuilder>,
     cell_posting_builder: Option<CellPostingBuilder>,
     prebuilt_multi_cell: Option<Vec<(u32, MergedIvfSubsection)>>,
-) -> Result<(Vec<u8>, Vec<u8>), BuildError> {
-    let vec_blob = if let Some(cells) = prebuilt_multi_cell {
-        crate::superfile::vector::builder::finish_multi_cell_blob(&cells)?
-    } else {
-        Vec::new()
-    };
-    match (
-        fts_builder,
-        vec_builder,
-        cell_posting_builder,
-        vec_blob.is_empty(),
-    ) {
-        (Some(fb), Some(vb), None, true) => {
-            let (fts, vec) = rayon::join(|| fb.finish(), || vb.finish());
-            Ok((fts?, vec?))
+    fts_out: &mut Wf,
+    vec_out: &mut Wv,
+) -> Result<(), BuildError> {
+    if let Some(cells) = prebuilt_multi_cell {
+        if vec_builder.is_some() || cell_posting_builder.is_some() {
+            return Err(BuildError::VectorSchemaMismatch(
+                "mixed ivf, cell_posting, and multi-cell builders".into(),
+            ));
         }
-        (Some(fb), None, Some(cb), true) => Ok((fb.finish()?, cb.finish()?)),
-        (Some(fb), None, None, true) => Ok((fb.finish()?, Vec::new())),
-        (None, Some(vb), None, true) => Ok((Vec::new(), vb.finish()?)),
-        (None, None, Some(cb), true) => Ok((Vec::new(), cb.finish()?)),
-        (None, None, None, true) => Ok((Vec::new(), Vec::new())),
-        (Some(fb), None, None, false) => Ok((fb.finish()?, vec_blob)),
-        (None, None, None, false) => Ok((Vec::new(), vec_blob)),
-        _ => Err(BuildError::VectorSchemaMismatch(
-            "mixed ivf, cell_posting, and multi-cell builders".into(),
-        )),
+        let vec_blob = crate::superfile::vector::builder::finish_multi_cell_blob(&cells)?;
+        vec_out.write_all(&vec_blob).map_err(BuildError::Io)?;
+        if let Some(fb) = fts_builder {
+            fb.finish_to(fts_out)?;
+        }
+        return Ok(());
     }
+    match (fts_builder, vec_builder, cell_posting_builder) {
+        (Some(fb), Some(vb), None) => {
+            // Disjoint sinks, so the two finalizers can run concurrently.
+            let (fts_res, vec_res) =
+                rayon::join(|| fb.finish_to(fts_out), || vb.finish_to(vec_out));
+            fts_res?;
+            vec_res?;
+        }
+        (Some(fb), None, Some(cb)) => {
+            fb.finish_to(fts_out)?;
+            vec_out.write_all(&cb.finish()?).map_err(BuildError::Io)?;
+        }
+        (Some(fb), None, None) => fb.finish_to(fts_out)?,
+        (None, Some(vb), None) => vb.finish_to(vec_out)?,
+        (None, None, Some(cb)) => vec_out.write_all(&cb.finish()?).map_err(BuildError::Io)?,
+        (None, None, None) => {}
+        _ => {
+            return Err(BuildError::VectorSchemaMismatch(
+                "mixed ivf, cell_posting, and multi-cell builders".into(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Reject user-supplied column names that would collide with

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -1171,6 +1171,20 @@ impl SuperfileBuilder {
     pub fn build_from_readers(
         readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
     ) -> Result<(Vec<u8>, SuperfileStats), BuildError> {
+        let mut buf = Vec::new();
+        let stats = Self::build_from_readers_to(readers, &mut buf)?;
+        Ok((buf, stats))
+    }
+
+    /// Streaming counterpart of [`build_from_readers`](Self::build_from_readers):
+    /// merges the readers and writes the assembled superfile to `output`
+    /// instead of returning a `Vec<u8>`, so the compaction caller can stream
+    /// to a temp file and never hold the merged superfile in RAM. Returns the
+    /// merged [`SuperfileStats`].
+    pub(crate) fn build_from_readers_to<W: Write>(
+        readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
+        output: W,
+    ) -> Result<SuperfileStats, BuildError> {
         let first = readers.first().ok_or(BuildError::BatchReadError)?;
 
         let builder_opts = BuilderOptions::new_from_reader(&first.0);
@@ -1182,10 +1196,8 @@ impl SuperfileBuilder {
             stats_collector.push(stats);
         }
 
-        let bytes = superfile_builder.finish()?;
-        let stats = SuperfileStats::from_children(stats_collector.as_slice());
-
-        Ok((bytes, stats))
+        superfile_builder.finish_to(output)?;
+        Ok(SuperfileStats::from_children(stats_collector.as_slice()))
     }
 
     /// Consume the builder and emit one self-contained superfile.

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -90,7 +90,10 @@ use crate::superfile::{
     BuildError, FtsError, ReadError, SuperfileReader,
     format::{
         self,
-        footer::{ParquetLayout, encode_parquet_body, splice_index_streams_to},
+        footer::{
+            EncodedBody, ParquetBodyEncoder, ParquetLayout, encode_parquet_body,
+            splice_index_streams_to,
+        },
         kv,
     },
     fts::{
@@ -699,25 +702,6 @@ impl SuperfileBuilder {
         Ok(())
     }
 
-    /// Append a scalar batch **without** indexing its text. The FTS blob is
-    /// supplied out of band via [`add_prebuilt_term_posting`](FtsBuilder::add_prebuilt_term_posting)
-    /// — used by the k-way FTS merge, which carries each input's already-built
-    /// posting lists across instead of re-tokenizing the corpus. Unlike
-    /// [`add_batch_ids_only`](Self::add_batch_ids_only) this deliberately skips
-    /// `index_fts_batch`: re-indexing here would double-count every term.
-    pub(crate) fn add_batch_scalar_only(&mut self, batch: &RecordBatch) -> Result<(), BuildError> {
-        if batch.schema().fields() != self.opts.schema.fields() {
-            return Err(BuildError::BatchSchemaMismatch {
-                batch: batch.schema().to_string(),
-                builder: self.opts.schema.to_string(),
-            });
-        }
-        let n_rows = batch.num_rows() as u32;
-        self.next_local_doc_id += n_rows;
-        self.batches.push(batch.clone());
-        Ok(())
-    }
-
     /// Index FTS text columns from `batch` starting at `self.next_local_doc_id`.
     /// Null cells index as empty strings so doc_lengths stay aligned with Parquet.
     fn index_fts_batch(&mut self, batch: &RecordBatch, n_rows: u32) -> Result<(), BuildError> {
@@ -1284,6 +1268,23 @@ impl SuperfileBuilder {
         let n_fts_columns = builder_opts.fts_columns.len() as u32;
         let mut superfile_builder = SuperfileBuilder::new(builder_opts)?;
 
+        // Encode the Parquet body incrementally: each input's surviving rows are
+        // written and dropped in the loop below, so the body holds at most one
+        // input's batch plus the writer's row-group buffer — never the whole
+        // corpus in `self.batches`. This is the lever that bounds merge RSS.
+        let mut body_encoder = {
+            let id_page_limit = [(
+                superfile_builder.opts.id_column.as_str(),
+                superfile_builder.opts.id_page_size_limit,
+            )];
+            ParquetBodyEncoder::new(
+                &superfile_builder.opts.schema,
+                superfile_builder.opts.compression,
+                superfile_builder.opts.row_group_size,
+                &id_page_limit,
+            )?
+        };
+
         // Per-column doc-lengths, concatenated across inputs in output-doc order.
         let mut merged_doc_lengths: Vec<Vec<u32>> = vec![Vec::new(); n_fts_columns as usize];
         let mut stats_collector = Vec::with_capacity(readers.len());
@@ -1377,8 +1378,15 @@ impl SuperfileBuilder {
                 }
             }
 
-            base += record_batch.num_rows() as u32;
-            superfile_builder.add_batch_scalar_only(&record_batch)?;
+            // Stream this input's surviving rows straight into the Parquet body
+            // and drop the batch — the corpus is never accumulated in RAM. The
+            // FTS index for these rows was already fed above from the input's
+            // prebuilt postings.
+            let n_rows = record_batch.num_rows() as u32;
+            body_encoder.write_batch(&record_batch)?;
+            drop(record_batch);
+            superfile_builder.next_local_doc_id += n_rows;
+            base += n_rows;
         }
 
         if let Some(fb) = superfile_builder.fts_builder.as_mut() {
@@ -1390,7 +1398,13 @@ impl SuperfileBuilder {
             }
         }
 
-        superfile_builder.finish_to(output)?;
+        // Every input fully tombstoned → no rows: match `finish_to`'s
+        // empty-superfile contract (write nothing, return the merged stats).
+        if superfile_builder.next_local_doc_id == 0 {
+            return Ok(SuperfileStats::from_children(stats_collector.as_slice()));
+        }
+        let body = body_encoder.finish()?;
+        superfile_builder.finish_to_with_body(body, output)?;
         Ok(SuperfileStats::from_children(stats_collector.as_slice()))
     }
 
@@ -1478,59 +1492,63 @@ impl SuperfileBuilder {
             || cell_posting_builder.is_some()
             || prebuilt_multi_cell.is_some();
 
-        // Stream the FTS and vector blobs to scratch temp files instead of
-        // materializing them as `Vec<u8>`. At corpus scale the positional FTS
-        // blob is multi-GB; holding it, the vector blob, the Parquet body, and
-        // the buffered input all at once is what OOMs a memory-tight build. The
-        // splice below streams the body + on-disk blobs to `output`, so no full
-        // blob is ever resident. `reopen()` gives an independent handle at
-        // offset 0, so the write handle and the later read handle don't share a
-        // cursor.
-        let fts_file = NamedTempFile::new().map_err(BuildError::Io)?;
-        let vec_file = NamedTempFile::new().map_err(BuildError::Io)?;
-        let fts_write = fts_file.reopen().map_err(BuildError::Io)?;
-        let vec_write = vec_file.reopen().map_err(BuildError::Io)?;
-        let stream_blobs = move || -> Result<(), BuildError> {
-            let mut fw = BufWriter::new(fts_write);
-            let mut vw = BufWriter::new(vec_write);
-            finish_index_blobs_streamed(
+        // Finalize the FTS + vector blobs to scratch temp files (see
+        // `stream_index_blobs_to_scratch`). Same overlap policy as the comment
+        // above: with a vector index present, finalize blobs first (the vector
+        // finalizer already saturates the pool), then encode the body;
+        // otherwise hide the body encode behind the blob finish.
+        let (body, fts_file, vec_file) = if has_vector {
+            let (fts_file, vec_file) = stream_index_blobs_to_scratch(
                 fts_builder,
                 vec_builder,
                 cell_posting_builder,
                 prebuilt_multi_cell,
-                &mut fw,
-                &mut vw,
             )?;
-            fw.flush().map_err(BuildError::Io)?;
-            vw.flush().map_err(BuildError::Io)?;
-            Ok(())
-        };
-
-        // Same overlap policy as before: with a vector index present, finalize
-        // blobs first (the vector finalizer already saturates the pool), then
-        // encode the body; otherwise hide the body encode behind the blob
-        // finish.
-        let body = if has_vector {
-            stream_blobs()?;
-            encode_body()?
+            (encode_body()?, fts_file, vec_file)
         } else {
-            let (body_res, blobs_res) = rayon::join(encode_body, stream_blobs);
-            blobs_res?;
-            body_res?
+            let (body_res, blobs_res) = rayon::join(encode_body, || {
+                stream_index_blobs_to_scratch(
+                    fts_builder,
+                    vec_builder,
+                    cell_posting_builder,
+                    prebuilt_multi_cell,
+                )
+            });
+            let (fts_file, vec_file) = blobs_res?;
+            (body_res?, fts_file, vec_file)
         };
+        splice_body_and_blobs_to(body, fts_file, vec_file, &kvs, output)
+    }
 
-        let fts_length = fts_file.as_file().metadata().map_err(BuildError::Io)?.len();
-        let vec_length = vec_file.as_file().metadata().map_err(BuildError::Io)?.len();
-        let layout = splice_index_streams_to(
-            body,
-            BufReader::new(fts_file.reopen().map_err(BuildError::Io)?),
-            fts_length,
-            BufReader::new(vec_file.reopen().map_err(BuildError::Io)?),
-            vec_length,
-            &kvs,
-            output,
+    /// Finish the build with a Parquet body the caller **already encoded** —
+    /// e.g. the FTS merge, which streams each input's row groups into a
+    /// [`ParquetBodyEncoder`] and drops them, so the corpus body is never held
+    /// whole. Finalizes the FTS/vector blobs and splices them onto `body`,
+    /// exactly as [`finish_to`](Self::finish_to) does after its own body encode.
+    ///
+    /// The caller must have advanced `next_local_doc_id` to the number of rows
+    /// written into `body`.
+    pub(crate) fn finish_to_with_body<W: Write>(
+        mut self,
+        body: EncodedBody,
+        output: W,
+    ) -> Result<ParquetLayout, BuildError> {
+        let n_docs = self.next_local_doc_id as u64;
+        let fts_builder = self.fts_builder.take();
+        let vec_builder = self.vec_builder.take();
+        let cell_posting_builder = self.cell_posting_builder.take();
+        let prebuilt_multi_cell = self.prebuilt_multi_cell.take();
+        let cell_ids: Option<Vec<u32>> = prebuilt_multi_cell
+            .as_ref()
+            .map(|cells| cells.iter().map(|(id, _)| *id).collect());
+        let kvs = superfile_kvs(&self.opts, n_docs, cell_ids.as_deref())?;
+        let (fts_file, vec_file) = stream_index_blobs_to_scratch(
+            fts_builder,
+            vec_builder,
+            cell_posting_builder,
+            prebuilt_multi_cell,
         )?;
-        Ok(layout)
+        splice_body_and_blobs_to(body, fts_file, vec_file, &kvs, output)
     }
 
     /// Finish the build and return the assembled superfile bytes.
@@ -1754,6 +1772,60 @@ fn scalar_batch_in_stable_id_order(
         batch: format!("reordered scalar RecordBatch construct failed: {e}"),
         builder: schema.to_string(),
     })
+}
+
+/// Finalize the FTS + vector blobs to two scratch temp files. At corpus scale
+/// the positional FTS blob is multi-GB; streaming it (and the vector blob) to
+/// disk instead of a `Vec` keeps a memory-tight build or merge under its RSS
+/// budget. `reopen()` gives an independent handle at offset 0, so the write
+/// handle here and the read handle at splice time don't share a cursor.
+fn stream_index_blobs_to_scratch(
+    fts_builder: Option<FtsBuilder>,
+    vec_builder: Option<VectorBuilder>,
+    cell_posting_builder: Option<CellPostingBuilder>,
+    prebuilt_multi_cell: Option<Vec<(u32, MergedIvfSubsection)>>,
+) -> Result<(NamedTempFile, NamedTempFile), BuildError> {
+    let fts_file = NamedTempFile::new().map_err(BuildError::Io)?;
+    let vec_file = NamedTempFile::new().map_err(BuildError::Io)?;
+    let fts_write = fts_file.reopen().map_err(BuildError::Io)?;
+    let vec_write = vec_file.reopen().map_err(BuildError::Io)?;
+    let mut fw = BufWriter::new(fts_write);
+    let mut vw = BufWriter::new(vec_write);
+    finish_index_blobs_streamed(
+        fts_builder,
+        vec_builder,
+        cell_posting_builder,
+        prebuilt_multi_cell,
+        &mut fw,
+        &mut vw,
+    )?;
+    fw.flush().map_err(BuildError::Io)?;
+    vw.flush().map_err(BuildError::Io)?;
+    Ok((fts_file, vec_file))
+}
+
+/// Splice an encoded body + the two on-disk blobs to `output`, streaming both
+/// blobs off disk so neither is ever resident. Cheap relative to the encode —
+/// byte appends + a footer rewrite.
+fn splice_body_and_blobs_to<W: Write>(
+    body: EncodedBody,
+    fts_file: NamedTempFile,
+    vec_file: NamedTempFile,
+    kvs: &[(String, String)],
+    output: W,
+) -> Result<ParquetLayout, BuildError> {
+    let fts_length = fts_file.as_file().metadata().map_err(BuildError::Io)?.len();
+    let vec_length = vec_file.as_file().metadata().map_err(BuildError::Io)?.len();
+    let layout = splice_index_streams_to(
+        body,
+        BufReader::new(fts_file.reopen().map_err(BuildError::Io)?),
+        fts_length,
+        BufReader::new(vec_file.reopen().map_err(BuildError::Io)?),
+        vec_length,
+        kvs,
+        output,
+    )?;
+    Ok(layout)
 }
 
 /// Streaming counterpart of [`finish_index_blobs`]: writes the FTS blob to

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -73,6 +73,8 @@ use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fmt,
     io::{BufReader, BufWriter, Cursor, Error, Seek, SeekFrom, Write},
+    mem,
+    str::from_utf8,
     sync::Arc,
 };
 
@@ -85,7 +87,7 @@ use tempfile::{NamedTempFile, tempfile};
 
 pub use crate::superfile::vector::builder::VectorConfig;
 use crate::superfile::{
-    BuildError, SuperfileReader,
+    BuildError, FtsError, ReadError, SuperfileReader,
     format::{
         self,
         footer::{ParquetLayout, encode_parquet_body, splice_index_streams_to},
@@ -697,6 +699,25 @@ impl SuperfileBuilder {
         Ok(())
     }
 
+    /// Append a scalar batch **without** indexing its text. The FTS blob is
+    /// supplied out of band via [`add_prebuilt_term_posting`](FtsBuilder::add_prebuilt_term_posting)
+    /// — used by the k-way FTS merge, which carries each input's already-built
+    /// posting lists across instead of re-tokenizing the corpus. Unlike
+    /// [`add_batch_ids_only`](Self::add_batch_ids_only) this deliberately skips
+    /// `index_fts_batch`: re-indexing here would double-count every term.
+    pub(crate) fn add_batch_scalar_only(&mut self, batch: &RecordBatch) -> Result<(), BuildError> {
+        if batch.schema().fields() != self.opts.schema.fields() {
+            return Err(BuildError::BatchSchemaMismatch {
+                batch: batch.schema().to_string(),
+                builder: self.opts.schema.to_string(),
+            });
+        }
+        let n_rows = batch.num_rows() as u32;
+        self.next_local_doc_id += n_rows;
+        self.batches.push(batch.clone());
+        Ok(())
+    }
+
     /// Index FTS text columns from `batch` starting at `self.next_local_doc_id`.
     /// Null cells index as empty strings so doc_lengths stay aligned with Parquet.
     fn index_fts_batch(&mut self, batch: &RecordBatch, n_rows: u32) -> Result<(), BuildError> {
@@ -1227,6 +1248,162 @@ impl SuperfileBuilder {
 
         superfile_builder.finish_to(output)?;
         Ok(SuperfileStats::from_children(stats_collector.as_slice()))
+    }
+
+    /// Merge FTS/scalar superfiles by **carrying each input's already-built
+    /// posting lists across** instead of re-tokenizing the corpus. The vector
+    /// merge does the analogous byte-level splice
+    /// ([`build_from_sq8_ivf_readers`](Self::build_from_sq8_ivf_readers)); this
+    /// is the FTS counterpart, and the memory-bounded path for compacting a
+    /// large corpus into one superfile.
+    ///
+    /// Per input `i` with cumulative surviving-doc base `base_i`, for each FTS
+    /// column it streams the input's `(term, doc_id, tf, positions)` postings
+    /// ([`FtsReader::for_each_term_posting`]) into the builder's prebuilt
+    /// accumulator with `doc_id` remapped to `base_i + rank` (`rank` = position
+    /// among that input's surviving docs). Deleted docs are dropped and the
+    /// doc-id space stays dense, so it aligns row-for-row with the concatenated
+    /// Parquet body. Positions flow into the spilled positions blob on disk, not
+    /// RAM; doc-lengths are read from each input and concatenated — never
+    /// recomputed from tokens.
+    ///
+    /// Requires FTS/scalar inputs (no vector index); vector-bearing merges use
+    /// [`build_from_sq8_ivf_readers`](Self::build_from_sq8_ivf_readers).
+    ///
+    /// Streams the assembled superfile to `output` (compaction feeds a temp
+    /// file it then mmaps) so the corpus-sized merge result is never held as an
+    /// anon `Vec`.
+    pub(crate) fn build_from_readers_fts_merge_to<W: Write>(
+        readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
+        output: W,
+    ) -> Result<SuperfileStats, BuildError> {
+        let first = readers.first().ok_or(BuildError::BatchReadError)?;
+        let builder_opts = BuilderOptions::new_from_reader(&first.0);
+        // FTS column ids run `0..n` in schema-declaration order, matching the
+        // reader's column order.
+        let n_fts_columns = builder_opts.fts_columns.len() as u32;
+        let mut superfile_builder = SuperfileBuilder::new(builder_opts)?;
+
+        // Per-column doc-lengths, concatenated across inputs in output-doc order.
+        let mut merged_doc_lengths: Vec<Vec<u32>> = vec![Vec::new(); n_fts_columns as usize];
+        let mut stats_collector = Vec::with_capacity(readers.len());
+        let mut base: u32 = 0;
+
+        for (idx, (reader, deleted)) in readers.iter().enumerate() {
+            superfile_builder.opts.check_mergeability(
+                reader.id_column(),
+                reader.schema(),
+                reader.fts().map(|f| f.fts_columns().collect::<Vec<_>>()),
+                reader
+                    .vec()
+                    .map(|v| v.vector_columns_config().collect::<Vec<_>>()),
+            )?;
+
+            let record_batch = reader.get_record_batch(deleted.clone()).map_err(|e| {
+                BuildError::Io(Error::other(format!(
+                    "fts merge input {idx}: read RecordBatch failed: {e}"
+                )))
+            })?;
+            stats_collector.push(SuperfileStats::try_compute_from_record_batch(
+                &record_batch,
+            )?);
+
+            // Map each input-local doc id to its output doc id. Survivors get
+            // dense ids `base + rank`; deleted docs map to `None`. `rank` walks
+            // local ids in order skipping tombstones, so it ends at the surviving
+            // row count — the same count and order as `record_batch`.
+            let fts = reader.fts();
+            let n_local = fts.map(|f| f.n_docs()).unwrap_or(reader.n_docs() as u32);
+            let mut remap: Vec<Option<u32>> = vec![None; n_local as usize];
+            let mut rank: u32 = 0;
+            for d in 0..n_local {
+                let is_deleted = deleted.as_ref().is_some_and(|b| b.contains(d));
+                if !is_deleted {
+                    remap[d as usize] = Some(base + rank);
+                    rank += 1;
+                }
+            }
+
+            if let Some(fts) = fts {
+                for column_id in 0..n_fts_columns {
+                    let fb = superfile_builder
+                        .fts_builder
+                        .as_mut()
+                        .ok_or(BuildError::BatchReadError)?;
+                    // `for_each_term_posting` surfaces read errors as `FtsError`;
+                    // a builder push error is a `BuildError`, so capture it out of
+                    // band and re-raise after the walk (the sentinel `FtsError`
+                    // only stops iteration).
+                    let mut push_err: Option<BuildError> = None;
+                    let walk =
+                        fts.for_each_term_posting(column_id, |term, local_doc, tf, positions| {
+                            let Some(out_doc) = remap[local_doc as usize] else {
+                                return Ok(());
+                            };
+                            let term_str = from_utf8(term).map_err(|_| {
+                                FtsError::Read(ReadError::MalformedVersion(
+                                    "non-utf8 term in FTS merge input".into(),
+                                ))
+                            })?;
+                            if let Err(e) = fb.add_prebuilt_term_posting(
+                                column_id, term_str, out_doc, tf, positions,
+                            ) {
+                                push_err = Some(e);
+                                return Err(FtsError::Read(ReadError::MalformedVersion(
+                                    "prebuilt push aborted".into(),
+                                )));
+                            }
+                            Ok(())
+                        });
+                    if let Some(e) = push_err {
+                        return Err(e);
+                    }
+                    walk.map_err(|e| {
+                        BuildError::Io(Error::other(format!(
+                            "fts merge input {idx} column {column_id}: posting walk failed: {e}"
+                        )))
+                    })?;
+
+                    let dls = fts.read_doc_lengths(column_id).map_err(|e| {
+                        BuildError::Io(Error::other(format!(
+                            "fts merge input {idx} column {column_id}: read doc-lengths failed: {e}"
+                        )))
+                    })?;
+                    for (d, &len) in dls.iter().enumerate() {
+                        if remap[d].is_some() {
+                            merged_doc_lengths[column_id as usize].push(len);
+                        }
+                    }
+                }
+            }
+
+            base += record_batch.num_rows() as u32;
+            superfile_builder.add_batch_scalar_only(&record_batch)?;
+        }
+
+        if let Some(fb) = superfile_builder.fts_builder.as_mut() {
+            for column_id in 0..n_fts_columns {
+                fb.set_prebuilt_doc_lengths(
+                    column_id,
+                    mem::take(&mut merged_doc_lengths[column_id as usize]),
+                );
+            }
+        }
+
+        superfile_builder.finish_to(output)?;
+        Ok(SuperfileStats::from_children(stats_collector.as_slice()))
+    }
+
+    /// Thin `Vec<u8>` wrapper over
+    /// [`build_from_readers_fts_merge_to`](Self::build_from_readers_fts_merge_to)
+    /// for callers and tests that want the merged superfile in memory. Prefer
+    /// the streaming `_to` form on the large-corpus compaction path.
+    pub fn build_from_readers_fts_merge(
+        readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
+    ) -> Result<(Vec<u8>, SuperfileStats), BuildError> {
+        let mut buf = Vec::new();
+        let stats = Self::build_from_readers_fts_merge_to(readers, &mut buf)?;
+        Ok((buf, stats))
     }
 
     /// Consume the builder and emit one self-contained superfile.
@@ -2870,6 +3047,166 @@ mod tests {
         assert_eq!(merged_batch.num_rows(), 4);
     }
 
+    /// Turn a slice of file-local doc ids into a tombstone bitmap, or `None`
+    /// when the slice is empty (the "nothing deleted" case).
+    fn tombstones(ids: &[u32]) -> Option<Arc<RoaringBitmap>> {
+        if ids.is_empty() {
+            return None;
+        }
+        let mut b = RoaringBitmap::new();
+        for &id in ids {
+            b.insert(id);
+        }
+        Some(Arc::new(b))
+    }
+
+    /// Collect a superfile's full FTS content — every `(term, doc_id, tf,
+    /// positions)` posting plus the per-doc lengths — into comparable form. Two
+    /// superfiles with equal collections score every BM25 query identically:
+    /// same postings, same term frequencies, same doc-lengths (avgdl), same doc
+    /// order. Postings are sorted so insertion order can't mask a real mismatch.
+    fn collect_fts_content(
+        reader: &SuperfileReader,
+    ) -> (Vec<(Vec<u8>, u32, u32, Vec<u32>)>, Vec<u32>) {
+        let fts = reader.fts().expect("merged superfile has an FTS blob");
+        let n_cols = fts.fts_columns().count() as u32;
+        let mut postings: Vec<(Vec<u8>, u32, u32, Vec<u32>)> = Vec::new();
+        let mut doc_lengths: Vec<u32> = Vec::new();
+        for column_id in 0..n_cols {
+            fts.for_each_term_posting(column_id, |term, doc_id, tf, pos| {
+                postings.push((term.to_vec(), doc_id, tf, pos.to_vec()));
+                Ok(())
+            })
+            .expect("enumerate postings");
+            doc_lengths.extend(fts.read_doc_lengths(column_id).expect("doc-lengths"));
+        }
+        postings.sort();
+        (postings, doc_lengths)
+    }
+
+    /// The k-way FTS merge must be indistinguishable from re-indexing: it carries
+    /// each input's prebuilt postings across instead of re-tokenizing, so the
+    /// merged superfile must return the same query results — identical postings,
+    /// term frequencies, positions, doc-lengths, and doc order (Parquet body) —
+    /// as `build_from_readers` produces from the same inputs. This is the
+    /// correctness bar — byte-identical top-k and scores — proven here on
+    /// planted corpora spanning shared terms across inputs, the positional
+    /// codec, and tombstoned rows.
+    fn assert_fts_merge_matches_reindex(positions: bool, deletes: &[&[u32]]) {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+                positions,
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        );
+        let schema = opts.schema.clone();
+
+        // Two inputs sharing terms (hello/world/rust/async) so the merge has to
+        // fold each input's postings into one term dictionary.
+        let build_input = |ids: Vec<u64>, titles: Vec<&str>, bodies: Vec<&str>| -> Vec<u8> {
+            let mut b = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(decimal128_ids(ids)),
+                    Arc::new(LargeStringArray::from(titles)),
+                    Arc::new(LargeStringArray::from(bodies)),
+                ],
+            )
+            .expect("build RecordBatch");
+            b.add_batch(&batch, &[]).expect("add_batch");
+            b.finish().expect("finish builder")
+        };
+
+        let bytes1 = build_input(
+            vec![10, 11, 12],
+            vec!["hello world", "rust async", "hello rust"],
+            vec!["a b", "c d", "e f"],
+        );
+        let bytes2 = build_input(
+            vec![20, 21],
+            vec!["world async", "hello world rust"],
+            vec!["g h", "i j"],
+        );
+
+        let reader1 = SuperfileReader::open(Bytes::from(bytes1)).expect("open reader1");
+        let reader2 = SuperfileReader::open(Bytes::from(bytes2)).expect("open reader2");
+        let inputs = vec![
+            (
+                Arc::new(reader1),
+                tombstones(deletes.first().copied().unwrap_or(&[])),
+            ),
+            (
+                Arc::new(reader2),
+                tombstones(deletes.get(1).copied().unwrap_or(&[])),
+            ),
+        ];
+
+        let (reindex_bytes, reindex_stats) =
+            SuperfileBuilder::build_from_readers(&inputs).expect("re-index build");
+        let (merge_bytes, merge_stats) =
+            SuperfileBuilder::build_from_readers_fts_merge(&inputs).expect("k-way fts merge");
+
+        assert_eq!(
+            reindex_stats.n_docs, merge_stats.n_docs,
+            "merge and re-index must agree on surviving doc count"
+        );
+
+        let reindex_reader =
+            SuperfileReader::open(Bytes::from(reindex_bytes)).expect("open re-index reader");
+        let merge_reader =
+            SuperfileReader::open(Bytes::from(merge_bytes)).expect("open merge reader");
+
+        // Parquet body: identical rows in identical order (dense doc-id space).
+        let reindex_batch = reindex_reader
+            .get_record_batch(None)
+            .expect("re-index batch");
+        let merge_batch = merge_reader.get_record_batch(None).expect("merge batch");
+        assert_eq!(
+            reindex_batch, merge_batch,
+            "scalar body must match row-for-row (positions={positions}, deletes={deletes:?})"
+        );
+
+        // FTS: identical postings, tfs, positions, and doc-lengths → identical
+        // BM25 scores for every query.
+        let (reindex_postings, reindex_dls) = collect_fts_content(&reindex_reader);
+        let (merge_postings, merge_dls) = collect_fts_content(&merge_reader);
+        assert_eq!(
+            reindex_dls, merge_dls,
+            "doc-lengths must match (positions={positions}, deletes={deletes:?})"
+        );
+        assert_eq!(
+            reindex_postings, merge_postings,
+            "FTS postings must match (positions={positions}, deletes={deletes:?})"
+        );
+    }
+
+    #[test]
+    fn fts_merge_matches_reindex_non_positional() {
+        assert_fts_merge_matches_reindex(false, &[]);
+    }
+
+    #[test]
+    fn fts_merge_matches_reindex_positional() {
+        assert_fts_merge_matches_reindex(true, &[]);
+    }
+
+    #[test]
+    fn fts_merge_matches_reindex_with_deletes() {
+        // Drop row 1 of input 0 and row 0 of input 1; the surviving doc-id space
+        // must stay dense and aligned across the FTS blob and the Parquet body.
+        assert_fts_merge_matches_reindex(false, &[&[1], &[0]]);
+    }
+
+    #[test]
+    fn fts_merge_matches_reindex_positional_with_deletes() {
+        assert_fts_merge_matches_reindex(true, &[&[0], &[1]]);
+    }
+
     #[test]
     fn build_from_readers_preserves_vectors_and_fts() {
         let opts = BuilderOptions::new(
@@ -2916,6 +3253,83 @@ mod tests {
             merged_reader.vec().is_some(),
             "Vector index should be present"
         );
+    }
+
+    /// The definitive merge oracle: run real BM25 queries against a merged
+    /// superfile built by re-indexing vs. by the k-way FTS merge, and require
+    /// **identical (doc_id, score) top-k** for every query shape — single term,
+    /// multi-term OR, multi-term AND, and a term shared across both inputs. If
+    /// postings, doc-lengths, and corpus stats carry across the merge correctly,
+    /// the scores are bit-for-bit identical.
+    #[tokio::test]
+    async fn fts_merge_scores_match_reindex() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig {
+                column: "title".into(),
+                positions: false,
+            }],
+            vec![],
+            Some(default_tokenizer()),
+        );
+        let schema = opts.schema.clone();
+
+        let build_input = |ids: Vec<u64>, titles: Vec<&str>| -> Vec<u8> {
+            let bodies: Vec<&str> = titles.iter().map(|_| "x").collect();
+            let mut b = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(decimal128_ids(ids)),
+                    Arc::new(LargeStringArray::from(titles)),
+                    Arc::new(LargeStringArray::from(bodies)),
+                ],
+            )
+            .expect("build RecordBatch");
+            b.add_batch(&batch, &[]).expect("add_batch");
+            b.finish().expect("finish builder")
+        };
+
+        let bytes1 = build_input(
+            vec![10, 11, 12],
+            vec!["hello world", "rust async await", "hello rust"],
+        );
+        let bytes2 = build_input(vec![20, 21], vec!["world async", "hello world rust async"]);
+        let open = |b: Vec<u8>| Arc::new(SuperfileReader::open(Bytes::from(b)).expect("open"));
+        let inputs = vec![(open(bytes1), None), (open(bytes2), None)];
+
+        let (reindex_bytes, _) =
+            SuperfileBuilder::build_from_readers(&inputs).expect("re-index build");
+        let (merge_bytes, _) =
+            SuperfileBuilder::build_from_readers_fts_merge(&inputs).expect("k-way fts merge");
+        let reindex_reader =
+            SuperfileReader::open(Bytes::from(reindex_bytes)).expect("open reindex");
+        let merge_reader = SuperfileReader::open(Bytes::from(merge_bytes)).expect("open merge");
+        let reindex_fts = reindex_reader.fts().expect("reindex fts");
+        let merge_fts = merge_reader.fts().expect("merge fts");
+
+        let queries: &[(&[&str], BoolMode)] = &[
+            (&["hello"], BoolMode::Or),
+            (&["world"], BoolMode::Or),
+            (&["hello", "async"], BoolMode::Or),
+            (&["hello", "rust"], BoolMode::And),
+            (&["rust", "async", "await"], BoolMode::Or),
+        ];
+        for (terms, mode) in queries {
+            let a = reindex_fts
+                .search("title", terms, 10, *mode)
+                .await
+                .expect("reindex search");
+            let b = merge_fts
+                .search("title", terms, 10, *mode)
+                .await
+                .expect("merge search");
+            assert_eq!(
+                a, b,
+                "merge scores must match re-index for query {terms:?} mode {mode:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -790,6 +790,19 @@ impl SuperfileBuilder {
     pub fn build_from_sq8_ivf_readers(
         readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
     ) -> Result<(Vec<u8>, SuperfileStats), BuildError> {
+        let mut buf = Vec::new();
+        let stats = Self::build_from_sq8_ivf_readers_to(readers, &mut buf)?;
+        Ok((buf, stats))
+    }
+
+    /// Streaming counterpart of
+    /// [`build_from_sq8_ivf_readers`](Self::build_from_sq8_ivf_readers): writes
+    /// the merged superfile to `output` instead of returning a `Vec<u8>`, so
+    /// the compaction caller can stream to a temp file.
+    pub(crate) fn build_from_sq8_ivf_readers_to<W: Write>(
+        readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
+        output: W,
+    ) -> Result<SuperfileStats, BuildError> {
         let first = readers.first().ok_or(BuildError::BatchReadError)?;
         let builder_opts = BuilderOptions::new_from_reader(&first.0);
         let mut superfile_builder = SuperfileBuilder::new(builder_opts)?;
@@ -837,9 +850,8 @@ impl SuperfileBuilder {
         let merged_sub = merge_sq8_ivf_subsections(&merge_refs)?;
         superfile_builder.set_prebuilt_ivf_subsection(0, merged_sub)?;
 
-        let bytes = superfile_builder.finish()?;
-        let stats = SuperfileStats::from_children(stats_collector.as_slice());
-        Ok((bytes, stats))
+        superfile_builder.finish_to(output)?;
+        Ok(SuperfileStats::from_children(stats_collector.as_slice()))
     }
 
     /// Merge multi-cell (v2) Sq8 IVF superfiles **per global cell id**, then
@@ -852,6 +864,23 @@ impl SuperfileBuilder {
         readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
         superseded_per_reader: &[BTreeSet<u32>],
     ) -> Result<(Vec<u8>, SuperfileStats), BuildError> {
+        let mut buf = Vec::new();
+        let stats = Self::build_from_multi_cell_sq8_ivf_readers_to(
+            readers,
+            superseded_per_reader,
+            &mut buf,
+        )?;
+        Ok((buf, stats))
+    }
+
+    /// Streaming counterpart of
+    /// [`build_from_multi_cell_sq8_ivf_readers`](Self::build_from_multi_cell_sq8_ivf_readers):
+    /// writes the merged superfile to `output` instead of returning a `Vec<u8>`.
+    pub(crate) fn build_from_multi_cell_sq8_ivf_readers_to<W: Write>(
+        readers: &[(Arc<SuperfileReader>, Option<Arc<RoaringBitmap>>)],
+        superseded_per_reader: &[BTreeSet<u32>],
+        output: W,
+    ) -> Result<SuperfileStats, BuildError> {
         let first = readers.first().ok_or(BuildError::BatchReadError)?;
         let builder_opts = BuilderOptions::new_from_reader(&first.0);
         if builder_opts.vector_layout != VectorLayout::MultiCellIvf {
@@ -1044,7 +1073,7 @@ impl SuperfileBuilder {
             // flows through `prepare_superfile` -> None -> NoDocsToBuild and the
             // compaction caller reclaims the dead inputs (removes them, writes no
             // replacement), instead of a hard schema error.
-            return Ok((Vec::new(), SuperfileStats::from_children(&[])));
+            return Ok(SuperfileStats::from_children(&[]));
         }
 
         // Parquet rows must follow the same cell-directory order as the packed
@@ -1059,7 +1088,7 @@ impl SuperfileBuilder {
         )?;
         superfile_builder.add_batch_ids_only(&scalar_batch)?;
         superfile_builder.set_prebuilt_multi_cell_ivfs(packed_cells)?;
-        let bytes = superfile_builder.finish()?;
+        superfile_builder.finish_to(output)?;
         let mut stats = SuperfileStats::from_children(stats_collector.as_slice());
         if scalar_schema.fields().len() == 1 {
             // Hidden id-only index: the merged doc set is exactly `all_stable_ids`
@@ -1071,7 +1100,7 @@ impl SuperfileBuilder {
             stats.id_min = all_stable_ids.iter().copied().min().unwrap_or(0);
             stats.id_max = all_stable_ids.iter().copied().max().unwrap_or(0);
         }
-        Ok((bytes, stats))
+        Ok(stats)
     }
 
     /// Add all data (Parquet + fts + vectors) from another [`SuperfileReader`] to this builder.

--- a/src/superfile/format/footer.rs
+++ b/src/superfile/format/footer.rs
@@ -25,7 +25,7 @@
 
 use std::{
     collections::HashMap,
-    io::{self, Cursor, Read, Write},
+    io::{self, BufReader, Cursor, Read, Seek, SeekFrom, Write},
     sync::Arc,
 };
 
@@ -44,6 +44,7 @@ use parquet::{
     },
     schema::types::ColumnPath,
 };
+use tempfile::NamedTempFile;
 
 use crate::superfile::{LazyByteSource, LazyByteSourceError, format::kv};
 
@@ -135,9 +136,13 @@ pub enum FooterError {
 /// holds everything that the CPU-bound column encode produced, ready for
 /// the cheap blob splice + footer rewrite.
 pub struct EncodedBody {
-    /// Parquet bytes truncated to the end of the last row group (footer
-    /// removed) — blobs and the rewritten footer get appended here.
-    buf: Vec<u8>,
+    /// Parquet body written to a scratch temp file and truncated to the end of
+    /// the last row group (footer removed). Streamed into the superfile at
+    /// splice time so the body — multi-GB at corpus scale — never materializes
+    /// as a whole `Vec`. Blobs and the rewritten footer get appended after it.
+    body_file: NamedTempFile,
+    /// Byte length of the footer-stripped body in `body_file`.
+    body_len: u64,
     /// Footer metadata decoded from the original write, carried through
     /// to the rewrite so row groups + column/offset indexes survive.
     metadata: ParquetMetaData,
@@ -171,40 +176,57 @@ pub fn encode_parquet_body(
             .set_column_data_page_size_limit(ColumnPath::from((*col).to_string()), *limit);
     }
     let props = props_builder.build();
-    let mut buf: Vec<u8> = Vec::new();
+
+    // Encode the Parquet body to a scratch temp file rather than a `Vec`, so
+    // the body — multi-GB at corpus scale — never materializes whole in RAM.
+    // The footer is read back from the file, then the file is truncated to the
+    // end of the last row group; the splice appends the blobs + rewritten
+    // footer.
+    let mut body_file = NamedTempFile::new()?;
     {
-        let mut writer = ArrowWriter::try_new(&mut buf, schema.clone(), Some(props))?;
+        let mut writer =
+            ArrowWriter::try_new(body_file.as_file_mut(), schema.clone(), Some(props))?;
         for batch in batches {
             writer.write(batch)?;
         }
         writer.close()?;
     }
 
-    // Locate the footer and decode it.
-    let n = buf.len();
-    if n < PARQUET_MIN_FILE_BYTES {
+    // Locate the footer and decode it, reading from the file end.
+    let file = body_file.as_file_mut();
+    let n = file.seek(SeekFrom::End(0))?;
+    if n < PARQUET_MIN_FILE_BYTES as u64 {
         return Err(FooterError::Malformed("parquet buffer too short"));
     }
-    if &buf[n - PARQUET_MAGIC_LEN..n] != b"PAR1" {
+    let mut suffix = [0u8; PARQUET_FOOTER_SUFFIX_BYTES];
+    file.seek(SeekFrom::Start(n - PARQUET_FOOTER_SUFFIX_BYTES as u64))?;
+    file.read_exact(&mut suffix)?;
+    if &suffix[PARQUET_FOOTER_LEN_FIELD_BYTES..] != b"PAR1" {
         return Err(FooterError::Malformed("missing trailing PAR1 magic"));
     }
-    let footer_len_bytes: [u8; PARQUET_FOOTER_LEN_FIELD_BYTES] = buf
-        [n - PARQUET_FOOTER_SUFFIX_BYTES..n - PARQUET_MAGIC_LEN]
+    let footer_len_bytes: [u8; PARQUET_FOOTER_LEN_FIELD_BYTES] = suffix
+        [..PARQUET_FOOTER_LEN_FIELD_BYTES]
         .try_into()
         .map_err(|_| FooterError::Malformed("footer length not 4 bytes"))?;
-    let footer_len = u32::from_le_bytes(footer_len_bytes) as usize;
-    if n < PARQUET_FOOTER_SUFFIX_BYTES + footer_len {
+    let footer_len = u32::from_le_bytes(footer_len_bytes) as u64;
+    if n < PARQUET_FOOTER_SUFFIX_BYTES as u64 + footer_len {
         return Err(FooterError::Malformed("footer length out of range"));
     }
-    let footer_start = n - PARQUET_FOOTER_SUFFIX_BYTES - footer_len;
-    let footer_bytes = buf[footer_start..n - PARQUET_FOOTER_SUFFIX_BYTES].to_vec();
+    let footer_start = n - PARQUET_FOOTER_SUFFIX_BYTES as u64 - footer_len;
+    let mut footer_bytes = vec![0u8; footer_len as usize];
+    file.seek(SeekFrom::Start(footer_start))?;
+    file.read_exact(&mut footer_bytes)?;
     let metadata = ParquetMetaDataReader::decode_metadata(&footer_bytes)?;
 
     // Truncate to end of last row group; blobs + the rewritten footer
-    // get appended in `splice_index_blobs`.
-    buf.truncate(footer_start);
+    // get appended by the splice.
+    file.set_len(footer_start)?;
 
-    Ok(EncodedBody { buf, metadata })
+    Ok(EncodedBody {
+        body_file,
+        body_len: footer_start,
+        metadata,
+    })
 }
 
 /// Splice the `fts_blob` and `vec_blob` between an [`EncodedBody`]'s last
@@ -222,8 +244,7 @@ pub fn splice_index_blobs(
     extra_kv: &[(String, String)],
 ) -> Result<ParquetParts, FooterError> {
     let mut bytes = Vec::with_capacity(
-        body.buf
-            .len()
+        (body.body_len as usize)
             .saturating_add(fts_blob.len())
             .saturating_add(vec_blob.len()),
     );
@@ -263,12 +284,22 @@ where
     F: Read,
     V: Read,
 {
-    let EncodedBody { buf, metadata } = body;
+    let EncodedBody {
+        body_file,
+        body_len,
+        metadata,
+    } = body;
     let mut output = CountingWriter {
         output: &mut output,
         written: 0,
     };
-    output.write_all(&buf)?;
+    // Stream the footer-stripped body from its scratch file; `reopen()` reads
+    // from offset 0 independently of the write handle.
+    let mut body_reader = BufReader::new(body_file.reopen()?);
+    let body_copied = io::copy(&mut body_reader, &mut output)?;
+    if body_copied != body_len {
+        return Err(FooterError::Malformed("body stream length mismatch"));
+    }
 
     let fts_offset = if fts_length > 0 {
         let offset = output.written;

--- a/src/superfile/format/footer.rs
+++ b/src/superfile/format/footer.rs
@@ -25,6 +25,7 @@
 
 use std::{
     collections::HashMap,
+    fs::File,
     io::{self, BufReader, Cursor, Read, Seek, SeekFrom, Write},
     sync::Arc,
 };
@@ -168,31 +169,73 @@ pub fn encode_parquet_body(
     row_group_size: usize,
     column_page_size_limits: &[(&str, usize)],
 ) -> Result<EncodedBody, FooterError> {
-    let mut props_builder = WriterProperties::builder()
-        .set_compression(compression)
-        .set_max_row_group_row_count(Some(row_group_size));
-    for (col, limit) in column_page_size_limits {
-        props_builder = props_builder
-            .set_column_data_page_size_limit(ColumnPath::from((*col).to_string()), *limit);
+    let mut encoder =
+        ParquetBodyEncoder::new(schema, compression, row_group_size, column_page_size_limits)?;
+    for batch in batches {
+        encoder.write_batch(batch)?;
     }
-    let props = props_builder.build();
+    encoder.finish()
+}
 
-    // Encode the Parquet body to a scratch temp file rather than a `Vec`, so
-    // the body — multi-GB at corpus scale — never materializes whole in RAM.
-    // The footer is read back from the file, then the file is truncated to the
-    // end of the last row group; the splice appends the blobs + rewritten
-    // footer.
-    let mut body_file = NamedTempFile::new()?;
-    {
-        let mut writer =
-            ArrowWriter::try_new(body_file.as_file_mut(), schema.clone(), Some(props))?;
-        for batch in batches {
-            writer.write(batch)?;
+/// Incremental Parquet-body encoder: feeds row batches to an `ArrowWriter`
+/// one at a time so the caller can drop each batch after writing it, instead
+/// of holding every batch until a single [`encode_parquet_body`] call. A
+/// compaction merge that streams many inputs then never holds more than the
+/// in-flight input batch plus the writer's current row-group buffer.
+///
+/// Because `ArrowWriter` cuts row groups purely on accumulated row count (not
+/// on `write` boundaries), streaming batches yields byte-identical output to
+/// one `encode_parquet_body` over the same batches in the same order.
+pub(crate) struct ParquetBodyEncoder {
+    body_file: NamedTempFile,
+    writer: ArrowWriter<File>,
+}
+
+impl ParquetBodyEncoder {
+    pub(crate) fn new(
+        schema: &Arc<Schema>,
+        compression: Compression,
+        row_group_size: usize,
+        column_page_size_limits: &[(&str, usize)],
+    ) -> Result<Self, FooterError> {
+        let mut props_builder = WriterProperties::builder()
+            .set_compression(compression)
+            .set_max_row_group_row_count(Some(row_group_size));
+        for (col, limit) in column_page_size_limits {
+            props_builder = props_builder
+                .set_column_data_page_size_limit(ColumnPath::from((*col).to_string()), *limit);
         }
-        writer.close()?;
+        let props = props_builder.build();
+
+        // Encode to a scratch temp file rather than a `Vec`, so the body —
+        // multi-GB at corpus scale — never materializes whole in RAM. The
+        // writer owns an independent handle to the same file (`reopen`); the
+        // struct's `body_file` handle reads the footer back after close, and
+        // their cursors don't alias.
+        let body_file = NamedTempFile::new()?;
+        let write_handle = body_file.reopen()?;
+        let writer = ArrowWriter::try_new(write_handle, schema.clone(), Some(props))?;
+        Ok(Self { body_file, writer })
     }
 
-    // Locate the footer and decode it, reading from the file end.
+    pub(crate) fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), FooterError> {
+        self.writer.write(batch)?;
+        Ok(())
+    }
+
+    /// Close the writer and strip the Parquet footer, yielding the same
+    /// [`EncodedBody`] as [`encode_parquet_body`].
+    pub(crate) fn finish(self) -> Result<EncodedBody, FooterError> {
+        let Self { body_file, writer } = self;
+        writer.close()?;
+        strip_parquet_footer(body_file)
+    }
+}
+
+/// Read back the just-written Parquet footer from `body_file`, decode its
+/// metadata, and truncate the file to the end of the last row group. The
+/// splice later appends the blobs + a rewritten footer.
+fn strip_parquet_footer(mut body_file: NamedTempFile) -> Result<EncodedBody, FooterError> {
     let file = body_file.as_file_mut();
     let n = file.seek(SeekFrom::End(0))?;
     if n < PARQUET_MIN_FILE_BYTES as u64 {

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1566,8 +1566,6 @@ impl FtsBuilder {
     /// transitions the column to the spilled accumulator (the same
     /// [`add_doc`]-time transition), after which each posting is written
     /// straight to the partition/position spill files.
-    // Wired by the FTS compaction k-way merge (landing incrementally).
-    #[allow(dead_code)]
     pub(crate) fn add_prebuilt_term_posting(
         &mut self,
         column_id: u32,
@@ -1778,11 +1776,18 @@ impl FtsBuilder {
     /// inputs' already-clamped stored lengths rather than recomputing them
     /// from text) and advance the builder's doc count so `finish` sizes the
     /// doc-lengths table and `n_docs` correctly.
-    // Wired by the FTS compaction k-way merge (landing incrementally).
-    #[allow(dead_code)]
+    ///
+    /// Also recomputes `total_tokens` as the sum of the lengths. `finish`
+    /// derives `avgdl = total_tokens / n_docs` from it, and a doc length *is*
+    /// its token count (`add_doc` clamps only at `u32::MAX`, never reached in
+    /// practice), so this sum equals what re-indexing the same corpus would
+    /// accumulate — keeping merged BM25 scores identical to a fresh build.
     pub(crate) fn set_prebuilt_doc_lengths(&mut self, column_id: u32, doc_lengths: Vec<u32>) {
         let n = doc_lengths.len() as u32;
-        self.columns[column_id as usize].doc_lengths = doc_lengths;
+        let total_tokens: u64 = doc_lengths.iter().map(|&dl| u64::from(dl)).sum();
+        let col = &mut self.columns[column_id as usize];
+        col.total_tokens = total_tokens;
+        col.doc_lengths = doc_lengths;
         self.n_docs = self.n_docs.max(n);
     }
 

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1550,6 +1550,90 @@ impl FtsBuilder {
         }
     }
 
+    /// Push one prebuilt posting `(term, doc_id, tf, positions)` into the
+    /// column's accumulator without tokenizing — the FTS-compaction-merge
+    /// counterpart of [`add_doc`]. `positions` is empty for a non-positional
+    /// column; otherwise it holds the `tf` token offsets for this `(term,
+    /// doc)`. Callers feed postings with each term's docs in ascending doc-id
+    /// order (the merge reads them that way), so a term's posting list stays
+    /// sorted — matching what `add_doc` produces. Mirrors the in-RAM drain in
+    /// [`add_doc_inram`], minus the tokenize + per-doc position-chain walk.
+    ///
+    /// Doc lengths are fed separately via [`set_prebuilt_doc_lengths`] — the
+    /// merge carries the inputs' stored lengths rather than recomputing them.
+    ///
+    /// Currently the in-RAM accumulator only; once a column spills (large
+    /// merges) this errors. The spill transition + spilled push land next.
+    // Wired by the FTS compaction k-way merge (landing incrementally).
+    #[allow(dead_code)]
+    pub(crate) fn add_prebuilt_term_posting(
+        &mut self,
+        column_id: u32,
+        term: &str,
+        doc_id: u32,
+        tf: u32,
+        positions: &[u32],
+    ) -> Result<(), BuildError> {
+        let col_idx = column_id as usize;
+        let positional = self.columns[col_idx].positions;
+        match &mut self.postings[col_idx] {
+            ColumnPostings::InRam {
+                terms,
+                pos_runs,
+                bytes,
+            } => {
+                let term_len = term.len();
+                let mut new_bytes: usize = 0;
+                match terms.get_mut(term) {
+                    Some(acc) => {
+                        acc.push((doc_id, tf));
+                        new_bytes = new_bytes.saturating_add(ACCUM_POSTING_BYTES);
+                    }
+                    None => {
+                        terms.insert(Box::<str>::from(term), vec![(doc_id, tf)]);
+                        new_bytes = new_bytes.saturating_add(
+                            ACCUM_NEW_TERM_FIXED_BYTES + term_len + ACCUM_POSTING_BYTES,
+                        );
+                    }
+                }
+                if positional {
+                    match pos_runs.get_mut(term) {
+                        Some(run) => {
+                            let before = run.len();
+                            encode_run(run, positions);
+                            new_bytes = new_bytes.saturating_add(run.len() - before);
+                        }
+                        None => {
+                            let mut run = Vec::new();
+                            encode_run(&mut run, positions);
+                            new_bytes = new_bytes
+                                .saturating_add(ACCUM_NEW_TERM_FIXED_BYTES + term_len + run.len());
+                            pos_runs.insert(Box::<str>::from(term), run);
+                        }
+                    }
+                }
+                *bytes = bytes.saturating_add(new_bytes);
+                Ok(())
+            }
+            ColumnPostings::Spilled { .. } => Err(BuildError::FtsColumnTypeInvalid {
+                column: format!("column_id {column_id}"),
+                actual: "prebuilt posting into a spilled column is not yet supported".to_string(),
+            }),
+        }
+    }
+
+    /// Set a column's per-doc lengths directly (the compaction merge feeds the
+    /// inputs' already-clamped stored lengths rather than recomputing them
+    /// from text) and advance the builder's doc count so `finish` sizes the
+    /// doc-lengths table and `n_docs` correctly.
+    // Wired by the FTS compaction k-way merge (landing incrementally).
+    #[allow(dead_code)]
+    pub(crate) fn set_prebuilt_doc_lengths(&mut self, column_id: u32, doc_lengths: Vec<u32>) {
+        let n = doc_lengths.len() as u32;
+        self.columns[column_id as usize].doc_lengths = doc_lengths;
+        self.n_docs = self.n_docs.max(n);
+    }
+
     /// Spilled-mode hot path. Per-token cost: intern lookup + dense-
     /// array tf bump; per-doc cost: drain `updated_terms` into the
     /// partition writers as 12-byte triples. Invariant maintained:

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1562,8 +1562,10 @@ impl FtsBuilder {
     /// Doc lengths are fed separately via [`set_prebuilt_doc_lengths`] — the
     /// merge carries the inputs' stored lengths rather than recomputing them.
     ///
-    /// Currently the in-RAM accumulator only; once a column spills (large
-    /// merges) this errors. The spill transition + spilled push land next.
+    /// Memory-bounded: while in-RAM, a push that crosses `spill_threshold_bytes`
+    /// transitions the column to the spilled accumulator (the same
+    /// [`add_doc`]-time transition), after which each posting is written
+    /// straight to the partition/position spill files.
     // Wired by the FTS compaction k-way merge (landing incrementally).
     #[allow(dead_code)]
     pub(crate) fn add_prebuilt_term_posting(
@@ -1575,8 +1577,15 @@ impl FtsBuilder {
         positions: &[u32],
     ) -> Result<(), BuildError> {
         let col_idx = column_id as usize;
+        if self.postings[col_idx].is_spilled() {
+            return self.push_prebuilt_spilled(col_idx, term, doc_id, tf, positions);
+        }
+
+        // In-RAM push, mirroring the `add_doc_inram` drain minus the tokenize +
+        // per-doc chain walk (positions arrive already decoded).
         let positional = self.columns[col_idx].positions;
-        match &mut self.postings[col_idx] {
+        let threshold = self.spill_threshold_bytes;
+        let crossed = match &mut self.postings[col_idx] {
             ColumnPostings::InRam {
                 terms,
                 pos_runs,
@@ -1613,13 +1622,156 @@ impl FtsBuilder {
                     }
                 }
                 *bytes = bytes.saturating_add(new_bytes);
-                Ok(())
+                *bytes > threshold
             }
-            ColumnPostings::Spilled { .. } => Err(BuildError::FtsColumnTypeInvalid {
-                column: format!("column_id {column_id}"),
-                actual: "prebuilt posting into a spilled column is not yet supported".to_string(),
-            }),
+            ColumnPostings::Spilled { .. } => unreachable!("spilled handled above"),
+        };
+
+        if crossed {
+            let (drained, drained_pos_runs) = match &mut self.postings[col_idx] {
+                ColumnPostings::InRam {
+                    terms, pos_runs, ..
+                } => (mem::take(terms), mem::take(pos_runs)),
+                ColumnPostings::Spilled { .. } => unreachable!("just pushed in-RAM"),
+            };
+            self.spill_inram_column(col_idx, drained, drained_pos_runs)?;
         }
+        Ok(())
+    }
+
+    /// Transition an in-RAM column to the spilled accumulator, draining the
+    /// given in-RAM maps into fresh spill partitions and building the term
+    /// interner. Same construction as the `add_doc_inram` threshold transition,
+    /// factored so the prebuilt-posting path reuses it. `drained_pos_runs` is
+    /// empty (and unused) for a non-positional column.
+    fn spill_inram_column(
+        &mut self,
+        col_idx: usize,
+        drained: FxHashMap<Box<str>, Vec<(u32, u32)>>,
+        drained_pos_runs: FxHashMap<Box<str>, Vec<u8>>,
+    ) -> Result<(), BuildError> {
+        let positional = self.columns[col_idx].positions;
+        let column_id = col_idx as u32;
+        let term_arena = Bump::new();
+        let mut term_to_id: TermIdMap = TermIdMap::default();
+        let mut id_to_term: Vec<&'static str> = Vec::with_capacity(drained.len());
+        let store = match positional {
+            false => {
+                let mut partitions = Self::open_partitions_for_column(
+                    self.scratch_dir.path(),
+                    column_id,
+                    self.spill_partitions,
+                )?;
+                Self::flush_in_ram_to_partitions(
+                    drained,
+                    &mut partitions,
+                    &mut term_to_id,
+                    &mut id_to_term,
+                    &term_arena,
+                )?;
+                SpillStore::Plain(partitions)
+            }
+            true => {
+                let mut partitions = Self::open_partitions_for_column(
+                    self.scratch_dir.path(),
+                    column_id,
+                    self.spill_partitions,
+                )?;
+                let mut blobs = Self::open_position_blobs_for_column(
+                    self.scratch_dir.path(),
+                    column_id,
+                    self.spill_partitions,
+                )?;
+                Self::flush_in_ram_to_positional_partitions(
+                    drained,
+                    drained_pos_runs,
+                    &mut partitions,
+                    &mut blobs,
+                    &mut term_to_id,
+                    &mut id_to_term,
+                    &term_arena,
+                )?;
+                SpillStore::Positional { partitions, blobs }
+            }
+        };
+        let dense_doc_tf = vec![0u32; id_to_term.len()];
+        let dense_doc_poshead = match positional {
+            true => vec![CHAIN_END; id_to_term.len()],
+            false => Vec::new(),
+        };
+        self.postings[col_idx] = ColumnPostings::Spilled {
+            partitions: store,
+            term_to_id,
+            id_to_term,
+            dense_doc_tf,
+            dense_doc_poshead,
+            updated_terms: Vec::new(),
+            term_arena,
+        };
+        Ok(())
+    }
+
+    /// Write one prebuilt posting straight to a spilled column's partition
+    /// (and position blob, for a positional column) as the fixed-size record
+    /// `add_doc_spilled` emits: interns the term, hash-selects the partition,
+    /// and appends the `(term_id, doc_id, tf[, pos_lo, pos_hi])` record. The
+    /// finish path k-way merges the partitions exactly as for a fresh build.
+    fn push_prebuilt_spilled(
+        &mut self,
+        col_idx: usize,
+        term: &str,
+        doc_id: u32,
+        tf: u32,
+        positions: &[u32],
+    ) -> Result<(), BuildError> {
+        let positional = self.columns[col_idx].positions;
+        let ColumnPostings::Spilled {
+            partitions,
+            term_to_id,
+            id_to_term,
+            dense_doc_tf,
+            dense_doc_poshead,
+            term_arena,
+            ..
+        } = &mut self.postings[col_idx]
+        else {
+            unreachable!("push_prebuilt_spilled on a non-spilled column");
+        };
+
+        let (term_id, is_new) = intern_term_id(term_to_id, id_to_term, term_arena, term);
+        if is_new {
+            // Keep the per-id parallel arrays in lockstep with the vocab.
+            dense_doc_tf.push(0);
+            if positional {
+                dense_doc_poshead.push(CHAIN_END);
+            }
+        }
+
+        match partitions {
+            SpillStore::Plain(parts) => {
+                let p = (term_id as usize) & (parts.len() - 1);
+                push_record_batched(&mut parts[p], [term_id, doc_id, tf])?;
+            }
+            SpillStore::Positional {
+                partitions: parts,
+                blobs,
+            } => {
+                let p = (term_id as usize) & (parts.len() - 1);
+                let blob = &mut blobs[p];
+                let writer = blob
+                    .writer
+                    .as_mut()
+                    .expect("positions blob writer open before finish");
+                let mut run = Vec::new();
+                encode_run(&mut run, positions);
+                writer.write_all(&run)?;
+                let pos_off = blob.len;
+                blob.len += run.len() as u64;
+                let (lo, hi) = pos_off_lanes(pos_off);
+                push_record_batched(&mut parts[p], [term_id, doc_id, tf, lo, hi])?;
+            }
+        }
+        Ok(())
     }
 
     /// Set a column's per-doc lengths directly (the compaction merge feeds the

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -5628,15 +5628,30 @@ mod tests {
             );
         }
         let t = |s: &str| s.as_bytes().to_vec();
-        assert_eq!(got.get(&t("rust")).unwrap().as_slice(), &[(0, 1), (1, 1)]);
         assert_eq!(
-            got.get(&t("runtime")).unwrap().as_slice(),
+            got.get(&t("rust")).expect("term streamed").as_slice(),
             &[(0, 1), (1, 1)]
         );
-        assert_eq!(got.get(&t("async")).unwrap().as_slice(), &[(0, 1)]);
-        assert_eq!(got.get(&t("tokio")).unwrap().as_slice(), &[(1, 1)]);
-        assert_eq!(got.get(&t("java")).unwrap().as_slice(), &[(2, 1)]);
-        assert_eq!(got.get(&t("boot")).unwrap().as_slice(), &[(2, 1)]);
+        assert_eq!(
+            got.get(&t("runtime")).expect("term streamed").as_slice(),
+            &[(0, 1), (1, 1)]
+        );
+        assert_eq!(
+            got.get(&t("async")).expect("term streamed").as_slice(),
+            &[(0, 1)]
+        );
+        assert_eq!(
+            got.get(&t("tokio")).expect("term streamed").as_slice(),
+            &[(1, 1)]
+        );
+        assert_eq!(
+            got.get(&t("java")).expect("term streamed").as_slice(),
+            &[(2, 1)]
+        );
+        assert_eq!(
+            got.get(&t("boot")).expect("term streamed").as_slice(),
+            &[(2, 1)]
+        );
         // Every stored term was streamed exactly once.
         assert_eq!(got.len() as u32, r.n_terms());
     }
@@ -5668,15 +5683,18 @@ mod tests {
         let t = |s: &str| s.as_bytes().to_vec();
         // PFOR positional: multi-doc terms, tf and positions per doc.
         assert_eq!(
-            got.get(&t("a")).unwrap().as_slice(),
+            got.get(&t("a")).expect("term streamed").as_slice(),
             &[(0, 2, vec![0, 2]), (1, 1, vec![1])]
         );
         assert_eq!(
-            got.get(&t("b")).unwrap().as_slice(),
+            got.get(&t("b")).expect("term streamed").as_slice(),
             &[(0, 1, vec![1]), (1, 1, vec![0])]
         );
         // Inline positional (df=1): the single position comes from the slot.
-        assert_eq!(got.get(&t("c")).unwrap().as_slice(), &[(1, 1, vec![2])]);
+        assert_eq!(
+            got.get(&t("c")).expect("term streamed").as_slice(),
+            &[(1, 1, vec![2])]
+        );
     }
 
     #[test]

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -5710,6 +5710,53 @@ mod tests {
     }
 
     #[test]
+    fn add_prebuilt_term_posting_spilled_round_trips() {
+        use std::collections::BTreeMap;
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower","positions":true}]"#;
+
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut a = FtsBuilder::new(tok.clone());
+        a.register_column("body".into(), true).expect("register a");
+        a.add_doc(0, 0, "a b c a").expect("a doc 0");
+        a.add_doc(0, 1, "b c d").expect("a doc 1");
+        a.add_doc(0, 2, "a d e").expect("a doc 2");
+        let ra = FtsReader::open(Bytes::from(a.finish().expect("finish a")), json).expect("open a");
+
+        // Force the spilled accumulator with a 1-byte threshold: the first
+        // prebuilt push spills the column, so the rest exercise the transition
+        // + push_prebuilt_spilled (partition + position-blob writes).
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), true).expect("register b");
+        b.set_spill_threshold_bytes(1);
+        ra.for_each_term_posting(0, |term, doc_id, tf, positions| {
+            let term_str = std::str::from_utf8(term).expect("utf8 term");
+            b.add_prebuilt_term_posting(0, term_str, doc_id, tf, positions)
+                .expect("prebuilt push (spilled)");
+            Ok(())
+        })
+        .expect("feed prebuilt postings");
+        b.set_prebuilt_doc_lengths(0, vec![4, 3, 3]);
+        let rb = FtsReader::open(Bytes::from(b.finish().expect("finish b")), json).expect("open b");
+
+        let collect = |r: &FtsReader| {
+            let mut m: BTreeMap<Vec<u8>, Vec<(u32, u32, Vec<u32>)>> = BTreeMap::new();
+            r.for_each_term_posting(0, |t, d, tf, p| {
+                m.entry(t.to_vec()).or_default().push((d, tf, p.to_vec()));
+                Ok(())
+            })
+            .expect("collect");
+            m
+        };
+        assert_eq!(
+            collect(&ra),
+            collect(&rb),
+            "spilled prebuilt-fed postings must match a fresh build"
+        );
+        assert_eq!(rb.n_docs(), 3);
+        assert_eq!(rb.n_terms(), ra.n_terms());
+    }
+
+    #[test]
     fn open_rejects_bad_magic() {
         let (mut blob_vec, json) = build_blob();
         let mut bytes = blob_vec.to_vec();

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1547,12 +1547,14 @@ impl FtsReader {
 
     /// Stream a column's postings for the FTS compaction merge: for every term
     /// (lex order) and every doc in its posting list (doc_ids ascending),
-    /// invoke `emit(term_bytes, local_doc_id, tf)`. Reuses the query-path
-    /// [`TermCursor`] block decode, so the doc_ids/tfs are exactly what a fresh
-    /// build would produce. Positions are read separately (a positional column
-    /// still yields the same `(doc_id, tf)` here; the caller pairs it with a
-    /// positions read). Tombstone filtering is the caller's job — this streams
-    /// every stored posting.
+    /// invoke `emit(term_bytes, local_doc_id, tf, positions)`. Reuses the
+    /// query-path [`TermCursor`] block decode for doc_ids/tfs and the
+    /// positional `decode_run` for positions, so what is streamed is exactly
+    /// what a fresh build produced. `positions` is empty for a non-positional
+    /// column; otherwise it holds the `tf` token offsets for this `(term, doc)`
+    /// (borrowed from a reused buffer — copy it if you need to retain it past
+    /// the call). Tombstone filtering is the caller's job — this streams every
+    /// stored posting.
     ///
     /// Synchronous: compaction opens its inputs over resident bytes, so every
     /// range resolves without a runtime. `emit` may return an error to abort.
@@ -1561,13 +1563,14 @@ impl FtsReader {
     pub(crate) fn for_each_term_posting(
         &self,
         column_id: u32,
-        mut emit: impl FnMut(&[u8], u32, u32) -> Result<(), FtsError>,
+        mut emit: impl FnMut(&[u8], u32, u32, &[u32]) -> Result<(), FtsError>,
     ) -> Result<(), FtsError> {
         let col_meta = &self.columns[column_id as usize];
         let positional = col_meta.positions;
         let n_docs = u64::from(self.n_docs);
         let column_name = col_meta.name.clone();
         let region_base = self.postings_range.start;
+        let positions_region = self.positions_range.clone();
 
         let fst_bytes = self.dict_bytes()?;
         let dict = DictReader::open(&fst_bytes).map_err(|e| {
@@ -1583,15 +1586,22 @@ impl FtsReader {
         column_prefix.push(FST_SEPARATOR);
         let prefix_len = column_prefix.len();
 
+        // Reused across (term, doc) to hold the decoded position run.
+        let mut positions_buf: Vec<u32> = Vec::new();
+
         for (key, packed) in dict.iter_prefix(&column_prefix) {
             let term = &key[prefix_len..];
             match FstValue::unpack(packed) {
                 FstValue::Inline { doc_id, tf } => {
-                    // A positional column only inlines tf == 1 postings; score
-                    // with the implied tf, not the slot (which carries the
-                    // single position).
-                    let tf = if positional { 1 } else { tf };
-                    emit(term, doc_id, tf)?;
+                    // A positional column only inlines tf == 1 postings; the
+                    // slot then carries the term's single position and tf is
+                    // implied 1. Non-positional: `tf` is the frequency, no
+                    // positions.
+                    if positional {
+                        emit(term, doc_id, 1, &[tf])?;
+                    } else {
+                        emit(term, doc_id, tf, &[])?;
+                    }
                 }
                 FstValue::Pfor {
                     metadata_offset,
@@ -1614,14 +1624,49 @@ impl FtsReader {
                         start..start + postings_length,
                         "fts/merge postings",
                     )?;
+
+                    // For a positional column, this term's position runs live
+                    // contiguously in the positions region at `positions_offset`,
+                    // one `decode_run` per doc in posting order. Read the slice
+                    // once and walk it in lockstep with the doc cursor.
+                    let position_bytes = if positional {
+                        let meta = TermMeta::parse(term_bytes.as_ref(), 0, true)?;
+                        let region = positions_region.as_ref().ok_or_else(|| {
+                            FtsError::Read(ReadError::MalformedVersion(
+                                "positional column missing a positions region".into(),
+                            ))
+                        })?;
+                        let pstart = region.start + meta.positions_offset as usize;
+                        let pend = pstart + meta.positions_length as usize;
+                        Some(fetch_source_range(
+                            &self.source,
+                            pstart..pend,
+                            "fts/merge positions",
+                        )?)
+                    } else {
+                        None
+                    };
+                    let mut pos_at = 0usize;
+
                     let mut cursor = TermCursor::new(term_bytes, n_docs, positional, None)?;
                     while !cursor.is_exhausted() {
                         while cursor.pos < cursor.block_n {
-                            emit(
-                                term,
-                                cursor.block_doc_ids[cursor.pos],
-                                cursor.block_tfs[cursor.pos],
-                            )?;
+                            let doc_id = cursor.block_doc_ids[cursor.pos];
+                            let tf = cursor.block_tfs[cursor.pos];
+                            let positions: &[u32] = match &position_bytes {
+                                Some(bytes) => {
+                                    positions_buf.clear();
+                                    decode_run(bytes.as_ref(), &mut pos_at, tf, &mut positions_buf)
+                                        .ok_or_else(|| {
+                                            FtsError::Read(ReadError::MalformedVersion(
+                                                "truncated position run in merge read".into(),
+                                            ))
+                                        })?;
+                                    &positions_buf
+                                }
+                                None => &[],
+                            };
+                            emit(term, doc_id, tf, positions)?;
                             cursor.pos += 1;
                         }
                         cursor.next();
@@ -5548,7 +5593,11 @@ mod tests {
         let r = FtsReader::open(blob, &json).expect("open");
 
         let mut got: BTreeMap<Vec<u8>, Vec<(u32, u32)>> = BTreeMap::new();
-        r.for_each_term_posting(0, |term, doc_id, tf| {
+        r.for_each_term_posting(0, |term, doc_id, tf, positions| {
+            assert!(
+                positions.is_empty(),
+                "non-positional column yields no positions"
+            );
             got.entry(term.to_vec()).or_default().push((doc_id, tf));
             Ok(())
         })
@@ -5573,6 +5622,44 @@ mod tests {
         assert_eq!(got.get(&t("boot")).unwrap().as_slice(), &[(2, 1)]);
         // Every stored term was streamed exactly once.
         assert_eq!(got.len() as u32, r.n_terms());
+    }
+
+    #[test]
+    fn for_each_term_posting_round_trips_positions() {
+        use std::collections::BTreeMap;
+        // doc 0 "a b a", doc 1 "b a c". "a"/"b" are df=2 (PFOR path); "c" is
+        // df=1 (inline path). Positions are token offsets within each doc.
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), true)
+            .expect("register positional column");
+        b.add_doc(0, 0, "a b a").expect("add doc 0");
+        b.add_doc(0, 1, "b a c").expect("add doc 1");
+        let bytes = b.finish().expect("finish");
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower","positions":true}]"#;
+        let r = FtsReader::open(Bytes::from(bytes), json).expect("open");
+
+        let mut got: BTreeMap<Vec<u8>, Vec<(u32, u32, Vec<u32>)>> = BTreeMap::new();
+        r.for_each_term_posting(0, |term, doc_id, tf, positions| {
+            got.entry(term.to_vec())
+                .or_default()
+                .push((doc_id, tf, positions.to_vec()));
+            Ok(())
+        })
+        .expect("stream positional postings");
+
+        let t = |s: &str| s.as_bytes().to_vec();
+        // PFOR positional: multi-doc terms, tf and positions per doc.
+        assert_eq!(
+            got.get(&t("a")).unwrap().as_slice(),
+            &[(0, 2, vec![0, 2]), (1, 1, vec![1])]
+        );
+        assert_eq!(
+            got.get(&t("b")).unwrap().as_slice(),
+            &[(0, 1, vec![1]), (1, 1, vec![0])]
+        );
+        // Inline positional (df=1): the single position comes from the slot.
+        assert_eq!(got.get(&t("c")).unwrap().as_slice(), &[(1, 1, vec![2])]);
     }
 
     #[test]

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -5663,6 +5663,53 @@ mod tests {
     }
 
     #[test]
+    fn add_prebuilt_term_posting_round_trips_read_to_write() {
+        use std::collections::BTreeMap;
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower","positions":true}]"#;
+
+        // Build A from text.
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut a = FtsBuilder::new(tok.clone());
+        a.register_column("body".into(), true).expect("register a");
+        a.add_doc(0, 0, "a b a").expect("a doc 0");
+        a.add_doc(0, 1, "b a c").expect("a doc 1");
+        let ra = FtsReader::open(Bytes::from(a.finish().expect("finish a")), json).expect("open a");
+
+        // Build B by streaming A's postings straight into the prebuilt path —
+        // no re-tokenization. Doc lengths carried over ("a b a"/"b a c" = 3/3).
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), true).expect("register b");
+        ra.for_each_term_posting(0, |term, doc_id, tf, positions| {
+            let term_str = std::str::from_utf8(term).expect("utf8 term");
+            b.add_prebuilt_term_posting(0, term_str, doc_id, tf, positions)
+                .expect("prebuilt push");
+            Ok(())
+        })
+        .expect("feed prebuilt postings");
+        b.set_prebuilt_doc_lengths(0, vec![3, 3]);
+        let rb = FtsReader::open(Bytes::from(b.finish().expect("finish b")), json).expect("open b");
+
+        // The two readers must expose identical postings (doc_ids, tfs,
+        // positions) for every term.
+        let collect = |r: &FtsReader| {
+            let mut m: BTreeMap<Vec<u8>, Vec<(u32, u32, Vec<u32>)>> = BTreeMap::new();
+            r.for_each_term_posting(0, |t, d, tf, p| {
+                m.entry(t.to_vec()).or_default().push((d, tf, p.to_vec()));
+                Ok(())
+            })
+            .expect("collect");
+            m
+        };
+        assert_eq!(
+            collect(&ra),
+            collect(&rb),
+            "prebuilt-fed postings must match"
+        );
+        assert_eq!(rb.n_docs(), 2);
+        assert_eq!(rb.n_terms(), ra.n_terms());
+    }
+
+    #[test]
     fn open_rejects_bad_magic() {
         let (mut blob_vec, json) = build_blob();
         let mut bytes = blob_vec.to_vec();

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1558,8 +1558,6 @@ impl FtsReader {
     ///
     /// Synchronous: compaction opens its inputs over resident bytes, so every
     /// range resolves without a runtime. `emit` may return an error to abort.
-    // Wired by the FTS compaction k-way merge (landing incrementally).
-    #[allow(dead_code)]
     pub(crate) fn for_each_term_posting(
         &self,
         column_id: u32,
@@ -1681,8 +1679,6 @@ impl FtsReader {
     /// local doc-id in `0..n_docs`. The FTS compaction merge carries these
     /// forward (with the input's doc-id remap) rather than recomputing them
     /// from text. These are the already-clamped values written at build time.
-    // Wired by the FTS compaction k-way merge (landing incrementally).
-    #[allow(dead_code)]
     pub(crate) fn read_doc_lengths(&self, column_id: u32) -> Result<Vec<u32>, FtsError> {
         let n = self.n_docs as usize;
         let range = self.columns[column_id as usize].doc_lengths_range.clone();

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1545,6 +1545,93 @@ impl FtsReader {
         self.iter_terms_with_prefix(column, b"")
     }
 
+    /// Stream a column's postings for the FTS compaction merge: for every term
+    /// (lex order) and every doc in its posting list (doc_ids ascending),
+    /// invoke `emit(term_bytes, local_doc_id, tf)`. Reuses the query-path
+    /// [`TermCursor`] block decode, so the doc_ids/tfs are exactly what a fresh
+    /// build would produce. Positions are read separately (a positional column
+    /// still yields the same `(doc_id, tf)` here; the caller pairs it with a
+    /// positions read). Tombstone filtering is the caller's job — this streams
+    /// every stored posting.
+    ///
+    /// Synchronous: compaction opens its inputs over resident bytes, so every
+    /// range resolves without a runtime. `emit` may return an error to abort.
+    // Wired by the FTS compaction k-way merge (landing incrementally).
+    #[allow(dead_code)]
+    pub(crate) fn for_each_term_posting(
+        &self,
+        column_id: u32,
+        mut emit: impl FnMut(&[u8], u32, u32) -> Result<(), FtsError>,
+    ) -> Result<(), FtsError> {
+        let col_meta = &self.columns[column_id as usize];
+        let positional = col_meta.positions;
+        let n_docs = u64::from(self.n_docs);
+        let column_name = col_meta.name.clone();
+        let region_base = self.postings_range.start;
+
+        let fst_bytes = self.dict_bytes()?;
+        let dict = DictReader::open(&fst_bytes).map_err(|e| {
+            FtsError::Read(ReadError::MalformedVersion(format!(
+                "FST parse failed: {e}"
+            )))
+        })?;
+
+        // Column-scoped FST keys are `column_name <FST_SEPARATOR> term`;
+        // `iter_prefix` yields `(key, packed_value)` in lex term order, so we
+        // read the posting metadata straight from the value — no re-lookup.
+        let mut column_prefix = column_name.as_bytes().to_vec();
+        column_prefix.push(FST_SEPARATOR);
+        let prefix_len = column_prefix.len();
+
+        for (key, packed) in dict.iter_prefix(&column_prefix) {
+            let term = &key[prefix_len..];
+            match FstValue::unpack(packed) {
+                FstValue::Inline { doc_id, tf } => {
+                    // A positional column only inlines tf == 1 postings; score
+                    // with the implied tf, not the slot (which carries the
+                    // single position).
+                    let tf = if positional { 1 } else { tf };
+                    emit(term, doc_id, tf)?;
+                }
+                FstValue::Pfor {
+                    metadata_offset,
+                    postings_length_hint,
+                } => {
+                    let start = region_base + metadata_offset as usize;
+                    let postings_length = match postings_length_hint {
+                        Some(len) => len as usize,
+                        None => {
+                            let header = fetch_source_range(
+                                &self.source,
+                                start..start + TERM_META_SIZE,
+                                "fts/merge header",
+                            )?;
+                            header_postings_length(header.as_ref())?
+                        }
+                    };
+                    let term_bytes = fetch_source_range(
+                        &self.source,
+                        start..start + postings_length,
+                        "fts/merge postings",
+                    )?;
+                    let mut cursor = TermCursor::new(term_bytes, n_docs, positional, None)?;
+                    while !cursor.is_exhausted() {
+                        while cursor.pos < cursor.block_n {
+                            emit(
+                                term,
+                                cursor.block_doc_ids[cursor.pos],
+                                cursor.block_tfs[cursor.pos],
+                            )?;
+                            cursor.pos += 1;
+                        }
+                        cursor.next();
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Walk the FST and collect every term registered under
     /// `column` whose bytes begin with `term_prefix`, in lex order.
     ///
@@ -5450,6 +5537,42 @@ mod tests {
         assert_eq!(r.n_docs(), 3);
         assert!(r.n_terms() > 0);
         assert_eq!(r.fts_columns().collect::<Vec<_>>(), vec!["body"]);
+    }
+
+    #[test]
+    fn for_each_term_posting_round_trips_doc_ids_and_tfs() {
+        use std::collections::BTreeMap;
+        // Docs (from build_blob): 0 "rust async runtime", 1 "tokio is a rust
+        // runtime", 2 "java spring boot".
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+
+        let mut got: BTreeMap<Vec<u8>, Vec<(u32, u32)>> = BTreeMap::new();
+        r.for_each_term_posting(0, |term, doc_id, tf| {
+            got.entry(term.to_vec()).or_default().push((doc_id, tf));
+            Ok(())
+        })
+        .expect("stream postings");
+
+        // doc_ids ascending within each term's list.
+        for postings in got.values() {
+            assert!(
+                postings.windows(2).all(|w| w[0].0 < w[1].0),
+                "doc_ids must be ascending"
+            );
+        }
+        let t = |s: &str| s.as_bytes().to_vec();
+        assert_eq!(got.get(&t("rust")).unwrap().as_slice(), &[(0, 1), (1, 1)]);
+        assert_eq!(
+            got.get(&t("runtime")).unwrap().as_slice(),
+            &[(0, 1), (1, 1)]
+        );
+        assert_eq!(got.get(&t("async")).unwrap().as_slice(), &[(0, 1)]);
+        assert_eq!(got.get(&t("tokio")).unwrap().as_slice(), &[(1, 1)]);
+        assert_eq!(got.get(&t("java")).unwrap().as_slice(), &[(2, 1)]);
+        assert_eq!(got.get(&t("boot")).unwrap().as_slice(), &[(2, 1)]);
+        // Every stored term was streamed exactly once.
+        assert_eq!(got.len() as u32, r.n_terms());
     }
 
     #[test]

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1677,6 +1677,27 @@ impl FtsReader {
         Ok(())
     }
 
+    /// Read a column's stored per-doc lengths (token counts), one `u32` per
+    /// local doc-id in `0..n_docs`. The FTS compaction merge carries these
+    /// forward (with the input's doc-id remap) rather than recomputing them
+    /// from text. These are the already-clamped values written at build time.
+    // Wired by the FTS compaction k-way merge (landing incrementally).
+    #[allow(dead_code)]
+    pub(crate) fn read_doc_lengths(&self, column_id: u32) -> Result<Vec<u32>, FtsError> {
+        let n = self.n_docs as usize;
+        let range = self.columns[column_id as usize].doc_lengths_range.clone();
+        let bytes = fetch_source_range(&self.source, range, "fts/merge doc_lengths")?;
+        let region = bytes.as_ref();
+        if region.len() < n * U32_BYTES {
+            return Err(FtsError::Read(ReadError::MalformedVersion(
+                "doc-lengths region shorter than n_docs entries".into(),
+            )));
+        }
+        Ok((0..n)
+            .map(|d| read_u32_le(&region[d * U32_BYTES..d * U32_BYTES + U32_BYTES]))
+            .collect())
+    }
+
     /// Walk the FST and collect every term registered under
     /// `column` whose bytes begin with `term_prefix`, in lex order.
     ///
@@ -5686,7 +5707,7 @@ mod tests {
             Ok(())
         })
         .expect("feed prebuilt postings");
-        b.set_prebuilt_doc_lengths(0, vec![3, 3]);
+        b.set_prebuilt_doc_lengths(0, ra.read_doc_lengths(0).expect("doc lengths"));
         let rb = FtsReader::open(Bytes::from(b.finish().expect("finish b")), json).expect("open b");
 
         // The two readers must expose identical postings (doc_ids, tfs,
@@ -5735,7 +5756,7 @@ mod tests {
             Ok(())
         })
         .expect("feed prebuilt postings");
-        b.set_prebuilt_doc_lengths(0, vec![4, 3, 3]);
+        b.set_prebuilt_doc_lengths(0, ra.read_doc_lengths(0).expect("doc lengths"));
         let rb = FtsReader::open(Bytes::from(b.finish().expect("finish b")), json).expect("open b");
 
         let collect = |r: &FtsReader| {
@@ -5754,6 +5775,18 @@ mod tests {
         );
         assert_eq!(rb.n_docs(), 3);
         assert_eq!(rb.n_terms(), ra.n_terms());
+    }
+
+    #[test]
+    fn read_doc_lengths_returns_token_counts() {
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false).expect("register");
+        b.add_doc(0, 0, "a b a").expect("doc 0"); // 3 tokens
+        b.add_doc(0, 1, "b a c d").expect("doc 1"); // 4 tokens
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(Bytes::from(b.finish().expect("finish")), json).expect("open");
+        assert_eq!(r.read_doc_lengths(0).expect("doc lengths"), vec![3, 4]);
     }
 
     #[test]

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -524,38 +524,38 @@ impl Supertable {
                     .next()
                     .map(|c| c.rerank_codec.is_ivf_mergeable())
             });
-            if multi_cell && sq8_merge == Some(true) {
-                let (bytes, stats) = SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(
-                    &readers_with_tombstones,
-                    &superseded_per_reader,
-                )?;
-                (Bytes::from(bytes), stats)
-            } else if sq8_merge == Some(true) {
-                let (bytes, stats) =
-                    SuperfileBuilder::build_from_sq8_ivf_readers(&readers_with_tombstones)?;
-                (Bytes::from(bytes), stats)
-            } else {
-                // FTS/SQL merge: stream the merged superfile to a temp file and
-                // mmap it back, so the corpus-sized merge output isn't held as an
-                // anon Vec — the allocation that OOMs compaction on a memory-tight
-                // host. Mapped pages are file-backed and reclaimable.
-                let mut output = NamedTempFile::new()
-                    .map_err(|e| BuildError::Store(format!("merge temp create: {e}")))?;
-                let stats = {
-                    let mut writer = BufWriter::new(output.as_file_mut());
-                    let stats = SuperfileBuilder::build_from_readers_to(
+            // Every merge kind streams its output to a temp file and mmaps it
+            // back, so the corpus-sized merge output is never held as an anon
+            // Vec — the allocation that OOMs compaction on a memory-tight host.
+            // Mapped pages are file-backed and reclaimable; downstream publish
+            // takes `Bytes` unchanged (large superfiles already stream via
+            // put_multipart).
+            let mut output = NamedTempFile::new()
+                .map_err(|e| BuildError::Store(format!("merge temp create: {e}")))?;
+            let stats = {
+                let mut writer = BufWriter::new(output.as_file_mut());
+                let stats = if multi_cell && sq8_merge == Some(true) {
+                    SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers_to(
+                        &readers_with_tombstones,
+                        &superseded_per_reader,
+                        &mut writer,
+                    )?
+                } else if sq8_merge == Some(true) {
+                    SuperfileBuilder::build_from_sq8_ivf_readers_to(
                         &readers_with_tombstones,
                         &mut writer,
-                    )?;
-                    writer
-                        .flush()
-                        .map_err(|e| BuildError::Store(format!("merge temp flush: {e}")))?;
-                    stats
+                    )?
+                } else {
+                    SuperfileBuilder::build_from_readers_to(&readers_with_tombstones, &mut writer)?
                 };
-                let bytes = mmap_readonly_bytes(output.path())
-                    .map_err(|e| BuildError::Store(format!("merge mmap: {e}")))?;
-                (bytes, stats)
-            }
+                writer
+                    .flush()
+                    .map_err(|e| BuildError::Store(format!("merge temp flush: {e}")))?;
+                stats
+            };
+            let bytes = mmap_readonly_bytes(output.path())
+                .map_err(|e| BuildError::Store(format!("merge mmap: {e}")))?;
+            (bytes, stats)
         };
 
         let shard = ShardOutput::new_with_params(

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -893,21 +893,26 @@ async fn seal_with_bounded_retry(
 mod tests {
     use std::{collections::HashSet, mem, str, sync::Arc};
 
-    use arrow_array::LargeStringArray;
+    use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+    use rayon::ThreadPoolBuilder;
     use tempfile::TempDir;
     use tokio::task;
 
     use super::*;
     use crate::{
-        Bm25Stats, BoolMode,
+        Bm25Stats, BoolMode, VectorSearchOptions,
         config::DEFAULT_STALE_SEAL_TIMEOUT_MS,
         memory::ConnectionMemoryBudget,
+        superfile::builder::FtsConfig,
         supertable::{
-            Supertable,
+            Supertable, SupertableOptions,
             error::CompactionError,
             storage::{LocalFsStorageProvider, StorageProvider},
         },
-        test_helpers::{build_title_batch, default_supertable_options},
+        test_helpers::{
+            build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
+        },
     };
 
     const DEFAULT_STALE_SEAL_TIMEOUT: std::time::Duration =
@@ -1736,6 +1741,142 @@ mod tests {
             "BM25 length normalization must carry across the merge: \
              short-doc score {short} must exceed long-doc score {long}"
         );
+    }
+
+    /// Compaction dispatch: superfiles whose vector column is **not**
+    /// IVF-mergeable (an `Fp32` rerank codec) must take the re-index branch
+    /// (`build_from_readers_to`), which re-encodes both FTS and vectors — not
+    /// the FTS-only k-way merge, which carries no vectors. This guards that
+    /// routing: after merging such inputs the merged superfile must still have
+    /// a queryable vector index (and its FTS index). If the dispatch had
+    /// wrongly picked the FTS merge, `vec()` would be `None` here.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn merge_superfiles_preserves_vectors_for_non_ivf_mergeable_inputs() {
+        const DIM: usize = 16;
+        let emb_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new(
+                "emb",
+                DataType::FixedSizeList(Arc::clone(&emb_field), DIM as i32),
+                false,
+            ),
+        ]));
+
+        // `default_vector_config` uses RerankCodec::Fp32 — deliberately the
+        // non-IVF-mergeable case, so compaction routes to the re-index branch.
+        let opts = SupertableOptions::new(
+            Arc::clone(&schema),
+            vec![FtsConfig {
+                column: "title".into(),
+                positions: false,
+            }],
+            vec![default_vector_config("emb", 42)],
+            Some(default_tokenizer()),
+        )
+        .expect("options with an fp32 vector column")
+        // One writer thread ⇒ one superfile per commit (deterministic doc-id
+        // layout), matching `default_supertable_options`.
+        .with_writer_pool(Arc::new(
+            ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("1-thread writer pool"),
+        ));
+
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let st = Supertable::create(opts.with_storage(Arc::clone(&storage))).expect("create");
+
+        // One-hot vectors so nearest-neighbour is unambiguous. `title` gives the
+        // FTS side something to index. `axes` are the hot dimension per row.
+        let make_batch = |titles: &[&str], axes: &[usize]| -> RecordBatch {
+            let mut flat = vec![0.0f32; titles.len() * DIM];
+            for (row, &ax) in axes.iter().enumerate() {
+                flat[row * DIM + ax] = 1.0;
+            }
+            let emb = FixedSizeListArray::try_new(
+                Arc::clone(&emb_field),
+                DIM as i32,
+                Arc::new(Float32Array::from(flat)),
+                None,
+            )
+            .expect("fixed-size-list");
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(LargeStringArray::from(titles.to_vec())) as ArrayRef,
+                    Arc::new(emb) as ArrayRef,
+                ],
+            )
+            .expect("batch")
+        };
+
+        {
+            let mut w = st.writer().expect("writer");
+            w.append(&make_batch(
+                &["alpha", "alpha", "alpha", "alpha"],
+                &[0, 1, 2, 3],
+            ))
+            .expect("append");
+            w.commit().expect("commit");
+        }
+        {
+            let mut w = st.writer().expect("writer");
+            w.append(&make_batch(
+                &["beta", "beta", "beta", "beta"],
+                &[4, 5, 6, 7],
+            ))
+            .expect("append");
+            w.commit().expect("commit");
+        }
+
+        let reader = st.reader().expect("reader");
+        let mut superfiles: Vec<Arc<SuperfileEntry>> =
+            reader.manifest().get_all_superfiles().to_vec();
+        assert_eq!(superfiles.len(), 2, "two ingest superfiles");
+        // Deterministic output doc-id layout: first superfile's rows land at 0..4.
+        superfiles.sort_by_key(|sf| sf.id_min);
+
+        let merged = st
+            .merge_superfiles(&superfiles)
+            .await
+            .expect("merge_superfiles should succeed");
+        let merged_reader = merged
+            .open_reader()
+            .expect("merged superfile should have bytes")
+            .expect("open reader on merged superfile");
+
+        assert_eq!(merged_reader.n_docs(), 8);
+        // The re-index branch must preserve BOTH indexes.
+        assert!(
+            merged_reader.vec().is_some(),
+            "vector index must survive the merge (routing must not use the FTS-only path)"
+        );
+        assert!(
+            merged_reader.fts().is_some(),
+            "FTS index must survive the merge"
+        );
+
+        // Vectors are queryable end to end. Query the exact one-hot of merged
+        // doc 0 (first superfile, row 0, axis 0); with a full-cluster nprobe and
+        // exact fp32 rerank it must come back as the nearest.
+        let mut query = vec![0.0f32; DIM];
+        query[0] = 1.0;
+        let hits = merged_reader
+            .vector_hits_async("emb", &query, 8, VectorSearchOptions::new().with_nprobe(64))
+            .await
+            .expect("vector search on the merged superfile");
+        assert!(!hits.is_empty(), "vector search must return hits");
+        assert_eq!(hits[0].0, 0, "nearest to the axis-0 query is merged doc 0");
+
+        // FTS side re-encoded too: every first-superfile doc carries "alpha".
+        let fts_hits = merged_reader
+            .token_match("title", &["alpha"], BoolMode::And)
+            .await
+            .expect("token_match on merged superfile");
+        assert_eq!(fts_hits.len(), 4, "all four 'alpha' docs must match");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -1656,6 +1656,88 @@ mod tests {
         }
     }
 
+    /// Ranked BM25 search must survive the k-way compaction merge. Two docs
+    /// with the same term frequency and the same document frequency but
+    /// different lengths must get *different*, length-normalized scores against
+    /// the merged-corpus average document length — the shorter one higher. That
+    /// only holds if the merge carried each input's per-doc lengths and token
+    /// totals across correctly; a merge that dropped them collapses the
+    /// length-normalization table (equal scores, or a panic on an empty table).
+    /// `token_match` (unranked) can't see this — it only checks presence — so
+    /// this exercises the ranked path through the actual `merge_superfiles`
+    /// dispatch + streamed temp-file output, complementing the builder oracle.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn merge_superfiles_preserves_bm25_length_normalization() {
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let st =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+                .expect("create supertable");
+
+        // Superfile 1: a short "cat" doc. Superfile 2: a long "cat" doc. Across
+        // the merged corpus tf(cat)=1 and df(cat)=2 for both, so the score gap
+        // is purely BM25 length normalization against avgdl.
+        {
+            let mut w = st.writer().expect("writer");
+            w.append(&build_title_batch(&["cat", "dog"]))
+                .expect("append");
+            w.commit().expect("commit");
+        }
+        {
+            let mut w = st.writer().expect("writer");
+            w.append(&build_title_batch(&[
+                "cat bird elephant giraffe hippo",
+                "dog",
+            ]))
+            .expect("append");
+            w.commit().expect("commit");
+        }
+
+        let reader = st.reader().expect("reader");
+        let mut superfiles: Vec<Arc<SuperfileEntry>> =
+            reader.manifest().get_all_superfiles().to_vec();
+        assert_eq!(superfiles.len(), 2, "two ingest superfiles");
+        // Merge input order fixes the output doc-id layout; order by id_min so
+        // the short-cat doc lands at merged doc 0 and the long-cat doc at 2.
+        superfiles.sort_by_key(|sf| sf.id_min);
+
+        let merged = st
+            .merge_superfiles(&superfiles)
+            .await
+            .expect("merge_superfiles should succeed");
+        let merged_reader = merged
+            .open_reader()
+            .expect("merged superfile should have bytes")
+            .expect("open reader on merged superfile");
+        assert_eq!(merged_reader.n_docs(), 4);
+
+        let hits = merged_reader
+            .bm25_search_pretokenized("title", &["cat"], 10, BoolMode::Or)
+            .await
+            .expect("ranked bm25 search on the merged superfile");
+        assert_eq!(hits.len(), 2, "both 'cat' docs must match after the merge");
+        for (doc, score) in &hits {
+            assert!(
+                score.is_finite() && *score > 0.0,
+                "doc {doc} score must be finite and positive, got {score}"
+            );
+        }
+        let score_of = |target: u32| -> f32 {
+            hits.iter()
+                .find(|(doc, _)| *doc == target)
+                .unwrap_or_else(|| panic!("expected a hit for merged doc {target}"))
+                .1
+        };
+        let short = score_of(0); // "cat" (length 1)
+        let long = score_of(2); // "cat bird elephant giraffe hippo" (length 5)
+        assert!(
+            short > long,
+            "BM25 length normalization must carry across the merge: \
+             short-doc score {short} must exceed long-doc score {long}"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn merge_superfiles_respects_connection_memory_budget() {
         let dir = TempDir::new().expect("tempdir");

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -10,6 +10,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    io::{BufWriter, Write},
     mem,
     sync::{
         Arc,
@@ -25,9 +26,12 @@ use futures::{
     stream::{self, StreamExt},
 };
 use roaring::RoaringBitmap;
+use tempfile::NamedTempFile;
 use tokio::time;
 use tracing::warn;
 use uuid::Uuid;
+
+use crate::supertable::reader_cache::disk::mmap_readonly_bytes;
 
 use crate::{
     config::CompactionSettings,
@@ -510,7 +514,7 @@ impl Supertable {
             readers_with_tombstones.push((reader.clone(), bitmap));
         }
 
-        let (merged_bytes, superfile_stats) = {
+        let (merged_bytes, superfile_stats): (Bytes, _) = {
             let first_vec = readers_with_tombstones
                 .first()
                 .and_then(|(reader, _)| reader.vec());
@@ -521,17 +525,38 @@ impl Supertable {
                     .map(|c| c.rerank_codec.is_ivf_mergeable())
             });
             if multi_cell && sq8_merge == Some(true) {
-                SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(
+                let (bytes, stats) = SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(
                     &readers_with_tombstones,
                     &superseded_per_reader,
-                )?
+                )?;
+                (Bytes::from(bytes), stats)
             } else if sq8_merge == Some(true) {
-                SuperfileBuilder::build_from_sq8_ivf_readers(&readers_with_tombstones)?
+                let (bytes, stats) =
+                    SuperfileBuilder::build_from_sq8_ivf_readers(&readers_with_tombstones)?;
+                (Bytes::from(bytes), stats)
             } else {
-                SuperfileBuilder::build_from_readers(&readers_with_tombstones)?
+                // FTS/SQL merge: stream the merged superfile to a temp file and
+                // mmap it back, so the corpus-sized merge output isn't held as an
+                // anon Vec — the allocation that OOMs compaction on a memory-tight
+                // host. Mapped pages are file-backed and reclaimable.
+                let mut output = NamedTempFile::new()
+                    .map_err(|e| BuildError::Store(format!("merge temp create: {e}")))?;
+                let stats = {
+                    let mut writer = BufWriter::new(output.as_file_mut());
+                    let stats = SuperfileBuilder::build_from_readers_to(
+                        &readers_with_tombstones,
+                        &mut writer,
+                    )?;
+                    writer
+                        .flush()
+                        .map_err(|e| BuildError::Store(format!("merge temp flush: {e}")))?;
+                    stats
+                };
+                let bytes = mmap_readonly_bytes(output.path())
+                    .map_err(|e| BuildError::Store(format!("merge mmap: {e}")))?;
+                (bytes, stats)
             }
         };
-        let merged_bytes = Bytes::from(merged_bytes);
 
         let shard = ShardOutput::new_with_params(
             merged_bytes,

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -545,7 +545,18 @@ impl Supertable {
                         &readers_with_tombstones,
                         &mut writer,
                     )?
+                } else if first_vec.is_none() {
+                    // FTS/scalar inputs (no vector index): carry each input's
+                    // already-built posting lists across instead of
+                    // re-tokenizing the whole corpus.
+                    SuperfileBuilder::build_from_readers_fts_merge_to(
+                        &readers_with_tombstones,
+                        &mut writer,
+                    )?
                 } else {
+                    // A vector index is present but not IVF-mergeable (e.g. an
+                    // fp32 rerank codec); the re-index path re-encodes both the
+                    // FTS and the vectors from the decoded rows.
                     SuperfileBuilder::build_from_readers_to(&readers_with_tombstones, &mut writer)?
                 };
                 writer

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -31,8 +31,6 @@ use tokio::time;
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::supertable::reader_cache::disk::mmap_readonly_bytes;
-
 use crate::{
     config::CompactionSettings,
     runtime_bridge::bridge_on_runtime,
@@ -47,6 +45,7 @@ use crate::{
         manifest::list::{DrainedVersionRanges, PartitionStrategy},
         opann::rerank_pool_hint,
         query::dispatch::open_compaction_input,
+        reader_cache::disk::mmap_readonly_bytes,
         wal::{
             Etag, SealRecord, TombstonesSidecar, WalStore,
             tombstones_admin::{self, TombstonesAdminError},

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1931,7 +1931,24 @@ fn build_one_shard_with_layout(
     let scalar_batches: Vec<&RecordBatch> = slice.iter().map(|b| &b.scalar).collect();
     let scalar_stats = ScalarStatsAgg::from_batches(&scalar_schema, &scalar_batches);
 
-    let bytes = Bytes::from(builder.finish()?);
+    // Stream the assembled superfile to a temp file, then mmap it back as
+    // zero-copy `Bytes`, rather than materializing the whole superfile as an
+    // anon `Vec<u8>` (which, on a corpus-sized single-shard build, is the
+    // dominant resident allocation and OOMs a memory-tight host). The mapped
+    // pages are file-backed and reclaimable; the downstream publish path takes
+    // `Bytes` unchanged and streams large superfiles via `put_multipart`. Same
+    // temp-file → mmap idiom the drain packed-shard path uses.
+    let mut output = NamedTempFile::new()
+        .map_err(|error| BuildError::Store(format!("shard temp create: {error}")))?;
+    {
+        let mut writer = BufWriter::new(output.as_file_mut());
+        builder.finish_to(&mut writer)?;
+        writer
+            .flush()
+            .map_err(|error| BuildError::Store(format!("shard temp flush: {error}")))?;
+    }
+    let bytes = mmap_readonly_bytes(output.path())
+        .map_err(|error| BuildError::Store(format!("shard mmap: {error}")))?;
 
     let (id_min, id_max) = if n_docs == 0 {
         (0, 0)
@@ -4995,7 +5012,21 @@ fn build_one_shard_from_packed_cells(
     let id_max = stable_ids.iter().copied().max().unwrap_or(0);
     let n_docs = stable_ids.len() as u64;
     let scalar_stats = ScalarStatsAgg::from_batches(&options.scalar_schema(), &[&scalar]);
-    let bytes = Bytes::from(builder.finish()?);
+    // Stream the compacted superfile to a temp file, then mmap it back as
+    // zero-copy `Bytes` (same idiom as the append-commit build path) instead of
+    // materializing the merged superfile as an anon `Vec<u8>` — the merge
+    // output is corpus-sized and OOMs a memory-tight host during compaction.
+    let mut output = NamedTempFile::new()
+        .map_err(|error| BuildError::Store(format!("compacted shard temp create: {error}")))?;
+    {
+        let mut writer = BufWriter::new(output.as_file_mut());
+        builder.finish_to(&mut writer)?;
+        writer
+            .flush()
+            .map_err(|error| BuildError::Store(format!("compacted shard temp flush: {error}")))?;
+    }
+    let bytes = mmap_readonly_bytes(output.path())
+        .map_err(|error| BuildError::Store(format!("compacted shard mmap: {error}")))?;
 
     Ok(ShardOutput {
         bytes,
@@ -5330,7 +5361,21 @@ fn build_one_packed_shard_via_drain(
         .map(|g| (g.cell_id, g.subsection))
         .collect();
     builder.set_prebuilt_multi_cell_ivfs(subsections)?;
-    let bytes = Bytes::from(builder.finish()?);
+    // Stream the compacted superfile to a temp file, then mmap it back as
+    // zero-copy `Bytes` (same idiom as the append-commit build path) instead of
+    // materializing the merged superfile as an anon `Vec<u8>` — the merge
+    // output is corpus-sized and OOMs a memory-tight host during compaction.
+    let mut output = NamedTempFile::new()
+        .map_err(|error| BuildError::Store(format!("compacted shard temp create: {error}")))?;
+    {
+        let mut writer = BufWriter::new(output.as_file_mut());
+        builder.finish_to(&mut writer)?;
+        writer
+            .flush()
+            .map_err(|error| BuildError::Store(format!("compacted shard temp flush: {error}")))?;
+    }
+    let bytes = mmap_readonly_bytes(output.path())
+        .map_err(|error| BuildError::Store(format!("compacted shard mmap: {error}")))?;
 
     Ok(Some(ShardOutput {
         bytes,


### PR DESCRIPTION
Three related changes that make building and compacting a large corpus into one superfile fit a memory-tight host. All target the peak RSS of the write path.

## 1. Stream build outputs to disk instead of holding them as RAM `Vec`s

The commit and compaction paths assembled the output superfile — and its intermediate Parquet body and FTS/vector blobs — as corpus-sized in-memory `Vec<u8>`s, so peak RSS carried the whole output on top of the inputs.

- `finish_to<W: Write>` streams the spliced superfile to any sink; `finish()` now wraps it.
- Commit assembles the built superfile into a temp file and mmaps it back (`mmap_readonly_bytes`); all compaction merges (`build_from_*_readers_to`) do the same.
- `encode_parquet_body` writes the Parquet body to a scratch file and reads the footer back; the FTS and vector blobs finalize to scratch sinks.

Mapped pages are file-backed and reclaimable, and downstream publish takes `Bytes` unchanged. No new `unsafe` — reuses the existing mmap helpers.

## 2. Compaction merges the FTS index instead of re-indexing from text

Compacting FTS/scalar superfiles previously re-read every input's text and **re-tokenized and rebuilt the whole posting index in RAM**, so a merge peaked as high as a fresh full-corpus build.

This carries each input's **already-built posting lists** across instead. For each FTS column it streams the input's `(term, doc_id, tf, positions)` postings into the builder's prebuilt accumulator, with doc ids remapped to a dense surviving-doc space (tombstoned rows dropped, aligned row-for-row with the concatenated Parquet body). Positions flow to the spilled positions blob on disk; doc-lengths are read from each input and concatenated rather than recomputed. The vector merge already does the analogous byte-level splice; this is the FTS counterpart.

`merge_superfiles` routes to it whenever the inputs carry **no vector index**. Vector-bearing merges are unchanged: IVF-mergeable inputs keep the byte-splice path, and vector-but-not-mergeable inputs stay on re-index.

## 3. Stream the merge's Parquet body row-group-wise

The merge above still fed every input's surviving rows into `self.batches` and encoded the body at finish — so peak RSS carried the whole corpus of decoded rows on top of the FTS interner. Now a `ParquetBodyEncoder` takes one batch at a time and the merge drops each input's batch immediately after writing it, so the body holds at most one input's batch plus the writer's row-group buffer. `ArrowWriter` cuts row groups on accumulated row count, so the streamed body is byte-identical to encoding all batches at once. `finish_to`'s blob-finalize + splice tail is factored into shared helpers that a new `finish_to_with_body` reuses.

**Net:** a compaction of N segments into one superfile now peaks at roughly the FTS term interner (inherent to one index over the corpus) + spill buffers + one input's batch + mmap'd (reclaimable) inputs — not the whole corpus of rows or the output. This is what lets the "ingest to bounded segments, then compact to one" workflow stay within a tight RSS budget. Peak-RSS numbers on a 5M-doc corpus to follow.

## Correctness

The FTS merge is proven equivalent to re-indexing by:
- a **byte-for-byte oracle** — merge-via-re-index vs merge-via-k-way return identical postings, tfs, positions, doc-lengths, and Parquet rows over planted corpora (shared terms across inputs, positional codec, tombstoned rows);
- a **direct BM25 query comparison** — identical `(doc_id, score)` top-k across single-term, multi-term OR/AND, and shared-term queries.

`set_prebuilt_doc_lengths` restores `total_tokens` so `avgdl` matches a fresh build. The merged superfile is query-identical to a fresh build (a single benign Parquet-metadata byte differs; the bar is identical top-k/scores).

## Tests

Streaming round-trips (byte-identical), the merge oracles, prebuilt-posting round-trips (incl. forced-spill), and the routed compaction path (`compact_gc`) pass; 704 superfile unit + 135 superfile integration + commit/compaction suites green. `make check` (nightly rustfmt with the crate's import opts + `clippy --all-targets -D warnings`) clean.