### PR TITLE
ci/bench: require two distinct A/B arms, drop push-to-main run

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,28 +8,16 @@ name: Benchmark
 # base-repo context where the Azure secrets live — a fork `pull_request` run
 # gets none. Fork code is gated on maintainer approval before secrets are
 # exposed (see `is_fork_pr`).
+#
+# PR events only: a push to main has no `pull_request` context, so both arms
+# would resolve to main and the run would compare main against itself. For any
+# other pair of refs, dispatch supertable-bench-azure.yml with `ref`+`base_ref`.
 on:
-  push:
-    branches: [main]
-    # Only refresh the baseline when perf-relevant code lands. Doc/example/
-    # binding-only merges can't move performance, so skip the VM spin-up.
-    # (GitHub Actions ignores YAML anchors, so the list is repeated below.)
-    paths:
-      - "src/**"
-      - "benches/**"
-      - "build.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/bench.yml"
-      - ".github/workflows/supertable-bench-azure.yml"
-      # The merge gate itself: a change to the classifier must be re-benchmarked.
-      - ".github/scripts/bench_summary.py"
   pull_request_target:
     branches: [main]
     # Code/state changes only — never on label or comment activity.
     types: [opened, synchronize, reopened]
-    # Same allowlist: skip the 4-VM bench on doc/example/binding-only PRs.
+    # Doc/example/binding-only PRs can't move performance — skip the VM spin-up.
     paths:
       - "src/**"
       - "benches/**"
@@ -79,12 +67,14 @@ jobs:
       metric: ${{ matrix.metric }}
       corpus: ${{ matrix.corpus }}
       corpus_dir: ${{ matrix.corpus_dir }}
+      # Both A/B arms passed explicitly (PR head vs the PR's base branch);
+      # relying on the callee's `main` default hides a missing ref as main-vs-main.
       ref: ${{ github.event.pull_request.head.sha }}
+      base_ref: ${{ github.event.pull_request.base.ref }}
       name_suffix: -${{ matrix.suffix }}
       pr_number: ${{ github.event.pull_request.number }}
-      # Fork PR ⇒ gate on maintainer approval before secrets are exposed.
-      # Guard on the event: a push has no pull_request context, so the bare
-      # inequality would treat every push as a fork and route it to the
-      # approval-gated environment, leaving baseline runs stuck awaiting review.
+      # Fork PR ⇒ gate on maintainer approval before secrets are exposed. The
+      # event guard keeps a non-PR trigger (no pull_request context) from
+      # reading as "fork" and parking the run on approval.
       is_fork_pr: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets: inherit

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,9 +9,8 @@ name: Benchmark
 # gets none. Fork code is gated on maintainer approval before secrets are
 # exposed (see `is_fork_pr`).
 #
-# PR events only: a push to main has no `pull_request` context, so both arms
-# would resolve to main and the run would compare main against itself. For any
-# other pair of refs, dispatch supertable-bench-azure.yml with `ref`+`base_ref`.
+# PR events only: a push has no `pull_request` context, so both A/B arms would
+# resolve to main. Other ref pairs: dispatch supertable-bench-azure.yml.
 on:
   pull_request_target:
     branches: [main]
@@ -67,14 +66,13 @@ jobs:
       metric: ${{ matrix.metric }}
       corpus: ${{ matrix.corpus }}
       corpus_dir: ${{ matrix.corpus_dir }}
-      # Both A/B arms passed explicitly (PR head vs the PR's base branch);
-      # relying on the callee's `main` default hides a missing ref as main-vs-main.
+      # Both arms explicit: the callee's `main` default would hide a missing ref.
       ref: ${{ github.event.pull_request.head.sha }}
       base_ref: ${{ github.event.pull_request.base.ref }}
       name_suffix: -${{ matrix.suffix }}
       pr_number: ${{ github.event.pull_request.number }}
       # Fork PR ⇒ gate on maintainer approval before secrets are exposed. The
-      # event guard keeps a non-PR trigger (no pull_request context) from
-      # reading as "fork" and parking the run on approval.
+      # event guard stops a non-PR trigger from reading as "fork": `environment`
+      # resolves before any step, so approval would park the run for good.
       is_fork_pr: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets: inherit

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -41,12 +41,12 @@ on:
         default: "main"
         type: string
       base_ref:
-        description: "A/B base arm ref (default main). Must differ from `ref` unless allow_same_ref is set."
+        description: "A/B base arm ref; must differ from `ref`."
         required: false
         default: "main"
         type: string
       allow_same_ref:
-        description: "Permit ref == base_ref. Only for measuring the same-host noise floor (A/B of a ref against itself)."
+        description: "Allow ref == base_ref (noise-floor run)."
         required: false
         default: false
         type: boolean
@@ -118,8 +118,7 @@ on:
       location:        { type: string, required: false, default: eastus }
       ref:             { type: string, required: false, default: main }
       base_ref:        { type: string, required: false, default: main }
-      # Opt-in for a ref benchmarked against itself (noise-floor measurement);
-      # otherwise two arms on the same commit fail the run as a config bug.
+      # Allow ref == base_ref; without it, two arms on one commit fail the run.
       allow_same_ref:  { type: boolean, required: false, default: false }
       keep_table:      { type: boolean, required: false, default: false }
       timeout_minutes: { type: string, required: false, default: "60" }
@@ -161,9 +160,8 @@ env:
   ADMIN: azureuser
   SCCACHE_VERSION: v0.8.2
   # Keepalive so a dead-but-unclosed SSH session fails in ~60s instead of
-  # hanging until the job timeout (ServerAliveInterval × CountMax). Left
-  # unquoted at every use — it is a flag list meant to word-split, hence the
-  # `shellcheck disable=SC2086` at each ssh/scp call.
+  # hanging until the job timeout (ServerAliveInterval × CountMax). A flag list
+  # meant to word-split, so each use is unquoted (hence the SC2086 disables).
   SSH_OPTS: "-o StrictHostKeyChecking=no -o ServerAliveInterval=15 -o ServerAliveCountMax=4"
   # Set "false" to suppress PR comments (summary-only).
   POST_PR_COMMENT: "true"
@@ -231,8 +229,8 @@ jobs:
           echo "args=[$args] reports=[$reports]"
 
       # A/B needs two distinct arms: identical (or empty, hence defaulted) refs
-      # build the same commit twice and report noise as a delta. Runs before the
-      # VM exists so a misconfigured caller costs nothing.
+      # build one commit twice and report noise as a delta. Runs before the VM
+      # exists, so a misconfigured caller costs nothing.
       - name: Validate A/B arms
         env:
           REF: ${{ inputs.ref }}
@@ -242,42 +240,32 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          for v in REF BASE_REF; do
-            if [ -z "${!v}" ]; then
-              echo "::error::empty $v — the caller must pass both A/B arms explicitly (an omitted arm falls back to 'main', which would compare main against itself)"
-              exit 1
-            fi
-          done
-
+          die() { echo "::error::$1"; exit 1; }
           same_arms() {
-            if [ "$ALLOW_SAME_REF" = "true" ]; then
-              echo "::warning::same-ref A/B ($1) — this measures the same-host noise floor, not a code change"
-              exit 0
-            fi
-            echo "::error::both A/B arms are the same commit ($1). Benchmarking a ref against itself measures noise, not a change. Pass two different refs, or set allow_same_ref=true for a deliberate noise-floor run."
-            exit 1
+            [ "$ALLOW_SAME_REF" = "true" ] \
+              || die "both A/B arms are $1 — a ref benchmarked against itself measures noise. Pass two refs, or set allow_same_ref for a noise-floor run."
+            echo "::warning::same-ref A/B ($1) — noise floor, not a code change"
+            exit 0
           }
 
-          # Literal match: `main` vs `main`, the shape a caller lands on when it
-          # fails to pass the ref under test.
-          if [ "$REF" = "$BASE_REF" ]; then
-            same_arms "ref = base_ref = $REF"
-          fi
+          # An omitted arm defaults to 'main', which reads as a valid base arm.
+          [ -n "$REF" ]      || die "empty ref — the caller must pass the ref under test"
+          [ -n "$BASE_REF" ] || die "empty base_ref"
 
-          # SHA match: also catches `main` against main's tip SHA. A fork PR head
-          # isn't always reachable from the base repo, so an unresolvable arm is
-          # only a warning — the literal check above still holds.
+          # Literal match: `main` vs `main`, what a caller drops to on a missing ref.
+          [ "$REF" != "$BASE_REF" ] || same_arms "$REF"
+
+          # SHA match: also catches `main` vs main's tip SHA. A fork head is not
+          # always reachable from the base repo, so an unresolvable arm only warns.
           resolve() { gh api "repos/$REPO/commits/$1" --jq .sha 2>/dev/null || true; }
           REF_SHA="$(resolve "$REF")"
           BASE_SHA="$(resolve "$BASE_REF")"
           if [ -z "$REF_SHA" ] || [ -z "$BASE_SHA" ]; then
-            echo "::warning::could not resolve both arms to SHAs in $REPO (ref='$REF' -> '${REF_SHA:-unresolved}', base_ref='$BASE_REF' -> '${BASE_SHA:-unresolved}') — skipping the SHA-level same-commit check"
+            echo "::warning::unresolved in $REPO (ref='$REF'->'${REF_SHA:-?}', base_ref='$BASE_REF'->'${BASE_SHA:-?}') — skipping the SHA check"
             exit 0
           fi
-          echo "A/B arms: ref=$REF ($REF_SHA) vs base_ref=$BASE_REF ($BASE_SHA)"
-          if [ "$REF_SHA" = "$BASE_SHA" ]; then
-            same_arms "$REF and $BASE_REF both resolve to $REF_SHA"
-          fi
+          echo "A/B arms: $REF ($REF_SHA) vs $BASE_REF ($BASE_SHA)"
+          [ "$REF_SHA" != "$BASE_SHA" ] || same_arms "$REF_SHA"
 
       - name: Validate bench gate metric
         run: |

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -41,10 +41,15 @@ on:
         default: "main"
         type: string
       base_ref:
-        description: "A/B base arm ref (default main; set = ref for same-host noise)."
+        description: "A/B base arm ref (default main). Must differ from `ref` unless allow_same_ref is set."
         required: false
         default: "main"
         type: string
+      allow_same_ref:
+        description: "Permit ref == base_ref. Only for measuring the same-host noise floor (A/B of a ref against itself)."
+        required: false
+        default: false
+        type: boolean
       is_fork_pr:
         description: "Simulate a fork PR (runner checks out base tooling, not the ref; routes to the approval-gated env). For verifying fork-safe checkout."
         required: false
@@ -113,6 +118,9 @@ on:
       location:        { type: string, required: false, default: eastus }
       ref:             { type: string, required: false, default: main }
       base_ref:        { type: string, required: false, default: main }
+      # Opt-in for a ref benchmarked against itself (noise-floor measurement);
+      # otherwise two arms on the same commit fail the run as a config bug.
+      allow_same_ref:  { type: boolean, required: false, default: false }
       keep_table:      { type: boolean, required: false, default: false }
       timeout_minutes: { type: string, required: false, default: "60" }
       # Discriminator appended to resource names so parallel callers
@@ -219,6 +227,55 @@ jobs:
           echo "args=$args"       >> "$GITHUB_OUTPUT"
           echo "reports=$reports" >> "$GITHUB_OUTPUT"
           echo "args=[$args] reports=[$reports]"
+
+      # A/B needs two distinct arms: identical (or empty, hence defaulted) refs
+      # build the same commit twice and report noise as a delta. Runs before the
+      # VM exists so a misconfigured caller costs nothing.
+      - name: Validate A/B arms
+        env:
+          REF: ${{ inputs.ref }}
+          BASE_REF: ${{ inputs.base_ref }}
+          ALLOW_SAME_REF: ${{ inputs.allow_same_ref }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          for v in REF BASE_REF; do
+            if [ -z "${!v}" ]; then
+              echo "::error::empty $v — the caller must pass both A/B arms explicitly (an omitted arm falls back to 'main', which would compare main against itself)"
+              exit 1
+            fi
+          done
+
+          same_arms() {
+            if [ "$ALLOW_SAME_REF" = "true" ]; then
+              echo "::warning::same-ref A/B ($1) — this measures the same-host noise floor, not a code change"
+              exit 0
+            fi
+            echo "::error::both A/B arms are the same commit ($1). Benchmarking a ref against itself measures noise, not a change. Pass two different refs, or set allow_same_ref=true for a deliberate noise-floor run."
+            exit 1
+          }
+
+          # Literal match: `main` vs `main`, the shape a caller lands on when it
+          # fails to pass the ref under test.
+          if [ "$REF" = "$BASE_REF" ]; then
+            same_arms "ref = base_ref = $REF"
+          fi
+
+          # SHA match: also catches `main` against main's tip SHA. A fork PR head
+          # isn't always reachable from the base repo, so an unresolvable arm is
+          # only a warning — the literal check above still holds.
+          resolve() { gh api "repos/$REPO/commits/$1" --jq .sha 2>/dev/null || true; }
+          REF_SHA="$(resolve "$REF")"
+          BASE_SHA="$(resolve "$BASE_REF")"
+          if [ -z "$REF_SHA" ] || [ -z "$BASE_SHA" ]; then
+            echo "::warning::could not resolve both arms to SHAs in $REPO (ref='$REF' -> '${REF_SHA:-unresolved}', base_ref='$BASE_REF' -> '${BASE_SHA:-unresolved}') — skipping the SHA-level same-commit check"
+            exit 0
+          fi
+          echo "A/B arms: ref=$REF ($REF_SHA) vs base_ref=$BASE_REF ($BASE_SHA)"
+          if [ "$REF_SHA" = "$BASE_SHA" ]; then
+            same_arms "$REF and $BASE_REF both resolve to $REF_SHA"
+          fi
 
       - name: Validate bench gate metric
         run: |

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -161,7 +161,9 @@ env:
   ADMIN: azureuser
   SCCACHE_VERSION: v0.8.2
   # Keepalive so a dead-but-unclosed SSH session fails in ~60s instead of
-  # hanging until the job timeout (ServerAliveInterval × CountMax).
+  # hanging until the job timeout (ServerAliveInterval × CountMax). Left
+  # unquoted at every use — it is a flag list meant to word-split, hence the
+  # `shellcheck disable=SC2086` at each ssh/scp call.
   SSH_OPTS: "-o StrictHostKeyChecking=no -o ServerAliveInterval=15 -o ServerAliveCountMax=4"
   # Set "false" to suppress PR comments (summary-only).
   POST_PR_COMMENT: "true"
@@ -344,6 +346,7 @@ jobs:
           set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
           for i in $(seq 1 30); do
+            # shellcheck disable=SC2086
             if ssh $SSH_OPTS -o ConnectTimeout=5 \
                  "${ADMIN}@${VM_IP}" true 2>/dev/null; then
               echo "SSH up after ${i} tries"; exit 0
@@ -360,6 +363,7 @@ jobs:
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
           # Single-quoted heredoc: the body is literal; only the
           # ssh-line assignments reach the VM as env.
+          # shellcheck disable=SC2086
           ssh $SSH_OPTS "${ADMIN}@${VM_IP}" \
             "GH_TOKEN='${{ github.token }}' \
              REPO='${{ github.repository }}' \
@@ -428,6 +432,7 @@ jobs:
         run: |
           set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          # shellcheck disable=SC2086
           ssh $SSH_OPTS "${ADMIN}@${VM_IP}" \
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
@@ -485,6 +490,7 @@ jobs:
         run: |
           set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          # shellcheck disable=SC2086
           ssh $SSH_OPTS "${ADMIN}@${VM_IP}" \
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
@@ -514,6 +520,7 @@ jobs:
           # diffs them against the PR arm's metrics (collected later).
           mkdir -p baseline
           for j in $REPORTS; do
+            # shellcheck disable=SC2086
             scp $SSH_OPTS \
               "${ADMIN}@${VM_IP}:infino-src/target/infino-bench/${j}.json" "baseline/${j}.json" \
               2>/dev/null && echo "baseline staged: $j" \
@@ -524,6 +531,7 @@ jobs:
         run: |
           set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          # shellcheck disable=SC2086
           ssh $SSH_OPTS "${ADMIN}@${VM_IP}" \
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
@@ -661,6 +669,7 @@ jobs:
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
           mkdir -p current
           for j in $REPORTS; do
+            # shellcheck disable=SC2086
             scp $SSH_OPTS \
               "${ADMIN}@${VM_IP}:infino-src/target/infino-bench/${j}.json" "current/${j}.json" \
               2>/dev/null && echo "collected: $j" \


### PR DESCRIPTION
## Why

The benchmark job was A/B-ing `main` against `main` on every merge — five VMs per push, producing deltas that were pure host noise.

`bench.yml` still carried a `push: branches: [main]` trigger from the era when a push published a stored baseline. #276 ("same-host A/B benchmark gate") removed the inputs that made a push run meaningful — its own changelog line reads *"drop stored baseline/history + push run"* — but only the inputs went; the trigger stayed. With the inputs gone:

- `ref: ${{ github.event.pull_request.head.sha }}` — a push has no `pull_request` context, so this evaluated to `""` and the callee's `default: main` filled in.
- `base_ref` was never passed at all, so it also defaulted to `main`.

Both arms therefore built the same commit. Two consequences:

1. **Cost with no signal.** Five ephemeral `Standard_D8s_v7` VMs per perf-relevant merge, each building two identical arms, reporting a commit's variance against itself.
2. **Merges cancelled each other's benches.** The concurrency group is `bench-${{ github.event.pull_request.number }}-${{ matrix.suffix }}`; on a push the PR number is empty, so every push shared group `bench--<suffix>` with `cancel-in-progress: true`.

The failure was silent: an omitted arm quietly became `main`, and the run looked healthy.

## What

**`.github/workflows/bench.yml`**

- Dropped the `push` trigger. Under same-host A/B there is no stored baseline left to refresh, so the bench is now exactly "PR branch → main".
- Both arms are passed explicitly (`ref: …head.sha`, `base_ref: …base.ref`). Leaning on the callee's `main` default is what let a missing arm disappear.

**`.github/workflows/supertable-bench-azure.yml`**

- New `Validate A/B arms` step, positioned **before** Azure login and VM provisioning so a misconfigured caller costs nothing. It fails on an empty arm, and on two arms resolving to the same commit — checked literally (`main` vs `main`) and by resolved SHA via `gh api` (catches `main` vs main's tip SHA). A fork PR head not reachable from the base repo downgrades the SHA check to a warning; the literal check still applies.
- New `allow_same_ref` input (default `false`) preserves the one legitimate same-ref run the old `base_ref` description advertised: A/B-ing a ref against itself to measure the same-host noise floor.
- Annotated the seven pre-existing SC2086 findings on `$SSH_OPTS`, which is a flag list that must word-split, using the `# shellcheck disable=SC2086` convention already in `dataset-bench.yml` / `dataset-prepare.yml`. No behavior change.

Branch-vs-branch and tag-vs-tag comparisons are unaffected: dispatch `supertable-bench-azure.yml` with `ref` + `base_ref`.

## Review notes

Three things a reviewer will reasonably poke at, checked before opening:

- **Removing the push trigger removed a `paths:` allowlist.** On `main` the `push` and `pull_request_target` lists were byte-identical duplicates — the deleted "GitHub Actions ignores YAML anchors, so the list is repeated below" comment existed precisely to explain that. Verified programmatically that the surviving list's paths, types, and branches are unchanged, so no filtering was lost.
- **`is_fork_pr`'s `github.event_name == 'pull_request_target'` guard is now always true — but not dead.** `environment: ${{ inputs.is_fork_pr && 'bench' || 'ci' }}` resolves at job start, before any step. If a non-PR trigger were re-added, the job would park awaiting approval and the new A/B guard would never fire, so the event guard is the only protection on that path. Kept deliberately, with the rationale inline.
- **`allow_same_ref` is placed 7th** in the dispatch inputs, inside GitHub's documented 10-input window, so it still renders if the form truncates. The input it displaces past 10 is `skip_calibration`.

## Validation

No Rust changed (`git diff --stat main..HEAD -- '*.rs' 'Cargo.*'` is empty), so there is no engine surface to benchmark and the recall@10 gate does not apply. The workflows were validated locally instead, in four layers.

**1. actionlint 1.7.7 + shellcheck 0.10**, compared against the same run on `main` to separate pre-existing noise:

| Finding | Status |
|---|---|
| 7× SC2086 on `$SSH_OPTS` | pre-existing on `main` → fixed here |
| `workflow_dispatch` inputs 15 → 16 vs documented max 10 | pre-existing overage, see note below |

The new step is shellcheck-clean on its own.

**2. Caller expressions evaluated against live PR payloads** from this repo:

| Event | `ref` | `base_ref` | `is_fork_pr` |
|---|---|---|---|
| fork PR #617 | `4823715c…` | `main` | `true` |
| same-repo PR #616 | `11fd5e1e…` | `main` | `false` |
| push to main *(trigger removed)* | `''` | `''` | `false` |

Two distinct arms on both PR paths. The push row is the old failure mode, which now lands on the empty-arm check instead of defaulting to `main`.

**3. The guard script executed against the live GitHub API** with real refs:

| Case | Result |
|---|---|
| PR #616 head vs `main` | pass |
| fork PR #617 head vs `main` | pass |
| `main` vs `main` | `::error::both A/B arms are main …` → exit 1 |
| main's tip SHA vs `main` | exit 1 — literal check misses, SHA check catches |
| `main` vs `main` + `allow_same_ref` | pass, with noise-floor warning |
| empty ref | `::error::empty ref …` → exit 1 |

Side finding: the fork PR head *did* resolve through `repos/infino-ai/infino/commits/<sha>`, so the unresolvable-arm warning path is rare — and it independently confirms the assumption in the existing VM-clone comment that fork PR objects are reachable from the base repo.

**4. Not locally reproducible:** `act` needs Docker, and the job is Azure-OIDC and ephemeral-VM bound, so no end-to-end local run. Note also that `pull_request_target` resolves workflow definitions from the **base** ref, so this PR's own bench run exercises `main`'s copy, not this change — the fix takes effect on merge. The zero-cost confirmation afterwards: dispatch `supertable-bench-azure.yml` with defaults (`ref=main`, `base_ref=main`); it fails at `Validate A/B arms` in ~30 s, before any VM is provisioned. Don't pair that with `allow_same_ref=true`, which proceeds to provision.

All of layers 1–3 were re-run after the final comment/description trim; verdicts are unchanged.

## Known remaining items

- **`workflow_dispatch` input count.** actionlint flags 16 inputs against GitHub's documented maximum of 10. `main` is already at 15 and 45 dispatch runs of this workflow have succeeded (most recent 2026-08-14, green), so the cap is documented but not enforced in practice. Deliberately left as-is: trimming to 10 means moving six maintainer-facing debug knobs (`is_fork_pr`, `keep_table`, `pr_number`, `bench_cpuset`, `timeout_minutes`, `noise_threshold_pct`) off the dispatch form for no observed benefit. Happy to split that out if you'd rather be compliant.
- **Nothing lints workflows in CI**, so this class of bug has no automated catch. Left out to keep this PR scoped; worth its own change. It would also cover two pre-existing false positives elsewhere (`release-on-merge.yml` SC2034, where the variables are consumed through `eval` indirection, and the `macos-15-intel` runner label that actionlint's label database predates).
- **No doc drift.** `benches/README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, and `docs/` were checked for references to the push-triggered bench run or a CI-published baseline; the only "baseline" mentions are the local `target/infino-bench/<bench>.json` previous-run delta, which this change does not touch.
