### PR TITLE
fts: prune ranked multi-term OR and tighten the ranked-AND bound

### DIFF
--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -325,16 +325,6 @@ pub(super) const OR_COUNT_BITSET_DENSITY_DIVISOR: u64 = 16;
 /// this same boundary to decide when a ranged kernel is heavy enough to
 /// ship to the reader pool (see `RANGED_KERNEL_POOL_MIN_TERMS`).
 pub(crate) const OR_WINDOW_MIN_TERMS: usize = 3;
-/// Route a multi-term OR to the windowed union scorer only when the top
-/// term's score upper bound is at most this multiple of the *average*
-/// term upper bound — i.e. no single term dominates. Uniform terms sit at
-/// ~1.0× the average (MaxScore can't prune them → windowed wins); a
-/// dominant rare term sits well above it (MaxScore prunes hard → it stays
-/// on MaxScore). Calibrated on the 1M tier; re-measured on every bench
-/// run by the superfile tier's per-algorithm probes
-/// (`benches/utils/superfile.rs`), whose shapes sit on both sides of
-/// this threshold.
-pub(super) const OR_WINDOW_DOMINANCE_MULT: f32 = 1.5;
 
 /// Largest `k` for which a 2-term OR routes to WAND+BMW instead of
 /// MaxScore. WAND's pivot pruning needs a high top-k threshold to skip
@@ -356,32 +346,20 @@ pub(super) const WAND_BMW_2TERM_MAX_K: usize = 128;
 /// (long list), which WAND can't skip — only df separates the cases.
 pub(super) const WAND_BMW_2TERM_DF_RATIO: u64 = 16;
 
-/// True when **no single term dominates** the score upper bound:
-/// `max_ub <= OR_WINDOW_DOMINANCE_MULT * avg_ub`. Uniform terms sit near
-/// the average — MaxScore can't prune them (its essential set never
-/// shrinks); a dominant (typically rare) term sits well above it, and
-/// MaxScore / WAND can skip hard against it. Shared by the windowed-union
-/// and 2-term WAND routers, which want opposite sides of this test. Cheap
-/// — the per-term upper bounds are already on the cursors.
-pub(super) fn no_dominant_term_ub(cursors: &[TermCursor]) -> bool {
-    let total: f32 = cursors.iter().map(|c| c.term_max_bm25).sum();
-    if total <= 0.0 {
-        return false;
-    }
-    let max = cursors
-        .iter()
-        .map(|c| c.term_max_bm25)
-        .fold(0.0f32, f32::max);
-    let avg = total / cursors.len() as f32;
-    max <= OR_WINDOW_DOMINANCE_MULT * avg
-}
-
-/// Choose the windowed union scorer over MaxScore+BMM for a multi-term
-/// OR: true when there are enough terms to amortize the window and no
-/// single term dominates (so MaxScore degrades to scoring the whole
-/// union).
-pub(super) fn prefer_windowed_union(cursors: &[TermCursor]) -> bool {
-    cursors.len() >= OR_WINDOW_MIN_TERMS && no_dominant_term_ub(cursors)
+/// Choose the non-pruning windowed union scorer over MaxScore+BMM for a
+/// multi-term OR — true **only when block-max pruning is dead at this `k`**
+/// ([`or_topk_pruning_ineffective`]), the single case where the SIMD
+/// full-union scan beats MaxScore's per-doc f-way merge. Otherwise MaxScore
+/// is the default, including for the uniform-upper-bound "common-heavy"
+/// shape that used to be forced onto the windowed path: at small/mid `k`
+/// the competitive threshold rises above the common terms' per-block maxima
+/// once the heap fills, so MaxScore skips those blocks — pruning the
+/// windowed scan ignores (its cost is independent of `k`). Both the
+/// single-shot (`dispatch_or_algo`) and ranged (`search_or_range_prebuilt`)
+/// OR entries call this, so a query runs the same kernel whether or not the
+/// fan-out sliced it.
+pub(super) fn route_or_to_windowed(cursors: &[TermCursor], k: usize) -> bool {
+    or_topk_pruning_ineffective(cursors, k)
 }
 
 /// Minimum dominant-term df for the deep-`k` reroute to the windowed

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -361,13 +361,14 @@ pub(super) const OR_WINDOW_DOMINANCE_MULT: f32 = 1.5;
 /// common terms' per-block maxima and their blocks skip. As `k` grows the
 /// threshold falls until no block clears it, MaxScore degrades to a scalar
 /// full union scan, and the windowed scorer does that same scan far faster
-/// (SIMD, no per-doc f-way merge). Calibrated on the ranked-union bench:
-/// MaxScore wins by a wide margin at page-sized `k` and holds into the low
-/// hundreds, then loses once `k` reaches the ~thousand-result range where
-/// its pruning is dead — so the crossover sits in between. Shares the value
-/// (and the "pruning stays alive below this k" rationale) with
-/// [`WAND_BMW_2TERM_MAX_K`].
-pub(super) const OR_WINDOWED_UNIFORM_MAX_PRUNING_K: usize = 128;
+/// (SIMD, no per-doc f-way merge). Calibrated on the x86 cross-engine
+/// ranked-union bench: MaxScore wins decisively at page-sized `k` (tens of
+/// results) but already loses to the SIMD windowed scan by the low hundreds,
+/// so the crossover sits just above page size — the value is set below it.
+/// (The crossover is architecture-sensitive: on a wide-SIMD x86 host the
+/// windowed scan is relatively faster than on ARM, so this is tuned to the
+/// x86 target, not a local dev machine.)
+pub(super) const OR_WINDOWED_UNIFORM_MAX_PRUNING_K: usize = 32;
 
 /// True when **no single term dominates** the score upper bound:
 /// `max_ub <= OR_WINDOW_DOMINANCE_MULT * avg_ub`. Uniform terms sit near

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -346,20 +346,71 @@ pub(super) const WAND_BMW_2TERM_MAX_K: usize = 128;
 /// (long list), which WAND can't skip — only df separates the cases.
 pub(super) const WAND_BMW_2TERM_DF_RATIO: u64 = 16;
 
+/// Score upper-bound spread below which a multi-term OR counts as
+/// "common-heavy" (no single term dominates): `max_ub <=
+/// OR_WINDOW_DOMINANCE_MULT * avg_ub`. Uniform terms sit near the average;
+/// a dominant (rarer) term sits well above it. See [`no_dominant_term_ub`].
+pub(super) const OR_WINDOW_DOMINANCE_MULT: f32 = 1.5;
+
+/// For a common-heavy (no-dominant-term) multi-term OR, the `k` at or below
+/// which MaxScore still out-prunes the non-pruning windowed scan, so the OR
+/// stays on MaxScore; above it the windowed SIMD scan wins.
+///
+/// Even with no dominant term MaxScore prunes at *small* `k`: once the heap
+/// fills, the competitive threshold (the k-th best score) rises above the
+/// common terms' per-block maxima and their blocks skip. As `k` grows the
+/// threshold falls until no block clears it, MaxScore degrades to a scalar
+/// full union scan, and the windowed scorer does that same scan far faster
+/// (SIMD, no per-doc f-way merge). Calibrated on the ranked-union bench:
+/// MaxScore wins by a wide margin at page-sized `k` and holds into the low
+/// hundreds, then loses once `k` reaches the ~thousand-result range where
+/// its pruning is dead — so the crossover sits in between. Shares the value
+/// (and the "pruning stays alive below this k" rationale) with
+/// [`WAND_BMW_2TERM_MAX_K`].
+pub(super) const OR_WINDOWED_UNIFORM_MAX_PRUNING_K: usize = 128;
+
+/// True when **no single term dominates** the score upper bound:
+/// `max_ub <= OR_WINDOW_DOMINANCE_MULT * avg_ub`. Uniform terms sit near
+/// the average — MaxScore can prune them only while the top-k threshold is
+/// high (small `k`); a dominant (typically rare) term sits well above it,
+/// and MaxScore / WAND can skip hard against it at any `k`. Cheap — the
+/// per-term upper bounds are already on the cursors.
+pub(super) fn no_dominant_term_ub(cursors: &[TermCursor]) -> bool {
+    let total: f32 = cursors.iter().map(|c| c.term_max_bm25).sum();
+    if total <= 0.0 {
+        return false;
+    }
+    let max = cursors
+        .iter()
+        .map(|c| c.term_max_bm25)
+        .fold(0.0f32, f32::max);
+    let avg = total / cursors.len() as f32;
+    max <= OR_WINDOW_DOMINANCE_MULT * avg
+}
+
 /// Choose the non-pruning windowed union scorer over MaxScore+BMM for a
-/// multi-term OR — true **only when block-max pruning is dead at this `k`**
-/// ([`or_topk_pruning_ineffective`]), the single case where the SIMD
-/// full-union scan beats MaxScore's per-doc f-way merge. Otherwise MaxScore
-/// is the default, including for the uniform-upper-bound "common-heavy"
-/// shape that used to be forced onto the windowed path: at small/mid `k`
-/// the competitive threshold rises above the common terms' per-block maxima
-/// once the heap fills, so MaxScore skips those blocks — pruning the
-/// windowed scan ignores (its cost is independent of `k`). Both the
-/// single-shot (`dispatch_or_algo`) and ranged (`search_or_range_prebuilt`)
-/// OR entries call this, so a query runs the same kernel whether or not the
-/// fan-out sliced it.
+/// multi-term OR — true only when block-max pruning is dead at this `k`, in
+/// either of two ways:
+///
+/// - **Dominant long list, deep `k`** ([`or_topk_pruning_ineffective`]): the
+///   heap can't fill without the common term's tail, so the threshold
+///   collapses to its upper bound and no block skips.
+/// - **Common-heavy (no dominant term), deep `k`**: with `>=
+///   OR_WINDOW_MIN_TERMS` uniform-upper-bound terms and `k >
+///   OR_WINDOWED_UNIFORM_MAX_PRUNING_K`, the threshold sits too low to skip
+///   any term's blocks. At small/mid `k` this shape stays on MaxScore, which
+///   still prunes once its heap fills — the case the old always-windowed
+///   heuristic got wrong.
+///
+/// Everything else defaults to MaxScore. Both the single-shot
+/// (`dispatch_or_algo`) and ranged (`search_or_range_prebuilt`) OR entries
+/// call this, so a query runs the same kernel whether or not the fan-out
+/// sliced it.
 pub(super) fn route_or_to_windowed(cursors: &[TermCursor], k: usize) -> bool {
     or_topk_pruning_ineffective(cursors, k)
+        || (k > OR_WINDOWED_UNIFORM_MAX_PRUNING_K
+            && cursors.len() >= OR_WINDOW_MIN_TERMS
+            && no_dominant_term_ub(cursors))
 }
 
 /// Minimum dominant-term df for the deep-`k` reroute to the windowed

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -352,30 +352,16 @@ pub(super) const WAND_BMW_2TERM_DF_RATIO: u64 = 16;
 /// a dominant (rarer) term sits well above it. See [`no_dominant_term_ub`].
 pub(super) const OR_WINDOW_DOMINANCE_MULT: f32 = 1.5;
 
-/// For a common-heavy (no-dominant-term) multi-term OR, the `k` at or below
-/// which MaxScore still out-prunes the non-pruning windowed scan, so the OR
-/// stays on MaxScore; above it the windowed SIMD scan wins.
-///
-/// Even with no dominant term MaxScore prunes at *small* `k`: once the heap
-/// fills, the competitive threshold (the k-th best score) rises above the
-/// common terms' per-block maxima and their blocks skip. As `k` grows the
-/// threshold falls until no block clears it, MaxScore degrades to a scalar
-/// full union scan, and the windowed scorer does that same scan far faster
-/// (SIMD, no per-doc f-way merge). Calibrated on the x86 cross-engine
-/// ranked-union bench: MaxScore wins decisively at page-sized `k` (tens of
-/// results) but already loses to the SIMD windowed scan by the low hundreds,
-/// so the crossover sits just above page size — the value is set below it.
-/// (The crossover is architecture-sensitive: on a wide-SIMD x86 host the
-/// windowed scan is relatively faster than on ARM, so this is tuned to the
-/// x86 target, not a local dev machine.)
+/// `k` cutoff for a common-heavy OR: at or below it MaxScore prunes (its
+/// heap fills and the threshold rises above the common terms' block maxima),
+/// so keep it there; above it pruning is dead and the SIMD windowed scan
+/// wins. Bench-tuned to the x86 target (the crossover is lower on wide-SIMD
+/// x86 than on ARM).
 pub(super) const OR_WINDOWED_UNIFORM_MAX_PRUNING_K: usize = 32;
 
-/// True when **no single term dominates** the score upper bound:
-/// `max_ub <= OR_WINDOW_DOMINANCE_MULT * avg_ub`. Uniform terms sit near
-/// the average — MaxScore can prune them only while the top-k threshold is
-/// high (small `k`); a dominant (typically rare) term sits well above it,
-/// and MaxScore / WAND can skip hard against it at any `k`. Cheap — the
-/// per-term upper bounds are already on the cursors.
+/// True when no single term dominates the score upper bound
+/// (`max_ub <= OR_WINDOW_DOMINANCE_MULT * avg_ub`). Such a "common-heavy" OR
+/// only prunes on MaxScore at small `k`; a dominant term skips hard at any `k`.
 pub(super) fn no_dominant_term_ub(cursors: &[TermCursor]) -> bool {
     let total: f32 = cursors.iter().map(|c| c.term_max_bm25).sum();
     if total <= 0.0 {
@@ -389,24 +375,12 @@ pub(super) fn no_dominant_term_ub(cursors: &[TermCursor]) -> bool {
     max <= OR_WINDOW_DOMINANCE_MULT * avg
 }
 
-/// Choose the non-pruning windowed union scorer over MaxScore+BMM for a
-/// multi-term OR — true only when block-max pruning is dead at this `k`, in
-/// either of two ways:
-///
-/// - **Dominant long list, deep `k`** ([`or_topk_pruning_ineffective`]): the
-///   heap can't fill without the common term's tail, so the threshold
-///   collapses to its upper bound and no block skips.
-/// - **Common-heavy (no dominant term), deep `k`**: with `>=
-///   OR_WINDOW_MIN_TERMS` uniform-upper-bound terms and `k >
-///   OR_WINDOWED_UNIFORM_MAX_PRUNING_K`, the threshold sits too low to skip
-///   any term's blocks. At small/mid `k` this shape stays on MaxScore, which
-///   still prunes once its heap fills — the case the old always-windowed
-///   heuristic got wrong.
-///
-/// Everything else defaults to MaxScore. Both the single-shot
-/// (`dispatch_or_algo`) and ranged (`search_or_range_prebuilt`) OR entries
-/// call this, so a query runs the same kernel whether or not the fan-out
-/// sliced it.
+/// Route a multi-term OR to the non-pruning windowed scan instead of MaxScore,
+/// true only where MaxScore's pruning is dead at this `k`: a dominant long list
+/// too deep to fill the heap without its tail ([`or_topk_pruning_ineffective`]),
+/// or a common-heavy shape past [`OR_WINDOWED_UNIFORM_MAX_PRUNING_K`]. Otherwise
+/// MaxScore. Shared by the single-shot and ranged OR entries so a query runs the
+/// same kernel whether or not the fan-out sliced it.
 pub(super) fn route_or_to_windowed(cursors: &[TermCursor], k: usize) -> bool {
     or_topk_pruning_ineffective(cursors, k)
         || (k > OR_WINDOWED_UNIFORM_MAX_PRUNING_K

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1521,17 +1521,20 @@ impl FtsReader {
         // cross-segment floor (`floor_eff` unset) — seeding WAND's
         // threshold from a floor mis-prunes, so a live floor stays on
         // MaxScore.
-        // The dominance heuristic (`prefer_windowed_union`) assumes a
-        // dominant term means MaxScore prunes hard — true only at small
-        // `k`. At large `k` relative to the rarer terms' combined df the
-        // top-k threshold collapses to the common term's upper bound,
-        // MaxScore can skip nothing, and it degrades to a *scalar* full
-        // scan. `or_topk_pruning_ineffective` catches exactly that case
-        // (including a 2-term rare+common OR too deep for WAND) and
-        // routes it to the SIMD windowed scorer, which does the same
-        // full scan without the per-doc f-way merge. Small-`k`
-        // dominant-term ORs fail this test and stay on MaxScore, where
-        // pruning still wins.
+        // MaxScore is the default for multi-term OR, *including* the
+        // common-heavy (uniform upper-bound) shape. The old heuristic sent
+        // that shape to the non-pruning windowed scanner on the premise
+        // "no dominant term ⇒ MaxScore can't prune"; that is wrong at
+        // small/mid `k`, where the competitive threshold rises above the
+        // common terms' per-block maxima once the heap fills and MaxScore
+        // skips those blocks — pruning the windowed scan ignores (its cost
+        // is independent of `k`). Route to the windowed scan only when
+        // pruning is genuinely dead at this `k` (`route_or_to_windowed` →
+        // `or_topk_pruning_ineffective`: a long dominant list plus `k`
+        // deep enough that the rarer terms can no longer fill the heap, so
+        // the threshold collapses to the common term's upper bound). There
+        // the SIMD full scan does the same work MaxScore would, without the
+        // per-doc f-way merge.
         let no_floor = floor_eff == f32::NEG_INFINITY;
         if cursors.len() == 2
             && k <= WAND_BMW_2TERM_MAX_K
@@ -1540,7 +1543,7 @@ impl FtsReader {
             && two_term_has_rare_anchor(&cursors)
         {
             self.run_wand_bmw(column_id, cursors, k)
-        } else if prefer_windowed_union(&cursors) || or_topk_pruning_ineffective(&cursors, k) {
+        } else if route_or_to_windowed(&cursors, k) {
             self.run_windowed_union(column_id, cursors, k, filter, floor_eff, 0, u32::MAX)
         } else {
             self.run_max_score_bmm(column_id, cursors, k, filter, floor_eff)
@@ -1819,10 +1822,16 @@ mod tests {
             .build_term_cursors(col, uniform_terms, None, false)
             .await
             .expect("uniform cursors");
-        assert!(
-            prefer_windowed_union(&uniform_cursors),
-            "production router should select windowed union for equal upper bounds"
-        );
+        // Phase 1 routing: the common-heavy (equal-upper-bound) shape is no
+        // longer forced onto the windowed scan — at these k it routes to the
+        // pruning MaxScore path. Windowed is reserved for the pruning-dead
+        // case (a long dominant list at deep k), which this shape isn't.
+        for k in [1usize, 5, 50, 1000] {
+            assert!(
+                !route_or_to_windowed(&uniform_cursors, k),
+                "common-heavy OR at k={k} should route to MaxScore, not windowed"
+            );
+        }
 
         let shapes: &[&[&str]] = &[
             &["alpha", "beta"],

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -79,26 +79,13 @@ fn count_and_intersect_bitset(cursors: Vec<TermCursor>, max_doc: u32) -> u64 {
     acc.iter().map(|w| w.count_ones() as u64).sum()
 }
 
-/// Block-Max-AND upper bound at the leader's current doc, plus the window it
-/// is valid over. `cursors[0]` is the leader (positioned on a real doc in its
-/// current block); the rest are bounded by the block that *contains* that doc
-/// (`shallow_advance_block_to` + `inspect_block_max_bm25`), not by a max over
-/// every block spanning the leader's whole — possibly wide — block range. The
-/// sum is a true upper bound for every doc in `[leader_doc, window_end]`,
-/// where `window_end` is the smallest block boundary across the leader and all
-/// others: past it some cursor enters a new block and its bound may rise.
-///
-/// This is the tight per-block-pair bound. The looser range-max
-/// (`block_max_in_range` over the leader's full block) collapses to a common
-/// term's *global* max on a rare∧common query — where the rare leader's one
-/// block spans thousands of the common term's docs — so the skip almost never
-/// fires. Bounding by the single overlapping block instead lets the skip fire
-/// on a common term's locally-low regions, and skipping only to `window_end`
-/// keeps every skip provably safe.
-///
-/// The leader's block max and block end are passed in (its callers hold it
-/// split off from `others` for the flat-merge), and `others` is bounded and
-/// window-clamped in place via each cursor's `inspect_block` hint pointer.
+/// Block-Max-AND upper bound at the leader's doc, valid over
+/// `[leader_doc, window_end]` where `window_end` is the smallest block boundary
+/// across all cursors. Each non-leader is bounded by the single block that
+/// *contains* `leader_doc`, not a max over every block under the leader's whole
+/// (possibly wide) block — the looser range-max collapsed to a common term's
+/// global max on rare∧common queries, so the skip rarely fired. Leader block
+/// max/end are passed in (callers hold the leader split off for the flat-merge).
 fn block_max_and_bound(
     leader_block_max: f32,
     leader_block_end: u32,
@@ -576,17 +563,11 @@ impl FtsReader {
                 break;
             }
 
-            // Block-Max-AND pruning (scoring sinks only; the unranked
-            // sink's `bar()` is NEG_INFINITY, so this whole block is
-            // skipped). The bar is the kth-best once the heap fills, or
-            // the caller's seeded floor before that — whichever is higher.
-            // Bound the leader's current doc by the single block each other
-            // cursor has covering it (`block_max_and_bound`) — a tight
-            // per-block-pair sum — and, if it can't beat the bar, skip only
-            // to the smallest block boundary across all cursors, past which
-            // some bound may rise. Skipping the leader's *whole* block with
-            // a max over every overlapping block instead let a common term's
-            // global max swamp the bound so it rarely fired.
+            // Block-Max-AND pruning (scoring sinks only; unranked `bar()` is
+            // NEG_INFINITY). If the tight per-block-pair bound at the leader's
+            // doc can't beat the bar, skip to the smallest block boundary
+            // across all cursors (past which a bound may rise). See
+            // `block_max_and_bound`.
             let bar = sink.bar();
             if bar > f32::NEG_INFINITY {
                 let leader_doc = cursors[0].current_doc_id();
@@ -736,12 +717,9 @@ impl FtsReader {
                 break;
             }
 
-            // Block-Max-AND pruning at the leader's current doc (scoring
-            // sinks only; the unranked sink's `bar()` is NEG_INFINITY, so
-            // this is skipped). The bar is the kth-best once the heap fills,
-            // or the caller's seeded floor before that — whichever is higher.
-            // Bound `c1` by the single block covering the leader doc and skip
-            // only to the nearer block boundary; see `block_max_and_bound`.
+            // Block-Max-AND pruning (scoring sinks only). Bound `c1` by the
+            // single block covering the leader doc; if it can't beat the bar,
+            // skip to the nearer block boundary. See `block_max_and_bound`.
             let bar = sink.bar();
             if bar > f32::NEG_INFINITY {
                 let leader_doc = c0.current_doc_id();
@@ -1565,20 +1543,10 @@ impl FtsReader {
         // cross-segment floor (`floor_eff` unset) — seeding WAND's
         // threshold from a floor mis-prunes, so a live floor stays on
         // MaxScore.
-        // MaxScore is the default for multi-term OR, *including* the
-        // common-heavy (uniform upper-bound) shape. The old heuristic sent
-        // that shape to the non-pruning windowed scanner on the premise
-        // "no dominant term ⇒ MaxScore can't prune"; that is wrong at
-        // small/mid `k`, where the competitive threshold rises above the
-        // common terms' per-block maxima once the heap fills and MaxScore
-        // skips those blocks — pruning the windowed scan ignores (its cost
-        // is independent of `k`). Route to the windowed scan only when
-        // pruning is genuinely dead at this `k` (`route_or_to_windowed` →
-        // `or_topk_pruning_ineffective`: a long dominant list plus `k`
-        // deep enough that the rarer terms can no longer fill the heap, so
-        // the threshold collapses to the common term's upper bound). There
-        // the SIMD full scan does the same work MaxScore would, without the
-        // per-doc f-way merge.
+        // A 2-term rare+common OR goes to WAND+BMW (it pivots on the rare
+        // term); otherwise MaxScore by default, and the windowed scan only
+        // where pruning is dead — see `route_or_to_windowed`. WAND takes no
+        // filter or floor, so a negated / floored query skips it.
         let no_floor = floor_eff == f32::NEG_INFINITY;
         if cursors.len() == 2
             && k <= WAND_BMW_2TERM_MAX_K

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -6,9 +6,7 @@
 //! dispatch, and the AND flat-merge intersection family. Split from the
 //! reader `core` as its own `impl FtsReader` block.
 
-use std::{cmp::Ordering, collections::BinaryHeap};
-
-use std::slice::from_mut;
+use std::{cmp::Ordering, collections::BinaryHeap, slice::from_mut};
 
 use super::{
     core::*,

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1822,14 +1822,20 @@ mod tests {
             .build_term_cursors(col, uniform_terms, None, false)
             .await
             .expect("uniform cursors");
-        // Phase 1 routing: the common-heavy (equal-upper-bound) shape is no
-        // longer forced onto the windowed scan — at these k it routes to the
-        // pruning MaxScore path. Windowed is reserved for the pruning-dead
-        // case (a long dominant list at deep k), which this shape isn't.
-        for k in [1usize, 5, 50, 1000] {
+        // Phase 1 routing is k-gated: the common-heavy (equal-upper-bound)
+        // shape stays on the pruning MaxScore path at small/mid k, and only
+        // falls to the windowed scan at deep k (past the pruning cutoff),
+        // where MaxScore can no longer prune it.
+        for k in [1usize, 5, 50, OR_WINDOWED_UNIFORM_MAX_PRUNING_K] {
             assert!(
                 !route_or_to_windowed(&uniform_cursors, k),
-                "common-heavy OR at k={k} should route to MaxScore, not windowed"
+                "common-heavy OR at k={k} (<= cutoff) should route to MaxScore"
+            );
+        }
+        for k in [OR_WINDOWED_UNIFORM_MAX_PRUNING_K + 1, 1000] {
+            assert!(
+                route_or_to_windowed(&uniform_cursors, k),
+                "common-heavy OR at deep k={k} should route to the windowed scan"
             );
         }
 

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1870,7 +1870,7 @@ mod tests {
         // shape stays on the pruning MaxScore path at small/mid k, and only
         // falls to the windowed scan at deep k (past the pruning cutoff),
         // where MaxScore can no longer prune it.
-        for k in [1usize, 5, 50, OR_WINDOWED_UNIFORM_MAX_PRUNING_K] {
+        for k in [1usize, 5, 16, OR_WINDOWED_UNIFORM_MAX_PRUNING_K] {
             assert!(
                 !route_or_to_windowed(&uniform_cursors, k),
                 "common-heavy OR at k={k} (<= cutoff) should route to MaxScore"

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -8,6 +8,8 @@
 
 use std::{cmp::Ordering, collections::BinaryHeap};
 
+use std::slice::from_mut;
+
 use super::{
     core::*,
     cursor::TermCursor,
@@ -77,6 +79,42 @@ fn count_and_intersect_bitset(cursors: Vec<TermCursor>, max_doc: u32) -> u64 {
         }
     }
     acc.iter().map(|w| w.count_ones() as u64).sum()
+}
+
+/// Block-Max-AND upper bound at the leader's current doc, plus the window it
+/// is valid over. `cursors[0]` is the leader (positioned on a real doc in its
+/// current block); the rest are bounded by the block that *contains* that doc
+/// (`shallow_advance_block_to` + `inspect_block_max_bm25`), not by a max over
+/// every block spanning the leader's whole — possibly wide — block range. The
+/// sum is a true upper bound for every doc in `[leader_doc, window_end]`,
+/// where `window_end` is the smallest block boundary across the leader and all
+/// others: past it some cursor enters a new block and its bound may rise.
+///
+/// This is the tight per-block-pair bound. The looser range-max
+/// (`block_max_in_range` over the leader's full block) collapses to a common
+/// term's *global* max on a rare∧common query — where the rare leader's one
+/// block spans thousands of the common term's docs — so the skip almost never
+/// fires. Bounding by the single overlapping block instead lets the skip fire
+/// on a common term's locally-low regions, and skipping only to `window_end`
+/// keeps every skip provably safe.
+///
+/// The leader's block max and block end are passed in (its callers hold it
+/// split off from `others` for the flat-merge), and `others` is bounded and
+/// window-clamped in place via each cursor's `inspect_block` hint pointer.
+fn block_max_and_bound(
+    leader_block_max: f32,
+    leader_block_end: u32,
+    others: &mut [TermCursor],
+    leader_doc: u32,
+) -> (f32, u32) {
+    let mut ub = leader_block_max;
+    let mut window_end = leader_block_end;
+    for c in others.iter_mut() {
+        c.shallow_advance_block_to(leader_doc);
+        ub += c.inspect_block_max_bm25();
+        window_end = window_end.min(c.inspect_block_last_doc_id());
+    }
+    (ub, window_end)
 }
 
 impl FtsReader {
@@ -540,26 +578,30 @@ impl FtsReader {
                 break;
             }
 
-            // Block-max-AND pruning (scoring sinks only; the unranked
+            // Block-Max-AND pruning (scoring sinks only; the unranked
             // sink's `bar()` is NEG_INFINITY, so this whole block is
             // skipped). The bar is the kth-best once the heap fills, or
-            // the caller's seeded floor before that — whichever is
-            // higher. If the leader's current block can't possibly
-            // produce a bar-beating score, skip the whole block — the
-            // safest UB sums leader's block_max with each other cursor's
-            // max block_max across all blocks that overlap the leader's
-            // block doc-id range.
+            // the caller's seeded floor before that — whichever is higher.
+            // Bound the leader's current doc by the single block each other
+            // cursor has covering it (`block_max_and_bound`) — a tight
+            // per-block-pair sum — and, if it can't beat the bar, skip only
+            // to the smallest block boundary across all cursors, past which
+            // some bound may rise. Skipping the leader's *whole* block with
+            // a max over every overlapping block instead let a common term's
+            // global max swamp the bound so it rarely fired.
             let bar = sink.bar();
             if bar > f32::NEG_INFINITY {
-                let range_start = cursors[0].current_doc_id();
-                let range_end = cursors[0].current_block_last_doc_id();
+                let leader_doc = cursors[0].current_doc_id();
                 let leader_block_max = cursors[0].current_block_max_bm25();
-                let mut other_ub = 0.0_f32;
-                for c in cursors[1..].iter_mut() {
-                    other_ub += c.block_max_in_range(range_start, range_end);
-                }
-                if leader_block_max + other_ub <= bar {
-                    cursors[0].skip_to(range_end.saturating_add(1));
+                let leader_block_end = cursors[0].current_block_last_doc_id();
+                let (ub, window_end) = block_max_and_bound(
+                    leader_block_max,
+                    leader_block_end,
+                    &mut cursors[1..],
+                    leader_doc,
+                );
+                if ub <= bar {
+                    cursors[0].skip_to(window_end.saturating_add(1));
                     continue;
                 }
             }
@@ -696,19 +738,23 @@ impl FtsReader {
                 break;
             }
 
-            // Block-max-AND pruning at the leader's current block
-            // (scoring sinks only; the unranked sink's `bar()` is
-            // NEG_INFINITY, so this is skipped). The bar is the kth-best
-            // once the heap fills, or the caller's seeded floor before
-            // that — whichever is higher.
+            // Block-Max-AND pruning at the leader's current doc (scoring
+            // sinks only; the unranked sink's `bar()` is NEG_INFINITY, so
+            // this is skipped). The bar is the kth-best once the heap fills,
+            // or the caller's seeded floor before that — whichever is higher.
+            // Bound `c1` by the single block covering the leader doc and skip
+            // only to the nearer block boundary; see `block_max_and_bound`.
             let bar = sink.bar();
             if bar > f32::NEG_INFINITY {
-                let range_start = c0.current_doc_id();
-                let range_end = c0.current_block_last_doc_id();
-                let ub =
-                    c0.current_block_max_bm25() + c1.block_max_in_range(range_start, range_end);
+                let leader_doc = c0.current_doc_id();
+                let (ub, window_end) = block_max_and_bound(
+                    c0.current_block_max_bm25(),
+                    c0.current_block_last_doc_id(),
+                    from_mut(c1),
+                    leader_doc,
+                );
                 if ub <= bar {
-                    c0.skip_to(range_end.saturating_add(1));
+                    c0.skip_to(window_end.saturating_add(1));
                     continue;
                 }
             }

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -662,15 +662,14 @@ impl FtsReader {
     /// [`Self::search_or_range_pretokenized_with_floor`] delegates here.
     /// The ranged path carries no negation in v1.
     ///
-    /// Kernel choice mirrors `dispatch_or_algo` instead of
-    /// hardcoding MaxScore+BMM: on a broad OR over uniform-upper-bound
-    /// terms BMM cannot prune (every block max ties), so it degrades to
-    /// per-doc min-scan bookkeeping over ~the whole union — the exact
-    /// shape `run_windowed_union` exists for, and it is natively ranged.
-    /// Hardcoding BMM here made the SAME query run a different kernel
-    /// depending on whether the fan-out sliced (few large superfiles,
-    /// i.e. post-compaction) or not (many small ones, pre-compaction) —
-    /// measured at 1M as the 11-24x post-compact broad-OR regression.
+    /// Kernel choice mirrors `dispatch_or_algo` via the shared
+    /// `route_or_to_windowed` seam instead of hardcoding a kernel: MaxScore
+    /// is the default, and the windowed scan is used only when block-max
+    /// pruning is dead at this `k`. Routing through the same predicate as
+    /// the single-shot path is what keeps the SAME query on the SAME kernel
+    /// whether or not the fan-out sliced it (few large superfiles
+    /// post-compaction vs many small ones pre-compaction) — hardcoding BMM
+    /// here once caused an 11-24x post-compact broad-OR regression.
     pub(crate) fn search_or_range_prebuilt(
         &self,
         set: &OrCursorSet,
@@ -683,7 +682,7 @@ impl FtsReader {
             return Ok(Vec::new());
         }
         let cursors = set.cursors.clone();
-        if prefer_windowed_union(&cursors) {
+        if route_or_to_windowed(&cursors, k) {
             self.run_windowed_union(
                 set.column_id,
                 cursors,
@@ -1360,32 +1359,31 @@ mod tests {
         let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
         let r = FtsReader::open(blob, json).expect("open");
 
-        // Uniform 4-term OR routes to the windowed union; the
-        // rare+common mix keeps a dominant term UB and stays on BMM.
-        // Assert the routing rather than assume it — a corpus tweak that
-        // silently stopped exercising one branch would otherwise turn
-        // this into a test of the other branch twice.
+        // Both shapes route to the MaxScore ranged branch at this corpus
+        // scale: Phase 1 reserves the windowed scan for the pruning-dead
+        // case (`or_topk_pruning_ineffective`), which needs a dominant list
+        // of ≥100k docs — unreachable in a fast in-memory test (that df
+        // threshold is unit-tested directly on `or_reroute_by_df`). The
+        // invariant under test here — partition union == un-ranged result —
+        // is kernel-agnostic, and both entries route through the same
+        // `route_or_to_windowed` seam, so a query cannot silently run a
+        // different kernel sliced vs whole. Assert the routing rather than
+        // assume it.
         let shapes: [&[&str]; 2] = [
             &["alpha", "beta", "gamma", "delta"],
             &["rareterm", "alpha", "beta"],
         ];
         let column_id = r.resolve_column_id("body").expect("column");
-        let uniform_cursors = r
-            .build_term_cursors(column_id, shapes[0], None, false)
-            .await
-            .expect("cursors");
-        assert!(
-            prefer_windowed_union(&uniform_cursors),
-            "uniform shape must route to the windowed ranged branch"
-        );
-        let dominant_cursors = r
-            .build_term_cursors(column_id, shapes[1], None, false)
-            .await
-            .expect("cursors");
-        assert!(
-            !prefer_windowed_union(&dominant_cursors),
-            "dominant-UB shape must route to the BMM ranged branch"
-        );
+        for terms in shapes {
+            let cursors = r
+                .build_term_cursors(column_id, terms, None, false)
+                .await
+                .expect("cursors");
+            assert!(
+                !route_or_to_windowed(&cursors, K_ALL) && !route_or_to_windowed(&cursors, K_TOP),
+                "{terms:?} routes to MaxScore at test scale (windowed needs a ≥100k dominant list)"
+            );
+        }
         // Uneven partitions, including window-boundary-crossing cuts.
         let partitions: [&[(u32, u32)]; 3] = [
             &[(0, N_DOCS)],

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -1359,31 +1359,39 @@ mod tests {
         let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
         let r = FtsReader::open(blob, json).expect("open");
 
-        // Both shapes route to the MaxScore ranged branch at this corpus
-        // scale: Phase 1 reserves the windowed scan for the pruning-dead
-        // case (`or_topk_pruning_ineffective`), which needs a dominant list
-        // of ≥100k docs — unreachable in a fast in-memory test (that df
-        // threshold is unit-tested directly on `or_reroute_by_df`). The
-        // invariant under test here — partition union == un-ranged result —
-        // is kernel-agnostic, and both entries route through the same
-        // `route_or_to_windowed` seam, so a query cannot silently run a
-        // different kernel sliced vs whole. Assert the routing rather than
-        // assume it.
+        // Phase-1 routing is k-gated, so this test exercises *both* ranged
+        // kernels. The uniform 4-term OR stays on MaxScore at the small
+        // top-k but falls to the windowed scan at K_ALL (k past the pruning
+        // cutoff); the dominant-UB shape stays on MaxScore at every k. Both
+        // entries route through the same `route_or_to_windowed` seam, so a
+        // query cannot silently run a different kernel sliced vs whole, and
+        // the invariant under test — partition union == un-ranged result —
+        // holds for either kernel. Assert the routing rather than assume it.
         let shapes: [&[&str]; 2] = [
             &["alpha", "beta", "gamma", "delta"],
             &["rareterm", "alpha", "beta"],
         ];
         let column_id = r.resolve_column_id("body").expect("column");
-        for terms in shapes {
-            let cursors = r
-                .build_term_cursors(column_id, terms, None, false)
-                .await
-                .expect("cursors");
-            assert!(
-                !route_or_to_windowed(&cursors, K_ALL) && !route_or_to_windowed(&cursors, K_TOP),
-                "{terms:?} routes to MaxScore at test scale (windowed needs a ≥100k dominant list)"
-            );
-        }
+        let uniform = r
+            .build_term_cursors(column_id, shapes[0], None, false)
+            .await
+            .expect("cursors");
+        assert!(
+            route_or_to_windowed(&uniform, K_ALL),
+            "uniform OR at K_ALL (deep k) must route to the windowed ranged branch"
+        );
+        assert!(
+            !route_or_to_windowed(&uniform, K_TOP),
+            "uniform OR at small k must route to the MaxScore ranged branch"
+        );
+        let dominant = r
+            .build_term_cursors(column_id, shapes[1], None, false)
+            .await
+            .expect("cursors");
+        assert!(
+            !route_or_to_windowed(&dominant, K_ALL) && !route_or_to_windowed(&dominant, K_TOP),
+            "dominant-UB OR must route to MaxScore at every k (not uniform, no ≥100k list)"
+        );
         // Uneven partitions, including window-boundary-crossing cuts.
         let partitions: [&[(u32, u32)]; 3] = [
             &[(0, N_DOCS)],

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -662,14 +662,10 @@ impl FtsReader {
     /// [`Self::search_or_range_pretokenized_with_floor`] delegates here.
     /// The ranged path carries no negation in v1.
     ///
-    /// Kernel choice mirrors `dispatch_or_algo` via the shared
-    /// `route_or_to_windowed` seam instead of hardcoding a kernel: MaxScore
-    /// is the default, and the windowed scan is used only when block-max
-    /// pruning is dead at this `k`. Routing through the same predicate as
-    /// the single-shot path is what keeps the SAME query on the SAME kernel
-    /// whether or not the fan-out sliced it (few large superfiles
-    /// post-compaction vs many small ones pre-compaction) — hardcoding BMM
-    /// here once caused an 11-24x post-compact broad-OR regression.
+    /// Kernel choice goes through the same `route_or_to_windowed` seam as the
+    /// single-shot path, so a query runs the same kernel whether or not the
+    /// fan-out sliced it — hardcoding BMM here once caused an 11-24x
+    /// post-compact broad-OR regression.
     pub(crate) fn search_or_range_prebuilt(
         &self,
         set: &OrCursorSet,
@@ -1359,14 +1355,10 @@ mod tests {
         let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
         let r = FtsReader::open(blob, json).expect("open");
 
-        // Phase-1 routing is k-gated, so this test exercises *both* ranged
-        // kernels. The uniform 4-term OR stays on MaxScore at the small
-        // top-k but falls to the windowed scan at K_ALL (k past the pruning
-        // cutoff); the dominant-UB shape stays on MaxScore at every k. Both
-        // entries route through the same `route_or_to_windowed` seam, so a
-        // query cannot silently run a different kernel sliced vs whole, and
-        // the invariant under test — partition union == un-ranged result —
-        // holds for either kernel. Assert the routing rather than assume it.
+        // k-gated routing exercises both ranged kernels: the uniform OR takes
+        // the windowed scan at K_ALL (deep k) but MaxScore at the small top-k;
+        // the dominant-UB OR stays on MaxScore throughout. Assert it rather
+        // than assume it, so a corpus tweak can't silently test one branch twice.
         let shapes: [&[&str]; 2] = [
             &["alpha", "beta", "gamma", "delta"],
             &["rareterm", "alpha", "beta"],

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -304,7 +304,7 @@ fn common_heavy_corpus(n: u64) -> Vec<(u64, String)> {
     for i in 5..n {
         let mut toks: Vec<&str> = Vec::new();
         for (t, name) in terms.iter().enumerate() {
-            if (i + t as u64) % 2 == 0 {
+            if (i + t as u64).is_multiple_of(2) {
                 toks.push(name);
             }
         }

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -276,6 +276,65 @@ async fn oracle_three_term_query_top5_set_matches() {
     assert_top_k_head_agrees(&infino, &oracle, "rust web framework", 3, 10).await;
 }
 
+/// A common-heavy 4-term corpus: four terms each in ~half the docs (no
+/// single dominant list — the "uniform upper bound" OR shape), plus five
+/// short high-tf anchor docs whose scores strictly decrease, giving a
+/// tie-free top-5 head. Large enough (`n`) that a k=1000 search exercises
+/// a genuinely deep top-k, not "return everything".
+fn common_heavy_corpus(n: u64) -> Vec<(u64, String)> {
+    let terms = ["alpha", "beta", "gamma", "delta"];
+    let mut docs = Vec::with_capacity(n as usize);
+    // Anchors 0..5: all four terms repeated (6-i) times ⇒ tf 6,5,4,3,2,
+    // each strictly above the bulk's tf=1, and strictly decreasing among
+    // themselves ⇒ a deterministic, tie-free top-5.
+    for i in 0..5u64 {
+        let reps = 6 - i as usize;
+        let mut doc = String::new();
+        for name in terms {
+            for _ in 0..reps {
+                doc.push_str(name);
+                doc.push(' ');
+            }
+        }
+        docs.push((i, doc.trim().to_string()));
+    }
+    // Bulk: each term present (tf=1) in a different ~half of the docs, on
+    // staggered strides so the four dfs are close (no dominant term) but
+    // the memberships differ per doc.
+    for i in 5..n {
+        let mut toks: Vec<&str> = Vec::new();
+        for (t, name) in terms.iter().enumerate() {
+            if (i + t as u64) % 2 == 0 {
+                toks.push(name);
+            }
+        }
+        if toks.is_empty() {
+            toks.push("filler");
+        }
+        docs.push((i, toks.join(" ")));
+    }
+    docs
+}
+
+#[tokio::test]
+async fn oracle_common_heavy_or_matches_brute_force_at_depth() {
+    // Phase-1 routing sends a common-heavy (uniform-UB) multi-term OR to
+    // the pruning MaxScore path instead of the non-pruning windowed scan.
+    // MaxScore prunes differently at each k (the competitive threshold
+    // engages later as k grows), so verify the *rerouted default* against
+    // ground-truth BM25 across the k regimes it now owns — not just against
+    // the windowed kernel it agrees with. The tie-free top-5 anchors make
+    // the head comparison deterministic regardless of tail tie-breaking.
+    let corp = common_heavy_corpus(4_000);
+    let corp_refs: Vec<(u64, &str)> = corp.iter().map(|(d, s)| (*d, s.as_str())).collect();
+    let infino = build_infino_superfile(&corp_refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp_refs, tok.as_ref());
+    for k in [10usize, 100, 1000] {
+        assert_top_k_head_agrees(&infino, &oracle, "alpha beta gamma delta", 5, k).await;
+    }
+}
+
 #[tokio::test]
 async fn oracle_no_match_query_returns_empty() {
     // "xyzzy" is in none of the docs; both engines must return empty.

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -318,13 +318,10 @@ fn common_heavy_corpus(n: u64) -> Vec<(u64, String)> {
 
 #[tokio::test]
 async fn oracle_common_heavy_or_matches_brute_force_at_depth() {
-    // Phase-1 routing sends a common-heavy (uniform-UB) multi-term OR to
-    // the pruning MaxScore path instead of the non-pruning windowed scan.
-    // MaxScore prunes differently at each k (the competitive threshold
-    // engages later as k grows), so verify the *rerouted default* against
-    // ground-truth BM25 across the k regimes it now owns — not just against
-    // the windowed kernel it agrees with. The tie-free top-5 anchors make
-    // the head comparison deterministic regardless of tail tie-breaking.
+    // A common-heavy OR now defaults to MaxScore, which prunes differently at
+    // each k. Verify the rerouted default against ground-truth BM25 across k,
+    // not just against the windowed kernel it agrees with. The tie-free top-5
+    // anchors keep the head comparison deterministic under tail tie-breaking.
     let corp = common_heavy_corpus(4_000);
     let corp_refs: Vec<(u64, &str)> = corp.iter().map(|(d, s)| (*d, s.as_str())).collect();
     let infino = build_infino_superfile(&corp_refs);


### PR DESCRIPTION
Two independent improvements to ranked (scored) multi-term top-k, both routing/bound changes with **unchanged top-k** (the windowed / MaxScore / WAND kernels agree with each other and with the brute-force BM25 oracle; a new common-heavy OR oracle checks the rerouted default against ground truth at k ∈ {10, 100, 1000}).

## 1. Prune ranked multi-term OR instead of full-scanning it

A common-heavy multi-term OR (uniform term upper bounds, no dominant term) was always sent to the windowed union scanner, which SIMD-scores every posting of every term in every non-empty window and consults the top-k threshold only at heap admission — so it never skips a block and its cost is independent of `k`. Make the pruning MaxScore path the default, **gated on `k`**: at small `k` the competitive threshold rises above the common terms' per-block maxima once the heap fills, so MaxScore skips their blocks; above the cutoff (`OR_WINDOWED_UNIFORM_MAX_PRUNING_K`) the threshold is too low to skip and it falls back to the windowed SIMD scan. Both the single-shot and ranged (fan-out) OR entries route through one `route_or_to_windowed` seam, so a query runs the same kernel whether or not the fan-out sliced it. Removes the now-unused dominance heuristic.

## 2. Tighten the ranked-AND block-max bound to a true Block-Max-AND

The AND flat-merge's block-max skip bounded each non-leader term by the max block-max over *every* block overlapping the leader's whole current block. On a rare∧common query the rare leader's one block spans thousands of the common term's docs, so that collapsed to the common term's global block-max — a bound so loose the skip almost never fired. Bound each non-leader by the single block that actually contains the leader's current doc (a per-block-pair sum) and skip only to the nearest block boundary across all cursors. Shared by the 2-term and general flat-merge (`block_max_and_bound`), so both the pure-AND and must+should paths benefit.

## Measured — infino before → after

Warm benchmark, min-of-runs, average per-query latency (µs) over each ranked query shape; `k` is the top-k size:

| shape | k | before | after | Δ |
| ----- | - | -----: | ----: | -: |
| ranked AND | 10 | 555 | 478 | **−14%** |
| ranked AND | 100 | 684 | 626 | −8% |
| ranked AND | 1000 | 784 | 745 | −5% |
| ranked OR (common-heavy) | 10 | 770 | 651 | **−15%** |
| ranked OR (common-heavy) | 100 / 1000 | — | — | neutral (routes to the unchanged windowed scan) |
| boolean (must+should)¹ | 100 | 838 | 506 | **−40%** |
| boolean (must+should)¹ | 1000 | 1165 | 749 | **−36%** |

¹ boolean uses the median — its mean is skewed by one heavy outlier query present in both arms.

No COUNT / phrase / single-term regression. No on-disk format change, no public-API change.