### PR TITLE
supertable query sql: withhold whole-domain bounds from statistics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,12 @@ tracing = "0.1"
 # against a per-Supertable cached Runtime. Tokio is single-worker
 # here: it drives DataFusion's I/O state machine, not CPU-bound work
 # (CPU work for skip + fan-out lives on the rayon reader pool).
+#
+# On bumping to 55: drop `spans_full_domain` in
+# `src/supertable/query/provider.rs`. It works around a cardinality
+# overflow that 54.x still carries; 55 has the upstream fix
+# (https://github.com/apache/datafusion/pull/22309), so the guard becomes
+# dead weight that only costs us statistics.
 datafusion = "54"
 # `macros` enables `#[tokio::test]` for the async DataFusion
 # integration tests; runtime weight on a release build is just the

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -126,6 +126,12 @@ use crate::{
 /// resolving filter columns to a physical pruning predicate.
 pub(crate) const TABLE_NAME: &str = "supertable";
 
+/// Distance between the endpoints of a min/max range that covers a
+/// 64-bit column type's entire domain (`0 ..= u64::MAX` for `UInt64`,
+/// `i64::MIN ..= i64::MAX` for `Int64`, and the same span for `Date64`
+/// / `Timestamp`). See [`spans_full_domain`].
+const FULL_DOMAIN_ENDPOINT_DISTANCE: u64 = u64::MAX;
+
 /// Object-store URL *prefix* the surviving superfiles are registered under
 /// for a scan. The authority is arbitrary — only a key into the session's
 /// object-store registry — but it must be **unique per provider**: a
@@ -599,7 +605,11 @@ impl SupertableProvider {
                     return stats;
                 }
                 let mut stats = ColumnStatistics::new_unknown();
-                if let Some((min, max)) = scalar_min_max(entries, name) {
+                // A range covering the column type's whole domain is
+                // withheld rather than reported — see `spans_full_domain`.
+                if let Some((min, max)) = scalar_min_max(entries, name)
+                    && !spans_full_domain(&min, &max)
+                {
                     stats.min_value = wrap(min);
                     stats.max_value = wrap(max);
                 }
@@ -709,6 +719,68 @@ fn scalar_min_max(
         };
     }
     acc
+}
+
+/// Whether `[min, max]` covers the column type's entire domain — the one
+/// range shape whose bounds are withheld from the statistics reported to
+/// the query planner.
+///
+/// # Why the bounds are withheld
+///
+/// The planner turns reported bounds into an interval and counts the
+/// values that interval holds as `max - min + 1`. A whole-domain range
+/// needs `u64::MAX + 1`, which does not fit the `u64` the count comes
+/// back in. The addition wraps to zero, the planner then divides by that
+/// count while estimating how many rows a filter keeps, and the resulting
+/// non-finite estimate trips an internal assertion — so every `<`, `>`,
+/// and `BETWEEN` on the column fails before it runs. `=` and a boundary
+/// `>=` escape only because they collapse the interval to a single point
+/// and take a distinct-count path that never divides, which is what makes
+/// the failure look arbitrary from the outside. Reporting no bounds
+/// instead routes the estimate through the planner's existing
+/// "range unknown" fallback.
+///
+/// # What withholding costs
+///
+/// Nothing for filtering: a range spanning every representable value
+/// excludes no row, so it could never have skipped a superfile, a row
+/// group, or a page. The planner also loses the ability to fold an
+/// unfiltered `MIN(col)` / `MAX(col)` out of these statistics — but the
+/// covered-aggregate rewrite folds those from the manifest directly and
+/// still answers them without a scan.
+///
+/// # Scope
+///
+/// The test is on the span, not on the type: any 64-bit-wide integer or
+/// temporal column reaches it once both endpoints appear in the data
+/// (`UInt64`, `Int64`, `Date64`, `Timestamp`). Narrower types cannot span
+/// far enough. Decimals are unaffected because the planner declines to
+/// count their intervals at all. Bounds are folded across every surviving
+/// superfile before this runs, so two superfiles that each contribute one
+/// endpoint trip it exactly as one superfile holding both does.
+///
+/// Floating-point columns are excluded, and the exclusion is load-bearing
+/// rather than cosmetic. The planner counts a float interval by the
+/// distance between the endpoints' *bit patterns*, and already returns no
+/// count when that saturates — floats were never exposed to the overflow.
+/// The endpoint distance used here is a difference in *value*, which for a
+/// wide float range is astronomically larger than any integer domain and
+/// saturates on the cast to an integer. Without this exclusion, an
+/// ordinary wide `Float64` column would match and lose its bounds for no
+/// reason.
+///
+/// # Removing this guard
+///
+/// TODO: delete this once the engine moves to DataFusion 55. The overflow
+/// is fixed upstream by DataFusion PR #22309, "Return None for cardinality
+/// overflow", which makes the count a checked add and returns no count on
+/// overflow — the same fallback this guard forces by hand. That fix landed
+/// after the 54 release branch was cut and was not backported, so 54.x
+/// still needs this.
+fn spans_full_domain(min: &ScalarValue, max: &ScalarValue) -> bool {
+    !min.data_type().is_floating()
+        && max.distance(min).and_then(|d| u64::try_from(d).ok())
+            == Some(FULL_DOMAIN_ENDPOINT_DISTANCE)
 }
 
 /// Extract a UTF-8 string literal from a scalar value, if it is one.
@@ -2485,6 +2557,58 @@ mod tests {
         assert_eq!(cs.max_value, Precision::Exact(ScalarValue::Int64(Some(20))));
         // One null planted in superfile 1.
         assert_eq!(cs.null_count, Precision::Exact(1));
+    }
+
+    /// A whole-domain min/max range is withheld from the reported
+    /// statistics; anything narrower is reported as usual. See
+    /// [`spans_full_domain`] for why the widest range is the harmful one.
+    #[test]
+    fn whole_domain_bounds_are_withheld_from_reported_statistics() {
+        let full = [
+            (
+                ScalarValue::UInt64(Some(0)),
+                ScalarValue::UInt64(Some(u64::MAX)),
+            ),
+            (
+                ScalarValue::Int64(Some(i64::MIN)),
+                ScalarValue::Int64(Some(i64::MAX)),
+            ),
+        ];
+        for (min, max) in &full {
+            assert!(spans_full_domain(min, max), "{min} .. {max}");
+        }
+
+        let narrower = [
+            (
+                ScalarValue::UInt64(Some(0)),
+                ScalarValue::UInt64(Some(u64::MAX - 1)),
+            ),
+            (
+                ScalarValue::UInt64(Some(1)),
+                ScalarValue::UInt64(Some(u64::MAX)),
+            ),
+            (
+                ScalarValue::Int64(Some(i64::MIN + 1)),
+                ScalarValue::Int64(Some(i64::MAX)),
+            ),
+            (ScalarValue::Int64(Some(1)), ScalarValue::Int64(Some(20))),
+            // A float range wider than any integer domain: the planner
+            // counts float intervals by bit pattern, not by value, and
+            // already guards that path.
+            (
+                ScalarValue::Float64(Some(f64::MIN)),
+                ScalarValue::Float64(Some(f64::MAX)),
+            ),
+            // A singleton, and a type the planner never counts anyway.
+            (ScalarValue::UInt64(Some(7)), ScalarValue::UInt64(Some(7))),
+            (
+                ScalarValue::LargeUtf8(Some("alpha".into())),
+                ScalarValue::LargeUtf8(Some("omega".into())),
+            ),
+        ];
+        for (min, max) in &narrower {
+            assert!(!spans_full_domain(min, max), "{min} .. {max}");
+        }
     }
 
     /// A superfile entry carrying only min/max for `col` (no null count,

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -721,66 +721,34 @@ fn scalar_min_max(
     acc
 }
 
-/// Whether `[min, max]` covers the column type's entire domain — the one
-/// range shape whose bounds are withheld from the statistics reported to
-/// the query planner.
+/// Whether `[min, max]` covers the column type's entire domain, the one
+/// range shape whose bounds are withheld from the reported statistics.
 ///
-/// # Why the bounds are withheld
+/// The planner counts the values an interval holds as `max - min + 1`. A
+/// whole-domain range needs `u64::MAX + 1`, which wraps to zero, and the
+/// row estimate then divides by that count: every `<`, `>`, and `BETWEEN`
+/// on the column fails an assertion before it runs. Withholding the bounds
+/// routes the estimate through the planner's "range unknown" fallback and
+/// costs nothing for filtering, since a range holding every representable
+/// value skips no superfile, row group, or page.
 ///
-/// The planner turns reported bounds into an interval and counts the
-/// values that interval holds as `max - min + 1`. A whole-domain range
-/// needs `u64::MAX + 1`, which does not fit the `u64` the count comes
-/// back in. The addition wraps to zero, the planner then divides by that
-/// count while estimating how many rows a filter keeps, and the resulting
-/// non-finite estimate trips an internal assertion — so every `<`, `>`,
-/// and `BETWEEN` on the column fails before it runs. `=` and a boundary
-/// `>=` escape only because they collapse the interval to a single point
-/// and take a distinct-count path that never divides, which is what makes
-/// the failure look arbitrary from the outside. Reporting no bounds
-/// instead routes the estimate through the planner's existing
-/// "range unknown" fallback.
+/// Any 64-bit integer or temporal type qualifies once both endpoints
+/// appear, hence a span test rather than a type test. Floats are excluded
+/// deliberately: the planner counts them by bit pattern and already guards
+/// that path, while the value distance used here saturates on a wide
+/// range, so without the exclusion an ordinary `Float64` column would
+/// match and lose its bounds for nothing.
 ///
-/// # What withholding costs
-///
-/// Nothing for filtering: a range spanning every representable value
-/// excludes no row, so it could never have skipped a superfile, a row
-/// group, or a page. The planner also loses the ability to fold an
-/// unfiltered `MIN(col)` / `MAX(col)` out of these statistics — but the
-/// covered-aggregate rewrite folds those from the manifest directly and
-/// still answers them without a scan.
-///
-/// # Scope
-///
-/// The test is on the span, not on the type: any 64-bit-wide integer or
-/// temporal column reaches it once both endpoints appear in the data
-/// (`UInt64`, `Int64`, `Date64`, `Timestamp`). Narrower types cannot span
-/// far enough. Decimals are unaffected because the planner declines to
-/// count their intervals at all. Bounds are folded across every surviving
-/// superfile before this runs, so two superfiles that each contribute one
-/// endpoint trip it exactly as one superfile holding both does.
-///
-/// Floating-point columns are excluded, and the exclusion is load-bearing
-/// rather than cosmetic. The planner counts a float interval by the
-/// distance between the endpoints' *bit patterns*, and already returns no
-/// count when that saturates — floats were never exposed to the overflow.
-/// The endpoint distance used here is a difference in *value*, which for a
-/// wide float range is astronomically larger than any integer domain and
-/// saturates on the cast to an integer. Without this exclusion, an
-/// ordinary wide `Float64` column would match and lose its bounds for no
-/// reason.
-///
-/// # Removing this guard
-///
-/// TODO: delete this once the engine moves to DataFusion 55. The overflow
-/// is fixed upstream by DataFusion PR #22309, "Return None for cardinality
-/// overflow", which makes the count a checked add and returns no count on
-/// overflow — the same fallback this guard forces by hand. That fix landed
-/// after the 54 release branch was cut and was not backported, so 54.x
-/// still needs this.
+/// TODO: delete on the move to DataFusion 55, which carries the upstream
+/// fix (checked add, no count on overflow):
+/// <https://github.com/apache/datafusion/pull/22309>
 fn spans_full_domain(min: &ScalarValue, max: &ScalarValue) -> bool {
+    // Never returns `None` for a reason a caller must handle: a missing or
+    // uncountable distance simply means "not whole-domain", and the bounds
+    // are reported as before. `usize` widens to `u64` losslessly on every
+    // supported target, so the comparison cannot fail either.
     !min.data_type().is_floating()
-        && max.distance(min).and_then(|d| u64::try_from(d).ok())
-            == Some(FULL_DOMAIN_ENDPOINT_DISTANCE)
+        && max.distance(min).map(|d| d as u64) == Some(FULL_DOMAIN_ENDPOINT_DISTANCE)
 }
 
 /// Extract a UTF-8 string literal from a scalar value, if it is one.

--- a/tests/supertable/query/stats_fold.rs
+++ b/tests/supertable/query/stats_fold.rs
@@ -1,20 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Plan-shape and correctness gates for manifest-statistics aggregate
-//! folding.
+//! Plan-shape and correctness gates for manifest statistics.
 //!
 //! On a tombstone-free table, `COUNT(*)` / `MIN` / `MAX` must be
 //! answered from manifest statistics — the physical plan contains no
 //! scan node at all. With tombstones, `COUNT(*)` may still fold (the
 //! bitmap cardinalities are exact) but value-derived stats degrade to
 //! a real scan; results must stay correct either way.
+//!
+//! The same statistics reach the planner a second way, as the column
+//! bounds behind its row estimate for a filter. Bounds covering a type's
+//! entire domain are withheld there (see `spans_full_domain` in
+//! `supertable::query::provider`), so the last group below pins both
+//! halves of that: range filters on such a column return rows, and
+//! withholding the bounds does not cost the aggregate fold.
 
 #![deny(clippy::unwrap_used)]
 
 use std::{collections::HashSet, sync::Arc};
 
-use arrow_array::{Array, Date32Array, Int64Array, LargeStringArray, RecordBatch};
+use arrow_array::{Array, Date32Array, Int64Array, LargeStringArray, RecordBatch, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::prelude::{col, lit};
 use infino::{
@@ -25,6 +31,7 @@ use infino::{
     },
     test_helpers::{build_title_batch, default_supertable_options},
 };
+use rayon::{ThreadPool, ThreadPoolBuilder};
 use tempfile::TempDir;
 
 /// Commits in the fold fixture — multiple segments so the statistics
@@ -362,4 +369,230 @@ fn temporal_fold_excludes_deleted_extremum() {
         scalar_date32(&st, "SELECT MAX(day) FROM supertable"),
         second_max_day
     );
+}
+
+/// One writer thread means one superfile per commit, so these fixtures
+/// control exactly which rows share a min/max range. The default pool
+/// shards a small batch across superfiles by row range, which would
+/// scatter the endpoints and make the fold depend on the host's core
+/// count.
+const FULL_DOMAIN_WRITER_THREADS: usize = 1;
+
+/// Row ids for the `UInt64` fixture, one per row, in append order.
+const U64_IDS: [i64; 5] = [1, 2, 3, 4, 5];
+/// The `u` column: both domain endpoints plus small and mid values, so a
+/// single superfile's min/max cover `0 ..= u64::MAX` exactly.
+const US: [u64; 5] = [0, 1, 1000, 1 << 63, u64::MAX];
+/// Mid-range literal for the `u` filters. Nowhere near the type's upper
+/// bound; only the column's committed range is.
+const SMALL_LITERAL: u64 = 1000;
+
+/// Row ids and `n` values for the split-domain `Int64` fixture. The first
+/// commit contributes the lower endpoint, the second the upper one, so
+/// neither superfile spans the domain on its own and only the fold does.
+const SPLIT_IDS_FIRST: [i64; 2] = [1, 2];
+const SPLIT_NS_FIRST: [i64; 2] = [i64::MIN, 5];
+const SPLIT_IDS_SECOND: [i64; 2] = [3, 4];
+const SPLIT_NS_SECOND: [i64; 2] = [10, i64::MAX];
+/// Threshold for the split-domain query, chosen so every superfile
+/// survives pruning: the first still holds `5`, the second only larger
+/// values. A threshold that pruned either would narrow the folded range
+/// and stop exercising the withholding at all.
+const SPLIT_THRESHOLD: i64 = 0;
+
+fn single_superfile_writer_pool() -> Arc<ThreadPool> {
+    Arc::new(
+        ThreadPoolBuilder::new()
+            .num_threads(FULL_DOMAIN_WRITER_THREADS)
+            .build()
+            .expect("writer pool"),
+    )
+}
+
+/// Schema `(i: Int64, u: UInt64)`; `i` labels the row, `u` carries the
+/// values under test.
+fn options_full_domain_u64() -> SupertableOptions {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("i", DataType::Int64, false),
+        Field::new("u", DataType::UInt64, false),
+    ]));
+    SupertableOptions::new(schema, vec![], vec![], None)
+        .expect("valid options")
+        .with_writer_pool(single_superfile_writer_pool())
+}
+
+/// Schema `(i: Int64, n: Int64)`, the signed counterpart of
+/// [`options_full_domain_u64`].
+fn options_split_domain_i64() -> SupertableOptions {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("i", DataType::Int64, false),
+        Field::new("n", DataType::Int64, false),
+    ]));
+    SupertableOptions::new(schema, vec![], vec![], None)
+        .expect("valid options")
+        .with_writer_pool(single_superfile_writer_pool())
+}
+
+/// Single-superfile table over [`U64_IDS`] / [`US`]: one superfile holds
+/// both `UInt64` endpoints.
+fn full_domain_u64_table() -> Supertable {
+    let st = Supertable::create(options_full_domain_u64()).expect("create");
+    let schema = st.options().schema.clone();
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(U64_IDS.to_vec())),
+            Arc::new(UInt64Array::from(US.to_vec())),
+        ],
+    )
+    .expect("batch");
+    let mut w = st.writer().expect("writer");
+    w.append(&batch).expect("append");
+    w.commit().expect("commit");
+    drop(w);
+    st
+}
+
+/// Two-superfile table where each superfile holds one `Int64` endpoint,
+/// so only the fold across survivors spans the domain.
+fn split_domain_i64_table() -> Supertable {
+    let st = Supertable::create(options_split_domain_i64()).expect("create");
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    for (ids, ns) in [
+        (SPLIT_IDS_FIRST, SPLIT_NS_FIRST),
+        (SPLIT_IDS_SECOND, SPLIT_NS_SECOND),
+    ] {
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(ids.to_vec())),
+                Arc::new(Int64Array::from(ns.to_vec())),
+            ],
+        )
+        .expect("batch");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+    }
+    drop(w);
+    st
+}
+
+/// The `i` column of `sql`'s result, sorted, so assertions don't depend
+/// on fan-out order.
+fn select_ids(st: &Supertable, sql: &str) -> Vec<i64> {
+    let batches = st
+        .reader()
+        .expect("reader")
+        .query_sql(sql)
+        .unwrap_or_else(|e| panic!("query failed: {sql}: {e}"));
+    let mut ids = Vec::new();
+    for batch in &batches {
+        let idx = batch.schema().index_of("i").expect("i column");
+        let arr = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("i is Int64");
+        for r in 0..arr.len() {
+            if !arr.is_null(r) {
+                ids.push(arr.value(r));
+            }
+        }
+    }
+    ids.sort_unstable();
+    ids
+}
+
+/// Single-cell u64 result of an aggregate query.
+fn scalar_u64(st: &Supertable, sql: &str) -> u64 {
+    let batches = st.reader().expect("reader").query_sql(sql).expect("sql");
+    let batch = batches.iter().find(|b| b.num_rows() > 0).expect("one row");
+    batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("u64 result")
+        .value(0)
+}
+
+/// Every comparison shape over a whole-domain column returns the right
+/// rows. `=` and the boundary `>=` always worked, because they collapse
+/// the column's range to a single point and take a distinct-count path
+/// that never divides; they are here so a change to the withholding rule
+/// can't quietly break the side that was fine.
+#[test]
+fn full_domain_column_answers_every_comparison_shape() {
+    let st = full_domain_u64_table();
+    let max = u64::MAX;
+
+    for (sql, expected) in [
+        (format!("SELECT i FROM supertable WHERE u = {max}"), vec![5]),
+        (
+            format!("SELECT i FROM supertable WHERE u >= {max}"),
+            vec![5],
+        ),
+        (
+            format!("SELECT i FROM supertable WHERE u = {SMALL_LITERAL}"),
+            vec![3],
+        ),
+        (
+            format!("SELECT i FROM supertable WHERE u > {SMALL_LITERAL}"),
+            vec![4, 5],
+        ),
+        (
+            format!("SELECT i FROM supertable WHERE u < {max}"),
+            vec![1, 2, 3, 4],
+        ),
+        (
+            format!("SELECT i FROM supertable WHERE u BETWEEN 1 AND {max}"),
+            vec![2, 3, 4, 5],
+        ),
+    ] {
+        assert_eq!(select_ids(&st, &sql), expected, "{sql}");
+    }
+}
+
+/// The domain is spanned only after folding two superfiles' bounds
+/// together, and the column is `Int64` rather than `UInt64`: the same
+/// failure reached along the two axes the single-superfile fixture
+/// doesn't cover. The threshold excludes only the `i64::MIN` row.
+#[test]
+fn range_filter_holds_when_domain_is_split_across_superfiles() {
+    let st = split_domain_i64_table();
+    assert_eq!(
+        select_ids(
+            &st,
+            &format!("SELECT i FROM supertable WHERE n > {SPLIT_THRESHOLD}")
+        ),
+        vec![2, 3, 4]
+    );
+}
+
+/// Withholding whole-domain bounds costs the aggregate fold nothing.
+/// Both extremes are still the right answer, and the query is still
+/// answered without a scan: the fold reads the per-superfile stats
+/// directly, so it never saw the withheld bounds.
+#[test]
+fn full_domain_column_still_folds_min_max_without_scanning() {
+    let st = full_domain_u64_table();
+
+    assert_eq!(scalar_u64(&st, "SELECT MIN(u) FROM supertable"), 0);
+    assert_eq!(scalar_u64(&st, "SELECT MAX(u) FROM supertable"), u64::MAX);
+    assert_eq!(
+        scalar_i64(&st, "SELECT COUNT(*) FROM supertable"),
+        U64_IDS.len() as i64
+    );
+
+    for sql in [
+        "SELECT MIN(u) FROM supertable",
+        "SELECT MAX(u) FROM supertable",
+        "SELECT COUNT(*) FROM supertable",
+    ] {
+        let plan = explain(&st, sql);
+        assert!(
+            !plan.contains("DataSourceExec"),
+            "{sql}: expected statistics fold (no scan); plan was:\n{plan}"
+        );
+    }
 }


### PR DESCRIPTION
### What does this PR do?
A range filter (<, >, BETWEEN) on a number column that stores both the smallest and largest value its type can hold used to fail instead of returning rows.

### Why do we need this change?
Before running a filter, the planner estimates how many rows will survive by comparing the width of the range you asked for against the width of the column's whole range. It measures width as biggest minus smallest plus one. Once the column's range covers every possible value, that count is one larger than the counter can hold, so it wraps to zero, the estimate divides by zero, and the resulting infinity fails a sanity check before the query touches any data. 

### How do we do this change?

- `statistics_for` withholds `min_value` / `max_value` when the folded range spans the column type's whole domain, so the planner falls back to its range-unknown estimate.
- Floats are excluded: the planner counts them by bit pattern and already guards that path, while the value distance used here saturates on a wide range.

### Notes
- The overflow is a DataFusion bug, fixed upstream by PR #22309, "Return None for cardinality overflow", which will be included in DataFusion 55, so we need to revert this change then.