### PR TITLE
release: crate 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "apache-avro",
  "arc-swap",


### PR DESCRIPTION
Release PR stamped by the `Release prep` workflow (scope: `crate`).

| Package | Version |
| ------- | ------- |
| crate   | 0.5.3  |
| node    | 0.5.0   |
| python  | 0.5.0 |

On merge, `Release on merge` tags and publishes whichever of these changed — see docs/versioning.md.