### PR TITLE
catalog: take query_sql's zero-row schema from the physical plan

### DIFF
--- a/infino-node/__test__/nulls_empty.test.mjs
+++ b/infino-node/__test__/nulls_empty.test.mjs
@@ -1,10 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 //
+// Absent values on the way back out.
+//
 // Null handling on the row-object append path: a nullable field that is
 // omitted from a row must store SQL NULL, exactly like passing `null`
 // explicitly — never a type's zero value. Also covers the Boolean column
 // edge where every value in a batch is null.
+//
+// Also the whole result: a query that matches nothing must decode to `[]`.
+// A zero-row result still ships a schema over Arrow IPC, and a plain (non-FTS)
+// string column is scanned as `Utf8View`, which `apache-arrow` cannot decode.
+// A view leaking there fails the call with
+// `Unrecognized type: "undefined" (24)`.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -26,6 +34,18 @@ const makeTable = (db, name, colName, type) =>
 // Read back the row for `id` and the table-wide IS NULL count for `col`.
 const nullCount = (db, table, col) =>
   Number(db.querySql(`SELECT count(*) AS c FROM ${table} WHERE ${col} IS NULL`)[0].c);
+
+// `id` is FTS-indexed, so it keeps its stored type. `body` is the plain
+// string column that gets viewed for the scan.
+const makeDocs = () => {
+  const db = connect("memory://");
+  const docs = makeTable(db, "docs", "body", new LargeUtf8());
+  docs.append([
+    { id: "present", body: "hello world" },
+    { id: "other", body: "goodbye" },
+  ]);
+  return { db, docs };
+};
 
 test("omitted nullable Int32 stores null, not 0", () => {
   const db = connect("memory://");
@@ -127,4 +147,68 @@ test("update accepts an all-null Bool replacement batch", () => {
 
   t.update("id = 'a'", [{ id: "a", flag: null }]);
   assert.deepEqual(db.querySql("SELECT flag FROM t WHERE id = 'a'"), [{ flag: null }]);
+});
+
+test("zero-match SELECT of a scalar string column returns []", () => {
+  const { db } = makeDocs();
+
+  // Control: the same query against a value that exists.
+  assert.deepEqual(db.querySql("SELECT body FROM docs WHERE id = 'present'"), [
+    { body: "hello world" },
+  ]);
+
+  assert.deepEqual(db.querySql("SELECT body FROM docs WHERE id = 'missing'"), []);
+});
+
+test("zero-match SELECT of the indexed column returns []", () => {
+  const { db } = makeDocs();
+
+  assert.deepEqual(db.querySql("SELECT id FROM docs WHERE id = 'missing'"), []);
+});
+
+test("zero-match SELECT * returns []", () => {
+  const { db } = makeDocs();
+
+  assert.deepEqual(db.querySql("SELECT * FROM docs WHERE id = 'missing'"), []);
+});
+
+// A table queried before its first append hits the same path, and is the way
+// most users meet it.
+test("SELECT from a table with no rows returns []", () => {
+  const db = connect("memory://");
+  makeTable(db, "docs", "body", new LargeUtf8());
+
+  assert.deepEqual(db.querySql("SELECT body FROM docs"), []);
+  assert.deepEqual(db.querySql("SELECT * FROM docs"), []);
+});
+
+// An aggregate always emits a batch, so it never synthesized a schema.
+test("zero-match COUNT(*) still returns one zero row", () => {
+  const { db } = makeDocs();
+
+  assert.deepEqual(db.querySql("SELECT COUNT(*) AS n FROM docs WHERE id = 'missing'"), [
+    { n: 0n },
+  ]);
+});
+
+test("zero-match SELECT with arrow:true yields an empty table with a readable schema", () => {
+  const { db } = makeDocs();
+
+  const table = db.querySql("SELECT body FROM docs WHERE id = 'missing'", { arrow: true });
+  assert.equal(table.numRows, 0);
+  assert.deepEqual(
+    table.schema.fields.map((f) => f.name),
+    ["body"],
+  );
+  // Same string type as a query that matches.
+  const matched = db.querySql("SELECT body FROM docs WHERE id = 'present'", { arrow: true });
+  assert.equal(String(table.schema.fields[0].type), String(matched.schema.fields[0].type));
+});
+
+test("zero-hit searches return []", () => {
+  const { docs } = makeDocs();
+
+  assert.deepEqual(docs.bm25Search("id", "missing", 10), []);
+  assert.deepEqual(docs.tokenMatch("id", "missing"), []);
+  assert.deepEqual(docs.exactMatch("id", "missing"), []);
 });

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -828,14 +828,6 @@ impl Connection {
                 .await
                 .map_err(|e| InfinoError::Query(e.to_string()).with_context("query_sql", None))?;
 
-            // A RecordBatch carries the schema; an empty Vec does not. Capture
-            // the output schema before collect() consumes the DataFrame so a
-            // zero-row result returns one empty batch with the projected schema,
-            // rather than a schema-less Vec, which the Python binding's
-            // Table.from_batches([]) can't build from. The scan's `Utf8View`
-            // columns are already coerced back to `LargeUtf8` here by
-            // `expand_views_at_output`, so the schema needs no further fixup.
-            let output_schema: SchemaRef = df.schema().inner().clone();
             // Execute through the physical plan (what `DataFrame::collect`
             // does internally) so the plan handle survives execution and
             // DataFusion's own operator metrics — elapsed compute, scan
@@ -850,6 +842,12 @@ impl Connection {
                 .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;
             harvest_datafusion_metrics(&plan, &op_stats);
             if batches.is_empty() {
+                // An empty Vec carries no schema, so hand back one empty batch
+                // instead. Its schema comes from the physical plan, not the
+                // DataFrame: the scan types scalar strings as `Utf8View`, and
+                // `expand_views_at_output` undoes that during optimization,
+                // which the DataFrame's logical plan predates.
+                let output_schema: SchemaRef = plan.schema();
                 Ok(vec![RecordBatch::new_empty(output_schema)])
             } else {
                 Ok(batches)
@@ -2658,6 +2656,71 @@ mod tests {
             batches[0].schema(),
             expected_schema,
             "zero-group schema must match the with-groups schema"
+        );
+    }
+
+    /// A zero-row result must expose the caller-facing `LargeUtf8`, never the
+    /// scan's `Utf8View`.
+    ///
+    /// The two zero-row tests above miss this. One uses an FTS column (never
+    /// viewed), the other a `GROUP BY` (still emits an empty batch to take the
+    /// schema from). A view only escapes when the plan emits no batch at all
+    /// and the schema has to come from somewhere else, so this covers the
+    /// shapes that emit nothing: an unmatched filter, an empty table, `LIMIT
+    /// 0`, and an unmatched join.
+    #[test]
+    fn query_sql_zero_row_string_schema_is_large_utf8_not_view() {
+        let conn = connect("memory://").expect("connect");
+        // No FTS on `title`, so it is a plain scalar string and gets viewed.
+        let docs = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new())
+            .expect("create docs");
+        docs.append(&build_title_batch(&["alpha", "beta"]))
+            .expect("append");
+        conn.create_table("blank", schema_id_title(), IndexSpec::new())
+            .expect("create blank");
+
+        // Ground truth: the same projection over rows that exist.
+        let matched = conn
+            .query_sql("SELECT title FROM docs WHERE title = 'alpha'")
+            .expect("matching query");
+        assert_eq!(n_rows(&matched), 1, "exactly one row matches");
+
+        // Collected rather than asserted per shape, so a regression names every
+        // shape it broke instead of stopping at the first.
+        let mut leaked: Vec<(&str, DataType)> = Vec::new();
+        for sql in [
+            "SELECT title FROM docs WHERE title = 'no_such_title'",
+            "SELECT title FROM docs LIMIT 0",
+            "SELECT title FROM blank",
+            "SELECT a.title FROM docs a JOIN docs b ON a.title = b.title \
+             WHERE a.title = 'no_such_title'",
+        ] {
+            let empty = conn.query_sql(sql).expect("zero-row query must not error");
+            assert!(
+                !empty.is_empty(),
+                "{sql}: needs one empty batch to carry the schema"
+            );
+            assert_eq!(n_rows(&empty), 0, "{sql}: must return no rows");
+            let ty = empty[0].schema().field(0).data_type().clone();
+            if ty != DataType::LargeUtf8 {
+                leaked.push((sql, ty));
+            }
+        }
+        assert!(
+            leaked.is_empty(),
+            "zero-row shapes not LargeUtf8: {leaked:?}"
+        );
+
+        // The plain filter shape also matches the with-rows schema exactly,
+        // names and nullability included.
+        let empty = conn
+            .query_sql("SELECT title FROM docs WHERE title = 'no_such_title'")
+            .expect("zero-row query");
+        assert_eq!(
+            empty[0].schema(),
+            matched[0].schema(),
+            "zero-row and matching results must carry the same schema"
         );
     }
 


### PR DESCRIPTION
### What does this PR do?
Fixes a query that returns no rows failing in the Node SDK instead of returning an empty result. Closes #571 

### Why do we need this change?
A zero-row result has no batch to take its schema from, so we build one, and it was coming from the wrong place. `query_sql` read it off the DataFrame, which holds the plan as written, before optimization. Scalar (non-FTS) string columns are scanned as `Utf8View`, and the pass that turns views back into `LargeUtf8` runs during optimization, so the DataFrame's copy still had the view on it. Results with rows were never affected, since their schema comes off a real batch, after the coercion.

`apache-arrow` has no decoder for `Utf8View`, so the Node SDK failed the whole call with `Unrecognized type: "undefined" (24)` instead of returning `[]`. Any plan that emits no batch hits this: a filter matching nothing, a table queried before its first append, `LIMIT 0`, an unmatched join. `COUNT(*)` always worked, because an aggregate emits a batch either way, and that was the workaround people landed on.

### Notes
- Python was never broken by this, `pyarrow` decodes `string_view` fine, but it did get a different type for a zero-row result than for a matching one. Not covered here.
- `Supertable::query_sql` (internal, no binding uses it for SQL) still returns a schema-less `Vec` for zero rows. Pre-existing, left alone.
