### PR TITLE
compaction: codec-agnostic saturation warning (stop hardcoding "Sq8")

### DIFF
--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -458,9 +458,9 @@ impl Supertable {
         if clamped_components > 0 {
             eprintln!(
                 "[supertable compaction] BUG: {clamped_components} component(s) saturated \
-                 their destination Sq8 quantizer during this pass's merges/splits (#512 \
-                 failure mode) — a destination grid failed to cover its inputs; affected \
-                 rows' recall silently degrades.",
+                 their destination quantizer during this pass's merges/splits — a \
+                 destination grid failed to cover its inputs; affected rows' recall \
+                 degrades.",
             );
         }
         Ok(())

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -4262,10 +4262,10 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
     if clamped_components > 0 {
         eprintln!(
             "[supertable drain] BUG: {clamped_components} component(s) saturated their \
-             destination Sq8 quantizer during this drain's re-encodes (#512 failure \
-             mode). Cosine: an ingest path bypassed normalization; L2/NegDot: a \
-             destination grid failed to cover its inputs. Affected rows' recall \
-             silently degrades — find the source and rebuild the table.",
+             destination quantizer during this drain's re-encodes. Cosine: an ingest \
+             path bypassed normalization; L2/NegDot: a destination grid failed to \
+             cover its inputs. Affected rows' recall degrades — find the source and \
+             rebuild the table.",
         );
     }
     // Membership has settled: publish the slow-CAS entry blob and stamp its


### PR DESCRIPTION
## What

The compaction saturation warning hardcoded **"destination Sq8 quantizer"**, but the counter it reports (`TRANSCODE_CLAMPED_COMPONENTS`) now also tallies clamps from **single-plane codecs** — `Sq16Adaptive` bumps it from its merge re-encode via `note_transcode_clamped_components`. So a `Sq16Adaptive` table (the L2/NegDot default) that clamps on merge printed a `BUG` line saying "Sq8", reading as if the wrong codec were selected.

This makes the message **codec-agnostic** ("destination quantizer") and drops "silently" (the line is emitted, so it isn't silent).

```
- their destination Sq8 quantizer during this pass's merges/splits ... rows' recall silently degrades.
+ their destination quantizer during this pass's merges/splits ... rows' recall degrades.
```

Logging-only change; no behavior change. The underlying clamp (destination grid sized from a subset, not the union of inputs) is the separate union-sizing work in #554.

Fixes #568.
