### PR TITLE
ci: grade spec deltas with oasdiff; refresh PRs must trigger checks

### DIFF
--- a/.github/workflows/hosted-api-drift.yml
+++ b/.github/workflows/hosted-api-drift.yml
@@ -29,7 +29,35 @@ jobs:
     name: Remote transport ⇄ hosted API spec
     runs-on: ubuntu-latest
     steps:
+      # Full history so the base branch's fixture is available to diff against.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Report-only changelog: when the vendored spec itself changed, grade the
+      # delta with oasdiff so the PR summary reads "N breaking / M additive"
+      # instead of raw JSON hunks. Never fails the job — by the time a refresh
+      # PR exists the service has already shipped the change; the conformance
+      # test below is the gate for "does the client still match".
+      - name: Summarize the spec delta (report-only)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          BASE_REF="origin/${{ github.base_ref }}"
+          if git diff --quiet "$BASE_REF"...HEAD -- tests/fixtures/hosted-openapi.json; then
+            echo "fixture unchanged in this PR — no spec delta to summarize"
+            exit 0
+          fi
+          VERSION=1.28.0
+          curl -fsSL "https://github.com/oasdiff/oasdiff/releases/download/v${VERSION}/oasdiff_${VERSION}_linux_amd64.tar.gz"             | tar -xz oasdiff
+          git show "$BASE_REF:tests/fixtures/hosted-openapi.json" > /tmp/base-spec.json
+          {
+            echo "## Hosted API spec delta (base → PR)"
+            echo '```'
+            ./oasdiff changelog /tmp/base-spec.json tests/fixtures/hosted-openapi.json || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # `--ignored` runs exactly the ignored drift test (kept out of `make ci`).

--- a/.github/workflows/refresh-hosted-openapi.yml
+++ b/.github/workflows/refresh-hosted-openapi.yml
@@ -19,9 +19,11 @@ on:
         description: "OpenAPI spec URL to fetch"
         default: "https://api.platform.infino.ws/openapi.json"
 
+# The push and PR use RELEASE_PAT (same fine-grained token release-prep
+# uses): a PR created with the default GITHUB_TOKEN triggers no workflows,
+# so the drift check this refresh exists to feed would never run on it.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: refresh-hosted-openapi
@@ -34,6 +36,8 @@ jobs:
     if: github.repository == 'infino-ai/infino'
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Fetch the published spec
         run: |
@@ -46,6 +50,7 @@ jobs:
       - name: Open a refresh PR if the spec changed
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           add-paths: tests/fixtures/hosted-openapi.json
           branch: bot/refresh-hosted-openapi
           commit-message: "test: refresh the vendored hosted API spec"


### PR DESCRIPTION
Two fixes to the hosted-spec loop repaired in #605, one of them a latent break found while adding the other:

**1. Refresh PRs never would have triggered the drift check.** `refresh-hosted-openapi.yml` created its PR with the default `GITHUB_TOKEN` — and a PR created that way triggers no workflows, so `hosted-api-drift.yml` (the check the refresh exists to feed) would never have run on it. This never surfaced only because the fetch URL was dead until #605: the workflow had never successfully opened a PR. The checkout and `create-pull-request` now use `RELEASE_PAT`, matching `release-prep.yml`'s pattern and documented rationale.

**2. Spec deltas now arrive classified.** When a PR changes the vendored fixture, `hosted-api-drift.yml` writes an oasdiff changelog (pinned 1.28.0) to the job summary — e.g. the #605 delta would have read *"5 potentially-breaking: nprobe/rerank_mult/n_centroids removed; 26 additive: 503/409/403/412 responses added"* instead of 160 lines of JSON. **Report-only by design**: by the time a refresh PR exists the service has already shipped the change, so the summary informs the human; the wiremock conformance test remains the gate for whether the client still matches.

Validated locally: oasdiff on the actual pre-#605 → current fixture pair produces exactly the classification above; both workflows parse clean.

Next scheduled refresh (Mondays 07:00 UTC) will exercise the full corrected loop: fetch → PAT-authored PR → CI + drift check + changelog summary → human merge.