### PR TITLE
fix update: refuse an unusable vector payload at call time

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -237,6 +237,8 @@ impl From<MutationError> for InfinoError {
             MutationError::CardinalityMismatch { .. }
             | MutationError::MatchCountExceedsCap { .. } => InfinoError::Cardinality(msg),
             MutationError::SchemaMismatch(_) => InfinoError::Schema(msg),
+            // Classifies exactly as the same rows would through `append`.
+            MutationError::InvalidNewRows(b) => InfinoError::from(b),
             // Matches the read path: a purged table's name resolves to nothing.
             MutationError::TableGone => InfinoError::NotFound(msg),
             _ => InfinoError::Backend(msg),

--- a/src/supertable/mutations.rs
+++ b/src/supertable/mutations.rs
@@ -171,6 +171,12 @@ pub enum MutationError {
     #[error("new_rows schema does not match the supertable's user schema: {0}")]
     SchemaMismatch(String),
 
+    /// `update()` only: `new_rows` carries a vector column the index can't
+    /// take — a null vector, or a width disagreeing with the declared dim.
+    /// The same check `append` runs, applied before anything is buffered.
+    #[error("new_rows rejected: {0}")]
+    InvalidNewRows(#[source] BuildError),
+
     /// Supertable has no storage attached; WAL pipeline requires
     /// durable storage. In-memory-only supertables can't be
     /// mutated through this API.

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1190,6 +1190,11 @@ impl SupertableWriter {
             )));
         }
 
+        // The vector check `append` runs, at call time rather than in the
+        // commit's append phase — where it would surface as a partial commit
+        // for a mutation that buffered nothing.
+        split_vectors(&new_rows, &self.inner.options).map_err(MutationError::InvalidNewRows)?;
+
         // Resolve the predicate against the latest committed manifest, not a
         // bounded-staleness snapshot: a stale resolve would miss a row
         // committed after the snapshot and leave the old version live beside

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -10,19 +10,28 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use arrow_array::Array;
+use arrow_array::{
+    Array, ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch,
+    new_null_array,
+};
+use arrow_schema::{DataType, Field, Schema};
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
     InfinoError,
     storage::{LocalFsStorageProvider, StorageProvider},
-    superfile::fts::reader::{Bm25Stats, BoolMode},
+    superfile::{
+        builder::FtsConfig,
+        fts::reader::{Bm25Stats, BoolMode},
+    },
     supertable::{
-        Supertable,
+        Supertable, SupertableOptions,
         mutations::MutationError,
         options::Consistency,
         reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
     },
-    test_helpers::{build_title_batch, default_supertable_options},
+    test_helpers::{
+        build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
+    },
 };
 use tempfile::TempDir;
 
@@ -38,6 +47,61 @@ const PREFETCH_CONCURRENCY: usize = 8;
 const MMAP_TIMER_DISABLED_SECS: u64 = 0;
 /// BM25 top-k for post-mutation FTS queries.
 const FTS_TOP_K: usize = 10;
+/// Matches `default_vector_config`'s dimension.
+const VECTOR_DIM: usize = 16;
+/// Random-rotation seed for the vector fixture's index.
+const VECTOR_ROT_SEED: u64 = 11;
+
+fn fixed_list_f32(dim: usize) -> DataType {
+    DataType::FixedSizeList(
+        Arc::new(Field::new("item", DataType::Float32, true)),
+        dim as i32,
+    )
+}
+
+/// `title` alongside a vector-indexed, nullable `emb`.
+fn vector_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("emb", fixed_list_f32(VECTOR_DIM), true),
+    ]))
+}
+
+fn vector_options() -> SupertableOptions {
+    SupertableOptions::new(
+        vector_schema(),
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        vec![default_vector_config("emb", VECTOR_ROT_SEED)],
+        Some(default_tokenizer()),
+    )
+    .expect("valid options")
+}
+
+/// One row of [`vector_schema`]. `embedded` false leaves `emb` null — the row
+/// a client sends when it forgets the vector column.
+fn vector_row(title: &str, embedded: bool) -> RecordBatch {
+    let emb: ArrayRef = if embedded {
+        Arc::new(
+            FixedSizeListArray::try_new(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                VECTOR_DIM as i32,
+                Arc::new(Float32Array::from(vec![1.0f32; VECTOR_DIM])) as ArrayRef,
+                None,
+            )
+            .expect("FSL"),
+        )
+    } else {
+        new_null_array(&fixed_list_f32(VECTOR_DIM), 1)
+    };
+    RecordBatch::try_new(
+        vector_schema(),
+        vec![Arc::new(LargeStringArray::from(vec![title])), emb],
+    )
+    .expect("batch")
+}
 
 fn make_disk_cache(
     storage: Arc<dyn StorageProvider>,
@@ -475,4 +539,90 @@ async fn update_emitted_superfile_carries_subsection_offsets() {
         .as_ref()
         .expect("update-emitted superfile carries subsection_offsets");
     assert!(offsets.total_size > 0, "total_size is stamped");
+}
+
+/// A replacement row whose vector column is null is refused at call time, so
+/// nothing is buffered and the row it targeted stands.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn writer_update_with_a_null_vector_is_rejected_before_buffering() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache_dir = TempDir::new().expect("cache");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let disk_cache = make_disk_cache(Arc::clone(&storage), cache_dir.path());
+    let st = Supertable::create(
+        vector_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(disk_cache),
+    )
+    .expect("create");
+
+    let mut w = st.writer().expect("writer");
+    w.append(&vector_row("alpha", true)).expect("append");
+    w.commit().expect("commit");
+
+    let err = w
+        .update(col("title").eq(lit("alpha")), vector_row("prime", false))
+        .expect_err("a null vector must be refused");
+    assert!(
+        matches!(err, MutationError::InvalidNewRows(_)),
+        "got: {err}"
+    );
+
+    let result = w.commit().expect("commit");
+    assert!(result.outcomes.is_empty(), "nothing was buffered");
+    drop(w);
+
+    let batches = st
+        .reader()
+        .expect("reader")
+        .query_sql("SELECT title FROM supertable")
+        .expect("sql");
+    let titles: Vec<String> = batches
+        .iter()
+        .flat_map(|b| {
+            let col = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("title col");
+            (0..col.len()).map(move |i| col.value(i).to_string())
+        })
+        .collect();
+    assert_eq!(titles, vec!["alpha".to_string()]);
+}
+
+/// The rejection is a schema fault, like the same rows through `append` — not a
+/// backend one, and never a partial commit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_with_a_null_vector_is_a_schema_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let cache_dir = TempDir::new().expect("cache");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let disk_cache = make_disk_cache(Arc::clone(&storage), cache_dir.path());
+    let st = Supertable::create(
+        vector_options()
+            .with_storage(Arc::clone(&storage))
+            .with_disk_cache(disk_cache),
+    )
+    .expect("create");
+    st.append(&vector_row("alpha", true)).expect("append");
+
+    let appended = st
+        .append(&vector_row("bravo", false))
+        .expect_err("append refuses a null vector");
+    let updated = st
+        .update(col("title").eq(lit("alpha")), &vector_row("prime", false))
+        .expect_err("update refuses the same rows");
+
+    assert!(
+        matches!(appended, InfinoError::Schema(_)),
+        "got: {appended}"
+    );
+    assert!(matches!(updated, InfinoError::Schema(_)), "got: {updated}");
+    assert!(
+        !updated.to_string().contains("partial commit"),
+        "got: {updated}"
+    );
 }


### PR DESCRIPTION
`update` validated its replacement rows only once the commit reached the append
phase. A null vector — the row a client sends when it omits the vector column —
therefore failed *after* the mutation was buffered, and the failure surfaced as:

```
Backend("update: partial commit: 0 of 1 mutations completed before append phase
failed: superfile build failed: vector_split: vector column \"emb\" contains null
entries at row offsets [0]; null vectors are not permitted in v1")
```

Nothing had been written, so that report was both alarming and the wrong error
class. `append` refuses the identical rows with a plain schema error.

## The fix

`SupertableWriter::update` now runs `split_vectors` — the same check `append`
runs on its own input — right after its schema check, before anything is
buffered, and reports it as a new `MutationError::InvalidNewRows`. That variant
classifies by delegating to the existing `BuildError → InfinoError` mapping, so
identical rows now get an identical verdict through either entry point.

Nine lines across three files; the rest of the diff is tests.

## Scope

- The check stays **index-scoped**, exactly as on the append path: a vector
  column with no index still accepts nulls.
- No batch that previously succeeded is now refused. The schema comparison
  inside `split_vectors` is order- and metadata-insensitive, so it accepts
  everything that already passed `update`'s stricter equality check just above
  it.
- Write-path only, and metadata-level — column lookups, a `list_size` compare
  and an O(1) `null_count` per indexed vector column. No data scan, no read-path
  or recall impact.

## Tests

Two regression tests in `tests/supertable/writer_mutations.rs`:

- writer level — refused at call time, nothing buffered (the following commit
  reports no outcome), and the row the update targeted still stands
- folded `Supertable::update` — the rejection is `InfinoError::Schema`, matching
  what `append` gives for the same rows, and the message never claims a partial
  commit

Both confirmed to fail without the source change, the second with the exact
`partial commit` text above.

## Gates

`make check` (fmt, clippy ×2, API parity, version-sync, doc-check), 2716 tests,
doctests, the remote lane, and `make coverage` at 92.81% lines / 89.44%
functions / 92.28% regions — all green.