### PR TITLE
vector: target_recall — one per-table knob for the recall/latency operating point

### DIFF
--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -138,6 +138,12 @@ vector:
   # each selected cell. The user-table routing default takes this; the
   # hidden index's per-table stamp in the manifest overrides it. Pairs with
   # fine_nprobe_pct as max(floor, floor(pct × cell fine-cluster count)).
+  # Recall the drain calibration targets when stamping this table's
+  # probe laws (width / fine depth / rerank budget). Lower trades recall
+  # for latency: on Cohere-10M, 0.99 serves recall@10 0.997 at 19.4 ms
+  # and 0.93 serves 0.969 at 8.4 ms. Serving recall lands above the
+  # target because the crossings are discrete.
+  target_recall: 0.99
   fine_nprobe_floor: 4
 
   # Proportional fine-probe fraction for UNFILTERED vector search: probe

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -268,6 +268,8 @@ const DEFAULT_VECTOR_KMEANS_PTS_PER_CENTROID: usize = 64;
 /// Default per-cell fine-probe floor: the minimum fine IVF clusters probed
 /// inside each selected cell. Small cells stay at this known-good minimum.
 const DEFAULT_VECTOR_FINE_NPROBE_FLOOR: usize = 4;
+/// Shipped `vector.target_recall`: the 0.99 bar the acceptance gates use.
+const DEFAULT_VECTOR_TARGET_RECALL: f64 = 0.99;
 /// Default proportional fine-probe fraction. `0.0` ⇒ proportional depth off:
 /// the probe is the fixed floor. `> 0` probes `floor(pct × cell fine clusters)`
 /// so depth tracks cell size (recall lever for large cells).
@@ -360,6 +362,20 @@ pub struct VectorSettings {
     /// the manifest overrides it. Pairs with [`Self::fine_nprobe_pct`]
     /// as `max(floor, floor(pct × clusters))`.
     pub fine_nprobe_floor: usize,
+    /// Recall the drain calibration targets when it stamps this table's
+    /// probe laws — the recall/latency lever. The width crossing takes
+    /// this value directly and the depth stages take a padded form of
+    /// it (see `supertable::opann`), so lowering it narrows width,
+    /// depth and the rerank budget together.
+    ///
+    /// Measured on Cohere-10M (768d cosine, 1K official queries):
+    /// 0.99 → recall@10 0.9972 / p50 19.4 ms; 0.993 → 0.9959 / 16.1 ms;
+    /// 0.93 → 0.9693 / 8.4 ms; 0.90 → 0.9577 / 8.4 ms. Serving recall
+    /// runs ABOVE the target (the crossings are discrete, so the
+    /// smallest width or depth that clears the bar usually overshoots
+    /// it), and below ~0.93 the k=10 latency stops responding — the
+    /// remaining cost is per-cell and per-query overhead, not rows.
+    pub target_recall: f64,
     /// Proportional fine-probe fraction for UNFILTERED vector search:
     /// probe `floor(pct × the cell's fine-cluster count)` so depth scales
     /// with cell size. `0.0` (the default) turns the proportional depth
@@ -445,6 +461,7 @@ impl Default for VectorSettings {
         Self {
             inner_budget: None,
             fine_nprobe_floor: DEFAULT_VECTOR_FINE_NPROBE_FLOOR,
+            target_recall: DEFAULT_VECTOR_TARGET_RECALL,
             fine_nprobe_pct: DEFAULT_VECTOR_FINE_NPROBE_PCT,
             serve_near_tie_slack: DEFAULT_VECTOR_SERVE_NEAR_TIE_SLACK,
             kmeans_pts_per_centroid: DEFAULT_VECTOR_KMEANS_PTS_PER_CENTROID,

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -716,6 +716,12 @@ pub(crate) fn plan_sq8_split_kway(
 /// same top-k cell spread.
 pub(crate) const WIDTH_LAW_QUERY_SAMPLE: usize = 256;
 
+/// Terminal fallback for a `target_recall` that fails validation, used only
+/// when the configured value is also out of range. The acceptance bar the
+/// project gates on, so a table calibrated after a bad knob is still held
+/// to the shipped standard rather than to an arbitrary number.
+const ACCEPTANCE_BAR_RECALL: f64 = 0.99;
+
 /// Z-multiplier on the width crossing's sampling error: the crossing
 /// tests `mean − Z·SE` against the target, so `0` crosses on the
 /// measured mean and a positive Z makes the sample PROVE the narrower
@@ -996,6 +1002,33 @@ fn floor_monotone(law: &mut [u32; WIDTH_LAW_KS.len()]) {
 
 impl WidthLawCalibration {
     pub(crate) fn new(dim: usize, metric: Metric, target_recall: f64) -> Self {
+        // The target arrives from user YAML, so validate it here rather than
+        // let a bad value reach the walk, where it fails silently: NaN makes
+        // every crossing comparison false, so nothing is ever stamped and the
+        // rerank cutoff collapses to zero; zero or negative is satisfied by
+        // the first candidate, stamping a width of 1 that under-provisions
+        // every query; above 1.0 no width can ever satisfy it. The configured
+        // value is the fallback but not a trusted one — it comes off the same
+        // YAML surface — so it is checked too, terminating on the shipped bar.
+        let valid = |v: f64| v.is_finite() && v > 0.0 && v <= 1.0;
+        let fallback_target = {
+            let configured = config::global().vector.target_recall;
+            if valid(configured) {
+                configured
+            } else {
+                ACCEPTANCE_BAR_RECALL
+            }
+        };
+        let target_recall = if valid(target_recall) {
+            target_recall
+        } else {
+            tracing::warn!(
+                target_recall,
+                fallback = fallback_target,
+                "vector.target_recall must be in (0, 1]; falling back to the default"
+            );
+            fallback_target
+        };
         Self {
             dim,
             metric,
@@ -1759,6 +1792,24 @@ mod tests {
                 "the calibration carries the target unmodified"
             );
         }
+    }
+
+    /// A target outside `(0, 1]` never reaches the walk. Each of these
+    /// fails silently if stored: NaN stamps nothing and zeroes the rerank
+    /// cutoff, `<= 0` stamps width 1, `> 1` can never be crossed.
+    #[test]
+    fn an_out_of_range_target_falls_back_to_the_configured_default() {
+        for bad in [f64::NAN, 0.0, -0.5, 1.5, f64::INFINITY, f64::NEG_INFINITY] {
+            let cal = WidthLawCalibration::new(8, Metric::Cosine, bad);
+            assert_eq!(
+                cal.target_recall,
+                shipped_target_recall(),
+                "target {bad} must fall back, not be stored"
+            );
+        }
+        // The boundary itself is a legal target and must survive untouched.
+        let cal = WidthLawCalibration::new(8, Metric::Cosine, 1.0);
+        assert_eq!(cal.target_recall, 1.0);
     }
 
     /// The shipped `vector.target_recall`, read from the live config so

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -716,16 +716,30 @@ pub(crate) fn plan_sq8_split_kway(
 /// same top-k cell spread.
 pub(crate) const WIDTH_LAW_QUERY_SAMPLE: usize = 256;
 
-/// One-sided 95% normal bound (z ≈ 1.645) for the width crossing's
-/// lower confidence bound — a statistical convention, not a tuned
-/// value. The width walk samples [`WIDTH_LAW_QUERY_SAMPLE`] queries;
-/// its mean-coverage estimate at a marginal crossing carries sampling
-/// error, and stamping on the raw mean turned that error into a
-/// run-to-run serving lottery (measured at 10M post-compact: width-1
-/// draws served 0.980–0.991, width-2 draws 0.994, identical corpus).
-/// The bound makes the sample prove the narrower width or stamp the
-/// wider one.
-const WIDTH_LAW_CONFIDENCE_Z: f64 = 1.645;
+/// Z-multiplier on the width crossing's sampling error: the crossing
+/// tests `mean − Z·SE` against the target, so `0` crosses on the
+/// measured mean and a positive Z makes the sample PROVE the narrower
+/// width before stamping it.
+///
+/// `0` (crossing on the mean) is what the width walk uses. It was
+/// 1.645 — a one-sided 95% bound — because on a 0.99 target the raw
+/// mean turned sampling error into a serving lottery (measured at 10M
+/// post-compact: width-1 draws served 0.980–0.991, width-2 draws
+/// 0.994, identical corpus), and straddling a hard acceptance bar is a
+/// violation. That argument is specific to targets AT the bar. With
+/// `vector.target_recall` configurable, a table set below the bar has
+/// deliberately traded recall for latency and is not protecting
+/// anything by over-provisioning: measured at 10M, target 0.90 stamped
+/// width [7,7,9,10] under the bound versus [5,5,6,8] on the mean, and
+/// served 0.9523 versus 0.9406 — a quarter more cells bought recall
+/// nobody asked for. The mean also tracks the configured target more
+/// closely, which is the point of exposing it.
+///
+/// The variance the bound guarded against is NOT re-measured here (one
+/// run per setting says nothing about run-to-run spread); if a table
+/// at a bar-level target shows stamp instability, this is the knob
+/// that addresses it.
+const WIDTH_LAW_CONFIDENCE_Z: f64 = 0.0;
 
 /// Rerank-law distractor pool: each calibration query counts 1-bit-estimate
 /// distractors only within its `RERANK_LAW_POOL_CELLS` grid-nearest cells —

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -856,10 +856,6 @@ pub(crate) struct WidthLawCalibration {
     /// Cohere-10M with every stage at the target: 0.993 served 0.9959,
     /// 0.93 served 0.9693, 0.90 served 0.9577. Padding would only
     /// widen probes for a loss that does not occur.
-    /// per-table
-    /// `vector.target_recall`. Width crosses at the target itself and
-    /// every law stage, so one knob
-    /// moves the whole recall/latency operating point.
     target_recall: f64,
     /// Rerank-law observation state, armed by [`Self::freeze`]; `None`
     /// (e.g. planted test fixtures) measures no rerank law.

--- a/src/supertable/opann.rs
+++ b/src/supertable/opann.rs
@@ -716,31 +716,6 @@ pub(crate) fn plan_sq8_split_kway(
 /// same top-k cell spread.
 pub(crate) const WIDTH_LAW_QUERY_SAMPLE: usize = 256;
 
-/// Coverage target for EVERY law stage (width, fine depth, rerank).
-/// Stage coverages compound multiplicatively toward the end-to-end
-/// recall bar (width x fine x rerank): stamping any stage at the 0.99
-/// bar itself leaves zero margin, and a crossing that lands exactly at
-/// target compounds the product to ~0.98 (measured, both ways: fine law
-/// 5 at a 0.99 target → post-drain 0.983; width at a 0.99 target over
-/// the post-split 3.5K-cell grid → post-compact 0.986-0.994 straddling
-/// the bar run-to-run, while stages that overshoot their crossing —
-/// width at 256 cells — deliver 0.996). 0.997 per stage keeps the
-/// three-stage product ≥ 0.991 even when every crossing is tight.
-const LAW_STAGE_TARGET_COVERAGE: f64 = 0.997;
-
-/// Width-walk coverage target: the 0.99 bar itself, NOT the padded
-/// stage target below. Width is the dominant cost term — every probed
-/// cell is a fetch — and the 0.997 pad measured a 2x width tax on
-/// real embeddings (Cohere-1M: width 97 vs 53 at k=100; -7 ms @ k=100
-/// and -2.3 ms @ k=10 at equal recall class when dropped to 0.99).
-/// The padded target exists for PER-STAGE COMPOUNDING, and width is
-/// where compounding is cheapest to absorb: the 10M gate at this
-/// split (2026-08-02, vec10m-width99.log) holds every lifecycle state
-/// at 0.991-0.997 — the historical "width at 0.99 straddles the bar"
-/// measurement predates the recalibration repair and the rerank law
-/// actually serving, both of which carry the margin now.
-const WIDTH_LAW_TARGET_COVERAGE: f64 = 0.99;
-
 /// One-sided 95% normal bound (z ≈ 1.645) for the width crossing's
 /// lower confidence bound — a statistical convention, not a tuned
 /// value. The width walk samples [`WIDTH_LAW_QUERY_SAMPLE`] queries;
@@ -857,6 +832,21 @@ pub(crate) struct WidthLawCalibration {
     /// Distractor-pool size (cells) chosen at [`Self::freeze`]; the
     /// legacy floor until then.
     pool_cells: usize,
+    /// Recall this drain calibrates its laws to hold — the per-table
+    /// `vector.target_recall`. EVERY stage (width, fine depth, rerank
+    /// budget) crosses at this value; there is deliberately no padded
+    /// per-stage variant. The stages compound, but on the SAME queries
+    /// — a query whose neighbors land in the probed cells is also the
+    /// query whose neighbors sit shallow in them — so the product runs
+    /// far above the independent-stages worst case. Measured on
+    /// Cohere-10M with every stage at the target: 0.993 served 0.9959,
+    /// 0.93 served 0.9693, 0.90 served 0.9577. Padding would only
+    /// widen probes for a loss that does not occur.
+    /// per-table
+    /// `vector.target_recall`. Width crosses at the target itself and
+    /// every law stage, so one knob
+    /// moves the whole recall/latency operating point.
+    target_recall: f64,
     /// Rerank-law observation state, armed by [`Self::freeze`]; `None`
     /// (e.g. planted test fixtures) measures no rerank law.
     rerank: Option<RerankLawObservation>,
@@ -995,7 +985,7 @@ fn floor_monotone(law: &mut [u32; WIDTH_LAW_KS.len()]) {
 }
 
 impl WidthLawCalibration {
-    pub(crate) fn new(dim: usize, metric: Metric) -> Self {
+    pub(crate) fn new(dim: usize, metric: Metric, target_recall: f64) -> Self {
         Self {
             dim,
             metric,
@@ -1007,6 +997,7 @@ impl WidthLawCalibration {
             fine_ranks: Mutex::new(HashMap::new()),
             max_fine: AtomicU32::new(0),
             pool_cells: RERANK_LAW_POOL_CELLS,
+            target_recall,
             rerank: None,
         }
     }
@@ -1350,7 +1341,7 @@ impl WidthLawCalibration {
     }
 
     /// Extract the width law: cells (in the grid's routing order) needed
-    /// for mean [`LAW_STAGE_TARGET_COVERAGE`] coverage of the exact top-k
+    /// for mean target-recall coverage of the exact top-k
     /// at each [`WIDTH_LAW_KS`] point. Each point is measured over the
     /// queries whose candidate count reaches its `k` — one boundary-starved
     /// query excludes itself, not the whole sample. Points NO query can
@@ -1504,7 +1495,7 @@ impl WidthLawCalibration {
             // all synthetic post-drain shapes) has SE = 0 and stamps
             // exactly as before; only genuinely marginal crossings widen.
             let n = support[ki] as f64;
-            let target = WIDTH_LAW_TARGET_COVERAGE * n;
+            let target = self.target_recall * n;
             if let Some(rank) = sums.iter().enumerate().position(|(rank, &s)| {
                 let mean = s / n;
                 let var = (coverage_sq_sums[ki][rank] / n - mean * mean).max(0.0);
@@ -1513,7 +1504,7 @@ impl WidthLawCalibration {
             }) {
                 law[ki] = (rank + 1) as u32;
             }
-            let stage_target = LAW_STAGE_TARGET_COVERAGE * support[ki] as f64;
+            let stage_target = self.target_recall * support[ki] as f64;
             if let Some(rank) = fine_sums[ki].iter().position(|&s| s >= stage_target) {
                 fine_law[ki] = (rank + 1) as u32;
             }
@@ -1531,7 +1522,7 @@ impl WidthLawCalibration {
             // crossing means the evidence cannot certify the target —
             // the point stays uncalibrated (constant fallback).
             ranks.sort_unstable();
-            let needed = (LAW_STAGE_TARGET_COVERAGE * ranks.len() as f64).ceil() as usize;
+            let needed = (self.target_recall * ranks.len() as f64).ceil() as usize;
             if let Some(&crossing) = ranks.get(needed.saturating_sub(1).min(ranks.len() - 1))
                 && crossing != u64::MAX
             {
@@ -1741,6 +1732,31 @@ mod tests {
 
     use super::*;
 
+    /// Every stage crosses at the target itself — no padded per-stage
+    /// variant, no derived second constant. Pins that the shipped
+    /// default still crosses width at 0.99 (the historical
+    /// `WIDTH_LAW_TARGET_COVERAGE`), which is what the acceptance
+    /// gates measure against.
+    #[test]
+    fn every_stage_crosses_at_the_configured_target() {
+        /// The historical width crossing this knob's default preserves.
+        const SHIPPED_WIDTH: f64 = 0.99;
+        assert_eq!(shipped_target_recall(), SHIPPED_WIDTH);
+        for target in [0.80, 0.90, 0.95, 0.99] {
+            let cal = WidthLawCalibration::new(8, Metric::Cosine, target);
+            assert_eq!(
+                cal.target_recall, target,
+                "the calibration carries the target unmodified"
+            );
+        }
+    }
+
+    /// The shipped `vector.target_recall`, read from the live config so
+    /// the pin below tracks the YAML default instead of a copy of it.
+    fn shipped_target_recall() -> f64 {
+        crate::config::global().vector.target_recall
+    }
+
     /// Raw fp32-le centroid-region bytes for planted calibration views.
     fn fp32_le_bytes(vals: &[f32]) -> Bytes {
         Bytes::from(
@@ -1772,7 +1788,7 @@ mod tests {
             ],
             vec![1; 4],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, shipped_target_recall());
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -1822,7 +1838,7 @@ mod tests {
     fn depth_law_walks_fine_ranks() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, shipped_target_recall());
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -1902,7 +1918,7 @@ mod tests {
     fn rerank_law_reads_survivor_budget_from_histograms() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, shipped_target_recall());
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -1958,7 +1974,7 @@ mod tests {
     fn depth_law_missing_rank_is_conservative() {
         const DIM: usize = 4;
         let grid = ClusterCentroids::from_fp32(1, DIM as u32, &[1.0, 0.0, 0.0, 0.0], vec![1; 1]);
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, shipped_target_recall());
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {
@@ -2018,7 +2034,7 @@ mod tests {
             ],
             vec![1; 4],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, shipped_target_recall());
         let mut queries = vec![0.0f32; 2 * DIM];
         queries[0] = 1.0;
         queries[DIM] = 1.0;
@@ -2081,7 +2097,7 @@ mod tests {
             ],
             vec![1; 2],
         );
-        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine);
+        let mut cal = WidthLawCalibration::new(DIM, Metric::Cosine, shipped_target_recall());
         let mut query = vec![0.0f32; DIM];
         query[0] = 1.0;
         cal.frozen = Some(WidthLawQueries {

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -470,6 +470,13 @@ pub struct SupertableOptions {
     /// [`SupertableOptions::apply_config`] copies `vector.drain_batch_superfiles`
     /// into this field; [`Self::with_drain_batch_superfiles`] overrides per table.
     pub drain_batch_superfiles: i64,
+    /// Recall the drain calibration targets when it stamps this table's
+    /// probe laws — the recall/latency lever. Width crosses at this
+    /// value and the depth stages at a padded form of it, so lowering
+    /// it narrows width, fine depth and the rerank budget together.
+    /// [`SupertableOptions::apply_config`] copies `vector.target_recall`
+    /// into this field; [`Self::with_target_recall`] overrides per table.
+    pub target_recall: f64,
     /// Per-cell consolidation op for the hidden-index drain. Default
     /// [`DrainConsolidate::Kmeans`]. [`SupertableOptions::apply_config`] copies
     /// `vector.drain_consolidate`; [`Self::with_drain_consolidate`] overrides
@@ -722,6 +729,7 @@ impl SupertableOptions {
             target_superfiles_per_part: DEFAULT_TARGET_SUPERFILES_PER_PART,
             part_size_threshold_bytes: DEFAULT_PART_SIZE_THRESHOLD_BYTES,
             drain_batch_superfiles: DEFAULT_DRAIN_BATCH_SUPERFILES,
+            target_recall: crate::config::global().vector.target_recall,
             drain_consolidate: DrainConsolidate::Kmeans,
             eager_load_threshold_parts: DEFAULT_EAGER_LOAD_THRESHOLD_PARTS,
             max_commit_retries: DEFAULT_MAX_COMMIT_RETRIES,
@@ -938,6 +946,14 @@ impl SupertableOptions {
         self
     }
 
+    /// Override the calibration's recall target for this table. Takes
+    /// effect on the NEXT drain or recalibration: the laws already
+    /// stamped in the manifest keep serving until then.
+    pub fn with_target_recall(mut self, target: f64) -> Self {
+        self.target_recall = target;
+        self
+    }
+
     /// Override the hidden-index drain consolidation op. See
     /// [`Self::drain_consolidate`].
     pub fn with_drain_consolidate(mut self, mode: DrainConsolidate) -> Self {
@@ -1079,6 +1095,7 @@ impl SupertableOptions {
         self.commit_threshold_size_mb = cfg.supertable.commit_threshold_size_mb;
         self.verify_crc_on_open = cfg.supertable.verify_crc_on_open;
         self.drain_batch_superfiles = cfg.vector.drain_batch_superfiles;
+        self.target_recall = cfg.vector.target_recall;
         self.drain_consolidate = cfg.vector.drain_consolidate;
         // The `config.yaml` source for the connection budget; the connect path
         // uses `ConnectOptions` instead. 0, the shipped default, is measure-only.

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -3428,8 +3428,13 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
     let clean_uncheckpointed_drain = local_checkpoint.batches_done == 0
         && completed_shards.is_empty()
         && local_checkpoint.spills.is_empty();
-    let mut width_law = clean_uncheckpointed_drain
-        .then(|| opann::WidthLawCalibration::new(running_clusters.dim as usize, metric));
+    let mut width_law = clean_uncheckpointed_drain.then(|| {
+        opann::WidthLawCalibration::new(
+            running_clusters.dim as usize,
+            metric,
+            user_inner.options.target_recall,
+        )
+    });
     // #512 invariant tripwire: no re-encode in this drain may saturate its
     // destination quantizer — cosine rows are unit (ingest-normalized) so
     // the fixed grid covers them, and data-derived grids are built to cover
@@ -7139,7 +7144,8 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
     // this scan measures. A drain that commits between the scan and the
     // stamp adds rows this evidence never saw.
     let scan_ids: HashSet<Uuid> = manifest.superfiles.iter().map(|e| e.superfile_id).collect();
-    let mut cal = opann::WidthLawCalibration::new(clusters.dim as usize, metric);
+    let mut cal =
+        opann::WidthLawCalibration::new(clusters.dim as usize, metric, inner.options.target_recall);
     // Query-sample pass: exactly `min(total_docs, WIDTH_LAW_QUERY_SAMPLE)`
     // evenly spaced ordinals over the cell-ordered live-row enumeration —
     // the law's noise floor is set by evidence size, and any fixed stride


### PR DESCRIPTION
The calibration's coverage crossings were hardcoded: width at 0.99, the depth stages (fine, rerank) at 0.997. That pair *is* the recall/latency lever — it sets width, fine depth and the rerank budget together — but it was unreachable without editing the source.

### The knob

`vector.target_recall` in config.yaml plus `SupertableOptions::with_target_recall` for per-table override, copied by `apply_config` like the other vector knobs. Every stage crosses at that one value. It takes effect on the next drain or recalibration — laws already stamped keep serving until then — and it is manifest metadata, not packed bytes, so it does not pin the drain epoch.

**No padded per-stage variant, and no formula deriving one crossing from another.** The 0.997 existed because the stages compound and stamping each at the bar was measured to land the product near 0.98 — but they compound on the *same* queries: a query whose neighbors fall in the probed cells is also the query whose neighbors sit shallow in them. Measured on Cohere-10M with every stage at the target: 0.993 served 0.9959, 0.93 served 0.9693, 0.90 served 0.9577 — each well above its target. Padding buys width for a compounding loss that does not occur.

### Width crosses on the mean

The width crossing tested `mean - 1.645*SE` against the target, so the sample had to prove the narrower width before it could be stamped. That guard was justified at a 0.99 target — the raw mean turned sampling error into a serving lottery (10M post-compact, identical corpus: width-1 draws serving 0.980–0.991 against width-2 draws serving 0.994) and straddling a hard acceptance bar is a violation.

It stops being justified once the target is configurable. A table set below the bar has deliberately traded recall for latency; over-provisioning protects nothing there and makes the configured number mean less. At target 0.90 the bound stamped width `[7,7,9,10]` serving 0.9523; the mean stamps `[5,5,6,8]` serving 0.9406.

The constant stays in place (now `0.0`) so a table at a bar-level target showing stamp instability has the knob to address it. **The variance the bound guarded against is not re-measured here** — one run per setting says nothing about run-to-run spread.

### Measured range (Cohere-10M, 768d cosine, 1K official queries, current main)

| target_recall | width law | recall@10 / p50 | recall@100 / p50 |
|---|---|---|---|
| 0.99 (default, z=1.645) | [34,34,34,34] | 0.9972 / 19.35 ms | 0.9981 / 43.83 ms |
| 0.90 | [5,5,6,8] | 0.9406 / 7.79 ms | 0.9624 / 14.64 ms |
| 0.80 | [2,3,4,5] | 0.8878 / 5.98 ms | 0.9073 / 9.58 ms |

3.2x at k=10 and 4.6x at k=100 across the range, and served recall now tracks the requested value closely enough for the number to be worth configuring (0.80 → 0.888; the padded version served 0.988 for a request of 0.90).

Serving recall still runs above target because the crossings are discrete — the smallest width or depth that clears the bar usually overshoots.

### Behavior change at the default

Width crosses where it does today, but two things move: the depth stages cross at 0.99 instead of 0.997, and width crosses on the mean instead of the lower bound. The measurements above cover the first; the second is unmeasured at 0.99 specifically and is the risk worth reviewing.

### Gates

clippy clean, lib 2193, supertable 283, public-api no drift.