### PR TITLE
supertable/vector: time the 1-bit scan on the deferred path

### DIFF
--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3567,9 +3567,20 @@ impl VectorReader {
                         budget,
                     };
                     let coarse_limit = k.saturating_mul(rerank_mult);
+                    // Record `vec.shortlist` here too. It was only recorded
+                    // on the immediate probe path, but every warm
+                    // hidden-index query is served by THIS arm, so the 1-bit
+                    // scan went untimed on the path that dominates the
+                    // query — it surfaced as unattributed `vec.fanout_wall`,
+                    // leaving the engine unable to see its own largest
+                    // phase.
+                    let shortlist_t0 = io_counters::phase_start();
                     let (shortlist, scan_kernel_ns) =
                         scan_shortlist(col, cb, &cluster_meta, &blocks, true, coarse_limit, &ctx)
                             .await?;
+                    if let Some(t0) = shortlist_t0 {
+                        io_counters::phase_record("vec.shortlist", t0.elapsed().as_micros() as u64);
+                    }
                     tally.kernel_cpu_ns += scan_kernel_ns;
                     let cands = shortlist
                         .into_iter()

--- a/tests/supertable/vector_phase_profile.rs
+++ b/tests/supertable/vector_phase_profile.rs
@@ -56,7 +56,15 @@ async fn vector_phase_profile() {
         &table_dir,
         infino::ConnectOptions::default()
             .with_cache_dir(&cache_dir)
-            .with_cache_budget_bytes(21_474_836_480),
+            .with_cache_budget_bytes(
+                env::var("INFINO_DIAG_CACHE_GIB")
+                    .ok()
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(20)
+                    * 1024
+                    * 1024
+                    * 1024,
+            ),
     )
     .expect("connect");
     let table = conn.open_table("vdbbench_infino").expect("open table");


### PR DESCRIPTION
`vec.shortlist` was recorded only in `probe_clusters_async`, the immediate probe path. Every warm hidden-index query is served by `search_clusters_scan_async` instead, where the scan went untimed and surfaced as unattributed `vec.fanout_wall` — so the engine could not see its own largest phase, and that phase's share ended up being argued from perf samples rather than measured.

Also make the phase-profile diagnostic's cache budget env-tunable (INFINO_DIAG_CACHE_GIB, default unchanged at 20 GiB). Against a 33 GiB table the hard-coded default profiles partly-cold I/O: 45 ms wall where the warm sweeps on the same table and code read 20 ms.

Measured with both, Cohere-10M k=10 warm (200 queries after warmup, width 35, rerank budget 3683): wall p50 23.1 ms; `vec.admit` 3.0 ms single-threaded ahead of the fan-out; `vec.fanout_wall` 22.4 ms, filled by the scan; `vec.rerank` 1.7 ms and `vec.survivor_fetch` 0.3 ms. The per-cell phases are summed across concurrently scanned cells and are inflated by queueing on the shared reader pool (464 ms of `vec.shortlist` against 22.4 ms of wall), so they bound wall time, not CPU.