### PR TITLE
fts: dense bitset blocks + count kernels — union/intersection/phrase COUNT to parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ infino-python/python/infino/*.so
 **/__pycache__/
 **/.pytest_cache/
 .infino/
+
+# proptest writes a failing-case seed here when a property test fails; it is
+# regenerated on demand and not tracked.
+proptest-regressions/

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -59,6 +59,18 @@ pub mod fts {
     /// where positions do.
     pub const VERSION_V3: u32 = 3;
 
+    /// The version written when any posting block is stored in the **bitset
+    /// encoding**: a dense block's doc ids are a presence bitset (header
+    /// byte 3 = [`crate::superfile::fts::posting::ENCODING_BITSET`]) rather
+    /// than PFOR deltas, so the union count OR's it in without decoding.
+    /// Same header + region layout as [`VERSION_V2`]/[`VERSION_V3`]
+    /// (positions region present iff positional; sub-index for positional
+    /// terms as in `V3`) — `V4` adds only the per-block encoding choice,
+    /// which is self-describing via the header byte. Readers accept
+    /// `V1`–`V4`; `V1`–`V3` blobs carry only PACKED blocks and read
+    /// unchanged, so existing indices need no reindex.
+    pub const VERSION_V4: u32 = 4;
+
     /// Stride of the position run-offset sub-index ([`VERSION_V3`]): one
     /// stored offset per this many pairs within a posting block. A decode
     /// skips at most `STRIDE - 1` runs from the nearest sub-index entry.

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -100,7 +100,7 @@ use crate::superfile::{
         dict::{DictBuilder, StreamingDictBuilder},
         fst_value::{FstValue, INLINE_TF_MAX},
         positions::{encode_run, read_varint, skip_run},
-        posting::{BLOCK_LEN, Block, EncodedBlock, encode_block},
+        posting::{BLOCK_LEN, Block, ENCODING_BITSET, EncodedBlock, encode_block},
         tokenize::{AsciiLowerTokenizer, Tokenizer},
     },
 };
@@ -163,6 +163,11 @@ const CHAIN_END: u32 = u32::MAX;
 #[derive(Default)]
 struct FinishProfile {
     enabled: bool,
+    /// Set once any posting block is emitted in the bitset encoding, so
+    /// the blob header is written as `VERSION_V4`. Not a profiling counter
+    /// — reused here because this struct already threads from term emit to
+    /// the final header write.
+    saw_bitset_block: bool,
     encode_calls: u64,
     encode_df1: u64,
     encode_pfor: u64,
@@ -3259,15 +3264,18 @@ fn assemble_and_write_blob<W: Write>(
     let blob_copy_start = finish_profile.enabled.then(Instant::now);
     let mut header = Vec::with_capacity(header_size as usize);
     header.extend_from_slice(format::fts::MAGIC); // 8
-    // V3 when the positions region has a real body (beyond its 4-byte
-    // CRC): a non-empty body means at least one non-inline positional term
-    // wrote position runs and therefore a run-offset sub-index. A
-    // positionless blob — or a positional one whose terms all inlined —
-    // leaves a CRC-only region and stays V2, byte-identical to before.
-    // Readers accept both.
-    let fts_version = match positions_region.1 > format::CRC_BYTES as u64 {
-        true => format::fts::VERSION_V3,
-        false => format::fts::VERSION_V2,
+    // V4 when any block took the bitset encoding. Otherwise V3 when the
+    // positions region has a real body (beyond its 4-byte CRC) — a
+    // non-empty body means a non-inline positional term wrote position runs
+    // and therefore a run-offset sub-index — else V2 (positionless, or a
+    // positional blob whose terms all inlined), byte-identical to before.
+    // Readers accept all of these.
+    let fts_version = if finish_profile.saw_bitset_block {
+        format::fts::VERSION_V4
+    } else if positions_region.1 > format::CRC_BYTES as u64 {
+        format::fts::VERSION_V3
+    } else {
+        format::fts::VERSION_V2
     };
     header.extend_from_slice(&fts_version.to_le_bytes()); // 4
     header.extend_from_slice(&n_columns.to_le_bytes()); // 4
@@ -3654,6 +3662,10 @@ fn encode_and_emit_term<W: Write>(
         scratch.tfs = block_tfs;
         if let Some(start) = block_build_start {
             profile.encode_block_build += start.elapsed();
+        }
+        // A block emitted in the bitset encoding bumps the blob to v4.
+        if encoded_blocks.iter().any(|b| b.bytes[3] == ENCODING_BITSET) {
+            profile.saw_bitset_block = true;
         }
         let num_blocks = encoded_blocks.len() as u32;
         let metadata_offset = *postings_len;
@@ -4641,7 +4653,15 @@ mod tests {
 
         let read_u64 = |at: usize| u64::from_le_bytes(v2[at..at + 8].try_into().expect("8 bytes"));
         let read_u32 = |at: usize| u32::from_le_bytes(v2[at..at + 4].try_into().expect("4 bytes"));
-        assert_eq!(read_u32(8), format::fts::VERSION_V2);
+        // Accept any 56-byte-header version (v2/v3/v4) as the downgrade
+        // source — they share the header layout this synthesizer edits.
+        let src_version = read_u32(8);
+        assert!(
+            src_version == format::fts::VERSION_V2
+                || src_version == format::fts::VERSION_V3
+                || src_version == format::fts::VERSION_V4,
+            "unexpected source version {src_version}"
+        );
         let fst_off = read_u64(24);
         let postings_off = read_u64(32);
         let doc_lengths_off = read_u64(40);
@@ -4755,7 +4775,7 @@ mod tests {
         // A positional build carries position runs ⇒ a sub-index ⇒ v3.
         assert_eq!(
             u32::from_le_bytes(spilled_pos[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION_V3
+            format::fts::VERSION_V4
         );
         let inram_pos = build_title_blob(&docs, true);
         let inram_plain = build_title_blob(&docs, false);
@@ -4836,8 +4856,8 @@ mod tests {
         let v3_blob = build_title_blob(&docs, true);
         assert_eq!(
             u32::from_le_bytes(v3_blob[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION_V3,
-            "a positional build is v3"
+            format::fts::VERSION_V4,
+            "this positional corpus is dense ⇒ v4"
         );
         // Downgrade the version field only; the header is not itself
         // CRC-covered, and the positions region + skip offsets are
@@ -4928,10 +4948,11 @@ mod tests {
         let version_of = |blob: &bytes::Bytes| {
             u32::from_le_bytes(blob[8..12].try_into().expect("4 header bytes"))
         };
-        // A positionless build is v2; a positional build carries a run-
-        // offset sub-index and is v3. v1 is a read-only legacy format.
-        assert_eq!(version_of(&plain), format::fts::VERSION_V2);
-        assert_eq!(version_of(&positional), format::fts::VERSION_V3);
+        // This corpus is dense enough that some block takes the bitset
+        // encoding, so both builds are v4 (v4 subsumes the v3 positions
+        // sub-index). v1 is a read-only legacy format.
+        assert_eq!(version_of(&plain), format::fts::VERSION_V4);
+        assert_eq!(version_of(&positional), format::fts::VERSION_V4);
 
         // A positionless build's region is just the CRC-of-empty.
         let read_u64_plain =
@@ -5028,7 +5049,7 @@ mod tests {
         let blob = bytes::Bytes::from(b.finish().expect("finish"));
         assert_eq!(
             u32::from_le_bytes(blob[8..12].try_into().expect("version bytes")),
-            format::fts::VERSION_V3
+            format::fts::VERSION_V4
         );
         let json = r#"[{"name":"body","tokenizer":"ascii_lower"},{"name":"title","tokenizer":"ascii_lower","positions":true}]"#;
         let r = FtsReader::open(blob, json).expect("open");

--- a/src/superfile/fts/posting.rs
+++ b/src/superfile/fts/posting.rs
@@ -60,9 +60,30 @@ use bitpacking::{BitPacker, BitPacker4x};
 /// match `BitPacker4x::BLOCK_LEN`.
 pub const BLOCK_LEN: usize = BitPacker4x::BLOCK_LEN;
 
-/// Header size in bytes (doc_count + delta_bits + tf_bits + reserved +
+/// Header size in bytes (doc_count + delta_bits + tf_bits + encoding +
 /// base_doc_id).
 pub const HEADER_SIZE: usize = 8;
+
+/// Header byte offset of the block `encoding` field (formerly reserved).
+pub const ENCODING_OFF: usize = 3;
+
+/// Block `encoding` (header byte 3): doc ids stored as PFOR-delta packing
+/// (today's layout). Every `V1`–`V3` block is this.
+pub const ENCODING_PACKED: u8 = 0;
+/// Block `encoding`: doc ids stored as a **presence bitset** over
+/// `[base_doc_id, last_doc_id]`, `base_doc_id` aligned down to a 64-bit
+/// word so the union count can OR it in word-aligned. Chosen only when it
+/// does not grow the block (dense blocks). Tfs follow, packed identically
+/// to PACKED. Only `VERSION_V4` blobs contain these.
+pub const ENCODING_BITSET: u8 = 1;
+
+/// Align a doc id down to the 64-bit word that contains it — the origin of
+/// a [`ENCODING_BITSET`] block's presence bitset, so its words line up
+/// with the union bitset and the OR needs no per-word bit shift.
+#[inline]
+pub fn bitset_block_base(doc_id: u32) -> u32 {
+    doc_id & !63
+}
 
 /// One block of postings — sorted-ascending `doc_ids` plus per-doc
 /// `tfs`. Both vectors must have the same length, ≤ [`BLOCK_LEN`].
@@ -133,26 +154,60 @@ pub fn encode_block(b: &Block) -> EncodedBlock {
 
     let deltas_size = BLOCK_LEN * delta_bits as usize / 8;
     let tfs_size = BLOCK_LEN * tf_bits as usize / 8;
-    let mut bytes = Vec::with_capacity(HEADER_SIZE + deltas_size + tfs_size);
+
+    // Store the doc ids as a presence bitset instead of PFOR deltas when
+    // that does not grow the block (a dense block — a common term's ~128
+    // near-consecutive docs). The bitset origin is word-aligned so the
+    // union count can OR it in without a per-word shift.
+    let aligned_base = bitset_block_base(b.doc_ids[0]);
+    let bitset_words = (last_doc_id - aligned_base) as usize / 64 + 1;
+    let bitset_size = bitset_words * 8;
+    let use_bitset = bitset_size <= deltas_size;
+
+    let doc_ids_size = if use_bitset { bitset_size } else { deltas_size };
+    let mut bytes = Vec::with_capacity(HEADER_SIZE + doc_ids_size + tfs_size);
 
     // Header.
     bytes.push(count as u8);
-    bytes.push(delta_bits);
+    bytes.push(if use_bitset { 0 } else { delta_bits });
     bytes.push(tf_bits);
-    bytes.push(0); // reserved
-    bytes.extend_from_slice(&base_doc_id.to_le_bytes());
-
-    // Packed deltas.
-    let deltas_start = bytes.len();
-    bytes.resize(deltas_start + deltas_size, 0);
-    bp.compress_sorted(
-        base_doc_id,
-        &padded_doc_ids,
-        &mut bytes[deltas_start..deltas_start + deltas_size],
-        delta_bits,
+    bytes.push(if use_bitset {
+        ENCODING_BITSET
+    } else {
+        ENCODING_PACKED
+    });
+    bytes.extend_from_slice(
+        &if use_bitset {
+            aligned_base
+        } else {
+            base_doc_id
+        }
+        .to_le_bytes(),
     );
 
-    // Packed tfs.
+    // Doc ids.
+    let doc_ids_start = bytes.len();
+    bytes.resize(doc_ids_start + doc_ids_size, 0);
+    if use_bitset {
+        let words = &mut bytes[doc_ids_start..doc_ids_start + bitset_size];
+        for &d in &b.doc_ids {
+            let bit = (d - aligned_base) as usize;
+            let w = (bit / 64) * 8;
+            let lane = bit % 64;
+            let mut word = u64::from_le_bytes(words[w..w + 8].try_into().expect("8 bytes"));
+            word |= 1u64 << lane;
+            words[w..w + 8].copy_from_slice(&word.to_le_bytes());
+        }
+    } else {
+        bp.compress_sorted(
+            base_doc_id,
+            &padded_doc_ids,
+            &mut bytes[doc_ids_start..doc_ids_start + deltas_size],
+            delta_bits,
+        );
+    }
+
+    // Packed tfs — identical in both encodings, in doc order.
     let tfs_start = bytes.len();
     bytes.resize(tfs_start + tfs_size, 0);
     bp.compress(
@@ -183,24 +238,24 @@ pub fn encode_block(b: &Block) -> EncodedBlock {
 pub fn decode_block(bytes: &[u8], dest_doc_ids: &mut [u32], dest_tfs: &mut [u32]) -> usize {
     let count = decode_block_doc_ids(bytes, dest_doc_ids);
 
-    // Term frequencies follow the packed deltas. The count paths skip
-    // this half (see `decode_block_doc_ids`); only scoring needs it.
+    // Term frequencies are always the trailing `tfs_size` bytes of the
+    // block, regardless of how the doc ids ahead of them are encoded
+    // (PACKED deltas or a BITSET). The count paths skip this half (see
+    // `decode_block_doc_ids`); only scoring needs it.
     assert!(
         dest_tfs.len() >= BLOCK_LEN,
         "decode_block: dest_tfs must have at least {BLOCK_LEN} slots"
     );
-    let delta_bits = bytes[1];
     let tf_bits = bytes[2];
     assert!(tf_bits <= 32, "decode_block: tf_bits {tf_bits} > 32");
-    let deltas_size = BLOCK_LEN * delta_bits as usize / 8;
     let tfs_size = BLOCK_LEN * tf_bits as usize / 8;
     assert!(
-        bytes.len() >= HEADER_SIZE + deltas_size + tfs_size,
-        "decode_block: bytes ({}) shorter than header+deltas+tfs ({})",
+        bytes.len() >= HEADER_SIZE + tfs_size,
+        "decode_block: bytes ({}) shorter than header+tfs ({})",
         bytes.len(),
-        HEADER_SIZE + deltas_size + tfs_size
+        HEADER_SIZE + tfs_size
     );
-    let tfs_start = HEADER_SIZE + deltas_size;
+    let tfs_start = bytes.len() - tfs_size;
     BitPacker4x::new().decompress(
         &bytes[tfs_start..tfs_start + tfs_size],
         &mut dest_tfs[..BLOCK_LEN],
@@ -228,7 +283,8 @@ pub fn decode_block_doc_ids(bytes: &[u8], dest_doc_ids: &mut [u32]) -> usize {
 
     let count = bytes[0] as usize;
     let delta_bits = bytes[1];
-    // bytes[2] = tf_bits (unused here), bytes[3] = reserved.
+    let tf_bits = bytes[2];
+    let encoding = bytes[3];
     assert!(
         delta_bits <= 32,
         "decode_block_doc_ids: delta_bits {delta_bits} > 32"
@@ -238,6 +294,31 @@ pub fn decode_block_doc_ids(bytes: &[u8], dest_doc_ids: &mut [u32]) -> usize {
         "decode_block_doc_ids: doc_count {count} > BLOCK_LEN"
     );
     let base_doc_id = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+
+    if encoding == ENCODING_BITSET {
+        // Doc ids are a presence bitset over `[base_doc_id, ...]`; the tfs
+        // are the trailing `tf_bits`-packed bytes, so the bitset is
+        // everything between the header and them. Emit the set bits in
+        // ascending order (= ascending doc id) — the sorted order every
+        // consumer expects.
+        let tfs_size = BLOCK_LEN * tf_bits as usize / 8;
+        assert!(
+            bytes.len() >= HEADER_SIZE + tfs_size,
+            "decode_block_doc_ids: bytes shorter than header+tfs"
+        );
+        let words = &bytes[HEADER_SIZE..bytes.len() - tfs_size];
+        let mut j = 0usize;
+        for (wi, chunk) in words.chunks_exact(8).enumerate() {
+            let mut word = u64::from_le_bytes(chunk.try_into().expect("8 bytes"));
+            while word != 0 {
+                dest_doc_ids[j] = base_doc_id + (wi as u32 * 64 + word.trailing_zeros());
+                j += 1;
+                word &= word - 1;
+            }
+        }
+        debug_assert_eq!(j, count, "bitset set-bit count must equal doc_count");
+        return count;
+    }
 
     let deltas_size = BLOCK_LEN * delta_bits as usize / 8;
     assert!(
@@ -298,6 +379,48 @@ mod tests {
         assert_eq!(enc.max_tf, 1);
         // Sanity on byte layout: header + 16*1 + 16*1 = 40 bytes.
         assert_eq!(enc.bytes.len(), HEADER_SIZE + 16 + 16);
+        // 1-bit deltas beat a bitset here, so it stays PACKED.
+        assert_eq!(enc.bytes[3], ENCODING_PACKED);
+    }
+
+    #[test]
+    fn roundtrip_dense_block_uses_bitset_encoding() {
+        // 128 docs at stride 2 (span 254): 2-bit deltas, so the bitset
+        // (≤ the packed deltas) is chosen. Round-trips through the bitset
+        // decode path and its set-bit ordering.
+        let doc_ids: Vec<u32> = (0..128).map(|i| i * 2).collect();
+        let tfs: Vec<u32> = (0..128).map(|i| (i % 5) + 1).collect();
+        let enc = roundtrip(&block(&doc_ids, &tfs));
+        assert_eq!(enc.bytes[3], ENCODING_BITSET, "dense block must be bitset");
+        assert_eq!(enc.last_doc_id, 254);
+        // base aligned down to a 64-bit boundary (0 here).
+        assert_eq!(u32::from_le_bytes(enc.bytes[4..8].try_into().expect("4 bytes")), 0);
+    }
+
+    #[test]
+    fn roundtrip_bitset_block_nonzero_aligned_base() {
+        // Dense block far from the origin: base aligns down to a word.
+        let doc_ids: Vec<u32> = (0..100).map(|i| 10_000 + i * 2).collect();
+        let tfs = vec![1u32; 100];
+        let enc = roundtrip(&block(&doc_ids, &tfs));
+        assert_eq!(enc.bytes[3], ENCODING_BITSET);
+        assert_eq!(
+            u32::from_le_bytes(enc.bytes[4..8].try_into().expect("4 bytes")),
+            10_000 & !63,
+            "base is word-aligned"
+        );
+    }
+
+    #[test]
+    fn roundtrip_sparse_block_stays_packed() {
+        // Widely-scattered docs: a bitset would be huge, so PACKED wins.
+        let doc_ids: Vec<u32> = (0..64).map(|i| i * 100_000).collect();
+        let tfs = vec![1u32; 64];
+        let enc = roundtrip(&block(&doc_ids, &tfs));
+        assert_eq!(
+            enc.bytes[3], ENCODING_PACKED,
+            "sparse block must stay packed"
+        );
     }
 
     #[test]
@@ -450,14 +573,19 @@ mod tests {
     }
 
     #[test]
-    fn header_reserved_byte_is_zero() {
-        let enc = encode_block(&block(&[1, 2, 3], &[1, 1, 1]));
-        assert_eq!(enc.bytes[3], 0, "reserved byte must be 0");
+    fn header_encoding_byte_marks_the_layout() {
+        // Byte 3 (formerly reserved) is the encoding: 0 = PACKED, 1 = BITSET.
+        let packed = encode_block(&block(&[1, 100_000], &[1, 1]));
+        assert_eq!(packed.bytes[3], ENCODING_PACKED, "sparse ⇒ PACKED");
+        let bitset = encode_block(&block(&[1, 2, 3], &[1, 1, 1]));
+        assert_eq!(bitset.bytes[3], ENCODING_BITSET, "dense ⇒ BITSET");
     }
 
     #[test]
     fn header_base_doc_id_is_first_minus_one() {
-        let enc = encode_block(&block(&[100, 102, 105], &[1, 1, 1]));
+        // A PACKED (sparse) block stores base = first doc - 1.
+        let enc = encode_block(&block(&[100, 100_000, 200_000], &[1, 1, 1]));
+        assert_eq!(enc.bytes[3], ENCODING_PACKED);
         let base_le = u32::from_le_bytes([enc.bytes[4], enc.bytes[5], enc.bytes[6], enc.bytes[7]]);
         assert_eq!(base_le, 99);
     }
@@ -660,12 +788,17 @@ mod tests {
                 .collect();
 
             let enc = encode_block(&Block { doc_ids, tfs });
-            let delta_bits = enc.bytes[1] as usize;
             let tf_bits = enc.bytes[2] as usize;
-            let expected_len = 8 /* header */
-                + (BLOCK_LEN * delta_bits) / 8
-                + (BLOCK_LEN * tf_bits) / 8;
-            prop_assert_eq!(enc.bytes.len(), expected_len);
+            let tfs_size = (BLOCK_LEN * tf_bits) / 8;
+            if enc.bytes[3] == ENCODING_BITSET {
+                // Doc ids are a whole number of 64-bit words; tfs trail.
+                prop_assert_eq!(enc.bytes[1], 0, "bitset block has delta_bits 0");
+                let bitset_bytes = enc.bytes.len() - 8 - tfs_size;
+                prop_assert!(bitset_bytes >= 8 && bitset_bytes.is_multiple_of(8));
+            } else {
+                let delta_bits = enc.bytes[1] as usize;
+                prop_assert_eq!(enc.bytes.len(), 8 + (BLOCK_LEN * delta_bits) / 8 + tfs_size);
+            }
         }
     }
 }

--- a/src/superfile/fts/posting.rs
+++ b/src/superfile/fts/posting.rs
@@ -394,7 +394,10 @@ mod tests {
         assert_eq!(enc.bytes[3], ENCODING_BITSET, "dense block must be bitset");
         assert_eq!(enc.last_doc_id, 254);
         // base aligned down to a 64-bit boundary (0 here).
-        assert_eq!(u32::from_le_bytes(enc.bytes[4..8].try_into().expect("4 bytes")), 0);
+        assert_eq!(
+            u32::from_le_bytes(enc.bytes[4..8].try_into().expect("4 bytes")),
+            0
+        );
     }
 
     #[test]

--- a/src/superfile/fts/posting.rs
+++ b/src/superfile/fts/posting.rs
@@ -181,34 +181,17 @@ pub fn encode_block(b: &Block) -> EncodedBlock {
 /// - `dest_doc_ids.len() < BLOCK_LEN` or `dest_tfs.len() < BLOCK_LEN`.
 /// - Header reports `delta_bits > 32` or `tf_bits > 32`.
 pub fn decode_block(bytes: &[u8], dest_doc_ids: &mut [u32], dest_tfs: &mut [u32]) -> usize {
-    assert!(
-        dest_doc_ids.len() >= BLOCK_LEN,
-        "decode_block: dest_doc_ids must have at least {BLOCK_LEN} slots"
-    );
+    let count = decode_block_doc_ids(bytes, dest_doc_ids);
+
+    // Term frequencies follow the packed deltas. The count paths skip
+    // this half (see `decode_block_doc_ids`); only scoring needs it.
     assert!(
         dest_tfs.len() >= BLOCK_LEN,
         "decode_block: dest_tfs must have at least {BLOCK_LEN} slots"
     );
-    assert!(
-        bytes.len() >= HEADER_SIZE,
-        "decode_block: bytes too short for header"
-    );
-
-    let count = bytes[0] as usize;
     let delta_bits = bytes[1];
     let tf_bits = bytes[2];
-    // bytes[3] = reserved, ignored.
-    assert!(
-        delta_bits <= 32,
-        "decode_block: delta_bits {delta_bits} > 32"
-    );
     assert!(tf_bits <= 32, "decode_block: tf_bits {tf_bits} > 32");
-    assert!(
-        count <= BLOCK_LEN,
-        "decode_block: doc_count {count} > BLOCK_LEN"
-    );
-    let base_doc_id = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
-
     let deltas_size = BLOCK_LEN * delta_bits as usize / 8;
     let tfs_size = BLOCK_LEN * tf_bits as usize / 8;
     assert!(
@@ -217,21 +200,58 @@ pub fn decode_block(bytes: &[u8], dest_doc_ids: &mut [u32], dest_tfs: &mut [u32]
         bytes.len(),
         HEADER_SIZE + deltas_size + tfs_size
     );
-
-    let bp = BitPacker4x::new();
-    let deltas_start = HEADER_SIZE;
-    bp.decompress_sorted(
-        base_doc_id,
-        &bytes[deltas_start..deltas_start + deltas_size],
-        &mut dest_doc_ids[..BLOCK_LEN],
-        delta_bits,
-    );
-
-    let tfs_start = deltas_start + deltas_size;
-    bp.decompress(
+    let tfs_start = HEADER_SIZE + deltas_size;
+    BitPacker4x::new().decompress(
         &bytes[tfs_start..tfs_start + tfs_size],
         &mut dest_tfs[..BLOCK_LEN],
         tf_bits,
+    );
+
+    count
+}
+
+/// Decode only the doc ids of a posting block, skipping the term-frequency
+/// half entirely. Unranked counts (union, intersection) never look at
+/// `tf` — they tally doc ids — so decoding + reading the packed tfs is
+/// pure waste there; this halves the per-block decode work on the count
+/// path. Returns the doc count. Shared by [`decode_block`], which appends
+/// the tf decode for the scoring path.
+pub fn decode_block_doc_ids(bytes: &[u8], dest_doc_ids: &mut [u32]) -> usize {
+    assert!(
+        dest_doc_ids.len() >= BLOCK_LEN,
+        "decode_block_doc_ids: dest_doc_ids must have at least {BLOCK_LEN} slots"
+    );
+    assert!(
+        bytes.len() >= HEADER_SIZE,
+        "decode_block_doc_ids: bytes too short for header"
+    );
+
+    let count = bytes[0] as usize;
+    let delta_bits = bytes[1];
+    // bytes[2] = tf_bits (unused here), bytes[3] = reserved.
+    assert!(
+        delta_bits <= 32,
+        "decode_block_doc_ids: delta_bits {delta_bits} > 32"
+    );
+    assert!(
+        count <= BLOCK_LEN,
+        "decode_block_doc_ids: doc_count {count} > BLOCK_LEN"
+    );
+    let base_doc_id = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+
+    let deltas_size = BLOCK_LEN * delta_bits as usize / 8;
+    assert!(
+        bytes.len() >= HEADER_SIZE + deltas_size,
+        "decode_block_doc_ids: bytes ({}) shorter than header+deltas ({})",
+        bytes.len(),
+        HEADER_SIZE + deltas_size
+    );
+
+    BitPacker4x::new().decompress_sorted(
+        base_doc_id,
+        &bytes[HEADER_SIZE..HEADER_SIZE + deltas_size],
+        &mut dest_doc_ids[..BLOCK_LEN],
+        delta_bits,
     );
 
     count

--- a/src/superfile/fts/posting.rs
+++ b/src/superfile/fts/posting.rs
@@ -307,6 +307,21 @@ pub fn decode_block_doc_ids(bytes: &[u8], dest_doc_ids: &mut [u32]) -> usize {
             "decode_block_doc_ids: bytes shorter than header+tfs"
         );
         let words = &bytes[HEADER_SIZE..bytes.len() - tfs_size];
+        // Bounds safety: `j` advances once per set bit, so it is bounded by
+        // `popcount(words)`, and the `dest_doc_ids[j]` writes carry no per-bit
+        // bounds check on this hot decode loop because two invariants keep that
+        // popcount ≤ `BLOCK_LEN`:
+        //   1. The builder sets exactly `doc_count` bits (≤ `BLOCK_LEN`, the
+        //      per-block cap) when it encodes a bitset block, so a well-formed
+        //      block has `popcount == count ≤ BLOCK_LEN`.
+        //   2. Decode only ever runs on CRC-validated bytes: the postings
+        //      region's checksum is verified in `SuperfileReader::open` before
+        //      any block is decoded, so a corrupted bitmap — which could carry
+        //      extra set bits — is rejected at open and never reaches here.
+        // The `debug_assert_eq!(j, count)` below is the test/debug tripwire that
+        // fires if a future builder change ever breaks invariant 1. This bound
+        // depends on invariant 2: if a path is ever added that decodes blocks
+        // before validating their CRC, a `j < BLOCK_LEN` bound becomes mandatory.
         let mut j = 0usize;
         for (wi, chunk) in words.chunks_exact(8).enumerate() {
             let mut word = u64::from_le_bytes(chunk.try_into().expect("8 bytes"));

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -47,6 +47,7 @@ use crate::superfile::{
         dict::{DictReader, make_key},
         fst_value::FstValue,
         positions::decode_run,
+        posting::{self, BLOCK_LEN, ENCODING_BITSET, decode_block_doc_ids},
         tokenize::{Tokenizer, tokenizer_for_name},
     },
     lazy_source::{LazyByteSource, PrefetchedSource, RangeCoalescePlan, Source},
@@ -557,18 +558,22 @@ impl FtsReader {
         if version != format::fts::VERSION_V1_LEGACY
             && version != format::fts::VERSION_V2
             && version != format::fts::VERSION_V3
+            && version != format::fts::VERSION_V4
         {
             return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
                 "fts section version {version}"
             ))));
         }
         // The FST directory starts right after whichever header
-        // applies; a v2/v3 header's extension bytes are already in the
+        // applies; a v2/v3/v4 header's extension bytes are already in the
         // fetched span (and in the overlay below), so
-        // `open_with_source` re-reads them without another GET. (v3 shares
+        // `open_with_source` re-reads them without another GET. (v3/v4 share
         // v2's header size.)
         let header_size = match version {
-            v if v == format::fts::VERSION_V2 || v == format::fts::VERSION_V3 => {
+            v if v == format::fts::VERSION_V2
+                || v == format::fts::VERSION_V3
+                || v == format::fts::VERSION_V4 =>
+            {
                 format::fts::HEADER_SIZE_V2
             }
             _ => FTS_HEADER_SIZE,
@@ -648,19 +653,23 @@ impl FtsReader {
         // the positions-region offset at [48..56] and a positions
         // region between the postings and the doc-lengths directory.
         let version = read_u32_le(&header[hdr::VERSION_OFF..hdr::VERSION_OFF + U32_BYTES]);
-        // v3 shares v2's header and region layout; it additionally carries
-        // a per-term position sub-index (handled in the phrase decode).
+        // v3/v4 share v2's header and region layout; v3+ additionally
+        // carries a per-term position sub-index (handled in the phrase
+        // decode), and v4 may store dense blocks in the bitset encoding
+        // (self-describing per block, handled in the codec).
         let positional_blob = match version {
             v if v == format::fts::VERSION_V1_LEGACY => false,
             v if v == format::fts::VERSION_V2 => true,
             v if v == format::fts::VERSION_V3 => true,
+            v if v == format::fts::VERSION_V4 => true,
             _ => {
                 return Err(FtsError::Read(ReadError::UnsupportedVersion(format!(
                     "fts section version {version}"
                 ))));
             }
         };
-        let has_position_subindex = version == format::fts::VERSION_V3;
+        let has_position_subindex =
+            version == format::fts::VERSION_V3 || version == format::fts::VERSION_V4;
         let header_size = match positional_blob {
             true => format::fts::HEADER_SIZE_V2,
             false => FTS_HEADER_SIZE,
@@ -1622,28 +1631,49 @@ pub(super) fn or_count_unranked(mut cursors: Vec<TermCursor>) -> u64 {
     n
 }
 
-/// Disjunction cardinality via a full doc-space bitset: OR every cursor's
-/// doc ids into one bitset, then popcount. Block-bulk — a whole decoded
-/// block's ids are scattered in one tight loop — and the `count_only`
-/// cursors decode doc ids without their term frequencies, so this streams
-/// the postings into memory with no per-doc/per-window bookkeeping.
-/// Overlap between terms is deduplicated for free by the bitset OR. Called
-/// only for dense unions (see the gate in [`or_count_unranked`]); the
+/// Disjunction cardinality via a full doc-space bitset: OR every term's
+/// doc ids into one bitset, then popcount. Iterates blocks at the byte
+/// level so a **bitset-encoded block** (`ENCODING_BITSET`, dense — a common
+/// term) is merged by a word-aligned `union[w] |= block[w]` with **no
+/// decode**; a PACKED block is decoded doc-ids-only (no tf) and scattered.
+/// Overlap between terms is deduplicated for free by the OR. Called only
+/// for dense unions (see the gate in [`or_count_unranked`]); the
 /// full-corpus alloc + popcount would dominate on a sparse one.
-fn or_count_bitset(mut cursors: Vec<TermCursor>, max_doc: u32) -> u64 {
+fn or_count_bitset(cursors: Vec<TermCursor>, max_doc: u32) -> u64 {
     let words = max_doc as usize / 64 + 1;
-    let mut bitset = vec![0u64; words];
-    for c in &mut cursors {
-        while !c.is_exhausted() {
-            // The current block is decoded (block 0 on build, later blocks
-            // on `advance_block`); `pos` is 0 at each block start.
-            for &d in &c.block_doc_ids[c.pos..c.block_n] {
-                bitset[(d >> 6) as usize] |= 1u64 << (d & 63);
+    let mut union = vec![0u64; words];
+    let mut scratch = [0u32; BLOCK_LEN];
+    for c in &cursors {
+        // Inline (df=1) cursors carry their single doc pre-decoded and have
+        // no postings bytes to slice.
+        if c.bytes.is_empty() {
+            for &d in &c.block_doc_ids[..c.block_n] {
+                union[(d >> 6) as usize] |= 1u64 << (d & 63);
             }
-            c.advance_block();
+            continue;
+        }
+        for block in c.blocks.iter() {
+            let bytes = c.bytes.slice(block.block_byte_offset..block.block_byte_end);
+            let bytes = bytes.as_ref();
+            if bytes[posting::ENCODING_OFF] == ENCODING_BITSET {
+                // Word-OR the presence bitset in at its aligned base word.
+                // Tfs trail; the bitset is everything between them.
+                let base_word = read_u32_le(&bytes[4..8]) as usize / 64;
+                let tf_bits = bytes[2] as usize;
+                let tfs_size = BLOCK_LEN * tf_bits / 8;
+                let presence = &bytes[posting::HEADER_SIZE..bytes.len() - tfs_size];
+                for (i, chunk) in presence.chunks_exact(8).enumerate() {
+                    union[base_word + i] |= u64::from_le_bytes(chunk.try_into().expect("8 bytes"));
+                }
+            } else {
+                let n = decode_block_doc_ids(bytes, &mut scratch);
+                for &d in &scratch[..n] {
+                    union[(d >> 6) as usize] |= 1u64 << (d & 63);
+                }
+            }
         }
     }
-    bitset.iter().map(|w| w.count_ones() as u64).sum()
+    union.iter().map(|w| w.count_ones() as u64).sum()
 }
 
 /// Pick the cursor whose df dominates the union, or `None` if no term is

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -307,6 +307,17 @@ pub(super) const OR_WINDOW_WORDS: usize = (OR_WINDOW as usize).div_ceil(64);
 /// windowed bitset, which is already faster when no term dominates.
 pub(super) const OR_COUNT_ANCHOR_DOMINANCE: u64 = 8;
 
+/// Density gate for the full-bitset union count. When the terms' combined
+/// postings reach `1/N` of the doc-id space, OR them all into one
+/// doc-space bitset and popcount, instead of the per-window walk — a dense
+/// union (several common terms, e.g. a 3-4 word title) touches most of the
+/// corpus, so the bitset streams the doc ids into memory with no per-doc
+/// window bookkeeping. Below the gate the union is sparse and the windowed
+/// bitset — whose state stays L1-resident and needs no full-corpus alloc +
+/// popcount — is cheaper. Expressed as the divisor `N`: bitset when
+/// `total_df >= max_doc / N`.
+pub(super) const OR_COUNT_BITSET_DENSITY_DIVISOR: u64 = 16;
+
 /// Multi-term OR dispatch floor. A 2-term OR is already sub-millisecond
 /// on MaxScore, so the window's per-window bookkeeping isn't worth it
 /// below this many terms. `pub(crate)`: the supertable fan-out reuses
@@ -1124,7 +1135,7 @@ impl FtsReader {
         let mut out: Vec<Option<AnyCursor>> = Vec::with_capacity(terms.len() + phrases.len());
         for term in terms {
             let mut cursors = self
-                .build_term_cursors(column_id, &[term], global_idf)
+                .build_term_cursors(column_id, &[term], global_idf, false)
                 .await?;
             dict_ranges += 1;
             out.push(cursors.pop().map(AnyCursor::Term));
@@ -1136,7 +1147,7 @@ impl FtsReader {
             // per-member rescale ratio cancels out of the phrase's tf/length
             // bound. Build members with the same `global_idf` as bare terms.
             let cursors = self
-                .build_term_cursors(column_id, &member_refs, global_idf)
+                .build_term_cursors(column_id, &member_refs, global_idf, false)
                 .await?;
             dict_ranges += 1;
             if cursors.len() != member_refs.len() {
@@ -1318,7 +1329,8 @@ impl FtsReader {
                     };
                     let mut pos_at = 0usize;
 
-                    let mut cursor = TermCursor::new(term_bytes, n_docs, positional, None, false)?;
+                    let mut cursor =
+                        TermCursor::new(term_bytes, n_docs, positional, None, false, false)?;
                     while !cursor.is_exhausted() {
                         while cursor.pos < cursor.block_n {
                             let doc_id = cursor.block_doc_ids[cursor.pos];
@@ -1555,6 +1567,20 @@ pub(super) fn or_count_unranked(mut cursors: Vec<TermCursor>) -> u64 {
     if let Some(anchor) = dominant_anchor_index(&cursors) {
         return or_count_anchored(cursors, anchor);
     }
+    // Dense union (no dominant term, but the terms together cover a large
+    // fraction of the corpus — e.g. a 3-4 common-word title): OR all doc
+    // ids into one doc-space bitset and popcount. Avoids the per-window
+    // bookkeeping the walk below pays per doc.
+    let total_df: u64 = cursors.iter().map(|c| c.df).sum();
+    let max_doc = cursors
+        .iter()
+        .filter_map(|c| c.blocks.last())
+        .map(|b| b.last_doc_id)
+        .max()
+        .unwrap_or(0);
+    if total_df.saturating_mul(OR_COUNT_BITSET_DENSITY_DIVISOR) >= u64::from(max_doc) {
+        return or_count_bitset(cursors, max_doc);
+    }
     let mut present = [0u64; OR_WINDOW_WORDS];
     let mut n = 0u64;
     loop {
@@ -1594,6 +1620,30 @@ pub(super) fn or_count_unranked(mut cursors: Vec<TermCursor>) -> u64 {
         }
     }
     n
+}
+
+/// Disjunction cardinality via a full doc-space bitset: OR every cursor's
+/// doc ids into one bitset, then popcount. Block-bulk — a whole decoded
+/// block's ids are scattered in one tight loop — and the `count_only`
+/// cursors decode doc ids without their term frequencies, so this streams
+/// the postings into memory with no per-doc/per-window bookkeeping.
+/// Overlap between terms is deduplicated for free by the bitset OR. Called
+/// only for dense unions (see the gate in [`or_count_unranked`]); the
+/// full-corpus alloc + popcount would dominate on a sparse one.
+fn or_count_bitset(mut cursors: Vec<TermCursor>, max_doc: u32) -> u64 {
+    let words = max_doc as usize / 64 + 1;
+    let mut bitset = vec![0u64; words];
+    for c in &mut cursors {
+        while !c.is_exhausted() {
+            // The current block is decoded (block 0 on build, later blocks
+            // on `advance_block`); `pos` is 0 at each block start.
+            for &d in &c.block_doc_ids[c.pos..c.block_n] {
+                bitset[(d >> 6) as usize] |= 1u64 << (d & 63);
+            }
+            c.advance_block();
+        }
+    }
+    bitset.iter().map(|w| w.count_ones() as u64).sum()
 }
 
 /// Pick the cursor whose df dominates the union, or `None` if no term is

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -503,6 +503,10 @@ pub struct FtsReader {
     /// `< POSITION_SUBINDEX_STRIDE` runs. `V1`/`V2` blobs lack it and take
     /// the block-start skip-walk fallback.
     pub(super) has_position_subindex: bool,
+    /// True iff the blob is `VERSION_V4` — some posting blocks may be
+    /// bitset-encoded, so the unranked count kernels prefer membership
+    /// bit-tests (no decode) over decoding a common term's blocks.
+    pub(super) has_bitset_blocks: bool,
     pub(super) columns: Vec<ColumnMeta>,
     pub(super) column_id_by_name: HashMap<String, u32>,
 }
@@ -670,6 +674,7 @@ impl FtsReader {
         };
         let has_position_subindex =
             version == format::fts::VERSION_V3 || version == format::fts::VERSION_V4;
+        let has_bitset_blocks = version == format::fts::VERSION_V4;
         let header_size = match positional_blob {
             true => format::fts::HEADER_SIZE_V2,
             false => FTS_HEADER_SIZE,
@@ -929,6 +934,7 @@ impl FtsReader {
             postings_range,
             positions_range,
             has_position_subindex,
+            has_bitset_blocks,
             columns,
             column_id_by_name,
         })

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1742,8 +1742,11 @@ fn or_count_anchored(mut cursors: Vec<TermCursor>, anchor_idx: usize) -> u64 {
         if min_doc == u32::MAX {
             break;
         }
-        anchor.skip_to(min_doc);
-        if anchor.is_exhausted() || anchor.current_doc_id() != min_doc {
+        // Membership by bit-test, not `skip_to`: the anchor is the dominant
+        // (common ⇒ dense) term, so its blocks are bitsets. `contains` answers
+        // in one word-load; `skip_to` would decode each block — expanding its
+        // ~128 doc ids — as the frontier drags the anchor across its whole list.
+        if !anchor.contains(min_doc) {
             n += 1;
         }
         for c in cursors.iter_mut() {

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1650,36 +1650,52 @@ fn or_count_bitset(cursors: Vec<TermCursor>, max_doc: u32) -> u64 {
     let mut union = vec![0u64; words];
     let mut scratch = [0u32; BLOCK_LEN];
     for c in &cursors {
-        // Inline (df=1) cursors carry their single doc pre-decoded and have
-        // no postings bytes to slice.
-        if c.bytes.is_empty() {
-            for &d in &c.block_doc_ids[..c.block_n] {
-                union[(d >> 6) as usize] |= 1u64 << (d & 63);
-            }
-            continue;
+        or_cursor_into_bitset(&mut union, c, &mut scratch);
+    }
+    union.iter().map(|w| w.count_ones() as u64).sum()
+}
+
+/// OR one cursor's doc presence into `dest` (a doc-space bitset spanning at
+/// least the cursor's largest doc id), reading blocks at the byte level: a
+/// **BITSET** block is word-copied at its aligned base word — no expansion to
+/// doc ids; a **PACKED** block is decoded doc-ids-only (no tf) and scattered; an
+/// inline (df=1) cursor scatters its single pre-decoded doc. `scratch` is a
+/// reused `BLOCK_LEN` decode buffer. Shared by the union count
+/// ([`or_count_bitset`]) and the intersection count (`count_and_intersect_bitset`)
+/// so a common term's dense blocks are merged at memory bandwidth either way.
+pub(super) fn or_cursor_into_bitset(
+    dest: &mut [u64],
+    c: &TermCursor,
+    scratch: &mut [u32; BLOCK_LEN],
+) {
+    // Inline (df=1) cursors carry their single doc pre-decoded and have no
+    // postings bytes to slice.
+    if c.bytes.is_empty() {
+        for &d in &c.block_doc_ids[..c.block_n] {
+            dest[(d >> 6) as usize] |= 1u64 << (d & 63);
         }
-        for block in c.blocks.iter() {
-            let bytes = c.bytes.slice(block.block_byte_offset..block.block_byte_end);
-            let bytes = bytes.as_ref();
-            if bytes[posting::ENCODING_OFF] == ENCODING_BITSET {
-                // Word-OR the presence bitset in at its aligned base word.
-                // Tfs trail; the bitset is everything between them.
-                let base_word = read_u32_le(&bytes[4..8]) as usize / 64;
-                let tf_bits = bytes[2] as usize;
-                let tfs_size = BLOCK_LEN * tf_bits / 8;
-                let presence = &bytes[posting::HEADER_SIZE..bytes.len() - tfs_size];
-                for (i, chunk) in presence.chunks_exact(8).enumerate() {
-                    union[base_word + i] |= u64::from_le_bytes(chunk.try_into().expect("8 bytes"));
-                }
-            } else {
-                let n = decode_block_doc_ids(bytes, &mut scratch);
-                for &d in &scratch[..n] {
-                    union[(d >> 6) as usize] |= 1u64 << (d & 63);
-                }
+        return;
+    }
+    for block in c.blocks.iter() {
+        let bytes = c.bytes.slice(block.block_byte_offset..block.block_byte_end);
+        let bytes = bytes.as_ref();
+        if bytes[posting::ENCODING_OFF] == ENCODING_BITSET {
+            // Word-OR the presence bitset in at its aligned base word.
+            // Tfs trail; the bitset is everything between them.
+            let base_word = read_u32_le(&bytes[4..8]) as usize / 64;
+            let tf_bits = bytes[2] as usize;
+            let tfs_size = BLOCK_LEN * tf_bits / 8;
+            let presence = &bytes[posting::HEADER_SIZE..bytes.len() - tfs_size];
+            for (i, chunk) in presence.chunks_exact(8).enumerate() {
+                dest[base_word + i] |= u64::from_le_bytes(chunk.try_into().expect("8 bytes"));
+            }
+        } else {
+            let n = decode_block_doc_ids(bytes, scratch);
+            for &d in &scratch[..n] {
+                dest[(d >> 6) as usize] |= 1u64 << (d & 63);
             }
         }
     }
-    union.iter().map(|w| w.count_ones() as u64).sum()
 }
 
 /// Pick the cursor whose df dominates the union, or `None` if no term is

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -69,15 +69,21 @@ impl FtsReader {
             BoolMode::And => {
                 let mut target = 0u32;
                 'docs: loop {
+                    // Phase 1 — align every atom by its cheap *approximation*: a
+                    // term atom is exact; a phrase atom advances only to a doc
+                    // holding all its members, without decoding positions. So a
+                    // rare co-clause (e.g. a term AND'd with a common-word
+                    // phrase) prunes the candidate set here, before any phrase
+                    // pays for adjacency.
                     let mut aligned = target;
                     let mut i = 0usize;
                     while i < atoms.len() {
                         let a = &mut atoms[i];
-                        a.skip_to(aligned)?;
+                        a.approx_skip_to(aligned);
                         if a.is_exhausted() {
                             break 'docs;
                         }
-                        let here = a.current_doc_id();
+                        let here = a.approx_current_doc();
                         if here > aligned {
                             aligned = here;
                             i = 0;
@@ -85,12 +91,25 @@ impl FtsReader {
                         }
                         i += 1;
                     }
-                    let admitted = match filter.as_mut() {
-                        Some(f) => f.admits(aligned)?,
-                        None => true,
-                    };
-                    if admitted {
-                        on_doc(aligned);
+                    // Phase 2 — every approximation agrees on `aligned`. Verify
+                    // the phrase atoms' positions here only: the intersection is
+                    // already down to the co-occurring docs, so position decode
+                    // runs on that handful, not on a phrase's whole match set.
+                    let mut matched = true;
+                    for a in atoms.iter_mut() {
+                        if !a.verify_at(aligned)? {
+                            matched = false;
+                            break;
+                        }
+                    }
+                    if matched {
+                        let admitted = match filter.as_mut() {
+                            Some(f) => f.admits(aligned)?,
+                            None => true,
+                        };
+                        if admitted {
+                            on_doc(aligned);
+                        }
                     }
                     let Some(next) = aligned.checked_add(1) else {
                         break;

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -223,7 +223,9 @@ impl FtsReader {
         if tokens.is_empty() {
             return Ok((Vec::new(), MatchWork::default()));
         }
-        let cursors = self.build_term_cursors(column_id, tokens, None).await?;
+        let cursors = self
+            .build_term_cursors(column_id, tokens, None, true)
+            .await?;
         // Tallied before the mode branch: the cursors that DID build cost
         // their bytes even when a missing AND token empties the result.
         // +1: the build's dictionary fetch.
@@ -261,7 +263,9 @@ impl FtsReader {
         if tokens.is_empty() {
             return Ok((0, MatchWork::default()));
         }
-        let cursors = self.build_term_cursors(column_id, tokens, None).await?;
+        let cursors = self
+            .build_term_cursors(column_id, tokens, None, true)
+            .await?;
         let mut work = MatchWork::for_cursors(&cursors);
         work.planned_ranges += 1;
         let (n, walk_ns) = timed_section(|| match mode {

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -562,6 +562,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn and_count_matches_merge_on_dense_bitset_corpus() {
+        // A dense corpus stores common terms as bitset blocks (v4). The
+        // intersection count must agree with `token_match`'s flat-merge AND
+        // length across both v4 intersection kernels: the bitset-AND
+        // (word-parallel presence AND, when every term is dense enough to
+        // trip the density gate) and the rarest-driven membership walk (when
+        // a sparse term keeps the intersection below the gate). `token_match`
+        // AND collects via the decode-based flat-merge, an independent
+        // reference from either count kernel.
+        const N_DOCS: u32 = OR_WINDOW * 2 + 500;
+        const RARE_STRIDE: u32 = 371; // sparse ⇒ below the density gate
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false).expect("register");
+        for i in 0..N_DOCS {
+            let mut text = String::from("alpha "); // every doc → dense
+            if i % 2 == 0 {
+                text.push_str("beta ");
+            }
+            if i % 3 == 0 {
+                text.push_str("gamma ");
+            }
+            if i % 5 == 0 {
+                text.push_str("delta ");
+            }
+            if i.is_multiple_of(RARE_STRIDE) {
+                text.push_str("rare ");
+            }
+            b.add_doc(0, i, text.trim()).expect("add doc");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+
+        let shapes: &[&[&str]] = &[
+            &["alpha", "beta"],                   // dense ∩ dense → bitset-AND
+            &["alpha", "beta", "gamma"],          // 3 dense → bitset-AND
+            &["alpha", "beta", "gamma", "delta"], // 4 dense → bitset-AND
+            &["beta", "gamma"],                   // dense ∩ dense, neither anchor
+            &["alpha", "rare"],                   // dense ∩ sparse → membership
+            &["gamma", "zzz_absent"],             // absent term ⇒ empty
+        ];
+        for terms in shapes {
+            let merge_len = r
+                .token_match("body", terms, BoolMode::And)
+                .await
+                .expect("token_match")
+                .0
+                .len() as u64;
+            let count = r
+                .token_match_count("body", terms, BoolMode::And)
+                .await
+                .expect("token_match_count")
+                .0;
+            assert_eq!(count, merge_len, "AND count vs merge len for {terms:?}");
+        }
+        // Absolute pin: `alpha` is in every doc, so `alpha ∩ beta` is exactly
+        // the docs where `beta` is present (i % 2 == 0) = ⌈N_DOCS / 2⌉.
+        assert_eq!(
+            r.token_match_count("body", &["alpha", "beta"], BoolMode::And)
+                .await
+                .expect("count")
+                .0,
+            u64::from(N_DOCS.div_ceil(2))
+        );
+    }
+
+    #[tokio::test]
     async fn or_count_anchored_matches_merge_on_dominant_term() {
         // When one term's df dwarfs the rest, the OR count takes the
         // df-anchored path (`df(dominant) + |others \ dominant|`) instead

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -405,7 +405,11 @@ mod tests {
     use bytes::Bytes;
 
     use super::{super::test_util::*, *};
-    use crate::superfile::fts::{builder::FtsBuilder, tokenize::AsciiLowerTokenizer};
+    use crate::superfile::fts::{
+        builder::FtsBuilder,
+        posting::{self, ENCODING_BITSET, ENCODING_PACKED},
+        tokenize::AsciiLowerTokenizer,
+    };
 
     #[tokio::test]
     async fn token_match_or_unions_and_intersects_unranked() {
@@ -511,7 +515,7 @@ mod tests {
         b.register_column("body".into(), false).expect("register");
         for i in 0..N_DOCS {
             let mut text = String::from("alpha "); // every doc
-            if i % 2 == 0 {
+            if i.is_multiple_of(2) {
                 text.push_str("beta ");
             }
             if i % 3 == 0 {
@@ -627,6 +631,95 @@ mod tests {
                 .0,
             u64::from(N_DOCS.div_ceil(2))
         );
+    }
+
+    #[tokio::test]
+    async fn count_kernels_handle_a_mixed_encoding_term() {
+        // A term that is dense early (near-consecutive doc ids ⇒ BITSET blocks)
+        // and sparse later (strided ⇒ PACKED blocks) has *both* block encodings
+        // in one posting list. The per-block encoding dispatch in the union
+        // (`or_cursor_into_bitset`), the membership probe (`TermCursor::contains`
+        // advancing across a bitset→packed boundary), and the doc-id decode must
+        // each pick the right branch block by block. Uniform-stride corpora
+        // never produce this, so drive it explicitly and cross-check every count
+        // kernel against `token_match`'s independent flat-merge length.
+        const DENSE_END: u32 = 256; // docs 0..256 hold `mix` every doc → BITSET
+        const SPARSE_STRIDE: u32 = 30; // docs after that every 30th → PACKED
+        const N_DOCS: u32 = 4200;
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false).expect("register");
+        for i in 0..N_DOCS {
+            let mut text = String::from("common "); // every doc → dense partner
+            if i % 2 == 0 {
+                text.push_str("even "); // every other doc → dense, non-dominant
+            }
+            let mix = i < DENSE_END || (i - DENSE_END).is_multiple_of(SPARSE_STRIDE);
+            if mix {
+                text.push_str("mix ");
+            }
+            if i.is_multiple_of(37) {
+                text.push_str("rareb "); // sparse ⇒ AND stays below the density gate
+            }
+            text.push_str(&format!("f{}", i % 50));
+            b.add_doc(0, i, text.trim()).expect("add doc");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+
+        // Prove `mix` really has both encodings — else the test silently checks
+        // nothing about the transition.
+        let cursors = r
+            .build_term_cursors(0, &["mix"], None, true)
+            .await
+            .expect("build cursors");
+        let mix = &cursors[0];
+        let (mut saw_bitset, mut saw_packed) = (false, false);
+        for blk in mix.blocks.iter() {
+            match mix.bytes.as_ref()[blk.block_byte_offset + posting::ENCODING_OFF] {
+                ENCODING_BITSET => saw_bitset = true,
+                ENCODING_PACKED => saw_packed = true,
+                other => panic!("unexpected encoding byte {other}"),
+            }
+        }
+        assert!(
+            saw_bitset && saw_packed,
+            "`mix` must carry both BITSET and PACKED blocks (bitset={saw_bitset}, packed={saw_packed})"
+        );
+
+        // Every count kernel over the mixed term must agree with the flat-merge.
+        // - `mix` alone: doc-id decode across mixed blocks.
+        // - `mix ∪ even`: dense union, neither dominant ⇒ `or_count_bitset` →
+        //   `or_cursor_into_bitset` takes both the word-copy and scatter branches.
+        // - `mix ∩ common`: `common` dominates → membership walk probes `mix`
+        //   (`contains`) across the bitset→packed boundary.
+        // - `mix ∩ rareb`: rarest is sparse ⇒ membership drives by `rareb` and
+        //   probes `mix`, again crossing the encoding boundary.
+        let cases: &[(&[&str], BoolMode)] = &[
+            (&["mix"], BoolMode::Or),
+            (&["mix", "even"], BoolMode::Or),
+            (&["mix", "common"], BoolMode::And),
+            (&["mix", "rareb"], BoolMode::And),
+            (&["mix", "even", "common"], BoolMode::And),
+        ];
+        for (tokens, mode) in cases {
+            let merge_len = r
+                .token_match("body", tokens, *mode)
+                .await
+                .expect("token_match")
+                .0
+                .len() as u64;
+            let count = r
+                .token_match_count("body", tokens, *mode)
+                .await
+                .expect("token_match_count")
+                .0;
+            assert_eq!(
+                count, merge_len,
+                "mixed-encoding count for {tokens:?} {mode:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -723,6 +723,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn intersection_count_edges_across_the_density_gate() {
+        // Dispatch edges in `count_and_intersect`: the density-gate boundary
+        // (bitset-AND just above, membership just below `min_df*DIVISOR >=
+        // max_doc`), a single-cursor AND, and inline (df=1) cursors in both an
+        // intersection (`contains` inline branch, true and false) and a dense
+        // union (`or_cursor_into_bitset` inline branch). All cross-checked
+        // against `token_match`'s independent flat-merge length.
+        const N_DOCS: u32 = 4096; // max doc id 4095
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false).expect("register");
+        for i in 0..N_DOCS {
+            let mut text = String::from("common"); // every doc
+            text.push_str(if i.is_multiple_of(2) { " even" } else { " odd" });
+            // `gatehi` in 256 docs (df*16 = 4096 ≥ 4095 ⇒ bitset-AND);
+            // `gatelo` in 255 docs (df*16 = 4080 < 4095 ⇒ membership).
+            if i.is_multiple_of(16) {
+                text.push_str(" gatehi");
+            }
+            if i.is_multiple_of(16) && i != 0 {
+                text.push_str(" gatelo");
+            }
+            if i == 100 {
+                text.push_str(" inlinea inlineb"); // two df=1 terms on one doc
+            }
+            if i == 200 {
+                text.push_str(" inlinec"); // a df=1 term on a different doc
+            }
+            b.add_doc(0, i, text.trim()).expect("add doc");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+
+        // Pin the gate arithmetic: `gatehi` lands on/above the switch, `gatelo`
+        // just below, so the two intersections below take different kernels.
+        let max_doc = u64::from(N_DOCS - 1);
+        let hi = r.term_df("body", "gatehi").await.expect("df").0;
+        let lo = r.term_df("body", "gatelo").await.expect("df").0;
+        assert!(
+            hi.saturating_mul(OR_COUNT_BITSET_DENSITY_DIVISOR) >= max_doc,
+            "gatehi df={hi} must sit on/above the density gate"
+        );
+        assert!(
+            lo.saturating_mul(OR_COUNT_BITSET_DENSITY_DIVISOR) < max_doc,
+            "gatelo df={lo} must sit below the density gate"
+        );
+        for token in ["inlinea", "inlineb", "inlinec"] {
+            assert_eq!(
+                r.term_df("body", token).await.expect("df").0,
+                1,
+                "{token} df"
+            );
+        }
+
+        let and_cases: &[&[&str]] = &[
+            &["common", "gatehi"],   // bitset-AND — just above the gate
+            &["common", "gatelo"],   // membership — just below the gate
+            &["common"],             // single-cursor AND
+            &["inlinea", "inlineb"], // two df=1 on the same doc ⇒ contains inline true
+            &["inlinea", "inlinec"], // df=1 on different docs ⇒ contains inline false
+            &["inlinea", "common"],  // inline drives, bitset term probed
+        ];
+        for tokens in and_cases {
+            let merge_len = r
+                .token_match("body", tokens, BoolMode::And)
+                .await
+                .expect("token_match")
+                .0
+                .len() as u64;
+            let count = r
+                .token_match_count("body", tokens, BoolMode::And)
+                .await
+                .expect("token_match_count")
+                .0;
+            assert_eq!(count, merge_len, "AND edge count for {tokens:?}");
+        }
+
+        // Dense union containing an inline term ⇒ `or_count_bitset` →
+        // the inline branch of `or_cursor_into_bitset`.
+        let or_tokens: &[&str] = &["inlinea", "even", "odd"];
+        let merge_len = r
+            .token_match("body", or_tokens, BoolMode::Or)
+            .await
+            .expect("token_match")
+            .0
+            .len() as u64;
+        let count = r
+            .token_match_count("body", or_tokens, BoolMode::Or)
+            .await
+            .expect("token_match_count")
+            .0;
+        assert_eq!(count, merge_len, "OR-with-inline count");
+
+        // Absolute pins on the inline intersections: same doc ⇒ 1, disjoint ⇒ 0.
+        assert_eq!(
+            r.token_match_count("body", &["inlinea", "inlineb"], BoolMode::And)
+                .await
+                .expect("count")
+                .0,
+            1
+        );
+        assert_eq!(
+            r.token_match_count("body", &["inlinea", "inlinec"], BoolMode::And)
+                .await
+                .expect("count")
+                .0,
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn or_count_anchored_matches_merge_on_dominant_term() {
         // When one term's df dwarfs the rest, the OR count takes the
         // df-anchored path (`df(dominant) + |others \ dominant|`) instead

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -24,7 +24,7 @@ use crate::superfile::{
     fts::{
         bm25,
         builder::{SKIP_ENTRY_SIZE, TERM_META_POSITIONAL_SIZE, TERM_META_SIZE},
-        posting::{BLOCK_LEN, decode_block},
+        posting::{BLOCK_LEN, decode_block, decode_block_doc_ids},
     },
 };
 
@@ -342,6 +342,12 @@ pub(crate) struct TermCursor {
     /// so the build probed the 20-byte header before fetching the body
     /// — two planned byte-source ranges instead of one.
     pub(super) header_probed: bool,
+    /// Count-only cursor: `decode_current_block` skips the tf half of each
+    /// block (see [`decode_block_doc_ids`]). Set by the unranked count
+    /// kernels (union / intersection), which never read `block_tfs`;
+    /// leaves `block_tfs` stale, so a `count_only` cursor must not be used
+    /// for scoring.
+    pub(super) count_only: bool,
 }
 
 impl TermCursor {
@@ -356,6 +362,7 @@ impl TermCursor {
         positional: bool,
         global_idf: Option<f32>,
         header_probed: bool,
+        count_only: bool,
     ) -> Result<Self, FtsError> {
         let postings: &[u8] = term_bytes.as_ref();
         let metadata_offset = 0usize;
@@ -418,6 +425,7 @@ impl TermCursor {
             inspect_block: 0,
             bytes: term_bytes,
             header_probed,
+            count_only,
         };
         if !cursor.blocks.is_empty() {
             cursor.decode_current_block();
@@ -471,6 +479,9 @@ impl TermCursor {
             inspect_block: 0,
             bytes: Bytes::new(),
             header_probed: false,
+            // Inline cursors carry their single posting pre-decoded and
+            // never call `decode_current_block`, so the flag is inert.
+            count_only: false,
         }
     }
 
@@ -479,7 +490,12 @@ impl TermCursor {
         let bytes = self
             .bytes
             .slice(block.block_byte_offset..block.block_byte_end);
-        self.block_n = decode_block(&bytes, &mut self.block_doc_ids, &mut self.block_tfs);
+        // Count-only cursors skip the tf half of the block; the count
+        // kernels never read `block_tfs`, so it is left stale.
+        self.block_n = match self.count_only {
+            true => decode_block_doc_ids(&bytes, &mut self.block_doc_ids),
+            false => decode_block(&bytes, &mut self.block_doc_ids, &mut self.block_tfs),
+        };
         self.pos = 0;
     }
 

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -24,7 +24,7 @@ use crate::superfile::{
     fts::{
         bm25,
         builder::{SKIP_ENTRY_SIZE, TERM_META_POSITIONAL_SIZE, TERM_META_SIZE},
-        posting::{BLOCK_LEN, decode_block, decode_block_doc_ids},
+        posting::{self, BLOCK_LEN, decode_block, decode_block_doc_ids},
     },
 };
 
@@ -348,6 +348,11 @@ pub(crate) struct TermCursor {
     /// leaves `block_tfs` stale, so a `count_only` cursor must not be used
     /// for scoring.
     pub(super) count_only: bool,
+    /// Which block index is currently decoded into `block_doc_ids`
+    /// (`usize::MAX` = none). Lets [`Self::contains`] skip re-decoding a
+    /// PACKED block it already holds while probing membership across a
+    /// run of ascending target docs.
+    pub(super) decoded_block: usize,
 }
 
 impl TermCursor {
@@ -426,6 +431,7 @@ impl TermCursor {
             bytes: term_bytes,
             header_probed,
             count_only,
+            decoded_block: usize::MAX,
         };
         if !cursor.blocks.is_empty() {
             cursor.decode_current_block();
@@ -482,6 +488,7 @@ impl TermCursor {
             // Inline cursors carry their single posting pre-decoded and
             // never call `decode_current_block`, so the flag is inert.
             count_only: false,
+            decoded_block: 0,
         }
     }
 
@@ -497,6 +504,74 @@ impl TermCursor {
             false => decode_block(&bytes, &mut self.block_doc_ids, &mut self.block_tfs),
         };
         self.pos = 0;
+        self.decoded_block = self.current_block;
+    }
+
+    /// Membership probe: does this term contain `doc`? Advances the block
+    /// cursor forward to the block that could hold `doc` (targets arrive
+    /// ascending on the AND-count leapfrog) and, on a **bitset block**,
+    /// answers with a single bit-test — no decode. A PACKED block is
+    /// decoded once (cached via `decoded_block`) and binary-searched. Used
+    /// only by the count leapfrog; it moves `current_block`, so a cursor
+    /// probed with `contains` must not also be iterated.
+    pub(super) fn contains(&mut self, doc: u32) -> bool {
+        while self.current_block < self.blocks.len()
+            && self.blocks[self.current_block].last_doc_id < doc
+        {
+            self.current_block += 1;
+        }
+        if self.current_block >= self.blocks.len() {
+            return false;
+        }
+        // Inline (df=1) cursor: single pre-decoded doc, no postings bytes.
+        if self.bytes.is_empty() {
+            return self.block_n > 0 && self.block_doc_ids[0] == doc;
+        }
+        let block = self.blocks[self.current_block];
+        let raw = self
+            .bytes
+            .slice(block.block_byte_offset..block.block_byte_end);
+        let raw = raw.as_ref();
+        if raw[posting::ENCODING_OFF] == posting::ENCODING_BITSET {
+            let base = read_u32_le(&raw[4..8]);
+            if doc < base {
+                return false;
+            }
+            let bit = (doc - base) as usize;
+            let tfs_size = BLOCK_LEN * raw[2] as usize / 8;
+            let bitset_end = raw.len() - tfs_size;
+            let word_at = posting::HEADER_SIZE + (bit / 64) * 8;
+            if word_at + 8 > bitset_end {
+                return false; // past this block's presence bits ⇒ absent
+            }
+            let word = u64::from_le_bytes(raw[word_at..word_at + 8].try_into().expect("8 bytes"));
+            (word >> (bit % 64)) & 1 == 1
+        } else {
+            if self.decoded_block != self.current_block {
+                self.decode_current_block();
+            }
+            self.block_doc_ids[..self.block_n]
+                .binary_search(&doc)
+                .is_ok()
+        }
+    }
+
+    /// Materialize a `contains`-probed cursor at `doc`: ensure the current
+    /// block is decoded and `pos` points at `doc`. A membership probe
+    /// (`contains`) advances `current_block` but, on a **bitset block**,
+    /// answers by bit-test without decoding — leaving `block_doc_ids`,
+    /// `block_tfs`, and `pos` stale. The phrase position-verification path
+    /// needs the fully decoded block; this decodes it (only when the current
+    /// block isn't already decoded) and scans `pos` up to `doc`. Callers
+    /// pass a `doc` a preceding `contains(doc)` confirmed is present, arriving
+    /// in ascending order, so the forward `pos` scan always lands on it.
+    pub(super) fn materialize_at(&mut self, doc: u32) {
+        if self.decoded_block != self.current_block {
+            self.decode_current_block();
+        }
+        while self.pos < self.block_n && self.block_doc_ids[self.pos] < doc {
+            self.pos += 1;
+        }
     }
 
     pub(super) fn is_exhausted(&self) -> bool {

--- a/src/superfile/fts/reader/filter.rs
+++ b/src/superfile/fts/reader/filter.rs
@@ -117,7 +117,7 @@ mod tests {
     async fn exclude_filter_for(reader: &FtsReader, terms: &[&str]) -> ExcludeFilter {
         let column_id = reader.resolve_column_id("body").expect("column exists");
         let cursors = reader
-            .build_term_cursors(column_id, terms, None)
+            .build_term_cursors(column_id, terms, None, false)
             .await
             .expect("build cursors");
         ExcludeFilter::new(cursors)

--- a/src/superfile/fts/reader/phrase.rs
+++ b/src/superfile/fts/reader/phrase.rs
@@ -248,7 +248,7 @@ impl PhraseCursor {
             current_tf: 0,
             verify_scratch: Vec::new(),
         };
-        cursor.seek_match(0, f32::NEG_INFINITY, &NormTable::empty())?;
+        cursor.seek_match_unranked(0)?;
         Ok(cursor)
     }
 
@@ -267,7 +267,7 @@ impl PhraseCursor {
         if self.is_exhausted() || self.current_doc >= target {
             return Ok(());
         }
-        self.seek_match(target, f32::NEG_INFINITY, &NormTable::empty())
+        self.seek_match_unranked(target)
     }
 
     /// [`Self::skip_to`] for ranked walks: additionally skips docs
@@ -288,6 +288,65 @@ impl PhraseCursor {
             return Ok(());
         }
         self.seek_match(target, bar, dl_norm_k1)
+    }
+
+    /// Unranked (match/count) doc alignment: drive off the rarest member
+    /// and confirm the rest by **membership bit-test**, never decoding a
+    /// common member's block during alignment. The rarest member
+    /// (`align_order[0]`) is the only one iterated — it seeds both the
+    /// candidate doc and, later, the phrase-start positions. Every other
+    /// member answers `contains(aligned)` by a single bit-test on a dense
+    /// (bitset) block, so a common word like "the" is never PFOR/bitset-
+    /// decoded just to align a doc; its block is materialized lazily in
+    /// [`Self::verify_at_aligned`] only for the far fewer docs that survive
+    /// every rarer member. This is the count-path twin of the ranked
+    /// [`Self::seek_match`], which must keep decoding tfs for its score bar.
+    pub(super) fn seek_match_unranked(&mut self, mut from: u32) -> Result<(), FtsError> {
+        let driver = self.align_order[0];
+        'docs: loop {
+            // Advance the rarest member; it alone drives the candidate doc.
+            {
+                let d = &mut self.members[driver].cursor;
+                d.skip_to(from);
+                if d.is_exhausted() {
+                    self.current_doc = u32::MAX;
+                    self.current_tf = 0;
+                    return Ok(());
+                }
+            }
+            let aligned = self.members[driver].cursor.current_doc_id();
+            // Every other member must contain `aligned` — a bit-test on a
+            // dense block, no decode. A miss advances the driver past it.
+            for oi in 1..self.align_order.len() {
+                let mi = self.align_order[oi];
+                if !self.members[mi].cursor.contains(aligned) {
+                    from = match aligned.checked_add(1) {
+                        Some(next) => next,
+                        None => {
+                            self.current_doc = u32::MAX;
+                            self.current_tf = 0;
+                            return Ok(());
+                        }
+                    };
+                    continue 'docs;
+                }
+            }
+            // Verify adjacency; the probed members are decoded here, lazily.
+            let tf = self.verify_at_aligned(aligned)?;
+            if tf > 0 {
+                self.current_doc = aligned;
+                self.current_tf = tf;
+                return Ok(());
+            }
+            from = match aligned.checked_add(1) {
+                Some(next) => next,
+                None => {
+                    self.current_doc = u32::MAX;
+                    self.current_tf = 0;
+                    return Ok(());
+                }
+            };
+        }
     }
 
     /// Leapfrog the members to their next common doc ≥ `from`, verify
@@ -353,7 +412,7 @@ impl PhraseCursor {
             }
 
             // Verify adjacency at the aligned doc.
-            let tf = self.verify_at_aligned()?;
+            let tf = self.verify_at_aligned(aligned)?;
             if tf > 0 {
                 self.current_doc = aligned;
                 self.current_tf = tf;
@@ -375,7 +434,7 @@ impl PhraseCursor {
     /// first member's positions `p` where member `i` also has `p + i`
     /// for every `i`. Member position lists are ascending, so each
     /// probe is a binary search over a per-doc-tf-sized slice.
-    pub(super) fn verify_at_aligned(&mut self) -> Result<u32, FtsError> {
+    pub(super) fn verify_at_aligned(&mut self, aligned: u32) -> Result<u32, FtsError> {
         // Staged, rarest-first, lazy-decode verification. A phrase match
         // starting at position `s` has member `j` at `s + j`, so any
         // member can seed the candidate starts: the rarest member (by
@@ -391,8 +450,14 @@ impl PhraseCursor {
         //     On the huge co-occurrence sets a phrase with a common word
         //     produces, almost every doc is rejected by a rare member
         //     first, so the common members are never decoded there.
+        //
+        // `materialize_at` decodes each member's block only now: on the
+        // unranked path a common member reached `aligned` by a `contains`
+        // bit-test and its block is not yet decoded; on the ranked path it
+        // was already decoded by `skip_to`, so this is a no-op there.
         let anchor = self.align_order[0];
         let anchor_off = anchor as u32;
+        self.members[anchor].cursor.materialize_at(aligned);
         self.members[anchor].decode_current_positions()?;
         self.verify_scratch.clear();
         for &pa in &self.members[anchor].pos_scratch {
@@ -405,6 +470,7 @@ impl PhraseCursor {
                 break;
             }
             let j = self.align_order[oi];
+            self.members[j].cursor.materialize_at(aligned);
             self.members[j].decode_current_positions()?;
             let plist = &self.members[j].pos_scratch;
             let off = j as u32;

--- a/src/superfile/fts/reader/phrase.rs
+++ b/src/superfile/fts/reader/phrase.rs
@@ -290,18 +290,22 @@ impl PhraseCursor {
         self.seek_match(target, bar, dl_norm_k1)
     }
 
-    /// Unranked (match/count) doc alignment: drive off the rarest member
-    /// and confirm the rest by **membership bit-test**, never decoding a
-    /// common member's block during alignment. The rarest member
-    /// (`align_order[0]`) is the only one iterated — it seeds both the
-    /// candidate doc and, later, the phrase-start positions. Every other
-    /// member answers `contains(aligned)` by a single bit-test on a dense
-    /// (bitset) block, so a common word like "the" is never PFOR/bitset-
-    /// decoded just to align a doc; its block is materialized lazily in
-    /// [`Self::verify_at_aligned`] only for the far fewer docs that survive
-    /// every rarer member. This is the count-path twin of the ranked
-    /// [`Self::seek_match`], which must keep decoding tfs for its score bar.
-    pub(super) fn seek_match_unranked(&mut self, mut from: u32) -> Result<(), FtsError> {
+    /// Approximate seek (the cheap half of a two-phase phrase): advance to the
+    /// next doc ≥ `from` that contains **every member** — the members'
+    /// doc-intersection — **without** verifying adjacency or decoding any
+    /// positions. Drives off the rarest member (`align_order[0]`, the only one
+    /// iterated) and confirms the rest by `contains` bit-test on their dense
+    /// blocks, so a common word like "the" is never decoded just to align a
+    /// doc. Sets `current_doc` to that doc (`u32::MAX` when exhausted) and
+    /// leaves `current_tf` at 0 — the doc is a *candidate*, not yet a verified
+    /// phrase match.
+    ///
+    /// An AND atom walk aligns on this approximation across all atoms (so a
+    /// rare co-clause prunes the candidate set first) and only then asks
+    /// [`Self::verify_at_aligned`] to decode positions on the survivors. On its
+    /// own, `approx_seek` + a `verify_at_aligned` retry loop is exactly
+    /// [`Self::seek_match_unranked`].
+    pub(super) fn approx_seek(&mut self, mut from: u32) {
         let driver = self.align_order[0];
         'docs: loop {
             // Advance the rarest member; it alone drives the candidate doc.
@@ -311,7 +315,7 @@ impl PhraseCursor {
                 if d.is_exhausted() {
                     self.current_doc = u32::MAX;
                     self.current_tf = 0;
-                    return Ok(());
+                    return;
                 }
             }
             let aligned = self.members[driver].cursor.current_doc_id();
@@ -320,32 +324,49 @@ impl PhraseCursor {
             for oi in 1..self.align_order.len() {
                 let mi = self.align_order[oi];
                 if !self.members[mi].cursor.contains(aligned) {
-                    from = match aligned.checked_add(1) {
-                        Some(next) => next,
+                    match aligned.checked_add(1) {
+                        Some(next) => from = next,
                         None => {
                             self.current_doc = u32::MAX;
                             self.current_tf = 0;
-                            return Ok(());
+                            return;
                         }
-                    };
+                    }
                     continue 'docs;
                 }
             }
+            self.current_doc = aligned;
+            self.current_tf = 0;
+            return;
+        }
+    }
+
+    /// Unranked (match/count) doc alignment to the next *verified* phrase match
+    /// ≥ `from`: the approximate member-intersection ([`Self::approx_seek`])
+    /// followed by adjacency verification, retrying at the next candidate until
+    /// one verifies or the members exhaust. The count-path twin of the ranked
+    /// [`Self::seek_match`], which must keep decoding tfs for its score bar.
+    pub(super) fn seek_match_unranked(&mut self, mut from: u32) -> Result<(), FtsError> {
+        loop {
+            self.approx_seek(from);
+            if self.current_doc == u32::MAX {
+                return Ok(());
+            }
+            let aligned = self.current_doc;
             // Verify adjacency; the probed members are decoded here, lazily.
             let tf = self.verify_at_aligned(aligned)?;
             if tf > 0 {
-                self.current_doc = aligned;
                 self.current_tf = tf;
                 return Ok(());
             }
-            from = match aligned.checked_add(1) {
-                Some(next) => next,
+            match aligned.checked_add(1) {
+                Some(next) => from = next,
                 None => {
                     self.current_doc = u32::MAX;
                     self.current_tf = 0;
                     return Ok(());
                 }
-            };
+            }
         }
     }
 
@@ -549,6 +570,41 @@ impl AnyCursor {
                 Ok(())
             }
             AnyCursor::Phrase(c) => c.skip_to(target),
+        }
+    }
+
+    /// Two-phase alignment for the AND walk: advance to the atom's next
+    /// *candidate* doc ≥ `target` without paying for a phrase's positions. A
+    /// term atom is exact (its doc *is* a match); a phrase atom advances to the
+    /// next doc holding all its members ([`PhraseCursor::approx_seek`]), leaving
+    /// adjacency for [`Self::verify_at`]. Pairs with [`Self::approx_current_doc`].
+    pub(super) fn approx_skip_to(&mut self, target: u32) {
+        match self {
+            AnyCursor::Term(c) => c.skip_to(target),
+            AnyCursor::Phrase(c) => c.approx_seek(target),
+        }
+    }
+
+    /// The atom's current *candidate* doc (see [`Self::approx_skip_to`]): a term
+    /// atom's decoded doc, or a phrase atom's member-aligned doc (`u32::MAX`
+    /// when exhausted).
+    pub(super) fn approx_current_doc(&self) -> u32 {
+        match self {
+            AnyCursor::Term(c) => c.current_doc_id(),
+            AnyCursor::Phrase(c) => c.current_doc,
+        }
+    }
+
+    /// Confirm the atom actually matches at `doc` — the doc its approximation
+    /// has already reached. A term atom trivially matches; a phrase atom decodes
+    /// positions and checks adjacency ([`PhraseCursor::verify_at_aligned`]). The
+    /// expensive half of the two-phase split, run by the AND walk only on docs
+    /// where every atom's approximation agrees, so a rare co-clause prunes the
+    /// position work.
+    pub(super) fn verify_at(&mut self, doc: u32) -> Result<bool, FtsError> {
+        match self {
+            AnyCursor::Term(_) => Ok(true),
+            AnyCursor::Phrase(c) => Ok(c.verify_at_aligned(doc)? > 0),
         }
     }
 

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -17,7 +17,10 @@ use super::{
         AndSink, CollectSink, CountSink, MustShouldSink, ScoreSink, TopKEntry, drain_top_k_desc,
     },
 };
-use crate::superfile::{error::FtsError, fts::bm25};
+use crate::superfile::{
+    error::FtsError,
+    fts::{bm25, posting::BLOCK_LEN},
+};
 
 /// Intersection cardinality by a rarest-driven membership walk: iterate the
 /// term with the fewest blocks and count docs the others all contain. Each
@@ -45,6 +48,35 @@ fn count_and_intersect_membership(mut cursors: Vec<TermCursor>) -> u64 {
         driver.next();
     }
     n
+}
+
+/// Intersection cardinality via bitset AND: build each term's doc presence into
+/// a doc-space bitset (byte-level — a dense term's bitset blocks are word-copied,
+/// never expanded to doc ids), AND them together, and popcount. Word-parallel, so
+/// its cost is `n_terms × max_doc/64` regardless of how many docs the rarest term
+/// holds — the opposite of the rarest-driven membership walk, which iterates the
+/// rarest term doc by doc. Wins when *every* term is common (dense), where the
+/// membership driver is itself a long list. `max_doc` is the largest doc id
+/// across the terms, so `acc`/`scratch` span every term's presence.
+fn count_and_intersect_bitset(cursors: Vec<TermCursor>, max_doc: u32) -> u64 {
+    let words = max_doc as usize / 64 + 1;
+    let mut acc = vec![0u64; words];
+    let mut scratch = vec![0u64; words];
+    let mut decode = [0u32; BLOCK_LEN];
+    let mut cursors = cursors.iter();
+    // The first term seeds the accumulator; the rest AND their presence in.
+    let Some(first) = cursors.next() else {
+        return 0;
+    };
+    or_cursor_into_bitset(&mut acc, first, &mut decode);
+    for c in cursors {
+        scratch.iter_mut().for_each(|w| *w = 0);
+        or_cursor_into_bitset(&mut scratch, c, &mut decode);
+        for (a, s) in acc.iter_mut().zip(scratch.iter()) {
+            *a &= *s;
+        }
+    }
+    acc.iter().map(|w| w.count_ones() as u64).sum()
 }
 
 impl FtsReader {
@@ -434,10 +466,29 @@ impl FtsReader {
         }
         // On a v4 blob a common term's blocks may be bitset-encoded, where
         // decoding (set-bit expansion) is slower than the PFOR path the
-        // flat-merge assumes. Drive the intersection by the rarest term and
-        // probe the rest by membership instead: a bitset block answers with
-        // an O(1) bit-test — no decode. See `count_and_intersect_membership`.
+        // flat-merge assumes.
         if self.has_bitset_blocks {
+            // When even the *rarest* term is dense (covers ≥ 1/DIVISOR of the
+            // corpus), the rarest-driven membership walk still iterates a long
+            // list. AND the terms' presence bitsets word-at-a-time instead —
+            // cost is independent of the terms' lengths. The two full-width
+            // bitsets it allocates only pay off at this density, so a sparser
+            // intersection keeps the membership probe.
+            if cursors.len() >= 2 {
+                let max_doc = cursors
+                    .iter()
+                    .filter_map(|c| c.blocks.last())
+                    .map(|b| b.last_doc_id)
+                    .max()
+                    .unwrap_or(0);
+                let min_df = cursors.iter().map(|c| c.df).min().unwrap_or(0);
+                if min_df.saturating_mul(OR_COUNT_BITSET_DENSITY_DIVISOR) >= u64::from(max_doc) {
+                    return count_and_intersect_bitset(cursors, max_doc);
+                }
+            }
+            // Rarest term is sparse: drive by it and probe the rest by
+            // membership — a bitset block answers with an O(1) bit-test, no
+            // decode. See `count_and_intersect_membership`.
             return count_and_intersect_membership(cursors);
         }
         let col_meta = &self.columns[column_id as usize];

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -19,6 +19,34 @@ use super::{
 };
 use crate::superfile::{error::FtsError, fts::bm25};
 
+/// Intersection cardinality by a rarest-driven membership walk: iterate the
+/// term with the fewest blocks and count docs the others all contain. Each
+/// membership probe is `TermCursor::contains`, which bit-tests a bitset
+/// block with no decode — so a common (bitset) term's blocks are never
+/// expanded. Used for `v4` blobs; the flat-merge stays for `v1`–`v3`, where
+/// every block is PFOR and the sorted merge over decoded blocks is faster.
+fn count_and_intersect_membership(mut cursors: Vec<TermCursor>) -> u64 {
+    // Drive by the rarest term (fewest blocks) to minimise membership
+    // probes. Ties don't matter; any driver yields the same count.
+    let driver_idx = cursors
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, c)| c.block_count())
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    let mut driver = cursors.swap_remove(driver_idx);
+    let mut others = cursors;
+    let mut n = 0u64;
+    while !driver.is_exhausted() {
+        let doc = driver.current_doc_id();
+        if others.iter_mut().all(|o| o.contains(doc)) {
+            n += 1;
+        }
+        driver.next();
+    }
+    n
+}
+
 impl FtsReader {
     /// Multi-term OR via WAND + BlockMaxWAND.
     ///
@@ -403,6 +431,14 @@ impl FtsReader {
     pub(super) fn count_and_intersect(&self, column_id: u32, mut cursors: Vec<TermCursor>) -> u64 {
         if cursors.is_empty() {
             return 0;
+        }
+        // On a v4 blob a common term's blocks may be bitset-encoded, where
+        // decoding (set-bit expansion) is slower than the PFOR path the
+        // flat-merge assumes. Drive the intersection by the rarest term and
+        // probe the rest by membership instead: a bitset block answers with
+        // an O(1) bit-test — no decode. See `count_and_intersect_membership`.
+        if self.has_bitset_blocks {
+            return count_and_intersect_membership(cursors);
         }
         let col_meta = &self.columns[column_id as usize];
         let dl_norm_k1 = &col_meta.dl_norm_k1;

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1481,7 +1481,9 @@ impl FtsReader {
         if terms.is_empty() || k == 0 {
             return Ok(Vec::new());
         }
-        let cursors = self.build_term_cursors(column_id, terms, None).await?;
+        let cursors = self
+            .build_term_cursors(column_id, terms, None, false)
+            .await?;
         if cursors.is_empty() {
             return Ok(Vec::new());
         }
@@ -1727,7 +1729,7 @@ mod tests {
         let col = r.resolve_column_id("body").expect("col");
         let uniform_terms: &[&str] = &["zeta", "eta", "theta"];
         let uniform_cursors = r
-            .build_term_cursors(col, uniform_terms, None)
+            .build_term_cursors(col, uniform_terms, None, false)
             .await
             .expect("uniform cursors");
         assert!(
@@ -1795,11 +1797,11 @@ mod tests {
         for terms in shapes {
             for k in [1usize, 5, 50, 128] {
                 let cw = r
-                    .build_term_cursors(col, terms, None)
+                    .build_term_cursors(col, terms, None, false)
                     .await
                     .expect("cursors");
                 let cb = r
-                    .build_term_cursors(col, terms, None)
+                    .build_term_cursors(col, terms, None, false)
                     .await
                     .expect("cursors");
                 let wand = r.run_wand_bmw(col, cw, k).expect("wand");
@@ -1844,7 +1846,7 @@ mod tests {
 
         // common (df≈N) + rare (df≈N/200): ratio 200 ≥ 16 → anchor.
         let anchored = r
-            .build_term_cursors(col, &["common", "rare"], None)
+            .build_term_cursors(col, &["common", "rare"], None, false)
             .await
             .expect("cursors");
         assert!(
@@ -1853,7 +1855,7 @@ mod tests {
         );
         // common (df≈N) + frequent (df≈N/2): ratio 2 < 16 → no anchor.
         let uniform = r
-            .build_term_cursors(col, &["common", "frequent"], None)
+            .build_term_cursors(col, &["common", "frequent"], None, false)
             .await
             .expect("cursors");
         assert!(
@@ -1962,14 +1964,14 @@ mod tests {
         for (pos, neg) in cases {
             for k in [1usize, 5, 50] {
                 let mut wf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None)
+                    r.build_term_cursors(col, neg, None, false)
                         .await
                         .expect("neg cursors"),
                 );
                 let win = r
                     .run_windowed_union(
                         col,
-                        r.build_term_cursors(col, pos, None)
+                        r.build_term_cursors(col, pos, None, false)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -1980,14 +1982,14 @@ mod tests {
                     )
                     .expect("windowed");
                 let mut bf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None)
+                    r.build_term_cursors(col, neg, None, false)
                         .await
                         .expect("neg cursors"),
                 );
                 let bmm = r
                     .run_max_score_bmm(
                         col,
-                        r.build_term_cursors(col, pos, None)
+                        r.build_term_cursors(col, pos, None, false)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -2017,7 +2019,9 @@ mod tests {
         let unfiltered = r
             .run_windowed_union(
                 col,
-                r.build_term_cursors(col, pos, None).await.expect("pos"),
+                r.build_term_cursors(col, pos, None, false)
+                    .await
+                    .expect("pos"),
                 N_DOCS as usize,
                 None,
                 f32::NEG_INFINITY,
@@ -2025,11 +2029,17 @@ mod tests {
                 u32::MAX,
             )
             .expect("unfiltered");
-        let mut f = ExcludeFilter::new(r.build_term_cursors(col, neg, None).await.expect("neg"));
+        let mut f = ExcludeFilter::new(
+            r.build_term_cursors(col, neg, None, false)
+                .await
+                .expect("neg"),
+        );
         let filtered = r
             .run_windowed_union(
                 col,
-                r.build_term_cursors(col, pos, None).await.expect("pos"),
+                r.build_term_cursors(col, pos, None, false)
+                    .await
+                    .expect("pos"),
                 N_DOCS as usize,
                 Some(&mut f),
                 f32::NEG_INFINITY,

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -412,7 +412,7 @@ impl FtsReader {
             // Negatives are a hard exclusion filter, not scored, so their
             // idf is irrelevant — always build them with local stats.
             _ => Some(ExcludeFilter::new(
-                self.build_term_cursors(column_id, lists.negatives, None)
+                self.build_term_cursors(column_id, lists.negatives, None, false)
                     .await?,
             )),
         };
@@ -453,7 +453,7 @@ impl FtsReader {
 
         if lists.musts.is_empty() {
             let cursors = self
-                .build_term_cursors(column_id, lists.shoulds, lists.global_idf)
+                .build_term_cursors(column_id, lists.shoulds, lists.global_idf, false)
                 .await?;
             dict_ranges += 1;
             if cursors.is_empty() {
@@ -479,7 +479,7 @@ impl FtsReader {
         // Build must cursors; if any must is missing, the
         // intersection is empty.
         let must_cursors = self
-            .build_term_cursors(column_id, lists.musts, lists.global_idf)
+            .build_term_cursors(column_id, lists.musts, lists.global_idf, false)
             .await?;
         dict_ranges += 1;
         if must_cursors.len() != lists.musts.len() {
@@ -508,7 +508,7 @@ impl FtsReader {
         // Shoulds absent from this superfile contribute nothing;
         // when none survive, the walk is a plain must intersection.
         let should_cursors = self
-            .build_term_cursors(column_id, lists.shoulds, lists.global_idf)
+            .build_term_cursors(column_id, lists.shoulds, lists.global_idf, false)
             .await?;
         dict_ranges += 1;
         if should_cursors.is_empty() {
@@ -651,7 +651,7 @@ impl FtsReader {
         let cursors = if terms.is_empty() {
             Vec::new()
         } else {
-            self.build_term_cursors(column_id, terms, global_idf)
+            self.build_term_cursors(column_id, terms, global_idf, false)
                 .await?
         };
         Ok(OrCursorSet { column_id, cursors })
@@ -919,6 +919,7 @@ impl FtsReader {
         column_id: u32,
         terms: &[&str],
         global_idf: Option<&GlobalTermIdf>,
+        count_only: bool,
     ) -> Result<Vec<TermCursor>, FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
         let dict = DictReader::open(&fst_bytes).map_err(|e| {
@@ -1015,6 +1016,7 @@ impl FtsReader {
                         col_meta.positions,
                         gidf,
                         header_probed,
+                        count_only,
                     )?);
                 }
             }
@@ -1369,7 +1371,7 @@ mod tests {
         ];
         let column_id = r.resolve_column_id("body").expect("column");
         let uniform_cursors = r
-            .build_term_cursors(column_id, shapes[0], None)
+            .build_term_cursors(column_id, shapes[0], None, false)
             .await
             .expect("cursors");
         assert!(
@@ -1377,7 +1379,7 @@ mod tests {
             "uniform shape must route to the windowed ranged branch"
         );
         let dominant_cursors = r
-            .build_term_cursors(column_id, shapes[1], None)
+            .build_term_cursors(column_id, shapes[1], None, false)
             .await
             .expect("cursors");
         assert!(

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -385,6 +385,61 @@ fn corrupt_fts_position_subindex_rejected() {
     assert_corruption_rejected(bytes, subindex_start + 1, "fts/position sub-index");
 }
 
+#[test]
+fn corrupt_fts_bitset_block_rejected() {
+    // The dense fixture (every doc shares the same terms) stores those common
+    // terms' postings as BITSET blocks — a new on-disk shape. Those bytes ride
+    // inside the already-CRC-protected postings region; this pins that a flip
+    // inside a bitset block's presence bitmap is caught at open, the bitset-block
+    // twin of `corrupt_fts_position_subindex_rejected`.
+    let bytes = build_corruptable_superfile();
+    let (fts_off, _) = locate_fts_blob_only(&bytes);
+    // Dense corpus ⇒ a v4 blob with at least one bitset block.
+    let version = u32::from_le_bytes(
+        bytes[fts_off + 8..fts_off + 12]
+            .try_into()
+            .expect("version bytes"),
+    );
+    assert_eq!(
+        version, 4,
+        "dense corpus must embed a v4 FTS blob (bitset blocks)"
+    );
+    // postings_offset (relative to the blob) at FTS header bytes [+32..+40].
+    let postings_offset_rel = u64::from_le_bytes(
+        bytes[fts_off + 32..fts_off + 40]
+            .try_into()
+            .expect("postings offset"),
+    ) as usize;
+    let term0 = fts_off + postings_offset_rel;
+    // A term is `[meta][skip table][blocks]`; the first block's offset *within
+    // the term* is recorded in skip entry 0's block-offset field, so read it
+    // directly instead of re-deriving the skip-table size. Non-positional term
+    // meta is 20 B (`TERM_META_SIZE`); a skip entry's block-offset u32 sits at
+    // its offset 4 (`BLOCK_OFFSET_OFF`).
+    const TERM_META: usize = 20;
+    const SKIP_BLOCK_OFFSET_FIELD: usize = 4;
+    let block0_off_in_term = u32::from_le_bytes(
+        bytes[term0 + TERM_META + SKIP_BLOCK_OFFSET_FIELD
+            ..term0 + TERM_META + SKIP_BLOCK_OFFSET_FIELD + 4]
+            .try_into()
+            .expect("block offset"),
+    ) as usize;
+    let block0 = term0 + block0_off_in_term;
+    // Block header byte 3 is the encoding (`ENCODING_BITSET == 1`). Assert the
+    // first postings term's block really is a bitset — both a fixture sanity
+    // check and proof the flip below lands in a presence bitmap, not a PFOR block.
+    const ENCODING_OFF: usize = 3;
+    const ENCODING_BITSET: u8 = 1;
+    const BLOCK_HEADER: usize = 8;
+    assert_eq!(
+        bytes[block0 + ENCODING_OFF],
+        ENCODING_BITSET,
+        "first postings term's block must be bitset-encoded on this dense corpus"
+    );
+    // Flip a byte in the presence bitmap, just past the 8-byte block header.
+    assert_corruption_rejected(bytes, block0 + BLOCK_HEADER, "fts/bitset block presence");
+}
+
 /// FTS blob range only (the positional fixture has no vector blob, so
 /// `locate_blobs` — which insists on both — doesn't apply).
 fn locate_fts_blob_only(bytes: &[u8]) -> (usize, usize) {

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -308,7 +308,7 @@ fn corruption_at_random_interior_positions_rejected() {
 
 #[test]
 fn corrupt_fts_positions_region_rejected() {
-    // v3 blob: the positions-region offset lives at header bytes
+    // v4 blob: the positions-region offset lives at header bytes
     // [48..56] (relative to the blob). Flip a byte inside the region
     // body — the multi-doc terms guarantee it is non-empty.
     let bytes = build_corruptable_positional_superfile();
@@ -319,8 +319,8 @@ fn corrupt_fts_positions_region_rejected() {
             .expect("version bytes"),
     );
     assert_eq!(
-        version, 3,
-        "positional superfile must embed a v3 FTS blob (positions sub-index)"
+        version, 4,
+        "positional superfile must embed a v4 FTS blob (dense corpus ⇒ bitset blocks)"
     );
     let positions_off_rel = u64::from_le_bytes(
         bytes[fts_off + 48..fts_off + 56]
@@ -342,10 +342,10 @@ fn corrupt_fts_positions_region_rejected() {
 
 #[test]
 fn uncorrupted_positional_superfile_opens() {
-    // Sanity twin of the corruption test: the same v3 bytes open
+    // Sanity twin of the corruption test: the same v4 bytes open
     // cleanly when untouched.
     let bytes = build_corruptable_positional_superfile();
-    SuperfileReader::open(Bytes::from(bytes)).expect("clean v3 superfile opens");
+    SuperfileReader::open(Bytes::from(bytes)).expect("clean v4 superfile opens");
 }
 
 #[test]

--- a/tests/superfile/fts/negation.rs
+++ b/tests/superfile/fts/negation.rs
@@ -400,3 +400,147 @@ async fn negation_with_multi_block_negated_list() {
         .collect();
     assert_eq!(got, want, "alpha minus beta over multi-block postings");
 }
+
+// ── negation over a dense (bitset-encoded) corpus ─────────────────────
+
+/// A few-thousand-doc corpus where the common terms and the phrase members are
+/// stored as BITSET blocks and the phrase AND is two-phase. `the`/`who` are in
+/// every doc (not adjacent); `"the who"` is planted on every 13th doc, `uk` on
+/// every 40th, `even` on every 2nd (a dense negation target), `tri` on every
+/// 3rd. Truth comes from the whitespace-token helpers, independent of the reader.
+fn dense_negation_corpus() -> Vec<(u64, String)> {
+    const N: u64 = 2600;
+    (0..N)
+        .map(|d| {
+            let mut s = format!("who a{d} the b{d}");
+            if d.is_multiple_of(13) {
+                s = format!("the who {s}");
+            }
+            if d.is_multiple_of(40) {
+                s.push_str(" uk");
+            }
+            if d.is_multiple_of(2) {
+                s.push_str(" even");
+            }
+            if d.is_multiple_of(3) {
+                s.push_str(" tri");
+            }
+            (d, s)
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn count_negation_over_dense_bitset_corpus() {
+    // Negation composes with the bitset count kernels and the two-phase phrase
+    // AND through the skip-probe exclude filter. Pin that a -term and a
+    // -"phrase" still exclude exactly, at a scale where the positives, the
+    // negatives, and the phrase members are all bitset-encoded.
+    let owned = dense_negation_corpus();
+    let corp: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile_positional(&corp);
+
+    async fn cnt(
+        r: &SuperfileReader,
+        terms: &[&str],
+        phrases: &[Vec<String>],
+        mode: BoolMode,
+        neg_terms: &[&str],
+        neg_phrases: &[Vec<String>],
+    ) -> u64 {
+        r.atoms_match_count("title", terms, phrases, mode, neg_terms, neg_phrases)
+            .await
+            .expect("atoms_match_count")
+            .0
+    }
+
+    let who_phrase = docs_with_phrase(&corp, &["the", "who"]);
+    let uk = docs_with(&corp, "uk");
+
+    // -term over a bitset negated list: +the -even ⇒ the odd docs.
+    let exp = exclude(docs_with(&corp, "the"), &corp, &["even"]);
+    assert_eq!(
+        cnt(&r, &["the"], &[], BoolMode::And, &["even"], &[]).await,
+        exp.len() as u64,
+        "the -even"
+    );
+
+    // Multiple negatives (bitset + packed): +the -even -tri.
+    let exp = exclude(docs_with(&corp, "the"), &corp, &["even", "tri"]);
+    assert_eq!(
+        cnt(&r, &["the"], &[], BoolMode::And, &["even", "tri"], &[]).await,
+        exp.len() as u64,
+        "the -even -tri"
+    );
+
+    // -"phrase" with bitset members: +uk -"the who".
+    let exp: HashSet<u64> = uk.difference(&who_phrase).copied().collect();
+    assert_eq!(
+        cnt(
+            &r,
+            &["uk"],
+            &[],
+            BoolMode::And,
+            &[],
+            &phrase(&["the", "who"])
+        )
+        .await,
+        exp.len() as u64,
+        "uk -\"the who\""
+    );
+
+    // Two-phase phrase AND minus a bitset term: +"the who" +uk -even.
+    let phrase_and_uk: HashSet<u64> = who_phrase.intersection(&uk).copied().collect();
+    let exp = exclude(phrase_and_uk, &corp, &["even"]);
+    assert_eq!(
+        cnt(
+            &r,
+            &["uk"],
+            &phrase(&["the", "who"]),
+            BoolMode::And,
+            &["even"],
+            &[]
+        )
+        .await,
+        exp.len() as u64,
+        "+\"the who\" +uk -even"
+    );
+
+    // OR positives minus the phrase: the who -"the who".
+    let exp: HashSet<u64> = or_match(&corp, &["the", "who"])
+        .difference(&who_phrase)
+        .copied()
+        .collect();
+    assert_eq!(
+        cnt(
+            &r,
+            &["the", "who"],
+            &[],
+            BoolMode::Or,
+            &[],
+            &phrase(&["the", "who"])
+        )
+        .await,
+        exp.len() as u64,
+        "the who -\"the who\""
+    );
+}
+
+#[tokio::test]
+async fn search_negation_with_phrase_over_dense_bitset_corpus() {
+    // The scored path with a negated clause over bitset-encoded phrase members.
+    // A narrow positive (`+"the who" +uk`, a handful of docs) keeps the result
+    // set below `k`, so top-k truncation can't hide a disagreement.
+    let owned = dense_negation_corpus();
+    let corp: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile_positional(&corp);
+
+    let got = search_set(&r, r#"+"the who" +uk -tri"#, K_ALL, BoolMode::And).await;
+    let phrase_and_uk: HashSet<u64> = docs_with_phrase(&corp, &["the", "who"])
+        .intersection(&docs_with(&corp, "uk"))
+        .copied()
+        .collect();
+    let want = exclude(phrase_and_uk, &corp, &["tri"]);
+    assert!(!want.is_empty(), "corpus must plant some matches");
+    assert_eq!(got, want, "+\"the who\" +uk -tri (scored, dense/bitset)");
+}

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -374,3 +374,61 @@ async fn unranked_ids_and_count_agree_with_oracle() {
         }
     }
 }
+
+/// A phrase of common words AND'd with a rare term: the AND walk aligns on the
+/// phrase's cheap member-approximation and verifies adjacency only where the
+/// rare term also lands. This pins that the two-phase split stays exact — a doc
+/// matches iff it holds the rare term AND the contiguous phrase — across every
+/// tricky case: phrase-adjacent-but-no-rare-term (pruned), rare-term-with-
+/// members-present-but-not-adjacent (rejected at verify), and rare-term-only.
+#[tokio::test]
+async fn phrase_and_rare_term_two_phase_agrees() {
+    // "the"/"who" are in most docs; "uk" in a few. Only docs with BOTH the
+    // contiguous phrase "the who" and "uk" may match.
+    let refs: Vec<(u64, &str)> = vec![
+        (0, "the who played in the uk last year"), // "the who" adjacent + uk  -> MATCH
+        (1, "the who reunion tour"),               // "the who" adjacent, no uk -> prune
+        (2, "who owns the uk media"),              // members + uk, not adjacent -> reject
+        (3, "the band who toured the uk"),         // members + uk, not adjacent -> reject
+        (4, "uk weather today"),                   // uk only, no phrase       -> no match
+        (5, "the who the who in the uk"),          // two "the who" starts + uk -> MATCH
+        (6, "nothing relevant here at all"),       // neither                  -> no match
+    ];
+    let r = build_infino_superfile_positional(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+
+    let terms = vec!["uk"];
+    let phrases = vec![vec!["the".to_string(), "who".to_string()]];
+    let owned_terms: Vec<String> = terms.iter().map(|t| t.to_string()).collect();
+
+    let want: HashSet<u64> = oracle
+        .top_k_atoms(&owned_terms, &phrases, &[], &[], &[], &[], refs.len())
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+    assert_eq!(
+        want,
+        HashSet::from([0, 5]),
+        "oracle sanity for +\"the who\" +uk"
+    );
+
+    let ids = r
+        .atoms_match_ids("title", &terms, &phrases, BoolMode::And)
+        .await
+        .expect("atoms_match_ids")
+        .0;
+    let got: HashSet<u64> = ids.into_iter().map(u64::from).collect();
+    assert_eq!(got, want, "two-phase AND ids for phrase + rare term");
+
+    let count = r
+        .atoms_match_count("title", &terms, &phrases, BoolMode::And, &[], &[])
+        .await
+        .expect("atoms_match_count")
+        .0;
+    assert_eq!(
+        count as usize,
+        want.len(),
+        "two-phase AND count for phrase + rare term"
+    );
+}

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -432,3 +432,70 @@ async fn phrase_and_rare_term_two_phase_agrees() {
         "two-phase AND count for phrase + rare term"
     );
 }
+
+/// The two-phase phrase AND at scale, where the phrase members are **dense**
+/// and therefore BITSET-encoded (the shape the optimization exists for). The
+/// small corpus above keeps members in single PACKED/inline blocks; here `the`
+/// and `who` appear in every one of a few thousand docs, so their posting lists
+/// are stored as bitset blocks. That exercises the path the small test can't:
+/// `approx_seek` confirming a member by `contains` bit-test on a bitset block
+/// (no decode), then `verify_at_aligned` → `materialize_at` decoding that same
+/// bitset block only for the aligned survivors. Cross-checked against the
+/// brute-force oracle for ids and count.
+#[tokio::test]
+async fn two_phase_phrase_with_dense_bitset_members_agrees() {
+    // Every doc holds `who` and `the` (dense ⇒ bitset members) but not adjacent
+    // as "the who"; the phrase is planted only on every 13th doc, and the rare
+    // co-term `uk` on every 40th. A doc matches `+"the who" +uk` iff both land,
+    // i.e. every lcm(13,40)=520th doc.
+    const N_DOCS: u64 = 2600;
+    const PHRASE_STRIDE: u64 = 13;
+    const UK_STRIDE: u64 = 40;
+    let owned: Vec<(u64, String)> = (0..N_DOCS)
+        .map(|d| {
+            // Base: `who` and `the` present but separated ⇒ no "the who".
+            let mut s = format!("who a{d} the b{d}");
+            if d.is_multiple_of(PHRASE_STRIDE) {
+                // Plant an adjacent "the who" at the front.
+                s = format!("the who {s}");
+            }
+            if d.is_multiple_of(UK_STRIDE) {
+                s.push_str(" uk");
+            }
+            (d, s)
+        })
+        .collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile_positional(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+
+    let terms = vec!["uk"];
+    let phrases = vec![vec!["the".to_string(), "who".to_string()]];
+    let owned_terms: Vec<String> = terms.iter().map(|t| t.to_string()).collect();
+
+    let want: HashSet<u64> = oracle
+        .top_k_atoms(&owned_terms, &phrases, &[], &[], &[], &[], refs.len())
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+    // Independent structural expectation: multiples of lcm(13, 40) = 520.
+    let expected: HashSet<u64> = (0..N_DOCS).filter(|d| d.is_multiple_of(520)).collect();
+    assert_eq!(want, expected, "oracle sanity for dense +\"the who\" +uk");
+    assert!(!want.is_empty(), "corpus must plant some matches");
+
+    let ids = r
+        .atoms_match_ids("title", &terms, &phrases, BoolMode::And)
+        .await
+        .expect("atoms_match_ids")
+        .0;
+    let got: HashSet<u64> = ids.into_iter().map(u64::from).collect();
+    assert_eq!(got, want, "dense two-phase AND ids");
+
+    let count = r
+        .atoms_match_count("title", &terms, &phrases, BoolMode::And, &[], &[])
+        .await
+        .expect("atoms_match_count")
+        .0;
+    assert_eq!(count as usize, want.len(), "dense two-phase AND count");
+}


### PR DESCRIPTION
## Summary

Closes the unranked **COUNT** performance gap on a dense corpus. Four changes,
all on the same posting-list machinery — a new dense block encoding plus three
count kernels that exploit it:

1. **Dense posting blocks stored as bitsets** — a block may be a presence bitset
   instead of PFOR deltas when it is dense; membership is answered directly
   against it, often with no decode.
2. **Two-phase phrase atoms in the AND walk** — a phrase AND'd with a rarer term
   verifies positions only where the rare term lands.
3. **Bit-test membership in the df-anchored union count** — a dominant common
   term is membership-tested, not decoded.
4. **Bitset-AND intersection count** — dense intersections AND presence bitsets
   word-at-a-time instead of walking the rarest term doc by doc.

Net: **all-COUNT −44%** on a dense 5M-doc corpus vs the current release, every
query shape faster, **0 count mismatches**, and **no reindex**.

## 1. Dense blocks as bitsets

A posting block is now encoded either as today's PACKED (PFOR deltas, unchanged)
or, when dense, as a BITSET of doc presence. The header's previously reserved
byte becomes a self-describing `encoding` byte; the encoder emits BITSET only
when it does not grow the block. Three count paths exploit it:

- **Union COUNT** word-ORs BITSET blocks into the result — a common term is
  merged at memory bandwidth, never PFOR-decoded.
- **Intersection / phrase membership** answers "does this doc contain the term?"
  with a single word-load + bit-test, no decode.

### On-disk format & compatibility

The blob version is bumped and a block encoding variant added. Existing indices
**need no reindex**: older blobs contain only PACKED blocks and read unchanged;
the new reader branches per-block on the encoding byte; compaction migrates
blocks organically. An older reader cleanly refuses a newer-version blob.
Storage is neutral-or-smaller (BITSET is chosen only when no larger than the
PACKED deltas); tfs are stored identically, so scoring is byte-for-byte
unchanged.

## 2. Two-phase phrase atoms

A phrase AND'd with a rarer term (e.g. an exact phrase of two common words next
to a rare term) was pathologically slow: the AND walk advanced the phrase atom
with `skip_to`, which position-verifies to produce its next match, so it decoded
positions across the phrase's whole match set instead of only where the rare
term also lands. The phrase atom is split into an **approximation** (`approx_seek`
— next doc holding all members, by bit-test, no positions) and **verification**
(decode positions, check adjacency). The AND walk aligns every atom by its
approximation first, so a rare term prunes candidates, then verifies phrase
adjacency only on survivors. Pure-phrase and OR behavior unchanged; ranked search
untouched.

## 3. Bit-test membership in the df-anchored union count

The df-anchored disjunction count (one dominant common term plus rarer ones)
membership-tested the anchor with `skip_to`, which decodes a bitset block (~128
doc ids expanded) — and the frontier merge drags the anchor across its whole
list, so a `the ∪ x ∪ y` count decoded all of `the`. Use `contains` (bit-test,
no decode) instead — the same primitive the intersection count uses.

## 4. Bitset-AND intersection count

The intersection count drove off the rarest term and probed the rest by bit-test.
Optimal when the rarest term is sparse — but when every term is common the
rarest is still millions of docs, so the driver iterates a long list. Added a
word-parallel path for that case: build each term's presence into a doc-space
bitset (dense blocks word-copied, never expanded), AND the bitsets, popcount.
Cost is `n_terms × max_doc/64`, independent of the terms' lengths. Gated on the
rarest term being dense; sparser intersections keep the membership probe. The
byte-level fill is shared with the union count (`or_cursor_into_bitset`).

## Performance (COUNT, dense 5M-doc single superfile, min-of-runs, 0 mismatches)

Cumulative vs the current release, on the same corpus rebuilt in the new format:

| slice        | before → after            |
| ------------ | ------------------------- |
| union        | 1319 → 426 µs (**−67.7%**), P90 −67% |
| intersection | 504 → 335 µs (**−33.4%**)  |
| phrase       | 1494 → 1283 µs (**−14.1%**) |
| phrase AND rare term (worst case) | 142 → 22 ms (**−84%**) |
| all-common intersection (worst case) | 18.5 → 2.3 ms (**8×**) |
| **all COUNT**| 1196 → 670 µs (**−44.0%**), P90 −33% |

Cross-engine, this brings all-COUNT from ~1.56× the reference engine to roughly
parity. The scored top-k paths are deliberately untouched (scoring needs tfs,
unchanged) and measured flat.

## Correctness

- Brute-force FTS oracles (union / intersection / count / phrase, ranked and
  unranked) pass; added a `phrase AND rare-term` case and a dense-corpus
  `AND count` case that exercises both the bitset-AND and membership kernels
  against an independent flat-merge reference.
- Block codec round-trips both encodings over dense and sparse corpora.
- A new-reader-on-old-index A/B returns identical counts (0 mismatches).
- `make ci` (fmt, clippy, api-parity, doctest, coverage, remote) green.
