### PR TITLE
runtime_metrics: per-query execution work stats (`op_stats`)

### DIFF
--- a/benches/utils/bin/profile_superfile.rs
+++ b/benches/utils/bin/profile_superfile.rs
@@ -161,7 +161,7 @@ fn mean_recall_filtered(
             None,
         ))
         .expect("vector_hits_filtered");
-        sum += corpus::recall_at_k(&hits, truth);
+        sum += corpus::recall_at_k(&hits.0, truth);
     }
     sum / queries.len() as f32
 }

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -755,7 +755,8 @@ pub mod fts {
                     return self
                         .atoms_match_count(column, &refs, &owned, eff_mode)
                         .await
-                        .expect("superfile atoms_match_count");
+                        .expect("superfile atoms_match_count")
+                        .0;
                 }
                 let refs: Vec<&str> = terms.iter().map(|t| &**t).collect();
                 // Single term: df is the exact match count, read O(1) from
@@ -768,10 +769,12 @@ pub mod fts {
                     self.term_df(column, refs[0])
                         .await
                         .expect("superfile term_df")
+                        .0
                 } else {
                     self.token_match_count(column, &refs, eff_mode)
                         .await
                         .expect("superfile token_match_count")
+                        .0
                 }
             })
         }

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -1256,7 +1256,7 @@ pub mod vector {
                 None,
             ))
             .expect("filtered sweep query");
-            sum += corpus::recall_at_k(&hits, gt);
+            sum += corpus::recall_at_k(&hits.0, gt);
         }
         sum / q_corr.len() as f32
     }
@@ -1583,7 +1583,7 @@ pub mod vector {
                             None,
                         ))
                         .expect("filtered recall query");
-                        recalls.push(corpus::recall_at_k(&hits, gt));
+                        recalls.push(corpus::recall_at_k(&hits.0, gt));
                     }
                     let mean: f32 = recalls.iter().sum::<f32>() / recalls.len() as f32;
                     eprintln!(
@@ -1664,7 +1664,7 @@ pub mod vector {
                             ))
                             .expect("filtered vector search");
                             samples.push(t0.elapsed());
-                            recall_samples.push(corpus::recall_at_k(&hits, &gt[qi]));
+                            recall_samples.push(corpus::recall_at_k(&hits.0, &gt[qi]));
                         }
                     }
                     samples.sort_unstable();

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -34,7 +34,7 @@ use std::{
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
 use dashmap::DashMap;
-use datafusion::{config::Dialect, error::DataFusionError};
+use datafusion::{config::Dialect, error::DataFusionError, physical_plan::collect as collect_plan};
 use futures::future::try_join_all;
 pub use index_spec::IndexSpec;
 use manifest::{
@@ -52,6 +52,7 @@ use crate::{
     memory::{ConnectionMemoryBudget, budgeted_session_context},
     runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
     runtime_metrics::io::{UsageMeter, UsageSnapshot},
+    runtime_metrics::op_stats,
     storage::{
         AzureStorageProvider, GcsStorageProvider, LocalFsStorageProvider, S3StorageProvider,
         StorageError, StorageProvider,
@@ -64,6 +65,7 @@ use crate::{
     supertable::{
         Supertable as SupertableHandle,
         options::SupertableOptions,
+        query::exec::common::harvest_datafusion_metrics,
         reader_cache::{DiskCacheConfig, DiskCacheError, DiskCacheStore},
     },
 };
@@ -806,6 +808,9 @@ impl Connection {
         search_tvf::register_search_tvfs(&ctx, self.clone());
 
         let sql = sql.to_owned();
+        // Caller-thread pickup, same as reader mint: the drive future may
+        // poll on runtime threads where the scope's slot is invisible.
+        let op_stats = op_stats::current();
         let drive = async move {
             let df = ctx
                 .sql(&sql)
@@ -820,10 +825,19 @@ impl Connection {
             // columns are already coerced back to `LargeUtf8` here by
             // `expand_views_at_output`, so the schema needs no further fixup.
             let output_schema: SchemaRef = df.schema().inner().clone();
-            let batches = df
-                .collect()
+            // Execute through the physical plan (what `DataFrame::collect`
+            // does internally) so the plan handle survives execution and
+            // DataFusion's own operator metrics — elapsed compute, scan
+            // output rows — can be folded into the per-query stats.
+            let task_ctx = ctx.task_ctx();
+            let plan = df
+                .create_physical_plan()
                 .await
                 .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;
+            let batches = collect_plan(Arc::clone(&plan), task_ctx)
+                .await
+                .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;
+            harvest_datafusion_metrics(&plan, &op_stats);
             if batches.is_empty() {
                 Ok(vec![RecordBatch::new_empty(output_schema)])
             } else {

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -51,8 +51,10 @@ use crate::{
     config::DEFAULT_CONNECTION_BUDGET_BYTES,
     memory::{ConnectionMemoryBudget, budgeted_session_context},
     runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
-    runtime_metrics::io::{UsageMeter, UsageSnapshot},
-    runtime_metrics::op_stats,
+    runtime_metrics::{
+        io::{UsageMeter, UsageSnapshot},
+        op_stats,
+    },
     storage::{
         AzureStorageProvider, GcsStorageProvider, LocalFsStorageProvider, S3StorageProvider,
         StorageError, StorageProvider,

--- a/src/catalog/search_tvf.rs
+++ b/src/catalog/search_tvf.rs
@@ -33,6 +33,7 @@ use datafusion::{
 };
 
 use super::Connection;
+use crate::runtime_metrics::op_stats::{self, OpStatsCollector};
 use crate::supertable::{
     handle::SupertableReader,
     query::exec::{
@@ -57,6 +58,11 @@ struct ResolvedTable {
 struct TableResolver {
     conn: Connection,
     cache: Mutex<HashMap<String, ResolvedTable>>,
+    /// Per-query work collector, captured when the TVFs are registered —
+    /// registration happens per query on the caller's thread inside
+    /// `query_sql`, while resolution runs later on runtime threads where
+    /// the scope's thread-local is invisible.
+    op_stats: Option<Arc<OpStatsCollector>>,
 }
 
 impl fmt::Debug for TableResolver {
@@ -70,6 +76,7 @@ impl TableResolver {
         Self {
             conn,
             cache: Mutex::new(HashMap::new()),
+            op_stats: op_stats::current(),
         }
     }
 
@@ -90,10 +97,14 @@ impl TableResolver {
         // `reader()` applies the read-consistency freshness check itself (and,
         // under Strong, fails rather than serving a stale snapshot), so there
         // is no separate `ensure_fresh` call here.
+        let mut reader = table.reader().map_err(|e| {
+            DataFusionError::Plan(format!("search over unknown table {name:?}: {e}"))
+        })?;
+        // The mint ran on a runtime thread where the scope's thread-local
+        // is invisible; hand it the collector captured at registration.
+        reader.op_stats = self.op_stats.clone();
         let resolved = ResolvedTable {
-            reader: Arc::new(table.reader().map_err(|e| {
-                DataFusionError::Plan(format!("search over unknown table {name:?}: {e}"))
-            })?),
+            reader: Arc::new(reader),
             scalar_schema: table.options().scalar_schema(),
         };
         self.cache

--- a/src/catalog/search_tvf.rs
+++ b/src/catalog/search_tvf.rs
@@ -33,15 +33,17 @@ use datafusion::{
 };
 
 use super::Connection;
-use crate::runtime_metrics::op_stats::{self, OpStatsCollector};
-use crate::supertable::{
-    handle::SupertableReader,
-    query::exec::{
-        common::arg_to_string,
-        fts_exec::{BM25_PREFIX_UDTF, BM25_SEARCH_UDTF, Bm25PrefixFunc, Bm25SearchFunc},
-        hybrid_exec::{HYBRID_SEARCH_UDTF, HybridSearchFunc},
-        match_exec::{EXACT_MATCH_UDTF, ExactMatchFunc, TOKEN_MATCH_UDTF, TokenMatchFunc},
-        vector_exec::{VECTOR_SEARCH_UDTF, VectorSearchFunc},
+use crate::{
+    runtime_metrics::op_stats::{self, OpStatsCollector},
+    supertable::{
+        handle::SupertableReader,
+        query::exec::{
+            common::arg_to_string,
+            fts_exec::{BM25_PREFIX_UDTF, BM25_SEARCH_UDTF, Bm25PrefixFunc, Bm25SearchFunc},
+            hybrid_exec::{HYBRID_SEARCH_UDTF, HybridSearchFunc},
+            match_exec::{EXACT_MATCH_UDTF, ExactMatchFunc, TOKEN_MATCH_UDTF, TokenMatchFunc},
+            vector_exec::{VECTOR_SEARCH_UDTF, VectorSearchFunc},
+        },
     },
 };
 

--- a/src/runtime_metrics/cpu.rs
+++ b/src/runtime_metrics/cpu.rs
@@ -102,10 +102,14 @@ pub(crate) fn thread_cpu_ns() -> Option<u128> {
 /// "no clock" means "no measured time", never an error. Must be called
 /// on the same thread that took `start`.
 pub(crate) fn thread_cpu_delta_ns(start: Option<u128>) -> u64 {
-    match (start, thread_cpu_ns()) {
-        (Some(t0), Some(t1)) => u64::try_from(t1.saturating_sub(t0)).unwrap_or(u64::MAX),
-        _ => 0,
-    }
+    // No opening reading (unmetered bracket, or procfs-less host) means
+    // no closing read either — the bracket must stay free when off.
+    let Some(t0) = start else {
+        return 0;
+    };
+    thread_cpu_ns().map_or(0, |t1| {
+        u64::try_from(t1.saturating_sub(t0)).unwrap_or(u64::MAX)
+    })
 }
 
 /// Run `f`, returning `(result, wall_duration, measured_on_cpu_seconds)`.

--- a/src/runtime_metrics/cpu.rs
+++ b/src/runtime_metrics/cpu.rs
@@ -84,6 +84,19 @@ pub fn cpu_seconds_since(start_ns: Option<u128>) -> Option<f64> {
     Some(end.saturating_sub(start) as f64 / NS_PER_SEC as f64)
 }
 
+/// Thread-local schedstat path (Linux): first field is this thread's
+/// cumulative on-CPU nanoseconds.
+const PROC_THREAD_SELF_SCHEDSTAT: &str = "/proc/thread-self/schedstat";
+
+/// The calling thread's own on-CPU nanoseconds (ns resolution, unlike the
+/// process-wide tick counter), or `None` off Linux procfs. Two reads
+/// bracket one synchronous kernel section for per-query CPU attribution;
+/// only valid when both reads happen on the same thread.
+pub(crate) fn thread_cpu_ns() -> Option<u128> {
+    let raw = fs::read_to_string(PROC_THREAD_SELF_SCHEDSTAT).ok()?;
+    raw.split_whitespace().next()?.parse().ok()
+}
+
 /// Run `f`, returning `(result, wall_duration, measured_on_cpu_seconds)`.
 ///
 /// Wall and on-CPU time are bracketed identically around the same work.
@@ -120,15 +133,6 @@ mod tests {
     const TEST_WORKER_BUSY_WINDOW: Duration = Duration::from_millis(50);
     /// Minimum process CPU seconds from exited workers.
     const TEST_MIN_EXITED_WORKER_CPU_S: f64 = 0.01;
-    /// Thread-local schedstat path (Linux).
-    const PROC_THREAD_SELF_SCHEDSTAT: &str = "/proc/thread-self/schedstat";
-
-    /// The calling thread's own on-CPU nanoseconds.
-    fn thread_cpu_ns() -> Option<u128> {
-        let raw = fs::read_to_string(PROC_THREAD_SELF_SCHEDSTAT).ok()?;
-        raw.split_whitespace().next()?.parse().ok()
-    }
-
     #[test]
     fn on_cpu_time_excludes_sleep() {
         let Some(start_busy) = thread_cpu_ns() else {

--- a/src/runtime_metrics/cpu.rs
+++ b/src/runtime_metrics/cpu.rs
@@ -97,6 +97,17 @@ pub(crate) fn thread_cpu_ns() -> Option<u128> {
     raw.split_whitespace().next()?.parse().ok()
 }
 
+/// On-CPU nanoseconds this thread accrued since `start` (a prior
+/// [`thread_cpu_ns`] reading). 0 when either reading is unavailable —
+/// "no clock" means "no measured time", never an error. Must be called
+/// on the same thread that took `start`.
+pub(crate) fn thread_cpu_delta_ns(start: Option<u128>) -> u64 {
+    match (start, thread_cpu_ns()) {
+        (Some(t0), Some(t1)) => u64::try_from(t1.saturating_sub(t0)).unwrap_or(u64::MAX),
+        _ => 0,
+    }
+}
+
 /// Run `f`, returning `(result, wall_duration, measured_on_cpu_seconds)`.
 ///
 /// Wall and on-CPU time are bracketed identically around the same work.

--- a/src/runtime_metrics/mod.rs
+++ b/src/runtime_metrics/mod.rs
@@ -3,10 +3,11 @@
 
 //! In-engine metering signals for benches and `features = ["metering"]`.
 //!
-//! Three resource families — parallel names, one ownership home:
+//! Four resource families — parallel names, one ownership home:
 //! - [`io`] — object-store request/byte ledger (+ background attribution)
 //! - [`cpu`] — process on-CPU time
 //! - [`rss`] — process resident set / peak sampler
+//! - [`op_stats`] — per-query execution work counters
 //!
 //! Storage providers `record_*` into [`UsageMeter`]; they do not own it.
 //! Benches and platform must use these APIs rather than reimplement
@@ -15,6 +16,7 @@
 pub mod cpu;
 pub mod ingest;
 pub mod io;
+pub mod op_stats;
 pub mod rss;
 
 pub use ingest::classify_batch_bytes;

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Per-query execution work stats — deterministic counters of the physical
+//! work one query performs, independent of cache temperature.
+//!
+//! Parallel to [`super::io`] (connection-scoped I/O ledger) and [`super::cpu`]
+//! (process CPU): this module scopes to a **single query**. A caller wraps a
+//! search in [`with_op_stats`]; the reader minted for that query picks the
+//! collector up ([`current`]) and threads it through the fan-out, and each
+//! kernel flushes its work counters into it. The same query against the same
+//! table state reports the same numbers whether the cache was warm or cold —
+//! these count what the plan *did*, not what the storage layer happened to
+//! fetch (the [`super::io::UsageMeter`] ledger keeps counting actuals).
+//!
+//! With no collector installed the per-flush cost is one `Option` check;
+//! counters accumulate locally in kernels and flush per superfile / work
+//! unit, never inside scoring loops.
+
+use std::cell::RefCell;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use serde::{Deserialize, Serialize};
+
+/// Physical work one query performed. Every field is a plain count; the
+/// struct is `#[non_exhaustive]` because counters land modality by modality
+/// (FTS first; vector, SQL, planned-read, and CPU attribution follow).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct OpStats {
+    /// FTS posting-list bytes resident for the query's clauses — the term
+    /// metadata + skip tables + posting blocks the kernels index into
+    /// (musts, shoulds, plain OR terms, and negation filters). Counted once
+    /// per superfile even when ranged slices share a cursor set.
+    pub fts_postings_bytes: u64,
+}
+
+/// Accumulates one query's work counters across its fan-out (tokio unit
+/// tasks and rayon kernel waves both add through the same `Arc`).
+#[derive(Debug, Default)]
+pub struct OpStatsCollector {
+    fts_postings_bytes: AtomicU64,
+}
+
+impl OpStatsCollector {
+    /// Flush a kernel's posting-bytes tally (one add per superfile).
+    pub(crate) fn add_fts_postings_bytes(&self, bytes: u64) {
+        self.fts_postings_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// The counters accumulated so far.
+    pub fn snapshot(&self) -> OpStats {
+        OpStats {
+            fts_postings_bytes: self.fts_postings_bytes.load(Ordering::Relaxed),
+        }
+    }
+}
+
+thread_local! {
+    /// The collector queries minted on this thread attach to. Set only inside
+    /// [`with_op_stats`]; the sync search entry points run on the caller's
+    /// thread up to reader mint, which is where [`current`] is read — from
+    /// there the collector travels as an explicit `Arc` through the fan-out,
+    /// so spawned tasks and pool closures never consult this slot.
+    static CURRENT: RefCell<Option<Arc<OpStatsCollector>>> = const { RefCell::new(None) };
+}
+
+/// Restores the previously-installed collector when the scope ends, so
+/// nested [`with_op_stats`] scopes and panics both unwind cleanly.
+struct ScopeGuard {
+    previous: Option<Arc<OpStatsCollector>>,
+}
+
+impl Drop for ScopeGuard {
+    fn drop(&mut self) {
+        CURRENT.with(|slot| {
+            *slot.borrow_mut() = self.previous.take();
+        });
+    }
+}
+
+/// Run `f` with a fresh per-query collector installed for the current
+/// thread, returning `f`'s result alongside the work stats every query
+/// executed inside the scope accumulated.
+///
+/// Scopes nest: an inner scope shadows the outer one and restores it on
+/// exit (including panic unwind), so an outer scope never absorbs an inner
+/// query's counters.
+pub fn with_op_stats<T>(f: impl FnOnce() -> T) -> (T, OpStats) {
+    let collector = Arc::new(OpStatsCollector::default());
+    let previous = CURRENT.with(|slot| slot.borrow_mut().replace(Arc::clone(&collector)));
+    let _guard = ScopeGuard { previous };
+    let value = f();
+    (value, collector.snapshot())
+}
+
+/// The collector installed on this thread, if a [`with_op_stats`] scope is
+/// active. Read at reader mint (the last point on the caller's thread before
+/// the query fans out).
+pub(crate) fn current() -> Option<Arc<OpStatsCollector>> {
+    CURRENT.with(|slot| slot.borrow().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_collects_and_clears() {
+        assert!(current().is_none(), "no collector outside a scope");
+        let (value, stats) = with_op_stats(|| {
+            let collector = current().expect("collector installed inside the scope");
+            collector.add_fts_postings_bytes(123);
+            7u32
+        });
+        assert_eq!(value, 7);
+        assert_eq!(stats.fts_postings_bytes, 123);
+        assert!(current().is_none(), "scope uninstalls its collector");
+    }
+
+    #[test]
+    fn nested_scopes_shadow_and_restore() {
+        let (_, outer) = with_op_stats(|| {
+            let outer_collector = current().expect("outer collector");
+            outer_collector.add_fts_postings_bytes(1);
+            let (_, inner) = with_op_stats(|| {
+                current()
+                    .expect("inner collector shadows outer")
+                    .add_fts_postings_bytes(10);
+            });
+            assert_eq!(inner.fts_postings_bytes, 10);
+            // The outer collector is restored and keeps accumulating.
+            current()
+                .expect("outer collector restored")
+                .add_fts_postings_bytes(2);
+        });
+        assert_eq!(
+            outer.fts_postings_bytes, 3,
+            "outer scope never absorbs the inner query's counters"
+        );
+    }
+
+    #[test]
+    fn a_panicking_scope_still_restores_the_previous_collector() {
+        let (_, outer) = with_op_stats(|| {
+            let result = std::panic::catch_unwind(|| {
+                let (_, _) = with_op_stats(|| panic!("kernel failure"));
+            });
+            assert!(result.is_err());
+            current()
+                .expect("outer collector survives the inner panic")
+                .add_fts_postings_bytes(5);
+        });
+        assert_eq!(outer.fts_postings_bytes, 5);
+    }
+}

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -276,6 +276,13 @@ pub(crate) fn timed_kernel<T>(
     collector: &Option<Arc<OpStatsCollector>>,
     f: impl FnOnce() -> T,
 ) -> T {
+    // Gate on the live-scope counter like the superfile-level brackets:
+    // a reader held past its scope still carries a collector, and its
+    // queries must not keep paying procfs reads into an Arc nobody
+    // snapshots.
+    if !metering_active() {
+        return f();
+    }
     let Some(stats) = collector else {
         return f();
     };

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -30,9 +30,12 @@
 //! index's per-generation fast state; and phase C's bookkeeping
 //! refetches (cluster index + Sq8 meta re-reads on the warm-only rerank
 //! wave — cold runs have no phase C, so pricing them would make the one
-//! priced counter temperature-dependent). Their expected cost is
-//! recovered through a consumer's calibrated rates, never surcharged on
-//! the query that happened to pay them.
+//! priced counter temperature-dependent); and the materialization takes'
+//! streamed page ranges (a promoted resident reader decodes in place —
+//! reader-cache state again; `rows_materialized` carries that leg
+//! invariantly). Their expected cost is recovered through a consumer's
+//! calibrated rates, never surcharged on the query that happened to pay
+//! them.
 
 use std::cell::RefCell;
 use std::sync::{
@@ -92,8 +95,11 @@ pub struct OpStats {
     /// table when the column stores one), plus one per stable-id region
     /// / `_id` remap read / hydrated-section cell read. Rerank rows are
     /// deliberately excluded — see [`Self::vector_rows_reranked`]. SQL:
-    /// one per Parquet range the scan requests. Materialization: one per
-    /// data range a projection take requests.
+    /// one per Parquet range the scan requests. Materialization takes are
+    /// deliberately excluded (a promoted resident reader decodes in place
+    /// while a lazy reader streams ranges — reader-cache state, so
+    /// counting them would break the warm/cold invariance);
+    /// [`Self::rows_materialized`] is that leg's invariant signal.
     pub planned_read_ranges: u64,
     /// Parquet **data-page** bytes SQL scans requested through the
     /// DataFusion store, independent of whether they were served from
@@ -121,7 +127,7 @@ pub struct OpStats {
 /// Accumulates one query's work counters across its fan-out (tokio unit
 /// tasks and rayon kernel waves both add through the same `Arc`).
 #[derive(Debug, Default)]
-pub struct OpStatsCollector {
+pub(crate) struct OpStatsCollector {
     fts_postings_bytes: AtomicU64,
     vector_cells_scanned: AtomicU64,
     vector_candidates_scanned: AtomicU64,

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -48,6 +48,12 @@ pub struct OpStats {
     /// serving state). The cold arm's immediate rerank is not yet
     /// attributed; its candidate scan above is.
     pub vector_rows_reranked: u64,
+    /// Byte-source ranges the plan requested, before coalescing and before
+    /// the cache decides whether a request becomes a local read or a GET —
+    /// the warm-equivalent request-work measure (FTS: one per term posting
+    /// range, two per phrase member; vector: cluster index + prefix/block
+    /// ranges per cell, one per rerank row).
+    pub planned_read_ranges: u64,
 }
 
 /// Accumulates one query's work counters across its fan-out (tokio unit
@@ -58,6 +64,7 @@ pub struct OpStatsCollector {
     vector_cells_scanned: AtomicU64,
     vector_candidates_scanned: AtomicU64,
     vector_rows_reranked: AtomicU64,
+    planned_read_ranges: AtomicU64,
 }
 
 impl OpStatsCollector {
@@ -79,6 +86,12 @@ impl OpStatsCollector {
         self.vector_rows_reranked.fetch_add(rows, Ordering::Relaxed);
     }
 
+    /// Flush a kernel's planned byte-source range count.
+    pub(crate) fn add_planned_read_ranges(&self, ranges: u64) {
+        self.planned_read_ranges
+            .fetch_add(ranges, Ordering::Relaxed);
+    }
+
     /// The counters accumulated so far.
     pub fn snapshot(&self) -> OpStats {
         OpStats {
@@ -86,6 +99,7 @@ impl OpStatsCollector {
             vector_cells_scanned: self.vector_cells_scanned.load(Ordering::Relaxed),
             vector_candidates_scanned: self.vector_candidates_scanned.load(Ordering::Relaxed),
             vector_rows_reranked: self.vector_rows_reranked.load(Ordering::Relaxed),
+            planned_read_ranges: self.planned_read_ranges.load(Ordering::Relaxed),
         }
     }
 }

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -25,9 +25,13 @@ use std::sync::{
 
 use serde::{Deserialize, Serialize};
 
-/// Physical work one query performed. Every field is a plain count; the
-/// struct is `#[non_exhaustive]` because counters land modality by modality
-/// (FTS first; vector, SQL, planned-read, and CPU attribution follow).
+use super::cpu;
+
+/// Physical work one query performed. Every field except
+/// [`Self::kernel_cpu_ns`] is a deterministic plan count (same query, same
+/// table state → same value, warm or cold); `kernel_cpu_ns` is a measured
+/// time refinement and varies run to run. The struct is `#[non_exhaustive]`
+/// because counters land modality by modality.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct OpStats {
@@ -59,6 +63,11 @@ pub struct OpStats {
     /// (footer, page index, and data pages), independent of whether they
     /// were served from resident bytes or fetched.
     pub sql_page_bytes: u64,
+    /// On-CPU nanoseconds of the query's bracketed synchronous kernel
+    /// sections (thread-CPU clock, ns resolution). A refinement of — not a
+    /// replacement for — a consumer's own process-level CPU accounting:
+    /// fan-out glue and async awaits are outside the brackets.
+    pub kernel_cpu_ns: u64,
 }
 
 /// Accumulates one query's work counters across its fan-out (tokio unit
@@ -71,6 +80,7 @@ pub struct OpStatsCollector {
     vector_rows_reranked: AtomicU64,
     planned_read_ranges: AtomicU64,
     sql_page_bytes: AtomicU64,
+    kernel_cpu_ns: AtomicU64,
 }
 
 impl OpStatsCollector {
@@ -103,6 +113,11 @@ impl OpStatsCollector {
         self.sql_page_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
 
+    /// Flush one bracketed kernel section's on-CPU nanoseconds.
+    pub(crate) fn add_kernel_cpu_ns(&self, ns: u64) {
+        self.kernel_cpu_ns.fetch_add(ns, Ordering::Relaxed);
+    }
+
     /// The counters accumulated so far.
     pub fn snapshot(&self) -> OpStats {
         OpStats {
@@ -112,6 +127,7 @@ impl OpStatsCollector {
             vector_rows_reranked: self.vector_rows_reranked.load(Ordering::Relaxed),
             planned_read_ranges: self.planned_read_ranges.load(Ordering::Relaxed),
             sql_page_bytes: self.sql_page_bytes.load(Ordering::Relaxed),
+            kernel_cpu_ns: self.kernel_cpu_ns.load(Ordering::Relaxed),
         }
     }
 }
@@ -159,6 +175,27 @@ pub fn with_op_stats<T>(f: impl FnOnce() -> T) -> (T, OpStats) {
 /// the query fans out).
 pub(crate) fn current() -> Option<Arc<OpStatsCollector>> {
     CURRENT.with(|slot| slot.borrow().clone())
+}
+
+/// Bracket one synchronous kernel section with the thread-CPU clock and
+/// flush the on-CPU delta into `collector`. `f` must run entirely on the
+/// calling thread (rayon pool closures and inline kernel branches do);
+/// with no collector — or off Linux procfs — it is a plain call.
+pub(crate) fn timed_kernel<T>(
+    collector: &Option<Arc<OpStatsCollector>>,
+    f: impl FnOnce() -> T,
+) -> T {
+    let Some(stats) = collector else {
+        return f();
+    };
+    let Some(start) = cpu::thread_cpu_ns() else {
+        return f();
+    };
+    let value = f();
+    if let Some(end) = cpu::thread_cpu_ns() {
+        stats.add_kernel_cpu_ns(u64::try_from(end.saturating_sub(start)).unwrap_or(u64::MAX));
+    }
+    value
 }
 
 /// Run `f` with NO collector installed, restoring the active scope after.

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -13,14 +13,16 @@
 //! these count what the plan *did*, not what the storage layer happened to
 //! fetch (the [`super::io::UsageMeter`] ledger keeps counting actuals).
 //!
-//! With no collector installed the per-flush cost is one `Option` check;
-//! counters accumulate locally in kernels and flush per superfile / work
-//! unit, never inside scoring loops.
+//! With no collector installed the per-flush cost is one `Option` check,
+//! and the superfile-level kernel-CPU brackets gate their procfs reads on
+//! [`metering_active`] (one relaxed atomic load); counters accumulate
+//! locally in kernels and flush per superfile / work unit, never inside
+//! scoring loops.
 
 use std::cell::RefCell;
 use std::sync::{
     Arc,
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicU64, AtomicUsize, Ordering},
 };
 
 use serde::{Deserialize, Serialize};
@@ -152,6 +154,32 @@ thread_local! {
     static CURRENT: RefCell<Option<Arc<OpStatsCollector>>> = const { RefCell::new(None) };
 }
 
+/// Live [`with_op_stats`] scopes, process-wide. Superfile-layer kernel
+/// brackets gate their procfs reads on this instead of a collector they
+/// cannot see (the collector rides the supertable reader, and the kernel
+/// may run on a different thread than the scope) — so an unmetered
+/// process pays one relaxed load per bracket, never a schedstat read.
+static ACTIVE_SCOPES: AtomicUsize = AtomicUsize::new(0);
+
+/// `true` while any [`with_op_stats`] scope is live anywhere in the
+/// process. A cross-thread gate, deliberately coarser than [`current`]:
+/// a kernel polled off the scope's thread must still measure.
+pub(crate) fn metering_active() -> bool {
+    ACTIVE_SCOPES.load(Ordering::Relaxed) > 0
+}
+
+/// Decrements [`ACTIVE_SCOPES`] when a [`with_op_stats`] scope ends
+/// (panic unwind included). [`suppressed`] never touches the counter:
+/// suppression detaches the thread-local inside a scope that is still
+/// running and still metering elsewhere.
+struct ActiveScopeGuard;
+
+impl Drop for ActiveScopeGuard {
+    fn drop(&mut self) {
+        ACTIVE_SCOPES.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 /// Restores the previously-installed collector when the scope ends, so
 /// nested [`with_op_stats`] scopes and panics both unwind cleanly.
 struct ScopeGuard {
@@ -177,6 +205,8 @@ pub fn with_op_stats<T>(f: impl FnOnce() -> T) -> (T, OpStats) {
     let collector = Arc::new(OpStatsCollector::default());
     let previous = CURRENT.with(|slot| slot.borrow_mut().replace(Arc::clone(&collector)));
     let _guard = ScopeGuard { previous };
+    ACTIVE_SCOPES.fetch_add(1, Ordering::Relaxed);
+    let _active = ActiveScopeGuard;
     let value = f();
     (value, collector.snapshot())
 }

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -18,6 +18,21 @@
 //! [`metering_active`] (one relaxed atomic load); counters accumulate
 //! locally in kernels and flush per superfile / work unit, never inside
 //! scoring loops.
+//!
+//! ## Deliberate exclusions
+//!
+//! Reads whose cost amortizes across queries or would break the
+//! warm/cold invariance are NOT counted, by design: superfile open I/O
+//! (footers, subsection headers) and the reader-cached Parquet
+//! metadata / page-index parse (paid once per reader lifetime, not per
+//! query); tombstone sidecar prefetches and manifest freshness probes
+//! (table-state / consistency-policy reads, not plan work); the hidden
+//! index's per-generation fast state; and phase C's bookkeeping
+//! refetches (cluster index + Sq8 meta re-reads on the warm-only rerank
+//! wave — cold runs have no phase C, so pricing them would make the one
+//! priced counter temperature-dependent). Their expected cost is
+//! recovered through a consumer's calibrated rates, never surcharged on
+//! the query that happened to pay them.
 
 use std::cell::RefCell;
 use std::sync::{
@@ -64,18 +79,32 @@ pub struct OpStats {
     pub vector_rows_reranked: u64,
     /// Byte-source ranges the plan requested, before coalescing and before
     /// the cache decides whether a request becomes a local read or a GET —
-    /// the warm-equivalent request-work measure. FTS: one per term posting
-    /// range, two per phrase member. Vector: per scanned cell, its cluster
-    /// index plus one prefix/block range per chosen cluster; plus the
-    /// plan's rerank budget — `min(k × rerank_mult, candidates)` on the
-    /// deferred path, the immediate probes' shortlist rows elsewhere —
-    /// one range per budgeted row, identical warm or cold on both arms.
-    /// SQL: one per Parquet range the scan requests.
+    /// the warm-equivalent request-work measure. FTS: one per PFOR term
+    /// posting range (two when a hint-less slot forces a header probe),
+    /// one per phrase-member posting and position-run range, one per
+    /// dictionary fetch a build performs, and one per df-header probe.
+    /// Vector: per scanned cell, its cluster index plus one prefix/block
+    /// range per chosen cluster (plus the lazy Sq8 meta table when the
+    /// column stores one); plus the plan's rerank budget —
+    /// `min(k × rerank_mult, candidates)` on the deferred path, the
+    /// immediate probes' shortlist rows elsewhere — one range per
+    /// budgeted row, identical warm or cold on both arms; plus one per
+    /// stable-id region / `_id` remap read. SQL: one per Parquet range
+    /// the scan requests. Materialization: one per data range a
+    /// projection take requests.
     pub planned_read_ranges: u64,
-    /// Parquet bytes SQL scans requested through the DataFusion store
-    /// (footer, page index, and data pages), independent of whether they
-    /// were served from resident bytes or fetched.
+    /// Parquet **data-page** bytes SQL scans requested through the
+    /// DataFusion store, independent of whether they were served from
+    /// resident bytes or fetched. Footer and page-index reads never
+    /// transit the store — they are open-time amortized state (see the
+    /// module's exclusions) — so they are deliberately not in here.
     pub sql_page_bytes: u64,
+    /// Rows decoded from stored columns to build results — the scalar
+    /// projection decode (`resolve_columns`), including the `_id` stamping
+    /// fallback it serves. The id-score arithmetic fast path decodes
+    /// nothing and counts nothing; remap/tombstone-internal id reads count
+    /// planned ranges only, never rows.
+    pub rows_materialized: u64,
     /// On-CPU nanoseconds of the query's bracketed synchronous kernel
     /// sections (thread-CPU clock, ns resolution). A refinement of — not a
     /// replacement for — a consumer's own process-level CPU accounting:
@@ -93,6 +122,7 @@ pub struct OpStatsCollector {
     vector_rows_reranked: AtomicU64,
     planned_read_ranges: AtomicU64,
     sql_page_bytes: AtomicU64,
+    rows_materialized: AtomicU64,
     kernel_cpu_ns: AtomicU64,
 }
 
@@ -126,6 +156,11 @@ impl OpStatsCollector {
         self.sql_page_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
 
+    /// Flush one resolve wave's decoded row count.
+    pub(crate) fn add_rows_materialized(&self, rows: u64) {
+        self.rows_materialized.fetch_add(rows, Ordering::Relaxed);
+    }
+
     /// Flush one bracketed kernel section's on-CPU nanoseconds.
     pub(crate) fn add_kernel_cpu_ns(&self, ns: u64) {
         self.kernel_cpu_ns.fetch_add(ns, Ordering::Relaxed);
@@ -140,6 +175,7 @@ impl OpStatsCollector {
             vector_rows_reranked: self.vector_rows_reranked.load(Ordering::Relaxed),
             planned_read_ranges: self.planned_read_ranges.load(Ordering::Relaxed),
             sql_page_bytes: self.sql_page_bytes.load(Ordering::Relaxed),
+            rows_materialized: self.rows_materialized.load(Ordering::Relaxed),
             kernel_cpu_ns: self.kernel_cpu_ns.load(Ordering::Relaxed),
         }
     }
@@ -233,6 +269,16 @@ pub(crate) fn timed_kernel<T>(
     let value = f();
     stats.add_kernel_cpu_ns(cpu::thread_cpu_delta_ns(start));
     value
+}
+
+/// Bracket one synchronous section with the thread-CPU clock, gated on
+/// [`metering_active`] so an unmetered process pays one relaxed load and
+/// no procfs reads. For the superfile layers, which have no collector —
+/// the ns travel back to the supertable as data.
+pub(crate) fn timed_section<R>(f: impl FnOnce() -> R) -> (R, u64) {
+    let start = metering_active().then(cpu::thread_cpu_ns).flatten();
+    let out = f();
+    (out, cpu::thread_cpu_delta_ns(start))
 }
 
 /// Run `f` with NO collector installed, restoring the active scope after.

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -37,10 +37,12 @@
 //! calibrated rates, never surcharged on the query that happened to pay
 //! them.
 
-use std::cell::RefCell;
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, AtomicUsize, Ordering},
+use std::{
+    cell::RefCell,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
 };
 
 use serde::{Deserialize, Serialize};

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -49,10 +49,8 @@ use super::cpu;
 /// [`Self::vector_rows_reranked`] (actual execution rows — the deferred
 /// path reranks cold cells in place, so the count can shift with cache
 /// temperature) is a deterministic plan count: same query, same table
-/// state → same value, warm or cold. The priced range counter stays
-/// canonical by charging the *plan's* rerank budget, never the executed
-/// row count — see [`Self::planned_read_ranges`]. The struct is
-/// `#[non_exhaustive]` because counters land modality by modality.
+/// state → same value, warm or cold. The struct is `#[non_exhaustive]`
+/// because counters land modality by modality.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct OpStats {
@@ -74,24 +72,28 @@ pub struct OpStats {
     /// (pre-drain user tables and filtered search). An execution
     /// diagnostic, not a plan count: on the deferred path cold cells
     /// rerank in place under a width-divided budget, so the total can
-    /// shift with cache temperature. Never priced — the range counter
-    /// below charges the plan's rerank budget instead.
+    /// shift with cache temperature. Never priced — the rerank leg's
+    /// cost is CPU-dominated and carried by a consumer's process-level
+    /// CPU accounting; rows are deliberately NOT folded into the
+    /// request-shaped range counter below (survivor fetches coalesce
+    /// into a handful of real requests, so one-range-per-row would
+    /// inflate it far past request scale).
     pub vector_rows_reranked: u64,
     /// Byte-source ranges the plan requested, before coalescing and before
     /// the cache decides whether a request becomes a local read or a GET —
-    /// the warm-equivalent request-work measure. FTS: one per PFOR term
-    /// posting range (two when a hint-less slot forces a header probe),
-    /// one per phrase-member posting and position-run range, one per
-    /// dictionary fetch a build performs, and one per df-header probe.
-    /// Vector: per scanned cell, its cluster index plus one prefix/block
-    /// range per chosen cluster (plus the lazy Sq8 meta table when the
-    /// column stores one); plus the plan's rerank budget —
-    /// `min(k × rerank_mult, candidates)` on the deferred path, the
-    /// immediate probes' shortlist rows elsewhere — one range per
-    /// budgeted row, identical warm or cold on both arms; plus one per
-    /// stable-id region / `_id` remap read. SQL: one per Parquet range
-    /// the scan requests. Materialization: one per data range a
-    /// projection take requests.
+    /// the warm-equivalent request-work measure, kept REQUEST-SHAPED:
+    /// its magnitudes stay commensurate with real object-store requests
+    /// so a consumer can price it at a per-request rate. FTS: one per
+    /// PFOR term posting range (two when a hint-less slot forces a
+    /// header probe), one per phrase-member posting and position-run
+    /// range, one per dictionary fetch a build performs, and one per
+    /// df-header probe. Vector: per scanned cell, its cluster index plus
+    /// one prefix/block range per chosen cluster (plus the lazy Sq8 meta
+    /// table when the column stores one), plus one per stable-id region
+    /// / `_id` remap read / hydrated-section cell read. Rerank rows are
+    /// deliberately excluded — see [`Self::vector_rows_reranked`]. SQL:
+    /// one per Parquet range the scan requests. Materialization: one per
+    /// data range a projection take requests.
     pub planned_read_ranges: u64,
     /// Parquet **data-page** bytes SQL scans requested through the
     /// DataFusion store, independent of whether they were served from

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -43,10 +43,10 @@ pub struct OpStats {
     /// Quantized codes the cell scans estimated (Σ cluster row counts over
     /// every chosen cluster, warm and cold arms alike).
     pub vector_candidates_scanned: u64,
-    /// Rows rescored at full precision by the global-shortlist rerank
-    /// (phase C of the deferred-rerank path — the steady post-drain
-    /// serving state). The cold arm's immediate rerank is not yet
-    /// attributed; its candidate scan above is.
+    /// Rows rescored at full precision, across every arm: the
+    /// global-shortlist rerank (phase C of the deferred path), the scan's
+    /// immediate cold-cell rerank, and the immediate probe paths
+    /// (pre-drain user tables and filtered search).
     pub vector_rows_reranked: u64,
     /// Byte-source ranges the plan requested, before coalescing and before
     /// the cache decides whether a request becomes a local read or a GET —

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -100,15 +100,19 @@ pub struct OpStats {
     /// module's exclusions) — so they are deliberately not in here.
     pub sql_page_bytes: u64,
     /// Rows decoded from stored columns to build results — the scalar
-    /// projection decode (`resolve_columns`), including the `_id` stamping
-    /// fallback it serves. The id-score arithmetic fast path decodes
-    /// nothing and counts nothing; remap/tombstone-internal id reads count
-    /// planned ranges only, never rows.
+    /// projection decode (`resolve_columns`, including the `_id` stamping
+    /// fallback it serves) plus, for SQL, the scan operators' output rows
+    /// from DataFusion's own metrics. The id-score arithmetic fast path
+    /// decodes nothing and counts nothing; remap/tombstone-internal id
+    /// reads count planned ranges only, never rows.
     pub rows_materialized: u64,
-    /// On-CPU nanoseconds of the query's bracketed synchronous kernel
-    /// sections (thread-CPU clock, ns resolution). A refinement of — not a
-    /// replacement for — a consumer's own process-level CPU accounting:
-    /// fan-out glue and async awaits are outside the brackets.
+    /// Nanoseconds of the query's bracketed synchronous kernel sections.
+    /// Engine kernels use the thread-CPU clock; SQL operator sections use
+    /// DataFusion's own `elapsed_compute` instrumentation (an `Instant`
+    /// timer around synchronous poll work — approximately on-CPU for
+    /// compute-bound operators, excluding async I/O waits). A refinement
+    /// of — not a replacement for — a consumer's own process-level CPU
+    /// accounting: fan-out glue and async awaits are outside the brackets.
     pub kernel_cpu_ns: u64,
 }
 

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -28,10 +28,14 @@ use serde::{Deserialize, Serialize};
 use super::cpu;
 
 /// Physical work one query performed. Every field except
-/// [`Self::kernel_cpu_ns`] is a deterministic plan count (same query, same
-/// table state → same value, warm or cold); `kernel_cpu_ns` is a measured
-/// time refinement and varies run to run. The struct is `#[non_exhaustive]`
-/// because counters land modality by modality.
+/// [`Self::kernel_cpu_ns`] (measured time, varies run to run) and
+/// [`Self::vector_rows_reranked`] (actual execution rows — the deferred
+/// path reranks cold cells in place, so the count can shift with cache
+/// temperature) is a deterministic plan count: same query, same table
+/// state → same value, warm or cold. The priced range counter stays
+/// canonical by charging the *plan's* rerank budget, never the executed
+/// row count — see [`Self::planned_read_ranges`]. The struct is
+/// `#[non_exhaustive]` because counters land modality by modality.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct OpStats {
@@ -47,17 +51,24 @@ pub struct OpStats {
     /// Quantized codes the cell scans estimated (Σ cluster row counts over
     /// every chosen cluster, warm and cold arms alike).
     pub vector_candidates_scanned: u64,
-    /// Rows rescored at full precision, across every arm: the
+    /// Rows actually rescored at full precision, across every arm: the
     /// global-shortlist rerank (phase C of the deferred path), the scan's
     /// immediate cold-cell rerank, and the immediate probe paths
-    /// (pre-drain user tables and filtered search).
+    /// (pre-drain user tables and filtered search). An execution
+    /// diagnostic, not a plan count: on the deferred path cold cells
+    /// rerank in place under a width-divided budget, so the total can
+    /// shift with cache temperature. Never priced — the range counter
+    /// below charges the plan's rerank budget instead.
     pub vector_rows_reranked: u64,
     /// Byte-source ranges the plan requested, before coalescing and before
     /// the cache decides whether a request becomes a local read or a GET —
-    /// the warm-equivalent request-work measure (FTS: one per term posting
-    /// range, two per phrase member; vector: cluster index + prefix/block
-    /// ranges per cell, one per rerank row; SQL: one per Parquet range the
-    /// scan requests).
+    /// the warm-equivalent request-work measure. FTS: one per term posting
+    /// range, two per phrase member. Vector: per scanned cell, its cluster
+    /// index plus one prefix/block range per chosen cluster; plus the
+    /// plan's rerank budget — `min(k × rerank_mult, candidates)` on the
+    /// deferred path, the immediate probes' shortlist rows elsewhere —
+    /// one range per budgeted row, identical warm or cold on both arms.
+    /// SQL: one per Parquet range the scan requests.
     pub planned_read_ranges: u64,
     /// Parquet bytes SQL scans requested through the DataFusion store
     /// (footer, page index, and data pages), independent of whether they
@@ -119,7 +130,7 @@ impl OpStatsCollector {
     }
 
     /// The counters accumulated so far.
-    pub fn snapshot(&self) -> OpStats {
+    pub(crate) fn snapshot(&self) -> OpStats {
         OpStats {
             fts_postings_bytes: self.fts_postings_bytes.load(Ordering::Relaxed),
             vector_cells_scanned: self.vector_cells_scanned.load(Ordering::Relaxed),
@@ -188,13 +199,9 @@ pub(crate) fn timed_kernel<T>(
     let Some(stats) = collector else {
         return f();
     };
-    let Some(start) = cpu::thread_cpu_ns() else {
-        return f();
-    };
+    let start = cpu::thread_cpu_ns();
     let value = f();
-    if let Some(end) = cpu::thread_cpu_ns() {
-        stats.add_kernel_cpu_ns(u64::try_from(end.saturating_sub(start)).unwrap_or(u64::MAX));
-    }
+    stats.add_kernel_cpu_ns(cpu::thread_cpu_delta_ns(start));
     value
 }
 
@@ -211,6 +218,8 @@ pub(crate) fn suppressed<T>(f: impl FnOnce() -> T) -> T {
 
 #[cfg(test)]
 mod tests {
+    use std::panic::catch_unwind;
+
     use super::*;
 
     #[test]
@@ -251,7 +260,7 @@ mod tests {
     #[test]
     fn a_panicking_scope_still_restores_the_previous_collector() {
         let (_, outer) = with_op_stats(|| {
-            let result = std::panic::catch_unwind(|| {
+            let result = catch_unwind(|| {
                 let (_, _) = with_op_stats(|| panic!("kernel failure"));
             });
             assert!(result.is_err());

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -36,6 +36,18 @@ pub struct OpStats {
     /// (musts, shoulds, plain OR terms, and negation filters). Counted once
     /// per superfile even when ranged slices share a cursor set.
     pub fts_postings_bytes: u64,
+    /// Vector cells the query's scans actually probed, summed across
+    /// superfiles (a cell counts once per superfile scan that chose at
+    /// least one of its clusters).
+    pub vector_cells_scanned: u64,
+    /// Quantized codes the cell scans estimated (Σ cluster row counts over
+    /// every chosen cluster, warm and cold arms alike).
+    pub vector_candidates_scanned: u64,
+    /// Rows rescored at full precision by the global-shortlist rerank
+    /// (phase C of the deferred-rerank path — the steady post-drain
+    /// serving state). The cold arm's immediate rerank is not yet
+    /// attributed; its candidate scan above is.
+    pub vector_rows_reranked: u64,
 }
 
 /// Accumulates one query's work counters across its fan-out (tokio unit
@@ -43,6 +55,9 @@ pub struct OpStats {
 #[derive(Debug, Default)]
 pub struct OpStatsCollector {
     fts_postings_bytes: AtomicU64,
+    vector_cells_scanned: AtomicU64,
+    vector_candidates_scanned: AtomicU64,
+    vector_rows_reranked: AtomicU64,
 }
 
 impl OpStatsCollector {
@@ -51,10 +66,26 @@ impl OpStatsCollector {
         self.fts_postings_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
 
+    /// Flush one superfile scan's cell + candidate tallies.
+    pub(crate) fn add_vector_scan(&self, cells: u64, candidates: u64) {
+        self.vector_cells_scanned
+            .fetch_add(cells, Ordering::Relaxed);
+        self.vector_candidates_scanned
+            .fetch_add(candidates, Ordering::Relaxed);
+    }
+
+    /// Flush the global-shortlist rerank's row count.
+    pub(crate) fn add_vector_rows_reranked(&self, rows: u64) {
+        self.vector_rows_reranked.fetch_add(rows, Ordering::Relaxed);
+    }
+
     /// The counters accumulated so far.
     pub fn snapshot(&self) -> OpStats {
         OpStats {
             fts_postings_bytes: self.fts_postings_bytes.load(Ordering::Relaxed),
+            vector_cells_scanned: self.vector_cells_scanned.load(Ordering::Relaxed),
+            vector_candidates_scanned: self.vector_candidates_scanned.load(Ordering::Relaxed),
+            vector_rows_reranked: self.vector_rows_reranked.load(Ordering::Relaxed),
         }
     }
 }

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -52,8 +52,13 @@ pub struct OpStats {
     /// the cache decides whether a request becomes a local read or a GET —
     /// the warm-equivalent request-work measure (FTS: one per term posting
     /// range, two per phrase member; vector: cluster index + prefix/block
-    /// ranges per cell, one per rerank row).
+    /// ranges per cell, one per rerank row; SQL: one per Parquet range the
+    /// scan requests).
     pub planned_read_ranges: u64,
+    /// Parquet bytes SQL scans requested through the DataFusion store
+    /// (footer, page index, and data pages), independent of whether they
+    /// were served from resident bytes or fetched.
+    pub sql_page_bytes: u64,
 }
 
 /// Accumulates one query's work counters across its fan-out (tokio unit
@@ -65,6 +70,7 @@ pub struct OpStatsCollector {
     vector_candidates_scanned: AtomicU64,
     vector_rows_reranked: AtomicU64,
     planned_read_ranges: AtomicU64,
+    sql_page_bytes: AtomicU64,
 }
 
 impl OpStatsCollector {
@@ -92,6 +98,11 @@ impl OpStatsCollector {
             .fetch_add(ranges, Ordering::Relaxed);
     }
 
+    /// Flush one SQL Parquet range request's byte length.
+    pub(crate) fn add_sql_page_bytes(&self, bytes: u64) {
+        self.sql_page_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
     /// The counters accumulated so far.
     pub fn snapshot(&self) -> OpStats {
         OpStats {
@@ -100,6 +111,7 @@ impl OpStatsCollector {
             vector_candidates_scanned: self.vector_candidates_scanned.load(Ordering::Relaxed),
             vector_rows_reranked: self.vector_rows_reranked.load(Ordering::Relaxed),
             planned_read_ranges: self.planned_read_ranges.load(Ordering::Relaxed),
+            sql_page_bytes: self.sql_page_bytes.load(Ordering::Relaxed),
         }
     }
 }
@@ -147,6 +159,17 @@ pub fn with_op_stats<T>(f: impl FnOnce() -> T) -> (T, OpStats) {
 /// the query fans out).
 pub(crate) fn current() -> Option<Arc<OpStatsCollector>> {
     CURRENT.with(|slot| slot.borrow().clone())
+}
+
+/// Run `f` with NO collector installed, restoring the active scope after.
+/// For constructing state that outlives the current query (e.g. a cached
+/// `SessionContext`): anything capturing [`current`] inside `f` stays
+/// detached, so a long-lived cache can never bill later queries into this
+/// scope.
+pub(crate) fn suppressed<T>(f: impl FnOnce() -> T) -> T {
+    let previous = CURRENT.with(|slot| slot.borrow_mut().take());
+    let _guard = ScopeGuard { previous };
+    f()
 }
 
 #[cfg(test)]

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -3504,7 +3504,8 @@ mod tests {
         let hits = fts_reader_merged
             .token_match("title", &["common"], BoolMode::Or)
             .await
-            .expect("token_match on merged");
+            .expect("token_match on merged")
+            .0;
         assert_eq!(
             hits.len() as u64,
             total_docs,

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -4685,8 +4685,8 @@ mod tests {
         }
         for term in ["common", "medium", "uniqueonce", "dupdup"] {
             assert_eq!(
-                ra.term_df("title", term).await.expect("df a"),
-                rb.term_df("title", term).await.expect("df b"),
+                ra.term_df("title", term).await.expect("df a").0,
+                rb.term_df("title", term).await.expect("df b").0,
                 "df diverged for {term}"
             );
         }
@@ -4760,8 +4760,8 @@ mod tests {
             assert!(!a.is_empty());
         }
         assert_eq!(
-            v1.term_df("title", "common").await.expect("v1 df"),
-            v2.term_df("title", "common").await.expect("v2 df"),
+            v1.term_df("title", "common").await.expect("v1 df").0,
+            v2.term_df("title", "common").await.expect("v2 df").0,
         );
     }
 
@@ -4881,17 +4881,19 @@ mod tests {
         // Count + df fast paths agree too (df reads the term meta's
         // first bytes — layout-stable across the stride change).
         for term in ["common", "medium", "uniqueonce", "dupdup"] {
-            let a = v1.term_df("title", term).await.expect("v1 df");
-            let b = v2.term_df("title", term).await.expect("v2 df");
+            let a = v1.term_df("title", term).await.expect("v1 df").0;
+            let b = v2.term_df("title", term).await.expect("v2 df").0;
             assert_eq!(a, b, "df diverged for {term}");
             let ca = v1
                 .token_match_count("title", &[term], BoolMode::Or)
                 .await
-                .expect("v1 count");
+                .expect("v1 count")
+                .0;
             let cb = v2
                 .token_match_count("title", &[term], BoolMode::Or)
                 .await
-                .expect("v2 count");
+                .expect("v2 count")
+                .0;
             assert_eq!(ca, cb, "count diverged for {term}");
         }
     }
@@ -4932,7 +4934,8 @@ mod tests {
         let shared_body = r
             .token_match_count("body", &["shared"], BoolMode::Or)
             .await
-            .expect("shared body");
+            .expect("shared body")
+            .0;
         assert_eq!(shared_body, BLOCK_LEN as u64 + 9);
     }
 }

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -52,11 +52,6 @@ use crate::superfile::{
     lazy_source::{LazyByteSource, PrefetchedSource, RangeCoalescePlan, Source},
 };
 
-/// Planned byte-source ranges per phrase member: its postings range plus
-/// its position runs — positional verification is exactly the work that
-/// separates phrase cost from term cost.
-const PHRASE_MEMBER_PLANNED_RANGES: u64 = 2;
-
 /// Largest gap worth overfetching when adjacent term postings share a request.
 const TERM_RANGE_COALESCE_MAX_GAP: usize = 64 * 1024;
 /// Maximum total gap bytes tolerated in one coalesced postings request.
@@ -264,16 +259,65 @@ fn atom_cursor_bytes(atoms: &[AnyCursor]) -> u64 {
         .sum()
 }
 
-/// Byte-source ranges the atoms' builds requested: one per plain term's
-/// posting range, [`PHRASE_MEMBER_PLANNED_RANGES`] per phrase member.
+/// Byte-source ranges a cursor set's build requested — one per PFOR
+/// term. Inline (df=1) cursors plan no fetch (their `bytes` is empty),
+/// matching the single-term arm's "bytes 0 implies ranges 0".
+fn term_cursor_ranges(cursors: &[TermCursor]) -> u64 {
+    cursors.iter().filter(|c| !c.bytes.is_empty()).count() as u64
+}
+
+/// Byte-source ranges the atoms' builds requested: one per PFOR term's
+/// posting range; a phrase member adds one for its postings and one for
+/// its position runs. Inline legs (empty buffers) plan no fetch.
 fn atom_planned_ranges(atoms: &[AnyCursor]) -> u64 {
     atoms
         .iter()
         .map(|a| match a {
-            AnyCursor::Term(_) => 1,
-            AnyCursor::Phrase(p) => PHRASE_MEMBER_PLANNED_RANGES * p.members.len() as u64,
+            AnyCursor::Term(c) => u64::from(!c.bytes.is_empty()),
+            AnyCursor::Phrase(p) => p
+                .members
+                .iter()
+                .map(|m| u64::from(!m.cursor.bytes.is_empty()) + u64::from(!m.positions.is_empty()))
+                .sum(),
         })
         .sum()
+}
+
+/// Work tallies from one unranked match / dictionary walk — the posting
+/// bytes indexed and the byte-source ranges the plan requested. Returned
+/// alongside match results so the supertable flushes once per superfile;
+/// `pub` because the carrying fns are the test-helpers-widened surface
+/// (the module gate in `lib.rs` keeps it crate-private in normal builds).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MatchWork {
+    /// Posting (and phrase-position / header) bytes the walk indexed into.
+    pub postings_bytes: u64,
+    /// Byte-source ranges the walk's build requested, pre-coalesce.
+    pub planned_ranges: u64,
+}
+
+impl MatchWork {
+    /// Tallies for a plain term-cursor set.
+    fn for_cursors(cursors: &[TermCursor]) -> Self {
+        Self {
+            postings_bytes: term_cursor_bytes(cursors),
+            planned_ranges: term_cursor_ranges(cursors),
+        }
+    }
+
+    /// Tallies for a heterogeneous atom set (terms + phrases).
+    fn for_atoms(atoms: &[AnyCursor]) -> Self {
+        Self {
+            postings_bytes: atom_cursor_bytes(atoms),
+            planned_ranges: atom_planned_ranges(atoms),
+        }
+    }
+
+    /// Fold another walk's tallies into this one (e.g. a negation set).
+    pub fn merge(&mut self, other: MatchWork) {
+        self.postings_bytes += other.postings_bytes;
+        self.planned_ranges += other.planned_ranges;
+    }
 }
 
 impl PreparedClauses {
@@ -348,16 +392,20 @@ impl PreparedClauses {
                 must_cursors,
                 filter,
                 ..
-            } => must_cursors.len() as u64 + filter_ranges(filter),
+            } => term_cursor_ranges(must_cursors) + filter_ranges(filter),
             PreparedClauses::MustShould {
                 must_cursors,
                 should_cursors,
                 filter,
                 ..
-            } => must_cursors.len() as u64 + should_cursors.len() as u64 + filter_ranges(filter),
+            } => {
+                term_cursor_ranges(must_cursors)
+                    + term_cursor_ranges(should_cursors)
+                    + filter_ranges(filter)
+            }
             PreparedClauses::Or {
                 cursors, filter, ..
-            } => cursors.len() as u64 + filter_ranges(filter),
+            } => term_cursor_ranges(cursors) + filter_ranges(filter),
         }
     }
 }
@@ -1593,27 +1641,23 @@ impl FtsReader {
         terms: &[&str],
         phrases: &[Vec<String>],
         mode: BoolMode,
-    ) -> Result<Vec<u32>, FtsError> {
+    ) -> Result<(Vec<u32>, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         // Unranked: idf is irrelevant to the match set, so build local.
         let built = self
             .build_atom_cursors(column_id, terms, phrases, None)
             .await?;
-        let atoms: Vec<AnyCursor> = match mode {
-            BoolMode::And => {
-                if built.iter().any(Option::is_none) {
-                    return Ok(Vec::new());
-                }
-                built.into_iter().flatten().collect()
-            }
-            BoolMode::Or => built.into_iter().flatten().collect(),
-        };
-        if atoms.is_empty() {
-            return Ok(Vec::new());
+        let missing_and_atom = mode == BoolMode::And && built.iter().any(Option::is_none);
+        let atoms: Vec<AnyCursor> = built.into_iter().flatten().collect();
+        // The atoms that DID build cost their bytes even when a missing
+        // AND atom empties the result — mirrors `prepare_clauses`.
+        let work = MatchWork::for_atoms(&atoms);
+        if missing_and_atom || atoms.is_empty() {
+            return Ok((Vec::new(), work));
         }
         let mut out = Vec::new();
         self.walk_atoms_match(atoms, mode, None, |d| out.push(d))?;
-        Ok(out)
+        Ok((out, work))
     }
 
     /// Phrase-aware unranked match **count** — the atoms sibling of
@@ -1624,27 +1668,21 @@ impl FtsReader {
         terms: &[&str],
         phrases: &[Vec<String>],
         mode: BoolMode,
-    ) -> Result<u64, FtsError> {
+    ) -> Result<(u64, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         // Unranked: idf is irrelevant to the match set, so build local.
         let built = self
             .build_atom_cursors(column_id, terms, phrases, None)
             .await?;
-        let atoms: Vec<AnyCursor> = match mode {
-            BoolMode::And => {
-                if built.iter().any(Option::is_none) {
-                    return Ok(0);
-                }
-                built.into_iter().flatten().collect()
-            }
-            BoolMode::Or => built.into_iter().flatten().collect(),
-        };
-        if atoms.is_empty() {
-            return Ok(0);
+        let missing_and_atom = mode == BoolMode::And && built.iter().any(Option::is_none);
+        let atoms: Vec<AnyCursor> = built.into_iter().flatten().collect();
+        let work = MatchWork::for_atoms(&atoms);
+        if missing_and_atom || atoms.is_empty() {
+            return Ok((0, work));
         }
         let mut n = 0u64;
         self.walk_atoms_match(atoms, mode, None, |_| n += 1)?;
-        Ok(n)
+        Ok((n, work))
     }
 
     /// Resolve a column name to its dense column_id, or
@@ -2111,7 +2149,7 @@ impl FtsReader {
         if must_cursors.len() != lists.musts.len() {
             let postings_bytes = term_cursor_bytes(&must_cursors)
                 + neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
-            let planned_ranges = must_cursors.len() as u64
+            let planned_ranges = term_cursor_ranges(&must_cursors)
                 + neg_filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
             return Ok(PreparedClauses::Done {
                 hits: Vec::new(),
@@ -2207,24 +2245,28 @@ impl FtsReader {
         column: &str,
         tokens: &[&str],
         mode: BoolMode,
-    ) -> Result<Vec<u32>, FtsError> {
+    ) -> Result<(Vec<u32>, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         if tokens.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), MatchWork::default()));
         }
         let cursors = self.build_term_cursors(column_id, tokens, None).await?;
-        Ok(match mode {
+        // Tallied before the mode branch: the cursors that DID build cost
+        // their bytes even when a missing AND token empties the result.
+        let work = MatchWork::for_cursors(&cursors);
+        let docs = match mode {
             BoolMode::And => {
                 // AND needs every token present; a missing token ⇒ empty
                 // set. Otherwise intersect via the same optimized
                 // block flat-merge the ranked scorer uses.
                 if cursors.len() != tokens.len() {
-                    return Ok(Vec::new());
+                    return Ok((Vec::new(), work));
                 }
                 self.collect_and_intersect(column_id, cursors)
             }
             BoolMode::Or => or_merge_unranked(cursors),
-        })
+        };
+        Ok((docs, work))
     }
 
     /// Unranked token-match **count** — the cardinality
@@ -2238,21 +2280,23 @@ impl FtsReader {
         column: &str,
         tokens: &[&str],
         mode: BoolMode,
-    ) -> Result<u64, FtsError> {
+    ) -> Result<(u64, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         if tokens.is_empty() {
-            return Ok(0);
+            return Ok((0, MatchWork::default()));
         }
         let cursors = self.build_term_cursors(column_id, tokens, None).await?;
-        Ok(match mode {
+        let work = MatchWork::for_cursors(&cursors);
+        let n = match mode {
             BoolMode::And => {
                 if cursors.len() != tokens.len() {
-                    return Ok(0);
+                    return Ok((0, work));
                 }
                 self.count_and_intersect(column_id, cursors)
             }
             BoolMode::Or => or_count_unranked(cursors),
-        })
+        };
+        Ok((n, work))
     }
 
     /// Document frequency for each of `tokens` in `column` — the number
@@ -2269,10 +2313,14 @@ impl FtsReader {
     /// ranges into a minimal set of parallel GETs). This matters on the
     /// global-statistics path, where a superfile is probed for every
     /// scored term of a query at once.
-    pub async fn term_dfs(&self, column: &str, tokens: &[&str]) -> Result<Vec<u64>, FtsError> {
+    pub async fn term_dfs(
+        &self,
+        column: &str,
+        tokens: &[&str],
+    ) -> Result<(Vec<u64>, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         if tokens.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), MatchWork::default()));
         }
         let fst_bytes = self.dict_bytes_async().await?;
         let dict = DictReader::open(&fst_bytes).map_err(|e| {
@@ -2305,19 +2353,24 @@ impl FtsReader {
             }
         }
 
-        // One coalesced fetch for every PFOR header; `df` is its first 4 bytes.
+        // One coalesced fetch for every PFOR header; `df` is its first 4
+        // bytes. Each header is one planned range (pre-coalesce), and its
+        // bytes count as indexed work — the walk read them.
+        let mut work = MatchWork::default();
         if !header_ranges.is_empty() {
             let fetched = self.fetch_term_postings(&header_ranges).await?;
+            work.planned_ranges = header_ranges.len() as u64;
             for (fetched_idx, &slot) in pfor_slots.iter().enumerate() {
                 let header = fetched.get(fetched_idx).ok_or_else(|| {
                     FtsError::Read(ReadError::MalformedVersion(
                         "term_dfs: fetched fewer headers than requested".into(),
                     ))
                 })?;
+                work.postings_bytes += header.len() as u64;
                 dfs[slot] = read_u32_le(&header.as_ref()[0..4]) as u64;
             }
         }
-        Ok(dfs)
+        Ok((dfs, work))
     }
 
     /// Document frequency of a single `token` in `column`. Thin wrapper
@@ -2327,8 +2380,9 @@ impl FtsReader {
     /// `WHERE` predicate's match count *ahead of* running `token_match`,
     /// so a predicate matching a large fraction of the superfile can
     /// fall back to a plain scan instead of a (losing) index pushdown.
-    pub async fn term_df(&self, column: &str, token: &str) -> Result<u64, FtsError> {
-        Ok(self.term_dfs(column, &[token]).await?.pop().unwrap_or(0))
+    pub async fn term_df(&self, column: &str, token: &str) -> Result<(u64, MatchWork), FtsError> {
+        let (mut dfs, work) = self.term_dfs(column, &[token]).await?;
+        Ok((dfs.pop().unwrap_or(0), work))
     }
 
     /// Multi-term OR BM25 search constrained to a doc_id sub-range.
@@ -4248,9 +4302,9 @@ impl OrCursorSet {
         term_cursor_bytes(&self.cursors)
     }
 
-    /// Byte-source ranges the set's build requested (one per term).
+    /// Byte-source ranges the set's build requested (one per PFOR term).
     pub(crate) fn planned_ranges(&self) -> u64 {
-        self.cursors.len() as u64
+        term_cursor_ranges(&self.cursors)
     }
 }
 
@@ -4769,9 +4823,9 @@ impl ExcludeFilter {
     }
 
     /// Byte-source ranges the negation cursors' builds requested (one per
-    /// term) — see [`PreparedClauses::planned_ranges`].
+    /// PFOR term) — see [`PreparedClauses::planned_ranges`].
     fn planned_ranges(&self) -> u64 {
-        self.cursors.len() as u64
+        term_cursor_ranges(&self.cursors)
     }
 }
 
@@ -6081,21 +6135,24 @@ mod tests {
         assert_eq!(
             r.token_match("body", &["rust"], BoolMode::Or)
                 .await
-                .expect("single"),
+                .expect("single")
+                .0,
             vec![0, 1]
         );
         // OR = union (rust ∪ java).
         assert_eq!(
             r.token_match("body", &["rust", "java"], BoolMode::Or)
                 .await
-                .expect("or"),
+                .expect("or")
+                .0,
             vec![0, 1, 2]
         );
         // AND = intersection (rust ∩ runtime).
         assert_eq!(
             r.token_match("body", &["rust", "runtime"], BoolMode::And)
                 .await
-                .expect("and"),
+                .expect("and")
+                .0,
             vec![0, 1]
         );
         // AND with an absent token → empty.
@@ -6103,13 +6160,15 @@ mod tests {
             r.token_match("body", &["rust", "zzz"], BoolMode::And)
                 .await
                 .expect("and absent")
+                .0
                 .is_empty()
         );
         // OR ignores an absent token.
         assert_eq!(
             r.token_match("body", &["java", "zzz"], BoolMode::Or)
                 .await
-                .expect("or absent"),
+                .expect("or absent")
+                .0,
             vec![2]
         );
         // Empty token list → empty.
@@ -6117,6 +6176,7 @@ mod tests {
             r.token_match("body", &[], BoolMode::And)
                 .await
                 .expect("empty")
+                .0
                 .is_empty()
         );
     }
@@ -6142,11 +6202,13 @@ mod tests {
                 .token_match("body", tokens, *mode)
                 .await
                 .expect("token_match")
+                .0
                 .len() as u64;
             let count = r
                 .token_match_count("body", tokens, *mode)
                 .await
-                .expect("token_match_count");
+                .expect("token_match_count")
+                .0;
             assert_eq!(count, len, "count vs len for {tokens:?} {mode:?}");
         }
     }
@@ -6192,11 +6254,13 @@ mod tests {
                 .token_match("body", terms, BoolMode::Or)
                 .await
                 .expect("token_match")
+                .0
                 .len() as u64;
             let count = r
                 .token_match_count("body", terms, BoolMode::Or)
                 .await
-                .expect("token_match_count");
+                .expect("token_match_count")
+                .0;
             assert_eq!(
                 count, merge_len,
                 "windowed count vs merge len for {terms:?}"
@@ -6208,7 +6272,8 @@ mod tests {
         assert_eq!(
             r.token_match_count("body", &["alpha"], BoolMode::Or)
                 .await
-                .expect("count"),
+                .expect("count")
+                .0,
             N_DOCS as u64
         );
     }
@@ -6229,7 +6294,8 @@ mod tests {
         let boolean = r
             .token_match("body", &["rust", "java"], BoolMode::Or)
             .await
-            .expect("boolean");
+            .expect("boolean")
+            .0;
         assert_eq!(bm25, boolean, "boolean Or doc set == bm25 doc set");
     }
 
@@ -6802,10 +6868,10 @@ mod tests {
         let r = FtsReader::open(blob, &json).expect("open");
         // common → df 3 (PFOR header read), rust → df 2 (PFOR),
         // uniqzero → df 1 (inline FST value), absent → 0.
-        assert_eq!(r.term_df("body", "common").await.expect("df"), 3);
-        assert_eq!(r.term_df("body", "rust").await.expect("df"), 2);
-        assert_eq!(r.term_df("body", "uniqzero").await.expect("df"), 1);
-        assert_eq!(r.term_df("body", "missing").await.expect("df"), 0);
+        assert_eq!(r.term_df("body", "common").await.expect("df").0, 3);
+        assert_eq!(r.term_df("body", "rust").await.expect("df").0, 2);
+        assert_eq!(r.term_df("body", "uniqzero").await.expect("df").0, 1);
+        assert_eq!(r.term_df("body", "missing").await.expect("df").0, 0);
     }
 
     #[tokio::test]
@@ -6825,11 +6891,11 @@ mod tests {
         // path (which fetches only the PFOR headers, then scatters the
         // results back) would surface as a mismatch here.
         let tokens = ["rust", "missing", "uniqzero", "common", "absent2"];
-        let batched = r.term_dfs("body", &tokens).await.expect("term_dfs");
+        let batched = r.term_dfs("body", &tokens).await.expect("term_dfs").0;
         // Element-wise identical to resolving each token on its own.
         let mut per_term = Vec::with_capacity(tokens.len());
         for t in tokens {
-            per_term.push(r.term_df("body", t).await.expect("term_df"));
+            per_term.push(r.term_df("body", t).await.expect("term_df").0);
         }
         assert_eq!(
             batched, per_term,
@@ -6839,7 +6905,7 @@ mod tests {
         // uniqzero=1 inline, absent tokens=0).
         assert_eq!(batched, vec![2, 0, 1, 3, 0], "planted document frequencies");
         // Empty input short-circuits to empty output (no dict open, no fetch).
-        assert!(r.term_dfs("body", &[]).await.expect("empty").is_empty());
+        assert!(r.term_dfs("body", &[]).await.expect("empty").0.is_empty());
     }
 
     // ---- phrase atoms ----

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -196,6 +196,9 @@ pub(crate) enum PreparedClauses {
     Done {
         hits: Vec<(u32, f32)>,
         postings_bytes: u64,
+        /// Byte-source ranges the inline walk requested (0 for the df=1
+        /// inline-FST and empty-resolution paths).
+        planned_ranges: u64,
     },
     /// AND-only: intersect `must_cursors`.
     Must {
@@ -249,6 +252,18 @@ fn atom_cursor_bytes(atoms: &[AnyCursor]) -> u64 {
         .sum()
 }
 
+/// Byte-source ranges the atoms' builds requested: one per plain term's
+/// posting range, two per phrase member (postings + position runs).
+fn atom_planned_ranges(atoms: &[AnyCursor]) -> u64 {
+    atoms
+        .iter()
+        .map(|a| match a {
+            AnyCursor::Term(_) => 1,
+            AnyCursor::Phrase(p) => 2 * p.members.len() as u64,
+        })
+        .sum()
+}
+
 impl PreparedClauses {
     /// Scan-cost proxy callers gate reader-pool dispatch on: the driving
     /// (smallest) posting list for the AND-intersect shapes, the full
@@ -295,6 +310,31 @@ impl PreparedClauses {
             PreparedClauses::Or {
                 cursors, filter, ..
             } => term_cursor_bytes(cursors) + filter_bytes(filter),
+        }
+    }
+
+    /// Byte-source ranges this prepared query requested — one per term
+    /// posting range across every clause list (see
+    /// [`Self::postings_bytes`] for the byte-volume counterpart).
+    pub(crate) fn planned_ranges(&self) -> u64 {
+        let filter_ranges =
+            |filter: &Option<ExcludeFilter>| filter.as_ref().map_or(0, |f| f.cursors.len() as u64);
+        match self {
+            PreparedClauses::Done { planned_ranges, .. } => *planned_ranges,
+            PreparedClauses::Must {
+                must_cursors,
+                filter,
+                ..
+            } => must_cursors.len() as u64 + filter_ranges(filter),
+            PreparedClauses::MustShould {
+                must_cursors,
+                should_cursors,
+                filter,
+                ..
+            } => must_cursors.len() as u64 + should_cursors.len() as u64 + filter_ranges(filter),
+            PreparedClauses::Or {
+                cursors, filter, ..
+            } => cursors.len() as u64 + filter_ranges(filter),
         }
     }
 }
@@ -1899,6 +1939,7 @@ impl FtsReader {
             return Ok(PreparedClauses::Done {
                 hits: Vec::new(),
                 postings_bytes: 0,
+                planned_ranges: 0,
             });
         }
         if lists.no_positive_atoms() {
@@ -1906,6 +1947,7 @@ impl FtsReader {
                 return Ok(PreparedClauses::Done {
                     hits: Vec::new(),
                     postings_bytes: 0,
+                    planned_ranges: 0,
                 });
             }
             return Err(FtsError::NegationOnly);
@@ -1924,6 +1966,7 @@ impl FtsReader {
                 return Ok(PreparedClauses::Done {
                     hits: Vec::new(),
                     postings_bytes: atom_cursor_bytes(&built),
+                    planned_ranges: atom_planned_ranges(&built),
                 });
             }
             let must_atoms: Vec<AnyCursor> = must_atoms.into_iter().flatten().collect();
@@ -1949,6 +1992,9 @@ impl FtsReader {
             let postings_bytes = atom_cursor_bytes(&must_atoms)
                 + atom_cursor_bytes(&should_atoms)
                 + atom_cursor_bytes(&negative_atoms);
+            let planned_ranges = atom_planned_ranges(&must_atoms)
+                + atom_planned_ranges(&should_atoms)
+                + atom_planned_ranges(&negative_atoms);
             let filter = match negative_atoms.is_empty() {
                 true => None,
                 false => Some(AtomExcludeFilter::new(negative_atoms)),
@@ -1958,6 +2004,7 @@ impl FtsReader {
             return Ok(PreparedClauses::Done {
                 hits: result,
                 postings_bytes,
+                planned_ranges,
             });
         }
 
@@ -1987,12 +2034,17 @@ impl FtsReader {
                 .expect("one atom");
             let mut filter = neg_filter;
             let filter_postings_bytes = filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
+            let filter_ranges = filter.as_ref().map_or(0, |f| f.cursors.len() as u64);
             let (result, term_postings_bytes) = self
                 .search_single_term_bmw(column_id, term, k, filter.as_mut(), floor_eff)
                 .await?;
+            // The PFOR arm requested one posting range; the inline df=1 and
+            // absent-term arms requested none (bytes 0 implies ranges 0).
+            let term_ranges = u64::from(term_postings_bytes > 0);
             return Ok(PreparedClauses::Done {
                 hits: result,
                 postings_bytes: term_postings_bytes + filter_postings_bytes,
+                planned_ranges: term_ranges + filter_ranges,
             });
         }
 
@@ -2002,9 +2054,11 @@ impl FtsReader {
                 .await?;
             if cursors.is_empty() {
                 let postings_bytes = neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
+                let planned_ranges = neg_filter.as_ref().map_or(0, |f| f.cursors.len() as u64);
                 return Ok(PreparedClauses::Done {
                     hits: Vec::new(),
                     postings_bytes,
+                    planned_ranges,
                 });
             }
             return Ok(PreparedClauses::Or {
@@ -2023,9 +2077,12 @@ impl FtsReader {
         if must_cursors.len() != lists.musts.len() {
             let postings_bytes = term_cursor_bytes(&must_cursors)
                 + neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
+            let planned_ranges = must_cursors.len() as u64
+                + neg_filter.as_ref().map_or(0, |f| f.cursors.len() as u64);
             return Ok(PreparedClauses::Done {
                 hits: Vec::new(),
                 postings_bytes,
+                planned_ranges,
             });
         }
         if lists.shoulds.is_empty() {
@@ -4140,6 +4197,11 @@ impl OrCursorSet {
     /// even when ranged slices share the set.
     pub(crate) fn postings_bytes(&self) -> u64 {
         term_cursor_bytes(&self.cursors)
+    }
+
+    /// Byte-source ranges the set's build requested (one per term).
+    pub(crate) fn planned_ranges(&self) -> u64 {
+        self.cursors.len() as u64
     }
 }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -189,8 +189,14 @@ impl ClauseLists<'_> {
 /// cursors for one clause shape still to score. Owns its `ExcludeFilter`
 /// rather than borrowing it, so it can move into a `'static` closure.
 pub(crate) enum PreparedClauses {
-    /// Already final — nothing left for `run_prepared` to do.
-    Done(Vec<(u32, f32)>),
+    /// Already final — nothing left for `run_prepared` to do. Carries
+    /// the posting (and phrase-position) bytes the inline walk indexed
+    /// into, so the fast paths report work like the cursor-carrying
+    /// shapes do.
+    Done {
+        hits: Vec<(u32, f32)>,
+        postings_bytes: u64,
+    },
     /// AND-only: intersect `must_cursors`.
     Must {
         column_id: u32,
@@ -219,13 +225,37 @@ pub(crate) enum PreparedClauses {
     },
 }
 
+/// Sum of the posting-byte ranges a cursor set indexes into (each cursor's
+/// term metadata + skip table + posting blocks). Feeds the per-query work
+/// stats ([`crate::runtime_metrics::op_stats`]).
+fn term_cursor_bytes(cursors: &[TermCursor]) -> u64 {
+    cursors.iter().map(|c| c.bytes.len() as u64).sum()
+}
+
+/// [`term_cursor_bytes`] for heterogeneous atoms: a phrase member counts
+/// its posting bytes **and** its position runs — positional verification
+/// is exactly the work that separates phrase cost from term cost.
+fn atom_cursor_bytes(atoms: &[AnyCursor]) -> u64 {
+    atoms
+        .iter()
+        .map(|a| match a {
+            AnyCursor::Term(c) => c.bytes.len() as u64,
+            AnyCursor::Phrase(p) => p
+                .members
+                .iter()
+                .map(|m| m.cursor.bytes.len() as u64 + m.positions.len() as u64)
+                .sum(),
+        })
+        .sum()
+}
+
 impl PreparedClauses {
     /// Scan-cost proxy callers gate reader-pool dispatch on: the driving
     /// (smallest) posting list for the AND-intersect shapes, the full
     /// union for OR. `Done` has nothing left to scan, so it's zero.
     pub(crate) fn posting_mass(&self) -> u64 {
         match self {
-            PreparedClauses::Done(_) => 0,
+            PreparedClauses::Done { .. } => 0,
             PreparedClauses::Must { must_cursors, .. } => {
                 must_cursors.iter().map(|c| c.df).min().unwrap_or(0)
             }
@@ -233,6 +263,38 @@ impl PreparedClauses {
                 must_cursors.iter().map(|c| c.df).min().unwrap_or(0)
             }
             PreparedClauses::Or { cursors, .. } => cursors.iter().map(|c| c.df).sum(),
+        }
+    }
+
+    /// Posting-list bytes resident for this prepared query — what the
+    /// kernels index into across musts, shoulds, OR terms, and negation
+    /// filters (plus phrase position runs on the inline `Done` path).
+    /// Deterministic for a given query against a given superfile (cache
+    /// temperature never changes it) — the per-query work stats flush
+    /// this once per superfile.
+    pub(crate) fn postings_bytes(&self) -> u64 {
+        let filter_bytes =
+            |filter: &Option<ExcludeFilter>| filter.as_ref().map_or(0, |f| f.postings_bytes());
+        match self {
+            PreparedClauses::Done { postings_bytes, .. } => *postings_bytes,
+            PreparedClauses::Must {
+                must_cursors,
+                filter,
+                ..
+            } => term_cursor_bytes(must_cursors) + filter_bytes(filter),
+            PreparedClauses::MustShould {
+                must_cursors,
+                should_cursors,
+                filter,
+                ..
+            } => {
+                term_cursor_bytes(must_cursors)
+                    + term_cursor_bytes(should_cursors)
+                    + filter_bytes(filter)
+            }
+            PreparedClauses::Or {
+                cursors, filter, ..
+            } => term_cursor_bytes(cursors) + filter_bytes(filter),
         }
     }
 }
@@ -1834,11 +1896,17 @@ impl FtsReader {
     ) -> Result<PreparedClauses, FtsError> {
         let column_id = self.resolve_column_id(column)?;
         if k == 0 {
-            return Ok(PreparedClauses::Done(Vec::new()));
+            return Ok(PreparedClauses::Done {
+                hits: Vec::new(),
+                postings_bytes: 0,
+            });
         }
         if lists.no_positive_atoms() {
             if lists.no_negative_atoms() {
-                return Ok(PreparedClauses::Done(Vec::new()));
+                return Ok(PreparedClauses::Done {
+                    hits: Vec::new(),
+                    postings_bytes: 0,
+                });
             }
             return Err(FtsError::NegationOnly);
         }
@@ -1850,8 +1918,13 @@ impl FtsReader {
                 .build_atom_cursors(column_id, lists.musts, lists.must_phrases, lists.global_idf)
                 .await?;
             if must_atoms.iter().any(Option::is_none) {
-                // A must atom can never match in this superfile.
-                return Ok(PreparedClauses::Done(Vec::new()));
+                // A must atom can never match in this superfile. The
+                // atoms that DID build still cost their bytes.
+                let built: Vec<AnyCursor> = must_atoms.into_iter().flatten().collect();
+                return Ok(PreparedClauses::Done {
+                    hits: Vec::new(),
+                    postings_bytes: atom_cursor_bytes(&built),
+                });
             }
             let must_atoms: Vec<AnyCursor> = must_atoms.into_iter().flatten().collect();
             let should_atoms: Vec<AnyCursor> = self
@@ -1873,13 +1946,19 @@ impl FtsReader {
                 .into_iter()
                 .flatten()
                 .collect();
+            let postings_bytes = atom_cursor_bytes(&must_atoms)
+                + atom_cursor_bytes(&should_atoms)
+                + atom_cursor_bytes(&negative_atoms);
             let filter = match negative_atoms.is_empty() {
                 true => None,
                 false => Some(AtomExcludeFilter::new(negative_atoms)),
             };
             let result =
                 self.run_atoms_search(column_id, must_atoms, should_atoms, k, filter, floor_eff)?;
-            return Ok(PreparedClauses::Done(result));
+            return Ok(PreparedClauses::Done {
+                hits: result,
+                postings_bytes,
+            });
         }
 
         let neg_filter = match lists.negatives {
@@ -1907,10 +1986,14 @@ impl FtsReader {
                 .next()
                 .expect("one atom");
             let mut filter = neg_filter;
-            let result = self
+            let filter_postings_bytes = filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
+            let (result, term_postings_bytes) = self
                 .search_single_term_bmw(column_id, term, k, filter.as_mut(), floor_eff)
                 .await?;
-            return Ok(PreparedClauses::Done(result));
+            return Ok(PreparedClauses::Done {
+                hits: result,
+                postings_bytes: term_postings_bytes + filter_postings_bytes,
+            });
         }
 
         if lists.musts.is_empty() {
@@ -1918,7 +2001,11 @@ impl FtsReader {
                 .build_term_cursors(column_id, lists.shoulds, lists.global_idf)
                 .await?;
             if cursors.is_empty() {
-                return Ok(PreparedClauses::Done(Vec::new()));
+                let postings_bytes = neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
+                return Ok(PreparedClauses::Done {
+                    hits: Vec::new(),
+                    postings_bytes,
+                });
             }
             return Ok(PreparedClauses::Or {
                 column_id,
@@ -1934,7 +2021,12 @@ impl FtsReader {
             .build_term_cursors(column_id, lists.musts, lists.global_idf)
             .await?;
         if must_cursors.len() != lists.musts.len() {
-            return Ok(PreparedClauses::Done(Vec::new()));
+            let postings_bytes = term_cursor_bytes(&must_cursors)
+                + neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
+            return Ok(PreparedClauses::Done {
+                hits: Vec::new(),
+                postings_bytes,
+            });
         }
         if lists.shoulds.is_empty() {
             return Ok(PreparedClauses::Must {
@@ -1973,7 +2065,7 @@ impl FtsReader {
     /// cursors it fetched. No I/O, so it can run on the reader pool.
     pub(crate) fn run_prepared(&self, prep: PreparedClauses) -> Result<Vec<(u32, f32)>, FtsError> {
         match prep {
-            PreparedClauses::Done(result) => Ok(result),
+            PreparedClauses::Done { hits, .. } => Ok(hits),
             PreparedClauses::Must {
                 column_id,
                 must_cursors,
@@ -2330,7 +2422,7 @@ impl FtsReader {
         k: usize,
         mut filter: Option<&mut ExcludeFilter>,
         floor_eff: f32,
-    ) -> Result<Vec<(u32, f32)>, FtsError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
         let dict = DictReader::open(&fst_bytes).map_err(|e| {
             FtsError::Read(ReadError::MalformedVersion(format!(
@@ -2340,7 +2432,7 @@ impl FtsReader {
         let col_meta = &self.columns[column_id as usize];
         let key = make_key(&col_meta.name, term);
         let Some(packed) = dict.lookup(&key) else {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         };
         let (metadata_offset, postings_length) = match FstValue::unpack(packed) {
             FstValue::Inline { doc_id, tf } => {
@@ -2359,17 +2451,19 @@ impl FtsReader {
                 let idf_t = bm25::idf(self.n_docs as u64, 1);
                 let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);
                 // Drop the lone match if a negated term excludes it.
+                // The inline slot read no postings-region bytes; the
+                // work-stats byte count for this path is genuinely zero.
                 if let Some(f) = filter.as_deref_mut()
                     && !f.admits(doc_id)
                 {
-                    return Ok(Vec::new());
+                    return Ok((Vec::new(), 0));
                 }
                 let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
                 let score = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
                 if score <= floor_eff {
-                    return Ok(Vec::new());
+                    return Ok((Vec::new(), 0));
                 }
-                return Ok(vec![(doc_id, score)]);
+                return Ok((vec![(doc_id, score)], 0));
             }
             FstValue::Pfor {
                 metadata_offset,
@@ -2458,7 +2552,7 @@ impl FtsReader {
             }
         }
 
-        Ok(drain_top_k_desc(heap))
+        Ok((drain_top_k_desc(heap), term_bytes.len() as u64))
     }
 
     /// Build one `TermCursor` per term that resolves in the FST.
@@ -4040,6 +4134,13 @@ impl OrCursorSet {
     pub(crate) fn len(&self) -> usize {
         self.cursors.len()
     }
+
+    /// Posting-list bytes this set's cursors index into — see
+    /// [`PreparedClauses::postings_bytes`]. Counted once per superfile
+    /// even when ranged slices share the set.
+    pub(crate) fn postings_bytes(&self) -> u64 {
+        term_cursor_bytes(&self.cursors)
+    }
 }
 
 /// Top-k min-heap entry `(score, doc_id)`, shared by every search
@@ -4548,6 +4649,12 @@ impl ExcludeFilter {
             cursors,
             last_doc: 0,
         }
+    }
+
+    /// Posting-list bytes the negation cursors index into — see
+    /// [`PreparedClauses::postings_bytes`].
+    fn postings_bytes(&self) -> u64 {
+        term_cursor_bytes(&self.cursors)
     }
 }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -2008,15 +2008,16 @@ impl FtsReader {
     /// [`Self::search`] that also returns the walk's work — posting
     /// bytes, planned ranges, and the bracketed kernel on-CPU ns
     /// (`prepare_clauses`' inline walks plus the `run_prepared`
-    /// section). Prefix search reports through this so an expansion to
-    /// thousands of terms carries its cost like any other query shape.
+    /// section), all carried on the one [`MatchWork`]. Prefix search
+    /// reports through this so an expansion to thousands of terms
+    /// carries its cost like any other query shape.
     pub(crate) async fn search_with_work(
         &self,
         column: &str,
         terms: &[&str],
         k: usize,
         mode: BoolMode,
-    ) -> Result<(Vec<(u32, f32)>, MatchWork, u64), FtsError> {
+    ) -> Result<(Vec<(u32, f32)>, MatchWork), FtsError> {
         let (musts, shoulds): (&[&str], &[&str]) = match mode {
             BoolMode::And => (terms, &[]),
             BoolMode::Or => (&[], terms),
@@ -2033,21 +2034,20 @@ impl FtsReader {
                 f32::NEG_INFINITY,
             )
             .await?;
-        let work = MatchWork {
+        let mut work = MatchWork {
             postings_bytes: prep.postings_bytes(),
             planned_ranges: prep.planned_ranges(),
-            kernel_cpu_ns: 0,
+            kernel_cpu_ns: prep.inline_kernel_cpu_ns(),
         };
-        let mut kernel_ns = prep.inline_kernel_cpu_ns();
         let hits = match prep {
             PreparedClauses::Done { hits, .. } => hits,
             prep => {
                 let (hits, run_ns) = timed_section(|| self.run_prepared(prep));
-                kernel_ns += run_ns;
+                work.kernel_cpu_ns += run_ns;
                 hits?
             }
         };
-        Ok((hits, work, kernel_ns))
+        Ok((hits, work))
     }
 
     /// BM25 search over explicit clause lists, with negated terms
@@ -2484,7 +2484,13 @@ impl FtsReader {
                     ))
                 })?;
                 work.postings_bytes += header.len() as u64;
-                dfs[slot] = read_u32_le(&header.as_ref()[0..4]) as u64;
+                let header_bytes = header.as_ref();
+                if header_bytes.len() < U32_BYTES {
+                    return Err(FtsError::Read(ReadError::MalformedVersion(
+                        "term_dfs: short postings header".into(),
+                    )));
+                }
+                dfs[slot] = read_u32_le(&header_bytes[0..U32_BYTES]) as u64;
             }
         }
         Ok((dfs, work))

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -25,6 +25,7 @@ use std::{
 use bytes::Bytes;
 use serde::Deserialize;
 
+use crate::runtime_metrics::cpu::{thread_cpu_delta_ns, thread_cpu_ns};
 use crate::superfile::{
     ReadError,
     error::FtsError,
@@ -49,6 +50,11 @@ use crate::superfile::{
     },
     lazy_source::{LazyByteSource, PrefetchedSource, RangeCoalescePlan, Source},
 };
+
+/// Planned byte-source ranges per phrase member: its postings range plus
+/// its position runs — positional verification is exactly the work that
+/// separates phrase cost from term cost.
+const PHRASE_MEMBER_PLANNED_RANGES: u64 = 2;
 
 /// Largest gap worth overfetching when adjacent term postings share a request.
 const TERM_RANGE_COALESCE_MAX_GAP: usize = 64 * 1024;
@@ -199,6 +205,11 @@ pub(crate) enum PreparedClauses {
         /// Byte-source ranges the inline walk requested (0 for the df=1
         /// inline-FST and empty-resolution paths).
         planned_ranges: u64,
+        /// On-CPU nanoseconds of the walk that produced `hits` inside
+        /// `prepare_clauses` (single-term BMW, atoms search) — the
+        /// kernel time `run_prepared` never sees for already-final
+        /// shapes. 0 for the trivial early returns.
+        kernel_cpu_ns: u64,
     },
     /// AND-only: intersect `must_cursors`.
     Must {
@@ -253,13 +264,13 @@ fn atom_cursor_bytes(atoms: &[AnyCursor]) -> u64 {
 }
 
 /// Byte-source ranges the atoms' builds requested: one per plain term's
-/// posting range, two per phrase member (postings + position runs).
+/// posting range, [`PHRASE_MEMBER_PLANNED_RANGES`] per phrase member.
 fn atom_planned_ranges(atoms: &[AnyCursor]) -> u64 {
     atoms
         .iter()
         .map(|a| match a {
             AnyCursor::Term(_) => 1,
-            AnyCursor::Phrase(p) => 2 * p.members.len() as u64,
+            AnyCursor::Phrase(p) => PHRASE_MEMBER_PLANNED_RANGES * p.members.len() as u64,
         })
         .sum()
 }
@@ -313,12 +324,23 @@ impl PreparedClauses {
         }
     }
 
+    /// On-CPU nanoseconds already spent producing an inline `Done`
+    /// result (0 for the cursor-carrying shapes, whose kernels are
+    /// bracketed at `run_prepared`).
+    pub(crate) fn inline_kernel_cpu_ns(&self) -> u64 {
+        match self {
+            PreparedClauses::Done { kernel_cpu_ns, .. } => *kernel_cpu_ns,
+            _ => 0,
+        }
+    }
+
     /// Byte-source ranges this prepared query requested — one per term
     /// posting range across every clause list (see
     /// [`Self::postings_bytes`] for the byte-volume counterpart).
     pub(crate) fn planned_ranges(&self) -> u64 {
-        let filter_ranges =
-            |filter: &Option<ExcludeFilter>| filter.as_ref().map_or(0, |f| f.cursors.len() as u64);
+        let filter_ranges = |filter: &Option<ExcludeFilter>| {
+            filter.as_ref().map_or(0, ExcludeFilter::planned_ranges)
+        };
         match self {
             PreparedClauses::Done { planned_ranges, .. } => *planned_ranges,
             PreparedClauses::Must {
@@ -1940,6 +1962,7 @@ impl FtsReader {
                 hits: Vec::new(),
                 postings_bytes: 0,
                 planned_ranges: 0,
+                kernel_cpu_ns: 0,
             });
         }
         if lists.no_positive_atoms() {
@@ -1948,6 +1971,7 @@ impl FtsReader {
                     hits: Vec::new(),
                     postings_bytes: 0,
                     planned_ranges: 0,
+                    kernel_cpu_ns: 0,
                 });
             }
             return Err(FtsError::NegationOnly);
@@ -1967,6 +1991,7 @@ impl FtsReader {
                     hits: Vec::new(),
                     postings_bytes: atom_cursor_bytes(&built),
                     planned_ranges: atom_planned_ranges(&built),
+                    kernel_cpu_ns: 0,
                 });
             }
             let must_atoms: Vec<AnyCursor> = must_atoms.into_iter().flatten().collect();
@@ -1999,12 +2024,17 @@ impl FtsReader {
                 true => None,
                 false => Some(AtomExcludeFilter::new(negative_atoms)),
             };
+            // The atom walk is the whole kernel for phrase shapes —
+            // `run_prepared` sees only the finished `Done` — so bracket
+            // its on-CPU time here (sync section, no awaits inside).
+            let kernel_start = thread_cpu_ns();
             let result =
                 self.run_atoms_search(column_id, must_atoms, should_atoms, k, filter, floor_eff)?;
             return Ok(PreparedClauses::Done {
                 hits: result,
                 postings_bytes,
                 planned_ranges,
+                kernel_cpu_ns: thread_cpu_delta_ns(kernel_start),
             });
         }
 
@@ -2034,8 +2064,8 @@ impl FtsReader {
                 .expect("one atom");
             let mut filter = neg_filter;
             let filter_postings_bytes = filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
-            let filter_ranges = filter.as_ref().map_or(0, |f| f.cursors.len() as u64);
-            let (result, term_postings_bytes) = self
+            let filter_ranges = filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
+            let (result, term_postings_bytes, kernel_cpu_ns) = self
                 .search_single_term_bmw(column_id, term, k, filter.as_mut(), floor_eff)
                 .await?;
             // The PFOR arm requested one posting range; the inline df=1 and
@@ -2045,6 +2075,7 @@ impl FtsReader {
                 hits: result,
                 postings_bytes: term_postings_bytes + filter_postings_bytes,
                 planned_ranges: term_ranges + filter_ranges,
+                kernel_cpu_ns,
             });
         }
 
@@ -2054,11 +2085,12 @@ impl FtsReader {
                 .await?;
             if cursors.is_empty() {
                 let postings_bytes = neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
-                let planned_ranges = neg_filter.as_ref().map_or(0, |f| f.cursors.len() as u64);
+                let planned_ranges = neg_filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
                 return Ok(PreparedClauses::Done {
                     hits: Vec::new(),
                     postings_bytes,
                     planned_ranges,
+                    kernel_cpu_ns: 0,
                 });
             }
             return Ok(PreparedClauses::Or {
@@ -2078,11 +2110,12 @@ impl FtsReader {
             let postings_bytes = term_cursor_bytes(&must_cursors)
                 + neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
             let planned_ranges = must_cursors.len() as u64
-                + neg_filter.as_ref().map_or(0, |f| f.cursors.len() as u64);
+                + neg_filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
             return Ok(PreparedClauses::Done {
                 hits: Vec::new(),
                 postings_bytes,
                 planned_ranges,
+                kernel_cpu_ns: 0,
             });
         }
         if lists.shoulds.is_empty() {
@@ -2472,6 +2505,11 @@ impl FtsReader {
     /// posting lists with high score variance — e.g. very long lists
     /// where most blocks contain mid-relevance docs and the top-k is
     /// dominated by a few outliers.
+    /// Returns `(hits, postings bytes indexed, on-CPU ns of the scoring
+    /// walk)` — the walk runs inside `prepare_clauses`, so its kernel
+    /// time must travel with the result (single-term is the most common
+    /// query shape; leaving it unbracketed would make `kernel_cpu_ns`
+    /// incomparable across clause shapes).
     async fn search_single_term_bmw(
         &self,
         column_id: u32,
@@ -2479,7 +2517,7 @@ impl FtsReader {
         k: usize,
         mut filter: Option<&mut ExcludeFilter>,
         floor_eff: f32,
-    ) -> Result<(Vec<(u32, f32)>, u64), FtsError> {
+    ) -> Result<(Vec<(u32, f32)>, u64, u64), FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
         let dict = DictReader::open(&fst_bytes).map_err(|e| {
             FtsError::Read(ReadError::MalformedVersion(format!(
@@ -2489,7 +2527,7 @@ impl FtsReader {
         let col_meta = &self.columns[column_id as usize];
         let key = make_key(&col_meta.name, term);
         let Some(packed) = dict.lookup(&key) else {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), 0, 0));
         };
         let (metadata_offset, postings_length) = match FstValue::unpack(packed) {
             FstValue::Inline { doc_id, tf } => {
@@ -2513,14 +2551,14 @@ impl FtsReader {
                 if let Some(f) = filter.as_deref_mut()
                     && !f.admits(doc_id)
                 {
-                    return Ok((Vec::new(), 0));
+                    return Ok((Vec::new(), 0, 0));
                 }
                 let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
                 let score = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
                 if score <= floor_eff {
-                    return Ok((Vec::new(), 0));
+                    return Ok((Vec::new(), 0, 0));
                 }
-                return Ok((vec![(doc_id, score)], 0));
+                return Ok((vec![(doc_id, score)], 0, 0));
             }
             FstValue::Pfor {
                 metadata_offset,
@@ -2543,6 +2581,9 @@ impl FtsReader {
         let postings = term_bytes.as_ref();
         let metadata_offset = 0usize;
 
+        // Everything below is the synchronous scoring walk (no awaits):
+        // bracket it on this thread for the per-query kernel CPU stat.
+        let kernel_start = thread_cpu_ns();
         let term_meta = TermMeta::parse(postings, metadata_offset, col_meta.positions)?;
 
         let idf_t = bm25::idf(self.n_docs as u64, term_meta.df);
@@ -2609,7 +2650,11 @@ impl FtsReader {
             }
         }
 
-        Ok((drain_top_k_desc(heap), term_bytes.len() as u64))
+        Ok((
+            drain_top_k_desc(heap),
+            term_bytes.len() as u64,
+            thread_cpu_delta_ns(kernel_start),
+        ))
     }
 
     /// Build one `TermCursor` per term that resolves in the FST.
@@ -4717,6 +4762,12 @@ impl ExcludeFilter {
     /// [`PreparedClauses::postings_bytes`].
     fn postings_bytes(&self) -> u64 {
         term_cursor_bytes(&self.cursors)
+    }
+
+    /// Byte-source ranges the negation cursors' builds requested (one per
+    /// term) — see [`PreparedClauses::planned_ranges`].
+    fn planned_ranges(&self) -> u64 {
+        self.cursors.len() as u64
     }
 }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -26,7 +26,7 @@ use bytes::Bytes;
 use serde::Deserialize;
 
 use crate::runtime_metrics::cpu::{thread_cpu_delta_ns, thread_cpu_ns};
-use crate::runtime_metrics::op_stats::metering_active;
+use crate::runtime_metrics::op_stats::{metering_active, timed_section};
 use crate::superfile::{
     ReadError,
     error::FtsError,
@@ -214,6 +214,9 @@ pub(crate) enum PreparedClauses {
         filter: Option<ExcludeFilter>,
         k: usize,
         floor_eff: f32,
+        /// FST-dictionary ranges the builds requested (one per
+        /// `build_term_cursors` call — must / should / negation lists).
+        dict_ranges: u64,
     },
     /// AND with should-boosted scoring.
     MustShould {
@@ -223,6 +226,8 @@ pub(crate) enum PreparedClauses {
         filter: Option<ExcludeFilter>,
         k: usize,
         floor_eff: f32,
+        /// See [`PreparedClauses::Must::dict_ranges`].
+        dict_ranges: u64,
     },
     /// Plain multi-term OR (no musts) — algorithm choice resolved in
     /// `run_prepared`.
@@ -232,6 +237,8 @@ pub(crate) enum PreparedClauses {
         filter: Option<ExcludeFilter>,
         k: usize,
         floor_eff: f32,
+        /// See [`PreparedClauses::Must::dict_ranges`].
+        dict_ranges: u64,
     },
 }
 
@@ -263,21 +270,32 @@ fn atom_cursor_bytes(atoms: &[AnyCursor]) -> u64 {
 /// term. Inline (df=1) cursors plan no fetch (their `bytes` is empty),
 /// matching the single-term arm's "bytes 0 implies ranges 0".
 fn term_cursor_ranges(cursors: &[TermCursor]) -> u64 {
-    cursors.iter().filter(|c| !c.bytes.is_empty()).count() as u64
+    cursors
+        .iter()
+        .filter(|c| !c.bytes.is_empty())
+        .map(|c| 1 + u64::from(c.header_probed))
+        .sum()
 }
 
 /// Byte-source ranges the atoms' builds requested: one per PFOR term's
 /// posting range; a phrase member adds one for its postings and one for
 /// its position runs. Inline legs (empty buffers) plan no fetch.
 fn atom_planned_ranges(atoms: &[AnyCursor]) -> u64 {
+    let term_ranges = |c: &TermCursor| {
+        if c.bytes.is_empty() {
+            0
+        } else {
+            1 + u64::from(c.header_probed)
+        }
+    };
     atoms
         .iter()
         .map(|a| match a {
-            AnyCursor::Term(c) => u64::from(!c.bytes.is_empty()),
+            AnyCursor::Term(c) => term_ranges(c),
             AnyCursor::Phrase(p) => p
                 .members
                 .iter()
-                .map(|m| u64::from(!m.cursor.bytes.is_empty()) + u64::from(!m.positions.is_empty()))
+                .map(|m| term_ranges(&m.cursor) + u64::from(!m.positions.is_empty()))
                 .sum(),
         })
         .sum()
@@ -294,6 +312,9 @@ pub struct MatchWork {
     pub postings_bytes: u64,
     /// Byte-source ranges the walk's build requested, pre-coalesce.
     pub planned_ranges: u64,
+    /// Bracketed on-CPU ns of the walk's synchronous scoring/merge
+    /// section (gated on `metering_active`; 0 when unmetered).
+    pub kernel_cpu_ns: u64,
 }
 
 impl MatchWork {
@@ -302,6 +323,7 @@ impl MatchWork {
         Self {
             postings_bytes: term_cursor_bytes(cursors),
             planned_ranges: term_cursor_ranges(cursors),
+            kernel_cpu_ns: 0,
         }
     }
 
@@ -310,6 +332,7 @@ impl MatchWork {
         Self {
             postings_bytes: atom_cursor_bytes(atoms),
             planned_ranges: atom_planned_ranges(atoms),
+            kernel_cpu_ns: 0,
         }
     }
 
@@ -317,6 +340,7 @@ impl MatchWork {
     pub fn merge(&mut self, other: MatchWork) {
         self.postings_bytes += other.postings_bytes;
         self.planned_ranges += other.planned_ranges;
+        self.kernel_cpu_ns += other.kernel_cpu_ns;
     }
 }
 
@@ -391,21 +415,27 @@ impl PreparedClauses {
             PreparedClauses::Must {
                 must_cursors,
                 filter,
+                dict_ranges,
                 ..
-            } => term_cursor_ranges(must_cursors) + filter_ranges(filter),
+            } => term_cursor_ranges(must_cursors) + filter_ranges(filter) + dict_ranges,
             PreparedClauses::MustShould {
                 must_cursors,
                 should_cursors,
                 filter,
+                dict_ranges,
                 ..
             } => {
                 term_cursor_ranges(must_cursors)
                     + term_cursor_ranges(should_cursors)
                     + filter_ranges(filter)
+                    + dict_ranges
             }
             PreparedClauses::Or {
-                cursors, filter, ..
-            } => term_cursor_ranges(cursors) + filter_ranges(filter),
+                cursors,
+                filter,
+                dict_ranges,
+                ..
+            } => term_cursor_ranges(cursors) + filter_ranges(filter) + dict_ranges,
         }
     }
 }
@@ -1327,24 +1357,30 @@ impl FtsReader {
     ///
     /// Multi-token phrases require the column to be positional;
     /// otherwise [`FtsError::PositionsUnavailable`].
+    /// The second element counts the FST-dictionary ranges the builds
+    /// requested (one per `build_term_cursors` call plus one per inline
+    /// phrase member's position recovery) — real byte-source ranges on
+    /// every query, tallied by the caller into the planned count.
     async fn build_atom_cursors(
         &self,
         column_id: u32,
         terms: &[&str],
         phrases: &[Vec<String>],
         global_idf: Option<&GlobalTermIdf>,
-    ) -> Result<Vec<Option<AnyCursor>>, FtsError> {
+    ) -> Result<(Vec<Option<AnyCursor>>, u64), FtsError> {
         let col_meta = &self.columns[column_id as usize];
         if !phrases.is_empty() && !col_meta.positions {
             return Err(FtsError::PositionsUnavailable {
                 column: col_meta.name.clone(),
             });
         }
+        let mut dict_ranges = 0u64;
         let mut out: Vec<Option<AnyCursor>> = Vec::with_capacity(terms.len() + phrases.len());
         for term in terms {
             let mut cursors = self
                 .build_term_cursors(column_id, &[term], global_idf)
                 .await?;
+            dict_ranges += 1;
             out.push(cursors.pop().map(AnyCursor::Term));
         }
         for phrase in phrases {
@@ -1356,6 +1392,7 @@ impl FtsReader {
             let cursors = self
                 .build_term_cursors(column_id, &member_refs, global_idf)
                 .await?;
+            dict_ranges += 1;
             if cursors.len() != member_refs.len() {
                 // A member is absent — the phrase can never match.
                 out.push(None);
@@ -1376,6 +1413,7 @@ impl FtsReader {
                         positional.push((Some(term_meta), None));
                     }
                     true => {
+                        dict_ranges += 1;
                         let fst_bytes = self.dict_bytes_async().await?;
                         let dict = DictReader::open(&fst_bytes).map_err(|e| {
                             FtsError::Read(ReadError::MalformedVersion(format!(
@@ -1409,7 +1447,7 @@ impl FtsReader {
                 cursors, positions, positional,
             )?)));
         }
-        Ok(out)
+        Ok((out, dict_ranges))
     }
 
     /// Ranked search over heterogeneous atoms — the walk every
@@ -1644,20 +1682,25 @@ impl FtsReader {
     ) -> Result<(Vec<u32>, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         // Unranked: idf is irrelevant to the match set, so build local.
-        let built = self
+        let (built, dict_ranges) = self
             .build_atom_cursors(column_id, terms, phrases, None)
             .await?;
         let missing_and_atom = mode == BoolMode::And && built.iter().any(Option::is_none);
         let atoms: Vec<AnyCursor> = built.into_iter().flatten().collect();
         // The atoms that DID build cost their bytes even when a missing
         // AND atom empties the result — mirrors `prepare_clauses`.
-        let work = MatchWork::for_atoms(&atoms);
+        let mut work = MatchWork::for_atoms(&atoms);
+        work.planned_ranges += dict_ranges;
         if missing_and_atom || atoms.is_empty() {
             return Ok((Vec::new(), work));
         }
-        let mut out = Vec::new();
-        self.walk_atoms_match(atoms, mode, None, |d| out.push(d))?;
-        Ok((out, work))
+        let (walk, walk_ns) = timed_section(|| {
+            let mut out = Vec::new();
+            self.walk_atoms_match(atoms, mode, None, |d| out.push(d))
+                .map(|()| out)
+        });
+        work.kernel_cpu_ns = walk_ns;
+        Ok((walk?, work))
     }
 
     /// Phrase-aware unranked match **count** — the atoms sibling of
@@ -1671,18 +1714,23 @@ impl FtsReader {
     ) -> Result<(u64, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         // Unranked: idf is irrelevant to the match set, so build local.
-        let built = self
+        let (built, dict_ranges) = self
             .build_atom_cursors(column_id, terms, phrases, None)
             .await?;
         let missing_and_atom = mode == BoolMode::And && built.iter().any(Option::is_none);
         let atoms: Vec<AnyCursor> = built.into_iter().flatten().collect();
-        let work = MatchWork::for_atoms(&atoms);
+        let mut work = MatchWork::for_atoms(&atoms);
+        work.planned_ranges += dict_ranges;
         if missing_and_atom || atoms.is_empty() {
             return Ok((0, work));
         }
-        let mut n = 0u64;
-        self.walk_atoms_match(atoms, mode, None, |_| n += 1)?;
-        Ok((n, work))
+        let (walk, walk_ns) = timed_section(|| {
+            let mut n = 0u64;
+            self.walk_atoms_match(atoms, mode, None, |_| n += 1)
+                .map(|()| n)
+        });
+        work.kernel_cpu_ns = walk_ns;
+        Ok((walk?, work))
     }
 
     /// Resolve a column name to its dense column_id, or
@@ -1809,7 +1857,7 @@ impl FtsReader {
                     };
                     let mut pos_at = 0usize;
 
-                    let mut cursor = TermCursor::new(term_bytes, n_docs, positional, None)?;
+                    let mut cursor = TermCursor::new(term_bytes, n_docs, positional, None, false)?;
                     while !cursor.is_exhausted() {
                         while cursor.pos < cursor.block_n {
                             let doc_id = cursor.block_doc_ids[cursor.pos];
@@ -1957,6 +2005,51 @@ impl FtsReader {
         self.run_prepared(prep)
     }
 
+    /// [`Self::search`] that also returns the walk's work — posting
+    /// bytes, planned ranges, and the bracketed kernel on-CPU ns
+    /// (`prepare_clauses`' inline walks plus the `run_prepared`
+    /// section). Prefix search reports through this so an expansion to
+    /// thousands of terms carries its cost like any other query shape.
+    pub(crate) async fn search_with_work(
+        &self,
+        column: &str,
+        terms: &[&str],
+        k: usize,
+        mode: BoolMode,
+    ) -> Result<(Vec<(u32, f32)>, MatchWork, u64), FtsError> {
+        let (musts, shoulds): (&[&str], &[&str]) = match mode {
+            BoolMode::And => (terms, &[]),
+            BoolMode::Or => (&[], terms),
+        };
+        let prep = self
+            .prepare_clauses(
+                column,
+                ClauseLists {
+                    musts,
+                    shoulds,
+                    ..ClauseLists::default()
+                },
+                k,
+                f32::NEG_INFINITY,
+            )
+            .await?;
+        let work = MatchWork {
+            postings_bytes: prep.postings_bytes(),
+            planned_ranges: prep.planned_ranges(),
+            kernel_cpu_ns: 0,
+        };
+        let mut kernel_ns = prep.inline_kernel_cpu_ns();
+        let hits = match prep {
+            PreparedClauses::Done { hits, .. } => hits,
+            prep => {
+                let (hits, run_ns) = timed_section(|| self.run_prepared(prep));
+                kernel_ns += run_ns;
+                hits?
+            }
+        };
+        Ok((hits, work, kernel_ns))
+    }
+
     /// BM25 search over explicit clause lists, with negated terms
     /// excluded.
     ///
@@ -2019,7 +2112,7 @@ impl FtsReader {
 
         if lists.has_phrases() {
             // Phrase-bearing query: the heterogeneous atom walks.
-            let must_atoms = self
+            let (must_atoms, must_dict) = self
                 .build_atom_cursors(column_id, lists.musts, lists.must_phrases, lists.global_idf)
                 .await?;
             if must_atoms.iter().any(Option::is_none) {
@@ -2029,36 +2122,35 @@ impl FtsReader {
                 return Ok(PreparedClauses::Done {
                     hits: Vec::new(),
                     postings_bytes: atom_cursor_bytes(&built),
-                    planned_ranges: atom_planned_ranges(&built),
+                    planned_ranges: atom_planned_ranges(&built) + must_dict,
                     kernel_cpu_ns: 0,
                 });
             }
             let must_atoms: Vec<AnyCursor> = must_atoms.into_iter().flatten().collect();
-            let should_atoms: Vec<AnyCursor> = self
+            let (should_built, should_dict) = self
                 .build_atom_cursors(
                     column_id,
                     lists.shoulds,
                     lists.should_phrases,
                     lists.global_idf,
                 )
-                .await?
-                .into_iter()
-                .flatten()
-                .collect();
+                .await?;
+            let should_atoms: Vec<AnyCursor> = should_built.into_iter().flatten().collect();
             // Negatives are a hard exclusion filter, not scored, so their
             // idf is irrelevant — always build them local.
-            let negative_atoms: Vec<AnyCursor> = self
+            let (negative_built, negative_dict) = self
                 .build_atom_cursors(column_id, lists.negatives, lists.negative_phrases, None)
-                .await?
-                .into_iter()
-                .flatten()
-                .collect();
+                .await?;
+            let negative_atoms: Vec<AnyCursor> = negative_built.into_iter().flatten().collect();
             let postings_bytes = atom_cursor_bytes(&must_atoms)
                 + atom_cursor_bytes(&should_atoms)
                 + atom_cursor_bytes(&negative_atoms);
             let planned_ranges = atom_planned_ranges(&must_atoms)
                 + atom_planned_ranges(&should_atoms)
-                + atom_planned_ranges(&negative_atoms);
+                + atom_planned_ranges(&negative_atoms)
+                + must_dict
+                + should_dict
+                + negative_dict;
             let filter = match negative_atoms.is_empty() {
                 true => None,
                 false => Some(AtomExcludeFilter::new(negative_atoms)),
@@ -2087,6 +2179,10 @@ impl FtsReader {
                     .await?,
             )),
         };
+        // FST-dictionary ranges the builds below request — one per
+        // `build_term_cursors` call (the dictionary fetch is a real
+        // byte-source range on every query, warm or cold).
+        let mut dict_ranges = u64::from(neg_filter.is_some());
 
         // Single-atom fast path: BlockMaxWAND-driven block skipping.
         // One term scores identically whichever clause list it sits
@@ -2105,16 +2201,15 @@ impl FtsReader {
             let mut filter = neg_filter;
             let filter_postings_bytes = filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
             let filter_ranges = filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
-            let (result, term_postings_bytes, kernel_cpu_ns) = self
+            let (result, term_work, kernel_cpu_ns) = self
                 .search_single_term_bmw(column_id, term, k, filter.as_mut(), floor_eff)
                 .await?;
-            // The PFOR arm requested one posting range; the inline df=1 and
-            // absent-term arms requested none (bytes 0 implies ranges 0).
-            let term_ranges = u64::from(term_postings_bytes > 0);
+            // +1: the BMW walk's own dictionary fetch.
+            dict_ranges += 1;
             return Ok(PreparedClauses::Done {
                 hits: result,
-                postings_bytes: term_postings_bytes + filter_postings_bytes,
-                planned_ranges: term_ranges + filter_ranges,
+                postings_bytes: term_work.postings_bytes + filter_postings_bytes,
+                planned_ranges: term_work.planned_ranges + filter_ranges + dict_ranges,
                 kernel_cpu_ns,
             });
         }
@@ -2123,9 +2218,11 @@ impl FtsReader {
             let cursors = self
                 .build_term_cursors(column_id, lists.shoulds, lists.global_idf)
                 .await?;
+            dict_ranges += 1;
             if cursors.is_empty() {
                 let postings_bytes = neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
-                let planned_ranges = neg_filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
+                let planned_ranges =
+                    neg_filter.as_ref().map_or(0, ExcludeFilter::planned_ranges) + dict_ranges;
                 return Ok(PreparedClauses::Done {
                     hits: Vec::new(),
                     postings_bytes,
@@ -2139,6 +2236,7 @@ impl FtsReader {
                 filter: neg_filter,
                 k,
                 floor_eff,
+                dict_ranges,
             });
         }
         // Build must cursors; if any must is missing, the
@@ -2146,11 +2244,13 @@ impl FtsReader {
         let must_cursors = self
             .build_term_cursors(column_id, lists.musts, lists.global_idf)
             .await?;
+        dict_ranges += 1;
         if must_cursors.len() != lists.musts.len() {
             let postings_bytes = term_cursor_bytes(&must_cursors)
                 + neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
             let planned_ranges = term_cursor_ranges(&must_cursors)
-                + neg_filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
+                + neg_filter.as_ref().map_or(0, ExcludeFilter::planned_ranges)
+                + dict_ranges;
             return Ok(PreparedClauses::Done {
                 hits: Vec::new(),
                 postings_bytes,
@@ -2165,6 +2265,7 @@ impl FtsReader {
                 filter: neg_filter,
                 k,
                 floor_eff,
+                dict_ranges,
             });
         }
         // Shoulds absent from this superfile contribute nothing;
@@ -2172,6 +2273,7 @@ impl FtsReader {
         let should_cursors = self
             .build_term_cursors(column_id, lists.shoulds, lists.global_idf)
             .await?;
+        dict_ranges += 1;
         if should_cursors.is_empty() {
             return Ok(PreparedClauses::Must {
                 column_id,
@@ -2179,6 +2281,7 @@ impl FtsReader {
                 filter: neg_filter,
                 k,
                 floor_eff,
+                dict_ranges,
             });
         }
         Ok(PreparedClauses::MustShould {
@@ -2188,6 +2291,7 @@ impl FtsReader {
             filter: neg_filter,
             k,
             floor_eff,
+            dict_ranges,
         })
     }
 
@@ -2200,6 +2304,7 @@ impl FtsReader {
                 column_id,
                 must_cursors,
                 mut filter,
+                dict_ranges: _,
                 k,
                 floor_eff,
             } => self.run_and_intersect(column_id, must_cursors, k, filter.as_mut(), floor_eff),
@@ -2210,6 +2315,7 @@ impl FtsReader {
                 mut filter,
                 k,
                 floor_eff,
+                dict_ranges: _,
             } => self.run_must_should(
                 column_id,
                 must_cursors,
@@ -2224,6 +2330,7 @@ impl FtsReader {
                 mut filter,
                 k,
                 floor_eff,
+                dict_ranges: _,
             } => self.dispatch_or_algo(column_id, cursors, k, filter.as_mut(), floor_eff),
         }
     }
@@ -2253,19 +2360,22 @@ impl FtsReader {
         let cursors = self.build_term_cursors(column_id, tokens, None).await?;
         // Tallied before the mode branch: the cursors that DID build cost
         // their bytes even when a missing AND token empties the result.
-        let work = MatchWork::for_cursors(&cursors);
-        let docs = match mode {
+        // +1: the build's dictionary fetch.
+        let mut work = MatchWork::for_cursors(&cursors);
+        work.planned_ranges += 1;
+        let (docs, walk_ns) = timed_section(|| match mode {
             BoolMode::And => {
                 // AND needs every token present; a missing token ⇒ empty
                 // set. Otherwise intersect via the same optimized
                 // block flat-merge the ranked scorer uses.
                 if cursors.len() != tokens.len() {
-                    return Ok((Vec::new(), work));
+                    return Vec::new();
                 }
                 self.collect_and_intersect(column_id, cursors)
             }
             BoolMode::Or => or_merge_unranked(cursors),
-        };
+        });
+        work.kernel_cpu_ns = walk_ns;
         Ok((docs, work))
     }
 
@@ -2286,16 +2396,18 @@ impl FtsReader {
             return Ok((0, MatchWork::default()));
         }
         let cursors = self.build_term_cursors(column_id, tokens, None).await?;
-        let work = MatchWork::for_cursors(&cursors);
-        let n = match mode {
+        let mut work = MatchWork::for_cursors(&cursors);
+        work.planned_ranges += 1;
+        let (n, walk_ns) = timed_section(|| match mode {
             BoolMode::And => {
                 if cursors.len() != tokens.len() {
-                    return Ok((0, work));
+                    return 0;
                 }
                 self.count_and_intersect(column_id, cursors)
             }
             BoolMode::Or => or_count_unranked(cursors),
-        };
+        });
+        work.kernel_cpu_ns = walk_ns;
         Ok((n, work))
     }
 
@@ -2356,10 +2468,15 @@ impl FtsReader {
         // One coalesced fetch for every PFOR header; `df` is its first 4
         // bytes. Each header is one planned range (pre-coalesce), and its
         // bytes count as indexed work — the walk read them.
-        let mut work = MatchWork::default();
+        // +1: the dictionary fetch that resolved the slots.
+        let mut work = MatchWork {
+            postings_bytes: 0,
+            planned_ranges: 1,
+            kernel_cpu_ns: 0,
+        };
         if !header_ranges.is_empty() {
             let fetched = self.fetch_term_postings(&header_ranges).await?;
-            work.planned_ranges = header_ranges.len() as u64;
+            work.planned_ranges += header_ranges.len() as u64;
             for (fetched_idx, &slot) in pfor_slots.iter().enumerate() {
                 let header = fetched.get(fetched_idx).ok_or_else(|| {
                     FtsError::Read(ReadError::MalformedVersion(
@@ -2561,11 +2678,12 @@ impl FtsReader {
     /// posting lists with high score variance — e.g. very long lists
     /// where most blocks contain mid-relevance docs and the top-k is
     /// dominated by a few outliers.
-    /// Returns `(hits, postings bytes indexed, on-CPU ns of the scoring
-    /// walk)` — the walk runs inside `prepare_clauses`, so its kernel
+    /// Returns `(hits, posting work, on-CPU ns of the scoring walk)` —
+    /// the walk runs inside `prepare_clauses`, so its work and kernel
     /// time must travel with the result (single-term is the most common
     /// query shape; leaving it unbracketed would make `kernel_cpu_ns`
-    /// incomparable across clause shapes).
+    /// incomparable across clause shapes). The work excludes the
+    /// dictionary fetch — the caller counts it once per build.
     async fn search_single_term_bmw(
         &self,
         column_id: u32,
@@ -2573,7 +2691,7 @@ impl FtsReader {
         k: usize,
         mut filter: Option<&mut ExcludeFilter>,
         floor_eff: f32,
-    ) -> Result<(Vec<(u32, f32)>, u64, u64), FtsError> {
+    ) -> Result<(Vec<(u32, f32)>, MatchWork, u64), FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
         let dict = DictReader::open(&fst_bytes).map_err(|e| {
             FtsError::Read(ReadError::MalformedVersion(format!(
@@ -2583,7 +2701,7 @@ impl FtsReader {
         let col_meta = &self.columns[column_id as usize];
         let key = make_key(&col_meta.name, term);
         let Some(packed) = dict.lookup(&key) else {
-            return Ok((Vec::new(), 0, 0));
+            return Ok((Vec::new(), MatchWork::default(), 0));
         };
         let (metadata_offset, postings_length) = match FstValue::unpack(packed) {
             FstValue::Inline { doc_id, tf } => {
@@ -2607,14 +2725,14 @@ impl FtsReader {
                 if let Some(f) = filter.as_deref_mut()
                     && !f.admits(doc_id)
                 {
-                    return Ok((Vec::new(), 0, 0));
+                    return Ok((Vec::new(), MatchWork::default(), 0));
                 }
                 let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
                 let score = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
                 if score <= floor_eff {
-                    return Ok((Vec::new(), 0, 0));
+                    return Ok((Vec::new(), MatchWork::default(), 0));
                 }
-                return Ok((vec![(doc_id, score)], 0, 0));
+                return Ok((vec![(doc_id, score)], MatchWork::default(), 0));
             }
             FstValue::Pfor {
                 metadata_offset,
@@ -2710,7 +2828,14 @@ impl FtsReader {
 
         Ok((
             drain_top_k_desc(heap),
-            term_bytes.len() as u64,
+            MatchWork {
+                postings_bytes: term_bytes.len() as u64,
+                // A hint-less slot costs a header probe before the body
+                // fetch — two planned ranges instead of one.
+                planned_ranges: 1 + u64::from(postings_length.is_none()),
+                // The walk's ns travel in the tuple's third element.
+                kernel_cpu_ns: 0,
+            },
             thread_cpu_delta_ns(kernel_start),
         ))
     }
@@ -2749,6 +2874,7 @@ impl FtsReader {
             },
             Pfor {
                 gidf: Option<f32>,
+                header_probed: bool,
             },
         }
         let mut resolved: Vec<Resolved> = Vec::with_capacity(terms.len());
@@ -2771,7 +2897,13 @@ impl FtsReader {
                         metadata_offset as usize,
                         postings_length_hint.map(|len| len as usize),
                     ));
-                    resolved.push(Resolved::Pfor { gidf });
+                    // A hint-less slot (21-bit length overflow) costs a
+                    // header probe BEFORE the body fetch — two planned
+                    // ranges, recorded on the cursor for the tallies.
+                    resolved.push(Resolved::Pfor {
+                        gidf,
+                        header_probed: postings_length_hint.is_none(),
+                    });
                 }
             }
         }
@@ -2802,13 +2934,17 @@ impl FtsReader {
                         gidf,
                     ));
                 }
-                Resolved::Pfor { gidf } => {
+                Resolved::Pfor {
+                    gidf,
+                    header_probed,
+                } => {
                     let term_bytes = pfor_iter.next().expect("one fetched range per PFOR term");
                     cursors.push(TermCursor::new(
                         term_bytes,
                         self.n_docs as u64,
                         col_meta.positions,
                         gidf,
+                        header_probed,
                     )?);
                 }
             }
@@ -5470,6 +5606,10 @@ pub(crate) struct TermCursor {
     /// plain term queries never pay for them in cursor or block-meta
     /// footprint.
     bytes: Bytes,
+    /// True when this term's FST slot carried no postings-length hint,
+    /// so the build probed the 20-byte header before fetching the body
+    /// — two planned byte-source ranges instead of one.
+    header_probed: bool,
 }
 
 impl TermCursor {
@@ -5483,6 +5623,7 @@ impl TermCursor {
         n_docs: u64,
         positional: bool,
         global_idf: Option<f32>,
+        header_probed: bool,
     ) -> Result<Self, FtsError> {
         let postings: &[u8] = term_bytes.as_ref();
         let metadata_offset = 0usize;
@@ -5542,6 +5683,7 @@ impl TermCursor {
             pos: 0,
             inspect_block: 0,
             bytes: term_bytes,
+            header_probed,
         };
         if !cursor.blocks.is_empty() {
             cursor.decode_current_block();
@@ -5594,6 +5736,7 @@ impl TermCursor {
             pos: 0,
             inspect_block: 0,
             bytes: Bytes::new(),
+            header_probed: false,
         }
     }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -25,31 +25,35 @@ use std::{
 use bytes::Bytes;
 use serde::Deserialize;
 
-use crate::runtime_metrics::cpu::{thread_cpu_delta_ns, thread_cpu_ns};
-use crate::runtime_metrics::op_stats::{metering_active, timed_section};
-use crate::superfile::{
-    ReadError,
-    error::FtsError,
-    format::{
-        self, FST_SEPARATOR,
-        checksum::crc32c,
+use crate::{
+    runtime_metrics::{
+        cpu::{thread_cpu_delta_ns, thread_cpu_ns},
+        op_stats::{metering_active, timed_section},
+    },
+    superfile::{
+        ReadError,
+        error::FtsError,
+        format::{
+            self, FST_SEPARATOR,
+            checksum::crc32c,
+            fts::{
+                HEADER_SIZE_V1_LEGACY as FTS_HEADER_SIZE, MAGIC_BYTES, U32_BYTES, U64_BYTES, hdr,
+                skip_entry, term_meta,
+            },
+        },
         fts::{
-            HEADER_SIZE_V1_LEGACY as FTS_HEADER_SIZE, MAGIC_BYTES, U32_BYTES, U64_BYTES, hdr,
-            skip_entry, term_meta,
+            bm25,
+            builder::{
+                DOC_LENGTHS_ENTRY_SIZE, SKIP_ENTRY_SIZE, TERM_META_POSITIONAL_SIZE, TERM_META_SIZE,
+            },
+            dict::{DictReader, make_key},
+            fst_value::FstValue,
+            positions::{decode_run, skip_run},
+            posting::{BLOCK_LEN, decode_block},
+            tokenize::{Tokenizer, tokenizer_for_name},
         },
+        lazy_source::{LazyByteSource, PrefetchedSource, RangeCoalescePlan, Source},
     },
-    fts::{
-        bm25,
-        builder::{
-            DOC_LENGTHS_ENTRY_SIZE, SKIP_ENTRY_SIZE, TERM_META_POSITIONAL_SIZE, TERM_META_SIZE,
-        },
-        dict::{DictReader, make_key},
-        fst_value::FstValue,
-        positions::{decode_run, skip_run},
-        posting::{BLOCK_LEN, decode_block},
-        tokenize::{Tokenizer, tokenizer_for_name},
-    },
-    lazy_source::{LazyByteSource, PrefetchedSource, RangeCoalescePlan, Source},
 };
 
 /// Largest gap worth overfetching when adjacent term postings share a request.

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -26,6 +26,7 @@ use bytes::Bytes;
 use serde::Deserialize;
 
 use crate::runtime_metrics::cpu::{thread_cpu_delta_ns, thread_cpu_ns};
+use crate::runtime_metrics::op_stats::metering_active;
 use crate::superfile::{
     ReadError,
     error::FtsError,
@@ -2027,7 +2028,8 @@ impl FtsReader {
             // The atom walk is the whole kernel for phrase shapes —
             // `run_prepared` sees only the finished `Done` — so bracket
             // its on-CPU time here (sync section, no awaits inside).
-            let kernel_start = thread_cpu_ns();
+            // Gated: an unmetered process must not pay the procfs reads.
+            let kernel_start = metering_active().then(thread_cpu_ns).flatten();
             let result =
                 self.run_atoms_search(column_id, must_atoms, should_atoms, k, filter, floor_eff)?;
             return Ok(PreparedClauses::Done {
@@ -2583,7 +2585,9 @@ impl FtsReader {
 
         // Everything below is the synchronous scoring walk (no awaits):
         // bracket it on this thread for the per-query kernel CPU stat.
-        let kernel_start = thread_cpu_ns();
+        // Gated: an unmetered process must not pay the procfs reads on
+        // the most common query shape.
+        let kernel_start = metering_active().then(thread_cpu_ns).flatten();
         let term_meta = TermMeta::parse(postings, metadata_offset, col_meta.positions)?;
 
         let idf_t = bm25::idf(self.n_docs as u64, term_meta.df);

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1423,8 +1423,10 @@ impl SuperfileReader {
         k: usize,
         options: VectorSearchOptions,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        self.vector_hits_filtered_async(column, query, k, options, None, None, None, None)
-            .await
+        Ok(self
+            .vector_hits_filtered_async(column, query, k, options, None, None, None, None)
+            .await?
+            .0)
     }
 
     /// As [`Self::vector_hits_async`], but restricts the kNN ranking to
@@ -1433,6 +1435,8 @@ impl SuperfileReader {
     /// shortlist, so the returned top-k is the true k-nearest among
     /// matching rows — pushdown, not post-filter, with no underflow.
     /// `allow == None` is identical to [`Self::vector_hits_async`].
+    /// Returns the hits plus the rows the probe reranked at full
+    /// precision, for the per-query work stats.
     pub async fn vector_hits_filtered_async(
         &self,
         column: &str,
@@ -1443,7 +1447,7 @@ impl SuperfileReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<Vec<(u32, f32)>, ReadError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), ReadError> {
         let filtered = allow.is_some();
         let (nprobe, rerank_mult) = options.resolve(filtered);
         let v = self
@@ -1477,16 +1481,20 @@ impl SuperfileReader {
         clusters: &[u32],
         options: VectorSearchOptions,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        self.vector_search_clusters_filtered(
-            column, query, k, clusters, options, None, None, None, None,
-        )
-        .await
+        Ok(self
+            .vector_search_clusters_filtered(
+                column, query, k, clusters, options, None, None, None, None,
+            )
+            .await?
+            .0)
     }
 
     /// As [`Self::vector_search_clusters`], but restricts the kNN
     /// ranking to the `local_doc_id`s in `allow` (a per-superfile
     /// predicate allow-set), applied inside the coarse shortlist.
     /// `allow == None` is identical to [`Self::vector_search_clusters`].
+    /// Returns the hits plus the rows the probe reranked at full
+    /// precision, for the per-query work stats.
     pub async fn vector_search_clusters_filtered(
         &self,
         column: &str,
@@ -1498,7 +1506,7 @@ impl SuperfileReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<Vec<(u32, f32)>, ReadError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), ReadError> {
         let filtered = allow.is_some();
         let (_, rerank_mult) = options.resolve(filtered);
         let v = self

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1224,22 +1224,25 @@ impl SuperfileReader {
     ///
     /// Returns an empty `Vec` if no indexed term begins with
     /// `prefix` or if `k == 0`.
+    /// Returns the hits plus the expansion's posting work and the
+    /// bracketed kernel on-CPU ns, so a prefix expanding to thousands
+    /// of terms carries its cost like any other query shape.
     pub async fn bm25_search_prefix(
         &self,
         column: &str,
         prefix: &str,
         k: usize,
-    ) -> Result<Vec<(u32, f32)>, ReadError> {
+    ) -> Result<(Vec<(u32, f32)>, MatchWork, u64), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
         if k == 0 {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), MatchWork::default(), 0));
         }
         let lowered = prefix.to_ascii_lowercase();
         let term_bytes = fts.iter_terms_with_prefix(column, lowered.as_bytes())?;
         if term_bytes.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), MatchWork::default(), 0));
         }
         // FST keys are valid UTF-8 by construction (AsciiLower
         // tokenizer only emits ASCII bytes); the from_utf8 below
@@ -1248,7 +1251,9 @@ impl SuperfileReader {
             .iter()
             .filter_map(|b| str::from_utf8(b).ok())
             .collect();
-        Ok(fts.search(column, &term_strings, k, BoolMode::Or).await?)
+        Ok(fts
+            .search_with_work(column, &term_strings, k, BoolMode::Or)
+            .await?)
     }
 
     /// Multi-term OR BM25 search restricted to a doc_id sub-range.
@@ -1578,7 +1583,8 @@ impl SuperfileReader {
     }
 
     /// Rerank this superfile's share of the globally selected shortlist —
-    /// phase C of the deferred-rerank width sweep.
+    /// phase C of the deferred-rerank width sweep. Returns the hits plus
+    /// the rerank kernel's bracketed on-CPU ns.
     pub(crate) async fn vector_rerank_selected(
         &self,
         column: &str,
@@ -1586,7 +1592,7 @@ impl SuperfileReader {
         k: usize,
         selected: Vec<ScanCandidate>,
         pool: Option<Arc<ThreadPool>>,
-    ) -> Result<Vec<(u32, f32)>, ReadError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), ReadError> {
         let v = self
             .vec()
             .ok_or_else(|| ReadError::MissingKv(kv::VEC_OFFSET))?;
@@ -2344,10 +2350,14 @@ mod tests {
         let bytes = build_simple_fts_only_superfile();
         let r = SuperfileReader::open(bytes).expect("open");
         // "rust" is a prefix of "rust" (docs 0,2); "ru" expands to it too.
-        let hits = r
+        let (hits, work, _kernel_ns) = r
             .bm25_search_prefix("title", "ru", 5)
             .await
             .expect("prefix search");
+        assert!(
+            work.postings_bytes > 0 && work.planned_ranges > 0,
+            "a matching prefix expansion reports its posting work"
+        );
         let ids: HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
         assert!(ids.contains(&0));
         assert!(ids.contains(&2));
@@ -2356,6 +2366,7 @@ mod tests {
             r.bm25_search_prefix("title", "zz", 5)
                 .await
                 .expect("prefix")
+                .0
                 .is_empty()
         );
         // k == 0 short-circuits.
@@ -2363,6 +2374,7 @@ mod tests {
             r.bm25_search_prefix("title", "ru", 0)
                 .await
                 .expect("zero k")
+                .0
                 .is_empty()
         );
     }

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -59,7 +59,7 @@ use crate::{
         },
         vector::{
             layout::VectorLayout,
-            reader::{self as vector_reader, ScanCandidate, ScanOutcome, VectorReader},
+            reader::{self as vector_reader, ProbeTally, ScanCandidate, ScanOutcome, VectorReader},
         },
     },
     supertable::query::provider::tombstone_access_plan,
@@ -1435,8 +1435,8 @@ impl SuperfileReader {
     /// shortlist, so the returned top-k is the true k-nearest among
     /// matching rows — pushdown, not post-filter, with no underflow.
     /// `allow == None` is identical to [`Self::vector_hits_async`].
-    /// Returns the hits plus the rows the probe reranked at full
-    /// precision, for the per-query work stats.
+    /// Returns the hits plus the probe's work tallies for the per-query
+    /// work stats.
     pub async fn vector_hits_filtered_async(
         &self,
         column: &str,
@@ -1447,7 +1447,7 @@ impl SuperfileReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<(Vec<(u32, f32)>, u64), ReadError> {
+    ) -> Result<(Vec<(u32, f32)>, ProbeTally), ReadError> {
         let filtered = allow.is_some();
         let (nprobe, rerank_mult) = options.resolve(filtered);
         let v = self
@@ -1493,8 +1493,8 @@ impl SuperfileReader {
     /// ranking to the `local_doc_id`s in `allow` (a per-superfile
     /// predicate allow-set), applied inside the coarse shortlist.
     /// `allow == None` is identical to [`Self::vector_search_clusters`].
-    /// Returns the hits plus the rows the probe reranked at full
-    /// precision, for the per-query work stats.
+    /// Returns the hits plus the probe's work tallies for the per-query
+    /// work stats.
     pub async fn vector_search_clusters_filtered(
         &self,
         column: &str,
@@ -1506,7 +1506,7 @@ impl SuperfileReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<(Vec<(u32, f32)>, u64), ReadError> {
+    ) -> Result<(Vec<(u32, f32)>, ProbeTally), ReadError> {
         let filtered = allow.is_some();
         let (_, rerank_mult) = options.resolve(filtered);
         let v = self

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1224,25 +1224,25 @@ impl SuperfileReader {
     ///
     /// Returns an empty `Vec` if no indexed term begins with
     /// `prefix` or if `k == 0`.
-    /// Returns the hits plus the expansion's posting work and the
-    /// bracketed kernel on-CPU ns, so a prefix expanding to thousands
-    /// of terms carries its cost like any other query shape.
+    /// Returns the hits plus the expansion's posting + kernel work, so
+    /// a prefix expanding to thousands of terms carries its cost like
+    /// any other query shape.
     pub async fn bm25_search_prefix(
         &self,
         column: &str,
         prefix: &str,
         k: usize,
-    ) -> Result<(Vec<(u32, f32)>, MatchWork, u64), ReadError> {
+    ) -> Result<(Vec<(u32, f32)>, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
         if k == 0 {
-            return Ok((Vec::new(), MatchWork::default(), 0));
+            return Ok((Vec::new(), MatchWork::default()));
         }
         let lowered = prefix.to_ascii_lowercase();
         let term_bytes = fts.iter_terms_with_prefix(column, lowered.as_bytes())?;
         if term_bytes.is_empty() {
-            return Ok((Vec::new(), MatchWork::default(), 0));
+            return Ok((Vec::new(), MatchWork::default()));
         }
         // FST keys are valid UTF-8 by construction (AsciiLower
         // tokenizer only emits ASCII bytes); the from_utf8 below
@@ -2350,7 +2350,7 @@ mod tests {
         let bytes = build_simple_fts_only_superfile();
         let r = SuperfileReader::open(bytes).expect("open");
         // "rust" is a prefix of "rust" (docs 0,2); "ru" expands to it too.
-        let (hits, work, _kernel_ns) = r
+        let (hits, work) = r
             .bm25_search_prefix("title", "ru", 5)
             .await
             .expect("prefix search");

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -476,12 +476,21 @@ impl SuperfileReader {
         &self.parquet_meta
     }
 
-    /// Parquet metadata with offset indexes loaded when available.
+    /// Parquet metadata with the page indexes (column + offset) loaded
+    /// when available.
     ///
-    /// Eager readers return their open-time metadata. Lazy readers fetch only
-    /// the page-index metadata range through their existing byte source; a
-    /// [`OnceCell`] coalesces concurrent first callers and keeps all later
-    /// targeted row reads local.
+    /// Eager readers return their open-time metadata. Lazy readers fetch
+    /// only the page-index metadata range through their existing byte
+    /// source; a [`OnceCell`] coalesces concurrent first callers and keeps
+    /// all later targeted row reads local.
+    ///
+    /// Both indexes load together even though the take path needs only the
+    /// offset index: the SQL scan serves this same parse to DataFusion's
+    /// parquet opener, whose page pruning short-circuits only when the
+    /// column index is present too. An index-complete parse here means the
+    /// opener never fetches index bytes through the metered DataFusion
+    /// store — which would make `sql_page_bytes` depend on how the reader
+    /// happened to be opened (see `SuperfileObjectStore`).
     pub(crate) async fn parquet_metadata_with_page_index(
         &self,
     ) -> Result<Arc<ParquetMetaData>, ReadError> {
@@ -498,7 +507,7 @@ impl SuperfileReader {
                 let mut fetch = LazyMetadataFetch { source };
                 let mut loader =
                     ParquetMetaDataReader::new_with_metadata((*self.parquet_meta).clone())
-                        .with_column_index_policy(PageIndexPolicy::Skip)
+                        .with_column_index_policy(PageIndexPolicy::Optional)
                         .with_offset_index_policy(PageIndexPolicy::Optional);
                 loader
                     .load_page_index(&mut fetch)

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -53,7 +53,8 @@ use crate::{
         format::{self, footer, kv},
         fts::{
             reader::{
-                self as fts_reader, BoolMode, ClauseLists, FtsReader, OrCursorSet, PreparedClauses,
+                self as fts_reader, BoolMode, ClauseLists, FtsReader, MatchWork, OrCursorSet,
+                PreparedClauses,
             },
             tokenize::{AsciiLowerTokenizer, Tokenizer},
         },
@@ -1019,7 +1020,7 @@ impl SuperfileReader {
         column: &str,
         tokens: &[&str],
         mode: BoolMode,
-    ) -> Result<Vec<u32>, ReadError> {
+    ) -> Result<(Vec<u32>, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
@@ -1035,7 +1036,7 @@ impl SuperfileReader {
         column: &str,
         tokens: &[&str],
         mode: BoolMode,
-    ) -> Result<u64, ReadError> {
+    ) -> Result<(u64, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
@@ -1053,7 +1054,7 @@ impl SuperfileReader {
         terms: &[&str],
         phrases: &[Vec<String>],
         mode: BoolMode,
-    ) -> Result<Vec<u32>, ReadError> {
+    ) -> Result<(Vec<u32>, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
@@ -1068,7 +1069,7 @@ impl SuperfileReader {
         terms: &[&str],
         phrases: &[Vec<String>],
         mode: BoolMode,
-    ) -> Result<u64, ReadError> {
+    ) -> Result<(u64, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
@@ -1079,7 +1080,7 @@ impl SuperfileReader {
     /// header-only read used to estimate a predicate's match count
     /// before running `token_match`. Delegates to
     /// [`FtsReader::term_df`].
-    pub async fn term_df(&self, column: &str, token: &str) -> Result<u64, ReadError> {
+    pub async fn term_df(&self, column: &str, token: &str) -> Result<(u64, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
@@ -1090,7 +1091,11 @@ impl SuperfileReader {
     /// (0 for any absent token). Batched sibling of [`Self::term_df`]:
     /// resolves the whole set with one FST parse and one coalesced header
     /// fetch. Delegates to [`FtsReader::term_dfs`].
-    pub async fn term_dfs(&self, column: &str, tokens: &[&str]) -> Result<Vec<u64>, ReadError> {
+    pub async fn term_dfs(
+        &self,
+        column: &str,
+        tokens: &[&str],
+    ) -> Result<(Vec<u64>, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
@@ -1112,7 +1117,12 @@ impl SuperfileReader {
     /// Returns the verified `local_doc_id`s in ascending order. Works
     /// for single-word and multi-word strings alike — the token count
     /// only affects pruning, never the raw-string comparison.
-    pub async fn exact_match(&self, column: &str, value: &str) -> Result<Vec<u32>, ReadError> {
+    /// Returns the verified ids plus the prune pass's posting-walk work.
+    pub async fn exact_match(
+        &self,
+        column: &str,
+        value: &str,
+    ) -> Result<(Vec<u32>, MatchWork), ReadError> {
         // Pass 1 — candidate rows via the index: the term-AND of the
         // string's tokens (a superset of the exact matches). Tokenize
         // with the column's configured tokenizer to match the index.
@@ -1122,15 +1132,15 @@ impl SuperfileReader {
             .and_then(|f| f.column_tokenizer(column).ok())
             .unwrap_or_else(|| Arc::new(AsciiLowerTokenizer));
         let tokens: Vec<String> = tok.tokenize(value).collect();
-        let candidates: Vec<u32> = if tokens.is_empty() {
+        let (candidates, work): (Vec<u32>, MatchWork) = if tokens.is_empty() {
             // No tokens to prune with: every row is a candidate.
-            (0..self.n_docs() as u32).collect()
+            ((0..self.n_docs() as u32).collect(), MatchWork::default())
         } else {
             let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
             self.token_match(column, &refs, BoolMode::And).await?
         };
         if candidates.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), work));
         }
 
         // Pass 2 — verify raw-string equality on the decoded text.
@@ -1153,7 +1163,7 @@ impl SuperfileReader {
                 out.push(doc);
             }
         }
-        Ok(out)
+        Ok((out, work))
     }
 
     /// Pre-tokenized BM25 search over explicit clause lists — the
@@ -2293,12 +2303,14 @@ mod tests {
         let and = r
             .token_match("title", &["rust", "runtime"], BoolMode::And)
             .await
-            .expect("and");
+            .expect("and")
+            .0;
         assert_eq!(and, vec![0]);
         let or = r
             .token_match("title", &["rust", "runtime"], BoolMode::Or)
             .await
-            .expect("or");
+            .expect("or")
+            .0;
         assert_eq!(or, vec![0, 2]);
     }
 
@@ -2306,8 +2318,8 @@ mod tests {
     async fn term_df_counts_documents() {
         let bytes = build_simple_fts_only_superfile();
         let r = SuperfileReader::open(bytes).expect("open");
-        assert_eq!(r.term_df("title", "rust").await.expect("df"), 2);
-        assert_eq!(r.term_df("title", "absent").await.expect("df"), 0);
+        assert_eq!(r.term_df("title", "rust").await.expect("df").0, 2);
+        assert_eq!(r.term_df("title", "absent").await.expect("df").0, 0);
     }
 
     #[tokio::test]
@@ -2319,10 +2331,11 @@ mod tests {
         let hits = r
             .exact_match("title", "rust async runtime")
             .await
-            .expect("exact_match");
+            .expect("exact_match")
+            .0;
         assert_eq!(hits, vec![0]);
         // No row stores just "rust", so the exact comparison yields none.
-        let none = r.exact_match("title", "rust").await.expect("exact_match");
+        let none = r.exact_match("title", "rust").await.expect("exact_match").0;
         assert!(none.is_empty());
     }
 
@@ -2658,7 +2671,8 @@ mod tests {
         let hits = r
             .exact_match("title", "rust javascript")
             .await
-            .expect("exact_match");
+            .expect("exact_match")
+            .0;
         assert!(hits.is_empty());
     }
 

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -4672,7 +4672,7 @@ mod tests {
             format!(r#"[{{"column":"emb","dim":{dim},"n_cent":2,"rot_seed":1,"metric":"l2sq"}}]"#);
         let reader = VectorReader::open(Bytes::from(blob), &json).expect("open");
         let q = vec![0.0f32; dim];
-        let hits = reader
+        let (hits, _) = reader
             .search_clusters_async("emb", &q, 3, &[0, 1, 2, 3], 8, None, None, None, None)
             .await
             .expect("search");
@@ -4749,7 +4749,7 @@ mod tests {
         allow.insert(5);
         allow.insert(6);
         let q = vec![0.0f32; dim];
-        let hits = reader
+        let (hits, _) = reader
             .search_clusters_async(
                 "emb",
                 &q,

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3392,6 +3392,7 @@ impl VectorReader {
             tally.candidates_scanned += cell_tally.candidates_scanned;
             tally.ranges_requested += cell_tally.ranges_requested;
             tally.rows_reranked += cell_tally.rows_reranked;
+            tally.kernel_cpu_ns += cell_tally.kernel_cpu_ns;
         }
         let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flat_map(|(hits, _)| hits).collect();
         // Distance ascending (smaller = closer), matching every other vector
@@ -5231,7 +5232,7 @@ async fn rerank_candidates_from_blocks(
                         let parsed = Arc::clone(
                             col.lazy_sq8_parsed
                                 .get()
-                                .expect("lazy Sq8 meta set just above"),
+                                .expect("invariant: lazy Sq8 meta set just above"),
                         );
                         let (scored, ns) = score_sq8_residual_candidates(
                             candidates,
@@ -5345,7 +5346,7 @@ async fn rerank_candidates_from_blocks(
                                 );
                                 let kernel = kernels
                                     .get(&cand.cluster_id)
-                                    .expect("kernel built for every candidate cluster");
+                                    .expect("invariant: kernel built for every candidate cluster");
                                 let norm = norm_by_pos
                                     .as_ref()
                                     .and_then(|norms| norms.get(&cand.pos).copied());
@@ -5421,7 +5422,7 @@ async fn score_sq8_residual_candidates(
         let row = candidate_full_bytes(cluster_blocks, survivor_full_rows, cand, stride);
         let kernel = kernels
             .get(&cand.cluster_id)
-            .expect("kernel prebuilt for every probed cluster");
+            .expect("invariant: kernel prebuilt for every probed cluster");
         let norm = per_doc_norms.as_ref().map(|norms| norms[cand.pos as usize]);
         (
             cand.did,
@@ -5447,7 +5448,7 @@ async fn score_sq8_residual_candidates(
                 let code = &row[..dim];
                 let kernel = kernels
                     .get(&cand.cluster_id)
-                    .expect("kernel prebuilt for every probed cluster");
+                    .expect("invariant: kernel prebuilt for every probed cluster");
                 let norm = norms.as_ref().map(|norms| norms[cand.pos as usize]);
                 (
                     cand.did,

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -33,6 +33,10 @@ pub(crate) use crate::superfile::lazy_source::Source;
 use crate::{
     memory::{ConnectionMemoryBudget, Reservation},
     runtime_bridge::{run_on_pool, spawn_on},
+    runtime_metrics::{
+        cpu::{thread_cpu_delta_ns, thread_cpu_ns},
+        op_stats::{metering_active, timed_section},
+    },
     storage::io_counters,
     superfile::{
         BuildError, ReadError,
@@ -3025,7 +3029,8 @@ impl VectorReader {
             // through the async paths); its cold fetch is not budget-gated.
             budget: None,
         };
-        let (candidates, survivor_full_ranges) = match build_shortlist(
+        // Superfile-tier direct API: no collector at this layer, ns dropped.
+        let (outcome, _scan_kernel_ns) = build_shortlist(
             col,
             cb,
             &cluster_meta,
@@ -3033,8 +3038,8 @@ impl VectorReader {
             survivor_only_rerank_fetch,
             &ctx,
         )
-        .await?
-        {
+        .await?;
+        let (candidates, survivor_full_ranges) = match outcome {
             ShortlistOutcome::Done(out) => return Ok(out),
             ShortlistOutcome::Rerank {
                 candidates,
@@ -3058,7 +3063,9 @@ impl VectorReader {
         //    scale/offset into the query (one `dim/8` SIMD pass);
         //    the per-doc inner step is then a plain u8→f32 widen
         //    + SIMD dot. Fp32 takes the flat dispatch.
-        rerank_candidates_from_blocks(
+        // Superfile-tier direct API: no collector reaches this layer, so
+        // the bracketed ns are dropped (the supertable paths carry them).
+        Ok(rerank_candidates_from_blocks(
             &self.source,
             lazy_sq8_meta_bytes.as_ref(),
             &cluster_blocks,
@@ -3069,7 +3076,8 @@ impl VectorReader {
             None,
             k,
         )
-        .await
+        .await?
+        .0)
     }
 
     /// Async sibling of [`Self::search`]. Byte-for-byte the same IVF
@@ -3434,6 +3442,7 @@ impl VectorReader {
             candidates_scanned: 0,
             ranges_requested: 0,
             rows_reranked: 0,
+            kernel_cpu_ns: 0,
         };
         if k == 0 || self.n_docs == 0 {
             return Ok(outcome);
@@ -3535,6 +3544,7 @@ impl VectorReader {
                         .sum(),
                     ranges_requested: 1 + prefix_ranges.len() as u64,
                     rows_reranked: 0,
+                    kernel_cpu_ns: 0,
                 };
                 // Warm fast path: every prefix resident -> defer rerank.
                 let prefix_blocks: Option<Vec<Bytes>> = prefix_ranges
@@ -3553,9 +3563,10 @@ impl VectorReader {
                         budget,
                     };
                     let coarse_limit = k.saturating_mul(rerank_mult);
-                    let shortlist =
+                    let (shortlist, scan_kernel_ns) =
                         scan_shortlist(col, cb, &cluster_meta, &blocks, true, coarse_limit, &ctx)
                             .await?;
+                    tally.kernel_cpu_ns += scan_kernel_ns;
                     let cands = shortlist
                         .into_iter()
                         .map(|(did, estimate, pos, cluster_id)| ScanCandidate {
@@ -3590,6 +3601,7 @@ impl VectorReader {
                 // cluster-index + prefix ranges before the branch, and the
                 // probe's own tallies cover the same clusters.
                 tally.rows_reranked = probe_tally.rows_reranked;
+                tally.kernel_cpu_ns += probe_tally.kernel_cpu_ns;
                 Ok((
                     hits.into_iter()
                         .map(|(local_id, score)| (base.saturating_add(local_id), score))
@@ -3612,6 +3624,7 @@ impl VectorReader {
             outcome.candidates_scanned += tally.candidates_scanned;
             outcome.ranges_requested += tally.ranges_requested;
             outcome.rows_reranked += tally.rows_reranked;
+            outcome.kernel_cpu_ns += tally.kernel_cpu_ns;
         }
         // Cold hits merge to this file's top-k exactly as the immediate
         // path does; candidates stay unbounded here (per-cell heaps
@@ -3637,9 +3650,9 @@ impl VectorReader {
         k: usize,
         selected: Vec<ScanCandidate>,
         pool: Option<Arc<ThreadPool>>,
-    ) -> Result<Vec<(u32, f32)>, VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
         if selected.is_empty() || k == 0 {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         if !self.column_id_by_name.contains_key(column) {
             return Err(VectorError::UnknownColumn(column.to_string()));
@@ -3749,14 +3762,15 @@ impl VectorReader {
             })
         });
         let max_in_flight = pool_wave_cap(pool.as_deref());
-        let per_cell: Vec<Vec<(u32, f32)>> = stream::iter(cell_reranks)
+        let per_cell: Vec<(Vec<(u32, f32)>, u64)> = stream::iter(cell_reranks)
             .buffer_unordered(max_in_flight)
             .try_collect()
             .await?;
-        let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flatten().collect();
+        let kernel_ns: u64 = per_cell.iter().map(|(_, ns)| ns).sum();
+        let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flat_map(|(hits, _)| hits).collect();
         merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         merged.truncate(k);
-        Ok(merged)
+        Ok((merged, kernel_ns))
     }
 
     /// Shared async tail of the IVF probe: given a chosen set of cluster
@@ -3784,13 +3798,18 @@ impl VectorReader {
         // Plan tallies, fixed before the warm/cold fetch branch: both arms
         // scan the same clusters and request one prefix/block range each
         // (the caller counts the cluster-index range it fetched).
+        let lazy_sq8_meta_range = lazy_sq8_meta_range(col);
         let mut tally = ProbeTally {
             cells_scanned: 1,
             candidates_scanned: cluster_meta.iter().map(|&(_, _, cnt)| u64::from(cnt)).sum(),
-            ranges_requested: cluster_meta.len() as u64,
+            // One range per chosen cluster, plus the lazy Sq8 meta table
+            // when the column stores one — the warm arm fetches it and
+            // the cold arm rides it on the coalesce plan, so the planned
+            // count is identical at either temperature.
+            ranges_requested: cluster_meta.len() as u64 + u64::from(lazy_sq8_meta_range.is_some()),
             rows_reranked: 0,
+            kernel_cpu_ns: 0,
         };
-        let lazy_sq8_meta_range = lazy_sq8_meta_range(col);
         // Warm fast path: every prefix already resident → sync zero-copy.
         let prefix_blocks_sync: Option<Vec<Bytes>> = cluster_prefix_ranges
             .iter()
@@ -3884,7 +3903,7 @@ impl VectorReader {
         // RaBitQ heap; survivor_fetch = warm/cold full-row gather; rerank =
         // Sq8/fp32 refine. Concurrent fan-out units each emit their own spans.
         let shortlist_t0 = io_counters::phase_start();
-        let (candidates, survivor_full_ranges) = match build_shortlist(
+        let (outcome, scan_kernel_ns) = build_shortlist(
             col,
             cb,
             &cluster_meta,
@@ -3892,8 +3911,9 @@ impl VectorReader {
             survivor_only_rerank_fetch,
             ctx,
         )
-        .await?
-        {
+        .await?;
+        tally.kernel_cpu_ns += scan_kernel_ns;
+        let (candidates, survivor_full_ranges) = match outcome {
             ShortlistOutcome::Done(out) => {
                 if let Some(t0) = shortlist_t0 {
                     io_counters::phase_record("vec.shortlist", t0.elapsed().as_micros() as u64);
@@ -3924,7 +3944,7 @@ impl VectorReader {
         }
 
         tally.rows_reranked = candidates.len() as u64;
-        let hits = io_counters::phase_timed_async("vec.rerank", async {
+        let (hits, rerank_ns) = io_counters::phase_timed_async("vec.rerank", async {
             rerank_candidates_from_blocks(
                 &self.source,
                 lazy_sq8_meta_bytes.as_ref(),
@@ -3939,6 +3959,7 @@ impl VectorReader {
             .await
         })
         .await?;
+        tally.kernel_cpu_ns += rerank_ns;
         Ok((hits, tally))
     }
 
@@ -4301,12 +4322,13 @@ fn scan_cluster_transposed(
     });
 }
 
-/// The pure-CPU half of [`build_shortlist`]/// The pure-CPU half of [`build_shortlist`]: score every probed cluster's
+/// The pure-CPU half of [`build_shortlist`]: score every probed cluster's
 /// 1-bit codes into one bounded heap of `coarse_limit` survivors, rayon-
 /// parallel when the candidate pool amortizes the hand-off. Shared by the
 /// immediate-rerank path ([`build_shortlist`]) and the deferred-rerank
 /// scan ([`VectorReader::search_clusters_scan_async`]). Returns unsorted
-/// `(did, estimate, pos, cluster_id)` survivors.
+/// `(did, estimate, pos, cluster_id)` survivors plus the scan's bracketed
+/// on-CPU ns (per-chunk brackets on the parallel arm).
 async fn scan_shortlist(
     col: &ColumnReader,
     cb: usize,
@@ -4315,7 +4337,7 @@ async fn scan_shortlist(
     survivor_only_rerank_fetch: bool,
     coarse_limit: usize,
     ctx: &ProbeCtx<'_>,
-) -> Result<Vec<(u32, f32, u32, u32)>, VectorError> {
+) -> Result<(Vec<(u32, f32, u32, u32)>, u64), VectorError> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
     let total_candidates: usize = cluster_meta.iter().map(|&(_, _, cnt)| cnt as usize).sum();
     // Collect every scored row, then keep the top `coarse_limit` with one
@@ -4380,7 +4402,7 @@ async fn scan_shortlist(
             &mut |cand| acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id)),
         );
     };
-    let mut acc = if total_candidates >= PARALLEL_SCAN_MIN && cluster_meta.len() > 1 {
+    let acc = if total_candidates >= PARALLEL_SCAN_MIN && cluster_meta.len() > 1 {
         // Parallelize the coarse 1-bit scan across the configured rayon
         // pool, bridged back via a oneshot so no tokio worker blocks under
         // the compute. Cluster scoring is order-independent — the partition
@@ -4405,6 +4427,7 @@ async fn scan_shortlist(
                 .par_chunks(chunk)
                 .zip(blocks_owned.par_chunks(chunk))
                 .map(|(meta_chunk, block_chunk)| {
+                    let kernel_start = metering_active().then(thread_cpu_ns).flatten();
                     let chunk_rows: usize =
                         meta_chunk.iter().map(|&(_, _, cnt)| cnt as usize).sum();
                     let cap = coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK);
@@ -4452,31 +4475,37 @@ async fn scan_shortlist(
                             truncate_to_top_estimates(&mut acc, coarse_limit);
                         }
                     }
-                    acc
+                    (acc, thread_cpu_delta_ns(kernel_start))
                 })
-                .reduce(Vec::new, |mut a, mut b| {
-                    a.append(&mut b);
-                    if a.len() >= coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK) {
-                        truncate_to_top_estimates(&mut a, coarse_limit);
-                    }
-                    a
-                });
+                .reduce(
+                    || (Vec::new(), 0u64),
+                    |(mut a, ns_a), (mut b, ns_b)| {
+                        a.append(&mut b);
+                        if a.len() >= coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK) {
+                            truncate_to_top_estimates(&mut a, coarse_limit);
+                        }
+                        (a, ns_a + ns_b)
+                    },
+                );
             let _ = tx.send(acc);
         });
         rx.await.map_err(|_| VectorError::TaskDropped("scan"))?
     } else {
-        let cap = coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK);
-        let mut acc = Vec::with_capacity(total_candidates.min(cap));
-        for item in cluster_meta.iter().zip(cluster_blocks.iter()) {
-            scan_vec(&mut acc, item);
-            if acc.len() >= cap {
-                truncate_to_top_estimates(&mut acc, coarse_limit);
+        timed_section(|| {
+            let cap = coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK);
+            let mut acc = Vec::with_capacity(total_candidates.min(cap));
+            for item in cluster_meta.iter().zip(cluster_blocks.iter()) {
+                scan_vec(&mut acc, item);
+                if acc.len() >= cap {
+                    truncate_to_top_estimates(&mut acc, coarse_limit);
+                }
             }
-        }
-        acc
+            acc
+        })
     };
+    let (mut acc, kernel_ns) = acc;
     truncate_to_top_estimates(&mut acc, coarse_limit);
-    Ok(acc)
+    Ok((acc, kernel_ns))
 }
 
 /// Keep the `limit` highest-estimate survivors of one cell scan via a
@@ -4555,6 +4584,11 @@ pub struct ProbeTally {
     /// Rows this probe actually reranked at full precision (execution
     /// diagnostic — see `OpStats::vector_rows_reranked`).
     pub rows_reranked: u64,
+    /// On-CPU nanoseconds of the probe's bracketed kernel sections (1-bit
+    /// scan + exact rerank; per-chunk brackets on the parallel arms, so
+    /// work-stolen chunks attribute their CPU too). Gated on
+    /// [`metering_active`]: 0 in an unmetered process.
+    pub kernel_cpu_ns: u64,
 }
 
 /// Result of a deferred-rerank scan over one superfile
@@ -4584,6 +4618,8 @@ pub(crate) struct ScanOutcome {
     /// Rows the cold arm reranked immediately (warm survivors defer to the
     /// supertable's global selection and are counted at phase C instead).
     pub(crate) rows_reranked: u64,
+    /// Σ per-cell bracketed kernel on-CPU ns (see `ProbeTally::kernel_cpu_ns`).
+    pub(crate) kernel_cpu_ns: u64,
 }
 
 async fn build_shortlist(
@@ -4593,7 +4629,7 @@ async fn build_shortlist(
     cluster_blocks: &[Bytes],
     survivor_only_rerank_fetch: bool,
     ctx: &ProbeCtx<'_>,
-) -> Result<ShortlistOutcome, VectorError> {
+) -> Result<(ShortlistOutcome, u64), VectorError> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
     // Score each probed cluster's 1-bit codes into the shortlist.
     // The per-cluster slices are zero-copy `Bytes` views; the actual
@@ -4608,9 +4644,9 @@ async fn build_shortlist(
         ctx.k.saturating_mul(ctx.rerank_mult)
     };
     if coarse_limit == 0 {
-        return Ok(ShortlistOutcome::Done(Vec::new()));
+        return Ok((ShortlistOutcome::Done(Vec::new()), 0));
     }
-    let mut shortlist = scan_shortlist(
+    let (mut shortlist, scan_kernel_ns) = scan_shortlist(
         col,
         cb,
         cluster_meta,
@@ -4622,7 +4658,7 @@ async fn build_shortlist(
     .await?;
 
     if shortlist.is_empty() {
-        return Ok(ShortlistOutcome::Done(Vec::new()));
+        return Ok((ShortlistOutcome::Done(Vec::new()), scan_kernel_ns));
     }
 
     // `RabitqOnly` short-circuit: the 1-bit shortlist *is* the final
@@ -4640,11 +4676,14 @@ async fn build_shortlist(
         // merge path — otherwise the two paths diverge on top-k for a
         // corrupt/degenerate score.
         shortlist.sort_unstable_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-        return Ok(ShortlistOutcome::Done(
-            shortlist
-                .into_iter()
-                .map(|(did, est, _pos, _c)| (did, -est))
-                .collect(),
+        return Ok((
+            ShortlistOutcome::Done(
+                shortlist
+                    .into_iter()
+                    .map(|(did, est, _pos, _c)| (did, -est))
+                    .collect(),
+            ),
+            scan_kernel_ns,
         ));
     }
 
@@ -4685,10 +4724,13 @@ async fn build_shortlist(
             full_idx,
         });
     }
-    Ok(ShortlistOutcome::Rerank {
-        candidates,
-        survivor_full_ranges,
-    })
+    Ok((
+        ShortlistOutcome::Rerank {
+            candidates,
+            survivor_full_ranges,
+        },
+        scan_kernel_ns,
+    ))
 }
 
 /// Maximum multiplier applied to filtered-search probe breadth and
@@ -4834,23 +4876,41 @@ fn parallel_chunks(n_items: usize) -> usize {
 /// compute runs on rayon (`par_iter().map().collect()`) bridged back to
 /// the async caller via a oneshot, so no tokio worker blocks under it.
 /// `f` and the items must be `'static` so the work can move onto rayon.
+/// Returns the mapped items plus the map's bracketed on-CPU ns. The
+/// parallel arm runs chunked (`par_chunks` + collect preserves input
+/// order exactly as the previous per-item `par_iter` did) with one
+/// bracket per chunk, so work-stolen chunks attribute their CPU too.
 async fn par_map<T, R, F>(
     items: Vec<T>,
     f: F,
     pool: Option<Arc<ThreadPool>>,
-) -> Result<Vec<R>, VectorError>
+) -> Result<(Vec<R>, u64), VectorError>
 where
     T: Send + Sync + 'static,
     R: Send + 'static,
     F: Fn(&T) -> R + Send + Sync + 'static,
 {
-    if parallel_chunks(items.len()) <= 1 {
-        return Ok(items.iter().map(&f).collect());
+    let n_tasks = parallel_chunks(items.len());
+    if n_tasks <= 1 {
+        return Ok(timed_section(|| items.iter().map(&f).collect()));
     }
     run_on_pool(
         pool.as_deref(),
         "rerank rayon task dropped result",
-        move || items.par_iter().map(f).collect(),
+        move || {
+            let chunk = items.len().div_ceil(n_tasks).max(1);
+            let per_chunk: Vec<(Vec<R>, u64)> = items
+                .par_chunks(chunk)
+                .map(|c| timed_section(|| c.iter().map(&f).collect()))
+                .collect();
+            let mut out = Vec::with_capacity(items.len());
+            let mut kernel_ns = 0u64;
+            for (chunk_out, ns) in per_chunk {
+                out.extend(chunk_out);
+                kernel_ns += ns;
+            }
+            (out, kernel_ns)
+        },
     )
     .await
     .map_err(|_| VectorError::TaskDropped("rerank"))
@@ -4984,9 +5044,11 @@ async fn rerank_candidates_from_blocks(
     query: &[f32],
     pool: Option<Arc<ThreadPool>>,
     k: usize,
-) -> Result<Vec<(u32, f32)>, VectorError> {
+) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
     let stride = col.rerank_codec.per_vector_bytes(col.dim);
     let map_lazy = |e: LazyByteSourceError| VectorError::LazySource(e.to_string());
+    // Bracketed on-CPU ns of the scoring sections below (fetches excluded).
+    let mut kernel_ns = 0u64;
     let reranked: Vec<(u32, f32)> = match col.rerank_codec {
         RerankCodec::Fp32 => {
             // Exact fp32 rerank — every survivor is independent, so the
@@ -5001,7 +5063,7 @@ async fn rerank_candidates_from_blocks(
                 let survivors: Option<Arc<Vec<Bytes>>> =
                     survivor_full_rows.map(|s| Arc::new(s.to_vec()));
                 let query: Arc<Vec<f32>> = Arc::new(query.to_vec());
-                par_map(
+                let (scored, ns) = par_map(
                     candidates.to_vec(),
                     move |cand: &RerankCandidate| {
                         let bytes = candidate_full_bytes(
@@ -5014,19 +5076,29 @@ async fn rerank_candidates_from_blocks(
                     },
                     pool.clone(),
                 )
-                .await?
+                .await?;
+                kernel_ns += ns;
+                scored
             } else {
-                candidates
-                    .iter()
-                    .map(|cand| {
-                        let bytes =
-                            candidate_full_bytes(cluster_blocks, survivor_full_rows, cand, stride);
-                        (
-                            cand.did,
-                            distance_bytes_codec(col.metric, col.rerank_codec, query, bytes),
-                        )
-                    })
-                    .collect()
+                let (scored, ns) = timed_section(|| {
+                    candidates
+                        .iter()
+                        .map(|cand| {
+                            let bytes = candidate_full_bytes(
+                                cluster_blocks,
+                                survivor_full_rows,
+                                cand,
+                                stride,
+                            );
+                            (
+                                cand.did,
+                                distance_bytes_codec(col.metric, col.rerank_codec, query, bytes),
+                            )
+                        })
+                        .collect()
+                });
+                kernel_ns += ns;
+                scored
             }
         }
         RerankCodec::Sq16 => {
@@ -5065,7 +5137,7 @@ async fn rerank_candidates_from_blocks(
                 let survivors: Option<Arc<Vec<Bytes>>> =
                     survivor_full_rows.map(|s| Arc::new(s.to_vec()));
                 let norms = norms.clone();
-                par_map(
+                let (scored, ns) = par_map(
                     candidates.to_vec(),
                     move |cand: &RerankCandidate| {
                         let bytes = candidate_full_bytes(
@@ -5079,17 +5151,27 @@ async fn rerank_candidates_from_blocks(
                     },
                     pool.clone(),
                 )
-                .await?
+                .await?;
+                kernel_ns += ns;
+                scored
             } else {
-                candidates
-                    .iter()
-                    .map(|cand| {
-                        let bytes =
-                            candidate_full_bytes(cluster_blocks, survivor_full_rows, cand, stride);
-                        let norm = norms.as_ref().map(|n| n[cand.pos as usize]);
-                        (cand.did, kernel.distance_with_norm(bytes, norm))
-                    })
-                    .collect()
+                let (scored, ns) = timed_section(|| {
+                    candidates
+                        .iter()
+                        .map(|cand| {
+                            let bytes = candidate_full_bytes(
+                                cluster_blocks,
+                                survivor_full_rows,
+                                cand,
+                                stride,
+                            );
+                            let norm = norms.as_ref().map(|n| n[cand.pos as usize]);
+                            (cand.did, kernel.distance_with_norm(bytes, norm))
+                        })
+                        .collect()
+                });
+                kernel_ns += ns;
+                scored
             }
         }
         RerankCodec::Sq8Residual | RerankCodec::Sq8FixedResidual => {
@@ -5111,7 +5193,7 @@ async fn rerank_candidates_from_blocks(
                     offset,
                     per_doc_norms,
                 } => {
-                    score_sq8_residual_candidates(
+                    let (scored, ns) = score_sq8_residual_candidates(
                         candidates,
                         cluster_blocks,
                         survivor_full_rows,
@@ -5125,7 +5207,9 @@ async fn rerank_candidates_from_blocks(
                         pool.clone(),
                         stride,
                     )
-                    .await?
+                    .await?;
+                    kernel_ns += ns;
+                    scored
                 }
                 Sq8ColumnMeta::Lazy {
                     scale_abs_off,
@@ -5149,24 +5233,22 @@ async fn rerank_candidates_from_blocks(
                                 .get()
                                 .expect("lazy Sq8 meta set just above"),
                         );
-                        return Ok(finalize_reranked(
-                            score_sq8_residual_candidates(
-                                candidates,
-                                cluster_blocks,
-                                survivor_full_rows,
-                                col.metric,
-                                col.dim,
-                                query,
-                                parsed.scale.as_slice(),
-                                parsed.offset.as_slice(),
-                                parsed.per_doc_norms.clone(),
-                                residual_divisor,
-                                pool.clone(),
-                                stride,
-                            )
-                            .await?,
-                            k,
-                        ));
+                        let (scored, ns) = score_sq8_residual_candidates(
+                            candidates,
+                            cluster_blocks,
+                            survivor_full_rows,
+                            col.metric,
+                            col.dim,
+                            query,
+                            parsed.scale.as_slice(),
+                            parsed.offset.as_slice(),
+                            parsed.per_doc_norms.clone(),
+                            residual_divisor,
+                            pool.clone(),
+                            stride,
+                        )
+                        .await?;
+                        return Ok((finalize_reranked(scored, k), kernel_ns + ns));
                     }
                     let mut clusters: Vec<u32> = candidates.iter().map(|c| c.cluster_id).collect();
                     clusters.sort_unstable();
@@ -5251,27 +5333,35 @@ async fn rerank_candidates_from_blocks(
                             )
                         })
                         .collect();
-                    candidates
-                        .iter()
-                        .map(|cand| {
-                            let row = candidate_full_bytes(
-                                cluster_blocks,
-                                survivor_full_rows,
-                                cand,
-                                stride,
-                            );
-                            let kernel = kernels
-                                .get(&cand.cluster_id)
-                                .expect("kernel built for every candidate cluster");
-                            let norm = norm_by_pos
-                                .as_ref()
-                                .and_then(|norms| norms.get(&cand.pos).copied());
-                            (
-                                cand.did,
-                                kernel.distance_with_norm(&row[..dim], &row[dim..dim * 2], norm),
-                            )
-                        })
-                        .collect()
+                    let (scored, ns) = timed_section(|| {
+                        candidates
+                            .iter()
+                            .map(|cand| {
+                                let row = candidate_full_bytes(
+                                    cluster_blocks,
+                                    survivor_full_rows,
+                                    cand,
+                                    stride,
+                                );
+                                let kernel = kernels
+                                    .get(&cand.cluster_id)
+                                    .expect("kernel built for every candidate cluster");
+                                let norm = norm_by_pos
+                                    .as_ref()
+                                    .and_then(|norms| norms.get(&cand.pos).copied());
+                                (
+                                    cand.did,
+                                    kernel.distance_with_norm(
+                                        &row[..dim],
+                                        &row[dim..dim * 2],
+                                        norm,
+                                    ),
+                                )
+                            })
+                            .collect()
+                    });
+                    kernel_ns += ns;
+                    scored
                 }
             }
         }
@@ -5280,7 +5370,7 @@ async fn rerank_candidates_from_blocks(
              have no full[] region and should short-circuit before the rerank step"
         ),
     };
-    Ok(finalize_reranked(reranked, k))
+    Ok((finalize_reranked(reranked, k), kernel_ns))
 }
 
 fn finalize_reranked(mut reranked: Vec<(u32, f32)>, k: usize) -> Vec<(u32, f32)> {
@@ -5311,7 +5401,7 @@ async fn score_sq8_residual_candidates(
     residual_divisor: f32,
     pool: Option<Arc<ThreadPool>>,
     stride: usize,
-) -> Result<Vec<(u32, f32)>, VectorError> {
+) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
     let mut cids: Vec<u32> = candidates.iter().map(|c| c.cluster_id).collect();
     cids.sort_unstable();
     cids.dedup();
@@ -5368,7 +5458,7 @@ async fn score_sq8_residual_candidates(
         )
         .await
     } else {
-        Ok(candidates.iter().map(score_one).collect())
+        Ok(timed_section(|| candidates.iter().map(score_one).collect()))
     }
 }
 
@@ -5838,7 +5928,7 @@ mod tests {
             })
             .collect();
 
-        let mut scored = score_sq8_residual_candidates(
+        let scored = score_sq8_residual_candidates(
             &candidates,
             &[Bytes::from(block)],
             None,
@@ -5856,6 +5946,7 @@ mod tests {
         )
         .await
         .expect("sq8 scorer");
+        let (mut scored, _kernel_ns) = scored;
         assert_eq!(scored.len(), candidates.len());
         scored.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         assert_eq!(
@@ -9449,7 +9540,8 @@ mod tests {
         let deferred = r
             .rerank_selected_async("v", &all[7], k, scan.candidates, None)
             .await
-            .expect("selected rerank");
+            .expect("selected rerank")
+            .0;
         assert_eq!(
             immediate.0, deferred,
             "deferred scan+select+rerank must equal the immediate probe's top-k"
@@ -9529,7 +9621,8 @@ mod tests {
         // parallel_chunks(items) <= 1 takes the serial map arm.
         let out = par_map(vec![1u32, 2, 3], |x| x * 10, None)
             .await
-            .expect("serial par_map cannot drop");
+            .expect("serial par_map cannot drop")
+            .0;
         assert_eq!(out, vec![10, 20, 30]);
     }
 

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3414,6 +3414,7 @@ impl VectorReader {
             rot_seed,
             cells_scanned: 0,
             candidates_scanned: 0,
+            ranges_requested: 0,
         };
         if k == 0 || self.n_docs == 0 {
             return Ok(outcome);
@@ -3495,12 +3496,17 @@ impl VectorReader {
                 let cb = col.quant.code_bytes();
                 let (cluster_meta, prefix_ranges) = chosen_cluster_meta(col, &cluster_idx, &locals);
                 if cluster_meta.is_empty() {
-                    return Ok((Vec::new(), Vec::new(), 0));
+                    // The cluster-index read itself was one planned range.
+                    return Ok((Vec::new(), Vec::new(), 0, 1));
                 }
-                // Work-stats tally, taken before the warm/cold branch so
-                // both arms count the codes their clusters hold.
+                // Work-stats tallies, taken before the warm/cold branch so
+                // both arms count the codes their clusters hold. Ranges:
+                // the cluster index plus one per prefix span (the warm
+                // arm's fetches; the cold arm's whole-cluster blocks are
+                // one range per chosen cluster, the same count).
                 let candidates_scanned: u64 =
                     cluster_meta.iter().map(|(_, _, cnt)| u64::from(*cnt)).sum();
+                let ranges_requested = 1 + prefix_ranges.len() as u64;
                 // Warm fast path: every prefix resident -> defer rerank.
                 let prefix_blocks: Option<Vec<Bytes>> = prefix_ranges
                     .iter()
@@ -3531,10 +3537,11 @@ impl VectorReader {
                             cell_idx,
                         })
                         .collect();
-                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64), VectorError>((
+                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64, u64), VectorError>((
                         Vec::new(),
                         cands,
                         candidates_scanned,
+                        ranges_requested,
                     ));
                 }
                 // Cold (or RabitqOnly): probe-and-rerank now, width-divided.
@@ -3556,18 +3563,20 @@ impl VectorReader {
                         .collect(),
                     Vec::new(),
                     candidates_scanned,
+                    ranges_requested,
                 ))
             })
         });
         let max_in_flight = pool_wave_cap(pool.as_deref());
-        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64)> =
+        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64, u64)> =
             stream::iter(cell_scans)
                 .buffer_unordered(max_in_flight)
                 .try_collect()
                 .await?;
-        for (hits, cands, candidates_scanned) in per_cell_results {
+        for (hits, cands, candidates_scanned, ranges_requested) in per_cell_results {
             outcome.hits.extend(hits);
             outcome.candidates.extend(cands);
+            outcome.ranges_requested += ranges_requested;
             if candidates_scanned > 0 {
                 outcome.cells_scanned += 1;
                 outcome.candidates_scanned += candidates_scanned;
@@ -4497,6 +4506,10 @@ pub(crate) struct ScanOutcome {
     /// Quantized codes estimated: Σ cluster row counts over every chosen
     /// cluster, warm and cold arms alike.
     pub(crate) candidates_scanned: u64,
+    /// Byte-source ranges the scan requested per cell: the cluster index
+    /// plus one range per prefix block (warm arm) or chosen cluster's
+    /// blocks (cold arm).
+    pub(crate) ranges_requested: u64,
 }
 
 async fn build_shortlist(

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3100,10 +3100,10 @@ impl VectorReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<Vec<(u32, f32)>, VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         let centroid_stride = col.dim * 4;
         let sub_start = col.subsection_range.start;
@@ -3130,7 +3130,7 @@ impl VectorReader {
         let Some((nprobe_eff, rerank_mult_eff)) =
             effective_filtered_params(&allow, col.n_docs, col.n_cent, nprobe, rerank_mult)
         else {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         };
         // 2. Score centroids → top `nprobe` clusters.
         let centroid_scores = score_centroids(&centroids, col, query, nprobe_eff);
@@ -3180,7 +3180,7 @@ impl VectorReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<Vec<(u32, f32)>, VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
         if self.is_multi_cell() {
             return self
                 .search_clusters_async_multi_cell(
@@ -3198,7 +3198,7 @@ impl VectorReader {
         }
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         let sub_start = col.subsection_range.start;
         let idx_start = sub_start + col.cluster_idx_off;
@@ -3220,7 +3220,7 @@ impl VectorReader {
         // every probed fragment (measured 70 ms survivor gather + 52 ms
         // Sq8 rerank per filtered query at 1M).
         if allow.as_ref().is_some_and(|bm| bm.is_empty()) {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         let ctx = ProbeCtx {
             q_rot: &q_rot,
@@ -3280,7 +3280,7 @@ impl VectorReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<Vec<(u32, f32)>, VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
         if !self.column_id_by_name.contains_key(column) {
             return Err(VectorError::UnknownColumn(column.to_string()));
         }
@@ -3296,12 +3296,12 @@ impl VectorReader {
             });
         }
         if k == 0 || self.n_docs == 0 {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
 
         let per_cell = self.resolve_cells_for_clusters(clusters);
         if per_cell.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
 
         // Probe the selected cells CONCURRENTLY — the same wave shape the
@@ -3348,14 +3348,15 @@ impl VectorReader {
                     pool,
                     budget,
                 };
-                let hits = self
+                let (hits, rows_reranked) = self
                     .probe_clusters_async(col, query, &ctx, &cluster_idx, &locals)
                     .await?;
-                Ok::<Vec<(u32, f32)>, VectorError>(
+                Ok::<(Vec<(u32, f32)>, u64), VectorError>((
                     hits.into_iter()
                         .map(|(local_id, score)| (base.saturating_add(local_id), score))
                         .collect(),
-                )
+                    rows_reranked,
+                ))
             })
         });
         // Wave-cap the concurrent probes to the pool width (the same
@@ -3363,17 +3364,18 @@ impl VectorReader {
         // many-celled shard must not open unbounded simultaneous
         // range reads / cold fetches.
         let max_in_flight = pool_wave_cap(pool.as_deref());
-        let per_cell: Vec<Vec<(u32, f32)>> = stream::iter(cell_probes)
+        let per_cell: Vec<(Vec<(u32, f32)>, u64)> = stream::iter(cell_probes)
             .buffer_unordered(max_in_flight)
             .try_collect()
             .await?;
-        let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flatten().collect();
+        let rows_reranked: u64 = per_cell.iter().map(|(_, rows)| rows).sum();
+        let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flat_map(|(hits, _)| hits).collect();
         // Distance ascending (smaller = closer), matching every other vector
         // search path. Descending here kept the farthest k hits and collapsed
         // packed-shard recall to ~0.
         merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         merged.truncate(k);
-        Ok(merged)
+        Ok((merged, rows_reranked))
     }
 
     /// Deferred-rerank scan for the supertable's GLOBAL shortlist selection
@@ -3415,6 +3417,7 @@ impl VectorReader {
             cells_scanned: 0,
             candidates_scanned: 0,
             ranges_requested: 0,
+            rows_reranked: 0,
         };
         if k == 0 || self.n_docs == 0 {
             return Ok(outcome);
@@ -3497,7 +3500,7 @@ impl VectorReader {
                 let (cluster_meta, prefix_ranges) = chosen_cluster_meta(col, &cluster_idx, &locals);
                 if cluster_meta.is_empty() {
                     // The cluster-index read itself was one planned range.
-                    return Ok((Vec::new(), Vec::new(), 0, 1));
+                    return Ok((Vec::new(), Vec::new(), 0, 1, 0));
                 }
                 // Work-stats tallies, taken before the warm/cold branch so
                 // both arms count the codes their clusters hold. Ranges:
@@ -3537,12 +3540,9 @@ impl VectorReader {
                             cell_idx,
                         })
                         .collect();
-                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64, u64), VectorError>((
-                        Vec::new(),
-                        cands,
-                        candidates_scanned,
-                        ranges_requested,
-                    ));
+                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64, u64, u64), VectorError>(
+                        (Vec::new(), cands, candidates_scanned, ranges_requested, 0),
+                    );
                 }
                 // Cold (or RabitqOnly): probe-and-rerank now, width-divided.
                 let ctx = ProbeCtx {
@@ -3554,7 +3554,7 @@ impl VectorReader {
                     pool,
                     budget,
                 };
-                let hits = self
+                let (hits, rows_reranked) = self
                     .probe_clusters_async(col, query, &ctx, &cluster_idx, &locals)
                     .await?;
                 Ok((
@@ -3564,19 +3564,21 @@ impl VectorReader {
                     Vec::new(),
                     candidates_scanned,
                     ranges_requested,
+                    rows_reranked,
                 ))
             })
         });
         let max_in_flight = pool_wave_cap(pool.as_deref());
-        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64, u64)> =
+        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64, u64, u64)> =
             stream::iter(cell_scans)
                 .buffer_unordered(max_in_flight)
                 .try_collect()
                 .await?;
-        for (hits, cands, candidates_scanned, ranges_requested) in per_cell_results {
+        for (hits, cands, candidates_scanned, ranges_requested, rows_reranked) in per_cell_results {
             outcome.hits.extend(hits);
             outcome.candidates.extend(cands);
             outcome.ranges_requested += ranges_requested;
+            outcome.rows_reranked += rows_reranked;
             if candidates_scanned > 0 {
                 outcome.cells_scanned += 1;
                 outcome.candidates_scanned += candidates_scanned;
@@ -3734,6 +3736,9 @@ impl VectorReader {
     /// Used by [`Self::search_async`] (clusters from this superfile's
     /// centroid scoring) and [`Self::search_clusters_async`] (clusters
     /// from the global cross-superfile selector).
+    /// Returns the hits plus the number of rows the probe reranked at
+    /// full precision (0 on the `RabitqOnly` and empty-shortlist paths),
+    /// for the per-query work stats.
     async fn probe_clusters_async(
         &self,
         col: &ColumnReader,
@@ -3741,11 +3746,11 @@ impl VectorReader {
         ctx: &ProbeCtx<'_>,
         cluster_idx: &[u8],
         chosen: &[usize],
-    ) -> Result<Vec<(u32, f32)>, VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
         let cb = col.quant.code_bytes();
         let (cluster_meta, cluster_prefix_ranges) = chosen_cluster_meta(col, cluster_idx, chosen);
         if cluster_meta.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         let lazy_sq8_meta_range = lazy_sq8_meta_range(col);
         // Warm fast path: every prefix already resident → sync zero-copy.
@@ -3855,7 +3860,7 @@ impl VectorReader {
                 if let Some(t0) = shortlist_t0 {
                     io_counters::phase_record("vec.shortlist", t0.elapsed().as_micros() as u64);
                 }
-                return Ok(out);
+                return Ok((out, 0));
             }
             ShortlistOutcome::Rerank {
                 candidates,
@@ -3880,7 +3885,8 @@ impl VectorReader {
             io_counters::phase_record("vec.survivor_fetch", t0.elapsed().as_micros() as u64);
         }
 
-        io_counters::phase_timed_async("vec.rerank", async {
+        let rows_reranked = candidates.len() as u64;
+        let hits = io_counters::phase_timed_async("vec.rerank", async {
             rerank_candidates_from_blocks(
                 &self.source,
                 lazy_sq8_meta_bytes.as_ref(),
@@ -3894,7 +3900,8 @@ impl VectorReader {
             )
             .await
         })
-        .await
+        .await?;
+        Ok((hits, rows_reranked))
     }
 
     /// Look up the column by name and validate `query.len() == col.dim`
@@ -4510,6 +4517,9 @@ pub(crate) struct ScanOutcome {
     /// plus one range per prefix block (warm arm) or chosen cluster's
     /// blocks (cold arm).
     pub(crate) ranges_requested: u64,
+    /// Rows the cold arm reranked immediately (warm survivors defer to the
+    /// supertable's global selection and are counted at phase C instead).
+    pub(crate) rows_reranked: u64,
 }
 
 async fn build_shortlist(
@@ -6111,11 +6121,11 @@ mod tests {
         let q = &all[0];
         let (k, rerank, n_cent) = (5usize, 5usize, 64u32);
 
-        let full = r
+        let (full, _) = r
             .search_async("v", q, k, n_cent as usize, rerank, None, None, None, None)
             .await
             .expect("search_async");
-        let probed = r
+        let (probed, _) = r
             .search_clusters_async(
                 "v",
                 q,
@@ -6140,7 +6150,7 @@ mod tests {
         );
 
         // Probing no clusters returns nothing.
-        let none = r
+        let (none, _) = r
             .search_clusters_async("v", q, k, &[], rerank, None, None, None, None)
             .await
             .expect("search_clusters_async empty");
@@ -6536,11 +6546,11 @@ mod tests {
         )
         .await
         .expect("lazy open");
-        let eager_hits = eager
+        let (eager_hits, _) = eager
             .search_async("v", &vectors[17], 5, 4, 20, None, None, None, None)
             .await
             .expect("eager search");
-        let lazy_hits = lazy
+        let (lazy_hits, _) = lazy
             .search_async("v", &vectors[17], 5, 4, 20, None, None, None, None)
             .await
             .expect("lazy search");
@@ -6564,11 +6574,11 @@ mod tests {
         )
         .await
         .expect("lazy open");
-        let eager_hits = eager
+        let (eager_hits, _) = eager
             .search_async("v", &vectors[17], 5, 4, 20, None, None, None, None)
             .await
             .expect("eager search");
-        let lazy_hits = lazy
+        let (lazy_hits, _) = lazy
             .search_async("v", &vectors[17], 5, 4, 20, None, None, None, None)
             .await
             .expect("lazy search");
@@ -6643,11 +6653,11 @@ mod tests {
         .expect("lazy multi-cell open");
 
         let q = vec![0.0f32; dim];
-        let eager_hits = eager
+        let (eager_hits, _) = eager
             .search_clusters_async("emb", &q, 3, &[0, 1, 2, 3], 8, None, None, None, None)
             .await
             .expect("eager multi-cell search");
-        let lazy_hits = lazy
+        let (lazy_hits, _) = lazy
             .search_clusters_async("emb", &q, 3, &[0, 1, 2, 3], 8, None, None, None, None)
             .await
             .expect("lazy multi-cell search");
@@ -9377,7 +9387,7 @@ mod tests {
             .await
             .expect("selected rerank");
         assert_eq!(
-            immediate, deferred,
+            immediate.0, deferred,
             "deferred scan+select+rerank must equal the immediate probe's top-k"
         );
     }
@@ -9598,11 +9608,11 @@ mod tests {
         .await
         .expect("open_lazy");
 
-        let hits_lazy = r_lazy
+        let (hits_lazy, _) = r_lazy
             .search_async("v", &all[17], 5, 4, 20, None, None, None, None)
             .await
             .expect("lazy cold Sq8 search_async");
-        let hits_eager = r_eager
+        let (hits_eager, _) = r_eager
             .search_async("v", &all[17], 5, 4, 20, None, None, None, None)
             .await
             .expect("eager Sq8 search_async");
@@ -9677,7 +9687,7 @@ mod tests {
         .expect("open_lazy");
 
         let budget = ConnectionMemoryBudget::measured();
-        let hits = r_lazy
+        let (hits, _) = r_lazy
             .search_async(
                 "v",
                 &all[0],
@@ -9724,7 +9734,7 @@ mod tests {
         let r_eager = VectorReader::open(blob, &json).expect("eager open");
         let budget = ConnectionMemoryBudget::with_limit(1);
 
-        let hits = r_eager
+        let (hits, _) = r_eager
             .search_async(
                 "v",
                 &all[0],
@@ -9755,7 +9765,7 @@ mod tests {
         );
         assert_eq!(budget.peak(), 0, "warm search commits no bytes");
         let denials_after_first = budget.denials();
-        let hits = r_eager
+        let (hits, _) = r_eager
             .search_async(
                 "v",
                 &all[0],
@@ -9795,7 +9805,7 @@ mod tests {
         counting.disable_sync();
 
         let clusters: Vec<u32> = (0..4).collect();
-        let hits_lazy = r_lazy
+        let (hits_lazy, _) = r_lazy
             .search_clusters_async(
                 "embedding",
                 &all[19],
@@ -9809,7 +9819,7 @@ mod tests {
             )
             .await
             .expect("lazy cold search_clusters_async");
-        let hits_eager = r_eager
+        let (hits_eager, _) = r_eager
             .search_clusters_async(
                 "embedding",
                 &all[19],
@@ -9829,7 +9839,7 @@ mod tests {
         );
         // Out-of-range cluster ids are ignored; an empty selection yields
         // no hits.
-        let none = r_lazy
+        let (none, _) = r_lazy
             .search_clusters_async(
                 "embedding",
                 &all[19],
@@ -9860,7 +9870,7 @@ mod tests {
             .await;
         assert!(matches!(dim, Err(VectorError::DimensionMismatch { .. })));
         // k == 0 short-circuits to an empty result.
-        let empty = r
+        let (empty, _) = r
             .search_async("embedding", &[0.0; 16], 0, 4, 5, None, None, None, None)
             .await
             .expect("k=0 empty");

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3412,6 +3412,8 @@ impl VectorReader {
             hits: Vec::new(),
             candidates: Vec::new(),
             rot_seed,
+            cells_scanned: 0,
+            candidates_scanned: 0,
         };
         if k == 0 || self.n_docs == 0 {
             return Ok(outcome);
@@ -3493,8 +3495,12 @@ impl VectorReader {
                 let cb = col.quant.code_bytes();
                 let (cluster_meta, prefix_ranges) = chosen_cluster_meta(col, &cluster_idx, &locals);
                 if cluster_meta.is_empty() {
-                    return Ok((Vec::new(), Vec::new()));
+                    return Ok((Vec::new(), Vec::new(), 0));
                 }
+                // Work-stats tally, taken before the warm/cold branch so
+                // both arms count the codes their clusters hold.
+                let candidates_scanned: u64 =
+                    cluster_meta.iter().map(|(_, _, cnt)| u64::from(*cnt)).sum();
                 // Warm fast path: every prefix resident -> defer rerank.
                 let prefix_blocks: Option<Vec<Bytes>> = prefix_ranges
                     .iter()
@@ -3525,9 +3531,10 @@ impl VectorReader {
                             cell_idx,
                         })
                         .collect();
-                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>), VectorError>((
+                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64), VectorError>((
                         Vec::new(),
                         cands,
+                        candidates_scanned,
                     ));
                 }
                 // Cold (or RabitqOnly): probe-and-rerank now, width-divided.
@@ -3548,17 +3555,23 @@ impl VectorReader {
                         .map(|(local_id, score)| (base.saturating_add(local_id), score))
                         .collect(),
                     Vec::new(),
+                    candidates_scanned,
                 ))
             })
         });
         let max_in_flight = pool_wave_cap(pool.as_deref());
-        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>)> = stream::iter(cell_scans)
-            .buffer_unordered(max_in_flight)
-            .try_collect()
-            .await?;
-        for (hits, cands) in per_cell_results {
+        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64)> =
+            stream::iter(cell_scans)
+                .buffer_unordered(max_in_flight)
+                .try_collect()
+                .await?;
+        for (hits, cands, candidates_scanned) in per_cell_results {
             outcome.hits.extend(hits);
             outcome.candidates.extend(cands);
+            if candidates_scanned > 0 {
+                outcome.cells_scanned += 1;
+                outcome.candidates_scanned += candidates_scanned;
+            }
         }
         // Cold hits merge to this file's top-k exactly as the immediate
         // path does; candidates stay unbounded here (per-cell heaps
@@ -4478,6 +4491,12 @@ pub(crate) struct ScanOutcome {
     /// The column's rotation seed — the supertable asserts every pooled
     /// unit agrees before comparing estimates across superfiles.
     pub(crate) rot_seed: u64,
+    /// Cells this scan probed (chose ≥1 cluster in), for the per-query
+    /// work stats.
+    pub(crate) cells_scanned: u64,
+    /// Quantized codes estimated: Σ cluster row counts over every chosen
+    /// cluster, warm and cold arms alike.
+    pub(crate) candidates_scanned: u64,
 }
 
 async fn build_shortlist(

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3100,10 +3100,10 @@ impl VectorReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, ProbeTally), VectorError> {
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), ProbeTally::default()));
         }
         let centroid_stride = col.dim * 4;
         let sub_start = col.subsection_range.start;
@@ -3130,7 +3130,7 @@ impl VectorReader {
         let Some((nprobe_eff, rerank_mult_eff)) =
             effective_filtered_params(&allow, col.n_docs, col.n_cent, nprobe, rerank_mult)
         else {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), ProbeTally::default()));
         };
         // 2. Score centroids → top `nprobe` clusters.
         let centroid_scores = score_centroids(&centroids, col, query, nprobe_eff);
@@ -3153,8 +3153,12 @@ impl VectorReader {
             pool,
             budget,
         };
-        self.probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
-            .await
+        let (hits, mut tally) = self
+            .probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
+            .await?;
+        // The centroid + cluster-index span above was one planned range.
+        tally.ranges_requested += 1;
+        Ok((hits, tally))
     }
 
     /// Async IVF probe over an **externally chosen** set of cluster ids.
@@ -3180,7 +3184,7 @@ impl VectorReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, ProbeTally), VectorError> {
         if self.is_multi_cell() {
             return self
                 .search_clusters_async_multi_cell(
@@ -3198,7 +3202,7 @@ impl VectorReader {
         }
         let (col, validated) = self.resolve_column(column, query, k)?;
         if !validated {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), ProbeTally::default()));
         }
         let sub_start = col.subsection_range.start;
         let idx_start = sub_start + col.cluster_idx_off;
@@ -3220,7 +3224,7 @@ impl VectorReader {
         // every probed fragment (measured 70 ms survivor gather + 52 ms
         // Sq8 rerank per filtered query at 1M).
         if allow.as_ref().is_some_and(|bm| bm.is_empty()) {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), ProbeTally::default()));
         }
         let ctx = ProbeCtx {
             q_rot: &q_rot,
@@ -3231,8 +3235,12 @@ impl VectorReader {
             pool,
             budget,
         };
-        self.probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
-            .await
+        let (hits, mut tally) = self
+            .probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
+            .await?;
+        // The cluster-index fetch above was one planned range.
+        tally.ranges_requested += 1;
+        Ok((hits, tally))
     }
 
     /// Map flat cluster ids to per-cell probe work on a multi-cell
@@ -3280,7 +3288,7 @@ impl VectorReader {
         deny: Option<Arc<RoaringBitmap>>,
         pool: Option<Arc<ThreadPool>>,
         budget: Option<Arc<ConnectionMemoryBudget>>,
-    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, ProbeTally), VectorError> {
         if !self.column_id_by_name.contains_key(column) {
             return Err(VectorError::UnknownColumn(column.to_string()));
         }
@@ -3296,12 +3304,12 @@ impl VectorReader {
             });
         }
         if k == 0 || self.n_docs == 0 {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), ProbeTally::default()));
         }
 
         let per_cell = self.resolve_cells_for_clusters(clusters);
         if per_cell.is_empty() {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), ProbeTally::default()));
         }
 
         // Probe the selected cells CONCURRENTLY — the same wave shape the
@@ -3348,14 +3356,16 @@ impl VectorReader {
                     pool,
                     budget,
                 };
-                let (hits, rows_reranked) = self
+                let (hits, mut tally) = self
                     .probe_clusters_async(col, query, &ctx, &cluster_idx, &locals)
                     .await?;
-                Ok::<(Vec<(u32, f32)>, u64), VectorError>((
+                // Each probed cell fetched its own cluster index above.
+                tally.ranges_requested += 1;
+                Ok::<(Vec<(u32, f32)>, ProbeTally), VectorError>((
                     hits.into_iter()
                         .map(|(local_id, score)| (base.saturating_add(local_id), score))
                         .collect(),
-                    rows_reranked,
+                    tally,
                 ))
             })
         });
@@ -3364,18 +3374,24 @@ impl VectorReader {
         // many-celled shard must not open unbounded simultaneous
         // range reads / cold fetches.
         let max_in_flight = pool_wave_cap(pool.as_deref());
-        let per_cell: Vec<(Vec<(u32, f32)>, u64)> = stream::iter(cell_probes)
+        let per_cell: Vec<(Vec<(u32, f32)>, ProbeTally)> = stream::iter(cell_probes)
             .buffer_unordered(max_in_flight)
             .try_collect()
             .await?;
-        let rows_reranked: u64 = per_cell.iter().map(|(_, rows)| rows).sum();
+        let mut tally = ProbeTally::default();
+        for (_, cell_tally) in &per_cell {
+            tally.cells_scanned += cell_tally.cells_scanned;
+            tally.candidates_scanned += cell_tally.candidates_scanned;
+            tally.ranges_requested += cell_tally.ranges_requested;
+            tally.rows_reranked += cell_tally.rows_reranked;
+        }
         let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flat_map(|(hits, _)| hits).collect();
         // Distance ascending (smaller = closer), matching every other vector
         // search path. Descending here kept the farthest k hits and collapsed
         // packed-shard recall to ~0.
         merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         merged.truncate(k);
-        Ok((merged, rows_reranked))
+        Ok((merged, tally))
     }
 
     /// Deferred-rerank scan for the supertable's GLOBAL shortlist selection
@@ -3500,16 +3516,26 @@ impl VectorReader {
                 let (cluster_meta, prefix_ranges) = chosen_cluster_meta(col, &cluster_idx, &locals);
                 if cluster_meta.is_empty() {
                     // The cluster-index read itself was one planned range.
-                    return Ok((Vec::new(), Vec::new(), 0, 1, 0));
+                    let tally = ProbeTally {
+                        ranges_requested: 1,
+                        ..ProbeTally::default()
+                    };
+                    return Ok((Vec::new(), Vec::new(), tally));
                 }
                 // Work-stats tallies, taken before the warm/cold branch so
                 // both arms count the codes their clusters hold. Ranges:
                 // the cluster index plus one per prefix span (the warm
                 // arm's fetches; the cold arm's whole-cluster blocks are
                 // one range per chosen cluster, the same count).
-                let candidates_scanned: u64 =
-                    cluster_meta.iter().map(|(_, _, cnt)| u64::from(*cnt)).sum();
-                let ranges_requested = 1 + prefix_ranges.len() as u64;
+                let mut tally = ProbeTally {
+                    cells_scanned: 1,
+                    candidates_scanned: cluster_meta
+                        .iter()
+                        .map(|(_, _, cnt)| u64::from(*cnt))
+                        .sum(),
+                    ranges_requested: 1 + prefix_ranges.len() as u64,
+                    rows_reranked: 0,
+                };
                 // Warm fast path: every prefix resident -> defer rerank.
                 let prefix_blocks: Option<Vec<Bytes>> = prefix_ranges
                     .iter()
@@ -3540,9 +3566,11 @@ impl VectorReader {
                             cell_idx,
                         })
                         .collect();
-                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64, u64, u64), VectorError>(
-                        (Vec::new(), cands, candidates_scanned, ranges_requested, 0),
-                    );
+                    return Ok::<(Vec<(u32, f32)>, Vec<ScanCandidate>, ProbeTally), VectorError>((
+                        Vec::new(),
+                        cands,
+                        tally,
+                    ));
                 }
                 // Cold (or RabitqOnly): probe-and-rerank now, width-divided.
                 let ctx = ProbeCtx {
@@ -3554,35 +3582,36 @@ impl VectorReader {
                     pool,
                     budget,
                 };
-                let (hits, rows_reranked) = self
+                let (hits, probe_tally) = self
                     .probe_clusters_async(col, query, &ctx, &cluster_idx, &locals)
                     .await?;
+                // Only the rerank rows come from the probe: this scan
+                // already counted the cell, its candidates, and its
+                // cluster-index + prefix ranges before the branch, and the
+                // probe's own tallies cover the same clusters.
+                tally.rows_reranked = probe_tally.rows_reranked;
                 Ok((
                     hits.into_iter()
                         .map(|(local_id, score)| (base.saturating_add(local_id), score))
                         .collect(),
                     Vec::new(),
-                    candidates_scanned,
-                    ranges_requested,
-                    rows_reranked,
+                    tally,
                 ))
             })
         });
         let max_in_flight = pool_wave_cap(pool.as_deref());
-        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>, u64, u64, u64)> =
+        let per_cell_results: Vec<(Vec<(u32, f32)>, Vec<ScanCandidate>, ProbeTally)> =
             stream::iter(cell_scans)
                 .buffer_unordered(max_in_flight)
                 .try_collect()
                 .await?;
-        for (hits, cands, candidates_scanned, ranges_requested, rows_reranked) in per_cell_results {
+        for (hits, cands, tally) in per_cell_results {
             outcome.hits.extend(hits);
             outcome.candidates.extend(cands);
-            outcome.ranges_requested += ranges_requested;
-            outcome.rows_reranked += rows_reranked;
-            if candidates_scanned > 0 {
-                outcome.cells_scanned += 1;
-                outcome.candidates_scanned += candidates_scanned;
-            }
+            outcome.cells_scanned += tally.cells_scanned;
+            outcome.candidates_scanned += tally.candidates_scanned;
+            outcome.ranges_requested += tally.ranges_requested;
+            outcome.rows_reranked += tally.rows_reranked;
         }
         // Cold hits merge to this file's top-k exactly as the immediate
         // path does; candidates stay unbounded here (per-cell heaps
@@ -3746,12 +3775,21 @@ impl VectorReader {
         ctx: &ProbeCtx<'_>,
         cluster_idx: &[u8],
         chosen: &[usize],
-    ) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
+    ) -> Result<(Vec<(u32, f32)>, ProbeTally), VectorError> {
         let cb = col.quant.code_bytes();
         let (cluster_meta, cluster_prefix_ranges) = chosen_cluster_meta(col, cluster_idx, chosen);
         if cluster_meta.is_empty() {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), ProbeTally::default()));
         }
+        // Plan tallies, fixed before the warm/cold fetch branch: both arms
+        // scan the same clusters and request one prefix/block range each
+        // (the caller counts the cluster-index range it fetched).
+        let mut tally = ProbeTally {
+            cells_scanned: 1,
+            candidates_scanned: cluster_meta.iter().map(|&(_, _, cnt)| u64::from(cnt)).sum(),
+            ranges_requested: cluster_meta.len() as u64,
+            rows_reranked: 0,
+        };
         let lazy_sq8_meta_range = lazy_sq8_meta_range(col);
         // Warm fast path: every prefix already resident → sync zero-copy.
         let prefix_blocks_sync: Option<Vec<Bytes>> = cluster_prefix_ranges
@@ -3860,7 +3898,7 @@ impl VectorReader {
                 if let Some(t0) = shortlist_t0 {
                     io_counters::phase_record("vec.shortlist", t0.elapsed().as_micros() as u64);
                 }
-                return Ok((out, 0));
+                return Ok((out, tally));
             }
             ShortlistOutcome::Rerank {
                 candidates,
@@ -3885,7 +3923,7 @@ impl VectorReader {
             io_counters::phase_record("vec.survivor_fetch", t0.elapsed().as_micros() as u64);
         }
 
-        let rows_reranked = candidates.len() as u64;
+        tally.rows_reranked = candidates.len() as u64;
         let hits = io_counters::phase_timed_async("vec.rerank", async {
             rerank_candidates_from_blocks(
                 &self.source,
@@ -3901,7 +3939,7 @@ impl VectorReader {
             .await
         })
         .await?;
-        Ok((hits, rows_reranked))
+        Ok((hits, tally))
     }
 
     /// Look up the column by name and validate `query.len() == col.dim`
@@ -4491,6 +4529,32 @@ pub(crate) struct ScanCandidate {
     pub(crate) cluster_id: u32,
     /// Cell directory index within this superfile.
     pub(crate) cell_idx: usize,
+}
+
+/// Work tallies from one cell probe (immediate arm) or one scanned cell
+/// (deferred arm) — named counters, so a flush or merge site can never
+/// silently swap two positional `u64`s and still type-check.
+/// `pub` (not `pub(crate)`) because the carrying search fns are the
+/// test-helpers-widened surface benches call; the module gate in
+/// `lib.rs` keeps all of it crate-private in normal builds.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ProbeTally {
+    /// Cells that contributed at least one chosen, non-empty cluster
+    /// (0 or 1 from a single probe; summed by multi-cell callers).
+    pub cells_scanned: u64,
+    /// Σ row counts over every chosen cluster — the quantized codes the
+    /// 1-bit estimator scanned. Identical warm or cold.
+    pub candidates_scanned: u64,
+    /// Byte-source ranges the probe plan requested: one prefix/block
+    /// range per chosen cluster, plus the cell's cluster index where the
+    /// probing fn fetched it itself. Rerank row ranges are NOT counted
+    /// here — the supertable charges the plan's rerank budget so the
+    /// priced count stays identical across the warm (survivor-fetch)
+    /// and cold (rows-in-block) executions.
+    pub ranges_requested: u64,
+    /// Rows this probe actually reranked at full precision (execution
+    /// diagnostic — see `OpStats::vector_rows_reranked`).
+    pub rows_reranked: u64,
 }
 
 /// Result of a deferred-rerank scan over one superfile
@@ -9854,6 +9918,79 @@ mod tests {
             .await
             .expect("out-of-range clusters");
         assert!(none.is_empty(), "ids >= n_cent are ignored");
+    }
+
+    #[tokio::test]
+    async fn probe_tallies_are_identical_warm_and_cold() {
+        // The plan tallies must not depend on residency: an eager
+        // (always warm) reader and a lazy reader with sync reads
+        // disabled (always cold) take different fetch branches — warm
+        // survivor-only gather vs cold rows-in-block — yet must report
+        // the same cells, candidates, planned ranges, AND rows: the
+        // immediate probe's shortlist is decided before the branch.
+        let (blob, json, all) = build_search_corpus();
+        let r_eager = VectorReader::open(blob.clone(), &json).expect("eager open");
+        let counting = StdArc::new(CountingLazyByteSource::new(blob));
+        let r_lazy = VectorReader::open_with_source(
+            Source::Lazy(StdArc::clone(&counting) as StdArc<dyn LazyByteSource>),
+            &json,
+            OpenOptions::default(),
+        )
+        .expect("lazy open");
+        counting.disable_sync();
+
+        let clusters: Vec<u32> = (0..4).collect();
+        let (_, cold) = r_lazy
+            .search_clusters_async(
+                "embedding",
+                &all[19],
+                5,
+                &clusters,
+                5,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("cold probe");
+        let (_, warm) = r_eager
+            .search_clusters_async(
+                "embedding",
+                &all[19],
+                5,
+                &clusters,
+                5,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("warm probe");
+        assert!(
+            warm.cells_scanned >= 1 && warm.candidates_scanned > 0,
+            "fixture probe must do real work (cells {}, candidates {})",
+            warm.cells_scanned,
+            warm.candidates_scanned
+        );
+        assert_eq!(
+            warm.cells_scanned, cold.cells_scanned,
+            "cells are plan-derived"
+        );
+        assert_eq!(
+            warm.candidates_scanned, cold.candidates_scanned,
+            "candidates are plan-derived"
+        );
+        assert_eq!(
+            warm.ranges_requested, cold.ranges_requested,
+            "planned ranges are cache-normalized: warm prefix fetches and cold \
+             whole-cluster blocks plan the same count"
+        );
+        assert_eq!(
+            warm.rows_reranked, cold.rows_reranked,
+            "the immediate probe's rerank set is fixed before the fetch branch"
+        );
     }
 
     #[tokio::test]

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -1722,7 +1722,7 @@ mod tests {
 
         // Each batch has 2 docs sharing a unique word — search for each batch's unique term
         for term in &["alpha", "beta", "gamma"] {
-            let hits = merged_reader
+            let (hits, _) = merged_reader
                 .token_match("title", &[*term], BoolMode::And)
                 .await
                 .unwrap_or_else(|_| panic!("token_match for '{term}'"));
@@ -1944,7 +1944,8 @@ mod tests {
         let fts_hits = merged_reader
             .token_match("title", &["alpha"], BoolMode::And)
             .await
-            .expect("token_match on merged superfile");
+            .expect("token_match on merged superfile")
+            .0;
         assert_eq!(fts_hits.len(), 4, "all four 'alpha' docs must match");
     }
 
@@ -2053,7 +2054,8 @@ mod tests {
         let only_hits = merged_reader
             .token_match("title", &["only"], BoolMode::And)
             .await
-            .expect("token_match for 'only'");
+            .expect("token_match for 'only'")
+            .0;
         assert_eq!(
             only_hits.len(),
             1,
@@ -2063,7 +2065,8 @@ mod tests {
         let second_hits = merged_reader
             .token_match("title", &["second"], BoolMode::And)
             .await
-            .expect("token_match for 'second'");
+            .expect("token_match for 'second'")
+            .0;
         assert_eq!(
             second_hits.len(),
             1,

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -595,17 +595,33 @@ impl Supertable {
     /// Pin the current in-memory manifest without a storage freshness check.
     /// Hidden vector queries use this for slow-state residency while their
     /// fast delete/watermark refresh runs concurrently with data I/O.
+    ///
+    /// Consults the caller's [`with_op_stats`] scope — valid only on the
+    /// thread that opened the scope, which the public search entry points
+    /// (reader mint on the caller's thread) satisfy. Mid-query mints run
+    /// on runtime threads where the scope's thread-local is invisible, so
+    /// they go through [`Self::pinned_reader_with`] and inherit the outer
+    /// reader's collector instead.
     fn pinned_reader(&self) -> SupertableReader {
+        self.pinned_reader_with(op_stats::current())
+    }
+    }
+
+    /// [`Self::pinned_reader`] with an explicitly supplied per-query
+    /// collector — the mint for readers created *mid-query* (the hidden
+    /// vector-index legs), which must inherit the driving reader's
+    /// collector rather than consult a thread-local that runtime threads
+    /// never see.
+    pub(crate) fn pinned_reader_with(
+        &self,
+        op_stats: Option<Arc<OpStatsCollector>>,
+    ) -> SupertableReader {
         SupertableReader {
             manifest: self.inner.manifest.load_full(),
             tombstone_cache: self.inner.tombstone_cache.clone(),
             inner: Arc::clone(&self.inner),
-            // The public search methods mint their reader on the caller's
-            // thread, so this is the one point where an active
-            // `with_op_stats` scope hands its collector to the query.
-            op_stats: op_stats::current(),
+            op_stats,
         }
-    }
     }
 
     test_visible! {

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -41,6 +41,7 @@ use super::{
 use crate::{
     config,
     runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
+    runtime_metrics::op_stats::{self, OpStatsCollector},
     storage::{PrefixedStorageProvider, StorageError},
     superfile::{
         builder::VectorConfig,
@@ -599,6 +600,10 @@ impl Supertable {
             manifest: self.inner.manifest.load_full(),
             tombstone_cache: self.inner.tombstone_cache.clone(),
             inner: Arc::clone(&self.inner),
+            // The public search methods mint their reader on the caller's
+            // thread, so this is the one point where an active
+            // `with_op_stats` scope hands its collector to the query.
+            op_stats: op_stats::current(),
         }
     }
     }
@@ -1784,6 +1789,12 @@ pub struct SupertableReader {
     /// keeps the runtime alive for the reader's lifetime, so a reader
     /// captured before its parent `Supertable` drops can still query.
     inner: Arc<SupertableInner>,
+    /// Per-query work collector, picked up from the caller's active
+    /// [`with_op_stats`](crate::runtime_metrics::op_stats::with_op_stats)
+    /// scope at mint time. `None` (the default) makes every counter
+    /// flush a no-op branch. Query kernels clone the `Arc` into their
+    /// fan-out bodies; the thread-local is never consulted past mint.
+    pub(crate) op_stats: Option<Arc<OpStatsCollector>>,
 }
 
 /// A non-owning handle to a pinned reader snapshot, held by the SQL
@@ -1908,6 +1919,12 @@ impl SupertableReader {
             manifest,
             tombstone_cache,
             inner,
+            // A `WeakReader` is cached inside a `SessionContext` that
+            // outlives individual queries, so a collector captured here
+            // would mis-attribute later queries to an earlier scope. The
+            // SQL path gets its own per-query attribution channel; until
+            // then TVF-driven searches deliberately record no work stats.
+            op_stats: None,
         }
     }
 

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1814,6 +1814,12 @@ pub(crate) struct WeakReader {
     inner: Weak<SupertableInner>,
     manifest: Arc<ManifestSnapshot>,
     tombstone_cache: Option<Arc<SidecarCache>>,
+    /// Per-query work collector carried through the weak round-trip. Safe
+    /// because TVF exec plans are built per query; state that outlives a
+    /// query (the cached SQL `SessionContext`) is constructed under
+    /// [`op_stats::suppressed`] and from a detached reader, so no
+    /// long-lived `WeakReader` ever holds a scope's collector.
+    op_stats: Option<Arc<OpStatsCollector>>,
 }
 
 impl fmt::Debug for WeakReader {
@@ -1829,6 +1835,7 @@ impl WeakReader {
             inner: Arc::downgrade(reader.inner_arc()),
             manifest: Arc::clone(reader.manifest()),
             tombstone_cache: reader.tombstone_cache.clone(),
+            op_stats: reader.op_stats.clone(),
         }
     }
 
@@ -1840,6 +1847,7 @@ impl WeakReader {
             inner,
             Arc::clone(&self.manifest),
             self.tombstone_cache.clone(),
+            self.op_stats.clone(),
         )))
     }
 }
@@ -1914,17 +1922,13 @@ impl SupertableReader {
         inner: Arc<SupertableInner>,
         manifest: Arc<ManifestSnapshot>,
         tombstone_cache: Option<Arc<SidecarCache>>,
+        op_stats: Option<Arc<OpStatsCollector>>,
     ) -> Self {
         Self {
             manifest,
             tombstone_cache,
             inner,
-            // A `WeakReader` is cached inside a `SessionContext` that
-            // outlives individual queries, so a collector captured here
-            // would mis-attribute later queries to an earlier scope. The
-            // SQL path gets its own per-query attribution channel; until
-            // then TVF-driven searches deliberately record no work stats.
-            op_stats: None,
+            op_stats,
         }
     }
 

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -51,7 +51,10 @@ use roaring::RoaringBitmap;
 use crate::{
     superfile::{
         ReadError, SuperfileReader,
-        fts::{reader::BoolMode, tokenize::Tokenizer},
+        fts::{
+            reader::{BoolMode, MatchWork},
+            tokenize::Tokenizer,
+        },
     },
     supertable::{
         error::QueryError,
@@ -111,44 +114,53 @@ impl CandidatePlan {
     /// — scan all rows"; `Ok(Some(bitmap))` is the candidate
     /// `local_doc_id` superset (possibly empty). `TermsAll` is one
     /// `token_match(.., And)`; `And`/`Or` intersect/union children.
+    /// The second element sums the posting-walk work of every `TermsAll`
+    /// leaf the evaluation touched (an early-out keeps the work already
+    /// done), so the caller can flush it per superfile.
     pub(crate) fn evaluate<'a>(
         &'a self,
         reader: &'a SuperfileReader,
-    ) -> BoxFuture<'a, Result<Option<RoaringBitmap>, ReadError>> {
+    ) -> BoxFuture<'a, Result<(Option<RoaringBitmap>, MatchWork), ReadError>> {
         Box::pin(async move {
             match self {
-                CandidatePlan::Unbounded => Ok(None),
+                CandidatePlan::Unbounded => Ok((None, MatchWork::default())),
                 CandidatePlan::TermsAll { column, tokens } => {
                     let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
-                    let docs = reader.token_match(column, &refs, BoolMode::And).await?;
-                    Ok(Some(docs.into_iter().collect()))
+                    let (docs, work) = reader.token_match(column, &refs, BoolMode::And).await?;
+                    Ok((Some(docs.into_iter().collect()), work))
                 }
                 CandidatePlan::And(children) => {
                     let mut acc: Option<RoaringBitmap> = None;
+                    let mut work = MatchWork::default();
                     for c in children {
-                        if let Some(bm) = c.evaluate(reader).await? {
+                        let (child, child_work) = c.evaluate(reader).await?;
+                        work.merge(child_work);
+                        if let Some(bm) = child {
                             acc = Some(match acc {
                                 Some(a) => a & bm,
                                 None => bm,
                             });
                             if acc.as_ref().is_some_and(RoaringBitmap::is_empty) {
-                                return Ok(Some(RoaringBitmap::new()));
+                                return Ok((Some(RoaringBitmap::new()), work));
                             }
                         }
                         // A `None` (unbounded) child adds no constraint.
                     }
-                    Ok(acc)
+                    Ok((acc, work))
                 }
                 CandidatePlan::Or(children) => {
                     let mut acc = RoaringBitmap::new();
+                    let mut work = MatchWork::default();
                     for c in children {
-                        match c.evaluate(reader).await? {
+                        let (child, child_work) = c.evaluate(reader).await?;
+                        work.merge(child_work);
+                        match child {
                             Some(bm) => acc |= bm,
                             // An unbounded branch makes the union unbounded.
-                            None => return Ok(None),
+                            None => return Ok((None, work)),
                         }
                     }
-                    Ok(Some(acc))
+                    Ok((Some(acc), work))
                 }
             }
         })
@@ -248,43 +260,47 @@ impl CandidatePlan {
     /// predicate would match a large fraction of the superfile — there the
     /// matches saturate the data pages so an index `RowSelection` can't
     /// skip any, and a plain scan is cheaper.
+    /// The second element sums the header-fetch work of every leaf df
+    /// probe, so the caller can flush it per superfile.
     pub(crate) fn estimate<'a>(
         &'a self,
         reader: &'a SuperfileReader,
-    ) -> BoxFuture<'a, Result<u64, ReadError>> {
+    ) -> BoxFuture<'a, Result<(u64, MatchWork), ReadError>> {
         Box::pin(async move {
             let n_docs = reader.n_docs();
             match self {
-                CandidatePlan::Unbounded => Ok(n_docs),
+                CandidatePlan::Unbounded => Ok((n_docs, MatchWork::default())),
                 CandidatePlan::TermsAll { column, tokens } => {
                     if tokens.is_empty() {
-                        return Ok(n_docs);
+                        return Ok((n_docs, MatchWork::default()));
                     }
                     // Intersection ≤ the rarest token's df — resolved with
                     // one batched df lookup (single FST parse + coalesced
                     // header fetch) rather than one parse + fetch per token.
                     let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
-                    let min_df = reader
-                        .term_dfs(column, &refs)
-                        .await?
-                        .into_iter()
-                        .min()
-                        .unwrap_or(u64::MAX);
-                    Ok(min_df.min(n_docs))
+                    let (dfs, work) = reader.term_dfs(column, &refs).await?;
+                    let min_df = dfs.into_iter().min().unwrap_or(u64::MAX);
+                    Ok((min_df.min(n_docs), work))
                 }
                 CandidatePlan::And(children) => {
                     let mut m = n_docs;
+                    let mut work = MatchWork::default();
                     for c in children {
-                        m = m.min(c.estimate(reader).await?);
+                        let (child, child_work) = c.estimate(reader).await?;
+                        work.merge(child_work);
+                        m = m.min(child);
                     }
-                    Ok(m)
+                    Ok((m, work))
                 }
                 CandidatePlan::Or(children) => {
                     let mut sum: u64 = 0;
+                    let mut work = MatchWork::default();
                     for c in children {
-                        sum = sum.saturating_add(c.estimate(reader).await?);
+                        let (child, child_work) = c.estimate(reader).await?;
+                        work.merge(child_work);
+                        sum = sum.saturating_add(child);
                     }
-                    Ok(sum.min(n_docs))
+                    Ok((sum.min(n_docs), work))
                 }
             }
         })

--- a/src/supertable/query/df_object_store.rs
+++ b/src/supertable/query/df_object_store.rs
@@ -59,10 +59,17 @@ const SUPERFILE_LAST_MODIFIED: DateTime<Utc> = DateTime::UNIX_EPOCH;
 /// [`Self::insert_source`] as immutable files are first opened, and reuses it
 /// for every DataFusion scan of that manifest.
 pub(crate) struct SuperfileObjectStore {
-    /// Per-query work collector, captured at construction — the provider
-    /// (and therefore this store) is built per query on the caller's
-    /// thread inside `query_sql`, so the capture is per-query by
-    /// construction and can never leak across queries.
+    /// Per-query work collector, captured at construction. On the catalog
+    /// path (`Connection::query_sql`) the provider — and therefore this
+    /// store — is built fresh per query on the caller's thread, so the
+    /// capture is per-query by construction and can never leak across
+    /// queries. The reader-level cached `SessionContext`
+    /// (`sql_session_context`) instead builds its provider under
+    /// `op_stats::suppressed`, so this is `None` there by design — a
+    /// collector riding a cached context would bill later queries into
+    /// an old scope. That cached path serves mutation id-capture
+    /// (`scan_ids_matching`) and the test-only reader `query_sql`,
+    /// neither of which is part of the metered read surface.
     op_stats: Option<Arc<OpStatsCollector>>,
     /// One byte source per surviving superfile, keyed by the same path
     /// used to build the superfile's `PartitionedFile`.

--- a/src/supertable/query/df_object_store.rs
+++ b/src/supertable/query/df_object_store.rs
@@ -41,6 +41,7 @@ use object_store::{
     PutPayload, PutResult, Result as OsResult, path::Path as ObjPath,
 };
 
+use crate::runtime_metrics::op_stats::{self, OpStatsCollector};
 use crate::superfile::{LazyByteSource, lazy_source::Source};
 
 /// Fixed `last_modified` reported for every registered superfile.
@@ -56,6 +57,11 @@ const SUPERFILE_LAST_MODIFIED: DateTime<Utc> = DateTime::UNIX_EPOCH;
 /// [`Self::insert_source`] as immutable files are first opened, and reuses it
 /// for every DataFusion scan of that manifest.
 pub(crate) struct SuperfileObjectStore {
+    /// Per-query work collector, captured at construction — the provider
+    /// (and therefore this store) is built per query on the caller's
+    /// thread inside `query_sql`, so the capture is per-query by
+    /// construction and can never leak across queries.
+    op_stats: Option<Arc<OpStatsCollector>>,
     /// One byte source per surviving superfile, keyed by the same path
     /// used to build the superfile's `PartitionedFile`.
     sources: Arc<DashMap<ObjPath, Arc<dyn LazyByteSource>>>,
@@ -79,6 +85,7 @@ impl SuperfileObjectStore {
     /// Empty registry filled lazily as a pinned provider prepares files.
     pub(crate) fn new() -> Self {
         Self {
+            op_stats: op_stats::current(),
             sources: Arc::new(DashMap::new()),
         }
     }
@@ -155,6 +162,14 @@ impl ObjectStore for SuperfileObjectStore {
 
         let range = resolve_range(options.range, size);
         let len = range.end.saturating_sub(range.start);
+        if let Some(stats) = &self.op_stats
+            && len > 0
+        {
+            // Parquet-driven plan reads: page/footer ranges the scan needs,
+            // counted before the byte source decides resident vs fetch.
+            stats.add_sql_page_bytes(len);
+            stats.add_planned_read_ranges(1);
+        }
         let bytes = if len == 0 {
             Bytes::new()
         } else {

--- a/src/supertable/query/df_object_store.rs
+++ b/src/supertable/query/df_object_store.rs
@@ -41,8 +41,10 @@ use object_store::{
     PutPayload, PutResult, Result as OsResult, path::Path as ObjPath,
 };
 
-use crate::runtime_metrics::op_stats::{self, OpStatsCollector};
-use crate::superfile::{LazyByteSource, lazy_source::Source};
+use crate::{
+    runtime_metrics::op_stats::{self, OpStatsCollector},
+    superfile::{LazyByteSource, lazy_source::Source},
+};
 
 /// Fixed `last_modified` reported for every registered superfile.
 /// Superfiles are immutable once committed, so a wall-clock timestamp

--- a/src/supertable/query/df_object_store.rs
+++ b/src/supertable/query/df_object_store.rs
@@ -90,6 +90,13 @@ impl SuperfileObjectStore {
         }
     }
 
+    /// The per-query collector this store captured at construction — the
+    /// provider flushes its predicate-walk work through the same channel
+    /// that meters this scan's page bytes.
+    pub(crate) fn op_stats(&self) -> Option<Arc<OpStatsCollector>> {
+        self.op_stats.clone()
+    }
+
     /// Build the store from the superfile byte sources gathered during a
     /// scan. Each key is the path the matching `PartitionedFile` is
     /// created with.

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -49,6 +49,7 @@ use uuid::Uuid;
 
 use super::SuperfileHit;
 use crate::{
+    runtime_metrics::op_stats::{self, OpStatsCollector},
     storage::StorageProvider,
     superfile::{
         SuperfileReader,
@@ -259,6 +260,7 @@ pub(crate) async fn attach_stable_ids(
     entry: &SuperfileEntry,
     hits: &mut [SuperfileHit],
     fetch_lazy_id_page: bool,
+    op_stats: &Option<Arc<OpStatsCollector>>,
 ) -> Result<(), QueryError> {
     if hits.is_empty() {
         return Ok(());
@@ -271,6 +273,12 @@ pub(crate) async fn attach_stable_ids(
     }
     let locals: Vec<u32> = hits.iter().map(|h| h.local_doc_id).collect();
     if let Some(ids) = stable_ids_for_tagged_hits(reader, &locals).await? {
+        // The inline stable-id region is one planned range per file —
+        // whether it resolved from residency, the cold ride-along stash,
+        // or a fetch (the plan requests it identically either way).
+        if let Some(stats) = op_stats {
+            stats.add_planned_read_ranges(1);
+        }
         for (hit, id) in hits.iter_mut().zip(ids) {
             hit.stable_id = Some(id);
         }
@@ -284,11 +292,17 @@ pub(crate) async fn attach_stable_ids(
     // promoted hybrid) — the async stream take pays per-call setup that
     // dominates targeted id reads; only genuinely lazy readers await it.
     let batch = if reader.can_take_by_local_doc_ids() {
-        reader
-            .take_by_local_doc_ids(&locals, &[id_column])
-            .map_err(|error| QueryError::Execute(error.to_string()))?
+        let (batch, decode_ns) = op_stats::timed_section(|| {
+            reader
+                .take_by_local_doc_ids(&locals, &[id_column])
+                .map_err(|error| QueryError::Execute(error.to_string()))
+        });
+        if let Some(stats) = op_stats {
+            stats.add_kernel_cpu_ns(decode_ns);
+        }
+        batch?
     } else {
-        take_rows_byte_source(reader, &locals, &[id_column])
+        take_rows_byte_source(reader, &locals, &[id_column], op_stats.clone())
             .await
             .map_err(|error| QueryError::Execute(error.to_string()))?
     };
@@ -344,6 +358,7 @@ pub(crate) async fn apply_resolved_tombstone_filter(
     entry: &SuperfileEntry,
     hits: &mut Vec<SuperfileHit>,
     now: Instant,
+    op_stats: &Option<Arc<OpStatsCollector>>,
 ) -> Result<(), QueryError> {
     if entry.vector_layout != VectorLayout::MultiCellIvf {
         return apply_tombstone_filter(cache, entry, hits, now);
@@ -360,9 +375,15 @@ pub(crate) async fn apply_resolved_tombstone_filter(
     let locals: Vec<u32> = bitmap.iter().collect();
     let id_column = reader.id_column();
     let batch = if reader.parquet_bytes().is_some() {
-        reader
-            .take_by_local_doc_ids(&locals, &[id_column])
-            .map_err(|e| QueryError::Execute(e.to_string()))?
+        let (batch, decode_ns) = op_stats::timed_section(|| {
+            reader
+                .take_by_local_doc_ids(&locals, &[id_column])
+                .map_err(|e| QueryError::Execute(e.to_string()))
+        });
+        if let Some(stats) = op_stats {
+            stats.add_kernel_cpu_ns(decode_ns);
+        }
+        batch?
     } else {
         let storage = storage.ok_or_else(|| {
             QueryError::Execute(
@@ -384,6 +405,7 @@ pub(crate) async fn apply_resolved_tombstone_filter(
             reader.n_docs(),
             &locals,
             &[id_column],
+            op_stats.clone(),
         )
         .await
         .map_err(|e| QueryError::Execute(e.to_string()))?

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -302,7 +302,7 @@ pub(crate) async fn attach_stable_ids(
         }
         batch?
     } else {
-        take_rows_byte_source(reader, &locals, &[id_column], op_stats.clone())
+        take_rows_byte_source(reader, &locals, &[id_column])
             .await
             .map_err(|error| QueryError::Execute(error.to_string()))?
     };
@@ -405,7 +405,6 @@ pub(crate) async fn apply_resolved_tombstone_filter(
             reader.n_docs(),
             &locals,
             &[id_column],
-            op_stats.clone(),
         )
         .await
         .map_err(|e| QueryError::Execute(e.to_string()))?

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -24,6 +24,7 @@ use bytes::Bytes;
 use datafusion::{
     error::{DataFusionError, Result as DfResult},
     logical_expr::Expr,
+    physical_plan::ExecutionPlan,
     scalar::ScalarValue,
 };
 use futures::{
@@ -88,6 +89,44 @@ pub(crate) fn search_query_df_error(e: QueryError) -> DataFusionError {
 /// by every public row-returning search method (`bm25_search`,
 /// `vector_search`, `token_match`, `exact_match`); `what` labels error
 /// messages with the calling method.
+/// Fold DataFusion's own operator instrumentation into the per-query
+/// stats after a SQL plan has executed. Every operator's
+/// `elapsed_compute` (DataFusion brackets its synchronous poll sections
+/// with an `Instant` timer — approximately on-CPU for compute-bound
+/// operators, and excluding async I/O waits) sums into the kernel
+/// counter; leaf (source) operators' `output_rows` sum into
+/// `rows_materialized` — the rows the scans decoded from storage.
+/// Infino's own TVF exec nodes report no DataFusion metrics (their
+/// kernels bracket and flush internally), so nothing double-counts.
+pub(crate) fn harvest_datafusion_metrics(
+    plan: &Arc<dyn ExecutionPlan>,
+    op_stats: &Option<Arc<OpStatsCollector>>,
+) {
+    fn walk(node: &Arc<dyn ExecutionPlan>, compute_ns: &mut u64, leaf_rows: &mut u64) {
+        if let Some(metrics) = node.metrics() {
+            if let Some(ns) = metrics.elapsed_compute() {
+                *compute_ns += ns as u64;
+            }
+            if node.children().is_empty()
+                && let Some(rows) = metrics.output_rows()
+            {
+                *leaf_rows += rows as u64;
+            }
+        }
+        for child in node.children() {
+            walk(child, compute_ns, leaf_rows);
+        }
+    }
+    let Some(stats) = op_stats else {
+        return;
+    };
+    let mut compute_ns = 0u64;
+    let mut leaf_rows = 0u64;
+    walk(plan, &mut compute_ns, &mut leaf_rows);
+    stats.add_kernel_cpu_ns(compute_ns);
+    stats.add_rows_materialized(leaf_rows);
+}
+
 pub(crate) async fn resolve_hits_named(
     reader: &SupertableReader,
     hits: &[SuperfileHit],

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -15,7 +15,7 @@
 //!
 //! [`SuperfileReader::take_by_local_doc_ids`]: crate::superfile::SuperfileReader::take_by_local_doc_ids
 
-use std::{ops::Range, sync::Arc};
+use std::{collections::HashSet, ops::Range, sync::Arc};
 
 use arrow::compute::{concat_batches, interleave_record_batch, take};
 use arrow_array::{ArrayRef, Decimal128Array, Float32Array, RecordBatch, RecordBatchOptions};
@@ -102,7 +102,18 @@ pub(crate) fn harvest_datafusion_metrics(
     plan: &Arc<dyn ExecutionPlan>,
     op_stats: &Option<Arc<OpStatsCollector>>,
 ) {
-    fn walk(node: &Arc<dyn ExecutionPlan>, compute_ns: &mut u64, leaf_rows: &mut u64) {
+    // Deduped by node identity: plans are trees in practice, but nothing
+    // forbids an operator `Arc` appearing under two parents, and a shared
+    // node's metrics must not be added once per path.
+    fn walk(
+        node: &Arc<dyn ExecutionPlan>,
+        seen: &mut HashSet<usize>,
+        compute_ns: &mut u64,
+        leaf_rows: &mut u64,
+    ) {
+        if !seen.insert(Arc::as_ptr(node) as *const () as usize) {
+            return;
+        }
         if let Some(metrics) = node.metrics() {
             if let Some(ns) = metrics.elapsed_compute() {
                 *compute_ns += ns as u64;
@@ -114,15 +125,16 @@ pub(crate) fn harvest_datafusion_metrics(
             }
         }
         for child in node.children() {
-            walk(child, compute_ns, leaf_rows);
+            walk(child, seen, compute_ns, leaf_rows);
         }
     }
     let Some(stats) = op_stats else {
         return;
     };
+    let mut seen = HashSet::new();
     let mut compute_ns = 0u64;
     let mut leaf_rows = 0u64;
-    walk(plan, &mut compute_ns, &mut leaf_rows);
+    walk(plan, &mut seen, &mut compute_ns, &mut leaf_rows);
     stats.add_kernel_cpu_ns(compute_ns);
     stats.add_rows_materialized(leaf_rows);
 }

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -44,6 +44,7 @@ use rayon::prelude::*;
 
 use crate::{
     runtime_bridge::run_on_pool,
+    runtime_metrics::op_stats::{OpStatsCollector, timed_section},
     superfile::{
         SuperfileReader,
         lazy_source::Source,
@@ -511,7 +512,7 @@ async fn resolve_columns(
 
     let warm_wave = async {
         if warm_inputs.is_empty() {
-            return Ok::<Vec<(usize, RecordBatch)>, DataFusionError>(Vec::new());
+            return Ok::<Vec<((usize, RecordBatch), u64)>, DataFusionError>(Vec::new());
         }
         // Owned inputs so the rayon closure is `'static`.
         let owned_names: Vec<String> = names.iter().map(|s| (*s).to_string()).collect();
@@ -522,11 +523,14 @@ async fn resolve_columns(
             "resolve decode: reader pool dropped result",
             move || {
                 let name_refs: Vec<&str> = owned_names.iter().map(String::as_str).collect();
-                let result: Result<Vec<(usize, RecordBatch)>, _> = inputs
+                let result: Result<Vec<((usize, RecordBatch), u64)>, _> = inputs
                     .into_par_iter()
                     .map(|(i, sf, locals)| {
-                        sf.take_by_local_doc_ids(&locals, &name_refs)
-                            .map(|batch| (i, batch))
+                        // Per-superfile bracket: the resident decode is
+                        // this wave's kernel section, one chunk per file.
+                        let (batch, ns) =
+                            timed_section(|| sf.take_by_local_doc_ids(&locals, &name_refs));
+                        batch.map(|batch| ((i, batch), ns))
                     })
                     .collect();
                 result
@@ -537,18 +541,26 @@ async fn resolve_columns(
         .map_err(|e| DataFusionError::Execution(e.to_string()))
     };
 
-    let cold_wave = try_join_all(
-        cold_units
-            .into_iter()
-            .map(|(i, reader, locals)| async move {
-                take_rows_byte_source(reader, locals, names)
-                    .await
-                    .map(|batch| (i, batch))
-            }),
-    );
+    let op_stats = reader.op_stats.clone();
+    let cold_wave = try_join_all(cold_units.into_iter().map(|(i, rd, locals)| {
+        let op_stats = op_stats.clone();
+        async move {
+            take_rows_byte_source(rd, locals, names, op_stats)
+                .await
+                .map(|batch| (i, batch))
+        }
+    }));
 
     let (warm_done, cold_done) = tokio::join!(warm_wave, cold_wave);
-    for (i, batch) in warm_done?.into_iter().chain(cold_done?) {
+    let warm_done = warm_done?;
+    if let Some(stats) = &reader.op_stats {
+        stats.add_kernel_cpu_ns(warm_done.iter().map(|(_, ns)| *ns).sum());
+    }
+    for (i, batch) in warm_done
+        .into_iter()
+        .map(|(item, _)| item)
+        .chain(cold_done?)
+    {
         decoded_cache.insert(seg_order[i], &seg_locals[i], names, batch.clone());
         slots[i] = Some(batch);
     }
@@ -560,9 +572,54 @@ async fn resolve_columns(
     // gathers from the per-superfile arrays in one pass; the old
     // concatenate-then-take path allocated and copied every projected column
     // twice before producing the same top-k-sized output.
+    // Every hit row was decoded from stored columns (cache hits included:
+    // the decoded-scalar cache is per reader generation, so a served batch
+    // is still this query's planned materialization).
+    if let Some(stats) = &reader.op_stats {
+        stats.add_rows_materialized(hits.len() as u64);
+    }
     let batches: Vec<&RecordBatch> = per_superfile.iter().collect();
     interleave_record_batch(&batches, &placement)
         .map_err(|error| DataFusionError::Execution(error.to_string()))
+}
+
+/// [`AsyncFileReader`] adapter that counts every requested data range into
+/// the per-query collector — the take/materialize sibling of the DataFusion
+/// scan store's `get_opts` accounting. Counts are planned (pre-coalesce),
+/// so warm zero-copy resolution and cold GETs report identically. Metadata
+/// requests are NOT counted: the byte-source arm serves them from the
+/// reader-cached parse and the object-store arm's footer read is open-time
+/// amortized state, so counting either would make the tally depend on
+/// reader lifetime rather than the plan.
+struct CountedFileReader<R> {
+    inner: R,
+    op_stats: Option<Arc<OpStatsCollector>>,
+}
+
+impl<R: AsyncFileReader + Send> AsyncFileReader for CountedFileReader<R> {
+    fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, ParquetResult<Bytes>> {
+        if let Some(stats) = &self.op_stats {
+            stats.add_planned_read_ranges(1);
+        }
+        self.inner.get_bytes(range)
+    }
+
+    fn get_byte_ranges(
+        &mut self,
+        ranges: Vec<Range<u64>>,
+    ) -> BoxFuture<'_, ParquetResult<Vec<Bytes>>> {
+        if let Some(stats) = &self.op_stats {
+            stats.add_planned_read_ranges(ranges.len() as u64);
+        }
+        self.inner.get_byte_ranges(ranges)
+    }
+
+    fn get_metadata<'a>(
+        &'a mut self,
+        options: Option<&'a ArrowReaderOptions>,
+    ) -> BoxFuture<'a, ParquetResult<Arc<ParquetMetaData>>> {
+        self.inner.get_metadata(options)
+    }
 }
 
 /// Parquet async reader backed by the `SuperfileReader`'s existing byte source.
@@ -621,10 +678,12 @@ impl AsyncFileReader for ByteSourceAsyncReader {
 }
 
 /// Stream projected rows through a reader's cache-aware byte source.
+/// Data-page requests count into `op_stats` as planned ranges.
 pub(crate) async fn take_rows_byte_source(
     reader: &SuperfileReader,
     local_doc_ids: &[u32],
     names: &[&str],
+    op_stats: Option<Arc<OpStatsCollector>>,
 ) -> DfResult<RecordBatch> {
     let metadata = reader
         .parquet_metadata_with_page_index()
@@ -640,6 +699,7 @@ pub(crate) async fn take_rows_byte_source(
         reader.n_docs(),
         local_doc_ids,
         names,
+        op_stats,
     )
     .await
 }
@@ -657,13 +717,22 @@ pub(crate) async fn take_rows_object_store(
     n_docs: u64,
     local_doc_ids: &[u32],
     names: &[&str],
+    op_stats: Option<Arc<OpStatsCollector>>,
 ) -> DfResult<RecordBatch> {
     let mut object_reader = ParquetObjectReader::new(store, path).with_preload_offset_index(true);
     if let Some(size) = file_size.filter(|&s| s > 0) {
         // Skip the size-discovery HEAD when the manifest already knows it.
         object_reader = object_reader.with_file_size(size);
     }
-    take_rows_async(object_reader, file_schema, n_docs, local_doc_ids, names).await
+    take_rows_async(
+        object_reader,
+        file_schema,
+        n_docs,
+        local_doc_ids,
+        names,
+        op_stats,
+    )
+    .await
 }
 
 async fn take_rows_async<R>(
@@ -672,10 +741,15 @@ async fn take_rows_async<R>(
     n_docs: u64,
     local_doc_ids: &[u32],
     names: &[&str],
+    op_stats: Option<Arc<OpStatsCollector>>,
 ) -> DfResult<RecordBatch>
 where
     R: AsyncFileReader + Unpin + Send + 'static,
 {
+    let input = CountedFileReader {
+        inner: input,
+        op_stats,
+    };
     // Projected column indices (file order) + output fields (caller order).
     let mut col_indices = Vec::with_capacity(names.len());
     let mut out_fields: Vec<Field> = Vec::with_capacity(names.len());
@@ -1376,6 +1450,7 @@ mod tests {
             n_docs,
             &[2, 0, 3],
             &["title"],
+            None,
         )
         .await
         .expect("take rows");
@@ -1401,6 +1476,7 @@ mod tests {
             n_docs,
             &[1, 1, 0],
             &["title"],
+            None,
         )
         .await
         .expect("take rows");
@@ -1416,9 +1492,10 @@ mod tests {
         let (schema, n_docs) = schema_and_n_docs(&bytes);
         let (store, path) = object_store_with(&bytes).await;
 
-        let batch = take_rows_object_store(store, path, None, &schema, n_docs, &[4], &["title"])
-            .await
-            .expect("take rows");
+        let batch =
+            take_rows_object_store(store, path, None, &schema, n_docs, &[4], &["title"], None)
+                .await
+                .expect("take rows");
 
         assert_eq!(titles_of(&batch), vec!["echo"]);
     }
@@ -1437,6 +1514,7 @@ mod tests {
             n_docs,
             &[],
             &["title"],
+            None,
         )
         .await
         .expect("empty ids");
@@ -1459,6 +1537,7 @@ mod tests {
             n_docs,
             &[n_docs as u32],
             &["title"],
+            None,
         )
         .await
         .expect_err("doc id past n_docs must error");
@@ -1482,6 +1561,7 @@ mod tests {
             n_docs,
             &[0],
             &["nope"],
+            None,
         )
         .await
         .expect_err("unknown column must error");

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -580,14 +580,10 @@ async fn resolve_columns(
         .map_err(|e| DataFusionError::Execution(e.to_string()))
     };
 
-    let op_stats = reader.op_stats.clone();
-    let cold_wave = try_join_all(cold_units.into_iter().map(|(i, rd, locals)| {
-        let op_stats = op_stats.clone();
-        async move {
-            take_rows_byte_source(rd, locals, names, op_stats)
-                .await
-                .map(|batch| (i, batch))
-        }
+    let cold_wave = try_join_all(cold_units.into_iter().map(|(i, rd, locals)| async move {
+        take_rows_byte_source(rd, locals, names)
+            .await
+            .map(|batch| (i, batch))
     }));
 
     let (warm_done, cold_done) = tokio::join!(warm_wave, cold_wave);
@@ -620,45 +616,6 @@ async fn resolve_columns(
     let batches: Vec<&RecordBatch> = per_superfile.iter().collect();
     interleave_record_batch(&batches, &placement)
         .map_err(|error| DataFusionError::Execution(error.to_string()))
-}
-
-/// [`AsyncFileReader`] adapter that counts every requested data range into
-/// the per-query collector — the take/materialize sibling of the DataFusion
-/// scan store's `get_opts` accounting. Counts are planned (pre-coalesce),
-/// so warm zero-copy resolution and cold GETs report identically. Metadata
-/// requests are NOT counted: the byte-source arm serves them from the
-/// reader-cached parse and the object-store arm's footer read is open-time
-/// amortized state, so counting either would make the tally depend on
-/// reader lifetime rather than the plan.
-struct CountedFileReader<R> {
-    inner: R,
-    op_stats: Option<Arc<OpStatsCollector>>,
-}
-
-impl<R: AsyncFileReader + Send> AsyncFileReader for CountedFileReader<R> {
-    fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, ParquetResult<Bytes>> {
-        if let Some(stats) = &self.op_stats {
-            stats.add_planned_read_ranges(1);
-        }
-        self.inner.get_bytes(range)
-    }
-
-    fn get_byte_ranges(
-        &mut self,
-        ranges: Vec<Range<u64>>,
-    ) -> BoxFuture<'_, ParquetResult<Vec<Bytes>>> {
-        if let Some(stats) = &self.op_stats {
-            stats.add_planned_read_ranges(ranges.len() as u64);
-        }
-        self.inner.get_byte_ranges(ranges)
-    }
-
-    fn get_metadata<'a>(
-        &'a mut self,
-        options: Option<&'a ArrowReaderOptions>,
-    ) -> BoxFuture<'a, ParquetResult<Arc<ParquetMetaData>>> {
-        self.inner.get_metadata(options)
-    }
 }
 
 /// Parquet async reader backed by the `SuperfileReader`'s existing byte source.
@@ -717,12 +674,16 @@ impl AsyncFileReader for ByteSourceAsyncReader {
 }
 
 /// Stream projected rows through a reader's cache-aware byte source.
-/// Data-page requests count into `op_stats` as planned ranges.
+///
+/// Deliberately reports NO planned ranges: whether a take streams page
+/// ranges (lazy reader) or decodes resident bytes in place (promoted
+/// reader) is reader-cache state, so counting the streamed ranges would
+/// make the priced counter cache-dependent. The invariant materialization
+/// signals are `rows_materialized` and the decode CPU brackets.
 pub(crate) async fn take_rows_byte_source(
     reader: &SuperfileReader,
     local_doc_ids: &[u32],
     names: &[&str],
-    op_stats: Option<Arc<OpStatsCollector>>,
 ) -> DfResult<RecordBatch> {
     let metadata = reader
         .parquet_metadata_with_page_index()
@@ -738,7 +699,6 @@ pub(crate) async fn take_rows_byte_source(
         reader.n_docs(),
         local_doc_ids,
         names,
-        op_stats,
     )
     .await
 }
@@ -756,22 +716,13 @@ pub(crate) async fn take_rows_object_store(
     n_docs: u64,
     local_doc_ids: &[u32],
     names: &[&str],
-    op_stats: Option<Arc<OpStatsCollector>>,
 ) -> DfResult<RecordBatch> {
     let mut object_reader = ParquetObjectReader::new(store, path).with_preload_offset_index(true);
     if let Some(size) = file_size.filter(|&s| s > 0) {
         // Skip the size-discovery HEAD when the manifest already knows it.
         object_reader = object_reader.with_file_size(size);
     }
-    take_rows_async(
-        object_reader,
-        file_schema,
-        n_docs,
-        local_doc_ids,
-        names,
-        op_stats,
-    )
-    .await
+    take_rows_async(object_reader, file_schema, n_docs, local_doc_ids, names).await
 }
 
 async fn take_rows_async<R>(
@@ -780,15 +731,10 @@ async fn take_rows_async<R>(
     n_docs: u64,
     local_doc_ids: &[u32],
     names: &[&str],
-    op_stats: Option<Arc<OpStatsCollector>>,
 ) -> DfResult<RecordBatch>
 where
     R: AsyncFileReader + Unpin + Send + 'static,
 {
-    let input = CountedFileReader {
-        inner: input,
-        op_stats,
-    };
     // Projected column indices (file order) + output fields (caller order).
     let mut col_indices = Vec::with_capacity(names.len());
     let mut out_fields: Vec<Field> = Vec::with_capacity(names.len());
@@ -1489,7 +1435,6 @@ mod tests {
             n_docs,
             &[2, 0, 3],
             &["title"],
-            None,
         )
         .await
         .expect("take rows");
@@ -1515,7 +1460,6 @@ mod tests {
             n_docs,
             &[1, 1, 0],
             &["title"],
-            None,
         )
         .await
         .expect("take rows");
@@ -1531,10 +1475,9 @@ mod tests {
         let (schema, n_docs) = schema_and_n_docs(&bytes);
         let (store, path) = object_store_with(&bytes).await;
 
-        let batch =
-            take_rows_object_store(store, path, None, &schema, n_docs, &[4], &["title"], None)
-                .await
-                .expect("take rows");
+        let batch = take_rows_object_store(store, path, None, &schema, n_docs, &[4], &["title"])
+            .await
+            .expect("take rows");
 
         assert_eq!(titles_of(&batch), vec!["echo"]);
     }
@@ -1553,7 +1496,6 @@ mod tests {
             n_docs,
             &[],
             &["title"],
-            None,
         )
         .await
         .expect("empty ids");
@@ -1576,7 +1518,6 @@ mod tests {
             n_docs,
             &[n_docs as u32],
             &["title"],
-            None,
         )
         .await
         .expect_err("doc id past n_docs must error");
@@ -1600,7 +1541,6 @@ mod tests {
             n_docs,
             &[0],
             &["nope"],
-            None,
         )
         .await
         .expect_err("unknown column must error");

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -66,6 +66,7 @@ use tracing::debug;
 
 use crate::{
     InfinoError,
+    runtime_metrics::op_stats,
     superfile::{
         fts::reader::{Bm25Stats, BoolMode},
         reader::VectorSearchOptions,
@@ -150,7 +151,12 @@ impl SupertableReader {
             self.vector_search_user_table_async(vec_col, &q_vec, k, options),
         )
         .await;
-        Ok(rrf_fuse(&bm25_res?, &vector_res?, k))
+        let (bm25_hits, vector_hits) = (bm25_res?, vector_res?);
+        // The fusion math is a real (small) kernel section; bracket it so
+        // hybrid's kernel CPU covers all three of its compute legs.
+        Ok(op_stats::timed_kernel(&self.op_stats, || {
+            rrf_fuse(&bm25_hits, &vector_hits, k)
+        }))
     }
 
     /// Hybrid BM25 + vector search fused with reciprocal-rank fusion

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -691,6 +691,7 @@ impl SupertableReader {
         let column_arc = Arc::new(column.to_owned());
         let terms_arc: Arc<Vec<String>> = Arc::new(terms.to_vec());
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
+        let op_stats = self.op_stats.clone();
         let per_sf: Vec<Vec<u64>> = dispatch::fanout_with(
             self,
             units,
@@ -699,15 +700,23 @@ impl SupertableReader {
             move |r, _entry, _sidecars, _now, _params: ()| {
                 let column_arc = Arc::clone(&column_arc);
                 let terms_arc = Arc::clone(&terms_arc);
+                let op_stats = op_stats.clone();
                 async move {
                     // One FST parse + one coalesced header fetch for all
                     // scored terms in this superfile, rather than a parse
                     // and fetch per term.
                     let refs: Vec<&str> = terms_arc.iter().map(String::as_str).collect();
-                    let dfs = r
+                    let (dfs, work) = r
                         .term_dfs(&column_arc, &refs)
                         .await
                         .map_err(fts_read_error)?;
+                    // The global-stats pre-pass reads real header ranges;
+                    // it is part of the query's plan and counts like any
+                    // other posting work.
+                    if let Some(stats) = &op_stats {
+                        stats.add_fts_postings_bytes(work.postings_bytes);
+                        stats.add_planned_read_ranges(work.planned_ranges);
+                    }
                     Ok::<Vec<u64>, QueryError>(dfs)
                 }
             },
@@ -995,18 +1004,20 @@ impl SupertableReader {
         let phrase_arc: Arc<Vec<Vec<String>>> = Arc::new(match_set.phrases);
         let neg_arc: Arc<Vec<String>> = Arc::new(negatives.terms);
         let neg_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(negatives.phrases);
+        let op_stats = self.op_stats.clone();
         let kernel = move |r: Arc<SuperfileReader>, _: ()| {
             let column_arc = Arc::clone(&column_arc);
             let term_arc = Arc::clone(&term_arc);
             let phrase_arc = Arc::clone(&phrase_arc);
             let neg_arc = Arc::clone(&neg_arc);
             let neg_ph_arc = Arc::clone(&neg_ph_arc);
+            let op_stats = op_stats.clone();
             async move {
                 let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
                 // Any phrase atom (match or negated) takes the
                 // phrase-aware walk; plain-token queries keep the
                 // optimized token_match path unchanged.
-                let docs = match phrase_involved {
+                let (docs, mut work) = match phrase_involved {
                     true => r
                         .atoms_match_ids(&column_arc, &refs, &phrase_arc, match_mode)
                         .await
@@ -1022,7 +1033,7 @@ impl SupertableReader {
                 // materialized walk over both sets.
                 let docs = if has_negatives {
                     let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
-                    let excluded: RoaringBitmap = match neg_ph_arc.is_empty() {
+                    let (neg_docs, neg_work) = match neg_ph_arc.is_empty() {
                         true => r
                             .token_match(&column_arc, &neg_refs, BoolMode::Or)
                             .await
@@ -1031,15 +1042,20 @@ impl SupertableReader {
                             .atoms_match_ids(&column_arc, &neg_refs, &neg_ph_arc, BoolMode::Or)
                             .await
                             .map_err(fts_read_error)?,
-                    }
-                    .into_iter()
-                    .collect();
+                    };
+                    work.merge(neg_work);
+                    let excluded: RoaringBitmap = neg_docs.into_iter().collect();
                     docs.into_iter()
                         .filter(|d| !excluded.contains(*d))
                         .collect::<Vec<_>>()
                 } else {
                     docs
                 };
+                // One flush per superfile: positive + negation walks.
+                if let Some(stats) = &op_stats {
+                    stats.add_fts_postings_bytes(work.postings_bytes);
+                    stats.add_planned_read_ranges(work.planned_ranges);
+                }
                 Ok(docs.into_iter().map(|d| (d, 0.0f32)).collect::<Vec<_>>())
             }
         };
@@ -1099,12 +1115,14 @@ impl SupertableReader {
         // spawns + opens each superfile concurrently, and short-circuits
         // on the first error. The per-superfile body returns this
         // superfile's match count; the totals are summed.
+        let op_stats = self.op_stats.clone();
         let per_superfile = dispatch::fanout_with(
             self,
             units,
             true,
             true,
             move |r, entry, tombstone_cache, now, _params: ()| {
+                let op_stats = op_stats.clone();
                 let column_arc = Arc::clone(&column_arc);
                 let term_arc = Arc::clone(&term_arc);
                 let phrase_arc = Arc::clone(&phrase_arc);
@@ -1128,7 +1146,7 @@ impl SupertableReader {
                     // matches, then drop any doc carrying a negated term
                     // (union of the negatives) or a tombstone.
                     if has_negatives || tomb.is_some() {
-                        let docs = match phrase_involved {
+                        let (docs, mut work) = match phrase_involved {
                             true => r
                                 .atoms_match_ids(&column_arc, &refs, &phrase_arc, match_mode)
                                 .await
@@ -1140,7 +1158,7 @@ impl SupertableReader {
                         };
                         let excluded: RoaringBitmap = if has_negatives {
                             let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
-                            match neg_ph_arc.is_empty() {
+                            let (neg_docs, neg_work) = match neg_ph_arc.is_empty() {
                                 true => r
                                     .token_match(&column_arc, &neg_refs, BoolMode::Or)
                                     .await
@@ -1154,12 +1172,16 @@ impl SupertableReader {
                                     )
                                     .await
                                     .map_err(fts_read_error)?,
-                            }
-                            .into_iter()
-                            .collect()
+                            };
+                            work.merge(neg_work);
+                            neg_docs.into_iter().collect()
                         } else {
                             RoaringBitmap::new()
                         };
+                        if let Some(stats) = &op_stats {
+                            stats.add_fts_postings_bytes(work.postings_bytes);
+                            stats.add_planned_read_ranges(work.planned_ranges);
+                        }
                         let n = docs
                             .iter()
                             .filter(|d| {
@@ -1173,7 +1195,7 @@ impl SupertableReader {
                     // without materializing ids — a single token resolves
                     // O(1) from the stored df, multi-token tallies the
                     // match walk through the counting sink.
-                    let n = if single_term {
+                    let (n, work) = if single_term {
                         r.term_df(&column_arc, &term_arc[0])
                             .await
                             .map_err(fts_read_error)?
@@ -1186,6 +1208,10 @@ impl SupertableReader {
                             .await
                             .map_err(fts_read_error)?
                     };
+                    if let Some(stats) = &op_stats {
+                        stats.add_fts_postings_bytes(work.postings_bytes);
+                        stats.add_planned_read_ranges(work.planned_ranges);
+                    }
                     Ok(n)
                 }
             },
@@ -1232,6 +1258,7 @@ impl SupertableReader {
         let column_arc = Arc::new(column.to_owned());
         let value_arc = Arc::new(value.to_owned());
         let tokens_arc = Arc::new(term_strings);
+        let op_stats = self.op_stats.clone();
         let body = move |r: Arc<SuperfileReader>,
                          entry: Arc<SuperfileEntry>,
                          tombstone_cache: Option<Arc<SidecarCache>>,
@@ -1240,14 +1267,23 @@ impl SupertableReader {
             let column_arc = Arc::clone(&column_arc);
             let value_arc = Arc::clone(&value_arc);
             let tokens_arc = Arc::clone(&tokens_arc);
+            let op_stats = op_stats.clone();
             async move {
                 let candidates: Vec<u32> = if tokens_arc.is_empty() {
                     (0..r.n_docs() as u32).collect()
                 } else {
                     let refs: Vec<&str> = tokens_arc.iter().map(String::as_str).collect();
-                    r.token_match(&column_arc, &refs, BoolMode::And)
+                    let (docs, work) = r
+                        .token_match(&column_arc, &refs, BoolMode::And)
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?
+                        .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                    // The prune pass's posting walk; the verify pass's row
+                    // decode is CPU-side (its take path reports no ranges).
+                    if let Some(stats) = &op_stats {
+                        stats.add_fts_postings_bytes(work.postings_bytes);
+                        stats.add_planned_read_ranges(work.planned_ranges);
+                    }
+                    docs
                 };
                 if candidates.is_empty() {
                     return Ok(Vec::new());

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -716,6 +716,7 @@ impl SupertableReader {
                     if let Some(stats) = &op_stats {
                         stats.add_fts_postings_bytes(work.postings_bytes);
                         stats.add_planned_read_ranges(work.planned_ranges);
+                        stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                     }
                     Ok::<Vec<u64>, QueryError>(dfs)
                 }
@@ -810,11 +811,13 @@ impl SupertableReader {
 
         // Shared fan-out — see `bm25_search` for the rationale; the
         // kernel differs only in calling the prefix search variants.
+        let op_stats = self.op_stats.clone();
         let kernel = move |r: Arc<SuperfileReader>, (range, suid): (Option<(u32, u32)>, Uuid)| {
             let column_arc = Arc::clone(&column_arc);
             let prefix_arc = Arc::clone(&prefix_arc);
             let cursor_sets = Arc::clone(&cursor_sets);
             let reader_pool = Arc::clone(&reader_pool);
+            let op_stats = op_stats.clone();
             async move {
                 match range {
                     Some((start, end)) => {
@@ -825,40 +828,69 @@ impl SupertableReader {
                         };
                         let set = cell
                             .get_or_try_init(|| async {
-                                r.bm25_prefix_cursor_set(&column_arc, &prefix_arc)
+                                let set = r
+                                    .bm25_prefix_cursor_set(&column_arc, &prefix_arc)
                                     .await
-                                    .map(Arc::new)
-                                    .map_err(fts_read_error)
+                                    .map_err(fts_read_error)?;
+                                // Flushed inside the OnceCell init so slices
+                                // sharing this superfile's expansion count
+                                // its posting work exactly once — the same
+                                // contract as the exact-term ranged path.
+                                if let Some(stats) = &op_stats {
+                                    stats.add_fts_postings_bytes(set.postings_bytes());
+                                    stats.add_planned_read_ranges(set.planned_ranges());
+                                }
+                                Ok(Arc::new(set))
                             })
                             .await?;
                         if set.len() >= RANGED_KERNEL_POOL_MIN_TERMS {
                             let kernel_reader = Arc::clone(&r);
                             let kernel_set = Arc::clone(set);
+                            let kernel_stats = op_stats.clone();
                             run_on_pool(
                                 Some(&reader_pool),
                                 "ranged prefix kernel: reader pool dropped result",
                                 move || {
-                                    kernel_reader.bm25_search_or_range_prebuilt(
-                                        &kernel_set,
-                                        k,
-                                        start,
-                                        end,
-                                        f32::NEG_INFINITY,
-                                    )
+                                    op_stats::timed_kernel(&kernel_stats, || {
+                                        kernel_reader.bm25_search_or_range_prebuilt(
+                                            &kernel_set,
+                                            k,
+                                            start,
+                                            end,
+                                            f32::NEG_INFINITY,
+                                        )
+                                    })
                                 },
                             )
                             .await
                             .map_err(|e| QueryError::Execute(e.to_string()))?
                             .map_err(fts_read_error)
                         } else {
-                            r.bm25_search_or_range_prebuilt(set, k, start, end, f32::NEG_INFINITY)
-                                .map_err(fts_read_error)
+                            op_stats::timed_kernel(&op_stats, || {
+                                r.bm25_search_or_range_prebuilt(
+                                    set,
+                                    k,
+                                    start,
+                                    end,
+                                    f32::NEG_INFINITY,
+                                )
+                            })
+                            .map_err(fts_read_error)
                         }
                     }
-                    None => r
-                        .bm25_search_prefix(&column_arc, &prefix_arc, k)
-                        .await
-                        .map_err(fts_read_error),
+                    None => {
+                        let (hits, work, kernel_ns) = r
+                            .bm25_search_prefix(&column_arc, &prefix_arc, k)
+                            .await
+                            .map_err(fts_read_error)?;
+                        if let Some(stats) = &op_stats {
+                            stats.add_fts_postings_bytes(work.postings_bytes);
+                            stats.add_planned_read_ranges(work.planned_ranges);
+                            stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
+                            stats.add_kernel_cpu_ns(kernel_ns);
+                        }
+                        Ok(hits)
+                    }
                 }
             }
         };
@@ -1055,6 +1087,7 @@ impl SupertableReader {
                 if let Some(stats) = &op_stats {
                     stats.add_fts_postings_bytes(work.postings_bytes);
                     stats.add_planned_read_ranges(work.planned_ranges);
+                    stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                 }
                 Ok(docs.into_iter().map(|d| (d, 0.0f32)).collect::<Vec<_>>())
             }
@@ -1181,6 +1214,7 @@ impl SupertableReader {
                         if let Some(stats) = &op_stats {
                             stats.add_fts_postings_bytes(work.postings_bytes);
                             stats.add_planned_read_ranges(work.planned_ranges);
+                            stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                         }
                         let n = docs
                             .iter()
@@ -1211,6 +1245,7 @@ impl SupertableReader {
                     if let Some(stats) = &op_stats {
                         stats.add_fts_postings_bytes(work.postings_bytes);
                         stats.add_planned_read_ranges(work.planned_ranges);
+                        stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                     }
                     Ok(n)
                 }
@@ -1277,11 +1312,13 @@ impl SupertableReader {
                         .token_match(&column_arc, &refs, BoolMode::And)
                         .await
                         .map_err(|e| QueryError::Parquet(e.to_string()))?;
-                    // The prune pass's posting walk; the verify pass's row
-                    // decode is CPU-side (its take path reports no ranges).
+                    // The prune pass's posting walk. The verify pass's
+                    // row reads count through the take path's own
+                    // collector accounting below.
                     if let Some(stats) = &op_stats {
                         stats.add_fts_postings_bytes(work.postings_bytes);
                         stats.add_planned_read_ranges(work.planned_ranges);
+                        stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                     }
                     docs
                 };
@@ -1292,7 +1329,7 @@ impl SupertableReader {
                     r.take_by_local_doc_ids(&candidates, &[column_arc.as_str()])
                         .map_err(|e| QueryError::Parquet(e.to_string()))?
                 } else {
-                    take_rows_byte_source(&r, &candidates, &[column_arc.as_str()])
+                    take_rows_byte_source(&r, &candidates, &[column_arc.as_str()], op_stats.clone())
                         .await
                         .map_err(|e| QueryError::Execute(e.to_string()))?
                 };
@@ -2621,7 +2658,9 @@ mod tests {
         }
 
         let oracle = build_oracle_superfile(&titles);
-        let oracle_hits = block_on(oracle.bm25_search_prefix("title", "rust", 5)).expect("oracle");
+        let oracle_hits = block_on(oracle.bm25_search_prefix("title", "rust", 5))
+            .expect("oracle")
+            .0;
         let oracle_globals: HashSet<u32> = oracle_hits.iter().map(|(d, _)| *d).collect();
 
         let st_reader = st.reader().expect("reader");

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -539,6 +539,7 @@ impl SupertableReader {
                                 // its posting bytes exactly once.
                                 if let Some(stats) = &op_stats {
                                     stats.add_fts_postings_bytes(set.postings_bytes());
+                                    stats.add_planned_read_ranges(set.planned_ranges());
                                 }
                                 Ok(Arc::new(set))
                             })
@@ -594,6 +595,7 @@ impl SupertableReader {
                             .map_err(fts_read_error)?;
                         if let Some(stats) = &op_stats {
                             stats.add_fts_postings_bytes(prep.postings_bytes());
+                            stats.add_planned_read_ranges(prep.planned_ranges());
                         }
                         // Gate on posting mass, not term count: this scan
                         // isn't sliced, so a rare-term query with many

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -123,7 +123,10 @@ use crate::{
         error::{FtsError, ReadError},
         fts::{
             bm25,
-            reader::{Bm25Stats, ClauseLists, GlobalTermIdf, OR_WINDOW_MIN_TERMS, OrCursorSet},
+            reader::{
+                Bm25Stats, ClauseLists, GlobalTermIdf, OR_WINDOW_MIN_TERMS, OrCursorSet,
+                PreparedClauses,
+            },
         },
     },
     supertable::{
@@ -608,27 +611,35 @@ impl SupertableReader {
                             // kernels are bracketed below).
                             stats.add_kernel_cpu_ns(prep.inline_kernel_cpu_ns());
                         }
-                        // Gate on posting mass, not term count: this scan
-                        // isn't sliced, so a rare-term query with many
-                        // terms can be cheaper than a common-term pair.
-                        if prep.posting_mass() >= UNRANGED_KERNEL_POOL_MIN_MASS {
-                            let kernel_reader = Arc::clone(&r);
-                            let kernel_stats = op_stats.clone();
-                            run_on_pool(
-                                Some(&reader_pool),
-                                "un-ranged fts kernel: reader pool dropped result",
-                                move || {
-                                    op_stats::timed_kernel(&kernel_stats, || {
-                                        kernel_reader.run_prepared(prep)
-                                    })
-                                },
-                            )
-                            .await
-                            .map_err(|e| QueryError::Execute(e.to_string()))?
-                            .map_err(fts_read_error)?
-                        } else {
-                            op_stats::timed_kernel(&op_stats, || r.run_prepared(prep))
+                        match prep {
+                            // Already-final shapes: the walk (and its
+                            // kernel time) happened inside
+                            // `prepare_clauses`; `run_prepared` would be
+                            // a no-op move and the bracket two wasted
+                            // schedstat reads.
+                            PreparedClauses::Done { hits, .. } => hits,
+                            // Gate on posting mass, not term count: this
+                            // scan isn't sliced, so a rare-term query
+                            // with many terms can be cheaper than a
+                            // common-term pair.
+                            prep if prep.posting_mass() >= UNRANGED_KERNEL_POOL_MIN_MASS => {
+                                let kernel_reader = Arc::clone(&r);
+                                let kernel_stats = op_stats.clone();
+                                run_on_pool(
+                                    Some(&reader_pool),
+                                    "un-ranged fts kernel: reader pool dropped result",
+                                    move || {
+                                        op_stats::timed_kernel(&kernel_stats, || {
+                                            kernel_reader.run_prepared(prep)
+                                        })
+                                    },
+                                )
+                                .await
+                                .map_err(|e| QueryError::Execute(e.to_string()))?
                                 .map_err(fts_read_error)?
+                            }
+                            prep => op_stats::timed_kernel(&op_stats, || r.run_prepared(prep))
+                                .map_err(fts_read_error)?,
                         }
                     }
                 };

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -454,6 +454,7 @@ impl SupertableReader {
         // excluded from the merge so deleted rows never raise the bar.
         let shared = SharedTopK::new(k);
         let tombstones = self.tombstone_cache.clone();
+        let op_stats = self.op_stats.clone();
         let now = Instant::now();
 
         // Ranged units are slices of ONE superfile: share its cursor build
@@ -493,6 +494,7 @@ impl SupertableReader {
             let reader_pool = Arc::clone(&reader_pool);
             let tombstones = tombstones.clone();
             let global_idf = global_idf.clone();
+            let op_stats = op_stats.clone();
             async move {
                 // Share the global kth-best floor with every superfile —
                 // single-term queries included — so each prunes its scored
@@ -524,14 +526,21 @@ impl SupertableReader {
                             .get_or_try_init(|| async {
                                 let should_refs: Vec<&str> =
                                     should_arc.iter().map(|s| s.as_str()).collect();
-                                r.bm25_or_cursor_set(
-                                    &column_arc,
-                                    &should_refs,
-                                    global_idf.as_deref(),
-                                )
-                                .await
-                                .map(Arc::new)
-                                .map_err(fts_read_error)
+                                let set = r
+                                    .bm25_or_cursor_set(
+                                        &column_arc,
+                                        &should_refs,
+                                        global_idf.as_deref(),
+                                    )
+                                    .await
+                                    .map_err(fts_read_error)?;
+                                // Flushed inside the OnceCell init so slices
+                                // sharing this superfile's cursor set count
+                                // its posting bytes exactly once.
+                                if let Some(stats) = &op_stats {
+                                    stats.add_fts_postings_bytes(set.postings_bytes());
+                                }
+                                Ok(Arc::new(set))
                             })
                             .await?;
                         // Heavy kernels go to the reader pool; trivial ones
@@ -583,6 +592,9 @@ impl SupertableReader {
                             )
                             .await
                             .map_err(fts_read_error)?;
+                        if let Some(stats) = &op_stats {
+                            stats.add_fts_postings_bytes(prep.postings_bytes());
+                        }
                         // Gate on posting mass, not term count: this scan
                         // isn't sliced, so a rare-term query with many
                         // terms can be cheaper than a common-term pair.

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -602,6 +602,11 @@ impl SupertableReader {
                         if let Some(stats) = &op_stats {
                             stats.add_fts_postings_bytes(prep.postings_bytes());
                             stats.add_planned_read_ranges(prep.planned_ranges());
+                            // Single-term / phrase shapes finish inside
+                            // `prepare_clauses`; their walk's on-CPU time
+                            // rides the `Done` (0 for cursor shapes, whose
+                            // kernels are bracketed below).
+                            stats.add_kernel_cpu_ns(prep.inline_kernel_cpu_ns());
                         }
                         // Gate on posting mass, not term count: this scan
                         // isn't sliced, so a rare-term query with many

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1310,7 +1310,7 @@ impl SupertableReader {
                     let (docs, work) = r
                         .token_match(&column_arc, &refs, BoolMode::And)
                         .await
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                        .map_err(fts_read_error)?;
                     // The prune pass's posting walk. The verify pass's
                     // row reads count through the take path's own
                     // collector accounting below.

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -117,6 +117,7 @@ pub use crate::superfile::fts::reader::BoolMode;
 use crate::{
     InfinoError,
     runtime_bridge::run_on_pool,
+    runtime_metrics::op_stats,
     superfile::{
         SuperfileReader,
         error::{FtsError, ReadError},
@@ -550,25 +551,30 @@ impl SupertableReader {
                         if should_arc.len() >= RANGED_KERNEL_POOL_MIN_TERMS {
                             let kernel_reader = Arc::clone(&r);
                             let kernel_set = Arc::clone(set);
+                            let kernel_stats = op_stats.clone();
                             run_on_pool(
                                 Some(&reader_pool),
                                 "ranged fts kernel: reader pool dropped result",
                                 move || {
-                                    kernel_reader.bm25_search_or_range_prebuilt(
-                                        &kernel_set,
-                                        k,
-                                        start,
-                                        end,
-                                        floor,
-                                    )
+                                    op_stats::timed_kernel(&kernel_stats, || {
+                                        kernel_reader.bm25_search_or_range_prebuilt(
+                                            &kernel_set,
+                                            k,
+                                            start,
+                                            end,
+                                            floor,
+                                        )
+                                    })
                                 },
                             )
                             .await
                             .map_err(|e| QueryError::Execute(e.to_string()))?
                             .map_err(fts_read_error)?
                         } else {
-                            r.bm25_search_or_range_prebuilt(set, k, start, end, floor)
-                                .map_err(fts_read_error)?
+                            op_stats::timed_kernel(&op_stats, || {
+                                r.bm25_search_or_range_prebuilt(set, k, start, end, floor)
+                            })
+                            .map_err(fts_read_error)?
                         }
                     }
                     None => {
@@ -602,16 +608,22 @@ impl SupertableReader {
                         // terms can be cheaper than a common-term pair.
                         if prep.posting_mass() >= UNRANGED_KERNEL_POOL_MIN_MASS {
                             let kernel_reader = Arc::clone(&r);
+                            let kernel_stats = op_stats.clone();
                             run_on_pool(
                                 Some(&reader_pool),
                                 "un-ranged fts kernel: reader pool dropped result",
-                                move || kernel_reader.run_prepared(prep),
+                                move || {
+                                    op_stats::timed_kernel(&kernel_stats, || {
+                                        kernel_reader.run_prepared(prep)
+                                    })
+                                },
                             )
                             .await
                             .map_err(|e| QueryError::Execute(e.to_string()))?
                             .map_err(fts_read_error)?
                         } else {
-                            r.run_prepared(prep).map_err(fts_read_error)?
+                            op_stats::timed_kernel(&op_stats, || r.run_prepared(prep))
+                                .map_err(fts_read_error)?
                         }
                     }
                 };

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -879,7 +879,7 @@ impl SupertableReader {
                         }
                     }
                     None => {
-                        let (hits, work, kernel_ns) = r
+                        let (hits, work) = r
                             .bm25_search_prefix(&column_arc, &prefix_arc, k)
                             .await
                             .map_err(fts_read_error)?;
@@ -887,7 +887,6 @@ impl SupertableReader {
                             stats.add_fts_postings_bytes(work.postings_bytes);
                             stats.add_planned_read_ranges(work.planned_ranges);
                             stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
-                            stats.add_kernel_cpu_ns(kernel_ns);
                         }
                         Ok(hits)
                     }
@@ -1329,7 +1328,7 @@ impl SupertableReader {
                     r.take_by_local_doc_ids(&candidates, &[column_arc.as_str()])
                         .map_err(|e| QueryError::Parquet(e.to_string()))?
                 } else {
-                    take_rows_byte_source(&r, &candidates, &[column_arc.as_str()], op_stats.clone())
+                    take_rows_byte_source(&r, &candidates, &[column_arc.as_str()])
                         .await
                         .map_err(|e| QueryError::Execute(e.to_string()))?
                 };

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -96,6 +96,7 @@ use tokio::sync::OnceCell;
 use uuid::Uuid;
 
 use crate::{
+    runtime_metrics::op_stats,
     superfile::{
         SuperfileReader,
         fts::{
@@ -301,13 +302,20 @@ impl SupertableProvider {
     /// segment) scan. Gets its own object-store registry key so the
     /// restricted scan's registration can't collide with the parent's.
     pub(crate) fn restricted_to(&self, segments: HashSet<Uuid>) -> Self {
-        let mut restricted = Self::new(
-            Arc::clone(&self.schema),
-            Arc::clone(&self.manifest),
-            Arc::clone(&self.store),
-            self.disk_cache.clone(),
-            self.tombstone_cache.clone(),
-        );
+        // Suppressed: `Self::new` mints a transient scan store that
+        // captures the thread-local collector, but the restricted scan
+        // reuses the PARENT's store (replaced just below) — this clone
+        // runs mid-query on whatever thread drives the rewrite, and no
+        // mid-query code may consult the scope's thread-local.
+        let mut restricted = op_stats::suppressed(|| {
+            Self::new(
+                Arc::clone(&self.schema),
+                Arc::clone(&self.manifest),
+                Arc::clone(&self.store),
+                self.disk_cache.clone(),
+                self.tombstone_cache.clone(),
+            )
+        });
         restricted.segment_filter = Some(segments);
         restricted.prepared_scan_files = Arc::clone(&self.prepared_scan_files);
         restricted.scan_store = Arc::clone(&self.scan_store);

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -851,6 +851,7 @@ impl TableProvider for SupertableProvider {
             if let Some(stats) = self.scan_store.op_stats() {
                 stats.add_fts_postings_bytes(predicate_work.postings_bytes);
                 stats.add_planned_read_ranges(predicate_work.planned_ranges);
+                stats.add_kernel_cpu_ns(predicate_work.kernel_cpu_ns);
             }
 
             // This superfile's tombstoned rows (empty when no overlay).

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -488,7 +488,16 @@ impl SupertableProvider {
                 let path = ObjPath::from(entry.uri.storage_path());
                 let source = reader.byte_source();
                 let size = source.size();
-                let parquet_meta = Arc::clone(reader.parquet_metadata());
+                // Index-complete metadata (column + offset page indexes),
+                // loaded through the reader's own byte source. Serving
+                // DataFusion a footer-only parse would make its opener
+                // fetch the page-index bytes through the metered store on
+                // predicated scans — but only for lazily-opened readers,
+                // making `sql_page_bytes` depend on reader-cache state.
+                let parquet_meta = reader
+                    .parquet_metadata_with_page_index()
+                    .await
+                    .map_err(|error| DataFusionError::Execution(error.to_string()))?;
                 let row_counts: Arc<[u32]> = parquet_meta
                     .row_groups()
                     .iter()
@@ -931,10 +940,12 @@ impl TableProvider for SupertableProvider {
                 .with_pushdown_filters(true)
                 .with_reorder_filters(true);
         }
-        // Serve DataFusion's opener the footers the readers already
-        // parsed — without this the opener re-reads + re-parses every
-        // superfile's footer on every query (~half the warm flat cost
-        // at 256 superfiles).
+        // Serve DataFusion's opener the index-complete footers the
+        // readers already parsed — without this the opener re-reads +
+        // re-parses every superfile's footer on every query (~half the
+        // warm flat cost at 256 superfiles), and on predicated scans it
+        // would fetch page-index bytes through the metered store for
+        // lazily-opened readers (a cache-state-dependent priced counter).
         source = source.with_parquet_file_reader_factory(Arc::new(CachedMetadataReaderFactory {
             store: Arc::clone(&store),
             metas: Arc::clone(&self.scan_metas),

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -828,21 +828,30 @@ impl TableProvider for SupertableProvider {
             // overhead. The floor keeps the pushdown active on small
             // superfiles; the density cap binds even under the floor so
             // an all-matching predicate never takes the index path.
-            let est = candidate_plan
+            let (est, est_work) = candidate_plan
                 .estimate(prepared.reader.as_ref())
                 .await
                 .map_err(|e| DataFusionError::Execution(e.to_string()))?;
             let gate = ((prepared.reader.n_docs() as f64 * PUSHDOWN_MAX_FRACTION) as u64)
                 .max(PUSHDOWN_MIN_ROWS);
             let density_cap = (prepared.reader.n_docs() as f64 * PUSHDOWN_MAX_DENSITY) as u64;
+            let mut predicate_work = est_work;
             let candidates = if est > gate || est >= density_cap {
                 None
             } else {
-                candidate_plan
+                let (bitmap, eval_work) = candidate_plan
                     .evaluate(prepared.reader.as_ref())
                     .await
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))?
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                predicate_work.merge(eval_work);
+                bitmap
             };
+            // The pushdown predicate's df probes + posting walks, flushed
+            // through the same collector that meters this scan's pages.
+            if let Some(stats) = self.scan_store.op_stats() {
+                stats.add_fts_postings_bytes(predicate_work.postings_bytes);
+                stats.add_planned_read_ranges(predicate_work.planned_ranges);
+            }
 
             // This superfile's tombstoned rows (empty when no overlay).
             let tombstones = match self.tombstone_cache.as_ref() {

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -65,9 +65,9 @@ use datafusion::{
     logical_expr::{Expr, LogicalPlan},
 };
 
-use crate::runtime_metrics::op_stats;
 use crate::{
     memory::budgeted_session_context,
+    runtime_metrics::op_stats,
     supertable::{
         error::QueryError,
         handle::{Supertable, SupertableReader},

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -207,6 +207,13 @@ impl SupertableReader {
     /// Sync API. The first call allocates a tokio Runtime
     /// (single worker thread) cached on the `SupertableInner`;
     /// subsequent calls reuse it.
+    ///
+    /// Not metered: this entry runs on the cached, collector-detached
+    /// [`SessionContext`] (see [`Self::sql_session_context`]), so a
+    /// surrounding `with_op_stats` scope reports zero SQL work for it.
+    /// The metered SQL surface is the catalog `Connection::query_sql`,
+    /// which builds a fresh per-query provider that carries the scope's
+    /// collector.
     // Single-table SQL — off the public surface; catalog-level SQL is the
     // public entry point. Reachable from tests/benches via `test-helpers`.
     #[cfg(any(test, feature = "test-helpers"))]

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -65,6 +65,7 @@ use datafusion::{
     logical_expr::{Expr, LogicalPlan},
 };
 
+use crate::runtime_metrics::op_stats;
 use crate::{
     memory::budgeted_session_context,
     supertable::{
@@ -290,8 +291,14 @@ impl SupertableReader {
     #[cfg_attr(feature = "detailed-tracing", tracing::instrument(skip_all))]
     fn sql_session_context(&self) -> Result<SessionContext, QueryError> {
         // This reader already pins the snapshot; clone is a handful of
-        // Arc refcount bumps.
-        let reader = Arc::new(self.clone());
+        // Arc refcount bumps. Detach any per-query work collector: this
+        // context is CACHED across queries, and a collector riding into it
+        // would bill later queries into this scope. The whole build below
+        // runs under `op_stats::suppressed` for the same reason (provider
+        // and TVF constructions capture the thread-local).
+        let mut detached = self.clone();
+        detached.op_stats = None;
+        let reader = Arc::new(detached);
         let manifest = Arc::clone(reader.manifest());
 
         let mut guard = self
@@ -309,13 +316,15 @@ impl SupertableReader {
         // Cached per-table schemas: the provider scans the string-viewed `scan`
         // schema; the TVFs bind to the plain `scalar` schema.
         let schemas = self.sql_schemas();
-        let provider = SupertableProvider::new(
-            schemas.scan().clone(),
-            Arc::clone(&manifest),
-            store,
-            disk_cache,
-            reader.tombstone_cache.clone(),
-        );
+        let provider = op_stats::suppressed(|| {
+            SupertableProvider::new(
+                schemas.scan().clone(),
+                Arc::clone(&manifest),
+                store,
+                disk_cache,
+                reader.tombstone_cache.clone(),
+            )
+        });
 
         // Gate SQL heap on the connection budget (shared across contexts, so
         // this reader's SQL counts against the same ceiling as the rest).

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2163,6 +2163,7 @@ impl SupertableReader {
                             .map_err(vector_read_query_error)?;
                         if let Some(stats) = &op_stats {
                             stats.add_vector_scan(scan.cells_scanned, scan.candidates_scanned);
+                            stats.add_planned_read_ranges(scan.ranges_requested);
                         }
                         if !scan.candidates.is_empty() {
                             scan_pool
@@ -2322,9 +2323,10 @@ impl SupertableReader {
                     })
                     .collect();
                 if let Some(stats) = &self.op_stats {
-                    stats.add_vector_rows_reranked(
-                        rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum(),
-                    );
+                    let rows: u64 = rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
+                    stats.add_vector_rows_reranked(rows);
+                    // Phase C gathers one survivor row range per winner.
+                    stats.add_planned_read_ranges(rows);
                 }
                 let column = Arc::clone(&column_arc2);
                 let query = Arc::clone(&query_arc2);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -96,6 +96,7 @@ pub use crate::superfile::reader::VectorSearchOptions;
 use crate::test_helpers::{admit_trace, served_shortlist_probe};
 use crate::{
     config,
+    runtime_metrics::op_stats::{self, OpStatsCollector},
     storage::io_counters,
     superfile::{
         SuperfileReader,
@@ -848,6 +849,7 @@ pub(crate) struct PreparedGlobalAllow {
 async fn lookup_user_placements_by_id(
     manifest: &ManifestSnapshot,
     user_row_ids: &[i128],
+    op_stats: &Option<Arc<OpStatsCollector>>,
 ) -> Result<Vec<(Arc<SuperfileEntry>, u32)>, QueryError> {
     if user_row_ids.is_empty() {
         return Ok(Vec::new());
@@ -892,7 +894,7 @@ async fn lookup_user_placements_by_id(
         // Cell-packed user files carry stable ids inline in Parquet row order.
         // Read each compact cell region once instead of decoding the full
         // Parquet `_id` column to place a top-k scalar projection.
-        let ids = read_ids_for_locals(manifest, &entry, &locals, id_column, true).await?;
+        let ids = read_ids_for_locals(manifest, &entry, &locals, id_column, true, op_stats).await?;
         Ok::<_, QueryError>((entry, ids))
     }))
     .await?;
@@ -968,6 +970,7 @@ pub(crate) async fn stable_ids_by_local_for_routing(
     manifest: &ManifestSnapshot,
     entry: &SuperfileEntry,
     reader: &SuperfileReader,
+    op_stats: &Option<Arc<OpStatsCollector>>,
 ) -> Result<Vec<i128>, QueryError> {
     if row_id_from_manifest_entry(entry, 0).is_some() {
         return Ok((0..entry.n_docs as u32)
@@ -991,7 +994,7 @@ pub(crate) async fn stable_ids_by_local_for_routing(
             .map_err(|e| QueryError::Execute(e.to_string()))?;
         return id_values_from_batch(&batch);
     }
-    read_ids_for_locals(manifest, entry, &locals, id_column, true).await
+    read_ids_for_locals(manifest, entry, &locals, id_column, true, op_stats).await
 }
 
 /// Read the `_id` column values at `local_ids` (in caller order) from one
@@ -1009,6 +1012,7 @@ async fn read_ids_for_locals(
     local_ids: &[u32],
     id_column: &str,
     allow_inline_region: bool,
+    op_stats: &Option<Arc<OpStatsCollector>>,
 ) -> Result<Vec<i128>, QueryError> {
     // Storage is optional: store-only tables (no object-store backend) serve
     // the superfile bytes from the in-memory reader cache. Cell-ordered
@@ -1025,12 +1029,17 @@ async fn read_ids_for_locals(
     // real Parquet rows, so the counts (and orders) match.
     let inline_is_parquet_ordered = reader.vec().is_none_or(|v| v.n_docs() == reader.n_docs());
     if allow_inline_region && inline_is_parquet_ordered {
+        // The inline-region read is one planned range per file — the plan
+        // requests it identically whether it resolves resident or cold.
         // Hidden cell superfiles inline the stable `_id` in the IVF blob — resolve
         // straight from it (resident; no scalar `_id` column read) when available.
         if let Some(ids) = reader
             .vec()
             .and_then(|v| v.inline_stable_ids_for_locals(local_ids))
         {
+            if let Some(stats) = op_stats {
+                stats.add_planned_read_ranges(1);
+            }
             return Ok(ids);
         }
         // Cold path: fetch the inline region async when present but not resident.
@@ -1040,16 +1049,24 @@ async fn read_ids_for_locals(
                 .await
                 .map_err(|e| QueryError::Execute(e.to_string()))?
         {
+            if let Some(stats) = op_stats {
+                stats.add_planned_read_ranges(1);
+            }
             return Ok(ids);
         }
     }
     if reader.parquet_bytes().is_some() {
-        let batch = reader
-            .take_by_local_doc_ids(local_ids, &[id_column])
-            .map_err(|e| QueryError::Execute(e.to_string()))?;
-        return id_values_from_batch(&batch);
+        let (batch, decode_ns) = op_stats::timed_section(|| {
+            reader
+                .take_by_local_doc_ids(local_ids, &[id_column])
+                .map_err(|e| QueryError::Execute(e.to_string()))
+        });
+        if let Some(stats) = op_stats {
+            stats.add_kernel_cpu_ns(decode_ns);
+        }
+        return id_values_from_batch(&batch?);
     }
-    let batch = take_rows_byte_source(&reader, local_ids, &[id_column])
+    let batch = take_rows_byte_source(&reader, local_ids, &[id_column], op_stats.clone())
         .await
         .map_err(|error| QueryError::Execute(error.to_string()))?;
     id_values_from_batch(&batch)
@@ -1069,6 +1086,7 @@ async fn hidden_hits_user_ids(
     hidden_manifest: &ManifestSnapshot,
     hidden_hits: &[SuperfileHit],
     id_column: &str,
+    op_stats: &Option<Arc<OpStatsCollector>>,
 ) -> Result<Vec<i128>, QueryError> {
     let mut ids = vec![0i128; hidden_hits.len()];
     let mut by_superfile: HashMap<SuperfileUri, Vec<usize>> = HashMap::new();
@@ -1101,7 +1119,8 @@ async fn hidden_hits_user_ids(
         }
         // Gapped span → one resident read of just the rows these hits touch.
         let locals: Vec<u32> = idxs.iter().map(|&i| hidden_hits[i].local_doc_id).collect();
-        let vals = read_ids_for_locals(hidden_manifest, &entry, &locals, id_column, true).await?;
+        let vals = read_ids_for_locals(hidden_manifest, &entry, &locals, id_column, true, op_stats)
+            .await?;
         for (j, &i) in idxs.iter().enumerate() {
             ids[i] = vals[j];
         }
@@ -1185,7 +1204,13 @@ pub(crate) async fn user_placement_for_scalar_resolve(
         let user_row_id = if let Some(id) = hit.stable_id {
             id
         } else if let Some(ref hm) = hidden_manifest {
-            hidden_hits_user_ids(hm, std::slice::from_ref(hit), id_column).await?[0]
+            hidden_hits_user_ids(
+                hm,
+                std::slice::from_ref(hit),
+                id_column,
+                &user_reader.op_stats,
+            )
+            .await?[0]
         } else {
             return Err(QueryError::Execute(format!(
                 "hit superfile {:?} missing from manifests",
@@ -1201,7 +1226,8 @@ pub(crate) async fn user_placement_for_scalar_resolve(
         placement_requests.push((i, user_row_id));
     }
     let requested_ids: Vec<i128> = placement_requests.iter().map(|(_, id)| *id).collect();
-    let placements = lookup_user_placements_by_id(user_manifest, &requested_ids).await?;
+    let placements =
+        lookup_user_placements_by_id(user_manifest, &requested_ids, &user_reader.op_stats).await?;
     for ((index, stable_id), (entry, local_doc_id)) in
         placement_requests.into_iter().zip(placements)
     {
@@ -1488,8 +1514,12 @@ impl SupertableReader {
         // gate. Phase timers (INFINO_TRACE_VECTOR_WARM_PHASES): admit covers
         // that work; fanout_wall is probe+rerank+remap wall.
         let admit_t0 = io_counters::phase_start();
+        // The grid/centroid ranking is the admit stage's kernel section —
+        // pure CPU over manifest summaries on this thread.
         let ranked_cells_scored: Option<Vec<(u32, f32)>> =
-            grid.map(|grid| grid.rank_cells(metric, query));
+            op_stats::timed_kernel(&self.op_stats, || {
+                grid.map(|grid| grid.rank_cells(metric, query))
+            });
         let ranked_cells: Option<Vec<u32>> = ranked_cells_scored
             .as_ref()
             .map(|cells| cells.iter().map(|(cell, _)| *cell).collect());
@@ -2222,6 +2252,7 @@ impl SupertableReader {
                             // PRICED rerank ranges are the canonical plan
                             // budget, flushed once after the fan-out.
                             stats.add_vector_rows_reranked(scan.rows_reranked);
+                            stats.add_kernel_cpu_ns(scan.kernel_cpu_ns);
                         }
                         total_candidates
                             .fetch_add(scan.candidates_scanned, atomic::Ordering::Relaxed);
@@ -2257,6 +2288,7 @@ impl SupertableReader {
                                 tally.ranges_requested + tally.rows_reranked,
                             );
                             stats.add_vector_rows_reranked(tally.rows_reranked);
+                            stats.add_kernel_cpu_ns(tally.kernel_cpu_ns);
                         }
                         hits
                     };
@@ -2264,8 +2296,14 @@ impl SupertableReader {
                     // Prefer manifest span arithmetic; only touch `_id` pages /
                     // inline IVF regions when the layout is cell-packed or gapped.
                     io_counters::phase_timed_async("vec.stable_id", async {
-                        dispatch::attach_stable_ids(&reader_for_ids, &entry, &mut tagged, false)
-                            .await
+                        dispatch::attach_stable_ids(
+                            &reader_for_ids,
+                            &entry,
+                            &mut tagged,
+                            false,
+                            &op_stats,
+                        )
+                        .await
                     })
                     .await?;
                     if !hidden_vector_index && !deny_pushdown {
@@ -2278,6 +2316,7 @@ impl SupertableReader {
                             &entry,
                             &mut tagged,
                             now,
+                            &op_stats,
                         )
                         .await?;
                     }
@@ -2461,6 +2500,7 @@ impl SupertableReader {
                 let column = Arc::clone(&column_arc2);
                 let query = Arc::clone(&query_arc2);
                 let reader_pool = Arc::clone(&manifest.options.reader_pool);
+                let op_stats_c = self.op_stats.clone();
                 let body_c = move |reader: Arc<SuperfileReader>,
                                    entry: Arc<SuperfileEntry>,
                                    _tombstone_cache: Option<Arc<SidecarCache>>,
@@ -2469,6 +2509,7 @@ impl SupertableReader {
                     let column = Arc::clone(&column);
                     let query = Arc::clone(&query);
                     let reader_pool = Arc::clone(&reader_pool);
+                    let op_stats = op_stats_c.clone();
                     async move {
                         // Hidden-path invariants: no tombstone sidecars (the
                         // manifest's deletes apply after the stable-id
@@ -2479,7 +2520,7 @@ impl SupertableReader {
                             .unwrap_or(0);
                         let k_fetch = k.saturating_add(replica_overhead);
                         let reader_for_ids = Arc::clone(&reader);
-                        let hits = reader
+                        let (hits, rerank_kernel_ns) = reader
                             .vector_rerank_selected(
                                 &column,
                                 &query,
@@ -2489,10 +2530,19 @@ impl SupertableReader {
                             )
                             .await
                             .map_err(vector_read_query_error)?;
+                        if let Some(stats) = &op_stats {
+                            stats.add_kernel_cpu_ns(rerank_kernel_ns);
+                        }
                         let mut tagged = dispatch::tag_hits(&entry, hits);
                         io_counters::phase_timed_async("vec.stable_id", async {
-                            dispatch::attach_stable_ids(&reader_for_ids, &entry, &mut tagged, false)
-                                .await
+                            dispatch::attach_stable_ids(
+                                &reader_for_ids,
+                                &entry,
+                                &mut tagged,
+                                false,
+                                &op_stats,
+                            )
+                            .await
                         })
                         .await?;
                         Ok::<Vec<SuperfileHit>, QueryError>(tagged)
@@ -2639,6 +2689,7 @@ impl SupertableReader {
                 if let Some(stats) = &op_stats {
                     stats.add_fts_postings_bytes(work.postings_bytes);
                     stats.add_planned_read_ranges(work.planned_ranges);
+                    stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                 }
                 Ok(docs.into_iter().collect::<RoaringBitmap>())
             }
@@ -2723,7 +2774,9 @@ impl SupertableReader {
                 continue;
             }
             let locals: Vec<u32> = bm.iter().collect();
-            let ids = read_ids_for_locals(manifest, &entry, &locals, id_column, false).await?;
+            let ids =
+                read_ids_for_locals(manifest, &entry, &locals, id_column, false, &self.op_stats)
+                    .await?;
             out.extend(ids);
         }
         Ok(out.into_iter().collect())
@@ -2845,14 +2898,20 @@ impl SupertableReader {
             if !superfiles.is_empty() {
                 let allow_for_cell = Arc::clone(&allow_global);
                 let manifest_for_ids = Arc::clone(&hidden_manifest);
+                let routing_stats = hidden_reader.op_stats.clone();
                 let allow_by_uri = hidden_reader
                     .fanout_candidate_bitmaps(&superfiles, move |r, entry| {
                         let allow_for_cell = Arc::clone(&allow_for_cell);
                         let manifest_for_ids = Arc::clone(&manifest_for_ids);
+                        let routing_stats = routing_stats.clone();
                         async move {
-                            let stable_ids =
-                                stable_ids_by_local_for_routing(&manifest_for_ids, &entry, &r)
-                                    .await?;
+                            let stable_ids = stable_ids_by_local_for_routing(
+                                &manifest_for_ids,
+                                &entry,
+                                &r,
+                                &routing_stats,
+                            )
+                            .await?;
                             let mut local = RoaringBitmap::new();
                             for (local_doc_id, stable_id) in stable_ids.into_iter().enumerate() {
                                 if let Ok(global_id) = u32::try_from(stable_id)
@@ -2968,14 +3027,21 @@ impl SupertableReader {
         let column_owned = column.to_string();
         let map_for_fanout = Arc::clone(&map);
         let manifest_for_ids = Arc::clone(&hidden_manifest);
+        let routing_stats = hidden_reader.op_stats.clone();
         let _ = hidden_reader
             .fanout_candidate_bitmaps(&superfiles, move |r, entry| {
                 let map = Arc::clone(&map_for_fanout);
                 let manifest_for_ids = Arc::clone(&manifest_for_ids);
                 let column = column_owned.clone();
+                let routing_stats = routing_stats.clone();
                 async move {
-                    let stable_ids =
-                        stable_ids_by_local_for_routing(&manifest_for_ids, &entry, &r).await?;
+                    let stable_ids = stable_ids_by_local_for_routing(
+                        &manifest_for_ids,
+                        &entry,
+                        &r,
+                        &routing_stats,
+                    )
+                    .await?;
                     if let Some(vs) = entry.vector_summary.get(&column) {
                         let mut idx = 0usize;
                         let mut guard = map.lock().expect("diag cell-map lock");
@@ -3047,14 +3113,20 @@ impl SupertableReader {
             if !superfiles.is_empty() {
                 let allow_for_cell = Arc::clone(&allow_set);
                 let manifest_for_ids = Arc::clone(&hidden_manifest);
+                let routing_stats = hidden_reader.op_stats.clone();
                 let allow_by_uri = hidden_reader
                     .fanout_candidate_bitmaps(&superfiles, move |r, entry| {
                         let allow_for_cell = Arc::clone(&allow_for_cell);
                         let manifest_for_ids = Arc::clone(&manifest_for_ids);
+                        let routing_stats = routing_stats.clone();
                         async move {
-                            let stable_ids =
-                                stable_ids_by_local_for_routing(&manifest_for_ids, &entry, &r)
-                                    .await?;
+                            let stable_ids = stable_ids_by_local_for_routing(
+                                &manifest_for_ids,
+                                &entry,
+                                &r,
+                                &routing_stats,
+                            )
+                            .await?;
                             let mut local = RoaringBitmap::new();
                             for (local_doc_id, stable_id) in stable_ids.into_iter().enumerate() {
                                 if allow_for_cell.contains(&stable_id) {
@@ -3096,13 +3168,20 @@ impl SupertableReader {
         }
         let allow_for_user = Arc::clone(&allow_set);
         let manifest_for_ids = Arc::clone(manifest);
+        let routing_stats = self.op_stats.clone();
         let allow_by_uri = self
             .fanout_candidate_bitmaps(&superfiles, move |r, entry| {
                 let allow_for_user = Arc::clone(&allow_for_user);
                 let manifest_for_ids = Arc::clone(&manifest_for_ids);
+                let routing_stats = routing_stats.clone();
                 async move {
-                    let stable_ids =
-                        stable_ids_by_local_for_routing(&manifest_for_ids, &entry, &r).await?;
+                    let stable_ids = stable_ids_by_local_for_routing(
+                        &manifest_for_ids,
+                        &entry,
+                        &r,
+                        &routing_stats,
+                    )
+                    .await?;
                     let mut local = RoaringBitmap::new();
                     for (local_doc_id, stable_id) in stable_ids.into_iter().enumerate() {
                         if allow_for_user.contains(&stable_id) {
@@ -3237,6 +3316,7 @@ impl SupertableReader {
                 if let Some(stats) = &op_stats {
                     stats.add_fts_postings_bytes(work.postings_bytes);
                     stats.add_planned_read_ranges(work.planned_ranges);
+                    stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                 }
                 bitmap.ok_or_else(|| {
                     QueryError::Execute(
@@ -4112,12 +4192,14 @@ mod tests {
             stable_id: Some(sid),
         };
         let hits = [mk(42)];
-        let ids = block_on(hidden_hits_user_ids(manifest, &hits, "_id")).expect("resolve one id");
+        let ids =
+            block_on(hidden_hits_user_ids(manifest, &hits, "_id", &None)).expect("resolve one id");
         assert_eq!(ids, vec![42], "single inline stable id returned verbatim");
 
         // Order is preserved across multiple stamped hits.
         let hits = [mk(42), mk(7)];
-        let ids = block_on(hidden_hits_user_ids(manifest, &hits, "_id")).expect("resolve two ids");
+        let ids =
+            block_on(hidden_hits_user_ids(manifest, &hits, "_id", &None)).expect("resolve two ids");
         assert_eq!(ids, vec![42, 7], "inline stable ids returned in hit order");
     }
 

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2403,8 +2403,17 @@ impl SupertableReader {
                 // Mirror phase A/C's `k_fetch = k + replica_overhead` in the
                 // global cut so boundary replicas (dormant today: overhead
                 // is 0 with replication off) cannot take shortlist slots
-                // from distinct rows before the stable-id dedup.
-                let replica_overhead = pooled.iter().map(|(_, _, o, _)| *o).max().unwrap_or(0);
+                // from distinct rows before the stable-id dedup. Taken
+                // over ALL scanned units — not just the pooled (warm)
+                // ones — so under replication the selection cap is
+                // temperature-invariant and always agrees with the
+                // canonical priced budget above, which uses the same max.
+                // (Pooled membership shifts with cache temperature: a
+                // fully cold unit reranks in-scan and pools nothing, so
+                // a pooled-only max could shrink the cap on cold runs.)
+                let replica_overhead =
+                    usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
+                        .unwrap_or(0);
                 let mut flat: Vec<(usize, ScanCandidate)> = pooled
                     .into_iter()
                     .flat_map(|(si, _, _, cands)| cands.into_iter().map(move |c| (si, c)))

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2147,6 +2147,14 @@ impl SupertableReader {
         let total_candidates_body = Arc::clone(&total_candidates);
         let max_replica_overhead = Arc::new(AtomicU64::new(0));
         let max_replica_overhead_body = Arc::clone(&max_replica_overhead);
+        // (#537) Pin-arm plan rows: under an explicit caller nprobe every
+        // probed cell keeps the full k x rerank_mult depth (floor ==
+        // budget, cold arm undivided), so the plan's rerank rows are the
+        // per-cell kept counts summed — warm survivors pooled for phase C
+        // plus cold rows reranked in-scan, which are the same
+        // min(cell candidates, depth) per cell at either temperature.
+        let pinned_plan_rows = Arc::new(AtomicU64::new(0));
+        let pinned_plan_rows_body = Arc::clone(&pinned_plan_rows);
         let body =
             move |reader: Arc<SuperfileReader>,
                   entry: Arc<SuperfileEntry>,
@@ -2161,6 +2169,7 @@ impl SupertableReader {
                 let scan_pool = Arc::clone(&scan_pool_body);
                 let total_candidates = Arc::clone(&total_candidates_body);
                 let max_replica_overhead = Arc::clone(&max_replica_overhead_body);
+                let pinned_plan_rows = Arc::clone(&pinned_plan_rows_body);
                 let op_stats = op_stats_scan.clone();
                 async move {
                     // Unfiltered user path on row-addressable locals: resolve the
@@ -2218,6 +2227,10 @@ impl SupertableReader {
                             .fetch_add(scan.candidates_scanned, atomic::Ordering::Relaxed);
                         max_replica_overhead
                             .fetch_max(replica_overhead as u64, atomic::Ordering::Relaxed);
+                        pinned_plan_rows.fetch_add(
+                            scan.candidates.len() as u64 + scan.rows_reranked,
+                            atomic::Ordering::Relaxed,
+                        );
                         if !scan.candidates.is_empty() {
                             scan_pool
                                 .lock()
@@ -2301,27 +2314,36 @@ impl SupertableReader {
         // units' estimates ever meet.
         if global_shortlist_width.is_some() {
             // Canonical rerank-leg pricing for the deferred plan: one
-            // planned survivor range per BUDGETED shortlist row —
-            // `min(shortlist limit, candidates scanned)` — flushed whether
-            // the winners rerank at phase C (warm) or already reranked
-            // inside their cell scans (cold). Same query, same table state
-            // → same priced count, at any cache temperature. (Under an
-            // explicit caller nprobe the per-cell floor can rerank a few
-            // rows beyond the budget; those stay unpriced.)
+            // planned survivor range per BUDGETED shortlist row, flushed
+            // whether the winners rerank at phase C (warm) or already
+            // reranked inside their cell scans (cold). Same query, same
+            // table state → same priced count, at any cache temperature.
+            // Law arm: the budget is the global shortlist cap —
+            // `min(shortlist limit, candidates scanned)`. Pin arm (#537):
+            // every probed cell keeps the full per-cell depth and cost is
+            // linear in the width the caller asked for, so the plan's
+            // rows are the per-cell kept counts summed (warm survivors +
+            // cold in-scan rows — the same min(candidates, depth) per
+            // cell at either temperature).
             if let Some(stats) = &self.op_stats {
-                let total = total_candidates.load(atomic::Ordering::Relaxed);
-                let overhead =
-                    usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
-                        .unwrap_or(0);
-                let limit = deferred_shortlist_limit(
-                    k,
-                    overhead,
-                    plan_rerank_mult,
-                    law_rerank_served,
-                    options.nprobe.is_some(),
-                    served_cells_over_width,
-                );
-                stats.add_planned_read_ranges((limit as u64).min(total));
+                let rows = if options.nprobe.is_some() {
+                    pinned_plan_rows.load(atomic::Ordering::Relaxed)
+                } else {
+                    let total = total_candidates.load(atomic::Ordering::Relaxed);
+                    let overhead =
+                        usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
+                            .unwrap_or(0);
+                    let limit = deferred_shortlist_limit(
+                        k,
+                        overhead,
+                        plan_rerank_mult,
+                        law_rerank_served,
+                        false,
+                        served_cells_over_width,
+                    );
+                    (limit as u64).min(total)
+                };
+                stats.add_planned_read_ranges(rows);
             }
             let pooled = {
                 let mut guard = scan_pool.lock().unwrap_or_else(PoisonError::into_inner);
@@ -2386,7 +2408,7 @@ impl SupertableReader {
                 // is linear in the width the caller asked for — the pin
                 // arm's stated semantics.
                 let cell_floor = if options.nprobe.is_some() {
-                    k.saturating_mul(rerank_mult)
+                    k.saturating_mul(plan_rerank_mult)
                 } else {
                     0
                 };

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1340,23 +1340,37 @@ impl SupertableReader {
         let deferred = if deferred.is_empty() {
             deferred
         } else if let Some(section) = self.centroid_section().await {
-            let mut leftovers = Vec::new();
-            for d in deferred {
-                let entry = &superfiles[d.si];
-                let read = section
-                    .read_cell(entry.superfile_id, column, d.cell_id)
-                    .map_err(|e| {
-                        QueryError::Execute(format!("centroid section spill read: {e}"))
-                    })?;
-                let Some(fp32) = read else {
-                    leftovers.push(d);
-                    continue;
-                };
-                if !score_cell_fp32(superfiles, column, &d, &fp32, query, metric, candidates) {
-                    leftovers.push(d);
+            // Sync section: the preads block the thread (off-CPU), so one
+            // bracket around the whole loop attributes only the fp32
+            // scoring. Each successful cell read is one planned range —
+            // a real per-query pread of the hydrated section, identical
+            // at any cache temperature.
+            let mut cells_read = 0u64;
+            let (leftovers, rescore_ns) = op_stats::timed_section(|| {
+                let mut leftovers = Vec::new();
+                for d in deferred {
+                    let entry = &superfiles[d.si];
+                    let read = section
+                        .read_cell(entry.superfile_id, column, d.cell_id)
+                        .map_err(|e| {
+                            QueryError::Execute(format!("centroid section spill read: {e}"))
+                        })?;
+                    let Some(fp32) = read else {
+                        leftovers.push(d);
+                        continue;
+                    };
+                    cells_read += 1;
+                    if !score_cell_fp32(superfiles, column, &d, &fp32, query, metric, candidates) {
+                        leftovers.push(d);
+                    }
                 }
+                Ok::<_, QueryError>(leftovers)
+            });
+            if let Some(stats) = &self.op_stats {
+                stats.add_planned_read_ranges(cells_read);
+                stats.add_kernel_cpu_ns(rescore_ns);
             }
-            leftovers
+            leftovers?
         } else {
             deferred
         };
@@ -1366,24 +1380,32 @@ impl SupertableReader {
         let deferred = if deferred.is_empty() {
             deferred
         } else if let Some(cache) = self.manifest().user_centroids_for_rescore().await {
-            let mut leftovers = Vec::new();
-            for d in deferred {
-                let entry = &superfiles[d.si];
-                let Some(fp32) = cache.cell(entry.superfile_id, column, d.cell_id) else {
-                    leftovers.push(d);
-                    continue;
-                };
-                if !score_cell_fp32(
-                    superfiles,
-                    column,
-                    &d,
-                    fp32.as_slice(),
-                    query,
-                    metric,
-                    candidates,
-                ) {
-                    leftovers.push(d);
+            // RAM-hydrated per-generation cache: no read to count, only
+            // the fp32 scoring CPU.
+            let (leftovers, rescore_ns) = op_stats::timed_section(|| {
+                let mut leftovers = Vec::new();
+                for d in deferred {
+                    let entry = &superfiles[d.si];
+                    let Some(fp32) = cache.cell(entry.superfile_id, column, d.cell_id) else {
+                        leftovers.push(d);
+                        continue;
+                    };
+                    if !score_cell_fp32(
+                        superfiles,
+                        column,
+                        &d,
+                        fp32.as_slice(),
+                        query,
+                        metric,
+                        candidates,
+                    ) {
+                        leftovers.push(d);
+                    }
                 }
+                leftovers
+            });
+            if let Some(stats) = &self.op_stats {
+                stats.add_kernel_cpu_ns(rescore_ns);
             }
             leftovers
         } else {

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2192,21 +2192,11 @@ impl SupertableReader {
         let scan_pool: Arc<Mutex<Vec<(usize, u64, usize, Vec<ScanCandidate>)>>> =
             Arc::new(Mutex::new(Vec::new()));
         let scan_pool_body = Arc::clone(&scan_pool);
-        // Deferred-arm plan inputs for the canonical rerank-row pricing:
-        // total candidates across every scanned unit (cold cells included,
-        // which never reach `scan_pool`), and the widest replica overhead.
-        let total_candidates = Arc::new(AtomicU64::new(0));
-        let total_candidates_body = Arc::clone(&total_candidates);
+        // Widest replica overhead across every scanned unit — phase C's
+        // selection cap reads it so pooled-set membership (which shifts
+        // with cache temperature) can never shrink the cap.
         let max_replica_overhead = Arc::new(AtomicU64::new(0));
         let max_replica_overhead_body = Arc::clone(&max_replica_overhead);
-        // (#537) Pin-arm plan rows: under an explicit caller nprobe every
-        // probed cell keeps the full k x rerank_mult depth (floor ==
-        // budget, cold arm undivided), so the plan's rerank rows are the
-        // per-cell kept counts summed — warm survivors pooled for phase C
-        // plus cold rows reranked in-scan, which are the same
-        // min(cell candidates, depth) per cell at either temperature.
-        let pinned_plan_rows = Arc::new(AtomicU64::new(0));
-        let pinned_plan_rows_body = Arc::clone(&pinned_plan_rows);
         let body =
             move |reader: Arc<SuperfileReader>,
                   entry: Arc<SuperfileEntry>,
@@ -2219,9 +2209,7 @@ impl SupertableReader {
                 let budget = budget.clone();
                 let storage = storage.clone();
                 let scan_pool = Arc::clone(&scan_pool_body);
-                let total_candidates = Arc::clone(&total_candidates_body);
                 let max_replica_overhead = Arc::clone(&max_replica_overhead_body);
-                let pinned_plan_rows = Arc::clone(&pinned_plan_rows_body);
                 let op_stats = op_stats_scan.clone();
                 async move {
                     // Unfiltered user path on row-addressable locals: resolve the
@@ -2268,22 +2256,16 @@ impl SupertableReader {
                             .map_err(vector_read_query_error)?;
                         if let Some(stats) = &op_stats {
                             stats.add_vector_scan(scan.cells_scanned, scan.candidates_scanned);
+                            // Request-shaped ranges only (cluster index +
+                            // prefixes/blocks + Sq8 meta). Rerank rows are
+                            // diagnostics; their cost rides the priced
+                            // CPU watermark.
                             stats.add_planned_read_ranges(scan.ranges_requested);
-                            // Actual rows only: cold cells rerank immediately
-                            // inside the scan, warm winners at phase C. The
-                            // PRICED rerank ranges are the canonical plan
-                            // budget, flushed once after the fan-out.
                             stats.add_vector_rows_reranked(scan.rows_reranked);
                             stats.add_kernel_cpu_ns(scan.kernel_cpu_ns);
                         }
-                        total_candidates
-                            .fetch_add(scan.candidates_scanned, atomic::Ordering::Relaxed);
                         max_replica_overhead
                             .fetch_max(replica_overhead as u64, atomic::Ordering::Relaxed);
-                        pinned_plan_rows.fetch_add(
-                            scan.candidates.len() as u64 + scan.rows_reranked,
-                            atomic::Ordering::Relaxed,
-                        );
                         if !scan.candidates.is_empty() {
                             scan_pool
                                 .lock()
@@ -2300,15 +2282,12 @@ impl SupertableReader {
                             .map_err(vector_read_query_error)?;
                         if let Some(stats) = &op_stats {
                             stats.add_vector_scan(tally.cells_scanned, tally.candidates_scanned);
-                            // The immediate probe's shortlist rows ARE its
-                            // plan's rerank set — fixed by budget and
-                            // candidates, not by temperature — and each is
-                            // one planned survivor range (a cold probe
-                            // serves them in-block; the plan is priced
-                            // identically either way).
-                            stats.add_planned_read_ranges(
-                                tally.ranges_requested + tally.rows_reranked,
-                            );
+                            // Request-shaped ranges only — rerank rows are
+                            // diagnostics; their cost rides the priced CPU
+                            // watermark (survivor fetches coalesce into a
+                            // handful of real requests, so counting one
+                            // range per row would not be request-shaped).
+                            stats.add_planned_read_ranges(tally.ranges_requested);
                             stats.add_vector_rows_reranked(tally.rows_reranked);
                             stats.add_kernel_cpu_ns(tally.kernel_cpu_ns);
                         }
@@ -2374,38 +2353,14 @@ impl SupertableReader {
         // column, table-wide — asserted here at the only place different
         // units' estimates ever meet.
         if global_shortlist_width.is_some() {
-            // Canonical rerank-leg pricing for the deferred plan: one
-            // planned survivor range per BUDGETED shortlist row, flushed
-            // whether the winners rerank at phase C (warm) or already
-            // reranked inside their cell scans (cold). Same query, same
-            // table state → same priced count, at any cache temperature.
-            // Law arm: the budget is the global shortlist cap —
-            // `min(shortlist limit, candidates scanned)`. Pin arm (#537):
-            // every probed cell keeps the full per-cell depth and cost is
-            // linear in the width the caller asked for, so the plan's
-            // rows are the per-cell kept counts summed (warm survivors +
-            // cold in-scan rows — the same min(candidates, depth) per
-            // cell at either temperature).
-            if let Some(stats) = &self.op_stats {
-                let rows = if options.nprobe.is_some() {
-                    pinned_plan_rows.load(atomic::Ordering::Relaxed)
-                } else {
-                    let total = total_candidates.load(atomic::Ordering::Relaxed);
-                    let overhead =
-                        usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
-                            .unwrap_or(0);
-                    let limit = deferred_shortlist_limit(
-                        k,
-                        overhead,
-                        plan_rerank_mult,
-                        law_rerank_served,
-                        false,
-                        served_cells_over_width,
-                    );
-                    (limit as u64).min(total)
-                };
-                stats.add_planned_read_ranges(rows);
-            }
+            // Rerank rows are deliberately NOT in the priced range
+            // counter: `planned_read_ranges` is request-shaped (numbers
+            // commensurate with real object-store requests, which
+            // coalesce survivor rows into a handful of GETs), and the
+            // platform prices it at a per-request rate. The rerank leg's
+            // cost is CPU-dominated and carried by the priced CPU
+            // watermark; the row counts stay visible in the
+            // rows-reranked / candidates diagnostics.
             let pooled = {
                 let mut guard = scan_pool.lock().unwrap_or_else(PoisonError::into_inner);
                 mem::take(&mut *guard)

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -70,7 +70,10 @@ use std::{
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet},
     future::Future,
     mem,
-    sync::{Arc, Mutex, PoisonError},
+    sync::{
+        Arc, Mutex, PoisonError,
+        atomic::{self, AtomicU64},
+    },
     time::Instant,
 };
 
@@ -1156,12 +1159,17 @@ pub(crate) async fn user_placement_for_scalar_resolve(
     }
     let user_manifest = user_reader.manifest();
     let id_column = user_reader.options().id_column.as_str();
-    let hidden_manifest = user_reader
-        .vector_index_table()
-        .map(|vit| Arc::clone(vit.pinned_reader().manifest()));
-    let deleted = user_reader
-        .vector_index_table()
-        .and_then(|vit| vit.pinned_reader().hidden_deleted_ids().ok());
+    let hidden_manifest = user_reader.vector_index_table().map(|vit| {
+        Arc::clone(
+            vit.pinned_reader_with(user_reader.op_stats.clone())
+                .manifest(),
+        )
+    });
+    let deleted = user_reader.vector_index_table().and_then(|vit| {
+        vit.pinned_reader_with(user_reader.op_stats.clone())
+            .hidden_deleted_ids()
+            .ok()
+    });
     let mut out: Vec<Option<SuperfileHit>> = vec![None; hits.len()];
     let mut placement_requests: Vec<(usize, i128)> = Vec::new();
     for (i, hit) in hits.iter().enumerate() {
@@ -2065,6 +2073,11 @@ impl SupertableReader {
         } else {
             None
         };
+        // The PLAN's rerank multiplier — post-law, pre-width-divide. The
+        // canonical rerank-row pricing and phase C's selection cap both
+        // read this value; the divided cold budget below is an execution
+        // detail that must never leak into the priced count.
+        let (_, plan_rerank_mult) = options.resolve(filtered);
         let mut cold_rerank_mult = 0;
         let options = match sweep_width {
             Some(w) if w > 1 => {
@@ -2105,6 +2118,13 @@ impl SupertableReader {
         let scan_pool: Arc<Mutex<Vec<(usize, u64, usize, Vec<ScanCandidate>)>>> =
             Arc::new(Mutex::new(Vec::new()));
         let scan_pool_body = Arc::clone(&scan_pool);
+        // Deferred-arm plan inputs for the canonical rerank-row pricing:
+        // total candidates across every scanned unit (cold cells included,
+        // which never reach `scan_pool`), and the widest replica overhead.
+        let total_candidates = Arc::new(AtomicU64::new(0));
+        let total_candidates_body = Arc::clone(&total_candidates);
+        let max_replica_overhead = Arc::new(AtomicU64::new(0));
+        let max_replica_overhead_body = Arc::clone(&max_replica_overhead);
         let body =
             move |reader: Arc<SuperfileReader>,
                   entry: Arc<SuperfileEntry>,
@@ -2117,6 +2137,8 @@ impl SupertableReader {
                 let budget = budget.clone();
                 let storage = storage.clone();
                 let scan_pool = Arc::clone(&scan_pool_body);
+                let total_candidates = Arc::clone(&total_candidates_body);
+                let max_replica_overhead = Arc::clone(&max_replica_overhead_body);
                 let op_stats = op_stats_scan.clone();
                 async move {
                     // Unfiltered user path on row-addressable locals: resolve the
@@ -2164,10 +2186,16 @@ impl SupertableReader {
                         if let Some(stats) = &op_stats {
                             stats.add_vector_scan(scan.cells_scanned, scan.candidates_scanned);
                             stats.add_planned_read_ranges(scan.ranges_requested);
-                            // Cold cells rerank immediately inside the scan;
-                            // warm survivors are counted at phase C below.
+                            // Actual rows only: cold cells rerank immediately
+                            // inside the scan, warm winners at phase C. The
+                            // PRICED rerank ranges are the canonical plan
+                            // budget, flushed once after the fan-out.
                             stats.add_vector_rows_reranked(scan.rows_reranked);
                         }
+                        total_candidates
+                            .fetch_add(scan.candidates_scanned, atomic::Ordering::Relaxed);
+                        max_replica_overhead
+                            .fetch_max(replica_overhead as u64, atomic::Ordering::Relaxed);
                         if !scan.candidates.is_empty() {
                             scan_pool
                                 .lock()
@@ -2176,14 +2204,24 @@ impl SupertableReader {
                         }
                         scan.hits
                     } else {
-                        let (hits, rows_reranked) = reader
+                        let (hits, tally) = reader
                             .vector_search_clusters_filtered(
                                 &column, &query, k_fetch, &ids, options, bitmap, deny, pool, budget,
                             )
                             .await
                             .map_err(vector_read_query_error)?;
                         if let Some(stats) = &op_stats {
-                            stats.add_vector_rows_reranked(rows_reranked);
+                            stats.add_vector_scan(tally.cells_scanned, tally.candidates_scanned);
+                            // The immediate probe's shortlist rows ARE its
+                            // plan's rerank set — fixed by budget and
+                            // candidates, not by temperature — and each is
+                            // one planned survivor range (a cold probe
+                            // serves them in-block; the plan is priced
+                            // identically either way).
+                            stats.add_planned_read_ranges(
+                                tally.ranges_requested + tally.rows_reranked,
+                            );
+                            stats.add_vector_rows_reranked(tally.rows_reranked);
                         }
                         hits
                     };
@@ -2240,6 +2278,29 @@ impl SupertableReader {
         // column, table-wide — asserted here at the only place different
         // units' estimates ever meet.
         if global_shortlist_width.is_some() {
+            // Canonical rerank-leg pricing for the deferred plan: one
+            // planned survivor range per BUDGETED shortlist row —
+            // `min(shortlist limit, candidates scanned)` — flushed whether
+            // the winners rerank at phase C (warm) or already reranked
+            // inside their cell scans (cold). Same query, same table state
+            // → same priced count, at any cache temperature. (Under an
+            // explicit caller nprobe the per-cell floor can rerank a few
+            // rows beyond the budget; those stay unpriced.)
+            if let Some(stats) = &self.op_stats {
+                let total = total_candidates.load(atomic::Ordering::Relaxed);
+                let overhead =
+                    usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
+                        .unwrap_or(0);
+                let limit = deferred_shortlist_limit(
+                    k,
+                    overhead,
+                    plan_rerank_mult,
+                    law_rerank_served,
+                    options.nprobe.is_some(),
+                    served_cells_over_width,
+                );
+                stats.add_planned_read_ranges((limit as u64).min(total));
+            }
             let pooled = {
                 let mut guard = scan_pool.lock().unwrap_or_else(PoisonError::into_inner);
                 mem::take(&mut *guard)
@@ -2256,7 +2317,6 @@ impl SupertableReader {
                         "pooled 1-bit estimates require one rotation seed per column".into(),
                     ));
                 }
-                let (_, rerank_mult) = options.resolve(filtered);
                 // Mirror phase A/C's `k_fetch = k + replica_overhead` in the
                 // global cut so boundary replicas (dormant today: overhead
                 // is 0 with replication off) cannot take shortlist slots
@@ -2300,16 +2360,14 @@ impl SupertableReader {
                 // decisive geometry serves width == stamp and is
                 // unchanged. Explicit caller rerank_mult stays an exact,
                 // unscaled request.
-                let (served, stamped_width) = served_cells_over_width;
-                let shortlist_limit = if law_rerank_served && options.nprobe.is_none() {
-                    k.saturating_add(replica_overhead)
-                        .saturating_mul(rerank_mult)
-                        .saturating_mul(served)
-                        .div_ceil(stamped_width)
-                } else {
-                    k.saturating_add(replica_overhead)
-                        .saturating_mul(rerank_mult)
-                };
+                let shortlist_limit = deferred_shortlist_limit(
+                    k,
+                    replica_overhead,
+                    plan_rerank_mult,
+                    law_rerank_served,
+                    options.nprobe.is_some(),
+                    served_cells_over_width,
+                );
                 // Regression probe for the serve-the-law scope bug: recall
                 // floors can't see a re-shadowed `options` (the constant
                 // budget only ADDS survivors); the served limit can.
@@ -2330,10 +2388,11 @@ impl SupertableReader {
                     })
                     .collect();
                 if let Some(stats) = &self.op_stats {
+                    // Actual winner rows; their planned ranges were priced
+                    // canonically above, from the budget these winners were
+                    // selected under.
                     let rows: u64 = rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
                     stats.add_vector_rows_reranked(rows);
-                    // Phase C gathers one survivor row range per winner.
-                    stats.add_planned_read_ranges(rows);
                 }
                 let column = Arc::clone(&column_arc2);
                 let query = Arc::clone(&query_arc2);
@@ -2614,7 +2673,12 @@ impl SupertableReader {
         }
         let drained = self
             .vector_index_table()
-            .map(|hidden| hidden.pinned_reader().manifest().get_drained_ranges())
+            .map(|hidden| {
+                hidden
+                    .pinned_reader_with(self.op_stats.clone())
+                    .manifest()
+                    .get_drained_ranges()
+            })
             .unwrap_or_default();
         let mut drained_allow = HashMap::new();
         let mut undrained_user = Vec::new();
@@ -2698,7 +2762,7 @@ impl SupertableReader {
             });
         }
         if let Some(vit) = self.vector_index_table() {
-            let hidden_reader = vit.pinned_reader();
+            let hidden_reader = vit.pinned_reader_with(self.op_stats.clone());
             let hidden_manifest = Arc::clone(hidden_reader.manifest());
             let drained = hidden_manifest.get_drained_ranges();
             let superfiles = hidden_manifest
@@ -2821,7 +2885,7 @@ impl SupertableReader {
         let Some(vit) = self.vector_index_table() else {
             return Ok(HashMap::new());
         };
-        let hidden_reader = vit.pinned_reader();
+        let hidden_reader = vit.pinned_reader_with(self.op_stats.clone());
         let hidden_manifest = Arc::clone(hidden_reader.manifest());
         let superfiles = hidden_manifest
             .get_all_superfiles_loaded()
@@ -2873,7 +2937,11 @@ impl SupertableReader {
     #[cfg(any(test, feature = "test-helpers"))]
     pub fn diag_hidden_probe_laws(&self) -> Option<(Vec<u32>, Vec<u32>, Vec<u32>)> {
         let vit = self.vector_index_table()?;
-        match vit.pinned_reader().manifest().get_partition_strategy() {
+        match vit
+            .pinned_reader_with(self.op_stats.clone())
+            .manifest()
+            .get_partition_strategy()
+        {
             PartitionStrategy::VectorCell { routing, .. } => Some((
                 routing.width_for_k.to_vec(),
                 routing.fine_for_k.to_vec(),
@@ -2896,7 +2964,7 @@ impl SupertableReader {
         let allow_set: Arc<HashSet<i128>> =
             Arc::new(allow_stable_ids.iter().copied().collect::<HashSet<i128>>());
         if let Some(vit) = self.vector_index_table() {
-            let hidden_reader = vit.pinned_reader();
+            let hidden_reader = vit.pinned_reader_with(self.op_stats.clone());
             let hidden_manifest = Arc::clone(hidden_reader.manifest());
             let drained = hidden_manifest.get_drained_ranges();
             let superfiles = hidden_manifest
@@ -3026,7 +3094,7 @@ impl SupertableReader {
             let vit = self.vector_index_table().ok_or_else(|| {
                 QueryError::Execute("prepared hidden allow-set but no hidden index table".into())
             })?;
-            let hidden_reader = vit.pinned_reader();
+            let hidden_reader = vit.pinned_reader_with(self.op_stats.clone());
             let superfiles = hidden_reader
                 .manifest()
                 .get_all_superfiles_loaded()
@@ -3184,7 +3252,7 @@ impl SupertableReader {
         // Wave 1: search the pinned hidden slow state while refreshing only the
         // fast delete state and loading any user parts known to be newer than
         // this exact hidden residency watermark.
-        let hidden_reader = vit.pinned_reader();
+        let hidden_reader = vit.pinned_reader_with(self.op_stats.clone());
         let hidden_manifest = Arc::clone(hidden_reader.manifest());
         let drained = hidden_manifest.get_drained_ranges();
         let hidden_entries = hidden_manifest
@@ -3202,7 +3270,7 @@ impl SupertableReader {
         };
         let fast_state = async {
             vit.ensure_fresh_async().await;
-            vit.pinned_reader()
+            vit.pinned_reader_with(self.op_stats.clone())
                 .hidden_deleted_ids()
                 .map_err(|error| QueryError::Execute(error.to_string()))
         };
@@ -3488,6 +3556,30 @@ fn apply_width_pin(
         Some(width.min(populated_cells))
     } else {
         None
+    }
+}
+
+/// The deferred-rerank plan's global shortlist budget. Phase C's selection
+/// cap and the canonical priced rerank-row count both derive from this one
+/// formula so the two can never drift: `(k + replica_overhead) x
+/// rerank_mult`, scaled by served-cells-over-stamped-width when the LAW's
+/// budget (not an explicit caller request) is serving a widened sweep.
+fn deferred_shortlist_limit(
+    k: usize,
+    replica_overhead: usize,
+    rerank_mult: usize,
+    law_rerank_served: bool,
+    caller_nprobe: bool,
+    served_cells_over_width: (usize, usize),
+) -> usize {
+    let base = k
+        .saturating_add(replica_overhead)
+        .saturating_mul(rerank_mult);
+    if law_rerank_served && !caller_nprobe {
+        let (served, stamped_width) = served_cells_over_width;
+        base.saturating_mul(served).div_ceil(stamped_width)
+    } else {
+        base
     }
 }
 

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2164,6 +2164,9 @@ impl SupertableReader {
                         if let Some(stats) = &op_stats {
                             stats.add_vector_scan(scan.cells_scanned, scan.candidates_scanned);
                             stats.add_planned_read_ranges(scan.ranges_requested);
+                            // Cold cells rerank immediately inside the scan;
+                            // warm survivors are counted at phase C below.
+                            stats.add_vector_rows_reranked(scan.rows_reranked);
                         }
                         if !scan.candidates.is_empty() {
                             scan_pool
@@ -2173,12 +2176,16 @@ impl SupertableReader {
                         }
                         scan.hits
                     } else {
-                        reader
+                        let (hits, rows_reranked) = reader
                             .vector_search_clusters_filtered(
                                 &column, &query, k_fetch, &ids, options, bitmap, deny, pool, budget,
                             )
                             .await
-                            .map_err(vector_read_query_error)?
+                            .map_err(vector_read_query_error)?;
+                        if let Some(stats) = &op_stats {
+                            stats.add_vector_rows_reranked(rows_reranked);
+                        }
+                        hits
                     };
                     let mut tagged = dispatch::tag_hits(&entry, hits);
                     // Prefer manifest span arithmetic; only touch `_id` pages /

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2086,6 +2086,7 @@ impl SupertableReader {
         let query_arc = Arc::new(query.to_vec());
         let column_arc2 = Arc::clone(&column_arc);
         let query_arc2 = Arc::clone(&query_arc);
+        let op_stats_scan = self.op_stats.clone();
         let reader_pool = Arc::clone(&manifest.options.reader_pool);
         // Per-connection memory budget: gates each superfile's cold cluster-block fetch.
         let budget = Some(Arc::clone(&manifest.options.connection_memory_budget));
@@ -2116,6 +2117,7 @@ impl SupertableReader {
                 let budget = budget.clone();
                 let storage = storage.clone();
                 let scan_pool = Arc::clone(&scan_pool_body);
+                let op_stats = op_stats_scan.clone();
                 async move {
                     // Unfiltered user path on row-addressable locals: resolve the
                     // bitmap once (warm after the orchestrator's prefetch) and
@@ -2159,6 +2161,9 @@ impl SupertableReader {
                             )
                             .await
                             .map_err(vector_read_query_error)?;
+                        if let Some(stats) = &op_stats {
+                            stats.add_vector_scan(scan.cells_scanned, scan.candidates_scanned);
+                        }
                         if !scan.candidates.is_empty() {
                             scan_pool
                                 .lock()
@@ -2316,6 +2321,11 @@ impl SupertableReader {
                             .map(|sel| (Arc::clone(entry), sel))
                     })
                     .collect();
+                if let Some(stats) = &self.op_stats {
+                    stats.add_vector_rows_reranked(
+                        rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum(),
+                    );
+                }
                 let column = Arc::clone(&column_arc2);
                 let query = Arc::clone(&query_arc2);
                 let reader_pool = Arc::clone(&manifest.options.reader_pool);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1066,7 +1066,7 @@ async fn read_ids_for_locals(
         }
         return id_values_from_batch(&batch?);
     }
-    let batch = take_rows_byte_source(&reader, local_ids, &[id_column], op_stats.clone())
+    let batch = take_rows_byte_source(&reader, local_ids, &[id_column])
         .await
         .map_err(|error| QueryError::Execute(error.to_string()))?;
     id_values_from_batch(&batch)
@@ -3725,7 +3725,10 @@ fn deferred_shortlist_limit(
         .saturating_mul(rerank_mult);
     if law_rerank_served && !caller_nprobe {
         let (served, stamped_width) = served_cells_over_width;
-        base.saturating_mul(served).div_ceil(stamped_width)
+        // Total over a degenerate zero stamp: the law path never
+        // produces one today ((1, 1) default, `.max(1)` at assignment),
+        // but a plain helper must not be able to panic.
+        base.saturating_mul(served).div_ceil(stamped_width.max(1))
     } else {
         base
     }

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2623,15 +2623,24 @@ impl SupertableReader {
     ) -> Result<HashMap<SuperfileUri, Arc<RoaringBitmap>>, QueryError> {
         let filter_col_arc = Arc::new(filter_col.to_owned());
         let tokens_arc: Arc<Vec<String>> = Arc::new(tokens.to_vec());
+        let op_stats = self.op_stats.clone();
         self.fanout_candidate_bitmaps(superfiles, move |r, _entry| {
             let filter_col_arc = Arc::clone(&filter_col_arc);
             let tokens_arc = Arc::clone(&tokens_arc);
+            let op_stats = op_stats.clone();
             async move {
                 let refs: Vec<&str> = tokens_arc.iter().map(String::as_str).collect();
-                r.token_match(&filter_col_arc, &refs, mode)
+                let (docs, work) = r
+                    .token_match(&filter_col_arc, &refs, mode)
                     .await
-                    .map_err(|e| QueryError::Parquet(e.to_string()))
-                    .map(|docs| docs.into_iter().collect::<RoaringBitmap>())
+                    .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                // The predicate-resolution leg of filtered vector search
+                // is FTS work like any other; flush it per superfile.
+                if let Some(stats) = &op_stats {
+                    stats.add_fts_postings_bytes(work.postings_bytes);
+                    stats.add_planned_read_ranges(work.planned_ranges);
+                }
+                Ok(docs.into_iter().collect::<RoaringBitmap>())
             }
         })
         .await
@@ -3214,17 +3223,26 @@ impl SupertableReader {
         plan: &CandidatePlan,
     ) -> Result<HashMap<SuperfileUri, Arc<RoaringBitmap>>, QueryError> {
         let plan_arc = Arc::new(plan.clone());
+        let op_stats = self.op_stats.clone();
         self.fanout_candidate_bitmaps(superfiles, move |r, _entry| {
             let plan = Arc::clone(&plan_arc);
+            let op_stats = op_stats.clone();
             async move {
-                plan.evaluate(r.as_ref())
+                let (bitmap, work) = plan
+                    .evaluate(r.as_ref())
                     .await
-                    .map_err(|e| QueryError::Parquet(e.to_string()))?
-                    .ok_or_else(|| {
-                        QueryError::Execute(
-                            "bounded CandidatePlan evaluated to Unbounded — planner bug".into(),
-                        )
-                    })
+                    .map_err(|e| QueryError::Parquet(e.to_string()))?;
+                // The SQL predicate's posting walks, summed across the
+                // plan tree — the pushdown leg of the vector TVF.
+                if let Some(stats) = &op_stats {
+                    stats.add_fts_postings_bytes(work.postings_bytes);
+                    stats.add_planned_read_ranges(work.planned_ranges);
+                }
+                bitmap.ok_or_else(|| {
+                    QueryError::Execute(
+                        "bounded CandidatePlan evaluated to Unbounded — planner bug".into(),
+                    )
+                })
             }
         })
         .await

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -9640,8 +9640,10 @@ mod tests {
                 && cell.clusters.centroids.len() == cell.clusters.n_cent as usize * dim
         }));
         // Every Parquet row lands in at least one cluster; boundary
-        // replication (on by default) may add stub copies up to the
-        // configured storage-amplification budget on top.
+        // replication (off by default: drain_replica_target_factor <= 1.0
+        // disables it) may add stub copies up to the configured
+        // storage-amplification budget on top. The assertions tolerate
+        // both states, so the test holds under any configured factor.
         let total: u64 = vs
             .cells
             .iter()
@@ -9705,11 +9707,13 @@ mod tests {
             .expect("decimal ids")
             .values()
             .to_vec();
-        // Parquet stores each row once, in vector (cell) order. The IVF
-        // additionally carries boundary-replica stubs (replication is on by
-        // default), so the inline id stream is the parquet order plus stub
-        // duplicates: first occurrences must line up 1:1 with parquet, and
-        // every remaining inline id must duplicate some parquet row.
+        // Parquet stores each row once, in vector (cell) order. When
+        // boundary replication is enabled (off by default; the
+        // drain_replica_target_factor knob), the IVF additionally carries
+        // stub copies, so the inline id stream is the parquet order plus
+        // stub duplicates: first occurrences must line up 1:1 with
+        // parquet, and every remaining inline id must duplicate some
+        // parquet row. Both checks also hold in the stub-free default.
         let mut seen = HashSet::new();
         let first_occurrence: Vec<i128> = vector_ids
             .iter()

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -3541,9 +3541,11 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                             )
                         }
                     };
-                    let stable_ids = stable_ids_by_local_for_routing(&manifest, &entry, &reader)
-                        .await
-                        .map_err(|e| BuildError::Store(e.to_string()))?;
+                    // Write-path materialization: no per-query collector.
+                    let stable_ids =
+                        stable_ids_by_local_for_routing(&manifest, &entry, &reader, &None)
+                            .await
+                            .map_err(|e| BuildError::Store(e.to_string()))?;
                     Ok::<_, BuildError>((reader, stable_ids))
                 }
             }))
@@ -4300,7 +4302,8 @@ async fn load_materialized_rows_from_ivf_superfile(
     }
 
     let manifest = inner.manifest.load_full();
-    let stable_ids = stable_ids_by_local_for_routing(&manifest, entry, &reader)
+    // Write-path materialization: no per-query collector.
+    let stable_ids = stable_ids_by_local_for_routing(&manifest, entry, &reader, &None)
         .await
         .map_err(|e| BuildError::Store(e.to_string()))?;
     materialized_ivf_rows_in_doc_order(vec_reader, column, &stable_ids, bitmap.as_deref()).await

--- a/tests/superfile/format/lazy_byte_source.rs
+++ b/tests/superfile/format/lazy_byte_source.rs
@@ -194,11 +194,13 @@ async fn open_lazy_reads_positional_v2_blob_like_eager() {
     let lazy_hits = lazy
         .token_match("title", &["special"], BoolMode::And)
         .await
-        .expect("lazy match");
+        .expect("lazy match")
+        .0;
     let eager_hits = eager
         .token_match("title", &["special"], BoolMode::And)
         .await
-        .expect("eager match");
+        .expect("eager match")
+        .0;
     assert_eq!(lazy_hits, eager_hits);
     assert_eq!(lazy_hits, vec![0, 2]);
 }

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -353,7 +353,8 @@ async fn unranked_ids_and_count_agree_with_oracle() {
             let ids = r
                 .atoms_match_ids("title", &terms, &phrases, mode)
                 .await
-                .expect("atoms_match_ids");
+                .expect("atoms_match_ids")
+                .0;
             let got: HashSet<u64> = ids.into_iter().map(u64::from).collect();
             assert_eq!(
                 got, want,
@@ -363,7 +364,8 @@ async fn unranked_ids_and_count_agree_with_oracle() {
             let count = r
                 .atoms_match_count("title", &terms, &phrases, mode)
                 .await
-                .expect("atoms_match_count");
+                .expect("atoms_match_count")
+                .0;
             assert_eq!(
                 count as usize,
                 want.len(),

--- a/tests/supertable/query/mod.rs
+++ b/tests/supertable/query/mod.rs
@@ -9,6 +9,7 @@ pub mod hierarchical;
 pub mod hybrid_search;
 mod id_resolve;
 pub mod match_search;
+mod op_stats;
 mod query_errors;
 mod query_surface;
 pub mod skip_pruning;

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -11,14 +11,16 @@
 
 use std::sync::Arc;
 
-use arrow_array::{ArrayRef, LargeStringArray, RecordBatch};
+use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
-    runtime_metrics::op_stats::with_op_stats,
+    runtime_metrics::op_stats::{OpStats, with_op_stats},
+    storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{builder::FtsConfig, fts::reader::BoolMode},
-    supertable::{Supertable, SupertableOptions},
-    test_helpers::default_tokenizer,
+    supertable::{Supertable, SupertableOptions, query::vector::VectorSearchOptions},
+    test_helpers::{default_tokenizer, default_vector_config},
 };
+use tempfile::TempDir;
 
 /// Docs per committed segment. Commits row-shard across the writer
 /// pool, so this must keep every term's per-superfile df ≥ 2 —
@@ -163,4 +165,141 @@ fn a_reader_minted_outside_the_scope_records_nothing() {
         stats.fts_postings_bytes, 0,
         "pickup happens at reader mint, not at query time"
     );
+}
+
+// ---- Vector: the drained (hidden-index) deferred-rerank path ----
+
+/// `default_vector_config` is dim=16.
+const DIM: usize = 16;
+/// Rows in the vector fixture — enough for a non-degenerate drain.
+const VECTOR_ROWS: usize = 64;
+/// Top-k for the vector work-stats queries.
+const VECTOR_K: usize = 4;
+/// Probe width > 1 so the drained table takes the deferred-rerank path
+/// (immediate-rerank widths report no scan tallies yet).
+const VECTOR_NPROBE: usize = 2;
+/// Random-rotation seed for the fixture's vector index.
+const VECTOR_ROT_SEED: u64 = 13;
+
+/// Deterministic non-degenerate vector for row `i`.
+fn row_vec(i: usize) -> Vec<f32> {
+    (0..DIM)
+        .map(|d| ((i * 31 + d * 17 + 7) % 97) as f32 / 97.0 + 0.05)
+        .collect()
+}
+
+fn vector_options() -> SupertableOptions {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new(
+            "emb",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIM as i32,
+            ),
+            false,
+        ),
+    ]));
+    SupertableOptions::new(
+        schema,
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        vec![default_vector_config("emb", VECTOR_ROT_SEED)],
+        Some(default_tokenizer()),
+    )
+    .expect("valid options")
+}
+
+fn vector_batch(schema: Arc<Schema>) -> RecordBatch {
+    let mut flat = Vec::<f32>::with_capacity(VECTOR_ROWS * DIM);
+    let mut titles = Vec::with_capacity(VECTOR_ROWS);
+    for i in 0..VECTOR_ROWS {
+        flat.extend(row_vec(i));
+        titles.push(format!("row{i:03}"));
+    }
+    let fsl = FixedSizeListArray::try_new(
+        Arc::new(Field::new("item", DataType::Float32, true)),
+        DIM as i32,
+        Arc::new(Float32Array::from(flat)) as ArrayRef,
+        None,
+    )
+    .expect("FSL");
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(LargeStringArray::from(titles)) as ArrayRef,
+            Arc::new(fsl),
+        ],
+    )
+    .expect("batch")
+}
+
+/// A committed + drained vector table (hidden cell index built), so
+/// queries run the deferred-rerank serving path the counters cover.
+fn drained_vector_table(dir: &TempDir) -> Supertable {
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(vector_options().with_storage(storage)).expect("create");
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    w.append(&vector_batch(schema)).expect("append");
+    w.commit().expect("commit");
+    drop(w);
+    st.drain_vectors_to_cells_sync().expect("drain");
+    st
+}
+
+/// One scoped vector query over the drained table.
+fn scoped_vector_stats(st: &Supertable) -> OpStats {
+    let query = row_vec(3);
+    let (hits, stats) = with_op_stats(|| {
+        st.vector_search(
+            "emb",
+            &query,
+            VECTOR_K,
+            VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+            None,
+            None,
+        )
+        .expect("vector search")
+    });
+    assert!(!hits.is_empty(), "fixture vector query must match");
+    stats
+}
+
+#[test]
+fn a_scoped_vector_query_reports_scan_and_rerank_work() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let stats = scoped_vector_stats(&st);
+    assert!(
+        stats.vector_cells_scanned >= VECTOR_NPROBE as u64,
+        "a width-{VECTOR_NPROBE} probe scans at least that many cells; got {}",
+        stats.vector_cells_scanned
+    );
+    assert!(
+        stats.vector_candidates_scanned >= stats.vector_cells_scanned,
+        "every scanned cell holds at least one code (candidates {}, cells {})",
+        stats.vector_candidates_scanned,
+        stats.vector_cells_scanned
+    );
+    assert!(
+        stats.vector_rows_reranked > 0,
+        "the global shortlist reranks a non-empty winner set"
+    );
+    assert!(
+        stats.vector_rows_reranked <= stats.vector_candidates_scanned,
+        "rerank rows are shortlist survivors of the scanned candidates"
+    );
+}
+
+#[test]
+fn vector_work_stats_are_deterministic_across_cache_temperature() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let cold = scoped_vector_stats(&st);
+    let warm = scoped_vector_stats(&st);
+    assert_eq!(cold, warm, "same plan, same table state, same work");
 }

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -113,10 +113,14 @@ fn demo_two_superfiles() -> Supertable {
     st
 }
 
-/// Zero the one measured-time field so determinism assertions compare only
-/// the plan counts (kernel CPU legitimately varies run to run).
+/// Zero the fields the determinism contract exempts: kernel CPU is
+/// measured time (varies run to run), and reranked rows are actual
+/// execution counts that the deferred path's cold arm can legitimately
+/// shift (they ARE deterministic at a fixed temperature, but this
+/// helper serves the cross-temperature comparisons).
 fn deterministic(mut stats: OpStats) -> OpStats {
     stats.kernel_cpu_ns = 0;
+    stats.vector_rows_reranked = 0;
     stats
 }
 

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -16,7 +16,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
-    Connection, IndexSpec, Metric, connect,
+    ConnectOptions, Connection, IndexSpec, Metric, connect, connect_with,
     runtime_metrics::op_stats::{OpStats, with_op_stats},
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
@@ -764,6 +764,44 @@ fn sql_work_stats_are_deterministic_across_cache_temperature() {
     let cold = deterministic(scoped_sql_stats(&db, sql));
     let warm = deterministic(scoped_sql_stats(&db, sql));
     assert_eq!(cold, warm, "same plan, same table state, same work");
+}
+
+#[test]
+fn sql_work_stats_do_not_depend_on_reader_open_shape() {
+    // A predicated scan makes DataFusion consult the Parquet page index.
+    // An eagerly-opened reader's footer parse already carries it; a cold
+    // disk-cache open serves the query through a lazy reader whose
+    // open-time parse is footer-only. The provider must serve DataFusion
+    // an index-complete parse loaded through the reader's own byte
+    // source — otherwise the opener fetches the index bytes through the
+    // metered store on the lazy shape only, and the same query prices
+    // differently depending on how its readers happened to be opened.
+    //
+    // The writer connection populates only its own in-memory reader
+    // tier, so the cache-backed connection's first query really takes
+    // the cold lazy-open path.
+    let dir = TempDir::new().expect("tempdir");
+    let cache = TempDir::new().expect("cache tempdir");
+    let sql = "SELECT rating FROM docs WHERE rating > 5";
+    let eager = {
+        let db = sql_fixture(&dir);
+        deterministic(scoped_sql_stats(&db, sql))
+    };
+    let lazy_db = connect_with(
+        dir.path().to_str().expect("utf-8 path"),
+        ConnectOptions::new().with_cache_dir(cache.path()),
+    )
+    .expect("connect with cold disk cache");
+    let lazy_cold = deterministic(scoped_sql_stats(&lazy_db, sql));
+    let lazy_warm = deterministic(scoped_sql_stats(&lazy_db, sql));
+    assert_eq!(
+        lazy_cold, lazy_warm,
+        "same plan, same table state, same work"
+    );
+    assert_eq!(
+        lazy_cold, eager,
+        "reader open shape (cold disk cache vs eager) must not change reported work"
+    );
 }
 
 /// A storage-backed catalog connection whose table also carries a

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -20,7 +20,10 @@ use infino::{
     Connection, IndexSpec, Metric, connect,
     runtime_metrics::op_stats::{OpStats, with_op_stats},
     storage::{LocalFsStorageProvider, StorageProvider},
-    superfile::{builder::FtsConfig, fts::reader::BoolMode},
+    superfile::{
+        builder::FtsConfig,
+        fts::reader::{Bm25Stats, BoolMode},
+    },
     supertable::{
         Supertable, SupertableOptions,
         query::vector::{VectorFilter, VectorSearchOptions},
@@ -185,9 +188,11 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
             .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
             .expect("bm25")
     });
+    // Per superfile: one dictionary fetch + one PFOR posting range.
     assert_eq!(
-        one_term.planned_read_ranges, n_superfiles,
-        "one PFOR term = one posting range per superfile"
+        one_term.planned_read_ranges,
+        2 * n_superfiles,
+        "single term = dict + posting range per superfile"
     );
     let (_, three_terms) = with_op_stats(|| {
         st.reader()
@@ -195,10 +200,11 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
             .bm25_hits("title", "rust async web", TOP_K, BoolMode::Or)
             .expect("bm25")
     });
+    // Per superfile: one dictionary fetch + three PFOR posting ranges.
     assert_eq!(
         three_terms.planned_read_ranges,
-        3 * n_superfiles,
-        "three PFOR terms = three posting ranges per superfile"
+        4 * n_superfiles,
+        "three PFOR terms = dict + three posting ranges per superfile"
     );
 }
 
@@ -364,6 +370,71 @@ fn a_scoped_exact_match_reports_posting_work() {
     assert!(
         stats.fts_postings_bytes > 0,
         "the prune pass walks posting bytes; got 0"
+    );
+}
+
+#[test]
+fn a_scoped_prefix_search_reports_posting_work() {
+    // Prefix expansion used to flush nothing at all — a prefix widening
+    // to many terms billed as zero FTS work.
+    let st = demo_two_superfiles();
+    let (hits, stats) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_search_prefix("title", "ru", TOP_K)
+            .expect("prefix search")
+    });
+    assert!(!hits.is_empty(), "fixture prefix must match");
+    assert!(
+        stats.fts_postings_bytes > 0,
+        "the prefix expansion walks posting bytes; got 0"
+    );
+    assert!(
+        stats.planned_read_ranges > 0,
+        "the prefix expansion plans posting ranges; got 0"
+    );
+}
+
+#[test]
+fn a_scalar_projection_reports_materialized_rows() {
+    // Materializing named columns decodes stored rows — real work the
+    // counters must carry; the id+score default decodes nothing.
+    let st = demo_two_superfiles();
+    let (batches, projected) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_search(
+                "title",
+                "rust",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+                Some(&["title"]),
+            )
+            .expect("projected search")
+    });
+    let returned: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
+    assert!(returned > 0);
+    assert_eq!(
+        projected.rows_materialized, returned,
+        "every returned row was decoded from stored columns"
+    );
+    let (_, bare) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_search(
+                "title",
+                "rust",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+                None,
+            )
+            .expect("bare search")
+    });
+    assert_eq!(
+        bare.rows_materialized, 0,
+        "the id+score fast path decodes no stored columns"
     );
 }
 
@@ -562,6 +633,34 @@ fn a_filtered_vector_query_meters_its_predicate_leg() {
     assert!(
         stats.vector_candidates_scanned > 0,
         "the vector leg still scans candidates; got 0"
+    );
+}
+
+#[test]
+fn a_scoped_vector_query_reports_kernel_cpu() {
+    // Same schedstat-resolution caveat as the FTS kernel test: batch the
+    // queries so the bracketed scan + rerank sections cross scheduler
+    // ticks.
+    const VECTOR_KERNEL_BATCH: usize = 200;
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let query = row_vec(3);
+    let (_, stats) = with_op_stats(|| {
+        for _ in 0..VECTOR_KERNEL_BATCH {
+            st.vector_search(
+                "emb",
+                &query,
+                VECTOR_K,
+                VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+                None,
+                None,
+            )
+            .expect("vector search");
+        }
+    });
+    assert!(
+        stats.kernel_cpu_ns > 0,
+        "the bracketed vector kernels report on-CPU time over {VECTOR_KERNEL_BATCH} queries; got 0"
     );
 }
 

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -729,6 +729,14 @@ fn a_scoped_sql_scan_reports_page_bytes() {
         stats.planned_read_ranges > 0,
         "each Parquet request is a planned range"
     );
+    assert!(
+        stats.rows_materialized > 0,
+        "the scan's decoded rows come from DataFusion's own metrics; got 0"
+    );
+    assert!(
+        stats.kernel_cpu_ns > 0,
+        "the plan's elapsed compute comes from DataFusion's own metrics; got 0"
+    );
 }
 
 #[test]

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -127,6 +127,33 @@ fn a_scoped_bm25_query_reports_its_posting_bytes() {
 }
 
 #[test]
+fn a_scoped_bm25_query_reports_its_planned_ranges() {
+    let st = demo_two_superfiles();
+    let (_, one_term) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+            .expect("bm25")
+    });
+    let (_, three_terms) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits("title", "rust async web", TOP_K, BoolMode::Or)
+            .expect("bm25")
+    });
+    assert!(
+        one_term.planned_read_ranges > 0,
+        "a PFOR term requests its posting range"
+    );
+    assert!(
+        three_terms.planned_read_ranges > one_term.planned_read_ranges,
+        "three terms request more ranges than one (three {}, one {})",
+        three_terms.planned_read_ranges,
+        one_term.planned_read_ranges
+    );
+}
+
+#[test]
 fn work_stats_are_deterministic_across_cache_temperature() {
     // The first run decodes from a cold state, the repeat hits every
     // warm structure — the whole point of the counter is that the
@@ -292,6 +319,13 @@ fn a_scoped_vector_query_reports_scan_and_rerank_work() {
     assert!(
         stats.vector_rows_reranked <= stats.vector_candidates_scanned,
         "rerank rows are shortlist survivors of the scanned candidates"
+    );
+    assert!(
+        stats.planned_read_ranges >= stats.vector_cells_scanned + stats.vector_rows_reranked,
+        "each scanned cell requests at least its cluster index and each          reranked row its survivor range (ranges {}, cells {}, rows {})",
+        stats.planned_read_ranges,
+        stats.vector_cells_scanned,
+        stats.vector_rows_reranked
     );
 }
 

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -104,6 +104,13 @@ fn demo_two_superfiles() -> Supertable {
     st
 }
 
+/// Zero the one measured-time field so determinism assertions compare only
+/// the plan counts (kernel CPU legitimately varies run to run).
+fn deterministic(mut stats: OpStats) -> OpStats {
+    stats.kernel_cpu_ns = 0;
+    stats
+}
+
 /// Posting bytes for one BM25 query run inside a fresh scope, minting the
 /// reader inside the scope (the pickup point).
 fn scoped_query_bytes(st: &Supertable, query: &str) -> u64 {
@@ -163,6 +170,28 @@ fn work_stats_are_deterministic_across_cache_temperature() {
     let cold = scoped_query_bytes(&st, "rust");
     let warm = scoped_query_bytes(&st, "rust");
     assert_eq!(cold, warm, "same plan, same table state, same work");
+}
+
+#[test]
+fn a_scoped_bm25_query_reports_kernel_cpu() {
+    // The thread-CPU clock (schedstat) advances at scheduler events, so a
+    // single microsecond kernel can legitimately read zero; a batch of
+    // queries crosses enough context switches that the cumulative
+    // bracketed time must register.
+    const KERNEL_CPU_BATCH: usize = 200;
+    let st = demo_two_superfiles();
+    let (_, stats) = with_op_stats(|| {
+        for _ in 0..KERNEL_CPU_BATCH {
+            st.reader()
+                .expect("reader")
+                .bm25_hits("title", "rust async web", TOP_K, BoolMode::Or)
+                .expect("bm25");
+        }
+    });
+    assert!(
+        stats.kernel_cpu_ns > 0,
+        "the bracketed FTS kernels report on-CPU time over {KERNEL_CPU_BATCH} queries; got 0"
+    );
 }
 
 #[test]
@@ -334,8 +363,8 @@ fn a_scoped_vector_query_reports_scan_and_rerank_work() {
 fn vector_work_stats_are_deterministic_across_cache_temperature() {
     let dir = TempDir::new().expect("tempdir");
     let st = drained_vector_table(&dir);
-    let cold = scoped_vector_stats(&st);
-    let warm = scoped_vector_stats(&st);
+    let cold = deterministic(scoped_vector_stats(&st));
+    let warm = deterministic(scoped_vector_stats(&st));
     assert_eq!(cold, warm, "same plan, same table state, same work");
 }
 
@@ -404,8 +433,8 @@ fn sql_work_stats_are_deterministic_across_cache_temperature() {
     let dir = TempDir::new().expect("tempdir");
     let db = sql_fixture(&dir);
     let sql = "SELECT rating FROM docs WHERE rating > 5";
-    let cold = scoped_sql_stats(&db, sql);
-    let warm = scoped_sql_stats(&db, sql);
+    let cold = deterministic(scoped_sql_stats(&db, sql));
+    let warm = deterministic(scoped_sql_stats(&db, sql));
     assert_eq!(cold, warm, "same plan, same table state, same work");
 }
 

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -9,8 +9,7 @@
 
 #![deny(clippy::unwrap_used)]
 
-use std::sync::Arc;
-use std::thread;
+use std::{sync::Arc, thread};
 
 use arrow_array::{
     ArrayRef, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray, RecordBatch,

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -21,7 +21,10 @@ use infino::{
     runtime_metrics::op_stats::{OpStats, with_op_stats},
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{builder::FtsConfig, fts::reader::BoolMode},
-    supertable::{Supertable, SupertableOptions, query::vector::VectorSearchOptions},
+    supertable::{
+        Supertable, SupertableOptions,
+        query::vector::{VectorFilter, VectorSearchOptions},
+    },
     test_helpers::{default_tokenizer, default_vector_config},
 };
 use tempfile::TempDir;
@@ -267,6 +270,103 @@ fn a_reader_minted_outside_the_scope_records_nothing() {
     );
 }
 
+#[test]
+fn an_inline_df1_term_plans_no_posting_range() {
+    // "filler0x0" is unique to one doc: inline in the FST of its home
+    // superfile (zero fetches planned), absent everywhere else. Adding
+    // it to a query must not change the planned range count — a phantom
+    // range per inline term was the old behavior.
+    let st = demo_two_superfiles();
+    let (_, base) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+            .expect("bm25")
+    });
+    let (_, with_inline) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits("title", "rust filler0x0", TOP_K, BoolMode::Or)
+            .expect("bm25")
+    });
+    assert_eq!(
+        with_inline.planned_read_ranges, base.planned_read_ranges,
+        "an inline df=1 term plans no fetch, so it must add no range"
+    );
+    assert!(
+        with_inline.fts_postings_bytes >= base.fts_postings_bytes,
+        "byte counts never shrink when a term is added"
+    );
+}
+
+#[test]
+fn a_scoped_token_match_reports_posting_work() {
+    let st = demo_two_superfiles();
+    let (hits, stats) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .token_match("title", "rust async", BoolMode::Or)
+            .expect("token_match")
+    });
+    assert!(!hits.is_empty());
+    assert!(
+        stats.fts_postings_bytes > 0,
+        "an unranked match walks posting bytes; got 0"
+    );
+    assert!(
+        stats.planned_read_ranges > 0,
+        "each PFOR term is one planned range; got 0"
+    );
+}
+
+#[test]
+fn a_scoped_count_reports_posting_work() {
+    let st = demo_two_superfiles();
+    // Single term: the df fast path reads one header range per superfile.
+    let (n_single, single) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .count("title", "rust", BoolMode::Or)
+            .expect("count")
+    });
+    assert!(n_single > 0);
+    assert!(
+        single.planned_read_ranges > 0 && single.fts_postings_bytes > 0,
+        "the df fast path reads real header ranges (ranges {}, bytes {})",
+        single.planned_read_ranges,
+        single.fts_postings_bytes
+    );
+    // Multi-term: the counting walk indexes full posting lists.
+    let (n_multi, multi) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .count("title", "rust async", BoolMode::Or)
+            .expect("count")
+    });
+    assert!(n_multi > 0);
+    assert!(
+        multi.fts_postings_bytes > single.fts_postings_bytes,
+        "the counting walk indexes posting lists, not just headers"
+    );
+}
+
+#[test]
+fn a_scoped_exact_match_reports_posting_work() {
+    let st = demo_two_superfiles();
+    let (hits, stats) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .exact_match("title", "filler0x0 rust")
+            .expect("exact_match")
+    });
+    // The exact string exists as doc 0 of segment 0.
+    assert!(!hits.is_empty(), "fixture exact value must match");
+    assert!(
+        stats.fts_postings_bytes > 0,
+        "the prune pass walks posting bytes; got 0"
+    );
+}
+
 // ---- Vector: the drained (hidden-index) deferred-rerank path ----
 
 /// `default_vector_config` is dim=16.
@@ -317,7 +417,9 @@ fn vector_batch(schema: Arc<Schema>) -> RecordBatch {
     let mut titles = Vec::with_capacity(VECTOR_ROWS);
     for i in 0..VECTOR_ROWS {
         flat.extend(row_vec(i));
-        titles.push(format!("row{i:03}"));
+        // "vec" appears in every row (df >= 2 ⇒ PFOR postings), so a
+        // text predicate on it exercises real posting-walk work.
+        titles.push(format!("vec row{i:03}"));
     }
     let fsl = FixedSizeListArray::try_new(
         Arc::new(Field::new("item", DataType::Float32, true)),
@@ -425,6 +527,41 @@ fn a_full_width_probe_scans_every_row_exactly_once() {
     assert_eq!(
         stats.vector_candidates_scanned, VECTOR_ROWS as u64,
         "a full-width probe estimates each stored code exactly once"
+    );
+}
+
+#[test]
+fn a_filtered_vector_query_meters_its_predicate_leg() {
+    // Filtered kNN first resolves the text predicate on the user table
+    // (posting walks), then ranks among matching rows. Both legs are
+    // real work and both must land in the counters — the predicate leg
+    // used to be invisible.
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let query = row_vec(3);
+    let (hits, stats) = with_op_stats(|| {
+        st.vector_search(
+            "emb",
+            &query,
+            VECTOR_K,
+            VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+            Some(VectorFilter {
+                column: "title",
+                query: "vec",
+                mode: BoolMode::Or,
+            }),
+            None,
+        )
+        .expect("filtered vector search")
+    });
+    assert!(!hits.is_empty(), "the fixture predicate matches every row");
+    assert!(
+        stats.fts_postings_bytes > 0,
+        "the predicate leg walks posting bytes; got 0"
+    );
+    assert!(
+        stats.vector_candidates_scanned > 0,
+        "the vector leg still scans candidates; got 0"
     );
 }
 

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -567,10 +567,17 @@ fn a_scoped_vector_query_reports_scan_and_rerank_work() {
         "rerank rows are shortlist survivors of the scanned candidates"
     );
     assert!(
-        stats.planned_read_ranges >= stats.vector_cells_scanned + stats.vector_rows_reranked,
-        "each scanned cell requests at least its cluster index and each          reranked row its survivor range (ranges {}, cells {}, rows {})",
+        stats.planned_read_ranges >= 2 * stats.vector_cells_scanned,
+        "each scanned cell requests its cluster index plus at least one \
+         prefix/block range (ranges {}, cells {})",
         stats.planned_read_ranges,
-        stats.vector_cells_scanned,
+        stats.vector_cells_scanned
+    );
+    assert!(
+        stats.planned_read_ranges < stats.vector_rows_reranked + 64 * stats.vector_cells_scanned,
+        "the range counter stays request-shaped: rerank rows must not be \
+         folded into it (ranges {}, rows {})",
+        stats.planned_read_ranges,
         stats.vector_rows_reranked
     );
 }

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -219,10 +219,15 @@ fn a_scoped_bm25_query_reports_kernel_cpu() {
     const KERNEL_CPU_BATCH: usize = 200;
     let st = demo_two_superfiles();
     let (_, stats) = with_op_stats(|| {
-        for _ in 0..KERNEL_CPU_BATCH {
+        for i in 0..KERNEL_CPU_BATCH {
+            // Alternate the single-term shape (whose walk finishes inside
+            // `prepare_clauses` and rides the `Done` result) with the
+            // multi-term OR (bracketed at `run_prepared`), so both kernel
+            // accounting paths contribute.
+            let query = if i % 2 == 0 { "rust" } else { "rust async web" };
             st.reader()
                 .expect("reader")
-                .bm25_hits("title", "rust async web", TOP_K, BoolMode::Or)
+                .bm25_hits("title", query, TOP_K, BoolMode::Or)
                 .expect("bm25");
         }
     });

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Per-query work stats over the sync BM25 surface: a query wrapped in
+//! [`with_op_stats`] reports the posting bytes its kernels indexed into,
+//! deterministically — the same query against the same committed corpus
+//! reports the same number on a cold first run and a warm repeat, and a
+//! reader minted outside a scope records nothing.
+
+#![deny(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use infino::{
+    runtime_metrics::op_stats::with_op_stats,
+    superfile::{builder::FtsConfig, fts::reader::BoolMode},
+    supertable::{Supertable, SupertableOptions},
+    test_helpers::default_tokenizer,
+};
+
+/// Docs per committed segment. Commits row-shard across the writer
+/// pool, so this must keep every term's per-superfile df ≥ 2 —
+/// df=1 terms store inline in the FST with genuinely zero
+/// postings-region bytes, which would make the assertions vacuous.
+const DOCS_PER_SEGMENT: usize = 40;
+/// Rayon pool size for deterministic builds (two shards per commit).
+const RAYON_POOL_THREADS: usize = 2;
+/// Top-k ≥ the corpus size so no assertion depends on ranking cutoffs.
+const TOP_K: usize = 128;
+
+/// Schema `[title (FTS, no positions)]` — the smallest corpus that
+/// exercises the full multi-superfile BM25 fan-out.
+fn options_title_only() -> SupertableOptions {
+    let writer_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(RAYON_POOL_THREADS)
+            .build()
+            .expect("writer pool"),
+    );
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "title",
+        DataType::LargeUtf8,
+        false,
+    )]));
+    SupertableOptions::new(
+        schema,
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        Vec::new(),
+        Some(default_tokenizer()),
+    )
+    .expect("valid options")
+    .with_writer_pool(writer_pool)
+}
+
+/// One segment's titles: `rust` in every other doc, `async` and `web`
+/// sprinkled every 4th/5th doc so each stays df ≥ 2 in every shard, and
+/// a unique filler token per doc keeps the corpus realistic.
+fn segment_titles(segment: usize) -> Vec<String> {
+    (0..DOCS_PER_SEGMENT)
+        .map(|i| {
+            let mut title = format!("filler{segment}x{i}");
+            if i % 2 == 0 {
+                title.push_str(" rust");
+            }
+            if i % 4 == 1 {
+                title.push_str(" async");
+            }
+            if i % 5 == 3 {
+                title.push_str(" web");
+            }
+            title
+        })
+        .collect()
+}
+
+fn title_batch(titles: &[String], schema: Arc<Schema>) -> RecordBatch {
+    let arr: ArrayRef = Arc::new(LargeStringArray::from(
+        titles.iter().map(String::as_str).collect::<Vec<_>>(),
+    ));
+    RecordBatch::try_new(schema, vec![arr]).expect("batch")
+}
+
+/// Two committed segments (each row-sharded into superfiles by the
+/// 2-thread writer pool), so the query fans out across superfiles.
+fn demo_two_superfiles() -> Supertable {
+    let st = Supertable::create(options_title_only()).expect("create");
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    w.append(&title_batch(&segment_titles(0), schema.clone()))
+        .expect("append seg1");
+    w.commit().expect("commit seg1");
+    w.append(&title_batch(&segment_titles(1), schema))
+        .expect("append seg2");
+    w.commit().expect("commit seg2");
+    drop(w);
+    st
+}
+
+/// Posting bytes for one BM25 query run inside a fresh scope, minting the
+/// reader inside the scope (the pickup point).
+fn scoped_query_bytes(st: &Supertable, query: &str) -> u64 {
+    let (hits, stats) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits("title", query, TOP_K, BoolMode::Or)
+            .expect("bm25")
+    });
+    assert!(!hits.is_empty(), "fixture query {query:?} must match");
+    stats.fts_postings_bytes
+}
+
+#[test]
+fn a_scoped_bm25_query_reports_its_posting_bytes() {
+    let st = demo_two_superfiles();
+    let bytes = scoped_query_bytes(&st, "rust");
+    assert!(
+        bytes > 0,
+        "a matching query indexes into posting bytes; got 0"
+    );
+}
+
+#[test]
+fn work_stats_are_deterministic_across_cache_temperature() {
+    // The first run decodes from a cold state, the repeat hits every
+    // warm structure — the whole point of the counter is that the
+    // reported work is identical either way.
+    let st = demo_two_superfiles();
+    let cold = scoped_query_bytes(&st, "rust");
+    let warm = scoped_query_bytes(&st, "rust");
+    assert_eq!(cold, warm, "same plan, same table state, same work");
+}
+
+#[test]
+fn more_clauses_index_more_posting_bytes() {
+    let st = demo_two_superfiles();
+    let narrow = scoped_query_bytes(&st, "async");
+    let wide = scoped_query_bytes(&st, "rust async web");
+    assert!(
+        wide > narrow,
+        "a three-term OR must index at least the one-term query's bytes \
+         (wide {wide} vs narrow {narrow})"
+    );
+}
+
+#[test]
+fn a_reader_minted_outside_the_scope_records_nothing() {
+    let st = demo_two_superfiles();
+    // Mint first, then open the scope: the collector is picked up at
+    // reader mint, so this query deliberately reports zero work.
+    let reader = st.reader().expect("reader");
+    let (hits, stats) = with_op_stats(|| {
+        reader
+            .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+            .expect("bm25")
+    });
+    assert!(!hits.is_empty());
+    assert_eq!(
+        stats.fts_postings_bytes, 0,
+        "pickup happens at reader mint, not at query time"
+    );
+}

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -123,9 +123,9 @@ fn deterministic(mut stats: OpStats) -> OpStats {
     stats
 }
 
-/// Posting bytes for one BM25 query run inside a fresh scope, minting the
-/// reader inside the scope (the pickup point).
-fn scoped_query_bytes(st: &Supertable, query: &str) -> u64 {
+/// One BM25 query's full work stats, run inside a fresh scope, minting
+/// the reader inside the scope (the pickup point).
+fn scoped_fts_stats(st: &Supertable, query: &str) -> OpStats {
     let (hits, stats) = with_op_stats(|| {
         st.reader()
             .expect("reader")
@@ -133,7 +133,12 @@ fn scoped_query_bytes(st: &Supertable, query: &str) -> u64 {
             .expect("bm25")
     });
     assert!(!hits.is_empty(), "fixture query {query:?} must match");
-    stats.fts_postings_bytes
+    stats
+}
+
+/// Posting bytes for one BM25 query run inside a fresh scope.
+fn scoped_query_bytes(st: &Supertable, query: &str) -> u64 {
+    scoped_fts_stats(st, query).fts_postings_bytes
 }
 
 #[test]
@@ -215,10 +220,12 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
 fn work_stats_are_deterministic_across_cache_temperature() {
     // The first run decodes from a cold state, the repeat hits every
     // warm structure — the whole point of the counter is that the
-    // reported work is identical either way.
+    // reported work is identical either way. Compare the full masked
+    // snapshot (like the vector/SQL siblings), not just posting bytes,
+    // so a warm/cold divergence in any FTS counter is caught.
     let st = demo_two_superfiles();
-    let cold = scoped_query_bytes(&st, "rust");
-    let warm = scoped_query_bytes(&st, "rust");
+    let cold = deterministic(scoped_fts_stats(&st, "rust"));
+    let warm = deterministic(scoped_fts_stats(&st, "rust"));
     assert_eq!(cold, warm, "same plan, same table state, same work");
 }
 

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    IndexSpec, connect,
     runtime_metrics::op_stats::{OpStats, with_op_stats},
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{builder::FtsConfig, fts::reader::BoolMode},
@@ -336,4 +337,90 @@ fn vector_work_stats_are_deterministic_across_cache_temperature() {
     let cold = scoped_vector_stats(&st);
     let warm = scoped_vector_stats(&st);
     assert_eq!(cold, warm, "same plan, same table state, same work");
+}
+
+// ---- SQL: the per-query channel through the catalog `query_sql` path ----
+
+/// Rows in the SQL fixture.
+const SQL_ROWS: usize = 64;
+
+/// A storage-backed catalog connection with one FTS-indexed table whose
+/// scans and search TVFs exercise the per-query SQL channel.
+fn sql_fixture(dir: &TempDir) -> infino::Connection {
+    let db = connect(dir.path().to_str().expect("utf-8 path")).expect("connect");
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("rating", arrow_schema::DataType::Int64, false),
+    ]));
+    let docs = db
+        .create_table("docs", schema.clone(), IndexSpec::new().fts("title"))
+        .expect("create_table");
+    let titles: Vec<String> = (0..SQL_ROWS)
+        .map(|i| {
+            let mut t = format!("filler{i}");
+            if i % 2 == 0 {
+                t.push_str(" rust");
+            }
+            t
+        })
+        .collect();
+    let title_arr: ArrayRef = Arc::new(LargeStringArray::from(
+        titles.iter().map(String::as_str).collect::<Vec<_>>(),
+    ));
+    let ratings: ArrayRef = Arc::new(arrow_array::Int64Array::from(
+        (0..SQL_ROWS as i64).collect::<Vec<_>>(),
+    ));
+    let batch = RecordBatch::try_new(schema, vec![title_arr, ratings]).expect("batch");
+    docs.append(&batch).expect("append");
+    db
+}
+
+/// One scoped SQL statement's work stats.
+fn scoped_sql_stats(db: &infino::Connection, sql: &str) -> OpStats {
+    let (batches, stats) = with_op_stats(|| db.query_sql(sql).expect("query_sql"));
+    assert!(!batches.is_empty(), "fixture SQL {sql:?} must return");
+    stats
+}
+
+#[test]
+fn a_scoped_sql_scan_reports_page_bytes() {
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_fixture(&dir);
+    // A row-returning range scan cannot fold to manifest statistics, so it
+    // must decode Parquet pages through the DataFusion store.
+    let stats = scoped_sql_stats(&db, "SELECT rating FROM docs WHERE rating > 5");
+    assert!(
+        stats.sql_page_bytes > 0,
+        "a scan-backed SQL query requests Parquet bytes; got 0"
+    );
+    assert!(
+        stats.planned_read_ranges > 0,
+        "each Parquet request is a planned range"
+    );
+}
+
+#[test]
+fn sql_work_stats_are_deterministic_across_cache_temperature() {
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_fixture(&dir);
+    let sql = "SELECT rating FROM docs WHERE rating > 5";
+    let cold = scoped_sql_stats(&db, sql);
+    let warm = scoped_sql_stats(&db, sql);
+    assert_eq!(cold, warm, "same plan, same table state, same work");
+}
+
+#[test]
+fn a_search_tvf_inside_sql_reports_fts_work() {
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_fixture(&dir);
+    // The TVF resolves its reader on a runtime thread; the collector must
+    // arrive via the registration-time capture, not the thread-local.
+    let stats = scoped_sql_stats(
+        &db,
+        "SELECT _id, score FROM bm25_search('docs', 'title', 'rust', 10)",
+    );
+    assert!(
+        stats.fts_postings_bytes > 0,
+        "the BM25 leg inside SQL indexes posting bytes; got 0"
+    );
 }

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -10,11 +10,14 @@
 #![deny(clippy::unwrap_used)]
 
 use std::sync::Arc;
+use std::thread;
 
-use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use arrow_array::{
+    ArrayRef, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray, RecordBatch,
+};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
-    IndexSpec, connect,
+    Connection, IndexSpec, Metric, connect,
     runtime_metrics::op_stats::{OpStats, with_op_stats},
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{builder::FtsConfig, fts::reader::BoolMode},
@@ -158,6 +161,41 @@ fn a_scoped_bm25_query_reports_its_planned_ranges() {
         "three terms request more ranges than one (three {}, one {})",
         three_terms.planned_read_ranges,
         one_term.planned_read_ranges
+    );
+}
+
+#[test]
+fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
+    // Every fixture term is PFOR (df >= 2) in every superfile, so the
+    // plan is EXACTLY one posting range per term per superfile. An exact
+    // pin: a double flush (2x), a missed superfile, or a phantom extra
+    // range all fail an equality that the >0 assertions would pass.
+    let st = demo_two_superfiles();
+    let n_superfiles = st.reader().expect("reader").n_superfiles() as u64;
+    assert!(
+        n_superfiles >= 2,
+        "fixture must fan out; got {n_superfiles}"
+    );
+    let (_, one_term) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+            .expect("bm25")
+    });
+    assert_eq!(
+        one_term.planned_read_ranges, n_superfiles,
+        "one PFOR term = one posting range per superfile"
+    );
+    let (_, three_terms) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits("title", "rust async web", TOP_K, BoolMode::Or)
+            .expect("bm25")
+    });
+    assert_eq!(
+        three_terms.planned_read_ranges,
+        3 * n_superfiles,
+        "three PFOR terms = three posting ranges per superfile"
     );
 }
 
@@ -360,6 +398,32 @@ fn a_scoped_vector_query_reports_scan_and_rerank_work() {
 }
 
 #[test]
+fn a_full_width_probe_scans_every_row_exactly_once() {
+    // nprobe >= the hidden cell count chooses every cluster, so the scan
+    // estimates every stored code exactly once: candidates == rows in
+    // the table. An exact pin — any double flush would report 2x.
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let query = row_vec(3);
+    let (hits, stats) = with_op_stats(|| {
+        st.vector_search(
+            "emb",
+            &query,
+            VECTOR_K,
+            VectorSearchOptions::new().with_nprobe(VECTOR_ROWS),
+            None,
+            None,
+        )
+        .expect("vector search")
+    });
+    assert!(!hits.is_empty());
+    assert_eq!(
+        stats.vector_candidates_scanned, VECTOR_ROWS as u64,
+        "a full-width probe estimates each stored code exactly once"
+    );
+}
+
+#[test]
 fn vector_work_stats_are_deterministic_across_cache_temperature() {
     let dir = TempDir::new().expect("tempdir");
     let st = drained_vector_table(&dir);
@@ -375,11 +439,11 @@ const SQL_ROWS: usize = 64;
 
 /// A storage-backed catalog connection with one FTS-indexed table whose
 /// scans and search TVFs exercise the per-query SQL channel.
-fn sql_fixture(dir: &TempDir) -> infino::Connection {
+fn sql_fixture(dir: &TempDir) -> Connection {
     let db = connect(dir.path().to_str().expect("utf-8 path")).expect("connect");
     let schema = Arc::new(Schema::new(vec![
         Field::new("title", DataType::LargeUtf8, false),
-        Field::new("rating", arrow_schema::DataType::Int64, false),
+        Field::new("rating", DataType::Int64, false),
     ]));
     let docs = db
         .create_table("docs", schema.clone(), IndexSpec::new().fts("title"))
@@ -396,16 +460,14 @@ fn sql_fixture(dir: &TempDir) -> infino::Connection {
     let title_arr: ArrayRef = Arc::new(LargeStringArray::from(
         titles.iter().map(String::as_str).collect::<Vec<_>>(),
     ));
-    let ratings: ArrayRef = Arc::new(arrow_array::Int64Array::from(
-        (0..SQL_ROWS as i64).collect::<Vec<_>>(),
-    ));
+    let ratings: ArrayRef = Arc::new(Int64Array::from((0..SQL_ROWS as i64).collect::<Vec<_>>()));
     let batch = RecordBatch::try_new(schema, vec![title_arr, ratings]).expect("batch");
     docs.append(&batch).expect("append");
     db
 }
 
 /// One scoped SQL statement's work stats.
-fn scoped_sql_stats(db: &infino::Connection, sql: &str) -> OpStats {
+fn scoped_sql_stats(db: &Connection, sql: &str) -> OpStats {
     let (batches, stats) = with_op_stats(|| db.query_sql(sql).expect("query_sql"));
     assert!(!batches.is_empty(), "fixture SQL {sql:?} must return");
     stats
@@ -436,6 +498,116 @@ fn sql_work_stats_are_deterministic_across_cache_temperature() {
     let cold = deterministic(scoped_sql_stats(&db, sql));
     let warm = deterministic(scoped_sql_stats(&db, sql));
     assert_eq!(cold, warm, "same plan, same table state, same work");
+}
+
+/// A storage-backed catalog connection whose table also carries a
+/// drained vector index, so SQL vector TVFs run the hidden-index path.
+fn sql_vector_fixture(dir: &TempDir) -> Connection {
+    let db = connect(dir.path().to_str().expect("utf-8 path")).expect("connect");
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new(
+            "emb",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIM as i32,
+            ),
+            false,
+        ),
+    ]));
+    let docs = db
+        .create_table(
+            "docs",
+            schema.clone(),
+            IndexSpec::new()
+                .fts("title")
+                .vector("emb", DIM, Metric::L2Sq),
+        )
+        .expect("create_table");
+    docs.append(&vector_batch(schema)).expect("append");
+    docs.local_handle()
+        .drain_vectors_to_cells_sync()
+        .expect("drain");
+    db
+}
+
+#[test]
+fn a_scope_minted_reader_meters_hidden_work_from_any_thread() {
+    // The collector is picked up at reader mint and must TRAVEL with the
+    // reader — never be re-read from a thread-local mid-query. The
+    // drained path mints the hidden vector-index reader mid-query, and
+    // real drivers (DataFusion partitions, spawned fan-out bodies) poll
+    // kernels on runtime threads where the caller's scope is invisible.
+    // Regression: run the query on a scope-less thread; the hidden mint
+    // used to consult that thread's empty slot and report zero vector
+    // work for exactly the query class the token meter is anchored on.
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let query = row_vec(3);
+    let (hits, stats) = with_op_stats(|| {
+        let reader = st.reader().expect("reader minted inside the scope");
+        thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    reader
+                        .vector_hits(
+                            "emb",
+                            &query,
+                            VECTOR_K,
+                            VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+                            None,
+                        )
+                        .expect("vector hits off-thread")
+                })
+                .join()
+                .expect("query thread")
+        })
+    });
+    assert!(!hits.is_empty(), "fixture vector query must match");
+    assert!(
+        stats.vector_cells_scanned > 0,
+        "the hidden-index leg meters cells from a scope-less thread; got 0"
+    );
+    assert!(
+        stats.vector_candidates_scanned > 0,
+        "the hidden-index leg meters candidates from a scope-less thread; got 0"
+    );
+    assert!(
+        stats.planned_read_ranges > 0,
+        "the hidden-index leg meters planned ranges from a scope-less thread; got 0"
+    );
+}
+
+#[test]
+fn a_vector_tvf_inside_sql_reports_vector_work() {
+    // The hidden-index reader is minted MID-QUERY, on a DataFusion
+    // runtime thread where the caller's `with_op_stats` thread-local is
+    // invisible — the collector must arrive by inheritance from the
+    // TVF's reader. Regression: this path used to report zero vector
+    // work for exactly the query class the token is anchored on.
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_vector_fixture(&dir);
+    let csv = row_vec(3)
+        .iter()
+        .map(f32::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let stats = scoped_sql_stats(
+        &db,
+        &format!("SELECT _id, score FROM vector_search('docs', 'emb', '{csv}', {VECTOR_K})"),
+    );
+    assert!(
+        stats.vector_cells_scanned > 0,
+        "the hidden-index leg inside SQL scans cells; got 0"
+    );
+    assert!(
+        stats.vector_candidates_scanned > 0,
+        "the hidden-index leg inside SQL estimates candidates; got 0"
+    );
+    assert!(
+        stats.planned_read_ranges > 0,
+        "the hidden-index leg inside SQL plans ranges; got 0"
+    );
 }
 
 #[test]


### PR DESCRIPTION
### What this adds

A feature-gated per-query work channel: a caller wraps a search in
`op_stats::with_op_stats(|| …)` and gets back an `OpStats` snapshot of
the physical work that query performed, alongside its result. Available
under `features = ["metering"]` (and to tests/benches via
`test-helpers`); without those features the module is `pub(crate)` and
nothing is reachable.

Note that the same query against the same table state must report the same work
whether the cache was warm or cold, because what the storage layer
happened to fetch is an operational detail of the deployment, not a
property of the query. The existing `UsageMeter` I/O ledger keeps
counting *actuals* (connection-scoped); this channel counts what the
*plan* did, per query.

### The counters

| field | meaning |
|---|---|
| `fts_postings_bytes` | posting bytes the clauses index into (terms, phrases, negations), once per superfile |
| `vector_cells_scanned` / `vector_candidates_scanned` | cells probed / quantized codes estimated, identical warm or cold |
| `vector_rows_reranked` | rows actually rescored at full precision — an execution diagnostic (see below) |
| `planned_read_ranges` | byte-source ranges the plan requested, before coalescing and before the cache decides local-read vs GET |
| `sql_page_bytes` | Parquet bytes SQL scans requested through the DataFusion store |
| `kernel_cpu_ns` | on-CPU ns of the bracketed synchronous kernel sections (thread-CPU clock) |

Every field except `kernel_cpu_ns` (measured time) and
`vector_rows_reranked` is a deterministic plan count. `planned_read_ranges`
stays canonical on the vector rerank leg by charging the *plan's* budget,
never the executed row count: the deferred path prices
`min(shortlist limit, candidates)` (law arm) or the per-cell kept depth
(explicit-`nprobe` arm, matching #537's cost-linear-in-width semantics)
whether winners rerank at phase C (warm) or inside their cell scans
(cold). `vector_rows_reranked` is deliberately the actual row count and
documented as temperature-dependent on that path.

### Design

- **Pickup at reader mint, explicit from there.** The scope installs a
  collector in a thread-local; the reader minted on the caller's thread
  picks it up once, and it travels as an `Arc` through the fan-out —
  spawned tasks and pool closures never consult the thread-local.
  Readers minted *mid-query* (the hidden vector-index legs, the SQL TVF
  round-trip) inherit the driving reader's collector explicitly
  (`pinned_reader_with`, `WeakReader`), so kernels polled on runtime
  threads meter correctly.
- **No atomics in scoring loops.** Tallies accumulate in locals
  (`ProbeTally`, cursor sets) and flush once per superfile / work unit.
- **Free when off.** Without a collector every flush is one `Option`
  branch, and the superfile-level kernel-CPU brackets gate their procfs
  reads on a process-wide live-scope counter (one relaxed load), so an
  unmetered process pays no syscalls on the hot path.
- **Cached state never captures a scope.** The supertable-level SQL
  `SessionContext` (cached across queries) is built from a detached
  reader under `op_stats::suppressed`, so a long-lived cache can never
  bill later queries into an old scope.

### Tests

- Determinism: identical stats cold-run vs warm-repeat for FTS, vector
  (drained), and SQL; a superfile-level test pins warm and cold probes
  to identical tallies through the divergent fetch branches.
- Exact pins that a double flush cannot satisfy: one posting range per
  PFOR term per superfile; a full-width probe counts each stored code
  exactly once.
- Thread robustness: a reader minted inside a scope and queried from a
  scope-less thread meters its hidden-index work (fails on thread-local
  pickup); a reader minted outside any scope records nothing.
- TVF-in-SQL coverage for both BM25 and vector legs; kernel-CPU
  coverage across single-term and multi-term shapes.
- Full suites green: 2,178 lib / 267 supertable / 135 superfile;
  clippy `-D warnings`; `public-api` snapshot unchanged (the surface is
  reachable only under the opt-in features).

### Known gaps (deliberate, documented in the field docs)

All are deterministic *under*-counts: the filtered-search predicate leg
(`token_match` posting reads) is not yet metered; an inline df=1 term
inside a multi-term query counts one phantom range (the single-term arm
counts it correctly as zero); cluster-index refetch and the
lazy Sq8-meta ranges aren't priced (temperature canonicalization);
kernel-CPU brackets cover FTS only — vector and SQL brackets are a
follow-up. A delete-heavy table can re-run the refill fan-out a
temperature-dependent number of times (pre-existing loop; counts stay
canonical per fan-out).

## behavior note — deferred-shortlist cap under boundary replication

this pr changes how the phase-c deferred-rerank shortlist cap and per-unit
`k_fetch` account for boundary-replica overhead: the cap now takes the max
over **all scanned units** (`max_replica_overhead`, updated before the
pooling check) instead of the max over the pooled/warm subset. dormant under
the default config — `drain_replica_target_factor: 1.0` disables replication,
so overhead is identically 0 and results are byte-identical to main. it goes
live (and is required) the moment a deployment raises the knob: the old
pooled-max varied with which units happened to pool, i.e. with cache
temperature, which is disqualifying for a selection cap. before any
deployment raises the factor above 1.0, the gate is recall@10 ≥ 0.99
(filtered + unfiltered) measured at that factor.

## off-build cost, precisely

with no `with_op_stats` scope live: no clock or procfs reads, no plan /
result / score / order change. the plan-arithmetic sums (candidates scanned,
planned ranges, posting bytes) are still computed, and each kernel bracket
pays one relaxed atomic load. "zero overhead" refers to the expensive
measurement paths, not to literal zero instructions.

## metered sql surface

`Connection::query_sql` is the only sql entry point in a shipped build and
builds a fresh per-query provider carrying the scope's collector. the
reader-level `query_sql` is test-helpers-only and runs on a cached,
collector-detached context (as does mutation id-capture, which reports via
`MutationStats`); a scope around it reports zero sql work by design.

### Performance

No behavior change to any query path; the metering additions are
local-tally arithmetic plus per-unit flushes, gated as above.