### PR TITLE
feat supertable gc: resolve liveness from the latest committed manifest

### DIFF
--- a/src/supertable/gc/mod.rs
+++ b/src/supertable/gc/mod.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::HashSet,
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -10,7 +11,7 @@ use tracing::{debug, warn};
 
 use crate::{
     runtime_bridge::bridge_on_runtime,
-    storage::StorageError,
+    storage::{StorageError, StorageProvider},
     supertable::{
         ManifestSnapshot, Supertable,
         error::GcError,
@@ -46,16 +47,28 @@ pub struct GcReport {
     pub delete_errors: u64,
 }
 
+/// Every storage key this manifest version references, and whether its superfile membership was
+/// fully resident. Anything absent from the returned set is an orphan as far as the caller is
+/// concerned, so a key that belongs here and is missed, gets deleted.
 fn build_live_set(manifest: &ManifestSnapshot) -> (HashSet<String>, bool) {
     let mut live = HashSet::new();
+
+    // The pointer, and the one manifest list it names. Superseded lists are left out on purpose:
+    // being unreferenced here is exactly what makes them reclaimable.
     live.insert(POINTER_PATH.to_string());
     live.insert(manifest_uri(manifest.manifest_id));
+
+    // The part fan this list is built from, plus each part's routing sibling where it has one.
     for entry in manifest.get_all_list_entries() {
         live.insert(entry.uri.clone());
         if let Some(routing) = &entry.routing {
             live.insert(routing.uri.clone());
         }
     }
+
+    // Every superfile, but only when the parts are all loaded. A partial view names some of the
+    // superfiles and no more, so the caller must skip `data/` entirely rather than treat the ones
+    // it cannot see as orphans. That is what the flag carries.
     let superfiles_complete = if let Some(superfiles) = manifest.complete_flat_superfiles() {
         for sf in superfiles {
             live.insert(sf.uri.storage_path());
@@ -64,20 +77,24 @@ fn build_live_set(manifest: &ManifestSnapshot) -> (HashSet<String>, bool) {
     } else {
         false
     };
-    // Slow-CAS objects (routing-shaped state blob + fp32 centroid
-    // section): the URIs are read straight off the manifest-list refs —
-    // sync, no fetch. Superseded generations (older drains) are absent
-    // from the current list and get swept once past the safety gap.
+
+    // The slow-CAS state blob and its centroid section, read straight off the list refs with no
+    // fetch. Older drains are absent from the current list and age out past the safety gap.
     if let Some((uri, _)) = manifest.slow_vector_state_blob() {
         live.insert(uri.to_owned());
     }
     if let Some(centroids) = manifest.slow_vector_state_centroids_blob() {
         live.insert(centroids.uri.clone());
     }
+
+    // Each resident superfile's tombstone sidecar. `superfiles/` is swept whatever the flag says,
+    // so these have to be named here or a sidecar past the gap is deleted and its deleted rows
+    // come back. The superfile paths repeat what the complete view above already inserted.
     for sf in manifest.get_all_superfiles() {
         live.insert(sf.uri.storage_path());
         live.insert(WalStore::tombstones_path(sf.superfile_id));
     }
+
     (live, superfiles_complete)
 }
 
@@ -95,16 +112,47 @@ impl Supertable {
     }
 }
 
-/// Delete storage objects not referenced by the current manifest once they are
-/// older than `safety_gap`. Supersedes inline post-commit deletes so readers
-/// pinned to an older snapshot cannot lose bytes mid-fetch.
-pub(super) async fn gc_storage_sweep_for_inner(
+/// Everything one manifest version references, with the `manifest_id` it came from and whether its
+/// superfile membership was fully resident (see [`build_live_set`]).
+struct LiveSet {
+    uris: HashSet<String>,
+    superfiles_complete: bool,
+    manifest_id: u64,
+}
+
+/// Advance the handle to the committed manifest, so the keep-set built next describes the table
+/// rather than one handle's memory of it. A superfile another handle committed after that snapshot
+/// is missing from the cached view, and a sweep built on it deletes a file the manifest still
+/// references, which nothing notices until a later read or compaction fails with `not found`.
+///
+/// Costs one conditional pointer GET while the pointer is unchanged, and inherits already-loaded
+/// parts when it has moved.
+///
+/// Any failure aborts the sweep rather than falling back to the cached snapshot, because a keep-set
+/// that cannot be verified is the input that deletes live data. That includes `PointerVanished`,
+/// where the table was dropped and purged and reclaiming the remains belongs to the purge.
+async fn refresh_to_committed(inner: &SupertableInner) -> Result<(), GcError> {
+    inner.refresh().await.map(|_advanced| ()).map_err(|error| {
+        GcError::Storage(StorageError::Permanent {
+            uri: POINTER_PATH.to_string(),
+            source: Box::new(error),
+        })
+    })
+}
+
+/// Keep-set for the manifest this handle currently holds. Callers run [`refresh_to_committed`]
+/// first; this reads no pointer of its own.
+///
+/// Not cheap on a table carrying slow-CAS vector state: hydrating the pending drain re-fetches that
+/// blob and re-hashes it, which is multi-GiB work on a large table. Build it once per manifest
+/// version, never speculatively.
+async fn live_set(
     inner: &SupertableInner,
-    safety_gap: Duration,
-) -> Result<GcReport, GcError> {
-    let storage = inner.options.storage.clone().ok_or(GcError::NoStorage)?;
+    storage: &Arc<dyn StorageProvider>,
+) -> Result<LiveSet, GcError> {
     let manifest = inner.manifest.load_full();
-    let (mut live, superfiles_complete) = build_live_set(&manifest);
+    let (mut uris, superfiles_complete) = build_live_set(&manifest);
+
     if let Some((uri, hash)) = manifest.slow_vector_state_blob() {
         // An unreadable slow-state blob is a permanent storage-level failure
         // on that URI (missing, corrupt, or hash-mismatched bytes) — surface
@@ -119,9 +167,39 @@ pub(super) async fn gc_storage_sweep_for_inner(
                 })
             })?;
         if let Some(pending) = state.pending_drain {
-            live.extend(pending.entries.iter().map(|entry| entry.uri.storage_path()));
+            uris.extend(pending.entries.iter().map(|entry| entry.uri.storage_path()));
         }
     }
+
+    Ok(LiveSet {
+        uris,
+        superfiles_complete,
+        manifest_id: manifest.manifest_id,
+    })
+}
+
+/// Delete storage objects not referenced by the current manifest once they are
+/// older than `safety_gap`. Supersedes inline post-commit deletes so readers
+/// pinned to an older snapshot cannot lose bytes mid-fetch.
+///
+/// Listing and deleting are not atomic against a commit, so liveness is resolved twice — once
+/// before listing and once more before deleting — and an object referenced by either version is
+/// kept. Unioning the two keep-sets rather than replacing the first is the point: a commit that
+/// lands mid-sweep would otherwise fall between them.
+pub(super) async fn gc_storage_sweep_for_inner(
+    inner: &SupertableInner,
+    safety_gap: Duration,
+) -> Result<GcReport, GcError> {
+    let storage = inner.options.storage.clone().ok_or(GcError::NoStorage)?;
+
+    refresh_to_committed(inner).await?;
+
+    let LiveSet {
+        uris: live_uris,
+        superfiles_complete,
+        manifest_id: live_manifest_id,
+    } = live_set(inner, &storage).await?;
+
     let cutoff = SystemTime::now()
         .checked_sub(safety_gap)
         .unwrap_or(SystemTime::UNIX_EPOCH);
@@ -139,10 +217,12 @@ pub(super) async fn gc_storage_sweep_for_inner(
     if superfiles_complete {
         prefixes.push(SUPERFILE_DATA_DIR);
     }
+
+    let mut candidates: Vec<(String, u64)> = Vec::new();
     for prefix in prefixes {
         let entries = storage.list_with_prefix_metadata(prefix).await?;
         for (key, meta) in entries {
-            if live.contains(&key) {
+            if live_uris.contains(&key) {
                 report.objects_skipped_live += 1;
                 continue;
             }
@@ -150,15 +230,52 @@ pub(super) async fn gc_storage_sweep_for_inner(
                 report.objects_skipped_too_new += 1;
                 continue;
             }
-            match storage.delete(&key).await {
-                Ok(()) => {
-                    report.objects_deleted += 1;
-                    report.bytes_freed += meta.size;
-                }
-                Err(e) => {
-                    warn!(object = %key, error = %e, "gc: failed to delete orphan object");
-                    report.delete_errors += 1;
-                }
+            candidates.push((key, meta.size));
+        }
+    }
+
+    // Nothing is deleted until the listing is complete and the pointer has been re-read once more,
+    // so candidates accumulate across every prefix first. That also keeps the re-read below at one
+    // probe per sweep rather than one per prefix.
+    //
+    // The first keep-set is spent at this point and holds a `String` per referenced object, so
+    // release it rather than carry it alongside the second.
+    drop(live_uris);
+
+    // A commit may have landed while the listing ran, so re-read the pointer and put back anything
+    // the newer manifest references. Only the pointer is re-read up front: rebuilding the keep-set
+    // costs a slow-state fetch on a vector table, so it happens solely when the manifest actually
+    // moved. Candidates can only be removed here, never added, so a re-check that comes back with a
+    // partial view keeps more than it should rather than deleting something it cannot see.
+    if !candidates.is_empty() {
+        refresh_to_committed(inner).await?;
+        if inner.manifest.load().manifest_id != live_manifest_id {
+            let recheck = live_set(inner, &storage).await?;
+            let before = candidates.len();
+            candidates.retain(|(key, _)| !recheck.uris.contains(key));
+
+            let rescued = before - candidates.len();
+            report.objects_skipped_live += rescued as u64;
+            if rescued > 0 {
+                debug!(
+                    rescued,
+                    from_manifest = live_manifest_id,
+                    to_manifest = recheck.manifest_id,
+                    "gc: a commit landed mid-sweep; keeping objects it references"
+                );
+            }
+        }
+    }
+
+    for (key, size) in candidates {
+        match storage.delete(&key).await {
+            Ok(()) => {
+                report.objects_deleted += 1;
+                report.bytes_freed += size;
+            }
+            Err(e) => {
+                warn!(object = %key, error = %e, "gc: failed to delete orphan object");
+                report.delete_errors += 1;
             }
         }
     }

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -244,6 +244,107 @@ impl SupertableInner {
         }
         cache.reconcile(tombstone_seq_view(&manifest));
     }
+
+    /// Re-read the manifest pointer from storage and advance this supertable's in-memory state to
+    /// whatever it now names.
+    ///
+    /// The pointer is probed with the last etag this handle saw, so an unchanged pointer answers
+    /// without a body. When it has advanced, the new manifest list is loaded, the parts that did
+    /// not change are inherited from the current `ManifestSnapshot` by content hash, only the
+    /// newly-referenced parts are fetched, and the resulting `ManifestSnapshot` is swapped in.
+    /// A `SupertableReader` built before the swap keeps the snapshot it pinned and never sees it.
+    ///
+    /// Three outcomes:
+    ///
+    /// - i) `Ok(true)` when a newer manifest was loaded and swapped in.
+    /// - ii) `Ok(false)` when there was nothing newer to load, either because the pointer had not
+    ///   moved or because this process's own commit already put that version in memory.
+    /// - iii) `Err(PointerVanished)` when the pointer is gone, which also latches
+    ///   `pointer_vanished` on this handle.
+    ///
+    /// Lives on the inner because the deferred storage reclaim holds only an `Arc<SupertableInner>`
+    /// and still has to resolve the committed manifest when it fires.
+    /// [`Supertable::refresh`] is the handle-level spelling of the same call.
+    pub(super) async fn refresh(&self) -> Result<bool, ManifestLoadError> {
+        let storage = self
+            .options
+            .storage
+            .as_ref()
+            // With no storage attached there is no pointer to refresh against. The read path stops
+            // before this (`pointer_refresh_due` is false without storage), so only a direct caller
+            // ever sees the error.
+            .ok_or(ManifestLoadError::NoLoaderAttached)?
+            .clone();
+
+        // Probing with the last-seen etag keeps the steady-state cost of a freshness check at one
+        // roundtrip: an unchanged pointer answers as a bodyless 304, with nothing to transfer or
+        // parse.
+        let prev_etag = self
+            .last_pointer_etag
+            .lock()
+            .expect("last_pointer_etag mutex poisoned")
+            .clone();
+        let probe = probe_pointer(storage.as_ref(), prev_etag.as_deref()).await?;
+        let (pointer, meta) = match probe {
+            // An absent pointer means the table was dropped and purged, never that it has not been
+            // committed yet: this handle exists, and every path that builds one over storage
+            // already has a pointer by then, since `open` fails with `PointerNotFound` without one
+            // and `create` publishes an empty manifest first.
+            PointerProbe::Absent => {
+                let _ = self.pointer_vanished.set(());
+                return Err(ManifestLoadError::PointerVanished);
+            }
+            PointerProbe::NotModified => return Ok(false),
+            PointerProbe::Read(pointer, meta) => (pointer, meta),
+        };
+
+        // The etag is recorded only once this pointer version has actually been accounted for,
+        // meaning after a successful load or when the in-memory state already covers it. Recording
+        // it before the load would leave the etag ahead of the snapshot whenever the load fails,
+        // say because a manifest is not yet visible to this process, and the next conditional probe
+        // would then answer `NotModified` and never retry. That pins the handle to the pre-commit
+        // manifest and serves its rows as empty, for good.
+        let current = self.manifest.load_full();
+        let manifest = match ManifestSnapshot::load_with_pointer(
+            Some(current),
+            storage,
+            None,
+            pointer,
+        )
+        .await
+        {
+            Ok(manifest) => manifest,
+            // The pointer moved but the in-memory state already covers that version, which is what
+            // this process's own commit leaves behind. Nothing newer to load, so record the etag
+            // and let the next probe be a cheap 304.
+            Err(ManifestLoadError::AlreadyLoaded) => {
+                *self
+                    .last_pointer_etag
+                    .lock()
+                    .expect("last_pointer_etag mutex poisoned") = meta.etag.clone();
+                return Ok(false);
+            }
+            // Leaving the etag unchanged on a failed load is what makes the next probe read the
+            // pointer again and retry, instead of short-circuiting to a 304.
+            Err(err) => return Err(err),
+        };
+
+        self.manifest.store(manifest);
+
+        self.reconcile_tombstone_seqs();
+
+        *self
+            .last_pointer_etag
+            .lock()
+            .expect("last_pointer_etag mutex poisoned") = meta.etag.clone();
+
+        debug!(
+            manifest_id = self.manifest.load().manifest_id,
+            "refreshed manifest"
+        );
+
+        Ok(true)
+    }
 }
 
 impl Supertable {
@@ -452,106 +553,15 @@ impl Supertable {
         create_table_async(options, vector_index_table, vector_index_storage_prefix).await
     }
 
-    /// Re-read the manifest pointer from storage.
-    /// If the pointer names a newer `manifest_id` than this
-    /// supertable's current in-memory state, load the new
-    /// list, **inherit** unchanged parts from the current
-    /// `ManifestSnapshot` via content-addressed lookup, eager-fetch
-    /// the newly-referenced parts, and `ArcSwap` the new
-    /// `ManifestSnapshot` into place. Pre-refresh `SupertableReader`s
-    /// keep their pinned snapshot — the swap is invisible to
-    /// them.
+    /// Re-read the manifest pointer from storage and advance this supertable to whatever it names.
+    /// See [`SupertableInner::refresh`] for the mechanism and the three outcomes.
     ///
-    /// Returns `Ok(true)` iff a newer manifest was loaded.
-    /// `Ok(false)` if the pointer hasn't advanced (the cheap
-    /// no-op refresh path).
-    ///
-    /// `pub(crate)` — not a public verb. Freshness is engine-driven
-    /// via [`Supertable::ensure_fresh`] on the read path, governed by
-    /// [`crate::supertable::options::Consistency`]. This is the
-    /// mechanism that drives the pointer re-check.
+    /// Not a public verb, despite the name. Freshness is engine-driven through
+    /// [`Supertable::ensure_fresh`] on the read path and governed by
+    /// [`crate::supertable::options::Consistency`]; this is the call underneath that drives the
+    /// pointer re-check.
     pub(crate) async fn refresh(&self) -> Result<bool, ManifestLoadError> {
-        let storage = self
-            .inner
-            .options
-            .storage
-            .as_ref()
-            // No storage attached ⇒ nothing to refresh against. The read path
-            // never reaches here (`pointer_refresh_due` returns false without
-            // storage); surfaced for direct callers.
-            .ok_or(ManifestLoadError::NoLoaderAttached)?
-            .clone();
-
-        // Conditional pointer probe: with the last-seen etag in hand,
-        // an unchanged pointer answers as a bodyless 304 — the
-        // steady-state cost of the consistency check is one
-        // roundtrip, no transfer, no parse.
-        let prev_etag = self
-            .inner
-            .last_pointer_etag
-            .lock()
-            .expect("last_pointer_etag mutex poisoned")
-            .clone();
-        let probe = probe_pointer(storage.as_ref(), prev_etag.as_deref()).await?;
-        let (pointer, meta) = match probe {
-            // Absent means the pointer was deleted — the table was
-            // dropped and purged. It is never "not committed yet": this handle
-            // exists, and every path that builds one over storage has a
-            // pointer by then (`open` fails with `PointerNotFound` without
-            // one; `create` publishes an empty manifest first). A handle with
-            // no storage never reaches here — `refresh` requires it above.
-            PointerProbe::Absent => {
-                let _ = self.inner.pointer_vanished.set(());
-                return Err(ManifestLoadError::PointerVanished);
-            }
-            PointerProbe::NotModified => return Ok(false),
-            PointerProbe::Read(pointer, meta) => (pointer, meta),
-        };
-
-        // Record the new pointer etag only once we've actually accounted for
-        // this pointer version — after a successful load, or when our in-memory
-        // state already covers it. Recording it *before* the load would, on a
-        // load failure (e.g. a manifest not yet visible to this process),
-        // advance the etag while the snapshot stays behind: the next conditional
-        // probe would then see `NotModified` and never retry the load, pinning
-        // the handle to the pre-commit manifest and serving its rows as empty.
-        let current = self.inner.manifest.load_full();
-        let manifest = match ManifestSnapshot::load_with_pointer(
-            Some(current),
-            storage,
-            None,
-            pointer,
-        )
-        .await
-        {
-            Ok(manifest) => manifest,
-            // Pointer changed but our in-memory state already covers it (e.g.
-            // this process's own commit rewrote the pointer) — nothing newer to
-            // load. Record the etag so the next probe is a cheap 304.
-            Err(ManifestLoadError::AlreadyLoaded) => {
-                *self
-                    .inner
-                    .last_pointer_etag
-                    .lock()
-                    .expect("last_pointer_etag mutex poisoned") = meta.etag.clone();
-                return Ok(false);
-            }
-            // Load failed. Leave the etag unchanged so the next probe reads the
-            // pointer again and retries rather than short-circuiting to 304.
-            Err(err) => return Err(err),
-        };
-        self.inner.manifest.store(manifest);
-        self.inner.reconcile_tombstone_seqs();
-        *self
-            .inner
-            .last_pointer_etag
-            .lock()
-            .expect("last_pointer_etag mutex poisoned") = meta.etag.clone();
-        debug!(
-            manifest_id = self.inner.manifest.load().manifest_id,
-            "refreshed manifest"
-        );
-        Ok(true)
+        self.inner.refresh().await
     }
 
     /// Current manifest's id, without pinning a reader. Useful for

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -214,6 +214,13 @@ pub enum Consistency {
     /// read replicas / time-bounded scans that never want surprise
     /// pointer reads.
     ///
+    /// This governs the *read* path. Calling `gc` (directly or through
+    /// `optimize`) still re-reads the pointer and advances the handle,
+    /// because a sweep decides what to delete from the committed
+    /// manifest and would otherwise delete superfiles another process
+    /// committed after this handle opened. Readers already pinned keep
+    /// their snapshot; the next one taken sees the advance.
+    ///
     /// Do not hold a `Snapshot` handle open longer than the GC safety
     /// gap (default 24 hours). GC removes old manifests once they age
     /// past that threshold; a handle whose pinned manifest has been

--- a/tests/supertable/gc_stale_snapshot.rs
+++ b/tests/supertable/gc_stale_snapshot.rs
@@ -1,0 +1,560 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! A gc sweep must decide liveness from the committed manifest, never from whatever snapshot the
+//! calling handle happens to hold. A handle that has not refreshed deletes superfiles another
+//! handle committed after its snapshot, and since the manifest still references them the loss goes
+//! unnoticed until a later read or compaction fails with `not found`, permanently.
+//!
+//! The tests below cover the two ways a keep-set goes stale (a handle that never refreshed, and a
+//! commit landing mid-sweep), what happens when liveness cannot be resolved at all, and the request
+//! shape of a sweep, since the sweep runs per table per grace window against object storage.
+
+use std::{
+    fs::FileTimes,
+    ops::Range,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::{Duration, SystemTime},
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use infino::{
+    storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
+    supertable::{
+        Supertable,
+        manifest::commit::{MANIFEST_PARTS_DIR, POINTER_PATH, manifest_uri},
+    },
+    test_helpers::{
+        build_title_batch, default_supertable_options,
+        fault_storage::{FaultOp, FaultStorage},
+    },
+};
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+
+/// One superfile per manifest part, so every commit splits a part and a few commits build a
+/// many-part manifest without writing a large table.
+const SUPERFILES_PER_PART: u64 = 1;
+
+/// Commits in the multi-part fixture, and therefore parts.
+const MULTI_PART_COMMITS: usize = 4;
+
+/// How far [`backdate_superfiles`] moves a superfile's mtime into the past. Anything clear of a
+/// `Duration::ZERO` cutoff works; an hour leaves no doubt.
+const BACKDATE: Duration = Duration::from_secs(60 * 60);
+
+/// Repeats armed on a fault the test needs to stay broken for a whole call rather than heal on a
+/// retry.
+const FANOUT_FAULTS: usize = 64;
+
+/// Pointer reads one sweep may issue: one per liveness resolve, and it resolves twice.
+const MAX_SWEEP_POINTER_READS: usize = 2;
+
+fn commit_titles(st: &Supertable, titles: &[&str]) {
+    let mut w = st.writer().expect("writer");
+    w.append(&build_title_batch(titles)).expect("append");
+    w.commit().expect("commit");
+}
+
+/// Move every superfile's mtime `BACKDATE` into the past, so the sweep's
+/// age check treats it as an old object rather than a fresh one. LocalFs
+/// reports mtime as `ObjectMeta::last_modified`.
+fn backdate_superfiles(data_dir: &std::path::Path) {
+    let stamp = SystemTime::now() - BACKDATE;
+    let times = FileTimes::new().set_accessed(stamp).set_modified(stamp);
+    let Ok(entries) = std::fs::read_dir(data_dir) else {
+        return;
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        if !entry.file_name().to_string_lossy().ends_with(".sf.parquet") {
+            continue;
+        }
+        let file = std::fs::File::options()
+            .write(true)
+            .open(entry.path())
+            .expect("open superfile to backdate");
+        file.set_times(times).expect("backdate superfile mtime");
+    }
+}
+
+/// Every `*.sf.parquet` under the table's data directory.
+fn superfiles(dir: &std::path::Path) -> Vec<String> {
+    let data_dir = dir.join("data");
+    let Ok(entries) = std::fs::read_dir(&data_dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".sf.parquet"))
+        .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn deferred_gc_from_an_earlier_handle_deletes_a_later_handles_superfile() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let options = || default_supertable_options().with_storage(Arc::clone(&storage));
+
+    // Pass one: open, commit, done. Its manifest swap is what arms the deferred
+    // reclaim, which captures this handle and keeps it alive past the pass.
+    let pass_one = Supertable::create(options()).expect("create");
+    commit_titles(&pass_one, &["alphatoken marker"]);
+    assert_eq!(
+        superfiles(dir.path()).len(),
+        1,
+        "one superfile after the first pass"
+    );
+
+    // Pass two: a fresh handle, as a process that reconnects per pass gets. It
+    // commits a superfile that pass one's captured view will never see. Pass one
+    // is no longer writing — only its armed reclaim outlives it.
+    let pass_two = Supertable::open(options()).expect("open");
+    commit_titles(&pass_two, &["betatoken marker"]);
+    let live = superfiles(dir.path());
+    assert_eq!(live.len(), 2, "two superfiles after the second pass");
+
+    // Pass one's deferred sweep fires. `Duration::ZERO` stands in for the
+    // wall-clock wait: after the real grace the newer superfile is older than
+    // the cutoff and equally eligible.
+    let report = pass_one.gc(Duration::ZERO).expect("gc");
+
+    let surviving = superfiles(dir.path());
+    assert_eq!(
+        surviving, live,
+        "the earlier handle's sweep deleted a superfile the current manifest \
+         still references; deleted {} object(s), kept {} as live",
+        report.objects_deleted, report.objects_skipped_live,
+    );
+}
+
+// Four commits at one superfile per part, a fifth from a second handle, and an orphan planted
+// under `data/`.
+//  - the sweep lists `data/` only when the manifest's superfile membership is fully resident.
+//  - a partial part view drops the prefix silently: nothing fails, reclaim just stops.
+//  - so the orphan disappearing is what shows the refreshed view was complete.
+// This pins the many-part shape, which the unit fixtures never reach.
+#[test]
+fn a_refreshed_multi_part_manifest_still_reclaims_under_the_data_prefix() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let options = || {
+        default_supertable_options()
+            .with_storage(Arc::clone(&storage))
+            .with_target_superfiles_per_part(SUPERFILES_PER_PART)
+    };
+
+    let first = Supertable::create(options()).expect("create");
+    for i in 0..MULTI_PART_COMMITS {
+        commit_titles(&first, &[&format!("parttoken marker {i}")]);
+    }
+    let live = superfiles(dir.path());
+    assert_eq!(live.len(), MULTI_PART_COMMITS, "one superfile per commit");
+
+    // A second handle commits, so the sweeper has to load the newest manifest rather than reuse
+    // its own view: it inherits the parts it already holds and fetches the rest.
+    let second = Supertable::open(options()).expect("open");
+    commit_titles(&second, &["parttoken marker last"]);
+
+    let orphan = dir.path().join("data").join("seg-orphan.sf.parquet");
+    std::fs::write(&orphan, b"not a superfile").expect("plant orphan");
+
+    let report = first.gc(Duration::ZERO).expect("gc");
+
+    assert!(
+        !orphan.exists(),
+        "the data prefix was not swept, so the manifest's part view was \
+         incomplete after the refresh: {report:?}"
+    );
+    let surviving = superfiles(dir.path());
+    assert_eq!(
+        surviving.len(),
+        MULTI_PART_COMMITS + 1,
+        "every referenced superfile across every part survives: {report:?}"
+    );
+}
+
+/// Runs a caller-supplied commit from inside a listing call, putting it in the window between the
+/// sweep's listing and its deletes without any timing assumption. The commit runs on a plain
+/// thread, which has no ambient runtime, so the sync commit path builds its own.
+struct CommitDuringList {
+    inner: Arc<dyn StorageProvider>,
+    /// Fires on the first listing after [`Self::arm`]; later listings pass straight through.
+    commit: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+    /// Opening a table and committing both list prefixes too, so an always-live hook would fire
+    /// before the sweep and leave the commit inside the keep-set, testing nothing.
+    armed: AtomicBool,
+    lists: AtomicUsize,
+}
+
+// `StorageProvider: Debug`, and a boxed closure isn't. The wrapper's identity
+// is its inner provider.
+impl std::fmt::Debug for CommitDuringList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommitDuringList")
+            .field("inner", &self.inner)
+            .field("lists", &self.lists)
+            .finish()
+    }
+}
+
+impl CommitDuringList {
+    fn wrap(inner: Arc<dyn StorageProvider>, commit: Box<dyn FnOnce() + Send>) -> Arc<Self> {
+        Arc::new(Self {
+            inner,
+            commit: Mutex::new(Some(commit)),
+            armed: AtomicBool::new(false),
+            lists: AtomicUsize::new(0),
+        })
+    }
+
+    fn arm(&self) {
+        self.armed.store(true, Ordering::Relaxed);
+        self.lists.store(0, Ordering::Relaxed);
+    }
+}
+
+#[async_trait]
+impl StorageProvider for CommitDuringList {
+    async fn head(&self, uri: &str) -> Result<ObjectMeta, StorageError> {
+        self.inner.head(uri).await
+    }
+
+    async fn get(&self, uri: &str) -> Result<(Bytes, ObjectMeta), StorageError> {
+        self.inner.get(uri).await
+    }
+
+    async fn get_if_none_match(
+        &self,
+        uri: &str,
+        etag: &str,
+    ) -> Result<Option<(Bytes, ObjectMeta)>, StorageError> {
+        self.inner.get_if_none_match(uri, etag).await
+    }
+
+    async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
+        self.inner.get_range(uri, range).await
+    }
+
+    async fn put_atomic(&self, uri: &str, bytes: Bytes) -> Result<Option<String>, StorageError> {
+        self.inner.put_atomic(uri, bytes).await
+    }
+
+    async fn put_if_match(
+        &self,
+        uri: &str,
+        bytes: Bytes,
+        expected_etag: Option<&str>,
+    ) -> Result<Option<String>, StorageError> {
+        self.inner.put_if_match(uri, bytes, expected_etag).await
+    }
+
+    async fn put_multipart(
+        &self,
+        uri: &str,
+    ) -> Result<Box<dyn object_store::MultipartUpload>, StorageError> {
+        self.inner.put_multipart(uri).await
+    }
+
+    async fn delete(&self, uri: &str) -> Result<(), StorageError> {
+        self.inner.delete(uri).await
+    }
+
+    async fn list_with_prefix_metadata(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<(String, ObjectMeta)>, StorageError> {
+        let entries = self.inner.list_with_prefix_metadata(prefix).await?;
+        self.lists.fetch_add(1, Ordering::Relaxed);
+        if !self.armed.load(Ordering::Relaxed) {
+            return Ok(entries);
+        }
+        let pending = self
+            .commit
+            .lock()
+            .expect("commit slot mutex poisoned")
+            .take();
+        if let Some(commit) = pending {
+            let (tx, rx) = oneshot::channel();
+            std::thread::spawn(move || {
+                commit();
+                let _ = tx.send(());
+            });
+            rx.await.expect("mid-sweep commit thread");
+        }
+        Ok(entries)
+    }
+}
+
+// A second handle commits while the sweep sits between its listing and its deletes.
+//  - the keep-set was built before that commit, so the new superfile is a delete candidate.
+//  - the hook backdates it past the cutoff, or the too-new guard would keep it and the test would
+//    pass with or without the re-resolve.
+//  - only the re-resolve before deleting can put it back.
+// A sweeping handle and a writing handle over one table is a maintenance pass beside an ingest one.
+#[test]
+fn a_commit_landing_between_the_listing_and_the_deletes_loses_nothing() {
+    let dir = TempDir::new().expect("tempdir");
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+
+    let sweeper_storage = Arc::clone(&local);
+    let writer = Arc::new(
+        Supertable::create(default_supertable_options().with_storage(Arc::clone(&local)))
+            .expect("create"),
+    );
+    commit_titles(&writer, &["alphatoken marker"]);
+
+    let interleaved = Arc::clone(&writer);
+    let data_dir = dir.path().join("data");
+    let hooked = CommitDuringList::wrap(
+        sweeper_storage,
+        Box::new(move || {
+            commit_titles(&interleaved, &["betatoken marker"]);
+            backdate_superfiles(&data_dir);
+        }),
+    );
+    let sweeper = Supertable::open(
+        default_supertable_options().with_storage(Arc::<CommitDuringList>::clone(&hooked)),
+    )
+    .expect("open");
+
+    hooked.arm();
+    let report = sweeper.gc(Duration::ZERO).expect("gc");
+    assert!(
+        hooked.lists.load(Ordering::Relaxed) > 0,
+        "the sweep must have listed at least one prefix"
+    );
+    assert!(
+        hooked
+            .commit
+            .lock()
+            .expect("commit slot mutex poisoned")
+            .is_none(),
+        "the interleaved commit must have fired inside the sweep"
+    );
+
+    assert_eq!(
+        superfiles(dir.path()).len(),
+        2,
+        "a superfile committed mid-sweep was deleted: {report:?}"
+    );
+    let reader = writer.reader().expect("reader");
+    assert_eq!(
+        reader.n_superfiles(),
+        2,
+        "the manifest still references both superfiles: {report:?}"
+    );
+}
+
+// Two commits leave the first manifest list unreferenced, then the pointer read is faulted.
+//  - the superseded list is a genuine orphan, so it witnesses whether the aborted sweep deleted
+//    anything at all.
+//  - a keep-set that cannot be verified must stop the sweep, not fall back to the cached snapshot.
+//  - clearing the fault must let the next sweep reclaim, so the refusal cannot latch.
+// This is a deliberate change: a transient pointer read used to be invisible to a sweep that never
+// read the pointer, and now fails it, which `optimize()` surfaces as `OptimizeError::Gc`. A failed
+// maintenance pass is recoverable; a deleted live superfile is not.
+#[test]
+fn a_failed_pointer_read_aborts_the_sweep_without_deleting_anything() {
+    let dir = TempDir::new().expect("tempdir");
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let faults = FaultStorage::wrap(local);
+    let st = Supertable::create(
+        default_supertable_options().with_storage(Arc::<FaultStorage>::clone(&faults)),
+    )
+    .expect("create");
+
+    commit_titles(&st, &["alphatoken marker"]);
+    commit_titles(&st, &["betatoken marker"]);
+    let orphan = dir.path().join(manifest_uri(1));
+    assert!(orphan.exists(), "the superseded manifest list is on disk");
+
+    faults.fail(FaultOp::Get, POINTER_PATH, FANOUT_FAULTS);
+    st.gc(Duration::ZERO)
+        .expect_err("an unresolvable keep-set must fail the sweep");
+    assert!(
+        faults.fired() > 0,
+        "the sweep never read the pointer, so this proves nothing about \
+         resolving liveness"
+    );
+    assert!(
+        orphan.exists(),
+        "the aborted sweep deleted an object anyway"
+    );
+    assert_eq!(
+        superfiles(dir.path()).len(),
+        2,
+        "the aborted sweep deleted a superfile"
+    );
+
+    // The failure is transient, not latching: the next sweep reclaims normally.
+    faults.clear();
+    st.gc(Duration::ZERO).expect("gc once the fault clears");
+    assert!(!orphan.exists(), "the healthy sweep reclaims the orphan");
+    assert_eq!(
+        superfiles(dir.path()).len(),
+        2,
+        "both referenced superfiles survive the healthy sweep"
+    );
+}
+
+// A deleted pointer means the table was dropped and purged, so the sweep has no keep-set to work
+// from and must abort. Reclaiming what the purge left behind belongs to the purge, which knows the
+// whole subtree.
+#[test]
+fn a_vanished_pointer_aborts_the_sweep() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st =
+        Supertable::create(default_supertable_options().with_storage(storage)).expect("create");
+    commit_titles(&st, &["alphatoken marker"]);
+
+    std::fs::remove_file(dir.path().join(POINTER_PATH)).expect("purge the pointer");
+
+    st.gc(Duration::ZERO)
+        .expect_err("a purged table's sweep must abort, not sweep a stale view");
+    assert_eq!(
+        superfiles(dir.path()).len(),
+        1,
+        "the aborted sweep deleted a superfile"
+    );
+}
+
+/// Counts reads by URI fragment, so a sweep's request shape can be asserted rather than assumed.
+#[derive(Debug)]
+struct CountingProxy {
+    inner: Arc<dyn StorageProvider>,
+    pointer_reads: AtomicUsize,
+    part_reads: AtomicUsize,
+}
+
+impl CountingProxy {
+    fn wrap(inner: Arc<dyn StorageProvider>) -> Arc<Self> {
+        Arc::new(Self {
+            inner,
+            pointer_reads: AtomicUsize::new(0),
+            part_reads: AtomicUsize::new(0),
+        })
+    }
+
+    fn note(&self, uri: &str) {
+        if uri.contains(POINTER_PATH) {
+            self.pointer_reads.fetch_add(1, Ordering::Relaxed);
+        }
+        if uri.contains(MANIFEST_PARTS_DIR) {
+            self.part_reads.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn reset(&self) {
+        self.pointer_reads.store(0, Ordering::Relaxed);
+        self.part_reads.store(0, Ordering::Relaxed);
+    }
+}
+
+#[async_trait]
+impl StorageProvider for CountingProxy {
+    async fn head(&self, uri: &str) -> Result<ObjectMeta, StorageError> {
+        self.inner.head(uri).await
+    }
+
+    async fn get(&self, uri: &str) -> Result<(Bytes, ObjectMeta), StorageError> {
+        self.note(uri);
+        self.inner.get(uri).await
+    }
+
+    async fn get_if_none_match(
+        &self,
+        uri: &str,
+        etag: &str,
+    ) -> Result<Option<(Bytes, ObjectMeta)>, StorageError> {
+        self.note(uri);
+        self.inner.get_if_none_match(uri, etag).await
+    }
+
+    async fn get_range(&self, uri: &str, range: Range<u64>) -> Result<Bytes, StorageError> {
+        self.note(uri);
+        self.inner.get_range(uri, range).await
+    }
+
+    async fn put_atomic(&self, uri: &str, bytes: Bytes) -> Result<Option<String>, StorageError> {
+        self.inner.put_atomic(uri, bytes).await
+    }
+
+    async fn put_if_match(
+        &self,
+        uri: &str,
+        bytes: Bytes,
+        expected_etag: Option<&str>,
+    ) -> Result<Option<String>, StorageError> {
+        self.inner.put_if_match(uri, bytes, expected_etag).await
+    }
+
+    async fn put_multipart(
+        &self,
+        uri: &str,
+    ) -> Result<Box<dyn object_store::MultipartUpload>, StorageError> {
+        self.inner.put_multipart(uri).await
+    }
+
+    async fn delete(&self, uri: &str) -> Result<(), StorageError> {
+        self.inner.delete(uri).await
+    }
+
+    async fn list_with_prefix_metadata(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<(String, ObjectMeta)>, StorageError> {
+        self.inner.list_with_prefix_metadata(prefix).await
+    }
+}
+
+// A many-part table swept through a counting provider, with the pointer unchanged throughout.
+//  - refreshing is only affordable because it starts from the handle's snapshot and inherits
+//    already-loaded parts, so re-fetching the part fan is the regression to catch.
+//  - a sweep runs once per table per grace window, so an amplifier here is invisible to any query
+//    bench.
+//  - the probe count is bounded on both sides: reading no pointer at all would satisfy an upper
+//    bound while being the exact bug this all exists to prevent.
+#[test]
+fn a_sweep_on_an_unchanged_pointer_reads_the_pointer_and_no_parts() {
+    let dir = TempDir::new().expect("tempdir");
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let counting = CountingProxy::wrap(local);
+    let st = Supertable::create(
+        default_supertable_options()
+            .with_storage(Arc::<CountingProxy>::clone(&counting))
+            .with_target_superfiles_per_part(SUPERFILES_PER_PART),
+    )
+    .expect("create");
+    for i in 0..MULTI_PART_COMMITS {
+        commit_titles(&st, &[&format!("parttoken marker {i}")]);
+    }
+
+    // Count only the sweep, not the table setup that precedes it.
+    counting.reset();
+    let report = st.gc(Duration::ZERO).expect("gc");
+
+    assert_eq!(
+        counting.part_reads.load(Ordering::Relaxed),
+        0,
+        "the sweep re-fetched manifest parts instead of inheriting them: {report:?}"
+    );
+    let probes = counting.pointer_reads.load(Ordering::Relaxed);
+    assert!(
+        (1..=MAX_SWEEP_POINTER_READS).contains(&probes),
+        "expected one pointer read per liveness resolve, got {probes}",
+    );
+}

--- a/tests/supertable/main.rs
+++ b/tests/supertable/main.rs
@@ -13,6 +13,9 @@
 //!   pruning end-to-end, brute-force BM25 oracle for
 //!   multi-superfile search.
 //! - **manifest/**: the eager-vs-lazy-open threshold path.
+//! - **compact_gc / gc_stale_snapshot**: reclaiming orphaned
+//!   objects, and the keep-set freshness that decides which
+//!   objects those are.
 //! - **disk_cache/**: the cold-fetch coordinator + hybrid /
 //!   sweep policies + supertable-disk-cache integration.
 //! - **storage/**: the supertable-driven S3 smoke run.
@@ -23,11 +26,14 @@
 //! audit (`license_audit.rs`) stay at the top level of
 //! `tests/` because they need their own binary.
 
+#![deny(clippy::unwrap_used)]
+
 mod bioasq_admit_diag;
 mod commit;
 mod compact_gc;
 mod disk_cache;
 mod drain_tombstones;
+mod gc_stale_snapshot;
 mod manifest;
 mod query;
 mod storage;


### PR DESCRIPTION
### What does this PR do?
Closes #549. Stops a gc sweep from deleting superfiles the committed manifest still references. The sweep now decides what is garbage from the pointer instead of from whatever snapshot the calling handle happened to hold.

### Why do we need this change?
`gc_storage_sweep_for_inner` built its "keep-set (of superfiles)" from `inner.manifest.load_full()` and never re-read the pointer, so a superfile committed after that snapshot read as an orphan and got deleted while the manifest still pointed at it. Nothing fails at delete time; it surfaces later as `not found: data/seg-….sf.parquet` on every read or compaction of that segment, permanently.

### How do we do this change?
- The sweep re-reads the manifest pointer before building its keep-set, so it decides against the committed manifest rather than the calling handle's snapshot.
- The pointer is read once more immediately before deleting, and anything either version references is kept, so a commit landing between the listing and the deletes cannot lose data.
- That second read only rebuilds the keep-set when the manifest actually moved, to avoid re-fetching and re-hashing the slow-CAS state blob.

### Testing
-  Added tests in `tests/supertable/gc_stale_snapshot.rs` for various situations. No regression.

### Performance
- An unchanged pointer costs one conditional GET per resolve and zero part reads, since the refresh inherits loaded parts by content hash. The second resolve runs only when candidates survived the listing.

### Notes
- The in-flight window stays open: an object written more than a grace period before the commit publishing it is in no keep-set the sweep builds. Closing it needs a liveness signal rather than a longer timer (superseded URIs recorded at commit, or a lease per in-flight commit), which changes commit semantics, a possible future work.