### PR TITLE
fts: speed up deep-k dominant-term union top-k

### DIFF
--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -347,6 +347,15 @@ fn prefer_windowed_union(cursors: &[TermCursor]) -> bool {
     cursors.len() >= OR_WINDOW_MIN_TERMS && no_dominant_term_ub(cursors)
 }
 
+/// Minimum dominant-term df for the deep-`k` reroute to the windowed
+/// scorer to pay off. Below this the union is small enough that
+/// MaxScore's scalar full scan beats the windowed scorer's fixed
+/// per-window setup, so short unions stay on MaxScore. Calibrated on the
+/// warm FTS bench: the win concentrates on dominant lists in the millions
+/// (~corpus-scale), the mid range is a wash, and lists shorter than this
+/// regressed. See [`or_topk_pruning_ineffective`].
+const OR_WINDOWED_MIN_DOMINANT_DF: u64 = 100_000;
+
 /// True when block-max pruning (MaxScore / WAND) can no longer skip
 /// blocks at this `k`, so both degrade to a full union scan — at which
 /// point the SIMD windowed scorer does that same scan far faster than
@@ -368,12 +377,29 @@ fn prefer_windowed_union(cursors: &[TermCursor]) -> bool {
 /// pruning is dead. This is `df`-only — no extra reads — and
 /// self-correcting: a "rare" second term that is actually long keeps
 /// `rest_df` high, leaves pruning alive, and stays on MaxScore.
+///
+/// Reroute only when the dominant list is also *long* (`max_df >=`
+/// [`OR_WINDOWED_MIN_DOMINANT_DF`]). Once pruning is dead both scorers
+/// scan the whole union, but the windowed scorer's per-window bookkeeping
+/// (a 4096-wide score accumulator + presence bitset) only pays off when
+/// the dominant list is long enough to amortize it; on a short union it
+/// is pure overhead and MaxScore's scalar scan is faster. A union with
+/// fewer than the floor's matches can't have a longer dominant list than
+/// the floor, so this gates out exactly the small-union case that
+/// regressed on the bench.
 fn or_topk_pruning_ineffective(cursors: &[TermCursor], k: usize) -> bool {
-    if cursors.len() < 2 {
-        return false;
-    }
     let max_df = cursors.iter().map(|c| c.df).max().unwrap_or(0);
     let total_df: u64 = cursors.iter().map(|c| c.df).sum();
+    or_reroute_by_df(max_df, total_df, cursors.len(), k)
+}
+
+/// Pure df-math behind [`or_topk_pruning_ineffective`], split out so the
+/// routing decision can be unit-tested at df values (hundreds of
+/// thousands) that a fast in-memory corpus can't reach.
+fn or_reroute_by_df(max_df: u64, total_df: u64, n_terms: usize, k: usize) -> bool {
+    if n_terms < 2 || max_df < OR_WINDOWED_MIN_DOMINANT_DF {
+        return false;
+    }
     let rest_df = total_df.saturating_sub(max_df);
     k as u64 >= rest_df
 }
@@ -7472,6 +7498,51 @@ mod tests {
         assert!(
             !two_term_has_rare_anchor(&uniform),
             "two common terms should not anchor"
+        );
+    }
+
+    #[test]
+    fn deep_k_dominant_union_reroutes_only_when_list_is_long() {
+        // The deep-k reroute to the windowed scorer fires only when
+        // pruning is dead (k reaches the rarer terms' combined df) AND the
+        // dominant list is long enough to amortize the window setup.
+        const LONG: u64 = 3_000_000; // dominant common term
+        const RARE: u64 = 500; // rare second term
+        let total = LONG + RARE;
+
+        // Deep k (>= rest_df) over a long dominant list: reroute.
+        assert!(
+            or_reroute_by_df(LONG, total, 2, 1000),
+            "deep k over a long dominant list should reroute to windowed"
+        );
+        // Shallow k (< rest_df): the rare term still fills the heap, pruning
+        // is alive, stay on MaxScore.
+        assert!(
+            !or_reroute_by_df(LONG, total, 2, 100),
+            "k below the rare term's df keeps pruning alive → MaxScore"
+        );
+        // Long list but only one term: not an OR.
+        assert!(
+            !or_reroute_by_df(LONG, LONG, 1, 1000),
+            "single term is not a union"
+        );
+        // Small union (dominant list below the floor): too little work to
+        // amortize the window; stay on MaxScore even at deep k. This is the
+        // case that regressed before the floor was added.
+        let small = OR_WINDOWED_MIN_DOMINANT_DF - 1;
+        assert!(
+            !or_reroute_by_df(small, small + RARE, 2, 1_000_000),
+            "a union below the dominant-df floor must not reroute"
+        );
+        // Exactly at the floor with deep k: reroute.
+        assert!(
+            or_reroute_by_df(
+                OR_WINDOWED_MIN_DOMINANT_DF,
+                OR_WINDOWED_MIN_DOMINANT_DF + RARE,
+                2,
+                1000
+            ),
+            "at the dominant-df floor a deep-k union reroutes"
         );
     }
 

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -347,6 +347,37 @@ fn prefer_windowed_union(cursors: &[TermCursor]) -> bool {
     cursors.len() >= OR_WINDOW_MIN_TERMS && no_dominant_term_ub(cursors)
 }
 
+/// True when block-max pruning (MaxScore / WAND) can no longer skip
+/// blocks at this `k`, so both degrade to a full union scan — at which
+/// point the SIMD windowed scorer does that same scan far faster than
+/// MaxScore's scalar per-doc f-way merge.
+///
+/// Pruning stays alive only while the top-k threshold sits *above* the
+/// common (low-idf, longest-list) term's score upper bound: only then
+/// can that term's blocks be skipped. The threshold holds there only as
+/// long as the rarer terms alone can fill the heap. Once `k` reaches the
+/// combined df of every term *except* the single longest list, the heap
+/// must admit docs from that longest list's tail — docs whose only
+/// matching term is the common one — the threshold collapses toward its
+/// low upper bound, and no block clears the skip test any more.
+///
+/// `rest_df` (sum of all dfs but the largest) is a conservative bound on
+/// how many docs the rarer terms can contribute: it ignores overlap, so
+/// the true fillable count is `<= rest_df`. When `k >= rest_df` the heap
+/// therefore *cannot* be filled without the common term's tail, and
+/// pruning is dead. This is `df`-only — no extra reads — and
+/// self-correcting: a "rare" second term that is actually long keeps
+/// `rest_df` high, leaves pruning alive, and stays on MaxScore.
+fn or_topk_pruning_ineffective(cursors: &[TermCursor], k: usize) -> bool {
+    if cursors.len() < 2 {
+        return false;
+    }
+    let max_df = cursors.iter().map(|c| c.df).max().unwrap_or(0);
+    let total_df: u64 = cursors.iter().map(|c| c.df).sum();
+    let rest_df = total_df.saturating_sub(max_df);
+    k as u64 >= rest_df
+}
+
 /// Initial capacity for a scan's top-k heap, in [`TopKEntry`] slots.
 ///
 /// `docs_in_scope` bounds the distinct doc_ids that can ever enter the
@@ -3972,6 +4003,17 @@ impl FtsReader {
         // cross-segment floor (`floor_eff` unset) — seeding WAND's
         // threshold from a floor mis-prunes, so a live floor stays on
         // MaxScore.
+        // The dominance heuristic (`prefer_windowed_union`) assumes a
+        // dominant term means MaxScore prunes hard — true only at small
+        // `k`. At large `k` relative to the rarer terms' combined df the
+        // top-k threshold collapses to the common term's upper bound,
+        // MaxScore can skip nothing, and it degrades to a *scalar* full
+        // scan. `or_topk_pruning_ineffective` catches exactly that case
+        // (including a 2-term rare+common OR too deep for WAND) and
+        // routes it to the SIMD windowed scorer, which does the same
+        // full scan without the per-doc f-way merge. Small-`k`
+        // dominant-term ORs fail this test and stay on MaxScore, where
+        // pruning still wins.
         let no_floor = floor_eff == f32::NEG_INFINITY;
         if cursors.len() == 2
             && k <= WAND_BMW_2TERM_MAX_K
@@ -3980,7 +4022,7 @@ impl FtsReader {
             && two_term_has_rare_anchor(&cursors)
         {
             self.run_wand_bmw(column_id, cursors, k)
-        } else if prefer_windowed_union(&cursors) {
+        } else if prefer_windowed_union(&cursors) || or_topk_pruning_ineffective(&cursors, k) {
             self.run_windowed_union(column_id, cursors, k, filter, floor_eff, 0, u32::MAX)
         } else {
             self.run_max_score_bmm(column_id, cursors, k, filter, floor_eff)

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -7521,6 +7521,19 @@ mod tests {
             !or_reroute_by_df(LONG, total, 2, 100),
             "k below the rare term's df keeps pruning alive → MaxScore"
         );
+        // Exact boundary k == rest_df: the heap needs one doc beyond the
+        // rare term's list, so pruning is already dead → reroute (the test
+        // is `>=`, so the boundary counts).
+        assert!(
+            or_reroute_by_df(LONG, total, 2, RARE as usize),
+            "k exactly at rest_df should reroute"
+        );
+        // One below the boundary (k == rest_df - 1): rare term still fills
+        // the heap, stay on MaxScore.
+        assert!(
+            !or_reroute_by_df(LONG, total, 2, RARE as usize - 1),
+            "k just below rest_df keeps pruning alive → MaxScore"
+        );
         // Long list but only one term: not an OR.
         assert!(
             !or_reroute_by_df(LONG, LONG, 1, 1000),


### PR DESCRIPTION
## Problem

The multi-term OR dispatcher routed any union with a dominant score
upper-bound term to MaxScore + Block-Max MaxScore (BMM), on the
assumption that a dominant term lets block-max pruning skip the common
term's long posting list. That holds only while the top-k threshold
stays above the common term's score upper bound — i.e. while the rarer
terms alone can fill the heap.

Once `k` reaches the combined df of every term but the longest list, the
heap must admit docs from that longest list's tail (docs whose only
matching term is the common one). The threshold collapses toward the
common term's low upper bound, no block clears the skip test, and BMM
degrades to a **scalar full union scan**. This is the worst case for
deep-`k` "common + rare" unions.

## Change

Route exactly that case — pruning dead at this `k`, and the dominant list
long — to the SIMD windowed scorer, which does the same full scan without
the per-doc f-way merge:

- `or_topk_pruning_ineffective` detects the dead-pruning case from df
  alone (no extra reads): reroute when `k >= (total_df - max_df)`.
- Gate the reroute on a dominant-list floor (`max_df >= 100k`). Once
  pruning is dead both scorers scan the whole union, but the windowed
  scorer's fixed per-window setup (a 4096-wide score accumulator + a
  presence bitset) only amortizes on a long dominant list; on a short
  union it is pure overhead and MaxScore's scalar scan wins. Short unions
  stay on MaxScore.

Small-`k` dominant-term unions are untouched and stay on MaxScore, where
pruning still wins. This is a routing change only — no scoring math
changes, so results and scores are identical (the windowed scorer already
agrees with BMM on the brute-force BM25 oracle).

## Results (public benchmark, single compacted superfile, single-threaded, min-of-10)

infino's own before → after (this branch vs `main`), union top-k. Ratios
are branch/main, **< 1 = faster**:

| Union TOP_1000 | main | branch | ratio |
|---|---:|---:|---:|
| dominant list > 1M postings | 552 ms | 420 ms | **0.76× (24% faster)** |
| overall union | 1190 ms | 1074 ms | **0.90×** |

The win concentrates where the dispatcher used to fall off pruning: deep
`k` over a corpus-scale dominant list. Small unions, all other query
shapes (term, intersection, phrase), and all COUNT modes are within
run-to-run noise.

The dominant-list floor closes a small-union regression that an unfloored
reroute introduced — confirmed on a same-machine A/B (tight noise floor):
`< 100k` unions at TOP_1000 went 1.05× → **1.01×** while the `> 1M` win
was preserved (0.88× on that machine).

## Tests

- Brute-force BM25 top-K oracle and the windowed-vs-MaxScore agreement
  tests stay green (routing must not change which docs/scores return).
- Added `deep_k_dominant_union_reroutes_only_when_list_is_long`, pinning
  the boundary decisions: deep vs shallow `k`, single term, and
  below/at the dominant-list floor.
