### PR TITLE
fts: block-max windowed MaxScore for page-sized common-heavy OR

### DIFF
--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -278,6 +278,10 @@ pub enum OrAlgo {
     /// merge; wins when no term dominates and the union is large (the
     /// MaxScore-can't-prune case).
     Windowed,
+    /// Block-max windowed MaxScore: the fusion — SIMD window accumulation of
+    /// the essential terms plus per-window block-max pruning and per-candidate
+    /// non-essential completion. The production OR default.
+    MaxScoreWindowed,
 }
 
 /// Doc-id window for the windowed union scorer. Power of two so the
@@ -358,6 +362,19 @@ pub(super) const OR_WINDOW_DOMINANCE_MULT: f32 = 1.5;
 /// wins. Bench-tuned to the x86 target (the crossover is lower on wide-SIMD
 /// x86 than on ARM).
 pub(super) const OR_WINDOWED_UNIFORM_MAX_PRUNING_K: usize = 32;
+
+/// Largest `k` for which a windowed-routed multi-term OR uses the fused
+/// block-max windowed MaxScore (`FtsReader::run_maxscore_windowed`) rather than
+/// the plain windowed scan. The fusion's per-window essential/non-essential
+/// partition only pays when the top-k threshold is selective enough that its
+/// competitive filter rejects most candidates before the per-candidate
+/// non-essential completion — a page-sized request. Past this depth the
+/// threshold stays low, nearly every union doc survives the filter, and the
+/// scalar per-candidate completion loses to the plain windowed SIMD scan, so
+/// deep requests stay on `run_windowed_union`. Set at a page boundary
+/// (measured: a decisive tail win at `k = 100`, a small regression by
+/// `k = 1000`).
+pub(super) const OR_MAXSCORE_WINDOWED_MAX_K: usize = 128;
 
 /// True when no single term dominates the score upper bound
 /// (`max_ub <= OR_WINDOW_DOMINANCE_MULT * avg_ub`). Such a "common-heavy" OR

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1360,6 +1360,235 @@ impl FtsReader {
         Ok(drain_top_k_desc(heap))
     }
 
+    /// Block-max windowed MaxScore for multi-term OR — the fusion of the
+    /// windowed union scanner and MaxScore. Per `OR_WINDOW`-doc window:
+    ///
+    /// 1. Bound each term by its block-max over the window; **skip the whole
+    ///    window** if their sum can't beat the threshold.
+    /// 2. **Partition** essential / non-essential by those per-window bounds:
+    ///    the low-max terms whose block-max sum still can't reach the threshold
+    ///    are non-essential — a doc lacking every essential term scores at most
+    ///    that sum, so it can't compete and need not be found.
+    /// 3. **Bulk-accumulate only the essentials** through the windowed scanner's
+    ///    SIMD fast path, but over the pruned term set.
+    /// 4. For each essential-seeded candidate, drop it if its partial score plus
+    ///    the non-essential bound can't beat the threshold; otherwise complete it
+    ///    with the non-essential terms per-candidate and admit.
+    ///
+    /// The threshold is re-read each window, so the essential set shrinks as the
+    /// heap fills. While the heap is filling every term is essential and this is
+    /// exactly [`Self::run_windowed_union`]; as the threshold rises it prunes
+    /// like MaxScore but keeps the SIMD bulk scan for the essentials, which a
+    /// doc-at-a-time MaxScore gives up. The demotion pays only when the
+    /// threshold is selective enough that few candidates survive the competitive
+    /// filter — a page-sized top-k; at a deep top-k the per-candidate completion
+    /// runs for most of the union and loses to the plain windowed SIMD scan, so
+    /// the caller routes deep-k unions to [`Self::run_windowed_union`] instead.
+    ///
+    /// Top-k identical to the other OR kernels (block-max is a valid upper
+    /// bound); gated by the all-algo-agreement and brute-force oracles. The one
+    /// nuance is summation order: the essentials are summed before the
+    /// non-essentials, so a score can differ from the term-major kernels by ≤1
+    /// ULP and a boundary tie can break to a different doc of equal score.
+    pub(super) fn run_maxscore_windowed(
+        &self,
+        column_id: u32,
+        mut cursors: Vec<TermCursor>,
+        k: usize,
+        mut filter: Option<&mut ExcludeFilter>,
+        floor_eff: f32,
+        doc_id_start: u32,
+        doc_id_end: u32,
+    ) -> Result<Vec<(u32, f32)>, FtsError> {
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        let col_meta = &self.columns[column_id as usize];
+        let dl_norm_k1 = &col_meta.dl_norm_k1;
+        if doc_id_start > 0 {
+            for c in &mut cursors {
+                c.skip_to(doc_id_start);
+            }
+        }
+        let n = cursors.len();
+        let initial_cap =
+            top_k_initial_capacity(k, u64::from(self.n_docs), Some((doc_id_start, doc_id_end)));
+        let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
+        let mut threshold: f32 = floor_eff.max(0.0);
+        let mut scores = vec![0.0f32; OR_WINDOW as usize];
+        let mut present = [0u64; OR_WINDOW_WORDS];
+        let mut wbm = vec![0.0f32; n]; // per-term block-max over the current window
+        let mut essential = vec![true; n];
+        let mut order: Vec<usize> = (0..n).collect();
+
+        loop {
+            let mut min_doc = u32::MAX;
+            for c in &cursors {
+                if !c.is_exhausted() {
+                    min_doc = min_doc.min(c.current_doc_id());
+                }
+            }
+            if min_doc == u32::MAX || min_doc >= doc_id_end {
+                break;
+            }
+            let base = min_doc & !(OR_WINDOW - 1);
+            let window_end = base.saturating_add(OR_WINDOW).min(doc_id_end);
+
+            // Per-term window block-max (a valid UB on each term's contribution
+            // in `[base, window_end)`).
+            let mut total_wbm = 0.0f32;
+            for i in 0..n {
+                wbm[i] = if cursors[i].is_exhausted() {
+                    0.0
+                } else {
+                    cursors[i].block_max_in_range(base, window_end - 1)
+                };
+                total_wbm += wbm[i];
+            }
+            // Window skip: nothing here can beat the bar.
+            if total_wbm <= threshold {
+                for c in &mut cursors {
+                    if !c.is_exhausted() {
+                        c.skip_to(window_end);
+                    }
+                }
+                continue;
+            }
+            // Partition: non-essential = the smallest-UB terms whose block-max
+            // sum still can't reach the bar. `total_wbm > threshold` guarantees
+            // at least the largest-UB term stays essential.
+            order.sort_by(|&a, &b| wbm[a].partial_cmp(&wbm[b]).unwrap_or(Ordering::Equal));
+            for e in essential.iter_mut() {
+                *e = true;
+            }
+            let mut nonessential_sum = 0.0f32;
+            for &i in &order {
+                if nonessential_sum + wbm[i] <= threshold {
+                    essential[i] = false;
+                    nonessential_sum += wbm[i];
+                } else {
+                    break;
+                }
+            }
+
+            // Bulk-accumulate the essential terms into the window score array.
+            for i in 0..n {
+                if !essential[i] {
+                    continue;
+                }
+                let c = &mut cursors[i];
+                while !c.is_exhausted() {
+                    let d = c.current_doc_id();
+                    if d >= window_end {
+                        break;
+                    }
+                    let pos = c.pos;
+                    if pos + bm25::SCORE_SIMD_LANES <= c.block_n {
+                        let doc_ids = [
+                            c.block_doc_ids[pos],
+                            c.block_doc_ids[pos + 1],
+                            c.block_doc_ids[pos + 2],
+                            c.block_doc_ids[pos + 3],
+                        ];
+                        if doc_ids[bm25::SCORE_SIMD_LANES - 1] < window_end {
+                            let contributions = bm25::score_one_term_x4(
+                                c.idf_x_k1p1,
+                                [
+                                    c.block_tfs[pos],
+                                    c.block_tfs[pos + 1],
+                                    c.block_tfs[pos + 2],
+                                    c.block_tfs[pos + 3],
+                                ],
+                                [
+                                    dl_norm_k1.get(doc_ids[0]),
+                                    dl_norm_k1.get(doc_ids[1]),
+                                    dl_norm_k1.get(doc_ids[2]),
+                                    dl_norm_k1.get(doc_ids[3]),
+                                ],
+                            );
+                            for lane in 0..bm25::SCORE_SIMD_LANES {
+                                let local = (doc_ids[lane] - base) as usize;
+                                scores[local] += contributions[lane];
+                                present[local >> 6] |= 1u64 << (local & 63);
+                            }
+                            c.advance_by(bm25::SCORE_SIMD_LANES);
+                            continue;
+                        }
+                    }
+                    let local = (d - base) as usize;
+                    scores[local] += bm25::score_with_dl_norm_k1(
+                        c.idf_x_k1p1,
+                        c.current_tf(),
+                        dl_norm_k1.get(d),
+                    );
+                    present[local >> 6] |= 1u64 << (local & 63);
+                    c.next();
+                }
+            }
+
+            // Drain candidates ascending: complete each with its non-essential
+            // contributions (per-candidate) and admit.
+            for (word_idx, word) in present.iter_mut().enumerate() {
+                let mut bits = *word;
+                *word = 0;
+                while bits != 0 {
+                    let b = bits.trailing_zeros() as usize;
+                    bits &= bits - 1;
+                    let local = (word_idx << 6) | b;
+                    let mut score = scores[local];
+                    scores[local] = 0.0;
+                    let doc = base + local as u32;
+                    if let Some(f) = filter.as_deref_mut()
+                        && !f.admits(doc)
+                    {
+                        continue;
+                    }
+                    // Competitive filter: even every non-essential's full window
+                    // max can't lift this candidate over the bar ⇒ drop it
+                    // without the per-candidate `skip_to`s.
+                    if score + nonessential_sum <= threshold {
+                        continue;
+                    }
+                    let norm = dl_norm_k1.get(doc);
+                    for i in 0..n {
+                        if essential[i] {
+                            continue;
+                        }
+                        let c = &mut cursors[i];
+                        c.skip_to(doc);
+                        if !c.is_exhausted() && c.current_doc_id() == doc {
+                            score +=
+                                bm25::score_with_dl_norm_k1(c.idf_x_k1p1, c.current_tf(), norm);
+                        }
+                    }
+                    if heap.len() < k {
+                        heap.push(TopKEntry(score, doc));
+                        if heap.len() == k {
+                            threshold = heap.peek().expect("non-empty").0.max(threshold);
+                        }
+                    } else if score > threshold {
+                        heap.pop();
+                        heap.push(TopKEntry(score, doc));
+                        threshold = heap.peek().expect("non-empty").0.max(threshold);
+                    }
+                }
+            }
+
+            // Advance non-essentials past the window (the essentials already
+            // walked past it during accumulation), so the next window makes
+            // progress. Their docs here were non-competitive by construction.
+            for i in 0..n {
+                if !essential[i] {
+                    let c = &mut cursors[i];
+                    if !c.is_exhausted() {
+                        c.skip_to(window_end);
+                    }
+                }
+            }
+        }
+        Ok(drain_top_k_desc(heap))
+    }
+
     /// Exhaustive union walk for multi-term OR. No threshold-driven
     /// block skipping — every doc in the union of the cursor postings
     /// is scored and offered to the top-K heap.
@@ -1557,7 +1786,19 @@ impl FtsReader {
         {
             self.run_wand_bmw(column_id, cursors, k)
         } else if route_or_to_windowed(&cursors, k) {
-            self.run_windowed_union(column_id, cursors, k, filter, floor_eff, 0, u32::MAX)
+            // MaxScore's per-doc merge prunes nothing at this `k` (see
+            // `route_or_to_windowed`), so the union is scored by a full SIMD
+            // window scan. At a page-sized `k` the fused scorer runs that same
+            // scan but keeps a live essential/non-essential partition and
+            // per-window block-max skip, reclaiming the pruning a plain windowed
+            // scan gives up — a large tail win. Past that depth the partition's
+            // per-candidate completion loses to the plain SIMD scan, so deep
+            // requests stay on the windowed scanner.
+            if k <= OR_MAXSCORE_WINDOWED_MAX_K {
+                self.run_maxscore_windowed(column_id, cursors, k, filter, floor_eff, 0, u32::MAX)
+            } else {
+                self.run_windowed_union(column_id, cursors, k, filter, floor_eff, 0, u32::MAX)
+            }
         } else {
             self.run_max_score_bmm(column_id, cursors, k, filter, floor_eff)
         }
@@ -1598,6 +1839,15 @@ impl FtsReader {
             OrAlgo::Windowed => {
                 self.run_windowed_union(column_id, cursors, k, None, f32::NEG_INFINITY, 0, u32::MAX)
             }
+            OrAlgo::MaxScoreWindowed => self.run_maxscore_windowed(
+                column_id,
+                cursors,
+                k,
+                None,
+                f32::NEG_INFINITY,
+                0,
+                u32::MAX,
+            ),
         }
     }
 }
@@ -1869,13 +2119,35 @@ mod tests {
                     .search_with_algo_for_bench("body", terms, k, OrAlgo::Windowed)
                     .await
                     .expect("windowed");
+                let msw = r
+                    .search_with_algo_for_bench("body", terms, k, OrAlgo::MaxScoreWindowed)
+                    .await
+                    .expect("maxscore-windowed");
                 assert_eq!(bmm.len(), win.len(), "len mismatch {terms:?} k={k}");
+                assert_eq!(bmm.len(), msw.len(), "msw len mismatch {terms:?} k={k}");
                 for ((db, sb), (dw, sw)) in bmm.iter().zip(win.iter()) {
                     assert_eq!(db, dw, "doc_id mismatch {terms:?} k={k}: bmm={db} win={dw}");
                     assert!(
                         (sb - sw).abs() < 1e-4,
                         "score mismatch {terms:?} k={k}: {sb} vs {sw}"
                     );
+                }
+                // MaxScoreWindowed sums the essential terms (into the window
+                // array) before the non-essential completion — a different
+                // float order than bmm's per-doc cursor-order sum — so near-tied
+                // scores may break to a different doc. Compare the top-k as a
+                // doc *set* plus the sorted score list (tolerance), not by
+                // position, the same way the brute-force oracle does.
+                use std::collections::HashSet;
+                let bset: HashSet<u32> = bmm.iter().map(|&(d, _)| d).collect();
+                let mset: HashSet<u32> = msw.iter().map(|&(d, _)| d).collect();
+                assert_eq!(bset, mset, "msw doc set mismatch {terms:?} k={k}");
+                let mut bs: Vec<f32> = bmm.iter().map(|&(_, s)| s).collect();
+                let mut ms: Vec<f32> = msw.iter().map(|&(_, s)| s).collect();
+                bs.sort_by(f32::total_cmp);
+                ms.sort_by(f32::total_cmp);
+                for (sb, sm) in bs.iter().zip(ms.iter()) {
+                    assert!((sb - sm).abs() < 1e-4, "msw score mismatch {terms:?} k={k}");
                 }
             }
         }

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -694,15 +694,31 @@ impl FtsReader {
         }
         let cursors = set.cursors.clone();
         if route_or_to_windowed(&cursors, k) {
-            self.run_windowed_union(
-                set.column_id,
-                cursors,
-                k,
-                None,
-                floor.next_down(),
-                doc_id_start,
-                doc_id_end,
-            )
+            // Fused windowed MaxScore where a plain windowed scan used to run,
+            // but only at a page-sized `k` where its per-window partition pays;
+            // deeper requests stay on the plain windowed scan. Mirrors
+            // `dispatch_or_algo` so a fanned-out query runs the same kernel.
+            if k <= OR_MAXSCORE_WINDOWED_MAX_K {
+                self.run_maxscore_windowed(
+                    set.column_id,
+                    cursors,
+                    k,
+                    None,
+                    floor.next_down(),
+                    doc_id_start,
+                    doc_id_end,
+                )
+            } else {
+                self.run_windowed_union(
+                    set.column_id,
+                    cursors,
+                    k,
+                    None,
+                    floor.next_down(),
+                    doc_id_start,
+                    doc_id_end,
+                )
+            }
         } else {
             self.run_max_score_bmm_range(
                 set.column_id,
@@ -1502,18 +1518,28 @@ mod tests {
             (3_000, N_DOCS),
             (0, N_DOCS),
         ];
-        for (lo, hi) in windows {
-            let fresh = r
-                .search_or_range_pretokenized("body", terms, K_ALL, lo, hi)
-                .await
-                .expect("fresh ranged search");
-            let pre = r
-                .search_or_range_prebuilt(&set, K_ALL, lo, hi, f32::NEG_INFINITY)
-                .expect("prebuilt ranged search");
-            let fresh_bits: Vec<(u32, u32)> =
-                fresh.iter().map(|&(d, s)| (d, s.to_bits())).collect();
-            let pre_bits: Vec<(u32, u32)> = pre.iter().map(|&(d, s)| (d, s.to_bits())).collect();
-            assert_eq!(pre_bits, fresh_bits, "window ({lo},{hi})");
+        // The four terms have near-uniform df (common-heavy), so `k` selects the
+        // ranged kernel: `K_ALL` is deep enough to route to the plain windowed
+        // scan, while a page-sized `k` (> the pruning cutoff, <=
+        // `OR_MAXSCORE_WINDOWED_MAX_K`) routes to the fused block-max windowed
+        // MaxScore. Both `k`s must give the prebuilt (fan-out) entry the exact
+        // result of the fresh single-shot entry — the seam that keeps a
+        // fanned-out query on the same kernel as an unsliced one.
+        for k in [K_ALL, 64] {
+            for (lo, hi) in windows {
+                let fresh = r
+                    .search_or_range_pretokenized("body", terms, k, lo, hi)
+                    .await
+                    .expect("fresh ranged search");
+                let pre = r
+                    .search_or_range_prebuilt(&set, k, lo, hi, f32::NEG_INFINITY)
+                    .expect("prebuilt ranged search");
+                let fresh_bits: Vec<(u32, u32)> =
+                    fresh.iter().map(|&(d, s)| (d, s.to_bits())).collect();
+                let pre_bits: Vec<(u32, u32)> =
+                    pre.iter().map(|&(d, s)| (d, s.to_bits())).collect();
+                assert_eq!(pre_bits, fresh_bits, "k={k} window ({lo},{hi})");
+            }
         }
     }
 

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -318,10 +318,12 @@ fn common_heavy_corpus(n: u64) -> Vec<(u64, String)> {
 
 #[tokio::test]
 async fn oracle_common_heavy_or_matches_brute_force_at_depth() {
-    // A common-heavy OR now defaults to MaxScore, which prunes differently at
-    // each k. Verify the rerouted default against ground-truth BM25 across k,
-    // not just against the windowed kernel it agrees with. The tie-free top-5
-    // anchors keep the head comparison deterministic under tail tie-breaking.
+    // A common-heavy OR routes by k: MaxScore at small k (k <= 32), the fused
+    // block-max windowed MaxScore at a page-sized k (32 < k <= 128), and the
+    // plain windowed scan at deep k. The k sweep exercises all three against
+    // ground-truth BM25 — not just the kernels they agree with. The tie-free
+    // top-5 anchors keep the head comparison deterministic under tail
+    // tie-breaking.
     let corp = common_heavy_corpus(4_000);
     let corp_refs: Vec<(u64, &str)> = corp.iter().map(|(d, s)| (*d, s.as_str())).collect();
     let infino = build_infino_superfile(&corp_refs);

--- a/tests/superfile/fts/negation.rs
+++ b/tests/superfile/fts/negation.rs
@@ -237,6 +237,47 @@ async fn or_four_term_minus_negative() {
 }
 
 #[tokio::test]
+async fn or_common_heavy_minus_negative_through_fused_scorer() {
+    // A common-heavy 3-term OR at a page-sized k (above the pruning cutoff,
+    // at or below the fused-scorer cutoff) is the shape dispatch sends to the
+    // block-max windowed MaxScore, and it must carry the negation filter into
+    // that scorer. Plant a corpus where all three positives are in every doc
+    // (identical upper bounds => common-heavy => the fused scorer) and the
+    // negative sits in every even doc. With k equal to the surviving-match
+    // count the whole result set is checkable: it must be exactly the odd docs,
+    // so the fused scorer's drain has to drop every even doc — including a
+    // high-tf even doc that would top the ranking if the filter were missed.
+    const N: u64 = 200; // < OR_WINDOW (single window); 100 odd docs == k
+    let owned: Vec<(u64, String)> = (0..N)
+        .map(|i| {
+            let mut s = String::from("aa bb cc");
+            if i % 2 == 0 {
+                s.push_str(" zzz"); // negative term, even docs only
+            }
+            if i == 2 {
+                // a high-scoring even doc: absent only if the filter fires
+                s.push_str(" aa aa aa aa aa aa aa aa");
+            }
+            (i, format!("{s} f{}", i % 7))
+        })
+        .collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let r = build_infino_superfile(&refs);
+
+    // k = 100 = the number of odd (surviving) docs, so the full set is exact.
+    let got = search_set(&r, "aa bb cc -zzz", 100, BoolMode::Or).await;
+    let want: HashSet<u64> = (0..N).filter(|i| i % 2 == 1).collect();
+    assert_eq!(
+        got, want,
+        "fused-scorer OR must exclude every doc carrying zzz"
+    );
+    assert!(
+        !got.contains(&2),
+        "the high-tf even doc must be filtered out, not ranked in"
+    );
+}
+
+#[tokio::test]
 async fn or_multi_positive_multi_negative() {
     // Multiple positives AND multiple negatives together.
     // (rust ∪ python) minus (web ∪ go).


### PR DESCRIPTION
## What

Common-heavy multi-term OR queries — where no single term dominates the score
upper bound — were scored by a plain windowed union: a full SIMD scan of every
posting in the union with no pruning, its cost proportional to total postings and
independent of `k`. That scan dominates the tail at page-sized top-k, where the
heap fills early and the bar rises above whole windows' block maxima, yet the
plain scan keeps touching every posting.

This adds a fused scorer, `run_maxscore_windowed`, that keeps the windowed SIMD
accumulate but layers MaxScore-style pruning on each `OR_WINDOW`-doc window: bound
each term by its block-max over the window and skip the window when the sum can't
beat the top-k bar; partition the low-max terms out as non-essential; bulk-score
only the essentials through the SIMD lane; then complete the surviving candidates
with the non-essential terms one at a time.

The essential/non-essential partition only pays when the bar is selective enough
that its competitive filter rejects most candidates — a page-sized request — so
the dispatcher routes to the fused scorer only up to `k = 128`
(`OR_MAXSCORE_WINDOWED_MAX_K`); deeper requests, where nearly every union doc
survives and the per-candidate completion loses to the plain SIMD scan, stay on
the windowed scanner. Both the single-shot and doc-id-ranged (fan-out) OR entries
route through the same seam, so a fanned-out query runs the same kernel as an
unsliced one.

## Perf

Measured with a min-of-runs before/after A/B (a warmup pass plus 15 timed
iterations per query, reporting the per-query best) over a representative
multi-term-OR query set against a single preloaded segment:

| request | average | p99 |
| ------- | ------- | --- |
| **page-sized common-heavy union (k = 100)** | **−4%** | **−36%** (11.8 ms → 7.5 ms) |
| small-k (k = 10) | unchanged — stays on the existing MaxScore path (below the routing cutoff) | — |
| deep-k (k = 1000) | unchanged — routes to the plain windowed scan (byte-identical path) | — |

The k = 100 line is the multi-term-OR tail this change targets. The change is
confined to the OR scoring path; COUNT, phrase, AND, and single-term queries run
exactly the code they did before and are unaffected.

## Testing

Ranked top-k is correctness-sensitive: a pruning bound that isn't a true upper
bound would silently drop a competitive doc rather than error. Every bound here is
`>=` the real per-window max, and the result set is gated against independent
references:

- **All-algorithm agreement** (`windowed_union_agrees_with_bmm`): the fused
  scorer's top-k is compared against the MaxScore+BMM path across term counts
  (2/3/5-term), the uniform-upper-bound (common-heavy) shape it targets, and
  `k ∈ {1, 5, 50, 1000}` on a corpus spanning multiple windows and posting
  blocks. Because the fused scorer sums the essentials before the non-essentials
  — a different float order than the per-doc kernels — the comparison is by
  doc-set plus sorted-score multiset within 1 ULP, not by position.
- **Brute-force BM25 oracle** (`oracle_common_heavy_or_matches_brute_force_at_depth`):
  a common-heavy multi-term OR is checked end-to-end through the production
  dispatcher against a textbook BM25 scorer at `k ∈ {10, 100, 1000}`, so the
  routed fused scorer (at `k = 100`) is validated against ground truth, not just
  against another optimized kernel.
- **Ranged fan-out** (`search_or_range_prebuilt_matches_fresh_calls`): extended to
  a page-sized `k` so the doc-id-ranged entry exercises the fused scorer and must
  return the exact result of the unsliced single-shot entry.
- **Negation through the fused scorer**
  (`or_common_heavy_minus_negative_through_fused_scorer`): a common-heavy OR with
  an excluded term at a page-sized `k`, on a planted corpus where the entire
  result set is checkable — the fused scorer's drain must drop every excluded doc,
  including a high-term-frequency one that would otherwise top the ranking.

`cargo fmt --all`, `cargo clippy --all-targets --features test-helpers`, and the
full `cargo test --test superfile fts::` suite (80 tests) are green locally.
