### PR TITLE
fts: prune phrase-in-boolean and tighten the MaxScore non-essential bound

### DIFF
--- a/src/superfile/fts/reader/phrase.rs
+++ b/src/superfile/fts/reader/phrase.rs
@@ -510,7 +510,11 @@ impl PhraseCursor {
             }
             self.verify_scratch.truncate(w);
         }
-        Ok(self.verify_scratch.len() as u32)
+        // The surviving starts are this doc's phrase occurrences — its tf.
+        // Store it so `score_current` scores the phrase after a two-phase
+        // `verify_at` (the single-phase `skip_to_pruned` sets it itself).
+        self.current_tf = self.verify_scratch.len() as u32;
+        Ok(self.current_tf)
     }
 
     /// Score the phrase at its current doc with the caller-supplied

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -926,14 +926,6 @@ impl FtsReader {
 
                 let block_end = cursors[0].current_block_last_doc_id();
                 let mut f_changed = false;
-                // Per-doc UB tightening: bound this doc's max possible
-                // score by `essential_score + sum_others_term_max`.
-                // If even this can't beat the heap threshold, skip
-                // the non-essential lookups + heap update entirely
-                // — those are the dominant per-doc cost. Only docs
-                // where the essential alone is "in striking distance"
-                // pay the full lookup price.
-                let others_term_ub = total_term_ub - cursors[0].term_max_bm25;
                 while !cursors[0].is_exhausted()
                     && cursors[0].current_doc_id() <= block_end
                     && cursors[0].current_doc_id() < doc_id_end
@@ -953,10 +945,23 @@ impl FtsReader {
                         cursors[0].current_tf(),
                         norm,
                     );
-                    if essential_score + others_term_ub <= threshold {
-                        // No combination of non-essential
-                        // contributions at `candidate` can push it
-                        // above threshold. Skip lookup + heap.
+                    // Per-doc UB tightening: bound the non-essentials at
+                    // `candidate` by each one's block-max for the block that
+                    // *contains* it — its local 128-doc max — not its global
+                    // term-max. The `inspect_block` hint advances monotonically
+                    // with `candidate`, so this is amortized O(1) per
+                    // non-essential. If even this tight bound can't beat the
+                    // threshold, skip the expensive non-essential `skip_to` +
+                    // SIMD score + heap entirely — the dominant per-doc cost.
+                    // A common non-essential's local block max is far below its
+                    // global max, so this fires on far more docs than the old
+                    // global-term-max bound did.
+                    let mut others_ub = 0.0f32;
+                    for c in cursors.iter_mut().skip(1) {
+                        c.shallow_advance_block_to(candidate);
+                        others_ub += c.inspect_block_max_bm25();
+                    }
+                    if essential_score + others_ub <= threshold {
                         cursors[0].next();
                         continue;
                     }

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -945,17 +945,13 @@ impl FtsReader {
                         cursors[0].current_tf(),
                         norm,
                     );
-                    // Per-doc UB tightening: bound the non-essentials at
-                    // `candidate` by each one's block-max for the block that
-                    // *contains* it — its local 128-doc max — not its global
-                    // term-max. The `inspect_block` hint advances monotonically
-                    // with `candidate`, so this is amortized O(1) per
-                    // non-essential. If even this tight bound can't beat the
-                    // threshold, skip the expensive non-essential `skip_to` +
-                    // SIMD score + heap entirely — the dominant per-doc cost.
-                    // A common non-essential's local block max is far below its
-                    // global max, so this fires on far more docs than the old
-                    // global-term-max bound did.
+                    // Bound the non-essentials at `candidate` by each one's
+                    // block-max for the block that *contains* it (via the
+                    // monotonic `inspect_block` hint — amortized O(1), no
+                    // decode), not by its global term-max. Far tighter for a
+                    // common term, so the skip below fires on many more docs,
+                    // dropping the non-essential `skip_to` + score + heap — the
+                    // dominant per-doc cost.
                     let mut others_ub = 0.0f32;
                     for c in cursors.iter_mut().skip(1) {
                         c.shallow_advance_block_to(candidate);

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -110,16 +110,13 @@ impl FtsReader {
             return Ok(drain_top_k_desc(heap));
         }
 
-        // Must-driven walk, two-phase per candidate: (1) align every must by
-        // its cheap approximation — a phrase advances only to a doc holding all
-        // its members, no position decode — so a selective must prunes the
-        // candidate set before any phrase pays for adjacency; (2) bar-skip on
-        // block-max upper bounds; (3) verify phrase positions and score only on
-        // the survivors. The old single-phase walk verified a phrase during
-        // alignment, decoding positions for every member co-occurrence — so a
-        // phrase of common words cost the same with or without a selective
-        // co-clause. Verifying only on the aligned intersection lets that
-        // co-clause prune the position work.
+        // Must-driven walk, two-phase per candidate: (1) align every must by its
+        // cheap approximation (a phrase advances only to a member co-occurrence,
+        // no positions); (2) bar-skip on block-max UBs; (3) verify phrase
+        // adjacency and score only on the survivors. The old single-phase walk
+        // verified phrases *during* alignment, so a phrase of common words cost
+        // the same with or without a selective co-clause; verifying only on the
+        // aligned intersection lets that clause prune the position work.
         let should_ub: f32 = shoulds.iter().map(AnyCursor::term_max_bm25).sum();
         let should_others_ub: Vec<f32> = {
             let must_ub_total: f32 = musts.iter().map(AnyCursor::term_max_bm25).sum();

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -110,10 +110,17 @@ impl FtsReader {
             return Ok(drain_top_k_desc(heap));
         }
 
-        // Must-driven walk: leapfrog the musts to each common doc,
-        // score musts + landing shoulds there.
+        // Must-driven walk, two-phase per candidate: (1) align every must by
+        // its cheap approximation — a phrase advances only to a doc holding all
+        // its members, no position decode — so a selective must prunes the
+        // candidate set before any phrase pays for adjacency; (2) bar-skip on
+        // block-max upper bounds; (3) verify phrase positions and score only on
+        // the survivors. The old single-phase walk verified a phrase during
+        // alignment, decoding positions for every member co-occurrence — so a
+        // phrase of common words cost the same with or without a selective
+        // co-clause. Verifying only on the aligned intersection lets that
+        // co-clause prune the position work.
         let should_ub: f32 = shoulds.iter().map(AnyCursor::term_max_bm25).sum();
-        let must_others_ub = atom_slack(&musts, should_ub);
         let should_others_ub: Vec<f32> = {
             let must_ub_total: f32 = musts.iter().map(AnyCursor::term_max_bm25).sum();
             atom_slack(&shoulds, must_ub_total)
@@ -124,15 +131,17 @@ impl FtsReader {
                 true => heap.peek().expect("heap len == k").0.max(floor_eff),
                 false => floor_eff,
             };
+            // Phase 1 — approximate alignment (phrase = member co-occurrence,
+            // no positions).
             let mut aligned = target;
             let mut i = 0usize;
             while i < musts.len() {
                 let a = &mut musts[i];
-                a.skip_to_pruned(aligned, bar - must_others_ub[i], dl_norm_k1)?;
+                a.approx_skip_to(aligned);
                 if a.is_exhausted() {
                     break 'docs;
                 }
-                let here = a.current_doc_id();
+                let here = a.approx_current_doc();
                 if here > aligned {
                     aligned = here;
                     i = 0;
@@ -140,13 +149,10 @@ impl FtsReader {
                 }
                 i += 1;
             }
-            // Bar skip: the kth-best (or the seeded floor) minus the
-            // most the shoulds could add bounds what the musts must
-            // reach; a candidate whose must-side block bounds can't
-            // get there is dead without scoring (and, for phrase
-            // shoulds, without any position work). `>=`, not `>`: a
-            // doc exactly at the bar can still displace the incumbent
-            // kth-best on the ascending-doc-id tie-break.
+            // Bar skip on block-max UBs, before any position work: a candidate
+            // whose musts + shoulds can't reach the kth-best is dead without a
+            // verify. `>=`, not `>`: a doc exactly at the bar can still displace
+            // the incumbent kth-best on the ascending-doc-id tie-break.
             let scoring_needed = match bar > f32::NEG_INFINITY {
                 true => {
                     let must_ub: f32 = musts
@@ -157,22 +163,34 @@ impl FtsReader {
                 }
                 false => true,
             };
-            let admitted = scoring_needed
-                && match filter.as_mut() {
-                    Some(f) => f.admits(aligned)?,
-                    None => true,
-                };
-            if admitted {
-                let norm = dl_norm_k1.get(aligned);
-                let mut score: f32 = musts.iter().map(|a| a.score_current(norm)).sum();
-                for (sh, &others) in shoulds.iter_mut().zip(&should_others_ub) {
-                    sh.skip_to_pruned(aligned, bar - others, dl_norm_k1)?;
-                    if !sh.is_exhausted() && sh.current_doc_id() == aligned {
-                        score += sh.score_current(norm);
+            if scoring_needed {
+                // Phase 2 — verify phrase adjacency at the aligned candidate;
+                // terms match trivially. Only survivors reach the position
+                // decode and scoring.
+                let mut matched = true;
+                for a in musts.iter_mut() {
+                    if !a.verify_at(aligned)? {
+                        matched = false;
+                        break;
                     }
                 }
-                if score > floor_eff {
-                    and_heap_push(&mut heap, k, None, score, aligned);
+                let admitted = matched
+                    && match filter.as_mut() {
+                        Some(f) => f.admits(aligned)?,
+                        None => true,
+                    };
+                if admitted {
+                    let norm = dl_norm_k1.get(aligned);
+                    let mut score: f32 = musts.iter().map(|a| a.score_current(norm)).sum();
+                    for (sh, &others) in shoulds.iter_mut().zip(&should_others_ub) {
+                        sh.skip_to_pruned(aligned, bar - others, dl_norm_k1)?;
+                        if !sh.is_exhausted() && sh.current_doc_id() == aligned {
+                            score += sh.score_current(norm);
+                        }
+                    }
+                    if score > floor_eff {
+                        and_heap_push(&mut heap, k, None, score, aligned);
+                    }
                 }
             }
             let Some(next) = aligned.checked_add(1) else {

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -332,6 +332,60 @@ async fn oracle_common_heavy_or_matches_brute_force_at_depth() {
     }
 }
 
+/// Corpus where a common non-essential ("hot") has a high block-max only in a
+/// *mid-range* block. Five anchors in block 10 (ids 1281..1289) carry `lead` +
+/// `hot`×{10,9,8,7,6} — strictly-decreasing scores far above the bulk (bulk hot
+/// tf=1), so the tie-free top-5 lives entirely in that block. It gates the
+/// per-block bound's failure mode: the filter must advance each non-essential's
+/// `inspect_block` hint *into* block 10 and read its high max there; a stale
+/// hint would under-bound and wrongly drop a top-5 anchor — something the
+/// uniform / block-0-hot corpora can't catch.
+fn mid_hot_block_corpus() -> Vec<(u64, String)> {
+    const N: u64 = 2560; // 20 × 128-doc blocks
+    let anchors: [(u64, usize); 5] = [(1281, 10), (1283, 9), (1285, 8), (1287, 7), (1289, 6)];
+    let mut docs = Vec::with_capacity(N as usize);
+    for i in 0..N {
+        if let Some(&(_, hot_tf)) = anchors.iter().find(|&&(id, _)| id == i) {
+            let mut toks = vec!["lead".to_string()];
+            for _ in 0..hot_tf {
+                toks.push("hot".to_string());
+            }
+            docs.push((i, toks.join(" ")));
+            continue;
+        }
+        let mut toks: Vec<String> = Vec::new();
+        if i.is_multiple_of(80) {
+            toks.push("lead".to_string());
+        }
+        if i.is_multiple_of(2) {
+            toks.push("hot".to_string());
+        }
+        if i.is_multiple_of(3) {
+            toks.push("other".to_string());
+        }
+        if toks.is_empty() {
+            toks.push(format!("f{}", i % 50));
+        }
+        docs.push((i, toks.join(" ")));
+    }
+    docs
+}
+
+#[tokio::test]
+async fn oracle_maxscore_mid_hot_block_nonessential_bound() {
+    // 3-term OR with a dominant "lead" ⇒ routes to MaxScore (not windowed: not
+    // common-heavy; not the 2-term WAND path). The tie-free top-5 lives in the
+    // mid hot block, so a correct per-block non-essential bound is load-bearing.
+    let corp = mid_hot_block_corpus();
+    let corp_refs: Vec<(u64, &str)> = corp.iter().map(|(d, s)| (*d, s.as_str())).collect();
+    let infino = build_infino_superfile(&corp_refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp_refs, tok.as_ref());
+    for k in [10usize, 50] {
+        assert_top_k_head_agrees(&infino, &oracle, "lead hot other", 5, k).await;
+    }
+}
+
 #[tokio::test]
 async fn oracle_no_match_query_returns_empty() {
     // "xyzzy" is in none of the docs; both engines must return empty.

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -284,6 +284,64 @@ async fn phrase_block_crossing_rejection() {
 }
 
 #[tokio::test]
+async fn must_phrase_skips_cooccurring_nonadjacent() {
+    // The must-driven walk is two-phase: Phase 1 aligns each phrase must by
+    // member *co-occurrence* (no positions), Phase 2 verifies adjacency and
+    // scores only the survivors. This pins that Phase 2 actually rejects the
+    // docs where the members co-occur but are not adjacent — a verify bug would
+    // leak every co-occurrence into the must result.
+    //
+    // In the multi-block corpus alpha (every 3rd doc) and gamma (every 5th)
+    // co-occur at every 15th doc, but beta (every 4th) is planted between them
+    // whenever the doc is also divisible by 4 (i.e. divisible by 60), so
+    // `"alpha gamma"` is adjacent exactly at the docs divisible by 15 but not 4.
+    // Co-occurrence: 67 docs (multiples of 15); adjacent: 50 (those 67 minus the
+    // 17 multiples of 60, where beta splits the pair).
+    let owned = build_multi_block_corpus();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile_positional(&refs);
+
+    // Guard the guard: the members really do co-occur at 67 docs (term-AND), so
+    // the smaller phrase result below is a Phase-2 rejection, not a thin
+    // intersection.
+    let cooccur = search_hits(&r, "+alpha +gamma", K_ALL_MULTI_BLOCK, BoolMode::Or).await;
+    assert_eq!(
+        cooccur.len(),
+        67,
+        "alpha and gamma co-occur at every 15th doc: {}",
+        cooccur.len()
+    );
+
+    // The must phrase keeps only the adjacent subset: the 17 docs divisible by
+    // 60, where beta sits between alpha and gamma, are aligned in Phase 1 and
+    // rejected in Phase 2.
+    let must_phrase = search_hits(&r, r#"+"alpha gamma""#, K_ALL_MULTI_BLOCK, BoolMode::Or).await;
+    assert_eq!(
+        must_phrase.len(),
+        50,
+        "must phrase matches only the adjacent docs (co-occurring-but-not-adjacent skipped): {}",
+        must_phrase.len()
+    );
+
+    // Pin the ranked walk against the oracle: the phrase must alone, the phrase
+    // must beside a should term (the should drags scoring onto verified docs),
+    // and the phrase as one of two musts (And). Small k keeps the pruning bar
+    // live through the two-phase walk, so a bug that skips or mis-scores a
+    // verified doc diverges from ground truth.
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+    for (query, mode) in [
+        (r#"+"alpha gamma""#, BoolMode::Or),
+        (r#"+"alpha gamma" delta"#, BoolMode::Or),
+        (r#""alpha gamma" delta"#, BoolMode::And),
+    ] {
+        for k in [3usize, 10, K_ALL_MULTI_BLOCK] {
+            assert_matches_oracle(&r, &oracle, query, mode, k).await;
+        }
+    }
+}
+
+#[tokio::test]
 async fn truncated_top_k_pruning_agrees_with_oracle() {
     // Every query shape whose ranked walk can skip phrase
     // verification once the heap fills — a small k keeps the bar live


### PR DESCRIPTION
Two independent ranked-search pruning fixes. Both are routing/bound changes with **unchanged top-k** — gated by the phrase, must+should, and brute-force BM25 oracles plus the all-algo-agreement tests (and 0 COUNT mismatches over the measured query set). No on-disk format change, no public-API change.

## 1. Two-phase must-walk for phrase-bearing boolean queries

The ranked must-walk advanced each phrase must to its next *verified* occurrence during alignment, decoding member positions across the whole co-occurrence set while searching for adjacency. For a phrase of common words that co-occur widely but are rarely adjacent, adding a *selective* must term (which should prune) instead made the query several times slower. Split the walk into two phases — approx-align every must (a phrase advances only to a member-co-occurrence doc, no positions), bar-skip on block-max upper bounds, then verify adjacency + score only on the survivors — so the selective co-clause prunes the position work. `verify_at_aligned` now stores the occurrence count in `current_tf` so two-phase scoring matches the single-phase path.

## 2. Per-block bound for MaxScore non-essentials

The f=1 MaxScore fast path already skips the non-essential `skip_to` + score for a candidate the essential alone can't lift over the threshold, but it bounded the non-essentials by their *global* term-max, so the filter rarely fired. Bound each non-essential by its block-max for the block that *contains* the candidate instead (via the `inspect_block` hint — amortized O(1), no decode). Far tighter, so the existing filter skips the per-doc cost on many more docs.

## Measured (warm, min-of-runs, average per-query latency at k=10; before = current `main`, after = this branch)

| shape | before | after | Δ |
| ----- | -----: | ----: | -: |
| phrase-in-boolean, worst case (common-word phrase + selective term) | 153 ms | 23 ms | **−85%** |
| boolean bucket, avg | 3436 µs | 1263 µs | **−63%** (entirely the case above; other boolean queries unchanged) |
| ranked multi-term OR (union), avg | 647 µs | 536 µs | **−17%** (worst case 34 ms → 15 ms) |

Phrase-only, uncommon-phrase, single-term, and pure-AND shapes are unchanged (each fix touches only its own path). COUNT unchanged (0 mismatches).