### PR TITLE
remote: send declared FTS analyzers in create_table

### DIFF
--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -68,9 +68,9 @@ impl IndexSpec {
 
     /// Mark `column` as full-text (BM25) indexed with a named analyzer
     /// (`"ascii_lower"` or `"standard"` — the Unicode-aware UAX #29
-    /// tokenizer that keeps non-ASCII text). All FTS columns in a table
-    /// must use the same analyzer; a table mixing analyzers is rejected
-    /// at [`create_table`](crate::Connection::create_table).
+    /// tokenizer that keeps non-ASCII text). Analysis is per column, so a
+    /// table may mix analyzers. An unrecognized name is rejected at
+    /// [`create_table`](crate::Connection::create_table).
     pub fn fts_with_analyzer(
         mut self,
         column: impl Into<String>,
@@ -105,6 +105,16 @@ impl IndexSpec {
     /// [`fts_columns`](Self::fts_columns)).
     pub(crate) fn fts_analyzers(&self) -> Vec<String> {
         self.fts.iter().map(|f| f.analyzer.clone()).collect()
+    }
+
+    /// FTS index declarations as `(column, analyzer)`, in declaration order.
+    /// Used by the remote transport, which needs the pair together rather
+    /// than re-zipping the two parallel name lists.
+    #[cfg(feature = "remote")]
+    pub(crate) fn fts_indexes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.fts
+            .iter()
+            .map(|f| (f.column.as_str(), f.analyzer.as_str()))
     }
 
     /// Vector index declarations as `(column, dim, metric)`, in declaration

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -17,7 +17,7 @@ use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema};
 use serde_json::{Value, json};
 
-use crate::{IndexSpec, InfinoError, Metric};
+use crate::{IndexSpec, InfinoError, Metric, superfile::fts::tokenize::ASCII_LOWER_TOKENIZER};
 
 /// Content type for an Arrow IPC streaming body — the encoding for `append`
 /// bodies and read responses.
@@ -83,13 +83,24 @@ pub(crate) fn metric_str(metric: Metric) -> &'static str {
 }
 
 /// An [`IndexSpec`] as the `indexes` object of a create-table request:
-/// `{fts: [col, …], vector: [{column, dim, metric}, …]}`. Absent index kinds
-/// are omitted (the server treats a missing key as "none").
+/// `{fts: [col | {column, analyzer}, …], vector: [{column, dim, metric}, …]}`.
+/// Absent index kinds are omitted (the server treats a missing key as "none").
+///
+/// An FTS column keeps the bare-name spelling when it uses the default
+/// analyzer, so requests stay byte-identical to those a server predating
+/// per-column analyzers accepts; only a column that declares a different
+/// analyzer takes the object form.
 pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
     let mut indexes = serde_json::Map::new();
-    let fts = spec.fts_columns();
+    let fts: Vec<Value> = spec
+        .fts_indexes()
+        .map(|(column, analyzer)| match analyzer {
+            ASCII_LOWER_TOKENIZER => json!(column),
+            other => json!({"column": column, "analyzer": other}),
+        })
+        .collect();
     if !fts.is_empty() {
-        indexes.insert("fts".to_string(), json!(fts));
+        indexes.insert("fts".to_string(), Value::Array(fts));
     }
     let vectors: Vec<Value> = spec
         .vector_indexes()
@@ -229,6 +240,8 @@ mod tests {
     use arrow_array::{Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field, FieldRef, Fields, Schema};
 
+    use crate::superfile::fts::tokenize::STANDARD_TOKENIZER;
+
     use super::*;
 
     #[test]
@@ -282,6 +295,38 @@ mod tests {
         assert_eq!(
             json["vector"][0],
             json!({"column": "embedding", "dim": 384, "metric": "cosine"})
+        );
+    }
+
+    #[test]
+    fn index_spec_json_carries_a_declared_analyzer() {
+        // A non-default analyzer must reach the server. Dropping it here
+        // indexed the column with `ascii_lower` regardless of what the caller
+        // asked for, so a remote table silently lost non-ASCII text.
+        let spec = IndexSpec::new().fts_with_analyzer("body", STANDARD_TOKENIZER);
+        let json = index_spec_to_json(&spec);
+        assert_eq!(
+            json["fts"],
+            json!([{"column": "body", "analyzer": "standard"}])
+        );
+    }
+
+    #[test]
+    fn index_spec_json_keeps_the_bare_form_for_the_default_analyzer() {
+        // The default stays the compact `["body"]` spelling so a server
+        // predating per-column analyzers keeps accepting the request.
+        let spec = IndexSpec::new().fts_with_analyzer("body", ASCII_LOWER_TOKENIZER);
+        assert_eq!(index_spec_to_json(&spec)["fts"], json!(["body"]));
+    }
+
+    #[test]
+    fn index_spec_json_mixes_analyzer_spellings_per_column() {
+        let spec = IndexSpec::new()
+            .fts("code")
+            .fts_with_analyzer("prose", STANDARD_TOKENIZER);
+        assert_eq!(
+            index_spec_to_json(&spec)["fts"],
+            json!(["code", {"column": "prose", "analyzer": "standard"}])
         );
     }
 


### PR DESCRIPTION
The remote transport encoded only `IndexSpec::fts_columns()` and dropped
`fts_analyzers()`, so `fts_with_analyzer("body", "standard")` reached the
server as a bare `["body"]` — the column was indexed with `ascii_lower`
whatever the caller asked for, and non-ASCII text in it silently became
unsearchable.

`index_spec_to_json` now emits the analyzer. A column on the default
analyzer keeps the bare-name spelling, so requests to a server predating
per-column analyzers stay byte-identical; only a column declaring a
different analyzer takes the `{column, analyzer}` object form.

Also adds `IndexSpec::fts_indexes()`, which yields `(column, analyzer)`
pairs so the wire layer stops re-zipping two parallel name lists —
mirroring the existing `vector_indexes()`. And corrects the
`fts_with_analyzer` doc comment, which claimed a table mixing analyzers is
rejected at `create_table`: nothing enforces that, and per-column analysis
is the actual design (`SupertableOptions::with_fts_tokenizers` is a vec
aligned to `fts_columns`, looked up by column index).

Tests, written first and watched fail: a declared analyzer reaches the
wire, the default keeps the compact spelling, and the two forms mix per
column.