### PR TITLE
supertable/query: width-independent per-cell shortlist depth (#537)

### DIFF
--- a/benches/utils/recall_while_ingest.rs
+++ b/benches/utils/recall_while_ingest.rs
@@ -563,9 +563,6 @@ fn measure_recall(
     id_map: &IdMap,
     nprobe: usize,
 ) -> f32 {
-    let reader = consumer.reader().expect("reader");
-    // nprobe == ENGINE_DEFAULT (0) keeps engine-default routing; a positive
-    // value overrides the coarse cell-probe width (breadth) via search_opts.
     // INFINO_BENCH_RERANK_MULT (diagnostic) overrides the Sq8 rerank shortlist
     // depth (candidates ≈ rerank_mult × k); default ENGINE_DEFAULT → 256. Tests
     // whether a deeper within-cell rerank recovers recall at COARSE grid cells.
@@ -573,6 +570,23 @@ fn measure_recall(
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(exec_vec::ENGINE_DEFAULT);
+    measure_recall_rm(consumer, queries, heaps, id_map, nprobe, rerank_mult)
+}
+
+/// [`measure_recall`] with an explicit rerank multiplier — the oracle rung
+/// forces `ceil(rows / K)` so the budget covers every row regardless of the
+/// env override.
+fn measure_recall_rm(
+    consumer: &Supertable,
+    queries: &[Vec<f32>],
+    heaps: &[HeldTopK],
+    id_map: &IdMap,
+    nprobe: usize,
+    rerank_mult: usize,
+) -> f32 {
+    let reader = consumer.reader().expect("reader");
+    // nprobe == ENGINE_DEFAULT (0) keeps engine-default routing; a positive
+    // value overrides the coarse cell-probe width (breadth) via search_opts.
     let opts = exec_vec::search_opts(nprobe, rerank_mult);
     // Misrank audit (diagnostic): retrieve INFINO_BENCH_FETCH_K results but still
     // score against the GT top-K. fetch_k=1000 vs the default K=10 answers: are
@@ -1145,6 +1159,20 @@ pub fn run() {
         {
             let r = measure_recall(&st, &queries, &heaps, &id_map, np);
             eprintln!("[breadth-sweep] nprobe={np:<5} recall@10={r:.3}");
+        }
+        // Oracle rung (INFINO_BENCH_ORACLE=1): all cells at a rerank budget
+        // covering every row — with the width-independent per-cell budget
+        // (#537) this exact-scores the whole table through the stored
+        // rerank payloads, bypassing 1-bit selection entirely. Recall vs
+        // GT here is the engine's stored-payload ceiling (codec error
+        // only); the ladder above must approach it as nprobe grows. Costs
+        // a full-table rerank per query — gated off by default.
+        if cells_now > 0 && std::env::var("INFINO_BENCH_ORACLE").is_ok_and(|v| v == "1") {
+            let oracle_rm = n.div_ceil(K).max(1);
+            let r = measure_recall_rm(&st, &queries, &heaps, &id_map, cells_now, oracle_rm);
+            eprintln!(
+                "[breadth-sweep] nprobe={cells_now:<5} recall@10={r:.3} (oracle rm={oracle_rm})"
+            );
         }
         if miss_trace {
             trace_misses(&st, &queries, &heaps, &id_map, &retained);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1993,7 +1993,30 @@ impl SupertableReader {
                 // cell, that cell's floor carries it into the exact rerank
                 // (replicas never collide inside one cell, so the floor
                 // needs no replica overhead).
-                let cell_floor = if options.nprobe.is_some() { k } else { 0 };
+                //
+                // (#537) The floor's DEPTH must not shrink as the caller
+                // widens. The global pool splits across probed cells, so a
+                // k-deep floor leaves each cell's retention to its own
+                // 1-bit top-k — and within-cell estimate noise evicts true
+                // neighbors from that at scale (measured: recall falls
+                // monotonically with nprobe past ~5M, 0.534 at all-cells
+                // on 10M, while narrow probes hold 0.99). Hold every
+                // probed cell at the depth the stamp certified for a
+                // served cell — the stamped rerank budget divided by the
+                // stamped width — so widening adds cells at full depth
+                // instead of diluting all of them. Rerank cost then scales
+                // with the width the caller asked for, which is the pin
+                // arm's stated semantics: read amplification is what was
+                // asked for.
+                let cell_floor = if options.nprobe.is_some() {
+                    let stamped_width = hidden_routing
+                        .and_then(|r| r.width_for_k_at(k))
+                        .unwrap_or(1)
+                        .max(1);
+                    k.max(k.saturating_mul(rerank_mult).div_ceil(stamped_width))
+                } else {
+                    0
+                };
                 let shortlist_limit = k
                     .saturating_add(replica_overhead)
                     .saturating_mul(rerank_mult);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2067,6 +2067,28 @@ impl SupertableReader {
         };
         let mut cold_rerank_mult = 0;
         let options = match sweep_width {
+            // (#537) An explicit caller nprobe keeps the FULL per-cell
+            // budget — the divide below is for the law arm only. Divided,
+            // per-cell retention shrinks as the caller widens, and the
+            // 1-bit in-cell ranking is too weak to hold the true
+            // neighbors in a thin cut: on the 10M dense grid (~2.8K-row
+            // cells) measured recall tracks the divided depth down its
+            // ladder — whole-cell at w<=4 serves 0.993, w=16 (~6% of
+            // each cell) serves 0.85, all-cells (20 rows/cell) serves
+            // 0.51 — monotone in DEPTH, inverted in width. Undivided,
+            // widening adds cells at constant depth, so the sweep is
+            // monotone and read cost is linear in the width the caller
+            // asked for: explicit nprobe is a diagnostic surface, and
+            // "probe everything" honestly costs a scan.
+            Some(w) if w > 1 && options.nprobe.is_some() => {
+                if global_shortlist_width.is_some() {
+                    let (_, rerank_mult) = options.resolve(filtered);
+                    cold_rerank_mult = rerank_mult;
+                }
+                options
+            }
+            // Law arm: the stamped budget is calibrated as a TOTAL at the
+            // stamped width, so it divides across the sweep.
             Some(w) if w > 1 => {
                 let (_, rerank_mult) = options.resolve(filtered);
                 let divided = rerank_mult
@@ -2276,25 +2298,22 @@ impl SupertableReader {
                 // needs no replica overhead).
                 //
                 // (#537) The floor's DEPTH must not shrink as the caller
-                // widens. The global pool splits across probed cells, so a
-                // k-deep floor leaves each cell's retention to its own
-                // 1-bit top-k — and within-cell estimate noise evicts true
-                // neighbors from that at scale (measured: recall falls
-                // monotonically with nprobe past ~5M, 0.534 at all-cells
-                // on 10M, while narrow probes hold 0.99). Hold every
-                // probed cell at the depth the stamp certified for a
-                // served cell — the stamped rerank budget divided by the
-                // stamped width — so widening adds cells at full depth
-                // instead of diluting all of them. Rerank cost then scales
-                // with the width the caller asked for, which is the pin
-                // arm's stated semantics: read amplification is what was
-                // asked for.
+                // widens — and the depth that holds recall is the full
+                // per-cell budget, not a share of it. The measured 10M
+                // ladder (see the width-divide comment above the fan-out)
+                // tracks per-cell retention depth almost mechanically:
+                // whole-cell retention serves 0.993, ~6% of a cell serves
+                // 0.85, 20 rows serves 0.51 — in-cell 1-bit ranking is
+                // too weak to concentrate the true neighbors into a thin
+                // cut, so no fixed pool or stamped share survives a wide
+                // sweep. Under an explicit caller nprobe every scanned
+                // cell therefore keeps the same k x rerank_mult depth the
+                // narrow probe would give it: widening adds cells at
+                // constant depth, the exact rerank adjudicates, and cost
+                // is linear in the width the caller asked for — the pin
+                // arm's stated semantics.
                 let cell_floor = if options.nprobe.is_some() {
-                    let stamped_width = hidden_routing
-                        .and_then(|r| r.width_for_k_at(k))
-                        .unwrap_or(1)
-                        .max(1);
-                    k.max(k.saturating_mul(rerank_mult).div_ceil(stamped_width))
+                    k.saturating_mul(rerank_mult)
                 } else {
                     0
                 };

--- a/tests/supertable/vector_law_serving.rs
+++ b/tests/supertable/vector_law_serving.rs
@@ -12,7 +12,8 @@
 //!
 //! The same probe pins the floor scoping from the same PR: law-served
 //! defaults run floor-free; an explicit caller `nprobe` arms the floor at
-//! the stamped per-cell depth (rerank budget / stamped width, >= k — #537).
+//! the full per-cell budget (`k x rerank_mult`, so per-cell depth never
+//! shrinks as the caller widens — #537).
 
 #![deny(clippy::unwrap_used)]
 
@@ -146,10 +147,10 @@ async fn law_stamped_table_serves_the_law_not_the_constant() {
         "caller rerank_mult must override the law exactly; recorded: {recs:?}"
     );
 
-    // 3) Explicit caller nprobe re-arms the per-cell floor — at the
-    //    stamped per-cell DEPTH (#537: rerank budget / stamped width,
-    //    never below k), so widening the probe adds cells at full depth
-    //    instead of diluting a shared pool (the ≥5M recall inversion).
+    // 3) Explicit caller nprobe re-arms the per-cell floor — at the full
+    //    per-cell budget (#537: k x rerank_mult, width-independent), so
+    //    widening the probe adds cells at constant depth instead of
+    //    diluting a shared pool (the >=5M recall inversion).
     st.vector_search(
         "emb",
         &query,

--- a/tests/supertable/vector_law_serving.rs
+++ b/tests/supertable/vector_law_serving.rs
@@ -11,7 +11,8 @@
 //! via the `served_shortlist_probe` test-helpers hook.
 //!
 //! The same probe pins the floor scoping from the same PR: law-served
-//! defaults run floor-free; an explicit caller `nprobe` gets `floor = k`.
+//! defaults run floor-free; an explicit caller `nprobe` arms the floor at
+//! the stamped per-cell depth (rerank budget / stamped width, >= k — #537).
 
 #![deny(clippy::unwrap_used)]
 
@@ -145,7 +146,10 @@ async fn law_stamped_table_serves_the_law_not_the_constant() {
         "caller rerank_mult must override the law exactly; recorded: {recs:?}"
     );
 
-    // 3) Explicit caller nprobe re-arms the per-cell floor at k.
+    // 3) Explicit caller nprobe re-arms the per-cell floor — at the
+    //    stamped per-cell DEPTH (#537: rerank budget / stamped width,
+    //    never below k), so widening the probe adds cells at full depth
+    //    instead of diluting a shared pool (the ≥5M recall inversion).
     st.vector_search(
         "emb",
         &query,
@@ -157,7 +161,8 @@ async fn law_stamped_table_serves_the_law_not_the_constant() {
     .expect("pinned-nprobe search");
     let recs = served_shortlist_probe::drain();
     assert!(
-        recs.iter().any(|&(_, floor)| floor == K),
-        "explicit nprobe must arm the per-cell floor at k; recorded: {recs:?}"
+        recs.iter().any(|&(_, floor)| floor >= K),
+        "explicit nprobe must arm the per-cell floor at >= k (stamped \
+         per-cell depth); recorded: {recs:?}"
     );
 }

--- a/tests/supertable/vector_law_serving.rs
+++ b/tests/supertable/vector_law_serving.rs
@@ -150,7 +150,11 @@ async fn law_stamped_table_serves_the_law_not_the_constant() {
     // 3) Explicit caller nprobe re-arms the per-cell floor — at the full
     //    per-cell budget (#537: k x rerank_mult, width-independent), so
     //    widening the probe adds cells at constant depth instead of
-    //    diluting a shared pool (the >=5M recall inversion).
+    //    diluting a shared pool (the >=5M recall inversion). The floor
+    //    must EQUAL the pooled limit (replica overhead is 0 here, so both
+    //    are k x rerank_mult): per-cell depth == full budget is exactly
+    //    #538's behavior, and a revert to the old `floor = k` fails this
+    //    (the law-stamped budget on this fixture is above k).
     st.vector_search(
         "emb",
         &query,
@@ -162,8 +166,10 @@ async fn law_stamped_table_serves_the_law_not_the_constant() {
     .expect("pinned-nprobe search");
     let recs = served_shortlist_probe::drain();
     assert!(
-        recs.iter().any(|&(_, floor)| floor >= K),
-        "explicit nprobe must arm the per-cell floor at >= k (stamped \
-         per-cell depth); recorded: {recs:?}"
+        recs.iter()
+            .any(|&(limit, floor)| floor == limit && floor > K),
+        "explicit nprobe must arm the per-cell floor at the full \
+         k x rerank_mult budget (== the pooled limit, > k on this \
+         fixture); recorded: {recs:?}"
     );
 }


### PR DESCRIPTION
Fixes #537.

## Problem

Recall fell monotonically as a caller widened `nprobe` at scale, while narrow probes held 0.99 — measured on the 10M dense grid (~3.6K cells): 0.995 at nprobe=2 down to 0.533 at all-cells. Grid-density-dependent, which is why 256-cell sweeps at the same doc count stayed monotone.

Root cause: an explicit caller `nprobe` went through the sweep's width-divided budget — each probed cell's retention is `k×rerank_mult×2/w`, so the deeper the caller probes, the thinner each cell's cut. The 1-bit in-cell ranking is too weak to concentrate the true neighbors into a thin cut: the measured ladder tracks retention depth almost mechanically (whole-cell retention serves 0.99, ~6% of a cell serves 0.85, 20 rows serves 0.51). An earlier version of this branch floored the pooled selection per cell — measured a no-op: the pool sits below the already-divided budget.

## Fix

Under an explicit caller `nprobe`, every probed cell keeps the full `k×rerank_mult` depth — the width divide stays law-arm-only, where the stamped budget genuinely is a total calibrated at the stamped width. The pooled selection's per-cell floor arms at the same depth. Widening adds cells at constant depth: monotone by construction, cost linear in the width asked for. `nprobe` is a testing surface; probing everything honestly costs a scan.

The law-served default path is untouched: stamps still decide width, fine depth, and rerank budget; the serving contract tests pin it, and the checkpoint default below is unchanged.

## Verification (5M docs, dense 3,294-cell grid, Azure, rm=256, 100 queries)

| nprobe | before (a24ec17 gate) | after |
|---|---|---:|
| 2 | 0.995 | 0.998 |
| 8 | 0.955 | 0.998 |
| 16 | 0.829 | 0.998 |
| 32 | 0.717 | 0.998 |
| all cells | 0.533 | **0.998** |
| oracle (rm=ceil(rows/k)) | — | **0.998** |

Default (law-served) checkpoint recall: 0.998, unchanged. The pre-fix 10M ladder is in the #537 thread.

## Oracle rung

`recall_while_ingest` gains `INFINO_BENCH_ORACLE=1`: all cells at rerank budget `ceil(rows/k)`, which with this fix exact-scores every live row through the stored rerank payloads — 1-bit selection bypassed, robust to cell-size skew (pre-fix the divide only guaranteed ~2× the average cell size, so skewed cells silently truncated even at oracle budgets). The ladder converging to it is the monotonicity proof, and the rung doubles as engine-side ground truth for tables without dataset GT (raw fp32 is never persisted, so stored-payload exact is the strongest engine-side truth). Already used on #542: nytimes-256 oracle = 0.9848 ⇒ that corpus's ceiling is Sq16 rerank precision, not 1-bit selection.

## Tests

lib 2172 / supertable 250 / superfile 135 green, `make check` clean. `vector_law_serving` pins the floor at the full per-cell budget (`floor == limit && floor > k`, so a revert to the k floor fails); the serving contract tests pin the default path unchanged.
