### PR TITLE
vector: normalize cosine rows at the fp32 cell-build seam (#512)

### DIFF
--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -1759,6 +1759,33 @@ fn stream_fp32_rows_to_buckets(
     });
     let chunk_rows = materialized_chunk_rows_for_dim(dim);
     let mut chunk_rotated = vec![0.0f32; chunk_rows * dim];
+    // Cosine rows must be unit before ANY consumer below sees them: the
+    // fixed cosine grid spans [-1, 1], so a non-unit component saturates at
+    // encode — silently, with no error and no clamp counter (the drain's
+    // transcode tripwire only observes RE-encodes). Issue #512 measured
+    // about -10 points of recall@10 from exactly this.
+    //
+    // #520 normalized at `VectorBuilder::add`, described there as "the
+    // single seam every downstream consumer reads through". That holds for
+    // that builder and not for the engine: the supertable buffers the
+    // caller's Arrow vector buffers zero-copy (`BufferedBatch`) and the
+    // commit-time hidden-index pack views them directly
+    // (`VectorColumnView` -> `PackRow::Fp32` -> `build_merged_subsection_
+    // from_fp32`), never passing through that seam. So the user table
+    // stored unit rows while the hidden index — what actually serves vector
+    // search — stored clamped ones.
+    //
+    // Normalizing here covers every fp32 cell build regardless of caller,
+    // and the scratch is chunk-bounded (same sizing as `chunk_rotated`),
+    // not corpus-bounded: normalizing at `append` instead would reintroduce
+    // the commit-wide vector copy `VectorColumnView` exists to avoid
+    // (12.8 GiB at a 3.125M-row x dim-1024 commit).
+    let cosine = cfg.metric == Metric::Cosine;
+    let mut chunk_unit = if cosine {
+        vec![0.0f32; chunk_rows * dim]
+    } else {
+        Vec::new()
+    };
     let mut chunk_codes = vec![0u8; chunk_rows * code_bytes];
     let mut chunk_payload = if fixed {
         vec![0u8; chunk_rows * dim * 2]
@@ -1768,7 +1795,19 @@ fn stream_fp32_rows_to_buckets(
     let mut row_base = 0usize;
     while row_base < n_docs {
         let take = (n_docs - row_base).min(chunk_rows);
-        let chunk = &vectors[row_base * dim..(row_base + take) * dim];
+        let raw = &vectors[row_base * dim..(row_base + take) * dim];
+        let chunk: &[f32] = if cosine {
+            chunk_unit[..take * dim]
+                .par_chunks_mut(dim)
+                .zip(raw.par_chunks(dim))
+                .for_each(|(dst, src)| {
+                    dst.copy_from_slice(src);
+                    normalize(dst);
+                });
+            &chunk_unit[..take * dim]
+        } else {
+            raw
+        };
         let mut assignments = vec![0u32; take];
         assign_to_centroids(chunk, centroids, dim, n_cent, &mut assignments);
         chunk_rotated[..take * dim]

--- a/src/superfile/vector/cell_posting.rs
+++ b/src/superfile/vector/cell_posting.rs
@@ -162,6 +162,40 @@ impl CellPostingBuilder {
     }
 }
 
+/// Tolerance on `‖x‖` for the cosine unit-input tripwire below. Wide
+/// enough that fp32 accumulation over thousands of dims never trips it,
+/// tight enough that genuinely un-normalized input always does (raw
+/// embedding norms are O(1..100), not 1 ± 0.01).
+#[cfg(debug_assertions)]
+const COSINE_UNIT_NORM_TOLERANCE: f32 = 1e-2;
+
+/// Debug-only guard that cosine rows reach the encoder already unit
+/// (issue #512). Both ingest seams normalize — `VectorBuilder::add` and
+/// `CellPostingBuilder::add` — but the failure this guards is a NEW path
+/// bypassing them: the fixed cosine grid then clamps out-of-range
+/// components at encode with no error and no counter, which measured
+/// −10 pts recall@10 the last time it shipped. A `debug_assert` means
+/// the next such path fails in tests instead of silently degrading data,
+/// and costs release builds nothing.
+#[cfg_attr(not(debug_assertions), allow(unused_variables))]
+fn debug_assert_cosine_rows_unit(metric: Metric, dim: usize, vectors: &[f32]) {
+    #[cfg(debug_assertions)]
+    if metric == Metric::Cosine {
+        for (row, chunk) in vectors.chunks_exact(dim).enumerate() {
+            let norm_sq: f32 = chunk.iter().map(|v| v * v).sum();
+            // A zero row is legitimate (degenerate input the normalizer
+            // leaves alone); anything else must be unit.
+            debug_assert!(
+                norm_sq == 0.0 || (norm_sq.sqrt() - 1.0).abs() <= COSINE_UNIT_NORM_TOLERANCE,
+                "cosine row {row} reached the cell-posting encoder with norm {} — an ingest \
+                 path skipped the unit-normalize seam (#512); the fixed grid would clamp it \
+                 silently",
+                norm_sq.sqrt()
+            );
+        }
+    }
+}
+
 pub fn encode_blob(
     metric: Metric,
     dim: usize,
@@ -187,6 +221,7 @@ pub fn encode_blob(
             codec.name()
         ));
     }
+    debug_assert_cosine_rows_unit(metric, dim, vectors);
     let rows: Vec<usize> = (0..ids.len()).collect();
     let posting = encode_rows(metric, vectors, ids, dim, &rows, codec)?;
     let mut out = MAGIC.to_vec();

--- a/tests/supertable/main.rs
+++ b/tests/supertable/main.rs
@@ -38,6 +38,7 @@ mod manifest;
 mod query;
 mod storage;
 mod update_crash_property;
+mod vector_cosine_normalize;
 mod vector_law_serving;
 mod vector_phase_profile;
 mod writer_mutations;

--- a/tests/supertable/vector_cosine_normalize.rs
+++ b/tests/supertable/vector_cosine_normalize.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Cosine ingest must normalize on EVERY path (#512).
+//!
+//! The fixed cosine rerank grid spans `[-1, 1]`, so a non-unit component
+//! saturates at ENCODE — silently, with no error and no clamp counter (the
+//! drain's transcode tripwire only observes re-encodes). Measured cost when
+//! this last shipped: about −10 points of recall@10 on raw Cohere input, and
+//! the failure presents as a bad experiment rather than bad data, so the
+//! time is lost doubting the wrong thing.
+//!
+//! #520 normalized at `VectorBuilder::add`, described there as "the single
+//! seam every downstream consumer reads through". True for that builder,
+//! false for the engine: the supertable buffers the caller's Arrow vector
+//! buffers zero-copy and the commit-time hidden-index pack views them
+//! directly (`VectorColumnView` → `PackRow::Fp32` →
+//! `build_merged_subsection_from_fp32`), bypassing that seam. The user table
+//! stored unit rows while the hidden index — what serves vector search —
+//! stored clamped ones.
+//!
+//! So this guard is deliberately end-to-end rather than a unit test on a
+//! seam: it drives the public `append()` path with vectors whose norms are
+//! far from 1 and asserts served recall matches the same corpus submitted
+//! pre-normalized. Any path that skips normalization fails it, whichever
+//! seam it bypassed.
+
+#![deny(clippy::unwrap_used)]
+
+use std::{collections::HashMap, sync::Arc};
+
+use arrow_array::{
+    ArrayRef, Decimal128Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch,
+};
+use arrow_schema::{DataType, Field, Schema};
+use infino::{
+    Metric, VectorSearchOptions,
+    storage::{LocalFsStorageProvider, StorageProvider},
+    superfile::builder::{FtsConfig, VectorConfig},
+    supertable::{Supertable, SupertableOptions},
+    test_helpers::default_tokenizer,
+};
+use tempfile::TempDir;
+
+/// Fixture dimension.
+const DIM: usize = 16;
+/// Random-rotation seed for the fixture's vector index.
+const ROT_SEED: u64 = 41;
+/// Corpus size: enough rows that clamped components reorder top-k, small
+/// enough to stay a fast integration test.
+const N_ROWS: usize = 512;
+/// Queries per arm.
+const N_QUERIES: usize = 32;
+/// Top-k under comparison.
+const K: usize = 10;
+/// Per-row magnitude. Real embedding norms are O(1..100); at this scale
+/// every component lands well outside the fixed `[-1, 1]` cosine grid, so an
+/// unnormalized path clamps hard rather than marginally.
+const RAW_MAGNITUDE: f32 = 12.0;
+/// Recall agreement required between the two ingest representations. Cosine
+/// declares magnitude irrelevant, so only fp-noise tie reordering is
+/// legitimate; the failure this guards is tens of points wide.
+const RECALL_EQUIVALENCE_TOLERANCE: f32 = 0.02;
+/// The pre-normalized arm must itself recall well, or the equivalence
+/// assertion could pass on two equally broken tables.
+const FIXTURE_RECALL_FLOOR: f32 = 0.90;
+
+fn fixed_list_f32(dim: usize) -> DataType {
+    DataType::FixedSizeList(
+        Arc::new(Field::new("item", DataType::Float32, true)),
+        dim as i32,
+    )
+}
+
+/// Cosine options on the engine's DEFAULT rerank codec — the fixed-grid one
+/// that clamps. Pinning `Fp32` here would pass on broken data, since an
+/// exact rerank plane has nothing to saturate.
+fn cosine_options() -> SupertableOptions {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("emb", fixed_list_f32(DIM), false),
+    ]));
+    SupertableOptions::new(
+        schema,
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        vec![VectorConfig::new(
+            "emb".into(),
+            DIM,
+            ROT_SEED,
+            Metric::Cosine,
+        )],
+        Some(default_tokenizer()),
+    )
+    .expect("valid options")
+}
+
+/// Deterministic row `i`, scaled to a deliberately non-unit magnitude and
+/// spread across directions so top-k is a real ranking, not a tie.
+fn raw_row(i: usize) -> Vec<f32> {
+    let mut v: Vec<f32> = (0..DIM)
+        .map(|d| {
+            let a = ((i * 37 + d * 11) % 101) as f32 / 101.0 - 0.5;
+            let b = ((i * 13 + d * 29) % 71) as f32 / 71.0 - 0.5;
+            a + 0.5 * b
+        })
+        .collect();
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let scale = RAW_MAGNITUDE / norm.max(f32::MIN_POSITIVE);
+    for x in &mut v {
+        *x *= scale;
+    }
+    v
+}
+
+fn unit(v: &[f32]) -> Vec<f32> {
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm == 0.0 {
+        return v.to_vec();
+    }
+    v.iter().map(|x| x / norm).collect()
+}
+
+fn batch(schema: Arc<Schema>, rows: &[Vec<f32>]) -> RecordBatch {
+    let mut flat = Vec::<f32>::with_capacity(rows.len() * DIM);
+    let mut titles = Vec::with_capacity(rows.len());
+    for (i, row) in rows.iter().enumerate() {
+        flat.extend_from_slice(row);
+        titles.push(format!("row{i:04}"));
+    }
+    let fsl = FixedSizeListArray::try_new(
+        Arc::new(Field::new("item", DataType::Float32, true)),
+        DIM as i32,
+        Arc::new(Float32Array::from(flat)) as ArrayRef,
+        None,
+    )
+    .expect("FSL");
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(LargeStringArray::from(titles)) as ArrayRef,
+            Arc::new(fsl),
+        ],
+    )
+    .expect("batch")
+}
+
+/// Engine `_id` → dense corpus row, the same way the bench harness does it
+/// (`corpus::engine_id_to_dense`): one ordered `SELECT _id` scan, enumerated
+/// in ingest order. Ids are generated per table, so two independently built
+/// tables never share them — this map is what makes their results
+/// comparable against one corpus-indexed ground truth.
+fn engine_id_to_dense(st: &Supertable) -> HashMap<i128, u32> {
+    let batches = st
+        .reader()
+        .expect("reader")
+        .query_sql("SELECT _id FROM supertable ORDER BY _id")
+        .expect("SELECT _id");
+    let mut ids = Vec::with_capacity(N_ROWS);
+    for b in &batches {
+        let col = b
+            .column(0)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .expect("_id is Decimal128");
+        ids.extend((0..col.len()).map(|i| col.value(i)));
+    }
+    assert_eq!(ids.len(), N_ROWS, "id scan must cover the corpus");
+    ids.into_iter()
+        .enumerate()
+        .map(|(dense, id)| (id, dense as u32))
+        .collect()
+}
+
+/// Served hits as dense corpus rows, in rank order.
+fn hit_rows(batches: &[RecordBatch], id_to_dense: &HashMap<i128, u32>) -> Vec<u32> {
+    let mut rows = Vec::new();
+    for b in batches {
+        let idx = b.schema().index_of("_id").expect("_id projected");
+        let col = b
+            .column(idx)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .expect("_id is Decimal128");
+        for i in 0..b.num_rows() {
+            rows.push(
+                *id_to_dense
+                    .get(&col.value(i))
+                    .expect("served _id present in the id map"),
+            );
+        }
+    }
+    rows
+}
+
+/// Brute-force cosine top-K over the unit corpus, as dense rows. Cosine
+/// ignores magnitude, so this ground truth is identical for both arms —
+/// exactly the property the engine must preserve.
+fn brute_force_rows(pre: &[Vec<f32>], query: &[f32]) -> Vec<u32> {
+    let mut scored: Vec<(u32, f32)> = pre
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let dot: f32 = row.iter().zip(query).map(|(a, b)| a * b).sum();
+            (i as u32, dot)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
+    scored.into_iter().take(K).map(|(i, _)| i).collect()
+}
+
+/// Build a drained table from `rows`, then serve `queries` and return each
+/// query's hits as dense corpus rows.
+fn served_rows(dir: &TempDir, rows: &[Vec<f32>], queries: &[Vec<f32>]) -> Vec<Vec<u32>> {
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(cosine_options().with_storage(storage)).expect("create");
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    w.append(&batch(schema, rows)).expect("append");
+    w.commit().expect("commit");
+    drop(w);
+    st.drain_vectors_to_cells_sync().expect("drain");
+
+    let id_to_dense = engine_id_to_dense(&st);
+    queries
+        .iter()
+        .map(|q| {
+            let batches = st
+                .vector_search("emb", q, K, VectorSearchOptions::new(), None, None)
+                .expect("search");
+            hit_rows(&batches, &id_to_dense)
+        })
+        .collect()
+}
+
+fn mean_recall(hits: &[Vec<u32>], pre: &[Vec<f32>], queries: &[Vec<f32>]) -> f32 {
+    let mut found = 0usize;
+    for (qi, got) in hits.iter().enumerate() {
+        let truth = brute_force_rows(pre, &queries[qi]);
+        found += got.iter().filter(|r| truth.contains(r)).count();
+    }
+    found as f32 / (hits.len() * K) as f32
+}
+
+/// Non-unit cosine input through `append()` must serve like the same corpus
+/// submitted pre-normalized. A gap means an ingest path skipped the
+/// unit-normalize seam and the fixed cosine grid clamped (#512).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unnormalized_cosine_append_serves_like_prenormalized() {
+    let raw: Vec<Vec<f32>> = (0..N_ROWS).map(raw_row).collect();
+    let pre: Vec<Vec<f32>> = raw.iter().map(|r| unit(r)).collect();
+    // Queries are unit on both arms; the corpus representation is the variable.
+    let queries: Vec<Vec<f32>> = (0..N_QUERIES).map(|i| unit(&raw_row(i * 7 + 3))).collect();
+
+    let raw_dir = TempDir::new().expect("tempdir");
+    let pre_dir = TempDir::new().expect("tempdir");
+    let raw_recall = mean_recall(&served_rows(&raw_dir, &raw, &queries), &pre, &queries);
+    let pre_recall = mean_recall(&served_rows(&pre_dir, &pre, &queries), &pre, &queries);
+
+    assert!(
+        pre_recall >= FIXTURE_RECALL_FLOOR,
+        "fixture too hard to detect clamping: pre-normalized recall@{K} \
+         {pre_recall:.4} < {FIXTURE_RECALL_FLOOR}"
+    );
+    assert!(
+        (pre_recall - raw_recall).abs() <= RECALL_EQUIVALENCE_TOLERANCE,
+        "un-normalized cosine ingest recall@{K} {raw_recall:.4} vs pre-normalized \
+         {pre_recall:.4} — an ingest path skipped the unit-normalize seam and the \
+         fixed cosine grid clamped the out-of-range components (#512)"
+    );
+}


### PR DESCRIPTION
Fixes #512 

The fixed cosine rerank grid spans [-1, 1], so a non-unit component saturates at ENCODE — with no error and no clamp counter, since the drain's transcode tripwire only observes re-encodes. Reported cost: recall@10 capped at ~0.898 on Cohere, unchanged even at all-cells with full rerank (degraded data, not routing), recovering to ~0.998 when the identical corpus is re-ingested pre-normalized.

#520 normalized at VectorBuilder::add, described there as "the single seam every downstream consumer reads through". That holds for that builder and not for the engine: SupertableWriter::append buffers the caller's Arrow vector buffers zero-copy, and the commit-time hidden-index pack reads them directly — VectorColumnView -> PackRow::Fp32 -> drain_pack_assigned_cell ->
build_merged_subsection_from_fp32 — never passing through that seam. So the user table stored unit rows while the hidden index, which is what serves vector search, stored clamped ones.

Normalize in stream_fp32_rows_to_buckets, the choke point every fp32 cell build funnels through, so the guarantee holds regardless of caller. The scratch is chunk-bounded (same sizing as the existing chunk_rotated buffer), deliberately not at append(): normalizing there would reintroduce the commit-wide vector copy VectorColumnView exists to avoid (12.8 GiB at a 3.125M-row x dim-1024 commit). Cosine declares magnitude irrelevant, so this is semantics-preserving and unit input is an fp-noise no-op.

Also adds a debug-only assertion at the cell-posting encoder that cosine rows arrive unit, so the next path that bypasses a normalize seam fails in tests instead of silently degrading data.

Regression test drives the public append() path end to end with rows at magnitude 12 and asserts served recall matches the same corpus submitted pre-normalized, mapping engine _ids to dense corpus rows the way the bench harness does (one ordered SELECT _id scan) rather than comparing per-table ids. Without the fix: 0.6969 vs 1.0000, test fails. With it: parity, test passes. Suites green — lib 2192, supertable 284, superfile 138, make check clean.