### PR TITLE
feat writer: shard commit fanout by buffered bytes, and pool width

### DIFF
--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -48,6 +48,11 @@ supertable:
   # superfiles.
   commit_threshold_size_mb: 1024
 
+  # Target buffered bytes per commit shard, in mebibytes. Each shard becomes one
+  # superfile, so this decides how many files a commit produces from data volume
+  # rather than core count. Set 0 to fall back to one shard per writer-pool thread.
+  shard_target_size_mb: 64
+
   # Verify the trailing whole-blob CRC and per-subsection CRCs
   # on every SuperfileReader::open. Defaults to true. Set to
   # false only when the underlying storage already validates

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -17,7 +17,7 @@
 # readable from files instead of reconstructed from process env.
 
 # Supertable runtime knobs. Reader fan-out (skip + per-superfile
-# search + top-k merge) and writer commit-time rayon-shard run on
+# search + top-k merge) and the writer's parallel commit builds run on
 # separate pools so a long-running commit can't spike reader p99 or
 # vice versa.
 #
@@ -42,16 +42,17 @@ supertable:
 
   # Threshold above which the supertable's writer triggers an
   # internal commit() to flush the in-memory buffer to disk-
-  # equivalent (one superfile per writer-pool thread). Specified
+  # equivalent. Specified
   # in mebibytes (1 MiB = 1024 × 1024 bytes). Set 0 to disable
   # auto-flush — only caller-driven commit() will produce
   # superfiles.
   commit_threshold_size_mb: 1024
 
-  # Target buffered bytes per commit shard, in mebibytes. Each shard becomes one
-  # superfile, so this decides how many files a commit produces from data volume
-  # rather than core count. Set 0 to fall back to one shard per writer-pool thread.
-  shard_target_size_mb: 64
+  # Split point for a commit's buffer, in mebibytes: the writer cuts the buffered
+  # rows every this many bytes and builds one superfile per piece, in parallel and
+  # capped by the writer pool. So the file count follows the data volume rather
+  # than the core count. Set 0 to fall back to one piece per writer-pool thread.
+  superfile_buffer_split_mb: 64
 
   # Verify the trailing whole-blob CRC and per-subsection CRCs
   # on every SuperfileReader::open. Defaults to true. Set to

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -159,7 +159,7 @@ pub fn global() -> &'static Config {
 pub struct SupertableSettings {
     /// Reader fan-out pool size. `auto` resolves to `num_cpus`.
     pub reader_threads: ThreadCount,
-    /// Writer commit-shard pool size. `auto` resolves to
+    /// Writer commit-build pool size. `auto` resolves to
     /// `max(1, num_cpus / 2)`.
     pub writer_threads: ThreadCount,
     /// Name of the system-managed primary-key column the
@@ -177,10 +177,10 @@ pub struct SupertableSettings {
     /// disables auto-flush — only caller-driven `commit()`
     /// produces superfiles.
     pub commit_threshold_size_mb: u64,
-    /// Target buffered bytes per commit shard, in mebibytes. Each shard becomes one
-    /// superfile, so this decides how many files a commit produces from data volume
-    /// rather than core count. `0` falls back to one shard per writer-pool thread.
-    pub shard_target_size_mb: u64,
+    /// Split point for a commit's buffer, in mebibytes: the writer cuts the buffered rows
+    /// every this many bytes and builds one superfile per piece, so the file count follows the
+    /// data volume rather than the core count. `0` falls back to one piece per pool thread.
+    pub superfile_buffer_split_mb: u64,
     /// Verify the trailing whole-blob CRC and per-subsection
     /// CRCs on every `SuperfileReader::open`. Defaults to
     /// `true`. Set to `false` only when the underlying
@@ -198,14 +198,14 @@ impl Default for SupertableSettings {
             writer_threads: ThreadCount::default(),
             id_column: default_id_column(),
             commit_threshold_size_mb: DEFAULT_COMMIT_THRESHOLD_SIZE_MB,
-            shard_target_size_mb: DEFAULT_SHARD_TARGET_SIZE_MB,
+            superfile_buffer_split_mb: DEFAULT_SUPERFILE_BUFFER_SPLIT_MB,
             verify_crc_on_open: DEFAULT_VERIFY_CRC_ON_OPEN,
         }
     }
 }
 
 const DEFAULT_COMMIT_THRESHOLD_SIZE_MB: u64 = 1024;
-const DEFAULT_SHARD_TARGET_SIZE_MB: u64 = 64;
+const DEFAULT_SUPERFILE_BUFFER_SPLIT_MB: u64 = 64;
 const DEFAULT_VERIFY_CRC_ON_OPEN: bool = true;
 
 // Compaction defaults

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -177,6 +177,10 @@ pub struct SupertableSettings {
     /// disables auto-flush — only caller-driven `commit()`
     /// produces superfiles.
     pub commit_threshold_size_mb: u64,
+    /// Target buffered bytes per commit shard, in mebibytes. Each shard becomes one
+    /// superfile, so this decides how many files a commit produces from data volume
+    /// rather than core count. `0` falls back to one shard per writer-pool thread.
+    pub shard_target_size_mb: u64,
     /// Verify the trailing whole-blob CRC and per-subsection
     /// CRCs on every `SuperfileReader::open`. Defaults to
     /// `true`. Set to `false` only when the underlying
@@ -194,12 +198,14 @@ impl Default for SupertableSettings {
             writer_threads: ThreadCount::default(),
             id_column: default_id_column(),
             commit_threshold_size_mb: DEFAULT_COMMIT_THRESHOLD_SIZE_MB,
+            shard_target_size_mb: DEFAULT_SHARD_TARGET_SIZE_MB,
             verify_crc_on_open: DEFAULT_VERIFY_CRC_ON_OPEN,
         }
     }
 }
 
 const DEFAULT_COMMIT_THRESHOLD_SIZE_MB: u64 = 1024;
+const DEFAULT_SHARD_TARGET_SIZE_MB: u64 = 64;
 const DEFAULT_VERIFY_CRC_ON_OPEN: bool = true;
 
 // Compaction defaults

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -238,6 +238,8 @@ const DEFAULT_MAX_COMMIT_RETRIES: u32 = 10;
 const DEFAULT_DRAIN_BATCH_SUPERFILES: i64 = 1;
 /// Default writer auto-flush threshold (1 GiB, in MiB units).
 const DEFAULT_COMMIT_THRESHOLD_SIZE_MB: u64 = 1024;
+/// Default target buffered bytes per commit shard (in MiB units).
+const DEFAULT_SHARD_TARGET_SIZE_MB: u64 = 64;
 /// Default object size (100 MiB) above which uploads route through
 /// multipart.
 const DEFAULT_PUT_MULTIPART_THRESHOLD_BYTES: u64 = 100 * (1 << 20);
@@ -516,6 +518,19 @@ pub struct SupertableOptions {
     /// caller-driven `commit()` produces superfiles.
     /// Default: 1024 (1 GiB).
     pub commit_threshold_size_mb: u64,
+    /// Target buffered bytes per commit shard, in MiB. A commit splits its buffer into
+    /// `ceil(buffered / target)` shards, capped by the writer pool; each shard builds in
+    /// parallel and becomes one superfile.
+    ///
+    /// A 1 GiB flush therefore lands as ~16 × 64 MiB superfiles whether the host has 16 cores
+    /// or 192: data volume sets the table's file geometry, the pool only caps build
+    /// parallelism. Small superfiles are pure overhead downstream (each one is a footer
+    /// parse and an object-store GET on cold open, a disk-cache entry, a compaction input),
+    /// which is what the target guards against.
+    ///
+    /// `0` removes the target: one shard per pool thread, tying file count to the machine.
+    /// Default: 64.
+    pub shard_target_size_mb: u64,
     /// Superfile size (in bytes) at or above which the writer
     /// routes the storage write through
     /// [`StorageProvider::put_multipart`] instead of
@@ -726,6 +741,7 @@ impl SupertableOptions {
             eager_load_threshold_parts: DEFAULT_EAGER_LOAD_THRESHOLD_PARTS,
             max_commit_retries: DEFAULT_MAX_COMMIT_RETRIES,
             commit_threshold_size_mb: DEFAULT_COMMIT_THRESHOLD_SIZE_MB,
+            shard_target_size_mb: DEFAULT_SHARD_TARGET_SIZE_MB,
             put_multipart_threshold_bytes: DEFAULT_PUT_MULTIPART_THRESHOLD_BYTES,
             verify_crc_on_open: true,
             read_consistency: Consistency::default(),
@@ -978,6 +994,13 @@ impl SupertableOptions {
         self
     }
 
+    /// Override the target buffered bytes per commit shard (MiB); see
+    /// [`Self::shard_target_size_mb`].
+    pub fn with_shard_target_size_mb(mut self, mb: u64) -> Self {
+        self.shard_target_size_mb = mb;
+        self
+    }
+
     /// Override the superfile-size threshold (bytes) at which
     /// the writer routes through `put_multipart` instead of
     /// `put_atomic`. See [`Self::put_multipart_threshold_bytes`].
@@ -1077,6 +1100,7 @@ impl SupertableOptions {
             ),
         };
         self.commit_threshold_size_mb = cfg.supertable.commit_threshold_size_mb;
+        self.shard_target_size_mb = cfg.supertable.shard_target_size_mb;
         self.verify_crc_on_open = cfg.supertable.verify_crc_on_open;
         self.drain_batch_superfiles = cfg.vector.drain_batch_superfiles;
         self.drain_consolidate = cfg.vector.drain_consolidate;

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -239,7 +239,7 @@ const DEFAULT_DRAIN_BATCH_SUPERFILES: i64 = 1;
 /// Default writer auto-flush threshold (1 GiB, in MiB units).
 const DEFAULT_COMMIT_THRESHOLD_SIZE_MB: u64 = 1024;
 /// Default target buffered bytes per commit shard (in MiB units).
-const DEFAULT_SHARD_TARGET_SIZE_MB: u64 = 64;
+const DEFAULT_SUPERFILE_BUFFER_SPLIT_MB: u64 = 64;
 /// Default object size (100 MiB) above which uploads route through
 /// multipart.
 const DEFAULT_PUT_MULTIPART_THRESHOLD_BYTES: u64 = 100 * (1 << 20);
@@ -530,7 +530,7 @@ pub struct SupertableOptions {
     ///
     /// `0` removes the target: one shard per pool thread, tying file count to the machine.
     /// Default: 64.
-    pub shard_target_size_mb: u64,
+    pub superfile_buffer_split_mb: u64,
     /// Superfile size (in bytes) at or above which the writer
     /// routes the storage write through
     /// [`StorageProvider::put_multipart`] instead of
@@ -741,7 +741,7 @@ impl SupertableOptions {
             eager_load_threshold_parts: DEFAULT_EAGER_LOAD_THRESHOLD_PARTS,
             max_commit_retries: DEFAULT_MAX_COMMIT_RETRIES,
             commit_threshold_size_mb: DEFAULT_COMMIT_THRESHOLD_SIZE_MB,
-            shard_target_size_mb: DEFAULT_SHARD_TARGET_SIZE_MB,
+            superfile_buffer_split_mb: DEFAULT_SUPERFILE_BUFFER_SPLIT_MB,
             put_multipart_threshold_bytes: DEFAULT_PUT_MULTIPART_THRESHOLD_BYTES,
             verify_crc_on_open: true,
             read_consistency: Consistency::default(),
@@ -995,9 +995,9 @@ impl SupertableOptions {
     }
 
     /// Override the target buffered bytes per commit shard (MiB); see
-    /// [`Self::shard_target_size_mb`].
-    pub fn with_shard_target_size_mb(mut self, mb: u64) -> Self {
-        self.shard_target_size_mb = mb;
+    /// [`Self::superfile_buffer_split_mb`].
+    pub fn with_superfile_buffer_split_mb(mut self, mb: u64) -> Self {
+        self.superfile_buffer_split_mb = mb;
         self
     }
 
@@ -1100,7 +1100,7 @@ impl SupertableOptions {
             ),
         };
         self.commit_threshold_size_mb = cfg.supertable.commit_threshold_size_mb;
-        self.shard_target_size_mb = cfg.supertable.shard_target_size_mb;
+        self.superfile_buffer_split_mb = cfg.supertable.superfile_buffer_split_mb;
         self.verify_crc_on_open = cfg.supertable.verify_crc_on_open;
         self.drain_batch_superfiles = cfg.vector.drain_batch_superfiles;
         self.drain_consolidate = cfg.vector.drain_consolidate;

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -180,10 +180,16 @@ use crate::{
 /// is derived from this target; it is not copied from the outer/global grid or
 /// repeated as a fixed count for every small commit delta.
 const DRAIN_FINE_RUN_TARGET_BYTES: usize = 2 * 1024 * 1024;
+
 /// Multipart chunk size for large superfile uploads.
 const SUPERFILE_MULTIPART_PART_BYTES: usize = 8 * (1 << 20);
+
 /// Stable IDs fed to the streamed shard Parquet builder per Arrow batch.
 const DRAIN_ID_BATCH_ROWS: usize = 64 * 1024;
+
+/// One mebibyte; converts `shard_target_size_mb` into bytes.
+const MIB: usize = 1 << 20;
+
 pub(in crate::supertable) const DRAIN_CHECKPOINT_SCHEMA: u32 = 1;
 /// Local checkpoint filename inside one epoch scratch directory.
 const DRAIN_LOCAL_CHECKPOINT_FILE: &str = "checkpoint.json";
@@ -459,6 +465,29 @@ impl<'a> VectorColumnView<'a> {
             .and_then(|values| values.get(start..start + self.dim))
             .ok_or_else(|| BuildError::Store(format!("vector row {local} out of buffered range")))
     }
+}
+
+/// Shard count for one taken buffer: `ceil(buffered_bytes / target_bytes)`, capped by the
+/// pool and the row count.
+///
+/// A 1 GiB buffer with the default 64 MiB target builds 16 shards on
+/// a 192-thread pool and 8 on an 8-thread pool; every shard carries between half and one
+/// full target. `target_bytes == 0` (the [`SupertableOptions::shard_target_size_mb`] escape
+/// hatch) caps by the pool alone.
+///
+/// Always at least one shard.
+fn commit_shard_count(
+    total_rows: usize,
+    buffered_bytes: usize,
+    pool_threads: usize,
+    target_bytes: usize,
+) -> usize {
+    let by_bytes = if target_bytes == 0 {
+        usize::MAX
+    } else {
+        buffered_bytes.div_ceil(target_bytes).max(1)
+    };
+    by_bytes.min(pool_threads.max(1)).min(total_rows.max(1))
 }
 
 /// Row-balanced split of the writer's buffered batches into
@@ -1681,7 +1710,16 @@ impl SupertableWriter {
 
         let writer_pool = Arc::clone(&self.inner.options.writer_pool);
         let n_threads = writer_pool.current_num_threads().max(1);
-        let n_shards = n_threads.min(total_rows);
+
+        // `scalar` is the whole buffer here: vector tables took the drain branch above, and text
+        // columns live inside `scalar`. Arrow reports capacity, not logical bytes — fine for a
+        // fanout heuristic that is clamped to the pool anyway.
+        let buffered_bytes: usize = buffer
+            .iter()
+            .map(|b| b.scalar.get_array_memory_size())
+            .sum();
+        let target_bytes = (self.inner.options.shard_target_size_mb as usize).saturating_mul(MIB);
+        let n_shards = commit_shard_count(total_rows, buffered_bytes, n_threads, target_bytes);
 
         let vector_dims: Vec<usize> = self
             .inner
@@ -8607,7 +8645,7 @@ mod tests {
         config::Config,
         superfile::{
             builder::{FtsConfig, VectorConfig},
-            fts::reader::BoolMode,
+            fts::reader::{Bm25Stats, BoolMode},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{SupertableOptions, handle::Supertable, storage::LocalFsStorageProvider},
@@ -8622,6 +8660,136 @@ mod tests {
     const COMMIT_AS_DRAIN_TEST_ROT_SEED: u64 = 7;
     /// Boundary test target that permits one extra posting per input row.
     const BOUNDARY_STUB_TARGET_FACTOR: f32 = 2.0;
+
+    /// Default shard target for the fanout unit tests, in bytes — mirrors the shipped
+    /// `shard_target_size_mb` default (64 MiB).
+    const TEST_SHARD_TARGET: usize = 64 * MIB;
+
+    /// Shard fanout follows buffered bytes (one shard per target's worth, rounded up), capped
+    /// by the pool and the row count — a big pool must not fragment a small buffer.
+    #[test]
+    fn commit_shard_count_follows_bytes_capped_by_pool() {
+        const T: usize = TEST_SHARD_TARGET;
+        // 10 MiB buffer on a 192-thread pool: one shard, not 192.
+        assert_eq!(commit_shard_count(1_000_000, 10 << 20, 192, T), 1);
+        // 1 GiB buffer: 16 shards by bytes, capped by a smaller pool.
+        assert_eq!(commit_shard_count(1_000_000, 1 << 30, 192, T), 16);
+        assert_eq!(commit_shard_count(1_000_000, 1 << 30, 8, T), 8);
+        // Never more shards than rows, and never zero.
+        assert_eq!(commit_shard_count(3, 1 << 30, 192, T), 3);
+        assert_eq!(commit_shard_count(1, 1, 0, T), 1);
+    }
+
+    /// Boundary behavior of the ceiling division: a buffer at the target is one shard, one
+    /// byte over splits, and each shard always carries at least half a target.
+    #[test]
+    fn commit_shard_count_target_boundaries() {
+        const T: usize = TEST_SHARD_TARGET;
+        // Exactly one target: one shard. One byte over: two.
+        assert_eq!(commit_shard_count(1_000_000, T, 192, T), 1);
+        assert_eq!(commit_shard_count(1_000_000, T + 1, 192, T), 2);
+        // Exactly k targets: k shards. One byte over: k + 1.
+        assert_eq!(commit_shard_count(1_000_000, 4 * T, 192, T), 4);
+        assert_eq!(commit_shard_count(1_000_000, 4 * T + 1, 192, T), 5);
+        // Zero bytes still yields one shard (rows exist; bytes is a heuristic).
+        assert_eq!(commit_shard_count(10, 0, 192, T), 1);
+        // Documented lower bound: bytes-per-shard never drops below half a
+        // target while the pool cap is not binding.
+        for bytes in [T + 1, 2 * T - 1, 3 * T + T / 2, 10 * T + 1] {
+            let n = commit_shard_count(1_000_000, bytes, 192, T);
+            assert!(bytes.div_ceil(n) >= T / 2, "bytes={bytes} n={n}");
+        }
+    }
+
+    /// `target_bytes == 0` is the configured escape hatch back to thread-count fanout:
+    /// shards = pool width (still capped by rows).
+    #[test]
+    fn commit_shard_count_zero_target_restores_thread_fanout() {
+        assert_eq!(commit_shard_count(1_000_000, 10 << 20, 192, 0), 192);
+        assert_eq!(commit_shard_count(1_000_000, 1 << 30, 8, 0), 8);
+        assert_eq!(commit_shard_count(3, 1 << 30, 192, 0), 3);
+    }
+
+    /// The configured `shard_target_size_mb` reaches the commit fanout: a 1 MiB target splits
+    /// a small buffer, `0` restores thread fanout, a large target keeps one file.
+    #[test]
+    fn shard_target_config_knob_reaches_commit_fanout() {
+        let batch = build_simple_batch(0, 50_000); // ~a few MiB in-memory
+        for (target_mb, expect) in [(1u64, 2usize), (0, 2)] {
+            let opts = options_id_title()
+                .with_writer_pool(writer_pool_with(2))
+                .with_shard_target_size_mb(target_mb);
+            let st = Supertable::create(opts).expect("create");
+            let mut w = st.writer().expect("writer");
+            w.append(&batch).expect("append");
+            w.commit().expect("commit");
+            let r = st.reader().expect("reader");
+            assert_eq!(
+                r.n_superfiles(),
+                expect,
+                "target_mb={target_mb} should shard to the 2-thread pool cap"
+            );
+        }
+        // Large target: the same buffer stays one superfile.
+        let opts = options_id_title()
+            .with_writer_pool(writer_pool_with(2))
+            .with_shard_target_size_mb(4096);
+        let st = Supertable::create(opts).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 1);
+    }
+
+    /// Fanout never spans commit boundaries: three small commits produce exactly one
+    /// superfile each on a wide pool.
+    #[test]
+    fn each_small_commit_produces_exactly_one_superfile() {
+        let opts = options_id_title().with_writer_pool(writer_pool_with(4));
+        let st = Supertable::create(opts).expect("create");
+        for round in 0..3u64 {
+            let mut w = st.writer().expect("writer");
+            w.append(&build_simple_batch(round * 10, 5))
+                .expect("append");
+            w.commit().expect("commit");
+            let r = st.reader().expect("reader");
+            assert_eq!(
+                r.n_superfiles(),
+                (round + 1) as usize,
+                "one new superfile per small commit"
+            );
+        }
+        let r = st.reader().expect("reader");
+        assert_eq!(r.n_docs_total(), 15);
+    }
+
+    /// A single-shard FTS commit produces a queryable index, not just a counted superfile.
+    #[test]
+    fn single_shard_fts_commit_is_searchable() {
+        let opts = options_id_title().with_writer_pool(writer_pool_with(4));
+        let st = Supertable::create(opts).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_simple_batch(0, 100)).expect("append");
+        w.commit().expect("commit");
+        drop(w);
+
+        let r = st.reader().expect("reader");
+        assert_eq!(r.n_superfiles(), 1, "small FTS commit stays one shard");
+        // Every doc's title contains "alpha" (see build_simple_batch); a match-all term must
+        // surface hits from the single-shard index.
+        let hits = st
+            .bm25_search(
+                "title",
+                "alpha",
+                10,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+                None,
+            )
+            .expect("bm25 over single-shard commit");
+        let n: usize = hits.iter().map(|b| b.num_rows()).sum();
+        assert!(n > 0, "single-shard FTS index must return hits");
+    }
 
     /// `SupertableWriter`'s `Debug` impl renders its buffered-batch summary.
     #[test]
@@ -9812,15 +9980,13 @@ mod tests {
     // ---- rayon-shard parallelism -------------------------------------
 
     #[test]
-    fn commit_produces_one_superfile_per_writer_pool_thread() {
-        // With N writer-pool threads and a buffer of M >= N
-        // batches, commit should emit N superfiles (one per
-        // shard).
+    fn commit_superfile_count_follows_bytes_not_pool_size() {
+        // A small buffer commits as one superfile no matter how wide the pool is — pool width
+        // alone must not fragment the table.
         for n_threads in [1usize, 2, 4] {
             let opts = options_id_title().with_writer_pool(writer_pool_with(n_threads));
             let st = Supertable::create(opts).expect("create");
             let mut w = st.writer().expect("writer");
-            // Push enough batches to fill every shard.
             for i in 0..n_threads * 2 {
                 w.append(&build_simple_batch(i as u64 * 10, 3))
                     .expect("append");
@@ -9830,32 +9996,45 @@ mod tests {
             let r = st.reader().expect("reader");
             assert_eq!(
                 r.n_superfiles(),
-                n_threads,
-                "expected {n_threads} superfiles for {n_threads}-thread pool",
+                1,
+                "small buffer must stay one superfile on a {n_threads}-thread pool",
             );
             assert_eq!(r.n_docs_total(), (n_threads * 2 * 3) as u64);
         }
     }
 
     #[test]
-    fn commit_with_fewer_batches_than_threads_skips_empty_shards() {
-        // 4 threads, only 2 batches — chunk_size = 1, two chunks
-        // get one batch each, the other two get nothing.
-        // Should produce 2 superfiles, not 4.
-        let opts = options_id_title().with_writer_pool(writer_pool_with(4));
+    fn commit_shards_wide_buffer_up_to_pool_width() {
+        // A buffer over the shard target splits, capped by the pool. Arrow reports capacity
+        // (not logical bytes), so the ~100 MiB buffer wants 2-3 shards; the 2-thread pool pins
+        // it to exactly 2.
+        const ROWS: usize = 100_000;
+        let opts = options_id_title()
+            .with_writer_pool(writer_pool_with(2))
+            .with_commit_threshold_size_mb(4096);
         let st = Supertable::create(opts).expect("create");
         let mut w = st.writer().expect("writer");
-        w.append(&build_simple_batch(0, 1)).expect("a");
-        w.append(&build_simple_batch(1, 1)).expect("b");
+        // ~1 KiB per title × 100K rows ≈ 100 MiB buffered.
+        let titles = LargeStringArray::from(
+            (0..ROWS)
+                .map(|i| format!("doc {i} {}", "x".repeat(1024)))
+                .collect::<Vec<_>>(),
+        );
+        let batch = RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)]).expect("batch");
+        w.append(&batch).expect("append");
         w.commit().expect("commit");
 
         let r = st.reader().expect("reader");
-        assert_eq!(r.n_superfiles(), 2);
-        assert_eq!(r.n_docs_total(), 2);
+        assert_eq!(
+            r.n_superfiles(),
+            2,
+            "~100 MiB buffer splits, pinned to 2 by the pool cap"
+        );
+        assert_eq!(r.n_docs_total(), ROWS as u64);
     }
 
     #[test]
-    fn apply_config_with_fixed_writer_threads_emits_that_many_superfiles() {
+    fn apply_config_with_fixed_writer_threads_sizes_the_pool() {
         let yaml = r#"
 commit_threshold_size_mb: 1024
 supertable:
@@ -9865,10 +10044,16 @@ supertable:
         let cfg =
             Config::from_figment(Figment::new().merge(Yaml::string(yaml))).expect("parse config");
 
-        // End-to-end: build options, route them through apply_config,
-        // and verify the writer pool actually sized to the config's
-        // 4 threads (one superfile per shard).
+        // End-to-end: build options, route them through apply_config, and
+        // verify the writer pool actually sized to the config's 4 threads.
+        // The pool caps shard fanout but no longer sets it — a small buffer
+        // stays one superfile (geometry follows bytes, not thread count).
         let opts = options_id_title().apply_config(&cfg).expect("apply_config");
+        assert_eq!(
+            opts.writer_pool.current_num_threads(),
+            4,
+            "writer_threads=4 should size the pool to 4"
+        );
         let st = Supertable::create(opts).expect("create");
         let mut w = st.writer().expect("writer");
         for i in 0..8u64 {
@@ -9877,11 +10062,7 @@ supertable:
         w.commit().expect("commit");
 
         let r = st.reader().expect("reader");
-        assert_eq!(
-            r.n_superfiles(),
-            4,
-            "writer_threads=4 should yield 4 shards"
-        );
+        assert_eq!(r.n_superfiles(), 1, "small buffer stays one superfile");
         assert_eq!(r.n_docs_total(), 24);
     }
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -9,7 +9,7 @@
 //! [`crate::superfile::SuperfileBuilder`], which is a single-shot
 //! factory consuming `self` to produce one immutable artifact.
 //! Each `commit` here internally spawns many superfile builders,
-//! one per shard.
+//! one per piece of the split buffer.
 //!
 //! Acquired via [`Supertable::writer`](super::Supertable::writer);
 //! at most one writer is outstanding per supertable at a time
@@ -28,9 +28,9 @@
 //!   `vector_split`, pushes a `BufferedBatch` onto the writer's
 //!   buffer, and triggers an internal `commit()` if the running
 //!   buffer-byte estimate crosses the configured threshold.
-//! - `commit()` drains the buffer, partitions across the writer
-//!   pool, runs each shard build in parallel, and publishes all
-//!   shards as new superfiles in one manifest swap. Idempotent on
+//! - `commit()` drains the buffer, splits it by buffered bytes (capped
+//!   by the writer pool), builds each piece in parallel, and publishes
+//!   them all as new superfiles in one manifest swap. Idempotent on
 //!   an empty buffer (no-op return Ok). The writer slot is
 //!   released on `Drop`; callers don't need a separate `finish()`
 //!   call.
@@ -187,7 +187,7 @@ const SUPERFILE_MULTIPART_PART_BYTES: usize = 8 * (1 << 20);
 /// Stable IDs fed to the streamed shard Parquet builder per Arrow batch.
 const DRAIN_ID_BATCH_ROWS: usize = 64 * 1024;
 
-/// One mebibyte; converts `shard_target_size_mb` into bytes.
+/// One mebibyte; converts `superfile_buffer_split_mb` into bytes.
 const MIB: usize = 1 << 20;
 
 pub(in crate::supertable) const DRAIN_CHECKPOINT_SCHEMA: u32 = 1;
@@ -467,16 +467,15 @@ impl<'a> VectorColumnView<'a> {
     }
 }
 
-/// Shard count for one taken buffer: `ceil(buffered_bytes / target_bytes)`, capped by the
-/// pool and the row count.
+/// How many superfiles one taken buffer becomes: `ceil(buffered_bytes / split_bytes)`, capped by
+/// the pool and the row count.
 ///
-/// A 1 GiB buffer with the default 64 MiB target builds 16 shards on
-/// a 192-thread pool and 8 on an 8-thread pool; every shard carries between half and one
-/// full target. `target_bytes == 0` (the [`SupertableOptions::shard_target_size_mb`] escape
-/// hatch) caps by the pool alone.
-///
-/// Always at least one shard.
-fn commit_shard_count(
+/// A 1 GiB buffer at the default 64 MiB split builds 16 superfiles on a 192-thread pool and 8 on
+/// an 8-thread pool, each carrying between half and one full split's worth of rows. Rounding up
+/// favours parallelism: every piece gets its own thread, since the count is capped by the pool.
+/// `split_bytes == 0` (the [`SupertableOptions::superfile_buffer_split_mb`] escape hatch) caps by
+/// the pool alone. Always at least one.
+fn superfiles_per_commit(
     total_rows: usize,
     buffered_bytes: usize,
     pool_threads: usize,
@@ -490,38 +489,35 @@ fn commit_shard_count(
     by_bytes.min(pool_threads.max(1)).min(total_rows.max(1))
 }
 
-/// Row-balanced split of the writer's buffered batches into
-/// `n_shards` shard inputs, each shaped as a `Vec<BufferedBatch>`
-/// that [`build_one_shard_with_layout`] can consume directly. The split walks
-/// rows across the original buffer in order and emits zero-copy
-/// Arrow slices (`RecordBatch::slice` + `Float32Array::slice` —
-/// adjust buffer offsets only; underlying memory stays Arc-counted),
-/// so no payload bytes are copied even when a shard boundary falls
-/// in the middle of a `BufferedBatch`.
+/// Row-balanced split of the writer's buffered batches into `n_superfiles` build inputs, each
+/// shaped as a `Vec<BufferedBatch>` that [`build_one_shard_with_layout`] can consume directly.
+/// The split walks rows across the original buffer in order and emits zero-copy Arrow slices
+/// (`RecordBatch::slice` + `Float32Array::slice` — adjust buffer offsets only; underlying memory
+/// stays Arc-counted), so no payload bytes are copied even when a split boundary falls in the
+/// middle of a `BufferedBatch`.
 ///
-/// Row imbalance across shards is ≤ 1: with `total_rows = q·n + r`,
-/// the first `r` shards get `q+1` rows and the rest get `q`.
+/// Row imbalance across pieces is ≤ 1: with `total_rows = q·n + r`, the first `r` pieces get
+/// `q+1` rows and the rest get `q`.
 ///
-/// Trailing empty shards (only possible when `total_rows < n_shards`)
-/// are dropped before return; callers see exactly the shards that
-/// will produce a non-empty superfile.
-fn split_buffer_into_row_shards(
+/// Trailing empty pieces (only possible when `total_rows < n_superfiles`) are dropped before
+/// return; callers see exactly the pieces that will produce a non-empty superfile.
+fn split_buffer_into_superfile_inputs(
     buffer: Vec<BufferedBatch>,
-    n_shards: usize,
+    n_superfiles: usize,
     vector_dims: &[usize],
 ) -> Vec<Vec<BufferedBatch>> {
-    debug_assert!(n_shards > 0);
+    debug_assert!(n_superfiles > 0);
     let total_rows: usize = buffer.iter().map(|b| b.scalar.num_rows()).sum();
     if total_rows == 0 {
         return Vec::new();
     }
-    let base = total_rows / n_shards;
-    let remainder = total_rows % n_shards;
+    let base = total_rows / n_superfiles;
+    let remainder = total_rows % n_superfiles;
     let target = |i: usize| if i < remainder { base + 1 } else { base };
 
-    let mut shards: Vec<Vec<BufferedBatch>> = (0..n_shards).map(|_| Vec::new()).collect();
-    let mut shard_idx = 0usize;
-    let mut shard_remaining = target(0);
+    let mut pieces: Vec<Vec<BufferedBatch>> = (0..n_superfiles).map(|_| Vec::new()).collect();
+    let mut piece_idx = 0usize;
+    let mut piece_remaining = target(0);
 
     for batch in buffer {
         let n_rows = batch.scalar.num_rows();
@@ -530,14 +526,14 @@ fn split_buffer_into_row_shards(
         }
         let mut row_cursor = 0;
         while row_cursor < n_rows {
-            // Skip ahead over any zero-target shards (only happens
-            // when total_rows < n_shards, leaving trailing shards
+            // Skip ahead over any zero-target pieces (only happens
+            // when total_rows < n_superfiles, leaving trailing pieces
             // with target == 0).
-            while shard_remaining == 0 && shard_idx + 1 < n_shards {
-                shard_idx += 1;
-                shard_remaining = target(shard_idx);
+            while piece_remaining == 0 && piece_idx + 1 < n_superfiles {
+                piece_idx += 1;
+                piece_remaining = target(piece_idx);
             }
-            let take = cmp::min(shard_remaining, n_rows - row_cursor);
+            let take = cmp::min(piece_remaining, n_rows - row_cursor);
             let scalar = batch.scalar.slice(row_cursor, take);
             let vectors: Vec<Arc<Float32Array>> = batch
                 .vectors
@@ -548,13 +544,13 @@ fn split_buffer_into_row_shards(
                     Arc::new(v.slice(row_cursor * dim, take * dim))
                 })
                 .collect();
-            shards[shard_idx].push(BufferedBatch { scalar, vectors });
+            pieces[piece_idx].push(BufferedBatch { scalar, vectors });
             row_cursor += take;
-            shard_remaining -= take;
+            piece_remaining -= take;
         }
     }
-    shards.retain(|s| !s.is_empty());
-    shards
+    pieces.retain(|s| !s.is_empty());
+    pieces
 }
 
 /// After a manifest swap that drops superfile references, schedule a deferred
@@ -1718,8 +1714,10 @@ impl SupertableWriter {
             .iter()
             .map(|b| b.scalar.get_array_memory_size())
             .sum();
-        let target_bytes = (self.inner.options.shard_target_size_mb as usize).saturating_mul(MIB);
-        let n_shards = commit_shard_count(total_rows, buffered_bytes, n_threads, target_bytes);
+        let target_bytes =
+            (self.inner.options.superfile_buffer_split_mb as usize).saturating_mul(MIB);
+        let n_superfiles =
+            superfiles_per_commit(total_rows, buffered_bytes, n_threads, target_bytes);
 
         let vector_dims: Vec<usize> = self
             .inner
@@ -1774,12 +1772,13 @@ impl SupertableWriter {
                         .collect();
                     (shards, hints)
                 } else {
-                    let shards = split_buffer_into_row_shards(owned, n_shards, &vector_dims);
+                    let shards =
+                        split_buffer_into_superfile_inputs(owned, n_superfiles, &vector_dims);
                     let hints = vec![None; shards.len()];
                     (shards, hints)
                 }
             } else {
-                let shards = split_buffer_into_row_shards(owned, n_shards, &vector_dims);
+                let shards = split_buffer_into_superfile_inputs(owned, n_superfiles, &vector_dims);
                 let hints = vec![None; shards.len()];
                 (shards, hints)
             };
@@ -3888,11 +3887,11 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         let scratch = drain_scratch.as_path();
         let n_cells_total = added_per_cell.len();
         let total_rows: u64 = added_per_cell.values().map(|count| u64::from(*count)).sum();
-        let n_shards = shard_count;
+        let n_superfiles = shard_count;
 
         let mut cell_counts_by_shard: HashMap<u32, Vec<(u32, u32)>> = HashMap::new();
         for (&cell, &count) in &added_per_cell {
-            let shard = packed_cell_shard(cell, n_shards) as u32;
+            let shard = packed_cell_shard(cell, n_superfiles) as u32;
             cell_counts_by_shard
                 .entry(shard)
                 .or_default()
@@ -3935,7 +3934,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                 "drain has cell counts but no cell build sources".into(),
             ));
         }
-        let mut shard_sources = group_cells_by_packed_shard(sources, n_shards);
+        let mut shard_sources = group_cells_by_packed_shard(sources, n_superfiles);
         shard_sources.retain(|(shard_id, _)| !completed_shards.contains(shard_id));
         let checkpoint = Arc::new(Mutex::new(local_checkpoint));
         let vector_config = hidden_inner
@@ -4057,9 +4056,9 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             .map_err(|_| BuildError::Store("drain checkpoint lock poisoned".into()))?
             .clone();
 
-        if prepared_shards.len() + completed_shards.len() > n_shards {
+        if prepared_shards.len() + completed_shards.len() > n_superfiles {
             return Err(BuildError::Store(format!(
-                "drain produced {} packed shards for {n_shards} workers",
+                "drain produced {} packed shards for {n_superfiles} workers",
                 prepared_shards.len() + completed_shards.len()
             )));
         }
@@ -4268,7 +4267,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             total_rows,
             n_cells_total,
             n_shard_files,
-            n_shards,
+            n_superfiles,
             build_t0.elapsed().as_secs_f64() * 1e3,
         );
         if crate::superfile::vector::builder::build_phase_timers::enabled() {
@@ -8662,41 +8661,41 @@ mod tests {
     const BOUNDARY_STUB_TARGET_FACTOR: f32 = 2.0;
 
     /// Default shard target for the fanout unit tests, in bytes — mirrors the shipped
-    /// `shard_target_size_mb` default (64 MiB).
-    const TEST_SHARD_TARGET: usize = 64 * MIB;
+    /// `superfile_buffer_split_mb` default (64 MiB).
+    const TEST_SPLIT_BYTES: usize = 64 * MIB;
 
     /// Shard fanout follows buffered bytes (one shard per target's worth, rounded up), capped
     /// by the pool and the row count — a big pool must not fragment a small buffer.
     #[test]
-    fn commit_shard_count_follows_bytes_capped_by_pool() {
-        const T: usize = TEST_SHARD_TARGET;
+    fn superfiles_per_commit_follows_bytes_capped_by_pool() {
+        const T: usize = TEST_SPLIT_BYTES;
         // 10 MiB buffer on a 192-thread pool: one shard, not 192.
-        assert_eq!(commit_shard_count(1_000_000, 10 << 20, 192, T), 1);
+        assert_eq!(superfiles_per_commit(1_000_000, 10 << 20, 192, T), 1);
         // 1 GiB buffer: 16 shards by bytes, capped by a smaller pool.
-        assert_eq!(commit_shard_count(1_000_000, 1 << 30, 192, T), 16);
-        assert_eq!(commit_shard_count(1_000_000, 1 << 30, 8, T), 8);
+        assert_eq!(superfiles_per_commit(1_000_000, 1 << 30, 192, T), 16);
+        assert_eq!(superfiles_per_commit(1_000_000, 1 << 30, 8, T), 8);
         // Never more shards than rows, and never zero.
-        assert_eq!(commit_shard_count(3, 1 << 30, 192, T), 3);
-        assert_eq!(commit_shard_count(1, 1, 0, T), 1);
+        assert_eq!(superfiles_per_commit(3, 1 << 30, 192, T), 3);
+        assert_eq!(superfiles_per_commit(1, 1, 0, T), 1);
     }
 
     /// Boundary behavior of the ceiling division: a buffer at the target is one shard, one
     /// byte over splits, and each shard always carries at least half a target.
     #[test]
-    fn commit_shard_count_target_boundaries() {
-        const T: usize = TEST_SHARD_TARGET;
+    fn superfiles_per_commit_split_boundaries() {
+        const T: usize = TEST_SPLIT_BYTES;
         // Exactly one target: one shard. One byte over: two.
-        assert_eq!(commit_shard_count(1_000_000, T, 192, T), 1);
-        assert_eq!(commit_shard_count(1_000_000, T + 1, 192, T), 2);
+        assert_eq!(superfiles_per_commit(1_000_000, T, 192, T), 1);
+        assert_eq!(superfiles_per_commit(1_000_000, T + 1, 192, T), 2);
         // Exactly k targets: k shards. One byte over: k + 1.
-        assert_eq!(commit_shard_count(1_000_000, 4 * T, 192, T), 4);
-        assert_eq!(commit_shard_count(1_000_000, 4 * T + 1, 192, T), 5);
+        assert_eq!(superfiles_per_commit(1_000_000, 4 * T, 192, T), 4);
+        assert_eq!(superfiles_per_commit(1_000_000, 4 * T + 1, 192, T), 5);
         // Zero bytes still yields one shard (rows exist; bytes is a heuristic).
-        assert_eq!(commit_shard_count(10, 0, 192, T), 1);
+        assert_eq!(superfiles_per_commit(10, 0, 192, T), 1);
         // Documented lower bound: bytes-per-shard never drops below half a
         // target while the pool cap is not binding.
         for bytes in [T + 1, 2 * T - 1, 3 * T + T / 2, 10 * T + 1] {
-            let n = commit_shard_count(1_000_000, bytes, 192, T);
+            let n = superfiles_per_commit(1_000_000, bytes, 192, T);
             assert!(bytes.div_ceil(n) >= T / 2, "bytes={bytes} n={n}");
         }
     }
@@ -8704,21 +8703,21 @@ mod tests {
     /// `target_bytes == 0` is the configured escape hatch back to thread-count fanout:
     /// shards = pool width (still capped by rows).
     #[test]
-    fn commit_shard_count_zero_target_restores_thread_fanout() {
-        assert_eq!(commit_shard_count(1_000_000, 10 << 20, 192, 0), 192);
-        assert_eq!(commit_shard_count(1_000_000, 1 << 30, 8, 0), 8);
-        assert_eq!(commit_shard_count(3, 1 << 30, 192, 0), 3);
+    fn superfiles_per_commit_zero_split_restores_thread_fanout() {
+        assert_eq!(superfiles_per_commit(1_000_000, 10 << 20, 192, 0), 192);
+        assert_eq!(superfiles_per_commit(1_000_000, 1 << 30, 8, 0), 8);
+        assert_eq!(superfiles_per_commit(3, 1 << 30, 192, 0), 3);
     }
 
-    /// The configured `shard_target_size_mb` reaches the commit fanout: a 1 MiB target splits
+    /// The configured `superfile_buffer_split_mb` reaches the commit fanout: a 1 MiB target splits
     /// a small buffer, `0` restores thread fanout, a large target keeps one file.
     #[test]
-    fn shard_target_config_knob_reaches_commit_fanout() {
+    fn superfile_buffer_split_config_knob_reaches_commit_fanout() {
         let batch = build_simple_batch(0, 50_000); // ~a few MiB in-memory
         for (target_mb, expect) in [(1u64, 2usize), (0, 2)] {
             let opts = options_id_title()
                 .with_writer_pool(writer_pool_with(2))
-                .with_shard_target_size_mb(target_mb);
+                .with_superfile_buffer_split_mb(target_mb);
             let st = Supertable::create(opts).expect("create");
             let mut w = st.writer().expect("writer");
             w.append(&batch).expect("append");
@@ -8733,7 +8732,7 @@ mod tests {
         // Large target: the same buffer stays one superfile.
         let opts = options_id_title()
             .with_writer_pool(writer_pool_with(2))
-            .with_shard_target_size_mb(4096);
+            .with_superfile_buffer_split_mb(4096);
         let st = Supertable::create(opts).expect("create");
         let mut w = st.writer().expect("writer");
         w.append(&batch).expect("append");
@@ -8763,9 +8762,9 @@ mod tests {
         assert_eq!(r.n_docs_total(), 15);
     }
 
-    /// A single-shard FTS commit produces a queryable index, not just a counted superfile.
+    /// A one-piece FTS commit produces a queryable index, not just a counted superfile.
     #[test]
-    fn single_shard_fts_commit_is_searchable() {
+    fn single_piece_fts_commit_is_searchable() {
         let opts = options_id_title().with_writer_pool(writer_pool_with(4));
         let st = Supertable::create(opts).expect("create");
         let mut w = st.writer().expect("writer");
@@ -8774,9 +8773,9 @@ mod tests {
         drop(w);
 
         let r = st.reader().expect("reader");
-        assert_eq!(r.n_superfiles(), 1, "small FTS commit stays one shard");
+        assert_eq!(r.n_superfiles(), 1, "small FTS commit stays one piece");
         // Every doc's title contains "alpha" (see build_simple_batch); a match-all term must
-        // surface hits from the single-shard index.
+        // surface hits from the one-piece index.
         let hits = st
             .bm25_search(
                 "title",
@@ -8786,7 +8785,7 @@ mod tests {
                 Bm25Stats::PerSuperfile,
                 None,
             )
-            .expect("bm25 over single-shard commit");
+            .expect("bm25 over one-piece commit");
         let n: usize = hits.iter().map(|b| b.num_rows()).sum();
         assert!(n > 0, "single-shard FTS index must return hits");
     }
@@ -10004,7 +10003,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_shards_wide_buffer_up_to_pool_width() {
+    fn commit_splits_wide_buffer_up_to_pool_width() {
         // A buffer over the shard target splits, capped by the pool. Arrow reports capacity
         // (not logical bytes), so the ~100 MiB buffer wants 2-3 shards; the 2-thread pool pins
         // it to exactly 2.


### PR DESCRIPTION
### What does this PR do?
This PR changes how the number of superfiles a commit produces is decided: it is now based on the amount of data being committed instead of only the machine's number of cores. Closes #594.

### Why do we need this change?
A commit splits its buffer into one shard per writer-pool thread, and each shard becomes its own superfile. So the larger the machine, the more superfiles a commit creates, even when the data is small. At real buffer sizes this fragments the table without buying any ingestion throughput. #594 has detailed observation.

### How do we do this change?
- The number of shards for a commit is now `ceil(buffered_bytes / target)`, still capped by the pool width. So the shard count grows with the data, each shard stays around the target size, and the cores only decide how many build in parallel.
- The target defaults to 64 MiB and is configurable as `shard_target_size_mb` in the config, next to the existing commit threshold. Setting it to `0` restores the old per-thread fanout.
- Vector commits already shard by cell and are untouched.

### Performance
- Measured on c7a.metal-48xl (192 cores), `supertable fts build` at 10M docs against main: ingest throughput went from 271K to 335.6K docs/s (+24%), superfiles from 3072 to 528, stored index from 13.94 to 8.88 GiB, object-store PUTs from 3122 to 578, and peak ingest RSS from 10.5 to 6.8 GiB.
- Small machines are unaffected: a 4-core host produces the same shards per flush before and after. The table content is identical either way, only the file boundaries change.

### Notes
- Existing configs pick up the 64 MiB default on upgrade; that is the fix taking effect, and `0` is the opt-out.