### PR TITLE
manifest: right-size the per-superfile FTS bloom

### DIFF
--- a/src/supertable/manifest/bloom.rs
+++ b/src/supertable/manifest/bloom.rs
@@ -76,6 +76,10 @@ pub const K: usize = 4;
 pub const DEFAULT_N_BLOCKS: usize = 1024;
 /// Default bloom byte size (64 KiB).
 pub const DEFAULT_BLOOM_BYTES: usize = DEFAULT_N_BLOCKS * BLOCK_BYTES;
+/// Target distinct terms per block when sizing a bloom to its term count.
+/// Matches the fixed default's loading (1024 blocks for ~100K terms), so a
+/// right-sized bloom keeps the same ~7% false-positive rate.
+const TERMS_PER_BLOCK: usize = 100;
 
 /// 64-bit golden-ratio constant (⌊2^64 / φ⌋, odd). Used as a
 /// multiplicative-avalanche mixer to decorrelate the in-block bit
@@ -152,6 +156,35 @@ impl Bloom {
         (self.n_blocks_mask as usize) + 1
     }
 
+    /// Down-fold to `target_blocks` (a power of two ≤ the current block count)
+    /// by OR-ing every source block into its residue class mod `target_blocks`.
+    /// A key present in the original is present in the fold (its block index
+    /// reduces by the same mask), so `contains` at the smaller size never turns
+    /// a hit into a miss — only the false-positive rate rises. Lets two blooms
+    /// of different sizes be unioned by folding both to the smaller. Returns
+    /// `None` if `target_blocks` is not a power of two ≤ the current count.
+    pub fn folded_to(&self, target_blocks: usize) -> Option<Bloom> {
+        let cur = self.n_blocks();
+        if target_blocks == 0 || !target_blocks.is_power_of_two() || target_blocks > cur {
+            return None;
+        }
+        if target_blocks == cur {
+            return Some(self.clone());
+        }
+        let mut words = vec![0u64; target_blocks * BLOCK_WORDS];
+        for src_block in 0..cur {
+            let dst = (src_block & (target_blocks - 1)) * BLOCK_WORDS;
+            let src = src_block * BLOCK_WORDS;
+            for w in 0..BLOCK_WORDS {
+                words[dst + w] |= self.words[src + w];
+            }
+        }
+        Some(Bloom {
+            words: words.into(),
+            n_blocks_mask: (target_blocks - 1) as u32,
+        })
+    }
+
     /// Total byte length.
     pub fn len(&self) -> usize {
         self.n_blocks() * BLOCK_BYTES
@@ -174,10 +207,27 @@ pub struct BloomBuilder {
     n_blocks_mask: u32,
 }
 
+/// Block count sized to the distinct-term count, preserving the default's
+/// ~100-terms-per-block loading (hence the target FPR), clamped to
+/// `[1, DEFAULT_N_BLOCKS]`. An 18-term superfile gets 1 block (64 B) instead
+/// of the fixed 1024 blocks (64 KiB); a 100K-term superfile still gets 1024.
+pub fn n_blocks_for_terms(n_terms: usize) -> usize {
+    n_terms
+        .div_ceil(TERMS_PER_BLOCK)
+        .max(1)
+        .next_power_of_two()
+        .min(DEFAULT_N_BLOCKS)
+}
+
 impl BloomBuilder {
     /// Builder sized at the default 64 KiB / 1024 blocks.
     pub fn new() -> Self {
         Self::with_n_blocks(DEFAULT_N_BLOCKS)
+    }
+
+    /// Builder sized to `n_terms` distinct terms. See [`n_blocks_for_terms`].
+    pub fn sized_for_terms(n_terms: usize) -> Self {
+        Self::with_n_blocks(n_blocks_for_terms(n_terms))
     }
 
     /// Builder with a caller-specified block count. Must be a
@@ -458,6 +508,44 @@ mod tests {
             n_collisions < probes.len(),
             "all probes false-positive — bloom appears saturated",
         );
+    }
+
+    // ---- adaptive sizing + fold ------------------------------------
+
+    #[test]
+    fn n_blocks_for_terms_sizes_down_and_clamps() {
+        // Tiny superfiles get a 1-block bloom; sizing tracks ~100 terms/block;
+        // and it never exceeds the 64 KiB / 1024-block ceiling no matter how
+        // many terms (so a >100K-term superfile is identical to today).
+        assert_eq!(n_blocks_for_terms(0), 1);
+        assert_eq!(n_blocks_for_terms(18), 1);
+        assert_eq!(n_blocks_for_terms(100), 1);
+        assert_eq!(n_blocks_for_terms(101), 2);
+        assert_eq!(n_blocks_for_terms(50_000), 512);
+        assert_eq!(n_blocks_for_terms(100_000), 1024);
+        assert_eq!(n_blocks_for_terms(1_000_000), DEFAULT_N_BLOCKS); // clamped
+        assert_eq!(n_blocks_for_terms(usize::MAX), DEFAULT_N_BLOCKS); // clamped
+    }
+
+    #[test]
+    fn fold_preserves_membership_and_halves_blocks() {
+        let mut b = BloomBuilder::with_n_blocks(16);
+        let keys: &[&[u8]] = &[b"alpha", b"beta", b"gamma", b"delta"];
+        for k in keys {
+            b.insert(k);
+        }
+        let big = b.finish();
+        let small = big.folded_to(4).expect("fold to a smaller power of two");
+        assert_eq!(small.n_blocks(), 4);
+        // A fold never turns a hit into a miss.
+        for k in keys {
+            assert!(small.contains(k), "membership survives the fold");
+        }
+        // Degenerate / invalid targets.
+        assert_eq!(big.folded_to(16).expect("same size").n_blocks(), 16);
+        assert!(big.folded_to(32).is_none(), "cannot fold up");
+        assert!(big.folded_to(3).is_none(), "target must be a power of two");
+        assert!(big.folded_to(0).is_none());
     }
 
     #[test]

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -1127,12 +1127,15 @@ impl FtsSummaryAgg {
     }
 }
 
-/// Bit-OR two same-shape blooms into their union. Different shapes can't be
-/// unioned (the block layout differs), so this returns `None` — "no bloom
-/// info", which the list-level pruner treats as always-keep.
+/// Bit-OR two blooms into their union. Per-superfile blooms are sized to their
+/// own distinct-term count, so a part can hold heterogeneous sizes; fold both
+/// down to the smaller block count first (block-blooms down-fold losslessly for
+/// may-contain) so the union is still valid. This preserves part-level skip
+/// even when a part mixes bloom sizes.
 fn union_blooms(a: &Bloom, b: &Bloom) -> Option<Bloom> {
-    let mut ab = a.to_bytes();
-    let bb = b.to_bytes();
+    let target = a.n_blocks().min(b.n_blocks());
+    let mut ab = a.folded_to(target)?.to_bytes();
+    let bb = b.folded_to(target)?.to_bytes();
     if ab.len() != bb.len() {
         return None;
     }
@@ -3185,15 +3188,20 @@ mod tests {
     }
 
     #[test]
-    fn fts_agg_merge_bloom_shape_mismatch_drops_to_none() {
-        // Different block counts can't be unioned → conservative "no info".
+    fn fts_agg_merge_bloom_shape_mismatch_folds_and_unions() {
+        // Different block counts are reconciled by folding the larger down to
+        // the smaller, so the part-level bloom is preserved (not dropped).
         let mut a = fts_agg(&[b"a"], 16, None);
         let b = fts_agg(&[b"b"], 8, None);
         a.merge_with(&b);
-        assert!(
-            a.term_bloom.is_none(),
-            "shape mismatch → no bloom info (always-keep)"
+        let bloom = a.term_bloom.as_ref().expect("folded union bloom");
+        assert_eq!(
+            bloom.n_blocks(),
+            8,
+            "union folds to the smaller block count"
         );
+        assert!(bloom.contains(b"a"), "self term survives fold+union");
+        assert!(bloom.contains(b"b"), "other term joins fold+union");
     }
 
     #[test]
@@ -3561,7 +3569,7 @@ mod tests {
     }
 
     #[test]
-    fn fts_merge_drops_column_on_bloom_shape_mismatch() {
+    fn fts_merge_folds_column_on_bloom_shape_mismatch() {
         let mut into = BTreeMap::new();
         let mut other = BTreeMap::new();
         let mut b1 = super::super::bloom::BloomBuilder::with_n_blocks(16);
@@ -3583,8 +3591,12 @@ mod tests {
         into.insert("col".to_string(), summary1);
         other.insert("col".to_string(), summary2);
         FtsSummaryAgg::merge(&mut into, &other);
-        // Column should be dropped because bloom shapes don't match
-        assert!(into.is_empty());
+        // Mismatched shapes fold to the smaller and union — the column survives.
+        let merged = into.get("col").expect("column kept via fold+union");
+        let bloom = merged.term_bloom.as_ref().expect("folded union bloom");
+        assert_eq!(bloom.n_blocks(), 8, "folded to the smaller block count");
+        assert!(bloom.contains(b"test1"));
+        assert!(bloom.contains(b"test2"));
     }
 
     #[test]

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -594,7 +594,9 @@ fn build_fts_summary(
             (Some(min), Some(max)) => (min.clone(), max.clone()),
             _ => (Vec::new(), Vec::new()),
         };
-        let mut bloom_builder = BloomBuilder::new();
+        // Size the bloom to this superfile's distinct-term count rather than a
+        // fixed 64 KiB. Readers derive the block count from the byte length.
+        let mut bloom_builder = BloomBuilder::sized_for_terms(terms.len());
         for term in &terms {
             bloom_builder.insert(term);
         }

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -2409,7 +2409,11 @@ pub(super) fn prepare_superfile_with_uri(
                 (Some(min), Some(max)) => (min.clone(), max.clone()),
                 _ => (Vec::new(), Vec::new()),
             };
-            let mut bloom_builder = BloomBuilder::new();
+            // Size the bloom to this superfile's distinct-term count rather
+            // than a fixed 64 KiB, which is ~1000x over-provisioned for a small
+            // superfile. Readers derive the block count from the byte length,
+            // so heterogeneous sizes coexist across superfiles.
+            let mut bloom_builder = BloomBuilder::sized_for_terms(terms.len());
             for term in &terms {
                 bloom_builder.insert(term);
             }


### PR DESCRIPTION
Builds on #534, which cut the *number* of manifest parts (fragment-count compaction trigger + empty-part prune). This attacks the complementary axis — the **bytes per superfile** inside each part — which further shrinks the per-superfile metadata for tiny superfiles and matters until compaction consolidates the fragments.

## Problem

Each superfile's manifest summary carries a per-column FTS bloom filter, and that summary is read at table-open time. The bloom was a **fixed 64 KiB** (1024 blocks), sized for a ~100K-distinct-term superfile — so a tiny superfile (e.g. a 32-row append with ~18 distinct terms) paid the same 64 KiB. That bloats opens and bounds how many superfiles fit in a part before it splits at the size threshold.

## Change

Size the bloom to the superfile's **distinct-term count**, clamped to the same 64 KiB ceiling:

- ~18-term superfile → one 64-byte block; a superfile with ≥100K terms is **unchanged** (still 64 KiB).
- **Reader-safe:** the block count is derived from the byte length (`Bloom::from_bytes`), so old and new blooms coexist with no format change.
- **Merge-safe:** merged/compacted blooms are rebuilt from the merged term set, so inputs need not share a size.
- `union_blooms` folds a larger bloom down to the smaller before OR-ing, so a part that mixes bloom sizes keeps its part-level keyword skip (block blooms down-fold losslessly for may-contain).

## Impact (isolation measurement)

Per-superfile FTS summary bytes:

| rows | before | after |
|---|---|---|
| 32 (~18 terms) | 80 KB | **15 KB** (−81%) |
| 512 | 110 KB | 44 KB (−60%) |
| 8192 | 142 KB | 77 KB (−46%) |

On a hybrid (FTS+vector) table the Full part read at open shrinks −29% (512-row) to −64% (32-row). No change at ≥100K terms.

## Correctness

The bloom keeps its **no-false-negative** guarantee at every size — "definitely not present" is always correct; a smaller bloom only raises the false-positive rate back to the same target (an extra unnecessary superfile open, never a missed hit). Covered by the BM25 oracle tests plus new unit tests: term-count sizing + the 64 KiB clamp, fold membership preservation, and heterogeneous-size union. FTS-only — the vector path is untouched, so recall is unaffected.

`make ci` green locally.