### PR TITLE
catalog: remove vector tuning knobs from the public API

### DIFF
--- a/api-parity.txt
+++ b/api-parity.txt
@@ -18,12 +18,12 @@ Supertable::count	covered	(&self, &str, &str, BoolMode) -> Result<u64, InfinoErr
 Supertable::delete	covered	(&self, Expr) -> Result<MutationStats, InfinoError>
 Supertable::exact_match	covered	(&self, &str, &str, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
 Supertable::gc	covered	(&self, Duration) -> Result<GcReport, GcError>
-Supertable::hybrid_search	covered	(&self, &str, &str, BoolMode, &str, &[f32], VectorSearchOptions, usize, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
+Supertable::hybrid_search	covered	(&self, &str, &str, BoolMode, &str, &[f32], usize, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
 Supertable::optimize	covered	(&self, &OptimizeOptions) -> Result<(), OptimizeError>
 Supertable::schema	covered	(&self) -> SchemaRef
 Supertable::token_match	covered	(&self, &str, &str, BoolMode, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
 Supertable::update	covered	(&self, Expr, &RecordBatch) -> Result<MutationStats, InfinoError>
-Supertable::vector_search	covered	(&self, &str, &[f32], usize, VectorSearchOptions, Option<VectorFilter<'_>>, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
+Supertable::vector_search	covered	(&self, &str, &[f32], usize, Option<VectorFilter<'_>>, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
 connect	covered	(impl AsRef<str>) -> Result<Connection, InfinoError>
 connect_with	covered	(impl AsRef<str>, ConnectOptions) -> Result<Connection, InfinoError>
 

--- a/crate-docs.md
+++ b/crate-docs.md
@@ -36,7 +36,7 @@ use std::sync::Arc;
 
 use infino::arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
 use infino::arrow_schema::{DataType, Field, Schema};
-use infino::{connect, Bm25SearchOptions, BoolMode, IndexSpec, Metric, VectorFilter, VectorSearchOptions};
+use infino::{connect, Bm25SearchOptions, BoolMode, IndexSpec, Metric, VectorFilter};
 
 // Tiny stand-in for your embedding model so this runs as-is — a 16-dim
 // one-hot by topic. Real embeddings are dense and higher-dimensional.
@@ -80,15 +80,15 @@ docs.append(&RecordBatch::try_new(
 // Retrieve context to ground the agent's next answer:
 let keyword =
     docs.bm25_search("body", "cancel subscription", 5, Bm25SearchOptions::new(), None)?;
-let semantic = docs.vector_search("embedding", &embed(0), 5, VectorSearchOptions::new(), None, None)?;
+let semantic = docs.vector_search("embedding", &embed(0), 5, None, None)?;
 // hybrid: BM25 + vector, fused with reciprocal-rank fusion:
 let hybrid = docs.hybrid_search(
     "body", "cancel subscription", BoolMode::Or,
-    "embedding", &embed(0), VectorSearchOptions::new(), 5, None,
+    "embedding", &embed(0), 5, None,
 )?;
 // vector kNN, restricted to rows whose body matches a keyword (pushdown filter):
 let filtered = docs.vector_search(
-    "embedding", &embed(0), 5, VectorSearchOptions::new(),
+    "embedding", &embed(0), 5,
     Some(VectorFilter { column: "body", query: "billing", mode: BoolMode::Or }), None,
 )?;
 let billing = db.query_sql("SELECT body FROM docs WHERE source = 'help-center'")?;
@@ -130,7 +130,7 @@ live on the [`Connection`] and [`Supertable`] pages:
     [`gc`](Supertable::gc), and [`schema`](Supertable::schema).
 
 Supporting types: [`IndexSpec`], [`Metric`], [`BoolMode`],
-[`VectorSearchOptions`], [`VectorFilter`], [`ConnectOptions`], [`MutationStats`],
+[`VectorFilter`], [`ConnectOptions`], [`MutationStats`],
 [`GcReport`], and the [`InfinoError`], [`OptimizeError`], and [`GcError`] error
 enums.
 

--- a/examples/locomo-recall/main.rs
+++ b/examples/locomo-recall/main.rs
@@ -43,7 +43,7 @@ use std::{
 };
 
 use infino::{
-    Bm25SearchOptions, IndexSpec, Metric, VectorSearchOptions,
+    Bm25SearchOptions, IndexSpec, Metric,
     arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch},
     arrow_schema::{DataType, Field, Schema},
     connect,
@@ -272,7 +272,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             "vector",
             &case.query_vector,
             k,
-            VectorSearchOptions::new(),
             None,
             Some(&["id", "score"]),
         )?)?;

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use arrow::util::pretty::pretty_format_batches;
 use infino::{
-    Bm25SearchOptions, BoolMode, IndexSpec, Metric, VectorFilter, VectorSearchOptions,
+    Bm25SearchOptions, BoolMode, IndexSpec, Metric, VectorFilter,
     arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch},
     arrow_schema::{DataType, Field, Schema},
     connect,
@@ -73,7 +73,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "emb",
         &query,
         SEARCH_TOP_K,
-        VectorSearchOptions::new(),
         None,
         Some(&["_id", "title", "score"]),
     )?;
@@ -89,7 +88,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "emb",
         &query,
         SEARCH_TOP_K,
-        VectorSearchOptions::new(),
         Some(VectorFilter {
             column: "title",
             query: "dog",

--- a/infino-node/__test__/azure.e2e.test.mjs
+++ b/infino-node/__test__/azure.e2e.test.mjs
@@ -127,7 +127,7 @@ test("hybridSearch", { skip }, () => {
     assert.ok(hits.length >= 1);
     assert.equal(typeof hits[0]._id, "bigint");
 
-    // The SQL TVF fixes mode="or" and default nprobe, so the direct call matches.
+    // The SQL TVF fixes mode="or"; vector serving is engine-decided, so the direct call matches.
     const qvec = onehot(0).join(",");
     const tvf = db.querySql(`SELECT _id FROM hybrid_search('docs', 'title', 'rust', 'emb', '${qvec}', 10)`);
     assert.ok(tvf.length >= 1);

--- a/infino-node/__test__/gcs.e2e.test.mjs
+++ b/infino-node/__test__/gcs.e2e.test.mjs
@@ -125,7 +125,7 @@ test("hybridSearch", { skip }, () => {
     assert.ok(hits.length >= 1);
     assert.equal(typeof hits[0]._id, "bigint");
 
-    // The SQL TVF fixes mode="or" and default nprobe, so the direct call matches.
+    // The SQL TVF fixes mode="or"; vector serving is engine-decided, so the direct call matches.
     const qvec = onehot(0).join(",");
     const tvf = db.querySql(`SELECT _id FROM hybrid_search('docs', 'title', 'rust', 'emb', '${qvec}', 10)`);
     assert.ok(tvf.length >= 1);

--- a/infino-node/__test__/smoke.test.mjs
+++ b/infino-node/__test__/smoke.test.mjs
@@ -135,7 +135,7 @@ test("hybridSearch fuses BM25 and vector retrieval", () => {
   const scores = hits.map((r) => r.score);
   assert.deepEqual(scores, [...scores].sort((a, b) => b - a));
 
-  // The SQL TVF fixes mode="or" and default nprobe, so the direct call matches.
+  // The SQL TVF fixes mode="or"; vector serving is engine-decided, so the direct call matches.
   const qvec = onehot(0, dim).join(",");
   const viaSql = db.querySql(`SELECT _id FROM hybrid_search('docs', 'title', 'rust', 'emb', '${qvec}', 10)`);
   assert.equal(viaSql.length, hits.length);
@@ -215,9 +215,10 @@ test("vector search end-to-end", () => {
   const rows = docs.vectorSearch("emb", onehot(0, dim), 10);
   assert.ok(rows.length >= 1);
 
-  // nprobe + rerankMult tuning knobs are accepted.
-  const tuned = docs.vectorSearch("emb", onehot(0, dim), 5, { nprobe: 1, rerankMult: 4 });
-  assert.ok(tuned.length >= 1);
+  // Probe width and rerank budget are engine-decided; the options object
+  // carries no tuning knobs, only projection / filter / arrow.
+  const projected = docs.vectorSearch("emb", onehot(0, dim), 5, { projection: ["_id", "score"] });
+  assert.ok(projected.length >= 1);
 });
 
 test("filtered vector search (pushdown text predicate)", () => {

--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -132,22 +132,16 @@ export interface VectorFilter {
   mode?: BoolMode;
 }
 export interface VectorSearchOptions {
-  /** IVF partitions to probe (higher = better recall, more work). */
-  nprobe?: number;
-  /** Over-fetch multiplier for the exact-rerank stage (higher = better recall). */
-  rerankMult?: number;
   projection?: string[];
   arrow?: boolean;
   /** Restrict the kNN to rows matching a text predicate (pushdown pre-filter). */
   filter?: VectorFilter;
 }
-/** Options for `hybridSearch`. `mode` applies to the BM25 side; `nprobe` to
- * the vector side. */
+/** Options for `hybridSearch`. `mode` applies to the BM25 side; vector
+ * probe width and rerank budget are engine-decided. */
 export interface HybridSearchOptions {
   /** BM25 boolean mode: `"or"` (default) or `"and"`. */
   mode?: BoolMode;
-  /** IVF partitions to probe on the vector side (higher = better recall). */
-  nprobe?: number;
   projection?: string[];
   arrow?: boolean;
 }
@@ -354,7 +348,7 @@ export class Table {
   vectorSearch(column: string, query: number[] | Float32Array, k: number, opts?: VectorSearchOptions): RowRecord[];
   vectorSearch(column: string, query: number[] | Float32Array, k: number, opts: VectorSearchOptions = {}): RowRecord[] | arrow.Table {
     const q = query instanceof Float32Array ? query : Float32Array.from(query);
-    const buf = this.inner.vectorSearch(column, q, k, opts.nprobe, opts.rerankMult, opts.projection, opts.filter);
+    const buf = this.inner.vectorSearch(column, q, k, opts.projection, opts.filter);
     return decode(buf, opts.arrow);
   }
 
@@ -365,7 +359,7 @@ export class Table {
   hybridSearch(textColumn: string, textQuery: string, vectorColumn: string, vectorQuery: number[] | Float32Array, k: number, opts?: HybridSearchOptions): RowRecord[];
   hybridSearch(textColumn: string, textQuery: string, vectorColumn: string, vectorQuery: number[] | Float32Array, k: number, opts: HybridSearchOptions = {}): RowRecord[] | arrow.Table {
     const q = vectorQuery instanceof Float32Array ? vectorQuery : Float32Array.from(vectorQuery);
-    const buf = this.inner.hybridSearch(textColumn, textQuery, vectorColumn, q, k, opts.mode, opts.nprobe, opts.projection);
+    const buf = this.inner.hybridSearch(textColumn, textQuery, vectorColumn, q, k, opts.mode, opts.projection);
     return decode(buf, opts.arrow);
   }
 

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -48,7 +48,6 @@ use datafusion::logical_expr::Expr;
 use infino::{
     Bm25SearchOptions, Bm25Stats, BoolMode, ColdFetchMode, CompactionSettings, GcError,
     InfinoError, Metric, OptimizeError, OptimizeOptions as InfinoOptimizeOptions,
-    VectorSearchOptions,
 };
 
 // ---------------------------------------------------------------------------
@@ -558,18 +557,11 @@ impl Table {
         column: String,
         query: Float32Array,
         k: u32,
-        nprobe: Option<u32>,
-        rerank_mult: Option<u32>,
         projection: Option<Vec<String>>,
         filter: Option<VectorFilter>,
     ) -> Result<Buffer> {
-        let mut opts = VectorSearchOptions::new();
-        if let Some(n) = nprobe {
-            opts = opts.with_nprobe(n as usize);
-        }
-        if let Some(m) = rerank_mult {
-            opts = opts.with_rerank_mult(m as usize);
-        }
+        // Probe width and rerank budget are engine-decided (drain-time
+        // calibration); there is no caller tuning surface.
         // Optional text-predicate filter (pushdown), borrowing the JS object.
         let vfilter = match &filter {
             Some(f) => Some(infino::VectorFilter {
@@ -588,7 +580,6 @@ impl Table {
                 &column,
                 query.as_ref(),
                 k as usize,
-                opts,
                 vfilter,
                 proj.as_deref(),
             )
@@ -650,9 +641,10 @@ impl Table {
 
     /// Hybrid BM25 + vector search fused with reciprocal-rank fusion.
     /// `text_column`/`text_query` (under `mode`) drive BM25; `vector_column`/
-    /// `vector_query` (a `Float32Array`, with optional `nprobe`) drive vector
-    /// kNN. Returns Arrow rows like [`Table::bm25_search`], with `score` the
-    /// fused RRF score (higher is better); `projection` selects columns.
+    /// `vector_query` (a `Float32Array`) drive vector kNN — probe width and
+    /// rerank budget are engine-decided. Returns Arrow rows like
+    /// [`Table::bm25_search`], with `score` the fused RRF score (higher is
+    /// better); `projection` selects columns.
     #[napi]
     #[allow(clippy::too_many_arguments)]
     pub fn hybrid_search(
@@ -663,14 +655,9 @@ impl Table {
         vector_query: Float32Array,
         k: u32,
         mode: Option<String>,
-        nprobe: Option<u32>,
         projection: Option<Vec<String>>,
     ) -> Result<Buffer> {
         let mode = parse_mode(mode.as_deref())?;
-        let mut opts = VectorSearchOptions::new();
-        if let Some(n) = nprobe {
-            opts = opts.with_nprobe(n as usize);
-        }
         let proj: Option<Vec<&str>> = projection
             .as_ref()
             .map(|v| v.iter().map(String::as_str).collect());
@@ -682,7 +669,6 @@ impl Table {
                 mode,
                 &vector_column,
                 vector_query.as_ref(),
-                opts,
                 k as usize,
                 proj.as_deref(),
             )

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -34,3 +34,10 @@ pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
 # datafusion version so the `Expr` type unifies with the core signatures;
 # feature unification reuses infino's already-compiled datafusion.
 datafusion = "54"
+
+[features]
+# Diagnostic wheel: exposes `nprobe` / `rerank_mult` kwargs on
+# `vector_search` / `hybrid_search` for recall sweeps and the exact-scan
+# oracle (all cells at rerank_mult = ceil(rows/k)). Never enabled for
+# published wheels — the shipped surface has no vector tuning knobs.
+diagnostics = ["infino/test-helpers"]

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -74,8 +74,6 @@ class Table:
         column: str,
         query: Sequence[float],
         k: int,
-        nprobe: int | None = ...,
-        rerank_mult: int | None = ...,
         filter_column: str | None = ...,
         filter_query: str | None = ...,
         filter_mode: BoolMode | None = ...,
@@ -108,8 +106,6 @@ class Table:
         vector_query: Sequence[float],
         k: int,
         mode: BoolMode | None = ...,
-        nprobe: int | None = ...,
-        rerank_mult: int | None = ...,
         projection: Sequence[str] | None = ...,
     ) -> ArrowTable: ...
     def delete(self, predicate: str) -> MutationStats: ...

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -33,8 +33,11 @@ use pyo3::types::{PyDict, PyList};
 use infino::{
     Bm25SearchOptions, Bm25Stats, BoolMode, ColdFetchMode, CompactionSettings, ConnectOptions,
     GcError, InfinoError as CoreError, Metric, OptimizeError, OptimizeOptions, VectorFilter,
-    VectorSearchOptions,
 };
+// Vector tuning knobs are a diagnostic-wheel-only surface; the type is off
+// the engine's public API and reachable only under `infino/test-helpers`.
+#[cfg(feature = "diagnostics")]
+use infino::VectorSearchOptions;
 
 // Typed exception surface for the bindings. `InfinoError` is the base for every
 // infino error, so a caller can catch the whole family with one `except` or
@@ -515,9 +518,37 @@ impl Table {
     /// matching rows rather than post-filtering the global top-`k`.
     /// `filter_mode` is `"or"` (default) or `"and"`.
     ///
-    /// `rerank_mult` sets how many coarse candidates are re-scored
-    /// exactly (`k * rerank_mult`) — the primary recall/latency lever.
-    /// Omitting it keeps the engine default.
+    /// Probe width and rerank budget are engine-decided (drain-time
+    /// calibration, per table and per `k`); there are no tuning kwargs.
+    #[cfg(not(feature = "diagnostics"))]
+    #[pyo3(signature = (column, query, k, filter_column=None, filter_query=None, filter_mode=None, projection=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn vector_search<'py>(
+        &self,
+        py: Python<'py>,
+        column: &str,
+        query: Vec<f32>,
+        k: usize,
+        filter_column: Option<String>,
+        filter_query: Option<String>,
+        filter_mode: Option<&str>,
+        projection: Option<Vec<String>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let filter = parse_filter(filter_column.as_deref(), filter_query.as_deref(), filter_mode)?;
+        let batches = py
+            .detach(|| {
+                let names = projection_refs(&projection);
+                self.inner
+                    .vector_search(column, &query, k, filter, names.as_deref())
+            })
+            .map_err(py_err)?;
+        batches_to_pyarrow_table(py, batches)
+    }
+
+    /// Diagnostic build only: `nprobe` / `rerank_mult` overrides for
+    /// recall sweeps and the exact-scan oracle. Published wheels do not
+    /// carry these kwargs.
+    #[cfg(feature = "diagnostics")]
     #[pyo3(signature = (column, query, k, nprobe=None, rerank_mult=None, filter_column=None, filter_query=None, filter_mode=None, projection=None))]
     #[allow(clippy::too_many_arguments)]
     fn vector_search<'py>(
@@ -540,37 +571,12 @@ impl Table {
         if let Some(n) = rerank_mult {
             opts = opts.with_rerank_mult(n);
         }
-        // Optional text-predicate filter (pushdown). `filter_column` and
-        // `filter_query` must be supplied together; `filter_mode` is only
-        // meaningful alongside them (a lone `filter_mode` is rejected rather
-        // than silently ignored, so an invalid value never passes unnoticed).
-        let filter = match (
-            filter_column.as_deref(),
-            filter_query.as_deref(),
-            filter_mode,
-        ) {
-            (Some(col), Some(q), mode) => Some(VectorFilter {
-                column: col,
-                query: q,
-                mode: parse_mode(mode)?,
-            }),
-            (None, None, None) => None,
-            (None, None, Some(_)) => {
-                return Err(PyValueError::new_err(
-                    "filter_mode requires filter_column and filter_query",
-                ));
-            }
-            _ => {
-                return Err(PyValueError::new_err(
-                    "filter_column and filter_query must be provided together",
-                ));
-            }
-        };
+        let filter = parse_filter(filter_column.as_deref(), filter_query.as_deref(), filter_mode)?;
         let batches = py
             .detach(|| {
                 let names = projection_refs(&projection);
                 self.inner
-                    .vector_search(column, &query, k, opts, filter, names.as_deref())
+                    .vector_search_with_options(column, &query, k, opts, filter, names.as_deref())
             })
             .map_err(py_err)?;
         batches_to_pyarrow_table(py, batches)
@@ -643,6 +649,41 @@ impl Table {
     /// fused result. Returns a pyarrow `Table` like `bm25_search`, with
     /// `score` the fused RRF score (higher is better); `projection`
     /// follows the same rules.
+    #[cfg(not(feature = "diagnostics"))]
+    #[pyo3(signature = (text_column, text_query, vector_column, vector_query, k, mode=None, projection=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn hybrid_search<'py>(
+        &self,
+        py: Python<'py>,
+        text_column: &str,
+        text_query: &str,
+        vector_column: &str,
+        vector_query: Vec<f32>,
+        k: usize,
+        mode: Option<&str>,
+        projection: Option<Vec<String>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let mode = parse_mode(mode)?;
+        let batches = py
+            .detach(|| {
+                let names = projection_refs(&projection);
+                self.inner.hybrid_search(
+                    text_column,
+                    text_query,
+                    mode,
+                    vector_column,
+                    &vector_query,
+                    k,
+                    names.as_deref(),
+                )
+            })
+            .map_err(py_err)?;
+        batches_to_pyarrow_table(py, batches)
+    }
+
+    /// Diagnostic build only: `nprobe` / `rerank_mult` overrides — see
+    /// `vector_search`. Published wheels do not carry these kwargs.
+    #[cfg(feature = "diagnostics")]
     #[pyo3(signature = (text_column, text_query, vector_column, vector_query, k, mode=None, nprobe=None, rerank_mult=None, projection=None))]
     #[allow(clippy::too_many_arguments)]
     fn hybrid_search<'py>(
@@ -669,7 +710,7 @@ impl Table {
         let batches = py
             .detach(|| {
                 let names = projection_refs(&projection);
-                self.inner.hybrid_search(
+                self.inner.hybrid_search_with_options(
                     text_column,
                     text_query,
                     mode,
@@ -806,6 +847,31 @@ fn parse_mode(mode: Option<&str>) -> PyResult<BoolMode> {
         other => Err(PyValueError::new_err(format!(
             "mode must be 'or' or 'and', got {other:?}"
         ))),
+    }
+}
+
+/// Optional text-predicate filter (pushdown). `filter_column` and
+/// `filter_query` must be supplied together; `filter_mode` is only
+/// meaningful alongside them (a lone `filter_mode` is rejected rather
+/// than silently ignored, so an invalid value never passes unnoticed).
+fn parse_filter<'a>(
+    column: Option<&'a str>,
+    query: Option<&'a str>,
+    mode: Option<&str>,
+) -> PyResult<Option<VectorFilter<'a>>> {
+    match (column, query, mode) {
+        (Some(col), Some(q), mode) => Ok(Some(VectorFilter {
+            column: col,
+            query: q,
+            mode: parse_mode(mode)?,
+        })),
+        (None, None, None) => Ok(None),
+        (None, None, Some(_)) => Err(PyValueError::new_err(
+            "filter_mode requires filter_column and filter_query",
+        )),
+        _ => Err(PyValueError::new_err(
+            "filter_column and filter_query must be provided together",
+        )),
     }
 }
 

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -644,11 +644,11 @@ impl Table {
 
     /// Hybrid BM25 + vector search fused with reciprocal-rank fusion.
     /// `text_column` / `text_query` (under `mode`) drive BM25;
-    /// `vector_column` / `vector_query` (with optional `nprobe` and
-    /// `rerank_mult`) drive vector kNN. `k` bounds each retriever and the
-    /// fused result. Returns a pyarrow `Table` like `bm25_search`, with
-    /// `score` the fused RRF score (higher is better); `projection`
-    /// follows the same rules.
+    /// `vector_column` / `vector_query` drive vector kNN — probe width
+    /// and rerank budget are engine-decided. `k` bounds each retriever
+    /// and the fused result. Returns a pyarrow `Table` like
+    /// `bm25_search`, with `score` the fused RRF score (higher is
+    /// better); `projection` follows the same rules.
     #[cfg(not(feature = "diagnostics"))]
     #[pyo3(signature = (text_column, text_query, vector_column, vector_query, k, mode=None, projection=None))]
     #[allow(clippy::too_many_arguments)]

--- a/infino-python/tests/test_azure_e2e.py
+++ b/infino-python/tests/test_azure_e2e.py
@@ -155,7 +155,7 @@ def test_hybrid_search(db: infino.Connection) -> None:
     assert hits.num_rows >= 1
     assert "_id" in hits.column_names and "score" in hits.column_names
 
-    # The SQL TVF fixes mode="or" and default nprobe, so the direct call matches.
+    # The SQL TVF fixes mode="or"; vector serving is engine-decided, so the direct call matches.
     csv = ",".join("1" if d == 0 else "0" for d in range(DIM))
     tvf = db.query_sql(f"SELECT _id FROM hybrid_search('docs', 'title', 'rust', 'emb', '{csv}', 10)")
     assert tvf.num_rows >= 1

--- a/infino-python/tests/test_gcs_e2e.py
+++ b/infino-python/tests/test_gcs_e2e.py
@@ -152,7 +152,7 @@ def test_hybrid_search(db: infino.Connection) -> None:
     assert hits.num_rows >= 1
     assert "_id" in hits.column_names and "score" in hits.column_names
 
-    # The SQL TVF fixes mode="or" and default nprobe, so the direct call matches.
+    # The SQL TVF fixes mode="or"; vector serving is engine-decided, so the direct call matches.
     csv = ",".join("1" if d == 0 else "0" for d in range(DIM))
     tvf = db.query_sql(f"SELECT _id FROM hybrid_search('docs', 'title', 'rust', 'emb', '{csv}', 10)")
     assert tvf.num_rows >= 1

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -453,9 +453,9 @@ def test_vector_search_end_to_end():
     assert hits.num_rows >= 1
     assert "_id" in hits.column_names and "score" in hits.column_names
 
-    # rerank_mult tunes recall/latency without breaking the search.
-    tuned = t.vector_search("emb", onehot(0), 10, nprobe=8, rerank_mult=32)
-    assert tuned.num_rows >= 1
+    # Serving is engine-decided; the call carries no tuning kwargs.
+    projected = t.vector_search("emb", onehot(0), 10, projection=["_id", "score"])
+    assert projected.num_rows >= 1
 
 
 def test_filtered_vector_search():
@@ -551,10 +551,6 @@ def test_hybrid_search_fuses_text_and_vector():
     assert hits.num_rows >= 1
     assert "_id" in hits.column_names and "score" in hits.column_names
 
-    # nprobe/rerank_mult tune the vector leg without breaking the search.
-    assert t.hybrid_search(
-        "title", "rust", "emb", onehot(0), 10, nprobe=8, rerank_mult=32
-    ).num_rows >= 1
     # RRF score is higher-is-better, so rows come back descending.
     scores = hits["score"].to_pylist()
     assert scores == sorted(scores, reverse=True)
@@ -566,7 +562,7 @@ def test_hybrid_search_fuses_text_and_vector():
     assert projected.column_names == ["_id", "title", "score"]
 
     # Direct call and the SQL table function agree on the `_id` set
-    # (the TVF fixes mode="or" and default nprobe, so match it).
+    # (the TVF fixes mode="or"; vector serving is engine-decided, so match it).
     csv = ",".join("1" if d == 0 else "0" for d in range(dim))
     via_sql = db.query_sql(
         f"SELECT _id FROM hybrid_search('docs', 'title', 'rust', 'emb', '{csv}', 10)"

--- a/infino-python/tests/typing/quickstart.py
+++ b/infino-python/tests/typing/quickstart.py
@@ -34,7 +34,7 @@ def vectors() -> None:
     schema = pa.schema([pa.field("emb", pa.list_(pa.float32(), 16), nullable=False)])
     spec = infino.IndexSpec().vector("emb", 16, "cosine")
     vecs: infino.Table = db.create_table("vecs", schema, spec)
-    vecs.vector_search("emb", [0.0] * 16, k=5, nprobe=8)
+    vecs.vector_search("emb", [0.0] * 16, k=5)
     vecs.vector_search(
         "emb",
         [0.0] * 16,

--- a/public-api.txt
+++ b/public-api.txt
@@ -378,12 +378,12 @@ pub fn infino::Supertable::count(&self, &str, &str, infino::BoolMode) -> core::r
 pub fn infino::Supertable::delete(&self, datafusion_expr::expr::Expr) -> core::result::Result<infino::MutationStats, infino::InfinoError>
 pub fn infino::Supertable::exact_match(&self, &str, &str, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
 pub fn infino::Supertable::gc(&self, core::time::Duration) -> core::result::Result<infino::GcReport, infino::GcError>
-pub fn infino::Supertable::hybrid_search(&self, &str, &str, infino::BoolMode, &str, &[f32], infino::VectorSearchOptions, usize, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
+pub fn infino::Supertable::hybrid_search(&self, &str, &str, infino::BoolMode, &str, &[f32], usize, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
 pub fn infino::Supertable::optimize(&self, &infino::OptimizeOptions) -> core::result::Result<(), infino::OptimizeError>
 pub fn infino::Supertable::schema(&self) -> arrow_schema::schema::SchemaRef
 pub fn infino::Supertable::token_match(&self, &str, &str, infino::BoolMode, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
 pub fn infino::Supertable::update(&self, datafusion_expr::expr::Expr, &arrow_array::record_batch::RecordBatch) -> core::result::Result<infino::MutationStats, infino::InfinoError>
-pub fn infino::Supertable::vector_search(&self, &str, &[f32], usize, infino::VectorSearchOptions, core::option::Option<infino::VectorFilter<'_>>, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
+pub fn infino::Supertable::vector_search(&self, &str, &[f32], usize, core::option::Option<infino::VectorFilter<'_>>, core::option::Option<&[&str]>) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
 impl core::clone::Clone for infino::Supertable
 pub fn infino::Supertable::clone(&self) -> infino::Supertable
 impl core::fmt::Debug for infino::Supertable
@@ -406,29 +406,6 @@ impl<'a> core::marker::Unpin for infino::VectorFilter<'a>
 impl<'a> core::marker::UnsafeUnpin for infino::VectorFilter<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for infino::VectorFilter<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for infino::VectorFilter<'a>
-pub struct infino::VectorSearchOptions
-pub infino::VectorSearchOptions::nprobe: core::option::Option<usize>
-impl infino::VectorSearchOptions
-pub const infino::VectorSearchOptions::DEFAULT_NPROBE: usize
-pub const infino::VectorSearchOptions::RERANK_MULT: usize
-pub fn infino::VectorSearchOptions::new() -> Self
-pub fn infino::VectorSearchOptions::rerank_mult(&self) -> core::option::Option<usize>
-pub fn infino::VectorSearchOptions::with_nprobe(self, usize) -> Self
-pub fn infino::VectorSearchOptions::with_rerank_mult(self, usize) -> Self
-impl core::clone::Clone for infino::VectorSearchOptions
-pub fn infino::VectorSearchOptions::clone(&self) -> infino::VectorSearchOptions
-impl core::default::Default for infino::VectorSearchOptions
-pub fn infino::VectorSearchOptions::default() -> infino::VectorSearchOptions
-impl core::fmt::Debug for infino::VectorSearchOptions
-pub fn infino::VectorSearchOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Copy for infino::VectorSearchOptions
-impl core::marker::Freeze for infino::VectorSearchOptions
-impl core::marker::Send for infino::VectorSearchOptions
-impl core::marker::Sync for infino::VectorSearchOptions
-impl core::marker::Unpin for infino::VectorSearchOptions
-impl core::marker::UnsafeUnpin for infino::VectorSearchOptions
-impl core::panic::unwind_safe::RefUnwindSafe for infino::VectorSearchOptions
-impl core::panic::unwind_safe::UnwindSafe for infino::VectorSearchOptions
 pub const infino::BUILDER_ID: &str
 pub fn infino::connect(impl core::convert::AsRef<str>) -> core::result::Result<infino::Connection, infino::InfinoError>
 pub fn infino::connect_with(impl core::convert::AsRef<str>, infino::ConnectOptions) -> core::result::Result<infino::Connection, infino::InfinoError>

--- a/src/catalog/remote/table.rs
+++ b/src/catalog/remote/table.rs
@@ -20,7 +20,8 @@ use serde_json::{Value, json};
 use super::{RemoteCatalog, read_arrow, read_json, wire};
 use crate::{
     Bm25SearchOptions, Bm25Stats, BoolMode, GcError, GcReport, InfinoError, MutationStats,
-    OptimizeError, OptimizeOptions, VectorFilter, VectorSearchOptions, catalog::table::Table,
+    OptimizeError, OptimizeOptions, VectorFilter, catalog::table::Table,
+    superfile::VectorSearchOptions,
 };
 
 /// A hosted table handle. Holds its `RemoteCatalog`, the table name, and the

--- a/src/catalog/remote/table.rs
+++ b/src/catalog/remote/table.rs
@@ -73,6 +73,20 @@ fn predicate_to_sql(predicate: &Expr) -> Result<String, InfinoError> {
         })
 }
 
+/// Refuse test-only vector tuning overrides on the remote transport. The
+/// public search methods always pass the default options, so this can only
+/// fire in a `test-helpers` build using the `_with_options` variants.
+fn reject_remote_overrides(opts: &VectorSearchOptions) -> Result<(), InfinoError> {
+    if opts.nprobe.is_some() || opts.rerank_mult().is_some() {
+        return Err(InfinoError::Query(
+            "vector tuning overrides are not supported over the remote transport; \
+             hosted tables serve engine-decided settings"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Parse an update/delete response (`{matched, n_tombstoned, n_not_found}`)
 /// into [`MutationStats`].
 fn parse_mutation_stats(op: &str, response: ureq::Response) -> Result<MutationStats, InfinoError> {
@@ -208,9 +222,13 @@ impl Table for RemoteTable {
         filter: Option<VectorFilter<'_>>,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
-        // The hosted endpoint applies its own nprobe/rerank defaults;
-        // VectorSearchOptions is not carried on the wire yet (tracked follow-up).
-        let _ = opts;
+        // Options never cross the wire: the public path always passes the
+        // default (serving is engine-decided), and the hosted API carries
+        // no tuning fields. A diagnostics-build caller reaching for the
+        // test-only overrides against a hosted table hears "no" loudly —
+        // silently serving defaults would corrupt whatever sweep or oracle
+        // measurement asked for the override.
+        reject_remote_overrides(&opts)?;
         let mut body = json!({
             "table_name": self.table_name,
             "field_name": column,
@@ -241,8 +259,8 @@ impl Table for RemoteTable {
         k: usize,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
-        // See `vector_search`: VectorSearchOptions is not on the wire yet.
-        let _ = opts;
+        // See `vector_search`: overrides never cross the wire; loud, not silent.
+        reject_remote_overrides(&opts)?;
         let body = json!({
             "table_name": self.table_name,
             "text_field": text_column,

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -20,7 +20,8 @@ use datafusion::prelude::Expr;
 
 use crate::{
     Bm25SearchOptions, BoolMode, GcError, GcReport, InfinoError, MutationStats, OptimizeError,
-    OptimizeOptions, VectorFilter, VectorSearchOptions, supertable::Supertable as SupertableHandle,
+    OptimizeOptions, VectorFilter, superfile::VectorSearchOptions,
+    supertable::Supertable as SupertableHandle,
 };
 
 /// The operation surface shared by every table implementation (local or
@@ -268,21 +269,52 @@ impl Supertable {
     }
 
     /// Vector (IVF kNN) search over one vector column.
+    ///
+    /// Probe width and rerank budget are decided by the engine — the
+    /// drain-time calibration stamps them per table and per `k`, and
+    /// serving extends them only on the query's own evidence. There is
+    /// no caller tuning surface; manual overrides are a test-and-bench
+    /// instrument behind `test-helpers` (`vector_search_with_options`).
     pub fn vector_search(
         &self,
         column: &str,
         query: &[f32],
         k: usize,
-        opts: VectorSearchOptions,
         filter: Option<VectorFilter<'_>>,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
-        self.inner
-            .vector_search(column, query, k, opts, filter, projection)
+        self.inner.vector_search(
+            column,
+            query,
+            k,
+            VectorSearchOptions::default(),
+            filter,
+            projection,
+        )
     }
 
-    /// Hybrid (BM25 + vector) search.
-    #[allow(clippy::too_many_arguments)]
+    test_visible! {
+        /// Test-and-bench-only [`Self::vector_search`] with explicit
+        /// probe-width / rerank overrides — recall sweeps and the
+        /// exact-scan oracle (all cells at `rerank_mult = ceil(rows/k)`).
+        /// Off the public surface: the `cargo-public-api` snapshot is
+        /// generated without `test-helpers`.
+        fn vector_search_with_options(
+            &self,
+            column: &str,
+            query: &[f32],
+            k: usize,
+            opts: VectorSearchOptions,
+            filter: Option<VectorFilter<'_>>,
+            projection: Option<&[&str]>,
+        ) -> Result<Vec<RecordBatch>, InfinoError> {
+            self.inner
+                .vector_search(column, query, k, opts, filter, projection)
+        }
+    }
+
+    /// Hybrid (BM25 + vector) search. As with [`Self::vector_search`],
+    /// vector probe width and rerank budget are engine-decided.
     pub fn hybrid_search(
         &self,
         text_column: &str,
@@ -290,7 +322,6 @@ impl Supertable {
         mode: BoolMode,
         vector_column: &str,
         vector_query: &[f32],
-        opts: VectorSearchOptions,
         k: usize,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
@@ -300,10 +331,39 @@ impl Supertable {
             mode,
             vector_column,
             vector_query,
-            opts,
+            VectorSearchOptions::default(),
             k,
             projection,
         )
+    }
+
+    test_visible! {
+        /// Test-and-bench-only [`Self::hybrid_search`] with explicit
+        /// vector probe-width / rerank overrides. Off the public
+        /// surface, exactly as [`Self::vector_search_with_options`].
+        #[allow(clippy::too_many_arguments)]
+        fn hybrid_search_with_options(
+            &self,
+            text_column: &str,
+            text_query: &str,
+            mode: BoolMode,
+            vector_column: &str,
+            vector_query: &[f32],
+            opts: VectorSearchOptions,
+            k: usize,
+            projection: Option<&[&str]>,
+        ) -> Result<Vec<RecordBatch>, InfinoError> {
+            self.inner.hybrid_search(
+                text_column,
+                text_query,
+                mode,
+                vector_column,
+                vector_query,
+                opts,
+                k,
+                projection,
+            )
+        }
     }
 
     /// Optimize (compact) the table.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,8 +172,14 @@ pub use catalog::{ColdFetchMode, ConnectOptions, Connection, IndexSpec, connect,
 pub use config::{CompactionSettings, GcSettings, OptimizeOptions};
 /// The single public error type for the curated API.
 pub use error::InfinoError;
-/// Value types named by the public method signatures.
+// `VectorSearchOptions` (probe width / rerank budget) is deliberately
+// NOT part of the public surface: serving is drain-calibrated, and
+// manual tuning is a test-and-bench-only instrument (recall sweeps,
+// the exact-scan oracle). Reachable only under `test-helpers`, which
+// the `cargo-public-api` snapshot excludes — users cannot set these.
+#[cfg(feature = "test-helpers")]
 pub use superfile::VectorSearchOptions;
+/// Value types named by the public method signatures.
 pub use superfile::{
     fts::reader::{Bm25SearchOptions, Bm25Stats, BoolMode},
     vector::distance::Metric,

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -3661,7 +3661,7 @@ impl Supertable {
     /// # use infino::arrow_array::{FixedSizeListArray, Float32Array, RecordBatch};
     /// # use infino::arrow_array::types::Float32Type;
     /// # use infino::arrow_schema::{DataType, Field, Schema};
-    /// # use infino::{connect, IndexSpec, Metric, VectorSearchOptions};
+    /// # use infino::{connect, IndexSpec, Metric};
     /// # let db = connect("memory://")?;
     /// # let schema = Arc::new(Schema::new(vec![Field::new(
     /// #     "emb",
@@ -3674,7 +3674,7 @@ impl Supertable {
     /// # vecs.append(&RecordBatch::try_new(schema, vec![Arc::new(col)])?)?;
     /// # let mut query = vec![0.0f32; 16]; query[0] = 1.0;
     /// // Bare call → `_id` + `score`, no scalar decode:
-    /// let hits = vecs.vector_search("emb", &query, 10, VectorSearchOptions::new(), None, None)?;
+    /// let hits = vecs.vector_search("emb", &query, 10, None, None)?;
     /// assert_eq!(hits[0].num_columns(), 2);
     /// // Explicit projection names the same columns (scalar columns,
     /// // when present, materialize row data):
@@ -3682,7 +3682,6 @@ impl Supertable {
     ///     "emb",
     ///     &query,
     ///     10,
-    ///     VectorSearchOptions::new(),
     ///     None,
     ///     Some(&["_id", "score"]),
     /// )?;

--- a/tests/catalog_public_api.rs
+++ b/tests/catalog_public_api.rs
@@ -16,7 +16,7 @@
 use std::{sync::Arc, time::Duration};
 
 use infino::{
-    BoolMode, IndexSpec, Metric, OptimizeOptions, VectorSearchOptions,
+    BoolMode, IndexSpec, Metric, OptimizeOptions,
     arrow_array::{
         Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch, StringArray,
     },
@@ -136,7 +136,6 @@ fn public_surface_search_maintain_query_and_drop() {
             "emb",
             &unit_embedding(0),
             SEARCH_TOP_K,
-            VectorSearchOptions::new(),
             None,
             Some(&["_id", "title", "score"]),
         )
@@ -152,7 +151,6 @@ fn public_surface_search_maintain_query_and_drop() {
             BoolMode::Or,
             "emb",
             &unit_embedding(FIRST_BATCH.len()),
-            VectorSearchOptions::new(),
             SEARCH_TOP_K,
             Some(&["_id", "title", "score"]),
         )
@@ -197,7 +195,6 @@ fn public_surface_search_maintain_query_and_drop() {
             "emb",
             &unit_embedding(0),
             SEARCH_TOP_K,
-            VectorSearchOptions::new(),
             None,
             Some(&["_id", "title", "score"]),
         )
@@ -247,7 +244,6 @@ fn open_table_returns_a_live_handle_on_a_fresh_connection() {
             "emb",
             &unit_embedding(1),
             SEARCH_TOP_K,
-            VectorSearchOptions::new(),
             None,
             Some(&["_id", "title", "score"]),
         )

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -19,7 +19,7 @@ use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use datafusion::prelude::{col, lit};
 use infino::{
     Bm25SearchOptions, BoolMode, ConnectOptions, IndexSpec, InfinoError, OptimizeError,
-    OptimizeOptions, VectorFilter,
+    OptimizeOptions, VectorFilter, VectorSearchOptions,
 };
 use serde_json::json;
 use wiremock::{
@@ -332,6 +332,32 @@ async fn vector_search_sends_query_filter_and_decodes_arrow() {
     })
     .await;
     assert_eq!(rows.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+}
+
+#[tokio::test]
+async fn vector_tuning_overrides_are_rejected_on_the_remote_transport() {
+    // Options never cross the wire; the test-only `_with_options` variants
+    // must fail loudly against a hosted table rather than silently serve
+    // engine defaults (a sweep or oracle run would record wrong numbers).
+    // No search endpoint is mounted: the rejection must precede any wire I/O.
+    let server = MockServer::start().await;
+    mount_schema(&server).await;
+
+    let err = with_connection(server.uri(), |db| {
+        let table = db.open_table("posts").expect("open");
+        table
+            .vector_search_with_options(
+                "emb",
+                &[1.0, 0.0],
+                5,
+                VectorSearchOptions::new().with_nprobe(2),
+                None,
+                None,
+            )
+            .expect_err("override must be refused")
+    })
+    .await;
+    assert!(err.to_string().contains("remote transport"), "got: {err}");
 }
 
 #[tokio::test]

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -19,7 +19,7 @@ use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use datafusion::prelude::{col, lit};
 use infino::{
     Bm25SearchOptions, BoolMode, ConnectOptions, IndexSpec, InfinoError, OptimizeError,
-    OptimizeOptions, VectorFilter, VectorSearchOptions,
+    OptimizeOptions, VectorFilter,
 };
 use serde_json::json;
 use wiremock::{
@@ -327,14 +327,7 @@ async fn vector_search_sends_query_filter_and_decodes_arrow() {
             mode: BoolMode::Or,
         };
         table
-            .vector_search(
-                "emb",
-                &[1.0, 0.0],
-                5,
-                VectorSearchOptions::new(),
-                Some(filter),
-                None,
-            )
+            .vector_search("emb", &[1.0, 0.0], 5, Some(filter), None)
             .expect("vector_search")
     })
     .await;
@@ -366,16 +359,7 @@ async fn hybrid_search_sends_text_and_vector_fields() {
     let rows = with_connection(server.uri(), |db| {
         db.open_table("posts")
             .expect("open")
-            .hybrid_search(
-                "id",
-                "hi",
-                BoolMode::Or,
-                "emb",
-                &[1.0, 0.0],
-                VectorSearchOptions::new(),
-                5,
-                None,
-            )
+            .hybrid_search("id", "hi", BoolMode::Or, "emb", &[1.0, 0.0], 5, None)
             .expect("hybrid_search")
     })
     .await;
@@ -567,24 +551,8 @@ async fn remote_client_matches_the_published_api_spec() {
             let _ = table.token_match("id", "x", BoolMode::Or, Some(&["_id"]));
             let _ = table.exact_match("id", "x", Some(&["_id"]));
             let _ = table.count("id", "x", BoolMode::Or);
-            let _ = table.vector_search(
-                "id",
-                &[1.0],
-                1,
-                VectorSearchOptions::new(),
-                None,
-                Some(&["_id"]),
-            );
-            let _ = table.hybrid_search(
-                "id",
-                "x",
-                BoolMode::Or,
-                "id",
-                &[1.0],
-                VectorSearchOptions::new(),
-                1,
-                Some(&["_id"]),
-            );
+            let _ = table.vector_search("id", &[1.0], 1, None, Some(&["_id"]));
+            let _ = table.hybrid_search("id", "x", BoolMode::Or, "id", &[1.0], 1, Some(&["_id"]));
             let _ = table.optimize(&OptimizeOptions::default());
             let _ = table.gc(Duration::from_secs(0));
         }


### PR DESCRIPTION
## What

`VectorSearchOptions` (`nprobe` / `rerank_mult`) leaves the public API entirely: `vector_search` and `hybrid_search` take no options parameter, the type is no longer re-exported at the crate root, the Python wheel drops the kwargs, and the Node binding drops them outright. Users cannot set vector tuning knobs on any shipped surface.

## Why

Serving is drain-calibrated — probe width, fine depth, and rerank budget are stamped per table and per `k`, and extended only on the query's own evidence. A caller tuning surface is not a lever users should hold; settings automation is the product.

## Test-and-bench access (unchanged capability, gated)

Manual overrides remain a diagnostic instrument behind `test-helpers`, which the public-api snapshot excludes: the crate-root re-export and new `vector_search_with_options` / `hybrid_search_with_options` catalog variants are only visible there (existing `test_visible!` pattern). Internal engine paths are untouched, so integration tests and benches keep per-call knobs — recall sweeps and the exact-scan oracle (#538) work as before. The Python side gains a `diagnostics` cargo feature (`= infino/test-helpers`) for building the sweep/oracle wheel; published wheels never enable it.

## Ripple

Examples, `crate-docs.md`, and the catalog-API / remote tests updated to the parameterless calls; `public-api.txt` (−25 lines, reviewed) and `api-parity.txt` regenerated.

## Tests

`make check` and `make public-api` clean; lib 2172 / supertable 250 / superfile 135 / catalog_public_api 2 green; Python binding compiles with and without `diagnostics`; Node binding compiles.
