### PR TITLE
supertable: report a zero-match update as a no-op, not a backend fault

### DIFF
--- a/src/supertable/mutations.rs
+++ b/src/supertable/mutations.rs
@@ -105,6 +105,17 @@ impl MutationStats {
         self.n_not_found
     }
 
+    /// Zero-count stats for a mutation that resolved to no rows. No WAL ran, so
+    /// `wal_id` is left nil.
+    pub(crate) fn empty() -> Self {
+        Self {
+            wal_id: WalId(0),
+            matched: 0,
+            n_tombstoned: 0,
+            n_not_found: 0,
+        }
+    }
+
     /// Build stats from a hosted (remote) mutation response. `wal_id` is a
     /// server-side recovery detail with no meaning — and no public accessor —
     /// for a remote client, so it is left nil.

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -759,6 +759,9 @@ impl Supertable {
     /// commit. `new_rows.num_rows()` must equal the match count.
     /// Durable when this returns.
     ///
+    /// A predicate matching no rows is a no-op rather than an error — the 1:1
+    /// rule holds at zero, and every returned count is zero.
+    ///
     /// ```
     /// # use std::sync::Arc;
     /// # use infino::arrow_array::{LargeStringArray, RecordBatch};
@@ -788,8 +791,14 @@ impl Supertable {
         let mut w = self
             .writer()
             .map_err(|e| InfinoError::from(e).with_context("update", None))?;
-        w.update(predicate, new_rows.clone())
+        let pending = w
+            .update(predicate, new_rows.clone())
             .map_err(|e| InfinoError::from(e).with_context("update", None))?;
+        // Nothing matched, so nothing was buffered and `commit` would produce no
+        // outcome for `single_outcome` to surface. A no-op is not a fault.
+        if pending.matched == 0 {
+            return Ok(MutationStats::empty());
+        }
         single_outcome(
             w.commit()
                 .map_err(|e| InfinoError::from(e).with_context("update", None))?,
@@ -1181,11 +1190,9 @@ impl SupertableWriter {
 
         // Cardinality 0 is a structurally-impossible update —
         // the WAL pipeline needs `preallocated_superfile_id`
-        // and at least one minted id span. We mint a wal_id so
-        // the caller's `PendingUpdate` is comparable to the
-        // non-zero shape, but skip buffering. The commit's
-        // `CommitResult.outcomes` will reflect `matched: 0` if
-        // the caller routes through the buffer instead.
+        // and at least one minted id span. Nothing is buffered,
+        // so `commit()` yields no outcome for this call; read
+        // the `matched: 0` here instead.
         if matched == 0 {
             return Ok(PendingUpdate { matched: 0 });
         }

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -13,6 +13,7 @@ use std::{collections::HashSet, sync::Arc};
 use arrow_array::Array;
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
+    InfinoError,
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::fts::reader::{Bm25Stats, BoolMode},
     supertable::{
@@ -372,6 +373,68 @@ async fn writer_update_cardinality_mismatch_is_rejected() {
             new_rows: 2
         }
     ));
+}
+
+/// The folded `Supertable::update` treats a predicate matching no rows as a
+/// zero-count no-op: the writer buffers nothing, so there is no commit outcome
+/// to read.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn folded_update_with_no_matches_is_a_zero_count_no_op() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache_dir = TempDir::new().expect("cache");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let disk_cache = make_disk_cache(Arc::clone(&storage), cache_dir.path());
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(disk_cache),
+    )
+    .expect("create");
+    st.append(&build_title_batch(&["alpha", "bravo"]))
+        .expect("append");
+
+    let stats = st
+        .update(col("title").eq(lit("not-present")), &build_title_batch(&[]))
+        .expect("a zero-match update is a no-op, not a fault");
+    assert_eq!(stats.matched(), 0);
+    assert_eq!(stats.n_tombstoned(), 0);
+    assert_eq!(stats.n_not_found(), 0);
+
+    // The no-op left the table exactly as it was.
+    let batches = st
+        .reader()
+        .expect("reader")
+        .query_sql("SELECT title FROM supertable")
+        .expect("sql");
+    let n_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(n_rows, 2);
+}
+
+/// Zero matches with replacement rows supplied is still a cardinality error —
+/// the no-op path must not swallow rows the caller handed over.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn folded_update_with_no_matches_but_replacement_rows_is_rejected() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache_dir = TempDir::new().expect("cache");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let disk_cache = make_disk_cache(Arc::clone(&storage), cache_dir.path());
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(disk_cache),
+    )
+    .expect("create");
+    st.append(&build_title_batch(&["alpha"])).expect("append");
+
+    let err = st
+        .update(
+            col("title").eq(lit("not-present")),
+            &build_title_batch(&["replacement"]),
+        )
+        .expect_err("zero matches against one replacement row is a mismatch");
+    assert!(matches!(err, InfinoError::Cardinality(_)), "got: {err}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
`Supertable::update` returns `Backend("commit produced no mutation outcome")` when the
predicate matches no rows, so a well-formed no-op surfaces as a backend fault (a 500 for
anyone serving the engine over HTTP). `Supertable::delete` reports the same situation as
`matched: 0`, so the two mutations disagree on the empty case.

## Root cause

`SupertableWriter::update` deliberately buffers nothing for a zero-cardinality update — the
WAL pipeline needs a preallocated superfile id and at least one minted id span, neither of
which a no-op has any use for — and returns `PendingUpdate { matched: 0 }`.

The folded `Supertable::update` then commits and pipes the result through `single_outcome`,
which errors on an empty `outcomes`. Nothing was buffered, so nothing was ever going to land
there. `delete` escapes this because it always pushes a pending entry, even for zero targets.

The comment on that branch claimed `CommitResult.outcomes` would reflect `matched: 0`, which
was never true — corrected here.

## Fix

`Supertable::update` reads the match count off the `PendingUpdate` and returns zero counts
when nothing matched, rather than committing an empty buffer and demanding an outcome. Note
this only triggers when `new_rows` is empty too: the 1:1 cardinality check runs first, so
zero matches against a non-empty batch is still `CardinalityMismatch`.

Skipping the commit is safe — the folded call owns a fresh writer whose only possible content
is this one mutation, so with nothing buffered `commit()` is a no-op; `SupertableWriter::drop`
only releases the writer slot.

`MutationStats::empty()` is `pub(crate)`, so the public API surface is unchanged. Its nil
`wal_id` cannot leak: the only consumer of that field is `CommitResult::committed_wal_ids`,
assembled inside `commit()` from `outcomes`, which this path never reaches.

## Tests

Two integration tests in `tests/supertable/writer_mutations.rs`, alongside the existing
`writer_delete_on_predicate_with_no_matches_returns_zero_outcome`:

- `folded_update_with_no_matches_is_a_zero_count_no_op` — zero counts returned and the table
  left untouched. Fails on `main` with the exact reported error.
- `folded_update_with_no_matches_but_replacement_rows_is_rejected` — zero matches with rows
  supplied is still a `Cardinality` error, so the no-op path cannot swallow caller rows.

## Gates

`make check` green (fmt, clippy with and without `remote`, public-API surface guard, docs);
`cargo test --doc` 17 passed; `cargo test --lib` 2154 passed; `cargo test --test supertable`
252 passed. `make coverage` was not run locally — `cargo-llvm-cov` is not installed on the
machine this was developed on; leaving it to CI. The change adds one `pub(crate)` function
and a two-line branch, both exercised by the new tests.
