### PR TITLE
fts: clean errors for unknown column and non-full-text search

### DIFF
--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -503,8 +503,8 @@ pub enum GcError {
 /// we don't propagate them as `#[from]`. Callers get the formatted
 /// message; structured introspection isn't a v1 concern. When the
 /// SQL surface gains a manifest-level skip planner, it'll get its
-/// own variant to distinguish "DataFusion failed" from "store
-/// failed mid-scan".
+/// own variant to distinguish "the query engine failed" from
+/// "store failed mid-scan".
 #[derive(Debug, Error)]
 pub enum QueryError {
     #[error("superfile store error during query: {0}")]
@@ -516,10 +516,10 @@ pub enum QueryError {
     #[error("invalid query: {0}")]
     InvalidQuery(String),
 
-    #[error("DataFusion failed to plan the query: {0}")]
+    #[error("failed to plan the query: {0}")]
     Plan(String),
 
-    #[error("DataFusion failed to execute the query: {0}")]
+    #[error("failed to run the query: {0}")]
     Execute(String),
 
     /// A query crossed the connection memory budget. The string is already

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -860,15 +860,25 @@ impl SupertableOptions {
         self
     }
 
-    /// Tokenizer configured for `column`, for tokenizing query text so
-    /// it matches how the column was indexed. Falls back to the ASCII
-    /// default when `column` is not a registered FTS column (the query
-    /// then fails downstream on the unknown column).
-    pub fn fts_tokenizer_for(&self, column: &str) -> Arc<dyn Tokenizer> {
+    /// Tokenizer configured for `column`, or `None` when `column` carries
+    /// no full-text index. `fts_tokenizers` is aligned to `fts_columns` (one
+    /// per column), so a hit on the column always yields its tokenizer — a
+    /// `None` return is exactly the "column is not full-text-indexed" signal,
+    /// which lets a search path reject up front instead of failing deep in
+    /// the scan. The lookup is a single pass over `fts_columns`.
+    pub fn try_fts_tokenizer_for(&self, column: &str) -> Option<Arc<dyn Tokenizer>> {
         self.fts_columns
             .iter()
             .position(|c| c.column == column)
             .and_then(|i| self.fts_tokenizers.get(i).cloned())
+    }
+
+    /// Tokenizer configured for `column`, for tokenizing query text so
+    /// it matches how the column was indexed. Falls back to the ASCII
+    /// default when `column` is not a registered FTS column; a caller that
+    /// must distinguish that case uses [`Self::try_fts_tokenizer_for`].
+    pub fn fts_tokenizer_for(&self, column: &str) -> Arc<dyn Tokenizer> {
+        self.try_fts_tokenizer_for(column)
             .unwrap_or_else(|| Arc::new(AsciiLowerTokenizer))
     }
 

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -143,8 +143,7 @@ pub(crate) async fn resolve_hits_named(
     reader: &SupertableReader,
     hits: &[SuperfileHit],
     projection: Option<&[&str]>,
-    what: &str,
-) -> DfResult<RecordBatch> {
+) -> Result<RecordBatch, QueryError> {
     let scalar_schema = reader.options().scalar_schema();
     let output_schema = output_schema_with_score(&scalar_schema);
     // `None` is the engine-native result: `_id` + `score` only.
@@ -158,24 +157,37 @@ pub(crate) async fn resolve_hits_named(
         Some(names) => names,
         None => &bare,
     };
-    let indices: Option<Vec<usize>> = Some(
-        names
-            .iter()
-            .map(|name| {
-                output_schema.index_of(name).map_err(|_| {
-                    DataFusionError::Execution(format!("{what}: unknown column {name:?}"))
-                })
-            })
-            .collect::<Result<_, _>>()?,
-    );
-    resolve_hits(
-        reader,
-        hits,
-        &scalar_schema,
-        &output_schema,
-        indices.as_deref(),
-    )
-    .await
+    // Resolving a projected name to a column is caller-input validation, not
+    // query execution: the single-table search methods run their own kernels
+    // (no SQL engine involved), so an unknown column must read as a bad request
+    // that names the column and the valid set — never as an internal execution
+    // failure.
+    let indices: Vec<usize> = names
+        .iter()
+        .map(|name| {
+            output_schema
+                .index_of(name)
+                .map_err(|_| QueryError::InvalidQuery(unknown_column_message(name, &output_schema)))
+        })
+        .collect::<Result<_, _>>()?;
+    // Past name resolution, any failure is a store/decode fault reading the
+    // projected columns — not the caller's mistake.
+    resolve_hits(reader, hits, &scalar_schema, &output_schema, Some(&indices))
+        .await
+        .map_err(|e| QueryError::Store(e.to_string()))
+}
+
+/// Message for a projection naming a column the search output does not
+/// carry. Lists the selectable columns (`_id`, the visible scalar columns,
+/// and the trailing `score`) so the caller can correct the request.
+fn unknown_column_message(name: &str, output_schema: &SchemaRef) -> String {
+    let available = output_schema
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("unknown column {name:?} in projection; valid columns: {available}")
 }
 
 /// Output column carrying the per-hit score (vector distance or BM25

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -238,9 +238,7 @@ impl Supertable {
                 // stable id before the scalar decode, exactly as the
                 // hybrid TVF and `vector_search` paths do.
                 let hits = user_placement_for_scalar_resolve(&reader, &hits).await?;
-                resolve_hits_named(&reader, &hits, projection, "hybrid_search")
-                    .await
-                    .map_err(|e| QueryError::Execute(e.to_string()))
+                resolve_hits_named(&reader, &hits, projection).await
             })
             .map_err(|e| InfinoError::Query(e.to_string()).with_context("hybrid_search", None))?;
         Ok(vec![batch])

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -328,24 +328,21 @@ impl SupertableReader {
             return Ok(Vec::new());
         }
         let manifest = self.manifest();
-        // A bm25 query names a column that must carry a full-text index. If it
-        // does not, every candidate superfile lacks the full-text section this
-        // scan reads, and the low-level reader fails deep in the scan with an
-        // opaque missing-metadata error. Reject up front with a message that
-        // names the column and the searchable set.
-        if !manifest
-            .options
-            .fts_columns
-            .iter()
-            .any(|c| c.column == column)
-        {
+        let pool_threads = manifest.options.reader_pool.current_num_threads();
+        let column_owned = column.to_owned();
+
+        // Resolve the query tokenizer, which doubles as the column's
+        // full-text-index check: a `None` here means `column` carries no
+        // full-text index, so every candidate superfile would lack the
+        // full-text section this scan reads and the low-level reader would
+        // fail deep in the scan with an opaque missing-metadata error. Reject
+        // up front instead, naming the column and the searchable set.
+        let Some(tokenizer) = manifest.options.try_fts_tokenizer_for(column) else {
             return Err(QueryError::InvalidQuery(no_fts_index_message(
                 column,
                 &manifest.options.fts_columns,
             )));
-        }
-        let pool_threads = manifest.options.reader_pool.current_num_threads();
-        let column_owned = column.to_owned();
+        };
 
         // Parse the query once here, not per superfile, resolving the
         // bare tokens' polarity from the default operator (`And` ⇒
@@ -353,11 +350,7 @@ impl SupertableReader {
         // ('static) data for tokio::spawn, so this is the one place
         // the tokens are copied — the prune and every per-superfile
         // search reuse them.
-        let clauses = manifest
-            .options
-            .fts_tokenizer_for(column)
-            .parse(query)
-            .into_clauses(mode);
+        let clauses = tokenizer.parse(query).into_clauses(mode);
         let musts: Vec<String> = clauses.musts.into_iter().map(Cow::into_owned).collect();
         let shoulds: Vec<String> = clauses.shoulds.into_iter().map(Cow::into_owned).collect();
         let negatives: Vec<String> = clauses.negatives.into_iter().map(Cow::into_owned).collect();
@@ -801,12 +794,10 @@ impl SupertableReader {
         // As in `bm25_search_async`: a prefix query over a column with no
         // full-text index would otherwise fail deep in the scan with an opaque
         // missing-metadata error. Reject up front, naming the searchable set.
-        if !manifest
-            .options
-            .fts_columns
-            .iter()
-            .any(|c| c.column == column)
-        {
+        // Prefix expansion lowercases the prefix bytes directly rather than
+        // tokenizing, so there is no tokenizer lookup to fold this into — but
+        // it is the same single pass over `fts_columns`, once per query.
+        if manifest.options.try_fts_tokenizer_for(column).is_none() {
             return Err(QueryError::InvalidQuery(no_fts_index_message(
                 column,
                 &manifest.options.fts_columns,

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -120,6 +120,7 @@ use crate::{
     runtime_metrics::op_stats,
     superfile::{
         SuperfileReader,
+        builder::FtsConfig,
         error::{FtsError, ReadError},
         fts::{
             bm25,
@@ -188,6 +189,26 @@ impl UnrankedNegatives {
 /// anchor (e.g. `-foo`). Shared by the scored and unranked FTS paths so
 /// both reject the case identically.
 const NEGATION_ONLY_QUERY_MSG: &str = "only negated terms; at least one positive term is required";
+
+/// Message for a bm25 / token query naming a column that carries no
+/// full-text index. Names the requested column and the searchable set so the
+/// caller can correct the request, rather than failing deep in the scan with
+/// an opaque "missing full-text section" error once a candidate superfile is
+/// opened.
+fn no_fts_index_message(column: &str, fts_columns: &[FtsConfig]) -> String {
+    if fts_columns.is_empty() {
+        return format!(
+            "no full-text index for column {column:?}: this table has no \
+             full-text-indexed columns"
+        );
+    }
+    let available = fts_columns
+        .iter()
+        .map(|c| c.column.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("no full-text index for column {column:?}; full-text-indexed columns: {available}")
+}
 
 /// Cross-segment top-k score sharing for the BM25 fan-out.
 ///
@@ -307,6 +328,22 @@ impl SupertableReader {
             return Ok(Vec::new());
         }
         let manifest = self.manifest();
+        // A bm25 query names a column that must carry a full-text index. If it
+        // does not, every candidate superfile lacks the full-text section this
+        // scan reads, and the low-level reader fails deep in the scan with an
+        // opaque missing-metadata error. Reject up front with a message that
+        // names the column and the searchable set.
+        if !manifest
+            .options
+            .fts_columns
+            .iter()
+            .any(|c| c.column == column)
+        {
+            return Err(QueryError::InvalidQuery(no_fts_index_message(
+                column,
+                &manifest.options.fts_columns,
+            )));
+        }
         let pool_threads = manifest.options.reader_pool.current_num_threads();
         let column_owned = column.to_owned();
 
@@ -761,6 +798,20 @@ impl SupertableReader {
             return Ok(Vec::new());
         }
         let manifest = self.manifest();
+        // As in `bm25_search_async`: a prefix query over a column with no
+        // full-text index would otherwise fail deep in the scan with an opaque
+        // missing-metadata error. Reject up front, naming the searchable set.
+        if !manifest
+            .options
+            .fts_columns
+            .iter()
+            .any(|c| c.column == column)
+        {
+            return Err(QueryError::InvalidQuery(no_fts_index_message(
+                column,
+                &manifest.options.fts_columns,
+            )));
+        }
         let pool_threads = manifest.options.reader_pool.current_num_threads();
         let column_owned = column.to_owned();
         let prefix_owned = prefix.to_owned();
@@ -1433,9 +1484,7 @@ impl SupertableReader {
             // visible scalar columns, or the trailing `score`); `None`
             // returns `_id` + `score` only. The shared resolver decodes
             // only the projected columns.
-            let batch = resolve_hits_named(self, &hits, projection, "bm25_search")
-                .await
-                .map_err(|e| QueryError::Execute(e.to_string()))?;
+            let batch = resolve_hits_named(self, &hits, projection).await?;
             Ok(vec![batch])
         })
     }
@@ -1807,13 +1856,8 @@ impl Supertable {
             .token_match(column, query, mode)
             .map_err(|e| InfinoError::from(e).with_context("token_match", None))?;
         let batch = self
-            .block_on_query(resolve_hits_named(
-                &reader,
-                &hits,
-                projection,
-                "token_match",
-            ))
-            .map_err(|e| InfinoError::Query(e.to_string()).with_context("token_match", None))?;
+            .block_on_query(resolve_hits_named(&reader, &hits, projection))
+            .map_err(|e| InfinoError::from(e).with_context("token_match", None))?;
         Ok(vec![batch])
     }
 
@@ -1838,13 +1882,8 @@ impl Supertable {
             .exact_match(column, value)
             .map_err(|e| InfinoError::from(e).with_context("exact_match", None))?;
         let batch = self
-            .block_on_query(resolve_hits_named(
-                &reader,
-                &hits,
-                projection,
-                "exact_match",
-            ))
-            .map_err(|e| InfinoError::Query(e.to_string()).with_context("exact_match", None))?;
+            .block_on_query(resolve_hits_named(&reader, &hits, projection))
+            .map_err(|e| InfinoError::from(e).with_context("exact_match", None))?;
         Ok(vec![batch])
     }
 
@@ -2541,6 +2580,50 @@ mod tests {
     }
 
     #[test]
+    fn bm25_search_unknown_projection_column_is_a_clean_error() {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_batch(0, &["rust async"])).expect("append");
+        w.commit().expect("commit");
+        let r = st.reader().expect("reader");
+
+        let err = r
+            .bm25_search(
+                "title",
+                "rust",
+                5,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+                Some(&["title", "does_not_exist"]),
+            )
+            .expect_err("unknown projection column must error");
+
+        // A bad projection is caller input, not an engine failure: it comes
+        // back as InvalidQuery, names the offending column and the valid set,
+        // and never leaks the query engine's internals into the message. (The
+        // single-table search kernels run without the SQL engine at all, so a
+        // "DataFusion"/"Execution error" phrasing would be doubly misleading.)
+        assert!(
+            matches!(err, QueryError::InvalidQuery(_)),
+            "expected InvalidQuery, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does_not_exist"),
+            "names the bad column: {msg}"
+        );
+        assert!(msg.contains("valid columns"), "lists valid columns: {msg}");
+        assert!(
+            msg.contains("title") && msg.contains("score"),
+            "valid set includes the real columns: {msg}"
+        );
+        assert!(
+            !msg.contains("DataFusion") && !msg.contains("Execution error"),
+            "must not leak query-engine internals: {msg}"
+        );
+    }
+
+    #[test]
     fn bm25_search_k_zero_short_circuits() {
         let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
@@ -2758,6 +2841,10 @@ mod tests {
     fn bm25_search_unknown_column_errors() {
         let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let mut w = st.writer().expect("writer");
+        // A committed superfile exists, so the query has real data to scan. The
+        // queried column carries no full-text index, though: the reject must
+        // happen up front, not deep in the scan where the low-level reader
+        // would surface an opaque storage-format error.
         w.append(&build_batch(0, &["rust"])).expect("append");
         w.commit().expect("commit");
 
@@ -2765,7 +2852,17 @@ mod tests {
         let err = r
             .bm25_hits("missing_column", "rust", 5, BoolMode::Or)
             .expect_err("expected error");
-        assert!(matches!(err, QueryError::Parquet(_)), "got {err:?}");
+        assert!(matches!(err, QueryError::InvalidQuery(_)), "got {err:?}");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no full-text index"),
+            "explains the miss: {msg}"
+        );
+        assert!(msg.contains("missing_column"), "names the column: {msg}");
+        assert!(
+            !msg.contains("inf.fts.offset") && !msg.contains("parquet"),
+            "must not leak the storage-format internals: {msg}"
+        );
     }
 
     #[test]

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -3865,9 +3865,7 @@ impl SupertableReader {
                 return Ok(vec![batch]);
             }
             let hits = user_placement_for_scalar_resolve(self, &hits).await?;
-            let batch = resolve_hits_named(self, &hits, projection, "vector_search")
-                .await
-                .map_err(|e| QueryError::Execute(e.to_string()))?;
+            let batch = resolve_hits_named(self, &hits, projection).await?;
             Ok(vec![batch])
         })
     }


### PR DESCRIPTION
## Problem

Two `bm25_search` failure modes surfaced internal query-engine and storage-format mechanics to the caller instead of an actionable message.

1. **Unknown projection column.** Passing a column the search output does not carry returned:

   ```
   failed to run the query: Execution error: bm25_search: unknown column "foo"
   ```

   The single-table search methods run their own kernels with no query engine involved, so naming an execution engine here is both a leak and misleading.

2. **Search over a column with no full-text index.** A bm25 query naming a non-full-text column ran all the way into the scan and failed deep in the reader with an opaque storage-format error:

   ```
   error reading parquet bytes during scan: required KV metadata key "inf.fts.offset" is missing
   ```

## Fix

- Treat projection-name resolution as caller-input validation. An unknown column is now an invalid-query error naming the offending column and listing the selectable ones (`_id`, the visible scalar columns, and `score`).
- Validate the search column against the table's full-text-indexed set up front, before any superfile is opened. A column with no full-text index returns a clear message naming the column and the searchable set, instead of the low-level missing-metadata error.
- Drop the engine name from the plan/execute error strings so no query path leaks it, and map the post-resolution decode failure to a store error rather than an execution error.

The same up-front guard covers the prefix-search path; `vector_search`, `hybrid_search`, `token_match`, and `exact_match` share the corrected projection resolver.

## Tests

- `bm25_search_unknown_projection_column_is_a_clean_error` — unknown projection column is an invalid-query error naming the column and the valid set, with no engine internals in the message.
- `bm25_search_unknown_column_errors` — updated: bm25 over a non-full-text column is now a clean up-front error, asserting the storage-format internals no longer leak.

No behavior change on the success path.