### PR TITLE
superfile/vector: batch the warm Sq16 rerank path

### DIFF
--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -1153,7 +1153,11 @@ impl Sq16Kernel {
 /// [`BitQuantizer::estimate_dot_rotated_with_total`]).
 #[inline]
 fn sq16_cross(q_prime: &[f32], code_bytes: &[u8]) -> f32 {
-    debug_assert_eq!(code_bytes.len(), q_prime.len() * 2);
+    // Release-enforced: the intrinsic tiers below read `2 * dim` code
+    // bytes through unaligned pointer loads, so a short slice would be
+    // an out-of-bounds read, not a panic. One predictable branch per
+    // candidate is free next to the ~dim FMAs that follow.
+    assert_eq!(code_bytes.len(), q_prime.len() * 2);
     #[cfg(target_arch = "x86_64")]
     {
         if avx512_enabled() {
@@ -1166,10 +1170,9 @@ fn sq16_cross(q_prime: &[f32], code_bytes: &[u8]) -> f32 {
             return unsafe { sq16_cross_avx512(q_prime, code_bytes) };
         }
         if avx2_enabled() {
-            // SAFETY: gated on `avx2_enabled()` (AVX2; FMA is checked
-            // by the same gate's platform baseline — see the explicit
-            // `fma` enable on the function). Bounds as above with an
-            // 8-code stride.
+            // SAFETY: gated on `avx2_enabled()`, which detects both
+            // `avx2` and `fma` — the two features the function enables.
+            // Bounds as above with an 8-code stride.
             return unsafe { sq16_cross_avx2(q_prime, code_bytes) };
         }
     }

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -1120,29 +1120,8 @@ impl Sq16Kernel {
     #[inline]
     pub fn distance_with_norm(&self, code_bytes: &[u8], norm: Option<f32>) -> f32 {
         debug_assert_eq!(code_bytes.len(), self.dim * 2);
-        let mut acc = f32x8::ZERO;
-        let mut i = 0;
-        while i + F32X8_LANES <= self.dim {
-            let qp: [f32; F32X8_LANES] = self.q_prime[i..i + F32X8_LANES]
-                .try_into()
-                .expect("q_prime[i..i+8] len 8");
-            let mut code = [0f32; F32X8_LANES];
-            for (j, lane) in code.iter_mut().enumerate() {
-                let b = 2 * (i + j);
-                *lane = u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]) as f32;
-            }
-            acc += f32x8::from(qp) * f32x8::from(code);
-            i += F32X8_LANES;
-        }
-        let mut cross = acc.reduce_add();
-        while i < self.dim {
-            let b = 2 * i;
-            let code = u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]) as f32;
-            cross += self.q_prime[i] * code;
-            i += 1;
-        }
         // dot(query, x_decoded) = Σ q_prime[d]·code[d] + q_dot_offset.
-        let dot = cross + self.q_dot_offset;
+        let dot = sq16_cross(&self.q_prime, code_bytes) + self.q_dot_offset;
         match self.metric {
             Metric::Cosine => {
                 let x_norm = norm
@@ -1160,6 +1139,128 @@ impl Sq16Kernel {
                 self.q_norm_sq - L2_CROSS_TERM_COEFF * dot + x_norm_sq
             }
         }
+    }
+}
+
+/// `Σ_d q_prime[d] · code_u16[d]` over `dim` little-endian `u16` codes —
+/// the [`Sq16Kernel`] cross term and the whole of its per-candidate
+/// arithmetic. Tier-dispatched: AVX-512F (16 codes/iteration), AVX2+FMA
+/// (8), and a safe `wide` fallback. The rerank phase at 1M measured this
+/// conversion as 92% of warm query wall when it ran through per-byte
+/// slice indexing; the intrinsic tiers convert with `cvtepu16` directly
+/// from the unaligned code bytes. Tiers may differ in the final f32 by
+/// add-order/FMA rounding only (same contract as
+/// [`BitQuantizer::estimate_dot_rotated_with_total`]).
+#[inline]
+fn sq16_cross(q_prime: &[f32], code_bytes: &[u8]) -> f32 {
+    debug_assert_eq!(code_bytes.len(), q_prime.len() * 2);
+    #[cfg(target_arch = "x86_64")]
+    {
+        if avx512_enabled() {
+            // SAFETY: gated on `avx512_enabled()` (avx512f+bw+dq+vl);
+            // the kernel uses AVX-512F conversions/FMA plus AVX2 loads,
+            // all implied by that gate. Bounds: the loop reads
+            // `16 * 2` code bytes and 16 `q_prime` floats per iteration
+            // strictly below `dim - dim % 16`, and the scalar tail
+            // covers the remainder — no out-of-bounds access.
+            return unsafe { sq16_cross_avx512(q_prime, code_bytes) };
+        }
+        if avx2_enabled() {
+            // SAFETY: gated on `avx2_enabled()` (AVX2; FMA is checked
+            // by the same gate's platform baseline — see the explicit
+            // `fma` enable on the function). Bounds as above with an
+            // 8-code stride.
+            return unsafe { sq16_cross_avx2(q_prime, code_bytes) };
+        }
+    }
+    sq16_cross_wide(q_prime, code_bytes)
+}
+
+/// Safe `wide` tier of [`sq16_cross`]: fixed-size 16-byte chunks so the
+/// u16 conversions compile without per-byte bounds checks.
+fn sq16_cross_wide(q_prime: &[f32], code_bytes: &[u8]) -> f32 {
+    let mut acc = f32x8::ZERO;
+    let mut q_chunks = q_prime.chunks_exact(F32X8_LANES);
+    let mut c_chunks = code_bytes.chunks_exact(F32X8_LANES * 2);
+    for (qp, cb) in (&mut q_chunks).zip(&mut c_chunks) {
+        let qp: [f32; F32X8_LANES] = qp.try_into().expect("len-8 q_prime chunk");
+        let cb: [u8; F32X8_LANES * 2] = cb.try_into().expect("len-16 code chunk");
+        let mut lanes = [0f32; F32X8_LANES];
+        for (j, lane) in lanes.iter_mut().enumerate() {
+            *lane = f32::from(u16::from_le_bytes([cb[2 * j], cb[2 * j + 1]]));
+        }
+        acc = f32x8::from(qp).mul_add(f32x8::from(lanes), acc);
+    }
+    let mut cross = acc.reduce_add();
+    for (qp, cb) in q_chunks
+        .remainder()
+        .iter()
+        .zip(c_chunks.remainder().chunks_exact(2))
+    {
+        cross += qp * f32::from(u16::from_le_bytes([cb[0], cb[1]]));
+    }
+    cross
+}
+
+/// AVX2+FMA tier of [`sq16_cross`]: 8 u16 codes load as one 128-bit
+/// vector, widen (`cvtepu16_epi32`), convert (`cvtepi32_ps`), and fold
+/// into a single FMA accumulator; scalar tail for `dim % 8`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn sq16_cross_avx2(q_prime: &[f32], code_bytes: &[u8]) -> f32 {
+    let dim = q_prime.len();
+    let mut acc = _mm256_setzero_ps();
+    let mut i = 0;
+    // SAFETY (callee): unaligned loads only, within `i + 8 <= dim`
+    // (16 code bytes, 8 floats per iteration).
+    unsafe {
+        while i + 8 <= dim {
+            let raw = _mm_loadu_si128(code_bytes.as_ptr().add(2 * i) as *const __m128i);
+            let vals = _mm256_cvtepi32_ps(_mm256_cvtepu16_epi32(raw));
+            let q = _mm256_loadu_ps(q_prime.as_ptr().add(i));
+            acc = _mm256_fmadd_ps(q, vals, acc);
+            i += 8;
+        }
+        let hi = _mm256_extractf128_ps(acc, 1);
+        let lo = _mm256_castps256_ps128(acc);
+        let sum4 = _mm_add_ps(lo, hi);
+        let sum2 = _mm_add_ps(sum4, _mm_movehl_ps(sum4, sum4));
+        let sum1 = _mm_add_ss(sum2, _mm_shuffle_ps(sum2, sum2, 1));
+        let mut cross = _mm_cvtss_f32(sum1);
+        while i < dim {
+            let b = 2 * i;
+            cross += q_prime[i] * f32::from(u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]));
+            i += 1;
+        }
+        cross
+    }
+}
+
+/// AVX-512F tier of [`sq16_cross`]: 16 u16 codes per iteration
+/// (256-bit load → 512-bit widen/convert → one FMA accumulator).
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f")]
+unsafe fn sq16_cross_avx512(q_prime: &[f32], code_bytes: &[u8]) -> f32 {
+    let dim = q_prime.len();
+    let mut acc = _mm512_setzero_ps();
+    let mut i = 0;
+    // SAFETY (callee): unaligned loads only, within `i + 16 <= dim`
+    // (32 code bytes, 16 floats per iteration).
+    unsafe {
+        while i + 16 <= dim {
+            let raw = _mm256_loadu_si256(code_bytes.as_ptr().add(2 * i) as *const __m256i);
+            let vals = _mm512_cvtepi32_ps(_mm512_cvtepu16_epi32(raw));
+            let q = _mm512_loadu_ps(q_prime.as_ptr().add(i));
+            acc = _mm512_fmadd_ps(q, vals, acc);
+            i += 16;
+        }
+        let mut cross = _mm512_reduce_add_ps(acc);
+        while i < dim {
+            let b = 2 * i;
+            cross += q_prime[i] * f32::from(u16::from_le_bytes([code_bytes[b], code_bytes[b + 1]]));
+            i += 1;
+        }
+        cross
     }
 }
 
@@ -2671,6 +2772,61 @@ mod tests {
     /// same raw-dot cosine (`1 − q·x`) the [`distance`] dispatch uses,
     /// so this is an apples-to-apples quantization-error bound. Sweeps a
     /// SIMD-aligned dim, a tail dim, and a production-shaped dim.
+    /// Every [`sq16_cross`] tier this host supports agrees with the safe
+    /// `wide` tier and with an f64 scalar reference, to f32
+    /// add-order/FMA tolerance — the cross-tier contract the 1-bit
+    /// estimator documents. Sweeps SIMD-aligned dims, tail dims, and the
+    /// production 768.
+    #[test]
+    fn sq16_cross_tiers_agree() {
+        for &dim in &[8usize, 13, 100, 384, 768, 771] {
+            let q_prime: Vec<f32> = (0..dim)
+                .map(|i| ((i as f32) * 0.013 - 0.2).sin() * 0.001)
+                .collect();
+            let codes: Vec<u8> = (0..dim)
+                .flat_map(|i| (((i * 2_654_435_761) % 65_536) as u16).to_le_bytes())
+                .collect();
+            let exact: f64 = (0..dim)
+                .map(|i| {
+                    f64::from(q_prime[i])
+                        * f64::from(u16::from_le_bytes([codes[2 * i], codes[2 * i + 1]]))
+                })
+                .sum();
+            let abs_sum: f64 = (0..dim)
+                .map(|i| {
+                    (f64::from(q_prime[i])
+                        * f64::from(u16::from_le_bytes([codes[2 * i], codes[2 * i + 1]])))
+                    .abs()
+                })
+                .sum();
+            let tol = (abs_sum * 1e-5 + 1e-3) as f32;
+            let reference = sq16_cross_wide(&q_prime, &codes);
+            assert!(
+                ((f64::from(reference) - exact).abs() as f32) <= tol,
+                "dim {dim}: wide {reference} vs exact {exact}"
+            );
+            #[cfg(target_arch = "x86_64")]
+            {
+                if avx2_enabled() {
+                    // SAFETY: gated on runtime AVX2 detection.
+                    let got = unsafe { sq16_cross_avx2(&q_prime, &codes) };
+                    assert!(
+                        (got - reference).abs() <= tol,
+                        "dim {dim}: avx2 {got} vs wide {reference}"
+                    );
+                }
+                if avx512_enabled() {
+                    // SAFETY: gated on runtime AVX-512 detection.
+                    let got = unsafe { sq16_cross_avx512(&q_prime, &codes) };
+                    assert!(
+                        (got - reference).abs() <= tol,
+                        "dim {dim}: avx512 {got} vs wide {reference}"
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn sq16_round_trip_within_16bit_tolerance_of_fp32() {
         fn normalize(v: &mut [f32]) {

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3726,15 +3726,42 @@ impl VectorReader {
                 // fetches, where round trips dominate — merges them into
                 // ~whole-cell spans that a resident cache then materializes
                 // (measured: ~300 MB touched per query to deliver ~10 MB of
-                // rows, 60% of warm query wall). When every row resolves
-                // synchronously from resident bytes, read the exact ranges
-                // instead; fall back to the coalesced remote plan otherwise.
-                let sync_rows: Option<Vec<Bytes>> = ranges
+                // rows, 60% of warm query wall). When the bytes are
+                // resident, resolve ONE zero-copy span per probed cluster
+                // (min..max survivor row) and slice each row out of it —
+                // resident spans are mmap/`Bytes` views, so pages fault in
+                // only for rows actually read, and the per-range source
+                // lookups drop from one per survivor to one per cluster
+                // (measured on Cohere-1M defaults: 25.3K sync lookups
+                // ≈ 8.5 ms of a 22 ms warm query). Any missing span falls
+                // back to the coalesced remote plan, as before.
+                let mut span_by_cluster: HashMap<u32, Range<usize>> = HashMap::new();
+                for (cand, range) in rerank_cands.iter().zip(&ranges) {
+                    span_by_cluster
+                        .entry(cand.cluster_id)
+                        .and_modify(|span| {
+                            span.start = span.start.min(range.start);
+                            span.end = span.end.max(range.end);
+                        })
+                        .or_insert_with(|| range.clone());
+                }
+                let spans: Option<HashMap<u32, (usize, Bytes)>> = span_by_cluster
                     .iter()
-                    .map(|range| self.source.try_get_range_sync(range.clone()))
+                    .map(|(&cid, span)| {
+                        self.source
+                            .try_get_range_sync(span.clone())
+                            .map(|bytes| (cid, (span.start, bytes)))
+                    })
                     .collect();
-                let survivor_rows = match sync_rows {
-                    Some(rows) => rows,
+                let survivor_rows = match spans {
+                    Some(spans) => rerank_cands
+                        .iter()
+                        .zip(&ranges)
+                        .map(|(cand, range)| {
+                            let (base, region) = &spans[&cand.cluster_id];
+                            region.slice(range.start - base..range.end - base)
+                        })
+                        .collect(),
                     None => get_survivor_ranges_coalesced_async(&self.source, &ranges)
                         .await
                         .map_err(|e| VectorError::LazySource(e.to_string()))?,
@@ -5035,6 +5062,32 @@ pub(crate) fn read_cluster_entry(cluster_idx_slice: &[u8], c: usize) -> (u32, u3
 /// - **Sq8Residual**: builds one [`Sq8ResidualKernel`] per selected cluster and
 ///   scores every RaBitQ shortlist survivor with both stored bytes. The
 ///   per-doc decoded norm cached at encode time short-circuits `Σx²` for L2Sq.
+/// Per-doc norm access for the Sq16 rerank arm: eager tables index the
+/// resident array; lazy tables read one little-endian f32 per candidate
+/// straight from the raw norm-table bytes (never a full-table parse on
+/// the query path). `Absent` covers NegDot, where the norm term cancels.
+#[derive(Clone)]
+enum NormLookup {
+    Arr(Option<Arc<[f32]>>),
+    Raw(Bytes),
+    Absent,
+}
+
+impl NormLookup {
+    #[inline]
+    fn get(&self, pos: u32) -> Option<f32> {
+        match self {
+            Self::Arr(arr) => arr.as_ref().map(|n| n[pos as usize]),
+            Self::Raw(bytes) => {
+                let p = pos as usize * 4;
+                let b: [u8; 4] = bytes[p..p + 4].try_into().expect("norm entry in range");
+                Some(f32::from_le_bytes(b))
+            }
+            Self::Absent => None,
+        }
+    }
+}
+
 async fn rerank_candidates_from_blocks(
     source: &Source,
     lazy_sq8_meta_bytes: Option<&Bytes>,
@@ -5112,24 +5165,31 @@ async fn rerank_candidates_from_blocks(
             // same expression the residual family uses
             // (`score_sq8_residual_candidates`), so a candidate's norm is
             // guaranteed to be its own — no parallel Sq16 norm path.
-            let norms: Option<Arc<[f32]>> = match col.sq8_meta.as_ref() {
-                Some(Sq8ColumnMeta::Eager { per_doc_norms, .. }) => per_doc_norms.clone(),
+            let norms: NormLookup = match col.sq8_meta.as_ref() {
+                Some(Sq8ColumnMeta::Eager { per_doc_norms, .. }) => {
+                    NormLookup::Arr(per_doc_norms.clone())
+                }
                 Some(Sq8ColumnMeta::Lazy { norms_abs_off, .. }) => {
                     if let Some(meta_bytes) = lazy_sq8_meta_bytes {
-                        // Sq16's codec_meta region IS the norm table.
-                        Some(Arc::from(parse_f32_le_vec(meta_bytes)))
+                        // Sq16's codec_meta region IS the norm table. Read
+                        // per-candidate 4-byte entries straight from the
+                        // raw bytes: parsing the whole table costs one
+                        // f32-decode per STORED row per rerank call
+                        // (measured on Cohere-1M defaults: 2.6 ms/query),
+                        // for the handful of positions a call touches.
+                        NormLookup::Raw(meta_bytes.clone())
                     } else if let Some(norms_abs_off) = norms_abs_off {
                         let range = *norms_abs_off..*norms_abs_off + col.n_docs as usize * 4;
-                        let fetched = source
+                        let mut fetched = source
                             .get_ranges_parallel(std::slice::from_ref(&range))
                             .map_err(map_lazy)?;
-                        Some(Arc::from(parse_f32_le_vec(&fetched[0])))
+                        NormLookup::Raw(fetched.swap_remove(0))
                     } else {
-                        None
+                        NormLookup::Absent
                     }
                 }
                 // NegDot (Sq16 is cosine-only in practice) → no norms.
-                None => None,
+                None => NormLookup::Absent,
             };
             let kernel = Sq16Kernel::new(col.metric, query);
             if candidates.len() >= PARALLEL_SCAN_MIN {
@@ -5147,7 +5207,7 @@ async fn rerank_candidates_from_blocks(
                             cand,
                             stride,
                         );
-                        let norm = norms.as_ref().map(|n| n[cand.pos as usize]);
+                        let norm = norms.get(cand.pos);
                         (cand.did, kernel.distance_with_norm(bytes, norm))
                     },
                     pool.clone(),
@@ -5166,7 +5226,7 @@ async fn rerank_candidates_from_blocks(
                                 cand,
                                 stride,
                             );
-                            let norm = norms.as_ref().map(|n| n[cand.pos as usize]);
+                            let norm = norms.get(cand.pos);
                             (cand.did, kernel.distance_with_norm(bytes, norm))
                         })
                         .collect()

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3735,16 +3735,7 @@ impl VectorReader {
                 // (measured on Cohere-1M defaults: 25.3K sync lookups
                 // ≈ 8.5 ms of a 22 ms warm query). Any missing span falls
                 // back to the coalesced remote plan, as before.
-                let mut span_by_cluster: HashMap<u32, Range<usize>> = HashMap::new();
-                for (cand, range) in rerank_cands.iter().zip(&ranges) {
-                    span_by_cluster
-                        .entry(cand.cluster_id)
-                        .and_modify(|span| {
-                            span.start = span.start.min(range.start);
-                            span.end = span.end.max(range.end);
-                        })
-                        .or_insert_with(|| range.clone());
-                }
+                let span_by_cluster = survivor_cluster_spans(&rerank_cands, &ranges);
                 let spans: Option<HashMap<u32, (usize, Bytes)>> = span_by_cluster
                     .iter()
                     .map(|(&cid, span)| {
@@ -5011,6 +5002,29 @@ struct RerankCandidate {
     block_idx: usize,
     full_off: usize,
     full_idx: Option<usize>,
+}
+
+/// One min..max byte span per probed cluster, covering every survivor
+/// range in it. The rerank gather resolves each span sync-resident once
+/// and slices per-survivor rows out of it; `range ⊆ span` holds by
+/// construction, so `range.start - span.start` never underflows and the
+/// slice returns byte-identical rows to a per-range fetch (pinned by
+/// `survivor_cluster_spans_slice_byte_identical_to_per_row_fetch`).
+fn survivor_cluster_spans(
+    rerank_cands: &[RerankCandidate],
+    ranges: &[Range<usize>],
+) -> HashMap<u32, Range<usize>> {
+    let mut span_by_cluster: HashMap<u32, Range<usize>> = HashMap::new();
+    for (cand, range) in rerank_cands.iter().zip(ranges) {
+        span_by_cluster
+            .entry(cand.cluster_id)
+            .and_modify(|span| {
+                span.start = span.start.min(range.start);
+                span.end = span.end.max(range.end);
+            })
+            .or_insert_with(|| range.clone());
+    }
+    span_by_cluster
 }
 
 #[inline]
@@ -11120,5 +11134,76 @@ mod tests {
             lazy_errors >= 2,
             "both the cluster-index and block fetch waves must surface LazySource"
         );
+    }
+
+    /// The rerank gather's span rewrite must be byte-identical to the
+    /// per-row path it replaced: for survivors scattered across clusters,
+    /// slicing each row out of its cluster's min..max span returns the
+    /// same bytes as fetching each range individually — including
+    /// duplicate ranges and single-row spans. Recall assertions cannot
+    /// pin this (a wrong-but-plausible row still scores), so the
+    /// equality is asserted directly.
+    #[test]
+    fn survivor_cluster_spans_slice_byte_identical_to_per_row_fetch() {
+        let backing: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+        let source = Source::InMemory(Bytes::from(backing));
+        let cand = |cluster_id: u32| RerankCandidate {
+            did: 0,
+            pos: 0,
+            cluster_id,
+            block_idx: 0,
+            full_off: 0,
+            full_idx: None,
+        };
+        // Cluster 7: rows at both ends of a wide span; cluster 3: one row;
+        // cluster 9: overlapping + duplicate ranges.
+        let rerank_cands = [cand(7), cand(3), cand(7), cand(9), cand(9), cand(9)];
+        let ranges: Vec<Range<usize>> = vec![
+            100..164,
+            2048..2112,
+            900..964,
+            3000..3064,
+            3032..3096,
+            3000..3064,
+        ];
+
+        let spans = survivor_cluster_spans(&rerank_cands, &ranges);
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[&7], 100..964);
+        assert_eq!(spans[&3], 2048..2112);
+        assert_eq!(spans[&9], 3000..3096);
+
+        for (cand, range) in rerank_cands.iter().zip(&ranges) {
+            let span = &spans[&cand.cluster_id];
+            let region = source
+                .try_get_range_sync(span.clone())
+                .expect("in-memory span");
+            let via_span = region.slice(range.start - span.start..range.end - span.start);
+            let direct = source
+                .try_get_range_sync(range.clone())
+                .expect("in-memory range");
+            assert_eq!(via_span, direct, "cluster {} range {range:?}", cand.cluster_id);
+        }
+    }
+
+    /// `NormLookup::Raw` (per-candidate 4-byte reads off the raw norm
+    /// table) must return bit-exactly what the eager arm returns over a
+    /// parsed copy of the same table, at every position — the lazy arm
+    /// replaced a parse-whole-table path and a norm off by one position
+    /// silently corrupts every cosine rerank score. `Absent` stays
+    /// `None`.
+    #[test]
+    fn norm_lookup_raw_matches_parsed_table() {
+        let norms = [0.5f32, -1.25, 3.75e10, f32::MIN_POSITIVE, 0.0, -0.0, 65_504.0];
+        let raw: Vec<u8> = norms.iter().flat_map(|n| n.to_le_bytes()).collect();
+        let raw_lookup = NormLookup::Raw(Bytes::from(raw));
+        let arr_lookup = NormLookup::Arr(Some(Arc::from(norms.as_slice())));
+        for pos in 0..norms.len() as u32 {
+            let raw_val = raw_lookup.get(pos).expect("raw norm");
+            let arr_val = arr_lookup.get(pos).expect("arr norm");
+            assert_eq!(raw_val.to_bits(), arr_val.to_bits(), "pos {pos}");
+        }
+        assert_eq!(NormLookup::Absent.get(0), None);
+        assert_eq!(NormLookup::Arr(None).get(0), None);
     }
 }

--- a/src/superfile/vector/simd_dispatch.rs
+++ b/src/superfile/vector/simd_dispatch.rs
@@ -145,7 +145,14 @@ pub fn avx2_enabled() -> bool {
         }
         #[cfg(target_arch = "x86_64")]
         {
+            // FMA is detected alongside AVX2: several kernels behind this
+            // gate compile with `target_feature(enable = "avx2,fma")`
+            // (`sq16_cross_avx2`, `sq8_encode_row_avx2`), and calling one
+            // on silicon without FMA is UB. Every known AVX2 part ships
+            // FMA, but detection is one CPUID read — cheap to be correct
+            // about, same doctrine as the AVX-512 gate above.
             std::arch::is_x86_feature_detected!("avx2")
+                && std::arch::is_x86_feature_detected!("fma")
         }
         #[cfg(not(target_arch = "x86_64"))]
         {

--- a/tests/supertable/main.rs
+++ b/tests/supertable/main.rs
@@ -39,4 +39,5 @@ mod query;
 mod storage;
 mod update_crash_property;
 mod vector_law_serving;
+mod vector_phase_profile;
 mod writer_mutations;

--- a/tests/supertable/vector_phase_profile.rs
+++ b/tests/supertable/vector_phase_profile.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Warm vector-query phase profile against a prebuilt local table
+//! (ignored: diagnostic, not CI). Prints the engine's own per-phase
+//! timers so a latency number decomposes into admit / fan-out /
+//! shortlist / survivor fetch / rerank / stable-id instead of being
+//! argued about. Companion to `bioasq_admit_diag` (same env contract):
+//!
+//! ```sh
+//! INFINO_DIAG_TABLE=/mnt/scratch/vdbb/vdbb10m \
+//! INFINO_DIAG_QUERIES=/mnt/scratch/vdbb/cohere_diag_queries.txt \
+//! INFINO_DIAG_K=100 \
+//! INFINO_TRACE_VECTOR_WARM_PHASES=1 \
+//! cargo test --test supertable vector_phase_profile -- --ignored --nocapture
+//! ```
+
+#![deny(clippy::unwrap_used)]
+
+use std::{env, fs};
+
+use infino::storage::io_counters;
+
+/// Queries used to warm caches before any timed pass.
+const WARMUP_QUERIES: usize = 50;
+/// Timed queries (each sampled individually so phase spans attribute to
+/// exactly one query).
+const TIMED_QUERIES: usize = 200;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "diagnostic against a prebuilt local table; see module docs"]
+async fn vector_phase_profile() {
+    let table_dir = env::var("INFINO_DIAG_TABLE").expect("INFINO_DIAG_TABLE");
+    let queries_path = env::var("INFINO_DIAG_QUERIES").expect("INFINO_DIAG_QUERIES");
+    let k: usize = env::var("INFINO_DIAG_K")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    let queries: Vec<Vec<f32>> = fs::read_to_string(&queries_path)
+        .expect("queries file")
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.split(',').map(|x| x.parse().expect("f32")).collect())
+        .collect();
+    assert!(
+        io_counters::phase_enabled(),
+        "set INFINO_TRACE_VECTOR_WARM_PHASES=1 so the engine records phases"
+    );
+
+    // Attach the disk cache exactly as the python sweeps and the admit diag
+    // do — without it every query re-reads and re-decodes code sections and
+    // the profile measures I/O, not serving (first run: 7.5s/query vs the
+    // harness's 69ms on this same table).
+    let cache_dir = format!("{table_dir}/cache");
+    let conn = infino::connect_with(
+        &table_dir,
+        infino::ConnectOptions::default()
+            .with_cache_dir(&cache_dir)
+            .with_cache_budget_bytes(21_474_836_480),
+    )
+    .expect("connect");
+    let table = conn.open_table("vdbbench_infino").expect("open table");
+    let st = table.local_handle();
+    let reader = st.reader().expect("reader");
+    if let Some((width, fine, rerank)) = reader.diag_hidden_probe_laws() {
+        println!("stamped laws: width={width:?} fine={fine:?} rerank={rerank:?}");
+    }
+
+    for q in queries.iter().cycle().take(WARMUP_QUERIES) {
+        st.vector_search("emb", q, k, Default::default(), None, None)
+            .expect("warmup search");
+    }
+
+    let mut walls_us: Vec<u64> = Vec::with_capacity(TIMED_QUERIES);
+    let mut phase_sums: Vec<(&'static str, u64)> = Vec::new();
+    for q in queries.iter().cycle().take(TIMED_QUERIES) {
+        io_counters::phase_reset();
+        let t0 = std::time::Instant::now();
+        st.vector_search("emb", q, k, Default::default(), None, None)
+            .expect("timed search");
+        walls_us.push(t0.elapsed().as_micros() as u64);
+        for (name, us) in io_counters::phase_take_summed() {
+            match phase_sums.iter_mut().find(|(n, _)| *n == name) {
+                Some((_, acc)) => *acc += us,
+                None => phase_sums.push((name, us)),
+            }
+        }
+    }
+
+    walls_us.sort_unstable();
+    let n = walls_us.len();
+    let sum: u64 = walls_us.iter().sum();
+    println!(
+        "k={k} queries={n}: wall avg={:.1}ms p50={:.1}ms p95={:.1}ms",
+        sum as f64 / n as f64 / 1000.0,
+        walls_us[n / 2] as f64 / 1000.0,
+        walls_us[n * 95 / 100] as f64 / 1000.0,
+    );
+    phase_sums.sort_by_key(|&(_, us)| std::cmp::Reverse(us));
+    for (name, us) in &phase_sums {
+        println!(
+            "  {name:<20} avg {:>8.1}ms  ({:>5.1}% of wall)",
+            *us as f64 / n as f64 / 1000.0,
+            *us as f64 / sum as f64 * 100.0,
+        );
+    }
+}


### PR DESCRIPTION
Three implementation-only changes to the deferred rerank, together 26.1 -> 19.3 ms warm k=100 on Cohere-1M engine defaults (phase-profile harness, scores equivalent within FMA/add-order rounding, recall machinery untouched):

- Tier the Sq16 cross-dot (AVX-512F / AVX2+FMA / safe `wide` fallback). The old inner loop converted u16 codes through per-byte slice indexing — measured as 24.1 ms of a 26.1 ms query; the intrinsic tiers convert via `cvtepu16` straight from the unaligned code bytes (9.9 ms, now DRAM-bound on the scattered rows). Tiers agree to add-order/FMA rounding, pinned by a parity test.

- Resolve warm survivor rows as ONE zero-copy span per probed cluster and slice each row out of it, instead of one source lookup per survivor (25.3K lookups ~= 8.5 ms -> 1.1 ms). Resident spans are mmap-backed Bytes views, so pages fault in only for rows actually read; any missing span falls back to the coalesced remote plan unchanged.

- Read per-candidate norms as single little-endian f32 loads from the raw norm-table bytes (NormLookup) instead of parsing the whole table on every rerank call (2.6 ms -> ~0).

Also adds the ignored vector_phase_profile diagnostic (per-phase decomposition of warm queries against a prebuilt local table) that produced these measurements.
