### PR TITLE
compaction: merge on fragment count, prune emptied manifest parts

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -209,6 +209,7 @@ impl core::panic::unwind_safe::UnwindSafe for infino::Bm25SearchOptions
 pub struct infino::CompactionSettings
 pub infino::CompactionSettings::max_memory_mb: u64
 pub infino::CompactionSettings::min_fill_percent: u8
+pub infino::CompactionSettings::min_superfiles_for_merge: u64
 pub infino::CompactionSettings::stale_seal_timeout_ms: u64
 pub infino::CompactionSettings::target_superfile_size_mb: u64
 impl core::clone::Clone for infino::CompactionSettings

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -116,6 +116,11 @@ compaction:
   # E.g. at 80% with a 1 GiB target, two 200 MiB superfiles (400 MiB) do not compact.
   min_fill_percent: 80
 
+  # Fragment-count merge trigger: merge once a partition has this many
+  # sub-target superfiles, even below the size floor. Fires on size OR count,
+  # so many tiny appends consolidate without lowering the floor. Min 2.
+  min_superfiles_for_merge: 50
+
   # Maximum memory budget for materializing inputs during a single merge, in MiB.
   max_memory_mb: 3072
 
@@ -194,7 +199,7 @@ vector:
   # at small scale (~0.998 vs ~0.94 at 100K, ~0.997 vs ~0.962 at 1M) and slightly
   # ahead at scale (0.991 vs 0.983 at 10M). The finer grid (~14x the cells) adds
   # per-cell drain generations, but compaction consolidates them
-  # (compaction_min_fill_percent = 0), so post-compact cold GET stays bounded.
+  # (compaction_min_superfiles_for_merge = 2), so post-compact cold GET stays bounded.
   # Set 0.0 to fall back to the fixed-grid path (cap trigger only).
   cell_split_modality_d: 8.0
 
@@ -261,15 +266,16 @@ vector:
   # bytes packed into one merge pass and must stay >= the target, or the
   # target is never reached.
   #
-  # 0 disables the byte floor, so a cell consolidates on fragment count alone
-  # (the >= 2 merge floor): drain generations collapse and post-compact cold
-  # GET stays at the post-drain level. Safe because the cell split is now the
-  # in-place append-child split (validated), so a merge that pushes a cell over
-  # the cap (or into multimodality with the trigger on) splits it correctly
-  # rather than hitting the old broken post-merge split path. Contrast the user
-  # table, which keeps an 80% floor to amortize writes on its transient data.
+  # The hidden index has no byte floor of its own: it derives min_fill_percent
+  # from the top-level `compaction:` section, and compaction_min_superfiles_for_merge
+  # (2 by default) dominates it — a cell consolidates on any two shards, so
+  # drain generations collapse and post-compact cold GET stays at the
+  # post-drain level. Safe because the cell split is now the in-place
+  # append-child split (validated), so a merge that pushes a cell over the cap
+  # (or into multimodality with the trigger on) splits it correctly rather than
+  # hitting the old broken post-merge split path.
   compaction_target_mb: 2048
-  compaction_min_fill_percent: 0
+  compaction_min_superfiles_for_merge: 2
   compaction_max_memory_mb: 4096
 
 # Diagnostic and hardware-capability toggles. Each gates

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -207,6 +207,11 @@ const DEFAULT_VERIFY_CRC_ON_OPEN: bool = true;
 // Compaction defaults
 const DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB: u64 = 1024;
 const DEFAULT_COMPACTION_MIN_FILL_PERCENT: u8 = 80;
+/// Default fragment-count merge trigger for the user table: consolidate a
+/// partition once it accumulates this many sub-target superfiles, even when
+/// their combined live bytes are far below the size floor. Catches the
+/// small-append fragmentation that would otherwise never reach `min_fill_percent`.
+const DEFAULT_COMPACTION_MIN_SUPERFILES_FOR_MERGE: u64 = 50;
 const DEFAULT_COMPACTION_MAX_MEMORY_MB: u64 = DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB + 2048;
 
 /// How old a tombstone sidecar seal has to be before compaction treats
@@ -223,6 +228,13 @@ pub struct CompactionSettings {
     /// Minimum estimated live bytes to trigger a merge,
     /// as a percentage of `target_superfile_size_mb`.
     pub min_fill_percent: u8,
+    /// Fragment-count merge trigger: consolidate a partition as soon as it has
+    /// this many sub-target superfiles, regardless of `min_fill_percent`. A
+    /// merge fires on size OR count, so a badly fragmented table (many tiny
+    /// appends) consolidates without lowering the byte floor for healthy
+    /// tables. Values below 2 are raised to 2 — merging fewer than two inputs
+    /// is a no-op rewrite.
+    pub min_superfiles_for_merge: u64,
     /// Maximum memory budget for materializing inputs during a single merge, in MiB.
     pub max_memory_mb: u64,
     /// How old a sealed tombstone sidecar has to be, in milliseconds,
@@ -235,6 +247,7 @@ impl Default for CompactionSettings {
         Self {
             target_superfile_size_mb: DEFAULT_COMPACTION_TARGET_SUPERFILE_SIZE_MB,
             min_fill_percent: DEFAULT_COMPACTION_MIN_FILL_PERCENT,
+            min_superfiles_for_merge: DEFAULT_COMPACTION_MIN_SUPERFILES_FOR_MERGE,
             max_memory_mb: DEFAULT_COMPACTION_MAX_MEMORY_MB,
             stale_seal_timeout_ms: DEFAULT_STALE_SEAL_TIMEOUT_MS,
         }
@@ -286,10 +299,12 @@ const DEFAULT_VECTOR_HIDDEN_CELL_COUNT: usize = 256;
 /// base shard stays a merge candidate and absorbs later deltas rather than
 /// being sealed as over-target on the first pass.
 const DEFAULT_VECTOR_COMPACTION_TARGET_MB: u64 = 2048;
-/// Default hidden vector-index compaction min-fill: `0` disables the size leg,
-/// so a cell consolidates on the >= 2 fragment count alone — drain generations
-/// collapse and post-compact cold GET stays at the post-drain level.
-const DEFAULT_VECTOR_COMPACTION_MIN_FILL_PERCENT: u8 = 0;
+/// Default hidden vector-index fragment-count merge trigger: `2` means a cell
+/// consolidates on any two shards, so drain generations collapse and
+/// post-compact cold GET stays at the post-drain level. The hidden index keeps
+/// no byte floor of its own — it inherits the user table's `min_fill_percent`,
+/// which this count trigger dominates.
+const DEFAULT_VECTOR_COMPACTION_MIN_SUPERFILES_FOR_MERGE: u64 = 2;
 /// Default hidden vector-index compaction per-pass memory ceiling (MiB). Must
 /// stay >= the target or it caps the packed inputs below a full output.
 const DEFAULT_VECTOR_COMPACTION_MAX_MEMORY_MB: u64 = DEFAULT_VECTOR_COMPACTION_TARGET_MB + 2048;
@@ -404,9 +419,11 @@ pub struct VectorSettings {
     /// from the user table's `compaction.target_superfile_size_mb`; a
     /// packed cell shard stays a merge candidate until it reaches this.
     pub compaction_target_mb: u64,
-    /// Hidden vector-index compaction min-fill: a merge fires only once its
-    /// combined inputs reach this percentage of `compaction_target_mb`.
-    pub compaction_min_fill_percent: u8,
+    /// Hidden vector-index fragment-count merge trigger: consolidate a cell
+    /// once it has this many shards (default `2`, so any two shards merge). See
+    /// [`CompactionSettings::min_superfiles_for_merge`] for the size-OR-count
+    /// semantics; the hidden index carries no byte floor of its own.
+    pub compaction_min_superfiles_for_merge: u64,
     /// Hidden vector-index compaction per-pass memory ceiling (MiB). Caps
     /// the input bytes packed into one merge, so it must stay >=
     /// `compaction_target_mb` or the target is never reached.
@@ -432,7 +449,7 @@ impl Default for VectorSettings {
             user_cell_count: DEFAULT_VECTOR_USER_CELL_COUNT,
             hidden_cell_count: DEFAULT_VECTOR_HIDDEN_CELL_COUNT,
             compaction_target_mb: DEFAULT_VECTOR_COMPACTION_TARGET_MB,
-            compaction_min_fill_percent: DEFAULT_VECTOR_COMPACTION_MIN_FILL_PERCENT,
+            compaction_min_superfiles_for_merge: DEFAULT_VECTOR_COMPACTION_MIN_SUPERFILES_FOR_MERGE,
             compaction_max_memory_mb: DEFAULT_VECTOR_COMPACTION_MAX_MEMORY_MB,
         }
     }

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -130,11 +130,16 @@ pub struct CompactionJob {
 /// reach the floor are left for next time.
 pub fn select(superfiles: &[SuperfileStats], cfg: &CompactionSettings) -> Vec<CompactionJob> {
     let target_bytes = cfg.target_superfile_size_mb.saturating_mul(MIB);
-    // `0%` disables the size leg: a merge then fires on the fragment-count
-    // floor alone (>= 2 inputs), which is how the hidden index consolidates
-    // drain generations that are far below any byte threshold.
+    // Size leg of the merge trigger: a job's combined live bytes must reach this
+    // fraction of the target. The count leg (`min_superfiles_for_merge`) fires
+    // independently, so a partition fragmented into many tiny superfiles still
+    // consolidates even when it sits far below this floor.
     let min_output_bytes =
         (target_bytes as u128 * cfg.min_fill_percent.clamp(0, 100) as u128 / 100) as u64;
+    // Count leg: merge once a partition has this many sub-target superfiles.
+    // Clamped to >= 2 — merging fewer than two inputs is a no-op rewrite, so a
+    // misconfigured smaller value is raised rather than rejected.
+    let min_superfiles_for_merge = cfg.min_superfiles_for_merge.max(2) as usize;
     let max_memory_bytes = cfg.max_memory_mb.saturating_mul(MIB);
 
     let mut by_partition: BTreeMap<&[u8], Vec<&SuperfileStats>> = BTreeMap::new();
@@ -149,6 +154,7 @@ pub fn select(superfiles: &[SuperfileStats], cfg: &CompactionSettings) -> Vec<Co
             segs,
             target_bytes,
             min_output_bytes,
+            min_superfiles_for_merge,
             max_memory_bytes,
             &mut jobs,
         );
@@ -161,6 +167,7 @@ fn pack_partition(
     segs: Vec<&SuperfileStats>,
     target_bytes: u64,
     min_output_bytes: u64,
+    min_superfiles_for_merge: usize,
     max_memory_bytes: u64,
     jobs: &mut Vec<CompactionJob>,
 ) {
@@ -183,11 +190,11 @@ fn pack_partition(
     let mut pending = PendingJob::default();
     for s in candidates {
         if !pending.fits(s, target_bytes, max_memory_bytes) {
-            pending.emit(key, min_output_bytes, jobs);
+            pending.emit(key, min_output_bytes, min_superfiles_for_merge, jobs);
         }
         pending.push(s);
     }
-    pending.emit(key, min_output_bytes, jobs);
+    pending.emit(key, min_output_bytes, min_superfiles_for_merge, jobs);
 }
 
 #[derive(Default)]
@@ -209,9 +216,21 @@ impl PendingJob {
         self.live_bytes += s.live_bytes();
     }
 
-    /// Emit a CompactionJob if ≥ 2 inputs and live bytes reach `min_output_bytes`.
-    fn emit(&mut self, key: &[u8], min_output_bytes: u64, jobs: &mut Vec<CompactionJob>) {
-        if self.inputs.len() >= 2 && self.live_bytes >= min_output_bytes {
+    /// Emit a CompactionJob when the pending inputs clear either leg of the
+    /// merge trigger — size OR count:
+    /// - size: `>= 2` inputs and live bytes reach `min_output_bytes`;
+    /// - count: `>= min_superfiles_for_merge` inputs (already `>= 2`), which
+    ///   fires even when the live bytes sit far below the size floor.
+    fn emit(
+        &mut self,
+        key: &[u8],
+        min_output_bytes: u64,
+        min_superfiles_for_merge: usize,
+        jobs: &mut Vec<CompactionJob>,
+    ) {
+        let size_ready = self.inputs.len() >= 2 && self.live_bytes >= min_output_bytes;
+        let count_ready = self.inputs.len() >= min_superfiles_for_merge;
+        if size_ready || count_ready {
             jobs.push(CompactionJob {
                 partition_key: key.to_vec(),
                 inputs: mem::take(&mut self.inputs),
@@ -1084,12 +1103,13 @@ mod tests {
 
     #[test]
     fn pending_job_emit_requires_two_inputs() {
-        // A single-input pending job never emits even if it reaches
-        // the fill floor.
+        // A single-input pending job never emits even if it reaches the fill
+        // floor and the count trigger (emit takes a pre-clamped count of 2, so
+        // one input clears neither the size nor the count leg).
         let mut jobs = Vec::new();
         let mut p = PendingJob::default();
         p.push(&seg(1, 200, 1000, 0));
-        p.emit(&[], 0, &mut jobs);
+        p.emit(&[], 0, 2, &mut jobs);
         assert!(jobs.is_empty(), "single-input job must not emit");
         // Reset to default after emit attempt.
         assert_eq!(p.inputs.len(), 0);
@@ -1382,6 +1402,55 @@ mod tests {
             select(&segs, &byte_floored).is_empty(),
             "a byte floor must block consolidation of tiny fragments"
         );
+    }
+
+    #[test]
+    fn user_table_merges_tiny_fragments_on_count_below_size_floor() {
+        // Many tiny appends, each a sub-target superfile, whose combined live
+        // bytes stay far under the 80% size floor. Without the fragment-count
+        // trigger these never merge, so the superfile (and manifest-part) count
+        // grows without bound. The count leg consolidates them on count alone.
+        // A low `min_superfiles_for_merge` lets the test trip the trigger with a
+        // handful of fragments instead of the default 50.
+        let cfg = CompactionSettings {
+            min_superfiles_for_merge: 3,
+            ..CompactionSettings::default() // 1 GiB target, 80% floor (819 MiB)
+        };
+        // Two 1 MiB fragments: below the count trigger and far below the floor.
+        let two = vec![seg(1, 1, 1000, 0), seg(2, 1, 1000, 0)];
+        assert!(
+            select(&two, &cfg).is_empty(),
+            "2 < min_superfiles_for_merge (3) and 2 MiB << 819 MiB floor: no merge"
+        );
+        // A third fragment trips the count trigger even though 3 MiB << the floor.
+        let three = vec![seg(1, 1, 1000, 0), seg(2, 1, 1000, 0), seg(3, 1, 1000, 0)];
+        let jobs = select(&three, &cfg);
+        assert_eq!(jobs.len(), 1, "count trigger merges once inputs reach 3");
+        assert_eq!(jobs[0].inputs.len(), 3);
+    }
+
+    #[test]
+    fn min_superfiles_for_merge_below_two_is_clamped() {
+        // A degenerate config (< 2) must not fire single-input no-op merges: it
+        // is raised to 2, so one fragment never merges but two do — even under a
+        // floor that blocks the size leg entirely.
+        let cfg = CompactionSettings {
+            target_superfile_size_mb: 2048,
+            min_fill_percent: 100, // size leg unreachable for tiny fragments
+            min_superfiles_for_merge: 1,
+            ..CompactionSettings::default()
+        };
+        assert!(
+            select(&[seg(1, 1, 1000, 0)], &cfg).is_empty(),
+            "one input never merges (clamped floor is 2)"
+        );
+        let jobs = select(&[seg(1, 1, 1000, 0), seg(2, 1, 1000, 0)], &cfg);
+        assert_eq!(
+            jobs.len(),
+            1,
+            "clamped count floor of 2 merges two fragments"
+        );
+        assert_eq!(jobs[0].inputs.len(), 2);
     }
 
     #[test]

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1371,10 +1371,16 @@ const CACHE_BUDGET_HEADROOM_DIVISOR: u64 = 10;
 /// ~one compact packed shard object per partition key instead of many
 /// small delta files.
 pub(crate) fn hidden_vector_index_compaction_settings() -> crate::config::CompactionSettings {
-    let vector = &crate::config::global().vector;
+    let cfg = crate::config::global();
+    let vector = &cfg.vector;
     crate::config::CompactionSettings {
         target_superfile_size_mb: vector.compaction_target_mb,
-        min_fill_percent: vector.compaction_min_fill_percent,
+        // The hidden index keeps no byte floor of its own: it derives
+        // `min_fill_percent` from the user table's `compaction` settings so the
+        // floor lives in one place. The fragment-count trigger below dominates
+        // it here (a cell merges on any two shards regardless of the floor).
+        min_fill_percent: cfg.compaction.min_fill_percent,
+        min_superfiles_for_merge: vector.compaction_min_superfiles_for_merge,
         max_memory_mb: vector.compaction_max_memory_mb,
         ..Default::default()
     }
@@ -3824,6 +3830,7 @@ mod tests {
         crate::config::CompactionSettings {
             target_superfile_size_mb: 1,
             min_fill_percent: 1,
+            min_superfiles_for_merge: 2,
             max_memory_mb: 64,
             stale_seal_timeout_ms: crate::config::DEFAULT_STALE_SEAL_TIMEOUT_MS,
         };

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -1769,6 +1769,20 @@ impl ManifestSnapshot {
                     continue;
                 }
 
+                // All superfiles removed from this part → drop it from the list
+                // rather than keeping a zero-superfile stub. A merge that lifts
+                // every fragment out of a part would otherwise leave the empty
+                // part live in the list forever (it survives GC as referenced),
+                // inflating the part count and the open-time GET fan for no data.
+                // Dropping the last part is safe: a user manifest with zero parts
+                // is a handled state (an empty table — the load path guards
+                // `parts.is_empty()`, and hidden vector-index manifests always
+                // run with zero parts), and nothing else would ever collect a
+                // retained empty stub (compaction merges superfiles, not parts).
+                if final_superfile_entries.is_empty() {
+                    continue;
+                }
+
                 let (fresh_entry, fresh_encoded_part) =
                     rebuild_part_and_entry(vec![], final_superfile_entries, None, hidden_table);
 
@@ -4973,6 +4987,106 @@ mod tests {
         );
     }
 
+    /// Emptying one of several parts must DROP that part, not leave a
+    /// zero-superfile stub behind. A merge that lifts all fragments out of a
+    /// part would otherwise keep the empty part live in the list forever (it
+    /// survives GC as still-referenced), inflating the part count and the
+    /// open-time GET fan for no data. As long as another part survives, the
+    /// list must gain no zero-superfile entry. Repro for the empty-part-stub bug.
+    #[tokio::test]
+    async fn removing_all_superfiles_from_a_part_drops_it() {
+        let opts = make_opts();
+        let (_dir, storage) = local_storage();
+
+        // Two parts, one superfile each, resident in the parts cache.
+        let sf_a = make_new_entry(100);
+        let sf_b = make_new_entry(200);
+        let part_a = ManifestPart {
+            format_version: part::FORMAT_VERSION.into(),
+            part_id: PartId::new_v4(),
+            superfiles: vec![sf_a.clone()],
+        };
+        let part_b = ManifestPart {
+            format_version: part::FORMAT_VERSION.into(),
+            part_id: PartId::new_v4(),
+            superfiles: vec![sf_b.clone()],
+        };
+        let (pa_id, pb_id) = (part_a.part_id, part_b.part_id);
+
+        let part_entry = |part_id| ManifestPartEntry {
+            part_id,
+            uri: String::new(),
+            content_hash: ContentHash([0u8; 32]),
+            routing: None,
+            size_bytes_compressed: 0,
+            size_bytes_uncompressed: 0,
+            n_superfiles: 1,
+            id_range: (0, 0),
+            scalar_stats_agg: Default::default(),
+            fts_summary_agg: Default::default(),
+        };
+
+        let list = Manifest {
+            drained_ranges: Default::default(),
+            global_vector_index: None,
+            tombstone_seqs: Default::default(),
+            superseded_cells: Default::default(),
+            format_version: list::FORMAT_VERSION.into(),
+            manifest_id: 0,
+            options_hash: ContentHash([0u8; 32]),
+            schema: vec![],
+            id_column: "_id".into(),
+            fts_columns: vec![],
+            vector_columns: vec![],
+            partition_strategy: PartitionStrategy::Hash {
+                column: "_id".into(),
+                n_buckets: 2,
+            },
+            vector_index_storage_prefix: None,
+            deleted_user_ids_inline: None,
+            slow_vector_state_uri: None,
+            slow_vector_state_content_hash: None,
+            slow_vector_state_centroids: None,
+            parts: vec![part_entry(pa_id), part_entry(pb_id)],
+        };
+        let loader = ManifestPartLoader::new(storage, &list);
+        let parts_map = DashMap::new();
+        parts_map.insert(pa_id, Arc::new(OnceCell::new_with(Some(Arc::new(part_a)))));
+        parts_map.insert(pb_id, Arc::new(OnceCell::new_with(Some(Arc::new(part_b)))));
+
+        let manifest = Arc::new(ManifestSnapshot {
+            superfile_list: SuperfileList {
+                manifest_id: 0,
+                options: opts.clone(),
+                superfiles: vec![sf_a.clone(), sf_b.clone()],
+                vector_index_storage_prefix: None,
+                next_manifest_id_floor: 0,
+            },
+            list: Some(list),
+            parts: parts_map,
+            loader: Some(Arc::new(loader)),
+            stamped_partition_strategy: None,
+            stamped_global_vector_index: None,
+            stamped_drained_ranges: None,
+        });
+
+        // Remove every superfile from part A only → A is emptied, B untouched.
+        let (after, _parts) = manifest.update(&[], from_ref(&sf_a)).await.expect("remove");
+        let entries = after.get_all_list_entries();
+
+        assert!(
+            entries.iter().all(|e| e.n_superfiles > 0),
+            "an emptied part must not survive as a 0-superfile stub while another part lives, got n_superfiles {:?}",
+            entries.iter().map(|e| e.n_superfiles).collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            entries.len(),
+            1,
+            "part A dropped, part B survives → exactly one part, got {}",
+            entries.len(),
+        );
+    }
+
     /// A manifest whose list carries a slow-state ref hydrated its
     /// membership from the blob — hidden manifests write NO parts. The
     /// undrained load must trust the resident flat view there: summing
@@ -7417,10 +7531,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_remove_all_superfiles_empties_partition() {
-        // All superfiles in a partition are removed. Documents the current
-        // behavior: the list entry survives with n_superfiles=0 and the
-        // part has no superfiles (empty partition).
+    async fn update_remove_all_superfiles_drops_the_emptied_part() {
+        // Every superfile in the only part is removed. The part must be dropped
+        // from the list rather than kept as a zero-superfile stub: an empty stub
+        // survives GC as still-referenced and inflates the part count (and the
+        // open-time GET fan) forever. Exercises the PartWriter-produced path,
+        // complementing `removing_all_superfiles_from_a_part_drops_it`.
         let opts = make_opts();
         let (_dir, storage) = local_storage();
 
@@ -7498,11 +7614,10 @@ mod tests {
             .expect("update");
         let list_entries = new_manifest.get_all_list_entries();
 
-        // Both superfiles removed: list entry remains with n_superfiles=0.
-        assert_eq!(list_entries.len(), 1);
-        assert_eq!(parts.len(), 1);
-        assert_eq!(list_entries[0].n_superfiles, 0);
-        assert_eq!(parts[0].part.superfiles.len(), 0);
+        // Both superfiles removed → the emptied part is dropped entirely, so the
+        // list has no entries and no parts remain (no zero-superfile stub).
+        assert!(list_entries.is_empty());
+        assert!(parts.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A table built from many small appends accumulates thousands of tiny superfiles. Two engine behaviors keep the superfile and manifest-part counts from ever collapsing, which inflates open-time GET fan-out and table-open latency:

1. **Compaction never fires below the byte floor.** User-table compaction emits a merge only when a partition's combined live bytes reach `min_fill_percent` (80%) of the target — 819 MiB for the 1 GiB default. A table whose fragments total well under that (e.g. ~140 MiB spread across thousands of superfiles) is never consolidated, no matter how fragmented it gets. `select()` emits **0 jobs, forever**.
2. **Emptied manifest parts stay live.** When a merge lifts *every* superfile out of a manifest part, `update_inner` rebuilds a **zero-superfile part** and keeps it in the list. It's a tiny stub that survives GC (still referenced), so the part count — and the per-open GET fan — doesn't fully collapse even after an otherwise-good merge.

## Fix

- **Fragment-count merge trigger (`min_superfiles_for_merge`).** Compaction now emits a merge when a partition clears **either** the byte floor **or** a fragment count — size OR count. A badly fragmented table consolidates on count alone, without lowering the byte floor for healthy tables. Defaults: user table **50**, hidden vector index **2**. A configured value below 2 is **clamped to 2** (merging fewer than two inputs is a no-op rewrite), so a misconfiguration is corrected rather than rejected.
- **One place for the fill floor.** The hidden vector index no longer carries its own min-fill percent (previously hardcoded to `0`); it now **derives `min_fill_percent` from the top-level `compaction` settings**, and its count trigger (2) dominates — a cell still consolidates on any two shards, matching the prior behavior. The only per-side knob now is the count trigger.
- **Prune emptied parts.** A manifest part emptied by removal is dropped from the list instead of retained as a zero-superfile stub.

## Why this shape

The alternative — lowering the byte floor globally — would force healthy tables to merge under-filled outputs and pay write amplification on transient data. A count trigger targets only the pathology (many tiny fragments) while leaving the byte floor intact for the common case, so both a heavily-fragmented small table and a healthy large one get the right policy. Deriving the hidden floor from the user table removes a second, easy-to-desync copy of the same percentage.

## Tests

- `user_table_merges_tiny_fragments_on_count_below_size_floor` — count trigger fires below the byte floor.
- `min_superfiles_for_merge_below_two_is_clamped` — a value < 2 is raised to 2.
- `removing_all_superfiles_from_a_part_drops_it` — an emptied part is pruned, not kept as a stub.
- Existing `zero_fill_floor_merges_tiny_fragments_on_count` / `hidden_profile_select_merges_small_same_cell_files` confirm the byte-floor leg is preserved when the count is out of reach.

Local `cargo fmt --all --check`, `cargo clippy --all-targets`, and the affected unit tests are green. End-to-end repro confirmation on a local store to follow.