### PR TITLE
node: null handling on append and HTTP status on hosted errors

### DIFF
--- a/infino-node/__test__/errors.test.mjs
+++ b/infino-node/__test__/errors.test.mjs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Hosted-API error status. A failure the hosted service reported is
+// rethrown unchanged except for one added property: `status`, the HTTP
+// status the API actually returned, so callers branch on a number instead
+// of regexing message text. Local (embedded) connections are untouched.
+//
+// The hosted-path tests run a stub API server on a worker thread — the
+// SDK's calls are synchronous and would deadlock a same-thread server.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Worker } from "node:worker_threads";
+
+import { connect, IndexSpec } from "../infino/index.js";
+
+// A one-route HTTP stub: every request gets `status` + `body` back.
+const SERVER_SRC = `
+  const { parentPort, workerData } = require("node:worker_threads");
+  const http = require("node:http");
+  const server = http.createServer((req, res) => {
+    res.writeHead(workerData.status, { "content-type": "application/json" });
+    res.end(workerData.body);
+  });
+  server.listen(0, "127.0.0.1", () => parentPort.postMessage(server.address().port));
+`;
+
+async function withStubApi(status, body, run) {
+  const worker = new Worker(SERVER_SRC, { eval: true, workerData: { status, body } });
+  const port = await new Promise((resolve) => worker.once("message", resolve));
+  try {
+    run(connect(`http://127.0.0.1:${port}/yelp`, { apiKey: "test-key" }));
+  } finally {
+    await worker.terminate();
+  }
+}
+
+const throws = (fn) => {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  assert.fail("expected the call to throw");
+};
+
+// --- hosted path: `.status` = what the API returned ---
+
+test("hosted 409 create carries status 409 and the API's message", async () => {
+  await withStubApi(409, '{"error":"database already exists: cust_x/yelp"}', (db) => {
+    const e = throws(() => db.createDatabase());
+    assert.equal(e.status, 409);
+    // The stable message prefix separates a duplicate from a bad argument.
+    assert.match(e.message, /^AlreadyExists: /);
+    // The API's own words stay visible.
+    assert.match(e.message, /database already exists/);
+  });
+});
+
+test("hosted 404 carries status 404", async () => {
+  await withStubApi(404, '{"error":"database does not exist"}', (db) => {
+    const e = throws(() => db.openTable("t"));
+    assert.equal(e.status, 404);
+  });
+});
+
+test("hosted 503 carries status 503 (transient — caller can retry)", async () => {
+  await withStubApi(503, '{"error":"no capacity to activate database"}', (db) => {
+    const e = throws(() => db.listTables());
+    assert.equal(e.status, 503);
+    assert.match(e.message, /no capacity/);
+  });
+});
+
+test("hosted 500 carries status 500", async () => {
+  await withStubApi(500, '{"error":"boom"}', (db) => {
+    const e = throws(() => db.listTables());
+    assert.equal(e.status, 500);
+  });
+});
+
+test("hosted 401 keeps the unauthorized message (transport carries no number)", async () => {
+  await withStubApi(401, '{"error":"invalid api key"}', (db) => {
+    const e = throws(() => db.listTables());
+    assert.equal(e.status, undefined);
+    assert.match(e.message, /unauthorized \(check the API key\)/);
+  });
+});
+
+// --- local path: untouched — no status, addon error rethrown as-is ---
+
+test("local duplicate createTable throws the addon error with no status", () => {
+  const db = connect("memory://");
+  const make = () => db.createTable("docs", { title: "large_utf8" }, new IndexSpec().fts("title"));
+  make();
+  const e = throws(make);
+  assert.equal(e.status, undefined);
+  assert.equal(e.code, "InvalidArg");
+  assert.match(e.message, /^AlreadyExists: /);
+});
+
+test("local openTable of a missing table throws the addon error with no status", () => {
+  const db = connect("memory://");
+  const e = throws(() => db.openTable("missing"));
+  assert.equal(e.status, undefined);
+  assert.equal(e.code, "GenericFailure");
+  assert.match(e.message, /^NotFound: /);
+});
+
+test("local query failures are untouched", () => {
+  const db = connect("memory://");
+  const e = throws(() => db.querySql("definitely not sql"));
+  assert.equal(e.status, undefined);
+  assert.equal(typeof e.code, "string");
+});

--- a/infino-node/__test__/nulls.test.mjs
+++ b/infino-node/__test__/nulls.test.mjs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+//
+// Null handling on the row-object append path: a nullable field that is
+// omitted from a row must store SQL NULL, exactly like passing `null`
+// explicitly — never a type's zero value. Also covers the Boolean column
+// edge where every value in a batch is null.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { connect, IndexSpec } from "../infino/index.js";
+import { Schema, Field, LargeUtf8, Int32, Int64, Float64, Bool } from "apache-arrow";
+
+// One non-null FTS column (createTable requires an index) plus one nullable
+// column of the type under test.
+const schemaWith = (name, type) =>
+  new Schema([new Field("id", new LargeUtf8(), false), new Field(name, type, true)]);
+
+const makeTable = (db, name, colName, type) =>
+  db.createTable(name, schemaWith(colName, type), new IndexSpec().fts("id"));
+
+// Read back the row for `id` and the table-wide IS NULL count for `col`.
+const nullCount = (db, table, col) =>
+  Number(db.querySql(`SELECT count(*) AS c FROM ${table} WHERE ${col} IS NULL`)[0].c);
+
+test("omitted nullable Int32 stores null, not 0", () => {
+  const db = connect("memory://");
+  const t = makeTable(db, "t", "i", new Int32());
+  t.append([{ id: "omitted" }, { id: "explicit", i: null }, { id: "present", i: 7 }]);
+
+  const [row] = db.querySql("SELECT i FROM t WHERE id = 'omitted'");
+  assert.equal(row.i, null);
+  assert.equal(nullCount(db, "t", "i"), 2);
+});
+
+test("omitted nullable LargeUtf8 stores null, not empty string", () => {
+  const db = connect("memory://");
+  const t = makeTable(db, "t", "s", new LargeUtf8());
+  t.append([{ id: "omitted" }, { id: "explicit", s: null }, { id: "present", s: "x" }]);
+
+  const [row] = db.querySql("SELECT s FROM t WHERE id = 'omitted'");
+  assert.equal(row.s, null);
+  assert.equal(nullCount(db, "t", "s"), 2);
+});
+
+test("omitted nullable Float64 stores null, not NaN", () => {
+  const db = connect("memory://");
+  const t = makeTable(db, "t", "f", new Float64());
+  t.append([{ id: "omitted" }, { id: "explicit", f: null }, { id: "present", f: 1.5 }]);
+
+  const [row] = db.querySql("SELECT f FROM t WHERE id = 'omitted'");
+  assert.equal(row.f, null);
+  assert.equal(nullCount(db, "t", "f"), 2);
+});
+
+test("omitted nullable Int64 stores null instead of throwing", () => {
+  const db = connect("memory://");
+  const t = makeTable(db, "t", "n", new Int64());
+  t.append([{ id: "omitted" }, { id: "explicit", n: null }, { id: "present", n: 9n }]);
+
+  const [row] = db.querySql("SELECT n FROM t WHERE id = 'omitted'");
+  assert.equal(row.n, null);
+  assert.equal(nullCount(db, "t", "n"), 2);
+});
+
+test("omitted nullable Bool stores null, not false", () => {
+  const db = connect("memory://");
+  const t = makeTable(db, "t", "flag", new Bool());
+  t.append([{ id: "omitted" }, { id: "present", flag: true }]);
+
+  const [row] = db.querySql("SELECT flag FROM t WHERE id = 'omitted'");
+  assert.equal(row.flag, null);
+  assert.equal(nullCount(db, "t", "flag"), 1);
+});
+
+test("all-null nullable Bool batch appends and reads back null", () => {
+  const db = connect("memory://");
+  const t = makeTable(db, "t", "flag", new Bool());
+  t.append([{ id: "a", flag: null }, { id: "b", flag: null }]);
+
+  assert.deepEqual(
+    db.querySql("SELECT id, flag FROM t ORDER BY id"),
+    [{ id: "a", flag: null }, { id: "b", flag: null }],
+  );
+  assert.equal(nullCount(db, "t", "flag"), 2);
+});
+
+test("single-row null Bool batch appends and reads back null", () => {
+  const db = connect("memory://");
+  const t = makeTable(db, "t", "flag", new Bool());
+  t.append([{ id: "a", flag: null }]);
+
+  assert.deepEqual(db.querySql("SELECT flag FROM t"), [{ flag: null }]);
+});
+
+test("mixed null and non-null Bool batch still round-trips", () => {
+  const db = connect("memory://");
+  const t = makeTable(db, "t", "flag", new Bool());
+  t.append([{ id: "a", flag: null }, { id: "b", flag: true }, { id: "c", flag: false }]);
+
+  assert.deepEqual(
+    db.querySql("SELECT id, flag FROM t ORDER BY id"),
+    [{ id: "a", flag: null }, { id: "b", flag: true }, { id: "c", flag: false }],
+  );
+});
+
+test("update replacement rows null omitted fields", () => {
+  const dir = mkdtempSync(join(tmpdir(), "infino-node-nulls-"));
+  const db = connect(dir);
+  const t = makeTable(db, "t", "i", new Int32());
+  t.append([{ id: "a", i: 1 }]);
+
+  // Replacement row omits `i`: it must become null, not 0.
+  t.update("id = 'a'", [{ id: "a" }]);
+  assert.deepEqual(db.querySql("SELECT i FROM t WHERE id = 'a'"), [{ i: null }]);
+});
+
+test("update accepts an all-null Bool replacement batch", () => {
+  const dir = mkdtempSync(join(tmpdir(), "infino-node-nulls-"));
+  const db = connect(dir);
+  const t = makeTable(db, "t", "flag", new Bool());
+  t.append([{ id: "a", flag: true }]);
+
+  t.update("id = 'a'", [{ id: "a", flag: null }]);
+  assert.deepEqual(db.querySql("SELECT flag FROM t WHERE id = 'a'"), [{ flag: null }]);
+});

--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -246,7 +246,10 @@ function schemaToIpc(schema: any): Buffer {
 // built by hand. The schema here is ours (from the addon), so its types
 // are same-instance.
 function buildColumn(field: arrow.Field, rows: RowRecord[]): arrow.Vector {
-  const values = rows.map((r) => r[field.name]);
+  // An omitted key reads as `undefined`, which `vectorFromArray` would
+  // coerce to the type's zero value (0, "", NaN, false) rather than null —
+  // its null set is `[null]` only. Normalize so omitted == explicit null.
+  const values = rows.map((r) => r[field.name] ?? null);
   const t = field.type as any;
   if (t && typeof t.listSize === "number") {
     const flat = Float32Array.from((values as number[][]).flat());

--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -316,19 +316,56 @@ function decode(buf: Buffer, asArrow?: boolean): RowRecord[] | arrow.Table {
   });
 }
 
+// --- hosted-API error status ---
+
+// The hosted transport types a few statuses before the number itself is
+// lost (the message keeps a stable prefix); every other HTTP failure it
+// reports as "<op>: server returned NNN: <body>". Both let the status be
+// recovered here. This table goes away once the transport carries the
+// status structurally.
+const PREFIX_STATUS: [string, number][] = [
+  ["NotFound: ", 404],
+  ["AlreadyExists: ", 409],
+  ["ConflictError: ", 412],
+];
+const SERVER_STATUS = /\bserver returned (\d{3}): /;
+
+/**
+ * Run a native call. On a hosted (Infino Cloud) connection, a failure is
+ * rethrown as-is but tagged with `status` — the HTTP status the API
+ * actually returned — so callers can branch (e.g. `409` = already exists,
+ * `503` = transient, retry) without parsing message text. Local
+ * connections rethrow untouched.
+ */
+function guard<T>(remote: boolean, fn: () => T): T {
+  if (!remote) return fn();
+  try {
+    return fn();
+  } catch (e) {
+    if (e instanceof Error && (e as any).status === undefined) {
+      const prefixed = PREFIX_STATUS.find(([prefix]) => e.message.startsWith(prefix));
+      const status = prefixed ? prefixed[1] : Number(SERVER_STATUS.exec(e.message)?.[1]);
+      if (Number.isFinite(status)) (e as any).status = status;
+    }
+    throw e;
+  }
+}
+
 // --- friendly handles ---
 
 /** A table handle. Obtain one from {@link Connection.createTable} or {@link Connection.openTable}. */
 export class Table {
   private inner: any;
+  private remote: boolean;
   /** @hidden */
-  constructor(inner: any) {
+  constructor(inner: any, remote = false) {
     this.inner = inner;
+    this.remote = remote;
   }
 
   /** The table's Arrow schema. */
   schema(): arrow.Schema {
-    return arrow.tableFromIPC(this.inner.schema()).schema;
+    return arrow.tableFromIPC(guard(this.remote, () => this.inner.schema())).schema;
   }
 
   /**
@@ -337,7 +374,8 @@ export class Table {
    * append == one commit.
    */
   append(data: AppendData): void {
-    this.inner.append(dataToIpc(data, () => this.schema()));
+    const ipc = dataToIpc(data, () => this.schema());
+    guard(this.remote, () => this.inner.append(ipc));
   }
 
   /** Ranked BM25 search; rows as records (or an Arrow `Table`). `score` is a
@@ -346,7 +384,7 @@ export class Table {
   bm25Search(column: string, query: string, k: number, opts: Bm25SearchOptions & { arrow: true }): arrow.Table;
   bm25Search(column: string, query: string, k: number, opts?: Bm25SearchOptions): RowRecord[];
   bm25Search(column: string, query: string, k: number, opts: Bm25SearchOptions = {}): RowRecord[] | arrow.Table {
-    const buf = this.inner.bm25Search(column, query, k, opts.mode, opts.stats, opts.projection);
+    const buf = guard(this.remote, () => this.inner.bm25Search(column, query, k, opts.mode, opts.stats, opts.projection));
     return decode(buf, opts.arrow);
   }
 
@@ -357,7 +395,7 @@ export class Table {
   vectorSearch(column: string, query: number[] | Float32Array, k: number, opts?: VectorSearchOptions): RowRecord[];
   vectorSearch(column: string, query: number[] | Float32Array, k: number, opts: VectorSearchOptions = {}): RowRecord[] | arrow.Table {
     const q = query instanceof Float32Array ? query : Float32Array.from(query);
-    const buf = this.inner.vectorSearch(column, q, k, opts.nprobe, opts.rerankMult, opts.projection, opts.filter);
+    const buf = guard(this.remote, () => this.inner.vectorSearch(column, q, k, opts.nprobe, opts.rerankMult, opts.projection, opts.filter));
     return decode(buf, opts.arrow);
   }
 
@@ -368,7 +406,7 @@ export class Table {
   hybridSearch(textColumn: string, textQuery: string, vectorColumn: string, vectorQuery: number[] | Float32Array, k: number, opts?: HybridSearchOptions): RowRecord[];
   hybridSearch(textColumn: string, textQuery: string, vectorColumn: string, vectorQuery: number[] | Float32Array, k: number, opts: HybridSearchOptions = {}): RowRecord[] | arrow.Table {
     const q = vectorQuery instanceof Float32Array ? vectorQuery : Float32Array.from(vectorQuery);
-    const buf = this.inner.hybridSearch(textColumn, textQuery, vectorColumn, q, k, opts.mode, opts.nprobe, opts.projection);
+    const buf = guard(this.remote, () => this.inner.hybridSearch(textColumn, textQuery, vectorColumn, q, k, opts.mode, opts.nprobe, opts.projection));
     return decode(buf, opts.arrow);
   }
 
@@ -376,7 +414,7 @@ export class Table {
   tokenMatch(column: string, query: string, opts: TokenMatchOptions & { arrow: true }): arrow.Table;
   tokenMatch(column: string, query: string, opts?: TokenMatchOptions): RowRecord[];
   tokenMatch(column: string, query: string, opts: TokenMatchOptions = {}): RowRecord[] | arrow.Table {
-    const buf = this.inner.tokenMatch(column, query, opts.mode, opts.projection);
+    const buf = guard(this.remote, () => this.inner.tokenMatch(column, query, opts.mode, opts.projection));
     return decode(buf, opts.arrow);
   }
 
@@ -384,27 +422,28 @@ export class Table {
   exactMatch(column: string, value: string, opts: MatchOptions & { arrow: true }): arrow.Table;
   exactMatch(column: string, value: string, opts?: MatchOptions): RowRecord[];
   exactMatch(column: string, value: string, opts: MatchOptions = {}): RowRecord[] | arrow.Table {
-    const buf = this.inner.exactMatch(column, value, opts.projection);
+    const buf = guard(this.remote, () => this.inner.exactMatch(column, value, opts.projection));
     return decode(buf, opts.arrow);
   }
 
   /** Count rows matching a BM25 keyword `query` over `column`, without
    * fetching them. `mode` is `"or"` (default) or `"and"`. */
   count(column: string, query: string, opts: CountOptions = {}): number {
-    return this.inner.count(column, query, opts.mode);
+    return guard(this.remote, () => this.inner.count(column, query, opts.mode));
   }
 
   /** Replace rows matching a SQL predicate (e.g. `"status = 'spam'"`) with
    * `data` (same shapes as `append`), 1:1 — the matched count must equal the
    * replacement-row count. Requires durable storage (not `memory://`). */
   update(predicate: string, data: AppendData): MutationStats {
-    return this.inner.update(predicate, dataToIpc(data, () => this.schema()));
+    const ipc = dataToIpc(data, () => this.schema());
+    return guard(this.remote, () => this.inner.update(predicate, ipc));
   }
 
   /** Delete rows matching a SQL predicate (e.g. `"status = 'spam'"`).
    * Requires durable storage (not `memory://`). */
   delete(predicate: string): MutationStats {
-    return this.inner.delete(predicate);
+    return guard(this.remote, () => this.inner.delete(predicate));
   }
 
   /**
@@ -415,7 +454,7 @@ export class Table {
    * so calling this on a hosted (`https://…`) connection throws.
    */
   optimize(settings?: OptimizeOptions): void {
-    this.inner.optimize(settings);
+    guard(this.remote, () => this.inner.optimize(settings));
   }
 
   /**
@@ -427,16 +466,18 @@ export class Table {
    * calling this on a hosted connection throws.
    */
   gc(graceSecs: number): GcReport {
-    return this.inner.gc(graceSecs);
+    return guard(this.remote, () => this.inner.gc(graceSecs));
   }
 }
 
 /** A catalog connection. Create one with {@link connect}. */
 export class Connection {
   private inner: any;
+  private remote: boolean;
   /** @hidden */
-  constructor(inner: any) {
+  constructor(inner: any, remote = false) {
     this.inner = inner;
+    this.remote = remote;
   }
 
   /**
@@ -445,31 +486,32 @@ export class Connection {
    * catalog root is the database, so it is a no-op success.
    */
   createDatabase(): void {
-    this.inner.createDatabase();
+    guard(this.remote, () => this.inner.createDatabase());
   }
 
   /** Create a table from an apache-arrow `Schema` or `{ column: type }`. */
   createTable(name: string, schema: arrow.Schema | SchemaDescriptor | Buffer, indexes: IndexSpec): Table {
-    return new Table(this.inner.createTable(name, schemaToIpc(schema), indexes));
+    const ipc = schemaToIpc(schema);
+    return new Table(guard(this.remote, () => this.inner.createTable(name, ipc, indexes)), this.remote);
   }
 
   openTable(name: string): Table {
-    return new Table(this.inner.openTable(name));
+    return new Table(guard(this.remote, () => this.inner.openTable(name)), this.remote);
   }
 
   dropTable(name: string, purge?: boolean): void {
-    this.inner.dropTable(name, purge);
+    guard(this.remote, () => this.inner.dropTable(name, purge));
   }
 
   listTables(): string[] {
-    return this.inner.listTables();
+    return guard(this.remote, () => this.inner.listTables());
   }
 
   /** SQL across the catalog; rows as records (or an Arrow `Table`). */
   querySql(sql: string, opts: QueryOptions & { arrow: true }): arrow.Table;
   querySql(sql: string, opts?: QueryOptions): RowRecord[];
   querySql(sql: string, opts: QueryOptions = {}): RowRecord[] | arrow.Table {
-    return decode(this.inner.querySql(sql), opts.arrow);
+    return decode(guard(this.remote, () => this.inner.querySql(sql)), opts.arrow);
   }
 }
 
@@ -484,7 +526,10 @@ export class Connection {
  * For a hosted (`https://`) target, authenticate with an API key: pass
  * {@link ConnectOptions.apiKey}, or set the `INFINO_API_KEY` environment
  * variable. Storage and cache tuning the URI can't carry also goes in
- * `options` (see {@link ConnectOptions}).
+ * `options` (see {@link ConnectOptions}). An operation failure the hosted
+ * API reported carries the HTTP status it returned as `status` on the
+ * thrown Error (`409` create conflict, `404` missing, `503` transient —
+ * retry with backoff); errors on local connections have no `status`.
  *
  * ```ts
  * // local
@@ -494,5 +539,6 @@ export class Connection {
  * ```
  */
 export function connect(uri: string, options?: ConnectOptions): Connection {
-  return new Connection(nativeConnect(uri, options as any));
+  const remote = /^https?:\/\//.test(uri);
+  return new Connection(guard(remote, () => nativeConnect(uri, options as any)), remote);
 }

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -37,8 +37,9 @@ use arrow::compute::concat_batches;
 use arrow::error::ArrowError;
 use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::StreamWriter;
+use arrow::ipc::{MessageHeader, root_as_message};
 use arrow_array::RecordBatch;
-use arrow_schema::Schema;
+use arrow_schema::{DataType, Schema};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -140,13 +141,191 @@ fn read_schema_ipc(bytes: &[u8]) -> Result<Schema> {
 }
 
 /// Read all record batches from an Arrow IPC stream.
+///
+/// Tolerates one known writer quirk: Apache Arrow JS serializes a Boolean
+/// column whose values are all null with a zero-length values buffer (the
+/// "fastest path" in its IPC assembler), which arrow-rs rejects during
+/// decode ("Need at least N bytes for bitmap in buffers[0]"). The plain
+/// decode runs first, so well-formed input never takes the repair path; on
+/// failure the stream's bytes are patched (see [`patch_all_null_bool_ipc`])
+/// and decoded again with full validation. If that fails too, the original
+/// error is the one reported.
 fn read_batches_ipc(bytes: &[u8]) -> Result<Vec<RecordBatch>> {
+    match read_batches_ipc_strict(bytes) {
+        Ok(batches) => Ok(batches),
+        Err(strict_err) => match patch_all_null_bool_ipc(bytes) {
+            Some(patched) => read_batches_ipc_strict(&patched).map_err(|_| strict_err),
+            None => Err(strict_err),
+        },
+    }
+}
+
+/// The plain, fully-validated IPC stream decode.
+fn read_batches_ipc_strict(bytes: &[u8]) -> Result<Vec<RecordBatch>> {
     let reader = StreamReader::try_new(Cursor::new(bytes), None).map_err(arrow_err)?;
     let mut batches = Vec::new();
     for batch in reader {
         batches.push(batch.map_err(arrow_err)?);
     }
     Ok(batches)
+}
+
+/// The end-of-stream / continuation marker in the Arrow IPC stream format.
+const IPC_CONTINUATION: u32 = 0xFFFF_FFFF;
+/// Byte width of one flatbuffer `Buffer` entry (i64 offset + i64 length).
+const IPC_BUFFER_ENTRY_BYTES: usize = 16;
+
+/// Repair an IPC stream whose all-null Boolean columns arrived with a
+/// zero-length values buffer, returning the patched bytes.
+///
+/// For such a column the validity bitmap is present, correctly sized, and
+/// all zeros — exactly the values bitmap we need. So the fix is a pure
+/// metadata edit: point the values-buffer entry at the validity buffer's
+/// region of the body. Buffer entries are fixed 16-byte structs inline in
+/// the flatbuffer, so the rewrite changes no sizes or offsets, and the
+/// caller re-runs the fully-validated decode on the result. Returns `None`
+/// (leaving the caller's original error to stand) if the stream is
+/// malformed, compressed, uses a layout we don't model, or needs no patch.
+fn patch_all_null_bool_ipc(bytes: &[u8]) -> Option<Vec<u8>> {
+    let schema = read_schema_ipc(bytes).ok()?;
+    let mut patched = bytes.to_vec();
+    let mut any = false;
+
+    // Walk the encapsulated messages: [continuation][u32 len][metadata][body].
+    let mut pos = 0usize;
+    while pos + 4 <= bytes.len() {
+        let word = u32::from_le_bytes(bytes[pos..pos + 4].try_into().ok()?);
+        let (meta_len, meta_start) = if word == IPC_CONTINUATION {
+            if pos + 8 > bytes.len() {
+                return None;
+            }
+            let len = u32::from_le_bytes(bytes[pos + 4..pos + 8].try_into().ok()?);
+            (len as usize, pos + 8)
+        } else {
+            (word as usize, pos + 4)
+        };
+        if meta_len == 0 {
+            break; // end-of-stream marker
+        }
+        let meta_end = meta_start.checked_add(meta_len)?;
+        let meta = bytes.get(meta_start..meta_end)?;
+        let message = root_as_message(meta).ok()?;
+        let body_len = usize::try_from(message.bodyLength()).ok()?;
+
+        if message.header_type() == MessageHeader::RecordBatch {
+            let batch = message.header_as_record_batch()?;
+            if batch.compression().is_some() {
+                return None; // entries index compressed frames; don't alias
+            }
+            let nodes = batch.nodes()?;
+            let buffers = batch.buffers()?;
+
+            // Pair nodes with their buffer indices by walking the schema in
+            // IPC (depth-first) order, collecting each Boolean node and the
+            // index of its values buffer.
+            let mut bools: Vec<(usize, usize)> = Vec::new();
+            let (mut node_idx, mut buf_idx) = (0usize, 0usize);
+            for field in schema.fields() {
+                walk_ipc_layout(field.data_type(), &mut node_idx, &mut buf_idx, &mut bools)?;
+            }
+            if node_idx != nodes.len() || buf_idx != buffers.len() {
+                return None; // layout mismatch — don't guess
+            }
+
+            for (node_i, values_i) in bools {
+                let node = nodes.get(node_i);
+                let rows = usize::try_from(node.length()).ok()?;
+                let nulls = usize::try_from(node.null_count()).ok()?;
+                let values = buffers.get(values_i);
+                if rows == 0 || nulls != rows || values.length() != 0 {
+                    continue;
+                }
+                // values_i > 0 always: a Boolean node's validity entry
+                // directly precedes its values entry.
+                let validity = buffers.get(values_i - 1);
+                if usize::try_from(validity.length()).ok()? * 8 < rows {
+                    return None; // validity absent/truncated — don't alias
+                }
+                // Overwrite the values entry (16 bytes, inline in the
+                // metadata section of the stream) with the validity entry.
+                let entry_pos =
+                    (values as *const _ as usize).checked_sub(bytes.as_ptr() as usize)?;
+                patched
+                    .get_mut(entry_pos..entry_pos + IPC_BUFFER_ENTRY_BYTES)?
+                    .copy_from_slice(&validity.0);
+                any = true;
+            }
+        }
+        pos = meta_end.checked_add(body_len)?;
+    }
+    any.then_some(patched)
+}
+
+/// Advance the node/buffer cursors across one field of the Arrow IPC
+/// record-batch layout, recording each Boolean node's index and the index
+/// of its values buffer into `bools`. Returns `None` for a type whose
+/// layout we don't model (the caller then abandons the patch).
+fn walk_ipc_layout(
+    data_type: &DataType,
+    node_idx: &mut usize,
+    buf_idx: &mut usize,
+    bools: &mut Vec<(usize, usize)>,
+) -> Option<()> {
+    let node = *node_idx;
+    *node_idx += 1;
+    match data_type {
+        DataType::Null => {} // one node, no buffers
+        DataType::Boolean => {
+            bools.push((node, *buf_idx + 1)); // [validity, values]
+            *buf_idx += 2;
+        }
+        // Fixed-width scalars: [validity, values].
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float16
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Decimal128(_, _)
+        | DataType::Decimal256(_, _)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Timestamp(_, _)
+        | DataType::Duration(_)
+        | DataType::Interval(_)
+        | DataType::FixedSizeBinary(_)
+        | DataType::Dictionary(_, _) => *buf_idx += 2, // dictionary: its keys
+        // Variable-length binary/strings: [validity, offsets, values].
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary | DataType::LargeBinary => {
+            *buf_idx += 3
+        }
+        // Nested with offsets: [validity, offsets] + child.
+        DataType::List(field) | DataType::LargeList(field) | DataType::Map(field, _) => {
+            *buf_idx += 2;
+            walk_ipc_layout(field.data_type(), node_idx, buf_idx, bools)?;
+        }
+        // Nested without offsets: [validity] + child(ren).
+        DataType::FixedSizeList(field, _) => {
+            *buf_idx += 1;
+            walk_ipc_layout(field.data_type(), node_idx, buf_idx, bools)?;
+        }
+        DataType::Struct(fields) => {
+            *buf_idx += 1;
+            for field in fields {
+                walk_ipc_layout(field.data_type(), node_idx, buf_idx, bools)?;
+            }
+        }
+        // Views, unions, run-end encoding, …: not modeled here.
+        _ => return None,
+    }
+    Some(())
 }
 
 /// Serialize batches to an Arrow IPC stream the JS side reads with

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -68,10 +68,15 @@ use infino::{
 fn map_err(e: InfinoError) -> Error {
     match e {
         InfinoError::NotFound(m) => Error::new(Status::GenericFailure, format!("NotFound: {m}")),
-        InfinoError::AlreadyExists(m)
-        | InfinoError::Schema(m)
-        | InfinoError::Cardinality(m)
-        | InfinoError::Query(m) => Error::new(Status::InvalidArg, m),
+        // Prefixed like `NotFound:` so callers (and, on a hosted connection,
+        // the JS wrapper attaching the 409 the API returned) can tell a
+        // duplicate create apart from a malformed argument.
+        InfinoError::AlreadyExists(m) => {
+            Error::new(Status::InvalidArg, format!("AlreadyExists: {m}"))
+        }
+        InfinoError::Schema(m) | InfinoError::Cardinality(m) | InfinoError::Query(m) => {
+            Error::new(Status::InvalidArg, m)
+        }
         InfinoError::Io(m) | InfinoError::Backend(m) => Error::new(Status::GenericFailure, m),
         // A recoverable connection-memory-budget refusal. Prefixed with the same
         // name Python raises (`ConnectionMemoryBudgetError`) so the concept reads


### PR DESCRIPTION
Two Node SDK fixes, both covered by new regression tests (`__test__/nulls.test.mjs`, `__test__/errors.test.mjs`; suite: 58 tests, 0 fail).

## Omitted row fields stored zero values instead of null

`Table.append(rows)` passed omitted keys as `undefined` to `vectorFromArray`, whose null set is `[null]` only — so an omitted nullable field silently stored the type's zero value (`Int32` 0, `LargeUtf8` "", `Float64` NaN, `Bool` false) and an omitted `Int64` threw. Omitted keys now normalize to `null` and store SQL NULL, identical to an explicit null.

Separately, an all-null nullable `Bool` batch was rejected outright: the Arrow JS IPC writer emits a zero-length values buffer when every value is null, which the Rust decoder refuses, and no client-side construction can avoid the writer shortcut. The addon now repairs such streams before decoding — the values-buffer entry is pointed at the column's validity buffer (an all-zero bitmap of exactly the needed size), a 16-byte in-place metadata edit — then the fully-validated decode runs as usual. Well-formed input never takes the repair path.

## Hosted API errors carried no machine-readable status

A failure from a hosted connection arrived as a plain `Error`: no HTTP status, and a 409 duplicate-create shared `err.code` with malformed-argument errors, so idempotent startup / retry logic had to regex message text. On hosted connections the wrapper now rethrows the same error tagged with `status` — the HTTP status the API actually returned (409 create conflict, 404 missing, 503 transient). The addon gives `AlreadyExists` its own message prefix (matching the existing `NotFound:` / `ConflictError:` convention). Errors on local connections are untouched and carry no `status`.

Binding-only change; the engine crate is untouched (no bench-relevant paths).