### PR TITLE
supertable/vector: residual codes adaptive rerank

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -55,8 +55,11 @@ jobs:
           - { bench: supertable_vector, docs: "1000000", suffix: st-vec-l2, metric: l2sq }
           - { bench: supertable_sql,    docs: "1000000", suffix: st-sql }
     # A new push to the PR cancels the in-flight run for that bench.
+    # Keyed on the SUFFIX, not the bench name: the two vector cells
+    # (cosine st-vec and l2sq st-vec-l2) share `matrix.bench`, and a
+    # bench-keyed group made them cancel each other on every run.
     concurrency:
-      group: bench-${{ github.event.pull_request.number }}-${{ matrix.bench }}
+      group: bench-${{ github.event.pull_request.number }}-${{ matrix.suffix }}
       cancel-in-progress: true
     permissions:
       id-token: write

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -252,6 +252,7 @@ fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOpti
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(default_tokenizer()),
     )

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -1510,6 +1510,7 @@ pub fn build_vector_index(vectors: &[f32], n_docs: usize, metric: Metric) -> Vec
     let mut b = VectorBuilder::new();
     b.register_column(VectorConfig {
         provided_centroids: None,
+        residual_codes: false,
         column: "v".into(),
         dim: DIM,
         rot_seed: ROT_SEED,
@@ -1561,6 +1562,7 @@ pub fn build_superfile(docs: &[String], vectors: &[f32]) -> Vec<u8> {
         }],
         vec![SfVectorConfig {
             provided_centroids: None,
+            residual_codes: false,
             column: "emb".into(),
             dim: DIM,
             rot_seed: ROT_SEED,
@@ -1603,6 +1605,7 @@ pub fn build_superfile_with_metric(docs: &[String], vectors: &[f32], metric: Met
         }],
         vec![SfVectorConfig {
             provided_centroids: None,
+            residual_codes: false,
             column: "emb".into(),
             dim: DIM,
             rot_seed: ROT_SEED,

--- a/benches/utils/harness/infino_sql_engine.rs
+++ b/benches/utils/harness/infino_sql_engine.rs
@@ -138,6 +138,7 @@ pub fn sql_options() -> SupertableOptions {
         ],
         vec![VectorConfig {
             provided_centroids: None,
+            residual_codes: false,
             column: VECTOR_COLUMN.into(),
             dim: SQL_DIM,
             rot_seed: ROT_SEED,

--- a/benches/utils/harness/infino_vector_engine.rs
+++ b/benches/utils/harness/infino_vector_engine.rs
@@ -56,6 +56,7 @@ fn build_superfile(
         vec![],
         vec![VectorConfig {
             provided_centroids: None,
+            residual_codes: false,
             column: column.into(),
             dim,
             rot_seed: ROT_SEED,

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -314,6 +314,7 @@ pub fn options_for(
     let vector = if modality.has_vector() {
         vec![VectorConfig {
             provided_centroids: None,
+            residual_codes: false,
             column: VEC_COLUMN.into(),
             dim: DIM,
             rot_seed: ROT_SEED,

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -241,6 +241,7 @@ fn build_superfile_bytes() -> Bytes {
         }],
         vec![VectorConfig {
             provided_centroids: None,
+            residual_codes: false,
             column: VEC_COLUMN.into(),
             dim,
             rot_seed: ROT_SEED,
@@ -1870,6 +1871,7 @@ pub(crate) mod diag {
             }],
             vec![VectorConfig {
                 provided_centroids: None,
+                residual_codes: false,
                 column: VEC_COLUMN.into(),
                 dim: crate::corpus::DIM,
                 rot_seed: ROT_SEED,

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -2440,6 +2440,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }];
         let s = vec_columns_json(&cols);
         assert!(s.contains(r#""column":"emb""#));
@@ -2907,6 +2908,7 @@ mod tests {
                 metric: Metric::L2Sq,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             None,
         );
@@ -4280,6 +4282,7 @@ mod tests {
             },
             rerank_codec,
             provided_centroids: None,
+            residual_codes: false,
         };
         let mut ids: Vec<i128> = Vec::new();
         let mut packed = Vec::with_capacity(cells.len());

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -338,6 +338,14 @@ impl BuilderOptions {
         let (vector_columns, vector_layout) = if let Some(vec) = &reader.vec() {
             if vec.is_multi_cell() {
                 // One logical column; cell IVFs live in the v2 cell directory.
+                // Residual provenance is per-subsection on disk (the KV JSON
+                // deliberately doesn't carry it): a rebuild must re-encode
+                // residual whenever ANY packed cell is v3, or a compaction
+                // through this config would silently downgrade the table's
+                // codes back to raw.
+                let residual = vec
+                    .vector_columns_config()
+                    .any(|cell| cell.residual_codes());
                 let v = vec
                     .vector_columns_config()
                     .next()
@@ -345,7 +353,8 @@ impl BuilderOptions {
                 (
                     vec![
                         VectorConfig::new(v.name.clone(), v.dim, v.rot_seed, v.metric)
-                            .with_rerank_codec(v.rerank_codec),
+                            .with_rerank_codec(v.rerank_codec)
+                            .with_residual_codes(residual),
                     ],
                     VectorLayout::MultiCellIvf,
                 )
@@ -355,6 +364,7 @@ impl BuilderOptions {
                         .map(|v| {
                             VectorConfig::new(v.name.clone(), v.dim, v.rot_seed, v.metric)
                                 .with_rerank_codec(v.rerank_codec)
+                                .with_residual_codes(v.residual_codes())
                         })
                         .collect::<Vec<_>>(),
                     VectorLayout::Ivf,
@@ -895,11 +905,24 @@ impl SuperfileBuilder {
         }
         let scalar_schema = builder_opts.schema.clone();
         let id_column = builder_opts.id_column.clone();
+        // Residual provenance across ALL inputs, not just the first:
+        // `new_from_reader` above only saw `first`, and a v2-first /
+        // v3-later mix would rebuild v3 rows under a raw config — the
+        // raw pack copies their residual sign codes verbatim into a v2
+        // cell, which serves as garbage. Any residual input forces the
+        // residual config; the pack core re-derives every code from the
+        // payload, so raw inputs re-encode correctly under it.
+        let any_residual = readers.iter().any(|(reader, _)| {
+            reader.vec().is_some_and(|v| {
+                v.vector_columns_config().any(|cell| cell.residual_codes())
+            })
+        });
         let vec_cfg = builder_opts
             .vector_columns
             .first()
             .cloned()
-            .ok_or(BuildError::VectorReadError)?;
+            .ok_or(BuildError::VectorReadError)?
+            .with_residual_codes(any_residual);
         let mut superfile_builder = SuperfileBuilder::new(builder_opts)?;
 
         let any_tombstones = readers
@@ -1009,9 +1032,17 @@ impl SuperfileBuilder {
             cell_ids.sort_unstable();
             for cell_id in cell_ids {
                 let sources = by_cell.remove(&cell_id).expect("cell present");
-                let same_shape = sources
-                    .windows(2)
-                    .all(|pair| pair[0].2.n_cent == pair[1].2.n_cent);
+                // Byte-splice needs uniform fine shape AND uniform residual
+                // provenance (the splice hard-errors on a mix — one output
+                // header flag can't describe both generations, and erroring
+                // here would wedge compaction permanently). Mixed v2+v3
+                // fragments of one cell take the materialize arm below,
+                // which re-encodes every row under `any_residual`.
+                let same_shape = sources.windows(2).all(|pair| {
+                    pair[0].2.n_cent == pair[1].2.n_cent
+                        && pair[0].2.residual_norms.is_some()
+                            == pair[1].2.residual_norms.is_some()
+                });
                 if same_shape {
                     let mut inputs: Vec<Sq8IvfMergeInput> =
                         sources.into_iter().map(|(_, _, inp)| inp).collect();

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -913,9 +913,9 @@ impl SuperfileBuilder {
         // residual config; the pack core re-derives every code from the
         // payload, so raw inputs re-encode correctly under it.
         let any_residual = readers.iter().any(|(reader, _)| {
-            reader.vec().is_some_and(|v| {
-                v.vector_columns_config().any(|cell| cell.residual_codes())
-            })
+            reader
+                .vec()
+                .is_some_and(|v| v.vector_columns_config().any(|cell| cell.residual_codes()))
         });
         let vec_cfg = builder_opts
             .vector_columns
@@ -1040,8 +1040,7 @@ impl SuperfileBuilder {
                 // which re-encodes every row under `any_residual`.
                 let same_shape = sources.windows(2).all(|pair| {
                     pair[0].2.n_cent == pair[1].2.n_cent
-                        && pair[0].2.residual_norms.is_some()
-                            == pair[1].2.residual_norms.is_some()
+                        && pair[0].2.residual_norms.is_some() == pair[1].2.residual_norms.is_some()
                 });
                 if same_shape {
                     let mut inputs: Vec<Sq8IvfMergeInput> =

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -377,12 +377,11 @@ pub mod vec {
         /// `[24..28]` residual-code flag (`u32` LE): `1` when the per-cluster
         /// 1-bit codes are signs of `rot(v − c_cell)` (cell-centroid residual)
         /// and a per-doc residual-norm region is present; `0` (the pre-v3
-        /// value) means raw-vector sign codes and no residual region.
+        /// value) means raw-vector sign codes and no residual region. The
+        /// scale κ is NOT stored here — it is drain-calibrated after these
+        /// immutable bytes are written and lives in the manifest routing
+        /// ([`CellRoutingParams::residual_kappa`]). `[28..32]` stays reserved.
         pub const RESIDUAL_FLAG_OFF: usize = 24;
-        /// `[28..32]` residual scale κ (`f32` LE): the drain-fitted multiplier
-        /// in `est = q·c_cell + κ·‖r‖·signdot`. Meaningful only when
-        /// [`RESIDUAL_FLAG_OFF`] is `1`.
-        pub const RESIDUAL_KAPPA_OFF: usize = 28;
         /// `[32..40]` centroids offset (`u64` LE).
         pub const CENTROIDS_OFF_OFF: usize = 32;
         /// `[40..48]` cluster-index offset (`u64` LE).

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -258,10 +258,25 @@ pub mod vec {
     ///   `per_cluster_blocks_off + doc_off[c] * (code_bytes + 4)`,
     ///   block size `count[c] * (code_bytes + 4)`.
     ///
-    /// Only this version is accepted on read; a superfile stamped
-    /// with any other value at this slot is rejected as malformed
-    /// rather than carrying an alternate parse path.
+    /// Baseline subsection version: raw-vector sign codes, reserved
+    /// `[24..32]` written zero. Written for every non-residual column and
+    /// still accepted on read unchanged.
     pub const SUBSECTION_VERSION: u32 = 2;
+
+    /// Residual subsection version: the per-cluster 1-bit codes are signs
+    /// of `rot(v − c_cell)` and a per-doc residual-norm region (`n_docs`
+    /// `f32`) sits between `codec_meta` and the stable-id region, with the
+    /// flag + κ in the reclaimed reserved slot (see [`sub_hdr`]). A reader
+    /// accepts `{SUBSECTION_VERSION, SUBSECTION_VERSION_RESIDUAL}`; an
+    /// older binary hard-fails on this value rather than mis-parsing the
+    /// extra region. Flag-off files stay [`SUBSECTION_VERSION`], so every
+    /// existing superfile and its parse are byte-identical.
+    pub const SUBSECTION_VERSION_RESIDUAL: u32 = 3;
+
+    /// True for any subsection layout version this build can decode.
+    pub const fn subsection_version_supported(v: u32) -> bool {
+        v == SUBSECTION_VERSION || v == SUBSECTION_VERSION_RESIDUAL
+    }
 
     /// Width of a little-endian `u32` field in the vector blob.
     pub const U32_BYTES: usize = 4;
@@ -357,7 +372,17 @@ pub mod vec {
         pub const CODEC_META_SIZE_OFF: usize = 12;
         /// `[16..24]` summary-centroid offset (`u64` LE).
         pub const SUMMARY_OFF_OFF: usize = 16;
-        // `[24..32]` reserved (`u64`).
+        // `[24..32]` was reserved (written zero). Reclaimed by the
+        // residual-code layer (subsection version 3): the two halves below.
+        /// `[24..28]` residual-code flag (`u32` LE): `1` when the per-cluster
+        /// 1-bit codes are signs of `rot(v − c_cell)` (cell-centroid residual)
+        /// and a per-doc residual-norm region is present; `0` (the pre-v3
+        /// value) means raw-vector sign codes and no residual region.
+        pub const RESIDUAL_FLAG_OFF: usize = 24;
+        /// `[28..32]` residual scale κ (`f32` LE): the drain-fitted multiplier
+        /// in `est = q·c_cell + κ·‖r‖·signdot`. Meaningful only when
+        /// [`RESIDUAL_FLAG_OFF`] is `1`.
+        pub const RESIDUAL_KAPPA_OFF: usize = 28;
         /// `[32..40]` centroids offset (`u64` LE).
         pub const CENTROIDS_OFF_OFF: usize = 32;
         /// `[40..48]` cluster-index offset (`u64` LE).

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -204,6 +204,13 @@ pub struct VectorConfig {
     /// cluster `c` → cell `c` without re-clustering. The centroid count is
     /// taken from the supplied centroids (`len / dim`).
     pub provided_centroids: Option<std::sync::Arc<[f32]>>,
+    /// Encode the per-cluster 1-bit codes as signs of `rot(v − c_cell)`
+    /// (cell-centroid residual, subsection version 3) and emit the per-doc
+    /// residual-norm region, instead of raw-vector sign codes. Only
+    /// meaningful with [`Self::provided_centroids`] — the residual is taken
+    /// against the row's assigned cluster centroid, so it sharpens the
+    /// 1-bit estimator exactly on the hidden cell grid. Default `false`.
+    pub residual_codes: bool,
 }
 
 /// Pick the default rerank codec for a new index built with `metric`.
@@ -235,6 +242,7 @@ impl VectorConfig {
             metric,
             rerank_codec: default_rerank_codec_for(metric),
             provided_centroids: None,
+            residual_codes: false,
         }
     }
 
@@ -3381,6 +3389,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }
     }
 
@@ -3519,6 +3528,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
 
         // Streaming build: distinct vectors at local_doc_ids 0..n.
@@ -3598,6 +3608,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
 
         // Build one materialized cell blob of `n` rows whose stable `_id`s are
@@ -3679,6 +3690,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register sq8 column");
         b.add(0, &[1.0; 16]).expect("add single row");
@@ -3892,6 +3904,7 @@ mod tests {
                 metric: Metric::L2Sq,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             };
             materialized_centroids(&cfg, requested, n_docs, &sample).0
         };
@@ -3926,6 +3939,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let (n_cent, centroids) = materialized_centroids(
             &cfg,
@@ -3989,6 +4003,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let ids: Vec<i128> = (0..n as i128).map(|i| 9_000 + i).collect();
         let sub = build_merged_subsection_from_fp32(cfg.clone(), 64, Arc::new(corpus), &ids)
@@ -4058,6 +4073,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         // Generate a small but distinguishable corpus where each
@@ -4116,6 +4132,7 @@ mod tests {
                 metric: Metric::L2Sq,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             })
             .expect("register column");
             for d in 0..n_docs {
@@ -4260,6 +4277,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         for d in 0..n_docs {
@@ -4401,6 +4419,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let sub0 = build_merged_subsection_from_materialized(cfg(), 2, make_rows(0, 4))
             .expect("cell 0 subsection");
@@ -4518,6 +4537,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq16,
             provided_centroids: None,
+            residual_codes: false,
         };
         let sub = build_merged_subsection_from_materialized(cfg, 2, rows).expect("Sq16 merge");
         let cells = vec![(0u32, sub)];
@@ -4599,6 +4619,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8FixedResidual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let source_rows: Vec<MaterializedIvfRow> = [make_rows(0), make_rows(1)].concat();
         let sub0 = build_merged_subsection_from_materialized(config.clone(), 2, make_rows(0))
@@ -4658,6 +4679,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8FixedResidual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let expected = build_merged_subsection_from_materialized(config.clone(), 4, rows.clone())
             .expect("in-memory materialized build");
@@ -4745,6 +4767,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let sub0 =
             build_merged_subsection_from_materialized(cfg(), 2, make_rows(0, 4)).expect("cell 0");
@@ -4817,6 +4840,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         // cell0 → file-local 0..3; cell1 → file-local 4..6.
         let sub0 =
@@ -4906,6 +4930,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let sub0 =
             build_merged_subsection_from_materialized(cfg(), 2, make_rows(7, 3)).expect("cell 7");

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -2204,6 +2204,7 @@ pub(crate) fn build_cell_subsection_from_source(
         cluster_stride,
         codec_meta_size,
         stable_ids_region_bytes,
+        false,
     );
     let cluster_order = centroid_storage_order(&centroids, n_cent, dim);
     let planned = plan_ivf_cluster_blocks(
@@ -2221,6 +2222,7 @@ pub(crate) fn build_cell_subsection_from_source(
         &mut open_region,
         &layout,
         codec_meta_size,
+        0.0,
         &summary_centroid,
         &centroids,
     );
@@ -2675,11 +2677,12 @@ fn build_subsection_streaming(
         cluster_stride,
         codec_meta_size,
         stable_ids_region_bytes,
+        false,
     );
     let total_size_before_crc = layout.total_size_before_crc;
 
     let mut bytes =
-        alloc_ivf_subsection_with_header(&layout, codec_meta_size, &summary_centroid, &centroids);
+        alloc_ivf_subsection_with_header(&layout, codec_meta_size, 0.0, &summary_centroid, &centroids);
 
     let sq8_scale_block_off = layout.codec_meta_off;
     let sq8_offset_block_off = sq8_scale_block_off + n_cent * dim * 4;
@@ -2965,6 +2968,13 @@ pub(crate) struct IvfSubsectionLayout {
     /// per-cluster Sq8 `scale` block offset.
     pub codec_meta_off: usize,
     pub per_cluster_blocks_off: usize,
+    /// Offset of the per-doc residual-norm region (`n_docs` `f32`, indexed by
+    /// `local_doc_id`), present only when the column stores cell-centroid
+    /// residual codes (subsection version 3). `None` for raw-code columns.
+    /// The region sits between `codec_meta` and the stable-id region; the
+    /// residual header flag tells the reader the first `n_docs*4` bytes of
+    /// the post-`codec_meta` gap are these norms.
+    pub residual_norms_off: Option<usize>,
     /// Offset of the inline stable-`_id` region (one i128 per doc, indexed by
     /// `local_doc_id`), present only for the materialized (hidden-cell) build.
     /// `None` when no region was requested. The region sits *between* the
@@ -2989,16 +2999,23 @@ impl IvfSubsectionLayout {
         per_cluster_stride: usize,
         codec_meta_size: usize,
         stable_ids_region_bytes: usize,
+        residual: bool,
     ) -> Self {
         let summary_off = SUB_HEADER_SIZE;
         let centroids_off = summary_off + dim * 4;
         let cluster_idx_off = centroids_off + n_cent * dim * 4;
         let codec_meta_off = cluster_idx_off + n_cent * CLUSTER_IDX_ENTRY_BYTES;
-        // The stable-`_id` region (if any) goes between codec_meta and the
-        // per-cluster blocks, so the blocks remain the trailing data region.
         let codec_meta_end = codec_meta_off + codec_meta_size;
-        let stable_ids_off = (stable_ids_region_bytes > 0).then_some(codec_meta_end);
-        let per_cluster_blocks_off = codec_meta_end + stable_ids_region_bytes;
+        // The residual-norm region (if any) precedes the stable-`_id` region
+        // in the post-codec_meta gap; both keep the per-cluster blocks as the
+        // trailing data region. The reader splits the gap using the residual
+        // header flag (first `n_docs*4` bytes are norms) then the same
+        // stable-id gap validation as before.
+        let residual_norms_bytes = if residual { n_docs * 4 } else { 0 };
+        let residual_norms_off = (residual_norms_bytes > 0).then_some(codec_meta_end);
+        let stable_ids_start = codec_meta_end + residual_norms_bytes;
+        let stable_ids_off = (stable_ids_region_bytes > 0).then_some(stable_ids_start);
+        let per_cluster_blocks_off = stable_ids_start + stable_ids_region_bytes;
         let total_size_before_crc = per_cluster_blocks_off + n_docs * per_cluster_stride;
         Self {
             summary_off,
@@ -3006,6 +3023,7 @@ impl IvfSubsectionLayout {
             cluster_idx_off,
             codec_meta_off,
             per_cluster_blocks_off,
+            residual_norms_off,
             stable_ids_off,
             total_size_before_crc,
         }
@@ -3019,6 +3037,7 @@ impl IvfSubsectionLayout {
 pub(crate) fn alloc_ivf_subsection_with_header(
     layout: &IvfSubsectionLayout,
     codec_meta_size: usize,
+    residual_kappa: f32,
     summary_centroid: &[f32],
     centroids: &[f32],
 ) -> Vec<u8> {
@@ -3027,6 +3046,7 @@ pub(crate) fn alloc_ivf_subsection_with_header(
         &mut bytes,
         layout,
         codec_meta_size,
+        residual_kappa,
         summary_centroid,
         centroids,
     );
@@ -3039,13 +3059,25 @@ fn write_ivf_subsection_header(
     bytes: &mut [u8],
     layout: &IvfSubsectionLayout,
     codec_meta_size: usize,
+    residual_kappa: f32,
     summary_centroid: &[f32],
     centroids: &[f32],
 ) {
     debug_assert!(bytes.len() >= layout.codec_meta_off);
     bytes[0..MAGIC_BYTES].copy_from_slice(format::vec::SUB_MAGIC);
+    // Residual columns stamp version 3 and the flag + κ in the reclaimed
+    // reserved slot; raw columns stamp version 2 and leave the slot zero,
+    // byte-identical to pre-residual builds.
+    let (version, residual_flag, kappa) = match layout.residual_norms_off {
+        Some(_) => (format::vec::SUBSECTION_VERSION_RESIDUAL, 1u32, residual_kappa),
+        None => (format::vec::SUBSECTION_VERSION, 0u32, 0.0f32),
+    };
     bytes[sub_hdr::VERSION_OFF..sub_hdr::VERSION_OFF + U32_BYTES]
-        .copy_from_slice(&format::vec::SUBSECTION_VERSION.to_le_bytes());
+        .copy_from_slice(&version.to_le_bytes());
+    bytes[sub_hdr::RESIDUAL_FLAG_OFF..sub_hdr::RESIDUAL_FLAG_OFF + U32_BYTES]
+        .copy_from_slice(&residual_flag.to_le_bytes());
+    bytes[sub_hdr::RESIDUAL_KAPPA_OFF..sub_hdr::RESIDUAL_KAPPA_OFF + U32_BYTES]
+        .copy_from_slice(&kappa.to_le_bytes());
     bytes[sub_hdr::CODEC_META_SIZE_OFF..sub_hdr::CODEC_META_SIZE_OFF + U32_BYTES]
         .copy_from_slice(&(codec_meta_size as u32).to_le_bytes());
     bytes[sub_hdr::SUMMARY_OFF_OFF..sub_hdr::SUMMARY_OFF_OFF + U64_BYTES]
@@ -3275,9 +3307,78 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::superfile::vector::{
-        cell_posting::EncodedCellRow, reader::VectorReader, spill::MaterializedRowSpillWriter,
+    use crate::superfile::{
+        format::vec::sub_hdr,
+        vector::{
+            cell_posting::EncodedCellRow, reader::VectorReader, spill::MaterializedRowSpillWriter,
+        },
     };
+
+    /// The residual layout inserts an `n_docs × f32` region between
+    /// `codec_meta` and the stable-id region, bumps the subsection version to
+    /// 3, and stamps the flag + κ into the reclaimed reserved slot — while the
+    /// non-residual layout stays byte-for-byte a version-2 subsection with a
+    /// zero reserved slot (every existing superfile unchanged). The header
+    /// writer round-trips both.
+    #[test]
+    fn residual_layout_offsets_and_header_roundtrip() {
+        const DIM: usize = 8;
+        const N_CENT: usize = 3;
+        const N_DOCS: usize = 40;
+        const STRIDE: usize = 4 + 4 + 0; // code_bytes(ceil 8/8=1)... use explicit below
+        let code_bytes = DIM.div_ceil(8);
+        let per_cluster_stride = code_bytes + format::vec::DOC_ID_BYTES;
+        let codec_meta_size = 0;
+        let stable_ids_bytes = N_DOCS * format::vec::STABLE_ID_BYTES;
+        let _ = STRIDE;
+
+        let raw = IvfSubsectionLayout::compute(
+            DIM, N_CENT, N_DOCS, per_cluster_stride, codec_meta_size, stable_ids_bytes, false,
+        );
+        let res = IvfSubsectionLayout::compute(
+            DIM, N_CENT, N_DOCS, per_cluster_stride, codec_meta_size, stable_ids_bytes, true,
+        );
+
+        // Residual region present only in the residual layout, sized n_docs·4,
+        // and it pushes the stable-id region + blocks down by exactly that.
+        assert_eq!(raw.residual_norms_off, None);
+        assert_eq!(res.residual_norms_off, Some(raw.stable_ids_off.unwrap()));
+        assert_eq!(
+            res.stable_ids_off.unwrap() - raw.stable_ids_off.unwrap(),
+            N_DOCS * 4
+        );
+        assert_eq!(
+            res.total_size_before_crc - raw.total_size_before_crc,
+            N_DOCS * 4
+        );
+
+        // Header writer: residual stamps version 3, flag 1, the passed κ;
+        // raw stamps version 2, flag 0, κ 0 — a zero reserved slot.
+        const KAPPA: f32 = 0.047_36;
+        let centroids = vec![0.0f32; N_CENT * DIM];
+        let summary = vec![0.0f32; DIM];
+        let res_bytes =
+            alloc_ivf_subsection_with_header(&res, codec_meta_size, KAPPA, &summary, &centroids);
+        let raw_bytes =
+            alloc_ivf_subsection_with_header(&raw, codec_meta_size, KAPPA, &summary, &centroids);
+
+        let u32_at = |b: &[u8], off: usize| u32::from_le_bytes(b[off..off + 4].try_into().unwrap());
+        let ver = |b: &[u8]| u32_at(b, sub_hdr::VERSION_OFF);
+        let flag = |b: &[u8]| u32_at(b, sub_hdr::RESIDUAL_FLAG_OFF);
+        let kappa = |b: &[u8]| {
+            f32::from_le_bytes(
+                b[sub_hdr::RESIDUAL_KAPPA_OFF..sub_hdr::RESIDUAL_KAPPA_OFF + 4]
+                    .try_into()
+                    .unwrap(),
+            )
+        };
+        assert_eq!(ver(&res_bytes), format::vec::SUBSECTION_VERSION_RESIDUAL);
+        assert_eq!(flag(&res_bytes), 1);
+        assert_eq!(kappa(&res_bytes), KAPPA);
+        assert_eq!(ver(&raw_bytes), format::vec::SUBSECTION_VERSION);
+        assert_eq!(flag(&raw_bytes), 0, "raw layout leaves the reserved flag zero");
+        assert_eq!(kappa(&raw_bytes), 0.0, "raw layout ignores κ (reserved zero)");
+    }
 
     /// Drive an async reader call to completion. The materialized read-back is
     /// async (the drain fetches-on-miss); these tests use in-memory readers, so

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -253,6 +253,16 @@ impl VectorConfig {
         self
     }
 
+    /// Store 1-bit codes as subsection-centroid residuals (subsection v3).
+    /// Requires a payload-carrying (`writes_full`) rerank codec; the cell
+    /// pack re-derives every code from the payload, so rebuilds from any
+    /// input generation land on this setting.
+    #[must_use]
+    pub fn with_residual_codes(mut self, residual: bool) -> Self {
+        self.residual_codes = residual;
+        self
+    }
+
     /// Partition against caller-supplied global centroids instead of
     /// local k-means. See [`Self::provided_centroids`].
     #[must_use]
@@ -3416,12 +3426,10 @@ mod tests {
         const DIM: usize = 8;
         const N_CENT: usize = 3;
         const N_DOCS: usize = 40;
-        const STRIDE: usize = 4 + 4 + 0; // code_bytes(ceil 8/8=1)... use explicit below
         let code_bytes = DIM.div_ceil(8);
         let per_cluster_stride = code_bytes + format::vec::DOC_ID_BYTES;
         let codec_meta_size = 0;
         let stable_ids_bytes = N_DOCS * format::vec::STABLE_ID_BYTES;
-        let _ = STRIDE;
 
         let raw = IvfSubsectionLayout::compute(
             DIM, N_CENT, N_DOCS, per_cluster_stride, codec_meta_size, stable_ids_bytes, false,
@@ -3433,11 +3441,10 @@ mod tests {
         // Residual region present only in the residual layout, sized n_docs·4,
         // and it pushes the stable-id region + blocks down by exactly that.
         assert_eq!(raw.residual_norms_off, None);
-        assert_eq!(res.residual_norms_off, Some(raw.stable_ids_off.unwrap()));
-        assert_eq!(
-            res.stable_ids_off.unwrap() - raw.stable_ids_off.unwrap(),
-            N_DOCS * 4
-        );
+        let raw_ids_off = raw.stable_ids_off.expect("raw layout has an id region");
+        let res_ids_off = res.stable_ids_off.expect("residual layout has an id region");
+        assert_eq!(res.residual_norms_off, Some(raw_ids_off));
+        assert_eq!(res_ids_off - raw_ids_off, N_DOCS * 4);
         assert_eq!(
             res.total_size_before_crc - raw.total_size_before_crc,
             N_DOCS * 4
@@ -3452,7 +3459,8 @@ mod tests {
         let raw_bytes =
             alloc_ivf_subsection_with_header(&raw, codec_meta_size, &summary, &centroids);
 
-        let u32_at = |b: &[u8], off: usize| u32::from_le_bytes(b[off..off + 4].try_into().unwrap());
+        let u32_at =
+            |b: &[u8], off: usize| u32::from_le_bytes(b[off..off + 4].try_into().expect("4 bytes"));
         let ver = |b: &[u8]| u32_at(b, sub_hdr::VERSION_OFF);
         let flag = |b: &[u8]| u32_at(b, sub_hdr::RESIDUAL_FLAG_OFF);
         assert_eq!(ver(&res_bytes), format::vec::SUBSECTION_VERSION_RESIDUAL);
@@ -4157,8 +4165,10 @@ mod tests {
         let bytes = &sub.bytes;
 
         // Header: version 3 + flag set.
-        let u32_at = |off: usize| u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
-        let u64_at = |off: usize| u64::from_le_bytes(bytes[off..off + 8].try_into().unwrap());
+        let u32_at =
+            |off: usize| u32::from_le_bytes(bytes[off..off + 4].try_into().expect("4 bytes"));
+        let u64_at =
+            |off: usize| u64::from_le_bytes(bytes[off..off + 8].try_into().expect("8 bytes"));
         assert_eq!(
             u32_at(sub_hdr::VERSION_OFF),
             format::vec::SUBSECTION_VERSION_RESIDUAL
@@ -4198,7 +4208,7 @@ mod tests {
             let centroid: Vec<f32> = bytes
                 [centroids_off + c * dim * 4..centroids_off + (c + 1) * dim * 4]
                 .chunks_exact(4)
-                .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+                .map(|b| f32::from_le_bytes(b.try_into().expect("4 bytes")))
                 .collect();
             rotation.apply(&centroid, &mut rot_centroid);
             let block_base = blocks_off + doc_off * stride;
@@ -4221,7 +4231,7 @@ mod tests {
                 );
                 let norm_off = residual_norms_off + (doc_off + i) * 4;
                 let stored_norm =
-                    f32::from_le_bytes(bytes[norm_off..norm_off + 4].try_into().unwrap());
+                    f32::from_le_bytes(bytes[norm_off..norm_off + 4].try_into().expect("4 bytes"));
                 assert!(
                     (stored_norm - expected_norm).abs() <= 1e-5 * expected_norm.max(1.0),
                     "cluster {c} row {i}: stored ‖r‖ {stored_norm} vs {expected_norm}"

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -4243,6 +4243,158 @@ mod tests {
         assert_eq!(resolved.len(), 2);
     }
 
+    /// Search parity: the SAME corpus packed raw and packed residual must
+    /// both recover the exact top-k — the residual estimator
+    /// (`q·c + κ·‖r‖·sign_dot`, applied because the v3 flag is set) has to
+    /// rank at least as well as the raw sign-dot it replaces. A mis-wired
+    /// estimator (raw sign-dot on residual codes, wrong centroid, wrong κ
+    /// indexing) collapses recall to noise and fails loudly here.
+    #[tokio::test]
+    async fn residual_search_matches_raw_and_exact() {
+        use bytes::Bytes;
+
+        use crate::superfile::vector::reader::VectorReader;
+
+        const DIM: usize = 24;
+        const N: usize = 600;
+        const K: usize = 10;
+        const N_QUERIES: usize = 24;
+        /// Fine clusters requested for the pack.
+        const N_CENT: usize = 8;
+        /// Rerank budget multiplier: keeps the shortlist well under the
+        /// corpus so the 1-bit estimator quality is what decides recall.
+        const RM: usize = 4;
+
+        fn unit_row(i: usize) -> Vec<f32> {
+            // Real-embedding-shaped corpus: each row = a strong cluster
+            // center (a pseudo-random dense direction, ~80% of the row's
+            // energy — the measured Cohere shape) plus idiosyncratic noise
+            // that decides who is whose neighbor. Raw sign codes spend
+            // their bits on the shared center; residual codes see the
+            // discriminative remainder — the regime the feature is for.
+            let cluster = i % 8;
+            let mut v: Vec<f32> = (0..DIM)
+                .map(|d| {
+                    let center =
+                        (((cluster * 2654435761 + d * 40503) % 1000) as f32 / 500.0 - 1.0) * 2.0;
+                    let noise =
+                        (((i * 2246822519 + d * 3266489917) % 1000) as f32 / 500.0 - 1.0) * 1.0;
+                    center + noise
+                })
+                .collect();
+            let n = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            v.iter_mut().for_each(|x| *x /= n);
+            v
+        }
+
+        let mut corpus = Vec::with_capacity(N * DIM);
+        for i in 0..N {
+            corpus.extend(unit_row(i));
+        }
+        let ids: Vec<i128> = (0..N as i128).collect();
+        let corpus = Arc::new(corpus);
+
+        let build = |residual: bool| {
+            let cfg = VectorConfig {
+                column: "v".into(),
+                dim: DIM,
+                rot_seed: 5,
+                metric: Metric::Cosine,
+                rerank_codec: RerankCodec::Sq16,
+                provided_centroids: None,
+                residual_codes: residual,
+            };
+            let sub = build_merged_subsection_from_fp32(cfg, N_CENT, Arc::clone(&corpus), &ids)
+                .expect("cell build");
+            let blob = finish_multi_cell_blob(&[(0, sub)]).expect("blob");
+            let json = format!(
+                r#"[{{"column":"v","dim":{DIM},"n_cent":{N_CENT},"rot_seed":5,"metric":"cosine","rerank_codec":"sq16"}}]"#
+            );
+            VectorReader::open(Bytes::from(blob), &json).expect("open")
+        };
+        let raw = build(false);
+        let res = build(true);
+
+        let mut raw_hits_total = 0usize;
+        let mut res_hits_total = 0usize;
+        for qi in 0..N_QUERIES {
+            // Query = perturbed corpus row, normalized.
+            let base = unit_row(qi * 23 % N);
+            let mut q: Vec<f32> = base
+                .iter()
+                .enumerate()
+                .map(|(d, x)| x + ((qi * 7 + d * 13) % 53) as f32 / 53.0 * 0.05)
+                .collect();
+            let n = q.iter().map(|x| x * x).sum::<f32>().sqrt();
+            q.iter_mut().for_each(|x| *x /= n);
+
+            // Exact top-K by cosine distance over the corpus.
+            let mut exact: Vec<(u32, f32)> = (0..N)
+                .map(|i| {
+                    let row = &corpus[i * DIM..(i + 1) * DIM];
+                    let dot: f32 = q.iter().zip(row).map(|(a, b)| a * b).sum();
+                    (i as u32, 1.0 - dot)
+                })
+                .collect();
+            exact.sort_by(|a, b| a.1.total_cmp(&b.1));
+            let truth: std::collections::HashSet<u32> =
+                exact[..K].iter().map(|&(d, _)| d).collect();
+
+            let raw_ids: std::collections::HashSet<u32> = raw
+                .search("v", &q, K, N_CENT, RM)
+                .await
+                .expect("raw search")
+                .into_iter()
+                .map(|(d, _)| d)
+                .collect();
+            let res_ids: std::collections::HashSet<u32> = res
+                .search("v", &q, K, N_CENT, RM)
+                .await
+                .expect("residual search")
+                .into_iter()
+                .map(|(d, _)| d)
+                .collect();
+            raw_hits_total += raw_ids.intersection(&truth).count();
+            res_hits_total += res_ids.intersection(&truth).count();
+
+            // Corpus-independent wiring tripwire: with the shortlist budget
+            // covering the whole corpus, the exact rerank adjudicates every
+            // row, so recall must be exact REGARDLESS of estimator quality.
+            // Any mis-wiring (wrong centroid, wrong norm index, raw
+            // sign-dot on residual codes feeding a truncated shortlist)
+            // breaks this; estimator variance cannot.
+            let res_full: std::collections::HashSet<u32> = res
+                .search("v", &q, K, N_CENT, N / K)
+                .await
+                .expect("residual full-budget search")
+                .into_iter()
+                .map(|(d, _)| d)
+                .collect();
+            assert_eq!(
+                res_full.intersection(&truth).count(),
+                K,
+                "query {qi}: full-budget residual search must be exact"
+            );
+        }
+        let raw_recall = raw_hits_total as f64 / (N_QUERIES * K) as f64;
+        let res_recall = res_hits_total as f64 / (N_QUERIES * K) as f64;
+        // Tight-budget parity: the residual estimator with the ANALYTIC κ
+        // (no per-table fit yet — the calibrated routing override is a
+        // later stage) must stay within a small slack of the raw baseline
+        // on this real-embedding-shaped corpus, and far from the ~K/N
+        // noise floor a broken estimator produces. Superiority is a
+        // real-corpus claim, measured by the bench recall gates — not
+        // provable on synthetic data.
+        assert!(
+            res_recall + 0.05 >= raw_recall,
+            "residual recall {res_recall} vs raw {raw_recall}"
+        );
+        assert!(
+            res_recall >= 0.85,
+            "residual recall {res_recall} suspiciously low — estimator mis-wired?"
+        );
+    }
+
     #[test]
     fn finish_two_columns_at_different_dims() {
         let mut b = VectorBuilder::new();

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -36,8 +36,8 @@ use crate::superfile::{
     vector::{
         cell_posting::{MaterializedIvfRow, sq8_residual_norm_sq},
         distance::{
-            Metric, distance, encode_sq16_row, mean_f32_cluster_major, normalize,
-            sq16_decoded_norm_sq,
+            Metric, dequantize_sq8_residual_into, dequantize_sq16_into, distance,
+            encode_sq16_row, mean_f32_cluster_major, normalize, sq16_decoded_norm_sq,
         },
         ivf_merge::MergedIvfSubsection,
         kmeans::{assign_to_centroids, kmeans, kmeans_with_assignments},
@@ -1844,6 +1844,23 @@ fn write_at(file: &mut File, offset: usize, bytes: &[u8]) -> Result<(), BuildErr
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Residual-encode context for one bucket (= one cluster) of a residual
+/// subsection: the pack streamer decodes each row's payload to fp32,
+/// rotates it, and re-encodes the 1-bit code as signs of
+/// `rot(v) − rot(c_cluster)`, writing `‖r‖` into the residual-norm region.
+/// The spilled raw-sign code in the bucket record is overwritten — the
+/// payload is the authority, and re-deriving here keeps the residual rule
+/// inside ONE function for every cell-pack feeder.
+struct ResidualPackCtx<'a> {
+    rotation: &'a RandomRotation,
+    quant: &'a BitQuantizer,
+    /// This bucket's cluster centroid, pre-rotated once by the caller.
+    rot_centroid: &'a [f32],
+    /// Absolute offset of the per-doc residual-norm region.
+    norms_offset: usize,
+}
+
+#[allow(clippy::too_many_arguments)]
 fn stream_bucket_into_subsection(
     output: &mut File,
     bucket_path: &Path,
@@ -1854,6 +1871,7 @@ fn stream_bucket_into_subsection(
     scale: &[f32],
     offset: &[f32],
     norms_offset: Option<usize>,
+    residual: Option<&ResidualPackCtx<'_>>,
 ) -> Result<(), BuildError> {
     let fixed = codec.uses_fixed_quantizer();
     // Single-plane fixed codecs (Sq16) store one `dim*2`-byte `u16` plane whose
@@ -1872,6 +1890,9 @@ fn stream_bucket_into_subsection(
     let encode_consts = (!fixed).then(|| Sq8EncodeConsts::from_scale_offset(scale, offset));
     let mut recon = vec![0.0f32; dim];
     let mut fp_row = vec![0.0f32; dim];
+    // Residual re-encode scratch: the rotated row and the residual buffer.
+    let mut rot_row = vec![0.0f32; dim];
+    let mut res_scratch = vec![0.0f32; dim];
     while rows_done < block.count {
         let take = (block.count - rows_done).min(chunk_rows);
         let mut records = vec![0u8; take * record_bytes];
@@ -1880,6 +1901,7 @@ fn stream_bucket_into_subsection(
         let mut codes = vec![0u8; take * code_bytes];
         let mut rerank = vec![0u8; take * dim * 2];
         let mut norms = norms_offset.map(|_| vec![0u8; take * size_of::<f32>()]);
+        let mut res_norms = residual.map(|_| vec![0u8; take * size_of::<f32>()]);
         for row_idx in 0..take {
             let record = &records[row_idx * record_bytes..(row_idx + 1) * record_bytes];
             let id_end = format::vec::DOC_ID_BYTES;
@@ -1932,6 +1954,38 @@ fn stream_bucket_into_subsection(
                 let start = row_idx * size_of::<f32>();
                 norm_bytes[start..start + size_of::<f32>()].copy_from_slice(&norm.to_le_bytes());
             }
+            if let (Some(res), Some(res_norm_bytes)) = (residual, res_norms.as_mut()) {
+                // Decode the payload to fp32 (the fitted-residual arm above
+                // already decoded the original into `fp_row`), then re-encode
+                // the 1-bit code as the cluster-centroid residual's signs and
+                // record ‖r‖. The payload is the authority: the estimator's
+                // `q·c + κ·‖r‖·sd` then estimates the same vector the exact
+                // rerank scores.
+                if single_plane {
+                    dequantize_sq16_into(rerank_row, &mut fp_row);
+                } else if fixed {
+                    dequantize_sq8_residual_into(
+                        scale,
+                        offset,
+                        &rerank_row[..dim],
+                        &rerank_row[dim..],
+                        codec
+                            .residual_divisor()
+                            .expect("fixed residual codec has divisor"),
+                        &mut fp_row,
+                    );
+                }
+                res.rotation.apply(&fp_row, &mut rot_row);
+                let r_norm = res.quant.encode_residual_into(
+                    &rot_row,
+                    res.rot_centroid,
+                    &mut res_scratch,
+                    &mut codes[row_idx * code_bytes..(row_idx + 1) * code_bytes],
+                );
+                let start = row_idx * size_of::<f32>();
+                res_norm_bytes[start..start + size_of::<f32>()]
+                    .copy_from_slice(&r_norm.to_le_bytes());
+            }
         }
         write_at(output, block.codes_base + rows_done * code_bytes, &codes)?;
         write_at(
@@ -1945,6 +1999,13 @@ fn stream_bucket_into_subsection(
                 output,
                 norms_base + (block.first_row + rows_done) * size_of::<f32>(),
                 &norm_bytes,
+            )?;
+        }
+        if let (Some(res), Some(res_norm_bytes)) = (residual, res_norms) {
+            write_at(
+                output,
+                res.norms_offset + (block.first_row + rows_done) * size_of::<f32>(),
+                &res_norm_bytes,
             )?;
         }
         rows_done += take;
@@ -2051,6 +2112,14 @@ pub(crate) fn build_cell_subsection_from_source(
             "cell IVF build does not support codec {} with metric {:?}",
             cfg.rerank_codec.name(),
             cfg.metric
+        )));
+    }
+    if cfg.residual_codes && !cfg.rerank_codec.writes_full() {
+        // The residual re-encode decodes each row from its rerank payload at
+        // pack time; a payload-less codec (RabitqOnly) cannot supply the row.
+        return Err(BuildError::VectorSchemaMismatch(format!(
+            "residual_codes requires a payload-carrying rerank codec, got {}",
+            cfg.rerank_codec.name()
         )));
     }
     match &source {
@@ -2212,7 +2281,7 @@ pub(crate) fn build_cell_subsection_from_source(
         cluster_stride,
         codec_meta_size,
         stable_ids_region_bytes,
-        false,
+        cfg.residual_codes,
     );
     let cluster_order = centroid_storage_order(&centroids, n_cent, dim);
     let planned = plan_ivf_cluster_blocks(
@@ -2277,6 +2346,14 @@ pub(crate) fn build_cell_subsection_from_source(
             "streamed stable-id bytes {copied} != expected {stable_ids_region_bytes}"
         )));
     }
+    // Residual re-encode context, shared across buckets: the rotation and
+    // quantizer are per-column; each bucket pre-rotates its own cluster
+    // centroid once (rotation is linear, so rot(v − c) = rot(v) − rot(c)).
+    let residual_rotation = cfg
+        .residual_codes
+        .then(|| RandomRotation::new(dim, cfg.rot_seed));
+    let residual_quant = cfg.residual_codes.then(|| BitQuantizer::new(dim));
+    let mut rot_centroid = vec![0.0f32; dim];
     for planned_block in &planned {
         let Some(block) = planned_block.block.as_ref() else {
             continue;
@@ -2285,6 +2362,22 @@ pub(crate) fn build_cell_subsection_from_source(
             .path()
             .join(format!("cluster-{}.bin", planned_block.centroid_id));
         let (scale, offset) = &quantizers[planned_block.centroid_id];
+        let residual_ctx = match (&residual_rotation, &residual_quant) {
+            (Some(rotation), Some(quant)) => {
+                let c = &centroids[planned_block.centroid_id * dim
+                    ..(planned_block.centroid_id + 1) * dim];
+                rotation.apply(c, &mut rot_centroid);
+                Some(ResidualPackCtx {
+                    rotation,
+                    quant,
+                    rot_centroid: &rot_centroid,
+                    norms_offset: layout
+                        .residual_norms_off
+                        .expect("residual layout carries the norm region"),
+                })
+            }
+            _ => None,
+        };
         stream_bucket_into_subsection(
             &mut output,
             &path,
@@ -2295,6 +2388,7 @@ pub(crate) fn build_cell_subsection_from_source(
             scale,
             offset,
             norms_offset,
+            residual_ctx.as_ref(),
         )?;
     }
     output.flush()?;
@@ -4019,6 +4113,134 @@ mod tests {
             .inline_stable_ids_for_locals(&[0, 1, 2])
             .expect("inline stable ids");
         assert_eq!(resolved, ids[0..3]);
+    }
+
+    /// End-to-end residual pack: build a cell subsection with
+    /// `residual_codes = true`, then verify against the raw bytes that for
+    /// EVERY row (1) the stored 1-bit code equals the sign pattern of
+    /// `rot(payload) − rot(assigned cluster centroid)` and (2) the stored
+    /// residual norm equals `‖rot(payload) − rot(centroid)‖` — i.e. the
+    /// code/norm pair is exactly what the query-time estimator
+    /// `q·c + κ·‖r‖·sign_dot` assumes, derived from the same payload the
+    /// exact rerank scores. Also proves the v3 blob opens through
+    /// [`VectorReader`].
+    #[test]
+    fn residual_cell_pack_roundtrips_codes_and_norms() {
+        use bytes::Bytes;
+
+        use crate::superfile::vector::reader::VectorReader;
+
+        let dim = 16usize;
+        let n = 64usize;
+        let mut corpus = Vec::with_capacity(n * dim);
+        for r in 0..n {
+            for c in 0..dim {
+                // Spread rows around the unit sphere-ish so clusters differ.
+                corpus.push(((r * 7 + c * 3) as f32 * 0.37).sin());
+            }
+        }
+        let cfg = VectorConfig {
+            column: "v".into(),
+            dim,
+            rot_seed: 11,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Sq16,
+            provided_centroids: None,
+            residual_codes: true,
+        };
+        let ids: Vec<i128> = (0..n as i128).map(|i| 40_000 + i).collect();
+        let sub = build_merged_subsection_from_fp32(cfg, 4, Arc::new(corpus), &ids)
+            .expect("residual fp32 cell build");
+        let n_cent = sub.n_cent;
+        let n_docs = sub.n_docs as usize;
+        assert_eq!(n_docs, n);
+        let bytes = &sub.bytes;
+
+        // Header: version 3 + flag set.
+        let u32_at = |off: usize| u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
+        let u64_at = |off: usize| u64::from_le_bytes(bytes[off..off + 8].try_into().unwrap());
+        assert_eq!(
+            u32_at(sub_hdr::VERSION_OFF),
+            format::vec::SUBSECTION_VERSION_RESIDUAL
+        );
+        assert_eq!(u32_at(sub_hdr::RESIDUAL_FLAG_OFF), 1);
+
+        // Region offsets per the v3 layout.
+        let centroids_off = u64_at(sub_hdr::CENTROIDS_OFF_OFF) as usize;
+        let cluster_idx_off = u64_at(sub_hdr::CLUSTER_IDX_OFF_OFF) as usize;
+        let blocks_off = u64_at(sub_hdr::PER_CLUSTER_BLOCKS_OFF_OFF) as usize;
+        let codec_meta_size = u32_at(sub_hdr::CODEC_META_SIZE_OFF) as usize;
+        assert_eq!(codec_meta_size, n_docs * 4, "Sq16+Cosine per-doc norms");
+        let codec_meta_off = cluster_idx_off + n_cent * CLUSTER_IDX_ENTRY_BYTES;
+        let residual_norms_off = codec_meta_off + codec_meta_size;
+
+        let quant = BitQuantizer::new(dim);
+        let rotation = RandomRotation::new(dim, 11);
+        let code_bytes = quant.code_bytes();
+        // Cell-pack block layout: each cluster's block is
+        // [codes | doc_ids | rerank payload] contiguous, blocks placed in
+        // storage order, `doc_off * stride` from the region base.
+        let stride = code_bytes + format::vec::DOC_ID_BYTES + dim * 2;
+
+        let mut payload = vec![0.0f32; dim];
+        let mut rot_row = vec![0.0f32; dim];
+        let mut rot_centroid = vec![0.0f32; dim];
+        let mut scratch = vec![0.0f32; dim];
+        let mut expected_code = vec![0u8; code_bytes];
+        let mut rows_seen = 0usize;
+        for c in 0..n_cent {
+            let idx = cluster_idx_off + c * CLUSTER_IDX_ENTRY_BYTES;
+            let doc_off = u32_at(idx) as usize;
+            let count = u32_at(idx + CLUSTER_IDX_COUNT_OFFSET) as usize;
+            if count == 0 {
+                continue;
+            }
+            let centroid: Vec<f32> = bytes
+                [centroids_off + c * dim * 4..centroids_off + (c + 1) * dim * 4]
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+                .collect();
+            rotation.apply(&centroid, &mut rot_centroid);
+            let block_base = blocks_off + doc_off * stride;
+            let payload_base = block_base + count * (code_bytes + format::vec::DOC_ID_BYTES);
+            for i in 0..count {
+                let stored_code =
+                    &bytes[block_base + i * code_bytes..block_base + (i + 1) * code_bytes];
+                let p = payload_base + i * dim * 2;
+                dequantize_sq16_into(&bytes[p..p + dim * 2], &mut payload);
+                rotation.apply(&payload, &mut rot_row);
+                let expected_norm = quant.encode_residual_into(
+                    &rot_row,
+                    &rot_centroid,
+                    &mut scratch,
+                    &mut expected_code,
+                );
+                assert_eq!(
+                    stored_code, &expected_code[..],
+                    "cluster {c} row {i}: stored code must be the residual signs"
+                );
+                let norm_off = residual_norms_off + (doc_off + i) * 4;
+                let stored_norm =
+                    f32::from_le_bytes(bytes[norm_off..norm_off + 4].try_into().unwrap());
+                assert!(
+                    (stored_norm - expected_norm).abs() <= 1e-5 * expected_norm.max(1.0),
+                    "cluster {c} row {i}: stored ‖r‖ {stored_norm} vs {expected_norm}"
+                );
+                rows_seen += 1;
+            }
+        }
+        assert_eq!(rows_seen, n_docs, "every row verified");
+
+        // The v3 subsection opens through the reader inside a multi-cell blob.
+        let blob = finish_multi_cell_blob(&[(0, sub)]).expect("multi-cell blob");
+        let json = format!(
+            r#"[{{"column":"v","dim":{dim},"n_cent":4,"rot_seed":11,"metric":"cosine","rerank_codec":"sq16"}}]"#
+        );
+        let reader = VectorReader::open(Bytes::from(blob), &json).expect("open residual cell pack");
+        let resolved = reader
+            .inline_stable_ids_for_locals(&[0, 1])
+            .expect("inline stable ids");
+        assert_eq!(resolved.len(), 2);
     }
 
     #[test]

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -2403,8 +2403,8 @@ pub(crate) fn build_cell_subsection_from_source(
         let (scale, offset) = &quantizers[planned_block.centroid_id];
         let residual_ctx = match (&residual_rotation, &residual_quant) {
             (Some(rotation), Some(quant)) => {
-                let c = &centroids[planned_block.centroid_id * dim
-                    ..(planned_block.centroid_id + 1) * dim];
+                let c = &centroids
+                    [planned_block.centroid_id * dim..(planned_block.centroid_id + 1) * dim];
                 rotation.apply(c, &mut rot_centroid);
                 Some(ResidualPackCtx {
                     rotation,
@@ -3220,7 +3220,13 @@ pub(crate) fn alloc_ivf_subsection_with_header(
     centroids: &[f32],
 ) -> Vec<u8> {
     let mut bytes = vec![0u8; layout.total_size_before_crc];
-    write_ivf_subsection_header(&mut bytes, layout, codec_meta_size, summary_centroid, centroids);
+    write_ivf_subsection_header(
+        &mut bytes,
+        layout,
+        codec_meta_size,
+        summary_centroid,
+        centroids,
+    );
     bytes
 }
 
@@ -3500,17 +3506,31 @@ mod tests {
         let stable_ids_bytes = N_DOCS * format::vec::STABLE_ID_BYTES;
 
         let raw = IvfSubsectionLayout::compute(
-            DIM, N_CENT, N_DOCS, per_cluster_stride, codec_meta_size, stable_ids_bytes, false,
+            DIM,
+            N_CENT,
+            N_DOCS,
+            per_cluster_stride,
+            codec_meta_size,
+            stable_ids_bytes,
+            false,
         );
         let res = IvfSubsectionLayout::compute(
-            DIM, N_CENT, N_DOCS, per_cluster_stride, codec_meta_size, stable_ids_bytes, true,
+            DIM,
+            N_CENT,
+            N_DOCS,
+            per_cluster_stride,
+            codec_meta_size,
+            stable_ids_bytes,
+            true,
         );
 
         // Residual region present only in the residual layout, sized n_docs·4,
         // and it pushes the stable-id region + blocks down by exactly that.
         assert_eq!(raw.residual_norms_off, None);
         let raw_ids_off = raw.stable_ids_off.expect("raw layout has an id region");
-        let res_ids_off = res.stable_ids_off.expect("residual layout has an id region");
+        let res_ids_off = res
+            .stable_ids_off
+            .expect("residual layout has an id region");
         assert_eq!(res.residual_norms_off, Some(raw_ids_off));
         assert_eq!(res_ids_off - raw_ids_off, N_DOCS * 4);
         assert_eq!(
@@ -3534,7 +3554,11 @@ mod tests {
         assert_eq!(ver(&res_bytes), format::vec::SUBSECTION_VERSION_RESIDUAL);
         assert_eq!(flag(&res_bytes), 1);
         assert_eq!(ver(&raw_bytes), format::vec::SUBSECTION_VERSION);
-        assert_eq!(flag(&raw_bytes), 0, "raw layout leaves the reserved flag zero");
+        assert_eq!(
+            flag(&raw_bytes),
+            0,
+            "raw layout leaves the reserved flag zero"
+        );
         // The κ slot [28..32] stays reserved-zero in both.
         assert_eq!(u32_at(&res_bytes, 28), 0);
         assert_eq!(u32_at(&raw_bytes, 28), 0);
@@ -4311,7 +4335,8 @@ mod tests {
                     &mut expected_code,
                 );
                 assert_eq!(
-                    stored_code, &expected_code[..],
+                    stored_code,
+                    &expected_code[..],
                     "cluster {c} row {i}: stored code must be the residual signs"
                 );
                 let norm_off = residual_norms_off + (doc_off + i) * 4;

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -2222,7 +2222,6 @@ pub(crate) fn build_cell_subsection_from_source(
         &mut open_region,
         &layout,
         codec_meta_size,
-        0.0,
         &summary_centroid,
         &centroids,
     );
@@ -2682,7 +2681,7 @@ fn build_subsection_streaming(
     let total_size_before_crc = layout.total_size_before_crc;
 
     let mut bytes =
-        alloc_ivf_subsection_with_header(&layout, codec_meta_size, 0.0, &summary_centroid, &centroids);
+        alloc_ivf_subsection_with_header(&layout, codec_meta_size, &summary_centroid, &centroids);
 
     let sq8_scale_block_off = layout.codec_meta_off;
     let sq8_offset_block_off = sq8_scale_block_off + n_cent * dim * 4;
@@ -3037,19 +3036,11 @@ impl IvfSubsectionLayout {
 pub(crate) fn alloc_ivf_subsection_with_header(
     layout: &IvfSubsectionLayout,
     codec_meta_size: usize,
-    residual_kappa: f32,
     summary_centroid: &[f32],
     centroids: &[f32],
 ) -> Vec<u8> {
     let mut bytes = vec![0u8; layout.total_size_before_crc];
-    write_ivf_subsection_header(
-        &mut bytes,
-        layout,
-        codec_meta_size,
-        residual_kappa,
-        summary_centroid,
-        centroids,
-    );
+    write_ivf_subsection_header(&mut bytes, layout, codec_meta_size, summary_centroid, centroids);
     bytes
 }
 
@@ -3059,25 +3050,23 @@ fn write_ivf_subsection_header(
     bytes: &mut [u8],
     layout: &IvfSubsectionLayout,
     codec_meta_size: usize,
-    residual_kappa: f32,
     summary_centroid: &[f32],
     centroids: &[f32],
 ) {
     debug_assert!(bytes.len() >= layout.codec_meta_off);
     bytes[0..MAGIC_BYTES].copy_from_slice(format::vec::SUB_MAGIC);
-    // Residual columns stamp version 3 and the flag + κ in the reclaimed
-    // reserved slot; raw columns stamp version 2 and leave the slot zero,
-    // byte-identical to pre-residual builds.
-    let (version, residual_flag, kappa) = match layout.residual_norms_off {
-        Some(_) => (format::vec::SUBSECTION_VERSION_RESIDUAL, 1u32, residual_kappa),
-        None => (format::vec::SUBSECTION_VERSION, 0u32, 0.0f32),
+    // Residual columns stamp version 3 and set the flag in the reclaimed
+    // reserved slot; raw columns stamp version 2 and leave it zero,
+    // byte-identical to pre-residual builds. κ is NOT written here — it is
+    // drain-calibrated into the manifest routing after these bytes land.
+    let (version, residual_flag) = match layout.residual_norms_off {
+        Some(_) => (format::vec::SUBSECTION_VERSION_RESIDUAL, 1u32),
+        None => (format::vec::SUBSECTION_VERSION, 0u32),
     };
     bytes[sub_hdr::VERSION_OFF..sub_hdr::VERSION_OFF + U32_BYTES]
         .copy_from_slice(&version.to_le_bytes());
     bytes[sub_hdr::RESIDUAL_FLAG_OFF..sub_hdr::RESIDUAL_FLAG_OFF + U32_BYTES]
         .copy_from_slice(&residual_flag.to_le_bytes());
-    bytes[sub_hdr::RESIDUAL_KAPPA_OFF..sub_hdr::RESIDUAL_KAPPA_OFF + U32_BYTES]
-        .copy_from_slice(&kappa.to_le_bytes());
     bytes[sub_hdr::CODEC_META_SIZE_OFF..sub_hdr::CODEC_META_SIZE_OFF + U32_BYTES]
         .copy_from_slice(&(codec_meta_size as u32).to_le_bytes());
     bytes[sub_hdr::SUMMARY_OFF_OFF..sub_hdr::SUMMARY_OFF_OFF + U64_BYTES]
@@ -3352,32 +3341,25 @@ mod tests {
             N_DOCS * 4
         );
 
-        // Header writer: residual stamps version 3, flag 1, the passed κ;
-        // raw stamps version 2, flag 0, κ 0 — a zero reserved slot.
-        const KAPPA: f32 = 0.047_36;
+        // Header writer: residual stamps version 3 + flag 1; raw stamps
+        // version 2 + flag 0. κ is NOT in the header (it lives in routing).
         let centroids = vec![0.0f32; N_CENT * DIM];
         let summary = vec![0.0f32; DIM];
         let res_bytes =
-            alloc_ivf_subsection_with_header(&res, codec_meta_size, KAPPA, &summary, &centroids);
+            alloc_ivf_subsection_with_header(&res, codec_meta_size, &summary, &centroids);
         let raw_bytes =
-            alloc_ivf_subsection_with_header(&raw, codec_meta_size, KAPPA, &summary, &centroids);
+            alloc_ivf_subsection_with_header(&raw, codec_meta_size, &summary, &centroids);
 
         let u32_at = |b: &[u8], off: usize| u32::from_le_bytes(b[off..off + 4].try_into().unwrap());
         let ver = |b: &[u8]| u32_at(b, sub_hdr::VERSION_OFF);
         let flag = |b: &[u8]| u32_at(b, sub_hdr::RESIDUAL_FLAG_OFF);
-        let kappa = |b: &[u8]| {
-            f32::from_le_bytes(
-                b[sub_hdr::RESIDUAL_KAPPA_OFF..sub_hdr::RESIDUAL_KAPPA_OFF + 4]
-                    .try_into()
-                    .unwrap(),
-            )
-        };
         assert_eq!(ver(&res_bytes), format::vec::SUBSECTION_VERSION_RESIDUAL);
         assert_eq!(flag(&res_bytes), 1);
-        assert_eq!(kappa(&res_bytes), KAPPA);
         assert_eq!(ver(&raw_bytes), format::vec::SUBSECTION_VERSION);
         assert_eq!(flag(&raw_bytes), 0, "raw layout leaves the reserved flag zero");
-        assert_eq!(kappa(&raw_bytes), 0.0, "raw layout ignores κ (reserved zero)");
+        // The κ slot [28..32] stays reserved-zero in both.
+        assert_eq!(u32_at(&res_bytes, 28), 0);
+        assert_eq!(u32_at(&raw_bytes, 28), 0);
     }
 
     /// Drive an async reader call to completion. The materialized read-back is

--- a/src/superfile/vector/cell_posting.rs
+++ b/src/superfile/vector/cell_posting.rs
@@ -1240,6 +1240,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let mut b = CellPostingBuilder::new();
         b.register_column(cfg).expect("register");

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -18,8 +18,9 @@ use crate::superfile::{
         CRC_BYTES,
         checksum::crc32c,
         vec::{
-            CLUSTER_IDX_ENTRY_BYTES, DOC_ID_BYTES, STABLE_ID_BYTES, SUB_HEADER_SIZE, U32_BYTES,
-            U64_BYTES, sub_hdr,
+            CLUSTER_IDX_ENTRY_BYTES, DOC_ID_BYTES, STABLE_ID_BYTES, SUB_HEADER_SIZE,
+            SUBSECTION_VERSION_RESIDUAL, U32_BYTES, U64_BYTES, sub_hdr,
+            subsection_version_supported,
         },
     },
     vector::{
@@ -74,6 +75,14 @@ pub(crate) struct Sq8IvfMergeInput {
     /// `None` for region-less sources (streaming/incoming). The merge produces a
     /// merged region only when every input has one.
     pub stable_ids: Option<Vec<i128>>,
+    /// Per-doc residual norms (`‖v − c_cluster‖`, subsection v3), indexed by
+    /// this input's local doc position — present iff the source subsection
+    /// carries residual 1-bit codes. Codes and norms are anchored to the
+    /// row's OWN cluster centroid, which every splice/merge below copies
+    /// verbatim, so both stay valid across the byte-splice; the merge output
+    /// is v3 iff every input is (mixed provenance is a schema mismatch, like
+    /// a codec mismatch — the caller rebuilds through the pack core instead).
+    pub residual_norms: Option<Vec<f32>>,
 }
 
 /// Output of a byte-splice merge, ready for [`super::builder::VectorBuilder::set_prebuilt_subsection`].
@@ -127,6 +136,11 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
     let n_cent = parsed[0].n_cent;
     let metric = parsed[0].metric;
     let codec = parsed[0].rerank_codec;
+    // Residual provenance is all-or-none for the same reason the codec is:
+    // one output header flag covers every merged row (see the splice's
+    // matching check). Mixed inputs only arise across a config-generation
+    // boundary; the caller rebuilds through the pack core instead.
+    let residual = parsed[0].residual_norms.is_some();
     for inp in &parsed[1..] {
         if inp.dim != dim
             || inp.n_cent != n_cent
@@ -135,6 +149,11 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
         {
             return Err(BuildError::VectorSchemaMismatch(
                 "Sq8 IVF merge inputs must share dim, n_cent, metric, and codec".into(),
+            ));
+        }
+        if inp.residual_norms.is_some() != residual {
+            return Err(BuildError::VectorSchemaMismatch(
+                "Sq8 IVF merge inputs must share residual-code provenance".into(),
             ));
         }
     }
@@ -230,7 +249,7 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
         cluster_stride,
         codec_meta_size,
         stable_ids_region_bytes,
-        false,
+        residual,
     );
 
     let mut bytes = alloc_ivf_subsection_with_header(
@@ -380,6 +399,20 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
                         let n_off = norms_off + (blk.first_row + out_i) * 4;
                         bytes[n_off..n_off + 4].copy_from_slice(&n_sq.to_le_bytes());
                     }
+                    // v3: residual ‖r‖ rides along, indexed by cluster-order
+                    // position on both sides (the serving scan's `cand.pos`
+                    // index space); the code above copied verbatim stays
+                    // anchored to this cluster's shared centroid.
+                    if let Some(nr_off) = layout.residual_norms_off {
+                        let norms = inp.residual_norms.as_deref().unwrap_or_default();
+                        let r_norm = *norms.get(doc_off + i).ok_or_else(|| {
+                            BuildError::VectorSchemaMismatch(
+                                "Sq8 IVF merge input residual-norm region too short".into(),
+                            )
+                        })?;
+                        let p = nr_off + (blk.first_row + out_i) * U32_BYTES;
+                        bytes[p..p + U32_BYTES].copy_from_slice(&r_norm.to_le_bytes());
+                    }
                     out_i += 1;
                 }
             }
@@ -452,10 +485,21 @@ pub(crate) fn splice_fragments_into_cell(
     let dim = fragments[0].0.dim;
     let metric = fragments[0].0.metric;
     let codec = fragments[0].0.rerank_codec;
+    // Residual provenance is all-or-none, like the codec: a mixed splice
+    // would emit rows whose 1-bit codes disagree with the output header's
+    // single residual flag — silently garbage at serve time. Callers hit
+    // this only across a config-generation boundary (e.g. a drain resumed
+    // over the residual upgrade) and rebuild through the pack core instead.
+    let residual = fragments[0].0.residual_norms.is_some();
     for (inp, _, _) in &fragments[1..] {
         if inp.dim != dim || inp.metric != metric || inp.rerank_codec != codec {
             return Err(BuildError::VectorSchemaMismatch(
                 "fragment splice inputs must share dim, metric, and codec".into(),
+            ));
+        }
+        if inp.residual_norms.is_some() != residual {
+            return Err(BuildError::VectorSchemaMismatch(
+                "fragment splice inputs must share residual-code provenance".into(),
             ));
         }
     }
@@ -516,7 +560,7 @@ pub(crate) fn splice_fragments_into_cell(
         cluster_stride,
         codec_meta_size,
         stable_ids_region_bytes,
-        false,
+        residual,
     );
 
     let mut bytes = alloc_ivf_subsection_with_header(
@@ -595,6 +639,20 @@ pub(crate) fn splice_fragments_into_cell(
                         .decoded_norm_sq(&inp.sub[rowb..rowb + dim * 2], dim, scale_c, offset_c);
                     let n_off = norms_off + out_row * 4;
                     bytes[n_off..n_off + 4].copy_from_slice(&n_sq.to_le_bytes());
+                }
+                // v3: residual ‖r‖ rides along, indexed by cluster-order
+                // position on both sides (the same index space the serving
+                // scan's `cand.pos` reads) — the code stays anchored to this
+                // cluster's own centroid, copied verbatim above.
+                if let Some(nr_off) = layout.residual_norms_off {
+                    let norms = inp.residual_norms.as_deref().unwrap_or_default();
+                    let r_norm = *norms.get(doc_off + i).ok_or_else(|| {
+                        BuildError::VectorSchemaMismatch(
+                            "fragment splice input residual-norm region too short".into(),
+                        )
+                    })?;
+                    let p = nr_off + out_row * U32_BYTES;
+                    bytes[p..p + U32_BYTES].copy_from_slice(&r_norm.to_le_bytes());
                 }
             }
             debug_assert_eq!(count, blk.count);
@@ -756,6 +814,30 @@ pub(crate) fn sq8_ivf_merge_input_from_subsection(
             "subsection too short for fragment merge".into(),
         ));
     }
+    // Same version/flag discipline as the reader's open path: the flag must
+    // agree with the version, so a half-written or foreign header fails loud
+    // instead of merging residual codes as raw (or vice versa).
+    let version = u32::from_le_bytes(
+        sub[sub_hdr::VERSION_OFF..sub_hdr::VERSION_OFF + U32_BYTES]
+            .try_into()
+            .expect("4-byte version"),
+    );
+    if !subsection_version_supported(version) {
+        return Err(BuildError::VectorSchemaMismatch(format!(
+            "fragment merge input has unsupported subsection version {version}"
+        )));
+    }
+    let residual = u32::from_le_bytes(
+        sub[sub_hdr::RESIDUAL_FLAG_OFF..sub_hdr::RESIDUAL_FLAG_OFF + U32_BYTES]
+            .try_into()
+            .expect("4-byte residual flag"),
+    ) == 1;
+    if residual != (version == SUBSECTION_VERSION_RESIDUAL) {
+        return Err(BuildError::VectorSchemaMismatch(format!(
+            "fragment merge input residual flag {residual} disagrees with \
+             subsection version {version}"
+        )));
+    }
     let centroids_off = u64::from_le_bytes(
         sub[sub_hdr::CENTROIDS_OFF_OFF..sub_hdr::CENTROIDS_OFF_OFF + U64_BYTES]
             .try_into()
@@ -801,6 +883,22 @@ pub(crate) fn sq8_ivf_merge_input_from_subsection(
     } else {
         (Vec::new(), Vec::new())
     };
+    // v3: the per-doc residual-norm region sits directly after codec_meta
+    // (the builder's layout places it between codec_meta and stable-ids;
+    // the reader's open path splits the same gap).
+    let residual_norms = residual
+        .then(|| {
+            let norms_off = codec_meta_off + codec_meta_size;
+            let norms_bytes = n_docs as usize * U32_BYTES;
+            sub.get(norms_off..norms_off + norms_bytes)
+                .map(decode_f32_le_vec)
+                .ok_or_else(|| {
+                    BuildError::VectorSchemaMismatch(
+                        "subsection truncated before residual-norm region".into(),
+                    )
+                })
+        })
+        .transpose()?;
     let quant = BitQuantizer::new(dim);
     let code_bytes = quant.code_bytes();
     let per_vec_bytes = rerank_codec.per_vector_bytes(dim);
@@ -821,6 +919,7 @@ pub(crate) fn sq8_ivf_merge_input_from_subsection(
         scale,
         offset,
         stable_ids,
+        residual_norms,
     })
 }
 
@@ -1021,6 +1120,183 @@ mod tests {
             "spliced cell holds every doc from both batches"
         );
         assert_eq!(ids.len(), 2 * ROWS, "one stable id per spliced doc");
+    }
+
+    /// Residual (subsection v3) sibling of
+    /// [`sq16_subsection_with_empty_clusters`]: 1-bit codes re-centered on
+    /// the provided grid, per-doc `‖r‖` region present. Row perturbations
+    /// make every row's residual norm distinct, so index slips show up as
+    /// value mismatches.
+    fn residual_subsection_with_empty_clusters(id_base: i128) -> MergedIvfSubsection {
+        let mut centroids = vec![0.0f32; N_CENT * DIM];
+        for c in 0..N_CENT {
+            centroids[c * DIM + c] = 1.0;
+        }
+        let mut vectors = Vec::with_capacity(ROWS * DIM);
+        for r in 0..ROWS {
+            let mut row = [0.0f32; DIM];
+            row[0] = 1.0;
+            row[4 + r % 4] = 0.05 + r as f32 * 0.01;
+            let norm = row.iter().map(|v| v * v).sum::<f32>().sqrt();
+            vectors.extend(row.iter().map(|v| v / norm));
+        }
+        let ids: Vec<i128> = (0..ROWS as i128).map(|i| id_base + i).collect();
+        let cfg = VectorConfig {
+            column: "emb".into(),
+            dim: DIM,
+            rot_seed: 7,
+            metric: Metric::Cosine,
+            rerank_codec: RerankCodec::Sq16,
+            provided_centroids: Some(Arc::from(centroids)),
+            residual_codes: true,
+        };
+        build_merged_subsection_from_fp32(cfg, N_CENT, Arc::new(vectors), &ids)
+            .expect("residual cell build")
+    }
+
+    /// Parse a merged subsection back and return its per-doc residual norms
+    /// plus per-cluster `(doc_off, count)` entries — the serving index space
+    /// the tests below compare in.
+    fn parsed_norms_and_clusters(
+        sub: &MergedIvfSubsection,
+    ) -> (Sq8IvfMergeInput, Vec<(usize, usize)>) {
+        let inp = sq8_ivf_merge_input_from_subsection(
+            &sub.bytes,
+            DIM,
+            sub.n_cent,
+            sub.n_docs,
+            Metric::Cosine,
+            sub.rerank_codec,
+            None,
+        )
+        .expect("read-back parses");
+        let clusters = (0..sub.n_cent)
+            .map(|c| cluster_entry(&inp.sub, inp.cluster_idx_off, c))
+            .collect();
+        (inp, clusters)
+    }
+
+    /// A splice of residual fragments must (a) stamp the merged subsection
+    /// v3 (the read-back's version/flag coherence check enforces the
+    /// header), and (b) carry every row's `‖r‖` to its new cluster-order
+    /// position — the index space the serving scan reads norms in. Output
+    /// cluster `k` is fragment `k` verbatim (left's clusters then right's),
+    /// so each output cluster's norm slice must equal its source cluster's.
+    #[test]
+    fn fragment_splice_carries_residual_norms_and_v3_header() {
+        let left = residual_subsection_with_empty_clusters(1_000);
+        let right = residual_subsection_with_empty_clusters(2_000);
+        let left_ids: Vec<i128> = (0..ROWS as i128).map(|i| 1_000 + i).collect();
+        let right_ids: Vec<i128> = (0..ROWS as i128).map(|i| 2_000 + i).collect();
+
+        let (merged, _) =
+            merge_fragment_subsections(&left, &left_ids, &right, &right_ids, DIM, Metric::Cosine)
+                .expect("residual fragment splice");
+
+        let (m_inp, m_clusters) = parsed_norms_and_clusters(&merged);
+        let m_norms = m_inp
+            .residual_norms
+            .as_deref()
+            .expect("spliced output carries the residual-norm region");
+        assert_eq!(m_norms.len(), 2 * ROWS, "one norm per spliced row");
+
+        let (l_inp, l_clusters) = parsed_norms_and_clusters(&left);
+        let (r_inp, r_clusters) = parsed_norms_and_clusters(&right);
+        let l_norms = l_inp.residual_norms.as_deref().expect("left norms");
+        let r_norms = r_inp.residual_norms.as_deref().expect("right norms");
+        for k in 0..merged.n_cent {
+            let (m_off, m_cnt) = m_clusters[k];
+            let (src_norms, (s_off, s_cnt)) = if k < left.n_cent {
+                (l_norms, l_clusters[k])
+            } else {
+                (r_norms, r_clusters[k - left.n_cent])
+            };
+            assert_eq!(m_cnt, s_cnt, "cluster {k}: row count survives splice");
+            assert_eq!(
+                &m_norms[m_off..m_off + m_cnt],
+                &src_norms[s_off..s_off + s_cnt],
+                "cluster {k}: residual norms must ride to the new cluster-order \
+                 positions"
+            );
+        }
+    }
+
+    /// Mixed residual provenance must fail the splice loudly (one output
+    /// header flag cannot describe both generations); the parsed-merge path
+    /// enforces the same rule.
+    #[test]
+    fn merges_reject_mixed_residual_provenance() {
+        let residual = residual_subsection_with_empty_clusters(1_000);
+        let raw = sq16_subsection_with_empty_clusters(2_000);
+        let residual_ids: Vec<i128> = (0..ROWS as i128).map(|i| 1_000 + i).collect();
+        let raw_ids: Vec<i128> = (0..ROWS as i128).map(|i| 2_000 + i).collect();
+
+        let err = match merge_fragment_subsections(
+            &residual,
+            &residual_ids,
+            &raw,
+            &raw_ids,
+            DIM,
+            Metric::Cosine,
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("mixed-provenance splice must fail"),
+        };
+        assert!(
+            err.to_string().contains("residual-code provenance"),
+            "unexpected splice error: {err}"
+        );
+
+        let (res_inp, _) = parsed_norms_and_clusters(&residual);
+        let (raw_inp, _) = parsed_norms_and_clusters(&raw);
+        let err = match merge_sq8_ivf_subsections_from_parsed(&[res_inp, raw_inp]) {
+            Err(e) => e,
+            Ok(_) => panic!("mixed-provenance parsed merge must fail"),
+        };
+        assert!(
+            err.to_string().contains("residual-code provenance"),
+            "unexpected parsed-merge error: {err}"
+        );
+    }
+
+    /// The parsed merge (same fine shape, e.g. compaction of same-cell
+    /// fragments) concatenates each cluster's rows across inputs in input
+    /// order; residual norms must land at the same concatenated cluster-order
+    /// positions, and the output must round-trip as v3.
+    #[test]
+    fn parsed_merge_carries_residual_norms() {
+        let a = residual_subsection_with_empty_clusters(1_000);
+        let b = residual_subsection_with_empty_clusters(2_000);
+        let (a_inp, a_clusters) = parsed_norms_and_clusters(&a);
+        let (mut b_inp, b_clusters) = parsed_norms_and_clusters(&b);
+        b_inp.doc_id_offset = a.n_docs;
+        let a_norms = a_inp.residual_norms.clone().expect("a norms");
+        let b_norms = b_inp.residual_norms.clone().expect("b norms");
+
+        let merged = merge_sq8_ivf_subsections_from_parsed(&[a_inp, b_inp])
+            .expect("residual parsed merge");
+        let (m_inp, m_clusters) = parsed_norms_and_clusters(&merged);
+        let m_norms = m_inp
+            .residual_norms
+            .as_deref()
+            .expect("merged output carries the residual-norm region");
+        assert_eq!(m_norms.len(), 2 * ROWS, "one norm per merged row");
+
+        for c in 0..merged.n_cent {
+            let (m_off, m_cnt) = m_clusters[c];
+            let (a_off, a_cnt) = a_clusters[c];
+            let (b_off, b_cnt) = b_clusters[c];
+            assert_eq!(m_cnt, a_cnt + b_cnt, "cluster {c}: merged row count");
+            let mut expected = Vec::with_capacity(m_cnt);
+            expected.extend_from_slice(&a_norms[a_off..a_off + a_cnt]);
+            expected.extend_from_slice(&b_norms[b_off..b_off + b_cnt]);
+            assert_eq!(
+                &m_norms[m_off..m_off + m_cnt],
+                &expected[..],
+                "cluster {c}: norms concatenate in input order at cluster-order \
+                 positions"
+            );
+        }
     }
 
     /// Splice-merging inputs that share an all-empty cluster must leave the

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -236,7 +236,6 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
     let mut bytes = alloc_ivf_subsection_with_header(
         &layout,
         codec_meta_size,
-        0.0,
         &summary_centroid,
         &out_centroids,
     );
@@ -523,7 +522,6 @@ pub(crate) fn splice_fragments_into_cell(
     let mut bytes = alloc_ivf_subsection_with_header(
         &layout,
         codec_meta_size,
-        0.0,
         &summary_centroid,
         &out_centroids,
     );

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -917,6 +917,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8FixedResidual,
             provided_centroids: Some(Arc::from(centroids)),
+            residual_codes: false,
         };
         build_merged_subsection_from_fp32(cfg, N_CENT, Arc::new(vectors), &ids).expect("cell build")
     }
@@ -973,6 +974,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq16,
             provided_centroids: Some(Arc::from(centroids)),
+            residual_codes: false,
         };
         build_merged_subsection_from_fp32(cfg, N_CENT, Arc::new(vectors), &ids)
             .expect("Sq16 cell build")

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -1292,8 +1292,8 @@ mod tests {
         let a_norms = a_inp.residual_norms.clone().expect("a norms");
         let b_norms = b_inp.residual_norms.clone().expect("b norms");
 
-        let merged = merge_sq8_ivf_subsections_from_parsed(&[a_inp, b_inp])
-            .expect("residual parsed merge");
+        let merged =
+            merge_sq8_ivf_subsections_from_parsed(&[a_inp, b_inp]).expect("residual parsed merge");
         let (m_inp, m_clusters) = parsed_norms_and_clusters(&merged);
         let m_norms = m_inp
             .residual_norms

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -230,11 +230,13 @@ pub(crate) fn merge_sq8_ivf_subsections_from_parsed(
         cluster_stride,
         codec_meta_size,
         stable_ids_region_bytes,
+        false,
     );
 
     let mut bytes = alloc_ivf_subsection_with_header(
         &layout,
         codec_meta_size,
+        0.0,
         &summary_centroid,
         &out_centroids,
     );
@@ -515,11 +517,13 @@ pub(crate) fn splice_fragments_into_cell(
         cluster_stride,
         codec_meta_size,
         stable_ids_region_bytes,
+        false,
     );
 
     let mut bytes = alloc_ivf_subsection_with_header(
         &layout,
         codec_meta_size,
+        0.0,
         &summary_centroid,
         &out_centroids,
     );

--- a/src/superfile/vector/quant.rs
+++ b/src/superfile/vector/quant.rs
@@ -166,6 +166,17 @@ impl BitQuantizer {
         }
     }
 
+    /// Analytic scale for the residual 1-bit estimator,
+    /// `κ = sqrt(π/2) / sqrt(dim)`: under a random orthonormal rotation the
+    /// sign-dot `⟨q_rot, sign(r_rot)⟩` concentrates on
+    /// `‖q‖·(q̂·r̂)·sqrt(2·dim/π)`, so `q·r ≈ κ·‖r‖·sign_dot` with this κ.
+    /// Per-table fits on Cohere-768d measured within 5% of the analytic
+    /// value (0.0465–0.0474 vs 0.0452); a calibrated
+    /// `CellRoutingParams::residual_kappa`, when stamped, overrides it.
+    pub fn residual_kappa_analytic(dim: usize) -> f32 {
+        (core::f32::consts::PI / 2.0).sqrt() / (dim.max(1) as f32).sqrt()
+    }
+
     /// Encode the cell-centroid **residual** of one already-rotated row:
     /// the sign code of `rot(v) − rot(c_cell)` and the residual's L2 norm
     /// `‖rot(v) − rot(c_cell)‖` (returned; the drain writes it to the

--- a/src/superfile/vector/quant.rs
+++ b/src/superfile/vector/quant.rs
@@ -166,6 +166,36 @@ impl BitQuantizer {
         }
     }
 
+    /// Encode the cell-centroid **residual** of one already-rotated row:
+    /// the sign code of `rot(v) − rot(c_cell)` and the residual's L2 norm
+    /// `‖rot(v) − rot(c_cell)‖` (returned; the drain writes it to the
+    /// per-doc residual-norm region). Rotation is orthonormal, so this
+    /// equals `‖v − c_cell‖` and the code is the sign pattern of the true
+    /// residual — the query-time estimator recovers
+    /// `q·c_cell + κ·‖r‖·sign_dot(q_rot, code)`. `rot_centroid` is the
+    /// row's cell centroid, pre-rotated once per build (rotation is linear,
+    /// so `rot(v − c) = rot(v) − rot(c)`). `scratch` is a caller-owned
+    /// `dim`-length buffer reused across rows.
+    pub fn encode_residual_into(
+        &self,
+        rot_row: &[f32],
+        rot_centroid: &[f32],
+        scratch: &mut [f32],
+        out: &mut [u8],
+    ) -> f32 {
+        debug_assert_eq!(rot_row.len(), self.dim);
+        debug_assert_eq!(rot_centroid.len(), self.dim);
+        debug_assert_eq!(scratch.len(), self.dim);
+        let mut norm_sq = 0.0f32;
+        for d in 0..self.dim {
+            let r = rot_row[d] - rot_centroid[d];
+            scratch[d] = r;
+            norm_sq += r * r;
+        }
+        self.encode_rotated_into(scratch, out);
+        norm_sq.sqrt()
+    }
+
     /// Estimate `<q_rot, doc_rot>` from the bit-encoded `code` of
     /// `doc_rot`. The result is an unbiased estimator of the rotated
     /// dot product (which equals the un-rotated dot product because
@@ -787,6 +817,33 @@ mod tests {
         assert_eq!(BitQuantizer::new(9).code_bytes(), 2);
         assert_eq!(BitQuantizer::new(15).code_bytes(), 2);
         assert_eq!(BitQuantizer::new(17).code_bytes(), 3);
+    }
+
+    /// The residual encoder produces the sign pattern of `rot(v) − rot(c)`
+    /// and its exact L2 norm, and agrees with encoding a pre-differenced
+    /// buffer directly. Uses an identity "rotation" (the encoder is fed
+    /// already-rotated inputs), so `rot(v)=v`, `rot(c)=c`.
+    #[test]
+    fn encode_residual_matches_signs_and_norm_of_the_difference() {
+        let dim = 10;
+        let q = BitQuantizer::new(dim);
+        let row: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.3 - 1.0).collect();
+        let centroid: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.25 - 0.9).collect();
+
+        let mut scratch = vec![0f32; dim];
+        let mut code = vec![0u8; q.code_bytes()];
+        let norm = q.encode_residual_into(&row, &centroid, &mut scratch, &mut code);
+
+        // Reference: difference, then the plain encoder + a scalar norm.
+        let diff: Vec<f32> = row.iter().zip(&centroid).map(|(r, c)| r - c).collect();
+        let mut ref_code = vec![0u8; q.code_bytes()];
+        q.encode_rotated_into(&diff, &mut ref_code);
+        let ref_norm = diff.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+        assert_eq!(code, ref_code, "residual code = signs of (row − centroid)");
+        assert!(approx(norm, ref_norm, 1e-6), "norm {norm} vs {ref_norm}");
+        // scratch holds the residual for the caller to reuse / inspect.
+        assert!(scratch.iter().zip(&diff).all(|(a, b)| approx(*a, *b, 1e-6)));
     }
 
     // --- encode --------------------------------------------------------

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -180,6 +180,9 @@ pub struct ColumnReader {
     /// present iff the column stores cell-centroid residual codes. `None` for
     /// raw-code columns. When set, the scan estimator forms
     /// `est = q·c_cell + residual_kappa·‖r‖·signdot`.
+    // Consumed by the scan estimator (next stage); parsed and carried now so
+    // the format/reader plumbing lands and is tested independently.
+    #[allow(dead_code)]
     residual_norms_off: Option<usize>,
     quant: BitQuantizer,
     /// Cached random rotation built once at open from `(dim, rot_seed)`.
@@ -5890,6 +5893,7 @@ mod tests {
             metric,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         for i in 0..n_docs {
@@ -5947,6 +5951,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let first = build_merged_subsection_from_materialized(config.clone(), 2, make_rows(7, 3))
             .expect("first cell subsection");
@@ -6215,6 +6220,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register Sq8 column");
         for i in 0..32u32 {
@@ -6242,6 +6248,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let mut all_vecs = Vec::new();
@@ -6536,6 +6543,7 @@ mod tests {
                 },
                 rerank_codec: codec,
                 provided_centroids: None,
+                residual_codes: false,
             })
             .unwrap_or_else(|e| panic!("codec {codec:?} must register, got {e:?}"));
         }
@@ -6560,6 +6568,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         for i in 0..n_docs {
@@ -6629,6 +6638,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8FixedResidual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         for i in 0..n_docs {
@@ -6671,6 +6681,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let make = |i: u32| -> Vec<f32> {
@@ -6720,6 +6731,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8FixedResidual,
                 provided_centroids: None,
+                residual_codes: false,
             })
             .expect("register fixed residual column");
         let make = |i: u32| -> Vec<f32> {
@@ -6853,6 +6865,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let sub0 =
             build_merged_subsection_from_materialized(cfg(), 2, make_rows(0, 4)).expect("cell 0");
@@ -6933,6 +6946,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let sub0 =
             build_merged_subsection_from_materialized(cfg(), 2, make_rows(0, 4)).expect("cell 0");
@@ -7005,6 +7019,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         let sub0 =
             build_merged_subsection_from_materialized(cfg(), 2, make_rows(0, 4)).expect("cell 0");
@@ -7057,6 +7072,7 @@ mod tests {
                 metric: Metric::L2Sq,
                 rerank_codec: RerankCodec::Sq8FixedResidual,
                 provided_centroids: None,
+                residual_codes: false,
             })
             .expect_err("fixed residual must reject L2Sq");
         assert!(matches!(error, BuildError::VectorSchemaMismatch(_)));
@@ -7081,6 +7097,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         for i in 0..n_docs {
@@ -7171,6 +7188,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let mut planted = Vec::with_capacity(n_docs as usize);
@@ -7271,6 +7289,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let make = |i: u32| -> Vec<f32> {
@@ -7335,6 +7354,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let make = |i: u32| -> Vec<f32> {
@@ -7400,6 +7420,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::RabitqOnly,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register None column");
         for i in 0..n_docs {
@@ -7457,6 +7478,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::RabitqOnly,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register None column");
         // Angularly diverse corpus — hashed-uniform vectors,
@@ -7544,6 +7566,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::RabitqOnly,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register None column");
         for i in 0..n_docs {
@@ -7776,6 +7799,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: codec,
                 provided_centroids: None,
+                residual_codes: false,
             })
             .expect("register");
             for v in &all {
@@ -7910,6 +7934,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let mut all = Vec::with_capacity(n_docs as usize);
@@ -8375,6 +8400,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let mut v = vec![0f32; dim];
@@ -8866,6 +8892,7 @@ mod tests {
             metric,
             rerank_codec: codec,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let mut all = Vec::with_capacity(n_docs as usize);
@@ -9288,6 +9315,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
 
@@ -9344,6 +9372,7 @@ mod tests {
                 metric: Metric::L2Sq,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             })
             .expect("register column");
         for i in 0u32..32 {
@@ -9387,6 +9416,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let bytes = b.finish().expect("finish vector builder");
@@ -9484,6 +9514,7 @@ mod tests {
             metric,
             rerank_codec: codec,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let mut all = Vec::with_capacity(n_docs as usize);
@@ -10187,6 +10218,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
         let mut planted = Vec::with_capacity(n_docs as usize);

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -176,6 +176,13 @@ pub struct ColumnReader {
     /// [`VectorReader::inline_stable_ids_for_locals`] so an id+score query (and
     /// the drain) skips resolving the stable `_id` through a scalar `_id` column.
     stable_ids_off: Option<usize>,
+    /// Relative offset of the per-doc residual-norm region (`n_docs` `f32`),
+    /// present iff the column stores cell-centroid residual codes. `None` for
+    /// raw-code columns. When set, the scan estimator forms
+    /// `est = q·c_cell + residual_kappa·‖r‖·signdot`.
+    residual_norms_off: Option<usize>,
+    /// Residual scale κ from the sub-header; `0.0` for raw-code columns.
+    residual_kappa: f32,
     quant: BitQuantizer,
     /// Cached random rotation built once at open from `(dim, rot_seed)`.
     /// Construction is `O(dim³)` for Gram-Schmidt — at dim=384 that's
@@ -1007,12 +1014,31 @@ impl VectorReader {
             //   [48..56] per_cluster_blocks_off (u64 LE)
             let subsection_version =
                 read_u32_le(&sub_header[sub_hdr::VERSION_OFF..sub_hdr::VERSION_OFF + U32_BYTES]);
-            if subsection_version != format::vec::SUBSECTION_VERSION {
+            if !format::vec::subsection_version_supported(subsection_version) {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' has unsupported subsection layout version \
-                     {subsection_version}; this build supports only {}",
+                     {subsection_version}; this build supports {} and {}",
                     cfg.column,
-                    format::vec::SUBSECTION_VERSION
+                    format::vec::SUBSECTION_VERSION,
+                    format::vec::SUBSECTION_VERSION_RESIDUAL,
+                ))));
+            }
+            // Residual columns (version 3) carry the flag + κ in the reclaimed
+            // reserved slot; version 2 leaves it zero. Reading it on version 2
+            // is a guaranteed zero, so no version branch is needed here.
+            let residual_codes = read_u32_le(
+                &sub_header[sub_hdr::RESIDUAL_FLAG_OFF..sub_hdr::RESIDUAL_FLAG_OFF + U32_BYTES],
+            ) == 1;
+            let residual_kappa = f32::from_le_bytes(
+                sub_header[sub_hdr::RESIDUAL_KAPPA_OFF..sub_hdr::RESIDUAL_KAPPA_OFF + U32_BYTES]
+                    .try_into()
+                    .expect("4-byte κ slot"),
+            );
+            if residual_codes != (subsection_version == format::vec::SUBSECTION_VERSION_RESIDUAL) {
+                return Err(VectorError::Read(ReadError::MalformedVersion(format!(
+                    "column '{}' residual flag {residual_codes} disagrees with subsection \
+                     version {subsection_version}",
+                    cfg.column
                 ))));
             }
 
@@ -1073,11 +1099,11 @@ impl VectorReader {
             } else {
                 codec_meta_off + codec_meta_size
             };
-            // Anything between `preceding_end` and `per_cluster_blocks_off` is
-            // the inline stable-`_id` region (materialized/hidden-cell builds);
-            // `0` means none. Validated against n_docs below. Self-describing
-            // from the offsets — no header flag.
-            let stable_ids_region_bytes =
+            // Everything between `preceding_end` and `per_cluster_blocks_off`
+            // is the optional residual-norm region (residual columns) followed
+            // by the optional inline stable-`_id` region — self-describing from
+            // the offsets plus the residual header flag.
+            let region_gap =
                 per_cluster_blocks_off.checked_sub(preceding_end).ok_or_else(|| {
                     VectorError::Read(ReadError::MalformedVersion(format!(
                         "column '{}' regions before per_cluster_blocks_off={per_cluster_blocks_off} \
@@ -1090,8 +1116,8 @@ impl VectorReader {
             // the trailing data region. Each doc contributes
             // `code_bytes + 4 (doc_id) + per_vec_bytes (full)` — codes, doc-id,
             // and rerank vector interleaved per cluster. Solve for n_docs from
-            // the region size (the stable-`_id` region, if any, is *before*
-            // per_cluster_blocks_off and so does not perturb this).
+            // the region size (the residual/stable-`_id` regions are *before*
+            // per_cluster_blocks_off and so do not perturb this).
             let blocks_region_size = sub_crc_pos - per_cluster_blocks_off;
             let per_doc_stride = code_bytes + format::vec::DOC_ID_BYTES + per_vec_bytes;
             if per_doc_stride == 0 || !blocks_region_size.is_multiple_of(per_doc_stride) {
@@ -1102,18 +1128,38 @@ impl VectorReader {
                 ))));
             }
             let col_n_docs = (blocks_region_size / per_doc_stride) as u32;
+            // Split the gap: the residual-norm region (present iff the flag is
+            // set) is exactly one f32 per doc at `preceding_end`; the stable-id
+            // region, if any, is exactly one i128 per doc after it.
+            let residual_norms_bytes = if residual_codes {
+                (col_n_docs as usize) * 4
+            } else {
+                0
+            };
+            let stable_ids_region_bytes = region_gap.checked_sub(residual_norms_bytes).ok_or_else(
+                || {
+                    VectorError::Read(ReadError::MalformedVersion(format!(
+                        "column '{}' region gap {region_gap} smaller than the residual-norm \
+                         region {residual_norms_bytes}",
+                        cfg.column
+                    )))
+                },
+            )?;
+            let residual_norms_off = residual_codes.then_some(preceding_end);
+            let stable_ids_start = preceding_end + residual_norms_bytes;
             // The stable-`_id` region, when present, is exactly one i128 per doc.
             let expected_stable_ids_bytes = (col_n_docs as usize) * format::vec::STABLE_ID_BYTES;
             if stable_ids_region_bytes != 0 && stable_ids_region_bytes != expected_stable_ids_bytes
             {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' gap before per_cluster_blocks_off is {stable_ids_region_bytes} \
-                     bytes; expected 0 or n_docs×16 = {expected_stable_ids_bytes}",
+                     bytes after the residual region; expected 0 or n_docs×16 = \
+                     {expected_stable_ids_bytes}",
                     cfg.column
                 ))));
             }
             // Relative offset of the stable-`_id` region (start of the i128s).
-            let stable_ids_off = (stable_ids_region_bytes != 0).then_some(preceding_end);
+            let stable_ids_off = (stable_ids_region_bytes != 0).then_some(stable_ids_start);
             let actual_codec_meta_size = codec_meta_size;
 
             // Sq8 + L2Sq adds the per-doc norms tail to codec_meta
@@ -1238,6 +1284,8 @@ impl VectorReader {
                 codec_meta_off,
                 per_cluster_blocks_off,
                 stable_ids_off,
+                residual_norms_off,
+                residual_kappa,
                 quant,
                 rot: RandomRotation::new(dim, rot_seed),
             });
@@ -1651,10 +1699,23 @@ impl VectorReader {
         }
         let subsection_version =
             read_u32_le(&sub_header[sub_hdr::VERSION_OFF..sub_hdr::VERSION_OFF + U32_BYTES]);
-        if subsection_version != format::vec::SUBSECTION_VERSION {
+        if !format::vec::subsection_version_supported(subsection_version) {
             return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                 "cell subsection unsupported layout version {subsection_version}"
             ))));
+        }
+        let residual_codes = read_u32_le(
+            &sub_header[sub_hdr::RESIDUAL_FLAG_OFF..sub_hdr::RESIDUAL_FLAG_OFF + U32_BYTES],
+        ) == 1;
+        let residual_kappa = f32::from_le_bytes(
+            sub_header[sub_hdr::RESIDUAL_KAPPA_OFF..sub_hdr::RESIDUAL_KAPPA_OFF + U32_BYTES]
+                .try_into()
+                .expect("4-byte κ slot"),
+        );
+        if residual_codes != (subsection_version == format::vec::SUBSECTION_VERSION_RESIDUAL) {
+            return Err(VectorError::Read(ReadError::MalformedVersion(
+                "cell subsection residual flag disagrees with layout version".into(),
+            )));
         }
         if verify_crc {
             let body = fetch_sync(source, subsection_off..sub_end, "cell subsection crc")?;
@@ -1717,7 +1778,7 @@ impl VectorReader {
             codec_meta_off + codec_meta_size
         };
         let sub_crc_pos = subsection_len - format::CRC_BYTES;
-        let stable_ids_region_bytes = per_cluster_blocks_off
+        let region_gap = per_cluster_blocks_off
             .checked_sub(preceding_end)
             .ok_or_else(|| {
                 VectorError::Read(ReadError::MalformedVersion(
@@ -1741,13 +1802,28 @@ impl VectorReader {
             ))));
         }
         let col_n_docs = (blocks_region_size / per_doc_stride) as u32;
+        // Gap split (same rule as the single-column path): residual-norm
+        // region (iff the flag is set) then the stable-`_id` region.
+        let residual_norms_bytes = if residual_codes {
+            (col_n_docs as usize) * 4
+        } else {
+            0
+        };
+        let stable_ids_region_bytes =
+            region_gap.checked_sub(residual_norms_bytes).ok_or_else(|| {
+                VectorError::Read(ReadError::MalformedVersion(
+                    "cell subsection region gap smaller than the residual-norm region".into(),
+                ))
+            })?;
+        let residual_norms_off = residual_codes.then_some(preceding_end);
+        let stable_ids_start = preceding_end + residual_norms_bytes;
         let expected_stable_ids_bytes = (col_n_docs as usize) * format::vec::STABLE_ID_BYTES;
         if stable_ids_region_bytes != 0 && stable_ids_region_bytes != expected_stable_ids_bytes {
             return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                 "cell subsection stable-id gap {stable_ids_region_bytes}, expected 0 or {expected_stable_ids_bytes}"
             ))));
         }
-        let stable_ids_off = (stable_ids_region_bytes != 0).then_some(preceding_end);
+        let stable_ids_off = (stable_ids_region_bytes != 0).then_some(stable_ids_start);
         let expected_codec_meta_size =
             rerank_codec.codec_meta_bytes(dim, col_n_docs as usize, n_cent, metric);
         if codec_meta_size != expected_codec_meta_size {
@@ -1829,6 +1905,8 @@ impl VectorReader {
             codec_meta_off,
             per_cluster_blocks_off,
             stable_ids_off,
+            residual_norms_off,
+            residual_kappa,
             quant,
             rot: RandomRotation::new(dim, rot_seed),
         })

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -181,8 +181,6 @@ pub struct ColumnReader {
     /// raw-code columns. When set, the scan estimator forms
     /// `est = q·c_cell + residual_kappa·‖r‖·signdot`.
     residual_norms_off: Option<usize>,
-    /// Residual scale κ from the sub-header; `0.0` for raw-code columns.
-    residual_kappa: f32,
     quant: BitQuantizer,
     /// Cached random rotation built once at open from `(dim, rot_seed)`.
     /// Construction is `O(dim³)` for Gram-Schmidt — at dim=384 that's
@@ -1029,11 +1027,6 @@ impl VectorReader {
             let residual_codes = read_u32_le(
                 &sub_header[sub_hdr::RESIDUAL_FLAG_OFF..sub_hdr::RESIDUAL_FLAG_OFF + U32_BYTES],
             ) == 1;
-            let residual_kappa = f32::from_le_bytes(
-                sub_header[sub_hdr::RESIDUAL_KAPPA_OFF..sub_hdr::RESIDUAL_KAPPA_OFF + U32_BYTES]
-                    .try_into()
-                    .expect("4-byte κ slot"),
-            );
             if residual_codes != (subsection_version == format::vec::SUBSECTION_VERSION_RESIDUAL) {
                 return Err(VectorError::Read(ReadError::MalformedVersion(format!(
                     "column '{}' residual flag {residual_codes} disagrees with subsection \
@@ -1285,7 +1278,6 @@ impl VectorReader {
                 per_cluster_blocks_off,
                 stable_ids_off,
                 residual_norms_off,
-                residual_kappa,
                 quant,
                 rot: RandomRotation::new(dim, rot_seed),
             });
@@ -1707,11 +1699,6 @@ impl VectorReader {
         let residual_codes = read_u32_le(
             &sub_header[sub_hdr::RESIDUAL_FLAG_OFF..sub_hdr::RESIDUAL_FLAG_OFF + U32_BYTES],
         ) == 1;
-        let residual_kappa = f32::from_le_bytes(
-            sub_header[sub_hdr::RESIDUAL_KAPPA_OFF..sub_hdr::RESIDUAL_KAPPA_OFF + U32_BYTES]
-                .try_into()
-                .expect("4-byte κ slot"),
-        );
         if residual_codes != (subsection_version == format::vec::SUBSECTION_VERSION_RESIDUAL) {
             return Err(VectorError::Read(ReadError::MalformedVersion(
                 "cell subsection residual flag disagrees with layout version".into(),
@@ -1906,7 +1893,6 @@ impl VectorReader {
             per_cluster_blocks_off,
             stable_ids_off,
             residual_norms_off,
-            residual_kappa,
             quant,
             rot: RandomRotation::new(dim, rot_seed),
         })

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3097,6 +3097,7 @@ impl VectorReader {
             budget: None,
         };
         // Superfile-tier direct API: no collector at this layer, ns dropped.
+        let residual_ctx = self.residual_scan_ctx(col).await?;
         let (outcome, _scan_kernel_ns) = build_shortlist(
             col,
             cb,
@@ -3104,6 +3105,7 @@ impl VectorReader {
             &cluster_blocks,
             survivor_only_rerank_fetch,
             &ctx,
+            residual_ctx.as_ref(),
         )
         .await?;
         let (candidates, survivor_full_ranges) = match outcome {
@@ -3631,9 +3633,18 @@ impl VectorReader {
                         budget,
                     };
                     let coarse_limit = k.saturating_mul(rerank_mult);
-                    let (shortlist, scan_kernel_ns) =
-                        scan_shortlist(col, cb, &cluster_meta, &blocks, true, coarse_limit, &ctx)
-                            .await?;
+                    let residual_ctx = self.residual_scan_ctx(col).await?;
+                    let (shortlist, scan_kernel_ns) = scan_shortlist(
+                        col,
+                        cb,
+                        &cluster_meta,
+                        &blocks,
+                        true,
+                        coarse_limit,
+                        &ctx,
+                        residual_ctx.as_ref(),
+                    )
+                    .await?;
                     tally.kernel_cpu_ns += scan_kernel_ns;
                     let cands = shortlist
                         .into_iter()
@@ -3850,6 +3861,48 @@ impl VectorReader {
     /// Returns the hits plus the number of rows the probe reranked at
     /// full precision (0 on the `RabitqOnly` and empty-shortlist paths),
     /// for the per-query work stats.
+    /// Fetch the residual-estimator inputs for one column, when its codes
+    /// are cell-centroid residuals: the raw centroid region (for the exact
+    /// per-cluster `q·c` term), the per-doc residual-norm region, and κ
+    /// (analytic default; a calibrated routing stamp can override at the
+    /// supertable layer). Both regions live in the resident open-time head,
+    /// so the sync hit is the normal path; the async fallback covers a
+    /// cold lazy open. `None` for raw-code columns — the estimator then
+    /// stays the raw sign-dot, byte-for-byte today's behavior.
+    async fn residual_scan_ctx(
+        &self,
+        col: &ColumnReader,
+    ) -> Result<Option<ResidualScanCtx>, VectorError> {
+        let Some(norms_off) = col.residual_norms_off else {
+            return Ok(None);
+        };
+        let sub = col.subsection_range.start;
+        let norms_range = sub + norms_off..sub + norms_off + col.n_docs as usize * 4;
+        let cent_range = sub + col.centroids_off
+            ..sub + col.centroids_off + col.n_cent as usize * col.dim * 4;
+        let norms = match self.source.try_get_range_sync(norms_range.clone()) {
+            Some(b) => b,
+            None => self
+                .source
+                .range_async(norms_range)
+                .await
+                .map_err(|e| VectorError::LazySource(e.to_string()))?,
+        };
+        let centroids = match self.source.try_get_range_sync(cent_range.clone()) {
+            Some(b) => b,
+            None => self
+                .source
+                .range_async(cent_range)
+                .await
+                .map_err(|e| VectorError::LazySource(e.to_string()))?,
+        };
+        Ok(Some(ResidualScanCtx {
+            centroids,
+            norms,
+            kappa: BitQuantizer::residual_kappa_analytic(col.dim),
+        }))
+    }
+
     async fn probe_clusters_async(
         &self,
         col: &ColumnReader,
@@ -3971,6 +4024,7 @@ impl VectorReader {
         // RaBitQ heap; survivor_fetch = warm/cold full-row gather; rerank =
         // Sq8/fp32 refine. Concurrent fan-out units each emit their own spans.
         let shortlist_t0 = io_counters::phase_start();
+        let residual_ctx = self.residual_scan_ctx(col).await?;
         let (outcome, scan_kernel_ns) = build_shortlist(
             col,
             cb,
@@ -3978,6 +4032,7 @@ impl VectorReader {
             &cluster_blocks,
             survivor_only_rerank_fetch,
             ctx,
+            residual_ctx.as_ref(),
         )
         .await?;
         tally.kernel_cpu_ns += scan_kernel_ns;
@@ -4366,6 +4421,64 @@ impl TransposedCodeCache {
 /// only; filtered scans keep the row-major estimator, whose per-row
 /// allow/deny checks precede scoring).
 #[allow(clippy::too_many_arguments)]
+/// Residual-estimator inputs for one column's scan, fetched once per probe
+/// from the resident open-time regions: the raw centroid bytes (to derive
+/// the exact `q·c_cluster` term per probed cluster), the per-doc
+/// residual-norm region, and κ. Present iff the column stores residual
+/// codes (subsection version 3).
+struct ResidualScanCtx {
+    centroids: Bytes,
+    norms: Bytes,
+    kappa: f32,
+}
+
+/// One probed cluster's resolved residual context: the exact
+/// `q·c_cluster` (computed as `q_rot·rot(c)` — the rotation is
+/// orthonormal), κ, and the norm region indexed by the row's absolute
+/// cluster-order position. The scan estimate becomes
+/// `q_dot + κ·‖r‖·sign_dot` — the estimator the residual codes were
+/// built for; raw sign-dot on residual codes would rank garbage.
+struct ClusterResidual {
+    q_dot: f32,
+    kappa: f32,
+    norms: Bytes,
+}
+
+impl ClusterResidual {
+    /// Resolve one cluster's context: slice its raw centroid, rotate,
+    /// and dot with the rotated query.
+    fn resolve(ctx: &ResidualScanCtx, col: &ColumnReader, cluster: usize, q_rot: &[f32]) -> Self {
+        let dim = col.dim;
+        let raw = &ctx.centroids[cluster * dim * 4..(cluster + 1) * dim * 4];
+        let mut c = vec![0.0f32; dim];
+        for (slot, b) in c.iter_mut().zip(raw.chunks_exact(4)) {
+            *slot = f32::from_le_bytes(b.try_into().expect("4-byte centroid component"));
+        }
+        let mut c_rot = vec![0.0f32; dim];
+        col.rot.apply(&c, &mut c_rot);
+        let q_dot = q_rot.iter().zip(&c_rot).map(|(a, b)| a * b).sum();
+        Self {
+            q_dot,
+            kappa: ctx.kappa,
+            norms: ctx.norms.clone(),
+        }
+    }
+
+    /// The residual estimate for the row at absolute cluster-order
+    /// position `pos`, given its raw sign-dot.
+    #[inline]
+    fn estimate(&self, pos: u32, sign_dot: f32) -> f32 {
+        let p = pos as usize * 4;
+        let norm = f32::from_le_bytes(
+            self.norms[p..p + 4]
+                .try_into()
+                .expect("4-byte residual norm"),
+        );
+        self.q_dot + self.kappa * norm * sign_dot
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn scan_cluster_transposed(
     transposed: &[u8],
     doc_ids: &[u8],
@@ -4374,6 +4487,7 @@ fn scan_cluster_transposed(
     cluster_id: u32,
     cb: usize,
     lut: &LutQuery,
+    residual: Option<&ClusterResidual>,
     acc: &mut Vec<(u32, f32, u32, u32)>,
 ) {
     for_each_code_block_scores(transposed, cb, lut, |base_r, scores| {
@@ -4385,7 +4499,12 @@ fn scan_cluster_transposed(
                     .try_into()
                     .expect("4-byte doc id"),
             );
-            acc.push((did, est, off + rr as u32, cluster_id));
+            let pos = off + rr as u32;
+            let est = match residual {
+                Some(res) => res.estimate(pos, est),
+                None => est,
+            };
+            acc.push((did, est, pos, cluster_id));
         }
     });
 }
@@ -4405,6 +4524,7 @@ async fn scan_shortlist(
     survivor_only_rerank_fetch: bool,
     coarse_limit: usize,
     ctx: &ProbeCtx<'_>,
+    residual: Option<&ResidualScanCtx>,
 ) -> Result<(Vec<(u32, f32, u32, u32)>, u64), VectorError> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
     let total_candidates: usize = cluster_meta.iter().map(|&(_, _, cnt)| cnt as usize).sum();
@@ -4422,7 +4542,18 @@ async fn scan_shortlist(
         .then(|| LutQuery::new(ctx.q_rot))
         .filter(|lut| lut.fits_i16())
         .map(Arc::new);
+    // Resolve every probed cluster's residual context once (exact q·c per
+    // cluster) — shared by the serial and rayon arms.
+    let cluster_residuals: Option<Arc<Vec<ClusterResidual>>> = residual.map(|r| {
+        Arc::new(
+            cluster_meta
+                .iter()
+                .map(|&(c, _, _)| ClusterResidual::resolve(r, col, c, ctx.q_rot))
+                .collect(),
+        )
+    });
     let scan_vec = |acc: &mut Vec<(u32, f32, u32, u32)>,
+                    cluster_residual: Option<&ClusterResidual>,
                     (&(c, off, cnt), block): (&(usize, u32, u32), &Bytes)| {
         let codes_len = (cnt as usize) * cb;
         let doc_ids_len = (cnt as usize) * 4;
@@ -4453,6 +4584,7 @@ async fn scan_shortlist(
                 c as u32,
                 cb,
                 lut,
+                cluster_residual,
                 acc,
             );
             return;
@@ -4467,6 +4599,7 @@ async fn scan_shortlist(
             ctx.q_rot,
             ctx.allow.as_deref(),
             ctx.deny.as_deref(),
+            cluster_residual,
             &mut |cand| acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id)),
         );
     };
@@ -4489,18 +4622,25 @@ async fn scan_shortlist(
         // task; each chunk borrows them as `Option<&RoaringBitmap>`.
         let allow_owned = ctx.allow.clone();
         let deny_owned = ctx.deny.clone();
+        let residuals_owned = cluster_residuals.clone();
         let (tx, rx) = oneshot::channel();
         spawn_on(ctx.pool.as_deref(), move || {
             let acc = meta_owned
                 .par_chunks(chunk)
                 .zip(blocks_owned.par_chunks(chunk))
-                .map(|(meta_chunk, block_chunk)| {
+                .enumerate()
+                .map(|(chunk_idx, (meta_chunk, block_chunk))| {
                     let kernel_start = metering_active().then(thread_cpu_ns).flatten();
                     let chunk_rows: usize =
                         meta_chunk.iter().map(|&(_, _, cnt)| cnt as usize).sum();
                     let cap = coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK);
                     let mut acc = Vec::with_capacity(chunk_rows.min(cap));
-                    for (&(c, off, cnt), block) in meta_chunk.iter().zip(block_chunk.iter()) {
+                    for (j, (&(c, off, cnt), block)) in
+                        meta_chunk.iter().zip(block_chunk.iter()).enumerate()
+                    {
+                        let cluster_residual = residuals_owned
+                            .as_ref()
+                            .map(|v| &v[chunk_idx * chunk + j]);
                         let codes_len = (cnt as usize) * cb;
                         let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
                         let codes = block.slice(0..codes_len);
@@ -4521,6 +4661,7 @@ async fn scan_shortlist(
                                 c as u32,
                                 cb,
                                 lut,
+                                cluster_residual,
                                 &mut acc,
                             );
                             continue;
@@ -4535,6 +4676,7 @@ async fn scan_shortlist(
                             &q_rot_v,
                             allow_owned.as_deref(),
                             deny_owned.as_deref(),
+                            cluster_residual,
                             &mut |cand| {
                                 acc.push((cand.did, cand.estimate, cand.pos, cand.cluster_id))
                             },
@@ -4562,8 +4704,9 @@ async fn scan_shortlist(
         timed_section(|| {
             let cap = coarse_limit.saturating_mul(SHORTLIST_TRUNCATE_SLACK);
             let mut acc = Vec::with_capacity(total_candidates.min(cap));
-            for item in cluster_meta.iter().zip(cluster_blocks.iter()) {
-                scan_vec(&mut acc, item);
+            for (idx, item) in cluster_meta.iter().zip(cluster_blocks.iter()).enumerate() {
+                let cluster_residual = cluster_residuals.as_ref().map(|v| &v[idx]);
+                scan_vec(&mut acc, cluster_residual, item);
                 if acc.len() >= cap {
                     truncate_to_top_estimates(&mut acc, coarse_limit);
                 }
@@ -4697,6 +4840,7 @@ async fn build_shortlist(
     cluster_blocks: &[Bytes],
     survivor_only_rerank_fetch: bool,
     ctx: &ProbeCtx<'_>,
+    residual: Option<&ResidualScanCtx>,
 ) -> Result<(ShortlistOutcome, u64), VectorError> {
     let full_vec_bytes = col.rerank_codec.per_vector_bytes(col.dim);
     // Score each probed cluster's 1-bit codes into the shortlist.
@@ -4722,6 +4866,7 @@ async fn build_shortlist(
         survivor_only_rerank_fetch,
         coarse_limit,
         ctx,
+        residual,
     )
     .await?;
 
@@ -4989,6 +5134,7 @@ where
 /// the top `coarse_limit` with one O(n) partition afterwards).
 #[inline]
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn score_cluster_codes_with(
     cluster_codes: &[u8],
     cluster_doc_ids: &[u8],
@@ -4999,6 +5145,7 @@ fn score_cluster_codes_with(
     q_rot: &[f32],
     allow: Option<&roaring::RoaringBitmap>,
     deny: Option<&roaring::RoaringBitmap>,
+    residual: Option<&ClusterResidual>,
     sink: &mut impl FnMut(CoarseCandidate),
 ) {
     let cb = quant.code_bytes();
@@ -5026,10 +5173,15 @@ fn score_cluster_codes_with(
         }
         let code = &cluster_codes[i * cb..(i + 1) * cb];
         let est = quant.estimate_dot_rotated_with_total(q_rot, code, q_total);
+        let pos = off + i as u32;
+        let est = match residual {
+            Some(res) => res.estimate(pos, est),
+            None => est,
+        };
         sink(CoarseCandidate {
             did,
             estimate: est,
-            pos: off + i as u32,
+            pos,
             cluster_id,
         });
     }

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -1140,15 +1140,16 @@ impl VectorReader {
             } else {
                 0
             };
-            let stable_ids_region_bytes = region_gap.checked_sub(residual_norms_bytes).ok_or_else(
-                || {
-                    VectorError::Read(ReadError::MalformedVersion(format!(
-                        "column '{}' region gap {region_gap} smaller than the residual-norm \
+            let stable_ids_region_bytes =
+                region_gap
+                    .checked_sub(residual_norms_bytes)
+                    .ok_or_else(|| {
+                        VectorError::Read(ReadError::MalformedVersion(format!(
+                            "column '{}' region gap {region_gap} smaller than the residual-norm \
                          region {residual_norms_bytes}",
-                        cfg.column
-                    )))
-                },
-            )?;
+                            cfg.column
+                        )))
+                    })?;
             let residual_norms_off = residual_codes.then_some(preceding_end);
             let stable_ids_start = preceding_end + residual_norms_bytes;
             // The stable-`_id` region, when present, is exactly one i128 per doc.
@@ -1811,11 +1812,13 @@ impl VectorReader {
             0
         };
         let stable_ids_region_bytes =
-            region_gap.checked_sub(residual_norms_bytes).ok_or_else(|| {
-                VectorError::Read(ReadError::MalformedVersion(
-                    "cell subsection region gap smaller than the residual-norm region".into(),
-                ))
-            })?;
+            region_gap
+                .checked_sub(residual_norms_bytes)
+                .ok_or_else(|| {
+                    VectorError::Read(ReadError::MalformedVersion(
+                        "cell subsection region gap smaller than the residual-norm region".into(),
+                    ))
+                })?;
         let residual_norms_off = residual_codes.then_some(preceding_end);
         let stable_ids_start = preceding_end + residual_norms_bytes;
         let expected_stable_ids_bytes = (col_n_docs as usize) * format::vec::STABLE_ID_BYTES;
@@ -3957,8 +3960,8 @@ impl VectorReader {
         };
         let sub = col.subsection_range.start;
         let norms_range = sub + norms_off..sub + norms_off + col.n_docs as usize * 4;
-        let cent_range = sub + col.centroids_off
-            ..sub + col.centroids_off + col.n_cent as usize * col.dim * 4;
+        let cent_range =
+            sub + col.centroids_off..sub + col.centroids_off + col.n_cent as usize * col.dim * 4;
         let norms = match self.source.try_get_range_sync(norms_range.clone()) {
             Some(b) => b,
             None => self
@@ -4574,8 +4577,7 @@ impl ClusterResidual {
         let start = pos_base as usize * 4;
         let bytes = &self.norms[start..start + live * 4];
         for (score, norm_bytes) in scores[..live].iter_mut().zip(bytes.chunks_exact(4)) {
-            let norm =
-                f32::from_le_bytes(norm_bytes.try_into().expect("4-byte residual norm"));
+            let norm = f32::from_le_bytes(norm_bytes.try_into().expect("4-byte residual norm"));
             *score = self.q_dot + self.kappa * norm * *score;
         }
     }
@@ -4750,9 +4752,8 @@ async fn scan_shortlist(
                     for (j, (&(c, off, cnt), block)) in
                         meta_chunk.iter().zip(block_chunk.iter()).enumerate()
                     {
-                        let cluster_residual = residuals_owned
-                            .as_ref()
-                            .map(|v| &v[chunk_idx * chunk + j]);
+                        let cluster_residual =
+                            residuals_owned.as_ref().map(|v| &v[chunk_idx * chunk + j]);
                         let codes_len = (cnt as usize) * cb;
                         let doc_ids = block.slice(codes_len..codes_len + (cnt as usize) * 4);
                         let codes = block.slice(0..codes_len);

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -276,6 +276,14 @@ impl ColumnReader {
 
     /// Per-doc byte stride inside a cluster block:
     /// `code_bytes + 4 (doc_id) + per_vec_bytes (full rerank)`.
+    /// `true` when this subsection's 1-bit codes are subsection-centroid
+    /// residuals (v3) — the on-disk truth a rebuild config must reproduce
+    /// (the KV column JSON deliberately doesn't carry it; the subsection
+    /// header is authoritative, like the codec id).
+    pub(crate) fn residual_codes(&self) -> bool {
+        self.residual_norms_off.is_some()
+    }
+
     /// A cluster's block packs `cnt` docs at this stride as
     /// `[codes_chunk][doc_ids_chunk][full_chunk]`.
     pub(super) fn per_cluster_doc_stride(&self) -> usize {
@@ -2246,6 +2254,42 @@ impl VectorReader {
         Some(out)
     }
 
+    /// Fine-centroid tables for this blob's RESIDUAL cells, keyed by global
+    /// cell id — the reference centers recalibration re-centers estimates
+    /// against ([`ResidualRef::Fine`] indexes a table by each row's fine
+    /// ordinal). Raw cells are absent. A lightweight sibling of
+    /// [`Self::cell_fine_calibration_views`] for the scoring sweep: no
+    /// stable-id walk, so holding every cell's table across the sweep costs
+    /// `n_fine × dim` floats per cell, not per-row maps. Same multi-cell
+    /// gate and degrade-to-`None` hardening; the caller decides whether
+    /// `None` is legacy-v1-benign or an error (a residual cell scored with
+    /// the raw formula corrupts the law, so multi-cell callers must not
+    /// silently continue).
+    pub(crate) fn cell_fine_scoring_tables(&self, column: &str) -> Option<HashMap<u32, Vec<f32>>> {
+        if !self.is_multi_cell() || !self.column_id_by_name.contains_key(column) {
+            return None;
+        }
+        let mut out = HashMap::new();
+        for (index, col) in self.columns.iter().enumerate() {
+            if col.n_docs == 0 || col.n_cent == 0 || col.residual_norms_off.is_none() {
+                continue;
+            }
+            let sub = self
+                .source
+                .try_get_range_sync(col.subsection_range.clone())?;
+            // Same corrupt-offset hardening as the views walk above.
+            let n_fine = col.n_cent as usize;
+            let centroids_len = n_fine.checked_mul(col.dim)?.checked_mul(F32_BYTES)?;
+            let centroids_end = col.centroids_off.checked_add(centroids_len)?;
+            if centroids_end > sub.len() {
+                return None;
+            }
+            let centroids = parse_f32_le_vec(&sub[col.centroids_off..centroids_end]);
+            out.insert(self.cell_ids.get(index).copied()?, centroids);
+        }
+        Some(out)
+    }
+
     /// Remap a file-local allow/deny bitmap onto one packed cell's local
     /// id space (`0..n_docs`). IVF cluster blocks store cell-local ids;
     /// callers pass file-local bitmaps (parquet / packed-shard space).
@@ -2556,6 +2600,18 @@ impl VectorReader {
                     .collect::<Result<Vec<_>, BuildError>>()
             })
             .transpose()?;
+        // v3: per-doc residual norms ride the merge input so splices carry
+        // them into the merged norm region (checked read, same rationale as
+        // the stable-id reads above).
+        let residual_norms = col
+            .residual_norms_off
+            .map(|off| {
+                sub.as_ref()
+                    .get(off..off + col.n_docs as usize * U32_BYTES)
+                    .map(parse_f32_le_vec)
+                    .ok_or(BuildError::VectorReadError)
+            })
+            .transpose()?;
         Ok(Sq8IvfMergeInput {
             sub: sub.as_ref().to_vec(),
             dim,
@@ -2573,6 +2629,7 @@ impl VectorReader {
             scale,
             offset,
             stable_ids,
+            residual_norms,
         })
     }
 
@@ -5133,7 +5190,6 @@ where
 /// candidate sink ([`scan_shortlist`] appends to a plain vec and keeps
 /// the top `coarse_limit` with one O(n) partition afterwards).
 #[inline]
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_arguments)]
 fn score_cluster_codes_with(
     cluster_codes: &[u8],

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3157,7 +3157,7 @@ impl VectorReader {
             budget: None,
         };
         // Superfile-tier direct API: no collector at this layer, ns dropped.
-        let residual_ctx = self.residual_scan_ctx(col).await?;
+        let residual_ctx = self.residual_scan_ctx(col, query).await?;
         let (outcome, _scan_kernel_ns) = build_shortlist(
             col,
             cb,
@@ -3693,7 +3693,7 @@ impl VectorReader {
                         budget,
                     };
                     let coarse_limit = k.saturating_mul(rerank_mult);
-                    let residual_ctx = self.residual_scan_ctx(col).await?;
+                    let residual_ctx = self.residual_scan_ctx(col, query).await?;
                     let (shortlist, scan_kernel_ns) = scan_shortlist(
                         col,
                         cb,
@@ -3950,6 +3950,7 @@ impl VectorReader {
     async fn residual_scan_ctx(
         &self,
         col: &ColumnReader,
+        query: &[f32],
     ) -> Result<Option<ResidualScanCtx>, VectorError> {
         let Some(norms_off) = col.residual_norms_off else {
             return Ok(None);
@@ -3978,6 +3979,7 @@ impl VectorReader {
             centroids,
             norms,
             kappa: BitQuantizer::residual_kappa_analytic(col.dim),
+            q: query.to_vec(),
         }))
     }
 
@@ -4102,7 +4104,7 @@ impl VectorReader {
         // RaBitQ heap; survivor_fetch = warm/cold full-row gather; rerank =
         // Sq8/fp32 refine. Concurrent fan-out units each emit their own spans.
         let shortlist_t0 = io_counters::phase_start();
-        let residual_ctx = self.residual_scan_ctx(col).await?;
+        let residual_ctx = self.residual_scan_ctx(col, query).await?;
         let (outcome, scan_kernel_ns) = build_shortlist(
             col,
             cb,
@@ -4508,11 +4510,16 @@ struct ResidualScanCtx {
     centroids: Bytes,
     norms: Bytes,
     kappa: f32,
+    /// The pre-rotation query (the vector whose rotation the scan ranks
+    /// with): `q·c` resolves as a raw dot against each probed centroid.
+    q: Vec<f32>,
 }
 
 /// One probed cluster's resolved residual context: the exact
-/// `q·c_cluster` (computed as `q_rot·rot(c)` — the rotation is
-/// orthonormal), κ, and the norm region indexed by the row's absolute
+/// `q·c_cluster` (a raw dot — the rotation is orthonormal, so
+/// `q_rot·rot(c) ≡ q·c`, and rotating every probed fine centroid per
+/// query cost ~7K structured rotations per 10M-scale probe), κ, and the
+/// norm region indexed by the row's absolute
 /// cluster-order position. The scan estimate becomes
 /// `q_dot + κ·‖r‖·sign_dot` — the estimator the residual codes were
 /// built for; raw sign-dot on residual codes would rank garbage.
@@ -4525,16 +4532,15 @@ struct ClusterResidual {
 impl ClusterResidual {
     /// Resolve one cluster's context: slice its raw centroid, rotate,
     /// and dot with the rotated query.
-    fn resolve(ctx: &ResidualScanCtx, col: &ColumnReader, cluster: usize, q_rot: &[f32]) -> Self {
+    fn resolve(ctx: &ResidualScanCtx, col: &ColumnReader, cluster: usize) -> Self {
         let dim = col.dim;
         let raw = &ctx.centroids[cluster * dim * 4..(cluster + 1) * dim * 4];
-        let mut c = vec![0.0f32; dim];
-        for (slot, b) in c.iter_mut().zip(raw.chunks_exact(4)) {
-            *slot = f32::from_le_bytes(b.try_into().expect("4-byte centroid component"));
-        }
-        let mut c_rot = vec![0.0f32; dim];
-        col.rot.apply(&c, &mut c_rot);
-        let q_dot = q_rot.iter().zip(&c_rot).map(|(a, b)| a * b).sum();
+        let q_dot = ctx
+            .q
+            .iter()
+            .zip(raw.chunks_exact(4))
+            .map(|(q, b)| q * f32::from_le_bytes(b.try_into().expect("4-byte centroid component")))
+            .sum();
         Self {
             q_dot,
             kappa: ctx.kappa,
@@ -4554,6 +4560,25 @@ impl ClusterResidual {
         );
         self.q_dot + self.kappa * norm * sign_dot
     }
+
+    /// Block form of [`Self::estimate`] for the LUT scan: one block's rows
+    /// sit at consecutive cluster-order positions, so their norms are one
+    /// contiguous f32-le run — stream it and fold the affine over the
+    /// whole score vector in a single auto-vectorizable pass. The per-lane
+    /// scalar lookup this replaces sat inside the scan's push loop and
+    /// cost ~10 ns/row — a flat ~+12 ms/query across every budget on
+    /// Cohere-10M-scale scans (~1.1M rows/query), erasing the residual
+    /// feature's budget win at serve time.
+    #[inline]
+    fn estimate_block(&self, pos_base: u32, live: usize, scores: &mut [f32; LUT_BLOCK_ROWS]) {
+        let start = pos_base as usize * 4;
+        let bytes = &self.norms[start..start + live * 4];
+        for (score, norm_bytes) in scores[..live].iter_mut().zip(bytes.chunks_exact(4)) {
+            let norm =
+                f32::from_le_bytes(norm_bytes.try_into().expect("4-byte residual norm"));
+            *score = self.q_dot + self.kappa * norm * *score;
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4570,6 +4595,19 @@ fn scan_cluster_transposed(
 ) {
     for_each_code_block_scores(transposed, cb, lut, |base_r, scores| {
         let live = cnt.saturating_sub(base_r).min(LUT_BLOCK_ROWS);
+        // Residual affine over the WHOLE block before the push loop — the
+        // per-lane scalar `estimate` here was the hidden serve-time tax
+        // (see `estimate_block`). One 128-byte copy per block buys a
+        // streamed, vectorizable pass.
+        let mut adjusted: [f32; LUT_BLOCK_ROWS];
+        let scores: &[f32; LUT_BLOCK_ROWS] = match residual {
+            Some(res) => {
+                adjusted = *scores;
+                res.estimate_block(off + base_r as u32, live, &mut adjusted);
+                &adjusted
+            }
+            None => scores,
+        };
         for (lane, &est) in scores.iter().enumerate().take(live) {
             let rr = base_r + lane;
             let did = u32::from_le_bytes(
@@ -4578,10 +4616,6 @@ fn scan_cluster_transposed(
                     .expect("4-byte doc id"),
             );
             let pos = off + rr as u32;
-            let est = match residual {
-                Some(res) => res.estimate(pos, est),
-                None => est,
-            };
             acc.push((did, est, pos, cluster_id));
         }
     });
@@ -4626,7 +4660,7 @@ async fn scan_shortlist(
         Arc::new(
             cluster_meta
                 .iter()
-                .map(|&(c, _, _)| ClusterResidual::resolve(r, col, c, ctx.q_rot))
+                .map(|&(c, _, _)| ClusterResidual::resolve(r, col, c))
                 .collect(),
         )
     });

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -3417,10 +3417,21 @@ mod tests {
              margin, got {}",
             first.rerank_margin
         );
+        // The width margin is TAIL-conditioned: it stamps positive iff
+        // some knot's bulk width sits under the full width (a tail
+        // exists to bound). On tight fixtures bulk == width at every
+        // knot and 0.0 (staging self-disabled) is the correct stamp.
+        let has_tail = first
+            .width_bulk_for_k
+            .iter()
+            .zip(first.width_for_k.iter())
+            .any(|(b, w)| *b > 0 && b < w);
         assert!(
-            first.width_margin > 0.0,
-            "post-first-optimize: cosine gap evidence must stamp a WIDTH \
-             margin, got {}",
+            !has_tail || first.width_margin > 0.0,
+            "post-first-optimize: a bulk law below the width cap (bulk \
+             {:?}, width {:?}) requires a positive width margin, got {}",
+            first.width_bulk_for_k,
+            first.width_for_k,
             first.width_margin
         );
         assert!(

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -2457,6 +2457,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8FixedResidual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(crate::test_helpers::default_tokenizer()),
             )
@@ -2750,6 +2751,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8FixedResidual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(crate::test_helpers::default_tokenizer()),
             )
@@ -2965,6 +2967,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8FixedResidual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -3067,6 +3070,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -3171,6 +3175,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -3272,6 +3277,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8FixedResidual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -3384,6 +3390,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 None,
             )
@@ -3507,6 +3514,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 None,
             )
@@ -3632,6 +3640,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(crate::test_helpers::default_tokenizer()),
             )
@@ -3821,6 +3830,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 None,
             )
@@ -4020,6 +4030,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(default_tokenizer()),
             )
@@ -4172,6 +4183,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -4266,6 +4278,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -4358,6 +4371,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -4530,6 +4544,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -4731,6 +4746,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -5013,6 +5029,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -5172,6 +5189,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -5275,6 +5293,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -5392,6 +5411,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -5559,6 +5579,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(crate::test_helpers::default_tokenizer()),
             )
@@ -5730,6 +5751,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -5955,6 +5977,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -6194,6 +6217,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -6382,6 +6406,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -6562,6 +6587,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(default_tokenizer()),
         )
@@ -6691,6 +6717,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -6818,6 +6845,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(crate::test_helpers::default_tokenizer()),
             )
@@ -6945,6 +6973,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -7084,6 +7113,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -7216,6 +7246,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -7344,6 +7375,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -7466,6 +7498,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(crate::test_helpers::default_tokenizer()),
             )
@@ -7644,6 +7677,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )
@@ -7783,6 +7817,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(crate::test_helpers::default_tokenizer()),
         )

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -3406,10 +3406,9 @@ mod tests {
                 .clone();
             let reader = hidden.reader().expect("hidden reader");
             let manifest = reader.manifest();
-            let routing = manifest
+            manifest
                 .vector_cell_routing()
-                .unwrap_or_else(|| panic!("{stage}: hidden manifest has routing"));
-            routing
+                .unwrap_or_else(|| panic!("{stage}: hidden manifest has routing"))
         };
         let first = hidden_routing("post-first-optimize");
         assert!(
@@ -3417,6 +3416,24 @@ mod tests {
             "post-first-optimize: cosine gap evidence must stamp a stop \
              margin, got {}",
             first.rerank_margin
+        );
+        assert!(
+            first.width_margin > 0.0,
+            "post-first-optimize: cosine gap evidence must stamp a WIDTH \
+             margin, got {}",
+            first.width_margin
+        );
+        assert!(
+            first.width_bulk_for_k.iter().any(|&w| w > 0)
+                && first
+                    .width_bulk_for_k
+                    .iter()
+                    .zip(first.width_for_k.iter())
+                    .all(|(b, w)| b <= w),
+            "post-first-optimize: the bulk width law must stamp and sit at \
+             or under the full width cap (bulk {:?}, width {:?})",
+            first.width_bulk_for_k,
+            first.width_for_k
         );
         // Force the second optimize to actually RESHAPE (append a fresh
         // hidden delta shard) so its recalibration runs — an idle second
@@ -3491,7 +3508,8 @@ mod tests {
                 .vector_cell_routing()
                 .unwrap_or_else(|| panic!("{stage}: hidden manifest has routing"))
         };
-        st.optimize(&OptimizeOptions::default()).expect("optimize 2");
+        st.optimize(&OptimizeOptions::default())
+            .expect("optimize 2");
         let second = hidden_routing("post-second-optimize");
         assert!(
             second.rerank_margin > 0.0,
@@ -3501,7 +3519,10 @@ mod tests {
             first.rerank_margin
         );
         assert!(
-            second.rerank_pool_cells.iter().all(|&p| p >= first.rerank_pool_cells[0]),
+            second
+                .rerank_pool_cells
+                .iter()
+                .all(|&p| p >= first.rerank_pool_cells[0]),
             "post-second-optimize: pool provenance must not collapse to \
              the legacy floor (first {:?}, second {:?})",
             first.rerank_pool_cells,

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -3306,7 +3306,7 @@ mod tests {
             None,
         );
         let batch = arrow_array::RecordBatch::try_new(
-            schema,
+            schema.clone(),
             vec![
                 Arc::new(titles) as Arc<dyn Array>,
                 Arc::new(fsl) as Arc<dyn Array>,
@@ -3391,6 +3391,122 @@ mod tests {
         // the splice/merge norm carry-through).
         st.optimize(&OptimizeOptions::default()).expect("optimize");
         assert_all_hidden_cells_residual("post-optimize");
+
+        // The stop margin and the rerank pool provenance must SURVIVE
+        // repeated optimizes: the 10M reproduction showed a re-optimize
+        // stamping margin 0.0 and the pool collapsed to the legacy floor
+        // — silently disabling adaptive stopping and invalidating the
+        // budget's provenance on every maintenance cycle.
+        let hidden_routing = |stage: &str| {
+            let hidden = st
+                .reader()
+                .expect("reader")
+                .vector_index_table()
+                .expect("hidden index")
+                .clone();
+            let reader = hidden.reader().expect("hidden reader");
+            let manifest = reader.manifest();
+            let routing = manifest
+                .vector_cell_routing()
+                .unwrap_or_else(|| panic!("{stage}: hidden manifest has routing"));
+            routing
+        };
+        let first = hidden_routing("post-first-optimize");
+        assert!(
+            first.rerank_margin > 0.0,
+            "post-first-optimize: cosine gap evidence must stamp a stop \
+             margin, got {}",
+            first.rerank_margin
+        );
+        // Force the second optimize to actually RESHAPE (append a fresh
+        // hidden delta shard) so its recalibration runs — an idle second
+        // optimize skips the restamp and the margin survives trivially.
+        let titles3 = LargeStringArray::from(vec!["i", "j", "k", "l"]);
+        let mut flat3 = vec![0.0f32; ROWS * dim];
+        for row in 0..ROWS {
+            flat3[row * dim + row] = 0.7;
+            flat3[row * dim + (row + 8) % dim] = 0.7;
+        }
+        let fsl3 = FixedSizeListArray::new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim as i32,
+            Arc::new(Float32Array::from(flat3)),
+            None,
+        );
+        let batch3 = arrow_array::RecordBatch::try_new(
+            st.options().schema.clone(),
+            vec![
+                Arc::new(titles3) as Arc<dyn Array>,
+                Arc::new(fsl3) as Arc<dyn Array>,
+            ],
+        )
+        .expect("batch3");
+        let mut w = st.writer().expect("writer");
+        w.append(&batch3).expect("append 3");
+        w.commit().expect("commit 3");
+        drop(w);
+        // The 10M reproduction lost the margin on a REOPENED handle (a
+        // fresh process re-running optimize), not the create-era handle —
+        // the split-visibility bug's exact divergence class. Reopen before
+        // the second optimize.
+        drop(st);
+        let st = Supertable::open(
+            SupertableOptions::new(
+                schema.clone(),
+                vec![FtsConfig {
+                    column: "title".into(),
+                    positions: false,
+                }],
+                vec![VectorConfig {
+                    column: "emb".into(),
+                    dim,
+                    rot_seed: 7,
+                    metric: Metric::Cosine,
+                    rerank_codec: RerankCodec::Sq8Residual,
+                    provided_centroids: None,
+                    residual_codes: false,
+                }],
+                Some(crate::test_helpers::default_tokenizer()),
+            )
+            .expect("valid options")
+            .with_storage(Arc::clone(&storage))
+            .with_writer_pool(Arc::new(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(1)
+                    .build()
+                    .expect("pool"),
+            )),
+        )
+        .expect("reopen before second optimize");
+        let hidden_routing = |stage: &str| {
+            let hidden = st
+                .reader()
+                .expect("reader")
+                .vector_index_table()
+                .expect("hidden index")
+                .clone();
+            let reader = hidden.reader().expect("hidden reader");
+            let manifest = reader.manifest();
+            manifest
+                .vector_cell_routing()
+                .unwrap_or_else(|| panic!("{stage}: hidden manifest has routing"))
+        };
+        st.optimize(&OptimizeOptions::default()).expect("optimize 2");
+        let second = hidden_routing("post-second-optimize");
+        assert!(
+            second.rerank_margin > 0.0,
+            "post-second-optimize: the stop margin must survive a \
+             re-optimize (got {}; first stamped {})",
+            second.rerank_margin,
+            first.rerank_margin
+        );
+        assert!(
+            second.rerank_pool_cells.iter().all(|&p| p >= first.rerank_pool_cells[0]),
+            "post-second-optimize: pool provenance must not collapse to \
+             the legacy floor (first {:?}, second {:?})",
+            first.rerank_pool_cells,
+            second.rerank_pool_cells
+        );
     }
 
     /// After a splice drain into the hidden vector index, the reader's derived-

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1533,6 +1533,14 @@ fn build_vector_index_options(
             } else {
                 RerankCodec::Sq8Residual
             },
+            // Hidden cells store 1-bit codes re-centered on each row's own
+            // subsection centroid (grid cell on incoming shards, fine
+            // centroid once packed) — sharper scan estimates than
+            // whole-space sign codes, so the calibrated rerank budget
+            // shrinks. Requires a writes_full rerank codec, which both
+            // arms above guarantee. Hidden-only: user-table superfiles
+            // keep raw codes.
+            residual_codes: true,
             ..vc.clone()
         })
         .collect();
@@ -3220,6 +3228,169 @@ mod tests {
             max_per_cell > 0 && max_per_cell <= total,
             "max-per-cell {max_per_cell} in 1..={total}",
         );
+    }
+
+    /// The hidden vector index stores residual (subsection v3) codes — on
+    /// EVERY superfile generation: the commit-time delta shards, the drained
+    /// packed cells, and the compacted outputs an optimize produces from
+    /// them. This is the end-to-end tripwire for the enable-was-a-no-op
+    /// class: `hidden_vector_columns` sets `residual_codes: true`, but a
+    /// pack- or merge-path config that pins or drops the flag (as
+    /// `drain_cell_vector_config` once did) silently writes raw codes while
+    /// every recall test keeps passing.
+    #[test]
+    fn hidden_index_superfiles_are_residual_coded_across_maintenance() {
+        use std::sync::Arc;
+
+        use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray};
+        use arrow_schema::{DataType, Field, Schema};
+
+        use crate::superfile::{
+            builder::{FtsConfig, VectorConfig},
+            vector::{distance::Metric, rerank_codec::RerankCodec},
+        };
+
+        /// Rows in the fixture batch (axis-aligned unit vectors).
+        const ROWS: usize = 4;
+
+        let dim = 16usize;
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new(
+                "emb",
+                DataType::FixedSizeList(item_field.clone(), dim as i32),
+                false,
+            ),
+        ]));
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let options = SupertableOptions::new(
+            schema.clone(),
+            vec![FtsConfig {
+                column: "title".into(),
+                positions: false,
+            }],
+            vec![VectorConfig {
+                column: "emb".into(),
+                dim,
+                rot_seed: 7,
+                metric: Metric::Cosine,
+                rerank_codec: RerankCodec::Sq8Residual,
+                provided_centroids: None,
+                residual_codes: false,
+            }],
+            Some(crate::test_helpers::default_tokenizer()),
+        )
+        .expect("valid options")
+        .with_storage(Arc::clone(&storage))
+        .with_writer_pool(pool);
+
+        let st = Supertable::create(options).expect("create");
+        let titles = LargeStringArray::from(vec!["a", "b", "c", "d"]);
+        let mut flat = vec![0.0f32; ROWS * dim];
+        for row in 0..ROWS {
+            flat[row * dim + row] = 1.0;
+        }
+        let fsl = FixedSizeListArray::new(
+            item_field,
+            dim as i32,
+            Arc::new(Float32Array::from(flat)),
+            None,
+        );
+        let batch = arrow_array::RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(titles) as Arc<dyn Array>,
+                Arc::new(fsl) as Arc<dyn Array>,
+            ],
+        )
+        .expect("batch");
+        let mut w = st.writer().expect("writer");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+        drop(w);
+
+        let assert_all_hidden_cells_residual = |stage: &str| {
+            // (The hidden index materializes at the first drain; callers
+            // only probe stages where it exists.)
+            let hidden = st
+                .reader()
+                .expect("reader")
+                .vector_index_table()
+                .expect("hidden index")
+                .clone();
+            let table_reader = hidden.reader().expect("hidden reader");
+            let manifest = table_reader.manifest();
+            let entries = bridge_sync_to_async(manifest.get_all_superfiles_loaded())
+                .expect("load hidden entries");
+            assert!(!entries.is_empty(), "{stage}: hidden index has superfiles");
+            let mut cells_seen = 0usize;
+            for entry in entries {
+                let reader = bridge_sync_to_async(open_reader(
+                    &manifest.options.store,
+                    manifest.options.disk_cache.as_ref(),
+                    manifest.options.storage.as_ref(),
+                    &entry,
+                    true,
+                ))
+                .expect("open hidden superfile");
+                let vector = reader.vec().expect("vector reader");
+                for col in vector.vector_columns_config() {
+                    if col.n_docs == 0 {
+                        continue;
+                    }
+                    cells_seen += 1;
+                    assert!(
+                        col.residual_codes(),
+                        "{stage}: hidden cell subsection must carry residual \
+                         (v3) codes, found raw"
+                    );
+                }
+            }
+            assert!(cells_seen > 0, "{stage}: hidden index has populated cells");
+        };
+
+        // Drained packed cells (the drain establishes the hidden index).
+        st.drain_vectors_to_cells_sync().expect("drain");
+        assert_all_hidden_cells_residual("post-drain");
+        // Commit-time delta shards: with the index live, a second commit
+        // dual-writes incoming cells through the same per-cell config.
+        let titles2 = LargeStringArray::from(vec!["e", "f", "g", "h"]);
+        let mut flat2 = vec![0.0f32; ROWS * dim];
+        for row in 0..ROWS {
+            flat2[row * dim + ROWS + row] = 1.0;
+        }
+        let fsl2 = FixedSizeListArray::new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim as i32,
+            Arc::new(Float32Array::from(flat2)),
+            None,
+        );
+        let batch2 = arrow_array::RecordBatch::try_new(
+            st.options().schema.clone(),
+            vec![
+                Arc::new(titles2) as Arc<dyn Array>,
+                Arc::new(fsl2) as Arc<dyn Array>,
+            ],
+        )
+        .expect("batch2");
+        let mut w = st.writer().expect("writer");
+        w.append(&batch2).expect("append 2");
+        w.commit().expect("commit 2");
+        drop(w);
+        assert_all_hidden_cells_residual("post-second-commit");
+        // Compaction/merge generation (`new_from_reader`-derived configs and
+        // the splice/merge norm carry-through).
+        st.optimize(&OptimizeOptions::default()).expect("optimize");
+        assert_all_hidden_cells_residual("post-optimize");
     }
 
     /// After a splice drain into the hidden vector index, the reader's derived-

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -483,13 +483,6 @@ impl CellRoutingParams {
         Self::law_at(&self.width_for_k, k)
     }
 
-    /// The adaptive-width bulk law at this query's `k` — same log-linear
-    /// interpolation and clamping as [`Self::width_for_k_at`]. `None`
-    /// (all-zero stamp) disables two-stage width serving.
-    pub(crate) fn width_bulk_for_k_at(&self, k: usize) -> Option<usize> {
-        Self::law_at(&self.width_bulk_for_k, k)
-    }
-
     /// The fine-depth law at this query's `k` — same log-linear
     /// interpolation and clamping as [`Self::width_for_k_at`].
     pub(crate) fn fine_for_k_at(&self, k: usize) -> Option<usize> {

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -420,6 +420,17 @@ pub struct CellRoutingParams {
     /// rerank budget stays the hard cap. `0.0` (the default, and every
     /// pre-margin manifest) disables early stopping.
     pub rerank_margin: f32,
+    /// Adaptive-width first-wave law: cells (in routing order) covering the
+    /// calibration's bulk share of exact top-k pairs. Serving probes these
+    /// first and escalates to the full `width_for_k` cap only when the
+    /// width margin cannot rule the remaining cells out. All-zero (the
+    /// default, and every pre-adaptive manifest) disables staging.
+    pub width_bulk_for_k: [u32; WIDTH_LAW_KS.len()],
+    /// Adaptive-width stop margin: the calibrated stage-coverage quantile
+    /// of `member_similarity − cell_routing_similarity` (cosine only).
+    /// `0.0` disables the escalation skip — every query probes the full
+    /// stamped width, byte-identical to pre-adaptive serving.
+    pub width_margin: f32,
 }
 
 impl Default for CellRoutingParams {
@@ -435,6 +446,8 @@ impl Default for CellRoutingParams {
             rerank_pool_cells: [RERANK_LAW_POOL_CELLS as u32; WIDTH_LAW_KS.len()],
             residual_kappa: 0.0,
             rerank_margin: 0.0,
+            width_bulk_for_k: [0; WIDTH_LAW_KS.len()],
+            width_margin: 0.0,
         }
     }
 }
@@ -1351,6 +1364,14 @@ struct CellRoutingParamsDto {
     /// (defaults to `0.0` = never stop early).
     #[serde(default)]
     rerank_margin: f32,
+    /// Adaptive-width first-wave law; absent on pre-adaptive manifests
+    /// (defaults to all-zero = staging disabled).
+    #[serde(default)]
+    width_bulk_for_k: [u32; WIDTH_LAW_KS.len()],
+    /// Adaptive-width stop margin; absent on pre-adaptive manifests
+    /// (defaults to `0.0` = never skip the escalation).
+    #[serde(default)]
+    width_margin: f32,
 }
 
 /// Serde default for [`CellRoutingParamsDto::rerank_pool_cells`]: every
@@ -1372,6 +1393,8 @@ impl From<CellRoutingParams> for CellRoutingParamsDto {
             rerank_pool_cells: r.rerank_pool_cells,
             residual_kappa: r.residual_kappa,
             rerank_margin: r.rerank_margin,
+            width_bulk_for_k: r.width_bulk_for_k,
+            width_margin: r.width_margin,
         }
     }
 }
@@ -1397,6 +1420,8 @@ impl From<CellRoutingParamsDto> for CellRoutingParams {
         r.rerank_pool_cells = d.rerank_pool_cells.map(|p| p.max(1));
         r.residual_kappa = d.residual_kappa;
         r.rerank_margin = d.rerank_margin;
+        r.width_bulk_for_k = d.width_bulk_for_k;
+        r.width_margin = d.width_margin;
         r.nprobe_max = r.nprobe_max.max(r.nprobe_min);
         r
     }
@@ -2968,6 +2993,8 @@ mod tests {
         let routing = CellRoutingParams {
             rerank_margin: 0.25,
             residual_kappa: 0.05,
+            width_bulk_for_k: [3, 7, 9, 12],
+            width_margin: 0.125,
             ..CellRoutingParams::default()
         };
         list.partition_strategy = PartitionStrategy::VectorCell {

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -399,6 +399,16 @@ pub struct CellRoutingParams {
     /// surviving next to fresh wide-pool ones). Pre-provenance
     /// manifests decode to the legacy floor.
     pub rerank_pool_cells: [u32; WIDTH_LAW_KS.len()],
+    /// Residual-code scale κ: the drain-calibrated multiplier in the
+    /// 1-bit estimator `est = q·c_cell + κ·‖r‖·sign_dot`, applied when a
+    /// column's codes are cell-centroid residuals (subsection version 3).
+    /// Table-global and calibrated *after* the immutable superfile bytes
+    /// are written, so it lives here — not in the subsection header — and
+    /// is refreshed by the same recalibration that restamps the probe
+    /// laws. `0.0` means "no residual calibration" (raw-code tables, or a
+    /// residual table not yet calibrated); the estimator falls back to the
+    /// raw sign-dot when κ is `0.0`.
+    pub residual_kappa: f32,
 }
 
 impl Default for CellRoutingParams {
@@ -412,6 +422,7 @@ impl Default for CellRoutingParams {
             fine_for_k: [0; WIDTH_LAW_KS.len()],
             rerank_for_k: [0; WIDTH_LAW_KS.len()],
             rerank_pool_cells: [RERANK_LAW_POOL_CELLS as u32; WIDTH_LAW_KS.len()],
+            residual_kappa: 0.0,
         }
     }
 }
@@ -1320,6 +1331,10 @@ struct CellRoutingParamsDto {
     /// them).
     #[serde(default = "legacy_rerank_pool")]
     rerank_pool_cells: [u32; WIDTH_LAW_KS.len()],
+    /// Residual-code scale κ; absent on pre-residual manifests (defaults
+    /// to `0.0` = no residual calibration).
+    #[serde(default)]
+    residual_kappa: f32,
 }
 
 /// Serde default for [`CellRoutingParamsDto::rerank_pool_cells`]: every
@@ -1339,6 +1354,7 @@ impl From<CellRoutingParams> for CellRoutingParamsDto {
             fine_for_k: r.fine_for_k,
             rerank_for_k: r.rerank_for_k,
             rerank_pool_cells: r.rerank_pool_cells,
+            residual_kappa: r.residual_kappa,
         }
     }
 }
@@ -1362,6 +1378,7 @@ impl From<CellRoutingParamsDto> for CellRoutingParams {
         r.fine_for_k = d.fine_for_k;
         r.rerank_for_k = d.rerank_for_k;
         r.rerank_pool_cells = d.rerank_pool_cells.map(|p| p.max(1));
+        r.residual_kappa = d.residual_kappa;
         r.nprobe_max = r.nprobe_max.max(r.nprobe_min);
         r
     }

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -483,6 +483,13 @@ impl CellRoutingParams {
         Self::law_at(&self.width_for_k, k)
     }
 
+    /// The adaptive-width bulk law at this query's `k` — same log-linear
+    /// interpolation and clamping as [`Self::width_for_k_at`]. `None`
+    /// (all-zero stamp) disables two-stage width serving.
+    pub(crate) fn width_bulk_for_k_at(&self, k: usize) -> Option<usize> {
+        Self::law_at(&self.width_bulk_for_k, k)
+    }
+
     /// The fine-depth law at this query's `k` — same log-linear
     /// interpolation and clamping as [`Self::width_for_k_at`].
     pub(crate) fn fine_for_k_at(&self, k: usize) -> Option<usize> {

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -399,15 +399,18 @@ pub struct CellRoutingParams {
     /// surviving next to fresh wide-pool ones). Pre-provenance
     /// manifests decode to the legacy floor.
     pub rerank_pool_cells: [u32; WIDTH_LAW_KS.len()],
-    /// Residual-code scale κ: the drain-calibrated multiplier in the
-    /// 1-bit estimator `est = q·c_cell + κ·‖r‖·sign_dot`, applied when a
-    /// column's codes are cell-centroid residuals (subsection version 3).
-    /// Table-global and calibrated *after* the immutable superfile bytes
-    /// are written, so it lives here — not in the subsection header — and
-    /// is refreshed by the same recalibration that restamps the probe
-    /// laws. `0.0` means "no residual calibration" (raw-code tables, or a
-    /// residual table not yet calibrated); the estimator falls back to the
-    /// raw sign-dot when κ is `0.0`.
+    /// Residual-code scale κ: reserved slot for a drain-calibrated
+    /// multiplier in the 1-bit estimator `est = q·c_cell + κ·‖r‖·sign_dot`
+    /// (codes that are subsection-centroid residuals, subsection
+    /// version 3). Table-global and refreshable after the immutable
+    /// superfile bytes are written, which is why it lives here — not in
+    /// the subsection header. NOT yet consumed: serving and calibration
+    /// both use the analytic κ (`BitQuantizer::residual_kappa_analytic`,
+    /// within ~5% of the measured fit on real embeddings), keyed off each
+    /// column's own residual flag — so `0.0` (the default, and every
+    /// stamp so far) changes nothing. Wiring a measured override through
+    /// the query path is deliberately deferred until calibration shows
+    /// the analytic value costing budget.
     pub residual_kappa: f32,
 }
 

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -412,6 +412,14 @@ pub struct CellRoutingParams {
     /// the query path is deliberately deferred until calibration shows
     /// the analytic value costing budget.
     pub residual_kappa: f32,
+    /// Adaptive-stopping margin for the deferred rerank: the calibrated
+    /// stage-coverage quantile of `exact_similarity − estimate` over
+    /// pooled calibration pairs (cosine tables only). Serving's
+    /// estimate-banded phase C may stop once no remaining estimate plus
+    /// this margin can reach the current kth exact score; the stamped
+    /// rerank budget stays the hard cap. `0.0` (the default, and every
+    /// pre-margin manifest) disables early stopping.
+    pub rerank_margin: f32,
 }
 
 impl Default for CellRoutingParams {
@@ -426,6 +434,7 @@ impl Default for CellRoutingParams {
             rerank_for_k: [0; WIDTH_LAW_KS.len()],
             rerank_pool_cells: [RERANK_LAW_POOL_CELLS as u32; WIDTH_LAW_KS.len()],
             residual_kappa: 0.0,
+            rerank_margin: 0.0,
         }
     }
 }
@@ -1338,6 +1347,10 @@ struct CellRoutingParamsDto {
     /// to `0.0` = no residual calibration).
     #[serde(default)]
     residual_kappa: f32,
+    /// Adaptive-stopping margin; absent on pre-margin manifests
+    /// (defaults to `0.0` = never stop early).
+    #[serde(default)]
+    rerank_margin: f32,
 }
 
 /// Serde default for [`CellRoutingParamsDto::rerank_pool_cells`]: every
@@ -1358,6 +1371,7 @@ impl From<CellRoutingParams> for CellRoutingParamsDto {
             rerank_for_k: r.rerank_for_k,
             rerank_pool_cells: r.rerank_pool_cells,
             residual_kappa: r.residual_kappa,
+            rerank_margin: r.rerank_margin,
         }
     }
 }
@@ -1382,6 +1396,7 @@ impl From<CellRoutingParamsDto> for CellRoutingParams {
         r.rerank_for_k = d.rerank_for_k;
         r.rerank_pool_cells = d.rerank_pool_cells.map(|p| p.max(1));
         r.residual_kappa = d.residual_kappa;
+        r.rerank_margin = d.rerank_margin;
         r.nprobe_max = r.nprobe_max.max(r.nprobe_min);
         r
     }
@@ -2948,6 +2963,13 @@ mod tests {
     fn partition_strategy_vector_cell_roundtrip() {
         use super::super::ClusterCentroids;
         let mut list = empty_list();
+        // Non-default stamped laws so the roundtrip covers every routing
+        // field, not just defaults surviving a default-deserialize.
+        let routing = CellRoutingParams {
+            rerank_margin: 0.25,
+            residual_kappa: 0.05,
+            ..CellRoutingParams::default()
+        };
         list.partition_strategy = PartitionStrategy::VectorCell {
             column: "emb".into(),
             clusters: ClusterCentroids::from_fp32(
@@ -2956,7 +2978,7 @@ mod tests {
                 &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
                 vec![1, 1],
             ),
-            routing: CellRoutingParams::default(),
+            routing,
         };
         let bytes = encode(&list).expect("encode");
         let decoded = decode(&bytes).expect("decode");

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -548,6 +548,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::default(),
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(default_tokenizer()),
         )
@@ -574,6 +575,7 @@ mod tests {
                     metric,
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(default_tokenizer()),
             )
@@ -597,6 +599,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 Some(default_tokenizer()),
             )

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -752,6 +752,24 @@ const WIDTH_LAW_TARGET_COVERAGE: f64 = 0.99;
 /// wider one.
 const WIDTH_LAW_CONFIDENCE_Z: f64 = 1.645;
 
+/// Minimum per-knot evidence (`support × k` coverage observations) for
+/// the confidence-bound crossing to be meaningful. Derived, not tuned:
+/// the bound can pass with at least one candidate still uncovered only
+/// when `n·k ≥ (1+z)/(1−t)` (most favorable partial state — one query
+/// at coverage `1−1/k`, the rest full — gives `LB ≈ 1 − (1+z)/(n·k)`).
+/// Below that, the bound degenerates into a max-statistic: no partial
+/// coverage can certify the target, so the crossing lands wherever the
+/// single WORST sampled query completes — an unbounded, tail-lottery
+/// width (measured on Cohere-10M post-split: raw-mean crossing 662 of
+/// 10,846 cells at k = 1, degenerate LB crossing 2,395 — and the
+/// monotone floor then spread that one noisy knot across the whole
+/// law). Knots under this evidence stamp the raw-mean crossing —
+/// the unbiased estimate — and leave the proof margin to the
+/// higher-k knots, which the monotone floor and the interpolator's
+/// clamp already propagate downward at query time.
+const WIDTH_LAW_LB_MIN_EVIDENCE: f64 =
+    (1.0 + WIDTH_LAW_CONFIDENCE_Z) / (1.0 - WIDTH_LAW_TARGET_COVERAGE);
+
 /// Rerank-law distractor pool: each calibration query counts 1-bit-estimate
 /// distractors only within its `RERANK_LAW_POOL_CELLS` grid-nearest cells —
 /// the pool a width-law sweep would actually scan. A `k` point whose
@@ -1505,7 +1523,15 @@ impl WidthLawCalibration {
             // exactly as before; only genuinely marginal crossings widen.
             let n = support[ki] as f64;
             let target = WIDTH_LAW_TARGET_COVERAGE * n;
+            // Confidence-bound crossing only where the knot carries enough
+            // evidence for the bound to be a measurement rather than a
+            // max-statistic (see [`WIDTH_LAW_LB_MIN_EVIDENCE`]); thin knots
+            // (k = 1 at the standard sample) stamp the raw-mean crossing.
+            let lb_certifiable = n * WIDTH_LAW_KS[ki] as f64 >= WIDTH_LAW_LB_MIN_EVIDENCE;
             if let Some(rank) = sums.iter().enumerate().position(|(rank, &s)| {
+                if !lb_certifiable {
+                    return s >= target;
+                }
                 let mean = s / n;
                 let var = (coverage_sq_sums[ki][rank] / n - mean * mean).max(0.0);
                 let se = (var / n).sqrt();
@@ -2064,6 +2090,79 @@ mod tests {
              to the k=10 width instead of stamping a recall inversion"
         );
         assert_eq!(law[3], 0, "k=1000 has no supporting query and stays 0");
+    }
+
+    /// A thin-evidence knot (k = 1: `support × k` below
+    /// [`WIDTH_LAW_LB_MIN_EVIDENCE`]) stamps the RAW-mean crossing — the
+    /// confidence bound cannot pass there with any query uncovered, so its
+    /// crossing would be the single worst query's completion rank (the
+    /// max-statistic that stamped width 2,395 of 10,846 cells flat across
+    /// every knot on Cohere-10M, via the monotone floor). Knots with
+    /// enough evidence (k = 10 here) keep the bound: one fully-uncovered
+    /// query still forces their crossing out to full coverage.
+    #[test]
+    fn width_law_thin_knot_uses_raw_mean_not_the_worst_query() {
+        const DIM: usize = 8;
+        const N_CELLS: usize = 8;
+        const N_QUERIES: usize = 100;
+        /// Cell holding the outlier query's candidates: ranked LAST for
+        /// the shared query vector (all queries are `e0`; ties above it
+        /// break toward lower cell ids).
+        const DEEP_CELL: u32 = 7;
+        let mut cents = vec![0f32; N_CELLS * DIM];
+        for c in 0..N_CELLS {
+            cents[c * DIM + c] = 1.0;
+        }
+        let grid = ClusterCentroids::from_fp32(
+            N_CELLS as u32,
+            DIM as u32,
+            &cents,
+            vec![1; N_CELLS],
+        );
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut queries = vec![0.0f32; N_QUERIES * DIM];
+        for qi in 0..N_QUERIES {
+            queries[qi * DIM] = 1.0;
+        }
+        cal.frozen = Some(WidthLawQueries {
+            queries,
+            ids: (10_000..10_000 + N_QUERIES as i128).collect(),
+        });
+        // 99 queries: 10 candidates each, all in the top-ranked cell 0.
+        // 1 outlier query: 10 candidates, all in the LAST-ranked cell.
+        let tops: Vec<Vec<(f32, u32, i128, f32)>> = (0..N_QUERIES)
+            .map(|qi| {
+                let cell = if qi == 0 { DEEP_CELL } else { 0 };
+                let mut acc = Vec::new();
+                let cand: Vec<(f32, u32, i128, f32)> = (0..10)
+                    .map(|j| {
+                        let id = (qi * 100 + j) as i128;
+                        (0.01 + j as f32 * 0.01, cell, id, f32::NEG_INFINITY)
+                    })
+                    .collect();
+                merge_candidates(&mut acc, cand, WIDTH_LAW_MAX_K);
+                acc
+            })
+            .collect();
+        *cal.tops.lock().unwrap_or_else(PoisonError::into_inner) = tops;
+
+        let law = cal
+            .finish(&grid)
+            .expect("law from planted candidates")
+            .width_for_k;
+        assert_eq!(
+            law[0], 1,
+            "k=1 carries 100 observations — below the bound's evidence \
+             floor — so the raw-mean crossing (0.99 at width 1) stamps, \
+             not the outlier's completion rank"
+        );
+        assert_eq!(
+            law[1], N_CELLS as u32,
+            "k=10 carries 1,000 observations — the confidence bound \
+             applies and one fully-uncovered query forces full coverage"
+        );
+        assert_eq!(law[2], 0, "k=100 has no supporting query");
+        assert_eq!(law[3], 0, "k=1000 has no supporting query");
     }
 
     /// An out-of-range cell id in the candidates (impossible in the current

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -808,6 +808,14 @@ const RERANK_LAW_EST_BINS: usize = 4096;
 const WIDTH_LAW_SAMPLE_SEED: u64 = 0x51ED_CA1B;
 /// Rows decoded per chunk while scoring a spilled cell.
 const WIDTH_LAW_SCORE_CHUNK: usize = 1024;
+/// Bounds for the residual estimate's histogram range: rows are unit
+/// (cosine tables), centers are means of unit rows, so `|q·c| ≤ ‖q‖` and
+/// `‖v − c‖ ≤ 2` — the residual estimate is inside
+/// `±(‖q‖·CENTER + κ·NORM·q_l1)`. Loose bounds only widen bins (rank
+/// error stays one bin's occupancy, always over-counting toward a wider
+/// law), never clip.
+const RESIDUAL_EST_CENTER_BOUND: f32 = 1.0;
+const RESIDUAL_EST_NORM_BOUND: f32 = 2.0;
 
 /// Frozen query sample: dequantized fp32 vectors + their stable ids
 /// (self-hit exclusion while scoring).
@@ -878,6 +886,11 @@ pub(crate) struct WidthLawCalibration {
     /// Rerank-law observation state, armed by [`Self::freeze`]; `None`
     /// (e.g. planted test fixtures) measures no rerank law.
     rerank: Option<RerankLawObservation>,
+    /// The table's codes are cell/fine-centroid residuals: the rerank-law
+    /// estimate must be the serving `q·c_ref + κ·‖r‖·sign_dot`, and the
+    /// histogram range widens accordingly. Callers then pass the per-call
+    /// [`ResidualRef`] into the score paths.
+    residual: bool,
 }
 
 /// Streaming state for the rerank law: per query, the 1-bit-encoded query
@@ -886,14 +899,49 @@ pub(crate) struct WidthLawCalibration {
 /// rank — the survivor budget that keeps it — is read at [`finish`].
 ///
 /// [`finish`]: WidthLawCalibration::finish
+/// Reference centers for residual-coded rows during calibration: the
+/// estimate the scan serves is `q·c_ref + κ·‖r‖·sign_dot`, so calibration
+/// must histogram THAT quantity, not the raw sign-dot. Which center a
+/// row's stored code was taken against depends on provenance:
+/// drain-spill rows come from incoming shards whose clusters ARE grid
+/// cells (one centroid per call); packed-cell rows carry fine-cluster
+/// residuals (`row.cluster` is the fine ordinal into that cell's
+/// centroid table). `None` at the call sites = raw codes, the exact
+/// pre-residual arithmetic.
+pub(crate) enum ResidualRef<'a> {
+    /// One grid-cell centroid for every row of the call (drain spills).
+    Cell(&'a [f32]),
+    /// Fine centroids (`n_fine × dim`), indexed by `row.cluster`
+    /// (packed-cell rows).
+    Fine(&'a [f32]),
+}
+
+impl ResidualRef<'_> {
+    /// The reference center for one row.
+    fn center(&self, row: &MaterializedIvfRow, dim: usize) -> &[f32] {
+        match self {
+            Self::Cell(c) => c,
+            Self::Fine(table) => {
+                let c = row.cluster as usize;
+                &table[c * dim..(c + 1) * dim]
+            }
+        }
+    }
+}
+
 struct RerankLawObservation {
     quant: BitQuantizer,
     /// Flat `n_queries x dim` rotated queries.
     q_rot: Vec<f32>,
     /// Per query `Σ q_rot[d]` — the estimator's per-query identity term.
     q_total: Vec<f32>,
-    /// Per query `Σ |q_rot[d]|` — the estimate range for binning.
+    /// Per query `Σ |q_rot[d]|` — the raw sign-dot's exact range.
     q_l1: Vec<f32>,
+    /// Per query histogram half-range. Raw codes: `q_l1` (the sign-dot's
+    /// exact range). Residual codes: `|q·c| + κ·‖r‖·|sd|` is bounded by
+    /// `q_norm·CENTER_NORM_MAX + κ·RESIDUAL_NORM_MAX·q_l1`, so the full
+    /// estimate bins linearly over that.
+    bin_range: Vec<f32>,
     /// Per query: ascending cell ids of its `RERANK_LAW_POOL_CELLS`
     /// grid-nearest cells.
     pools: Vec<Vec<u32>>,
@@ -908,11 +956,11 @@ impl RerankLawObservation {
     /// Histogram bin for `est` under this query's `[-l1, +l1]` range;
     /// bin 0 holds the best (largest) estimates.
     fn bin(&self, qi: usize, est: f32) -> usize {
-        let l1 = self.q_l1[qi];
-        if l1 <= 0.0 {
+        let range = self.bin_range[qi];
+        if range <= 0.0 {
             return RERANK_LAW_EST_BINS - 1;
         }
-        let frac = ((l1 - est) / (2.0 * l1)).clamp(0.0, 1.0);
+        let frac = ((range - est) / (2.0 * range)).clamp(0.0, 1.0);
         ((frac * RERANK_LAW_EST_BINS as f32) as usize).min(RERANK_LAW_EST_BINS - 1)
     }
 }
@@ -1013,7 +1061,8 @@ fn floor_monotone(law: &mut [u32; WIDTH_LAW_KS.len()]) {
 }
 
 impl WidthLawCalibration {
-    pub(crate) fn new(dim: usize, metric: Metric) -> Self {
+    pub(crate) fn new(dim: usize, metric: Metric, residual: bool) -> Self {
+        let _ = &residual;
         Self {
             dim,
             metric,
@@ -1026,6 +1075,7 @@ impl WidthLawCalibration {
             max_fine: AtomicU32::new(0),
             pool_cells: RERANK_LAW_POOL_CELLS,
             rerank: None,
+            residual,
         }
     }
 
@@ -1064,12 +1114,21 @@ impl WidthLawCalibration {
             let mut q_rot = vec![0f32; n_queries * self.dim];
             let mut q_total = Vec::with_capacity(n_queries);
             let mut q_l1 = Vec::with_capacity(n_queries);
+            let mut bin_range = Vec::with_capacity(n_queries);
             let mut pools = Vec::with_capacity(n_queries);
+            let kappa = BitQuantizer::residual_kappa_analytic(self.dim);
             for (qi, q) in queries.chunks_exact(self.dim).enumerate() {
                 let out = &mut q_rot[qi * self.dim..(qi + 1) * self.dim];
                 rotation.apply(q, out);
+                let l1: f32 = out.iter().map(|v| v.abs()).sum();
                 q_total.push(out.iter().sum());
-                q_l1.push(out.iter().map(|v| v.abs()).sum());
+                q_l1.push(l1);
+                bin_range.push(if self.residual {
+                    let q_norm = q.iter().map(|v| v * v).sum::<f32>().sqrt();
+                    q_norm * RESIDUAL_EST_CENTER_BOUND + kappa * RESIDUAL_EST_NORM_BOUND * l1
+                } else {
+                    l1
+                });
                 let mut pool: Vec<u32> = grid
                     .rank_cells(self.metric, q)
                     .into_iter()
@@ -1084,6 +1143,7 @@ impl WidthLawCalibration {
                 q_rot,
                 q_total,
                 q_l1,
+                bin_range,
                 pools,
                 hist: Mutex::new(vec![Vec::new(); n_queries]),
             });
@@ -1094,7 +1154,12 @@ impl WidthLawCalibration {
     /// Score every row of one spilled cell against the frozen queries and
     /// merge into the per-query candidate lists. Safe to call from the
     /// pack fan-out workers; the merge takes one lock per cell.
-    pub(crate) fn score_cell(&self, cell: u32, spill: &SpilledCellRows) -> Result<(), BuildError> {
+    pub(crate) fn score_cell(
+        &self,
+        cell: u32,
+        spill: &SpilledCellRows,
+        residual_ref: Option<&ResidualRef<'_>>,
+    ) -> Result<(), BuildError> {
         let Some(frozen) = self.frozen.as_ref() else {
             return Err(BuildError::Store(
                 "width-law score_cell before freeze".into(),
@@ -1118,6 +1183,7 @@ impl WidthLawCalibration {
                 cell,
                 &chunk,
                 &members,
+                residual_ref,
                 &mut scratch,
                 &mut partial,
                 &mut hist_local,
@@ -1134,6 +1200,7 @@ impl WidthLawCalibration {
         &self,
         cell: u32,
         rows: &[MaterializedIvfRow],
+        residual_ref: Option<&ResidualRef<'_>>,
     ) -> Result<(), BuildError> {
         let Some(frozen) = self.frozen.as_ref() else {
             return Err(BuildError::Store(
@@ -1154,6 +1221,7 @@ impl WidthLawCalibration {
                 cell,
                 chunk,
                 &members,
+                residual_ref,
                 &mut scratch,
                 &mut partial,
                 &mut hist_local,
@@ -1213,20 +1281,45 @@ impl WidthLawCalibration {
     /// candidate carries its own estimate so [`Self::finish`] can read its
     /// survivor rank; candidates outside the pool carry `NEG_INFINITY`
     /// (unrankable — conservative).
+    #[allow(clippy::too_many_arguments)]
     fn score_slice(
         &self,
         frozen: &WidthLawQueries,
         cell: u32,
         rows: &[MaterializedIvfRow],
         members: &[usize],
+        residual_ref: Option<&ResidualRef<'_>>,
         scratch: &mut [f32],
         partial: &mut [Vec<(f32, u32, i128, f32)>],
         hist_local: &mut HashMap<usize, Vec<u64>>,
     ) {
         let k_max = WIDTH_LAW_MAX_K;
         let rl = self.rerank.as_ref();
+        let kappa = BitQuantizer::residual_kappa_analytic(self.dim);
+        // Exact `q·c_ref` per (query, reference center), cached across rows —
+        // the residual estimate's center term (`u32::MAX` keys the single
+        // Cell center).
+        let mut cref_dots: HashMap<(usize, u32), f32> = HashMap::new();
         let mut est_of = vec![f32::NEG_INFINITY; frozen.ids.len()];
         for row in rows {
+            // Dequantize first: the residual norm is taken on the payload
+            // row BEFORE the cosine normalization the exact walk uses —
+            // matching the stored ‖r‖ the serving estimator reads.
+            dequantize_row_into(&row.encoded, scratch);
+            let row_residual = residual_ref.map(|rref| {
+                let c_ref = rref.center(row, self.dim);
+                let r_norm = scratch
+                    .iter()
+                    .zip(c_ref)
+                    .map(|(v, c)| (v - c) * (v - c))
+                    .sum::<f32>()
+                    .sqrt();
+                let key = match rref {
+                    ResidualRef::Cell(_) => u32::MAX,
+                    ResidualRef::Fine(_) => row.cluster,
+                };
+                (r_norm, key)
+            });
             if let Some(rl) = rl
                 && row.rabitq_code.len() == rl.quant.code_bytes()
             {
@@ -1239,11 +1332,26 @@ impl WidthLawCalibration {
                         continue;
                     }
                     let q_rot = &rl.q_rot[qi * self.dim..(qi + 1) * self.dim];
-                    let est = rl.quant.estimate_dot_rotated_with_total(
+                    let sd = rl.quant.estimate_dot_rotated_with_total(
                         q_rot,
                         &row.rabitq_code,
                         rl.q_total[qi],
                     );
+                    // Serving-consistent estimate: raw sign-dot for raw
+                    // codes; `q·c_ref + κ·‖r‖·sign_dot` for residual codes
+                    // (the quantity the scan ranks by, so the histogram
+                    // measures the budget serving actually needs).
+                    let est = match (&row_residual, residual_ref) {
+                        (Some((r_norm, key)), Some(rref)) => {
+                            let q_dot = *cref_dots.entry((qi, *key)).or_insert_with(|| {
+                                let q = &frozen.queries[qi * self.dim..(qi + 1) * self.dim];
+                                let c_ref = rref.center(row, self.dim);
+                                q.iter().zip(c_ref).map(|(a, b)| a * b).sum()
+                            });
+                            q_dot + kappa * r_norm * sd
+                        }
+                        _ => sd,
+                    };
                     // A non-finite estimate (corrupt code, degenerate
                     // quantizer) is not rank evidence: NaN casts to bin 0 —
                     // the BEST bin — and would count as a top distractor in
@@ -1260,7 +1368,6 @@ impl WidthLawCalibration {
                     }
                 }
             }
-            dequantize_row_into(&row.encoded, scratch);
             if self.metric == Metric::Cosine {
                 // The rerank kernels divide by the stored row norm;
                 // unit-normalizing the row lets the shared [`distance`]
@@ -1798,7 +1905,7 @@ mod tests {
             ],
             vec![1; 4],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -1848,7 +1955,7 @@ mod tests {
     fn depth_law_walks_fine_ranks() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -1928,7 +2035,7 @@ mod tests {
     fn rerank_law_reads_survivor_budget_from_histograms() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -1942,6 +2049,7 @@ mod tests {
             q_rot: vec![0.0; DIM],
             q_total: vec![0.0],
             q_l1: vec![1.0],
+            bin_range: vec![1.0],
             pools: vec![vec![0]],
             hist: Mutex::new(vec![Vec::new()]),
         };
@@ -1984,7 +2092,7 @@ mod tests {
     fn depth_law_missing_rank_is_conservative() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -2044,7 +2152,7 @@ mod tests {
             ],
             vec![1; 4],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
         let mut queries = vec![0.0f32; 2 * DIM];
         queries[0] = 1.0;
         queries[DIM] = 1.0;
@@ -2119,7 +2227,7 @@ mod tests {
             &cents,
             vec![1; N_CELLS],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
         let mut queries = vec![0.0f32; N_QUERIES * DIM];
         for qi in 0..N_QUERIES {
             queries[qi * DIM] = 1.0;
@@ -2180,7 +2288,7 @@ mod tests {
             ],
             vec![1; 2],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -2269,6 +2377,94 @@ mod tests {
             encode_blob(Metric::L2Sq, dim, &ids, &vecs, RerankCodec::Sq8Residual).expect("encode");
         let stable_ids: Vec<i128> = (0..n).map(|i| i as i128).collect();
         load_encoded_rows_from_blob(&blob, &stable_ids, None).expect("load")
+    }
+
+    /// Residual calibration coherence: with a [`ResidualRef`], the estimate
+    /// the rerank law records for each candidate is exactly the serving
+    /// formula `q·c_ref + κ·‖r‖·sign_dot` — recomputed manually here from
+    /// the same inputs — and the raw path stays the raw sign-dot. A wrong
+    /// center, a missed ‖r‖, or a raw sign-dot slipping through would stamp
+    /// a law for an estimator serving never runs.
+    #[test]
+    fn residual_calibration_estimate_matches_serving_formula() {
+        const DIM: usize = 8;
+        const ROT_SEED: u64 = 7;
+        let mut grid_fp32 = vec![0.0f32; DIM];
+        grid_fp32[0] = 1.0;
+        let grid = ClusterCentroids::from_fp32(1, DIM as u32, &grid_fp32, vec![4]);
+
+        // The reference center the residual codes were (notionally) taken
+        // against — deliberately NOT the grid centroid, so using the wrong
+        // center fails the assertion.
+        let c_ref: Vec<f32> = (0..DIM).map(|d| 0.2 + d as f32 * 0.05).collect();
+
+        let run = |residual: bool| -> Vec<(f32, u32, i128, f32)> {
+            let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, residual);
+            let query_row = &synth_fixed_rows(DIM, 1, 200)[0];
+            cal.offer(&MaterializedIvfRow {
+                local_doc_id: 0,
+                stable_id: 999,
+                cluster: 0,
+                rabitq_code: vec![0u8; BitQuantizer::new(DIM).code_bytes()],
+                encoded: query_row.clone(),
+            });
+            cal.freeze(&grid, ROT_SEED, 64);
+            let rows: Vec<MaterializedIvfRow> = synth_fixed_rows(DIM, 2, 90)
+                .into_iter()
+                .enumerate()
+                .map(|(i, encoded)| MaterializedIvfRow {
+                    local_doc_id: i as u32,
+                    stable_id: 10 + i as i128,
+                    cluster: 0,
+                    rabitq_code: vec![0b1010_1010u8; BitQuantizer::new(DIM).code_bytes()],
+                    encoded,
+                })
+                .collect();
+            let rref = ResidualRef::Cell(&c_ref);
+            cal.score_rows(0, &rows, residual.then_some(&rref))
+                .expect("score rows");
+            let tops = cal.tops.lock().unwrap_or_else(PoisonError::into_inner);
+            tops[0].clone()
+        };
+
+        // Manual serving formula from the same inputs.
+        let quant = BitQuantizer::new(DIM);
+        let rotation = RandomRotation::new(DIM, ROT_SEED);
+        let mut q = vec![0.0f32; DIM];
+        dequantize_row_into(&synth_fixed_rows(DIM, 1, 200)[0], &mut q);
+        let mut q_rot = vec![0.0f32; DIM];
+        rotation.apply(&q, &mut q_rot);
+        let q_total: f32 = q_rot.iter().sum();
+        let code = vec![0b1010_1010u8; quant.code_bytes()];
+        let sd = quant.estimate_dot_rotated_with_total(&q_rot, &code, q_total);
+        let mut v = vec![0.0f32; DIM];
+        dequantize_row_into(&synth_fixed_rows(DIM, 1, 90)[0], &mut v);
+        let r_norm = v
+            .iter()
+            .zip(&c_ref)
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f32>()
+            .sqrt();
+        let q_dot: f32 = q.iter().zip(&c_ref).map(|(a, b)| a * b).sum();
+        let kappa = BitQuantizer::residual_kappa_analytic(DIM);
+        let expected = q_dot + kappa * r_norm * sd;
+
+        let res_tops = run(true);
+        assert!(!res_tops.is_empty());
+        for &(_, _, id, est) in &res_tops {
+            assert!(id == 10 || id == 11);
+            assert!(
+                (est - expected).abs() <= 1e-4 * expected.abs().max(1.0),
+                "residual est {est} vs serving formula {expected}"
+            );
+        }
+        let raw_tops = run(false);
+        for &(_, _, _, est) in &raw_tops {
+            assert!(
+                (est - sd).abs() <= 1e-4 * sd.abs().max(1.0),
+                "raw est {est} vs sign-dot {sd}"
+            );
+        }
     }
 
     fn synth_fixed_rows(dim: usize, n: usize, code: u8) -> Vec<EncodedCellRow> {

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -40,7 +40,8 @@ use crate::{
     superfile::vector::{
         cell_posting::{EncodedCellRow, MaterializedIvfRow, manifest_centroid_components_from_row},
         distance::{
-            Metric, distance, nearest_k_centroids_bytes, nearest_k_centroids_transposed, normalize,
+            COSINE_DISTANCE_BASE, Metric, distance, nearest_k_centroids_bytes,
+            nearest_k_centroids_transposed, normalize,
             relative_score_window,
         },
         kmeans::{kmeans, kmeans_pp},
@@ -808,6 +809,12 @@ const RERANK_LAW_EST_BINS: usize = 4096;
 const WIDTH_LAW_SAMPLE_SEED: u64 = 0x51ED_CA1B;
 /// Rows decoded per chunk while scoring a spilled cell.
 const WIDTH_LAW_SCORE_CHUNK: usize = 1024;
+/// Half-range of the stop-margin gap histogram. Cosine exact similarities
+/// live in `[-1, 1]` and 1-bit estimates concentrate within a few units of
+/// zero, so ±4 covers every realistic `exact − estimate` gap; anything
+/// beyond clamps into the edge bin, which can only WIDEN the measured
+/// margin (disabling early stops — the safe failure).
+const STOP_MARGIN_GAP_RANGE: f32 = 4.0;
 /// Frozen query sample: dequantized fp32 vectors + their stable ids
 /// (self-hit exclusion while scoring).
 struct WidthLawQueries {
@@ -935,6 +942,17 @@ struct RerankLawObservation {
     /// on a large table must never wrap a bin and silently NARROW the
     /// measured survivor budget.
     hist: Mutex<Vec<Vec<u64>>>,
+    /// Global histogram of `exact_similarity − estimate` gaps over every
+    /// pooled (query, row) pair — cosine tables only (the one metric whose
+    /// exact score and 1-bit estimate share a scale). Bins span
+    /// `±STOP_MARGIN_GAP_RANGE`; [`WidthLawCalibration::finish`] reads the
+    /// [`LAW_STAGE_TARGET_COVERAGE`] quantile's UPPER bin edge as the stop
+    /// margin: the serving rerank may stop once no remaining estimate plus
+    /// this margin can reach the current kth exact score. Tail clamping is
+    /// conservative — an over-range gap lands in the top bin and drags the
+    /// margin to the range edge, disabling early stops rather than firing
+    /// them wrongly.
+    gap_hist: Mutex<Vec<u64>>,
 }
 
 impl RerankLawObservation {
@@ -948,6 +966,41 @@ impl RerankLawObservation {
         let frac = ((range - est) / (2.0 * range)).clamp(0.0, 1.0);
         ((frac * RERANK_LAW_EST_BINS as f32) as usize).min(RERANK_LAW_EST_BINS - 1)
     }
+
+    /// Histogram bin for one `exact − estimate` gap under the fixed
+    /// `±STOP_MARGIN_GAP_RANGE`; bin 0 = most negative gap. The inverse
+    /// (a bin's UPPER gap edge) is [`stop_margin_bin_upper_edge`].
+    fn gap_bin(gap: f32) -> usize {
+        let frac = ((gap + STOP_MARGIN_GAP_RANGE) / (2.0 * STOP_MARGIN_GAP_RANGE)).clamp(0.0, 1.0);
+        ((frac * RERANK_LAW_EST_BINS as f32) as usize).min(RERANK_LAW_EST_BINS - 1)
+    }
+}
+
+/// The UPPER gap edge of one stop-margin histogram bin — the conservative
+/// read-out direction: a margin taken at the bin's upper edge can only be
+/// larger than the true quantile, and a larger margin only stops later.
+fn stop_margin_bin_upper_edge(bin: usize) -> f32 {
+    let frac = (bin + 1) as f32 / RERANK_LAW_EST_BINS as f32;
+    frac * 2.0 * STOP_MARGIN_GAP_RANGE - STOP_MARGIN_GAP_RANGE
+}
+
+/// The stop margin from a gap histogram: the
+/// [`LAW_STAGE_TARGET_COVERAGE`] quantile's upper bin edge; `0.0` on an
+/// empty histogram (no cosine evidence — serving never stops early).
+fn stop_margin_from_hist(gaps: &[u64]) -> f32 {
+    let total: u64 = gaps.iter().sum();
+    if total == 0 {
+        return 0.0;
+    }
+    let needed = (LAW_STAGE_TARGET_COVERAGE * total as f64).ceil() as u64;
+    let mut seen = 0u64;
+    for (bin, &n) in gaps.iter().enumerate() {
+        seen += n;
+        if seen >= needed {
+            return stop_margin_bin_upper_edge(bin);
+        }
+    }
+    STOP_MARGIN_GAP_RANGE
 }
 
 /// Both laws the drain calibration measures — cells for the width sweep,
@@ -963,6 +1016,13 @@ pub(crate) struct CalibratedLaws {
     /// against — the stamp records it so a later, wider law knows
     /// whether the budget's evidence still covers it.
     pub(crate) pool_cells: u32,
+    /// Adaptive-stopping margin: the [`LAW_STAGE_TARGET_COVERAGE`] quantile
+    /// of `exact_similarity − estimate` over the pooled calibration pairs
+    /// (cosine only). Serving's estimate-banded rerank may stop once no
+    /// remaining estimate plus this margin can reach the current kth exact
+    /// score. `0.0` = no evidence (non-cosine, or no pooled pairs) —
+    /// serving never stops early.
+    pub(crate) rerank_margin: f32,
 }
 
 #[cfg(test)]
@@ -1120,6 +1180,7 @@ impl WidthLawCalibration {
                 q_l1,
                 pools,
                 hist: Mutex::new(vec![Vec::new(); n_queries]),
+                gap_hist: Mutex::new(Vec::new()),
             });
         }
         self.frozen = Some(WidthLawQueries { queries, ids });
@@ -1149,6 +1210,7 @@ impl WidthLawCalibration {
         let mut reader = spill.reader()?;
         let mut remaining = spill.n_rows();
         let mut scratch = vec![0f32; self.dim];
+        let mut gap_local: Vec<u64> = Vec::new();
         while remaining > 0 {
             let chunk = reader.next_chunk(WIDTH_LAW_SCORE_CHUNK.min(remaining))?;
             remaining -= chunk.len();
@@ -1161,9 +1223,10 @@ impl WidthLawCalibration {
                 &mut scratch,
                 &mut partial,
                 &mut hist_local,
+                &mut gap_local,
             );
         }
-        self.merge_partial(partial, hist_local);
+        self.merge_partial(partial, hist_local, gap_local);
         Ok(())
     }
 
@@ -1189,6 +1252,7 @@ impl WidthLawCalibration {
         let members = self.pool_members(cell);
         let mut hist_local: HashMap<usize, Vec<u64>> = HashMap::new();
         let mut scratch = vec![0f32; self.dim];
+        let mut gap_local: Vec<u64> = Vec::new();
         for chunk in rows.chunks(WIDTH_LAW_SCORE_CHUNK) {
             self.score_slice(
                 frozen,
@@ -1199,9 +1263,10 @@ impl WidthLawCalibration {
                 &mut scratch,
                 &mut partial,
                 &mut hist_local,
+                &mut gap_local,
             );
         }
-        self.merge_partial(partial, hist_local);
+        self.merge_partial(partial, hist_local, gap_local);
         Ok(())
     }
 
@@ -1213,6 +1278,7 @@ impl WidthLawCalibration {
         &self,
         partial: Vec<Vec<(f32, u32, i128, f32)>>,
         hist_local: HashMap<usize, Vec<u64>>,
+        gap_local: Vec<u64>,
     ) {
         let k_max = WIDTH_LAW_MAX_K;
         let mut tops = self.tops.lock().unwrap_or_else(PoisonError::into_inner);
@@ -1232,6 +1298,18 @@ impl WidthLawCalibration {
                     for (a, b) in slot.iter_mut().zip(delta) {
                         *a = a.saturating_add(b);
                     }
+                }
+            }
+        }
+        if let Some(rl) = self.rerank.as_ref()
+            && !gap_local.is_empty()
+        {
+            let mut gaps = rl.gap_hist.lock().unwrap_or_else(PoisonError::into_inner);
+            if gaps.is_empty() {
+                *gaps = gap_local;
+            } else {
+                for (a, b) in gaps.iter_mut().zip(gap_local) {
+                    *a = a.saturating_add(b);
                 }
             }
         }
@@ -1266,6 +1344,7 @@ impl WidthLawCalibration {
         scratch: &mut [f32],
         partial: &mut [Vec<(f32, u32, i128, f32)>],
         hist_local: &mut HashMap<usize, Vec<u64>>,
+        gap_local: &mut Vec<u64>,
     ) {
         let k_max = WIDTH_LAW_MAX_K;
         let rl = self.rerank.as_ref();
@@ -1350,12 +1429,22 @@ impl WidthLawCalibration {
                 if row.stable_id == frozen.ids[qi] {
                     continue;
                 }
-                partial[qi].push((
-                    distance(self.metric, q, scratch),
-                    cell,
-                    row.stable_id,
-                    est_of[qi],
-                ));
+                let exact = distance(self.metric, q, scratch);
+                // Stop-margin evidence: this (query, row) pair's
+                // exact-similarity minus its serving estimate — pooled
+                // pairs only (a finite `est_of` IS pool membership), and
+                // cosine only, the one metric where the two share a scale.
+                // Measured here because it is the one place the exact
+                // score and the serving estimate exist side by side.
+                if self.metric == Metric::Cosine && est_of[qi].is_finite() {
+                    let gap = (COSINE_DISTANCE_BASE - exact) - est_of[qi];
+                    if gap_local.is_empty() {
+                        gap_local.resize(RERANK_LAW_EST_BINS, 0);
+                    }
+                    let bin = RerankLawObservation::gap_bin(gap);
+                    gap_local[bin] = gap_local[bin].saturating_add(1);
+                }
+                partial[qi].push((exact, cell, row.stable_id, est_of[qi]));
             }
             if rl.is_some() {
                 for &qi in members {
@@ -1648,11 +1737,25 @@ impl WidthLawCalibration {
         floor_monotone(&mut law);
         floor_monotone(&mut fine_law);
         floor_monotone(&mut rerank_law);
+        // Stop margin: the LAW_STAGE_TARGET_COVERAGE quantile of the pooled
+        // `exact − estimate` gaps, read at the bin's UPPER edge (the
+        // conservative direction — a larger margin only stops later).
+        // `0.0` = no cosine gap evidence; serving treats it as "never stop
+        // early".
+        let rerank_margin = self
+            .rerank
+            .as_ref()
+            .map(|rl| {
+                let gaps = rl.gap_hist.lock().unwrap_or_else(PoisonError::into_inner);
+                stop_margin_from_hist(&gaps)
+            })
+            .unwrap_or(0.0);
         (law.iter().any(|&w| w > 0)).then_some(CalibratedLaws {
             width_for_k: law,
             fine_for_k: fine_law,
             rerank_for_k: rerank_law,
             pool_cells: self.pool_cells as u32,
+            rerank_margin,
         })
     }
 }
@@ -2020,6 +2123,7 @@ mod tests {
             q_l1: vec![1.0],
             pools: vec![vec![0]],
             hist: Mutex::new(vec![Vec::new()]),
+            gap_hist: Mutex::new(Vec::new()),
         };
         let mut hist = vec![0u64; RERANK_LAW_EST_BINS];
         hist[rl.bin(0, 0.9)] = 3;
@@ -2176,6 +2280,52 @@ mod tests {
     /// every knot on Cohere-10M, via the monotone floor). Knots with
     /// enough evidence (k = 10 here) keep the bound: one fully-uncovered
     /// query still forces their crossing out to full coverage.
+    #[test]
+    fn stop_margin_quantile_reads_the_upper_bin_edge() {
+        // Empty histogram: no evidence, margin 0 (serving never stops).
+        assert_eq!(stop_margin_from_hist(&[]), 0.0);
+        assert_eq!(stop_margin_from_hist(&vec![0u64; RERANK_LAW_EST_BINS]), 0.0);
+
+        // All mass in one bin: the margin is that bin's UPPER edge —
+        // strictly above any gap the bin holds (conservative direction).
+        let mid = RERANK_LAW_EST_BINS / 2;
+        let mut gaps = vec![0u64; RERANK_LAW_EST_BINS];
+        gaps[mid] = 1_000;
+        let margin = stop_margin_from_hist(&gaps);
+        assert!(
+            margin > 0.0 && margin <= 2.0 * STOP_MARGIN_GAP_RANGE / RERANK_LAW_EST_BINS as f32,
+            "gaps at ~0 read a one-bin-wide positive margin, got {margin}"
+        );
+        // The bin math round-trips: a gap bins into the bin whose upper
+        // edge exceeds it.
+        for gap in [-3.9f32, -1.0, 0.0, 0.5, 3.9] {
+            let bin = RerankLawObservation::gap_bin(gap);
+            assert!(
+                stop_margin_bin_upper_edge(bin) >= gap,
+                "upper edge covers the binned gap {gap}"
+            );
+        }
+
+        // A 0.3% tail of large gaps sits ABOVE the 0.997 quantile: the
+        // margin tracks the bulk, not the outliers…
+        let mut gaps = vec![0u64; RERANK_LAW_EST_BINS];
+        gaps[mid] = 997;
+        gaps[RERANK_LAW_EST_BINS - 1] = 3;
+        let bulk = stop_margin_from_hist(&gaps);
+        assert!(
+            bulk < 0.1,
+            "0.3% outlier tail must not widen the margin, got {bulk}"
+        );
+        // …but a 1% tail crosses the coverage target and drags the margin
+        // to the tail's bin (wider = later stops = safe).
+        gaps[RERANK_LAW_EST_BINS - 1] = 11;
+        let tail = stop_margin_from_hist(&gaps);
+        assert!(
+            (tail - STOP_MARGIN_GAP_RANGE).abs() < 1e-3,
+            "a supra-target tail widens the margin to its bin, got {tail}"
+        );
+    }
+
     #[test]
     fn width_law_thin_knot_uses_raw_mean_not_the_worst_query() {
         const DIM: usize = 8;

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -892,14 +892,15 @@ pub(crate) struct WidthLawCalibration {
     /// (e.g. planted test fixtures) measures no rerank law.
     rerank: Option<RerankLawObservation>,
     /// Adaptive-width gap evidence (cosine only): per observed
-    /// (query, top-k member), `member_similarity − cell_routing_similarity`
-    /// where the routing similarity is the member cell's BEST fine-centroid
-    /// similarity for that query — the exact score serving's escalation
-    /// check consults. The stage-coverage quantile of these gaps is the
-    /// width margin: serving may stop probing once no remaining cell's
-    /// routing similarity plus this margin can reach the running kth exact
-    /// score. Same bins and conservative edge read as the rerank margin.
-    width_gap_hist: Mutex<Vec<u64>>,
+    /// (query, top-k member) pair, the member's cell and
+    /// `member_similarity − cell_routing_similarity`, where the routing
+    /// similarity is the cell's BEST fine-centroid similarity for that
+    /// query — the exact score serving's escalation check consults.
+    /// [`Self::finish`] takes the stage-coverage quantile over the TAIL
+    /// pairs only (cells ranked beyond the bulk width): the stop rule only
+    /// ever bounds tail cells, and bulk-cell gaps — larger and irrelevant
+    /// to the proof — would inflate the margin until it never fires.
+    width_gaps: Mutex<Vec<(u32, u32, f32)>>,
 }
 
 /// Streaming state for the rerank law: per query, the 1-bit-encoded query
@@ -1145,7 +1146,7 @@ impl WidthLawCalibration {
             max_fine: AtomicU32::new(0),
             pool_cells: RERANK_LAW_POOL_CELLS,
             rerank: None,
-            width_gap_hist: Mutex::new(Vec::new()),
+            width_gaps: Mutex::new(Vec::new()),
         }
     }
 
@@ -1510,7 +1511,7 @@ impl WidthLawCalibration {
             }
             map
         };
-        let mut width_gaps_local: Vec<u64> = Vec::new();
+        let mut width_gaps_local: Vec<(u32, u32, f32)> = Vec::new();
         for view in views {
             let Some(cell_id) = view.cell_id else {
                 continue;
@@ -1567,27 +1568,15 @@ impl WidthLawCalibration {
                     && member_dist.is_finite()
                     && best_fine_dist.is_finite()
                 {
-                    let gap = *best_fine_dist - member_dist;
-                    if width_gaps_local.is_empty() {
-                        width_gaps_local.resize(RERANK_LAW_EST_BINS, 0);
-                    }
-                    let bin = RerankLawObservation::gap_bin(gap);
-                    width_gaps_local[bin] = width_gaps_local[bin].saturating_add(1);
+                    width_gaps_local.push((qi, cell_id, *best_fine_dist - member_dist));
                 }
             }
         }
         if !width_gaps_local.is_empty() {
-            let mut gaps = self
-                .width_gap_hist
+            self.width_gaps
                 .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            if gaps.is_empty() {
-                *gaps = width_gaps_local;
-            } else {
-                for (a, b) in gaps.iter_mut().zip(width_gaps_local) {
-                    *a = a.saturating_add(b);
-                }
-            }
+                .unwrap_or_else(PoisonError::into_inner)
+                .extend(width_gaps_local);
         }
     }
 
@@ -1605,13 +1594,20 @@ impl WidthLawCalibration {
             return None;
         }
         let n_cells = grid.n_cent as usize;
-        let width_margin = {
-            let gaps = self
-                .width_gap_hist
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            stop_margin_from_hist(&gaps)
-        };
+        // Width-margin evidence, grouped per query so the main loop below —
+        // which re-ranks the grid per query anyway — can attach each pair's
+        // cell rank; the quantile is taken over TAIL pairs only, after the
+        // bulk width is known.
+        let mut width_gap_pairs: HashMap<u32, Vec<(u32, f32)>> = HashMap::new();
+        for (qi, cell, gap) in self
+            .width_gaps
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .drain(..)
+        {
+            width_gap_pairs.entry(qi).or_default().push((cell, gap));
+        }
+        let mut ranked_gaps: Vec<(u32, f32)> = Vec::new();
         let tops = self
             .tops
             .into_inner()
@@ -1671,6 +1667,13 @@ impl WidthLawCalibration {
             for (rank, (cell, _)) in ranked.iter().enumerate() {
                 if let Some(slot) = rank_of_cell.get_mut(*cell as usize) {
                     *slot = rank as u32;
+                }
+            }
+            if let Some(pairs) = width_gap_pairs.get(&(qi as u32)) {
+                for &(cell, gap) in pairs {
+                    if let Some(&rank) = rank_of_cell.get(cell as usize) {
+                        ranked_gaps.push((rank + 1, gap));
+                    }
                 }
             }
             // [`merge_candidates`] keeps one entry per stable id, so the
@@ -1813,6 +1816,35 @@ impl WidthLawCalibration {
         floor_monotone(&mut bulk);
         floor_monotone(&mut fine_law);
         floor_monotone(&mut rerank_law);
+        // Width margin: the stage-coverage quantile of member-vs-routing
+        // gaps over TAIL pairs — members whose cell ranks beyond the bulk
+        // width the serving stage actually probes first. Bulk-cell pairs
+        // are excluded: the stop rule never bounds them, and their larger
+        // gaps inflate the margin until it cannot fire (measured 0.109
+        // all-pairs vs the tail population on Cohere-10M). The k=10 knot
+        // anchors the conditioning; no tail evidence ⇒ 0.0 ⇒ staging off.
+        let width_margin = {
+            let bulk_anchor = bulk
+                .iter()
+                .find(|&&b| b > 0)
+                .copied()
+                .unwrap_or(0)
+                .max(bulk[1]);
+            let mut tail_gaps: Vec<f32> = ranked_gaps
+                .iter()
+                .filter(|&&(rank, _)| bulk_anchor > 0 && rank > bulk_anchor)
+                .map(|&(_, gap)| gap)
+                .collect();
+            if tail_gaps.is_empty() {
+                0.0
+            } else {
+                tail_gaps.sort_unstable_by(f32::total_cmp);
+                let idx = ((LAW_STAGE_TARGET_COVERAGE * tail_gaps.len() as f64).ceil() as usize)
+                    .clamp(1, tail_gaps.len())
+                    - 1;
+                tail_gaps[idx].max(0.0)
+            }
+        };
         // Stop margin: the LAW_STAGE_TARGET_COVERAGE quantile of the pooled
         // `exact − estimate` gaps, read at the bin's UPPER edge (the
         // conservative direction — a larger margin only stops later).

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -41,8 +41,7 @@ use crate::{
         cell_posting::{EncodedCellRow, MaterializedIvfRow, manifest_centroid_components_from_row},
         distance::{
             COSINE_DISTANCE_BASE, Metric, distance, nearest_k_centroids_bytes,
-            nearest_k_centroids_transposed, normalize,
-            relative_score_window,
+            nearest_k_centroids_transposed, normalize, relative_score_window,
         },
         kmeans::{kmeans, kmeans_pp},
         quant::BitQuantizer,
@@ -2339,12 +2338,8 @@ mod tests {
         for c in 0..N_CELLS {
             cents[c * DIM + c] = 1.0;
         }
-        let grid = ClusterCentroids::from_fp32(
-            N_CELLS as u32,
-            DIM as u32,
-            &cents,
-            vec![1; N_CELLS],
-        );
+        let grid =
+            ClusterCentroids::from_fp32(N_CELLS as u32, DIM as u32, &cents, vec![1; N_CELLS]);
         let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
         let mut queries = vec![0.0f32; N_QUERIES * DIM];
         for qi in 0..N_QUERIES {

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -808,6 +808,14 @@ const RERANK_LAW_EST_BINS: usize = 4096;
 const WIDTH_LAW_SAMPLE_SEED: u64 = 0x51ED_CA1B;
 /// Rows decoded per chunk while scoring a spilled cell.
 const WIDTH_LAW_SCORE_CHUNK: usize = 1024;
+/// First-wave ("bulk") width coverage: the adaptive-width serving stage
+/// probes the cells covering this share of calibration (query, member)
+/// pairs first, and escalates to the full stamped width only when the
+/// calibrated width margin cannot rule the remaining cells out. Recall is
+/// unaffected by construction — the margin gates the stop, the full width
+/// stays the cap; this quantile only positions the p50/p95 latency split.
+const WIDTH_LAW_BULK_COVERAGE: f64 = 0.9;
+
 /// Half-range of the stop-margin gap histogram. Cosine exact similarities
 /// live in `[-1, 1]` and 1-bit estimates concentrate within a few units of
 /// zero, so ±4 covers every realistic `exact − estimate` gap; anything
@@ -883,6 +891,15 @@ pub(crate) struct WidthLawCalibration {
     /// Rerank-law observation state, armed by [`Self::freeze`]; `None`
     /// (e.g. planted test fixtures) measures no rerank law.
     rerank: Option<RerankLawObservation>,
+    /// Adaptive-width gap evidence (cosine only): per observed
+    /// (query, top-k member), `member_similarity − cell_routing_similarity`
+    /// where the routing similarity is the member cell's BEST fine-centroid
+    /// similarity for that query — the exact score serving's escalation
+    /// check consults. The stage-coverage quantile of these gaps is the
+    /// width margin: serving may stop probing once no remaining cell's
+    /// routing similarity plus this margin can reach the running kth exact
+    /// score. Same bins and conservative edge read as the rerank margin.
+    width_gap_hist: Mutex<Vec<u64>>,
 }
 
 /// Streaming state for the rerank law: per query, the 1-bit-encoded query
@@ -1022,6 +1039,16 @@ pub(crate) struct CalibratedLaws {
     /// score. `0.0` = no evidence (non-cosine, or no pooled pairs) —
     /// serving never stops early.
     pub(crate) rerank_margin: f32,
+    /// Adaptive-width first-wave law: cells (routing order) covering
+    /// [`WIDTH_LAW_BULK_COVERAGE`] of exact top-k pairs — the p50-economy
+    /// stage width; `width_for_k` stays the escalation cap.
+    pub(crate) width_bulk_for_k: [u32; WIDTH_LAW_KS.len()],
+    /// Adaptive-width stop margin: the stage-coverage quantile of
+    /// `member_similarity − cell_routing_similarity` over observed pairs
+    /// (cosine only). Serving may skip the escalation once no remaining
+    /// cell's routing similarity plus this margin reaches the running kth
+    /// exact score. `0.0` = never skip.
+    pub(crate) width_margin: f32,
 }
 
 #[cfg(test)]
@@ -1118,6 +1145,7 @@ impl WidthLawCalibration {
             max_fine: AtomicU32::new(0),
             pool_cells: RERANK_LAW_POOL_CELLS,
             rerank: None,
+            width_gap_hist: Mutex::new(Vec::new()),
         }
     }
 
@@ -1472,16 +1500,17 @@ impl WidthLawCalibration {
         }
         // Candidates per cell, gathered once — observation touches only
         // rows that currently matter to some query's top-k.
-        let per_cell: HashMap<u32, Vec<(u32, i128)>> = {
+        let per_cell: HashMap<u32, Vec<(u32, i128, f32)>> = {
             let tops = self.tops.lock().unwrap_or_else(PoisonError::into_inner);
-            let mut map: HashMap<u32, Vec<(u32, i128)>> = HashMap::new();
+            let mut map: HashMap<u32, Vec<(u32, i128, f32)>> = HashMap::new();
             for (qi, cands) in tops.iter().enumerate() {
-                for &(_, cell, id, _) in cands {
-                    map.entry(cell).or_default().push((qi as u32, id));
+                for &(dist, cell, id, _) in cands {
+                    map.entry(cell).or_default().push((qi as u32, id, dist));
                 }
             }
             map
         };
+        let mut width_gaps_local: Vec<u64> = Vec::new();
         for view in views {
             let Some(cell_id) = view.cell_id else {
                 continue;
@@ -1495,17 +1524,20 @@ impl WidthLawCalibration {
             self.max_fine
                 .fetch_max(view.n_fine as u32, AtomicOrdering::Relaxed);
             // Per-query fine ranking, computed once per query that has
-            // candidates in this cell.
-            let mut rank_cache: HashMap<u32, Vec<u32>> = HashMap::new();
+            // candidates in this cell. The best fine distance rides along:
+            // it is the cell's routing similarity for this query — the
+            // score the adaptive-width escalation check consults — so the
+            // width-margin gaps are measured on serving's own scale.
+            let mut rank_cache: HashMap<u32, (Vec<u32>, f32)> = HashMap::new();
             let mut ranks = self
                 .fine_ranks
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner);
-            for &(qi, id) in cands {
+            for &(qi, id, member_dist) in cands {
                 let Some(&cluster) = view.cluster_of_stable.get(&id) else {
                     continue;
                 };
-                let rank_of = rank_cache.entry(qi).or_insert_with(|| {
+                let (rank_of, best_fine_dist) = rank_cache.entry(qi).or_insert_with(|| {
                     let q = &frozen.queries[qi as usize * self.dim..(qi as usize + 1) * self.dim];
                     // Full ranking (`k = n_fine`) through the shared
                     // row-major centroid-scan owner — identical distance
@@ -1518,14 +1550,42 @@ impl WidthLawCalibration {
                         view.dim,
                         view.n_fine,
                     );
+                    let best = ranked.first().map(|&(_, d)| d).unwrap_or(f32::MAX);
                     let mut rank_of = vec![0u32; view.n_fine];
                     for (rank, (c, _)) in ranked.iter().enumerate() {
                         rank_of[*c as usize] = rank as u32;
                     }
-                    rank_of
+                    (rank_of, best)
                 });
                 if let Some(&r) = rank_of.get(cluster as usize) {
                     ranks.insert((qi, id, cell_id), r);
+                }
+                // Width-margin gap (cosine only — the metric whose exact
+                // score and routing score share the similarity scale):
+                // member_sim − routing_sim = best_fine_dist − member_dist.
+                if self.metric == Metric::Cosine
+                    && member_dist.is_finite()
+                    && best_fine_dist.is_finite()
+                {
+                    let gap = *best_fine_dist - member_dist;
+                    if width_gaps_local.is_empty() {
+                        width_gaps_local.resize(RERANK_LAW_EST_BINS, 0);
+                    }
+                    let bin = RerankLawObservation::gap_bin(gap);
+                    width_gaps_local[bin] = width_gaps_local[bin].saturating_add(1);
+                }
+            }
+        }
+        if !width_gaps_local.is_empty() {
+            let mut gaps = self
+                .width_gap_hist
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            if gaps.is_empty() {
+                *gaps = width_gaps_local;
+            } else {
+                for (a, b) in gaps.iter_mut().zip(width_gaps_local) {
+                    *a = a.saturating_add(b);
                 }
             }
         }
@@ -1545,6 +1605,13 @@ impl WidthLawCalibration {
             return None;
         }
         let n_cells = grid.n_cent as usize;
+        let width_margin = {
+            let gaps = self
+                .width_gap_hist
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            stop_margin_from_hist(&gaps)
+        };
         let tops = self
             .tops
             .into_inner()
@@ -1553,6 +1620,7 @@ impl WidthLawCalibration {
         // them, this count does not) — an over-probe, never an under-probe;
         // fresh drains, the normal calibration moment, have neither.
         let mut law = [0u32; WIDTH_LAW_KS.len()];
+        let mut bulk = [0u32; WIDTH_LAW_KS.len()];
         let mut coverage_sums: Vec<Vec<f64>> = vec![vec![0f64; n_cells]; WIDTH_LAW_KS.len()];
         // Per-query squared coverages alongside the sums: the crossing
         // rule needs the sample's own variance to know when its mean is
@@ -1703,6 +1771,14 @@ impl WidthLawCalibration {
             }) {
                 law[ki] = (rank + 1) as u32;
             }
+            // Bulk crossing: the raw-mean width covering the first-wave
+            // share of pairs. No confidence ceremony — a bulk miss
+            // escalates to the full law width instead of losing recall,
+            // so this knot prices latency, not correctness.
+            let bulk_target = WIDTH_LAW_BULK_COVERAGE * n;
+            if let Some(rank) = sums.iter().enumerate().position(|(_, &s)| s >= bulk_target) {
+                bulk[ki] = (rank + 1) as u32;
+            }
             let stage_target = LAW_STAGE_TARGET_COVERAGE * support[ki] as f64;
             if let Some(rank) = fine_sums[ki].iter().position(|&s| s >= stage_target) {
                 fine_law[ki] = (rank + 1) as u32;
@@ -1734,6 +1810,7 @@ impl WidthLawCalibration {
         // recall inversion at query time). Unmeasured points (0) stay 0; the
         // interpolator skips them.
         floor_monotone(&mut law);
+        floor_monotone(&mut bulk);
         floor_monotone(&mut fine_law);
         floor_monotone(&mut rerank_law);
         // Stop margin: the LAW_STAGE_TARGET_COVERAGE quantile of the pooled
@@ -1751,10 +1828,12 @@ impl WidthLawCalibration {
             .unwrap_or(0.0);
         (law.iter().any(|&w| w > 0)).then_some(CalibratedLaws {
             width_for_k: law,
+            width_bulk_for_k: bulk,
             fine_for_k: fine_law,
             rerank_for_k: rerank_law,
             pool_cells: self.pool_cells as u32,
             rerank_margin,
+            width_margin,
         })
     }
 }

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -900,7 +900,7 @@ pub(crate) struct WidthLawCalibration {
     /// pairs only (cells ranked beyond the bulk width): the stop rule only
     /// ever bounds tail cells, and bulk-cell gaps — larger and irrelevant
     /// to the proof — would inflate the margin until it never fires.
-    width_gaps: Mutex<Vec<(u32, u32, f32)>>,
+    width_gaps: Mutex<Vec<(u32, i128, u32, f32)>>,
 }
 
 /// Streaming state for the rerank law: per query, the 1-bit-encoded query
@@ -1511,7 +1511,7 @@ impl WidthLawCalibration {
             }
             map
         };
-        let mut width_gaps_local: Vec<(u32, u32, f32)> = Vec::new();
+        let mut width_gaps_local: Vec<(u32, i128, u32, f32)> = Vec::new();
         for view in views {
             let Some(cell_id) = view.cell_id else {
                 continue;
@@ -1568,7 +1568,7 @@ impl WidthLawCalibration {
                     && member_dist.is_finite()
                     && best_fine_dist.is_finite()
                 {
-                    width_gaps_local.push((qi, cell_id, *best_fine_dist - member_dist));
+                    width_gaps_local.push((qi, id, cell_id, *best_fine_dist - member_dist));
                 }
             }
         }
@@ -1598,16 +1598,19 @@ impl WidthLawCalibration {
         // which re-ranks the grid per query anyway — can attach each pair's
         // cell rank; the quantile is taken over TAIL pairs only, after the
         // bulk width is known.
-        let mut width_gap_pairs: HashMap<u32, Vec<(u32, f32)>> = HashMap::new();
-        for (qi, cell, gap) in self
+        let mut gap_of: HashMap<(u32, i128), (u32, f32)> = HashMap::new();
+        for (qi, id, cell, gap) in self
             .width_gaps
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .drain(..)
         {
-            width_gap_pairs.entry(qi).or_default().push((cell, gap));
+            gap_of.insert((qi, id), (cell, gap));
         }
-        let mut ranked_gaps: Vec<(u32, f32)> = Vec::new();
+        // Per (knot, member-rank≤k) gaps of TAIL-cell members: (cell rank,
+        // gap), joined per query inside the main loop where the grid
+        // ranking is fresh.
+        let mut knot_gaps: [Vec<(u32, f32)>; WIDTH_LAW_KS.len()] = Default::default();
         let tops = self
             .tops
             .into_inner()
@@ -1669,13 +1672,6 @@ impl WidthLawCalibration {
                     *slot = rank as u32;
                 }
             }
-            if let Some(pairs) = width_gap_pairs.get(&(qi as u32)) {
-                for &(cell, gap) in pairs {
-                    if let Some(&rank) = rank_of_cell.get(cell as usize) {
-                        ranked_gaps.push((rank + 1, gap));
-                    }
-                }
-            }
             // [`merge_candidates`] keeps one entry per stable id, so the
             // accumulator only needs ranking by score for the prefix walk.
             let mut sorted = cand.clone();
@@ -1687,6 +1683,13 @@ impl WidthLawCalibration {
                     continue;
                 }
                 support[ki] += 1;
+                for (_, _, id, _) in &sorted[..k] {
+                    if let Some(&(cell, gap)) = gap_of.get(&(qi as u32, *id))
+                        && let Some(&rank) = rank_of_cell.get(cell as usize)
+                    {
+                        knot_gaps[ki].push((rank + 1, gap));
+                    }
+                }
                 // Per-rank counts of this query's top-k, then a prefix walk
                 // accumulates the mean coverage curve.
                 let mut per_rank = vec![0u32; n_cells];
@@ -1823,28 +1826,28 @@ impl WidthLawCalibration {
         // gaps inflate the margin until it cannot fire (measured 0.109
         // all-pairs vs the tail population on Cohere-10M). The k=10 knot
         // anchors the conditioning; no tail evidence ⇒ 0.0 ⇒ staging off.
-        let width_margin = {
-            let bulk_anchor = bulk
+        let knot_margin = |ki: usize| -> f32 {
+            let anchor = bulk[ki].max(1);
+            let mut tail: Vec<f32> = knot_gaps[ki]
                 .iter()
-                .find(|&&b| b > 0)
-                .copied()
-                .unwrap_or(0)
-                .max(bulk[1]);
-            let mut tail_gaps: Vec<f32> = ranked_gaps
-                .iter()
-                .filter(|&&(rank, _)| bulk_anchor > 0 && rank > bulk_anchor)
+                .filter(|&&(rank, _)| rank > anchor)
                 .map(|&(_, gap)| gap)
                 .collect();
-            if tail_gaps.is_empty() {
-                0.0
-            } else {
-                tail_gaps.sort_unstable_by(f32::total_cmp);
-                let idx = ((LAW_STAGE_TARGET_COVERAGE * tail_gaps.len() as f64).ceil() as usize)
-                    .clamp(1, tail_gaps.len())
-                    - 1;
-                tail_gaps[idx].max(0.0)
+            if tail.is_empty() {
+                return 0.0;
             }
+            tail.sort_unstable_by(f32::total_cmp);
+            let idx = ((LAW_STAGE_TARGET_COVERAGE * tail.len() as f64).ceil() as usize)
+                .clamp(1, tail.len())
+                - 1;
+            tail[idx].max(0.0)
         };
+        // Stamp the serving anchor knot (k=10): the stop rule protects the
+        // top-k members, so the margin is calibrated over top-k members in
+        // tail cells only — not the full top-1000 calibration walk, whose
+        // deep members are extreme within-cell outliers the k=10 stop
+        // never needs to find.
+        let width_margin = knot_margin(1);
         // Stop margin: the LAW_STAGE_TARGET_COVERAGE quantile of the pooled
         // `exact − estimate` gaps, read at the bin's UPPER edge (the
         // conservative direction — a larger margin only stops later).

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -808,15 +808,6 @@ const RERANK_LAW_EST_BINS: usize = 4096;
 const WIDTH_LAW_SAMPLE_SEED: u64 = 0x51ED_CA1B;
 /// Rows decoded per chunk while scoring a spilled cell.
 const WIDTH_LAW_SCORE_CHUNK: usize = 1024;
-/// Bounds for the residual estimate's histogram range: rows are unit
-/// (cosine tables), centers are means of unit rows, so `|q·c| ≤ ‖q‖` and
-/// `‖v − c‖ ≤ 2` — the residual estimate is inside
-/// `±(‖q‖·CENTER + κ·NORM·q_l1)`. Loose bounds only widen bins (rank
-/// error stays one bin's occupancy, always over-counting toward a wider
-/// law), never clip.
-const RESIDUAL_EST_CENTER_BOUND: f32 = 1.0;
-const RESIDUAL_EST_NORM_BOUND: f32 = 2.0;
-
 /// Frozen query sample: dequantized fp32 vectors + their stable ids
 /// (self-hit exclusion while scoring).
 struct WidthLawQueries {
@@ -886,11 +877,6 @@ pub(crate) struct WidthLawCalibration {
     /// Rerank-law observation state, armed by [`Self::freeze`]; `None`
     /// (e.g. planted test fixtures) measures no rerank law.
     rerank: Option<RerankLawObservation>,
-    /// The table's codes are cell/fine-centroid residuals: the rerank-law
-    /// estimate must be the serving `q·c_ref + κ·‖r‖·sign_dot`, and the
-    /// histogram range widens accordingly. Callers then pass the per-call
-    /// [`ResidualRef`] into the score paths.
-    residual: bool,
 }
 
 /// Streaming state for the rerank law: per query, the 1-bit-encoded query
@@ -901,16 +887,13 @@ pub(crate) struct WidthLawCalibration {
 /// [`finish`]: WidthLawCalibration::finish
 /// Reference centers for residual-coded rows during calibration: the
 /// estimate the scan serves is `q·c_ref + κ·‖r‖·sign_dot`, so calibration
-/// must histogram THAT quantity, not the raw sign-dot. Which center a
-/// row's stored code was taken against depends on provenance:
-/// drain-spill rows come from incoming shards whose clusters ARE grid
-/// cells (one centroid per call); packed-cell rows carry fine-cluster
-/// residuals (`row.cluster` is the fine ordinal into that cell's
-/// centroid table). `None` at the call sites = raw codes, the exact
-/// pre-residual arithmetic.
+/// must histogram THAT quantity, not the raw sign-dot. Only packed cells
+/// carry residual codes (`row.cluster` is the fine ordinal into that
+/// cell's own centroid table); drain spills are user-table rows — raw
+/// codes always — and score with `None`, the exact pre-residual
+/// arithmetic (a spill-time reference is impossible in principle: the
+/// serving centers are the fine centroids the pack has not trained yet).
 pub(crate) enum ResidualRef<'a> {
-    /// One grid-cell centroid for every row of the call (drain spills).
-    Cell(&'a [f32]),
     /// Fine centroids (`n_fine × dim`), indexed by `row.cluster`
     /// (packed-cell rows).
     Fine(&'a [f32]),
@@ -920,7 +903,6 @@ impl ResidualRef<'_> {
     /// The reference center for one row.
     fn center(&self, row: &MaterializedIvfRow, dim: usize) -> &[f32] {
         match self {
-            Self::Cell(c) => c,
             Self::Fine(table) => {
                 let c = row.cluster as usize;
                 &table[c * dim..(c + 1) * dim]
@@ -935,13 +917,16 @@ struct RerankLawObservation {
     q_rot: Vec<f32>,
     /// Per query `Σ q_rot[d]` — the estimator's per-query identity term.
     q_total: Vec<f32>,
-    /// Per query `Σ |q_rot[d]|` — the raw sign-dot's exact range.
+    /// Per query `Σ |q_rot[d]|` — the histogram half-range, uniform across
+    /// raw and residual codes so mixed-generation estimates bin on one
+    /// scale. Raw sign-dots span `[-l1, +l1]` exactly. Residual estimates
+    /// (`q·c_ref + κ·‖r‖·sign_dot`) are bounded by `‖q‖₂ + 2κ·l1`
+    /// (unit-ish centers, `‖r‖ ≤ 2`, `|sign_dot| ≤ l1`), so with
+    /// `‖q‖₂ ≤ l1` they overshoot ±l1 by at most `2κ·l1 ≈ 0.09·l1`
+    /// (κ ≈ 0.045 at dim 768) — that sliver clamps into the edge bins,
+    /// and edge clamping only over-counts a candidate's rank toward a
+    /// WIDER (safer) law.
     q_l1: Vec<f32>,
-    /// Per query histogram half-range. Raw codes: `q_l1` (the sign-dot's
-    /// exact range). Residual codes: `|q·c| + κ·‖r‖·|sd|` is bounded by
-    /// `q_norm·CENTER_NORM_MAX + κ·RESIDUAL_NORM_MAX·q_l1`, so the full
-    /// estimate bins linearly over that.
-    bin_range: Vec<f32>,
     /// Per query: ascending cell ids of its `RERANK_LAW_POOL_CELLS`
     /// grid-nearest cells.
     pools: Vec<Vec<u32>>,
@@ -956,7 +941,7 @@ impl RerankLawObservation {
     /// Histogram bin for `est` under this query's `[-l1, +l1]` range;
     /// bin 0 holds the best (largest) estimates.
     fn bin(&self, qi: usize, est: f32) -> usize {
-        let range = self.bin_range[qi];
+        let range = self.q_l1[qi];
         if range <= 0.0 {
             return RERANK_LAW_EST_BINS - 1;
         }
@@ -1061,8 +1046,7 @@ fn floor_monotone(law: &mut [u32; WIDTH_LAW_KS.len()]) {
 }
 
 impl WidthLawCalibration {
-    pub(crate) fn new(dim: usize, metric: Metric, residual: bool) -> Self {
-        let _ = &residual;
+    pub(crate) fn new(dim: usize, metric: Metric) -> Self {
         Self {
             dim,
             metric,
@@ -1075,7 +1059,6 @@ impl WidthLawCalibration {
             max_fine: AtomicU32::new(0),
             pool_cells: RERANK_LAW_POOL_CELLS,
             rerank: None,
-            residual,
         }
     }
 
@@ -1114,21 +1097,13 @@ impl WidthLawCalibration {
             let mut q_rot = vec![0f32; n_queries * self.dim];
             let mut q_total = Vec::with_capacity(n_queries);
             let mut q_l1 = Vec::with_capacity(n_queries);
-            let mut bin_range = Vec::with_capacity(n_queries);
             let mut pools = Vec::with_capacity(n_queries);
-            let kappa = BitQuantizer::residual_kappa_analytic(self.dim);
             for (qi, q) in queries.chunks_exact(self.dim).enumerate() {
                 let out = &mut q_rot[qi * self.dim..(qi + 1) * self.dim];
                 rotation.apply(q, out);
                 let l1: f32 = out.iter().map(|v| v.abs()).sum();
                 q_total.push(out.iter().sum());
                 q_l1.push(l1);
-                bin_range.push(if self.residual {
-                    let q_norm = q.iter().map(|v| v * v).sum::<f32>().sqrt();
-                    q_norm * RESIDUAL_EST_CENTER_BOUND + kappa * RESIDUAL_EST_NORM_BOUND * l1
-                } else {
-                    l1
-                });
                 let mut pool: Vec<u32> = grid
                     .rank_cells(self.metric, q)
                     .into_iter()
@@ -1143,7 +1118,6 @@ impl WidthLawCalibration {
                 q_rot,
                 q_total,
                 q_l1,
-                bin_range,
                 pools,
                 hist: Mutex::new(vec![Vec::new(); n_queries]),
             });
@@ -1296,9 +1270,8 @@ impl WidthLawCalibration {
         let k_max = WIDTH_LAW_MAX_K;
         let rl = self.rerank.as_ref();
         let kappa = BitQuantizer::residual_kappa_analytic(self.dim);
-        // Exact `q·c_ref` per (query, reference center), cached across rows —
-        // the residual estimate's center term (`u32::MAX` keys the single
-        // Cell center).
+        // Exact `q·c_ref` per (query, fine cluster), cached across rows —
+        // the residual estimate's center term.
         let mut cref_dots: HashMap<(usize, u32), f32> = HashMap::new();
         let mut est_of = vec![f32::NEG_INFINITY; frozen.ids.len()];
         for row in rows {
@@ -1314,11 +1287,7 @@ impl WidthLawCalibration {
                     .map(|(v, c)| (v - c) * (v - c))
                     .sum::<f32>()
                     .sqrt();
-                let key = match rref {
-                    ResidualRef::Cell(_) => u32::MAX,
-                    ResidualRef::Fine(_) => row.cluster,
-                };
-                (r_norm, key)
+                (r_norm, row.cluster)
             });
             if let Some(rl) = rl
                 && row.rabitq_code.len() == rl.quant.code_bytes()
@@ -1905,7 +1874,7 @@ mod tests {
             ],
             vec![1; 4],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -1955,7 +1924,7 @@ mod tests {
     fn depth_law_walks_fine_ranks() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -2035,7 +2004,7 @@ mod tests {
     fn rerank_law_reads_survivor_budget_from_histograms() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -2049,7 +2018,6 @@ mod tests {
             q_rot: vec![0.0; DIM],
             q_total: vec![0.0],
             q_l1: vec![1.0],
-            bin_range: vec![1.0],
             pools: vec![vec![0]],
             hist: Mutex::new(vec![Vec::new()]),
         };
@@ -2092,7 +2060,7 @@ mod tests {
     fn depth_law_missing_rank_is_conservative() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -2152,7 +2120,7 @@ mod tests {
             ],
             vec![1; 4],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
         let mut queries = vec![0.0f32; 2 * DIM];
         queries[0] = 1.0;
         queries[DIM] = 1.0;
@@ -2227,7 +2195,7 @@ mod tests {
             &cents,
             vec![1; N_CELLS],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
         let mut queries = vec![0.0f32; N_QUERIES * DIM];
         for qi in 0..N_QUERIES {
             queries[qi * DIM] = 1.0;
@@ -2288,7 +2256,7 @@ mod tests {
             ],
             vec![1; 2],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, false);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -2399,7 +2367,7 @@ mod tests {
         let c_ref: Vec<f32> = (0..DIM).map(|d| 0.2 + d as f32 * 0.05).collect();
 
         let run = |residual: bool| -> Vec<(f32, u32, i128, f32)> {
-            let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, residual);
+            let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
             let query_row = &synth_fixed_rows(DIM, 1, 200)[0];
             cal.offer(&MaterializedIvfRow {
                 local_doc_id: 0,
@@ -2420,7 +2388,9 @@ mod tests {
                     encoded,
                 })
                 .collect();
-            let rref = ResidualRef::Cell(&c_ref);
+            // A one-cluster fine table whose rows all carry `cluster: 0`,
+            // so every row's reference center is `c_ref`.
+            let rref = ResidualRef::Fine(&c_ref);
             cal.score_rows(0, &rows, residual.then_some(&rref))
                 .expect("score rows");
             let tops = cal.tops.lock().unwrap_or_else(PoisonError::into_inner);

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -1257,6 +1257,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }
     }
 

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -992,6 +992,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -616,6 +616,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )
@@ -1179,6 +1180,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -580,6 +580,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -456,6 +456,7 @@ mod tests {
                     metric: Metric::Cosine,
                     rerank_codec: RerankCodec::Fp32,
                     provided_centroids: None,
+                    residual_codes: false,
                 }],
                 None,
             )

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -1724,6 +1724,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -92,10 +92,10 @@ use super::{
     prune::{PruneLeaf, select_superfiles},
 };
 pub use crate::superfile::reader::VectorSearchOptions;
-#[cfg(feature = "test-helpers")]
-use crate::test_helpers::{admit_trace, served_shortlist_probe};
 #[cfg(any(test, feature = "test-helpers"))]
 use crate::test_helpers::stop_band_floor_override;
+#[cfg(feature = "test-helpers")]
+use crate::test_helpers::{admit_trace, served_shortlist_probe};
 use crate::{
     config,
     runtime_bridge::run_on_pool,
@@ -2716,8 +2716,7 @@ impl SupertableReader {
                         // Actual winner rows; their planned ranges were
                         // priced canonically above, from the budget these
                         // winners were selected under.
-                        let rows: u64 =
-                            rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
+                        let rows: u64 = rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
                         stats.add_vector_rows_reranked(rows);
                     }
                     per_superfile.extend(

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1683,20 +1683,6 @@ impl SupertableReader {
 
         let mut gated = Vec::new();
         let mut scored = Vec::new();
-        // Adaptive-width staging plan, captured at cell-selection time and
-        // consumed by the wave loop at the fan-out: each selected cell's
-        // wave index (a geometric schedule over the routing order — bulk,
-        // then bulk more, then the remainder), each fine candidate's owning
-        // cell, and the escalation stop bound BEFORE each wave (the best
-        // fine-centroid DISTANCE over every cell from that wave onward —
-        // `None` when any of those cells is unbounded, which forces the
-        // wave). Armed only on the law-served cosine default with a
-        // stamped bulk law + width margin.
-        let mut width_staging: Option<(
-            HashMap<u32, usize>,
-            HashMap<(usize, u32), u32>,
-            Vec<Option<f32>>,
-        )> = None;
         // Width the sweep was pinned to (caller nprobe or the width law);
         // `None` on the fine-first default and legacy paths.
         let mut sweep_width: Option<usize> = None;
@@ -1996,62 +1982,6 @@ impl SupertableReader {
                     );
                 }
                 let selected_cells: HashSet<u32> = selected_cells_ordered.iter().copied().collect();
-                // Two-stage width: probe the bulk-law cells first; the rest
-                // of the law width escalates only when the calibrated width
-                // margin cannot rule those cells out against the running
-                // kth exact score (see the stage loop at the fan-out).
-                if law_default
-                    && let Some(routing_ref) = hidden_routing.as_ref()
-                    && routing_ref.width_margin > 0.0
-                    && let Some(bulk) = routing_ref.width_bulk_for_k_at(k)
-                    && bulk > 0
-                    && bulk < selected_cells_ordered.len()
-                {
-                    let n = selected_cells_ordered.len();
-                    // Geometric wave schedule over the routing order: the
-                    // bulk width, then bulk more, then the remainder — a
-                    // query needing slightly more than the bulk pays one
-                    // extra wave, not the whole cap.
-                    let wave_starts: Vec<usize> = [0, bulk, (2 * bulk).min(n)]
-                        .into_iter()
-                        .chain(std::iter::once(n))
-                        .collect::<Vec<_>>()
-                        .windows(2)
-                        .filter(|w| w[1] > w[0])
-                        .map(|w| w[0])
-                        .collect();
-                    let mut wave_of_cell: HashMap<u32, usize> = HashMap::new();
-                    for (pos, cell) in selected_cells_ordered.iter().enumerate() {
-                        let wave = wave_starts
-                            .iter()
-                            .rposition(|&start| pos >= start)
-                            .unwrap_or(0);
-                        wave_of_cell.insert(*cell, wave);
-                    }
-                    let cell_of: HashMap<(usize, u32), u32> = candidates
-                        .iter()
-                        .filter_map(|&(si, cluster, _, cell, _)| cell.map(|c| ((si, cluster), c)))
-                        .collect();
-                    // Per-position suffix bound: the best fine-centroid
-                    // distance over every ordered cell from that position
-                    // onward; a cell without a fine score poisons every
-                    // suffix containing it (`None` ⇒ that wave always runs).
-                    let fine_of: HashMap<u32, f32> = fine_ranked.iter().copied().collect();
-                    let mut suffix: Vec<Option<f32>> = vec![None; n + 1];
-                    suffix[n] = Some(f32::INFINITY);
-                    for pos in (0..n).rev() {
-                        suffix[pos] = match (
-                            fine_of.get(&selected_cells_ordered[pos]).copied(),
-                            suffix[pos + 1],
-                        ) {
-                            (Some(d), Some(rest)) => Some(d.min(rest)),
-                            _ => None,
-                        };
-                    }
-                    let wave_bounds: Vec<Option<f32>> =
-                        wave_starts.iter().map(|&start| suffix[start]).collect();
-                    width_staging = Some((wave_of_cell, cell_of, wave_bounds));
-                }
                 // Wave-pooled depth is the p=1 read-volume model: keep runs
                 // per drain wave so reads track wave count, not probed-cell
                 // count — which also means widening the cell sweep alone
@@ -2504,113 +2434,23 @@ impl SupertableReader {
         // carries no bitmaps and fans out all units at once (matching
         // main's concurrency — every superfile GET overlaps on tokio).
         let fanout_t0 = io_counters::phase_start();
-        // Adaptive-width stages: when the plan is armed (law-served cosine
-        // default with a stamped bulk law + margin), partition the fan-out
-        // units by each fine cluster's owning cell — stage 1 = bulk cells
-        // (plus any candidate without a cell tag, conservatively), stage 2
-        // = the escalation remainder, probed only when the width margin
-        // cannot rule its cells out against the running kth exact score.
-        // One stage = today's path, byte-for-byte.
-        let width_margin_val = hidden_routing
-            .as_ref()
-            .map(|r| r.width_margin)
-            .unwrap_or(0.0);
-        let mut stage_bounds: Vec<Option<f32>> = Vec::new();
-        let stage_sets: Vec<
-            Vec<(
-                Arc<SuperfileEntry>,
-                (usize, Vec<u32>, Option<Arc<RoaringBitmap>>),
-            )>,
-        > = match width_staging
-            .as_ref()
-            .filter(|_| allow.is_none() && global_shortlist_width.is_some())
-        {
-            Some((wave_of_cell, cell_of, wave_bounds)) => {
-                let n_waves = wave_bounds.len();
-                let mut waves: Vec<Vec<_>> = vec![Vec::new(); n_waves];
-                for (entry, (si, ids, bitmap)) in &units {
-                    let mut per_wave: Vec<Vec<u32>> = vec![Vec::new(); n_waves];
-                    for &c in ids {
-                        // Cell-less candidates ride wave 0 (probed
-                        // unconditionally — conservative).
-                        let wave = cell_of
-                            .get(&(*si, c))
-                            .and_then(|cell| wave_of_cell.get(cell))
-                            .copied()
-                            .unwrap_or(0);
-                        per_wave[wave].push(c);
-                    }
-                    for (wave, wave_ids) in per_wave.into_iter().enumerate() {
-                        if !wave_ids.is_empty() {
-                            waves[wave].push((Arc::clone(entry), (*si, wave_ids, bitmap.clone())));
-                        }
-                    }
-                }
-                if waves.first().is_some_and(|w| !w.is_empty()) && n_waves > 1 {
-                    stage_bounds = wave_bounds.clone();
-                    waves
-                } else {
-                    vec![units]
-                }
-            }
-            None => vec![units],
-        };
-        let mut per_superfile: Vec<Vec<SuperfileHit>> = Vec::new();
-        // Pooled candidates retained ACROSS stages (the global selection in
-        // a later stage competes old and new candidates together), plus the
-        // identity keys of candidates already exactly reranked, so a row
-        // never reranks twice.
-        let mut flat_retained: Vec<(usize, ScanCandidate)> = Vec::new();
-        let mut reranked_keys: HashSet<(usize, usize, u32, u32)> = HashSet::new();
-        for (stage_idx, stage_units) in stage_sets.into_iter().enumerate() {
-            if stage_idx > 0 {
-                // Escalation stop: no remaining cell's best routing
-                // similarity plus the calibrated margin can reach the
-                // running kth exact score — the tail cells cannot change
-                // the top-k. An unbounded tail (any escalation cell
-                // without a fine score) always escalates.
-                let k_stop = k.saturating_add(
-                    usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
-                        .unwrap_or(0),
-                );
-                if let Some(bound_dist) = stage_bounds.get(stage_idx).copied().flatten()
-                    && k_stop > 0
-                {
-                    let mut dists: Vec<f32> =
-                        per_superfile.iter().flatten().map(|h| h.score).collect();
-                    if dists.len() >= k_stop {
-                        let (_, kth, _) = dists.select_nth_unstable_by(k_stop - 1, f32::total_cmp);
-                        if width_escalation_stops(*kth, bound_dist, width_margin_val) {
-                            break;
-                        }
-                    }
-                }
-            }
-            let mut stage_units = stage_units;
-            let stage_hits = if allow.is_some() {
-                let fanout_width = manifest.options.reader_pool.current_num_threads().max(1);
-                let mut collected = Vec::new();
-                while !stage_units.is_empty() {
-                    let n = fanout_width.min(stage_units.len());
-                    let wave: Vec<_> = stage_units.drain(..n).collect();
-                    collected.extend(
-                        dispatch::fanout_with(
-                            self,
-                            wave,
-                            !hidden_vector_index,
-                            false,
-                            body.clone(),
-                        )
+        let mut per_superfile = if allow.is_some() {
+            let fanout_width = manifest.options.reader_pool.current_num_threads().max(1);
+            let mut collected = Vec::new();
+            let mut units = units;
+            while !units.is_empty() {
+                let n = fanout_width.min(units.len());
+                let wave: Vec<_> = units.drain(..n).collect();
+                collected.extend(
+                    dispatch::fanout_with(self, wave, !hidden_vector_index, false, body.clone())
                         .await?,
-                    );
-                }
-                collected
-            } else {
-                dispatch::fanout_with(self, stage_units, !hidden_vector_index, false, body.clone())
-                    .await?
-            };
-            per_superfile.extend(stage_hits);
-
+                );
+            }
+            collected
+        } else {
+            dispatch::fanout_with(self, units, !hidden_vector_index, false, body).await?
+        };
+        {
             // Phase C of the deferred-rerank width sweep: select the best
             // `k x rerank_mult` estimates ACROSS every warm-scanned cell and
             // superfile, then rerank only those winners where they live. The
@@ -2656,12 +2496,10 @@ impl SupertableReader {
                     let replica_overhead =
                         usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
                             .unwrap_or(0);
-                    flat_retained.extend(
-                        pooled
-                            .into_iter()
-                            .flat_map(|(si, _, _, cands)| cands.into_iter().map(move |c| (si, c))),
-                    );
-                    let mut flat: Vec<(usize, ScanCandidate)> = flat_retained.clone();
+                    let mut flat: Vec<(usize, ScanCandidate)> = pooled
+                        .into_iter()
+                        .flat_map(|(si, _, _, cands)| cands.into_iter().map(move |c| (si, c)))
+                        .collect();
                     // Per-cell floor ONLY under an explicit caller nprobe. The
                     // floor exists for the #494 inversion — far cells' 1-bit
                     // noise evicting near cells' true neighbors from the fixed
@@ -2730,11 +2568,6 @@ impl SupertableReader {
                     #[cfg(feature = "test-helpers")]
                     served_shortlist_probe::record(shortlist_limit, cell_floor);
                     flat = select_global_shortlist(flat, shortlist_limit, cell_floor);
-                    // A later stage must not rerank rows an earlier stage
-                    // already scored exactly (their hits are already pooled).
-                    flat.retain(|(si, c)| {
-                        !reranked_keys.contains(&(*si, c.cell_idx, c.pos, c.did))
-                    });
                     let column = Arc::clone(&column_arc2);
                     let query = Arc::clone(&query_arc2);
                     let reader_pool = Arc::clone(&manifest.options.reader_pool);
@@ -2827,7 +2660,6 @@ impl SupertableReader {
                             let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> =
                                 HashMap::new();
                             for (si, cand) in &flat[cursor..band_end] {
-                                reranked_keys.insert((*si, cand.cell_idx, cand.pos, cand.did));
                                 winners_by_seg.entry(*si).or_default().push(*cand);
                             }
                             cursor = band_end;
@@ -2880,7 +2712,6 @@ impl SupertableReader {
                     } else {
                         let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
                         for (si, cand) in flat {
-                            reranked_keys.insert((si, cand.cell_idx, cand.pos, cand.did));
                             winners_by_seg.entry(si).or_default().push(cand);
                         }
                         let rerank_units: Vec<(Arc<SuperfileEntry>, Vec<ScanCandidate>)> =
@@ -4104,18 +3935,6 @@ fn deferred_shortlist_limit(
     }
 }
 
-/// The adaptive-width escalation stop: `true` when no remaining cell's
-/// best routing similarity (`COSINE_DISTANCE_BASE − bound_dist`, the best
-/// fine-centroid distance among the escalation cells) plus the calibrated
-/// width margin can reach the running kth exact similarity — the tail
-/// cells provably cannot change the top-k, so stage 2 is skipped. All
-/// quantities are on the cosine similarity scale; the margin is only ever
-/// stamped on cosine tables.
-fn width_escalation_stops(kth_dist: f32, bound_dist: f32, width_margin: f32) -> bool {
-    let kth_sim = COSINE_DISTANCE_BASE - kth_dist;
-    (COSINE_DISTANCE_BASE - bound_dist) + width_margin < kth_sim
-}
-
 /// The shortlist's total order: best estimate first, ties on
 /// `(unit, cell, pos, did)` — shared by [`select_global_shortlist`]'s cut
 /// and the adaptive-stopping band sort so both walk one deterministic
@@ -4392,7 +4211,7 @@ mod tests {
         hidden_hits_user_ids, is_hidden_vector_manifest, law_floor_serve_selection,
         postings_by_cell_from_summaries, projection_is_id_score_only, rerank_mult_from_law,
         score_fine_candidates, select_global_shortlist, stop_band_floor_override,
-        union_cell_selection, vector_read_query_error, width_escalation_stops,
+        union_cell_selection, vector_read_query_error,
     };
     use crate::{
         BoolMode, InfinoError,
@@ -6084,22 +5903,6 @@ mod tests {
     /// Planted neighbors among `hits` (orthogonal docs score exactly 1.0).
     fn near_count(hits: &[SuperfileHit]) -> usize {
         hits.iter().filter(|h| h.score < ORTHOGONAL_SCORE).count()
-    }
-
-    /// The width-escalation stop is conservative in every direction: it
-    /// fires only when the margin-padded best possible similarity of the
-    /// tail cells sits strictly below the kth exact similarity, and any
-    /// tie or unbounded margin keeps probing.
-    #[test]
-    fn width_escalation_stop_rule_is_conservative() {
-        // kth_sim = 0.9; tail's best routing sim = 0.5. Margin 0.3 pads to
-        // 0.8 < 0.9 → stop. Margin 0.5 pads to 1.0 ≥ 0.9 → keep probing.
-        assert!(width_escalation_stops(0.1, 0.5, 0.3));
-        assert!(!width_escalation_stops(0.1, 0.5, 0.5));
-        // Exact tie must NOT stop (strict inequality): 0.5 + 0.4 == 0.9.
-        assert!(!width_escalation_stops(0.1, 0.5, 0.4));
-        // A tail cell ranked better than the kth never stops, margin 0.
-        assert!(!width_escalation_stops(0.5, 0.1, 0.0));
     }
 
     /// The estimate-banded adaptive rerank returns exactly the planted

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -4498,6 +4498,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )
@@ -4565,6 +4566,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         );
@@ -6465,6 +6467,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )
@@ -6532,6 +6535,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )
@@ -6639,6 +6643,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )
@@ -6754,6 +6759,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -94,6 +94,8 @@ use super::{
 pub use crate::superfile::reader::VectorSearchOptions;
 #[cfg(feature = "test-helpers")]
 use crate::test_helpers::{admit_trace, served_shortlist_probe};
+#[cfg(any(test, feature = "test-helpers"))]
+use crate::test_helpers::stop_band_floor_override;
 use crate::{
     config,
     runtime_metrics::op_stats::{self, OpStatsCollector},
@@ -103,7 +105,7 @@ use crate::{
         error::ReadError,
         fts::reader::BoolMode,
         vector::{
-            distance::{Metric, distance, normalize, relative_score_window},
+            distance::{COSINE_DISTANCE_BASE, Metric, distance, normalize, relative_score_window},
             layout::VectorLayout,
             reader::ScanCandidate,
         },
@@ -127,6 +129,23 @@ use crate::{
 /// is exactly the fine-first default's sweep, so the law only engages
 /// when it demands a WIDER read than the default already performs.
 const LAW_WIDTH_WITHIN_DEFAULT: usize = 1;
+
+/// Smallest estimate band the adaptive-stopping rerank will fan out
+/// (rows). Bands halve the remaining shortlist down to this floor; a
+/// shortlist smaller than two floors reranks in one pass — per-band
+/// fanout has fixed dispatch cost, and sub-floor bands would spend more
+/// on dispatch than the rows they might skip.
+const STOP_BAND_MIN_ROWS: usize = 1024;
+
+/// The band floor serving actually uses: the compiled constant, unless a
+/// test lowered it to walk the band loop on a unit-scale fixture.
+fn stop_band_min_rows() -> usize {
+    #[cfg(any(test, feature = "test-helpers"))]
+    if let Some(rows) = stop_band_floor_override::get() {
+        return rows;
+    }
+    STOP_BAND_MIN_ROWS
+}
 
 /// Oversample factor on the per-sweep rerank budget. Dividing
 /// `k x rerank_mult` evenly across the sweep under-serves the nearest
@@ -2463,26 +2482,6 @@ impl SupertableReader {
                 #[cfg(feature = "test-helpers")]
                 served_shortlist_probe::record(shortlist_limit, cell_floor);
                 flat = select_global_shortlist(flat, shortlist_limit, cell_floor);
-                let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
-                for (si, cand) in flat {
-                    winners_by_seg.entry(si).or_default().push(cand);
-                }
-                let rerank_units: Vec<(Arc<SuperfileEntry>, Vec<ScanCandidate>)> = superfiles
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(si, entry)| {
-                        winners_by_seg
-                            .remove(&si)
-                            .map(|sel| (Arc::clone(entry), sel))
-                    })
-                    .collect();
-                if let Some(stats) = &self.op_stats {
-                    // Actual winner rows; their planned ranges were priced
-                    // canonically above, from the budget these winners were
-                    // selected under.
-                    let rows: u64 = rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
-                    stats.add_vector_rows_reranked(rows);
-                }
                 let column = Arc::clone(&column_arc2);
                 let query = Arc::clone(&query_arc2);
                 let reader_pool = Arc::clone(&manifest.options.reader_pool);
@@ -2534,8 +2533,112 @@ impl SupertableReader {
                         Ok::<Vec<SuperfileHit>, QueryError>(tagged)
                     }
                 };
-                per_superfile
-                    .extend(dispatch::fanout_with(self, rerank_units, false, false, body_c).await?);
+                // Adaptive stopping: on the law-served default (never under
+                // caller overrides), walk the shortlist in estimate bands —
+                // half the remainder per band, floored — and stop once no
+                // unprocessed candidate can reach the running kth exact
+                // score even granted its estimate plus the calibrated
+                // margin. A stamped margin (> 0) is cosine-only evidence
+                // by construction (the calibration measures gaps on cosine
+                // tables alone), so `BASE − distance` is the exact
+                // similarity scale here. The stamped rerank budget already
+                // capped the shortlist above — stopping only SKIPS work,
+                // never adds candidates.
+                let stop_margin = hidden_routing
+                    .as_ref()
+                    .map(|r| r.rerank_margin)
+                    .filter(|&m| m > 0.0)
+                    .filter(|_| law_rerank_served && options.nprobe.is_none());
+                let band_floor = stop_band_min_rows();
+                let banded = match stop_margin {
+                    Some(margin) if flat.len() > 2 * band_floor => Some(margin),
+                    _ => None,
+                };
+                if let Some(margin) = banded {
+                    // The selection's own total order — deterministic bands.
+                    flat.sort_unstable_by(shortlist_total_order);
+                    // The stop rule's kth is over raw reranked hits;
+                    // replica duplicates (dedup happens downstream) can
+                    // only WEAKEN the kth, firing the stop later — safe.
+                    let k_stop = k.saturating_add(replica_overhead);
+                    let mut exact_dists: Vec<f32> = Vec::new();
+                    let mut cursor = 0usize;
+                    while cursor < flat.len() {
+                        let remaining = flat.len() - cursor;
+                        let band_len = (remaining / 2).max(band_floor).min(remaining);
+                        let band_end = cursor + band_len;
+                        let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
+                        for (si, cand) in &flat[cursor..band_end] {
+                            winners_by_seg.entry(*si).or_default().push(*cand);
+                        }
+                        cursor = band_end;
+                        let rerank_units: Vec<(Arc<SuperfileEntry>, Vec<ScanCandidate>)> =
+                            superfiles
+                                .iter()
+                                .enumerate()
+                                .filter_map(|(si, entry)| {
+                                    winners_by_seg
+                                        .remove(&si)
+                                        .map(|sel| (Arc::clone(entry), sel))
+                                })
+                                .collect();
+                        if let Some(stats) = &self.op_stats {
+                            // Actual rows this band reranks — skipped bands
+                            // never reach the counter, so the diagnostic
+                            // reflects the adaptive work, not the cap.
+                            let rows: u64 =
+                                rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
+                            stats.add_vector_rows_reranked(rows);
+                        }
+                        let band_hits =
+                            dispatch::fanout_with(self, rerank_units, false, false, body_c.clone())
+                                .await?;
+                        let done = cursor >= flat.len();
+                        if !done {
+                            exact_dists.extend(band_hits.iter().flatten().map(|h| h.score));
+                            exact_dists.sort_unstable_by(f32::total_cmp);
+                            exact_dists.truncate(k_stop);
+                        }
+                        per_superfile.extend(band_hits);
+                        if done {
+                            break;
+                        }
+                        if exact_dists.len() >= k_stop
+                            && let Some(&kth_dist) = exact_dists.last()
+                        {
+                            let kth_sim = COSINE_DISTANCE_BASE - kth_dist;
+                            let next_best_est = flat[cursor].1.estimate;
+                            if next_best_est + margin < kth_sim {
+                                break;
+                            }
+                        }
+                    }
+                } else {
+                    let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
+                    for (si, cand) in flat {
+                        winners_by_seg.entry(si).or_default().push(cand);
+                    }
+                    let rerank_units: Vec<(Arc<SuperfileEntry>, Vec<ScanCandidate>)> = superfiles
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(si, entry)| {
+                            winners_by_seg
+                                .remove(&si)
+                                .map(|sel| (Arc::clone(entry), sel))
+                        })
+                        .collect();
+                    if let Some(stats) = &self.op_stats {
+                        // Actual winner rows; their planned ranges were
+                        // priced canonically above, from the budget these
+                        // winners were selected under.
+                        let rows: u64 =
+                            rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
+                        stats.add_vector_rows_reranked(rows);
+                    }
+                    per_superfile.extend(
+                        dispatch::fanout_with(self, rerank_units, false, false, body_c).await?,
+                    );
+                }
             }
         }
         if let Some(t0) = fanout_t0 {
@@ -3734,6 +3837,16 @@ fn deferred_shortlist_limit(
     }
 }
 
+/// The shortlist's total order: best estimate first, ties on
+/// `(unit, cell, pos, did)` — shared by [`select_global_shortlist`]'s cut
+/// and the adaptive-stopping band sort so both walk one deterministic
+/// sequence.
+fn shortlist_total_order(a: &(usize, ScanCandidate), b: &(usize, ScanCandidate)) -> Ordering {
+    b.1.estimate.total_cmp(&a.1.estimate).then_with(|| {
+        (a.0, a.1.cell_idx, a.1.pos, a.1.did).cmp(&(b.0, b.1.cell_idx, b.1.pos, b.1.did))
+    })
+}
+
 /// Deterministic global shortlist selection for deferred-rerank width
 /// sweeps: keep the `limit` best 1-bit estimates pooled across every
 /// scanned unit, plus each scanned (unit, cell)'s `cell_floor` best.
@@ -3746,11 +3859,7 @@ fn select_global_shortlist(
     limit: usize,
     cell_floor: usize,
 ) -> Vec<(usize, ScanCandidate)> {
-    let cmp = |a: &(usize, ScanCandidate), b: &(usize, ScanCandidate)| {
-        b.1.estimate.total_cmp(&a.1.estimate).then_with(|| {
-            (a.0, a.1.cell_idx, a.1.pos, a.1.did).cmp(&(b.0, b.1.cell_idx, b.1.pos, b.1.did))
-        })
-    };
+    let cmp = shortlist_total_order;
     if pooled.len() <= limit {
         return pooled;
     }
@@ -4003,8 +4112,8 @@ mod tests {
         calibrated_query_for, cells_ranked_by_fine_score, gate_fine_candidates_by_fragment,
         hidden_hits_user_ids, is_hidden_vector_manifest, law_floor_serve_selection,
         postings_by_cell_from_summaries, projection_is_id_score_only, rerank_mult_from_law,
-        score_fine_candidates, select_global_shortlist, union_cell_selection,
-        vector_read_query_error,
+        score_fine_candidates, select_global_shortlist, stop_band_floor_override,
+        union_cell_selection, vector_read_query_error,
     };
     use crate::{
         BoolMode, InfinoError,
@@ -5452,6 +5561,40 @@ mod tests {
     /// Planted neighbors among `hits` (orthogonal docs score exactly 1.0).
     fn near_count(hits: &[SuperfileHit]) -> usize {
         hits.iter().filter(|h| h.score < ORTHOGONAL_SCORE).count()
+    }
+
+    /// The estimate-banded adaptive rerank returns exactly the planted
+    /// top-k with the band floor lowered to unit scale — bands partition
+    /// the same selected shortlist, so every planted neighbor either
+    /// reranks in an early band or the stop rule provably cannot fire
+    /// before its band (its estimate is within margin of the kth). Also
+    /// pins determinism: two identical banded searches return identical
+    /// hits. The floor override is process-global; this test asserts only
+    /// its own table's results.
+    #[test]
+    fn banded_adaptive_rerank_keeps_planted_neighbors_and_determinism() {
+        let (_dir, st, q, k) = drained_three_direction_fixture();
+        stop_band_floor_override::set(4);
+        let search = || {
+            st.reader()
+                .expect("reader")
+                .vector_hits("emb", &q, k, VectorSearchOptions::new(), None)
+                .expect("banded default search")
+        };
+        let first = search();
+        let second = search();
+        stop_band_floor_override::clear();
+        assert_eq!(
+            near_count(&first),
+            k,
+            "banded default search must keep every planted neighbor"
+        );
+        let key = |hits: &[SuperfileHit]| -> Vec<(u32, u32)> {
+            hits.iter()
+                .map(|h| (h.local_doc_id, h.score.to_bits()))
+                .collect()
+        };
+        assert_eq!(key(&first), key(&second), "banded search is deterministic");
     }
 
     /// Explicit caller `nprobe` widens the post-drain UNFILTERED cell sweep.

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1684,14 +1684,19 @@ impl SupertableReader {
         let mut gated = Vec::new();
         let mut scored = Vec::new();
         // Adaptive-width staging plan, captured at cell-selection time and
-        // consumed by the stage loop at the fan-out: the bulk cell set,
-        // each fine candidate's owning cell, and the escalation stop bound
-        // (the best fine-centroid DISTANCE among the escalation cells —
-        // `None` when any escalation cell is unbounded, which forces the
-        // escalation). Armed only on the law-served cosine default with a
+        // consumed by the wave loop at the fan-out: each selected cell's
+        // wave index (a geometric schedule over the routing order — bulk,
+        // then bulk more, then the remainder), each fine candidate's owning
+        // cell, and the escalation stop bound BEFORE each wave (the best
+        // fine-centroid DISTANCE over every cell from that wave onward —
+        // `None` when any of those cells is unbounded, which forces the
+        // wave). Armed only on the law-served cosine default with a
         // stamped bulk law + width margin.
-        let mut width_staging: Option<(HashSet<u32>, HashMap<(usize, u32), u32>, Option<f32>)> =
-            None;
+        let mut width_staging: Option<(
+            HashMap<u32, usize>,
+            HashMap<(usize, u32), u32>,
+            Vec<Option<f32>>,
+        )> = None;
         // Width the sweep was pinned to (caller nprobe or the width law);
         // `None` on the fine-first default and legacy paths.
         let mut sweep_width: Option<usize> = None;
@@ -2002,22 +2007,50 @@ impl SupertableReader {
                     && bulk > 0
                     && bulk < selected_cells_ordered.len()
                 {
-                    let bulk_cells: HashSet<u32> =
-                        selected_cells_ordered[..bulk].iter().copied().collect();
+                    let n = selected_cells_ordered.len();
+                    // Geometric wave schedule over the routing order: the
+                    // bulk width, then bulk more, then the remainder — a
+                    // query needing slightly more than the bulk pays one
+                    // extra wave, not the whole cap.
+                    let wave_starts: Vec<usize> = [0, bulk, (2 * bulk).min(n)]
+                        .into_iter()
+                        .chain(std::iter::once(n))
+                        .collect::<Vec<_>>()
+                        .windows(2)
+                        .filter(|w| w[1] > w[0])
+                        .map(|w| w[0])
+                        .collect();
+                    let mut wave_of_cell: HashMap<u32, usize> = HashMap::new();
+                    for (pos, cell) in selected_cells_ordered.iter().enumerate() {
+                        let wave = wave_starts
+                            .iter()
+                            .rposition(|&start| pos >= start)
+                            .unwrap_or(0);
+                        wave_of_cell.insert(*cell, wave);
+                    }
                     let cell_of: HashMap<(usize, u32), u32> = candidates
                         .iter()
                         .filter_map(|&(si, cluster, _, cell, _)| cell.map(|c| ((si, cluster), c)))
                         .collect();
-                    // The stop check needs EVERY escalation cell bounded by
-                    // its routing similarity; a cell without a fine score
-                    // cannot be bounded and forces the escalation.
+                    // Per-position suffix bound: the best fine-centroid
+                    // distance over every ordered cell from that position
+                    // onward; a cell without a fine score poisons every
+                    // suffix containing it (`None` ⇒ that wave always runs).
                     let fine_of: HashMap<u32, f32> = fine_ranked.iter().copied().collect();
-                    let bound = selected_cells_ordered[bulk..]
-                        .iter()
-                        .map(|c| fine_of.get(c).copied())
-                        .collect::<Option<Vec<f32>>>()
-                        .map(|ds| ds.into_iter().fold(f32::INFINITY, f32::min));
-                    width_staging = Some((bulk_cells, cell_of, bound));
+                    let mut suffix: Vec<Option<f32>> = vec![None; n + 1];
+                    suffix[n] = Some(f32::INFINITY);
+                    for pos in (0..n).rev() {
+                        suffix[pos] = match (
+                            fine_of.get(&selected_cells_ordered[pos]).copied(),
+                            suffix[pos + 1],
+                        ) {
+                            (Some(d), Some(rest)) => Some(d.min(rest)),
+                            _ => None,
+                        };
+                    }
+                    let wave_bounds: Vec<Option<f32>> =
+                        wave_starts.iter().map(|&start| suffix[start]).collect();
+                    width_staging = Some((wave_of_cell, cell_of, wave_bounds));
                 }
                 // Wave-pooled depth is the p=1 read-volume model: keep runs
                 // per drain wave so reads track wave count, not probed-cell
@@ -2482,7 +2515,7 @@ impl SupertableReader {
             .as_ref()
             .map(|r| r.width_margin)
             .unwrap_or(0.0);
-        let mut stage_bound: Option<f32> = None;
+        let mut stage_bounds: Vec<Option<f32>> = Vec::new();
         let stage_sets: Vec<
             Vec<(
                 Arc<SuperfileEntry>,
@@ -2492,28 +2525,32 @@ impl SupertableReader {
             .as_ref()
             .filter(|_| allow.is_none() && global_shortlist_width.is_some())
         {
-            Some((bulk_cells, cell_of, bound)) => {
-                let mut stage1 = Vec::new();
-                let mut stage2 = Vec::new();
+            Some((wave_of_cell, cell_of, wave_bounds)) => {
+                let n_waves = wave_bounds.len();
+                let mut waves: Vec<Vec<_>> = vec![Vec::new(); n_waves];
                 for (entry, (si, ids, bitmap)) in &units {
-                    let (bulk_ids, tail_ids): (Vec<u32>, Vec<u32>) = ids.iter().partition(|&&c| {
-                        cell_of
+                    let mut per_wave: Vec<Vec<u32>> = vec![Vec::new(); n_waves];
+                    for &c in ids {
+                        // Cell-less candidates ride wave 0 (probed
+                        // unconditionally — conservative).
+                        let wave = cell_of
                             .get(&(*si, c))
-                            .map(|cell| bulk_cells.contains(cell))
-                            .unwrap_or(true)
-                    });
-                    if !bulk_ids.is_empty() {
-                        stage1.push((Arc::clone(entry), (*si, bulk_ids, bitmap.clone())));
+                            .and_then(|cell| wave_of_cell.get(cell))
+                            .copied()
+                            .unwrap_or(0);
+                        per_wave[wave].push(c);
                     }
-                    if !tail_ids.is_empty() {
-                        stage2.push((Arc::clone(entry), (*si, tail_ids, bitmap.clone())));
+                    for (wave, wave_ids) in per_wave.into_iter().enumerate() {
+                        if !wave_ids.is_empty() {
+                            waves[wave].push((Arc::clone(entry), (*si, wave_ids, bitmap.clone())));
+                        }
                     }
                 }
-                if stage1.is_empty() || stage2.is_empty() {
-                    vec![units]
+                if waves.first().is_some_and(|w| !w.is_empty()) && n_waves > 1 {
+                    stage_bounds = wave_bounds.clone();
+                    waves
                 } else {
-                    stage_bound = *bound;
-                    vec![stage1, stage2]
+                    vec![units]
                 }
             }
             None => vec![units],
@@ -2536,7 +2573,7 @@ impl SupertableReader {
                     usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
                         .unwrap_or(0),
                 );
-                if let Some(bound_dist) = stage_bound
+                if let Some(bound_dist) = stage_bounds.get(stage_idx).copied().flatten()
                     && k_stop > 0
                 {
                     let mut dists: Vec<f32> =

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1683,6 +1683,15 @@ impl SupertableReader {
 
         let mut gated = Vec::new();
         let mut scored = Vec::new();
+        // Adaptive-width staging plan, captured at cell-selection time and
+        // consumed by the stage loop at the fan-out: the bulk cell set,
+        // each fine candidate's owning cell, and the escalation stop bound
+        // (the best fine-centroid DISTANCE among the escalation cells —
+        // `None` when any escalation cell is unbounded, which forces the
+        // escalation). Armed only on the law-served cosine default with a
+        // stamped bulk law + width margin.
+        let mut width_staging: Option<(HashSet<u32>, HashMap<(usize, u32), u32>, Option<f32>)> =
+            None;
         // Width the sweep was pinned to (caller nprobe or the width law);
         // `None` on the fine-first default and legacy paths.
         let mut sweep_width: Option<usize> = None;
@@ -1982,6 +1991,34 @@ impl SupertableReader {
                     );
                 }
                 let selected_cells: HashSet<u32> = selected_cells_ordered.iter().copied().collect();
+                // Two-stage width: probe the bulk-law cells first; the rest
+                // of the law width escalates only when the calibrated width
+                // margin cannot rule those cells out against the running
+                // kth exact score (see the stage loop at the fan-out).
+                if law_default
+                    && let Some(routing_ref) = hidden_routing.as_ref()
+                    && routing_ref.width_margin > 0.0
+                    && let Some(bulk) = routing_ref.width_bulk_for_k_at(k)
+                    && bulk > 0
+                    && bulk < selected_cells_ordered.len()
+                {
+                    let bulk_cells: HashSet<u32> =
+                        selected_cells_ordered[..bulk].iter().copied().collect();
+                    let cell_of: HashMap<(usize, u32), u32> = candidates
+                        .iter()
+                        .filter_map(|&(si, cluster, _, cell, _)| cell.map(|c| ((si, cluster), c)))
+                        .collect();
+                    // The stop check needs EVERY escalation cell bounded by
+                    // its routing similarity; a cell without a fine score
+                    // cannot be bounded and forces the escalation.
+                    let fine_of: HashMap<u32, f32> = fine_ranked.iter().copied().collect();
+                    let bound = selected_cells_ordered[bulk..]
+                        .iter()
+                        .map(|c| fine_of.get(c).copied())
+                        .collect::<Option<Vec<f32>>>()
+                        .map(|ds| ds.into_iter().fold(f32::INFINITY, f32::min));
+                    width_staging = Some((bulk_cells, cell_of, bound));
+                }
                 // Wave-pooled depth is the p=1 read-volume model: keep runs
                 // per drain wave so reads track wave count, not probed-cell
                 // count — which also means widening the cell sweep alone
@@ -2434,229 +2471,381 @@ impl SupertableReader {
         // carries no bitmaps and fans out all units at once (matching
         // main's concurrency — every superfile GET overlaps on tokio).
         let fanout_t0 = io_counters::phase_start();
-        let mut per_superfile = if allow.is_some() {
-            let fanout_width = manifest.options.reader_pool.current_num_threads().max(1);
-            let mut collected = Vec::new();
-            while !units.is_empty() {
-                let n = fanout_width.min(units.len());
-                let wave: Vec<_> = units.drain(..n).collect();
-                collected.extend(
-                    dispatch::fanout_with(self, wave, !hidden_vector_index, false, body.clone())
-                        .await?,
-                );
-            }
-            collected
-        } else {
-            dispatch::fanout_with(self, units, !hidden_vector_index, false, body).await?
-        };
-
-        // Phase C of the deferred-rerank width sweep: select the best
-        // `k x rerank_mult` estimates ACROSS every warm-scanned cell and
-        // superfile, then rerank only those winners where they live. The
-        // estimates are comparable across units — one rotation seed per
-        // column, table-wide — asserted here at the only place different
-        // units' estimates ever meet.
-        if global_shortlist_width.is_some() {
-            // Rerank rows are deliberately NOT in the priced range
-            // counter: `planned_read_ranges` is request-shaped (numbers
-            // commensurate with real object-store requests, which
-            // coalesce survivor rows into a handful of GETs), and the
-            // platform prices it at a per-request rate. The rerank leg's
-            // cost is CPU-dominated and carried by the priced CPU
-            // watermark; the row counts stay visible in the
-            // rows-reranked / candidates diagnostics.
-            let pooled = {
-                let mut guard = scan_pool.lock().unwrap_or_else(PoisonError::into_inner);
-                mem::take(&mut *guard)
-            };
-            if !pooled.is_empty() {
-                // Hard error, not debug_assert: this is the one site where
-                // estimates from different superfiles are pooled and ranked
-                // against each other. Backstopped by the open-time seed
-                // check today, but if a future path ever admits a
-                // differently-seeded unit, fail the query loudly instead of
-                // silently ranking incomparable estimates.
-                if pooled.windows(2).any(|w| w[0].1 != w[1].1) {
-                    return Err(QueryError::Execute(
-                        "pooled 1-bit estimates require one rotation seed per column".into(),
-                    ));
-                }
-                // Mirror phase A/C's `k_fetch = k + replica_overhead` in the
-                // global cut so boundary replicas (dormant today: overhead
-                // is 0 with replication off) cannot take shortlist slots
-                // from distinct rows before the stable-id dedup. Taken
-                // over ALL scanned units — not just the pooled (warm)
-                // ones — so under replication the selection cap is
-                // temperature-invariant and always agrees with the
-                // canonical priced budget above, which uses the same max.
-                // (Pooled membership shifts with cache temperature: a
-                // fully cold unit reranks in-scan and pools nothing, so
-                // a pooled-only max could shrink the cap on cold runs.)
-                let replica_overhead =
-                    usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
-                        .unwrap_or(0);
-                let mut flat: Vec<(usize, ScanCandidate)> = pooled
-                    .into_iter()
-                    .flat_map(|(si, _, _, cands)| cands.into_iter().map(move |c| (si, c)))
-                    .collect();
-                // Per-cell floor ONLY under an explicit caller nprobe. The
-                // floor exists for the #494 inversion — far cells' 1-bit
-                // noise evicting near cells' true neighbors from the fixed
-                // budget as a CALLER widens the sweep — so it guards
-                // exactly the widths a caller pins. Law-served defaults
-                // are calibrated against realized recall at their own
-                // stamped width and run floor-free: at law widths the
-                // floor measured +0.0001 recall for ~3.4 ms of extra
-                // rerank at k=100 (Cohere-1M), and at width 1-2 it is a
-                // near-no-op by construction. Re-measured at the WIDENED
-                // widths the #515 admit extension serves (Cohere defaults
-                // with the loop active, diffuse stamps both k): still
-                // floor-free, 0.9955 @ k=100 and 0.9940 @ k=10 — above
-                // the stamped-width baseline, no inversion dip. If a
-                // future gate dips, the targeted fix is arming floor = k
-                // on the extension subset only, not on the law's picks.
-                // Floor = k when it applies:
-                // even if the entire true top-k concentrates in one probed
-                // cell, that cell's floor carries it into the exact rerank
-                // (replicas never collide inside one cell, so the floor
-                // needs no replica overhead).
-                //
-                // (#537) The floor's DEPTH must not shrink as the caller
-                // widens — and the depth that holds recall is the full
-                // per-cell budget, not a share of it. The measured 10M
-                // ladder (see the width-divide comment above the fan-out)
-                // tracks per-cell retention depth almost mechanically:
-                // whole-cell retention serves 0.993, ~6% of a cell serves
-                // 0.85, 20 rows serves 0.51 — in-cell 1-bit ranking is
-                // too weak to concentrate the true neighbors into a thin
-                // cut, so no fixed pool or stamped share survives a wide
-                // sweep. Under an explicit caller nprobe every scanned
-                // cell therefore keeps the same k x rerank_mult depth the
-                // narrow probe would give it: widening adds cells at
-                // constant depth, the exact rerank adjudicates, and cost
-                // is linear in the width the caller asked for — the pin
-                // arm's stated semantics.
-                let cell_floor = if options.nprobe.is_some() {
-                    k.saturating_mul(plan_rerank_mult)
-                } else {
-                    0
-                };
-                // (#515) The LAW's rerank budget is calibrated on drain
-                // rows at the stamped width; when the serve window extends
-                // serving past that width, the same budget starves the
-                // widened candidate set — measured at true defaults on
-                // BioASQ-1M: stamped budget serves 0.9510 where the knee
-                // sits at ~3-6x (rm=32 → 0.9820, rm=64 → 0.9880, flat by
-                // 128). Scale the pooled budget by served-cells over
-                // stamped-width, so the pool grows exactly with the cells
-                // the evidence serves: BioASQ lands at the measured knee;
-                // decisive geometry serves width == stamp and is
-                // unchanged. Explicit caller rerank_mult stays an exact,
-                // unscaled request.
-                let shortlist_limit = deferred_shortlist_limit(
-                    k,
-                    replica_overhead,
-                    plan_rerank_mult,
-                    law_rerank_served,
-                    options.nprobe.is_some(),
-                    served_cells_over_width,
-                );
-                // Regression probe for the serve-the-law scope bug: recall
-                // floors can't see a re-shadowed `options` (the constant
-                // budget only ADDS survivors); the served limit can.
-                #[cfg(feature = "test-helpers")]
-                served_shortlist_probe::record(shortlist_limit, cell_floor);
-                flat = select_global_shortlist(flat, shortlist_limit, cell_floor);
-                let column = Arc::clone(&column_arc2);
-                let query = Arc::clone(&query_arc2);
-                let reader_pool = Arc::clone(&manifest.options.reader_pool);
-                let op_stats_c = self.op_stats.clone();
-                let body_c = move |reader: Arc<SuperfileReader>,
-                                   entry: Arc<SuperfileEntry>,
-                                   _tombstone_cache: Option<Arc<SidecarCache>>,
-                                   _now: Instant,
-                                   selected: Vec<ScanCandidate>| {
-                    let column = Arc::clone(&column);
-                    let query = Arc::clone(&query);
-                    let reader_pool = Arc::clone(&reader_pool);
-                    let op_stats = op_stats_c.clone();
-                    async move {
-                        // Hidden-path invariants: no tombstone sidecars (the
-                        // manifest's deletes apply after the stable-id
-                        // remap upstream), replica slack mirrors phase A.
-                        let replica_overhead = reader
-                            .vec()
-                            .map(|v| (v.n_docs() as usize).saturating_sub(reader.n_docs() as usize))
-                            .unwrap_or(0);
-                        let k_fetch = k.saturating_add(replica_overhead);
-                        let reader_for_ids = Arc::clone(&reader);
-                        let (hits, rerank_kernel_ns) = reader
-                            .vector_rerank_selected(
-                                &column,
-                                &query,
-                                k_fetch,
-                                selected,
-                                Some(reader_pool),
-                            )
-                            .await
-                            .map_err(vector_read_query_error)?;
-                        if let Some(stats) = &op_stats {
-                            stats.add_kernel_cpu_ns(rerank_kernel_ns);
-                        }
-                        let mut tagged = dispatch::tag_hits(&entry, hits);
-                        io_counters::phase_timed_async("vec.stable_id", async {
-                            dispatch::attach_stable_ids(
-                                &reader_for_ids,
-                                &entry,
-                                &mut tagged,
-                                false,
-                                &op_stats,
-                            )
-                            .await
-                        })
-                        .await?;
-                        Ok::<Vec<SuperfileHit>, QueryError>(tagged)
+        // Adaptive-width stages: when the plan is armed (law-served cosine
+        // default with a stamped bulk law + margin), partition the fan-out
+        // units by each fine cluster's owning cell — stage 1 = bulk cells
+        // (plus any candidate without a cell tag, conservatively), stage 2
+        // = the escalation remainder, probed only when the width margin
+        // cannot rule its cells out against the running kth exact score.
+        // One stage = today's path, byte-for-byte.
+        let width_margin_val = hidden_routing
+            .as_ref()
+            .map(|r| r.width_margin)
+            .unwrap_or(0.0);
+        let mut stage_bound: Option<f32> = None;
+        let stage_sets: Vec<
+            Vec<(
+                Arc<SuperfileEntry>,
+                (usize, Vec<u32>, Option<Arc<RoaringBitmap>>),
+            )>,
+        > = match width_staging
+            .as_ref()
+            .filter(|_| allow.is_none() && global_shortlist_width.is_some())
+        {
+            Some((bulk_cells, cell_of, bound)) => {
+                let mut stage1 = Vec::new();
+                let mut stage2 = Vec::new();
+                for (entry, (si, ids, bitmap)) in &units {
+                    let (bulk_ids, tail_ids): (Vec<u32>, Vec<u32>) = ids.iter().partition(|&&c| {
+                        cell_of
+                            .get(&(*si, c))
+                            .map(|cell| bulk_cells.contains(cell))
+                            .unwrap_or(true)
+                    });
+                    if !bulk_ids.is_empty() {
+                        stage1.push((Arc::clone(entry), (*si, bulk_ids, bitmap.clone())));
                     }
-                };
-                // Adaptive stopping: on the law-served default (never under
-                // caller overrides), walk the shortlist in estimate bands —
-                // half the remainder per band, floored — and stop once no
-                // unprocessed candidate can reach the running kth exact
-                // score even granted its estimate plus the calibrated
-                // margin. A stamped margin (> 0) is cosine-only evidence
-                // by construction (the calibration measures gaps on cosine
-                // tables alone), so `BASE − distance` is the exact
-                // similarity scale here. The stamped rerank budget already
-                // capped the shortlist above — stopping only SKIPS work,
-                // never adds candidates.
-                let stop_margin = hidden_routing
-                    .as_ref()
-                    .map(|r| r.rerank_margin)
-                    .filter(|&m| m > 0.0)
-                    .filter(|_| law_rerank_served && options.nprobe.is_none());
-                let band_floor = stop_band_min_rows();
-                let banded = match stop_margin {
-                    Some(margin) if flat.len() > 2 * band_floor => Some(margin),
-                    _ => None,
-                };
-                if let Some(margin) = banded {
-                    // The selection's own total order — deterministic bands.
-                    flat.sort_unstable_by(shortlist_total_order);
-                    // The stop rule's kth is over raw reranked hits;
-                    // replica duplicates (dedup happens downstream) can
-                    // only WEAKEN the kth, firing the stop later — safe.
-                    let k_stop = k.saturating_add(replica_overhead);
-                    let mut exact_dists: Vec<f32> = Vec::new();
-                    let mut cursor = 0usize;
-                    while cursor < flat.len() {
-                        let remaining = flat.len() - cursor;
-                        let band_len = (remaining / 2).max(band_floor).min(remaining);
-                        let band_end = cursor + band_len;
-                        let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
-                        for (si, cand) in &flat[cursor..band_end] {
-                            winners_by_seg.entry(*si).or_default().push(*cand);
+                    if !tail_ids.is_empty() {
+                        stage2.push((Arc::clone(entry), (*si, tail_ids, bitmap.clone())));
+                    }
+                }
+                if stage1.is_empty() || stage2.is_empty() {
+                    vec![units]
+                } else {
+                    stage_bound = *bound;
+                    vec![stage1, stage2]
+                }
+            }
+            None => vec![units],
+        };
+        let mut per_superfile: Vec<Vec<SuperfileHit>> = Vec::new();
+        // Pooled candidates retained ACROSS stages (the global selection in
+        // a later stage competes old and new candidates together), plus the
+        // identity keys of candidates already exactly reranked, so a row
+        // never reranks twice.
+        let mut flat_retained: Vec<(usize, ScanCandidate)> = Vec::new();
+        let mut reranked_keys: HashSet<(usize, usize, u32, u32)> = HashSet::new();
+        for (stage_idx, stage_units) in stage_sets.into_iter().enumerate() {
+            if stage_idx > 0 {
+                // Escalation stop: no remaining cell's best routing
+                // similarity plus the calibrated margin can reach the
+                // running kth exact score — the tail cells cannot change
+                // the top-k. An unbounded tail (any escalation cell
+                // without a fine score) always escalates.
+                let k_stop = k.saturating_add(
+                    usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
+                        .unwrap_or(0),
+                );
+                if let Some(bound_dist) = stage_bound
+                    && k_stop > 0
+                {
+                    let mut dists: Vec<f32> =
+                        per_superfile.iter().flatten().map(|h| h.score).collect();
+                    if dists.len() >= k_stop {
+                        let (_, kth, _) = dists.select_nth_unstable_by(k_stop - 1, f32::total_cmp);
+                        if width_escalation_stops(*kth, bound_dist, width_margin_val) {
+                            break;
                         }
-                        cursor = band_end;
+                    }
+                }
+            }
+            let mut stage_units = stage_units;
+            let stage_hits = if allow.is_some() {
+                let fanout_width = manifest.options.reader_pool.current_num_threads().max(1);
+                let mut collected = Vec::new();
+                while !stage_units.is_empty() {
+                    let n = fanout_width.min(stage_units.len());
+                    let wave: Vec<_> = stage_units.drain(..n).collect();
+                    collected.extend(
+                        dispatch::fanout_with(
+                            self,
+                            wave,
+                            !hidden_vector_index,
+                            false,
+                            body.clone(),
+                        )
+                        .await?,
+                    );
+                }
+                collected
+            } else {
+                dispatch::fanout_with(self, stage_units, !hidden_vector_index, false, body.clone())
+                    .await?
+            };
+            per_superfile.extend(stage_hits);
+
+            // Phase C of the deferred-rerank width sweep: select the best
+            // `k x rerank_mult` estimates ACROSS every warm-scanned cell and
+            // superfile, then rerank only those winners where they live. The
+            // estimates are comparable across units — one rotation seed per
+            // column, table-wide — asserted here at the only place different
+            // units' estimates ever meet.
+            if global_shortlist_width.is_some() {
+                // Rerank rows are deliberately NOT in the priced range
+                // counter: `planned_read_ranges` is request-shaped (numbers
+                // commensurate with real object-store requests, which
+                // coalesce survivor rows into a handful of GETs), and the
+                // platform prices it at a per-request rate. The rerank leg's
+                // cost is CPU-dominated and carried by the priced CPU
+                // watermark; the row counts stay visible in the
+                // rows-reranked / candidates diagnostics.
+                let pooled = {
+                    let mut guard = scan_pool.lock().unwrap_or_else(PoisonError::into_inner);
+                    mem::take(&mut *guard)
+                };
+                if !pooled.is_empty() {
+                    // Hard error, not debug_assert: this is the one site where
+                    // estimates from different superfiles are pooled and ranked
+                    // against each other. Backstopped by the open-time seed
+                    // check today, but if a future path ever admits a
+                    // differently-seeded unit, fail the query loudly instead of
+                    // silently ranking incomparable estimates.
+                    if pooled.windows(2).any(|w| w[0].1 != w[1].1) {
+                        return Err(QueryError::Execute(
+                            "pooled 1-bit estimates require one rotation seed per column".into(),
+                        ));
+                    }
+                    // Mirror phase A/C's `k_fetch = k + replica_overhead` in the
+                    // global cut so boundary replicas (dormant today: overhead
+                    // is 0 with replication off) cannot take shortlist slots
+                    // from distinct rows before the stable-id dedup. Taken
+                    // over ALL scanned units — not just the pooled (warm)
+                    // ones — so under replication the selection cap is
+                    // temperature-invariant and always agrees with the
+                    // canonical priced budget above, which uses the same max.
+                    // (Pooled membership shifts with cache temperature: a
+                    // fully cold unit reranks in-scan and pools nothing, so
+                    // a pooled-only max could shrink the cap on cold runs.)
+                    let replica_overhead =
+                        usize::try_from(max_replica_overhead.load(atomic::Ordering::Relaxed))
+                            .unwrap_or(0);
+                    flat_retained.extend(
+                        pooled
+                            .into_iter()
+                            .flat_map(|(si, _, _, cands)| cands.into_iter().map(move |c| (si, c))),
+                    );
+                    let mut flat: Vec<(usize, ScanCandidate)> = flat_retained.clone();
+                    // Per-cell floor ONLY under an explicit caller nprobe. The
+                    // floor exists for the #494 inversion — far cells' 1-bit
+                    // noise evicting near cells' true neighbors from the fixed
+                    // budget as a CALLER widens the sweep — so it guards
+                    // exactly the widths a caller pins. Law-served defaults
+                    // are calibrated against realized recall at their own
+                    // stamped width and run floor-free: at law widths the
+                    // floor measured +0.0001 recall for ~3.4 ms of extra
+                    // rerank at k=100 (Cohere-1M), and at width 1-2 it is a
+                    // near-no-op by construction. Re-measured at the WIDENED
+                    // widths the #515 admit extension serves (Cohere defaults
+                    // with the loop active, diffuse stamps both k): still
+                    // floor-free, 0.9955 @ k=100 and 0.9940 @ k=10 — above
+                    // the stamped-width baseline, no inversion dip. If a
+                    // future gate dips, the targeted fix is arming floor = k
+                    // on the extension subset only, not on the law's picks.
+                    // Floor = k when it applies:
+                    // even if the entire true top-k concentrates in one probed
+                    // cell, that cell's floor carries it into the exact rerank
+                    // (replicas never collide inside one cell, so the floor
+                    // needs no replica overhead).
+                    //
+                    // (#537) The floor's DEPTH must not shrink as the caller
+                    // widens — and the depth that holds recall is the full
+                    // per-cell budget, not a share of it. The measured 10M
+                    // ladder (see the width-divide comment above the fan-out)
+                    // tracks per-cell retention depth almost mechanically:
+                    // whole-cell retention serves 0.993, ~6% of a cell serves
+                    // 0.85, 20 rows serves 0.51 — in-cell 1-bit ranking is
+                    // too weak to concentrate the true neighbors into a thin
+                    // cut, so no fixed pool or stamped share survives a wide
+                    // sweep. Under an explicit caller nprobe every scanned
+                    // cell therefore keeps the same k x rerank_mult depth the
+                    // narrow probe would give it: widening adds cells at
+                    // constant depth, the exact rerank adjudicates, and cost
+                    // is linear in the width the caller asked for — the pin
+                    // arm's stated semantics.
+                    let cell_floor = if options.nprobe.is_some() {
+                        k.saturating_mul(plan_rerank_mult)
+                    } else {
+                        0
+                    };
+                    // (#515) The LAW's rerank budget is calibrated on drain
+                    // rows at the stamped width; when the serve window extends
+                    // serving past that width, the same budget starves the
+                    // widened candidate set — measured at true defaults on
+                    // BioASQ-1M: stamped budget serves 0.9510 where the knee
+                    // sits at ~3-6x (rm=32 → 0.9820, rm=64 → 0.9880, flat by
+                    // 128). Scale the pooled budget by served-cells over
+                    // stamped-width, so the pool grows exactly with the cells
+                    // the evidence serves: BioASQ lands at the measured knee;
+                    // decisive geometry serves width == stamp and is
+                    // unchanged. Explicit caller rerank_mult stays an exact,
+                    // unscaled request.
+                    let shortlist_limit = deferred_shortlist_limit(
+                        k,
+                        replica_overhead,
+                        plan_rerank_mult,
+                        law_rerank_served,
+                        options.nprobe.is_some(),
+                        served_cells_over_width,
+                    );
+                    // Regression probe for the serve-the-law scope bug: recall
+                    // floors can't see a re-shadowed `options` (the constant
+                    // budget only ADDS survivors); the served limit can.
+                    #[cfg(feature = "test-helpers")]
+                    served_shortlist_probe::record(shortlist_limit, cell_floor);
+                    flat = select_global_shortlist(flat, shortlist_limit, cell_floor);
+                    // A later stage must not rerank rows an earlier stage
+                    // already scored exactly (their hits are already pooled).
+                    flat.retain(|(si, c)| {
+                        !reranked_keys.contains(&(*si, c.cell_idx, c.pos, c.did))
+                    });
+                    let column = Arc::clone(&column_arc2);
+                    let query = Arc::clone(&query_arc2);
+                    let reader_pool = Arc::clone(&manifest.options.reader_pool);
+                    let op_stats_c = self.op_stats.clone();
+                    let body_c =
+                        move |reader: Arc<SuperfileReader>,
+                              entry: Arc<SuperfileEntry>,
+                              _tombstone_cache: Option<Arc<SidecarCache>>,
+                              _now: Instant,
+                              selected: Vec<ScanCandidate>| {
+                            let column = Arc::clone(&column);
+                            let query = Arc::clone(&query);
+                            let reader_pool = Arc::clone(&reader_pool);
+                            let op_stats = op_stats_c.clone();
+                            async move {
+                                // Hidden-path invariants: no tombstone sidecars (the
+                                // manifest's deletes apply after the stable-id
+                                // remap upstream), replica slack mirrors phase A.
+                                let replica_overhead = reader
+                                    .vec()
+                                    .map(|v| {
+                                        (v.n_docs() as usize)
+                                            .saturating_sub(reader.n_docs() as usize)
+                                    })
+                                    .unwrap_or(0);
+                                let k_fetch = k.saturating_add(replica_overhead);
+                                let reader_for_ids = Arc::clone(&reader);
+                                let (hits, rerank_kernel_ns) = reader
+                                    .vector_rerank_selected(
+                                        &column,
+                                        &query,
+                                        k_fetch,
+                                        selected,
+                                        Some(reader_pool),
+                                    )
+                                    .await
+                                    .map_err(vector_read_query_error)?;
+                                if let Some(stats) = &op_stats {
+                                    stats.add_kernel_cpu_ns(rerank_kernel_ns);
+                                }
+                                let mut tagged = dispatch::tag_hits(&entry, hits);
+                                io_counters::phase_timed_async("vec.stable_id", async {
+                                    dispatch::attach_stable_ids(
+                                        &reader_for_ids,
+                                        &entry,
+                                        &mut tagged,
+                                        false,
+                                        &op_stats,
+                                    )
+                                    .await
+                                })
+                                .await?;
+                                Ok::<Vec<SuperfileHit>, QueryError>(tagged)
+                            }
+                        };
+                    // Adaptive stopping: on the law-served default (never under
+                    // caller overrides), walk the shortlist in estimate bands —
+                    // half the remainder per band, floored — and stop once no
+                    // unprocessed candidate can reach the running kth exact
+                    // score even granted its estimate plus the calibrated
+                    // margin. A stamped margin (> 0) is cosine-only evidence
+                    // by construction (the calibration measures gaps on cosine
+                    // tables alone), so `BASE − distance` is the exact
+                    // similarity scale here. The stamped rerank budget already
+                    // capped the shortlist above — stopping only SKIPS work,
+                    // never adds candidates.
+                    let stop_margin = hidden_routing
+                        .as_ref()
+                        .map(|r| r.rerank_margin)
+                        .filter(|&m| m > 0.0)
+                        .filter(|_| law_rerank_served && options.nprobe.is_none());
+                    let band_floor = stop_band_min_rows();
+                    let banded = match stop_margin {
+                        Some(margin) if flat.len() > 2 * band_floor => Some(margin),
+                        _ => None,
+                    };
+                    if let Some(margin) = banded {
+                        // The selection's own total order — deterministic bands.
+                        flat.sort_unstable_by(shortlist_total_order);
+                        // The stop rule's kth is over raw reranked hits;
+                        // replica duplicates (dedup happens downstream) can
+                        // only WEAKEN the kth, firing the stop later — safe.
+                        let k_stop = k.saturating_add(replica_overhead);
+                        let mut exact_dists: Vec<f32> = Vec::new();
+                        let mut cursor = 0usize;
+                        while cursor < flat.len() {
+                            let remaining = flat.len() - cursor;
+                            let band_len = (remaining / 2).max(band_floor).min(remaining);
+                            let band_end = cursor + band_len;
+                            let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> =
+                                HashMap::new();
+                            for (si, cand) in &flat[cursor..band_end] {
+                                reranked_keys.insert((*si, cand.cell_idx, cand.pos, cand.did));
+                                winners_by_seg.entry(*si).or_default().push(*cand);
+                            }
+                            cursor = band_end;
+                            let rerank_units: Vec<(Arc<SuperfileEntry>, Vec<ScanCandidate>)> =
+                                superfiles
+                                    .iter()
+                                    .enumerate()
+                                    .filter_map(|(si, entry)| {
+                                        winners_by_seg
+                                            .remove(&si)
+                                            .map(|sel| (Arc::clone(entry), sel))
+                                    })
+                                    .collect();
+                            if let Some(stats) = &self.op_stats {
+                                // Actual rows this band reranks — skipped bands
+                                // never reach the counter, so the diagnostic
+                                // reflects the adaptive work, not the cap.
+                                let rows: u64 =
+                                    rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
+                                stats.add_vector_rows_reranked(rows);
+                            }
+                            let band_hits = dispatch::fanout_with(
+                                self,
+                                rerank_units,
+                                false,
+                                false,
+                                body_c.clone(),
+                            )
+                            .await?;
+                            let done = cursor >= flat.len();
+                            if !done {
+                                exact_dists.extend(band_hits.iter().flatten().map(|h| h.score));
+                                exact_dists.sort_unstable_by(f32::total_cmp);
+                                exact_dists.truncate(k_stop);
+                            }
+                            per_superfile.extend(band_hits);
+                            if done {
+                                break;
+                            }
+                            if exact_dists.len() >= k_stop
+                                && let Some(&kth_dist) = exact_dists.last()
+                            {
+                                let kth_sim = COSINE_DISTANCE_BASE - kth_dist;
+                                let next_best_est = flat[cursor].1.estimate;
+                                if next_best_est + margin < kth_sim {
+                                    break;
+                                }
+                            }
+                        }
+                    } else {
+                        let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
+                        for (si, cand) in flat {
+                            reranked_keys.insert((si, cand.cell_idx, cand.pos, cand.did));
+                            winners_by_seg.entry(si).or_default().push(cand);
+                        }
                         let rerank_units: Vec<(Arc<SuperfileEntry>, Vec<ScanCandidate>)> =
                             superfiles
                                 .iter()
@@ -2668,60 +2857,17 @@ impl SupertableReader {
                                 })
                                 .collect();
                         if let Some(stats) = &self.op_stats {
-                            // Actual rows this band reranks — skipped bands
-                            // never reach the counter, so the diagnostic
-                            // reflects the adaptive work, not the cap.
+                            // Actual winner rows; their planned ranges were
+                            // priced canonically above, from the budget these
+                            // winners were selected under.
                             let rows: u64 =
                                 rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
                             stats.add_vector_rows_reranked(rows);
                         }
-                        let band_hits =
-                            dispatch::fanout_with(self, rerank_units, false, false, body_c.clone())
-                                .await?;
-                        let done = cursor >= flat.len();
-                        if !done {
-                            exact_dists.extend(band_hits.iter().flatten().map(|h| h.score));
-                            exact_dists.sort_unstable_by(f32::total_cmp);
-                            exact_dists.truncate(k_stop);
-                        }
-                        per_superfile.extend(band_hits);
-                        if done {
-                            break;
-                        }
-                        if exact_dists.len() >= k_stop
-                            && let Some(&kth_dist) = exact_dists.last()
-                        {
-                            let kth_sim = COSINE_DISTANCE_BASE - kth_dist;
-                            let next_best_est = flat[cursor].1.estimate;
-                            if next_best_est + margin < kth_sim {
-                                break;
-                            }
-                        }
+                        per_superfile.extend(
+                            dispatch::fanout_with(self, rerank_units, false, false, body_c).await?,
+                        );
                     }
-                } else {
-                    let mut winners_by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
-                    for (si, cand) in flat {
-                        winners_by_seg.entry(si).or_default().push(cand);
-                    }
-                    let rerank_units: Vec<(Arc<SuperfileEntry>, Vec<ScanCandidate>)> = superfiles
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(si, entry)| {
-                            winners_by_seg
-                                .remove(&si)
-                                .map(|sel| (Arc::clone(entry), sel))
-                        })
-                        .collect();
-                    if let Some(stats) = &self.op_stats {
-                        // Actual winner rows; their planned ranges were
-                        // priced canonically above, from the budget these
-                        // winners were selected under.
-                        let rows: u64 = rerank_units.iter().map(|(_, sel)| sel.len() as u64).sum();
-                        stats.add_vector_rows_reranked(rows);
-                    }
-                    per_superfile.extend(
-                        dispatch::fanout_with(self, rerank_units, false, false, body_c).await?,
-                    );
                 }
             }
         }
@@ -3921,6 +4067,18 @@ fn deferred_shortlist_limit(
     }
 }
 
+/// The adaptive-width escalation stop: `true` when no remaining cell's
+/// best routing similarity (`COSINE_DISTANCE_BASE − bound_dist`, the best
+/// fine-centroid distance among the escalation cells) plus the calibrated
+/// width margin can reach the running kth exact similarity — the tail
+/// cells provably cannot change the top-k, so stage 2 is skipped. All
+/// quantities are on the cosine similarity scale; the margin is only ever
+/// stamped on cosine tables.
+fn width_escalation_stops(kth_dist: f32, bound_dist: f32, width_margin: f32) -> bool {
+    let kth_sim = COSINE_DISTANCE_BASE - kth_dist;
+    (COSINE_DISTANCE_BASE - bound_dist) + width_margin < kth_sim
+}
+
 /// The shortlist's total order: best estimate first, ties on
 /// `(unit, cell, pos, did)` — shared by [`select_global_shortlist`]'s cut
 /// and the adaptive-stopping band sort so both walk one deterministic
@@ -4197,7 +4355,7 @@ mod tests {
         hidden_hits_user_ids, is_hidden_vector_manifest, law_floor_serve_selection,
         postings_by_cell_from_summaries, projection_is_id_score_only, rerank_mult_from_law,
         score_fine_candidates, select_global_shortlist, stop_band_floor_override,
-        union_cell_selection, vector_read_query_error,
+        union_cell_selection, vector_read_query_error, width_escalation_stops,
     };
     use crate::{
         BoolMode, InfinoError,
@@ -5889,6 +6047,22 @@ mod tests {
     /// Planted neighbors among `hits` (orthogonal docs score exactly 1.0).
     fn near_count(hits: &[SuperfileHit]) -> usize {
         hits.iter().filter(|h| h.score < ORTHOGONAL_SCORE).count()
+    }
+
+    /// The width-escalation stop is conservative in every direction: it
+    /// fires only when the margin-padded best possible similarity of the
+    /// tail cells sits strictly below the kth exact similarity, and any
+    /// tie or unbounded margin keeps probing.
+    #[test]
+    fn width_escalation_stop_rule_is_conservative() {
+        // kth_sim = 0.9; tail's best routing sim = 0.5. Margin 0.3 pads to
+        // 0.8 < 0.9 → stop. Margin 0.5 pads to 1.0 ≥ 0.9 → keep probing.
+        assert!(width_escalation_stops(0.1, 0.5, 0.3));
+        assert!(!width_escalation_stops(0.1, 0.5, 0.5));
+        // Exact tie must NOT stop (strict inequality): 0.5 + 0.4 == 0.9.
+        assert!(!width_escalation_stops(0.1, 0.5, 0.4));
+        // A tail cell ranked better than the kth never stops, margin 0.
+        assert!(!width_escalation_stops(0.5, 0.1, 0.0));
     }
 
     /// The estimate-banded adaptive rerank returns exactly the planted

--- a/src/supertable/utils/vector_split.rs
+++ b/src/supertable/utils/vector_split.rs
@@ -226,6 +226,7 @@ mod tests {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }
     }
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -4198,6 +4198,13 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                 &mut routing.rerank_for_k,
                 &routing.rerank_pool_cells,
             );
+            // Stop margin follows the same shrink discipline as the drain's
+            // rerank merge: keep the LARGER (more conservative) margin — a
+            // wider margin only stops later. The recalibration pass replaces
+            // it under current evidence, like the rerank law.
+            if laws.rerank_margin > routing.rerank_margin {
+                routing.rerank_margin = laws.rerank_margin;
+            }
             info!(
                 "supertable drain: probe laws at k={WIDTH_LAW_KS:?}: width measured {:?} stamped {:?}; fine depth measured {:?} stamped {:?}; rerank measured {:?} stamped {:?}",
                 laws.width_for_k,
@@ -7453,6 +7460,15 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
                     *pool = laws.pool_cells;
                 }
             }
+            // The stop margin rides the same evidence gate: measured over
+            // the full current superfile set with the serving-exact
+            // estimator, it replaces (a fresh sharper-estimator margin is
+            // SMALLER, and max-merge would pin the blunter one forever).
+            // `0.0` (no cosine evidence) keeps the previous value, like an
+            // unsupported rerank knot.
+            if laws.rerank_margin > 0.0 {
+                routing.rerank_margin = laws.rerank_margin;
+            }
         } else {
             opann::merge_rerank_with_pools(
                 &mut routing.rerank_for_k,
@@ -7460,6 +7476,9 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
                 &laws.rerank_for_k,
                 laws.pool_cells,
             );
+            if laws.rerank_margin > routing.rerank_margin {
+                routing.rerank_margin = laws.rerank_margin;
+            }
         }
         opann::clear_rerank_beyond_pool(
             &routing.width_for_k,

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -3429,7 +3429,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         && completed_shards.is_empty()
         && local_checkpoint.spills.is_empty();
     let mut width_law = clean_uncheckpointed_drain
-        .then(|| opann::WidthLawCalibration::new(running_clusters.dim as usize, metric, false));
+        .then(|| opann::WidthLawCalibration::new(running_clusters.dim as usize, metric));
     // #512 invariant tripwire: no re-encode in this drain may saturate its
     // destination quantizer — cosine rows are unit (ingest-normalized) so
     // the fixed grid covers them, and data-derived grids are built to cover
@@ -3949,6 +3949,23 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                         DrainCellSource::Rows(spill) => {
                             // Calibration reads the spill the pack pass is
                             // about to read anyway (before remove_files).
+                            // Scored RAW (`None`) even on residual tables:
+                            // spill rows are materialized USER-table rows,
+                            // and user superfiles carry whole-vector sign
+                            // codes always (residual is hidden-only) — a
+                            // residual reference here would histogram
+                            // `q·c + κ·‖r‖·sd_raw`, a chimera whose center
+                            // term double-counts what the raw sign-dot
+                            // already contains. The serving-consistent
+                            // residual reference (each packed cell's own
+                            // fine centroids + re-encoded codes) only
+                            // exists after the pack below; the raw sign-dot
+                            // is the blunter estimator, so the budget it
+                            // measures over-covers residual serving (recall-
+                            // safe, cost-conservative), and the optimize
+                            // recalibration — which rescores PACKED cells
+                            // with `ResidualRef::Fine` — is the
+                            // serving-exact stamp.
                             if let Some(cal) = width_law_ref {
                                 cal.score_cell(*cell_id, spill, None)?;
                             }
@@ -4936,10 +4953,17 @@ fn drain_cell_vector_config(cfg: &VectorConfig, n_rows: usize) -> (VectorConfig,
         rabitq_bytes + DOC_ID_BYTES + rerank_bytes + STABLE_ID_BYTES + mem::size_of::<f32>();
     let rows_per_run = (DRAIN_FINE_RUN_TARGET_BYTES / row_stride.max(1)).max(1);
     let n_cent = n_rows.div_ceil(rows_per_run).clamp(1, n_rows);
+    // `residual_codes` inherits from the caller's config (`..cfg.clone()`):
+    // this function shapes EVERY hidden cell pack — commit-time incoming
+    // shards, drain spill packs, and split children — so pinning it here
+    // silently turns the whole residual feature off on disk while the
+    // drain calibration still scores with the residual estimator (the
+    // enable-was-a-no-op failure this comment exists to prevent). Both
+    // codec arms above are `writes_full`, which residual re-encoding
+    // requires.
     let cell_cfg = VectorConfig {
         rerank_codec,
         provided_centroids: None,
-        residual_codes: false,
         ..cfg.clone()
     };
     (cell_cfg, n_cent)
@@ -7140,7 +7164,7 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
     // this scan measures. A drain that commits between the scan and the
     // stamp adds rows this evidence never saw.
     let scan_ids: HashSet<Uuid> = manifest.superfiles.iter().map(|e| e.superfile_id).collect();
-    let mut cal = opann::WidthLawCalibration::new(clusters.dim as usize, metric, false);
+    let mut cal = opann::WidthLawCalibration::new(clusters.dim as usize, metric);
     // Query-sample pass: exactly `min(total_docs, WIDTH_LAW_QUERY_SAMPLE)`
     // evenly spaced ordinals over the cell-ordered live-row enumeration —
     // the law's noise floor is set by evidence size, and any fixed stride
@@ -7243,6 +7267,41 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
     // memory stays bounded at one chunk of materialized cells.
     let chunk_cells = pool.current_num_threads().max(1);
     for (entry, cells) in &work {
+        // Bytes for this entry resolve SYNCHRONOUSLY here (both the
+        // scoring tables below and the fine observation after go through
+        // `try_get_range_sync`), and the lazy query opener only exposes
+        // sync bytes after a BACKGROUND mmap promotion — a fresh
+        // post-compaction output racing that promotion would silently
+        // degrade, keeping the previous law: the staleness this pass
+        // exists to fix. Open the way compaction opens its own inputs:
+        // resident bytes guaranteed.
+        let reader = open_compaction_input(
+            &inner.options.store,
+            inner.options.disk_cache.as_ref(),
+            inner.options.storage.as_ref(),
+            entry,
+        )
+        .await
+        .map_err(|e| BuildError::Store(e.to_string()))?;
+        // Per residual cell: its fine-centroid table, the reference
+        // centers `score_rows` re-centers estimates against
+        // (`ResidualRef::Fine` indexes it by each row's fine ordinal).
+        // Raw cells are absent and score as plain sign-dots. Multi-cell
+        // entries must resolve tables — a residual cell scored with the
+        // raw formula silently corrupts the law, so a degraded read is
+        // an error, not a skip. Legacy single-cell (v1) layouts predate
+        // residual codes: raw formula is correct, no tables.
+        let fine_tables: Arc<HashMap<u32, Vec<f32>>> = Arc::new(match reader.vec() {
+            Some(v) if v.is_multi_cell() => {
+                v.cell_fine_scoring_tables(&column).ok_or_else(|| {
+                    BuildError::Store(format!(
+                        "recalibration scoring tables unavailable for superfile {}",
+                        entry.superfile_id
+                    ))
+                })?
+            }
+            _ => HashMap::new(),
+        });
         for chunk in cells.chunks(chunk_cells) {
             let mut loaded: Vec<(u32, Vec<MaterializedIvfRow>)> = Vec::with_capacity(chunk.len());
             for &(cell, _) in chunk {
@@ -7257,10 +7316,14 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
                 loaded.push((cell, rows));
             }
             let chunk_cal = Arc::clone(&cal);
+            let chunk_tables = Arc::clone(&fine_tables);
             run_on_pool(Some(pool), "recalibration score", move || {
-                let result = loaded
-                    .par_iter()
-                    .try_for_each(|(cell, rows)| chunk_cal.score_rows(*cell, rows, None));
+                let result = loaded.par_iter().try_for_each(|(cell, rows)| {
+                    let fine_ref = chunk_tables
+                        .get(cell)
+                        .map(|table| opann::ResidualRef::Fine(table));
+                    chunk_cal.score_rows(*cell, rows, fine_ref.as_ref())
+                });
                 // Release the shared handle BEFORE returning — the oneshot
                 // send follows the return, and the awaiting side unwraps
                 // the Arc after the final recv (a send-then-drop order
@@ -7272,25 +7335,12 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
             .await
             .map_err(|e| BuildError::Store(format!("recalibration score: {e}")))??;
         }
-        // The fine observation reads subsection/stable-id bytes
-        // SYNCHRONOUSLY (`cell_fine_calibration_views` resolves through
-        // `try_get_range_sync`), and the lazy query opener only exposes
-        // sync bytes after a BACKGROUND mmap promotion — a fresh
-        // post-compaction output racing that promotion would silently
-        // skip its depth observation and keep the previous law, the
-        // staleness this pass exists to fix. Open the way compaction
-        // opens its own inputs: resident bytes guaranteed.
-        let reader = open_compaction_input(
-            &inner.options.store,
-            inner.options.disk_cache.as_ref(),
-            inner.options.storage.as_ref(),
-            entry,
-        )
-        .await
-        .map_err(|e| BuildError::Store(e.to_string()))?;
-        // `None` here is a legacy single-cell layout — skip its depth
-        // observation; the finish fallback keeps the previous depth law
-        // rather than shallowing it on partial evidence.
+        // The fine observation walks stable ids per row — deliberately
+        // extracted AFTER the scoring chunks so its per-row maps never
+        // coexist with a loaded chunk (the one-chunk transient-memory
+        // bound). `None` here is a legacy single-cell layout — skip its
+        // depth observation; the finish fallback keeps the previous depth
+        // law rather than shallowing it on partial evidence.
         if let Some(views) = reader
             .vec()
             .and_then(|v| v.cell_fine_calibration_views(&column))
@@ -7370,23 +7420,47 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
                 *slot = (*slot).max(measured);
             }
         }
-        // Fine depth and rerank MAX-MERGE against the live stamp, exactly as
-        // the drain does: a sample that under-measures a per-stage walk must
+        // Fine depth MAX-MERGES against the live stamp, exactly as the
+        // drain does: a sample that under-measures a per-stage walk must
         // never shallow a stamp the previous full measurement certified —
-        // that is the query-time under-probe this PR exists to fix. Their
+        // that is the query-time under-probe this PR exists to fix. Its
         // shrink direction buys only intra-fetch compute, so keeping the
         // deeper value is recall-safe at bounded cost. A measured `0`
-        // (unsupported point) keeps the previous value under both rules.
+        // (unsupported point) keeps the previous value.
         for (slot, measured) in routing.fine_for_k.iter_mut().zip(laws.fine_for_k) {
             *slot = (*slot).max(measured);
         }
-        // Same per-knot merge + provenance as the drain stamp.
-        opann::merge_rerank_with_pools(
-            &mut routing.rerank_for_k,
-            &mut routing.rerank_pool_cells,
-            &laws.rerank_for_k,
-            laws.pool_cells,
-        );
+        // Rerank: REPLACE under current evidence (same gate as width),
+        // max-merge otherwise. The replace arm is load-bearing for
+        // residual tables: the drain stamps a budget measured with the
+        // BLUNTER raw sign-dot estimator (its spill rows are user rows —
+        // raw codes always), which over-covers residual serving; this
+        // pass rescores every packed cell with the serving-exact
+        // estimator (`ResidualRef::Fine` per provenance), and a max-merge
+        // would keep the drain's inflated budget forever — the sharper
+        // estimator's smaller measured budget could never land. A
+        // measured `0` (unsupported point) keeps the previous value
+        // under both rules, exactly like width.
+        if evidence_current {
+            for ((slot, pool), measured) in routing
+                .rerank_for_k
+                .iter_mut()
+                .zip(routing.rerank_pool_cells.iter_mut())
+                .zip(laws.rerank_for_k.iter())
+            {
+                if *measured > 0 {
+                    *slot = *measured;
+                    *pool = laws.pool_cells;
+                }
+            }
+        } else {
+            opann::merge_rerank_with_pools(
+                &mut routing.rerank_for_k,
+                &mut routing.rerank_pool_cells,
+                &laws.rerank_for_k,
+                laws.pool_cells,
+            );
+        }
         opann::clear_rerank_beyond_pool(
             &routing.width_for_k,
             &mut routing.rerank_for_k,
@@ -9812,6 +9886,35 @@ mod tests {
             2,
             "a fully drained cell needs two ~2 MiB fine runs"
         );
+    }
+
+    /// The per-cell drain config must inherit `residual_codes` — this
+    /// function shapes every hidden cell pack, so a pinned `false` here
+    /// silently turns the residual feature off on disk while calibration
+    /// keeps scoring with the residual estimator (the regression that
+    /// invalidated a full 1M bench arm). Both codec arms must preserve it.
+    #[test]
+    fn drain_cell_vector_config_preserves_residual_codes() {
+        for rerank_codec in [RerankCodec::Sq16, RerankCodec::Fp32] {
+            let cfg = VectorConfig {
+                column: "emb".into(),
+                dim: 16,
+                rot_seed: 7,
+                metric: Metric::Cosine,
+                rerank_codec,
+                provided_centroids: None,
+                residual_codes: true,
+            };
+            let (cell_cfg, _) = drain_cell_vector_config(&cfg, 100);
+            assert!(
+                cell_cfg.residual_codes,
+                "{rerank_codec:?}: drain cell config must inherit residual_codes"
+            );
+            assert!(
+                cell_cfg.rerank_codec.writes_full(),
+                "{rerank_codec:?}: residual codes require a writes_full cell codec"
+            );
+        }
     }
 
     // ---- rayon-shard parallelism -------------------------------------

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -3429,7 +3429,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         && completed_shards.is_empty()
         && local_checkpoint.spills.is_empty();
     let mut width_law = clean_uncheckpointed_drain
-        .then(|| opann::WidthLawCalibration::new(running_clusters.dim as usize, metric));
+        .then(|| opann::WidthLawCalibration::new(running_clusters.dim as usize, metric, false));
     // #512 invariant tripwire: no re-encode in this drain may saturate its
     // destination quantizer — cosine rows are unit (ingest-normalized) so
     // the fixed grid covers them, and data-derived grids are built to cover
@@ -3950,7 +3950,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                             // Calibration reads the spill the pack pass is
                             // about to read anyway (before remove_files).
                             if let Some(cal) = width_law_ref {
-                                cal.score_cell(*cell_id, spill)?;
+                                cal.score_cell(*cell_id, spill, None)?;
                             }
                             let cell = build_spilled_packed_cell_from_rows(
                                 scratch,
@@ -7140,7 +7140,7 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
     // this scan measures. A drain that commits between the scan and the
     // stamp adds rows this evidence never saw.
     let scan_ids: HashSet<Uuid> = manifest.superfiles.iter().map(|e| e.superfile_id).collect();
-    let mut cal = opann::WidthLawCalibration::new(clusters.dim as usize, metric);
+    let mut cal = opann::WidthLawCalibration::new(clusters.dim as usize, metric, false);
     // Query-sample pass: exactly `min(total_docs, WIDTH_LAW_QUERY_SAMPLE)`
     // evenly spaced ordinals over the cell-ordered live-row enumeration —
     // the law's noise floor is set by evidence size, and any fixed stride
@@ -7260,7 +7260,7 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
             run_on_pool(Some(pool), "recalibration score", move || {
                 let result = loaded
                     .par_iter()
-                    .try_for_each(|(cell, rows)| chunk_cal.score_rows(*cell, rows));
+                    .try_for_each(|(cell, rows)| chunk_cal.score_rows(*cell, rows, None));
                 // Release the shared handle BEFORE returning — the oneshot
                 // send follows the return, and the awaiting side unwraps
                 // the Arc after the final recv (a send-then-drop order

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -4939,6 +4939,7 @@ fn drain_cell_vector_config(cfg: &VectorConfig, n_rows: usize) -> (VectorConfig,
     let cell_cfg = VectorConfig {
         rerank_codec,
         provided_centroids: None,
+        residual_codes: false,
         ..cfg.clone()
     };
     (cell_cfg, n_cent)
@@ -9132,6 +9133,7 @@ mod tests {
                 metric: Metric::L2Sq,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             Some(tok()),
         )
@@ -9604,6 +9606,7 @@ mod tests {
                 metric: Metric::Cosine,
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
+                residual_codes: false,
             }],
             None,
         )
@@ -9774,6 +9777,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         for group in assigned {
             let n_members = group.members.len();
@@ -9796,6 +9800,7 @@ mod tests {
             metric: Metric::L2Sq,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         };
         assert_eq!(
             drain_cell_vector_config(&cfg, COMMIT_CELL_ROWS).1,

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -4180,6 +4180,13 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             for (slot, measured) in routing.width_for_k.iter_mut().zip(laws.width_for_k) {
                 *slot = (*slot).max(measured);
             }
+            for (slot, measured) in routing
+                .width_bulk_for_k
+                .iter_mut()
+                .zip(laws.width_bulk_for_k)
+            {
+                *slot = (*slot).max(measured);
+            }
             for (slot, measured) in routing.fine_for_k.iter_mut().zip(laws.fine_for_k) {
                 *slot = (*slot).max(measured);
             }
@@ -4198,12 +4205,15 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                 &mut routing.rerank_for_k,
                 &routing.rerank_pool_cells,
             );
-            // Stop margin follows the same shrink discipline as the drain's
+            // Stop margins follow the same shrink discipline as the drain's
             // rerank merge: keep the LARGER (more conservative) margin — a
             // wider margin only stops later. The recalibration pass replaces
-            // it under current evidence, like the rerank law.
+            // them under current evidence, like the rerank law.
             if laws.rerank_margin > routing.rerank_margin {
                 routing.rerank_margin = laws.rerank_margin;
+            }
+            if laws.width_margin > routing.width_margin {
+                routing.width_margin = laws.width_margin;
             }
             info!(
                 "supertable drain: probe laws at k={WIDTH_LAW_KS:?}: width measured {:?} stamped {:?}; fine depth measured {:?} stamped {:?}; rerank measured {:?} stamped {:?}",
@@ -7427,6 +7437,21 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
                 *slot = (*slot).max(measured);
             }
         }
+        // The bulk width follows the width law's own merge discipline —
+        // replace under current evidence, max-merge otherwise.
+        for (slot, measured) in routing
+            .width_bulk_for_k
+            .iter_mut()
+            .zip(laws.width_bulk_for_k)
+        {
+            if evidence_current {
+                if measured > 0 {
+                    *slot = measured;
+                }
+            } else {
+                *slot = (*slot).max(measured);
+            }
+        }
         // Fine depth MAX-MERGES against the live stamp, exactly as the
         // drain does: a sample that under-measures a per-stage walk must
         // never shallow a stamp the previous full measurement certified —
@@ -7469,6 +7494,9 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
             if laws.rerank_margin > 0.0 {
                 routing.rerank_margin = laws.rerank_margin;
             }
+            if laws.width_margin > 0.0 {
+                routing.width_margin = laws.width_margin;
+            }
         } else {
             opann::merge_rerank_with_pools(
                 &mut routing.rerank_for_k,
@@ -7478,6 +7506,9 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
             );
             if laws.rerank_margin > routing.rerank_margin {
                 routing.rerank_margin = laws.rerank_margin;
+            }
+            if laws.width_margin > routing.width_margin {
+                routing.width_margin = laws.width_margin;
             }
         }
         opann::clear_rerank_beyond_pool(

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -88,6 +88,35 @@ pub mod served_shortlist_probe {
     }
 }
 
+/// Test-only override of the adaptive-stopping band floor
+/// (`STOP_BAND_MIN_ROWS`): the banded rerank only engages naturally at
+/// 10M-scale shortlists, so unit-scale tests lower the floor to walk the
+/// band loop on a small fixture. Process-global — tests that set it must
+/// not assume exclusivity (assert on their own table's results, never on
+/// the counter of another test's query).
+pub mod stop_band_floor_override {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// `0` = no override (the compiled constant serves).
+    static ROWS: AtomicUsize = AtomicUsize::new(0);
+
+    pub fn set(rows: usize) {
+        ROWS.store(rows, Ordering::Relaxed);
+    }
+
+    pub fn clear() {
+        ROWS.store(0, Ordering::Relaxed);
+    }
+
+    /// Read by the query path (test-helpers builds only).
+    pub fn get() -> Option<usize> {
+        match ROWS.load(Ordering::Relaxed) {
+            0 => None,
+            n => Some(n),
+        }
+    }
+}
+
 use std::{collections::HashSet, path::Path, sync::Arc};
 
 use arrow_array::{Decimal128Array, LargeStringArray, RecordBatch};

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -219,6 +219,7 @@ pub fn default_vector_config(column: &str, rot_seed: u64) -> VectorConfig {
         metric: Metric::Cosine,
         rerank_codec: RerankCodec::Fp32,
         provided_centroids: None,
+        residual_codes: false,
     }
 }
 

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -88,6 +88,7 @@ fn build_pipeline_superfile() -> Bytes {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(default_tokenizer()),
     );
@@ -395,6 +396,7 @@ fn add_batch_from_reader_mergeability_compatible_superfiles() {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(default_tokenizer()),
     );
@@ -626,6 +628,7 @@ fn add_batch_from_reader_mergeability_vector_column_count_mismatch() {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         None,
     );
@@ -679,6 +682,7 @@ fn add_batch_from_reader_mergeability_vector_column_name_mismatch() {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         None,
     );
@@ -718,6 +722,7 @@ fn add_batch_from_reader_mergeability_vector_column_name_mismatch() {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         None,
     );
@@ -745,6 +750,7 @@ fn add_batch_from_reader_mergeability_vector_dimension_mismatch() {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         None,
     );
@@ -784,6 +790,7 @@ fn add_batch_from_reader_mergeability_vector_dimension_mismatch() {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         None,
     );
@@ -976,6 +983,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_vectors() {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         None,
     );
@@ -1025,6 +1033,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_vectors() {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         None,
     );
@@ -1179,6 +1188,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(default_tokenizer()),
     );
@@ -1230,6 +1240,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(default_tokenizer()),
     );

--- a/tests/superfile/vector/brute_force_oracle.rs
+++ b/tests/superfile/vector/brute_force_oracle.rs
@@ -149,6 +149,7 @@ fn build_reader_with_codec(
         metric,
         rerank_codec,
         provided_centroids: None,
+        residual_codes: false,
     })
     .expect("register column");
     for v in corpus {

--- a/tests/superfile/vector/pipeline.rs
+++ b/tests/superfile/vector/pipeline.rs
@@ -63,6 +63,7 @@ fn build_two_column_blob(n_docs: u32) -> (Bytes, String) {
         metric: Metric::Cosine,
         rerank_codec: RerankCodec::Fp32,
         provided_centroids: None,
+        residual_codes: false,
     })
     .expect("register column");
     b.register_column(VectorConfig {
@@ -72,6 +73,7 @@ fn build_two_column_blob(n_docs: u32) -> (Bytes, String) {
         metric: Metric::L2Sq,
         rerank_codec: RerankCodec::Fp32,
         provided_centroids: None,
+        residual_codes: false,
     })
     .expect("register column");
 
@@ -250,6 +252,7 @@ async fn end_to_end_planted_clusters_recovered() {
         metric: Metric::L2Sq,
         rerank_codec: RerankCodec::Fp32,
         provided_centroids: None,
+        residual_codes: false,
     })
     .expect("register column");
 

--- a/tests/superfile/vector/recall_ceiling_debug.rs
+++ b/tests/superfile/vector/recall_ceiling_debug.rs
@@ -114,6 +114,7 @@ fn build_blob(vectors: &[f32], codec: RerankCodec) -> Vec<u8> {
         metric: Metric::Cosine,
         rerank_codec: codec,
         provided_centroids: None,
+        residual_codes: false,
     })
     .expect("register column");
     for i in 0..N_DOCS {

--- a/tests/superfile/vector/reservoir_recall.rs
+++ b/tests/superfile/vector/reservoir_recall.rs
@@ -129,6 +129,7 @@ fn build_reader_with_sample_size(
             metric: Metric::Cosine,
             rerank_codec,
             provided_centroids: None,
+            residual_codes: false,
         })
         .expect("register column");
     b.set_kmeans_sample_size(cid, sample_size)
@@ -245,6 +246,7 @@ async fn recall_with_default_reservoir_equivalent_to_full_corpus_training() {
         metric: Metric::Cosine,
         rerank_codec: RerankCodec::Fp32,
         provided_centroids: None,
+        residual_codes: false,
     })
     .expect("register column");
     for i in 0..n_docs {

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -218,6 +218,7 @@ fn options_title_emb() -> SupertableOptions {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(default_tokenizer()),
     )

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -112,6 +112,7 @@ fn real_azure_options(dim: usize) -> infino::supertable::SupertableOptions {
             metric: infino::superfile::vector::distance::Metric::Cosine,
             rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(infino::test_helpers::default_tokenizer()),
     )

--- a/tests/supertable/storage/smoke_gcs.rs
+++ b/tests/supertable/storage/smoke_gcs.rs
@@ -86,6 +86,7 @@ fn gcs_options(dim: usize) -> SupertableOptions {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(default_tokenizer()),
     )

--- a/tests/supertable/storage/smoke_rustfs.rs
+++ b/tests/supertable/storage/smoke_rustfs.rs
@@ -301,6 +301,7 @@ fn rustfs_vector_options(dim: usize) -> infino::supertable::SupertableOptions {
             metric: infino::superfile::vector::distance::Metric::Cosine,
             rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(infino::test_helpers::default_tokenizer()),
     )

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -79,6 +79,7 @@ fn real_s3_options(dim: usize) -> infino::supertable::SupertableOptions {
             metric: infino::superfile::vector::distance::Metric::Cosine,
             rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(infino::test_helpers::default_tokenizer()),
     )

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -328,6 +328,7 @@ fn vector_crash_fixture() -> (SupertableOptions, arrow_array::RecordBatch) {
             metric: Metric::Cosine,
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
+            residual_codes: false,
         }],
         Some(default_tokenizer()),
     )


### PR DESCRIPTION
## What

Two serving-cost features for the hidden vector index, plus the kernel
integration that makes them pay at serve time:

1. **Residual 1-bit codes (subsection v3).** Hidden cells store RaBitQ
   codes as signs of `rot(v − c)` against each row's own subsection
   centroid, with a per-doc `‖r‖` region; the scan estimate becomes
   `q·c + κ·‖r‖·sign_dot`. Sharper estimates on real embeddings mean
   the drain-time calibration certifies narrower widths and smaller
   survivor budgets for the same coverage target.
2. **Adaptive rerank stopping.** Calibration also stamps a stop margin
   (the stage-coverage quantile of `exact − estimate` over pooled
   pairs, cosine only). The deferred rerank walks the shortlist in
   estimate bands and stops once no unprocessed candidate can reach
   the running kth exact score even granted its estimate plus the
   margin. The stamped budget stays the hard cap; easy queries stop
   early, hard queries run to the cap.

## Format

- Subsection version 3: residual flag in the reclaimed reserved slot
  `[24..28]`, per-doc `‖r‖` f32 region between codec_meta and the
  stable-id region. Readers accept {2, 3}; flag-off files stay
  byte-identical version-2 (every existing superfile unchanged).
- κ is NOT in the header — the estimator uses the analytic
  `sqrt(π/2)/sqrt(dim)` (within ~5% of the measured fit);
  `CellRoutingParams::residual_kappa` is a reserved override slot.
- Splice and parsed merges carry the norm region (cluster-order index
  space) and enforce all-or-none residual provenance, like the codec
  check; mixed v2+v3 cells rebuild through the pack core, which
  re-derives every code from the payload.

## Calibration semantics (reviewers: this is the part to weigh)

- Drain spills are user-table rows (raw codes), so the drain scores
  them raw — the blunter estimator's budget over-covers residual
  serving (recall-safe). The optimize recalibration rescores packed
  cells with the serving-exact estimator per cell provenance.
- **Recalibration now REPLACES rerank knots (and the stop margin)
  under current evidence** — the same gate width already replaces
  under — and max-merges otherwise. Without this, the sharper
  estimator's smaller certified budget can never enter the stamp
  (max-merge keeps the drain's blunter value forever). This also
  means an evidence-current recalibration can shrink a raw table's
  rerank stamp.

## Measurements (Cohere, fresh tables, same box, identical protocol,
## fully warm — verified by tail percentiles; max within 2.2x of p50)

**Cohere-10M, 768d cosine, k=10, warm serial p50 (100 queries):**

| config  | main @637fb24     | this branch       |
|---------|-------------------|-------------------|
| default | 0.9970 @ 25.2 ms  | 0.9980 @ 21.9 ms  |
| rm=256  | 0.9950 @ 22.2     | 0.9950 @ 19.0     |
| rm=128  | 0.9850 @ 21.1     | 0.9900 @ 17.4     |
| rm=32   | 0.9590 @ 19.7     | 0.9440 @ 16.7     |

Stamped laws on the same data: width 30 vs main's 34 cells at k=10;
k=100 survivor budget 18,883 vs 25,835 rows (−27%); stop margin
0.037. Default k=100: 0.9973 @ 46.1 ms vs the rm=256 constant's
0.9980 @ 62.7 ms.

**Cohere-1M (same protocol): parity.** 0.9930 @ 5.2 ms vs main's
0.9940 @ 4.8 ms — within 100-query sampling noise. Expected: at 1M
the law serves ~1–2 cells and the shortlist sits below the banding
floor, so neither feature has room to engage. The win is a scale
effect.

**Standard synthetic gates:** 1M lifecycle recall@10 0.996 post-drain
/ 0.998 post-compact (bar: 0.99), both arms; latency parity.

## Serve-time integration

The first cut lost the calibration win to estimator arithmetic in the
scan loop (measured as a flat +12 ms across every budget at 10M). Two
fixes, both arithmetic-identical: fold the residual affine over each
LUT block's score vector in one streamed pass (norms are cluster-order
contiguous), and resolve `q·c` as a raw dot against the resident
centroid bytes instead of rotating every probed fine centroid per
query (the rotation is orthonormal — `q_rot·rot(c) ≡ q·c`).

## Tests

- End-to-end on-disk tripwire: hidden superfiles assert v3 across
  drain / delta-commit / optimize generations (the class of test whose
  absence let an earlier flag-only enablement ship as a no-op).
- Byte-level roundtrips: layout offsets + header; every row's code and
  `‖r‖` re-derived independently; splice + parsed-merge norm carry
  with per-cluster slice equality; mixed-provenance rejection.
- Search parity vs raw codes and brute force, with a full-budget
  exactness tripwire (corpus-independent wiring proof).
- Margin quantile math (bulk vs outlier tails, conservative edges);
  banded serving walked at unit scale via a test-helpers band floor
  (planted top-k intact, determinism pinned).
- Full gates: lib 2,204 / supertable 283 / superfile 137, clippy
  clean.

## Trade-offs

- Residual tables spend `n_docs × 4` extra bytes per cell (the norm
  region) and one extra streamed norm read per scanned row.
- The drain's rerank stamp on a fresh residual table is measured with
  the raw estimator (conservative until the first optimize
  recalibration replaces it with the serving-exact value).
- At 1M-scale tables the features are inert by design (band floor,
  tiny widths): measured parity, no regression.