### PR TITLE
vector: probe enough cells to fill top-k across cluster boundaries

### DIFF
--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -3217,6 +3217,114 @@ mod tests {
         );
     }
 
+    /// A top-k vector query blended between two axis clusters must return all
+    /// `k` results once the drain has split those axes into separate hidden
+    /// cells. Under default routing (no caller nprobe) the coarse cell cutoff
+    /// widened only by score-slack — probing the single nearest cell and
+    /// returning `k/2`; it must instead probe enough cells to fill `k`.
+    #[test]
+    fn blended_vector_search_fills_topk_across_hidden_cells() {
+        use std::sync::Arc;
+
+        use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray};
+        use arrow_schema::{DataType, Field, Schema};
+
+        use crate::superfile::{
+            builder::{FtsConfig, VectorConfig},
+            reader::VectorSearchOptions,
+            vector::{distance::Metric, rerank_codec::RerankCodec},
+        };
+
+        const DIM: usize = 16;
+        const AXES: usize = 5;
+        const ROWS: usize = 60; // AXES clusters, ROWS / AXES = 12 rows each
+
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new(
+                "emb",
+                DataType::FixedSizeList(item_field.clone(), DIM as i32),
+                false,
+            ),
+        ]));
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let options = SupertableOptions::new(
+            schema.clone(),
+            vec![FtsConfig {
+                column: "title".into(),
+                positions: false,
+            }],
+            vec![VectorConfig {
+                column: "emb".into(),
+                dim: DIM,
+                rot_seed: 7,
+                metric: Metric::Cosine,
+                rerank_codec: RerankCodec::Sq8FixedResidual,
+                provided_centroids: None,
+            }],
+            Some(crate::test_helpers::default_tokenizer()),
+        )
+        .expect("valid options")
+        .with_storage(Arc::clone(&storage))
+        .with_writer_pool(pool);
+
+        // Row i is a one-hot vector on axis `i % AXES`, so the drain lands each
+        // axis in its own hidden cell.
+        let titles = LargeStringArray::from((0..ROWS).map(|i| format!("r{i}")).collect::<Vec<_>>());
+        let mut flat = vec![0.0f32; ROWS * DIM];
+        for i in 0..ROWS {
+            flat[i * DIM + (i % AXES)] = 1.0;
+        }
+        let fsl = FixedSizeListArray::new(
+            item_field,
+            DIM as i32,
+            Arc::new(Float32Array::from(flat)),
+            None,
+        );
+        let batch = arrow_array::RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(titles) as Arc<dyn Array>,
+                Arc::new(fsl) as Arc<dyn Array>,
+            ],
+        )
+        .expect("batch");
+
+        let st = Supertable::create(options).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+        drop(w);
+        st.drain_vectors_to_cells_sync().expect("drain to cells");
+
+        // Query blended between axis 0 (weight 1.0) and axis 1 (weight 0.5): the
+        // top `k` spans both axes' rows, which the drain split across two cells.
+        let k = 2 * (ROWS / AXES); // 24
+        let mut q = vec![0.0f32; DIM];
+        q[0] = 1.0;
+        q[1] = 0.5;
+        let hits = st
+            .reader()
+            .expect("reader")
+            .vector_hits("emb", &q, k, VectorSearchOptions::new(), None)
+            .expect("vector search");
+        assert_eq!(
+            hits.len(),
+            k,
+            "blended top-k must span both hidden cells, got {}",
+            hits.len()
+        );
+    }
+
     /// After a splice drain into the hidden vector index, the reader's derived-
     /// state accessors report a live hidden index: a storage prefix is stamped,
     /// the hidden-superfile stats are non-empty, the user superfiles carry real

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -742,6 +742,31 @@ fn union_cell_selection(grid: &[u32], fine: &[u32]) -> Vec<u32> {
     selected
 }
 
+/// Widen a grid cell cutoff so the probed cells' indexed row counts cover at
+/// least `k`. `grid_cell_cutoff`'s slack window stops at the nearest near-tie
+/// cluster — a single cell for a query blended between two clusters — so a
+/// top-k request that spans cells could otherwise probe one undersized cell and
+/// return fewer than `k` rows. Walks the cell ranking past `cutoff`, adding each
+/// cell's indexed row count (from `postings_by_cell`) until coverage reaches `k`
+/// or the ranking is exhausted. A no-op once the already-probed cells hold `k`
+/// (the common single-cluster case, and every cell large relative to `k` at
+/// scale), so a sufficient query is never widened.
+fn cover_k_cell_cutoff(
+    cutoff: usize,
+    ranked: &[(u32, f32)],
+    postings_by_cell: &HashMap<u32, u64>,
+    k: usize,
+) -> usize {
+    let cell_rows = |cell: u32| postings_by_cell.get(&cell).copied().unwrap_or(0);
+    let mut covered: u64 = ranked[..cutoff].iter().map(|(c, _)| cell_rows(*c)).sum();
+    let mut cut = cutoff;
+    while cut < ranked.len() && covered < k as u64 {
+        covered += cell_rows(ranked[cut].0);
+        cut += 1;
+    }
+    cut
+}
+
 // Serve-time near-tie window on the exact-fine cell ranking (#515),
 // law-pinned default path only. Past the law's width, selection keeps
 // following the ranking while each next cell's best exact fine score
@@ -1786,6 +1811,19 @@ impl SupertableReader {
                 ));
             }
             let cutoff = grid_cell_cutoff(&ranked_for_beam, &cell_routing);
+            // Default routing only: a top-k request with no caller `nprobe`
+            // must probe enough cells to actually hold `k` rows. The slack
+            // window above stops at the nearest near-tie cluster, so a query
+            // blended between two clusters selects one undersized cell and
+            // returns fewer than `k`; widen along the grid ranking until the
+            // probed cells cover `k`. No-op once the nearest cell(s) already
+            // hold `k`. An explicit caller `nprobe` is a deliberate width
+            // constraint and is left untouched even when it under-fills `k`.
+            let cutoff = if options.nprobe.is_none() {
+                cover_k_cell_cutoff(cutoff, &ranked_for_beam, &postings_by_cell, k)
+            } else {
+                cutoff
+            };
             // 1-bit prefilter for the exact fine scan: the grid's cutoff
             // picks are must-include so every cell the beam can select has
             // exact candidate scores (near-tie checks included). Filtered


### PR DESCRIPTION
## Problem

An unfiltered vector `top-k` search can return fewer than `k` rows when the query vector sits between two clusters.

After the drain distributes rows across hidden cells, the coarse cell selector chooses how many cells to probe by a **score-slack window**: start at the nearest cell and keep adding cells only while the next cell's score stays within a slack margin of the best. A query blended between two clusters (primary weight 1.0, secondary 0.5) has its secondary cell fall outside that margin, so only the nearest cell is probed. If that cell holds fewer than `k` rows, the query returns short — e.g. **12 of a requested 24** — silently, under the default config with no caller `nprobe`.

The slack window decides coverage by score proximity, never by whether `k` is satisfied.

## Fix

`cover_k_cell_cutoff`, applied right after the slack cutoff: keep extending the probed cells down the ranking — summing each cell's indexed row count — until the probed cells can hold `k`, or the ranking is exhausted.

- A **k-sufficiency floor** on top of the existing slack window: slack still handles the common single-cluster early stop; this guarantees a top-k request can't come back short.
- **No-op whenever the nearest cell(s) already hold `k`**, so single-cluster queries and every query at scale (top cell ≫ k) are unaffected — no extra cells probed, scored, or fetched.
- The widened cutoff flows into the must-include set, so the extra cells are scored and their rows returned.

## Testing

New unit test `blended_vector_search_fills_topk_across_hidden_cells`: 60 one-hot rows across 5 axis clusters, drained into separate hidden cells; a `k=24` query blended between two axes must return 24. Returns 12 without the fix, 24 with it. Existing vector/query integration suite stays green.
