### PR TITLE
fix gc: erase the disk-cache copy also of each deleted superfile

### DIFF
--- a/src/supertable/gc/mod.rs
+++ b/src/supertable/gc/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         error::GcError,
         handle::SupertableInner,
         manifest::{
-            SUPERFILE_DATA_DIR,
+            SUPERFILE_DATA_DIR, SuperfileUri,
             commit::{MANIFEST_DIR, MANIFEST_PARTS_DIR, POINTER_PATH, manifest_uri},
         },
         slow_vector_state::{self, STORAGE_PREFIX as SLOW_VECTOR_STATE_STORAGE_PREFIX},
@@ -268,6 +268,14 @@ pub(super) async fn gc_storage_sweep_for_inner(
     }
 
     for (key, size) in candidates {
+        // Drop the cache copy first.
+        if let (Some(cache), Some(uri)) = (
+            inner.options.disk_cache.as_ref(),
+            SuperfileUri::from_storage_path(&key),
+        ) {
+            cache.erase_superfile_local_copy(&uri);
+        }
+
         match storage.delete(&key).await {
             Ok(()) => {
                 report.objects_deleted += 1;
@@ -299,7 +307,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        storage::{LocalFsStorageProvider, StorageProvider},
+        storage::{LocalFsStorageProvider, PrefixedStorageProvider, StorageProvider},
         supertable::{
             SupertableOptions,
             manifest::{
@@ -313,6 +321,37 @@ mod tests {
         },
         test_helpers::default_supertable_options,
     };
+
+    /// The hidden vector index sweeps through a `PrefixedStorageProvider`, which
+    /// strips its sub-prefix on list. Its keys therefore reach the cache
+    /// drop-through in the same `data/seg-<uuid>.sf.parquet` shape as the user
+    /// table's, so the sweep drops the right entry from the shared cache.
+    #[tokio::test]
+    async fn keys_listed_through_a_prefixed_provider_parse_as_superfile_uris() {
+        let dir = tempdir().expect("tempdir");
+        let root: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let prefixed: Arc<dyn StorageProvider> = Arc::new(PrefixedStorageProvider::new(
+            Arc::clone(&root),
+            "hidden-index-prefix/",
+        ));
+        let uri = SuperfileUri::new_v4();
+        prefixed
+            .put_atomic(&uri.storage_path(), bytes::Bytes::from_static(b"superfile"))
+            .await
+            .expect("put");
+
+        let listed = prefixed
+            .list_with_prefix_metadata(SUPERFILE_DATA_DIR)
+            .await
+            .expect("list");
+        assert_eq!(listed.len(), 1, "the prefixed listing sees its own object");
+        assert_eq!(
+            SuperfileUri::from_storage_path(&listed[0].0),
+            Some(uri),
+            "prefix-stripped key parses back to the URI GC must drop"
+        );
+    }
 
     /// Bucket count for a minimal hash-partitioned manifest list fixture.
     const TEST_HASH_BUCKETS: u32 = 1;

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -2473,6 +2473,12 @@ impl SuperfileUri {
         let body = name.strip_prefix("seg-")?.strip_suffix(".sf.parquet")?;
         Uuid::parse_str(body).ok().map(SuperfileUri)
     }
+
+    /// Inverse of [`Self::storage_path`]. Fetches the superfile name from the path.
+    pub fn from_storage_path(key: &str) -> Option<Self> {
+        let name = key.strip_prefix(SUPERFILE_DATA_DIR)?.strip_prefix('/')?;
+        Self::from_cache_filename(name)
+    }
 }
 
 /// Merge min/max arrays by comparing values and keeping the actual min and max.
@@ -3874,6 +3880,37 @@ mod tests {
         assert!(mutated.transposed.get().is_none());
         let _ = mutated.transposed(); // rebuild
         assert!(mutated.transposed.get().is_some());
+    }
+
+    /// `from_storage_path` recovers a URI from a superfile object key and only
+    /// from one: every other key shape a storage listing can yield (manifest
+    /// parts, tombstone sidecars, in-flight tmps, foreign files) falls through,
+    /// so GC can feed it every candidate it deletes.
+    #[test]
+    fn from_storage_path_parses_only_superfile_keys() {
+        let uri = SuperfileUri::new_v4();
+        assert_eq!(
+            SuperfileUri::from_storage_path(&uri.storage_path()),
+            Some(uri),
+            "round-trips its own storage_path"
+        );
+
+        for key in [
+            "manifests/manifest-42.json",
+            "manifest-parts/ab12cd.part",
+            "superfiles/seg-not-a-uuid.tombstones",
+            &format!("superfiles/seg-{}.tombstones", uri.0), // valid uuid, sidecar dir
+            &format!("data/seg-{}.sf.parquet.tmp", uri.0),
+            &format!("seg-{}.sf.parquet", uri.0), // missing data/ prefix
+            "data/seg-not-a-uuid.sf.parquet",
+            "",
+        ] {
+            assert_eq!(
+                SuperfileUri::from_storage_path(key),
+                None,
+                "must not parse: {key}"
+            );
+        }
     }
 
     /// The 1-bit admit estimate must prefer the instance holding the

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -228,6 +228,8 @@ pub struct CacheStats {
     /// by the idle-threshold sweep thread. Includes individual
     /// `sweep_once()` invocations.
     pub n_madvise_calls: u64,
+    /// Total count of entries dropped because GC deleted from objectstore.
+    pub n_gc_drops: u64,
 }
 
 /// Pulls superfile bytes through a [`StorageProvider`] and
@@ -262,6 +264,7 @@ pub struct DiskCacheStore {
     budget_warned: AtomicBool,
     n_cold_fetches: AtomicU64,
     n_evictions: AtomicU64,
+    n_gc_drops: AtomicU64,
     n_madvise_calls: AtomicU64,
     /// Number of callers explicitly waiting for lazy background
     /// promotion. A waiter means promotion is now latency-critical,
@@ -334,6 +337,7 @@ impl DiskCacheStore {
             budget_warned: AtomicBool::new(false),
             n_cold_fetches: AtomicU64::new(0),
             n_evictions: AtomicU64::new(0),
+            n_gc_drops: AtomicU64::new(0),
             n_madvise_calls: AtomicU64::new(0),
             n_promotion_waiters: AtomicU64::new(0),
             pinned_fn: std::sync::Mutex::new(pinned_fn),
@@ -752,6 +756,7 @@ impl DiskCacheStore {
             n_cold_fetches: self.n_cold_fetches.load(Ordering::Acquire),
             n_evictions: self.n_evictions.load(Ordering::Acquire),
             n_madvise_calls: self.n_madvise_calls.load(Ordering::Acquire),
+            n_gc_drops: self.n_gc_drops.load(Ordering::Acquire),
         }
     }
 
@@ -1806,6 +1811,30 @@ impl DiskCacheStore {
         Ok(())
     }
 
+    /// Erase every local trace of a superfile: its in-memory index entry, the promoted file, the
+    /// sparse block sidecar, and the per-URI fetch coordinator.
+    ///
+    /// GC calls this immediately before deleting the superfile from storage, so the local copy never
+    /// outlives its source. Returns whether an index entry was present, which is what `n_gc_drops`
+    /// counts.
+    pub(crate) fn erase_superfile_local_copy(&self, uri: &SuperfileUri) -> bool {
+        let present = if let Some((_, entry)) = self.cached.remove(uri) {
+            self.release_entry_accounting(&entry);
+            true
+        } else {
+            false
+        };
+
+        self.coordinators.remove(uri);
+        let _ = fs::remove_file(self.cache_path(uri));
+        let _ = fs::remove_file(self.blocks_path(uri));
+        if present {
+            self.n_gc_drops.fetch_add(1, Ordering::AcqRel);
+        }
+
+        present
+    }
+
     /// Fetch `size` bytes from `storage_uri` into `dest_path`
     /// via parallel range-GETs. Mutex-serialized writes; the
     /// fetches are the slow path so the per-write mutex
@@ -2840,6 +2869,9 @@ mod tests {
     const TEST_TINY_BUDGET_BYTES: u64 = 4;
     /// A comfortably large budget floor for the raise paths.
     const TEST_RAISED_FLOOR_BYTES: u64 = 1 << 20;
+    /// Attempts per interleaving-sensitive test; enough to surface a torn
+    /// drop-vs-fill without making the suite slow.
+    const RACE_ITERATIONS: usize = 200;
 
     #[tokio::test]
     async fn auto_budget_is_raised_and_admits_previously_oversized_entry() {
@@ -2879,6 +2911,138 @@ mod tests {
         store.reconcile_budget_floor(TEST_RAISED_FLOOR_BYTES, TEST_RAISED_FLOOR_BYTES);
         assert_eq!(store.disk_budget_bytes(), TEST_TINY_BUDGET_BYTES);
         assert_eq!(store.stats().budget_bytes, TEST_TINY_BUDGET_BYTES);
+    }
+
+    #[tokio::test]
+    async fn erase_superfile_local_copy_removes_entry_file_and_accounting() {
+        // GC drop-through: a dropped URI leaves no entry, no promoted file, no
+        // block sidecar, and balanced byte accounting.
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("insert_warm");
+        assert!(store.cache_path(&uri).is_file());
+        assert_eq!(store.stats().n_entries, 1);
+
+        assert!(store.erase_superfile_local_copy(&uri), "entry was present");
+        let s = store.stats();
+        assert_eq!(s.n_entries, 0);
+        assert_eq!(s.current_bytes, 0, "accounting released");
+        assert_eq!(s.n_gc_drops, 1);
+        assert!(!store.cache_path(&uri).exists(), "promoted file unlinked");
+        assert!(!store.blocks_path(&uri).exists(), "block sidecar unlinked");
+
+        // A second drop of the same URI is a no-op, and a never-cached URI
+        // reports absent — only real drops count.
+        assert!(!store.erase_superfile_local_copy(&uri));
+        assert!(!store.erase_superfile_local_copy(&SuperfileUri::new_v4()));
+        assert_eq!(store.stats().n_gc_drops, 1);
+    }
+
+    #[tokio::test]
+    async fn erase_superfile_local_copy_keeps_a_held_reader_alive() {
+        // GC can drop a URI a query is reading. The mapping survives: unlink
+        // removes the directory entry, not the inode, so the held `Arc<Mmap>`
+        // keeps faulting valid pages (this is why eviction has always been
+        // safe under live readers).
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("insert_warm");
+        let held = store.reader(&uri).await.expect("reader");
+        let n_docs = held.n_docs();
+
+        assert!(store.erase_superfile_local_copy(&uri));
+        assert!(!store.cache_path(&uri).exists(), "file unlinked");
+
+        // Same reader, after the drop: still serving its own mapping.
+        assert_eq!(held.n_docs(), n_docs, "held reader still reads its mmap");
+
+        // A refetch of the same URI writes a fresh inode via tmp + rename, so
+        // it cannot zero the bytes the held reader is still mapping.
+        store
+            .insert_warm(&uri, tiny_superfile_bytes())
+            .await
+            .expect("refetch after drop");
+        assert_eq!(
+            held.n_docs(),
+            n_docs,
+            "refetch left the held mapping intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn erase_superfile_local_copy_leaves_source_owned_accounting_to_its_owner() {
+        // A block-backed entry's bytes are accounted by the block source, not
+        // the entry (`EntryAccounting::SourceOwned`). Dropping the entry must
+        // not decrement for it — the source's own release does that, and a
+        // second decrement here would underflow `current_bytes`.
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let filled = Arc::new(AtomicU64::new(4096));
+        let token = Arc::new(());
+        store.install_block_entry_for_test(uri, Arc::clone(&filled), Arc::clone(&token));
+        assert_eq!(store.stats().current_bytes, 0, "source owns these bytes");
+
+        assert!(store.erase_superfile_local_copy(&uri), "entry was present");
+        let s = store.stats();
+        assert_eq!(s.n_entries, 0);
+        assert_eq!(s.current_bytes, 0, "no decrement, no underflow");
+        assert_eq!(s.n_gc_drops, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn erase_superfile_local_copy_concurrent_with_a_fill_keeps_accounting_consistent() {
+        // GC can drop a URI while a fill for it is in flight. Either outcome is
+        // fine (the fill lands and leaves a dead entry a later eviction
+        // reclaims, or the drop wins), but accounting must match the outcome:
+        // bytes present exactly when the entry is.
+        let (_dir, store) = test_store();
+        let size = tiny_superfile_bytes().len() as u64;
+
+        for _ in 0..RACE_ITERATIONS {
+            let uri = SuperfileUri::new_v4();
+            let filler = Arc::clone(&store);
+            let dropper = Arc::clone(&store);
+            let fill =
+                tokio::spawn(async move { filler.insert_warm(&uri, tiny_superfile_bytes()).await });
+            let drop_task = tokio::spawn(async move { dropper.erase_superfile_local_copy(&uri) });
+            let (fill_res, drop_res) = tokio::join!(fill, drop_task);
+            fill_res.expect("fill task").expect("insert_warm");
+            drop_res.expect("drop task");
+
+            let s = store.stats();
+            let expected = if s.n_entries == 1 { size } else { 0 };
+            assert_eq!(
+                s.current_bytes, expected,
+                "bytes must match entry presence (entries={})",
+                s.n_entries
+            );
+            // Leave a clean slate for the next iteration.
+            store.erase_superfile_local_copy(&uri);
+            assert_eq!(store.stats().current_bytes, 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn erase_superfile_local_copy_unlinks_file_left_without_an_entry() {
+        // A cache file can exist with no map entry (crash between rename and
+        // insert); erase_superfile_local_copy still unlinks it so the orphan cannot outlive its
+        // storage object.
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        fs::write(store.cache_path(&uri), b"stale bytes").expect("write orphan");
+
+        assert!(!store.erase_superfile_local_copy(&uri), "no entry to drop");
+        assert!(
+            !store.cache_path(&uri).exists(),
+            "orphan file still unlinked"
+        );
+        assert_eq!(store.stats().n_gc_drops, 0);
     }
 
     #[tokio::test]

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -10,18 +10,22 @@
 //!    on disk until GC runs.
 //! 4. GC (safety_gap = 0) deletes stale objects; only live files remain.
 //! 5. Data remains fully queryable after GC.
+//! 6. GC drops the disk-cache copy of every superfile it deletes.
 
 #![deny(clippy::unwrap_used)]
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, path::Path, sync::Arc, time::Duration};
 
+use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
 use chrono::{Duration as ChronoDuration, Utc};
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
     CompactionSettings, GcSettings, OptimizeOptions,
-    superfile::fts::reader::BoolMode,
+    superfile::{builder::FtsConfig, fts::reader::BoolMode},
     supertable::{
-        Supertable,
+        Supertable, SupertableOptions,
+        reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
         storage::{LocalFsStorageProvider, StorageProvider},
         wal::{
             persistence::WalStore,
@@ -31,11 +35,16 @@ use infino::{
             },
         },
     },
-    test_helpers::{build_title_batch, default_supertable_options},
+    test_helpers::{
+        build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
+    },
 };
 use tempfile::TempDir;
 
 const TOP_K: usize = 10;
+/// Disk-cache budget for the drop-through tests: large enough that eviction
+/// never fires, so anything missing from the cache was dropped by gc.
+const CACHE_BUDGET_BYTES: u64 = 1 << 30;
 
 fn small_optimize_opts() -> OptimizeOptions {
     OptimizeOptions::compact(CompactionSettings {
@@ -377,5 +386,220 @@ fn optimize_honors_overridden_gc_safety_gap() {
         count_dir(&data_dir),
         r.n_superfiles(),
         "gc_safety_gap=0 must reclaim every orphaned superfile down to the live set"
+    );
+}
+
+/// A table wired to its own disk cache, the shape both drop-through tests need:
+/// commits warm-fill this cache, so gc has copies to drop.
+fn table_with_disk_cache(
+    options: SupertableOptions,
+    storage: Arc<dyn StorageProvider>,
+    cache_root: &Path,
+) -> (Supertable, Arc<DiskCacheStore>) {
+    let cfg = DiskCacheConfig {
+        cache_root: cache_root.to_path_buf(),
+        disk_budget_bytes: CACHE_BUDGET_BYTES,
+        cold_fetch_mode: ColdFetchMode::HybridWithPrefetch,
+        mmap_cold_threshold_secs: 0,
+        mmap_sweep_interval_secs: 0,
+        eviction: Box::new(LruPolicy::new()),
+        ..Default::default()
+    };
+    let pinned: Arc<dyn Fn() -> HashSet<_> + Send + Sync> = Arc::new(HashSet::new);
+    let cache = DiskCacheStore::new(Arc::clone(&storage), cfg, pinned).expect("cache");
+    let table = Supertable::create(
+        options
+            .with_storage(storage)
+            .with_disk_cache(Arc::clone(&cache)),
+    )
+    .expect("create");
+    (table, cache)
+}
+
+/// Count promoted superfile copies in a disk-cache root (ignores `.tmp`
+/// in-flight files and block sidecars).
+fn count_cached_superfiles(dir: &Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("readdir cache")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with(".sf.parquet"))
+        .count()
+}
+
+#[test]
+fn gc_drops_disk_cache_copies_of_deleted_superfiles() {
+    // 1. Ten commits warm-fill the cache with the superfiles they publish.
+    // 2. Compaction supersedes those superfiles; GC deletes them from storage.
+    // 3. The cache must end up holding no more than the live set, not dead
+    //    copies waiting on budget pressure.
+    let dir = TempDir::new().expect("tempdir");
+    let cache_dir = TempDir::new().expect("cache tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let (st, cache) =
+        table_with_disk_cache(default_supertable_options(), storage, cache_dir.path());
+
+    for i in 0..10 {
+        let t1 = format!("cache doc alpha {i}");
+        let t2 = format!("cache doc beta {i}");
+        commit_titles(&st, &[t1.as_str(), t2.as_str()]);
+    }
+    let cached_before = count_cached_superfiles(cache_dir.path());
+    assert!(
+        cached_before >= 10,
+        "writer warm-inserts each commit's superfiles: {cached_before}"
+    );
+
+    st.optimize(&small_optimize_opts()).expect("optimize");
+    let report = st.gc(Duration::ZERO).expect("gc");
+    assert!(report.objects_deleted > 0, "superseded fragments reclaimed");
+
+    // Cache converged: dead copies dropped alongside their storage objects,
+    // live superfiles (and only those) may remain cached.
+    let data_dir = dir.path().join("data");
+    let cached_after = count_cached_superfiles(cache_dir.path());
+    assert!(
+        cached_after <= count_dir(&data_dir),
+        "cache holds no more superfiles than storage: {cached_after} vs {}",
+        count_dir(&data_dir)
+    );
+    assert!(
+        cache.stats().n_gc_drops > 0,
+        "drops are visible in cache stats"
+    );
+
+    // Data still fully queryable through the converged cache.
+    let hits = st
+        .bm25_search(
+            "title",
+            "alpha",
+            TOP_K,
+            BoolMode::Or,
+            Default::default(),
+            None,
+        )
+        .expect("bm25 after gc");
+    assert!(!hits.is_empty(), "queries survive the drop-through");
+}
+
+/// Dimension for the hidden-index fixture; matches `default_vector_config`.
+const HIDDEN_DIM: usize = 16;
+/// Random-rotation seed for the fixture's vector index.
+const HIDDEN_ROT_SEED: u64 = 37;
+/// Commit + drain rounds. The hidden profile merges a cell on any two shards,
+/// so two rounds already leave superseded inputs for gc to reclaim.
+const HIDDEN_ROUNDS: usize = 3;
+
+fn hidden_vector_options() -> SupertableOptions {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new(
+            "emb",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, false)),
+                HIDDEN_DIM as i32,
+            ),
+            false,
+        ),
+    ]));
+    SupertableOptions::new(
+        schema,
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        vec![default_vector_config("emb", HIDDEN_ROT_SEED)],
+        Some(default_tokenizer()),
+    )
+    .expect("valid options")
+}
+
+/// One-hot rows: doc `i` points at dim `i`, so every round lands in the same
+/// cells and the hidden index accumulates shards there.
+fn hidden_batch(schema: Arc<Schema>, round: usize) -> RecordBatch {
+    let titles: Vec<String> = (0..HIDDEN_DIM)
+        .map(|i| format!("hidden doc {round} {i}"))
+        .collect();
+    let mut flat = Vec::<f32>::with_capacity(HIDDEN_DIM * HIDDEN_DIM);
+    for i in 0..HIDDEN_DIM {
+        for d in 0..HIDDEN_DIM {
+            flat.push(if d == i { 1.0 } else { 0.0 });
+        }
+    }
+    let item = Arc::new(Field::new("item", DataType::Float32, false));
+    let embeddings = FixedSizeListArray::try_new(
+        item,
+        HIDDEN_DIM as i32,
+        Arc::new(Float32Array::from(flat)),
+        None,
+    )
+    .expect("fixed list");
+    let cols: Vec<ArrayRef> = vec![
+        Arc::new(LargeStringArray::from(
+            titles.iter().map(String::as_str).collect::<Vec<_>>(),
+        )),
+        Arc::new(embeddings),
+    ];
+    RecordBatch::try_new(schema, cols).expect("batch")
+}
+
+#[test]
+fn gc_on_the_hidden_vector_index_drops_its_cache_copies() {
+    // The hidden vector index shares the user table's cache but sweeps through
+    // its own prefixed storage provider, so it needs its own proof:
+    // 1. Each round commits rows and drains them into hidden cells, so a cell
+    //    accumulates shards across rounds. The explicit drain matters: without
+    //    it the whole corpus drains in one pass and nothing is superseded.
+    // 2. Compaction merges each cell (the hidden profile merges on two shards).
+    // 3. The hidden GC deletes the superseded shards, and must drop their cache
+    //    copies. Counted after the user sweep, so the drops are its own.
+    let dir = TempDir::new().expect("tempdir");
+    let cache_dir = TempDir::new().expect("cache tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let (st, cache) = table_with_disk_cache(hidden_vector_options(), storage, cache_dir.path());
+
+    // Drain per round so each round adds its own shards to the same cells;
+    // without the explicit drain the whole corpus lands in one pass and
+    // nothing is ever superseded.
+    let schema = st.options().schema.clone();
+    for round in 0..HIDDEN_ROUNDS {
+        let mut w = st.writer().expect("writer");
+        w.append(&hidden_batch(Arc::clone(&schema), round))
+            .expect("append");
+        w.commit().expect("commit");
+        drop(w);
+        st.drain_vectors_to_cells_sync().expect("drain");
+    }
+
+    let prefix = st
+        .vector_index_storage_prefix()
+        .expect("hidden prefix")
+        .to_owned();
+    let hidden_data = dir.path().join(&prefix).join("data");
+    let hidden_before = count_dir(&hidden_data);
+
+    // Compact both tables, then sweep the user table first so anything the
+    // hidden sweep drops is attributable to it alone.
+    st.optimize(&small_optimize_opts()).expect("optimize");
+    st.gc(Duration::ZERO).expect("user gc");
+    let drops_before_hidden = cache.stats().n_gc_drops;
+
+    let hidden = st.vector_index_table().expect("hidden index table");
+    let hidden_report = hidden.gc(Duration::ZERO).expect("hidden gc");
+    assert!(
+        count_dir(&hidden_data) < hidden_before,
+        "hidden compaction + gc must reclaim superseded shards ({} -> {})",
+        hidden_before,
+        count_dir(&hidden_data)
+    );
+    assert!(
+        hidden_report.objects_deleted > 0,
+        "hidden objects reclaimed"
+    );
+    assert!(
+        cache.stats().n_gc_drops > drops_before_hidden,
+        "the hidden sweep must drop its own cache copies (before={drops_before_hidden}, after={})",
+        cache.stats().n_gc_drops
     );
 }


### PR DESCRIPTION
### What does this PR do?
GC now also erases the disk-cache copy of every superfile it deletes. Closes #595.

### Why do we need this change?
The disk cache holds copies of storage objects, and superfiles are immutable, so a copy whose source object is gone can never be wanted again. The sweep deletes storage's copy, but the cache only ever removes entries under byte-budget pressure, so the two sides of the same object have a lifecycle on one side only. On a small cache the budget does eventually force the dead copies out, but it evicts by recency rather than by liveness, so a live entry can go while dead ones stay.

### How do we do this change?
- The sweep now erases a superfile's local cache copy right before it deletes the object from storage, so the cache never holds a superfile whose source is gone.
- Erasing covers all of it: the in-memory entry, the promoted file on disk, the partial block file, and the pending-fetch slot. A query already reading that superfile is unaffected, since unlink removes the name and not the inode.
- Only superfile keys are touched. Manifests, tombstone sidecars, and in-flight temp objects fall through untouched.

### Notes
- `drop_table(purge = true)` deletes objects directly rather than through the sweep, so a purged table's cache directory is still left behind. Each table has its own cache directory, so that one is a directory removal rather than per-URI work, tracked separately.
- The hidden vector index shares the user table's cache and sweeps through its own prefixed storage provider, so the same wiring covers it.