### PR TITLE
fts: faster COUNT — position sub-index for phrases + dedup repeated tokens

### DIFF
--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -22,6 +22,8 @@ pub const CRC_BYTES: usize = 4;
 
 /// FTS section magic bytes and constants.
 pub mod fts {
+    use crate::superfile::fts::posting::BLOCK_LEN;
+
     /// 8-byte magic at the start of the FTS blob: `INF` + `FTS` +
     /// `01`. The trailing `01` is a fixed part of the section
     /// identity, **not** a version — it never changes across blob
@@ -63,6 +65,14 @@ pub mod fts {
     /// Divides evenly into the posting-block length so every block's
     /// sub-index has `ceil(pairs_in_block / STRIDE)` entries.
     pub const POSITION_SUBINDEX_STRIDE: usize = 16;
+
+    /// Sub-index run-offset checkpoints stored per posting block
+    /// ([`VERSION_V3`]): the whole-block entry count, one every
+    /// [`POSITION_SUBINDEX_STRIDE`] pairs across a full posting block.
+    /// Both the writer's per-term sub-index sizing and the reader's flat
+    /// `block * ENTRIES + slot` indexing derive from this single value, so
+    /// they stay in lockstep.
+    pub const POSITION_SUBINDEX_ENTRIES_PER_BLOCK: usize = BLOCK_LEN / POSITION_SUBINDEX_STRIDE;
 
     /// Fixed-point scale for the per-column average document length.
     /// The builder stores `round(avgdl × 1000)` in the doc-lengths

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -43,6 +43,27 @@ pub mod fts {
     /// both versions.
     pub const VERSION_V2: u32 = 2;
 
+    /// The version new code writes when a column stores positions: same
+    /// header and region layout as [`VERSION_V2`], but each positional
+    /// term's region gains a **position run-offset sub-index** between its
+    /// skip table and its posting blocks. The sub-index stores, every
+    /// [`POSITION_SUBINDEX_STRIDE`] pairs within a block, the byte offset
+    /// of that pair's position run (relative to the term's positions), so
+    /// the reader reaches a pair's positions by skipping `< STRIDE` runs
+    /// instead of walking every run from the block start. Readers accept
+    /// `V1`/`V2`/`V3`; `V1`/`V2` files (no sub-index) stay readable
+    /// unchanged, so existing indices need no reindex. A column *without*
+    /// positions is written as [`VERSION_V2`] — the sub-index only exists
+    /// where positions do.
+    pub const VERSION_V3: u32 = 3;
+
+    /// Stride of the position run-offset sub-index ([`VERSION_V3`]): one
+    /// stored offset per this many pairs within a posting block. A decode
+    /// skips at most `STRIDE - 1` runs from the nearest sub-index entry.
+    /// Divides evenly into the posting-block length so every block's
+    /// sub-index has `ceil(pairs_in_block / STRIDE)` entries.
+    pub const POSITION_SUBINDEX_STRIDE: usize = 16;
+
     /// Fixed-point scale for the per-column average document length.
     /// The builder stores `round(avgdl × 1000)` in the doc-lengths
     /// directory as a `u32` (`avgdl_x1000`); the reader recovers the

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -3668,9 +3668,9 @@ fn encode_and_emit_term<W: Write>(
         // `ENTRIES_PER_BLOCK` per block, written between the skip table and
         // the posting blocks. Zero-sized on positionless terms, which keep
         // the V2 layout byte-for-byte.
-        const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / format::fts::POSITION_SUBINDEX_STRIDE;
+        let entries_per_block = format::fts::POSITION_SUBINDEX_ENTRIES_PER_BLOCK;
         let subindex_size = match term_positions {
-            Some(_) => num_blocks as usize * ENTRIES_PER_BLOCK * format::fts::U32_BYTES,
+            Some(_) => num_blocks as usize * entries_per_block * format::fts::U32_BYTES,
             None => 0,
         };
         let postings_length =
@@ -3703,16 +3703,16 @@ fn encode_and_emit_term<W: Write>(
             }
             debug_assert_eq!(at, runs.len(), "runs must cover exactly the pairs");
             // Pad the final (partial) block's sub-index up to a whole
-            // `ENTRIES_PER_BLOCK`, so entry `(block, slot)` is a flat
-            // `block * ENTRIES_PER_BLOCK + slot`. The pad offsets point at
+            // `entries_per_block`, so entry `(block, slot)` is a flat
+            // `block * entries_per_block + slot`. The pad offsets point at
             // the run end and are never read (no pair maps to them).
-            while !pos_subindex_offsets.len().is_multiple_of(ENTRIES_PER_BLOCK) {
+            while !pos_subindex_offsets.len().is_multiple_of(entries_per_block) {
                 pos_subindex_offsets.push(at as u32);
             }
             debug_assert_eq!(
                 pos_subindex_offsets.len() * format::fts::U32_BYTES,
                 subindex_size,
-                "sub-index must hold ENTRIES_PER_BLOCK offsets per block"
+                "sub-index must hold entries_per_block offsets per block"
             );
         }
 

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -3259,7 +3259,17 @@ fn assemble_and_write_blob<W: Write>(
     let blob_copy_start = finish_profile.enabled.then(Instant::now);
     let mut header = Vec::with_capacity(header_size as usize);
     header.extend_from_slice(format::fts::MAGIC); // 8
-    header.extend_from_slice(&format::fts::VERSION_V2.to_le_bytes()); // 4
+    // V3 when the positions region has a real body (beyond its 4-byte
+    // CRC): a non-empty body means at least one non-inline positional term
+    // wrote position runs and therefore a run-offset sub-index. A
+    // positionless blob — or a positional one whose terms all inlined —
+    // leaves a CRC-only region and stays V2, byte-identical to before.
+    // Readers accept both.
+    let fts_version = match positions_region.1 > format::CRC_BYTES as u64 {
+        true => format::fts::VERSION_V3,
+        false => format::fts::VERSION_V2,
+    };
+    header.extend_from_slice(&fts_version.to_le_bytes()); // 4
     header.extend_from_slice(&n_columns.to_le_bytes()); // 4
     header.extend_from_slice(&n_docs.to_le_bytes()); // 4
     header.extend_from_slice(&n_terms_total.to_le_bytes()); // 4
@@ -3359,6 +3369,13 @@ struct TermScratch {
     /// offset of the block's first run within the term's positions
     /// bytes) for positional columns. Reused like the other buffers.
     pos_block_offsets: Vec<u32>,
+    /// Per-term position run-offset sub-index (VERSION_V3, positional
+    /// columns): `ENTRIES_PER_BLOCK` byte offsets per block — one every
+    /// `POSITION_SUBINDEX_STRIDE` pairs — each relative to the term's
+    /// positions bytes. Padded to a whole `ENTRIES_PER_BLOCK` per block
+    /// so entry `(block, slot)` sits at a flat `block * ENTRIES_PER_BLOCK
+    /// + slot`. Reused like the other buffers.
+    pos_subindex_offsets: Vec<u32>,
 }
 
 /// Merge one spilled column's sorted partition files and emit every
@@ -3646,14 +3663,28 @@ fn encode_and_emit_term<W: Write>(
             Some(_) => TERM_META_POSITIONAL_SIZE,
             None => TERM_META_SIZE,
         };
-        let postings_length = (term_meta_size + skip_table_size + blocks_total_size) as u64;
+        // VERSION_V3 position sub-index (positional terms only): one run
+        // offset every `POSITION_SUBINDEX_STRIDE` pairs, padded to a whole
+        // `ENTRIES_PER_BLOCK` per block, written between the skip table and
+        // the posting blocks. Zero-sized on positionless terms, which keep
+        // the V2 layout byte-for-byte.
+        const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / format::fts::POSITION_SUBINDEX_STRIDE;
+        let subindex_size = match term_positions {
+            Some(_) => num_blocks as usize * ENTRIES_PER_BLOCK * format::fts::U32_BYTES,
+            None => 0,
+        };
+        let postings_length =
+            (term_meta_size + skip_table_size + subindex_size + blocks_total_size) as u64;
 
-        // Per-block byte offsets into this term's position runs: walk
-        // the runs once, recording where each 128-doc block's first
-        // run starts, so the reader can fetch/decode one block's
-        // positions without touching its predecessors.
+        // Walk the runs once, recording where each 128-doc block's first
+        // run starts (the skip table's per-block offset) and, every
+        // `POSITION_SUBINDEX_STRIDE` pairs, a finer sub-index offset — so
+        // the reader reaches a pair's positions by skipping `< STRIDE`
+        // runs rather than every run from the block start.
         let pos_block_offsets = &mut scratch.pos_block_offsets;
+        let pos_subindex_offsets = &mut scratch.pos_subindex_offsets;
         pos_block_offsets.clear();
+        pos_subindex_offsets.clear();
         if let Some((_, runs)) = &term_positions {
             debug_assert!(
                 runs.len() <= u32::MAX as usize,
@@ -3661,12 +3692,28 @@ fn encode_and_emit_term<W: Write>(
             );
             let mut at: usize = 0;
             for (i, &(_, tf)) in pairs.iter().enumerate() {
-                if i % BLOCK_LEN == 0 {
+                let in_block = i % BLOCK_LEN;
+                if in_block == 0 {
                     pos_block_offsets.push(at as u32);
+                }
+                if in_block.is_multiple_of(format::fts::POSITION_SUBINDEX_STRIDE) {
+                    pos_subindex_offsets.push(at as u32);
                 }
                 skip_run(runs, &mut at, tf).expect("builder-encoded runs are well-formed");
             }
             debug_assert_eq!(at, runs.len(), "runs must cover exactly the pairs");
+            // Pad the final (partial) block's sub-index up to a whole
+            // `ENTRIES_PER_BLOCK`, so entry `(block, slot)` is a flat
+            // `block * ENTRIES_PER_BLOCK + slot`. The pad offsets point at
+            // the run end and are never read (no pair maps to them).
+            while !pos_subindex_offsets.len().is_multiple_of(ENTRIES_PER_BLOCK) {
+                pos_subindex_offsets.push(at as u32);
+            }
+            debug_assert_eq!(
+                pos_subindex_offsets.len() * format::fts::U32_BYTES,
+                subindex_size,
+                "sub-index must hold ENTRIES_PER_BLOCK offsets per block"
+            );
         }
 
         debug_assert!(df <= u32::MAX as u64, "df overflows u32");
@@ -3705,7 +3752,9 @@ fn encode_and_emit_term<W: Write>(
             profile.encode_meta_write += start.elapsed();
         }
 
-        let mut block_offset: u32 = (term_meta_size + skip_table_size) as u32;
+        // Blocks follow the meta, the skip table, and the (V3-only)
+        // position sub-index, so their offsets start past all three.
+        let mut block_offset: u32 = (term_meta_size + skip_table_size + subindex_size) as u32;
         let skip_write_start = profile.enabled.then(Instant::now);
         for (i, blk) in encoded_blocks.iter().enumerate() {
             let max_bm25 = block_ub_per_block[i];
@@ -3730,6 +3779,12 @@ fn encode_and_emit_term<W: Write>(
         }
         if let Some(start) = skip_write_start {
             profile.encode_skip_write += start.elapsed();
+        }
+
+        // Position sub-index (VERSION_V3, positional terms): sits between
+        // the skip table and the blocks. Empty on positionless terms.
+        for &off in pos_subindex_offsets.iter() {
+            term_buf.extend_from_slice(&off.to_le_bytes());
         }
 
         let block_write_start = profile.enabled.then(Instant::now);
@@ -4697,9 +4752,10 @@ mod tests {
         let docs = positional_corpus();
         let k = docs.len();
         let spilled_pos = build_title_blob_spilled(&docs, true, None);
+        // A positional build carries position runs ⇒ a sub-index ⇒ v3.
         assert_eq!(
             u32::from_le_bytes(spilled_pos[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION_V2
+            format::fts::VERSION_V3
         );
         let inram_pos = build_title_blob(&docs, true);
         let inram_plain = build_title_blob(&docs, false);
@@ -4809,7 +4865,7 @@ mod tests {
     }
 
     #[test]
-    fn every_build_writes_v2_and_positionless_region_is_empty() {
+    fn positionless_is_v2_positional_is_v3_and_positionless_region_is_empty() {
         let docs = positional_corpus();
         let plain = build_title_blob(&docs, false);
         let positional = build_title_blob(&docs, true);
@@ -4817,9 +4873,10 @@ mod tests {
         let version_of = |blob: &bytes::Bytes| {
             u32::from_le_bytes(blob[8..12].try_into().expect("4 header bytes"))
         };
-        // New code always writes v2; v1 is a read-only legacy format.
+        // A positionless build is v2; a positional build carries a run-
+        // offset sub-index and is v3. v1 is a read-only legacy format.
         assert_eq!(version_of(&plain), format::fts::VERSION_V2);
-        assert_eq!(version_of(&positional), format::fts::VERSION_V2);
+        assert_eq!(version_of(&positional), format::fts::VERSION_V3);
 
         // A positionless build's region is just the CRC-of-empty.
         let read_u64_plain =
@@ -4916,7 +4973,7 @@ mod tests {
         let blob = bytes::Bytes::from(b.finish().expect("finish"));
         assert_eq!(
             u32::from_le_bytes(blob[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION_V2
+            format::fts::VERSION_V3
         );
         let json = r#"[{"name":"body","tokenizer":"ascii_lower"},{"name":"title","tokenizer":"ascii_lower","positions":true}]"#;
         let r = FtsReader::open(blob, json).expect("open");

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -4821,6 +4821,61 @@ mod tests {
         );
     }
 
+    /// Backwards compatibility: the new reader must read a **v2 positional**
+    /// blob — every already-written positional index — through the
+    /// block-start walk fallback, giving results identical to the v3
+    /// sub-index fast path on the same corpus. A positional build is v3;
+    /// downgrade its version byte to v2 so the reader ignores the sub-index
+    /// and takes the fallback (the sub-index bytes become dead space the
+    /// walk never reads, since blocks are located from the skip table).
+    #[tokio::test]
+    async fn new_code_reads_v2_positional_via_fallback() {
+        use crate::superfile::fts::reader::{BoolMode, FtsReader};
+
+        let docs = positional_corpus();
+        let v3_blob = build_title_blob(&docs, true);
+        assert_eq!(
+            u32::from_le_bytes(v3_blob[8..12].try_into().expect("version bytes")),
+            format::fts::VERSION_V3,
+            "a positional build is v3"
+        );
+        // Downgrade the version field only; the header is not itself
+        // CRC-covered, and the positions region + skip offsets are
+        // byte-identical to v2, so the fallback path reads it correctly.
+        let mut v2_bytes = v3_blob.to_vec();
+        v2_bytes[8..12].copy_from_slice(&format::fts::VERSION_V2.to_le_bytes());
+        let v2_blob = bytes::Bytes::from(v2_bytes);
+
+        let v3 = FtsReader::open(v3_blob, title_json(true)).expect("v3 opens");
+        let v2 = FtsReader::open(v2_blob, title_json(true)).expect("v2 opens");
+        // Phrases exercise the position decode. `common filler` matches in
+        // every one of the 391 docs (spanning 4 posting blocks), so
+        // `common`'s decode runs at pairs across many blocks and non-
+        // checkpoint offsets — exactly the sub-index path. The fast path
+        // (v3) and the block-start walk (v2 fallback) must agree exactly,
+        // and match a nonzero count so the decode really ran.
+        let phrases: &[(&[&str], u64)] = &[
+            (&["common", "filler"], 391),
+            (&["medium", "medium"], 79),
+            (&["filler", "medium"], 79),
+        ];
+        for (terms, want) in phrases {
+            let phrase = vec![terms.iter().map(|t| t.to_string()).collect()];
+            let a = v3
+                .atoms_match_count("title", &[], &phrase, BoolMode::And, &[], &[])
+                .await
+                .expect("v3 phrase count")
+                .0;
+            let b = v2
+                .atoms_match_count("title", &[], &phrase, BoolMode::And, &[], &[])
+                .await
+                .expect("v2 phrase count")
+                .0;
+            assert_eq!(a, b, "v3 fast path vs v2 fallback diverged for {terms:?}");
+            assert_eq!(a, *want, "unexpected phrase count for {terms:?}");
+        }
+    }
+
     /// Column-json for the single "title" column, with or without the
     /// positions flag — matching what `fts_columns_json` emits.
     fn title_json(positional: bool) -> &'static str {

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -485,6 +485,12 @@ pub struct FtsReader {
     /// iff the blob is v2. Phrase queries fetch per-term run ranges
     /// out of it via [`Self::fetch_term_positions`].
     pub(super) positions_range: Option<Range<usize>>,
+    /// True iff the blob is `VERSION_V3` — its positional terms carry a
+    /// position run-offset sub-index between skip table and blocks, which
+    /// the phrase decode uses to reach a pair's runs by skipping
+    /// `< POSITION_SUBINDEX_STRIDE` runs. `V1`/`V2` blobs lack it and take
+    /// the block-start skip-walk fallback.
+    pub(super) has_position_subindex: bool,
     pub(super) columns: Vec<ColumnMeta>,
     pub(super) column_id_by_name: HashMap<String, u32>,
 }
@@ -537,17 +543,23 @@ impl FtsReader {
             }));
         }
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
-        if version != format::fts::VERSION_V1_LEGACY && version != format::fts::VERSION_V2 {
+        if version != format::fts::VERSION_V1_LEGACY
+            && version != format::fts::VERSION_V2
+            && version != format::fts::VERSION_V3
+        {
             return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
                 "fts section version {version}"
             ))));
         }
         // The FST directory starts right after whichever header
-        // applies; a v2 header's extension bytes are already in the
+        // applies; a v2/v3 header's extension bytes are already in the
         // fetched span (and in the overlay below), so
-        // `open_with_source` re-reads them without another GET.
+        // `open_with_source` re-reads them without another GET. (v3 shares
+        // v2's header size.)
         let header_size = match version {
-            v if v == format::fts::VERSION_V2 => format::fts::HEADER_SIZE_V2,
+            v if v == format::fts::VERSION_V2 || v == format::fts::VERSION_V3 => {
+                format::fts::HEADER_SIZE_V2
+            }
             _ => FTS_HEADER_SIZE,
         };
         if header.len() < header_size {
@@ -625,15 +637,19 @@ impl FtsReader {
         // the positions-region offset at [48..56] and a positions
         // region between the postings and the doc-lengths directory.
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
+        // v3 shares v2's header and region layout; it additionally carries
+        // a per-term position sub-index (handled in the phrase decode).
         let positional_blob = match version {
             v if v == format::fts::VERSION_V1_LEGACY => false,
             v if v == format::fts::VERSION_V2 => true,
+            v if v == format::fts::VERSION_V3 => true,
             _ => {
                 return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
                     "fts section version {version}"
                 ))));
             }
         };
+        let has_position_subindex = version == format::fts::VERSION_V3;
         let header_size = match positional_blob {
             true => format::fts::HEADER_SIZE_V2,
             false => FTS_HEADER_SIZE,
@@ -892,6 +908,7 @@ impl FtsReader {
             fst_range,
             postings_range,
             positions_range,
+            has_position_subindex,
             columns,
             column_id_by_name,
         })
@@ -1138,7 +1155,15 @@ impl FtsReader {
             for (cursor, term) in cursors.iter().zip(&member_refs) {
                 match cursor.bytes.is_empty() {
                     false => {
-                        let term_meta = TermMeta::parse(cursor.bytes.as_ref(), 0, true)?;
+                        // This is the phrase member's own term_meta —
+                        // the one `decode_current_positions` uses — so it
+                        // carries the sub-index when the blob has one.
+                        let term_meta = TermMeta::parse(
+                            cursor.bytes.as_ref(),
+                            0,
+                            true,
+                            self.has_position_subindex,
+                        )?;
                         positional.push((Some(term_meta), None));
                     }
                     true => {
@@ -1275,7 +1300,7 @@ impl FtsReader {
                     // one `decode_run` per doc in posting order. Read the slice
                     // once and walk it in lockstep with the doc cursor.
                     let position_bytes = if positional {
-                        let meta = TermMeta::parse(term_bytes.as_ref(), 0, true)?;
+                        let meta = TermMeta::parse(term_bytes.as_ref(), 0, true, false)?;
                         let region = positions_region.as_ref().ok_or_else(|| {
                             FtsError::Read(ReadError::MalformedVersion(
                                 "positional column missing a positions region".into(),

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -54,6 +54,12 @@ pub(super) struct TermMeta {
     /// Byte length of this term's position runs (positional columns;
     /// zero otherwise).
     pub(super) positions_length: u32,
+    /// Absolute offset (within the postings region) of this term's
+    /// position run-offset sub-index — the block of
+    /// `num_blocks × ENTRIES_PER_BLOCK` `u32`s sitting right after the
+    /// skip table on a `VERSION_V3` positional term. `None` on
+    /// `V1`/`V2` (no sub-index) and on positionless terms.
+    pub(super) subindex_start: Option<usize>,
 }
 
 impl TermMeta {
@@ -65,6 +71,7 @@ impl TermMeta {
         postings: &[u8],
         metadata_offset: usize,
         positional: bool,
+        has_subindex: bool,
     ) -> Result<Self, FtsError> {
         // Positional columns carry the extended 32-byte header (the
         // term's positions offset + length after `num_blocks`); the
@@ -122,6 +129,23 @@ impl TermMeta {
                 "skip table runs past postings region".into(),
             )));
         }
+        // v3 positional terms store a run-offset sub-index right after the
+        // skip table: `num_blocks × ENTRIES_PER_BLOCK` u32s. Bound it now;
+        // the blocks follow it (their offsets are read from the skip
+        // table, which the writer already shifted past the sub-index).
+        let subindex_start = match has_subindex {
+            true => {
+                const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / format::fts::POSITION_SUBINDEX_STRIDE;
+                let subindex_end = skip_end + num_blocks * ENTRIES_PER_BLOCK * U32_BYTES;
+                if subindex_end > postings.len() {
+                    return Err(FtsError::Read(ReadError::MalformedVersion(
+                        "position sub-index runs past postings region".into(),
+                    )));
+                }
+                Some(skip_end)
+            }
+            false => None,
+        };
         Ok(Self {
             df,
             postings_length,
@@ -129,7 +153,32 @@ impl TermMeta {
             skip_start,
             positions_offset,
             positions_length,
+            subindex_start,
         })
+    }
+
+    /// For a `VERSION_V3` positional term, the run offset of the nearest
+    /// sub-index checkpoint at or before pair `pair_in_block` of block
+    /// `block`, and the number of runs to skip from it to reach the pair.
+    /// The offset is relative to the term's positions (like
+    /// [`Self::positions_block_offset`]). `None` when there is no
+    /// sub-index (`V1`/`V2`) — the caller falls back to the block-start
+    /// walk. The skip is always `< POSITION_SUBINDEX_STRIDE`.
+    #[inline]
+    pub(super) fn positions_subindex_offset(
+        &self,
+        postings: &[u8],
+        block: usize,
+        pair_in_block: usize,
+    ) -> Option<(u32, usize)> {
+        const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / format::fts::POSITION_SUBINDEX_STRIDE;
+        let start = self.subindex_start?;
+        let slot = pair_in_block / format::fts::POSITION_SUBINDEX_STRIDE;
+        let idx = block * ENTRIES_PER_BLOCK + slot;
+        let at = start + idx * U32_BYTES;
+        let checkpoint = read_u32_le(&postings[at..at + U32_BYTES]);
+        let runs_to_skip = pair_in_block % format::fts::POSITION_SUBINDEX_STRIDE;
+        Some((checkpoint, runs_to_skip))
     }
 
     /// Decode skip-table entry `i` into `(last_doc_id,
@@ -309,7 +358,9 @@ impl TermCursor {
         let postings: &[u8] = term_bytes.as_ref();
         let metadata_offset = 0usize;
 
-        let term_meta = TermMeta::parse(postings, metadata_offset, positional)?;
+        // The plain-term cursor never decodes positions, so it needs no
+        // sub-index (it reads block offsets straight from the skip table).
+        let term_meta = TermMeta::parse(postings, metadata_offset, positional, false)?;
         let local_idf = bm25::idf(n_docs, term_meta.df);
         let idf = global_idf.unwrap_or(local_idf);
         // Stored per-block BMW upper bounds bake in the LOCAL idf. Only a

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -16,7 +16,10 @@ use crate::superfile::{
     error::FtsError,
     format::{
         self,
-        fts::{POSITION_SUBINDEX_STRIDE, U32_BYTES, U64_BYTES, skip_entry, term_meta},
+        fts::{
+            POSITION_SUBINDEX_ENTRIES_PER_BLOCK, POSITION_SUBINDEX_STRIDE, U32_BYTES, U64_BYTES,
+            skip_entry, term_meta,
+        },
     },
     fts::{
         bm25,
@@ -135,8 +138,8 @@ impl TermMeta {
         // table, which the writer already shifted past the sub-index).
         let subindex_start = match has_subindex {
             true => {
-                const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / POSITION_SUBINDEX_STRIDE;
-                let subindex_end = skip_end + num_blocks * ENTRIES_PER_BLOCK * U32_BYTES;
+                let subindex_end =
+                    skip_end + num_blocks * POSITION_SUBINDEX_ENTRIES_PER_BLOCK * U32_BYTES;
                 if subindex_end > postings.len() {
                     return Err(FtsError::Read(ReadError::MalformedVersion(
                         "position sub-index runs past postings region".into(),
@@ -171,10 +174,9 @@ impl TermMeta {
         block: usize,
         pair_in_block: usize,
     ) -> Option<(u32, usize)> {
-        const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / POSITION_SUBINDEX_STRIDE;
         let start = self.subindex_start?;
         let slot = pair_in_block / POSITION_SUBINDEX_STRIDE;
-        let idx = block * ENTRIES_PER_BLOCK + slot;
+        let idx = block * POSITION_SUBINDEX_ENTRIES_PER_BLOCK + slot;
         let at = start + idx * U32_BYTES;
         let checkpoint = read_u32_le(&postings[at..at + U32_BYTES]);
         let runs_to_skip = pair_in_block % POSITION_SUBINDEX_STRIDE;

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -16,7 +16,7 @@ use crate::superfile::{
     error::FtsError,
     format::{
         self,
-        fts::{U32_BYTES, U64_BYTES, skip_entry, term_meta},
+        fts::{POSITION_SUBINDEX_STRIDE, U32_BYTES, U64_BYTES, skip_entry, term_meta},
     },
     fts::{
         bm25,
@@ -135,7 +135,7 @@ impl TermMeta {
         // table, which the writer already shifted past the sub-index).
         let subindex_start = match has_subindex {
             true => {
-                const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / format::fts::POSITION_SUBINDEX_STRIDE;
+                const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / POSITION_SUBINDEX_STRIDE;
                 let subindex_end = skip_end + num_blocks * ENTRIES_PER_BLOCK * U32_BYTES;
                 if subindex_end > postings.len() {
                     return Err(FtsError::Read(ReadError::MalformedVersion(
@@ -171,13 +171,13 @@ impl TermMeta {
         block: usize,
         pair_in_block: usize,
     ) -> Option<(u32, usize)> {
-        const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / format::fts::POSITION_SUBINDEX_STRIDE;
+        const ENTRIES_PER_BLOCK: usize = BLOCK_LEN / POSITION_SUBINDEX_STRIDE;
         let start = self.subindex_start?;
-        let slot = pair_in_block / format::fts::POSITION_SUBINDEX_STRIDE;
+        let slot = pair_in_block / POSITION_SUBINDEX_STRIDE;
         let idx = block * ENTRIES_PER_BLOCK + slot;
         let at = start + idx * U32_BYTES;
         let checkpoint = read_u32_le(&postings[at..at + U32_BYTES]);
-        let runs_to_skip = pair_in_block % format::fts::POSITION_SUBINDEX_STRIDE;
+        let runs_to_skip = pair_in_block % POSITION_SUBINDEX_STRIDE;
         Some((checkpoint, runs_to_skip))
     }
 

--- a/src/superfile/fts/reader/phrase.rs
+++ b/src/superfile/fts/reader/phrase.rs
@@ -45,10 +45,20 @@ pub(super) struct PhraseMember {
     pub(super) idf: f32,
     /// Byte offset of each decoded-block pair's run within
     /// `positions`, valid for `run_offsets_block`. Rebuilt on block
-    /// crossings by one `skip_run` walk over the block's runs.
+    /// crossings by one `skip_run` walk over the block's runs. Used by
+    /// the `V1`/`V2` fallback decode (no sub-index).
     pub(super) run_offsets: Vec<u32>,
-    /// Which block index `run_offsets` covers (`usize::MAX` = none).
+    /// Which block index `run_offsets` / the sub-index cache covers
+    /// (`usize::MAX` = none).
     pub(super) run_offsets_block: usize,
+    /// Sub-index decode (`V3`) cache: the last pair whose run offset was
+    /// resolved in `run_offsets_block`, and that run's byte offset. Pairs
+    /// are visited in ascending order within a block, so the next decode
+    /// skips from `max(this cached pair, the sub-index checkpoint)` —
+    /// dense reuse costs ~one `skip_run`, sparse access at most
+    /// `POSITION_SUBINDEX_STRIDE - 1`. `usize::MAX` = nothing cached.
+    pub(super) cached_pair: usize,
+    pub(super) cached_run_offset: u32,
     /// Scratch for the member's decoded positions at the aligned doc.
     pub(super) pos_scratch: Vec<u32>,
 }
@@ -70,24 +80,38 @@ impl PhraseMember {
         let pair = self.cursor.pos;
 
         // Fast path (VERSION_V3): the run-offset sub-index gives the
-        // nearest checkpoint at or before `pair`, so we skip only the
-        // `< POSITION_SUBINDEX_STRIDE` runs between it and `pair` — never
-        // the whole block from its start. Returns an owned tuple, so no
-        // `term_meta` borrow is held across the decode below.
+        // nearest checkpoint at or before `pair`. Start the skip from
+        // whichever is closer to `pair` — that checkpoint, or the pair we
+        // resolved last in this same block (pairs are visited ascending,
+        // so the last one is `<= pair`). Dense reuse then costs ~one
+        // `skip_run`; sparse access at most `STRIDE - 1`. Returns an owned
+        // tuple, so no `term_meta` borrow is held across the decode below.
         let subindex = self
             .term_meta
             .as_ref()
             .expect("PFOR member has term meta")
             .positions_subindex_offset(self.cursor.bytes.as_ref(), block, pair);
         if let Some((checkpoint, runs_to_skip)) = subindex {
-            let mut at = checkpoint as usize;
-            for p in (pair - runs_to_skip)..pair {
+            let checkpoint_pair = pair - runs_to_skip;
+            let (mut from_pair, mut at) = (checkpoint_pair, checkpoint as usize);
+            if self.run_offsets_block == block
+                && self.cached_pair >= checkpoint_pair
+                && self.cached_pair <= pair
+            {
+                from_pair = self.cached_pair;
+                at = self.cached_run_offset as usize;
+            }
+            for p in from_pair..pair {
                 skip_run(&self.positions, &mut at, self.cursor.block_tfs[p]).ok_or_else(|| {
                     FtsError::Read(ReadError::MalformedVersion(
                         "position runs truncated within block".into(),
                     ))
                 })?;
             }
+            // Cache this pair's run start for the next (higher) pair.
+            self.run_offsets_block = block;
+            self.cached_pair = pair;
+            self.cached_run_offset = at as u32;
             decode_run(
                 &self.positions,
                 &mut at,
@@ -205,6 +229,8 @@ impl PhraseCursor {
                     idf,
                     run_offsets: Vec::new(),
                     run_offsets_block: NO_BLOCK_CACHED,
+                    cached_pair: NO_BLOCK_CACHED,
+                    cached_run_offset: 0,
                     pos_scratch: Vec::new(),
                 }
             })

--- a/src/superfile/fts/reader/phrase.rs
+++ b/src/superfile/fts/reader/phrase.rs
@@ -67,15 +67,52 @@ impl PhraseMember {
             return Ok(());
         }
         let block = self.cursor.current_block;
+        let pair = self.cursor.pos;
+
+        // Fast path (VERSION_V3): the run-offset sub-index gives the
+        // nearest checkpoint at or before `pair`, so we skip only the
+        // `< POSITION_SUBINDEX_STRIDE` runs between it and `pair` — never
+        // the whole block from its start. Returns an owned tuple, so no
+        // `term_meta` borrow is held across the decode below.
+        let subindex = self
+            .term_meta
+            .as_ref()
+            .expect("PFOR member has term meta")
+            .positions_subindex_offset(self.cursor.bytes.as_ref(), block, pair);
+        if let Some((checkpoint, runs_to_skip)) = subindex {
+            let mut at = checkpoint as usize;
+            for p in (pair - runs_to_skip)..pair {
+                skip_run(&self.positions, &mut at, self.cursor.block_tfs[p]).ok_or_else(|| {
+                    FtsError::Read(ReadError::MalformedVersion(
+                        "position runs truncated within block".into(),
+                    ))
+                })?;
+            }
+            decode_run(
+                &self.positions,
+                &mut at,
+                self.cursor.block_tfs[pair],
+                &mut self.pos_scratch,
+            )
+            .ok_or_else(|| {
+                FtsError::Read(ReadError::MalformedVersion(
+                    "position run truncated or overflowing".into(),
+                ))
+            })?;
+            return Ok(());
+        }
+
+        // Fallback (V1/V2, no sub-index): build the block's run offsets by
+        // walking every run from the block's recorded first-run offset.
         if self.run_offsets_block != block {
-            // One forward walk locates every pair's run in this
-            // block: start at the block's recorded first-run offset
-            // (the skip entry's fourth field), then skip each pair's
-            // `tf` varints.
             self.run_offsets.clear();
-            let term_meta = self.term_meta.as_ref().expect("PFOR member has term meta");
-            let mut at =
-                term_meta.positions_block_offset(self.cursor.bytes.as_ref(), block) as usize;
+            let block_first = self
+                .term_meta
+                .as_ref()
+                .expect("PFOR member has term meta")
+                .positions_block_offset(self.cursor.bytes.as_ref(), block)
+                as usize;
+            let mut at = block_first;
             for i in 0..self.cursor.block_n {
                 self.run_offsets.push(at as u32);
                 skip_run(&self.positions, &mut at, self.cursor.block_tfs[i]).ok_or_else(|| {
@@ -86,7 +123,6 @@ impl PhraseMember {
             }
             self.run_offsets_block = block;
         }
-        let pair = self.cursor.pos;
         let mut at = self.run_offsets[pair] as usize;
         decode_run(
             &self.positions,

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -830,7 +830,7 @@ impl FtsReader {
         // Gated: an unmetered process must not pay the procfs reads on
         // the most common query shape.
         let kernel_start = metering_active().then(thread_cpu_ns).flatten();
-        let term_meta = TermMeta::parse(postings, metadata_offset, col_meta.positions)?;
+        let term_meta = TermMeta::parse(postings, metadata_offset, col_meta.positions, false)?;
 
         let idf_t = bm25::idf(self.n_docs as u64, term_meta.df);
         let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -943,9 +943,32 @@ impl SupertableReader {
             .fts_tokenizer_for(column)
             .parse(query)
             .into_clauses(mode);
-        let musts: Vec<String> = clauses.musts.into_iter().map(Cow::into_owned).collect();
-        let shoulds: Vec<String> = clauses.shoulds.into_iter().map(Cow::into_owned).collect();
-        let negatives: Vec<String> = clauses.negatives.into_iter().map(Cow::into_owned).collect();
+        // Drop repeated tokens within each clause role. Unranked
+        // matching is set-valued — an AND/OR/exclude over a term repeated
+        // in the query (e.g. `+to +be +or +not +to +be`) is idempotent —
+        // so a duplicate only adds a redundant cursor that intersects (or
+        // unions) a list with itself. Order-preserving so the rarest-first
+        // cursor ordering downstream is unaffected. Phrase members are
+        // *not* deduped: position matters there. (Count path only; the
+        // scored path must keep repeats, which can affect BM25.)
+        // Linear dedup, not a HashSet: clause token lists are tiny (a
+        // handful of terms), so an O(n²) scan over the already-kept
+        // tokens is cheaper than allocating a set + hashing, and — unlike
+        // the set — it adds no per-query allocation on the overwhelmingly
+        // common no-duplicate query. Order-preserving; only the first
+        // occurrence's `String` is materialized.
+        let dedup = |tokens: Vec<Cow<'_, str>>| -> Vec<String> {
+            let mut out: Vec<String> = Vec::with_capacity(tokens.len());
+            for t in tokens {
+                if !out.iter().any(|k| k.as_str() == t.as_ref()) {
+                    out.push(t.into_owned());
+                }
+            }
+            out
+        };
+        let musts: Vec<String> = dedup(clauses.musts);
+        let shoulds: Vec<String> = dedup(clauses.shoulds);
+        let negatives: Vec<String> = dedup(clauses.negatives);
         let own_phrases = |phrases: Vec<Vec<Cow<'_, str>>>| -> Vec<Vec<String>> {
             phrases
                 .into_iter()

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -318,7 +318,10 @@ fn corrupt_fts_positions_region_rejected() {
             .try_into()
             .expect("version bytes"),
     );
-    assert_eq!(version, 2, "positional superfile must embed a v2 FTS blob");
+    assert_eq!(
+        version, 3,
+        "positional superfile must embed a v3 FTS blob (positions sub-index)"
+    );
     let positions_off_rel = u64::from_le_bytes(
         bytes[fts_off + 48..fts_off + 56]
             .try_into()

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -48,8 +48,8 @@ const CRC_TEST_SECONDARY_AXIS_OFFSET: usize = 3;
 const CORRUPTION_FLIP_MASK: u8 = 0xFF;
 
 /// Positional variant of the corruptable superfile: same corpus, the
-/// FTS column records token positions, so the blob is v2 and carries a
-/// CRC-protected positions region.
+/// FTS column records token positions, so the blob is v3 and carries a
+/// CRC-protected positions region (plus the position sub-index).
 fn build_corruptable_positional_superfile() -> Vec<u8> {
     let schema = Arc::new(Schema::new(vec![
         Field::new(
@@ -308,7 +308,7 @@ fn corruption_at_random_interior_positions_rejected() {
 
 #[test]
 fn corrupt_fts_positions_region_rejected() {
-    // v2 blob: the positions-region offset lives at header bytes
+    // v3 blob: the positions-region offset lives at header bytes
     // [48..56] (relative to the blob). Flip a byte inside the region
     // body — the multi-doc terms guarantee it is non-empty.
     let bytes = build_corruptable_positional_superfile();
@@ -342,10 +342,10 @@ fn corrupt_fts_positions_region_rejected() {
 
 #[test]
 fn uncorrupted_positional_superfile_opens() {
-    // Sanity twin of the corruption test: the same v2 bytes open
+    // Sanity twin of the corruption test: the same v3 bytes open
     // cleanly when untouched.
     let bytes = build_corruptable_positional_superfile();
-    SuperfileReader::open(Bytes::from(bytes)).expect("clean v2 superfile opens");
+    SuperfileReader::open(Bytes::from(bytes)).expect("clean v3 superfile opens");
 }
 
 /// FTS blob range only (the positional fixture has no vector blob, so

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -348,6 +348,43 @@ fn uncorrupted_positional_superfile_opens() {
     SuperfileReader::open(Bytes::from(bytes)).expect("clean v3 superfile opens");
 }
 
+#[test]
+fn corrupt_fts_position_subindex_rejected() {
+    // The v3 position run-offset sub-index is not a new CRC region — it
+    // rides inside each term's postings region, which is already
+    // CRC-protected. This pins that the new bytes are covered: land a flip
+    // squarely inside the first term's sub-index and confirm the reader
+    // rejects it at open.
+    //
+    // A v3 positional term's region is `[meta][skip table][sub-index]
+    // [blocks]`. The postings region holds only non-inline terms (inline
+    // df=1 terms live in the FST value), and the fixture's FTS column is
+    // positional, so its first postings term is a positional term whose
+    // sub-index begins right after its skip table.
+    let bytes = build_corruptable_positional_superfile();
+    let (fts_off, _) = locate_fts_blob_only(&bytes);
+    // postings_offset (relative to the blob) at FTS header bytes [+32..+40].
+    let postings_offset_rel = u64::from_le_bytes(
+        bytes[fts_off + 32..fts_off + 40]
+            .try_into()
+            .expect("postings offset"),
+    ) as usize;
+    let term0 = fts_off + postings_offset_rel;
+    // Positional term header is 32 bytes; `num_blocks` is the u32 at its
+    // offset 16; each skip entry is 16 bytes. The sub-index starts right
+    // after the skip table.
+    const POSITIONAL_META: usize = 32;
+    const SKIP_ENTRY: usize = 16;
+    let num_blocks = u32::from_le_bytes(
+        bytes[term0 + 16..term0 + 20]
+            .try_into()
+            .expect("num_blocks"),
+    ) as usize;
+    assert!(num_blocks >= 1, "first postings term must have ≥1 block");
+    let subindex_start = term0 + POSITIONAL_META + num_blocks * SKIP_ENTRY;
+    assert_corruption_rejected(bytes, subindex_start + 1, "fts/position sub-index");
+}
+
 /// FTS blob range only (the positional fixture has no vector blob, so
 /// `locate_blobs` — which insists on both — doesn't apply).
 fn locate_fts_blob_only(bytes: &[u8]) -> (usize, usize) {

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -195,6 +195,30 @@ fn count_agrees_with_token_match_cardinality() {
     }
 }
 
+/// A token repeated in the query is idempotent for an unranked count —
+/// AND/OR/exclude over the same term twice is the same set — so the
+/// count path drops duplicate tokens, and the count must match the
+/// query with the repeat removed. (Phrase members are exempt: position
+/// matters there.)
+#[test]
+fn count_dedups_repeated_query_tokens() {
+    let st = demo_two_superfiles();
+    let reader = st.reader().expect("reader");
+    // (mode, query-with-duplicate, equivalent-deduped-query)
+    let cases = [
+        // AND: doc 7 ("rust systems") is the only match either way.
+        (BoolMode::And, "+rust +systems +rust", "+rust +systems"),
+        // OR: the union of {rust, go} is unchanged by repeating `rust`.
+        (BoolMode::Or, "rust rust go", "rust go"),
+    ];
+    for (mode, dup, uniq) in cases {
+        let n_dup = reader.count("title", dup, mode).expect("count dup");
+        let n_uniq = reader.count("title", uniq, mode).expect("count uniq");
+        assert_eq!(n_dup, n_uniq, "dup {dup:?} must count as {uniq:?}");
+        assert!(n_dup > 0, "sanity: {dup:?} should match something");
+    }
+}
+
 /// BM25 with GLOBAL statistics gathers corpus-wide document frequencies
 /// across every superfile before scoring. Statistics change SCORES,
 /// never MEMBERSHIP: with `k` covering every match, the global-stats

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -219,6 +219,50 @@ fn count_dedups_repeated_query_tokens() {
     }
 }
 
+/// Dedup on the count path, negative-clause cases: a term required and
+/// excluded matches nothing, a repeated negative dedups to a single one,
+/// and a repeated negation-only query is rejected exactly like the
+/// single-term form.
+#[test]
+fn count_dedups_repeated_negatives_and_required_excluded() {
+    let st = demo_two_superfiles();
+    let reader = st.reader().expect("reader");
+
+    // A term both required and excluded is a contradiction — count 0.
+    // (`rust` appears in the corpus, so this is 0 by exclusion, not by
+    // the term being absent.)
+    let contradiction = reader
+        .count("title", "+rust -rust", BoolMode::And)
+        .expect("count +rust -rust");
+    assert_eq!(contradiction, 0, "+rust -rust must match nothing");
+
+    // A repeated negative dedups to the single-negative form, and
+    // excluding `go` (which co-occurs with `rust` in "go rust") drops at
+    // least that doc from the `+rust` set.
+    let rust = reader
+        .count("title", "+rust", BoolMode::And)
+        .expect("count +rust");
+    let one_neg = reader
+        .count("title", "+rust -go", BoolMode::And)
+        .expect("count +rust -go");
+    let dup_neg = reader
+        .count("title", "+rust -go -go", BoolMode::And)
+        .expect("count +rust -go -go");
+    assert_eq!(dup_neg, one_neg, "+rust -go -go must count as +rust -go");
+    assert!(one_neg < rust, "excluding `go` must drop the `go rust` doc");
+
+    // A negation-only query is rejected; repeating the negated term
+    // dedups to the same single-term query, so `-rust -rust` is rejected
+    // identically to `-rust` (never a spurious count).
+    let repeated = reader.count("title", "-rust -rust", BoolMode::And);
+    let single = reader.count("title", "-rust", BoolMode::And);
+    assert!(single.is_err(), "negation-only `-rust` is rejected");
+    assert!(
+        repeated.is_err(),
+        "negation-only `-rust -rust` is rejected like `-rust`"
+    );
+}
+
 /// BM25 with GLOBAL statistics gathers corpus-wide document frequencies
 /// across every superfile before scoring. Statistics change SCORES,
 /// never MEMBERSHIP: with `k` covering every match, the global-stats


### PR DESCRIPTION
## What

Two independent speedups for unranked FTS `count` (and the count half of `TOP_k_COUNT`), the slowest of which was phrase counting:

1. **Position run-offset sub-index (new blob version V3)** — the big one. Phrase verification reached a doc's position runs by walking *every* run in its 128-doc block from the block start; for a phrase filtering a common member (docs scattered one-per-block) that walk dominated, often skipping far more position bytes than it decoded. V3 stores, per positional term, one run offset every 16 pairs between the skip table and the blocks, so the decode jumps to the nearest checkpoint and skips `< 16` runs. A cached last-pair keeps high-reuse blocks (all-common phrases) from re-skipping.

2. **Dedup repeated query tokens on the count path** — an unranked AND/OR/exclude over a term repeated in the query (e.g. `+to +be +or +not +to +be`) is idempotent, yet each occurrence built a cursor that intersected/unioned a list with itself. Drop duplicates per clause role (phrase members and the scored path are left untouched).

## Backwards-compatible — no reindex

The sub-index is **additive**: readers accept V1/V2/V3, and existing V1/V2 indices read unchanged through the block-start walk. Validated on a real V2 index — the new reader returned identical counts to `main` across all 962 bench queries × {COUNT, TOP_100_COUNT}, **0 mismatches**. A unit test also downgrades a V3 blob to V2 to exercise the fallback. Old superfiles migrate to V3 as compaction rewrites them. (Not forward-compatible: an old reader rejects a V3 blob cleanly as an unknown version — reader and writer ship together.)

## Correctness

Result-identical throughout — **0 count mismatches** on the full bench set. The brute-force phrase oracle and the unranked id/count oracle both pass; positions decoded via the sub-index match the block-walk exactly. New tests: the V2-fallback equality test, a dedup-equivalence test, and (unchanged) the oracles.

## Measurement

Local A/B, full 962-query set, min-of-10, 0 mismatches.

**Sub-index, isolated** (same binary, V2 index / block-walk vs V3 index / sub-index):

| slice | COUNT AVG | TOP_100_COUNT AVG |
| ----- | --------- | ----------------- |
| phrase | 2542 → 1433 µs (**−44%**) | 4353 → 2571 µs (**−41%**) |

`the movement` −57%, `secretary of state` −59%. Union/intersection/term unchanged (untouched paths).

**Cumulative** (both changes vs `main`):

| command | ALL AVG | P90 |
| ------- | ------- | --- |
| COUNT | 1556 → 1119 µs (**−28%**) | 3227 → 1790 µs (−45%) |
| TOP_100_COUNT | 2858 → 2195 µs (**−23%**) | 5651 → 3644 µs (−35%) |

Storage: ~0.25 B/posting of added index on positional columns only; positionless columns are byte-identical to V2.

## Verification

- `cargo test` fts + supertable-query + format suites green; brute-force oracles green.
- `cargo fmt --check` + `clippy --all-targets --features test-helpers -- -D warnings` clean.
- `make ci` passed — check + doctest + coverage + test-remote all green; coverage 93.1% lines / 89.6% functions (above the ≥90%/≥89% gate).
