### PR TITLE
vector: add Sq16Adaptive rerank codec (16-bit fitted ruler), default for L2/NegDot

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,6 +50,9 @@ jobs:
           - { bench: superfile,         docs: "1000000", suffix: sf }
           - { bench: supertable_fts,    docs: "1000000", suffix: st-fts }
           - { bench: supertable_vector, docs: "1000000", suffix: st-vec }
+          # Non-cosine (L2) leg: exercises the Sq16Adaptive default codec
+          # (the cosine leg above stays on the fixed-grid Sq16).
+          - { bench: supertable_vector, docs: "1000000", suffix: st-vec-l2, metric: l2sq }
           - { bench: supertable_sql,    docs: "1000000", suffix: st-sql }
     # A new push to the PR cancels the in-flight run for that bench.
     concurrency:
@@ -63,6 +66,7 @@ jobs:
     with:
       bench: ${{ matrix.bench }}
       docs: ${{ matrix.docs }}
+      metric: ${{ matrix.metric }}
       ref: ${{ github.event.pull_request.head.sha }}
       name_suffix: -${{ matrix.suffix }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -98,6 +98,10 @@ on:
     inputs:
       bench:           { type: string, required: false, default: supertable_all }
       docs:            { type: string, required: false, default: "1000000" }
+      # Vector metric: ""/cosine → the cosine Sq16 path; l2sq|negdot → the
+      # unbounded metrics whose default codec is Sq16Adaptive. Passed to the
+      # bench as INFINO_BENCH_METRIC. (Empty on legs that don't set it → cosine.)
+      metric:          { type: string, required: false, default: "" }
       vm_size:         { type: string, required: false, default: "Standard_D8s_v7" }
       location:        { type: string, required: false, default: eastus }
       ref:             { type: string, required: false, default: main }
@@ -411,6 +415,7 @@ jobs:
              INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
              INFINO_BENCH_SUPERFILE_DOCS='${{ inputs.docs }}' \
              INFINO_BENCH_SUPERTABLE_DOCS='${{ inputs.docs }}' \
+             INFINO_BENCH_METRIC='${{ inputs.metric }}' \
              BENCH_ARGS='${{ steps.resolve.outputs.args }}' \
              CPUSET='${{ inputs.bench_cpuset }}' \
              SKIP_CALIBRATION='${{ inputs.skip_calibration }}' \
@@ -449,6 +454,7 @@ jobs:
              INFINO_REAL_AZURE_CONTAINER='${{ secrets.INFINO_REAL_AZURE_CONTAINER }}' \
              INFINO_BENCH_SUPERFILE_DOCS='${{ inputs.docs }}' \
              INFINO_BENCH_SUPERTABLE_DOCS='${{ inputs.docs }}' \
+             INFINO_BENCH_METRIC='${{ inputs.metric }}' \
              BENCH_ARGS='${{ steps.resolve.outputs.args }}' \
              CPUSET='${{ inputs.bench_cpuset }}' \
              KEEP='${{ inputs.keep_table }}' \

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -92,19 +92,23 @@ pub fn block_on_inmem<F: std::future::Future>(fut: F) -> F::Output {
 // ─── Scale constants ──────────────────────────────────────────────────
 
 /// Codec benches build vector columns with. Mirrors the engine default
-/// (`VectorConfig::new`): the fixed cosine grid for cosine, locally fitted
-/// residuals for unbounded metrics. Codec choice is engine configuration
+/// (`default_rerank_codec_for`): the fixed cosine grid (`Sq16`) for cosine, and
+/// the per-cluster-fitted 16-bit `Sq16Adaptive` for the unbounded metrics
+/// (L2Sq / NegDot). Codec choice is engine configuration
 /// (`vector.rerank_codec` in YAML), not a bench env knob.
 pub fn bench_rerank_codec(metric: Metric) -> RerankCodec {
-    // Diagnostic (env-gated): force an EXACT fp32 rerank column to isolate Sq8
-    // codec loss from routing/coverage. INFINO_BENCH_RERANK_CODEC=fp32 → if the
-    // recall ceiling jumps to ~1.0, the residual gap was the Sq8 quantization.
+    // Diagnostic (env-gated): force a codec to isolate its recall/latency from
+    // routing/coverage, or to A/B the new default against the prior one.
+    // INFINO_BENCH_RERANK_CODEC=fp32 → if the recall ceiling jumps to ~1.0, the
+    // gap was quantization; =sq8_residual → A/B the pre-Sq16Adaptive default.
     let codec = match std::env::var("INFINO_BENCH_RERANK_CODEC").ok().as_deref() {
         Some("fp32") => RerankCodec::Fp32,
         Some("sq16") => RerankCodec::Sq16,
+        Some("sq16_adaptive") => RerankCodec::Sq16Adaptive,
+        Some("sq8_residual") => RerankCodec::Sq8Residual,
         Some("sq8_fixed_residual") => RerankCodec::Sq8FixedResidual,
         _ if metric == Metric::Cosine => RerankCodec::default(),
-        _ => RerankCodec::Sq8Residual,
+        _ => RerankCodec::Sq16Adaptive,
     };
     assert!(
         codec.supports_metric(metric),

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -107,8 +107,17 @@ const ROT_SEED: u64 = 7;
 /// Bytes in one gibibyte, for GiB-denominated memory and report values.
 const GIB_BYTES: u64 = 1u64 << 30;
 
-/// Distance metric for the bench vector index.
-const BENCH_METRIC: Metric = Metric::Cosine;
+/// Distance metric for the bench vector index. Defaults to cosine (the
+/// historical baseline, so existing bench deltas are unchanged);
+/// `INFINO_BENCH_METRIC=l2sq|negdot` selects an unbounded metric so CI can
+/// exercise the `Sq16Adaptive` default rather than only the cosine `Sq16` path.
+fn bench_metric() -> Metric {
+    match std::env::var("INFINO_BENCH_METRIC").ok().as_deref() {
+        Some("l2sq") | Some("l2") => Metric::L2Sq,
+        Some("negdot") | Some("dot") => Metric::NegDot,
+        _ => Metric::Cosine,
+    }
+}
 /// Writer auto-flush threshold (MiB) per superfile roll.
 const COMMIT_THRESHOLD_SIZE_MB: u64 = 1024;
 /// Table-doc-count boundary for the bench's pinned CELL-GRID shape:
@@ -317,8 +326,8 @@ pub fn options_for(
             column: VEC_COLUMN.into(),
             dim: DIM,
             rot_seed: ROT_SEED,
-            metric: BENCH_METRIC,
-            rerank_codec: corpus::bench_rerank_codec(BENCH_METRIC),
+            metric: bench_metric(),
+            rerank_codec: corpus::bench_rerank_codec(bench_metric()),
         }]
     } else {
         vec![]
@@ -350,8 +359,10 @@ pub fn current_knobs(modality: Modality) -> crate::dataset::Knobs {
         vec_seed: CORPUS_VEC_SEED,
         text_seed: CORPUS_TEXT_SEED,
         rot_seed: ROT_SEED,
-        metric: format!("{BENCH_METRIC:?}"),
-        rerank_codec: corpus::bench_rerank_codec(BENCH_METRIC).name().to_string(),
+        metric: format!("{:?}", bench_metric()),
+        rerank_codec: corpus::bench_rerank_codec(bench_metric())
+            .name()
+            .to_string(),
         modality: format!("{modality:?}"),
     }
 }

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -36,8 +36,8 @@ use crate::superfile::{
     vector::{
         cell_posting::{MaterializedIvfRow, sq8_residual_norm_sq},
         distance::{
-            Metric, distance, encode_sq16_row, mean_f32_cluster_major, normalize,
-            sq16_decoded_norm_sq,
+            Metric, distance, encode_sq16_adaptive_row, encode_sq16_row, mean_f32_cluster_major,
+            normalize, sq16_adaptive_norm_sq, sq16_decoded_norm_sq,
         },
         ivf_merge::MergedIvfSubsection,
         kmeans::{assign_to_centroids, kmeans, kmeans_with_assignments},
@@ -157,11 +157,6 @@ const N_CENT_MEDIUM: usize = 1024;
 /// Maximum IVF centroids for small physical vector indexes.
 const N_CENT_SMALL: usize = 64;
 
-/// Maximum Sq8 code value: each component quantizes to one unsigned
-/// byte, so the per-dim scale maps a cluster's value span onto
-/// `[0, SQ8_CODE_MAX]`.
-const SQ8_CODE_MAX: f32 = 255.0;
-
 fn n_cent_row_count_cap(n_docs: usize) -> usize {
     if n_docs >= N_CENT_LARGE_DOC_THRESHOLD {
         N_CENT_LARGE
@@ -209,24 +204,25 @@ pub struct VectorConfig {
 /// Pick the default rerank codec for a new index built with `metric`.
 /// Cosine columns use the configured
 /// [`crate::config::VectorSettings::rerank_codec`] (`Sq16` by default);
-/// metrics whose values are not bounded to `[-1, 1]` use locally fitted
-/// [`RerankCodec::Sq8Residual`]. A per-column codec set at table-create
-/// time overrides this default.
+/// metrics whose values are not bounded to `[-1, 1]` use the 16-bit,
+/// per-cluster-fitted [`RerankCodec::Sq16Adaptive`] — the same 2 bytes/dim as
+/// the older `Sq8Residual` but a single `u16` plane with no residual leg. A
+/// per-column codec set at table-create time overrides this default; existing
+/// `Sq8Residual` tables keep their stored codec on reopen.
 fn default_rerank_codec_for(metric: Metric) -> RerankCodec {
     if metric == Metric::Cosine {
         RerankCodec::default()
     } else {
-        RerankCodec::Sq8Residual
+        RerankCodec::Sq16Adaptive
     }
 }
 
 impl VectorConfig {
     /// Construct a config with the engine's cosine default codec
-    /// ([`RerankCodec::default`] — `Sq16`) and locally fitted residual
-    /// encoding ([`RerankCodec::Sq8Residual`]) for metrics whose values
-    /// are not bounded to [-1, 1]. The codec is internal — not a config
-    /// knob, not part of the public spec; tests override per column with
-    /// [`Self::with_rerank_codec`].
+    /// ([`RerankCodec::default`] — `Sq16`) and the 16-bit, per-cluster-fitted
+    /// [`RerankCodec::Sq16Adaptive`] for metrics whose values are not bounded to
+    /// [-1, 1]. The codec is internal — not a config knob, not part of the
+    /// public spec; tests override per column with [`Self::with_rerank_codec`].
     pub fn new(column: String, dim: usize, rot_seed: u64, metric: Metric) -> Self {
         Self {
             column,
@@ -1584,9 +1580,12 @@ fn bucket_encoded_rows_chunk(
     let dim = cfg.dim;
     let code_bytes = dim.div_ceil(u8::BITS as usize);
     let fixed = cfg.rerank_codec.uses_fixed_quantizer();
-    // Single-plane fixed codecs (Sq16) store the whole `dim*2`-byte body in
-    // `codes`; the residual family splits it into `codes` + `residuals`.
-    let single_plane = cfg.rerank_codec.is_sq16();
+    // Only the fixed-grid single-plane codec (Sq16) can byte-copy its whole
+    // `dim*2`-byte body from `codes`; the fitted single-plane codec
+    // (Sq16Adaptive) must round-trip through fp32 below so re-bucketing re-fits
+    // its ruler, and the residual family splits the body into `codes` +
+    // `residuals`.
+    let fixed_single_plane = cfg.rerank_codec.is_sq16();
     let ops = cfg
         .rerank_codec
         .ops()
@@ -1615,7 +1614,7 @@ fn bucket_encoded_rows_chunk(
     let mut assignments = vec![0u32; rows.len()];
     assign_to_centroids(&decoded, centroids, dim, n_cent, &mut assignments);
     for (row_idx, (row, &cluster)) in rows.iter().zip(&assignments).enumerate() {
-        let payload = if single_plane {
+        let payload = if fixed_single_plane {
             BucketRecordPayload::FixedPlane(&row.encoded.codes)
         } else if fixed {
             BucketRecordPayload::FixedSq8 {
@@ -1734,17 +1733,19 @@ fn stream_fp32_rows_to_buckets(
     let dim = cfg.dim;
     let n_docs = vectors.len() / dim;
     let fixed = cfg.rerank_codec.uses_fixed_quantizer();
-    // Single-plane fixed codecs (Sq16) encode one `dim*2`-byte `u16` plane on
-    // the fixed grid; the residual family encodes a `[codes | residual]` body
-    // against the same grid and carries a divisor.
-    let single_plane = cfg.rerank_codec.is_sq16();
+    // The fixed-grid single-plane codec (Sq16) encodes one `dim*2`-byte `u16`
+    // plane on the fixed grid; the residual family encodes a `[codes | residual]`
+    // body against the same grid and carries a divisor. The fitted single-plane
+    // codec (Sq16Adaptive) is neither fixed nor residual here — it is buffered as
+    // fp32 and encoded against its cluster ruler downstream.
+    let fixed_single_plane = cfg.rerank_codec.is_sq16();
     let mut min_max = sq8_min_max;
     let rotation = RandomRotation::new(dim, cfg.rot_seed);
     let quant = BitQuantizer::new(dim);
     let code_bytes = quant.code_bytes();
     let (fixed_scale, fixed_offset) = fixed_sq8_quantizer(dim);
     // Residual-family encode consts + divisor; unused by the single-plane path.
-    let residual_encode = (fixed && !single_plane).then(|| {
+    let residual_encode = (fixed && !fixed_single_plane).then(|| {
         (
             Sq8EncodeConsts::from_scale_offset(&fixed_scale, &fixed_offset),
             cfg.rerank_codec
@@ -1795,14 +1796,14 @@ fn stream_fp32_rows_to_buckets(
                         );
                     },
                 );
-        } else if single_plane {
+        } else if fixed_single_plane {
             chunk_payload[..take * dim * 2]
                 .par_chunks_mut(dim * 2)
                 .zip(chunk.par_chunks(dim))
                 .for_each(|(payload, row)| encode_sq16_row(row, payload));
         }
         for i in 0..take {
-            let payload = if single_plane {
+            let payload = if fixed_single_plane {
                 BucketRecordPayload::FixedPlane(&chunk_payload[i * dim * 2..(i + 1) * dim * 2])
             } else if fixed {
                 let (codes, residuals) =
@@ -1848,10 +1849,17 @@ fn stream_bucket_into_subsection(
     norms_offset: Option<usize>,
 ) -> Result<(), BuildError> {
     let fixed = codec.uses_fixed_quantizer();
-    // Single-plane fixed codecs (Sq16) store one `dim*2`-byte `u16` plane whose
-    // norm is read off the fixed grid; the residual family reconstructs the
-    // norm from the per-cluster quantizer + residual.
-    let single_plane = codec.is_sq16();
+    let single_u16 = codec.writes_single_u16_plane();
+    // The two single-plane cases split on the body-shape × ruler axes:
+    //   fixed_single_plane  (Sq16): the bucket record holds pre-encoded
+    //     fixed-grid `u16` codes, copied verbatim; norm read off the fixed grid.
+    //   fitted_single_plane (Sq16Adaptive): the bucket record holds raw fp32,
+    //     re-encoded against this cluster's fitted ruler; no residual leg, no
+    //     divisor.
+    // The residual family reconstructs the norm from the per-cluster quantizer
+    // + residual.
+    let fixed_single_plane = single_u16 && fixed;
+    let fitted_single_plane = single_u16 && !fixed;
     let payload_bytes = if fixed {
         dim * 2
     } else {
@@ -1861,7 +1869,10 @@ fn stream_bucket_into_subsection(
     let chunk_rows = (MATERIALIZED_BUCKET_CHUNK_BYTES / record_bytes.max(1)).max(1);
     let mut reader = BufReader::new(File::open(bucket_path)?);
     let mut rows_done = 0usize;
-    let encode_consts = (!fixed).then(|| Sq8EncodeConsts::from_scale_offset(scale, offset));
+    // Only the two-plane residual encode path reads these reciprocals; the
+    // fitted single-plane codec encodes via encode_sq16_adaptive_row instead.
+    let encode_consts =
+        (!fixed && !single_u16).then(|| Sq8EncodeConsts::from_scale_offset(scale, offset));
     let mut recon = vec![0.0f32; dim];
     let mut fp_row = vec![0.0f32; dim];
     while rows_done < block.count {
@@ -1880,9 +1891,18 @@ fn stream_bucket_into_subsection(
             codes[row_idx * code_bytes..(row_idx + 1) * code_bytes]
                 .copy_from_slice(&record[id_end..code_end]);
             let rerank_row = &mut rerank[row_idx * dim * 2..(row_idx + 1) * dim * 2];
-            let norm = if single_plane {
+            let norm = if fixed_single_plane {
                 rerank_row.copy_from_slice(&record[code_end..code_end + dim * 2]);
                 norms_offset.map(|_| sq16_decoded_norm_sq(rerank_row, dim))
+            } else if fitted_single_plane {
+                for (value, bytes) in fp_row
+                    .iter_mut()
+                    .zip(record[code_end..].chunks_exact(size_of::<f32>()))
+                {
+                    *value = f32::from_le_bytes(bytes.try_into().expect("4-byte f32 bucket value"));
+                }
+                encode_sq16_adaptive_row(&fp_row, scale, offset, rerank_row);
+                norms_offset.map(|_| sq16_adaptive_norm_sq(rerank_row, dim, scale, offset))
             } else if fixed {
                 rerank_row.copy_from_slice(&record[code_end..code_end + dim * 2]);
                 norms_offset.map(|_| {
@@ -2124,7 +2144,7 @@ pub(crate) fn build_cell_subsection_from_source(
         ));
     }
     let mut bucket_counts = vec![0u32; n_cent];
-    let fit_quantizer = matches!(cfg.rerank_codec, RerankCodec::Sq8Residual);
+    let fit_quantizer = cfg.rerank_codec.fits_per_cluster_ruler();
     let (mut sq8_min, mut sq8_max) = if fit_quantizer {
         (
             vec![f32::INFINITY; n_cent * dim],
@@ -2183,9 +2203,10 @@ pub(crate) fn build_cell_subsection_from_source(
         (0..n_cent)
             .map(|centroid| {
                 let start = centroid * dim;
-                derive_sq8_quantizer_from_min_max(
+                derive_quantizer_from_min_max(
                     &sq8_min[start..start + dim],
                     &sq8_max[start..start + dim],
+                    cfg.rerank_codec.code_max(),
                 )
             })
             .collect()
@@ -2505,10 +2526,13 @@ fn build_subsection_streaming(
             codec.name()
         )));
     }
-    // Residual-family codecs use per-cluster scale/offset codec_meta plus
-    // an i8 residual sidecar in `full[]`.
-    let sq8_family = codec.is_sq8_residual_family();
-    let fit_sq8_quantizer = matches!(codec, RerankCodec::Sq8Residual);
+    // Codecs that carry per-cluster scale/offset in codec_meta (the residual
+    // family and `Sq16Adaptive`). Named `sq8_family` historically; it now gates
+    // the codec_meta scale/offset+norm layout, which `Sq16Adaptive` shares.
+    let sq8_family = codec.carries_cluster_quant_meta();
+    // Codecs that FIT the per-cluster ruler from the data (Sq8Residual +
+    // Sq16Adaptive); the fixed-grid residual codec seeds a fixed quantizer below.
+    let fit_sq8_quantizer = codec.fits_per_cluster_ruler();
     let (mut sq8_min_arr, mut sq8_max_arr): (Vec<f32>, Vec<f32>) = if fit_sq8_quantizer {
         (
             vec![f32::INFINITY; n_cent * dim],
@@ -2565,9 +2589,10 @@ fn build_subsection_streaming(
         (0..n_cent)
             .map(|c| {
                 let off = c * dim;
-                derive_sq8_quantizer_from_min_max(
+                derive_quantizer_from_min_max(
                     &sq8_min_arr[off..off + dim],
                     &sq8_max_arr[off..off + dim],
+                    codec.code_max(),
                 )
             })
             .collect()
@@ -2780,6 +2805,37 @@ fn build_subsection_streaming(
                         }
                     }
                 }
+                RerankCodec::Sq16Adaptive => {
+                    // Single `u16` plane like `Sq16`, but quantized against this
+                    // cluster's fitted ruler (like the residual family) instead
+                    // of the fixed grid. Norms use the residual-family position
+                    // convention (`sq8_norms_block_off`, which sits after the
+                    // scale/offset arrays) since `Sq16Adaptive` carries those
+                    // arrays in codec_meta.
+                    let cluster_rows: &[f32] = bytemuck::cast_slice(&full_block);
+                    let (scale_c, offset_c) = &sq8_quantizers[centroid_id];
+                    for i in 0..blk.count {
+                        let src = &cluster_rows[i * dim..(i + 1) * dim];
+                        let row_off = blk.rerank_base + i * per_vec_bytes;
+                        encode_sq16_adaptive_row(
+                            src,
+                            scale_c,
+                            offset_c,
+                            &mut bytes[row_off..row_off + per_vec_bytes],
+                        );
+                        if let Some(norms_off) = sq8_norms_block_off {
+                            let n_sq = sq16_adaptive_norm_sq(
+                                &bytes[row_off..row_off + per_vec_bytes],
+                                dim,
+                                scale_c,
+                                offset_c,
+                            );
+                            let pos = blk.first_row + i;
+                            let n_off = norms_off + pos * 4;
+                            bytes[n_off..n_off + 4].copy_from_slice(&n_sq.to_le_bytes());
+                        }
+                    }
+                }
                 RerankCodec::Sq8Residual | RerankCodec::Sq8FixedResidual => {
                     let cluster_rows: &[f32] = bytemuck::cast_slice(&full_block);
                     let (scale_c, offset_c) = &sq8_quantizers[centroid_id];
@@ -2884,7 +2940,11 @@ fn encode_sq8_residual_cluster_simd(
 /// Sq8 per-cluster (min, max) → (scale, offset) derivation. Shared with the
 /// cell-posting encode path so both derive the quantizer identically.
 #[inline]
-pub(crate) fn derive_sq8_quantizer_from_min_max(min: &[f32], max: &[f32]) -> (Vec<f32>, Vec<f32>) {
+pub(crate) fn derive_quantizer_from_min_max(
+    min: &[f32],
+    max: &[f32],
+    code_max: f32,
+) -> (Vec<f32>, Vec<f32>) {
     debug_assert_eq!(min.len(), max.len());
     let dim = min.len();
     let mut scale = vec![0.0f32; dim];
@@ -2893,7 +2953,7 @@ pub(crate) fn derive_sq8_quantizer_from_min_max(min: &[f32], max: &[f32]) -> (Ve
         let span = max[d] - min[d];
         if span > 0.0 && span.is_finite() {
             offset[d] = min[d];
-            scale[d] = span / SQ8_CODE_MAX;
+            scale[d] = span / code_max;
         } else {
             offset[d] = if min[d].is_finite() { min[d] } else { 0.0 };
             scale[d] = 1.0;
@@ -3278,6 +3338,23 @@ mod tests {
     use crate::superfile::vector::{
         cell_posting::EncodedCellRow, reader::VectorReader, spill::MaterializedRowSpillWriter,
     };
+
+    /// The default rerank codec by metric: non-cosine
+    /// metrics (L2Sq / NegDot) default to the per-cluster-fitted `Sq16Adaptive`;
+    /// Cosine keeps the fixed-grid `Sq16`. A change here silently reshapes every
+    /// newly built table that doesn't override `rerank_codec`, so it's pinned.
+    #[test]
+    fn default_rerank_codec_is_sq16adaptive_for_non_cosine() {
+        assert_eq!(
+            default_rerank_codec_for(Metric::L2Sq),
+            RerankCodec::Sq16Adaptive
+        );
+        assert_eq!(
+            default_rerank_codec_for(Metric::NegDot),
+            RerankCodec::Sq16Adaptive
+        );
+        assert_eq!(default_rerank_codec_for(Metric::Cosine), RerankCodec::Sq16);
+    }
 
     /// Drive an async reader call to completion. The materialized read-back is
     /// async (the drain fetches-on-miss); these tests use in-memory readers, so

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -206,9 +206,13 @@ pub struct VectorConfig {
 /// [`crate::config::VectorSettings::rerank_codec`] (`Sq16` by default);
 /// metrics whose values are not bounded to `[-1, 1]` use the 16-bit,
 /// per-cluster-fitted [`RerankCodec::Sq16Adaptive`] — the same 2 bytes/dim as
-/// the older `Sq8Residual` but a single `u16` plane with no residual leg. A
-/// per-column codec set at table-create time overrides this default; existing
-/// `Sq8Residual` tables keep their stored codec on reopen.
+/// the older `Sq8Residual` but a single `u16` plane with no residual leg. This
+/// default only selects the codec for a **newly created** table: the codec is
+/// not persisted, so reopen re-derives it, but scoring dispatches on each
+/// superfile's own stored codec (the verifier trusts a valid stored codec over
+/// the re-derived default), so tables written before the default changed keep
+/// being served with the codec their data was written with. A per-column codec
+/// set at table-create time overrides this default.
 fn default_rerank_codec_for(metric: Metric) -> RerankCodec {
     if metric == Metric::Cosine {
         RerankCodec::default()

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -2083,7 +2083,8 @@ pub(crate) fn build_cell_subsection_from_source(
                 .any(|row| row.encoded.rerank_codec != cfg.rerank_codec)
             {
                 return Err(BuildError::VectorSchemaMismatch(
-                    "materialized IVF rebuild requires one matching residual-family codec".into(),
+                    "materialized IVF rebuild requires every row to share the table's rerank codec"
+                        .into(),
                 ));
             }
         }

--- a/src/superfile/vector/cell_posting.rs
+++ b/src/superfile/vector/cell_posting.rs
@@ -1331,4 +1331,43 @@ mod tests {
             "a covering destination grid never clamps"
         );
     }
+
+    /// Parity with the Sq8 tripwire for the new default codec: a Sq16Adaptive
+    /// merge transcode whose destination ruler is narrower than the source
+    /// saturates the out-of-range components and bumps the same process tally,
+    /// so the compaction `BUG` line fires instead of the clamp being silent.
+    /// (The clamp itself goes away once the merge union-sizes the destination
+    /// ruler; until then it must at least be observable, never silent.)
+    #[test]
+    fn sq16_adaptive_transcode_counts_saturated_components() {
+        let dim = 4;
+        // Source ruler decodes [-2.5, 2.5] across the full u16 range.
+        let src_scale: Arc<[f32]> = vec![5.0 / f32::from(u16::MAX); dim].into();
+        let src_offset: Arc<[f32]> = vec![-2.5; dim].into();
+        // Codes decode to [2.5, -2.5, 2.5, ~0.0]: three outside [-1, 1], one fits.
+        let code_vals: [u16; 4] = [u16::MAX, 0, u16::MAX, u16::MAX / 2];
+        let codes: Vec<u8> = code_vals.iter().flat_map(|c| c.to_le_bytes()).collect();
+        let row = EncodedCellRow {
+            stable_id: 0,
+            rerank_codec: RerankCodec::Sq16Adaptive,
+            scale: src_scale,
+            offset: src_offset,
+            codes,
+            residuals: Vec::new(),
+            norm_sq: None,
+        };
+        // Destination ruler covers only [-1, 1] (single u16 plane, no residual).
+        let dst_scale = vec![2.0 / f32::from(u16::MAX); dim];
+        let dst_offset = vec![-1.0f32; dim];
+        let mut out = vec![0u8; dim * 2];
+        let ops = RerankCodec::Sq16Adaptive.ops().expect("Sq16Adaptive ops");
+        let before = transcode_clamped_components();
+        ops.materialize_row_into_cluster_quant(&row, &dst_scale, &dst_offset, dim, &mut out, false)
+            .expect("transcode");
+        assert_eq!(
+            transcode_clamped_components() - before,
+            3,
+            "the three components outside the destination ruler must be counted, not silently clamped"
+        );
+    }
 }

--- a/src/superfile/vector/cell_posting.rs
+++ b/src/superfile/vector/cell_posting.rs
@@ -938,9 +938,15 @@ pub fn load_encoded_rows_from_blob(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex, PoisonError};
 
     use super::*;
+
+    /// Serializes the tests that assert an exact delta on the process-wide
+    /// [`TRANSCODE_CLAMPED_COMPONENTS`] counter. cargo runs tests in parallel,
+    /// so without this each would observe the other's increments in its
+    /// before/after window and see the wrong count.
+    static TRANSCODE_COUNTER_TEST_LOCK: Mutex<()> = Mutex::new(());
     use crate::superfile::{
         builder::VectorConfig,
         vector::{
@@ -1268,6 +1274,9 @@ mod tests {
     /// whose destination covers the source adds nothing.
     #[test]
     fn transcode_counts_components_that_saturate_the_destination_grid() {
+        let _serialize = TRANSCODE_COUNTER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         let dim = 4;
         // Source: a raw-ingest-class data-derived grid decoding [-2.5, 2.5].
         let raw_scale: Arc<[f32]> = vec![5.0 / f32::from(u8::MAX); dim].into();
@@ -1340,6 +1349,9 @@ mod tests {
     /// ruler; until then it must at least be observable, never silent.)
     #[test]
     fn sq16_adaptive_transcode_counts_saturated_components() {
+        let _serialize = TRANSCODE_COUNTER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         let dim = 4;
         // Source ruler decodes [-2.5, 2.5] across the full u16 range.
         let src_scale: Arc<[f32]> = vec![5.0 / f32::from(u16::MAX); dim].into();

--- a/src/superfile/vector/cell_posting.rs
+++ b/src/superfile/vector/cell_posting.rs
@@ -19,7 +19,7 @@ use crate::superfile::{
     builder::VectorConfig,
     format::vec::{METRIC_ID_COSINE, METRIC_ID_L2SQ, METRIC_ID_NEGDOT},
     vector::{
-        builder::derive_sq8_quantizer_from_min_max,
+        builder::derive_quantizer_from_min_max,
         distance::{Metric, Sq8ResidualKernel},
         rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
     },
@@ -576,9 +576,12 @@ fn encode_rows(
                     max[d] = max[d].max(src[d]);
                 }
             }
-            derive_sq8_quantizer_from_min_max(&min, &max)
+            derive_quantizer_from_min_max(&min, &max, SQ8_CODE_MAX)
         }
-        RerankCodec::Fp32 | RerankCodec::Sq16 | RerankCodec::RabitqOnly => {
+        RerankCodec::Fp32
+        | RerankCodec::Sq16
+        | RerankCodec::Sq16Adaptive
+        | RerankCodec::RabitqOnly => {
             return Err(format!(
                 "cell posting encode requires an Sq8 residual-family codec, got {}",
                 codec.name()
@@ -727,6 +730,15 @@ static TRANSCODE_CLAMPED_COMPONENTS: AtomicU64 = AtomicU64::new(0);
 /// Snapshot of [`TRANSCODE_CLAMPED_COMPONENTS`]; callers report deltas.
 pub(crate) fn transcode_clamped_components() -> u64 {
     TRANSCODE_CLAMPED_COMPONENTS.load(AtomicOrdering::Relaxed)
+}
+
+/// Add to the transcode-clamp tally. Used by single-plane codecs whose merge
+/// re-encode lives outside this module (the Sq8 residual transcode above bumps
+/// the counter inline); a no-op for the common zero-clamp row.
+pub(crate) fn note_transcode_clamped_components(n: u64) {
+    if n > 0 {
+        TRANSCODE_CLAMPED_COMPONENTS.fetch_add(n, AtomicOrdering::Relaxed);
+    }
 }
 
 /// True when two per-cluster Sq8 quantizers are bitwise identical.

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -758,10 +758,11 @@ pub(crate) fn distance_bytes_codec(
                  norm context)"
             )
         }
-        RerankCodec::Sq16 => {
+        RerankCodec::Sq16 | RerankCodec::Sq16Adaptive => {
             unreachable!(
-                "distance_bytes_codec called with Sq16 — Sq16 rerank goes through \
-                 Sq16Kernel (u16 → f32 dequant front on the fp32 distance path)"
+                "distance_bytes_codec called with a single-u16-plane codec — Sq16 / \
+                 Sq16Adaptive rerank goes through Sq16Kernel (u16 → f32 dequant front \
+                 on the fp32 distance path; adaptive folds the per-cluster ruler)"
             )
         }
         RerankCodec::RabitqOnly => {
@@ -1110,6 +1111,35 @@ impl Sq16Kernel {
         }
     }
 
+    /// Adaptive-ruler counterpart of [`Self::new`]: the single-`u16`-plane
+    /// kernel over a per-cluster fitted grid (`Sq16Adaptive`) instead of the
+    /// fixed `[-1, 1]` constants. The scoring body ([`Self::distance_with_norm`])
+    /// is identical — only the query fold differs, so this is the sole ruler
+    /// override. `q_prime[d] = query[d]·scale[d]` and `q_dot_offset =
+    /// Σ_d offset[d]·query[d]` (vs the fixed grid's `OFFSET·Σq`). `scale`/`offset`
+    /// are the probed cluster's stored quantizer (`scale.len() == query.len()`).
+    pub fn new_adaptive(metric: Metric, query: &[f32], scale: &[f32], offset: &[f32]) -> Self {
+        let dim = query.len();
+        debug_assert_eq!(scale.len(), dim);
+        debug_assert_eq!(offset.len(), dim);
+        let mut q_prime = vec![0.0f32; dim];
+        for d in 0..dim {
+            q_prime[d] = query[d] * scale[d];
+        }
+        let q_dot_offset = dot(query, offset);
+        let q_norm_sq = match metric {
+            Metric::L2Sq => dot(query, query),
+            Metric::Cosine | Metric::NegDot => 0.0,
+        };
+        Self {
+            metric,
+            dim,
+            q_prime,
+            q_dot_offset,
+            q_norm_sq,
+        }
+    }
+
     /// Distance for one candidate whose `full[]` row is `dim`
     /// little-endian `u16` codes (`code_bytes.len() == dim * 2`), with
     /// its stored per-doc dequantized norm `‖d̂‖²` in `norm` (absent
@@ -1222,6 +1252,96 @@ pub(crate) fn sq16_decoded_norm_sq(code_bytes: &[u8], dim: usize) -> f32 {
         let x = code * SQ16_FIXED_SCALE + SQ16_FIXED_OFFSET;
         s += x * x;
         i += 1;
+    }
+    s
+}
+
+/// Adaptive-ruler counterparts of [`encode_sq16_row`] /
+/// [`dequantize_sq16_into`] / [`sq16_decoded_norm_sq`]: identical single-`u16`
+/// -plane layout, but the grid is the cluster's fitted `scale[d]`/`offset[d]`
+/// (`x = code·scale[d] + offset[d]`) instead of the fixed `[-1, 1]` constants.
+/// Used by `Sq16Adaptive`; `scale.len() == offset.len() == dim`.
+///
+/// On the build path the ruler is fit to the cluster's own `[min,max]`, so
+/// every component lands in `0..=65535` and the clamp never trips. On merge the
+/// destination reuses the first input's ruler, so a component of a later input
+/// that falls outside that range is clamped to the grid edge here.
+///
+/// Returns the number of components that landed beyond the grid (past a
+/// half-code slack) and were clamped. Build callers ignore it; the merge
+/// transcode feeds it to the maintenance clamp tripwire so a destination ruler
+/// that fails to cover its inputs shouts instead of silently losing recall.
+#[inline]
+pub(crate) fn encode_sq16_adaptive_row(
+    src: &[f32],
+    scale: &[f32],
+    offset: &[f32],
+    out: &mut [u8],
+) -> u64 {
+    debug_assert_eq!(out.len(), src.len() * 2);
+    debug_assert_eq!(scale.len(), src.len());
+    debug_assert_eq!(offset.len(), src.len());
+    let mut clamped = 0u64;
+    for (d, &v) in src.iter().enumerate() {
+        // A zero-span dimension (min == max) has scale 0; map every value to
+        // code 0 so decode returns the constant offset exactly.
+        let code = if scale[d] > 0.0 {
+            let q = (v - offset[d]) / scale[d];
+            if !(-SQ16_CLAMP_DETECT_SLACK_CODES..=65535.0 + SQ16_CLAMP_DETECT_SLACK_CODES)
+                .contains(&q)
+            {
+                clamped += 1;
+            }
+            q.round().clamp(0.0, 65535.0) as u16
+        } else {
+            0
+        };
+        let b = d * 2;
+        out[b..b + 2].copy_from_slice(&code.to_le_bytes());
+    }
+    clamped
+}
+
+/// Half-code slack before an out-of-grid `Sq16Adaptive` component counts as
+/// clamped, mirroring the residual family's tripwire tolerance.
+const SQ16_CLAMP_DETECT_SLACK_CODES: f32 = 0.5;
+
+/// Inverse of [`encode_sq16_adaptive_row`]. `code.len() == out.len() * 2`.
+#[inline]
+pub(crate) fn dequantize_sq16_adaptive_into(
+    code: &[u8],
+    scale: &[f32],
+    offset: &[f32],
+    out: &mut [f32],
+) {
+    let dim = out.len();
+    debug_assert_eq!(code.len(), dim * 2);
+    debug_assert_eq!(scale.len(), dim);
+    debug_assert_eq!(offset.len(), dim);
+    for (d, slot) in out.iter_mut().enumerate() {
+        let b = d * 2;
+        let c = u16::from_le_bytes([code[b], code[b + 1]]) as f32;
+        *slot = c * scale[d] + offset[d];
+    }
+}
+
+/// Adaptive-ruler [`sq16_decoded_norm_sq`]: `Σ_d (code[d]·scale[d] + offset[d])²`.
+#[inline]
+pub(crate) fn sq16_adaptive_norm_sq(
+    code_bytes: &[u8],
+    dim: usize,
+    scale: &[f32],
+    offset: &[f32],
+) -> f32 {
+    debug_assert_eq!(code_bytes.len(), dim * 2);
+    debug_assert_eq!(scale.len(), dim);
+    debug_assert_eq!(offset.len(), dim);
+    let mut s = 0.0f32;
+    for d in 0..dim {
+        let b = 2 * d;
+        let c = u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]) as f32;
+        let x = c * scale[d] + offset[d];
+        s += x * x;
     }
     s
 }
@@ -2732,6 +2852,72 @@ mod tests {
                 (got - decoded_ref).abs() <= 1e-4,
                 "dim {dim}: kernel {got} disagrees with decoded ref {decoded_ref}"
             );
+        }
+    }
+
+    /// `Sq16Adaptive`: a per-cluster fitted ruler (NOT the fixed `[-1, 1]`
+    /// grid) round-trips within its per-dim step, and the adaptive kernel's L2
+    /// distance matches the exact fp32 L2 — i.e. overriding only the ruler is
+    /// arithmetically sound. Uses arbitrary (non-normalized, out-of-`[-1,1]`)
+    /// values the fixed grid could not represent, sizing the ruler from the
+    /// corpus's per-dim `[min,max]` exactly as the build/merge path does.
+    #[test]
+    fn sq16_adaptive_round_trip_and_kernel_match_fp32_l2() {
+        for &dim in &[8usize, 13, 100, 384] {
+            let corpus: Vec<Vec<f32>> = (0..16)
+                .map(|c| {
+                    (0..dim)
+                        .map(|i| ((c * 7 + i) as f32 * 0.031).sin() * 5.0 - 1.0)
+                        .collect()
+                })
+                .collect();
+            // Per-dim ruler = union of the corpus range (min-of-mins / max-of-maxes),
+            // then scale = span / 65535, offset = min — the u16 analogue of the
+            // build path's `derive_sq8_quantizer_from_min_max`.
+            let mut min = vec![f32::INFINITY; dim];
+            let mut max = vec![f32::NEG_INFINITY; dim];
+            for v in &corpus {
+                for d in 0..dim {
+                    min[d] = min[d].min(v[d]);
+                    max[d] = max[d].max(v[d]);
+                }
+            }
+            let scale: Vec<f32> = (0..dim)
+                .map(|d| {
+                    let s = max[d] - min[d];
+                    if s > 0.0 { s / 65535.0 } else { 0.0 }
+                })
+                .collect();
+            let offset = min.clone();
+            let query = &corpus[3];
+            let kernel = Sq16Kernel::new_adaptive(Metric::L2Sq, query, &scale, &offset);
+            for v in &corpus {
+                let mut bytes = vec![0u8; dim * 2];
+                encode_sq16_adaptive_row(v, &scale, &offset, &mut bytes);
+
+                // Round-trip: every component within one quant step (no clamp,
+                // because the ruler covers the corpus by construction).
+                let mut decoded = vec![0.0f32; dim];
+                dequantize_sq16_adaptive_into(&bytes, &scale, &offset, &mut decoded);
+                for d in 0..dim {
+                    assert!(
+                        (decoded[d] - v[d]).abs() <= scale[d] + 1e-4,
+                        "dim {dim} d{d}: decoded {} vs {} (step {})",
+                        decoded[d],
+                        v[d],
+                        scale[d]
+                    );
+                }
+
+                // Adaptive kernel L2 vs exact fp32 L2.
+                let norm = sq16_adaptive_norm_sq(&bytes, dim, &scale, &offset);
+                let got = kernel.distance_with_norm(&bytes, Some(norm));
+                let want = distance(Metric::L2Sq, query, v);
+                assert!(
+                    (got - want).abs() <= 1e-2 + 1e-3 * want.abs(),
+                    "dim {dim}: adaptive L2 {got} vs fp32 {want}"
+                );
+            }
         }
     }
 

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -19,7 +19,9 @@ use std::sync::Arc;
 
 use wide::f32x8;
 
-use crate::superfile::vector::rerank_codec::{RerankCodec, SQ16_FIXED_OFFSET, SQ16_FIXED_SCALE};
+use crate::superfile::vector::rerank_codec::{
+    RerankCodec, SQ16_CODE_MAX, SQ16_FIXED_OFFSET, SQ16_FIXED_SCALE,
+};
 #[cfg(target_arch = "x86_64")]
 use crate::superfile::vector::simd_dispatch::{avx2_enabled, avx512_enabled};
 
@@ -58,6 +60,10 @@ pub(crate) const COSINE_DISTANCE_BASE: f32 = 1.0;
 /// `‖q − x‖² = ‖q‖² − L2_CROSS_TERM_COEFF·(q·x) + ‖x‖²`, used by the
 /// Sq8 rerank kernels that reconstruct L2 from a fused dot product.
 pub(crate) const L2_CROSS_TERM_COEFF: f32 = 2.0;
+
+/// Half-code slack before an out-of-grid `Sq16Adaptive` component counts as
+/// clamped, mirroring the residual family's tripwire tolerance.
+const SQ16_CLAMP_DETECT_SLACK_CODES: f32 = 0.5;
 
 /// Distance metric for a vector index. Stored per-column in
 /// `inf.vec.columns` JSON, applied at query time.
@@ -1202,7 +1208,7 @@ pub(crate) fn encode_sq16_row(src: &[f32], out: &mut [u8]) {
     debug_assert_eq!(out.len(), src.len() * 2);
     let inv_scale = 1.0 / SQ16_FIXED_SCALE;
     for (d, &v) in src.iter().enumerate() {
-        let code = (((v - SQ16_FIXED_OFFSET) * inv_scale).round()).clamp(0.0, 65535.0) as u16;
+        let code = (((v - SQ16_FIXED_OFFSET) * inv_scale).round()).clamp(0.0, SQ16_CODE_MAX) as u16;
         let b = d * 2;
         out[b..b + 2].copy_from_slice(&code.to_le_bytes());
     }
@@ -1283,16 +1289,19 @@ pub(crate) fn encode_sq16_adaptive_row(
     debug_assert_eq!(offset.len(), src.len());
     let mut clamped = 0u64;
     for (d, &v) in src.iter().enumerate() {
-        // A zero-span dimension (min == max) has scale 0; map every value to
-        // code 0 so decode returns the constant offset exactly.
+        // Guard a zero-span dimension: when the ruler's scale is 0, map every
+        // value to code 0 so decode returns the constant offset exactly. The
+        // build fit assigns scale = 1.0 (not 0) for a constant dim, so on the
+        // real build/merge path this is a defensive floor rather than the
+        // expected shape.
         let code = if scale[d] > 0.0 {
             let q = (v - offset[d]) / scale[d];
-            if !(-SQ16_CLAMP_DETECT_SLACK_CODES..=65535.0 + SQ16_CLAMP_DETECT_SLACK_CODES)
+            if !(-SQ16_CLAMP_DETECT_SLACK_CODES..=SQ16_CODE_MAX + SQ16_CLAMP_DETECT_SLACK_CODES)
                 .contains(&q)
             {
                 clamped += 1;
             }
-            q.round().clamp(0.0, 65535.0) as u16
+            q.round().clamp(0.0, SQ16_CODE_MAX) as u16
         } else {
             0
         };
@@ -1301,10 +1310,6 @@ pub(crate) fn encode_sq16_adaptive_row(
     }
     clamped
 }
-
-/// Half-code slack before an out-of-grid `Sq16Adaptive` component counts as
-/// clamped, mirroring the residual family's tripwire tolerance.
-const SQ16_CLAMP_DETECT_SLACK_CODES: f32 = 0.5;
 
 /// Inverse of [`encode_sq16_adaptive_row`]. `code.len() == out.len() * 2`.
 #[inline]

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -183,11 +183,11 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
     // (`sq8_ivf_merge_input_at` is `is_ivf_mergeable`-gated), so
     // the extra family check is a guard: single-plane Sq16 must never
     // seed the fixed sq8 grid here.
-    // Only the residual family carries a per-cluster scale/offset table.
-    // Single-plane codecs (Sq16) quantize on a fixed grid with no per-cluster
-    // quantizer, so their `scale`/`offset` merge inputs are empty and never
-    // seeded, sliced, or written to codec_meta below.
-    let has_cluster_quant = codec.is_sq8_residual_family();
+    // Only cluster-quant codecs carry a per-cluster scale/offset table.
+    // The fixed-grid single-plane codec (Sq16) quantizes on a fixed grid with no
+    // per-cluster quantizer, so its `scale`/`offset` merge inputs are empty and
+    // never seeded, sliced, or written to codec_meta below.
+    let has_cluster_quant = codec.carries_cluster_quant_meta();
     let (mut dst_scale, mut dst_offset) = if codec.uses_fixed_quantizer() && has_cluster_quant {
         let (scale, offset) = fixed_sq8_quantizer(dim);
         (scale.repeat(n_cent), offset.repeat(n_cent))
@@ -195,6 +195,12 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
         (vec![1.0f32; n_cent * dim], vec![0.0f32; n_cent * dim])
     };
     if has_cluster_quant {
+        // Copy the first contributing input's per-cluster ruler as the
+        // destination grid; per-row transcode below re-encodes the other inputs
+        // onto it (clamping any out-of-range component). This matches the
+        // existing merge behavior for every fitted/fixed cluster-quant codec.
+        // (Sizing the destination grid to cover every input's range so no
+        // component clamps is a separate future change, not bundled here.)
         for c in 0..n_cent {
             for inp in parsed {
                 let (_, count) = cluster_entry(&inp.sub, inp.cluster_idx_off, c);
@@ -353,13 +359,26 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
                                 )
                             })
                         } else {
+                            // Body layout depends on the codec: the residual
+                            // family splits `[codes(dim) ‖ residuals(dim)]`,
+                            // while the single-`u16`-plane `Sq16Adaptive` keeps
+                            // the whole `dim*2`-byte plane as `codes` with no
+                            // residual leg.
+                            let (codes, residuals) = if inp.rerank_codec.writes_single_u16_plane() {
+                                (inp.sub[rowb..rowb + dim * 2].to_vec(), Vec::new())
+                            } else {
+                                (
+                                    inp.sub[rowb..rowb + dim].to_vec(),
+                                    inp.sub[rowb + dim..rowb + dim + dim].to_vec(),
+                                )
+                            };
                             let encoded = EncodedCellRow {
                                 stable_id: 0,
                                 rerank_codec: inp.rerank_codec,
                                 scale: std::sync::Arc::from(src_scale),
                                 offset: std::sync::Arc::from(src_offset),
-                                codes: inp.sub[rowb..rowb + dim].to_vec(),
-                                residuals: inp.sub[rowb + dim..rowb + dim + dim].to_vec(),
+                                codes,
+                                residuals,
                                 norm_sq: None,
                             };
                             let n = ops.materialize_row_into_cluster_quant(
@@ -464,7 +483,7 @@ pub(crate) fn splice_fragments_into_cell(
     // per-doc norm table. Splice supports both: the rerank bytes are copied
     // verbatim regardless of codec, and the codec_meta write below branches on
     // this to lay out either `[scale|offset|norms]` or norms-only.
-    let has_cluster_quant = codec.is_sq8_residual_family();
+    let has_cluster_quant = codec.carries_cluster_quant_meta();
 
     let out_n_cent = fragments.len();
     let counts: Vec<u32> = fragments
@@ -780,7 +799,7 @@ pub(crate) fn sq8_ivf_merge_input_from_subsection(
     // row's norm from the codes, so the merge input carries empty scale/offset for
     // Sq16 — parsing the norm table as scale/offset would error (small cell) or
     // silently corrupt the reranker (large cell).
-    let (scale, offset) = if rerank_codec.is_sq8_residual_family() {
+    let (scale, offset) = if rerank_codec.carries_cluster_quant_meta() {
         let so_bytes = n_cent * dim * 4;
         if codec_meta_size < 2 * so_bytes {
             return Err(BuildError::VectorSchemaMismatch(
@@ -1017,6 +1036,66 @@ mod tests {
             "spliced cell holds every doc from both batches"
         );
         assert_eq!(ids.len(), 2 * ROWS, "one stable id per spliced doc");
+    }
+
+    /// The genuine build-path guard for the 16-bit-vs-8-bit fit bug: build the
+    /// SAME corpus through the real `Sq16Adaptive` and `Sq8Residual` build/fit
+    /// paths and read back each fitted per-cluster ruler. The only difference
+    /// must be the code max — `Sq16Adaptive` fits `scale = span/65535`,
+    /// `Sq8Residual` fits `span/255` — so the per-dim ratio is exactly
+    /// `255/65535`. Before the fix both used `span/255` (ratio 1.0), i.e.
+    /// `Sq16Adaptive` was silently an 8-bit quantizer. Rotation-agnostic: both
+    /// codecs fit the same rotated min/max, so the raw span never enters.
+    #[test]
+    fn sq16_adaptive_fit_uses_full_u16_range_not_8bit() {
+        const D: usize = 8;
+        const NR: usize = 64;
+        // One-centroid grid so every row lands in cluster 0; wide, varied
+        // per-dim values so the fitted span is comfortably non-degenerate.
+        let centroids = vec![0.0f32; D];
+        let mut vectors = Vec::with_capacity(NR * D);
+        for r in 0..NR {
+            for d in 0..D {
+                vectors.push(((r * 7 + d * 13) % 97) as f32 - 40.0);
+            }
+        }
+        let ids: Vec<i128> = (0..NR as i128).collect();
+        let fitted_scale = |codec: RerankCodec| -> Vec<f32> {
+            let cfg = VectorConfig {
+                column: "emb".into(),
+                dim: D,
+                rot_seed: 7,
+                metric: Metric::L2Sq,
+                rerank_codec: codec,
+                provided_centroids: Some(Arc::from(centroids.clone())),
+            };
+            let sub = build_merged_subsection_from_fp32(cfg, 1, Arc::new(vectors.clone()), &ids)
+                .expect("cell build");
+            sq8_ivf_merge_input_from_subsection(
+                &sub.bytes,
+                D,
+                1,
+                sub.n_docs,
+                Metric::L2Sq,
+                codec,
+                None,
+            )
+            .expect("parse fitted ruler")
+            .scale
+        };
+        let s8 = fitted_scale(RerankCodec::Sq8Residual);
+        let s16 = fitted_scale(RerankCodec::Sq16Adaptive);
+        let expected = 255.0f32 / 65535.0;
+        for d in 0..D {
+            if s8[d] > 0.0 {
+                let ratio = s16[d] / s8[d];
+                assert!(
+                    (ratio - expected).abs() <= expected * 0.05,
+                    "dim {d}: Sq16Adaptive ruler must be span/65535 — {expected}x Sq8Residual's \
+                     span/255 — got ratio {ratio} (1.0 ⇒ Sq16Adaptive is secretly 8-bit)"
+                );
+            }
+        }
     }
 
     /// Splice-merging inputs that share an all-empty cluster must leave the

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -1131,7 +1131,7 @@ impl VectorReader {
                 ))));
             }
 
-            let sq8_meta = if rerank_codec.is_sq8_residual_family() {
+            let sq8_meta = if rerank_codec.carries_cluster_quant_meta() {
                 let meta_abs_start = subsection_off + codec_meta_off;
                 let meta_abs_end = meta_abs_start + actual_codec_meta_size;
                 let so_block_bytes = (n_cent as usize) * dim * 4;
@@ -1345,6 +1345,9 @@ impl VectorReader {
                     RerankCodec::Sq8FixedResidual
                 }
                 value if value == u32::from(RerankCodec::Sq16.codec_id()) => RerankCodec::Sq16,
+                value if value == u32::from(RerankCodec::Sq16Adaptive.codec_id()) => {
+                    RerankCodec::Sq16Adaptive
+                }
                 _ => {
                     return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                         "multi-cell directory has unknown rerank codec id {raw_codec}"
@@ -1756,7 +1759,7 @@ impl VectorReader {
             ))));
         }
 
-        let sq8_meta = if rerank_codec.is_sq8_residual_family() {
+        let sq8_meta = if rerank_codec.carries_cluster_quant_meta() {
             let meta_abs_start = subsection_off + codec_meta_off;
             let meta_abs_end = meta_abs_start + codec_meta_size;
             let so_block_bytes = n_cent * dim * 4;
@@ -2791,7 +2794,7 @@ impl VectorReader {
             // fixed-grid codecs (Sq16) decode off the fixed grid and store empty
             // scale/offset, so there is nothing to slice per cluster.
             let (sc, of): (std::sync::Arc<[f32]>, std::sync::Arc<[f32]>) =
-                if col.rerank_codec.is_sq8_residual_family() {
+                if col.rerank_codec.carries_cluster_quant_meta() {
                     (
                         std::sync::Arc::from(
                             scale
@@ -5035,6 +5038,90 @@ pub(crate) fn read_cluster_entry(cluster_idx_slice: &[u8], c: usize) -> (u32, u3
 /// - **Sq8Residual**: builds one [`Sq8ResidualKernel`] per selected cluster and
 ///   scores every RaBitQ shortlist survivor with both stored bytes. The
 ///   per-doc decoded norm cached at encode time short-circuits `Σx²` for L2Sq.
+/// Fetch per-cluster quantizer rulers (scale/offset) and the per-doc norms for
+/// exactly the probed clusters directly from the lazy source, for the
+/// no-prefetch fallback. Shared by every cluster-quant codec's lazy path; the
+/// caller then builds its own per-cluster kernel and scores. Returns the deduped
+/// probed cluster ids, their `(scale, offset)` rulers keyed by cluster, and —
+/// when the column stores norms — a candidate-position → norm map.
+fn fetch_lazy_cluster_meta(
+    source: &Source,
+    candidates: &[RerankCandidate],
+    rerank_codec: RerankCodec,
+    dim: usize,
+    scale_abs_off: usize,
+    offset_abs_off: usize,
+    norms_abs_off: Option<usize>,
+) -> Result<
+    (
+        Vec<u32>,
+        HashMap<u32, (Vec<f32>, Vec<f32>)>,
+        Option<HashMap<u32, f32>>,
+    ),
+    VectorError,
+> {
+    let map_lazy = |e: LazyByteSourceError| VectorError::LazySource(e.to_string());
+    let mut clusters: Vec<u32> = candidates.iter().map(|c| c.cluster_id).collect();
+    clusters.sort_unstable();
+    clusters.dedup();
+
+    let cluster_meta_len = dim * 4;
+    let mut ranges = Vec::with_capacity(clusters.len() * 2);
+    for &cluster_id in &clusters {
+        let c = cluster_id as usize;
+        let scale_start = scale_abs_off + c * cluster_meta_len;
+        let offset_start = offset_abs_off + c * cluster_meta_len;
+        ranges.push(scale_start..scale_start + cluster_meta_len);
+        ranges.push(offset_start..offset_start + cluster_meta_len);
+    }
+    let bytes = source.get_ranges_parallel(&ranges).map_err(map_lazy)?;
+    let mut scale_offset_by_cluster: HashMap<u32, (Vec<f32>, Vec<f32>)> =
+        HashMap::with_capacity(clusters.len());
+    for (idx, &cluster_id) in clusters.iter().enumerate() {
+        let scale = parse_f32_le_vec(&bytes[idx * 2]);
+        let offset = parse_f32_le_vec(&bytes[idx * 2 + 1]);
+        validate_quantizer_meta(rerank_codec, &scale, &offset, "lazy per-cluster metadata")?;
+        scale_offset_by_cluster.insert(cluster_id, (scale, offset));
+    }
+
+    let norm_by_pos = if let Some(norms_abs_off) = norms_abs_off {
+        let mut spans: HashMap<u32, (u32, u32)> = HashMap::new();
+        for cand in candidates {
+            spans
+                .entry(cand.cluster_id)
+                .and_modify(|(lo, hi)| {
+                    *lo = (*lo).min(cand.pos);
+                    *hi = (*hi).max(cand.pos);
+                })
+                .or_insert((cand.pos, cand.pos));
+        }
+        let mut span_items: Vec<(u32, u32, u32)> = spans
+            .into_iter()
+            .map(|(cluster_id, (lo, hi))| (cluster_id, lo, hi))
+            .collect();
+        span_items.sort_unstable_by_key(|&(cluster_id, _, _)| cluster_id);
+        let norm_ranges: Vec<Range<usize>> = span_items
+            .iter()
+            .map(|&(_, lo, hi)| {
+                let start = norms_abs_off + lo as usize * 4;
+                start..start + (hi - lo + 1) as usize * 4
+            })
+            .collect();
+        let norm_bytes = source.get_ranges_parallel(&norm_ranges).map_err(map_lazy)?;
+        let mut out = HashMap::new();
+        for ((_, lo, hi), bytes) in span_items.into_iter().zip(norm_bytes) {
+            let vals = parse_f32_le_vec(&bytes);
+            for (i, pos) in (lo..=hi).enumerate() {
+                out.insert(pos, vals[i]);
+            }
+        }
+        Some(out)
+    } else {
+        None
+    };
+    Ok((clusters, scale_offset_by_cluster, norm_by_pos))
+}
+
 async fn rerank_candidates_from_blocks(
     source: &Source,
     lazy_sq8_meta_bytes: Option<&Bytes>,
@@ -5251,70 +5338,15 @@ async fn rerank_candidates_from_blocks(
                         .await?;
                         return Ok((finalize_reranked(scored, k), kernel_ns + ns));
                     }
-                    let mut clusters: Vec<u32> = candidates.iter().map(|c| c.cluster_id).collect();
-                    clusters.sort_unstable();
-                    clusters.dedup();
-
-                    let cluster_meta_len = dim * 4;
-                    let mut ranges = Vec::with_capacity(clusters.len() * 2);
-                    for &cluster_id in &clusters {
-                        let c = cluster_id as usize;
-                        let scale_start = *scale_abs_off + c * cluster_meta_len;
-                        let offset_start = *offset_abs_off + c * cluster_meta_len;
-                        ranges.push(scale_start..scale_start + cluster_meta_len);
-                        ranges.push(offset_start..offset_start + cluster_meta_len);
-                    }
-                    let bytes = source.get_ranges_parallel(&ranges).map_err(map_lazy)?;
-                    let mut scale_offset_by_cluster: HashMap<u32, (Vec<f32>, Vec<f32>)> =
-                        HashMap::with_capacity(clusters.len());
-                    for (idx, &cluster_id) in clusters.iter().enumerate() {
-                        let scale = parse_f32_le_vec(&bytes[idx * 2]);
-                        let offset = parse_f32_le_vec(&bytes[idx * 2 + 1]);
-                        validate_quantizer_meta(
-                            col.rerank_codec,
-                            &scale,
-                            &offset,
-                            "lazy per-cluster metadata",
-                        )?;
-                        scale_offset_by_cluster.insert(cluster_id, (scale, offset));
-                    }
-
-                    let norm_by_pos = if let Some(norms_abs_off) = norms_abs_off {
-                        let mut spans: HashMap<u32, (u32, u32)> = HashMap::new();
-                        for cand in candidates {
-                            spans
-                                .entry(cand.cluster_id)
-                                .and_modify(|(lo, hi)| {
-                                    *lo = (*lo).min(cand.pos);
-                                    *hi = (*hi).max(cand.pos);
-                                })
-                                .or_insert((cand.pos, cand.pos));
-                        }
-                        let mut span_items: Vec<(u32, u32, u32)> = spans
-                            .into_iter()
-                            .map(|(cluster_id, (lo, hi))| (cluster_id, lo, hi))
-                            .collect();
-                        span_items.sort_unstable_by_key(|&(cluster_id, _, _)| cluster_id);
-                        let norm_ranges: Vec<Range<usize>> = span_items
-                            .iter()
-                            .map(|&(_, lo, hi)| {
-                                let start = *norms_abs_off + lo as usize * 4;
-                                start..start + (hi - lo + 1) as usize * 4
-                            })
-                            .collect();
-                        let norm_bytes =
-                            source.get_ranges_parallel(&norm_ranges).map_err(map_lazy)?;
-                        let mut out = HashMap::new();
-                        for ((_, lo, hi), bytes) in span_items.into_iter().zip(norm_bytes) {
-                            let vals = parse_f32_le_vec(&bytes);
-                            for (i, pos) in (lo..=hi).enumerate() {
-                                out.insert(pos, vals[i]);
-                            }
-                        }
-                        Some(out)
-                    } else {
-                        None
-                    };
+                    let (clusters, scale_offset_by_cluster, norm_by_pos) = fetch_lazy_cluster_meta(
+                        source,
+                        candidates,
+                        col.rerank_codec,
+                        dim,
+                        *scale_abs_off,
+                        *offset_abs_off,
+                        *norms_abs_off,
+                    )?;
 
                     let kernels: HashMap<u32, Sq8ResidualKernel> = clusters
                         .into_iter()
@@ -5366,6 +5398,125 @@ async fn rerank_candidates_from_blocks(
                 }
             }
         }
+        RerankCodec::Sq16Adaptive => {
+            // Single-`u16`-plane rerank over per-cluster fitted rulers. Reuses
+            // the residual family's `Sq8ColumnMeta` (scale/offset + per-doc
+            // norms) and the same Eager/Lazy meta-fetch; only the kernel
+            // (per-cluster `Sq16Kernel::new_adaptive`) and the single-plane body
+            // differ — no residual divisor.
+            let meta = col
+                .sq8_meta
+                .as_ref()
+                .expect("Sq16Adaptive column must carry sq8_meta (built in open_with)");
+            let dim = col.dim;
+            match meta {
+                Sq8ColumnMeta::Eager {
+                    scale,
+                    offset,
+                    per_doc_norms,
+                } => {
+                    let (scored, ns) = score_sq16_adaptive_candidates(
+                        candidates,
+                        cluster_blocks,
+                        survivor_full_rows,
+                        col.metric,
+                        dim,
+                        query,
+                        scale,
+                        offset,
+                        per_doc_norms.clone(),
+                        pool.clone(),
+                        stride,
+                    )
+                    .await?;
+                    kernel_ns += ns;
+                    scored
+                }
+                Sq8ColumnMeta::Lazy {
+                    scale_abs_off,
+                    offset_abs_off,
+                    norms_abs_off,
+                } => {
+                    if let Some(meta_bytes) = lazy_sq8_meta_bytes {
+                        if col.lazy_sq8_parsed.get().is_none() {
+                            let parsed = parse_sq8_meta_bytes(
+                                meta_bytes,
+                                col.n_cent as usize,
+                                dim,
+                                col.n_docs as usize,
+                                norms_abs_off.is_some(),
+                                col.rerank_codec,
+                            )?;
+                            let _ = col.lazy_sq8_parsed.set(Arc::new(parsed));
+                        }
+                        let parsed = Arc::clone(
+                            col.lazy_sq8_parsed
+                                .get()
+                                .expect("lazy Sq8 meta set just above"),
+                        );
+                        let (scored, ns) = score_sq16_adaptive_candidates(
+                            candidates,
+                            cluster_blocks,
+                            survivor_full_rows,
+                            col.metric,
+                            dim,
+                            query,
+                            parsed.scale.as_slice(),
+                            parsed.offset.as_slice(),
+                            parsed.per_doc_norms.clone(),
+                            pool.clone(),
+                            stride,
+                        )
+                        .await?;
+                        return Ok((finalize_reranked(scored, k), kernel_ns + ns));
+                    }
+                    let (clusters, scale_offset_by_cluster, norm_by_pos) = fetch_lazy_cluster_meta(
+                        source,
+                        candidates,
+                        col.rerank_codec,
+                        dim,
+                        *scale_abs_off,
+                        *offset_abs_off,
+                        *norms_abs_off,
+                    )?;
+
+                    let kernels: HashMap<u32, Sq16Kernel> = clusters
+                        .into_iter()
+                        .map(|cluster_id| {
+                            let (scale, offset) = scale_offset_by_cluster
+                                .get(&cluster_id)
+                                .expect("cluster metadata fetched");
+                            (
+                                cluster_id,
+                                Sq16Kernel::new_adaptive(col.metric, query, scale, offset),
+                            )
+                        })
+                        .collect();
+                    let (scored, ns) = timed_section(|| {
+                        candidates
+                            .iter()
+                            .map(|cand| {
+                                let row = candidate_full_bytes(
+                                    cluster_blocks,
+                                    survivor_full_rows,
+                                    cand,
+                                    stride,
+                                );
+                                let kernel = kernels
+                                    .get(&cand.cluster_id)
+                                    .expect("invariant: kernel built for every candidate cluster");
+                                let norm = norm_by_pos
+                                    .as_ref()
+                                    .and_then(|norms| norms.get(&cand.pos).copied());
+                                (cand.did, kernel.distance_with_norm(row, norm))
+                            })
+                            .collect()
+                    });
+                    kernel_ns += ns;
+                    scored
+                }
+            }
+        }
         RerankCodec::RabitqOnly => unreachable!(
             "rerank_candidates_in_run reached with None codec — None columns \
              have no full[] region and should short-circuit before the rerank step"
@@ -5383,40 +5534,40 @@ fn finalize_reranked(mut reranked: Vec<(u32, f32)>, k: usize) -> Vec<(u32, f32)>
     reranked
 }
 
-/// Score every RaBitQ shortlist survivor with its full Sq8+residual payload.
-/// Builds one [`Sq8ResidualKernel`] per distinct probed cluster and parallelizes
-/// once the shortlist exceeds [`PARALLEL_SCAN_MIN`].
+/// Score every RaBitQ shortlist survivor with its per-cluster rerank kernel,
+/// building one kernel per distinct probed cluster and parallelizing once the
+/// shortlist exceeds [`PARALLEL_SCAN_MIN`].
 ///
-/// Both code paths keep their own data-access strategy (eager mmap vs
-/// lazy range GETs); only the scoring math is shared here.
-async fn score_sq8_residual_candidates(
+/// Generic over the kernel type `K` so the two-plane residual codecs and the
+/// single-`u16`-plane `Sq16Adaptive` codec share the cluster-dedup, per-cluster
+/// kernel map, and serial/parallel fan-out. The caller supplies `build_kernel`
+/// (cluster id → kernel, folding that cluster's ruler) and `score_row` (kernel,
+/// full row bytes, optional norm → distance), which is where the body layout
+/// (two-plane `[code | residual]` vs single `u16` plane) and any divisor live.
+/// Both code paths keep their own data-access strategy (eager mmap vs lazy range
+/// GETs); only the scoring fan-out is shared here.
+#[allow(clippy::too_many_arguments)]
+async fn score_candidates_with_kernel<K, B, S>(
     candidates: &[RerankCandidate],
     cluster_blocks: &[Bytes],
     survivor_full_rows: Option<&[Bytes]>,
-    metric: Metric,
-    dim: usize,
-    query: &[f32],
-    scale: &[f32],
-    offset: &[f32],
     per_doc_norms: Option<Arc<[f32]>>,
-    residual_divisor: f32,
     pool: Option<Arc<ThreadPool>>,
     stride: usize,
-) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
+    build_kernel: B,
+    score_row: S,
+) -> Result<(Vec<(u32, f32)>, u64), VectorError>
+where
+    K: Send + Sync + 'static,
+    B: Fn(usize) -> K,
+    S: Fn(&K, &[u8], Option<f32>) -> f32 + Send + Sync + 'static,
+{
     let mut cids: Vec<u32> = candidates.iter().map(|c| c.cluster_id).collect();
     cids.sort_unstable();
     cids.dedup();
-    let kernels: HashMap<u32, Sq8ResidualKernel> = cids
+    let kernels: HashMap<u32, K> = cids
         .into_iter()
-        .map(|cid| {
-            let c = cid as usize;
-            let scale_c = &scale[c * dim..(c + 1) * dim];
-            let offset_c = &offset[c * dim..(c + 1) * dim];
-            (
-                cid,
-                Sq8ResidualKernel::new(metric, query, scale_c, offset_c, residual_divisor),
-            )
-        })
+        .map(|cid| (cid, build_kernel(cid as usize)))
         .collect();
     let score_one = |cand: &RerankCandidate| {
         let row = candidate_full_bytes(cluster_blocks, survivor_full_rows, cand, stride);
@@ -5424,10 +5575,7 @@ async fn score_sq8_residual_candidates(
             .get(&cand.cluster_id)
             .expect("invariant: kernel prebuilt for every probed cluster");
         let norm = per_doc_norms.as_ref().map(|norms| norms[cand.pos as usize]);
-        (
-            cand.did,
-            kernel.distance_with_norm(&row[..dim], &row[dim..dim * 2], norm),
-        )
+        (cand.did, score_row(kernel, row, norm))
     };
     if candidates.len() >= PARALLEL_SCAN_MIN {
         // Every candidate is independent and the caller sorts the completed
@@ -5445,15 +5593,11 @@ async fn score_sq8_residual_candidates(
                     cand,
                     stride,
                 );
-                let code = &row[..dim];
                 let kernel = kernels
                     .get(&cand.cluster_id)
                     .expect("invariant: kernel prebuilt for every probed cluster");
                 let norm = norms.as_ref().map(|norms| norms[cand.pos as usize]);
-                (
-                    cand.did,
-                    kernel.distance_with_norm(code, &row[dim..dim * 2], norm),
-                )
+                (cand.did, score_row(kernel, row, norm))
             },
             pool,
         )
@@ -5461,6 +5605,77 @@ async fn score_sq8_residual_candidates(
     } else {
         Ok(timed_section(|| candidates.iter().map(score_one).collect()))
     }
+}
+
+/// Score survivors with their full Sq8+residual payload: one
+/// [`Sq8ResidualKernel`] per probed cluster, two-plane `[code | residual]` body.
+#[allow(clippy::too_many_arguments)]
+async fn score_sq8_residual_candidates(
+    candidates: &[RerankCandidate],
+    cluster_blocks: &[Bytes],
+    survivor_full_rows: Option<&[Bytes]>,
+    metric: Metric,
+    dim: usize,
+    query: &[f32],
+    scale: &[f32],
+    offset: &[f32],
+    per_doc_norms: Option<Arc<[f32]>>,
+    residual_divisor: f32,
+    pool: Option<Arc<ThreadPool>>,
+    stride: usize,
+) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
+    score_candidates_with_kernel(
+        candidates,
+        cluster_blocks,
+        survivor_full_rows,
+        per_doc_norms,
+        pool,
+        stride,
+        |c| {
+            let scale_c = &scale[c * dim..(c + 1) * dim];
+            let offset_c = &offset[c * dim..(c + 1) * dim];
+            Sq8ResidualKernel::new(metric, query, scale_c, offset_c, residual_divisor)
+        },
+        move |kernel: &Sq8ResidualKernel, row: &[u8], norm| {
+            kernel.distance_with_norm(&row[..dim], &row[dim..dim * 2], norm)
+        },
+    )
+    .await
+}
+
+/// Adaptive-ruler twin: score survivors with their single-`u16`-plane
+/// `Sq16Adaptive` payload, building one [`Sq16Kernel`] per probed cluster via
+/// `new_adaptive` (folding that cluster's fitted ruler). The whole `stride`-byte
+/// row is the `u16` codes; no residual divisor.
+#[allow(clippy::too_many_arguments)]
+async fn score_sq16_adaptive_candidates(
+    candidates: &[RerankCandidate],
+    cluster_blocks: &[Bytes],
+    survivor_full_rows: Option<&[Bytes]>,
+    metric: Metric,
+    dim: usize,
+    query: &[f32],
+    scale: &[f32],
+    offset: &[f32],
+    per_doc_norms: Option<Arc<[f32]>>,
+    pool: Option<Arc<ThreadPool>>,
+    stride: usize,
+) -> Result<(Vec<(u32, f32)>, u64), VectorError> {
+    score_candidates_with_kernel(
+        candidates,
+        cluster_blocks,
+        survivor_full_rows,
+        per_doc_norms,
+        pool,
+        stride,
+        |c| {
+            let scale_c = &scale[c * dim..(c + 1) * dim];
+            let offset_c = &offset[c * dim..(c + 1) * dim];
+            Sq16Kernel::new_adaptive(metric, query, scale_c, offset_c)
+        },
+        |kernel: &Sq16Kernel, row: &[u8], norm| kernel.distance_with_norm(row, norm),
+    )
+    .await
 }
 
 fn parse_sq8_meta_bytes(
@@ -7240,6 +7455,61 @@ mod tests {
         assert!(
             hits[0].1 <= 1.0,
             "Sq8 self-query distance {} should be small (≤ 1.0)",
+            hits[0].1
+        );
+    }
+
+    /// `Sq16Adaptive` build + open + self-query recovers the planted
+    /// self-vector at top-1 (L2Sq — the new default codec for non-cosine
+    /// metrics). Exercises the whole single-`u16`-plane + per-cluster-ruler
+    /// path end-to-end: the pass-3 adaptive encode, the codec_meta scale/offset
+    /// + norm layout, the open-side `Sq8ColumnMeta` load, and the per-cluster
+    /// `Sq16Kernel::new_adaptive` rerank dispatch. Any layout drift surfaces as
+    /// a wrong-doc or out-of-bounds. The 16-bit grid is strictly finer than
+    /// Sq8, so the round-trip error is smaller.
+    #[tokio::test]
+    async fn sq16_adaptive_self_query_round_trips_top1_l2sq() {
+        let dim = 32usize;
+        let n_docs = 64u32;
+        let mut b = VectorBuilder::new();
+        b.register_column(VectorConfig {
+            column: "v".into(),
+            dim,
+            rot_seed: 13,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Sq16Adaptive,
+            provided_centroids: None,
+        })
+        .expect("register column");
+        let make = |i: u32| -> Vec<f32> {
+            (0..dim)
+                .map(|j| ((i.wrapping_mul(17) + j as u32 * 3) % 64) as f32 * 0.5)
+                .collect()
+        };
+        let mut all = Vec::with_capacity(n_docs as usize);
+        for i in 0..n_docs {
+            let v = make(i);
+            b.add(0, &v).expect("add");
+            all.push(v);
+        }
+        let blob = b.finish().expect("finish");
+
+        let json =
+            r#"[{"column":"v","dim":32,"n_cent":4,"rot_seed":13,"metric":"l2sq"}]"#.to_string();
+        let r = VectorReader::open(Bytes::from(blob), &json).expect("open");
+        let hits = r
+            .search("v", &all[17], 5, 4, 20)
+            .await
+            .expect("search must succeed on Sq16Adaptive column");
+        assert_eq!(
+            hits[0].0, 17,
+            "Sq16Adaptive self-query must recover self at top-1"
+        );
+        // 16-bit per-dim step is ~256x finer than Sq8, so the self-distance is
+        // near zero; a generous bound keeps the test RNG-robust.
+        assert!(
+            hits[0].1 <= 1.0,
+            "Sq16Adaptive self-query distance {} should be small (≤ 1.0)",
             hits[0].1
         );
     }

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -892,15 +892,15 @@ impl VectorReader {
                 VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' has unknown rerank-codec id {codec_id} \
                      (known ids: 0=fp32, 1=sq8_residual, 2=rabitq_only, \
-                      3=sq8_fixed_residual)",
+                      3=sq8_fixed_residual, 4=sq16, 5=sq16_adaptive)",
                     cfg.column
                 )))
             })?;
             if !rerank_codec.is_implemented() {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' uses rerank codec {} which is not implemented yet \
-                     (`fp32`, `sq8_residual`, `sq8_fixed_residual`, \
-                      `rabitq_only` are the supported codecs)",
+                     (`fp32`, `sq8_residual`, `sq8_fixed_residual`, `sq16`, \
+                      `sq16_adaptive`, `rabitq_only` are the supported codecs)",
                     cfg.column,
                     rerank_codec.name()
                 ))));

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -61,8 +61,9 @@ use crate::superfile::{
     vector::{
         cell_posting::{EncodedCellRow, residual_family_materialize_into_cluster_quant},
         distance::{
-            Metric, SQ8_RESIDUAL_DIVISOR, dequantize_sq8_residual_into, dequantize_sq16_into,
-            sq8_residual_norm_sq, sq16_decoded_norm_sq,
+            Metric, SQ8_RESIDUAL_DIVISOR, dequantize_sq8_residual_into,
+            dequantize_sq16_adaptive_into, dequantize_sq16_into, encode_sq16_adaptive_row,
+            sq8_residual_norm_sq, sq16_adaptive_norm_sq, sq16_decoded_norm_sq,
         },
     },
 };
@@ -147,6 +148,20 @@ pub enum RerankCodec {
     /// clamps any out-of-range component, so callers must normalize (the engine
     /// and bindings do not normalize on your behalf).
     Sq16,
+    /// `Sq16`'s single-plane `u16` body over a **per-cluster, data-fitted**
+    /// range instead of the fixed `[-1, 1]` grid — i.e. the 16-bit,
+    /// variable-ruler counterpart of [`Self::Sq8Residual`], with no residual
+    /// plane (the 16-bit grid is fine enough that the residual leg is
+    /// unnecessary). One little-endian `u16` per dim (`dim × 2` bytes — the same
+    /// storage as `Sq8Residual`), reconstructed as `x = code × scale_c[d] +
+    /// offset_c[d]` from the cluster's stored quantizer. On merge the
+    /// destination cluster reuses the first contributing input's ruler and
+    /// re-encodes the rest onto it, clamping any component that falls outside
+    /// that range (the same first-input-ruler behaviour as the residual family;
+    /// a wider destination ruler that covers every input's range is future
+    /// work). Metric-agnostic (not pinned to `[-1, 1]`); the default rerank
+    /// codec for L2Sq / NegDot.
+    Sq16Adaptive,
     /// No rerank column at all. The 1-bit RaBitQ shortlist is
     /// the final ranking. Opt-in — recall drops 0.05–0.15 on
     /// typical normalized-Gaussian / image-embedding corpora;
@@ -166,7 +181,7 @@ impl Default for RerankCodec {
     /// a provably ≤ per-component quantization error, so recall is ≥ in
     /// expectation (and ≥ in the codec-isolated measurements) — not a strict
     /// per-query guarantee, since ranking can flip on a near-tie. Metric-aware
-    /// constructors retain local residual encoding (`Sq8Residual`) for
+    /// constructors use the data-fitted `Sq16Adaptive` ruler for
     /// non-cosine metrics, whose values are not bounded to `[-1, 1]`.
     fn default() -> Self {
         Self::Sq16
@@ -186,6 +201,7 @@ impl RerankCodec {
             Self::RabitqOnly => 2,
             Self::Sq8FixedResidual => 3,
             Self::Sq16 => 4,
+            Self::Sq16Adaptive => 5,
         }
     }
 
@@ -201,6 +217,7 @@ impl RerankCodec {
             2 => Some(Self::RabitqOnly),
             3 => Some(Self::Sq8FixedResidual),
             4 => Some(Self::Sq16),
+            5 => Some(Self::Sq16Adaptive),
             _ => None,
         }
     }
@@ -215,6 +232,7 @@ impl RerankCodec {
             Self::RabitqOnly => "rabitq_only",
             Self::Sq8FixedResidual => "sq8_fixed_residual",
             Self::Sq16 => "sq16",
+            Self::Sq16Adaptive => "sq16_adaptive",
         }
     }
 
@@ -224,7 +242,7 @@ impl RerankCodec {
     pub const fn per_vector_bytes(self, dim: usize) -> usize {
         match self {
             Self::Fp32 => dim * 4,
-            Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16 => dim * 2,
+            Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16 | Self::Sq16Adaptive => dim * 2,
             Self::RabitqOnly => 0,
         }
     }
@@ -266,7 +284,12 @@ impl RerankCodec {
     pub const fn is_implemented(self) -> bool {
         matches!(
             self,
-            Self::Fp32 | Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16 | Self::RabitqOnly
+            Self::Fp32
+                | Self::Sq8Residual
+                | Self::Sq8FixedResidual
+                | Self::Sq16
+                | Self::Sq16Adaptive
+                | Self::RabitqOnly
         )
     }
 
@@ -281,10 +304,10 @@ impl RerankCodec {
     /// Whether this codec participates in the IVF drain / merge / compaction
     /// maintenance paths that re-quantize rows into a destination cluster
     /// quantizer. True for the residual family (`Sq8Residual`,
-    /// `Sq8FixedResidual`) and for the single-plane `Sq16` codec, all of which
-    /// carry a cold-path `ops()` impl and so can be built-from-source, drained,
-    /// merged, and compacted. `Fp32` / `RabitqOnly` have their own (or no)
-    /// rerank plane and are never IVF-merged here.
+    /// `Sq8FixedResidual`) and for the single-plane codecs (`Sq16`,
+    /// `Sq16Adaptive`), all of which carry a cold-path `ops()` impl and so can be
+    /// built-from-source, drained, merged, and compacted. `Fp32` / `RabitqOnly`
+    /// have their own (or no) rerank plane and are never IVF-merged here.
     ///
     /// This is the gate predicate for the maintenance sites; it replaces the
     /// former direct use of [`Self::is_sq8_residual_family`] at those sites so
@@ -294,8 +317,57 @@ impl RerankCodec {
     pub const fn is_ivf_mergeable(self) -> bool {
         matches!(
             self,
-            Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16
+            Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16 | Self::Sq16Adaptive
         )
+    }
+
+    /// Whether the codec's per-vector body is a single little-endian `u16`
+    /// plane (`Sq16`, `Sq16Adaptive`) rather than the two-plane
+    /// `[u8 code ‖ i8 residual]` layout of the residual family. Both single
+    /// -plane codecs share the same body/parse/dequant code — they differ only
+    /// in the ruler (fixed grid vs per-cluster fitted).
+    #[inline]
+    pub const fn writes_single_u16_plane(self) -> bool {
+        matches!(self, Self::Sq16 | Self::Sq16Adaptive)
+    }
+
+    /// Largest quantizer code value for this codec's coarse plane: `65535` for
+    /// the single-`u16`-plane codecs, `255` for the `u8`-coarse residual family.
+    /// The per-cluster ruler is fit as `scale = (max - min) / code_max`, so this
+    /// MUST match the plane's integer width — fitting a `u16` plane with the
+    /// `u8` `255` confines every code to `0..=255` and silently throws away 8
+    /// bits of the 16-bit grid.
+    #[inline]
+    pub const fn code_max(self) -> f32 {
+        if self.writes_single_u16_plane() {
+            65535.0
+        } else {
+            255.0
+        }
+    }
+
+    /// Whether the codec stores per-cluster `scale`/`offset` quantizer arrays in
+    /// `codec_meta` (so open/merge must load them). True for the residual family
+    /// and for `Sq16Adaptive`; **not** `Sq16` (fixed grid, no arrays). This is
+    /// the ruler-storage axis, distinct from the body-layout axis
+    /// ([`Self::is_sq8_residual_family`]) — `Sq16Adaptive` carries the arrays
+    /// but is single-plane, so the two axes no longer coincide.
+    #[inline]
+    pub const fn carries_cluster_quant_meta(self) -> bool {
+        matches!(
+            self,
+            Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16Adaptive
+        )
+    }
+
+    /// Whether the codec fits its per-cluster ruler from the data (rather than
+    /// pinning a fixed grid): the build path scans each cluster's `[min,max]`,
+    /// and a merge reuses the first contributing input's ruler for the
+    /// destination cluster. True for `Sq8Residual` and `Sq16Adaptive`; the
+    /// fixed-grid codecs (`Sq8FixedResidual`, `Sq16`) are excluded.
+    #[inline]
+    pub const fn fits_per_cluster_ruler(self) -> bool {
+        matches!(self, Self::Sq8Residual | Self::Sq16Adaptive)
     }
 
     /// Whether this is the flat single-plane `u16` codec. Scored via
@@ -312,8 +384,8 @@ impl RerankCodec {
         match self {
             Self::Sq8Residual => Some(SQ8_RESIDUAL_DIVISOR),
             Self::Sq8FixedResidual => Some(SQ8_FIXED_RESIDUAL_DIVISOR),
-            // `Sq16` is a single plane — no residual step, no divisor.
-            Self::Fp32 | Self::Sq16 | Self::RabitqOnly => None,
+            // `Sq16`/`Sq16Adaptive` are single planes — no residual step, no divisor.
+            Self::Fp32 | Self::Sq16 | Self::Sq16Adaptive | Self::RabitqOnly => None,
         }
     }
 
@@ -357,9 +429,9 @@ impl RerankCodec {
     pub const fn recommended_rerank_mult_floor(self, dim: usize) -> Option<usize> {
         let high_dim = dim > LOW_DIM_RERANK_FLOOR_THRESHOLD;
         match self {
-            // `Sq16` is ~16-bit clean, so its rerank floor matches
-            // `Fp32` rather than the lossier Sq8 first-pass.
-            Self::Fp32 | Self::Sq16 => Some(if high_dim {
+            // `Sq16`/`Sq16Adaptive` are ~16-bit clean, so their rerank floor
+            // matches `Fp32` rather than the lossier Sq8 first-pass.
+            Self::Fp32 | Self::Sq16 | Self::Sq16Adaptive => Some(if high_dim {
                 FP32_HIGH_DIM_RERANK_FLOOR
             } else {
                 FP32_LOW_DIM_RERANK_FLOOR
@@ -431,7 +503,10 @@ impl RerankCodec {
                 Metric::L2Sq | Metric::Cosine => n_docs * 4,
                 Metric::NegDot => 0,
             },
-            Self::Sq8Residual | Self::Sq8FixedResidual => {
+            // Residual family and `Sq16Adaptive` all carry per-cluster
+            // scale/offset arrays; `Sq16Adaptive` differs only in the body
+            // (single u16 plane), not the codec_meta shape.
+            Self::Sq8Residual | Self::Sq8FixedResidual | Self::Sq16Adaptive => {
                 let scale_offset_bytes = 2 * n_cent * dim * 4;
                 let norms_bytes = match metric {
                     Metric::L2Sq | Metric::Cosine => n_docs * 4,
@@ -546,6 +621,7 @@ pub(crate) trait RerankCodecOps: Sync {
 pub(crate) struct Sq8ResidualOps;
 pub(crate) struct Sq8FixedResidualOps;
 pub(crate) struct Sq16Ops;
+pub(crate) struct Sq16AdaptiveOps;
 
 /// Shared residual-family row split: `dim` u8 coarse codes + `dim` i8 residual
 /// codes; norm via [`sq8_residual_norm_sq`] with the codec's `divisor`.
@@ -827,6 +903,90 @@ impl RerankCodecOps for Sq16Ops {
     }
 }
 
+/// `Sq16Adaptive` = `Sq16`'s single-`u16`-plane body over a per-cluster fitted
+/// ruler. It reuses the body/parse layout of [`Sq16Ops`] and overrides only the
+/// ruler: the arithmetic reads the passed `scale`/`offset` (via the
+/// `*_adaptive_*` distance functions) instead of the fixed grid, its
+/// `codec_meta` carries the per-cluster scale/offset arrays like the residual
+/// family, and a merge transcodes rather than byte-copies (source and
+/// destination cluster grids differ, so each row is decoded against its source
+/// ruler and re-encoded against the destination ruler).
+impl RerankCodecOps for Sq16AdaptiveOps {
+    fn parse_materialized_row(
+        &self,
+        row: &[u8],
+        dim: usize,
+        scale: &[f32],
+        offset: &[f32],
+        store_norm: bool,
+    ) -> EncodedRowParts {
+        let codes = row[..dim * 2].to_vec();
+        let norm_sq = store_norm.then(|| sq16_adaptive_norm_sq(&codes, dim, scale, offset));
+        EncodedRowParts {
+            codes,
+            residuals: Vec::new(),
+            norm_sq,
+        }
+    }
+
+    fn dequantize_row_into(
+        &self,
+        codes: &[u8],
+        _residuals: &[u8],
+        _dim: usize,
+        scale: &[f32],
+        offset: &[f32],
+        out: &mut [f32],
+    ) {
+        dequantize_sq16_adaptive_into(codes, scale, offset, out);
+    }
+
+    fn decoded_norm_sq(&self, code: &[u8], dim: usize, scale: &[f32], offset: &[f32]) -> f32 {
+        sq16_adaptive_norm_sq(&code[..dim * 2], dim, scale, offset)
+    }
+
+    fn materialize_row_into_cluster_quant(
+        &self,
+        row: &EncodedCellRow,
+        dst_scale: &[f32],
+        dst_offset: &[f32],
+        dim: usize,
+        out: &mut [u8],
+        store_norm: bool,
+    ) -> Result<Option<f32>, BuildError> {
+        if row.rerank_codec != RerankCodec::Sq16Adaptive {
+            return Err(BuildError::VectorSchemaMismatch(format!(
+                "cannot transcode Sq16Adaptive row from {} to {}",
+                row.rerank_codec.name(),
+                RerankCodec::Sq16Adaptive.name()
+            )));
+        }
+        // Per-cluster grids differ across source and destination, so transcode:
+        // decode against the source ruler, re-encode against the destination
+        // ruler. The destination reuses the first input's ruler, so a component
+        // outside that range is clamped by encode_sq16_adaptive_row; feed the
+        // clamp count to the maintenance tripwire so a destination ruler that
+        // fails to cover its inputs shouts rather than silently losing recall.
+        let mut decoded = vec![0.0f32; dim];
+        dequantize_sq16_adaptive_into(&row.codes, &row.scale, &row.offset, &mut decoded);
+        let clamped = encode_sq16_adaptive_row(&decoded, dst_scale, dst_offset, out);
+        super::cell_posting::note_transcode_clamped_components(clamped);
+        Ok(store_norm.then(|| sq16_adaptive_norm_sq(out, dim, dst_scale, dst_offset)))
+    }
+
+    fn codec_meta_layout(
+        &self,
+        meta_off: usize,
+        n_cent: usize,
+        dim: usize,
+        metric: Metric,
+    ) -> CodecMetaLayout {
+        // Same `[scale ‖ offset ‖ norms?]` layout as the residual family — the
+        // ruler storage is identical; only the row body differs.
+        residual_family_codec_meta_layout(meta_off, n_cent, dim, metric)
+    }
+}
+
 impl RerankCodec {
     /// Cold-path ops for the quantized-rerank family; `None` for `Fp32` /
     /// `RabitqOnly` (no quantized rerank plane — they keep their own paths).
@@ -835,6 +995,7 @@ impl RerankCodec {
             Self::Sq8Residual => Some(&Sq8ResidualOps),
             Self::Sq8FixedResidual => Some(&Sq8FixedResidualOps),
             Self::Sq16 => Some(&Sq16Ops),
+            Self::Sq16Adaptive => Some(&Sq16AdaptiveOps),
             Self::Fp32 | Self::RabitqOnly => None,
         }
     }
@@ -873,6 +1034,7 @@ mod tests {
             RerankCodec::Sq8Residual,
             RerankCodec::Sq8FixedResidual,
             RerankCodec::Sq16,
+            RerankCodec::Sq16Adaptive,
             RerankCodec::RabitqOnly,
         ] {
             assert_eq!(
@@ -883,13 +1045,47 @@ mod tests {
         }
     }
 
+    /// `Sq16Adaptive` sits on both axes the codebase used to conflate: it shares
+    /// the single-`u16` body with `Sq16` but the per-cluster fitted ruler with
+    /// `Sq8Residual`. Pins each predicate so a future refactor can't silently
+    /// re-route it (e.g. onto the fixed grid, or the two-plane body).
+    #[test]
+    fn sq16_adaptive_sits_on_both_axes() {
+        let c = RerankCodec::Sq16Adaptive;
+        // additive id, 2 bytes/dim (storage-neutral vs Sq8Residual)
+        assert_eq!(c.codec_id(), 5);
+        assert_eq!(c.per_vector_bytes(384), 384 * 2);
+        // u16 plane ⇒ the ruler MUST be fit to the full 16-bit range, not 255
+        // (fitting with 255 confines codes to 0..=255 and drops 8 bits — the
+        // recall bug this guards).
+        assert_eq!(c.code_max(), 65535.0);
+        assert_eq!(RerankCodec::Sq8Residual.code_max(), 255.0);
+        // single-u16 body (like Sq16), NOT the two-plane residual body
+        assert!(c.writes_single_u16_plane());
+        assert!(!c.is_sq8_residual_family());
+        // per-cluster fitted ruler (like Sq8Residual), NOT a fixed grid
+        assert!(c.fits_per_cluster_ruler());
+        assert!(c.carries_cluster_quant_meta());
+        assert!(!c.uses_fixed_quantizer());
+        // single plane ⇒ no residual divisor; IVF-mergeable; metric-agnostic
+        assert_eq!(c.residual_divisor(), None);
+        assert!(c.is_ivf_mergeable());
+        assert!(c.supports_metric(Metric::L2Sq) && c.supports_metric(Metric::NegDot));
+        // dim recovered as half the u16 code length
+        assert_eq!(c.dim_from_codes_len(384 * 2), 384);
+    }
+
     /// Unknown discriminator bytes (any value not currently
-    /// assigned, e.g. `5`, `255`) return `None`. The reader
+    /// assigned, e.g. `6`, `255`) return `None`. The reader
     /// upgrades that into a `MalformedVersion` error rather than
-    /// guessing.
+    /// guessing. Id `5` now maps to `Sq16Adaptive`.
     #[test]
     fn unknown_codec_id_is_none() {
-        for id in [5u8, 6, 16, 200, 255] {
+        assert_eq!(
+            RerankCodec::from_codec_id(5),
+            Some(RerankCodec::Sq16Adaptive)
+        );
+        for id in [6u8, 16, 200, 255] {
             assert_eq!(
                 RerankCodec::from_codec_id(id),
                 None,

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -59,7 +59,10 @@ use serde::{Deserialize, Serialize};
 use crate::superfile::{
     BuildError,
     vector::{
-        cell_posting::{EncodedCellRow, residual_family_materialize_into_cluster_quant},
+        cell_posting::{
+            EncodedCellRow, note_transcode_clamped_components,
+            residual_family_materialize_into_cluster_quant,
+        },
         distance::{
             Metric, SQ8_RESIDUAL_DIVISOR, dequantize_sq8_residual_into,
             dequantize_sq16_adaptive_into, dequantize_sq16_into, encode_sq16_adaptive_row,
@@ -970,7 +973,7 @@ impl RerankCodecOps for Sq16AdaptiveOps {
         let mut decoded = vec![0.0f32; dim];
         dequantize_sq16_adaptive_into(&row.codes, &row.scale, &row.offset, &mut decoded);
         let clamped = encode_sq16_adaptive_row(&decoded, dst_scale, dst_offset, out);
-        super::cell_posting::note_transcode_clamped_components(clamped);
+        note_transcode_clamped_components(clamped);
         Ok(store_norm.then(|| sq16_adaptive_norm_sq(out, dim, dst_scale, dst_offset)))
     }
 

--- a/src/superfile/vector/rerank_codec.rs
+++ b/src/superfile/vector/rerank_codec.rs
@@ -107,11 +107,16 @@ pub(crate) const SQ8_FIXED_SCALE: f32 = 2.0 / 255.0;
 /// Residual divisor for the portable cosine-only Sq8 grid.
 pub(crate) const SQ8_FIXED_RESIDUAL_DIVISOR: f32 = 256.0;
 
+/// Largest code value of a single `u16` rerank plane. The single point of
+/// truth for the 16-bit range, shared by [`SQ16_FIXED_SCALE`], the codec's
+/// [`RerankCodec::code_max`], and the encode/dequant math in `distance.rs`, so
+/// the ruler and the plane width can't silently disagree.
+pub(crate) const SQ16_CODE_MAX: f32 = 65535.0;
 /// Absolute offset for the flat cosine-only Sq16 grid.
 pub(crate) const SQ16_FIXED_OFFSET: f32 = -1.0;
 /// Absolute scale for the flat cosine-only Sq16 grid: the full
-/// `u16` range (`0..=65535`) spans `[-1, 1]` in even steps.
-pub(crate) const SQ16_FIXED_SCALE: f32 = 2.0 / 65535.0;
+/// `u16` range (`0..=SQ16_CODE_MAX`) spans `[-1, 1]` in even steps.
+pub(crate) const SQ16_FIXED_SCALE: f32 = 2.0 / SQ16_CODE_MAX;
 
 /// Per-vector-index rerank codec. Picks the on-disk byte layout of the
 /// per-vector rerank values inside the subsection's `full[]`
@@ -343,7 +348,7 @@ impl RerankCodec {
     #[inline]
     pub const fn code_max(self) -> f32 {
         if self.writes_single_u16_plane() {
-            65535.0
+            SQ16_CODE_MAX
         } else {
             255.0
         }

--- a/src/superfile/vector/spill.rs
+++ b/src/superfile/vector/spill.rs
@@ -532,22 +532,27 @@ impl MaterializedRowSpillWriter {
         } else {
             self.rerank_codec = Some(enc.rerank_codec);
         }
-        // The residual family carries a two-plane body (`codes` + `residuals`,
-        // each `dim`) plus a per-cluster `dim`-length quantizer. Single-plane
-        // codecs (Sq16) carry only the `dim*2`-byte code plane on a fixed grid:
-        // no residual plane, no per-cluster quantizer sidecar.
-        let uses_cluster_quant = enc.rerank_codec.is_sq8_residual_family();
-        let shape_ok = if uses_cluster_quant {
-            enc.codes.len() == self.dim
-                && enc.residuals.len() == self.dim
-                && enc.scale.len() == self.dim
-                && enc.offset.len() == self.dim
+        // Two independent axes: body shape and ruler presence.
+        // - body: the residual family is two-plane (`codes` + `residuals`, each
+        //   `dim`); the single-u16-plane codecs (`Sq16`, `Sq16Adaptive`) carry a
+        //   `dim*2`-byte code plane and no residual plane.
+        // - ruler: `Sq8Residual`/`Sq8FixedResidual`/`Sq16Adaptive` carry a
+        //   per-cluster `dim`-length scale/offset; fixed-grid `Sq16` carries none.
+        // `Sq16Adaptive` is the combination that splits these apart (single-plane
+        // body WITH a per-cluster ruler), so the checks can't be a single branch.
+        let single_plane = enc.rerank_codec.writes_single_u16_plane();
+        let has_ruler = enc.rerank_codec.carries_cluster_quant_meta();
+        let body_ok = if single_plane {
+            enc.codes.len() == self.dim * 2 && enc.residuals.is_empty()
         } else {
-            enc.codes.len() == self.dim * 2
-                && enc.residuals.is_empty()
-                && enc.scale.is_empty()
-                && enc.offset.is_empty()
+            enc.codes.len() == self.dim && enc.residuals.len() == self.dim
         };
+        let ruler_ok = if has_ruler {
+            enc.scale.len() == self.dim && enc.offset.len() == self.dim
+        } else {
+            enc.scale.is_empty() && enc.offset.is_empty()
+        };
+        let shape_ok = body_ok && ruler_ok;
         if !shape_ok || row.rabitq_code.len() != self.rabitq_len {
             return Err(BuildError::Io(Error::new(
                 ErrorKind::InvalidData,
@@ -565,7 +570,7 @@ impl MaterializedRowSpillWriter {
                 ),
             )));
         }
-        let quant_idx = if uses_cluster_quant {
+        let quant_idx = if has_ruler {
             let ptr = Arc::as_ptr(&enc.scale) as *const () as usize;
             match self.quant_idx_by_ptr.get(&ptr) {
                 Some(&idx) => idx,
@@ -715,10 +720,11 @@ fn read_spilled_row(
         u32::from_le_bytes(prefix[20..24].try_into().expect("4-byte u32 slice")) as usize;
     let norm_flag = prefix[24];
     let norm = f32::from_le_bytes(prefix[25..29].try_into().expect("4-byte f32 slice"));
-    // Single-plane codecs (Sq16) carry no quantizer table; their scale/offset
-    // are empty and the parse below ignores them. The residual family looks up
-    // the per-cluster quantizer by the index stored in the row prefix.
-    let (scale, offset) = if rerank_codec.is_sq8_residual_family() {
+    // The fixed-grid codec (Sq16) carries no quantizer table; its scale/offset
+    // are empty and the parse below ignores them. The cluster-quant codecs (the
+    // residual family and the fitted single-plane Sq16Adaptive) look up the
+    // per-cluster quantizer by the index stored in the row prefix.
+    let (scale, offset) = if rerank_codec.carries_cluster_quant_meta() {
         quants.get(quant_idx).cloned().ok_or_else(|| {
             BuildError::Io(Error::new(
                 ErrorKind::InvalidData,

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -629,10 +629,14 @@ mod codec_verify_tests {
     use bytes::Bytes;
 
     use super::verify_superfile_vector_codecs;
-    use crate::superfile::SuperfileReader;
-    use crate::superfile::builder::{BuilderOptions, SuperfileBuilder, VectorConfig};
-    use crate::superfile::vector::{distance::Metric, rerank_codec::RerankCodec};
-    use crate::test_helpers::{decimal128_id_field, decimal128_ids, default_vector_config};
+    use crate::{
+        superfile::{
+            SuperfileReader,
+            builder::{BuilderOptions, SuperfileBuilder, VectorConfig},
+            vector::{distance::Metric, rerank_codec::RerankCodec},
+        },
+        test_helpers::{decimal128_id_field, decimal128_ids, default_vector_config},
+    };
 
     const DIM: usize = 16;
 

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -51,11 +51,7 @@ use super::SuperfileHit;
 use crate::{
     runtime_metrics::op_stats::{self, OpStatsCollector},
     storage::StorageProvider,
-    superfile::{
-        SuperfileReader,
-        builder::VectorConfig,
-        vector::{layout::VectorLayout, rerank_codec::RerankCodec},
-    },
+    superfile::{SuperfileReader, builder::VectorConfig, vector::layout::VectorLayout},
     supertable::{
         error::QueryError,
         handle::SupertableReader,
@@ -97,7 +93,20 @@ pub(crate) async fn open_reader(
     .map_err(|e| QueryError::Store(e.to_string()))
 }
 
-/// Verify that parsed on-disk vector codecs match this table's write options.
+/// Verify that each configured vector column is present in this superfile and
+/// that its stored rerank codec can actually serve the table.
+///
+/// The stored superfile codec is **authoritative**: scoring dispatches on each
+/// superfile's own codec id (per unit), so any codec that was written is scored
+/// correctly regardless of the table's *current* default. The default is not
+/// persisted — reopen re-derives it from the metric — so it can differ from what
+/// a table was created with (e.g. across a release that changes the default for
+/// a metric), and a table may legitimately hold a mix of codecs across
+/// generations. Comparing the stored codec against the re-derived default would
+/// therefore reject valid data. Instead we reject only a stored codec that
+/// genuinely cannot serve this table: one that does not support the table's
+/// metric, or a non-IVF-mergeable codec inside a multi-cell (hidden-index) unit,
+/// which requires mergeable codecs.
 pub(crate) fn verify_superfile_vector_codecs(
     reader: &SuperfileReader,
     expected: &[VectorConfig],
@@ -109,23 +118,26 @@ pub(crate) fn verify_superfile_vector_codecs(
         QueryError::Execute("superfile is missing configured vector index".into())
     })?;
     for config in expected {
-        let expected_codec = if vector.is_multi_cell() && !config.rerank_codec.is_ivf_mergeable() {
-            RerankCodec::Sq8Residual
-        } else {
-            config.rerank_codec
-        };
         let mut matched = false;
         for column in vector
             .vector_columns_config()
             .filter(|column| column.name == config.column)
         {
             matched = true;
-            if column.rerank_codec != expected_codec {
+            let stored = column.rerank_codec;
+            let usable = stored.supports_metric(config.metric)
+                && (!vector.is_multi_cell() || stored.is_ivf_mergeable());
+            if !usable {
                 return Err(QueryError::Execute(format!(
-                    "vector codec mismatch for {:?}: table expects {}, superfile stores {}",
+                    "vector codec {} stored for {:?} cannot serve this table (metric {:?}{})",
+                    stored.name(),
                     config.column,
-                    expected_codec.name(),
-                    column.rerank_codec.name()
+                    config.metric,
+                    if vector.is_multi_cell() {
+                        "; a multi-cell unit requires an IVF-mergeable codec"
+                    } else {
+                        ""
+                    },
                 )));
             }
         }
@@ -606,4 +618,76 @@ where
         }
     });
     try_join_all(handles).await
+}
+
+#[cfg(test)]
+mod codec_verify_tests {
+    use std::sync::Arc;
+
+    use arrow_array::RecordBatch;
+    use arrow_schema::Schema;
+    use bytes::Bytes;
+
+    use super::verify_superfile_vector_codecs;
+    use crate::superfile::SuperfileReader;
+    use crate::superfile::builder::{BuilderOptions, SuperfileBuilder, VectorConfig};
+    use crate::superfile::vector::{distance::Metric, rerank_codec::RerankCodec};
+    use crate::test_helpers::{decimal128_id_field, decimal128_ids, default_vector_config};
+
+    const DIM: usize = 16;
+
+    fn cfg(metric: Metric, codec: RerankCodec) -> VectorConfig {
+        VectorConfig {
+            metric,
+            ..default_vector_config("emb", 7).with_rerank_codec(codec)
+        }
+    }
+
+    /// Build one tiny single superfile whose "emb" column is written with
+    /// `codec` under `metric`, and open it as a reader.
+    fn build_reader(metric: Metric, codec: RerankCodec) -> SuperfileReader {
+        let schema = Arc::new(Schema::new(vec![decimal128_id_field("doc_id")]));
+        let opts = BuilderOptions::new(
+            schema.clone(),
+            "doc_id",
+            vec![],
+            vec![cfg(metric, codec)],
+            None,
+        );
+        let mut b = SuperfileBuilder::new(opts).expect("new builder");
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(decimal128_ids(vec![10u64, 11]))])
+            .expect("batch");
+        let mut v = vec![0.0f32; 2 * DIM]; // two rows, each on a distinct axis
+        v[0] = 1.0;
+        v[DIM + 1] = 1.0;
+        b.add_batch(&batch, &[v.as_slice()]).expect("add_batch");
+        SuperfileReader::open(Bytes::from(b.finish().expect("finish"))).expect("open")
+    }
+
+    /// Regression for the backward-compat break: a table written with
+    /// `Sq8Residual` (the pre-flip L2/NegDot default) must still verify — and so
+    /// serve — when reopened under code whose re-derived default is now
+    /// `Sq16Adaptive`. The catalog does not persist the rerank codec, so reopen
+    /// rebuilds the config from the metric with the *current* default; the stored
+    /// superfile codec is authoritative, so the verifier must accept it.
+    #[test]
+    fn reopen_after_default_flip_accepts_stored_codec() {
+        let reader = build_reader(Metric::L2Sq, RerankCodec::Sq8Residual);
+        let expected = [cfg(Metric::L2Sq, RerankCodec::Sq16Adaptive)];
+        verify_superfile_vector_codecs(&reader, &expected)
+            .expect("stored Sq8Residual must be accepted under the Sq16Adaptive default");
+    }
+
+    /// The relaxation trusts *valid* stored codecs, not invalid ones: a stored
+    /// codec that cannot serve the table's metric (a fixed-grid cosine-only
+    /// `Sq16` under an L2Sq config) is still rejected.
+    #[test]
+    fn verifier_rejects_metric_incompatible_stored_codec() {
+        let reader = build_reader(Metric::Cosine, RerankCodec::Sq16);
+        let expected = [cfg(Metric::L2Sq, RerankCodec::Sq16Adaptive)];
+        assert!(
+            verify_superfile_vector_codecs(&reader, &expected).is_err(),
+            "a cosine-only Sq16 codec must not be accepted for an L2Sq table"
+        );
+    }
 }

--- a/tests/superfile/vector/brute_force_oracle.rs
+++ b/tests/superfile/vector/brute_force_oracle.rs
@@ -273,6 +273,63 @@ async fn oracle_negdot_full_nprobe_recovers_exact_topk() {
 }
 
 #[tokio::test]
+async fn oracle_sq16_adaptive_l2sq_full_nprobe_recovers_exact_topk() {
+    // The new non-cosine default codec must recover exact top-k at full nprobe,
+    // the same guarantee the fp32 and fixed-residual legs above assert.
+    let corpus = generate_corpus(ORACLE_N_DOCS, ORACLE_DIM, L2SQ_CORPUS_SEED, false);
+    let reader = build_reader_with_codec(
+        &corpus,
+        ORACLE_DIM,
+        ORACLE_N_CENT,
+        Metric::L2Sq,
+        L2SQ_ROT_SEED,
+        RerankCodec::Sq16Adaptive,
+    );
+    for q_idx in [0usize, 47, 99, 142, 199] {
+        let query = &corpus[q_idx];
+        let exact = brute_force_top_k(&corpus, query, Metric::L2Sq, ORACLE_TOP_K);
+        let approx = reader
+            .search("v", query, ORACLE_TOP_K, ORACLE_N_CENT, ORACLE_RERANK_MULT)
+            .await
+            .expect("Sq16Adaptive L2Sq search");
+        assert_eq!(approx[0].0 as usize, q_idx, "self-NN must be top-1");
+        let exact_set: HashSet<u32> = exact.iter().map(|(d, _)| *d).collect();
+        let approx_set: HashSet<u32> = approx.iter().map(|(d, _)| *d).collect();
+        assert_eq!(
+            exact_set, approx_set,
+            "Sq16Adaptive L2Sq full-nprobe top-5 set diverges; query={q_idx}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn oracle_sq16_adaptive_negdot_full_nprobe_recovers_exact_topk() {
+    let corpus = generate_corpus(ORACLE_N_DOCS, ORACLE_DIM, NEGDOT_CORPUS_SEED, false);
+    let reader = build_reader_with_codec(
+        &corpus,
+        ORACLE_DIM,
+        ORACLE_N_CENT,
+        Metric::NegDot,
+        NEGDOT_ROT_SEED,
+        RerankCodec::Sq16Adaptive,
+    );
+    for q_idx in [0usize, 33, 77, 145, 199] {
+        let query = &corpus[q_idx];
+        let exact = brute_force_top_k(&corpus, query, Metric::NegDot, ORACLE_TOP_K);
+        let approx = reader
+            .search("v", query, ORACLE_TOP_K, ORACLE_N_CENT, ORACLE_RERANK_MULT)
+            .await
+            .expect("Sq16Adaptive NegDot search");
+        let exact_set: HashSet<u32> = exact.iter().map(|(d, _)| *d).collect();
+        let approx_set: HashSet<u32> = approx.iter().map(|(d, _)| *d).collect();
+        assert_eq!(
+            exact_set, approx_set,
+            "Sq16Adaptive NegDot full-nprobe top-5 set diverges; query={q_idx}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn oracle_partial_nprobe_top1_preserved() {
     // With reduced nprobe we may miss tail of the top-k, but the
     // single most-similar doc (= the query itself for self-query) is

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -20,8 +20,9 @@ use infino::{
     runtime_metrics::op_stats::{OpStats, with_op_stats},
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
-        builder::FtsConfig,
+        builder::{FtsConfig, VectorConfig},
         fts::reader::{Bm25Stats, BoolMode},
+        vector::rerank_codec::RerankCodec,
     },
     supertable::{
         Supertable, SupertableOptions,
@@ -230,6 +231,10 @@ fn work_stats_are_deterministic_across_cache_temperature() {
 }
 
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "per-thread CPU clock is Linux procfs (schedstat); off Linux kernel_cpu_ns is always 0"
+)]
 fn a_scoped_bm25_query_reports_kernel_cpu() {
     // The thread-CPU clock (schedstat) advances at scheduler events, so a
     // single microsecond kernel can legitimately read zero; a batch of
@@ -592,6 +597,88 @@ fn a_scoped_vector_query_reports_scan_and_rerank_work() {
     );
 }
 
+/// A committed + drained L2Sq vector table whose rerank codec is the
+/// non-cosine default, `Sq16Adaptive`. The other vector fixtures build the
+/// cosine/`Fp32` path, so this is the only op-stats coverage of the new
+/// default codec's rerank kernel.
+fn drained_sq16_adaptive_table(dir: &TempDir) -> Supertable {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new(
+            "emb",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIM as i32,
+            ),
+            false,
+        ),
+    ]));
+    let vector = VectorConfig {
+        metric: Metric::L2Sq,
+        ..default_vector_config("emb", VECTOR_ROT_SEED).with_rerank_codec(RerankCodec::Sq16Adaptive)
+    };
+    let opts = SupertableOptions::new(
+        schema,
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        vec![vector],
+        Some(default_tokenizer()),
+    )
+    .expect("valid options");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(opts.with_storage(storage)).expect("create");
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    w.append(&vector_batch(schema)).expect("append");
+    w.commit().expect("commit");
+    drop(w);
+    st.drain_vectors_to_cells_sync().expect("drain");
+    st
+}
+
+/// #550 kernel-CPU metering must fire for the new default codec, not only the
+/// residual/cosine paths: a drained `Sq16Adaptive` (L2Sq) table reports a
+/// non-zero rerank kernel CPU time. Regression guard for a rebase or refactor
+/// that drops the metering from the generic scorer's Sq16Adaptive arms.
+#[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "per-thread CPU clock is Linux procfs (schedstat); off Linux kernel_cpu_ns is always 0"
+)]
+fn a_scoped_sq16_adaptive_vector_query_reports_kernel_cpu() {
+    // Same thread-CPU-clock granularity handling as the BM25 kernel-CPU test: a
+    // single tiny rerank can legitimately read zero, so batch enough queries
+    // that the cumulative bracketed time registers.
+    const KERNEL_CPU_BATCH: usize = 200;
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_sq16_adaptive_table(&dir);
+    let query = row_vec(3);
+    let (_, stats) = with_op_stats(|| {
+        for _ in 0..KERNEL_CPU_BATCH {
+            st.vector_search(
+                "emb",
+                &query,
+                VECTOR_K,
+                VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+                None,
+                None,
+            )
+            .expect("vector search");
+        }
+    });
+    assert!(
+        stats.vector_rows_reranked > 0,
+        "the Sq16Adaptive shortlist must rerank a non-empty winner set"
+    );
+    assert!(
+        stats.kernel_cpu_ns > 0,
+        "the Sq16Adaptive rerank kernel reports on-CPU time over {KERNEL_CPU_BATCH} queries; got 0"
+    );
+}
+
 #[test]
 fn a_full_width_probe_scans_every_row_exactly_once() {
     // nprobe >= the hidden cell count chooses every cluster, so the scan
@@ -654,6 +741,10 @@ fn a_filtered_vector_query_meters_its_predicate_leg() {
 }
 
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "per-thread CPU clock is Linux procfs (schedstat); off Linux kernel_cpu_ns is always 0"
+)]
 fn a_scoped_vector_query_reports_kernel_cpu() {
     // Same schedstat-resolution caveat as the FTS kernel test: batch the
     // queries so the bracketed scan + rerank sections cross scheduler


### PR DESCRIPTION
## What

Adds `Sq16Adaptive`, a new rerank codec: a single `u16` plane per vector over a **per-cluster, data-fitted** ruler — the 16-bit, variable-ruler counterpart of `Sq8Residual`, with no residual leg. It becomes the **default rerank codec for L2 and NegDot** vector tables. Cosine tables keep the fixed-grid `Sq16`.

## Why

`Sq8Residual` (the prior non-cosine default) spends 2 bytes/dim on a `u8` code plus an `i8` residual. `Sq16Adaptive` spends the same 2 bytes/dim on a single `u16` code fitted to each cluster's own value span — finer per-component resolution, no residual bookkeeping. It is **storage-neutral** and improves recall on every non-cosine ann-benchmarks dataset (table below), with p95 unchanged.

## Compatibility

- Added as a **new codec id (5)**, so existing tables reopen unchanged and resolve their codec by the stored id — `Sq8Residual` tables keep scoring exactly as before.
- The rerank codec is deliberately **excluded from the table options identity hash**, so changing the default does not change table identity or affect reopen.
- No new env var or config knob — the codec is chosen by metric, unconditionally.

## Recall + p95 — ann-benchmarks, all 5 non-cosine datasets

Measured on the same 16-core x86 box and harness as the #490 baseline (k=10, `default` stamped law, native `_id` path, index + 10% disk cache). `pre` = `Sq8Residual` (#490 baseline); `post` = `Sq16Adaptive`. Recall is hardware-independent; p95 is same-box.

| dataset | metric | recall pre (#490) | recall post | Δ | p95 pre | p95 post |
|---|---|---:|---:|---:|---:|---:|
| sift-128 | L2 | 0.9903 | 0.9908 | +0.0005 | 4 ms | 4.2 ms |
| gist-960 | L2 | 0.9938 | 0.9983 | +0.0045 | 13 ms | 13.8 ms |
| mnist-784 | L2 | 0.9924 | 0.9931 | +0.0007 | 1 ms | 0.8 ms |
| fashion-mnist-784 | L2 | 0.9910 | 0.9965 | +0.0055 | 2 ms | 1.6 ms |
| lastfm-64 | NegDot | 0.9864 | 0.9917 | +0.0053 | 38 ms | 38.1 ms |

Recall improves on every dataset (+0.0005 … +0.0055); p95 is within run-to-run noise (mnist/fashion are marginally faster). The NegDot path (lastfm) is validated alongside L2.

## Implementation notes

- The codec surface previously conflated two independent axes — **body shape** (two-plane `[u8 code | i8 residual]` vs a single `u16` plane) and **ruler** (per-cluster fitted vs fixed grid). `Sq16Adaptive` is the first codec that is single-plane *and* fitted, so build / drain-spill / merge / read now branch on capability predicates (`writes_single_u16_plane`, `carries_cluster_quant_meta`, `fits_per_cluster_ruler`) rather than on codec identity.
- The ruler is fit across the full `u16` range (`scale = span / 65535`) via a codec-aware `code_max()`; reusing the 8-bit divisor here would leave the plane carrying only 8 bits of precision.
- On merge the destination cluster reuses the first contributing input's ruler and re-encodes the rest onto it (the same behaviour as the residual family); a component outside that range is clamped. Because this codec has no residual leg to recover a clamp, the merge transcode feeds its clamp count to the existing compaction clamp tripwire, so a destination ruler that fails to cover its inputs shouts rather than silently losing recall.

## Follow-ups (not in this PR)

- Rename `Sq16` → `Sq16Fixed` so the fixed-grid vs adaptive-ruler distinction is explicit in the codec names.
- Size the merge destination ruler from the union of all inputs' ranges so no component ever clamps (tracked in #554).
- Make the per-thread/process CPU metering platform-independent (`clock_gettime`) so non-Linux hosts report real `kernel_cpu_ns` instead of a silent 0 — currently Linux-procfs-only (tracked in #565).
- The non-cosine (L2) `supertable_vector` CI bench leg added here activates once this merges to `main`: the bench runs on `pull_request_target`, which uses the base branch's workflow, so this PR still shows the base legs.

Closes #555.

