### PR TITLE
fix deletes: acquire lease on WAL during delete

### DIFF
--- a/src/supertable/wal/lease.rs
+++ b/src/supertable/wal/lease.rs
@@ -11,6 +11,21 @@
 //! "this is safe because we hold the lease" are wrong — every
 //! state transition has to surface at the CAS layer.
 //!
+//! ## Where leases come from
+//!
+//! Two places, and only the first one lives in this module:
+//!
+//! - [`try_acquire`], used by the recovery sweep to take over a
+//!   WAL some other process left behind.
+//! - The create itself, for a WAL whose creator is about to drive
+//!   it. The delete path stamps a lease straight into the doc it
+//!   creates: creating and acquiring in one write leaves no window
+//!   for a sweep to pick the WAL up before the writer gets going,
+//!   whereas a `try_acquire` issued after the create would.
+//!
+//! So a `None` lease does not imply "nobody has started this
+//! WAL yet" — it means nobody owns it *now*.
+//!
 //! ## What lives here
 //!
 //! - [`try_acquire`] — vacant or expired → CAS-take. Vacant means

--- a/src/supertable/wal/mod.rs
+++ b/src/supertable/wal/mod.rs
@@ -22,14 +22,19 @@
 //!
 //! - [`lease`] — advisory cooperative ownership: `try_acquire` /
 //!   `try_heartbeat` / `try_release` + a `spawn_heartbeat`
-//!   background task with stuck-worker detection.
+//!   background task with stuck-worker detection. The delete
+//!   path doesn't call `try_acquire` at all — it stamps the lease
+//!   into the doc it creates, so the WAL it is about to drive is
+//!   owned from birth.
 //! - [`pipeline`] — the append-phase + tombstone-phase
 //!   orchestrators that drive a WAL through its state machine
 //!   (Intent → Appended → Complete for UPDATE; Intent →
 //!   Complete for DELETE).
 //! - [`recovery`] — on-demand sweep that lists WALs at
-//!   `wal/mutations/*.json`, takes the lease, and drives each
-//!   non-`Complete` WAL through the rest of its pipeline.
+//!   `wal/mutations/*.json`, takes the lease where it is vacant
+//!   or expired, and drives each non-`Complete` WAL it wins
+//!   through the rest of its pipeline. WALs a live owner still
+//!   holds are skipped for the pass.
 //! - [`gc`] — sweep over `wal/mutations/*` reaping `Complete`
 //!   state docs past the wal-grace window + orphan `.arrow`
 //!   sidecars past the sidecar-grace window.

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -59,7 +59,7 @@ use std::{collections::HashMap, io::Cursor, sync::Arc, time::Duration};
 use arrow::ipc::reader::StreamReader;
 use arrow_array::{ArrayRef, Decimal128Array, RecordBatch};
 use bytes::Bytes;
-use chrono::Utc;
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use roaring::RoaringBitmap;
 use tokio::time::sleep;
 use uuid::Uuid;
@@ -889,6 +889,51 @@ const SEALED_RETRY_CAP_MS: u64 = 30_000;
 /// rather than overflowing on a high attempt count.
 const SEALED_RETRY_MAX_SHIFT: u32 = 8;
 
+/// The lease span the current driver was granted, or `None` when the WAL
+/// carries no lease. Read once per phase, before any renewal moves
+/// `expires_at`.
+fn granted_lease_span(doc: &WalStateDoc) -> Option<ChronoDuration> {
+    doc.lease
+        .as_ref()
+        .map(|lease| lease.expires_at - lease.acquired_at)
+}
+
+/// Push the WAL's lease expiry out one full span from now, in the caller's
+/// in-memory doc, so the next state-doc write carries a fresh lease.
+///
+/// The tombstone phase can easily outlive a single lease grant: the
+/// per-target loop is sequential and spends three storage round trips per
+/// target, so a delete of a few thousand rows runs well past the default
+/// 60 s. Without renewal the lease lapses mid-phase, a recovery sweep
+/// preempts, and the driver's next CAS fails — losing the phase (and, for a
+/// writer-driven delete, the caller's whole `commit`) after the work had
+/// already landed.
+///
+/// Renewal rides on writes the phase is making anyway: no extra round trip,
+/// and — unlike a background heartbeat task — no second writer racing the
+/// `etag_cur` chain. A heartbeat's own CAS would invalidate the driver's
+/// etag and break the very phase it was meant to protect.
+///
+/// Tying the expiry to writes ties it to observable forward progress: a
+/// wedged driver stops landing writes, its lease lapses, and recovery takes
+/// the WAL over — the same outcome the heartbeat's stuck-worker check exists
+/// to produce. A driver parked in the sealed-sidecar backoff below is
+/// therefore preemptible, which is deliberate: that wait is unbounded from
+/// the lease's point of view and a peer deserves the chance to try.
+///
+/// `span` comes from [`granted_lease_span`], so whoever took the lease keeps
+/// the duration they chose — a writer stamping its default at create time, or
+/// a sweep passing its own `lease_duration`.
+///
+/// `acquired_at` stays put: it records when ownership began, which renewal
+/// doesn't change. That matches `lease::try_heartbeat`, which also moves only
+/// `expires_at`.
+fn renew_lease(doc: &mut WalStateDoc, span: Option<ChronoDuration>, now: DateTime<Utc>) {
+    if let (Some(lease), Some(span)) = (doc.lease.as_mut(), span) {
+        lease.expires_at = now + span;
+    }
+}
+
 /// The non-idempotent fast path for the tombstone loop. For each
 /// `Pending` target in `wal_doc.tombstone_progress`: resolve →
 /// CAS-PUT the bit → CAS-update the WAL state doc. Once every
@@ -913,6 +958,10 @@ async fn do_tombstone_apply(
 
     let mut wal_cur = wal_doc.clone();
     let mut etag_cur = wal_etag.clone();
+    // Sampled before the loop starts moving `expires_at`: deriving the
+    // span per write would compound it, since each renewal would measure
+    // from the original `acquired_at` and hand back elapsed + span.
+    let lease_span = granted_lease_span(&wal_cur);
 
     // Per-target loop. A `Pending` entry walks through resolve
     // + sidecar-CAS + per-target WAL state CAS; anything else
@@ -931,6 +980,7 @@ async fn do_tombstone_apply(
         // Per-target WAL state CAS. We persist after each
         // target so recovery has a fresh cursor and a crash
         // never wastes more than one target's work.
+        renew_lease(&mut wal_cur, lease_span, Utc::now());
         etag_cur = wal_store
             .update_with_etag(wal_cur.wal_id, &etag_cur, &wal_cur)
             .await?;
@@ -962,8 +1012,11 @@ async fn do_tombstone_apply(
     // WAL itself to Complete. One CAS — if it loses, the
     // caller's recovery loop picks up at the now-no-op
     // tombstone scan above (everything's already non-Pending)
-    // and re-attempts the final advance.
+    // and re-attempts the final advance. The manifest stamp
+    // above can take a while, so this write gets a fresh lease
+    // too: it is the one whose loss wastes the whole phase.
     wal_cur.state = WalState::Complete;
+    renew_lease(&mut wal_cur, lease_span, Utc::now());
     etag_cur = wal_store
         .update_with_etag(wal_cur.wal_id, &etag_cur, &wal_cur)
         .await?;
@@ -1268,8 +1321,8 @@ mod tests {
             manifest::ManifestSnapshot,
             wal::{
                 state_doc::{
-                    OpKind, RowId, SCHEMA_VERSION, SealRecord, TombstoneEntry, TombstoneOutcome,
-                    WalId, WalState,
+                    Lease, OpKind, RowId, SCHEMA_VERSION, SealRecord, SupertableHandleId,
+                    TombstoneEntry, TombstoneOutcome, WalId, WalState,
                 },
                 tombstones_codec::TombstonesSidecar,
             },
@@ -2107,6 +2160,170 @@ mod tests {
         let bitmap = read_sidecar_bitmap(&ws, sf_id).await;
         assert_eq!(bitmap.len(), 1);
         assert!(bitmap.contains(1u32));
+    }
+
+    // ---- lease renewal across the tombstone phase --------------------
+
+    /// Lease span the renewal tests grant. Deliberately far shorter than
+    /// the phase itself would need, so an un-renewed lease would be long
+    /// expired by the time the phase finishes.
+    const LEASE_RENEWAL_SPAN_MS: i64 = 50;
+    /// Owner of the seeded lease: stands in for the writer handle that
+    /// created the WAL and is driving it.
+    const LEASE_RENEWAL_OWNER: i128 = 0x0D12_1E55;
+
+    /// Seed a DELETE WAL that is already leased, the way a writer's create
+    /// stamps one before it drives the tombstone phase.
+    async fn create_leased_delete_wal(
+        ws: &WalStore,
+        wal_id_value: i128,
+        target_ids: &[i128],
+        span: ChronoDuration,
+    ) -> (WalStateDoc, Etag) {
+        let (mut wal, etag) = create_delete_wal(ws, wal_id_value, target_ids).await;
+        let now = Utc::now();
+        wal.lease = Some(Lease {
+            owner: SupertableHandleId(LEASE_RENEWAL_OWNER),
+            acquired_at: now,
+            expires_at: now + span,
+        });
+        let etag = ws
+            .update_with_etag(wal.wal_id, &etag, &wal)
+            .await
+            .expect("stamp lease");
+        (wal, etag)
+    }
+
+    /// The phase pushes the driver's lease expiry out on the state-doc
+    /// writes it is already making, so a phase that runs longer than one
+    /// lease grant can't be preempted out from under its driver. Ownership
+    /// is untouched, and the renewal reaches storage — not just the
+    /// in-memory copy the phase returns.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn tombstone_phase_renews_the_drivers_lease_as_it_writes() {
+        let (_dir, st, ws, _sf_id, id_min, _id_max) =
+            published_superfile_fixture(&["aa", "bb", "cc"], 60_000).await;
+        let span = ChronoDuration::milliseconds(LEASE_RENEWAL_SPAN_MS);
+        let (wal, etag) =
+            create_leased_delete_wal(&ws, 260, &[id_min, id_min + 1, id_min + 2], span).await;
+        let granted = wal.lease.clone().expect("seeded lease");
+
+        let (outcome, new_wal, _) = run_tombstone_phase(&st, &ws, &wal, &etag)
+            .await
+            .expect("phase ok");
+        assert_eq!(
+            outcome,
+            TombstonePhaseOutcome::Applied {
+                n_tombstoned: 3,
+                n_not_found: 0,
+            }
+        );
+
+        let renewed = new_wal.lease.expect("the phase must not drop the lease");
+        assert_eq!(
+            renewed.owner, granted.owner,
+            "renewal must not change who owns the WAL"
+        );
+        assert_eq!(
+            renewed.acquired_at, granted.acquired_at,
+            "renewal moves the expiry, not the moment ownership began"
+        );
+        assert!(
+            renewed.expires_at > granted.expires_at,
+            "the phase's own writes must push the expiry out, granted {} still at {}",
+            granted.expires_at,
+            renewed.expires_at
+        );
+
+        let (persisted, _) = ws.read(wal.wal_id).await.expect("read back");
+        assert_eq!(
+            persisted
+                .lease
+                .expect("persisted doc must carry the lease")
+                .expires_at,
+            renewed.expires_at,
+            "the renewal must ride along on the phase's state-doc write"
+        );
+    }
+
+    /// Each renewal is exactly one granted span past the write it rides
+    /// on. The span is sampled once per phase for this reason: re-deriving
+    /// it from the renewed doc (`expires_at - acquired_at`) compounds,
+    /// handing the driver an ever-wider window. This pins both halves —
+    /// the exact renewal arithmetic, and the compounding that sampling
+    /// per-write would produce.
+    #[test]
+    fn lease_renewal_is_one_span_from_the_write_it_rides_on() {
+        let t0 = Utc::now();
+        let span = ChronoDuration::seconds(60);
+        let mut doc = WalStateDoc {
+            wal_id: WalId(261),
+            schema_version: SCHEMA_VERSION,
+            op_kind: OpKind::Delete,
+            state: WalState::Intent,
+            created_at: t0,
+            lease: Some(Lease {
+                owner: SupertableHandleId(LEASE_RENEWAL_OWNER),
+                acquired_at: t0,
+                expires_at: t0 + span,
+            }),
+            predicate_repr: "renewal arithmetic".into(),
+            target_ids: vec![RowId(1)],
+            new_row_count: None,
+            new_row_content_hash: None,
+            preallocated_superfile_id: None,
+            minted_id_spans: Vec::new(),
+            tombstone_progress: Vec::new(),
+        };
+
+        let granted = granted_lease_span(&doc).expect("leased doc has a span");
+        assert_eq!(granted, span, "the granted span is the acquirer's window");
+
+        renew_lease(&mut doc, Some(granted), t0 + ChronoDuration::seconds(30));
+        assert_eq!(
+            doc.lease.as_ref().expect("lease").expires_at,
+            t0 + ChronoDuration::seconds(90),
+            "a write at t+30s must own the WAL until t+90s"
+        );
+
+        renew_lease(&mut doc, Some(granted), t0 + ChronoDuration::seconds(70));
+        let lease = doc.lease.as_ref().expect("lease").clone();
+        assert_eq!(
+            lease.expires_at,
+            t0 + ChronoDuration::seconds(130),
+            "the next write must land one span out, not one span plus elapsed"
+        );
+        assert_eq!(lease.acquired_at, t0, "ownership start must not drift");
+
+        assert!(
+            granted_lease_span(&doc).expect("span") > granted,
+            "re-deriving the span mid-phase widens it — which is why the \
+             phase samples it once, before the first renewal"
+        );
+    }
+
+    /// A WAL nobody holds has nothing to renew: the phase must leave the
+    /// `None` alone rather than inventing an owner-less lease.
+    #[test]
+    fn lease_renewal_is_a_no_op_on_an_unleased_wal() {
+        let mut doc = WalStateDoc {
+            wal_id: WalId(262),
+            schema_version: SCHEMA_VERSION,
+            op_kind: OpKind::Delete,
+            state: WalState::Intent,
+            created_at: Utc::now(),
+            lease: None,
+            predicate_repr: "unleased".into(),
+            target_ids: vec![RowId(1)],
+            new_row_count: None,
+            new_row_content_hash: None,
+            preallocated_superfile_id: None,
+            minted_id_spans: Vec::new(),
+            tombstone_progress: Vec::new(),
+        };
+        assert!(granted_lease_span(&doc).is_none());
+        renew_lease(&mut doc, None, Utc::now());
+        assert!(doc.lease.is_none(), "renewal must not mint a lease");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/src/supertable/wal/state_doc.rs
+++ b/src/supertable/wal/state_doc.rs
@@ -178,7 +178,9 @@ pub enum WalState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Lease {
     /// Handle id of the process currently driving this WAL.
-    /// Set on take; cleared on COMPLETE or preemption.
+    /// Set on take — or stamped straight into the created doc by
+    /// the writer that is about to drive it; cleared on COMPLETE
+    /// or preemption.
     pub owner: SupertableHandleId,
     pub acquired_at: DateTime<Utc>,
     /// Heartbeat-extended; recovery treats expiry as the cue to
@@ -283,10 +285,12 @@ pub struct WalStateDoc {
     pub state: WalState,
     pub created_at: DateTime<Utc>,
 
-    /// `None` if no process currently owns this WAL (e.g. fresh
-    /// WAL between create and the first heartbeat, or after
-    /// preemption clears the field). Recovery treats absent +
-    /// expired equivalently.
+    /// `None` if no process currently owns this WAL — after
+    /// preemption or a release clears the field, or on a doc
+    /// created by something that isn't going to drive it itself.
+    /// A writer driving its own op stamps the lease into the doc
+    /// it creates, so a freshly created WAL is normally already
+    /// owned. Recovery treats absent + expired equivalently.
     #[serde(default)]
     pub lease: Option<Lease>,
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -73,7 +73,7 @@ use arrow_array::{
 };
 use blake3::Hasher as Blake3Hasher;
 use bytes::Bytes;
-use chrono::Utc;
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use datafusion::prelude::Expr;
 use futures::{
     future::try_join_all,
@@ -106,8 +106,8 @@ use super::{
         WalStore,
         pipeline::{self, TombstonePhaseOutcome},
         state_doc::{
-            IdSpan, OpKind, RowId, SCHEMA_VERSION, TombstoneEntry, TombstoneOutcome, WalId,
-            WalState, WalStateDoc,
+            IdSpan, OpKind, RowId, SCHEMA_VERSION, SupertableHandleId, TombstoneEntry,
+            TombstoneOutcome, WalId, WalState, WalStateDoc,
         },
     },
 };
@@ -171,8 +171,11 @@ use crate::{
             vector::stable_ids_by_local_for_routing,
         },
         reader_cache::{DiskCacheStore, disk::mmap_readonly_bytes},
-        slow_vector_state,
-        slow_vector_state::{CentroidSection, fetch_centroid_section},
+        slow_vector_state::{self, CentroidSection, fetch_centroid_section},
+        wal::{
+            Lease,
+            lease::{self, DEFAULT_LEASE_DURATION},
+        },
     },
 };
 
@@ -1441,24 +1444,39 @@ impl SupertableWriter {
         })
     }
 
-    /// Drive one pending delete entry through its tombstone
-    /// phase. Returns the per-op outcome on success.
-    fn drive_one_delete(&self, entry: &PendingDeleteEntry) -> Result<MutationStats, MutationError> {
-        let storage = self
-            .inner
-            .options
-            .storage
-            .as_ref()
-            .ok_or(MutationError::NoStorageAttached)?
-            .clone();
-
-        let wal_doc = WalStateDoc {
+    /// Build the `Intent` state doc for one buffered delete.
+    ///
+    /// The doc is born already leased to this handle. `create` is the WAL's
+    /// first appearance on storage, so stamping the lease into the created
+    /// bytes leaves no window in which a peer's recovery sweep could see an
+    /// unowned `Intent` doc and start driving the same tombstone phase
+    /// underneath us — a `try_acquire` issued after `create` would leave
+    /// exactly that window, and losing the race there costs the caller its
+    /// whole delete (the peer's CAS invalidates our etag, so every
+    /// subsequent per-target write fails and `commit` reports a partial
+    /// commit for work that actually landed).
+    ///
+    /// The lease stays advisory: the etag CAS chain in the tombstone phase
+    /// is what keeps concurrent drivers correct. This only keeps a peer
+    /// from duplicating the work and knocking us off our etag.
+    ///
+    /// One `now` stamps `created_at` and both lease timestamps so the
+    /// doc's creation time and its lease window come from a single clock
+    /// reading.
+    fn delete_wal_doc(&self, entry: &PendingDeleteEntry, now: DateTime<Utc>) -> WalStateDoc {
+        let lease_span = ChronoDuration::from_std(DEFAULT_LEASE_DURATION)
+            .expect("default lease duration should be a valid chronoduration");
+        WalStateDoc {
             wal_id: entry.wal_id,
             schema_version: SCHEMA_VERSION,
             op_kind: OpKind::Delete,
             state: WalState::Intent,
-            created_at: Utc::now(),
-            lease: None,
+            created_at: now,
+            lease: Some(Lease {
+                owner: self.inner.handle_id,
+                acquired_at: now,
+                expires_at: now + lease_span,
+            }),
             predicate_repr: "writer.delete()".into(),
             target_ids: entry.target_ids.iter().map(|&v| RowId(v)).collect(),
             new_row_count: None,
@@ -1474,7 +1492,21 @@ impl SupertableWriter {
                     tombstoned_in_superfile: None,
                 })
                 .collect(),
-        };
+        }
+    }
+
+    /// Drive one pending delete entry through its tombstone
+    /// phase. Returns the per-op outcome on success.
+    fn drive_one_delete(&self, entry: &PendingDeleteEntry) -> Result<MutationStats, MutationError> {
+        let storage = self
+            .inner
+            .options
+            .storage
+            .as_ref()
+            .ok_or(MutationError::NoStorageAttached)?
+            .clone();
+
+        let wal_doc = self.delete_wal_doc(entry, Utc::now());
 
         let wal_store = WalStore::new(Arc::clone(&storage));
         let supertable = Supertable::from_inner(Arc::clone(&self.inner));
@@ -1489,13 +1521,21 @@ impl SupertableWriter {
             .as_ref()
             .map(|vit| Arc::clone(vit.inner()));
         let deleted_ids: Vec<i128> = entry.target_ids.clone();
+        let owner = self.inner.handle_id;
         let drive = async move {
             let etag = wal_store
                 .create(&wal_doc)
                 .await
                 .map_err(MutationError::WalStore)?;
-            let (outcome, _post, _post_etag) =
-                pipeline::run_tombstone_phase(&supertable, &wal_store, &wal_doc, &etag).await?;
+            let phase =
+                pipeline::run_tombstone_phase(&supertable, &wal_store, &wal_doc, &etag).await;
+            let (outcome, _post, _post_etag) = match phase {
+                Ok(applied) => applied,
+                Err(cause) => {
+                    release_mutation_lease(&wal_store, wal_id, owner).await;
+                    return Err(cause.into());
+                }
+            };
             let (n_t, n_nf) = match outcome {
                 TombstonePhaseOutcome::Applied {
                     n_tombstoned,
@@ -7654,6 +7694,30 @@ pub(in crate::supertable) async fn stamp_slow_vector_state(
     ))
 }
 
+/// Best-effort lease hand-back after a mutation drive failed part-way.
+///
+/// The WAL itself stays on storage: its per-target progress is the recovery
+/// cursor, and a sweep finishes what we started. Clearing our lease first is
+/// what lets that sweep act on its very next pass — a sweep that finds a
+/// still-live lease counts the WAL as held-by-peer and skips it, and sweeps
+/// only run when a handle opens, so "skip this pass" can mean the tombstones
+/// wait a long while for another one.
+///
+/// Every failure here is a no-op we can ignore: a lease already preempted or
+/// cleared surfaces `Preempted` / `LeaseMissing` (a peer owns the WAL now, so
+/// it is exactly as recoverable as we wanted), a lost CAS means somebody else
+/// just wrote the doc, and a storage error leaves the lease to expire on its
+/// own. Logged at debug because none of it is actionable.
+async fn release_mutation_lease(wal_store: &WalStore, wal_id: WalId, owner: SupertableHandleId) {
+    if let Err(e) = lease::try_release(wal_store, wal_id, owner).await {
+        debug!(
+            error = %e,
+            "supertable: could not hand back the WAL lease after a failed mutation; \
+             recovery picks the WAL up once the lease expires"
+        );
+    }
+}
+
 async fn record_hidden_deleted_ids(
     inner: &SupertableInner,
     new_deleted: &[i128],
@@ -8595,6 +8659,7 @@ mod tests {
         Array, Decimal128Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch,
     };
     use arrow_schema::{DataType, Field, Schema};
+    use datafusion::prelude::{col, lit};
     use figment::{
         Figment,
         providers::{Format, Yaml},
@@ -8610,8 +8675,16 @@ mod tests {
             fts::reader::BoolMode,
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
-        supertable::{SupertableOptions, handle::Supertable, storage::LocalFsStorageProvider},
-        test_helpers::default_tokenizer as tok,
+        supertable::{
+            SupertableOptions,
+            handle::Supertable,
+            storage::LocalFsStorageProvider,
+            wal::{recovery::scan_and_recover, state_doc::SupertableHandleId},
+        },
+        test_helpers::{
+            build_title_batch, default_supertable_options, default_tokenizer as tok,
+            fault_storage::{FaultKind, FaultOp, FaultStorage},
+        },
     };
 
     /// Small fixed vector dimension accepted by the vector builder.
@@ -10315,6 +10388,214 @@ supertable:
         assert_ne!(
             read_second, read_first,
             "object content actually changed between writes"
+        );
+    }
+
+    // ---- delete-WAL lease ownership ----------------------------------
+
+    /// WAL id for the delete-lease tests below. Fixed so the state-doc
+    /// path is predictable; nothing else writes this prefix here.
+    const DELETE_LEASE_WAL_ID: i128 = 0x0DE1_5EA5;
+    /// `_id` the seeded delete targets. No superfile claims it, so a sweep
+    /// that did drive this WAL would resolve it as `NotFound` and still
+    /// march the WAL to `Complete` — which is what the sweep assertions
+    /// below detect.
+    const DELETE_LEASE_TARGET_ID: i128 = 42;
+    /// Owner id of the peer running the recovery sweep. Distinct from the
+    /// writer handle's own id: `try_acquire` treats a same-owner lease as
+    /// a renewal, so only a foreign owner exercises the conflict path.
+    const DELETE_LEASE_PEER_OWNER: i128 = 0x0BAD_0BAD;
+
+    fn delete_lease_test_table(directory: &TempDir) -> Supertable {
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(directory.path()).expect("provider"));
+        Supertable::create(default_supertable_options().with_storage(storage)).expect("create")
+    }
+
+    fn delete_lease_test_entry() -> PendingDeleteEntry {
+        PendingDeleteEntry {
+            wal_id: WalId(DELETE_LEASE_WAL_ID),
+            target_ids: vec![DELETE_LEASE_TARGET_ID],
+        }
+    }
+
+    /// A delete's WAL state doc is born holding a live lease owned by the
+    /// handle that is about to drive it, and `created_at` + both lease
+    /// timestamps come from the single clock reading passed in.
+    #[test]
+    fn delete_wal_doc_is_born_leased_by_this_handle() {
+        let directory = TempDir::new().expect("tempdir");
+        let table = delete_lease_test_table(&directory);
+        let writer = table.writer().expect("writer");
+
+        let now = Utc::now();
+        let doc = writer.delete_wal_doc(&delete_lease_test_entry(), now);
+
+        assert_eq!(doc.op_kind, OpKind::Delete);
+        assert_eq!(doc.state, WalState::Intent);
+        assert_eq!(
+            doc.created_at, now,
+            "created_at must come from the passed clock reading, not a second sample"
+        );
+        let lease = doc
+            .lease
+            .expect("a delete WAL must be born leased, not left unowned until a later acquire");
+        assert_eq!(
+            lease.owner,
+            table.handle_id(),
+            "the lease must name the handle that will drive the tombstone phase"
+        );
+        assert_eq!(
+            lease.acquired_at, now,
+            "acquired_at must share created_at's clock reading"
+        );
+        assert_eq!(
+            lease.expires_at,
+            now + ChronoDuration::from_std(DEFAULT_LEASE_DURATION)
+                .expect("default lease duration converts"),
+            "the lease must run a full default duration from the same reading"
+        );
+    }
+
+    /// Regression: a peer's recovery sweep must not take a delete WAL away
+    /// from the writer that just created it. The creating handle holds a
+    /// live lease from the moment the doc lands, so the sweep counts it as
+    /// held-by-peer and leaves the bytes alone. Before the lease was
+    /// stamped at create time the sweep drove the WAL to `Complete`, which
+    /// invalidated the writer's etag and turned an in-flight delete into a
+    /// partial-commit failure.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn peer_sweep_skips_a_freshly_created_delete_wal() {
+        let directory = TempDir::new().expect("tempdir");
+        let table = delete_lease_test_table(&directory);
+        let storage = table
+            .inner()
+            .options
+            .storage
+            .as_ref()
+            .expect("storage attached")
+            .clone();
+        let writer = table.writer().expect("writer");
+
+        // The doc as `drive_one_delete` writes it, at the point where the
+        // create has landed but the tombstone phase hasn't started.
+        let wal_store = WalStore::new(storage);
+        let doc = writer.delete_wal_doc(&delete_lease_test_entry(), Utc::now());
+        let etag_before = wal_store.create(&doc).await.expect("create wal state doc");
+
+        let report = scan_and_recover(
+            &table,
+            SupertableHandleId(DELETE_LEASE_PEER_OWNER),
+            DEFAULT_LEASE_DURATION,
+        )
+        .await
+        .expect("sweep");
+
+        assert_eq!(report.n_scanned, 1, "the sweep must see the seeded WAL");
+        assert_eq!(
+            report.n_held_by_peer, 1,
+            "the writer's live lease must fence the sweep off this WAL"
+        );
+        assert_eq!(
+            report.n_tombstone_only_completed, 0,
+            "the sweep must not drive a delete the writer is still holding"
+        );
+
+        let (after, etag_after) = wal_store
+            .read(WalId(DELETE_LEASE_WAL_ID))
+            .await
+            .expect("read back");
+        assert_eq!(
+            etag_after, etag_before,
+            "etag unchanged → the sweep never wrote the state doc"
+        );
+        assert_eq!(
+            after.state,
+            WalState::Intent,
+            "the WAL must still be waiting for its owner's tombstone phase"
+        );
+        assert_eq!(
+            after.lease.expect("lease survives the sweep").owner,
+            table.handle_id(),
+            "ownership must still sit with the creating handle"
+        );
+    }
+
+    /// Rule budget for the sidecar-CAS fault: comfortably above the
+    /// tombstone loop's own per-sidecar retry budget, so every attempt in
+    /// that loop loses its race and the phase gives up.
+    const DELETE_LEASE_SIDECAR_FAULTS: usize = 64;
+    /// Suffix of the per-superfile tombstone sidecars the delete path
+    /// CAS-writes. Faulting it leaves superfile, manifest, and WAL-state
+    /// writes alone — including the release this test is watching for.
+    const DELETE_LEASE_TOMBSTONES_SUFFIX: &str = ".tombstones";
+
+    /// A delete that fails part-way hands its lease back, so the next
+    /// recovery sweep can finish the WAL on its very first pass instead of
+    /// counting it held-by-peer and skipping until the lease expires. The
+    /// WAL itself must stay put — its per-target progress is the cursor
+    /// recovery resumes from.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_failed_delete_hands_back_its_wal_lease() {
+        let directory = TempDir::new().expect("tempdir");
+        let local: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(directory.path()).expect("provider"));
+        let faults = FaultStorage::wrap(local);
+        let storage: Arc<dyn StorageProvider> = Arc::<FaultStorage>::clone(&faults);
+        let table =
+            Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+                .expect("create");
+
+        let mut writer = table.writer().expect("writer");
+        writer
+            .append(&build_title_batch(&["alpha", "beta"]))
+            .expect("append");
+        writer.commit().expect("commit appends");
+
+        // Resolve the predicate while storage is healthy, then break every
+        // sidecar CAS so the tombstone phase exhausts its retries.
+        writer
+            .delete(col("title").eq(lit("alpha")))
+            .expect("buffer delete");
+        faults.fail_with(
+            FaultKind::Precondition,
+            FaultOp::PutIfMatch,
+            DELETE_LEASE_TOMBSTONES_SUFFIX,
+            DELETE_LEASE_SIDECAR_FAULTS,
+        );
+        let err = writer
+            .commit()
+            .expect_err("a sidecar CAS that never lands must fail the delete");
+        assert!(
+            matches!(err, CommitError::PartialCommit { .. }),
+            "the failed delete must surface as a partial commit, got {err:?}"
+        );
+        assert!(
+            faults.fired() > 1,
+            "the failure must come from the injected sidecar faults, fired {}",
+            faults.fired()
+        );
+
+        // The WAL is still there for recovery, and it is unowned.
+        faults.clear();
+        let wal_store = WalStore::new(storage);
+        let wal_ids = wal_store.list_wal_ids().await.expect("list wal ids");
+        assert_eq!(
+            wal_ids.len(),
+            1,
+            "the failed delete must leave its WAL for recovery, found {wal_ids:?}"
+        );
+        let (doc, _etag) = wal_store.read(wal_ids[0]).await.expect("read wal doc");
+        assert_eq!(
+            doc.state,
+            WalState::Intent,
+            "the WAL must still be waiting for its tombstone phase"
+        );
+        assert!(
+            doc.lease.is_none(),
+            "a failed delete must release its lease so the next sweep can take \
+             the WAL immediately, still held by {:?}",
+            doc.lease
         );
     }
 }


### PR DESCRIPTION
### What does this PR do?
- Acquires the lease on the WAL file created during deletes, to allow it to complete without any CAS issues

### Why do we need this change?
- During an in-progress delete, opening another table starts its sweep flow, which looks at the WAL files and starts "work" on them, even though a delete is already in progress
- This is because, the "delete" process does not acquire a lease. ( `lease: None` before this change )
- This may cause the delete to fail, due to CAS errors, and return an error to the user. But the data may be deleted by the background delete job

### How do we do this change?
- Create the WAL file with a lease
- Periodically extend this lease, while the delete is in progress
- In case of errors, relesae the lease before erroring out

### How has this been tested?
- Unit tests added