### PR TITLE
improv manifest error: propagate manifest load error reason

### DIFF
--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -310,7 +310,7 @@ pub enum OpenError {
     ManifestListParse(String),
 
     /// ManifestSnapshot load error.
-    #[error("manifest load error")]
+    #[error("manifest load error: {0}")]
     ManifestLoadError(#[from] ManifestLoadError),
 
     /// ManifestSnapshot part load or parse failed during open or


### PR DESCRIPTION
### What does this PR do?
- Propagates the ManifestLoadError reason forward, to the caller

### Why do we need this change?
- Before this change, we get an opaque `"manifest load error"` message for errors when loading the manifest. This PR improves the error message to display the exact reason for the error e.ge `"manifest load error: content-hash mismatch: expected 2ea5adbbc09d589f8fd7e4dd0bc752b3c4303e2204fe0a97cb09fa7f62b57a9f, got 954b2ffb6e797594d9c215aa8a009e5b019e6e82f68f44d19cc1201239178f59"`
- The more verbose error is useful to debug and understand the exact reason for the error