### PR TITLE
bench/ci: exclude cold and footprint metrics from the merge gate

### DIFF
--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -40,6 +40,22 @@ COST_TOKENS = ("$", "cost", "measured", "per-unit")
 SECONDARY_HEADERS = ("cold search", "peak rss")
 SECONDARY_THRESHOLD_PCT = 30.0
 
+# Memory-footprint columns are byte sizes (MiB/GiB), not nanosecond latencies:
+# peak/median RSS, peak anon/file mappings, and total bytes stored. They are
+# run-order biased, so they are never treated as latencies and never gate.
+# is_latency() and human() both key off this set - a token here keeps a
+# footprint column from being mistaken for a nanosecond latency (which would
+# both misformat it as "ms" and sweep it into the merge gate).
+FOOTPRINT_TOKENS = ("rss", "stored", "peak", "anon")
+
+# Cold-cache latencies - object-store first-touch ("cold ...") and the
+# fetch-augmented variants ("+fetch ...") - swing widely run-to-run with
+# network and VM page-cache state, so they are advisory-only and never block a
+# merge. Only warm, CPU-bound latencies and the ingest/optimize/drain walls
+# gate. Identical code routinely moves a cold metric by hundreds of percent;
+# gating on that fails PRs that changed no engine code at all.
+GATE_EXCLUDE_TOKENS = ("cold", "+fetch")
+
 # Map a report basename to (subsystem label, source area).
 SUBSYSTEM = {
     "supertable": ("Ingest", "src/supertable/writer.rs"),
@@ -61,13 +77,15 @@ DEFAULT_OUT = "/tmp/ai-summary.md"
 DEFAULT_THRESHOLD = 5.0
 DEFAULT_GATE_FILE = "/tmp/bench-gate.status"
 
-# Merge-blocking gate: a time-valued metric (warm/cold latency, ingest /
-# drain / optimize wall) must be worse than the main baseline by BOTH of
-# these to block the merge. The AND is the noise guard: a big percent of a
-# sub-millisecond metric never blocks, and neither does a small-percent
-# wiggle on a long wall. The 5% advisory tiers above stay as REPORTING
-# thresholds only; this pair is the sole blocking criterion (enforced by
-# the workflow's "Enforce benchmark merge gate" step reading GATE_FILE).
+# Merge-blocking gate: a gateable time metric (warm latency, count(), ingest
+# Time, or a drain / optimize wall - see gates()) must be worse than the main
+# baseline by BOTH of these to block the merge. The AND is the noise guard: a
+# big percent of a sub-millisecond metric never blocks, and neither does a
+# small-percent wiggle on a long wall. Cold object-store timings and memory
+# footprints are out of scope entirely (too variable to gate on). The 5%
+# advisory tiers above stay as REPORTING thresholds only; this pair is the
+# sole blocking criterion (enforced by the workflow's "Enforce benchmark
+# merge gate" step reading GATE_FILE).
 GATE_REL_PCT = 50.0
 GATE_ABS_NS = 5_000_000.0
 
@@ -110,9 +128,23 @@ def primary_latency_header_from_gate_metric(metric):
 
 
 def is_latency(header):
-    """Lower-is-better and measured in nanoseconds (Time, p50, cold, count())."""
+    """Lower-is-better and measured in nanoseconds (Time, p50, cold, count()).
+
+    Footprint columns (peak/median RSS, peak anon/file, bytes stored) are byte
+    sizes, not latencies, so they are excluded here - otherwise a memory move
+    would be misformatted as "ms" and, worse, treated as a gateable latency.
+    """
     h = header.lower()
-    return not higher_is_better(header) and "rss" not in h and "stored" not in h
+    return not higher_is_better(header) and not any(t in h for t in FOOTPRINT_TOKENS)
+
+
+def gates(header):
+    """Eligible for the merge-blocking gate: a controllable, low-variance time
+    metric - warm latency, count(), ingest Time, or a drain/optimize wall.
+    Cold object-store timings and memory footprints are excluded (see
+    GATE_EXCLUDE_TOKENS and FOOTPRINT_TOKENS)."""
+    h = header.lower()
+    return is_latency(header) and not any(t in h for t in GATE_EXCLUDE_TOKENS)
 
 
 def human(header, value):
@@ -122,7 +154,7 @@ def human(header, value):
         return f"{value:,.0f} docs/s"
     if "bandwidth" in h:
         return f"{value / 1048576:,.1f} MiB/s"
-    if "rss" in h or "stored" in h:
+    if any(t in h for t in FOOTPRINT_TOKENS):
         if value >= 1073741824:
             return f"{value / 1073741824:.2f} GiB"
         return f"{value / 1048576:.1f} MiB"
@@ -173,10 +205,11 @@ def diff(reports, baseline_dir, current_dir, threshold, primary_headers):
             if old is None or old == 0.0:
                 continue
             had_baseline = True
-            # Merge-blocking gate: every time-valued lower-is-better metric
-            # is eligible regardless of advisory tier, so optimize/drain
-            # walls and every latency row are covered.
-            if is_latency(header):
+            # Merge-blocking gate: warm latency, count(), ingest Time, and the
+            # optimize/drain walls are eligible regardless of advisory tier.
+            # Cold object-store timings and memory footprints are excluded -
+            # they vary too much run-to-run to gate on (see gates()).
+            if gates(header):
                 delta_ns = new - old
                 gate_pct = delta_ns / old * 100.0
                 if delta_ns > GATE_ABS_NS and gate_pct > GATE_REL_PCT:

--- a/.github/scripts/test_bench_summary.py
+++ b/.github/scripts/test_bench_summary.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Regression tests for the benchmark merge gate (bench_summary.py).
+
+Run: python3 -m unittest .github/scripts/test_bench_summary.py
+
+The gate must fire only on controllable, low-variance time metrics - warm
+latency, count(), ingest Time, and the drain/optimize walls. Cold object-store
+timings and memory-footprint columns swing by hundreds of percent run-to-run on
+identical code, so gating on them fails PRs that changed no engine code (and one
+footprint column, "Peak file", was even being misread as a nanosecond latency).
+These tests pin that boundary.
+"""
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "bench_summary", os.path.join(os.path.dirname(__file__), "bench_summary.py")
+)
+bs = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(bs)
+
+MS = 1e6  # nanoseconds per millisecond
+
+
+def _key(label, header):
+    # Report keys are "anchor|subtitle|label|header".
+    return f"anchor|subtitle|{label}|{header}"
+
+
+class PredicateTests(unittest.TestCase):
+    def test_footprint_columns_are_not_latencies(self):
+        for header in ("Peak file", "Peak anon", "Peak RSS", "Median RSS", "Stored"):
+            self.assertFalse(bs.is_latency(header), header)
+
+    def test_time_metrics_are_latencies(self):
+        for header in ("warm p90", "warm p50", "Time", "count()", "optimize wall"):
+            self.assertTrue(bs.is_latency(header), header)
+
+    def test_gate_excludes_cold_and_footprint(self):
+        for header in (
+            "cold 1st query (median)",
+            "cold open (median)",
+            "+fetch cold",
+            "Peak file",
+            "Peak RSS",
+        ):
+            self.assertFalse(bs.gates(header), header)
+
+    def test_gate_includes_warm_and_walls(self):
+        for header in ("warm p90", "warm p50", "Time", "count()", "drain wall"):
+            self.assertTrue(bs.gates(header), header)
+
+    def test_footprint_renders_as_bytes_not_ms(self):
+        self.assertTrue(bs.human("Peak file", 322.59e6).endswith("MiB"))
+        self.assertTrue(bs.human("Peak RSS", 2 * 1073741824).endswith("GiB"))
+
+
+class BlockingGateTests(unittest.TestCase):
+    def _diff(self, base, cur):
+        d = tempfile.mkdtemp()
+        os.makedirs(os.path.join(d, "base"))
+        os.makedirs(os.path.join(d, "cur"))
+        with open(os.path.join(d, "base", "r.json"), "w") as fh:
+            json.dump(base, fh)
+        with open(os.path.join(d, "cur", "r.json"), "w") as fh:
+            json.dump(cur, fh)
+        primary = (bs.primary_latency_header_from_gate_metric("p90"), "time", "stored", "wall")
+        _, _, blocking, _, _ = bs.diff(
+            ["r"], os.path.join(d, "base"), os.path.join(d, "cur"), 5.0, primary
+        )
+        return {e["metric"] for e in blocking}
+
+    def test_cold_regression_does_not_block(self):
+        # The #585 / #586 signature: a huge cold-cache swing on identical code.
+        blocked = self._diff(
+            {_key("two_term_and", "cold 1st query (median)"): 18.72 * MS},
+            {_key("two_term_and", "cold 1st query (median)"): 1260.0 * MS},  # +6640%
+        )
+        self.assertEqual(blocked, set())
+
+    def test_fetch_cold_regression_does_not_block(self):
+        blocked = self._diff(
+            {_key("forty_term_or", "+fetch cold"): 189.78 * MS},
+            {_key("forty_term_or", "+fetch cold"): 1550.0 * MS},  # +718%
+        )
+        self.assertEqual(blocked, set())
+
+    def test_peak_footprint_does_not_block(self):
+        # 322 MiB -> 524 MiB was blocking as a mislabeled "322 ms -> 523 ms".
+        blocked = self._diff(
+            {_key("vector-only", "Peak file"): 322.59e6},
+            {_key("vector-only", "Peak file"): 523.80e6},
+        )
+        self.assertEqual(blocked, set())
+
+    def test_real_warm_regression_blocks(self):
+        blocked = self._diff(
+            {_key("bm25_search", "warm p90"): 10.0 * MS},
+            {_key("bm25_search", "warm p90"): 20.0 * MS},  # +100%, +10ms
+        )
+        self.assertIn("bm25_search / warm p90", blocked)
+
+    def test_ingest_wall_regression_blocks(self):
+        blocked = self._diff(
+            {_key("ingest", "Time"): 1000.0 * MS},
+            {_key("ingest", "Time"): 2000.0 * MS},  # +100%
+        )
+        self.assertIn("ingest / Time", blocked)
+
+    def test_sub_5ms_warm_move_does_not_block(self):
+        # The AND noise guard: +60% but under the 5 ms absolute floor.
+        blocked = self._diff(
+            {_key("single_common", "warm p90"): 4.0 * MS},
+            {_key("single_common", "warm p90"): 6.4 * MS},  # +60%, +2.4ms
+        )
+        self.assertEqual(blocked, set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The benchmark merge gate blocked a PR when any lower-is-better nanosecond metric was worse than the same-host `main` baseline by **both >50% and >5 ms**. That scope was too wide and swept in two classes of metric that vary far too much to gate on:

- **Cold-cache latencies** (`cold 1st query (median)`, `cold open (median)`, `+fetch cold`) are object-store first-touch timings. They swing hundreds to thousands of percent run-to-run purely from network and VM page-cache state. On *identical* code they trip both legs of the gate, so PRs that changed no engine code failed — and the failure also fires on `main` post-merge.
- **Peak memory-footprint columns** (`Peak file`, `Peak anon`) are byte sizes, not latencies. `is_latency()` only excluded the literal `"rss"` token, so these slipped through, got misformatted as `"ms"` by `human()`, and were gated as if a `338 MiB -> 524 MiB` move were a `+62%` latency regression.

### Observed

Recent no-code / post-merge runs failed the gate with blocking lists that were **100% cold or footprint** metrics — no warm latency moved:

```
# release version bump (no engine code):
ten_term_or / cold 1st query (median): 50.28 ms -> 1.47 s (+2823%)
three_wide_or / cold 1st query (median): 58.77 ms -> 685.55 ms (+1066%)
... (12 blocking, all cold)

# post-merge run on main:
two_term_and / cold 1st query (median): 18.72 ms -> 1.26 s (+6640%)
bm25_search / cold open (median): 227.44 ms -> 368.72 ms (+62%)
vector-only / Peak file: 322.59 ms -> 523.80 ms (+62%)   # a memory column, mislabeled as ms
```

## Fix

- Add `gates(header)`: the blocking gate now fires only on controllable, low-variance time metrics — **warm latency, `count()`, ingest `Time`, and the drain/optimize walls**. Cold (`cold`/`+fetch`) timings are excluded.
- Widen the footprint token set (`rss`, `stored`, `peak`, `anon`) so peak/anon/file columns are never treated as latencies — fixing both the gate and the MiB/GiB unit formatting in `human()`.
- The 5%/30% advisory tiers and the `>50% AND >5 ms` blocking pair are unchanged; only the **set of metrics eligible to block** is narrowed. Cold and footprint moves remain visible as advisory findings.

## Tests

Adds `.github/scripts/test_bench_summary.py` (stdlib `unittest`, run with `python3 .github/scripts/test_bench_summary.py`). It pins the boundary using the exact signatures above:

- cold and `+fetch cold` regressions → **do not block**
- `Peak file` footprint move → **does not block**, renders as MiB
- real warm p90 regression (+100%, +10 ms) → **blocks**
- ingest `Time` wall regression → **blocks**
- sub-5 ms warm move (+60%, +2.4 ms) → **does not block** (noise guard intact)

Verified the cold/footprint cases **fail against the pre-fix script and pass after**; all 11 tests green.