### PR TITLE
fts: faster COUNT + phrase search — skip-based negation, staged phrase verify

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -753,7 +753,7 @@ pub mod fts {
                         .map(|p| p.into_iter().map(|t| t.into_owned()).collect())
                         .collect();
                     return self
-                        .atoms_match_count(column, &refs, &owned, eff_mode)
+                        .atoms_match_count(column, &refs, &owned, eff_mode, &[], &[])
                         .await
                         .expect("superfile atoms_match_count")
                         .0;

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1798,7 +1798,14 @@ impl FtsReader {
                 .build_atom_cursors(column_id, neg_terms, neg_phrases, None)
                 .await?;
             let neg_atoms: Vec<AnyCursor> = neg_built.into_iter().flatten().collect();
-            work.planned_ranges += neg_dict_ranges;
+            // Count the negated clause's posting work the same way the
+            // positive atoms above (and the scored path's `ExcludeFilter`)
+            // are counted — planned posting bytes + ranges from cursor
+            // metadata — so op_stats prices a negated count consistently.
+            // (Like every skip/leapfrog path, this is a planned figure, not
+            // the partial bytes the skip probe actually decodes.)
+            work.postings_bytes += atom_cursor_bytes(&neg_atoms);
+            work.planned_ranges += atom_planned_ranges(&neg_atoms) + neg_dict_ranges;
             if !neg_atoms.is_empty() {
                 filter = Some(AtomExcludeFilter::new(neg_atoms));
             }

--- a/src/superfile/fts/reader.rs
+++ b/src/superfile/fts/reader.rs
@@ -1772,6 +1772,8 @@ impl FtsReader {
         terms: &[&str],
         phrases: &[Vec<String>],
         mode: BoolMode,
+        neg_terms: &[&str],
+        neg_phrases: &[Vec<String>],
     ) -> Result<(u64, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         // Unranked: idf is irrelevant to the match set, so build local.
@@ -1785,9 +1787,25 @@ impl FtsReader {
         if missing_and_atom || atoms.is_empty() {
             return Ok((0, work));
         }
+        // Negated clauses become a skip-based exclusion gate, never a
+        // materialized set: each surviving positive doc is `skip_to`-probed
+        // against the negated cursors, so a common negated term's long list
+        // is only partially decoded. Empty ⇒ `None`, the same walk as an
+        // unnegated count.
+        let mut filter = None;
+        if !neg_terms.is_empty() || !neg_phrases.is_empty() {
+            let (neg_built, neg_dict_ranges) = self
+                .build_atom_cursors(column_id, neg_terms, neg_phrases, None)
+                .await?;
+            let neg_atoms: Vec<AnyCursor> = neg_built.into_iter().flatten().collect();
+            work.planned_ranges += neg_dict_ranges;
+            if !neg_atoms.is_empty() {
+                filter = Some(AtomExcludeFilter::new(neg_atoms));
+            }
+        }
         let (walk, walk_ns) = timed_section(|| {
             let mut n = 0u64;
-            self.walk_atoms_match(atoms, mode, None, |_| n += 1)
+            self.walk_atoms_match(atoms, mode, filter, |_| n += 1)
                 .map(|()| n)
         });
         work.kernel_cpu_ns = walk_ns;
@@ -4669,6 +4687,15 @@ impl PhraseMember {
 /// the BM25 tf-factor is monotone in tf.
 struct PhraseCursor {
     members: Vec<PhraseMember>,
+    /// Member indices in ascending posting-list length (rarest first).
+    /// The doc-alignment in [`Self::seek_match`] is a set intersection —
+    /// order-independent — so it probes members rarest-first: the short
+    /// lists drive the candidate doc and the long lists (a common word
+    /// like "the") are only skip-confirmed last, once per candidate,
+    /// instead of being re-skipped on every advance of a rare member.
+    /// Positional verification still runs in query order (`members`
+    /// order), which the phrase adjacency check requires.
+    align_order: Vec<usize>,
     /// Σ member idf × (K1 + 1) — the phrase's scoring constant.
     idf_x_k1p1: f32,
     /// Phrase-scaled term-level upper bound (see type docs).
@@ -4677,6 +4704,10 @@ struct PhraseCursor {
     current_doc: u32,
     /// Number of verified anchors at `current_doc`.
     current_tf: u32,
+    /// Reused across `verify_at_aligned` calls to hold the candidate
+    /// phrase-start positions as they are filtered member by member —
+    /// avoids a per-doc allocation on the hot verify path.
+    verify_scratch: Vec<u32>,
 }
 
 impl PhraseCursor {
@@ -4714,12 +4745,18 @@ impl PhraseCursor {
                 }
             })
             .collect();
+        // Rarest-first probe order for alignment: fewest posting blocks
+        // (shortest list) first. Query order is preserved in `members`.
+        let mut align_order: Vec<usize> = (0..members.len()).collect();
+        align_order.sort_by_key(|&i| members[i].cursor.block_count());
         let mut cursor = Self {
             idf_x_k1p1: idf_sum * (bm25::K1 + 1.0),
             term_max_bm25: idf_sum * min_scaled_bound,
             members,
+            align_order,
             current_doc: 0,
             current_tf: 0,
+            verify_scratch: Vec::new(),
         };
         cursor.seek_match(0, f32::NEG_INFINITY, &NormTable::empty())?;
         Ok(cursor)
@@ -4779,11 +4816,14 @@ impl PhraseCursor {
         dl_norm_k1: &NormTable,
     ) -> Result<(), FtsError> {
         'docs: loop {
-            // Align every member to the same doc ≥ `from`.
+            // Align every member to the same doc ≥ `from`, probing
+            // rarest-first so a common member is skip-confirmed last
+            // rather than re-skipped on every rare-member advance.
             let mut aligned = from;
-            let mut i = 0usize;
-            while i < self.members.len() {
-                let c = &mut self.members[i].cursor;
+            let mut oi = 0usize;
+            while oi < self.align_order.len() {
+                let mi = self.align_order[oi];
+                let c = &mut self.members[mi].cursor;
                 c.skip_to(aligned);
                 if c.is_exhausted() {
                     self.current_doc = u32::MAX;
@@ -4794,10 +4834,10 @@ impl PhraseCursor {
                 if here > aligned {
                     // Restart alignment at the higher doc.
                     aligned = here;
-                    i = 0;
+                    oi = 0;
                     continue;
                 }
-                i += 1;
+                oi += 1;
             }
 
             if bar > f32::NEG_INFINITY {
@@ -4846,24 +4886,54 @@ impl PhraseCursor {
     /// for every `i`. Member position lists are ascending, so each
     /// probe is a binary search over a per-doc-tf-sized slice.
     fn verify_at_aligned(&mut self) -> Result<u32, FtsError> {
-        for m in self.members.iter_mut() {
-            m.decode_current_positions()?;
+        // Staged, rarest-first, lazy-decode verification. A phrase match
+        // starting at position `s` has member `j` at `s + j`, so any
+        // member can seed the candidate starts: the rarest member (by
+        // posting length — `align_order[0]`) seeds them, then each
+        // remaining member filters the survivors *in rarest-first order*.
+        //
+        // Two wins over decode-all-then-probe-from-the-first-member:
+        //   * The seed loop is as short as the rarest member's per-doc tf,
+        //     not the (often common) query-first member's.
+        //   * Decoding is lazy: a common member's positions — whose
+        //     per-block run-offset walk is the real cost — are only
+        //     decoded once some candidate survives every rarer member.
+        //     On the huge co-occurrence sets a phrase with a common word
+        //     produces, almost every doc is rejected by a rare member
+        //     first, so the common members are never decoded there.
+        let anchor = self.align_order[0];
+        let anchor_off = anchor as u32;
+        self.members[anchor].decode_current_positions()?;
+        self.verify_scratch.clear();
+        for &pa in &self.members[anchor].pos_scratch {
+            if let Some(start) = pa.checked_sub(anchor_off) {
+                self.verify_scratch.push(start);
+            }
         }
-        let (anchor, rest) = self.members.split_first_mut().expect("members >= 2");
-        let mut tf = 0u32;
-        'anchors: for &p in &anchor.pos_scratch {
-            for (i, m) in rest.iter().enumerate() {
-                let want = match p.checked_add(i as u32 + 1) {
-                    Some(w) => w,
-                    None => continue 'anchors,
-                };
-                if m.pos_scratch.binary_search(&want).is_err() {
-                    continue 'anchors;
+        for oi in 1..self.align_order.len() {
+            if self.verify_scratch.is_empty() {
+                break;
+            }
+            let j = self.align_order[oi];
+            self.members[j].decode_current_positions()?;
+            let plist = &self.members[j].pos_scratch;
+            let off = j as u32;
+            // Compact the survivors in place: keep a start iff member `j`
+            // holds `start + j`.
+            let mut w = 0usize;
+            for r in 0..self.verify_scratch.len() {
+                let start = self.verify_scratch[r];
+                let keep = start
+                    .checked_add(off)
+                    .is_some_and(|want| plist.binary_search(&want).is_ok());
+                if keep {
+                    self.verify_scratch[w] = start;
+                    w += 1;
                 }
             }
-            tf += 1;
+            self.verify_scratch.truncate(w);
         }
-        Ok(tf)
+        Ok(self.verify_scratch.len() as u32)
     }
 
     /// Score the phrase at its current doc with the caller-supplied

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1071,18 +1071,25 @@ impl SuperfileReader {
     }
 
     /// Phrase-aware unranked match **count** — the phrase sibling of
-    /// [`token_match_count`](Self::token_match_count).
+    /// [`token_match_count`](Self::token_match_count). `neg_terms` /
+    /// `neg_phrases` are counted as a skip-based exclusion gate (a doc
+    /// matching any negated clause is not counted); pass empty slices for
+    /// an unnegated count.
     pub async fn atoms_match_count(
         &self,
         column: &str,
         terms: &[&str],
         phrases: &[Vec<String>],
         mode: BoolMode,
+        neg_terms: &[&str],
+        neg_phrases: &[Vec<String>],
     ) -> Result<(u64, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
-        Ok(fts.atoms_match_count(column, terms, phrases, mode).await?)
+        Ok(fts
+            .atoms_match_count(column, terms, phrases, mode, neg_terms, neg_phrases)
+            .await?)
     }
 
     /// Document frequency of `token` in `column` (0 if absent) — a cheap

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1173,11 +1173,13 @@ impl SupertableReader {
                     };
                     let refs: Vec<&str> = term_arc.iter().map(|s| s.as_str()).collect();
                     // Negated terms or deletes both force materialization:
-                    // the df read and the bare match count can't subtract
-                    // excluded or tombstoned docs. Materialize the positive
-                    // matches, then drop any doc carrying a negated term
-                    // (union of the negatives) or a tombstone.
-                    if has_negatives || tomb.is_some() {
+                    // Deletes force materialization: a tombstone bitmap can
+                    // only be subtracted from an explicit id set, so when this
+                    // superfile has deletes we materialize the positive matches
+                    // and drop any doc carrying a negated term (union of the
+                    // negatives) or a tombstone. Negation *without* deletes
+                    // takes the skip-based counting path below instead.
+                    if tomb.is_some() {
                         let (docs, mut work) = match phrase_involved {
                             true => r
                                 .atoms_match_ids(&column_arc, &refs, &phrase_arc, match_mode)
@@ -1224,19 +1226,35 @@ impl SupertableReader {
                             .count() as u64;
                         return Ok::<u64, QueryError>(n);
                     }
-                    // No negatives and no deletes (the common case): count
-                    // without materializing ids — a single token resolves
-                    // O(1) from the stored df, multi-token tallies the
-                    // match walk through the counting sink.
-                    let (n, work) = if single_term {
+                    // No deletes (the common case): count without
+                    // materializing ids.
+                    let (n, work) = if has_negatives {
+                        // Negation, delete-free: walk the positive atoms and
+                        // skip-exclude the negated ones — the negated union is
+                        // never materialized. Covers term-only and phrase
+                        // positives alike.
+                        let neg_refs: Vec<&str> = neg_arc.iter().map(|s| s.as_str()).collect();
+                        r.atoms_match_count(
+                            &column_arc,
+                            &refs,
+                            &phrase_arc,
+                            match_mode,
+                            &neg_refs,
+                            &neg_ph_arc,
+                        )
+                        .await
+                        .map_err(fts_read_error)?
+                    } else if single_term {
+                        // A single token resolves O(1) from the stored df.
                         r.term_df(&column_arc, &term_arc[0])
                             .await
                             .map_err(fts_read_error)?
                     } else if phrase_involved {
-                        r.atoms_match_count(&column_arc, &refs, &phrase_arc, match_mode)
+                        r.atoms_match_count(&column_arc, &refs, &phrase_arc, match_mode, &[], &[])
                             .await
                             .map_err(fts_read_error)?
                     } else {
+                        // Multi-token AND/OR tallies through the counting sink.
                         r.token_match_count(&column_arc, &refs, match_mode)
                             .await
                             .map_err(fts_read_error)?

--- a/tests/superfile/fts/negation.rs
+++ b/tests/superfile/fts/negation.rs
@@ -15,7 +15,8 @@ use std::collections::HashSet;
 use infino::superfile::{SuperfileReader, fts::reader::BoolMode};
 
 use crate::fts::brute_force_oracle::{
-    build_infino_superfile, build_multi_block_corpus, build_multi_block_reader, corpus,
+    build_infino_superfile, build_infino_superfile_positional, build_multi_block_corpus,
+    build_multi_block_reader, corpus,
 };
 
 // ── corpus-truth helpers ──────────────────────────────────────────────
@@ -50,6 +51,22 @@ fn and_match(corp: &[(u64, &str)], terms: &[&str]) -> HashSet<u64> {
 fn exclude(base: HashSet<u64>, corp: &[(u64, &str)], negatives: &[&str]) -> HashSet<u64> {
     let drop: HashSet<u64> = or_match(corp, negatives);
     base.difference(&drop).copied().collect()
+}
+
+/// Doc-ids whose text contains `phrase` as a contiguous, in-order token run.
+fn docs_with_phrase(corp: &[(u64, &str)], phrase: &[&str]) -> HashSet<u64> {
+    corp.iter()
+        .filter(|(_, t)| {
+            let toks: Vec<&str> = t.split_whitespace().collect();
+            toks.windows(phrase.len()).any(|w| w == phrase)
+        })
+        .map(|(i, _)| *i)
+        .collect()
+}
+
+/// A phrase as the `&[Vec<String>]` the count/search API expects.
+fn phrase(tokens: &[&str]) -> Vec<Vec<String>> {
+    vec![tokens.iter().map(|t| t.to_string()).collect()]
 }
 
 /// Run a query and collect the result doc-ids as a set.
@@ -92,7 +109,9 @@ async fn or_single_positive_minus_negative() {
 #[tokio::test]
 async fn count_with_negation_matches_corpus_truth() {
     let corp = corpus();
-    let r = build_infino_superfile(&corp);
+    // Positional index so the phrase cases below can run; term-only counts
+    // are identical on a positional index.
+    let r = build_infino_superfile_positional(&corp);
     async fn count(r: &SuperfileReader, pos: &[&str], mode: BoolMode, neg: &[&str]) -> u64 {
         r.atoms_match_count("title", pos, &[], mode, neg, &[])
             .await
@@ -128,6 +147,50 @@ async fn count_with_negation_matches_corpus_truth() {
         or_match(&corp, &["rust"]).len() as u64,
         "rust (OR count, no negation)"
     );
+
+    // Positive phrase + negated term: +"web framework" -go. Docs with the
+    // adjacent phrase, minus docs containing "go" (drops doc 7, keeps 8).
+    let got = r
+        .atoms_match_count(
+            "title",
+            &[],
+            &phrase(&["web", "framework"]),
+            BoolMode::And,
+            &["go"],
+            &[],
+        )
+        .await
+        .expect("atoms_match_count")
+        .0;
+    let want = exclude(
+        docs_with_phrase(&corp, &["web", "framework"]),
+        &corp,
+        &["go"],
+    );
+    assert_eq!(
+        got,
+        want.len() as u64,
+        "+\"web framework\" -go (phrase + neg term)"
+    );
+
+    // Negated phrase: web -"web framework". Docs with "web", minus docs where
+    // it is the adjacent phrase — keeps doc 4 ("web" but not "web framework").
+    let got = r
+        .atoms_match_count(
+            "title",
+            &["web"],
+            &[],
+            BoolMode::Or,
+            &[],
+            &phrase(&["web", "framework"]),
+        )
+        .await
+        .expect("atoms_match_count")
+        .0;
+    let base = docs_with(&corp, "web");
+    let drop = docs_with_phrase(&corp, &["web", "framework"]);
+    let want = base.difference(&drop).count() as u64;
+    assert_eq!(got, want, "web -\"web framework\" (term + neg phrase)");
 }
 
 #[tokio::test]

--- a/tests/superfile/fts/negation.rs
+++ b/tests/superfile/fts/negation.rs
@@ -85,6 +85,51 @@ async fn or_single_positive_minus_negative() {
     assert_eq!(got, want, "rust -async (OR)");
 }
 
+/// Count with negation goes through the skip-based exclusion path
+/// (`atoms_match_count` with negated atoms) rather than materializing the
+/// negated union. Pin it against corpus truth for OR and AND positives
+/// with single and multiple negatives.
+#[tokio::test]
+async fn count_with_negation_matches_corpus_truth() {
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    async fn count(r: &SuperfileReader, pos: &[&str], mode: BoolMode, neg: &[&str]) -> u64 {
+        r.atoms_match_count("title", pos, &[], mode, neg, &[])
+            .await
+            .expect("atoms_match_count")
+            .0
+    }
+    // OR positive, one negative.
+    assert_eq!(
+        count(&r, &["rust"], BoolMode::Or, &["async"]).await,
+        exclude(or_match(&corp, &["rust"]), &corp, &["async"]).len() as u64,
+        "rust -async (OR count)"
+    );
+    // OR positive, multiple negatives.
+    assert_eq!(
+        count(&r, &["rust", "python"], BoolMode::Or, &["async", "web"]).await,
+        exclude(
+            or_match(&corp, &["rust", "python"]),
+            &corp,
+            &["async", "web"]
+        )
+        .len() as u64,
+        "rust python -async -web (OR count)"
+    );
+    // AND positive, one negative.
+    assert_eq!(
+        count(&r, &["rust", "web"], BoolMode::And, &["async"]).await,
+        exclude(and_match(&corp, &["rust", "web"]), &corp, &["async"]).len() as u64,
+        "+rust +web -async (AND count)"
+    );
+    // No negatives ⇒ identical to the plain match count (the `None`-filter walk).
+    assert_eq!(
+        count(&r, &["rust"], BoolMode::Or, &[]).await,
+        or_match(&corp, &["rust"]).len() as u64,
+        "rust (OR count, no negation)"
+    );
+}
+
 #[tokio::test]
 async fn or_multi_positive_minus_negative() {
     // "rust python -web": (rust ∪ python) minus web. Multi-term OR

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -362,7 +362,7 @@ async fn unranked_ids_and_count_agree_with_oracle() {
             );
 
             let count = r
-                .atoms_match_count("title", &terms, &phrases, mode)
+                .atoms_match_count("title", &terms, &phrases, mode, &[], &[])
                 .await
                 .expect("atoms_match_count")
                 .0;


### PR DESCRIPTION
Two exact optimizations to the FTS count path; the phrase one also speeds scored phrase top-k. Counts and results are unchanged (brute-force oracle + corpus-truth tests pin them).

## 1. Negation count without materializing the negated union

The count path handled `+term -term` by materializing the **entire** negated union into a bitmap and subtracting it — e.g. `+jaguar -car -football` built a `car ∪ football` set of millions of docs to exclude from ~1.7k positive matches. Now the negated terms are fed as a **skip-based exclusion gate** (`AtomExcludeFilter`) to the existing count walk, so a common negated list is only `skip_to`-probed, never decoded whole — the same mechanism the scored search path already used for negation.

The delete path is unchanged (a tombstone bitmap still needs an explicit id set); only the delete-free case takes the skip path.

## 2. Phrase verification: rarest-first, staged, lazy

Phrase verification anchored on the query-first member and eagerly decoded every member's per-doc positions. The first word of a phrase is often a common word (`the`, `of`), and a phrase containing one produces a huge co-occurrence candidate set — e.g. `the book of life` aligns ~92k docs to find 95 matches. Decoding the common members' positions (a per-block run-offset walk) on every candidate was the dominant cost.

Now verification seeds candidate start positions from the **rarest** member and filters the rest **rarest-first with lazy decode**: a common member's positions are decoded only once a candidate has survived every rarer member. On these big co-occurrence sets almost every doc is rejected by a rare member first, so the common members are never decoded there. Doc alignment probes rarest-first too. This is the phrase cursor's shared doc-advance, so **scored phrase top-k benefits as well as count**.

## Results (single compacted superfile, single-threaded, min-of-10)

infino before (main) → after (this branch):

| shape | main | branch |
|---|---:|---:|
| phrase COUNT | 2210 ms | **1338 ms** |
| phrase TOP_100 | 1719 ms | **1002 ms** |
| phrase TOP_1000 | 2036 ms | **1231 ms** |
| negation COUNT (bucket) | 434 ms | **286 ms** |
| **total COUNT** | 3467 ms | **2500 ms** |

Worst-case per-query (COUNT): `+jaguar -car -football` ~24×, `the book of life` ~5.4×, `the news journal` ~5.6×. Plain-term, union, and intersection paths are untouched (their arm-to-arm differences are run-to-run noise).

## Tests

- Brute-force BM25 top-K oracle and phrase count-vs-oracle agreement stay green — verification changes cannot change which docs/counts return.
- Added `count_with_negation_matches_corpus_truth` (OR/AND positives, single/multiple negatives, and the no-negation identity) pinning the skip-based count against corpus truth.
- Full FTS integration + supertable query suites pass.

No on-disk format change; no public API change (the extended `atoms_match_count` is internal).
