### PR TITLE
bench/ci: report cold-path regressions instead of failing the gate

### DIFF
--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -10,6 +10,7 @@ Inputs (env):
   CURRENT_DIR                dir holding <report>.json from this run
   BENCH_NOISE_THRESHOLD_PCT  threshold in percent (default 5)
   GATE_FILE                  merge-gate verdict destination (default /tmp/bench-gate.status)
+  INFO_FILE                  non-gating cold findings (default /tmp/bench-gate.info)
   OUT_FILE                   markdown destination (default /tmp/ai-summary.md)
   BENCH_LABEL                human label for the run (the `bench` input)
   BENCH_VM_SIZE              VM size label for context
@@ -36,9 +37,14 @@ TEXT_ONLY = ("corpus", "superfiles")
 COST_TOKENS = ("$", "cost", "measured", "per-unit")
 
 # Secondary metrics - cold (object-store network variance) and peak RSS
-# (run-order biased) are noisy and non-gating for PR decisions.
-SECONDARY_HEADERS = ("cold search", "peak rss")
+# (run-order biased) are noisy and non-gating for PR decisions. Substring
+# match, so every cold spelling is covered, not just one.
+SECONDARY_HEADERS = ("cold", "peak rss")
 SECONDARY_THRESHOLD_PCT = 30.0
+
+# Cold latency is a fresh-cache network round trip — it tracks the object store,
+# not the diff — so it is reported and never blocks.
+NON_GATING_HEADERS = ("cold",)
 
 # Map a report basename to (subsystem label, source area).
 SUBSYSTEM = {
@@ -60,8 +66,9 @@ MIN_LATENCY_DELTA_NS = 100_000.0
 DEFAULT_OUT = "/tmp/ai-summary.md"
 DEFAULT_THRESHOLD = 5.0
 DEFAULT_GATE_FILE = "/tmp/bench-gate.status"
+DEFAULT_INFO_FILE = "/tmp/bench-gate.info"
 
-# Merge-blocking gate: a time-valued metric (warm/cold latency, ingest /
+# Merge-blocking gate: a gating time-valued metric (warm latency, ingest /
 # drain / optimize wall) must be worse than the main baseline by BOTH of
 # these to block the merge. The AND is the noise guard: a big percent of a
 # sub-millisecond metric never blocks, and neither does a small-percent
@@ -83,6 +90,10 @@ def higher_is_better(header):
 def is_cost(header):
     h = header.lower()
     return any(t in h for t in COST_TOKENS)
+
+
+def is_non_gating(header):
+    return any(t in header.lower() for t in NON_GATING_HEADERS)
 
 
 def tier(header, primary_headers):
@@ -143,13 +154,15 @@ def load(path):
 def diff(reports, baseline_dir, current_dir, threshold, primary_headers):
     """Classify changes per report.
 
-    Returns (regressions, improvements, blocking, had_baseline, cost_present).
+    Returns (regressions, improvements, blocking, informational, had_baseline,
+    cost_present).
 
     `regressions` / `improvements` are the advisory findings (the 5%/30%
     tier thresholds — report-only). `blocking` is the merge gate: time
     metrics worse than baseline by BOTH >GATE_REL_PCT and >GATE_ABS_NS.
+    `informational` holds the same-sized moves on non-gating (cold) headers.
     """
-    regressions, improvements, blocking = [], [], []
+    regressions, improvements, blocking, informational = [], [], [], []
     had_baseline = False
     cost_present = False
     for report in reports:
@@ -173,23 +186,22 @@ def diff(reports, baseline_dir, current_dir, threshold, primary_headers):
             if old is None or old == 0.0:
                 continue
             had_baseline = True
-            # Merge-blocking gate: every time-valued lower-is-better metric
-            # is eligible regardless of advisory tier, so optimize/drain
-            # walls and every latency row are covered.
+            # Every time-valued metric is eligible regardless of advisory tier,
+            # so optimize/drain walls and warm latency are covered.
             if is_latency(header):
                 delta_ns = new - old
                 gate_pct = delta_ns / old * 100.0
                 if delta_ns > GATE_ABS_NS and gate_pct > GATE_REL_PCT:
-                    blocking.append(
-                        {
-                            "subsystem": subsystem,
-                            "area": area,
-                            "metric": f"{label} / {header}".strip(" /"),
-                            "change": f"{human(header, old)} -> {human(header, new)}",
-                            "pct": round(gate_pct, 1),
-                            "tier": "blocking",
-                        }
-                    )
+                    non_gating = is_non_gating(header)
+                    entry = {
+                        "subsystem": subsystem,
+                        "area": area,
+                        "metric": f"{label} / {header}".strip(" /"),
+                        "change": f"{human(header, old)} -> {human(header, new)}",
+                        "pct": round(gate_pct, 1),
+                        "tier": "informational" if non_gating else "blocking",
+                    }
+                    (informational if non_gating else blocking).append(entry)
             if t is None:
                 continue
             if is_latency(header):
@@ -214,7 +226,8 @@ def diff(reports, baseline_dir, current_dir, threshold, primary_headers):
     regressions.sort(key=lambda e: -abs(e["pct"]))
     improvements.sort(key=lambda e: -abs(e["pct"]))
     blocking.sort(key=lambda e: -abs(e["pct"]))
-    return regressions, improvements, blocking, had_baseline, cost_present
+    informational.sort(key=lambda e: -abs(e["pct"]))
+    return regressions, improvements, blocking, informational, had_baseline, cost_present
 
 
 def finding(entry):
@@ -245,8 +258,9 @@ def main():
         threshold = DEFAULT_THRESHOLD
 
     gate_file = os.environ.get("GATE_FILE", DEFAULT_GATE_FILE)
+    info_file = os.environ.get("INFO_FILE", DEFAULT_INFO_FILE)
     failures = [ln.strip() for ln in os.environ.get("ERRORS", "").splitlines() if ln.strip()]
-    regressions, improvements, blocking, had_baseline, cost_present = diff(
+    regressions, improvements, blocking, informational, had_baseline, cost_present = diff(
         reports, baseline_dir, current_dir, threshold, primary_headers
     )
 
@@ -267,6 +281,7 @@ def main():
         f">{GATE_REL_PCT:g}% AND >{GATE_ABS_NS / 1e6:g} ms vs {base_ref}"
     )
     parts.append(f"Advisory findings: {counts}, threshold ±{threshold:g}% (report-only)")
+    parts.append(f"Cold movers (informational): {len(informational)}")
     parts.append(
         f"Run Context: bench={label} vm={vm_size} region={location} cpuset={cpuset or 'auto'}"
     )
@@ -279,6 +294,11 @@ def main():
         # Never truncate merge-blocking signals.
         parts += ["### Blocking Regressions (merge gate)", ""]
         parts.extend(finding(e) for e in blocking)
+        parts.append("")
+
+    if informational:
+        parts += ["### Cold Movers (informational — not gating)", ""]
+        parts.extend(finding(e) for e in informational)
         parts.append("")
 
     if not failures and not had_baseline:
@@ -359,10 +379,15 @@ def main():
         else:
             fh.write("PASS\n")
 
+    # Surfaced as workflow warnings; deliberately kept out of the verdict file.
+    with open(info_file, "w", encoding="utf-8") as fh:
+        for e in informational:
+            fh.write(f"{e['metric']}: {e['change']} ({e['pct']:+.0f}%)\n")
+
     print(
-        f"wrote {out_file}: {len(blocking)} blocking, {len(regressions)} advisory regressions, "
-        f"{len(improvements)} improvements, {len(failures)} failure line(s), "
-        f"baseline={'yes' if had_baseline else 'no'}"
+        f"wrote {out_file}: {len(blocking)} blocking, {len(informational)} informational, "
+        f"{len(regressions)} advisory regressions, {len(improvements)} improvements, "
+        f"{len(failures)} failure line(s), baseline={'yes' if had_baseline else 'no'}"
     )
 
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -64,7 +64,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: write # post the bench-results comment on the PR
+      # Kept so summary_destination=pr_comment stays usable; PR runs default to
+      # step_summary, so this path is exercised only by a manual dispatch.
+      pull-requests: write
     uses: ./.github/workflows/supertable-bench-azure.yml
     with:
       bench: ${{ matrix.bench }}

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -616,15 +616,23 @@ jobs:
           ERRORS="$(cat /tmp/bench.errors 2>/dev/null || true)" \
             python3 .github/scripts/bench_summary.py
 
-      # Enforce the merge-blocking benchmark gate: a time metric worse than
-      # the same-host main baseline by BOTH >50% and >5 ms fails this job
+      # Enforce the merge-blocking benchmark gate: a warm/wall time metric worse
+      # than the same-host main baseline by BOTH >50% and >5 ms fails this job
       # (bench_summary.py writes the verdict; the 5% findings stay advisory).
-      # A separate step so the summary still posts to the PR on FAIL.
+      # Cold movers are reported as warnings — they track object-store network
+      # variance, not the diff. A separate step so the summary still posts on FAIL.
       - name: Enforce benchmark merge gate
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           STATUS_FILE=/tmp/bench-gate.status
+          INFO_FILE=/tmp/bench-gate.info
+          if [ -s "$INFO_FILE" ]; then
+            echo "::warning::cold movers past >50% AND >5ms vs main (informational, not gating):"
+            while IFS= read -r line; do
+              echo "::warning::  $line"
+            done < "$INFO_FILE"
+          fi
           if [ ! -f "$STATUS_FILE" ]; then
             echo "no gate verdict produced (no baseline or summary skipped) — pass"
             exit 0


### PR DESCRIPTION
## Problem

The benchmark merge gate fails on cold-path noise. On [run 31509065524](https://github.com/infino-ai/infino/actions/runs/31509065524) (PR #585) three of five legs failed the gate with 21 findings — **every one of them a cold metric** (`cold 1st query (median)`, `+fetch cold`, `cold steady`):

```
ten_term_or / cold 1st query (median): 50.28 ms -> 1.47 s (+2823%)
three_wide_or / cold 1st query (median): 58.77 ms -> 685.55 ms (+1066%)
exact_match / cold 1st query (median): 174.93 ms -> 488.60 ms (+179%)
```

PR #585 is the release version bump: seven files, all version strings, no code. A +2823% reading against a no-op diff is object-store network variance, not a regression. The `superfile` leg passed precisely because it is in-memory and has no cold fetch.

`bench_summary.py` already knew this and contradicted itself. It declares cold non-gating:

```python
# Secondary metrics - cold (object-store network variance) and peak RSS
# (run-order biased) are noisy and non-gating for PR decisions.
SECONDARY_HEADERS = ("cold search", "peak rss")
```

…then built the blocking list from every time-valued header with no tier check, so cold rows were simultaneously "non-gating" and merge-blocking.

A second bug compounded it: `SECONDARY_HEADERS` matched the literal `"cold search"`, which no report emits. `tier()` returned `None` for real cold headers, so they were classified as unsurfaced context — invisible in the summary, yet fatal to the job.

## Change

Cold latency is reported, never blocking. Warm, wall, and ingest metrics gate exactly as before.

- `NON_GATING_HEADERS = ("cold",)`; cold rows crossing the >50% AND >5 ms pair go to a new `informational` bucket instead of `blocking`.
- `SECONDARY_HEADERS` fixed to `("cold", "peak rss")` so cold rows classify correctly and appear in the 30% advisory tier.
- Script writes `/tmp/bench-gate.info`; the gate step emits one `::warning::` per cold mover, then applies the FAIL check to gating metrics only.
- Summary gains a "Cold Movers (informational — not gating)" section and a count line.

Summaries continue to go to the Actions run summary (`summary_destination` defaults to `step_summary`); the PR-comment path is untouched and still reachable via `workflow_dispatch`.

## Verification

The gate step's shell was extracted verbatim from the workflow and driven with the real summary script.

Replaying run 31509065524's actual numbers — all 21 findings reproduce with matching labels and percentages, and every leg now passes:

| Leg | Findings | Before | After |
| --- | --- | --- | --- |
| `supertable_fts` | 12 | exit 1 | 12 warnings, exit 0 |
| `supertable_vector` | 2 | exit 1 | 2 warnings, exit 0 |
| `supertable_sql` | 7 | exit 1 | 7 warnings, exit 0 |

Edge cases:

| Scenario | Result |
| --- | --- |
| warm p90 + optimize wall regression | exit 1 — still blocks, cold warns alongside |
| warm 1 -> 4 ms (under the 5 ms floor) | not blocking, correctly excluded |
| clean run within noise | exit 0 |
| improvements only, incl. cold | exit 0 |
| no baseline (first run) | exit 0, empty info file, no warning block |
| harness panic in `ERRORS` | exit 1 — failure path intact |
| summary step skipped entirely | exit 0, no stale-file read |

Every header the bench suite declares was swept through the real predicates. The only newly-exempt ones are `cold 1st`, `cold steady`, and `Cold open GET/bytes` — no warm, wall, or ingest metric contains "cold", so the blocking surface lost nothing it should keep. (`Cold open GET/bytes` is a request count that `is_latency()` was misreading as nanoseconds; it should never have been gated as a time.)

`actionlint` reports one finding on the workflow — `workflow_dispatch` has 15 inputs against a documented max of 10 — identical on `main` and not introduced here. It is not enforced in practice: the last 40 runs of that workflow were all dispatches.

No benchmark comparison is included because this change touches only `.github/`; no engine code is modified, so query latency, ingest throughput, cost profile, and vector recall are all unaffected.

## Trade-off

A genuine cold-path regression will no longer block a merge — it surfaces as a warning and in the summary instead. That is the deliberate call: with cold deltas swinging +2823% on a zero-diff branch, the signal cannot carry a blocking decision, and a gate that fires on release bumps trains reviewers to ignore it.
