### PR TITLE
config: remove the rerank_codec knob — codec is internal

### DIFF
--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -129,18 +129,6 @@ compaction:
 # needs to touch this section. These are the levers that used to be
 # one-off INFINO_* env vars; they are YAML-only now.
 vector:
-  # Default rerank codec for cosine vector columns. Non-cosine metrics
-  # still use locally fitted sq8_residual (values are not bounded to
-  # [-1, 1]). Override per column at table-create time when needed.
-  #   sq16               — single 16-bit plane on the fixed [-1, 1] grid
-  #                        (default; finer grid than sq8_fixed_residual at
-  #                        the same 2 bytes/dim, faster rerank)
-  #   sq8_fixed_residual — coarse u8 + i8 residual on the fixed grid
-  #   sq8_residual       — per-cluster fitted quantizer
-  #   fp32               — full-precision rerank
-  #   rabitq_only        — no rerank column
-  rerank_codec: sq16
-
   # Absolute cap on fine IVF centroids probed per vector search.
   # Empty (~) derives the budget from nprobe × eligible superfiles at
   # query time; set an integer to force exactly that many.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -51,8 +51,6 @@ use serde::{
     ser::Serializer,
 };
 
-use crate::superfile::vector::rerank_codec::RerankCodec;
-
 /// Embedded baseline. Compiled in via `include_str!`.
 const EMBEDDED_DEFAULT: &str = include_str!("config.yaml");
 
@@ -379,11 +377,6 @@ pub struct VectorSettings {
     /// measure real-query slack, the same distribution mismatch that
     /// under-stamped the width law on such corpora.
     pub serve_near_tie_slack: f32,
-    /// Default rerank codec for cosine vector columns. Non-cosine
-    /// metrics still use locally fitted [`RerankCodec::Sq8Residual`]
-    /// at column construction time. Per-column overrides at table
-    /// create win over this default.
-    pub rerank_codec: RerankCodec,
     /// K-means training points per centroid for the drain's per-cell
     /// sub-builds. Higher trains on more points (slower, tighter
     /// clusters).
@@ -454,7 +447,6 @@ impl Default for VectorSettings {
             fine_nprobe_floor: DEFAULT_VECTOR_FINE_NPROBE_FLOOR,
             fine_nprobe_pct: DEFAULT_VECTOR_FINE_NPROBE_PCT,
             serve_near_tie_slack: DEFAULT_VECTOR_SERVE_NEAR_TIE_SLACK,
-            rerank_codec: RerankCodec::default(),
             kmeans_pts_per_centroid: DEFAULT_VECTOR_KMEANS_PTS_PER_CENTROID,
             cell_split_doc_cap: DEFAULT_VECTOR_CELL_SPLIT_DOC_CAP,
             cell_split_modality_d: DEFAULT_VECTOR_CELL_SPLIT_MODALITY_D,
@@ -1226,7 +1218,6 @@ supertable:
         assert_eq!(cfg.vector.cell_split_doc_cap, 500_000);
         assert_eq!(cfg.vector.user_centroids, CentroidAlignment::Local);
         assert_eq!(cfg.vector.drain_consolidate, DrainConsolidate::Kmeans);
-        assert_eq!(cfg.vector.rerank_codec, RerankCodec::Sq16);
         assert_eq!(cfg.vector.drain_read_concurrency, ThreadCount::Auto);
     }
 
@@ -1246,7 +1237,6 @@ vector:
   cell_split_doc_cap: 100000
   user_centroids: global
   drain_consolidate: splice
-  rerank_codec: sq8_residual
   drain_replica_target_factor: 1.25
   drain_read_concurrency: 12
 "#;
@@ -1258,7 +1248,6 @@ vector:
         assert_eq!(cfg.vector.cell_split_doc_cap, 100_000);
         assert_eq!(cfg.vector.user_centroids, CentroidAlignment::Global);
         assert_eq!(cfg.vector.drain_consolidate, DrainConsolidate::Splice);
-        assert_eq!(cfg.vector.rerank_codec, RerankCodec::Sq8Residual);
         assert_eq!(cfg.vector.drain_replica_target_factor, 1.25);
         assert_eq!(cfg.vector.drain_read_concurrency, ThreadCount::Fixed(12));
         // Untouched keys fall through to the embedded default.

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -23,36 +23,33 @@ use std::{
 use rayon::prelude::*;
 use tempfile::{tempdir, tempdir_in};
 
-use crate::{
-    config,
-    superfile::{
-        BuildError,
-        format::{
-            self, FST_SEPARATOR, RESERVED_PREFIX,
-            checksum::{crc32c, crc32c_append},
-            vec::{
-                CELL_DIR_ENTRY_SIZE, CLUSTER_IDX_COUNT_OFFSET, CLUSTER_IDX_ENTRY_BYTES,
-                MAGIC_BYTES, U32_BYTES, U64_BYTES, cell_dir_entry, sub_hdr,
-            },
+use crate::superfile::{
+    BuildError,
+    format::{
+        self, FST_SEPARATOR, RESERVED_PREFIX,
+        checksum::{crc32c, crc32c_append},
+        vec::{
+            CELL_DIR_ENTRY_SIZE, CLUSTER_IDX_COUNT_OFFSET, CLUSTER_IDX_ENTRY_BYTES, MAGIC_BYTES,
+            U32_BYTES, U64_BYTES, cell_dir_entry, sub_hdr,
         },
-        vector::{
-            cell_posting::{MaterializedIvfRow, sq8_residual_norm_sq},
-            distance::{
-                Metric, distance, encode_sq16_row, mean_f32_cluster_major, normalize,
-                sq16_decoded_norm_sq,
-            },
-            ivf_merge::MergedIvfSubsection,
-            kmeans::{assign_to_centroids, kmeans, kmeans_with_assignments},
-            quant::BitQuantizer,
-            rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
-            reservoir::{Reservoir, default_kmeans_sample_size, partition_kmeans_sample_size},
-            rotation::RandomRotation,
-            spill::{
-                ChunkedVectorSource, InMemoryVectorSource, MmapVectorSource, SpillWriter,
-                SpilledCellRows,
-            },
-            sq8_simd::{Sq8EncodeConsts, encode_sq8_residual_row, update_min_max},
+    },
+    vector::{
+        cell_posting::{MaterializedIvfRow, sq8_residual_norm_sq},
+        distance::{
+            Metric, distance, encode_sq16_row, mean_f32_cluster_major, normalize,
+            sq16_decoded_norm_sq,
         },
+        ivf_merge::MergedIvfSubsection,
+        kmeans::{assign_to_centroids, kmeans, kmeans_with_assignments},
+        quant::BitQuantizer,
+        rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
+        reservoir::{Reservoir, default_kmeans_sample_size, partition_kmeans_sample_size},
+        rotation::RandomRotation,
+        spill::{
+            ChunkedVectorSource, InMemoryVectorSource, MmapVectorSource, SpillWriter,
+            SpilledCellRows,
+        },
+        sq8_simd::{Sq8EncodeConsts, encode_sq8_residual_row, update_min_max},
     },
 };
 
@@ -217,17 +214,18 @@ pub struct VectorConfig {
 /// time overrides this default.
 fn default_rerank_codec_for(metric: Metric) -> RerankCodec {
     if metric == Metric::Cosine {
-        config::global().vector.rerank_codec
+        RerankCodec::default()
     } else {
         RerankCodec::Sq8Residual
     }
 }
 
 impl VectorConfig {
-    /// Construct a config with the configured cosine default codec
-    /// ([`crate::config::VectorSettings::rerank_codec`] — `Sq16`) and locally
-    /// fitted residual encoding ([`RerankCodec::Sq8Residual`]) for metrics
-    /// whose values are not bounded to [-1, 1]. Override per column with
+    /// Construct a config with the engine's cosine default codec
+    /// ([`RerankCodec::default`] — `Sq16`) and locally fitted residual
+    /// encoding ([`RerankCodec::Sq8Residual`]) for metrics whose values
+    /// are not bounded to [-1, 1]. The codec is internal — not a config
+    /// knob, not part of the public spec; tests override per column with
     /// [`Self::with_rerank_codec`].
     pub fn new(column: String, dim: usize, rot_seed: u64, metric: Metric) -> Self {
         Self {
@@ -1130,13 +1128,15 @@ pub(crate) mod build_phase_timers {
         time::Instant,
     };
 
+    use crate::config;
+
     pub static TRAIN_US: AtomicU64 = AtomicU64::new(0);
     pub static ASSIGN_US: AtomicU64 = AtomicU64::new(0);
     pub static CALIB_US: AtomicU64 = AtomicU64::new(0);
 
     pub fn enabled() -> bool {
         static ON: OnceLock<bool> = OnceLock::new();
-        *ON.get_or_init(|| crate::config::global().diagnostics.drain_build_timers)
+        *ON.get_or_init(|| config::global().diagnostics.drain_build_timers)
     }
 
     /// Run `f`, adding its elapsed micros to `counter` when timing is enabled.


### PR DESCRIPTION
## What

Removes `vector.rerank_codec` from the YAML config surface. The stored rerank payload codec is an engine-internal decision: cosine columns use `Sq16`, unbounded metrics use locally fitted `Sq8Residual`. Per-column overrides remain a test-only surface (`VectorConfig::with_rerank_codec`, not part of the public spec).

## Why

A config layer that changes storage bytes is not a lever users should hold, and the knob had become actively misleading: `fp32` names storage the engine deliberately never produces — raw vectors are never stored fp32 (fp32 is intake and centroids only), verified empirically at drain scale during the #542 investigation.

## Notes

- Not in `public-api.txt` (never exported); `make public-api` clean, no API drift.
- The two config unit tests lose only their codec assertions; every other key they exercise is unchanged.
- Suites: lib 2172 / supertable 250 / superfile 135 green, `make check` clean.
- No behavior change for any default deployment: the embedded default was `sq16`, which is exactly what the internal default resolves to.
