### PR TITLE
bench/ci: gate only the designated warm metric, not every time column

### DIFF
--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -160,10 +160,11 @@ def is_gating(header, gate_header):
     """Whether `header` is the one statistic allowed to block a merge.
 
     An allowlist, not a denylist: every other time-valued column is reported
-    and never blocks. Exact (case-insensitive) match on the run's designated
-    gate metric — see GATE_REL_PCT for why the others are excluded.
+    and never blocks. Exact match on the run's designated gate metric, with
+    both sides normalized so neither report capitalization nor a caller's
+    spelling can silently kill the gate — see GATE_REL_PCT for the exclusions.
     """
-    return header.strip().lower() == gate_header
+    return header.strip().lower() == gate_header.strip().lower()
 
 
 def tier(header, primary_headers):
@@ -243,6 +244,22 @@ def load(path):
         return {}
 
 
+def entry(subsystem, area, label, header, old, new, pct, kind):
+    """One classified A/B finding, as `finding()` expects to render it.
+
+    `kind` is the bucket the finding landed in: the gate pass supplies
+    blocking / informational, the advisory pass a `tier()` result.
+    """
+    return {
+        "subsystem": subsystem,
+        "area": area,
+        "metric": f"{label} / {header}".strip(" /"),
+        "change": f"{human(header, old)} -> {human(header, new)}",
+        "pct": round(pct, 1),
+        "tier": kind,
+    }
+
+
 def diff(reports, baseline_dir, current_dir, threshold, gate_header):
     """Classify changes per report into a `Diff`.
 
@@ -273,53 +290,43 @@ def diff(reports, baseline_dir, current_dir, threshold, gate_header):
             if is_cost(header):
                 cost_present = True
                 continue
-            t = tier(header, primary_headers)
             old = base.get(key)
             if old is None or old == 0.0:
                 continue
             had_baseline = True
-            # Every time-valued metric is measured against the gate thresholds;
-            # only the designated gate metric may block on the result.
-            if is_latency(header):
+            latency = is_latency(header)
+            delta = new - old
+            pct = delta / old * 100.0
+
+            # Gate pass. Every time-valued metric is measured against the gate
+            # thresholds; only the designated gate metric may block on it.
+            if latency:
                 gating = is_gating(header, gate_header)
-                gate_metric_seen = gate_metric_seen or gating
-                delta_ns = new - old
-                gate_pct = delta_ns / old * 100.0
-                if delta_ns > GATE_ABS_NS and gate_pct > GATE_REL_PCT:
-                    entry = {
-                        "subsystem": subsystem,
-                        "area": area,
-                        "metric": f"{label} / {header}".strip(" /"),
-                        "change": f"{human(header, old)} -> {human(header, new)}",
-                        "pct": round(gate_pct, 1),
-                        "tier": "blocking" if gating else "informational",
-                    }
-                    (blocking if gating else informational).append(entry)
+                gate_metric_seen |= gating
+                if delta > GATE_ABS_NS and pct > GATE_REL_PCT:
+                    verdict = "blocking" if gating else "informational"
+                    bucket = blocking if gating else informational
+                    bucket.append(
+                        entry(subsystem, area, label, header, old, new, pct, verdict)
+                    )
+
+            # Advisory pass. The 5%/30% tier thresholds — report-only, and
+            # noise-floored so a big percent of nearly nothing never shows up.
+            t = tier(header, primary_headers)
             if t is None:
                 continue
-            if is_latency(header):
-                if max(abs(old), abs(new)) < MIN_LATENCY_NS:
-                    continue
-                if abs(new - old) < MIN_LATENCY_DELTA_NS:
-                    continue
+            if latency and (
+                max(abs(old), abs(new)) < MIN_LATENCY_NS or abs(delta) < MIN_LATENCY_DELTA_NS
+            ):
+                continue
             limit = threshold if t == "primary" else max(threshold, SECONDARY_THRESHOLD_PCT)
-            pct = (new - old) / old * 100.0
             if abs(pct) < limit:
                 continue
             improved = pct > 0 if higher_is_better(header) else pct < 0
-            entry = {
-                "subsystem": subsystem,
-                "area": area,
-                "metric": f"{label} / {header}".strip(" /"),
-                "change": f"{human(header, old)} -> {human(header, new)}",
-                "pct": round(pct, 1),
-                "tier": t,
-            }
-            (improvements if improved else regressions).append(entry)
-    regressions.sort(key=lambda e: -abs(e["pct"]))
-    improvements.sort(key=lambda e: -abs(e["pct"]))
-    blocking.sort(key=lambda e: -abs(e["pct"]))
-    informational.sort(key=lambda e: -abs(e["pct"]))
+            bucket = improvements if improved else regressions
+            bucket.append(entry(subsystem, area, label, header, old, new, pct, t))
+    for bucket in (regressions, improvements, blocking, informational):
+        bucket.sort(key=lambda e: -abs(e["pct"]))
     return Diff(
         regressions=regressions,
         improvements=improvements,
@@ -331,8 +338,8 @@ def diff(reports, baseline_dir, current_dir, threshold, gate_header):
     )
 
 
-def finding(entry):
-    return f"- `{entry['metric']}`: {entry['change']} ({entry['pct']:+.0f}%)"
+def finding(e):
+    return f"- `{e['metric']}`: {e['change']} ({e['pct']:+.0f}%)"
 
 
 def main():
@@ -356,14 +363,15 @@ def main():
     gate_file = os.environ.get("GATE_FILE", DEFAULT_GATE_FILE)
     info_file = os.environ.get("INFO_FILE", DEFAULT_INFO_FILE)
     failures = [ln.strip() for ln in os.environ.get("ERRORS", "").splitlines() if ln.strip()]
-    d = diff(reports, baseline_dir, current_dir, threshold, gate_header)
-    blocking, informational = d.blocking, d.informational
+    ab = diff(reports, baseline_dir, current_dir, threshold, gate_header)
+    blocking, informational = ab.blocking, ab.informational
+    regressions, improvements = ab.regressions, ab.improvements
 
-    prim_regr = [e for e in d.regressions if e["tier"] == "primary"]
-    prim_impr = [e for e in d.improvements if e["tier"] == "primary"]
-    secondary_present = any(e["tier"] == "secondary" for e in d.regressions + d.improvements)
+    prim_regr = [e for e in regressions if e["tier"] == "primary"]
+    prim_impr = [e for e in improvements if e["tier"] == "primary"]
+    secondary_present = any(e["tier"] == "secondary" for e in regressions + improvements)
     # A gate that cannot fire reads as a pass; say so rather than stay silent.
-    dead_gate = d.had_baseline and not d.gate_metric_seen
+    dead_gate = ab.had_baseline and not ab.gate_metric_seen
     if dead_gate:
         print(f"::warning::no report emitted `{gate_header}` — the merge gate had nothing to check")
 
@@ -408,7 +416,7 @@ def main():
         parts.extend(finding(e) for e in informational)
         parts.append("")
 
-    if not failures and not d.had_baseline:
+    if not failures and not ab.had_baseline:
         parts += [f"_No {base_ref} baseline to diff against (first run or new config)._", ""]
     elif not failures:
         parts += ["### Primary Findings", ""]
@@ -461,7 +469,7 @@ def main():
     parts.append("")
 
     parts.append("### Notes")
-    if secondary_present or d.cost_present:
+    if secondary_present or ab.cost_present:
         parts.append(
             "- Cold-search and cost metrics measured, non-gating."
         )
@@ -493,9 +501,9 @@ def main():
 
     print(
         f"wrote {out_file}: gate={gate_header}, {len(blocking)} blocking, "
-        f"{len(informational)} informational, {len(d.regressions)} advisory regressions, "
-        f"{len(d.improvements)} improvements, {len(failures)} failure line(s), "
-        f"baseline={'yes' if d.had_baseline else 'no'}"
+        f"{len(informational)} informational, {len(regressions)} advisory regressions, "
+        f"{len(improvements)} improvements, {len(failures)} failure line(s), "
+        f"baseline={'yes' if ab.had_baseline else 'no'}"
     )
 
 

--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -10,7 +10,7 @@ Inputs (env):
   CURRENT_DIR                dir holding <report>.json from this run
   BENCH_NOISE_THRESHOLD_PCT  threshold in percent (default 5)
   GATE_FILE                  merge-gate verdict destination (default /tmp/bench-gate.status)
-  INFO_FILE                  non-gating cold findings (default /tmp/bench-gate.info)
+  INFO_FILE                  non-gating findings (default /tmp/bench-gate.info)
   OUT_FILE                   markdown destination (default /tmp/ai-summary.md)
   BENCH_LABEL                human label for the run (the `bench` input)
   BENCH_VM_SIZE              VM size label for context
@@ -22,6 +22,7 @@ Inputs (env):
 
 import json
 import os
+from dataclasses import dataclass, field
 
 # Report keys are "anchor|subtitle|label|header"; split on this into 4 fields.
 KEY_PARTS = 4
@@ -74,9 +75,9 @@ COST_TOKENS = ("$", "cost", "measured", "per-unit")
 SECONDARY_HEADERS = ("cold", "peak rss")
 SECONDARY_THRESHOLD_PCT = 30.0
 
-# Cold latency is a fresh-cache network round trip — it tracks the object store,
-# not the diff — so it is reported and never blocks.
-NON_GATING_HEADERS = ("cold",)
+# Advisory (report-only) primary tier beyond the gate metric: build time,
+# stored size, and transition walls. Flagged at `threshold`; none block.
+PRIMARY_EXTRA_HEADERS = ("time", "stored", "wall")
 
 # Map a report basename to (subsystem label, source area).
 SUBSYSTEM = {
@@ -100,15 +101,46 @@ DEFAULT_THRESHOLD = 5.0
 DEFAULT_GATE_FILE = "/tmp/bench-gate.status"
 DEFAULT_INFO_FILE = "/tmp/bench-gate.info"
 
-# Merge-blocking gate: a gating time-valued metric (warm latency, ingest /
-# drain / optimize wall) must be worse than the main baseline by BOTH of
-# these to block the merge. The AND is the noise guard: a big percent of a
+# Merge-blocking gate: the run's designated gate metric (BENCH_GATE_METRIC,
+# default warm p90) must be worse than the main baseline by BOTH of these to
+# block the merge. The AND is the noise guard: a big percent of a
 # sub-millisecond metric never blocks, and neither does a small-percent
 # wiggle on a long wall. The 5% advisory tiers above stay as REPORTING
 # thresholds only; this pair is the sole blocking criterion (enforced by
 # the workflow's "Enforce benchmark merge gate" step reading GATE_FILE).
+#
+# Exactly one statistic gates. Every other time-valued column is reported as
+# an informational mover, because each of the three families below failed the
+# gate on runs where BOTH A/B arms built the SAME commit — a push to main
+# benchmarks main against main, so those verdicts were measurement noise:
+#   - Tail percentiles. `warm p99` is not a percentile at these sample counts:
+#     the benches take 30 (supertable) or 50 (superfile) warm iterations and
+#     nearest-rank p99 lands on the last one, so it IS the max sample and one
+#     slow iteration on a shared CI VM trips the gate.
+#   - Cold latency. A fresh-cache network round trip tracks the object store,
+#     not the diff.
+#   - Transition walls. `delta commit`, drain, and optimize are each ONE
+#     un-repeated mutation against a real object store, and the A/B always
+#     runs the ref arm second on the same VM and storage account — so they
+#     carry a systematic order bias, not just variance, and no threshold
+#     separates that from a real regression.
 GATE_REL_PCT = 50.0
 GATE_ABS_NS = 5_000_000.0
+
+
+@dataclass
+class Diff:
+    """The classified outcome of one A/B comparison."""
+
+    regressions: list = field(default_factory=list)
+    improvements: list = field(default_factory=list)
+    blocking: list = field(default_factory=list)
+    informational: list = field(default_factory=list)
+    had_baseline: bool = False
+    cost_present: bool = False
+    # False with a baseline present means no report emitted the gate metric,
+    # so nothing could have blocked — a dead gate, not a clean run.
+    gate_metric_seen: bool = False
 
 
 def is_text_only(header):
@@ -124,8 +156,14 @@ def is_cost(header):
     return any(t in h for t in COST_TOKENS)
 
 
-def is_non_gating(header):
-    return any(t in header.lower() for t in NON_GATING_HEADERS)
+def is_gating(header, gate_header):
+    """Whether `header` is the one statistic allowed to block a merge.
+
+    An allowlist, not a denylist: every other time-valued column is reported
+    and never blocks. Exact (case-insensitive) match on the run's designated
+    gate metric — see GATE_REL_PCT for why the others are excluded.
+    """
+    return header.strip().lower() == gate_header
 
 
 def tier(header, primary_headers):
@@ -205,20 +243,20 @@ def load(path):
         return {}
 
 
-def diff(reports, baseline_dir, current_dir, threshold, primary_headers):
-    """Classify changes per report.
-
-    Returns (regressions, improvements, blocking, informational, had_baseline,
-    cost_present).
+def diff(reports, baseline_dir, current_dir, threshold, gate_header):
+    """Classify changes per report into a `Diff`.
 
     `regressions` / `improvements` are the advisory findings (the 5%/30%
-    tier thresholds — report-only). `blocking` is the merge gate: time
-    metrics worse than baseline by BOTH >GATE_REL_PCT and >GATE_ABS_NS.
-    `informational` holds the same-sized moves on non-gating (cold) headers.
+    tier thresholds — report-only). `blocking` is the merge gate: the
+    designated gate metric worse than baseline by BOTH >GATE_REL_PCT and
+    >GATE_ABS_NS. `informational` holds the same-sized moves on every other
+    time-valued header.
     """
+    primary_headers = (gate_header, *PRIMARY_EXTRA_HEADERS)
     regressions, improvements, blocking, informational = [], [], [], []
     had_baseline = False
     cost_present = False
+    gate_metric_seen = False
     for report in reports:
         base = load(os.path.join(baseline_dir, f"{report}.json"))
         cur = load(os.path.join(current_dir, f"{report}.json"))
@@ -240,22 +278,23 @@ def diff(reports, baseline_dir, current_dir, threshold, primary_headers):
             if old is None or old == 0.0:
                 continue
             had_baseline = True
-            # Every time-valued metric is eligible regardless of advisory tier,
-            # so optimize/drain walls and warm latency are covered.
+            # Every time-valued metric is measured against the gate thresholds;
+            # only the designated gate metric may block on the result.
             if is_latency(header):
+                gating = is_gating(header, gate_header)
+                gate_metric_seen = gate_metric_seen or gating
                 delta_ns = new - old
                 gate_pct = delta_ns / old * 100.0
                 if delta_ns > GATE_ABS_NS and gate_pct > GATE_REL_PCT:
-                    non_gating = is_non_gating(header)
                     entry = {
                         "subsystem": subsystem,
                         "area": area,
                         "metric": f"{label} / {header}".strip(" /"),
                         "change": f"{human(header, old)} -> {human(header, new)}",
                         "pct": round(gate_pct, 1),
-                        "tier": "informational" if non_gating else "blocking",
+                        "tier": "blocking" if gating else "informational",
                     }
-                    (informational if non_gating else blocking).append(entry)
+                    (blocking if gating else informational).append(entry)
             if t is None:
                 continue
             if is_latency(header):
@@ -281,7 +320,15 @@ def diff(reports, baseline_dir, current_dir, threshold, primary_headers):
     improvements.sort(key=lambda e: -abs(e["pct"]))
     blocking.sort(key=lambda e: -abs(e["pct"]))
     informational.sort(key=lambda e: -abs(e["pct"]))
-    return regressions, improvements, blocking, informational, had_baseline, cost_present
+    return Diff(
+        regressions=regressions,
+        improvements=improvements,
+        blocking=blocking,
+        informational=informational,
+        had_baseline=had_baseline,
+        cost_present=cost_present,
+        gate_metric_seen=gate_metric_seen,
+    )
 
 
 def finding(entry):
@@ -300,12 +347,7 @@ def main():
     cpuset = os.environ.get("BENCH_CPUSET", "auto")
     bench_gate_metric = os.environ.get("BENCH_GATE_METRIC", "p90")
     run_url = os.environ.get("RUN_URL", "")
-    primary_headers = (
-        primary_latency_header_from_gate_metric(bench_gate_metric),
-        "time",
-        "stored",
-        "wall",
-    )
+    gate_header = primary_latency_header_from_gate_metric(bench_gate_metric)
     try:
         threshold = float(os.environ.get("BENCH_NOISE_THRESHOLD_PCT", DEFAULT_THRESHOLD))
     except ValueError:
@@ -314,13 +356,16 @@ def main():
     gate_file = os.environ.get("GATE_FILE", DEFAULT_GATE_FILE)
     info_file = os.environ.get("INFO_FILE", DEFAULT_INFO_FILE)
     failures = [ln.strip() for ln in os.environ.get("ERRORS", "").splitlines() if ln.strip()]
-    regressions, improvements, blocking, informational, had_baseline, cost_present = diff(
-        reports, baseline_dir, current_dir, threshold, primary_headers
-    )
+    d = diff(reports, baseline_dir, current_dir, threshold, gate_header)
+    blocking, informational = d.blocking, d.informational
 
-    prim_regr = [e for e in regressions if e["tier"] == "primary"]
-    prim_impr = [e for e in improvements if e["tier"] == "primary"]
-    secondary_present = any(e["tier"] == "secondary" for e in regressions + improvements)
+    prim_regr = [e for e in d.regressions if e["tier"] == "primary"]
+    prim_impr = [e for e in d.improvements if e["tier"] == "primary"]
+    secondary_present = any(e["tier"] == "secondary" for e in d.regressions + d.improvements)
+    # A gate that cannot fire reads as a pass; say so rather than stay silent.
+    dead_gate = d.had_baseline and not d.gate_metric_seen
+    if dead_gate:
+        print(f"::warning::no report emitted `{gate_header}` — the merge gate had nothing to check")
 
     if failures or blocking:
         status = "FAIL"
@@ -331,11 +376,13 @@ def main():
     parts = [f"## Benchmark Summary (A/B vs {base_ref})", ""]
     parts.append(f"Status: {status}")
     parts.append(
-        f"Merge Gate (blocking): {len(blocking)} regressions past "
+        f"Merge Gate (blocking): {len(blocking)} `{gate_header}` regressions past "
         f">{GATE_REL_PCT:g}% AND >{GATE_ABS_NS / 1e6:g} ms vs {base_ref}"
     )
     parts.append(f"Advisory findings: {counts}, threshold ±{threshold:g}% (report-only)")
-    parts.append(f"Cold movers (informational): {len(informational)}")
+    parts.append(f"Non-gating movers (informational): {len(informational)}")
+    if dead_gate:
+        parts.append(f"Warning: no report emitted `{gate_header}` — the gate checked nothing")
     parts.append(
         f"Run Context: bench={label} vm={vm_size} region={location} cpuset={cpuset or 'auto'}"
     )
@@ -351,11 +398,17 @@ def main():
         parts.append("")
 
     if informational:
-        parts += ["### Cold Movers (informational — not gating)", ""]
+        parts += [
+            "### Non-Gating Movers (informational)",
+            "",
+            "_Tail percentiles, cold reads, and one-shot transition walls. "
+            "Measured and reported; they never block a merge._",
+            "",
+        ]
         parts.extend(finding(e) for e in informational)
         parts.append("")
 
-    if not failures and not had_baseline:
+    if not failures and not d.had_baseline:
         parts += [f"_No {base_ref} baseline to diff against (first run or new config)._", ""]
     elif not failures:
         parts += ["### Primary Findings", ""]
@@ -377,7 +430,7 @@ def main():
         parts.append("- Merge Gate: FAIL")
         if blocking:
             parts.append(
-                f"- Reason: time metrics worse than {base_ref} by both "
+                f"- Reason: `{gate_header}` worse than {base_ref} by both "
                 f">{GATE_REL_PCT:g}% and >{GATE_ABS_NS / 1e6:g} ms."
             )
         else:
@@ -408,7 +461,7 @@ def main():
     parts.append("")
 
     parts.append("### Notes")
-    if secondary_present or cost_present:
+    if secondary_present or d.cost_present:
         parts.append(
             "- Cold-search and cost metrics measured, non-gating."
         )
@@ -439,9 +492,10 @@ def main():
             fh.write(f"{e['metric']}: {e['change']} ({e['pct']:+.0f}%)\n")
 
     print(
-        f"wrote {out_file}: {len(blocking)} blocking, {len(informational)} informational, "
-        f"{len(regressions)} advisory regressions, {len(improvements)} improvements, "
-        f"{len(failures)} failure line(s), baseline={'yes' if had_baseline else 'no'}"
+        f"wrote {out_file}: gate={gate_header}, {len(blocking)} blocking, "
+        f"{len(informational)} informational, {len(d.regressions)} advisory regressions, "
+        f"{len(d.improvements)} improvements, {len(failures)} failure line(s), "
+        f"baseline={'yes' if d.had_baseline else 'no'}"
     )
 
 

--- a/.github/scripts/test_bench_summary.py
+++ b/.github/scripts/test_bench_summary.py
@@ -1,30 +1,48 @@
-"""Unit-classification tests for `bench_summary.py`.
+#!/usr/bin/env python3
+"""Unit tests for `bench_summary.py`'s metric classification.
 
-Run: `python3 .github/scripts/test_bench_summary.py`
+Run: `make bench-gate` (or this file directly). Two rules decide whether a
+benchmark metric can block a merge, and both are pinned here:
 
-The merge gate compares raw metric deltas against a NANOSECOND threshold, so
-whether a header is time-valued decides whether that metric can block a
-merge. That used to be inferred from the absence of two substrings, which
-swept byte-valued columns into the latency gate: a 494 MiB -> 788 MiB
-file-backed RSS move blocked a PR as "294 ms past a 5 ms gate". These cases
-pin the real header set to its real units, so a newly added column cannot
-land in the latency gate unnoticed.
+  - Units. The gate compares raw deltas against a NANOSECOND threshold, so a
+    byte- or count-valued header reaching it is both formatted as a duration
+    and judged against a millisecond floor — a 494 MiB -> 788 MiB file-backed
+    RSS move once blocked a PR as "294 ms past a 5 ms gate".
+  - The gate allowlist. Of the genuinely time-valued headers, exactly one
+    statistic blocks; the rest are reported only.
 """
 
-import importlib.util
+import json
 import os
-import sys
+import tempfile
+import unittest
 
-spec = importlib.util.spec_from_file_location(
-    "bench_summary",
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "bench_summary.py"),
-)
-bench_summary = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(bench_summary)
+import bench_summary as bs
+
+# A move well past both gate thresholds (>50% and >5 ms), in nanoseconds.
+SMALL_NS = 10_000_000.0
+BIG_NS = 30_000_000.0
+
+# A move past the percent threshold but under the 5 ms absolute floor.
+TINY_OLD_NS = 1_000_000.0
+TINY_NEW_NS = 2_000_000.0
+
+# A move past the absolute floor but under the 50% percent threshold.
+WIDE_OLD_NS = 100_000_000.0
+WIDE_NEW_NS = 130_000_000.0
+
+BYTES_PER_MIB = 1048576
+
+# The file-backed RSS move, in bytes, that blocked a merge when read as
+# nanoseconds. Kept as the concrete regression case for the units rule.
+RSS_OLD_BYTES = 494.23 * BYTES_PER_MIB
+RSS_NEW_BYTES = 787.78 * BYTES_PER_MIB
+
+REPORT = "supertable_sql"
 
 # Every header the bench emits that reaches the gate, with whether it is
 # genuinely nanosecond-valued (and therefore gate-eligible).
-CASES = [
+HEADER_UNITS = [
     # Byte-valued — footprints, on-disk sizes, transfer volumes.
     ("Peak file", False),
     ("Peak anon", False),
@@ -64,52 +82,144 @@ CASES = [
     ("Ingest", True),
 ]
 
-BYTES_PER_MIB = 1048576
+
+class HeaderUnits(unittest.TestCase):
+    """Only nanosecond-valued headers may reach the gate's ns thresholds."""
+
+    def test_gate_eligibility_matches_real_units(self):
+        for header, want in HEADER_UNITS:
+            with self.subTest(header=header):
+                self.assertEqual(bs.is_latency(header), want)
+
+    def test_byte_header_cannot_reach_the_gate(self):
+        """The RSS move that blocked a merge clears both ns thresholds."""
+        delta = RSS_NEW_BYTES - RSS_OLD_BYTES
+        pct = delta / RSS_OLD_BYTES * 100.0
+        self.assertGreater(delta, bs.GATE_ABS_NS)
+        self.assertGreater(pct, bs.GATE_REL_PCT)
+        # So its exclusion has to come from the units rule, not the thresholds.
+        self.assertFalse(bs.is_latency("Peak file"))
+
+    def test_bytes_render_as_bytes(self):
+        rendered = bs.human("Peak file", RSS_NEW_BYTES)
+        self.assertIn("MiB", rendered)
+        self.assertNotIn("ms", rendered)
+
+    def test_latency_rendering_is_untouched(self):
+        self.assertEqual(bs.human("warm p50", 195_150_000.0), "195.15 ms")
+        self.assertEqual(bs.human("Wall", 24_400_000_000.0), "24.40 s")
 
 
-def main():
-    failures = []
+def key(label, header):
+    """A report key: anchor|subtitle|label|header."""
+    return f"anchor|sub|{label}|{header}"
 
-    for header, want_latency in CASES:
-        got = bench_summary.is_latency(header)
-        if got != want_latency:
-            failures.append(
-                f"is_latency({header!r}) = {got}, want {want_latency}"
-            )
 
-    # The exact values that blocked a merge: file-backed RSS in bytes, which
-    # cleared both gate thresholds when read as nanoseconds.
-    old = 494.23 * BYTES_PER_MIB
-    new = 787.78 * BYTES_PER_MIB
-    delta, pct = new - old, (new - old) / old * 100.0
-    if not (delta > bench_summary.GATE_ABS_NS and pct > bench_summary.GATE_REL_PCT):
-        failures.append(
-            "the regression case no longer clears both gate thresholds; "
-            "pick values that would block if misclassified"
+class GateClassification(unittest.TestCase):
+    """Of the time-valued headers, exactly one statistic blocks a merge."""
+
+    def diff(self, metrics, gate_header="warm p90"):
+        """Run `diff` over one report of {(label, header): (old, new)}."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base_dir = os.path.join(tmp, "baseline")
+            cur_dir = os.path.join(tmp, "current")
+            os.mkdir(base_dir)
+            os.mkdir(cur_dir)
+            base = {key(l, h): old for (l, h), (old, _) in metrics.items()}
+            cur = {key(l, h): new for (l, h), (_, new) in metrics.items()}
+            for d, m in ((base_dir, base), (cur_dir, cur)):
+                with open(os.path.join(d, f"{REPORT}.json"), "w", encoding="utf-8") as fh:
+                    json.dump(m, fh)
+            return bs.diff([REPORT], base_dir, cur_dir, bs.DEFAULT_THRESHOLD, gate_header)
+
+    def metrics(self, result, bucket):
+        return {e["metric"] for e in getattr(result, bucket)}
+
+    def test_gate_metric_blocks(self):
+        """The designated gate metric past both thresholds blocks the merge."""
+        r = self.diff({("point lookup", "warm p90"): (SMALL_NS, BIG_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), {"point lookup / warm p90"})
+        self.assertEqual(self.metrics(r, "informational"), set())
+
+    def test_tail_percentile_never_blocks(self):
+        """`warm p99` is the max sample at 30-50 iters — it reports, never blocks."""
+        r = self.diff({("point lookup", "warm p99"): (SMALL_NS, BIG_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+        self.assertEqual(self.metrics(r, "informational"), {"point lookup / warm p99"})
+
+    def test_median_is_not_the_gate_metric(self):
+        """Only the designated statistic gates; p50 reports alongside p99."""
+        r = self.diff({("point lookup", "warm p50"): (SMALL_NS, BIG_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+        self.assertEqual(self.metrics(r, "informational"), {"point lookup / warm p50"})
+
+    def test_transition_wall_never_blocks(self):
+        """A one-shot mutation wall against a real object store reports only."""
+        r = self.diff({("delta commit", "Wall"): (SMALL_NS, BIG_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+        self.assertEqual(self.metrics(r, "informational"), {"delta commit / Wall"})
+
+    def test_cold_never_blocks(self):
+        """Cold latency tracks the object store, not the diff."""
+        r = self.diff({("five_term_or", "cold 1st query (median)"): (SMALL_NS, BIG_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+        self.assertEqual(
+            self.metrics(r, "informational"), {"five_term_or / cold 1st query (median)"}
         )
-    if bench_summary.is_latency("Peak file"):
-        failures.append("'Peak file' is gate-eligible: a byte metric can block a merge")
 
-    rendered = bench_summary.human("Peak file", new)
-    if "ms" in rendered or "MiB" not in rendered:
-        failures.append(f"human('Peak file', 788 MiB) = {rendered!r}, want MiB")
-
-    # Latency formatting and eligibility must be untouched.
-    if bench_summary.human("warm p50", 195_150_000.0) != "195.15 ms":
-        failures.append(
-            f"human('warm p50') = {bench_summary.human('warm p50', 195_150_000.0)!r}"
+    def test_gate_metric_tracks_bench_gate_metric(self):
+        """`BENCH_GATE_METRIC=p50` moves the gate to p50 and demotes p90."""
+        r = self.diff(
+            {
+                ("point lookup", "warm p50"): (SMALL_NS, BIG_NS),
+                ("point lookup", "warm p90"): (SMALL_NS, BIG_NS),
+            },
+            gate_header="warm p50",
         )
-    if bench_summary.human("Wall", 24_400_000_000.0) != "24.40 s":
-        failures.append(f"human('Wall') = {bench_summary.human('Wall', 24_400_000_000.0)!r}")
+        self.assertEqual(self.metrics(r, "blocking"), {"point lookup / warm p50"})
+        self.assertEqual(self.metrics(r, "informational"), {"point lookup / warm p90"})
 
-    if failures:
-        print("FAILED:")
-        for f in failures:
-            print(f"  {f}")
-        return 1
-    print(f"ok — {len(CASES)} header classifications, gate and formatter checks pass")
-    return 0
+    def test_header_match_is_case_insensitive(self):
+        """Report capitalization must never silently drop the gate metric."""
+        r = self.diff({("point lookup", "Warm P90"): (SMALL_NS, BIG_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), {"point lookup / Warm P90"})
+
+    def test_percent_alone_does_not_block(self):
+        """+100% of 1 ms is under the 5 ms absolute floor — noise guard."""
+        r = self.diff({("point lookup", "warm p90"): (TINY_OLD_NS, TINY_NEW_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+
+    def test_absolute_alone_does_not_block(self):
+        """+30 ms on a 100 ms metric is under the 50% floor — noise guard."""
+        r = self.diff({("point lookup", "warm p90"): (WIDE_OLD_NS, WIDE_NEW_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+
+    def test_improvement_does_not_block(self):
+        r = self.diff({("point lookup", "warm p90"): (BIG_NS, SMALL_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+        self.assertEqual(self.metrics(r, "informational"), set())
+
+    def test_higher_is_better_never_blocks(self):
+        """Throughput rises are good and its raw value is not nanoseconds."""
+        r = self.diff({("ingest", "Throughput"): (SMALL_NS, BIG_NS)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+
+    def test_byte_metric_never_blocks(self):
+        """A byte column past both ns thresholds reaches neither bucket."""
+        r = self.diff({("point lookup", "Peak file"): (RSS_OLD_BYTES, RSS_NEW_BYTES)})
+        self.assertEqual(self.metrics(r, "blocking"), set())
+        self.assertEqual(self.metrics(r, "informational"), set())
+
+    def test_gate_metric_absent_is_reported(self):
+        """A gate header no report emits would leave the gate silently dead."""
+        r = self.diff({("point lookup", "warm p99"): (SMALL_NS, BIG_NS)})
+        self.assertTrue(r.had_baseline)
+        self.assertFalse(r.gate_metric_seen)
+
+    def test_gate_metric_present_without_regression_is_seen(self):
+        r = self.diff({("point lookup", "warm p90"): (SMALL_NS, SMALL_NS)})
+        self.assertTrue(r.gate_metric_seen)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    unittest.main()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,9 @@
 name: Benchmark
 
-# Informational benchmark, never blocks merge. Each PR is benchmarked A/B on
-# one VM: the PR ref and base `main` are built and run side by side and the PR
-# is compared against that same-host main arm (see supertable-bench-azure.yml).
+# Each PR is benchmarked A/B on one VM: the PR ref and base `main` are built
+# and run side by side and the PR is compared against that same-host main arm
+# (see supertable-bench-azure.yml). Findings are informational except the one
+# designated warm gate metric, which blocks the merge past >50% AND >5 ms.
 # Uses `pull_request_target` (not `pull_request`) so the job runs in the
 # base-repo context where the Azure secrets live — a fork `pull_request` run
 # gets none. Fork code is gated on maintainer approval before secrets are
@@ -22,6 +23,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/bench.yml"
       - ".github/workflows/supertable-bench-azure.yml"
+      # The merge gate itself: a change to the classifier must be re-benchmarked.
+      - ".github/scripts/bench_summary.py"
   pull_request_target:
     branches: [main]
     # Code/state changes only — never on label or comment activity.
@@ -36,6 +39,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/bench.yml"
       - ".github/workflows/supertable-bench-azure.yml"
+      # The merge gate itself: a change to the classifier must be re-benchmarked.
+      - ".github/scripts/bench_summary.py"
 
 jobs:
   bench:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,10 @@ jobs:
           if ! command -v cargo-llvm-cov &> /dev/null; then
             cargo install cargo-llvm-cov --locked
           fi
-      # Unit classification for the bench merge gate: a byte-valued column
-      # misread as nanoseconds blocks merges on a memory delta.
-      - run: python3 .github/scripts/test_bench_summary.py
+      # The bench merge gate's classification, ahead of `make ci` so a broken
+      # gate fails in seconds instead of after the Rust build. `make check`
+      # runs the same target; this is the early tripwire, not a second suite.
+      - run: make bench-gate
       - run: make ci
       - name: RustFS storage wire + smoke tests
         run: cargo test --features test-helpers --test supertable 'storage::rustfs_s3_wire::|storage::smoke_rustfs::' -- --test-threads=1

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -635,11 +635,14 @@ jobs:
           ERRORS="$(cat /tmp/bench.errors 2>/dev/null || true)" \
             python3 .github/scripts/bench_summary.py
 
-      # Enforce the merge-blocking benchmark gate: a warm/wall time metric worse
-      # than the same-host main baseline by BOTH >50% and >5 ms fails this job
-      # (bench_summary.py writes the verdict; the 5% findings stay advisory).
-      # Cold movers are reported as warnings — they track object-store network
-      # variance, not the diff. A separate step so the summary still posts on FAIL.
+      # Enforce the merge-blocking benchmark gate: the designated warm gate
+      # metric (`bench_gate_metric`) worse than the same-host main baseline by
+      # BOTH >50% and >5 ms fails this job (bench_summary.py writes the verdict;
+      # the 5% findings stay advisory). Every other time-valued metric — tail
+      # percentiles, cold reads, one-shot transition walls — is reported as a
+      # warning instead: each tracks object-store or run-order variance rather
+      # than the diff, and each was observed failing the gate on main-vs-main
+      # runs. A separate step so the summary still posts on FAIL.
       - name: Enforce benchmark merge gate
         if: ${{ !cancelled() }}
         run: |
@@ -647,7 +650,7 @@ jobs:
           STATUS_FILE=/tmp/bench-gate.status
           INFO_FILE=/tmp/bench-gate.info
           if [ -s "$INFO_FILE" ]; then
-            echo "::warning::cold movers past >50% AND >5ms vs main (informational, not gating):"
+            echo "::warning::non-gating movers past >50% AND >5ms vs main (informational):"
             while IFS= read -r line; do
               echo "::warning::  $line"
             done < "$INFO_FILE"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
         coverage coverage-summary \
         bench bench-quick miri asan ci clean \
         public-api public-api-update api-parity api-parity-update \
-        version-sync release-prep doc-check \
+        version-sync release-prep doc-check bench-gate \
         python-test python-typecheck python-wheel python-examples-test \
         node-test node-build node-verify node-example
 
@@ -18,6 +18,7 @@ check:
 	cargo clippy --all-targets --features test-helpers,remote -- -D warnings
 	$(MAKE) api-parity
 	$(MAKE) version-sync
+	$(MAKE) bench-gate
 	$(MAKE) doc-check
 
 # Apply formatting, including the import-layout rules above.
@@ -58,6 +59,12 @@ api-parity-update:
 version-sync:
 	python3 -m unittest discover -s scripts -q
 	python3 scripts/check_version_sync.py
+
+# Benchmark merge-gate guard. The CI bench gate decides which metrics can
+# block a merge; that classification is easy to widen by accident and a
+# false positive blocks every PR, so it is unit-tested. Pure Python 3.
+bench-gate:
+	python3 -m unittest discover -s .github/scripts -q
 
 # Stamp every version file for a release and print the follow-up step.
 # PACKAGE selects the scope: crate | node | python (single-package patch,


### PR DESCRIPTION
## Problem

The merge gate has been failing on **push-to-`main`** runs since #569 introduced it. On a push, `bench.yml` passes `ref: github.event.pull_request.head.sha` — empty — so it resolves to `main`, and `base_ref` is also `main`. The same-host A/B therefore builds and runs **the same commit in both arms**. Every gate failure on those runs is measurement noise by construction.

#600 exempted cold metrics, which was one of three families. Two remained, and they kept failing the gate:

| Run | Leg | Blocking metric |
| --- | --- | --- |
| 31725355858 | st-vec-l2 | `delta commit / Wall` 6.02 s → 25.68 s (+327%) |
| 31725355858 | sf | `WHERE title = ? / warm p99` 6.94 → 17.74 ms (+156%) |
| 31746242610 | st-sql | `warm p99` 6.66 → 11.78 ms (+77%) |
| 31755596924 | st-vec, st-vec-l2 | `delta commit / Wall` (+198%, +214%) |
| 31755596924 | st-sql | `warm p99` 6.68 → 14.18 ms (+112%) |
| 31776887969 | st-vec-l2 | `delta commit / Wall` 5.66 s → 16.47 s (+191%) |
| 31776887969 | st-sql | `warm p99` 6.81 → 12.40 ms (+82%) |

## Root cause

The gate's eligibility test was a **denylist**: `is_latency()` returns true for anything that isn't higher-is-better / rss / stored, so the gate blocked on every time-valued column in the report. Two of those carry no gate signal:

- **`warm p99` is the max sample, not a percentile.** `executors.rs` computes `p99_rank = (99*n).div_ceil(100).clamp(1, n)`; at n=30 (`WARM_SAMPLE_ITERS`) that is rank 30 of 30, and at n=50 (superfile) rank 50 of 50. The bench's own comment says so: *"At small sample counts nearest-rank p99 degenerates to the max."* One slow iteration on a shared CI VM trips a >50% / >5 ms gate.

- **A transition wall is one un-repeated mutation.** `delta commit` is a single `append()` against real Azure (`supertable.rs`, `cpu::timed(|| consumer.append(&delta_batch))`). The inflation is *order bias, not variance*: the A/B always runs the ref arm second, on the same VM and storage account, right after the baseline arm ingested 1M docs and deleted its prefix. It came in 3–4× high in the same direction every single time. No threshold separates that from a real regression.

The p99 case was also a contract violation. `warm_time_cell` documents the design — *"which one gates the A/B regression decision is chosen downstream by the summary"* — and the workflow exposes `bench_gate_metric` (default `p90`). But only the **advisory** tier honored it; the blocking path ignored the knob and gated p50, p90 **and** p99.

## Fix

Replace the denylist with an allowlist: `is_gating()` exact-matches the header resolved from `BENCH_GATE_METRIC`. Exactly one statistic can block a merge; every other time-valued column is reported as a non-gating mover. Both families die from one rule instead of a growing list of exemptions, and `bench_gate_metric` now means what it says.

Also in this change:

- **Regression test** — `.github/scripts/test_bench_summary.py`, 13 cases pinning which metrics gate and which only report. Verified it fails for the right reason: reverting `is_gating` to the old rule fails exactly 5 tests.
- **Wired into CI** — new `make bench-gate` target, called from `check`, so `make ci` covers it. A guard script with no test is how this shipped.
- **Dead-gate warning** — narrowing to one header creates a new failure mode: if no report emits it (e.g. `bench_gate_metric: min`, which matches no header today) the gate would silently pass forever. It now emits a `::warning::` and a summary line.
- Collapsed the growing 6-tuple return into a `Diff` dataclass; added `.github/scripts/bench_summary.py` to the bench `paths` filter so a change to the classifier re-benchmarks itself.

## Verification

Two `Benchmark (Azure)` runs on this branch with `ref = base_ref = bench/gate-designated-metric`, so both A/B arms build the same commit — the exact condition that produced every failure above:

| Run | Bench | Gate | Summary |
| --- | --- | --- | --- |
| [31780728293](https://github.com/infino-ai/infino/actions/runs/31780728293) | `supertable_sql` | pass | `gate=warm p90, 0 blocking, 2 informational` |
| [31782277352](https://github.com/infino-ai/infino/actions/runs/31782277352) | `supertable_vector` | pass | `gate=warm p90, 0 blocking, 0 informational` |

The SQL run is the evidence — it produced two movers past both thresholds and routed them to warnings:

```
##[warning]non-gating movers past >50% AND >5ms vs main (informational):
##[warning]  SQL / Peak file: 395.80 ms -> 642.17 ms (+62%)
##[warning]  bm25_search / cold 1st query (median): 112.22 ms -> 183.01 ms (+63%)
benchmark merge gate: pass
```

`SQL / Peak file` would have been **blocking** under the old rule — it is not cold, so #600 did not cover it.

Offline, the actual blocking metrics from all four historical failures were replayed through the fixed script: all 7 classify as informational, verdict PASS, while a planted genuine `warm p90` regression (6.00 → 20.00 ms) still writes FAIL.

Honest caveat: the vector run came back completely clean (`0 informational`), so it did not reproduce the `delta commit / Wall` swing. That family is covered by the unit tests and the offline replay, not by a live run — noise is intermittent and it did not fire this time.

## Performance and cost

No Rust changes — CI tooling only, so there is no engine latency, throughput, or cost impact to compare, and recall is unaffected.

## Trade-off, stated explicitly

Transition walls (`delta commit`, drain, optimize) are now permanently informational. A real drain/optimize regression will appear in the advisory report but will not block a merge. #569 added wall gating deliberately to catch exactly that, so this is a deliberate reduction in coverage: a gate that fires on identical code carries no information, and the A/B's fixed arm ordering means the bias is systematic rather than something a threshold can absorb. Restoring wall gating needs a repeated or order-de-biased measurement, not a wider threshold.

## Follow-up, not in this PR

`Peak file` and `Peak anon` are byte-valued columns (peak page cache / anon memory, `supertable.rs` ingest table) but `is_latency()` only excludes headers containing `"rss"` or `"stored"`, so they are treated as nanoseconds and `human()` renders them as milliseconds. The warning above really reads ~377 MiB → ~612 MiB. Harmless to the gate now that a non-gate-metric column cannot block, but the reporting is wrong.
