### PR TITLE
fts: df-anchor the disjunction count when one term dominates

### DIFF
--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1579,19 +1579,26 @@ pub(super) fn or_count_unranked(mut cursors: Vec<TermCursor>) -> u64 {
 /// df read + skip-probe wins. Requires ≥ 2 cursors (a single cursor's
 /// count is just its df, and the windowed walk handles it trivially).
 fn dominant_anchor_index(cursors: &[TermCursor]) -> Option<usize> {
-    if cursors.len() < 2 {
+    dominant_anchor_of_dfs(cursors.iter().map(|c| c.df))
+}
+
+/// The routing decision behind [`dominant_anchor_index`], over raw dfs so
+/// the boundary behaviour is unit-testable without building cursors.
+/// Returns the index of the term whose df is at least
+/// [`OR_COUNT_ANCHOR_DOMINANCE`]× the sum of all the others' (a `>=`
+/// boundary — exactly `N×` still routes to the anchor), or `None` when no
+/// term dominates or there are fewer than two terms.
+fn dominant_anchor_of_dfs(dfs: impl IntoIterator<Item = u64>) -> Option<usize> {
+    let dfs: Vec<u64> = dfs.into_iter().collect();
+    if dfs.len() < 2 {
         return None;
     }
-    let (max_idx, max_df) = cursors
-        .iter()
-        .enumerate()
-        .map(|(i, c)| (i, c.df))
-        .max_by_key(|&(_, df)| df)?;
-    let others_df: u64 = cursors
+    let (max_idx, &max_df) = dfs.iter().enumerate().max_by_key(|&(_, df)| *df)?;
+    let others_df: u64 = dfs
         .iter()
         .enumerate()
         .filter(|&(i, _)| i != max_idx)
-        .map(|(_, c)| c.df)
+        .map(|(_, df)| *df)
         .sum();
     // `others_df == 0` (every other term inline/df-1-summing-to-0 is
     // impossible, but guard anyway) trivially dominates.
@@ -2116,6 +2123,31 @@ mod tests {
         assert_eq!(read_u32_le(&b32), 0x1234_5678);
         let b64 = [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         assert_eq!(read_u64_le(&b64), 1);
+    }
+
+    #[test]
+    fn dominant_anchor_routes_at_the_dominance_boundary() {
+        // The union count anchors on a term only when its df is at least
+        // OR_COUNT_ANCHOR_DOMINANCE× the others' combined df. Pin the
+        // routing at the boundary (values chosen against the 8× default).
+        let k = OR_COUNT_ANCHOR_DOMINANCE;
+        // Exactly N× the rest → dominates (the boundary is inclusive).
+        assert_eq!(dominant_anchor_of_dfs([100 * k, 100]), Some(0));
+        // One below the boundary → no anchor, fall back to windowed.
+        assert_eq!(dominant_anchor_of_dfs([100 * k - 1, 100]), None);
+        // The anchor is the max-df term wherever it sits.
+        assert_eq!(dominant_anchor_of_dfs([100, 100 * k]), Some(1));
+        // Single term → no anchor (its count is just its df).
+        assert_eq!(dominant_anchor_of_dfs([100 * k]), None);
+        // Two-way tie → neither dominates.
+        assert_eq!(dominant_anchor_of_dfs([500, 500]), None);
+        // Dominance is measured against the *sum* of the others, not the
+        // largest single other: 8×(100+100)=1600 > 1500, so no anchor.
+        assert_eq!(dominant_anchor_of_dfs([1500, 100, 100]), None);
+        // …and just clears when the sum is small enough.
+        assert_eq!(dominant_anchor_of_dfs([100 * k, 60, 40]), Some(0));
+        // Empty → no anchor.
+        assert_eq!(dominant_anchor_of_dfs([0u64; 0]), None);
     }
 
     #[test]

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -288,6 +288,17 @@ pub(super) const OR_WINDOW: u32 = 4096;
 /// Number of 64-bit words in the window presence bitset.
 pub(super) const OR_WINDOW_WORDS: usize = (OR_WINDOW as usize).div_ceil(64);
 
+/// Dominance threshold for the df-anchored union count. When one term's
+/// document frequency is at least this multiple of *all the other terms'
+/// dfs combined*, a disjunction count is cheaper computed as
+/// `df(dominant) + |others \ dominant|` — the dominant term's df is read
+/// from its header (no decode) and its skip table is traversed once to
+/// membership-test the rarer docs — than by walking every posting of
+/// every term. Conservative (≥ this ratio) so only a clear dominant term
+/// takes the anchored path; balanced unions keep the windowed bitset,
+/// which is already faster when no term dominates.
+pub(super) const OR_COUNT_ANCHOR_DOMINANCE: u64 = 4;
+
 /// Multi-term OR dispatch floor. A 2-term OR is already sub-millisecond
 /// on MaxScore, so the window's per-window bookkeeping isn't worth it
 /// below this many terms. `pub(crate)`: the supertable fan-out reuses
@@ -1505,6 +1516,12 @@ pub(super) fn or_merge_unranked(cursors: Vec<TermCursor>) -> Vec<u32> {
 /// drops scoring and the top-k heap, since a count needs neither order
 /// nor scores. No doc-id list is materialized.
 pub(super) fn or_count_unranked(mut cursors: Vec<TermCursor>) -> u64 {
+    // Fast path: when one term's list dwarfs the rest, count it as
+    // `df(dominant) + |others \ dominant|` instead of walking the
+    // dominant term's whole posting list. See `or_count_anchored`.
+    if let Some(anchor) = dominant_anchor_index(&cursors) {
+        return or_count_anchored(cursors, anchor);
+    }
     let mut present = [0u64; OR_WINDOW_WORDS];
     let mut n = 0u64;
     loop {
@@ -1541,6 +1558,72 @@ pub(super) fn or_count_unranked(mut cursors: Vec<TermCursor>) -> u64 {
         for word in present.iter_mut() {
             n += word.count_ones() as u64;
             *word = 0;
+        }
+    }
+    n
+}
+
+/// Pick the cursor whose df dominates the union, or `None` if no term is
+/// dominant enough for the anchored count to pay off. Dominant means the
+/// largest df is at least [`OR_COUNT_ANCHOR_DOMINANCE`]× the sum of all
+/// the other dfs — so the dominant list is longer than everything else
+/// combined by a wide margin, exactly when replacing its full walk with a
+/// df read + skip-probe wins. Requires ≥ 2 cursors (a single cursor's
+/// count is just its df, and the windowed walk handles it trivially).
+fn dominant_anchor_index(cursors: &[TermCursor]) -> Option<usize> {
+    if cursors.len() < 2 {
+        return None;
+    }
+    let (max_idx, max_df) = cursors
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (i, c.df))
+        .max_by_key(|&(_, df)| df)?;
+    let others_df: u64 = cursors
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| i != max_idx)
+        .map(|(_, c)| c.df)
+        .sum();
+    // `others_df == 0` (every other term inline/df-1-summing-to-0 is
+    // impossible, but guard anyway) trivially dominates.
+    match max_df >= others_df.saturating_mul(OR_COUNT_ANCHOR_DOMINANCE) {
+        true => Some(max_idx),
+        false => None,
+    }
+}
+
+/// Disjunction cardinality anchored on a dominant term. The union size is
+/// `df(anchor) + |(the other cursors' union) \ anchor|`: every doc in the
+/// anchor is counted once by its df (no decode), and each doc in the
+/// rarer cursors' union is added once iff the anchor does not already
+/// contain it. The anchor is advanced monotonically by `skip_to` as the
+/// others' merge frontier ascends, so its skip table is traversed once
+/// rather than its whole posting list decoded.
+fn or_count_anchored(mut cursors: Vec<TermCursor>, anchor_idx: usize) -> u64 {
+    let mut anchor = cursors.swap_remove(anchor_idx);
+    let mut n = anchor.df;
+    // Frontier merge over the remaining (rarer) cursors: smallest current
+    // doc, membership-test the anchor, then advance every other cursor
+    // sitting on that doc so each distinct doc is visited once.
+    loop {
+        let mut min_doc = u32::MAX;
+        for c in &cursors {
+            if !c.is_exhausted() {
+                min_doc = min_doc.min(c.current_doc_id());
+            }
+        }
+        if min_doc == u32::MAX {
+            break;
+        }
+        anchor.skip_to(min_doc);
+        if anchor.is_exhausted() || anchor.current_doc_id() != min_doc {
+            n += 1;
+        }
+        for c in cursors.iter_mut() {
+            if !c.is_exhausted() && c.current_doc_id() == min_doc {
+                c.next();
+            }
         }
     }
     n

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -294,10 +294,18 @@ pub(super) const OR_WINDOW_WORDS: usize = (OR_WINDOW as usize).div_ceil(64);
 /// `df(dominant) + |others \ dominant|` — the dominant term's df is read
 /// from its header (no decode) and its skip table is traversed once to
 /// membership-test the rarer docs — than by walking every posting of
-/// every term. Conservative (≥ this ratio) so only a clear dominant term
-/// takes the anchored path; balanced unions keep the windowed bitset,
-/// which is already faster when no term dominates.
-pub(super) const OR_COUNT_ANCHOR_DOMINANCE: u64 = 4;
+/// every term.
+///
+/// The anchored path does one skip-probe per doc in the *others* union,
+/// and a skip-probe costs several times what the windowed walk's linear
+/// `next()` does. So it only pays when the dominant list — the postings
+/// the anchor avoids decoding — is larger than the others' combined df by
+/// more than that per-probe penalty. Measurement puts the crossover
+/// between ~6× (where the probe cost still loses) and ~130× (a clear
+/// win); this threshold sits above the loss region so only a decisively
+/// dominant term takes the anchored path. Balanced unions keep the
+/// windowed bitset, which is already faster when no term dominates.
+pub(super) const OR_COUNT_ANCHOR_DOMINANCE: u64 = 8;
 
 /// Multi-term OR dispatch floor. A 2-term OR is already sub-millisecond
 /// on MaxScore, so the window's per-window bookkeeping isn't worth it

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -539,6 +539,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn or_count_anchored_matches_merge_on_dominant_term() {
+        // When one term's df dwarfs the rest, the OR count takes the
+        // df-anchored path (`df(dominant) + |others \ dominant|`) instead
+        // of walking the dominant list. It must return the identical
+        // cardinality as the independent naive ascending merge
+        // (`token_match` length). The corpus spans several OR_WINDOW
+        // windows and — crucially — leaves gaps where the dominant term
+        // is *absent* but a rare term is present, so the "doc not in the
+        // anchor" branch is exercised, not just `df(dominant)`.
+        const N_DOCS: u32 = OR_WINDOW * 2 + 137;
+        const RARE_STRIDE: u32 = 250; // rare term hits ~1/250 docs
+        const RAREB_STRIDE: u32 = 400;
+        const HOLE_STRIDE: u32 = 300; // docs missing the dominant term
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false).expect("register");
+        for i in 0..N_DOCS {
+            let mut text = String::new();
+            // `common` is in almost every doc (the dominant term) — but
+            // not the holes, so the anchor genuinely lacks some docs the
+            // rare terms supply.
+            if !i.is_multiple_of(HOLE_STRIDE) {
+                text.push_str("common ");
+            }
+            if i.is_multiple_of(RARE_STRIDE) {
+                text.push_str("rare ");
+            }
+            if i.is_multiple_of(RAREB_STRIDE) {
+                text.push_str("rareb ");
+            }
+            // Guarantee no empty doc (a hole that hits neither rare term).
+            if text.is_empty() {
+                text.push_str("filler ");
+            }
+            b.add_doc(0, i, text.trim()).expect("add doc");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+
+        // `common` alone is far more than 4× `rare` + `rareb` combined, so
+        // these shapes drive the anchored path; `filler` never dominates.
+        let shapes: &[&[&str]] = &[
+            &["common", "rare"],
+            &["common", "rare", "rareb"],
+            &["common", "rareb", "zzz_absent"],
+            &["common", "filler"],
+        ];
+        for terms in shapes {
+            let merge_len = r
+                .token_match("body", terms, BoolMode::Or)
+                .await
+                .expect("token_match")
+                .0
+                .len() as u64;
+            let count = r
+                .token_match_count("body", terms, BoolMode::Or)
+                .await
+                .expect("token_match_count")
+                .0;
+            assert_eq!(
+                count, merge_len,
+                "anchored count vs merge len for {terms:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn term_df_reports_document_frequency() {
         let (blob, json) = build_mixed_df_blob();
         let r = FtsReader::open(blob, &json).expect("open");


### PR DESCRIPTION
## What

Speeds up unranked `OR` counts dominated by one very common term. `or_count_unranked` walked every posting of every term — including the entire list of a term appearing in a large fraction of the corpus — just to produce a cardinality. When one term's df dwarfs the rest, that full walk is the whole cost.

## How

For a disjunction whose size is dominated by one long list:

```
|A ∪ B ∪ …| = df(D) + |(the other terms' union) \ D|
```

where `D` is the highest-df term. `df(D)` is read from `TermCursor.df` (no decode); the rarer cursors are frontier-merged, and each distinct doc they produce is membership-tested against `D` by advancing its skip table monotonically. `D`'s skip table is traversed once instead of its postings decoded end to end — cost drops from `O(Σ df)` to `O(Σ df_rest + skip-traversal(D))`.

Gated behind a conservative dominance threshold (`8×`): the anchored path is taken only when the dominant term's df is at least 8× the others' combined, so balanced unions keep the windowed-bitset walk, which is already faster when no term dominates. The threshold was calibrated from measurement — a skip-probe costs several× a windowed `next()`, so the crossover sits well above a naive ratio (an earlier `4×` cut regressed a few unions whose dominance was only ~4–6×).

## Correctness

Result-identical: docs in `D` are counted once via its df, docs in the rarer union are added once each iff `D` lacks them, and a doc in both counts only through the df. A new test drives the anchored path on a multi-window corpus with gaps where the dominant term is absent (exercising the "doc not in the anchor" branch) and asserts equality with the independent naive merge. Full-corpus check: **0 count mismatches across all 962 queries** of the standard bench set.

## Measurement

Local A/B over the full 962-query count set (min-of-10, same machine, before = `main`, index unchanged — this is a read-path-only change):

| slice | AVG before→after | P90 before→after |
| ----- | ---------------- | ---------------- |
| union | 1612 → 1284 µs (**−20%**) | 7202 → 3313 µs (**−54%**) |
| ALL count | 1560 → 1467 µs | 3229 → 2658 µs |

Dominant-common-term unions collapse: `the incredibles` 7360 → **69 µs**, `the preakness` 7325 → 127 µs, `the progressive` 7660 → 1430 µs, `helen of troy` 6722 → 1273 µs. Non-union slices (phrase, intersection) are unchanged — those paths aren't touched.

## Verification

- `cargo test --lib superfile::fts` + `--test superfile fts::` + `--test supertable query::` green.
- `cargo fmt --check` and `clippy --all-targets --features test-helpers -- -D warnings` clean.