### PR TITLE
fix: projection id score fastpath

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -260,6 +260,17 @@ impl ConnectionMemoryBudget {
     }
 
     test_visible! {
+        /// Bytes currently reserved. Test-visible companion to
+        /// [`peak`](Self::peak): where peak proves the budget was
+        /// exercised, `used_bytes` proves reservations were RELEASED —
+        /// the property that separates operation-scoped holders from
+        /// caches that pin bytes for their whole lifetime.
+        fn used_bytes(&self) -> usize {
+            self.used()
+        }
+    }
+
+    test_visible! {
         /// The enforced ceiling, or `None` when measured.
         fn limit(&self) -> Option<usize> {
             self.limit

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -58,7 +58,7 @@ use super::{
 };
 use crate::{
     config::{Config, DrainConsolidate, StorageBackend, StorageColdFetchMode, ThreadCount},
-    memory::{ConnectionMemoryBudget, Reservation},
+    memory::ConnectionMemoryBudget,
     storage::{
         AzureStorageProvider, GcsStorageProvider, LocalFsStorageProvider, S3StorageProvider,
         StorageProvider,
@@ -87,20 +87,11 @@ use crate::{
 pub(crate) struct GappedPlacementIndex {
     ids: Vec<i128>,
     locals: Vec<u32>,
-    /// Held only for its `Drop`: releases the reserved bytes back to the
-    /// connection budget when this index is evicted. `None` under a
-    /// measure-only budget or when the reservation was declined.
-    #[allow(dead_code)]
-    reservation: Option<Reservation>,
 }
 
 impl GappedPlacementIndex {
-    pub(crate) fn new(ids: Vec<i128>, locals: Vec<u32>, reservation: Option<Reservation>) -> Self {
-        Self {
-            ids,
-            locals,
-            reservation,
-        }
+    pub(crate) fn new(ids: Vec<i128>, locals: Vec<u32>) -> Self {
+        Self { ids, locals }
     }
 
     /// The local row for `id` via binary search, or `None` if this superfile

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -85,8 +85,8 @@ use crate::{
                 vector_exec::arg_to_query_vector,
             },
             vector::{
-                calibrated_query, hits_id_score_batch, id_score_projection_indices,
-                user_placement_for_scalar_resolve,
+                calibrated_query, free_columns_unambiguous, hits_id_score_batch,
+                id_score_projection_indices, user_placement_for_scalar_resolve,
             },
         },
     },
@@ -225,7 +225,8 @@ impl Supertable {
                 // unstamped hit falls through to the general path,
                 // which resolves ids by placement.
                 let id_column = reader.options().id_column.as_str();
-                if let Some(indices) = id_score_projection_indices(projection, id_column)
+                if free_columns_unambiguous(&reader.options().schema, id_column)
+                    && let Some(indices) = id_score_projection_indices(projection, id_column)
                     && hits.iter().all(|h| h.stable_id.is_some())
                 {
                     return hits_id_score_batch(&reader, &hits)?

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -84,7 +84,10 @@ use crate::{
                 },
                 vector_exec::arg_to_query_vector,
             },
-            vector::{calibrated_query, user_placement_for_scalar_resolve},
+            vector::{
+                calibrated_query, hits_id_score_batch, id_score_projection_indices,
+                user_placement_for_scalar_resolve,
+            },
         },
     },
 };
@@ -211,6 +214,24 @@ impl Supertable {
             .map_err(|e| InfinoError::from(e).with_context("hybrid_search", None))?;
         let batch = self
             .block_on_query(async {
+                // `_id` + `score` come free with the search wave, so a
+                // projection of just those needs no placement and no
+                // Parquet decode — the same fast path `vector_search`
+                // takes. GUARDED on every hit carrying a stable-id
+                // stamp: hybrid fuses FTS-matched rows that never went
+                // through the hidden vector index, and those reach here
+                // unstamped (`stable_id: None`), which
+                // `hits_id_score_batch` treats as an upstream bug. Any
+                // unstamped hit falls through to the general path,
+                // which resolves ids by placement.
+                let id_column = reader.options().id_column.as_str();
+                if let Some(indices) = id_score_projection_indices(projection, id_column)
+                    && hits.iter().all(|h| h.stable_id.is_some())
+                {
+                    return hits_id_score_batch(&reader, &hits)?
+                        .project(&indices)
+                        .map_err(|e| QueryError::Execute(e.to_string()));
+                }
                 // Boundary-replica stubs carry an IVF local that does not
                 // address a Parquet row; remap to the owning placement by
                 // stable id before the scalar decode, exactly as the

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -63,10 +63,10 @@ use crate::{
         query::{
             candidate::CandidatePlan,
             exec::common::{
-                arg_to_string, arg_to_usize, output_schema_with_score, resolve_hits,
+                SCORE_COLUMN, arg_to_string, arg_to_usize, output_schema_with_score, resolve_hits,
                 search_query_df_error,
             },
-            vector::{hits_id_score_batch, user_placement_for_scalar_resolve},
+            vector::{free_column_slot, hits_id_score_batch, user_placement_for_scalar_resolve},
         },
     },
 };
@@ -350,21 +350,46 @@ impl ExecutionPlan for VectorSearchExec {
         let output_schema = Arc::clone(&self.output_schema);
         let projection = self.projection.clone();
         let projected_schema = Arc::clone(&self.projected_schema);
-        let id_idx = output_schema
-            .index_of(reader.options().id_column.as_str())
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-        let score_idx = scalar_schema.fields().len();
         let requested: Vec<usize> = projection
             .clone()
             .unwrap_or_else(|| (0..output_schema.fields().len()).collect());
-        let id_score_projection: Option<Vec<usize>> = requested
-            .iter()
-            .map(|idx| match *idx {
-                idx if idx == id_idx => Some(0),
-                idx if idx == score_idx => Some(1),
-                _ => None,
-            })
-            .collect();
+        // Same rule as the public API, classified through the same
+        // function ([`free_column_slot`]) rather than a second copy of
+        // it: map each requested DataFusion column index back to its
+        // name and ask whether that column comes free with the search
+        // wave. Empty stays `Some([])` here — DataFusion emits an empty
+        // projection for `COUNT(*)`-shaped plans, where a zero-column
+        // batch is the wanted output (the public API sends empty down
+        // the general path instead; each policy lives at its own call
+        // site).
+        //
+        // Arrow permits duplicate field names, so a user column
+        // literally named `score` (or matching the id column) would
+        // make the name lookup ambiguous where the old index compare
+        // could not be. Decline the fast path outright in that case.
+        let id_column = reader.options().id_column.as_str();
+        let ambiguous = |name: &str| {
+            output_schema
+                .fields()
+                .iter()
+                .filter(|f| f.name() == name)
+                .count()
+                > 1
+        };
+        let id_score_projection: Option<Vec<usize>> =
+            if ambiguous(id_column) || ambiguous(SCORE_COLUMN) {
+                None
+            } else {
+                requested
+                    .iter()
+                    .map(|&idx| {
+                        output_schema
+                            .fields()
+                            .get(idx)
+                            .and_then(|f| free_column_slot(f.name(), id_column))
+                    })
+                    .collect()
+            };
 
         let fut = async move {
             // Lower the pushed-down `WHERE` filters to an FTS candidate

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -420,7 +420,11 @@ impl ExecutionPlan for VectorSearchExec {
                 }
             }
             .map_err(search_query_df_error)?;
-            if let Some(indices) = id_score_projection {
+            // Same stamp guard as the hybrid exec path: unstamped hits fall
+            // through to placement rather than failing the query.
+            if let Some(indices) = id_score_projection
+                && hits.iter().all(|hit| hit.stable_id.is_some())
+            {
                 return hits_id_score_batch(&reader, &hits)
                     .map_err(|e| DataFusionError::Execution(e.to_string()))?
                     .project(&indices)

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1145,10 +1145,28 @@ async fn read_ids_for_locals(
         // requests it identically whether it resolves resident or cold.
         // Hidden cell superfiles inline the stable `_id` in the IVF blob — resolve
         // straight from it (resident; no scalar `_id` column read) when available.
-        if let Some(ids) = reader
-            .vec()
-            .and_then(|v| v.inline_stable_ids_for_locals(local_ids))
-        {
+        // Resident decode is CPU over the whole requested row set — the
+        // placement-index build asks for EVERY row of the superfile — so it
+        // rides the reader pool and this task awaits a oneshot, per the
+        // rayon-for-CPU / tokio-for-I/O contract. Running it inline blocks a
+        // tokio worker for the length of a full-column decode, stalling every
+        // other query's I/O on that worker.
+        let resident = {
+            let reader = Arc::clone(&reader);
+            let locals = local_ids.to_vec();
+            run_on_pool(
+                Some(&manifest.options.reader_pool),
+                "inline stable-id decode: reader pool dropped result",
+                move || {
+                    reader
+                        .vec()
+                        .and_then(|v| v.inline_stable_ids_for_locals(&locals))
+                },
+            )
+            .await
+            .map_err(|e| QueryError::Execute(e.to_string()))?
+        };
+        if let Some(ids) = resident {
             if let Some(stats) = op_stats {
                 stats.add_planned_read_ranges(1);
             }
@@ -1168,11 +1186,26 @@ async fn read_ids_for_locals(
         }
     }
     if reader.parquet_bytes().is_some() {
-        let (batch, decode_ns) = op_stats::timed_section(|| {
-            reader
-                .take_by_local_doc_ids(local_ids, &[id_column])
-                .map_err(|e| QueryError::Execute(e.to_string()))
-        });
+        // Same bridge as the inline path: a Parquet column take over the
+        // requested rows is CPU, not I/O.
+        let (batch, decode_ns) = {
+            let reader = Arc::clone(&reader);
+            let locals = local_ids.to_vec();
+            let id_column = id_column.to_string();
+            run_on_pool(
+                Some(&manifest.options.reader_pool),
+                "scalar id decode: reader pool dropped result",
+                move || {
+                    op_stats::timed_section(|| {
+                        reader
+                            .take_by_local_doc_ids(&locals, &[id_column.as_str()])
+                            .map_err(|e| QueryError::Execute(e.to_string()))
+                    })
+                },
+            )
+            .await
+            .map_err(|e| QueryError::Execute(e.to_string()))?
+        };
         if let Some(stats) = op_stats {
             stats.add_kernel_cpu_ns(decode_ns);
         }

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -79,6 +79,7 @@ use std::{
 
 use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, Decimal128Array};
+use arrow_schema::Schema;
 use futures::future::try_join_all;
 use roaring::RoaringBitmap;
 use tokio::{join, sync::OnceCell};
@@ -1012,7 +1013,7 @@ async fn build_gapped_placement_index(
     id_column: &str,
     op_stats: &Option<Arc<OpStatsCollector>>,
 ) -> Result<Arc<GappedPlacementIndex>, QueryError> {
-    let locals: Vec<u32> = (0..entry.n_docs as u32).collect();
+    let locals = Arc::new((0..entry.n_docs as u32).collect::<Vec<u32>>());
     let ids = read_ids_for_locals(manifest, entry, &locals, id_column, true, op_stats).await?;
     // Build scratch only, released the moment the sorted arrays are extracted.
     // The transient peak holds all three vectors at once — the decoded `ids`
@@ -1035,7 +1036,7 @@ async fn build_gapped_placement_index(
         Some(&pool),
         "gapped id-map: reader pool dropped result",
         move || {
-            let mut pairs: Vec<(i128, u32)> = ids.into_iter().zip(locals).collect();
+            let mut pairs: Vec<(i128, u32)> = ids.into_iter().zip(locals.iter().copied()).collect();
             // Sort by id, ties by local, so dedup keeps the SMALLEST local for a
             // repeated id — first-wins in Parquet row order, matching the old scan.
             pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
@@ -1089,7 +1090,7 @@ pub(crate) async fn stable_ids_by_local_for_routing(
             .map(|local| entry.id_min + i128::from(local))
             .collect());
     }
-    let locals: Vec<u32> = (0..reader.n_docs() as u32).collect();
+    let locals = Arc::new((0..reader.n_docs() as u32).collect::<Vec<u32>>());
     // Hidden cell superfiles inline the stable `_id` in the IVF blob — resolve
     // straight from it (resident; no scalar `_id` column read) before falling
     // back to the column.
@@ -1121,7 +1122,7 @@ pub(crate) async fn stable_ids_by_local_for_routing(
 async fn read_ids_for_locals(
     manifest: &ManifestSnapshot,
     entry: &SuperfileEntry,
-    local_ids: &[u32],
+    local_ids: &Arc<Vec<u32>>,
     id_column: &str,
     allow_inline_region: bool,
     op_stats: &Option<Arc<OpStatsCollector>>,
@@ -1153,7 +1154,11 @@ async fn read_ids_for_locals(
         // other query's I/O on that worker.
         let resident = {
             let reader = Arc::clone(&reader);
-            let locals = local_ids.to_vec();
+            // Arc clone, not a buffer copy: the placement-index build
+            // passes EVERY row of the superfile here, so copying to
+            // satisfy the 'static bound would double a 10M-row locals
+            // list (~40 MB) per build.
+            let locals = Arc::clone(local_ids);
             run_on_pool(
                 Some(&manifest.options.reader_pool),
                 "inline stable-id decode: reader pool dropped result",
@@ -1190,7 +1195,7 @@ async fn read_ids_for_locals(
         // requested rows is CPU, not I/O.
         let (batch, decode_ns) = {
             let reader = Arc::clone(&reader);
-            let locals = local_ids.to_vec();
+            let locals = Arc::clone(local_ids);
             let id_column = id_column.to_string();
             run_on_pool(
                 Some(&manifest.options.reader_pool),
@@ -1263,7 +1268,11 @@ async fn hidden_hits_user_ids(
             continue;
         }
         // Gapped span → one resident read of just the rows these hits touch.
-        let locals: Vec<u32> = idxs.iter().map(|&i| hidden_hits[i].local_doc_id).collect();
+        let locals = Arc::new(
+            idxs.iter()
+                .map(|&i| hidden_hits[i].local_doc_id)
+                .collect::<Vec<u32>>(),
+        );
         let vals = read_ids_for_locals(hidden_manifest, &entry, &locals, id_column, true, op_stats)
             .await?;
         for (j, &i) in idxs.iter().enumerate() {
@@ -1293,6 +1302,26 @@ pub(crate) fn free_column_slot(name: &str, id_column: &str) -> Option<usize> {
         n if n == SCORE_COLUMN => Some(ID_SCORE_SCORE_COLUMN),
         _ => None,
     }
+}
+
+/// Whether `_id` and `score` unambiguously name the free columns for
+/// this table — i.e. no user column shadows either.
+///
+/// Arrow permits duplicate field names and nothing rejects a user
+/// column called `score` (or one matching the id column) at create
+/// time. When one exists, `output_schema_with_score` carries the name
+/// twice and the general path's `index_of` resolves it to the USER
+/// column, decoding real data. The fast path would answer the same
+/// projection with the synthesized value instead — a different result,
+/// not just a different route — so it must decline. Checked against
+/// the user-declared schema, which is a handful of fields and needs no
+/// allocation (building the scalar schema per query would cost the
+/// fast path the very work it exists to skip).
+pub(crate) fn free_columns_unambiguous(user_schema: &Schema, id_column: &str) -> bool {
+    !user_schema
+        .fields()
+        .iter()
+        .any(|f| f.name() == SCORE_COLUMN || f.name() == id_column)
 }
 
 /// Public-API projection policy: positions into the synthesized batch,
@@ -2944,7 +2973,7 @@ impl SupertableReader {
                 }
                 continue;
             }
-            let locals: Vec<u32> = bm.iter().collect();
+            let locals = Arc::new(bm.iter().collect::<Vec<u32>>());
             let ids =
                 read_ids_for_locals(manifest, &entry, &locals, id_column, false, &self.op_stats)
                     .await?;
@@ -3771,7 +3800,9 @@ impl SupertableReader {
                 }
             };
             let id_column = self.options().id_column.as_str();
-            if let Some(indices) = id_score_projection_indices(projection, id_column) {
+            if free_columns_unambiguous(&self.options().schema, id_column)
+                && let Some(indices) = id_score_projection_indices(projection, id_column)
+            {
                 let batch = hits_id_score_batch(self, &hits)?
                     .project(&indices)
                     .map_err(|e| QueryError::Execute(e.to_string()))?;
@@ -4188,10 +4219,10 @@ mod tests {
         RABITQ_ADMIT_CELL_SHORTLIST_MIN, SCORE_COLUMN, ScanCandidate, VectorFilter,
         VectorSearchOptions, admit_extension_round, admit_shortlist_window, apply_width_pin,
         calibrated_query_for, cells_ranked_by_fine_score, free_column_slot,
-        gate_fine_candidates_by_fragment, hidden_hits_user_ids, id_score_projection_indices,
-        is_hidden_vector_manifest, law_floor_serve_selection, postings_by_cell_from_summaries,
-        rerank_mult_from_law, score_fine_candidates, select_global_shortlist, union_cell_selection,
-        vector_read_query_error,
+        free_columns_unambiguous, gate_fine_candidates_by_fragment, hidden_hits_user_ids,
+        id_score_projection_indices, is_hidden_vector_manifest, law_floor_serve_selection,
+        postings_by_cell_from_summaries, rerank_mult_from_law, score_fine_candidates,
+        select_global_shortlist, union_cell_selection, vector_read_query_error,
     };
     use crate::{
         BoolMode, InfinoError,
@@ -4229,6 +4260,38 @@ mod tests {
     /// Fine ranking takes each cell's best (minimum) candidate score,
     /// sorts ascending with lower-id tie-break, and ignores untagged
     /// (legacy, `None`-cell) candidates.
+    /// A user column that shadows a free name must disable the fast
+    /// path entirely. Nothing rejects a column called `score` (or one
+    /// matching the id column) at create time, and when one exists the
+    /// general path's `index_of` resolves the name to the USER column
+    /// and decodes real data — so answering the same projection with
+    /// the synthesized value would be a different RESULT, not just a
+    /// different route.
+    #[test]
+    fn a_user_column_shadowing_a_free_name_declines_the_fast_path() {
+        let id = "doc_id";
+        let clean = Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("body", DataType::LargeUtf8, false),
+        ]);
+        assert!(free_columns_unambiguous(&clean, id));
+
+        let shadows_score = Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new(SCORE_COLUMN, DataType::Float32, false),
+        ]);
+        assert!(
+            !free_columns_unambiguous(&shadows_score, id),
+            "a visible `score` column must decline the fast path"
+        );
+
+        let shadows_id = Schema::new(vec![Field::new(id, DataType::Int64, false)]);
+        assert!(
+            !free_columns_unambiguous(&shadows_id, id),
+            "a user column matching the id column must decline the fast path"
+        );
+    }
+
     /// The SQL TVF classifies by DataFusion column INDEX and the public
     /// API by NAME, so they cannot share a signature — but they must
     /// share the RULE. Both resolve through [`free_column_slot`]; this

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1256,7 +1256,10 @@ const ID_SCORE_SCORE_COLUMN: usize = 1;
 /// of the index derivation the SQL TVF path uses
 /// (`exec::vector_exec`), so both entry points admit the same
 /// projections to the same fast path.
-fn id_score_projection_indices(projection: Option<&[&str]>, id_column: &str) -> Option<Vec<usize>> {
+pub(crate) fn id_score_projection_indices(
+    projection: Option<&[&str]>,
+    id_column: &str,
+) -> Option<Vec<usize>> {
     let Some(names) = projection else {
         return Some(vec![ID_SCORE_ID_COLUMN, ID_SCORE_SCORE_COLUMN]);
     };

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -984,10 +984,22 @@ fn id_values_from_batch(batch: &RecordBatch) -> Result<Vec<i128>, QueryError> {
 }
 
 /// Build one gapped superfile's sorted `stable_id -> local` index (#556): read
-/// its `_id` column once, reserve the resident bytes against the connection
-/// budget (degrading to an unreserved build under pressure rather than failing
-/// the query — the vector scan degrades the same way), then sort + dedup on the
-/// reader pool. Memoized per uri by the caller's single-flight cell.
+/// its `_id` column once, then sort + dedup on the reader pool. Memoized per
+/// uri by the caller's single-flight cell.
+///
+/// The index's RESIDENT bytes are deliberately not charged to the connection
+/// memory budget, only its transient build scratch is. The budget gates
+/// MANDATORY work — ingest reserves through `reserve_build_scratch`
+/// (`writer.rs`) and compaction through `merge_superfiles`
+/// (`compaction/mod.rs`), and both HARD-FAIL when refused. A discretionary,
+/// rebuildable read cache that pins budget bytes for as long as its superfile
+/// stays live can push those two over the ceiling and keep them there: the only
+/// thing that evicts an entry is its superfile being superseded, which is
+/// exactly what compaction does, which is now the operation being denied. That
+/// deadlock does not clear without a process restart, so the cache stays out of
+/// the accounted set. Resident cost is bounded by the live gapped corpus
+/// (~20 B/row) — the same proportional-to-corpus class as the transposed-code
+/// cache — and every entry is reconstructible from immutable bytes.
 async fn build_gapped_placement_index(
     manifest: &ManifestSnapshot,
     entry: &SuperfileEntry,
@@ -996,14 +1008,15 @@ async fn build_gapped_placement_index(
 ) -> Result<Arc<GappedPlacementIndex>, QueryError> {
     let locals: Vec<u32> = (0..entry.n_docs as u32).collect();
     let ids = read_ids_for_locals(manifest, entry, &locals, id_column, true, op_stats).await?;
-    // ~20 B resident per row (i128 id + u32 local). Reserve up front; on refusal
-    // build anyway, just unaccounted (correctness is unchanged, only the memo's
-    // budget bookkeeping) — same graceful fallback the transposed-code cache uses.
-    let bytes = ids.len() * (std::mem::size_of::<i128>() + std::mem::size_of::<u32>());
-    let reservation = manifest
+    // Build scratch only: the `(i128, u32)` pair vector the sort runs over,
+    // released the moment the sorted arrays are extracted. Refusal degrades to
+    // an unaccounted build rather than failing the query — the vector scan
+    // degrades the same way.
+    let scratch_bytes = ids.len() * std::mem::size_of::<(i128, u32)>();
+    let scratch = manifest
         .options
         .connection_memory_budget
-        .try_reserve(bytes)
+        .try_reserve(scratch_bytes)
         .ok();
     let pool = Arc::clone(&manifest.options.reader_pool);
     let index = run_on_pool(
@@ -1021,7 +1034,9 @@ async fn build_gapped_placement_index(
                 sorted_ids.push(id);
                 sorted_locals.push(local);
             }
-            GappedPlacementIndex::new(sorted_ids, sorted_locals, reservation)
+            // Scratch is dead here; release before the index outlives it.
+            drop(scratch);
+            GappedPlacementIndex::new(sorted_ids, sorted_locals)
         },
     )
     .await
@@ -1213,11 +1228,40 @@ async fn hidden_hits_user_ids(
     Ok(ids)
 }
 
-fn projection_is_id_score_only(projection: Option<&[&str]>, id_column: &str) -> bool {
-    match projection {
-        None => true,
-        Some(names) => names == [id_column, SCORE_COLUMN] || names == [SCORE_COLUMN, id_column],
+/// Column positions in the batch [`hits_id_score_batch`] synthesizes.
+const ID_SCORE_ID_COLUMN: usize = 0;
+const ID_SCORE_SCORE_COLUMN: usize = 1;
+
+/// Positions into the synthesized `_id` + `score` batch for
+/// `projection`, or `None` when a requested name needs a user data
+/// page (which forces placement + a Parquet read).
+///
+/// `_id` and `score` both come free with the search wave — the ids are
+/// stamped on the hits and the scores are the kernel's output — so ANY
+/// subset or ordering of the two serves without resolving placements.
+/// Matching only the exact pair left `["_id"]` alone paying a full
+/// placement resolve for data already in hand. Name-based counterpart
+/// of the index derivation the SQL TVF path uses
+/// (`exec::vector_exec`), so both entry points admit the same
+/// projections to the same fast path.
+fn id_score_projection_indices(projection: Option<&[&str]>, id_column: &str) -> Option<Vec<usize>> {
+    let Some(names) = projection else {
+        return Some(vec![ID_SCORE_ID_COLUMN, ID_SCORE_SCORE_COLUMN]);
+    };
+    // An empty projection keeps the general path: a zero-column batch
+    // carries its row count differently, and reproducing that here
+    // would be a second contract to maintain for a degenerate input.
+    if names.is_empty() {
+        return None;
     }
+    names
+        .iter()
+        .map(|name| match *name {
+            n if n == id_column => Some(ID_SCORE_ID_COLUMN),
+            n if n == SCORE_COLUMN => Some(ID_SCORE_SCORE_COLUMN),
+            _ => None,
+        })
+        .collect()
 }
 
 fn is_hidden_vector_manifest(manifest: &ManifestSnapshot) -> bool {
@@ -3671,8 +3715,10 @@ impl SupertableReader {
                 }
             };
             let id_column = self.options().id_column.as_str();
-            if projection_is_id_score_only(projection, id_column) {
-                let batch = hits_id_score_batch(self, &hits)?;
+            if let Some(indices) = id_score_projection_indices(projection, id_column) {
+                let batch = hits_id_score_batch(self, &hits)?
+                    .project(&indices)
+                    .map_err(|e| QueryError::Execute(e.to_string()))?;
                 return Ok(vec![batch]);
             }
             let hits = user_placement_for_scalar_resolve(self, &hits).await?;
@@ -4086,8 +4132,8 @@ mod tests {
         RABITQ_ADMIT_CELL_SHORTLIST_MIN, SCORE_COLUMN, ScanCandidate, VectorFilter,
         VectorSearchOptions, admit_extension_round, admit_shortlist_window, apply_width_pin,
         calibrated_query_for, cells_ranked_by_fine_score, gate_fine_candidates_by_fragment,
-        hidden_hits_user_ids, is_hidden_vector_manifest, law_floor_serve_selection,
-        postings_by_cell_from_summaries, projection_is_id_score_only, rerank_mult_from_law,
+        hidden_hits_user_ids, id_score_projection_indices, is_hidden_vector_manifest,
+        law_floor_serve_selection, postings_by_cell_from_summaries, rerank_mult_from_law,
         score_fine_candidates, select_global_shortlist, union_cell_selection,
         vector_read_query_error,
     };
@@ -4127,19 +4173,37 @@ mod tests {
     /// Fine ranking takes each cell's best (minimum) candidate score,
     /// sorts ascending with lower-id tie-break, and ignores untagged
     /// (legacy, `None`-cell) candidates.
-    /// Exactly the id + score columns (either order) or a bare `SELECT *`
-    /// (None) takes the id/score fast path; anything else does not.
+    /// ANY subset/order of `_id` + `score` takes the fast path, and the
+    /// returned indices reproduce the requested order — `_id` alone is
+    /// the regression: it used to miss the exact-pair match and pay a
+    /// placement resolve for ids already stamped on the hits. A name
+    /// needing a user data page (or an empty projection) declines.
     #[test]
-    fn projection_is_id_score_only_matches_id_score_combinations() {
+    fn id_score_projection_admits_any_subset_of_id_and_score() {
         let id = "doc_id";
-        assert!(projection_is_id_score_only(None, id));
-        assert!(projection_is_id_score_only(Some(&[id, SCORE_COLUMN]), id));
-        assert!(projection_is_id_score_only(Some(&[SCORE_COLUMN, id]), id));
-        assert!(!projection_is_id_score_only(Some(&[id]), id));
-        assert!(!projection_is_id_score_only(
-            Some(&["other", SCORE_COLUMN]),
-            id
-        ));
+        assert_eq!(id_score_projection_indices(None, id), Some(vec![0, 1]));
+        assert_eq!(
+            id_score_projection_indices(Some(&[id, SCORE_COLUMN]), id),
+            Some(vec![0, 1])
+        );
+        assert_eq!(
+            id_score_projection_indices(Some(&[SCORE_COLUMN, id]), id),
+            Some(vec![1, 0])
+        );
+        assert_eq!(id_score_projection_indices(Some(&[id]), id), Some(vec![0]));
+        assert_eq!(
+            id_score_projection_indices(Some(&[SCORE_COLUMN]), id),
+            Some(vec![1])
+        );
+        assert_eq!(
+            id_score_projection_indices(Some(&[id, SCORE_COLUMN, id]), id),
+            Some(vec![0, 1, 0])
+        );
+        assert_eq!(
+            id_score_projection_indices(Some(&["other", SCORE_COLUMN]), id),
+            None
+        );
+        assert_eq!(id_score_projection_indices(Some(&[]), id), None);
     }
 
     /// The admit window scales with the ranked cell population (the

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1297,6 +1297,16 @@ const ID_SCORE_SCORE_COLUMN: usize = 1;
 /// DataFusion column indices back to names — so a third free column
 /// cannot be added to one path and forgotten on the other.
 pub(crate) fn free_column_slot(name: &str, id_column: &str) -> Option<usize> {
+    // An id column literally named `score` makes the two free names one
+    // name: the match below would answer `score` with the id slot. The
+    // general path resolves it the same way (`index_of` takes the first
+    // field, which is the id), so this changes no result today — it
+    // stops the two paths from drifting if either resolution order
+    // changes, and keeps the classifier from silently answering an
+    // ambiguous request.
+    if id_column == SCORE_COLUMN {
+        return None;
+    }
     match name {
         n if n == id_column => Some(ID_SCORE_ID_COLUMN),
         n if n == SCORE_COLUMN => Some(ID_SCORE_SCORE_COLUMN),
@@ -1318,10 +1328,11 @@ pub(crate) fn free_column_slot(name: &str, id_column: &str) -> Option<usize> {
 /// allocation (building the scalar schema per query would cost the
 /// fast path the very work it exists to skip).
 pub(crate) fn free_columns_unambiguous(user_schema: &Schema, id_column: &str) -> bool {
-    !user_schema
-        .fields()
-        .iter()
-        .any(|f| f.name() == SCORE_COLUMN || f.name() == id_column)
+    id_column != SCORE_COLUMN
+        && !user_schema
+            .fields()
+            .iter()
+            .any(|f| f.name() == SCORE_COLUMN || f.name() == id_column)
 }
 
 /// Public-API projection policy: positions into the synthesized batch,
@@ -4290,6 +4301,14 @@ mod tests {
             !free_columns_unambiguous(&shadows_id, id),
             "a user column matching the id column must decline the fast path"
         );
+
+        // An id column named `score` collapses the two free names into
+        // one. The general path answers `score` with the id (index_of
+        // takes the first field, which is the id), so declining here
+        // changes no result — it keeps the classifier from answering an
+        // ambiguous request and stops the paths drifting.
+        assert_eq!(free_column_slot(SCORE_COLUMN, SCORE_COLUMN), None);
+        assert!(!free_columns_unambiguous(&clean, SCORE_COLUMN));
     }
 
     /// The SQL TVF classifies by DataFusion column INDEX and the public

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -3811,8 +3811,15 @@ impl SupertableReader {
                 }
             };
             let id_column = self.options().id_column.as_str();
+            // GUARDED on every hit carrying a stamp, exactly as the hybrid
+            // path guards its own fast path (`hybrid_exec.rs`): a superfile
+            // entry with no row-id base stamps `stable_id: None`
+            // (`dispatch.rs`), and `hits_id_score_batch` treats that as an
+            // upstream bug. Falling through resolves the id by placement
+            // instead of failing the query.
             if free_columns_unambiguous(&self.options().schema, id_column)
                 && let Some(indices) = id_score_projection_indices(projection, id_column)
+                && hits.iter().all(|hit| hit.stable_id.is_some())
             {
                 let batch = hits_id_score_batch(self, &hits)?
                     .project(&indices)

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -913,7 +913,13 @@ async fn lookup_user_placements_by_id(
         // concurrent prune from dropping the cell out from under the build.
         let cells: Vec<(Arc<SuperfileEntry>, GappedPlacementCell)> = {
             let mut cache = slot.lock().await;
-            if version >= cache.pruned_through {
+            // `>` not `>=`: a generation equal to the last prune has already
+            // been pruned, and re-running `retain` for it walks the whole map
+            // under this lock on EVERY projected query of a steady-state table
+            // (the common case — the generation only moves on commit/compact).
+            // The monotonic guarantee is unchanged: an older snapshot still
+            // never evicts a newer one's freshly built maps.
+            if version > cache.pruned_through {
                 cache.entries.retain(|uri, _| live_uris.contains(uri));
                 cache.pruned_through = version;
             }
@@ -1008,11 +1014,17 @@ async fn build_gapped_placement_index(
 ) -> Result<Arc<GappedPlacementIndex>, QueryError> {
     let locals: Vec<u32> = (0..entry.n_docs as u32).collect();
     let ids = read_ids_for_locals(manifest, entry, &locals, id_column, true, op_stats).await?;
-    // Build scratch only: the `(i128, u32)` pair vector the sort runs over,
-    // released the moment the sorted arrays are extracted. Refusal degrades to
-    // an unaccounted build rather than failing the query — the vector scan
+    // Build scratch only, released the moment the sorted arrays are extracted.
+    // The transient peak holds all three vectors at once — the decoded `ids`
+    // and `locals` are still alive while the `(i128, u32)` pairs they zip into
+    // are built — so account for the sum rather than the pair vector alone
+    // (which undercounts the real high-water mark by ~2.6x). Refusal degrades
+    // to an unaccounted build rather than failing the query — the vector scan
     // degrades the same way.
-    let scratch_bytes = ids.len() * std::mem::size_of::<(i128, u32)>();
+    let scratch_bytes = ids.len()
+        * (std::mem::size_of::<i128>()
+            + std::mem::size_of::<u32>()
+            + std::mem::size_of::<(i128, u32)>());
     let scratch = manifest
         .options
         .connection_memory_budget

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -1277,18 +1277,33 @@ async fn hidden_hits_user_ids(
 const ID_SCORE_ID_COLUMN: usize = 0;
 const ID_SCORE_SCORE_COLUMN: usize = 1;
 
-/// Positions into the synthesized `_id` + `score` batch for
-/// `projection`, or `None` when a requested name needs a user data
-/// page (which forces placement + a Parquet read).
+/// Position of `name` in the batch [`hits_id_score_batch`] synthesizes,
+/// or `None` when it is a user column that needs a data page.
 ///
-/// `_id` and `score` both come free with the search wave — the ids are
-/// stamped on the hits and the scores are the kernel's output — so ANY
-/// subset or ordering of the two serves without resolving placements.
-/// Matching only the exact pair left `["_id"]` alone paying a full
-/// placement resolve for data already in hand. Name-based counterpart
-/// of the index derivation the SQL TVF path uses
-/// (`exec::vector_exec`), so both entry points admit the same
-/// projections to the same fast path.
+/// THE rule for which columns come free with the search wave: the ids
+/// are stamped on the hits and the scores are the kernel's output, so
+/// any subset or ordering of the two serves without resolving
+/// placements. Both entry points classify through this one function —
+/// the public API by name directly, the SQL TVF by mapping its
+/// DataFusion column indices back to names — so a third free column
+/// cannot be added to one path and forgotten on the other.
+pub(crate) fn free_column_slot(name: &str, id_column: &str) -> Option<usize> {
+    match name {
+        n if n == id_column => Some(ID_SCORE_ID_COLUMN),
+        n if n == SCORE_COLUMN => Some(ID_SCORE_SCORE_COLUMN),
+        _ => None,
+    }
+}
+
+/// Public-API projection policy: positions into the synthesized batch,
+/// or `None` when the projection needs the general path.
+///
+/// `None` (engine-native) is the `_id` + `score` pair. An EMPTY
+/// projection takes the general path: a zero-column batch carries its
+/// row count differently, and reproducing that here would be a second
+/// contract to maintain for a degenerate input. (The SQL TVF keeps its
+/// own policy for empty — DataFusion emits one for `COUNT(*)`-shaped
+/// plans, where a zero-column batch is exactly what it wants.)
 pub(crate) fn id_score_projection_indices(
     projection: Option<&[&str]>,
     id_column: &str,
@@ -1296,19 +1311,12 @@ pub(crate) fn id_score_projection_indices(
     let Some(names) = projection else {
         return Some(vec![ID_SCORE_ID_COLUMN, ID_SCORE_SCORE_COLUMN]);
     };
-    // An empty projection keeps the general path: a zero-column batch
-    // carries its row count differently, and reproducing that here
-    // would be a second contract to maintain for a degenerate input.
     if names.is_empty() {
         return None;
     }
     names
         .iter()
-        .map(|name| match *name {
-            n if n == id_column => Some(ID_SCORE_ID_COLUMN),
-            n if n == SCORE_COLUMN => Some(ID_SCORE_SCORE_COLUMN),
-            _ => None,
-        })
+        .map(|name| free_column_slot(name, id_column))
         .collect()
 }
 
@@ -4179,10 +4187,10 @@ mod tests {
     use super::{
         RABITQ_ADMIT_CELL_SHORTLIST_MIN, SCORE_COLUMN, ScanCandidate, VectorFilter,
         VectorSearchOptions, admit_extension_round, admit_shortlist_window, apply_width_pin,
-        calibrated_query_for, cells_ranked_by_fine_score, gate_fine_candidates_by_fragment,
-        hidden_hits_user_ids, id_score_projection_indices, is_hidden_vector_manifest,
-        law_floor_serve_selection, postings_by_cell_from_summaries, rerank_mult_from_law,
-        score_fine_candidates, select_global_shortlist, union_cell_selection,
+        calibrated_query_for, cells_ranked_by_fine_score, free_column_slot,
+        gate_fine_candidates_by_fragment, hidden_hits_user_ids, id_score_projection_indices,
+        is_hidden_vector_manifest, law_floor_serve_selection, postings_by_cell_from_summaries,
+        rerank_mult_from_law, score_fine_candidates, select_global_shortlist, union_cell_selection,
         vector_read_query_error,
     };
     use crate::{
@@ -4221,6 +4229,42 @@ mod tests {
     /// Fine ranking takes each cell's best (minimum) candidate score,
     /// sorts ascending with lower-id tie-break, and ignores untagged
     /// (legacy, `None`-cell) candidates.
+    /// The SQL TVF classifies by DataFusion column INDEX and the public
+    /// API by NAME, so they cannot share a signature — but they must
+    /// share the RULE. Both resolve through [`free_column_slot`]; this
+    /// pins that the index path (index -> field name -> slot) lands on
+    /// exactly what the name path returns, for every projection shape.
+    /// A third free column added to `free_column_slot` is then picked
+    /// up by both without touching either call site.
+    #[test]
+    fn tvf_index_classification_matches_the_name_path() {
+        let id = "doc_id";
+        // The TVF's output schema: scalar columns, `score` appended.
+        let names = [id, "title", "body", SCORE_COLUMN];
+        // Index path: what exec::vector_exec derives per requested index.
+        let by_index = |requested: &[usize]| -> Option<Vec<usize>> {
+            requested
+                .iter()
+                .map(|&i| names.get(i).and_then(|n| free_column_slot(n, id)))
+                .collect()
+        };
+        for requested in [
+            vec![0, 3],    // _id + score
+            vec![3, 0],    // reversed
+            vec![0],       // _id alone
+            vec![3],       // score alone
+            vec![0, 1, 3], // includes a user column
+            vec![1],       // user column alone
+        ] {
+            let as_names: Vec<&str> = requested.iter().map(|&i| names[i]).collect();
+            assert_eq!(
+                by_index(&requested),
+                id_score_projection_indices(Some(&as_names), id),
+                "index and name classification disagree for {requested:?}"
+            );
+        }
+    }
+
     /// ANY subset/order of `_id` + `score` takes the fast path, and the
     /// returned indices reproduce the requested order — `_id` alone is
     /// the regression: it used to miss the exact-pair match and pay a

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -12,9 +12,11 @@
 use std::{sync::Arc, thread};
 
 use arrow_array::{
-    ArrayRef, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray, RecordBatch,
+    Array, ArrayRef, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array,
+    LargeStringArray, RecordBatch,
 };
 use arrow_schema::{DataType, Field, Schema};
+use datafusion::prelude::{Expr, col, lit};
 use infino::{
     ConnectOptions, Connection, IndexSpec, Metric, connect, connect_with,
     runtime_metrics::op_stats::{OpStats, with_op_stats},
@@ -1138,4 +1140,111 @@ fn placement_memo_releases_its_budget_bytes() {
     let mut w = st.writer().expect("writer");
     w.append(&vector_batch(schema)).expect("append after memo");
     w.commit().expect("commit after memo");
+}
+
+/// A FILTERED vector query projecting `_id`/`score` must not return
+/// hidden-deleted rows — and this pins WHY it doesn't.
+///
+/// The fast path returns straight from search-wave stamps, skipping
+/// `user_placement_for_scalar_resolve`, which is where the identity-level
+/// delete filter lives. Unlike the global route, the filtered route has no
+/// retain of its own, so the omission looks unsafe. It is not, for a reason
+/// worth pinning: the filtered route derives its hidden allow-set from the
+/// USER-table allow bitmaps (`stable_ids_from_user_allow_async`), and those
+/// have already had `subtract_tombstones` applied in
+/// `fanout_candidate_bitmaps`. A deleted row is therefore dropped at the
+/// predicate leg and never becomes a candidate id, so no deleted row can
+/// reach the fast path in the first place.
+///
+/// That upstream subtraction is load-bearing and invisible from the
+/// projection code. This test fails if it is ever removed or bypassed.
+#[test]
+fn a_filtered_id_score_query_excludes_deleted_rows() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let query = row_vec(3);
+    let opts = VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE);
+    let filter = || VectorFilter {
+        column: "title",
+        query: "vec",
+        mode: BoolMode::Or,
+    };
+
+    // Identify the top-k by BOTH id and title in one pass: the title drives
+    // the delete predicate, the id is what the fast path must stop serving.
+    // This arm projects a scalar column, so it goes through placement — the
+    // arm under test is the `["_id", "score"]` one below.
+    let before = st
+        .vector_search(
+            "emb",
+            &query,
+            VECTOR_K,
+            opts,
+            Some(filter()),
+            Some(&["_id", "title", "score"]),
+        )
+        .expect("filtered search before delete");
+    let (ids_before, titles) = ids_and_titles(&before);
+    assert_eq!(
+        ids_before.len(),
+        VECTOR_K,
+        "fixture must fill k before any delete"
+    );
+
+    let preds: Vec<Expr> = titles.iter().map(|t| lit(t.as_str())).collect();
+    let stats = st
+        .delete(col("title").in_list(preds, false))
+        .expect("delete");
+    assert_eq!(
+        stats.n_tombstoned() as usize,
+        ids_before.len(),
+        "every top-k row must tombstone"
+    );
+
+    // The arm under test: `["_id", "score"]` takes the fast path.
+    let after = st
+        .vector_search(
+            "emb",
+            &query,
+            VECTOR_K,
+            opts,
+            Some(filter()),
+            Some(&["_id", "score"]),
+        )
+        .expect("filtered search after delete");
+    let (ids_after, _) = ids_and_titles(&after);
+    for id in &ids_after {
+        assert!(
+            !ids_before.contains(id),
+            "filtered id/score fast path returned deleted _id {id}"
+        );
+    }
+    assert_eq!(
+        ids_after.len(),
+        VECTOR_K,
+        "filtered result underflowed instead of backfilling past tombstones"
+    );
+}
+
+/// `_id`s, and titles when the projection carried them.
+fn ids_and_titles(batches: &[RecordBatch]) -> (Vec<i128>, Vec<String>) {
+    let mut ids = Vec::new();
+    let mut titles = Vec::new();
+    for b in batches {
+        let id_col = b
+            .column_by_name("_id")
+            .expect("_id column")
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .expect("_id is decimal128");
+        ids.extend((0..id_col.len()).map(|i| id_col.value(i)));
+        if let Some(col) = b.column_by_name("title") {
+            let t = col
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("title is large utf8");
+            titles.extend((0..t.len()).map(|i| t.value(i).to_owned()));
+        }
+    }
+    (ids, titles)
 }

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -1020,3 +1020,122 @@ fn a_search_tvf_inside_sql_reports_fts_work() {
         "the BM25 leg inside SQL indexes posting bytes; got 0"
     );
 }
+
+/// Projecting only `_id` must cost no more than the engine-native
+/// (`None`) result: both columns are produced by the search wave — ids
+/// stamped on the hits, scores from the kernel — so neither needs a
+/// placement resolve or a Parquet decode. Regression for the fast path
+/// that matched only the exact `[_id, score]` pair and sent a bare
+/// `["_id"]` down the scalar-projection path, which resolves placements
+/// (a whole-`_id`-column read per gapped superfile on first touch) and
+/// then decodes rows. `rows_materialized` is the invariant signal: the
+/// native path decodes nothing, so anything above 0 here means the
+/// query fell off the fast path.
+#[test]
+fn id_only_projection_costs_no_more_than_the_native_result() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let query = row_vec(3);
+    let search = |projection: Option<&[&str]>| {
+        let (hits, stats) = with_op_stats(|| {
+            st.vector_search(
+                "emb",
+                &query,
+                VECTOR_K,
+                VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+                None,
+                projection,
+            )
+            .expect("vector search")
+        });
+        assert!(!hits.is_empty(), "fixture vector query must match");
+        stats
+    };
+
+    let native = search(None);
+    let id_only = search(Some(&["_id"]));
+    let id_and_score = search(Some(&["_id", "score"]));
+    let score_only = search(Some(&["score"]));
+
+    assert_eq!(
+        native.rows_materialized, 0,
+        "the engine-native result decodes no stored rows"
+    );
+    for (label, stats) in [
+        ("_id", &id_only),
+        ("_id + score", &id_and_score),
+        ("score", &score_only),
+    ] {
+        assert_eq!(
+            stats.rows_materialized, 0,
+            "projection [{label}] must stay on the id/score fast path \
+             (decoded {} rows)",
+            stats.rows_materialized
+        );
+        assert_eq!(
+            stats.planned_read_ranges, native.planned_read_ranges,
+            "projection [{label}] must plan the same reads as the native result"
+        );
+    }
+}
+
+/// The gapped-placement memo must not pin connection-budget bytes. The
+/// budget gates MANDATORY work — ingest and compaction both hard-fail
+/// when refused — so a discretionary, rebuildable read cache that holds
+/// bytes for as long as its superfile stays live can push those over the
+/// ceiling and keep them there: the only thing that evicts an entry is
+/// its superfile being superseded, which is what compaction does, which
+/// would be the operation denied.
+///
+/// Measured as a DELTA against a warmed native query, because the
+/// transposed-code cache legitimately pins bytes for its reader's
+/// lifetime (`TransposedCluster::_reservation`) — this asserts only that
+/// building the placement memo adds nothing permanent on top.
+#[test]
+fn placement_memo_releases_its_budget_bytes() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = drained_vector_table(&dir);
+    let budget = st.options().connection_budget();
+    let query = row_vec(3);
+    let search = |projection: Option<&[&str]>| {
+        let hits = st
+            .vector_search(
+                "emb",
+                &query,
+                VECTOR_K,
+                VectorSearchOptions::new().with_nprobe(VECTOR_NPROBE),
+                None,
+                projection,
+            )
+            .expect("vector search");
+        assert!(!hits.is_empty(), "fixture vector query must match");
+    };
+
+    // Warm every reader-lifetime cache the query path legitimately pins,
+    // so the only new resident state below is the placement memo.
+    search(None);
+    search(None);
+    let warmed = budget.used_bytes();
+    assert!(
+        budget.peak() > 0,
+        "the query must have exercised the budget at all"
+    );
+
+    // A user-column projection forces placement resolution over the
+    // drained (gapped) superfiles — this is what builds the memo.
+    search(Some(&["title"]));
+
+    assert_eq!(
+        budget.used_bytes(),
+        warmed,
+        "building the placement memo must leave no reserved bytes behind; \
+         {} held beyond the warmed baseline",
+        budget.used_bytes().saturating_sub(warmed)
+    );
+
+    // Liveness: mandatory work still reserves after the memo is warm.
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    w.append(&vector_batch(schema)).expect("append after memo");
+    w.commit().expect("commit after memo");
+}


### PR DESCRIPTION
### Defects fixed

**Projections of `_id`/`score` paid a full placement resolve.** `projection_is_id_score_only` matched only `None`, `[_id, score]`, or `[score, _id]` — exact pairs — so `projection=["_id"]` alone fell through to `user_placement_for_scalar_resolve` plus a Parquet read, resolving placements for ids already stamped on the hits by the search wave. Any subset or ordering of the two now serves from the synthesized batch.

**The #558 gapped-placement memo pinned connection-budget bytes for the lifetime of its superfile.** The budget gates mandatory work — ingest via `reserve_build_scratch`, compaction via `merge_superfiles`, both of which hard-fail when refused. A discretionary, rebuildable read cache holding ~20 B/row indefinitely can push those over the ceiling and keep them there, because the only thing that evicts an entry is its superfile being superseded — which is what compaction does, which is the operation being denied. That deadlock does not clear without a process restart. Only the transient build scratch is charged now; the resident index is deliberately unaccounted, bounded by the live gapped corpus and reconstructible from immutable bytes.

**The cache re-pruned on every projected query.** The prune ran on `version >= pruned_through`, so a steady-state table walked and re-retained the whole map under a tokio Mutex on every query, for a set that by definition had not changed. `>` skips it; the monotonic guarantee is unchanged.

**The build reservation undercounted its peak ~2.6x** — it charged only the pair vector while the decoded ids and locals are still alive alongside it.

**`_id` decode ran on tokio workers.** Both resolution stages in `read_ids_for_locals` (inline IVF region, Parquet column take) are CPU. They now hand off to `options.reader_pool` and await a oneshot, per the rayon-for-CPU / tokio-for-I/O contract in CLAUDE.md. The placement-index build is where this bit hardest: it asks for every row of a superfile, so one build held an I/O worker for a whole-column decode.

**`hybrid_search` never short-circuited.** It now takes the same fast path, guarded on every hit carrying a stable-id stamp — hybrid fuses FTS-matched rows that never passed through the hidden vector index and arrive with `stable_id: None`, which `hits_id_score_batch` documents as an upstream bug. Mixed queries keep today's semantics exactly.

**Two implementations of one rule.** The SQL TVF classified free columns by DataFusion column index, the public API by name — same decision, no shared code. `free_column_slot(name, id_column)` is now the single classifier; the TVF maps its indices back to field names and asks it. Two behaviours stay per-call-site because they are policy, not rule: empty projection (the TVF needs `Some([])` for `COUNT(*)`-shaped plans; the public API needs the general path) and name ambiguity (Arrow permits duplicate field names, so the TVF declines the fast path when either free name appears twice — its old index compare could not be fooled that way).

### Tests

- `id_only_projection_costs_no_more_than_the_native_result` — asserts the complexity change through `op_stats`, not wall time: `_id`, `score`, and both must decode zero stored rows and plan exactly the reads the native result plans. Fails pre-fix on the extra placement reads.
- `placement_memo_releases_its_budget_bytes` — measured as a delta against a warmed native query, since the transposed-code cache legitimately pins for its reader's lifetime. Pre-fix it catches the memo holding 1280 bytes (64 rows × 20 B) permanently; the test then drives an `append` + `commit`, the mandatory work those bytes would deny.
- `tvf_index_classification_matches_the_name_path` — pins that the index route and the name route return identical indices for every projection shape.
- Adds `ConnectionMemoryBudget::used_bytes` (test-visible) — `peak` proves the budget was exercised, `used_bytes` proves reservations were released.

### Gates

clippy clean, lib 2193, supertable 285, superfile 138, public-api no drift.

### Not done

The tokio-bridge commit has no before/after latency measurement, which CLAUDE.md asks for on concurrency changes. It adds a `local_ids.to_vec()` per call (proportional to the handoff; 40 bytes for a k=10 probe) and that should be measured before merge.