### PR TITLE
vector: centroid-HNSW ivf router for the hidden vector index

### DIFF
--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -211,6 +211,17 @@ vector:
   # within each cell into contiguous reads. Ignored under search_mode = ivf.
   global_fine_coalesce: false
 
+  # For search_mode = global_fine_centroid: route via the centroid-HNSW graph
+  # over the resident fp32 fine centroids (default) instead of the brute-force
+  # centroid scan. The graph ranks by normalized cosine, selecting better
+  # clusters. Ignored under search_mode = ivf.
+  global_fine_use_graph: true
+
+  # For search_mode = global_fine_centroid with the graph router: the HNSW
+  # walk's ef (candidate breadth). 0 = auto (fanout * 2). Ignored under
+  # search_mode = ivf or when global_fine_use_graph = false.
+  global_fine_graph_ef: 0
+
   # For search_mode = hnsw_ivf: upper bound on the calibration ef grid. The drain
   # sweeps the ef candidates up to this ceiling and stamps the winning per-table
   # ef into the persisted graph bundle; that stamped value drives every query.

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -188,38 +188,36 @@ vector:
   #                          different column) serves `ivf` AUTOMATICALLY, so
   #                          correctness never depends on the graph. Best for
   #                          single-box, latency-tier, RAM-provisioned tables.
-  #   global_fine_centroid — EXPERIMENTAL: score every fine centroid globally
-  #                          across all cells and read the top fanout clusters,
-  #                          bypassing the grid. A cold-read win at scale (10M+);
-  #                          opt-in while the per-table fanout stamp is built.
   search_mode: ivf
 
-  # For search_mode = global_fine_centroid: the NUMBER of fine clusters the
+  # For search_mode = ivf: the cluster router.
+  #   stamped        — DEFAULT. Grid routing to cells, then the manifest's
+  #                    stamped per-cell width. The established path.
+  #   centroid_graph — EXPERIMENTAL: score fine centroids via an HNSW over the
+  #                    resident fp32 fine centroids and read the top fanout
+  #                    clusters, bypassing the grid. A cold-read win at scale
+  #                    (10M+); opt-in while the per-table fanout stamp is built.
+  ivf_router: stamped
+
+  # For ivf_router = centroid_graph: the NUMBER of fine clusters the
   # query fans out to (globally scored), clamped to the table's cluster
   # total. Higher reads more clusters — more cold bytes, higher recall.
   # 1024 is the ~0.99 point at 10M; it over-serves smaller tables and
   # under-serves larger ones (the fanout for a recall target grows ~sqrt(N)),
-  # pending a per-table calibrated stamp. Ignored under search_mode = ivf.
+  # pending a per-table calibrated stamp. Ignored under ivf_router = stamped.
   global_fine_fanout: 1024
 
-  # For search_mode = global_fine_centroid: exact-rerank over-fetch multiplier
+  # For ivf_router = centroid_graph: exact-rerank over-fetch multiplier
   # for this path only (a caller-set rerank_mult still wins). Scoped here so
   # tuning it never touches the ivf / filtered / user-table defaults.
   global_fine_rerank_mult: 128
 
-  # For search_mode = global_fine_centroid: coalesce the selected clusters
-  # within each cell into contiguous reads. Ignored under search_mode = ivf.
+  # For ivf_router = centroid_graph: coalesce the selected clusters within
+  # each cell into contiguous reads. Ignored under ivf_router = stamped.
   global_fine_coalesce: false
 
-  # For search_mode = global_fine_centroid: route via the centroid-HNSW graph
-  # over the resident fp32 fine centroids (default) instead of the brute-force
-  # centroid scan. The graph ranks by normalized cosine, selecting better
-  # clusters. Ignored under search_mode = ivf.
-  global_fine_use_graph: true
-
-  # For search_mode = global_fine_centroid with the graph router: the HNSW
-  # walk's ef (candidate breadth). 0 = auto (fanout * 2). Ignored under
-  # search_mode = ivf or when global_fine_use_graph = false.
+  # For ivf_router = centroid_graph: the centroid-HNSW walk's ef (candidate
+  # breadth). 0 = auto (fanout * 2). Ignored under ivf_router = stamped.
   global_fine_graph_ef: 0
 
   # For search_mode = hnsw_ivf: upper bound on the calibration ef grid. The drain

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -287,9 +287,9 @@ const DEFAULT_VECTOR_CELL_SPLIT_DOC_CAP: u64 = 500_000;
 const DEFAULT_VECTOR_CELL_SPLIT_MODALITY_D: f64 = 8.0;
 /// Default k-means training points per centroid for per-cell sub-builds.
 const DEFAULT_VECTOR_KMEANS_PTS_PER_CENTROID: usize = 64;
-/// Default fine-cluster fanout for `search_mode = global_fine_centroid`.
+/// Default fine-cluster fanout for `ivf_router = centroid_graph`.
 const DEFAULT_VECTOR_GLOBAL_FINE_FANOUT: usize = 1024;
-/// Default exact-rerank over-fetch for `search_mode = global_fine_centroid` —
+/// Default exact-rerank over-fetch for `ivf_router = centroid_graph` —
 /// the measured knee; scoped to this path so it never shifts the stamped,
 /// filtered, or user-table defaults.
 const DEFAULT_VECTOR_GLOBAL_FINE_RERANK_MULT: usize = 128;
@@ -432,10 +432,6 @@ pub enum VectorSearchMode {
     /// queries.
     #[default]
     Ivf,
-    /// EXPERIMENTAL (opt-in): score every fine centroid globally and read the
-    /// top `vector.global_fine_fanout` clusters, bypassing the grid. A
-    /// cold-read win at scale, not at small scale — see `config.yaml`.
-    GlobalFineCentroid,
     /// OPT-IN (`hnsw_ivf`): walk a resident in-memory HNSW graph built over
     /// every row's Sq16 codes, bypassing the grid, cell selection, and disk
     /// reads. Built at drain and held resident (RAM-pinned) for corpora
@@ -445,6 +441,21 @@ pub enum VectorSearchMode {
     /// or a different column) always serves `ivf`. Search walks the graph at
     /// the `k`-scaled `ef` law.
     HnswIvf,
+}
+
+/// Cluster router for `search_mode = ivf`: how a query selects which cells or
+/// clusters to read. Selected by `vector.ivf_router`.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum IvfRouter {
+    /// DEFAULT. Grid routing to cells, then the manifest's stamped per-cell
+    /// width. The established path.
+    #[default]
+    Stamped,
+    /// EXPERIMENTAL (opt-in): score fine centroids via an HNSW over the
+    /// resident fp32 fine centroids and read the top `global_fine_fanout`
+    /// clusters, bypassing the grid. A cold-read win at scale.
+    CentroidGraph,
 }
 
 /// Vector-index build / search / drain tuning knobs. Grouped so the
@@ -504,28 +515,24 @@ pub struct VectorSettings {
     /// Default `ivf`; `global_fine_centroid` is experimental (see
     /// [`VectorSearchMode`]).
     pub search_mode: VectorSearchMode,
-    /// For `search_mode = global_fine_centroid`: number of fine clusters the
-    /// query reads (globally scored, clamped to the table's total). See
-    /// `config.yaml` for sizing guidance. Ignored under `search_mode = ivf`.
+    /// For `search_mode = ivf`: the cluster router — the established stamped
+    /// grid, or the centroid-HNSW over the resident fp32 fine centroids.
+    /// Ignored under `search_mode = hnsw_ivf`.
+    pub ivf_router: IvfRouter,
+    /// For `ivf_router = centroid_graph`: number of fine clusters the query
+    /// reads (globally scored, clamped to the table's total). See `config.yaml`
+    /// for sizing guidance. Ignored otherwise.
     pub global_fine_fanout: usize,
-    /// For `search_mode = global_fine_centroid`: the exact-rerank over-fetch
+    /// For `ivf_router = centroid_graph`: the exact-rerank over-fetch
     /// multiplier for this path specifically (a caller-set `rerank_mult`
     /// still wins). Scoped here rather than the shared default so tuning
-    /// it never touches the ivf / filtered / user-table paths.
+    /// it never touches the stamped / filtered / user-table paths.
     pub global_fine_rerank_mult: usize,
-    /// For `search_mode = global_fine_centroid`: coalesce the selected
-    /// clusters within each cell into contiguous reads. Ignored under
-    /// `search_mode = ivf`.
+    /// For `ivf_router = centroid_graph`: coalesce the selected clusters
+    /// within each cell into contiguous reads. Ignored otherwise.
     pub global_fine_coalesce: bool,
-    /// For `search_mode = global_fine_centroid`: route via the centroid-HNSW
-    /// graph over the resident fp32 fine centroids (default) instead of the
-    /// brute-force centroid scan. The graph ranks centroids by normalized
-    /// cosine, which selects better clusters than the scan's raw-dot ranking.
-    /// Ignored under `search_mode = ivf`.
-    pub global_fine_use_graph: bool,
-    /// For `search_mode = global_fine_centroid` with the graph router: the
-    /// HNSW walk's `ef` (candidate breadth). `0` = auto (`fanout * 2`).
-    /// Ignored under `search_mode = ivf` or `global_fine_use_graph = false`.
+    /// For `ivf_router = centroid_graph`: the centroid-HNSW walk's `ef`
+    /// (candidate breadth). `0` = auto (`fanout * 2`). Ignored otherwise.
     pub global_fine_graph_ef: usize,
     /// For `search_mode = hnsw_ivf`: the upper bound on the calibration ef grid —
     /// the drain sweeps [`HNSW_EF_CANDIDATES`] up to this ceiling and stamps
@@ -631,10 +638,10 @@ impl Default for VectorSettings {
             serve_near_tie_slack: DEFAULT_VECTOR_SERVE_NEAR_TIE_SLACK,
             kmeans_pts_per_centroid: DEFAULT_VECTOR_KMEANS_PTS_PER_CENTROID,
             search_mode: VectorSearchMode::Ivf,
+            ivf_router: IvfRouter::Stamped,
             global_fine_fanout: DEFAULT_VECTOR_GLOBAL_FINE_FANOUT,
             global_fine_rerank_mult: DEFAULT_VECTOR_GLOBAL_FINE_RERANK_MULT,
             global_fine_coalesce: false,
-            global_fine_use_graph: true,
             global_fine_graph_ef: 0,
             hnsw_ef_ceil: DEFAULT_VECTOR_HNSW_EF_CEIL,
             hnsw_ef_construction: DEFAULT_VECTOR_HNSW_EF_CONSTRUCTION,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -517,6 +517,16 @@ pub struct VectorSettings {
     /// clusters within each cell into contiguous reads. Ignored under
     /// `search_mode = ivf`.
     pub global_fine_coalesce: bool,
+    /// For `search_mode = global_fine_centroid`: route via the centroid-HNSW
+    /// graph over the resident fp32 fine centroids (default) instead of the
+    /// brute-force centroid scan. The graph ranks centroids by normalized
+    /// cosine, which selects better clusters than the scan's raw-dot ranking.
+    /// Ignored under `search_mode = ivf`.
+    pub global_fine_use_graph: bool,
+    /// For `search_mode = global_fine_centroid` with the graph router: the
+    /// HNSW walk's `ef` (candidate breadth). `0` = auto (`fanout * 2`).
+    /// Ignored under `search_mode = ivf` or `global_fine_use_graph = false`.
+    pub global_fine_graph_ef: usize,
     /// For `search_mode = hnsw_ivf`: the upper bound on the calibration ef grid —
     /// the drain sweeps [`HNSW_EF_CANDIDATES`] up to this ceiling and stamps
     /// the winning `ef` per table into the persisted bundle. Must be at least
@@ -624,6 +634,8 @@ impl Default for VectorSettings {
             global_fine_fanout: DEFAULT_VECTOR_GLOBAL_FINE_FANOUT,
             global_fine_rerank_mult: DEFAULT_VECTOR_GLOBAL_FINE_RERANK_MULT,
             global_fine_coalesce: false,
+            global_fine_use_graph: true,
+            global_fine_graph_ef: 0,
             hnsw_ef_ceil: DEFAULT_VECTOR_HNSW_EF_CEIL,
             hnsw_ef_construction: DEFAULT_VECTOR_HNSW_EF_CONSTRUCTION,
             hnsw_m0: DEFAULT_VECTOR_HNSW_M0,

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -1885,59 +1885,13 @@ impl VectorReader {
         Some((lo, flat - bases[lo]))
     }
 
-    /// Global-fine router scoring (`vector.search_mode = global_fine_centroid`):
-    /// score `query` against EVERY fine centroid of every cell in this superfile,
-    /// sourced from the resident centroid `section` (zero superfile opens —
-    /// the routing scan is a pure RAM op over the page-cache-backed spill).
-    /// Returns `(flat_cluster_id, score)` for all clusters, where the flat id
-    /// is the cumulative-`n_cent` numbering [`Self::resolve_flat_cluster`]
-    /// inverts — so the selected ids feed straight into
-    /// [`Self::search_clusters_async`]. Score is the same SIMD centroid
-    /// distance query-time fine ranking uses (smaller = nearer). Multi-cell
-    /// hidden readers only; others return empty (caller falls back to the
-    /// stamped-law path).
-    pub(crate) fn global_fine_cluster_scores(
-        &self,
-        column: &str,
-        query: &[f32],
-        section: &crate::supertable::slow_vector_state::CentroidSection,
-        superfile_id: uuid::Uuid,
-    ) -> Result<Vec<(u32, f32)>, VectorError> {
-        if !self.is_multi_cell() || !self.column_id_by_name.contains_key(column) {
-            return Ok(Vec::new());
-        }
-        let mut out = Vec::new();
-        for (ci, col) in self.columns.iter().enumerate() {
-            if col.n_docs == 0 || col.n_cent == 0 {
-                continue;
-            }
-            // Section is keyed by the grid cell id; multi-cell readers carry
-            // one per column entry (parallel to `columns`).
-            let cell_id = self.cell_ids.get(ci).copied();
-            let Some(bytes) = section
-                .read_cell_bytes(superfile_id, column, cell_id)
-                .map_err(|e| VectorError::LazySource(e.to_string()))?
-            else {
-                continue;
-            };
-            let base = self.flat_cluster_base.get(ci).copied().unwrap_or(0);
-            // `score_centroids` is the SIMD (`f32x8`) owner query-time fine
-            // ranking uses; `nprobe = n_cent` scores every cluster.
-            for (local, score) in score_centroids(&bytes, col, query, col.n_cent as usize) {
-                out.push((base + local as u32, score));
-            }
-        }
-        Ok(out)
-    }
-
-    /// Sibling of [`Self::global_fine_cluster_scores`] that emits the fp32
-    /// centroid VECTORS instead of their query scores, tagged with the exact
-    /// same per-superfile `flat` cluster ids. Feeds the in-memory centroid
-    /// router (an HNSW over the pooled fine centroids that replaces the
-    /// brute-force scan): building the graph from this guarantees a graph node
-    /// maps back to the same `flat` the scan path would have produced, so the
-    /// downstream per-cell read plan is identical. Cluster-major fp32-LE bytes,
-    /// `n_cent × dim` per cell.
+    /// Emit the fp32 centroid VECTORS of every fine cluster in this superfile,
+    /// tagged with their per-superfile `flat` cluster ids, from the resident
+    /// centroid `section` (zero superfile opens). Feeds the in-memory centroid
+    /// router (an HNSW over the pooled fine centroids): building the graph from
+    /// these guarantees a graph node maps back to the same `flat` the stamped
+    /// per-cell read plan expects, so the downstream read is identical.
+    /// Cluster-major fp32-LE bytes, `n_cent × dim` per cell.
     pub(crate) fn global_fine_cluster_vectors(
         &self,
         column: &str,

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -1930,6 +1930,53 @@ impl VectorReader {
         Ok(out)
     }
 
+    /// Sibling of [`Self::global_fine_cluster_scores`] that emits the fp32
+    /// centroid VECTORS instead of their query scores, tagged with the exact
+    /// same per-superfile `flat` cluster ids. Feeds the in-memory centroid
+    /// router (an HNSW over the pooled fine centroids that replaces the
+    /// brute-force scan): building the graph from this guarantees a graph node
+    /// maps back to the same `flat` the scan path would have produced, so the
+    /// downstream per-cell read plan is identical. Cluster-major fp32-LE bytes,
+    /// `n_cent × dim` per cell.
+    pub(crate) fn global_fine_cluster_vectors(
+        &self,
+        column: &str,
+        section: &crate::supertable::slow_vector_state::CentroidSection,
+        superfile_id: uuid::Uuid,
+    ) -> Result<Vec<(u32, Vec<f32>)>, VectorError> {
+        if !self.is_multi_cell() || !self.column_id_by_name.contains_key(column) {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        for (ci, col) in self.columns.iter().enumerate() {
+            if col.n_docs == 0 || col.n_cent == 0 {
+                continue;
+            }
+            let cell_id = self.cell_ids.get(ci).copied();
+            let Some(bytes) = section
+                .read_cell_bytes(superfile_id, column, cell_id)
+                .map_err(|e| VectorError::LazySource(e.to_string()))?
+            else {
+                continue;
+            };
+            let base = self.flat_cluster_base.get(ci).copied().unwrap_or(0);
+            let dim = col.dim;
+            let stride = dim * 4;
+            for local in 0..col.n_cent as usize {
+                let off = local * stride;
+                let Some(slab) = bytes.get(off..off + stride) else {
+                    break;
+                };
+                let vec: Vec<f32> = slab
+                    .chunks_exact(4)
+                    .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                    .collect();
+                out.push((base + local as u32, vec));
+            }
+        }
+        Ok(out)
+    }
+
     /// Per-cell coalesced read plan for global-fine (`vector.global_fine_coalesce`):
     /// given selected flat cluster ids, return every cluster in each touched
     /// cell's `[min..max]` selected span. Clusters are stored in id order, so

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -415,6 +415,14 @@ pub struct SupertableOptions {
     /// Warm queries never touch it — they resolve on the cache mutex's fast
     /// path — so the download never serializes steady-state serving.
     pub(crate) graph_hydration_lock: Arc<TokioMutex<()>>,
+    /// Build-once cache for the in-memory centroid-router HNSW (an HNSW over
+    /// the resident fp32 fine centroids that replaces the brute-force
+    /// `global_fine_cluster_scores` scan on the global-fine path). Built from
+    /// the resident centroid section at first global-fine query, so testing it
+    /// needs no re-drain; the persisted centroid graph is a follow-on.
+    /// Experimental: only populated when the global-fine graph path is enabled.
+    pub(crate) centroid_router_cache:
+        Arc<tokio::sync::OnceCell<Arc<crate::supertable::query::vector::CentroidRouterGraph>>>,
     /// Read-time reverse (`stable_id -> local`) lookup backing scalar
     /// projection over gapped user superfiles, so a hit resolves in O(k) after
     /// a one-time per-superfile build instead of the per-query O(corpus) `_id`
@@ -742,6 +750,7 @@ impl SupertableOptions {
             centroid_section_cache: Arc::new(TokioMutex::new(None)),
             graph_sections_cache: Arc::new(TokioMutex::new(None)),
             graph_hydration_lock: Arc::new(TokioMutex::new(())),
+            centroid_router_cache: Arc::new(tokio::sync::OnceCell::new()),
             gapped_id_placement_cache: Arc::new(TokioMutex::new(GappedIdPlacementCache::default())),
             user_centroid_cache: Arc::new(TokioMutex::new(None)),
             prepopulate_cache_on_commit: true,

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -416,11 +416,11 @@ pub struct SupertableOptions {
     /// path — so the download never serializes steady-state serving.
     pub(crate) graph_hydration_lock: Arc<TokioMutex<()>>,
     /// Build-once cache for the in-memory centroid-router HNSW (an HNSW over
-    /// the resident fp32 fine centroids that replaces the brute-force
-    /// `global_fine_cluster_scores` scan on the global-fine path). Built from
-    /// the resident centroid section at first global-fine query, so testing it
-    /// needs no re-drain; the persisted centroid graph is a follow-on.
-    /// Experimental: only populated when the global-fine graph path is enabled.
+    /// the resident fp32 fine centroids, used by `ivf_router = centroid_graph`
+    /// to select clusters). Built from the resident centroid section at the
+    /// first such query, so testing it needs no re-drain; the persisted
+    /// centroid graph is a follow-on. Only populated when the centroid-graph
+    /// router is enabled.
     pub(crate) centroid_router_cache:
         Arc<tokio::sync::OnceCell<Arc<crate::supertable::query::vector::CentroidRouterGraph>>>,
     /// Read-time reverse (`stable_id -> local`) lookup backing scalar

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -785,7 +785,12 @@ fn build_centroid_router(
     let mut node_map: Vec<(usize, u32)> = Vec::new();
     for (si, reader) in readers.iter().enumerate() {
         let Some(vr) = reader.vec() else { continue };
-        let sfid = superfiles[si].superfile_id;
+        // Checked access: a concurrent optimize can shift the reader/superfile
+        // set while the router builds; skip a missing entry rather than panic.
+        let Some(sf) = superfiles.get(si) else {
+            continue;
+        };
+        let sfid = sf.superfile_id;
         for (flat, mut vec) in vr
             .global_fine_cluster_vectors(column, section, sfid)
             .map_err(|e| QueryError::Execute(e.to_string()))?
@@ -2788,11 +2793,28 @@ impl SupertableReader {
             warn_hnsw_no_resident_graph(column, manifest.slow_vector_state_graphs_blob().is_some());
             // fall through to the ivf scan below
         }
+        // The centroid router ranks by cosine (unit-normalized centroids, a
+        // -dot scorer), so it is only correct for a Cosine column. A NegDot or
+        // L2Sq table falls through to the stamped router rather than being
+        // mis-ranked; per-metric centroid scoring is a router-productionization
+        // follow-on.
+        let centroid_graph_metric_ok = manifest
+            .options
+            .vector_columns
+            .iter()
+            .find(|vc| vc.column == column)
+            .is_some_and(|vc| {
+                matches!(
+                    vc.metric,
+                    crate::superfile::vector::distance::Metric::Cosine
+                )
+            });
         if !filtered
             && hidden_vector_index
             && vcfg.search_mode == config::VectorSearchMode::Ivf
             && vcfg.ivf_router == config::IvfRouter::CentroidGraph
             && vcfg.global_fine_fanout > 0
+            && centroid_graph_metric_ok
         {
             return self
                 .global_fine_fanout(

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -746,6 +746,65 @@ fn union_cell_selection(grid: &[u32], fine: &[u32]) -> Vec<u32> {
     selected
 }
 
+/// In-memory centroid router: an HNSW over the pooled fp32 fine centroids,
+/// used on the global-fine path to select the top-`fanout` clusters in place
+/// of the brute-force `global_fine_cluster_scores` scan. Experimental,
+/// validation-grade — built once per handle from the resident centroid section
+/// (no drain change). A graph node maps back to the `(superfile index, flat
+/// cluster id)` the scan path would have produced, so the downstream per-cell
+/// read plan is byte-identical.
+pub(crate) struct CentroidRouterGraph {
+    scorer: crate::superfile::vector::hnsw::Fp32Scorer,
+    graph: crate::superfile::vector::hnsw::Hnsw,
+    node_map: Vec<(usize, u32)>,
+}
+
+/// Unit-normalize in place so the centroid graph's `−dot` scorer ranks by
+/// cosine (the fine centroids are means of unit vectors, not themselves unit).
+fn gfc_unit_normalize(v: &mut [f32]) {
+    let n: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if n > 0.0 {
+        let inv = 1.0 / n;
+        for x in v.iter_mut() {
+            *x *= inv;
+        }
+    }
+}
+
+/// Build the in-memory centroid router from the resident centroid section.
+/// `readers[si]` corresponds to `superfiles[si]`; centroids are pulled via
+/// `global_fine_cluster_vectors` so the flat ids match the scan path exactly.
+fn build_centroid_router(
+    superfiles: &[Arc<SuperfileEntry>],
+    readers: &[Arc<SuperfileReader>],
+    column: &str,
+    section: &crate::supertable::slow_vector_state::CentroidSection,
+    dim: usize,
+) -> Result<CentroidRouterGraph, QueryError> {
+    use crate::superfile::vector::hnsw::{Fp32Scorer, Hnsw, HnswParams};
+    let mut vecs: Vec<Vec<f32>> = Vec::new();
+    let mut node_map: Vec<(usize, u32)> = Vec::new();
+    for (si, reader) in readers.iter().enumerate() {
+        let Some(vr) = reader.vec() else { continue };
+        let sfid = superfiles[si].superfile_id;
+        for (flat, mut vec) in vr
+            .global_fine_cluster_vectors(column, section, sfid)
+            .map_err(|e| QueryError::Execute(e.to_string()))?
+        {
+            gfc_unit_normalize(&mut vec);
+            vecs.push(vec);
+            node_map.push((si, flat));
+        }
+    }
+    let scorer = Fp32Scorer::from_vectors(&vecs, dim);
+    let graph = Hnsw::build(&scorer, HnswParams::default());
+    Ok(CentroidRouterGraph {
+        scorer,
+        graph,
+        node_map,
+    })
+}
+
 /// Widen a grid cell cutoff so the probed cells' indexed row counts cover at
 /// least `k`. `grid_cell_cutoff`'s slack window stops at the nearest near-tie
 /// cluster — a single cell for a query blended between two clusters — so a
@@ -2521,37 +2580,97 @@ impl SupertableReader {
         // Phase 1: build the global candidate pool. Scores are comparable
         // across cells/superfiles (one metric + one query), so a single
         // top-`fc` cut over the pool is a valid global selection.
+        // Open every eligible superfile reader (phase 2 needs them regardless
+        // of how the top-`fanout` clusters are selected).
         let mut readers: Vec<Arc<SuperfileReader>> = Vec::with_capacity(superfiles.len());
-        let mut cands: Vec<(usize, u32, f32)> = Vec::new();
         for entry in superfiles.iter() {
             let reader =
                 dispatch::open_reader(&store, disk_cache.as_ref(), storage.as_ref(), entry, false)
                     .await?;
-            let si = readers.len();
-            if let Some(vr) = reader.vec() {
-                let scores = vr
-                    .global_fine_cluster_scores(column, query, section.as_ref(), entry.superfile_id)
-                    .map_err(|e| QueryError::Execute(e.to_string()))?;
-                for (flat, score) in scores {
-                    cands.push((si, flat, score));
-                }
-            }
             readers.push(reader);
         }
-        if cands.is_empty() {
+
+        // Cluster selection: the centroid-router HNSW (default) walks a graph
+        // over the fp32 fine centroids to pick the top-`fanout` clusters; the
+        // fallback is the exact brute-force scan (`global_fine_use_graph =
+        // false`). Both produce the same `by_sf` map, so phase 2 is identical.
+        let use_graph = config::global().vector.global_fine_use_graph;
+        let by_sf: HashMap<usize, Vec<u32>> = if use_graph {
+            let cache = Arc::clone(&manifest.options.centroid_router_cache);
+            let router = {
+                let sfs = superfiles.to_vec();
+                let rdrs = readers.clone();
+                let col = column.to_string();
+                let sect = Arc::clone(&section);
+                let dim = query.len();
+                cache
+                    .get_or_try_init(|| async move {
+                        build_centroid_router(&sfs, &rdrs, &col, sect.as_ref(), dim).map(Arc::new)
+                    })
+                    .await?
+                    .clone()
+            };
+            let mut q = query.to_vec();
+            gfc_unit_normalize(&mut q);
+            let fc = fanout.clamp(1, router.node_map.len().max(1));
+            // `ef` governs graph-vs-exact parity; `global_fine_graph_ef = 0`
+            // auto-selects `fanout * 2`.
+            let ef_cfg = config::global().vector.global_fine_graph_ef;
+            let ef = if ef_cfg > 0 {
+                ef_cfg
+            } else {
+                fc.saturating_mul(2)
+            }
+            .max(fc);
+            let hits = router.graph.search(&router.scorer, &q, fc, ef);
+            let mut m: HashMap<usize, Vec<u32>> = HashMap::new();
+            for (node, _) in hits {
+                if let Some(&(si, flat)) = router.node_map.get(node as usize) {
+                    m.entry(si).or_default().push(flat);
+                }
+            }
+            m
+        } else {
+            let mut cands: Vec<(usize, u32, f32)> = Vec::new();
+            for (si, reader) in readers.iter().enumerate() {
+                if let Some(vr) = reader.vec() {
+                    let scores = vr
+                        .global_fine_cluster_scores(
+                            column,
+                            query,
+                            section.as_ref(),
+                            superfiles[si].superfile_id,
+                        )
+                        .map_err(|e| QueryError::Execute(e.to_string()))?;
+                    for (flat, score) in scores {
+                        cands.push((si, flat, score));
+                    }
+                }
+            }
+            // `cands` now holds EVERY fine cluster across all cells/superfiles;
+            // clamp the requested fanout to that total. Global top-`fc` by
+            // ascending distance (smaller = nearer).
+            let fc = fanout.clamp(1, cands.len().max(1));
+            if cands.len() > fc {
+                cands.select_nth_unstable_by(fc - 1, |a, b| a.2.total_cmp(&b.2));
+                cands.truncate(fc);
+            }
+            let mut m: HashMap<usize, Vec<u32>> = HashMap::new();
+            for (si, flat, _) in cands {
+                m.entry(si).or_default().push(flat);
+            }
+            m
+        };
+        if std::env::var("INFINO_LOG_GETS").is_ok() {
+            let probed: usize = by_sf.values().map(Vec::len).sum();
+            eprintln!(
+                "[GFC] clusters_probed={probed} superfiles={} fanout={fanout} graph={}",
+                by_sf.len(),
+                use_graph as u8
+            );
+        }
+        if by_sf.is_empty() {
             return Ok(Vec::new());
-        }
-        // `cands` now holds EVERY fine cluster across all cells/superfiles;
-        // clamp the requested fanout to that total. Global top-`fc` by
-        // ascending distance (smaller = nearer).
-        let fc = fanout.clamp(1, cands.len());
-        if cands.len() > fc {
-            cands.select_nth_unstable_by(fc - 1, |a, b| a.2.total_cmp(&b.2));
-            cands.truncate(fc);
-        }
-        let mut by_sf: HashMap<usize, Vec<u32>> = HashMap::new();
-        for (si, flat, _) in cands {
-            by_sf.entry(si).or_default().push(flat);
         }
 
         // Phase 2: DEFERRED per-cell scan on the selected clusters, pooling
@@ -2686,9 +2805,15 @@ impl SupertableReader {
             && vcfg.search_mode == config::VectorSearchMode::GlobalFineCentroid
             && vcfg.global_fine_fanout > 0
         {
-            let fanout = vcfg.global_fine_fanout;
             return self
-                .global_fine_fanout(&superfiles, column, query, k, &options, fanout)
+                .global_fine_fanout(
+                    &superfiles,
+                    column,
+                    query,
+                    k,
+                    &options,
+                    vcfg.global_fine_fanout,
+                )
                 .await;
         }
         // Borrow routing — do not clone the VectorCell centroid grid just to

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -747,12 +747,11 @@ fn union_cell_selection(grid: &[u32], fine: &[u32]) -> Vec<u32> {
 }
 
 /// In-memory centroid router: an HNSW over the pooled fp32 fine centroids,
-/// used on the global-fine path to select the top-`fanout` clusters in place
-/// of the brute-force `global_fine_cluster_scores` scan. Experimental,
-/// validation-grade — built once per handle from the resident centroid section
-/// (no drain change). A graph node maps back to the `(superfile index, flat
-/// cluster id)` the scan path would have produced, so the downstream per-cell
-/// read plan is byte-identical.
+/// used by `ivf_router = centroid_graph` to select the top-`fanout` clusters
+/// globally, bypassing the grid. Experimental, validation-grade — built once
+/// per handle from the resident centroid section (no drain change). A graph
+/// node maps back to the `(superfile index, flat cluster id)` the stamped
+/// per-cell read plan expects, so the downstream read is byte-identical.
 pub(crate) struct CentroidRouterGraph {
     scorer: crate::superfile::vector::hnsw::Fp32Scorer,
     graph: crate::superfile::vector::hnsw::Hnsw,
@@ -2542,18 +2541,15 @@ impl SupertableReader {
             .await
     }
 
-    /// Global-fine fanout (`vector.search_mode = global_fine_centroid`, reading
+    /// Global-fine fanout (`vector.ivf_router = centroid_graph`, reading
     /// `fanout = vector.global_fine_fanout` clusters, clamped to the table's
-    /// cluster total). Phase 1: score `query` against every cell's fp32 fine
-    /// centroids from the resident centroid section (a RAM scan — no superfile
-    /// opens for the scoring) and keep the global top-`fanout`
-    /// `(superfile, flat cluster)` by ascending distance. Phase 2: scan only those clusters per superfile, pool the
-    /// warm survivors across all cells, take one global shortlist cut, and
-    /// exact-rerank where the winners live. The router overrides only cluster
-    /// SELECTION; the byte fetch, 1-bit shortlist, rerank, and id remap are
-    /// the stamped path's own code. A tree/HNSW centroid router replaces the
-    /// brute-force scan later; see
-    /// [`SuperfileReader::global_fine_cluster_scores`].
+    /// cluster total). Phase 1: walk the centroid-HNSW over the resident fp32
+    /// fine centroids (a RAM op — no superfile opens for the selection) and
+    /// keep the global top-`fanout` `(superfile, flat cluster)`. Phase 2: scan
+    /// only those clusters per superfile, pool the warm survivors across all
+    /// cells, take one global shortlist cut, and exact-rerank where the winners
+    /// live. The router overrides only cluster SELECTION; the byte fetch, 1-bit
+    /// shortlist, rerank, and id remap are the stamped path's own code.
     async fn global_fine_fanout(
         &self,
         superfiles: &[Arc<SuperfileEntry>],
@@ -2590,12 +2586,12 @@ impl SupertableReader {
             readers.push(reader);
         }
 
-        // Cluster selection: the centroid-router HNSW (default) walks a graph
-        // over the fp32 fine centroids to pick the top-`fanout` clusters; the
-        // fallback is the exact brute-force scan (`global_fine_use_graph =
-        // false`). Both produce the same `by_sf` map, so phase 2 is identical.
-        let use_graph = config::global().vector.global_fine_use_graph;
-        let by_sf: HashMap<usize, Vec<u32>> = if use_graph {
+        // Cluster selection: the centroid-router HNSW walks a graph over the
+        // resident fp32 fine centroids to pick the top-`fanout` clusters; phase
+        // 2 then reads only those clusters. The graph is built once (cached) at
+        // the first query from the same fine centroids, so a graph node maps
+        // back to the exact `flat` cluster id and the read plan is identical.
+        let by_sf: HashMap<usize, Vec<u32>> = {
             let cache = Arc::clone(&manifest.options.centroid_router_cache);
             let router = {
                 let sfs = superfiles.to_vec();
@@ -2630,45 +2626,7 @@ impl SupertableReader {
                 }
             }
             m
-        } else {
-            let mut cands: Vec<(usize, u32, f32)> = Vec::new();
-            for (si, reader) in readers.iter().enumerate() {
-                if let Some(vr) = reader.vec() {
-                    let scores = vr
-                        .global_fine_cluster_scores(
-                            column,
-                            query,
-                            section.as_ref(),
-                            superfiles[si].superfile_id,
-                        )
-                        .map_err(|e| QueryError::Execute(e.to_string()))?;
-                    for (flat, score) in scores {
-                        cands.push((si, flat, score));
-                    }
-                }
-            }
-            // `cands` now holds EVERY fine cluster across all cells/superfiles;
-            // clamp the requested fanout to that total. Global top-`fc` by
-            // ascending distance (smaller = nearer).
-            let fc = fanout.clamp(1, cands.len().max(1));
-            if cands.len() > fc {
-                cands.select_nth_unstable_by(fc - 1, |a, b| a.2.total_cmp(&b.2));
-                cands.truncate(fc);
-            }
-            let mut m: HashMap<usize, Vec<u32>> = HashMap::new();
-            for (si, flat, _) in cands {
-                m.entry(si).or_default().push(flat);
-            }
-            m
         };
-        if std::env::var("INFINO_LOG_GETS").is_ok() {
-            let probed: usize = by_sf.values().map(Vec::len).sum();
-            eprintln!(
-                "[GFC] clusters_probed={probed} superfiles={} fanout={fanout} graph={}",
-                by_sf.len(),
-                use_graph as u8
-            );
-        }
         if by_sf.is_empty() {
             return Ok(Vec::new());
         }
@@ -2760,7 +2718,7 @@ impl SupertableReader {
         let (resolved_nprobe, _) = options.resolve(filtered);
         let manifest = self.manifest();
         let hidden_vector_index = is_hidden_vector_manifest(manifest);
-        // Global-fine routing (`vector.search_mode = global_fine_centroid`):
+        // Global-fine routing (`vector.ivf_router = centroid_graph`):
         // select the top-`global_fine_fanout` fine centroids GLOBALLY across
         // every cell/superfile from the resident centroid section, bypassing
         // the grid + stamped-law selection, and read only those clusters.
@@ -2802,7 +2760,8 @@ impl SupertableReader {
         }
         if !filtered
             && hidden_vector_index
-            && vcfg.search_mode == config::VectorSearchMode::GlobalFineCentroid
+            && vcfg.search_mode == config::VectorSearchMode::Ivf
+            && vcfg.ivf_router == config::IvfRouter::CentroidGraph
             && vcfg.global_fine_fanout > 0
         {
             return self

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -80,7 +80,7 @@ use std::{
 use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, Decimal128Array};
 use arrow_schema::Schema;
-use futures::future::try_join_all;
+use futures::{StreamExt, TryStreamExt, future::try_join_all, stream};
 use roaring::RoaringBitmap;
 use tokio::{join, sync::OnceCell};
 use uuid::Uuid;
@@ -108,7 +108,7 @@ use crate::{
             distance::{Metric, distance, normalize, relative_score_window},
             hnsw::{self, HnswParams, Sq16Scorer, encode_hnsw},
             layout::VectorLayout,
-            reader::ScanCandidate,
+            reader::{ScanCandidate, ScanOutcome},
         },
     },
     supertable::{
@@ -2640,35 +2640,65 @@ impl SupertableReader {
         // ~4% of the true top-k at 10M (all neighbors are read — recall@100
         // is 1.0 — but a single cross-cell exact rerank is needed to seat
         // them in the top-k).
+        // Parallelize the per-cell cold scan across superfiles. Each selected
+        // superfile's scan is independent, and the stamped whole-cell path
+        // already fans out this way (`fanout_with`). A serial loop here
+        // RTT-serializes the cold Blob reads — the graph router's dominant cold
+        // cost — so run them concurrently, bounded to the reader-pool width
+        // (the same cap every other fan-out here uses). `coalesce` expands each
+        // touched cell's selection to its [min..max] contiguous span.
+        let coalesce = config::global().vector.global_fine_coalesce;
+        let scan_width = manifest.options.reader_pool.current_num_threads().max(1);
+        // Share the connection memory budget and reader pool across the
+        // concurrent scans, matching the stamped fan-out: cold fetches then gate
+        // on `OverBudget` and score on the reader pool. A serial loop needed
+        // neither (one fetch in flight), but concurrency does.
+        let scan_pool = Arc::clone(&manifest.options.reader_pool);
+        let scan_budget = Arc::clone(&manifest.options.connection_memory_budget);
+        // Build the per-superfile scan futures in a plain loop (concrete
+        // borrows) rather than a lifetime-generic `.map()` closure, then run
+        // them concurrently bounded to the pool width.
+        let mut scan_futs = Vec::new();
+        for (si, flats) in by_sf {
+            let Some(vr) = readers[si].as_ref().vec() else {
+                continue;
+            };
+            let pool = Arc::clone(&scan_pool);
+            let budget = Arc::clone(&scan_budget);
+            scan_futs.push(async move {
+                let flats = if coalesce {
+                    vr.coalesce_flats_to_cell_spans(&flats)
+                } else {
+                    flats
+                };
+                let scan = vr
+                    .search_clusters_scan_async(
+                        column,
+                        query,
+                        k,
+                        &flats,
+                        rerank_mult,
+                        rerank_mult,
+                        None,
+                        None,
+                        Some(pool),
+                        Some(budget),
+                    )
+                    .await
+                    .map_err(|e| QueryError::Execute(e.to_string()))?;
+                Ok::<_, QueryError>((si, scan))
+            });
+        }
+        let scans: Vec<(usize, ScanOutcome)> = stream::iter(scan_futs)
+            .buffer_unordered(scan_width)
+            .try_collect()
+            .await?;
+        // Tag + stable-id attach + pool the survivors (cheap, post-I/O).
         let mut per_superfile: Vec<Vec<SuperfileHit>> = Vec::new();
         let mut pooled: Vec<(usize, ScanCandidate)> = Vec::new();
-        for (si, flats) in by_sf {
+        for (si, scan) in scans {
             let entry = &superfiles[si];
             let reader = readers[si].as_ref();
-            let Some(vr) = reader.vec() else { continue };
-            // Per-cell coalesced read (`vector.global_fine_coalesce`): expand
-            // each touched cell's selection to its [min..max] contiguous span
-            // so the cell reads as one GET instead of scattered clusters.
-            let flats = if config::global().vector.global_fine_coalesce {
-                vr.coalesce_flats_to_cell_spans(&flats)
-            } else {
-                flats
-            };
-            let scan = vr
-                .search_clusters_scan_async(
-                    column,
-                    query,
-                    k,
-                    &flats,
-                    rerank_mult,
-                    rerank_mult,
-                    None,
-                    None,
-                    None,
-                    None,
-                )
-                .await
-                .map_err(|e| QueryError::Execute(e.to_string()))?;
             // Cold cells rerank in-scan; take their exact hits directly.
             if !scan.hits.is_empty() {
                 let mut tagged = dispatch::tag_hits(entry, scan.hits);

--- a/src/supertable/reader_cache/block_source.rs
+++ b/src/supertable/reader_cache/block_source.rs
@@ -124,7 +124,7 @@ impl BlockCachedSource {
         Self::new_with_accounting(inner, store, uri, path, false, passthrough)
     }
 
-    fn new_with_accounting(
+    pub(crate) fn new_with_accounting(
         inner: Arc<dyn LazyByteSource>,
         store: Weak<DiskCacheStore>,
         uri: SuperfileUri,
@@ -161,7 +161,6 @@ impl BlockCachedSource {
 
     /// Shared filled-bytes counter, installed as the cache entry's
     /// `size_bytes` so accounting and eviction see live growth.
-    #[cfg(test)]
     pub(crate) fn filled_bytes_handle(&self) -> Arc<AtomicU64> {
         Arc::clone(&self.filled_bytes)
     }

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -205,7 +205,6 @@ enum EntryAccounting {
     /// Store-reserved entry; removal releases `size_bytes`.
     Eager,
     /// Block-source-reserved entry; source drop releases bytes.
-    #[cfg(test)]
     SourceOwned,
 }
 
@@ -1341,7 +1340,8 @@ impl DiskCacheStore {
         let result = cell
             .get_or_init(|| async {
                 let fetch_storage = self.resolve_storage(storage);
-                self.cold_fetch_lazy(uri, offsets, fetch_storage).await
+                self.cold_fetch_lazy(uri, offsets, fetch_storage, allow_background_fill)
+                    .await
             })
             .await;
         let fetch_storage = self.resolve_storage(storage);
@@ -1354,7 +1354,10 @@ impl DiskCacheStore {
             }
             Err(_e) => {
                 self.coordinators.remove(uri);
-                match self.cold_fetch_lazy(uri, offsets, fetch_storage).await {
+                match self
+                    .cold_fetch_lazy(uri, offsets, fetch_storage, allow_background_fill)
+                    .await
+                {
                     Ok(entry) => {
                         if allow_background_fill {
                             self.maybe_spawn_background_fill(uri, &entry, storage);
@@ -1386,7 +1389,17 @@ impl DiskCacheStore {
         {
             return;
         }
-        let size = entry.size_bytes.load(Ordering::Acquire);
+        // A source-owned (vector-opened) entry accounts its live filled bytes,
+        // so `size_bytes` is NOT the object size. Take the full size from the
+        // block source, and reserve it here — the vector open never did, so the
+        // promotion's mmap needs budget reserved before it downloads.
+        let size = entry
+            .block_source
+            .as_ref()
+            .map(|bs| bs.size())
+            .filter(|&s| s > 0)
+            .unwrap_or_else(|| entry.size_bytes.load(Ordering::Acquire));
+        let needs_reserve = matches!(entry.accounting, EntryAccounting::SourceOwned);
         let skip_vec = vector_blob_range(&entry.reader);
         let store = Arc::downgrade(self);
         let reader = Arc::downgrade(&entry.reader);
@@ -1394,6 +1407,14 @@ impl DiskCacheStore {
         let storage_uri_owned = Self::storage_path(uri);
         let fetch_storage = self.resolve_storage(storage);
         tokio::spawn(async move {
+            if needs_reserve {
+                let Some(s) = store.upgrade() else {
+                    return;
+                };
+                if s.reserve_manual(size).await.is_err() {
+                    return;
+                }
+            }
             let _ = lazy_background_fill(
                 store,
                 reader,
@@ -1428,6 +1449,7 @@ impl DiskCacheStore {
         uri: &SuperfileUri,
         offsets: Option<&SubsectionOffsets>,
         fetch_storage: Arc<dyn StorageProvider>,
+        allow_background_fill: bool,
     ) -> Result<Arc<CachedEntry>, DiskCacheError> {
         let storage_uri = Self::storage_path(uri);
         let block_source_arc: Arc<BlockCachedSource>;
@@ -1471,11 +1493,12 @@ impl DiskCacheStore {
                 storage_uri.clone(),
                 total_size,
             ));
-            let block_source = BlockCachedSource::new_pre_reserved(
+            let block_source = BlockCachedSource::new_with_accounting(
                 inner,
                 Arc::downgrade(self),
                 *uri,
                 self.blocks_path(uri),
+                !allow_background_fill,
                 // FTS subsection reads bypass block rounding (exact ranges);
                 // see the `passthrough` field docs.
                 offsets.fts,
@@ -1554,11 +1577,12 @@ impl DiskCacheStore {
                     Arc::clone(&fetch_storage),
                     storage_uri.clone(),
                 ));
-            let block_source = BlockCachedSource::new_pre_reserved(
+            let block_source = BlockCachedSource::new_with_accounting(
                 range_src,
                 Arc::downgrade(self),
                 *uri,
                 self.blocks_path(uri),
+                !allow_background_fill,
                 // No manifest hints here, so the FTS subsection is unknown.
                 None,
             );
@@ -1573,15 +1597,30 @@ impl DiskCacheStore {
             (lazy_reader, size)
         };
 
-        self.reserve_manual(size).await?;
+        // Vector opens keep their blob sparse and never mmap-promote, so they
+        // account their live filled bytes (source-owned) instead of reserving
+        // the whole superfile up front. Otherwise a fanout touching many
+        // superfiles over-reserves and evicts live peers. FTS/SQL opens promote
+        // to a full mmap, so they keep the eager full-size reservation.
+        if allow_background_fill {
+            self.reserve_manual(size).await?;
+        }
 
         let lazy_reader = Arc::new(lazy_reader);
         let block_token = block_source_arc.entry_token();
+        let (size_bytes, accounting) = if allow_background_fill {
+            (Arc::new(AtomicU64::new(size)), EntryAccounting::Eager)
+        } else {
+            (
+                block_source_arc.filled_bytes_handle(),
+                EntryAccounting::SourceOwned,
+            )
+        };
         let entry = Arc::new(CachedEntry {
             reader: Arc::clone(&lazy_reader),
             mmap: None,
-            size_bytes: Arc::new(AtomicU64::new(size)),
-            accounting: EntryAccounting::Eager,
+            size_bytes,
+            accounting,
             block_token: Some(block_token),
             block_source: Some(block_source_arc),
             // Fill is modality-gated via [`Self::maybe_spawn_background_fill`]

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -4359,9 +4359,9 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             .await
             .map_err(|e| BuildError::Store(e.to_string()))?;
         // Opt-in gate: only build the resident data graph when queries will
-        // walk it (`search_mode = hnsw_ivf`). Under the default `ivf` (or
-        // `global_fine_centroid`) the drain skips the build — no build tax, no
-        // RAM-pinned graph — and queries serve ivf. Gating here (not inside
+        // walk it (`search_mode = hnsw_ivf`). Under the default `ivf` the drain
+        // skips the build — no build tax, no RAM-pinned graph — and queries
+        // serve ivf. Gating here (not inside
         // `build_hnsw_graph_ref`) keeps that function a pure, directly-testable
         // build step.
         let building_graph =


### PR DESCRIPTION
## vector: centroid-HNSW ivf router for the hidden vector index

### Problem / motivation
Real-dataset scale runs — **LAION 100M**, tracked in #490 — showed the engine is **multi-second per query at 100M**, in *both* regimes:

- **warm** (cache-resident, 0 GETs): **~3–5 s**. The stamped router scans whole IVF cells, and #490 shows it probes ~29 of 256 cells for `k=10` — at 100M that's ~11.6M vectors scored per query, *even with the data cached*. This is compute, not I/O.
- **cold** (first touch): ~4–9 s (#490), Blob-read-bound as each serial query cold-fetches its cells.

Single-digit-ms latency needs a router that scores **far fewer candidates**. This PR adds one.

### What this adds
`ivf_router = centroid_graph`: instead of scanning whole stamped cells, it walks an HNSW over the resident fp32 fine centroids and scores only the top-`fanout` **fine clusters**. **Rebased onto current `main` (post-#603).**

```yaml
search_mode: ivf | hnsw_ivf
ivf_router:  stamped | centroid_graph   # ivf only; default stamped
```
Folds the experimental `global_fine_centroid` search mode into `ivf_router = centroid_graph` and drops the intermediate brute-force scan (superseded by the graph). Default stays `stamped`.

### stamped vs centroid_graph — LAION 100M, 768-d, co-located Azure Blob

| metric | `stamped` | `centroid_graph` |
|---|---|---|
| **warm** p50 (cache-resident, 0 GETs) | ~4.0 s (p95 6.4 s) | **~30 ms** |
| **cold** p50 | ~5.6 s | **~5.4 s** |
| cold q0 (fully cold, first query) | 15.4 s | 19.4 s |
| cold bytes / query (q0) | 12.8 GiB | **9.7 GiB** |
| recall@10 (fanout-dependent, see below) | 0.988 | 0.990–0.993 |

**The headline is warm: ~135× (4.0 s → 30 ms).** Scoring `fanout` targeted fine clusters instead of whole cells removes the per-query compute wall. Cold lands at **parity** with `stamped` (on fewer bytes) — but only after the fan-out fix below; without it the router's cold p50 was ~56 s (its per-cell reads were issued serially).

### Cold path: parallel per-cell fan-out

The router's phase-2 scan over the selected fine clusters ran one superfile at a time, awaiting each cell's cold read before the next — RTT-serializing the object-store fetches. The stamped whole-cell path already fans its per-superfile reads out concurrently; this brings the graph path to the same discipline: the per-superfile scans run through `buffer_unordered` bounded to the reader-pool width, sharing the same connection-memory budget and reader pool (so concurrent cold fetches still gate on `OverBudget`). Survivors are pooled and reranked exactly as before. Reads are unchanged — same clusters, same bytes — so recall is identical.

LAION 100M, `centroid_graph`, fanout 2048 (cold p50 over 20 cold queries):

| | serial | parallel |
|---|---|---|
| cold **p50** | 55.9 s | **5.4 s** |
| cold q0 (fully cold) | 60.5 s | 19.4 s |

~10× lower cold p50, pure read concurrency. The gain scales with how much cold I/O is serialized: **~10× at 100M**, **~2× at 10M** (2.05 s → 0.97 s). Recall verified unchanged (Cohere 10M `centroid_graph`, identical before and after).

The remaining q0 gap (19.4 s vs `stamped`'s 15.4 s) is the one-time per-handle centroid/graph load on the first query. **Building the graph at drain and persisting it (instead of per-handle at first query) is the next follow-up PR** — it removes that first-query build and the q0 tail entirely.

### Recall by fanout — Cohere 10M (cache-independent)

| router / fanout | recall@10 |
|---|---|
| `stamped` (ivf) | 0.988 |
| `centroid_graph`, 512 | 0.990 |
| `centroid_graph`, 1024 | 0.993 |

Ranking centroids by normalized cosine also beats the dropped scan's raw-dot ranking: 0.956 → 0.983 at fanout 128 on Cohere-1M.

### Centroid-HNSW router
- Built once per handle from the resident centroid section at the first query (no drain change); reuses #603's HNSW machinery.
- A graph node maps back to the exact `flat` cluster id the stamped read plan expects, so phase 2 is **byte-identical**.
- Knobs: `global_fine_fanout`, `global_fine_graph_ef` (0 = auto), `global_fine_rerank_mult`.
- **Next follow-up PR:** build + persist the graph at drain time (removes the first-query build and the q0 tail). Later: per-table fanout/ef calibration.

### Enabling fix (reader-cache)
Included because the router is unusable at scale without it: block-cached entries for sparse vector blobs reserved their whole superfile size up front, so a wide fanout over-reserved the cache budget and evicted live entries — vector reads never warmed. Now they account their live filled bytes (source-owned), gated on the promotion signal so FTS/SQL mmap promotion is unaffected.

### Validation
Full lib suite green (2246); clippy clean; `reader_cache` accounting suite 67/67. Parallel fan-out: reads byte-identical (recall unchanged), cold p50 ~10× at 100M / ~2× at 10M, memory-safe under concurrency (shared budget + pool).
