### PR TITLE
fts: rarest-driven membership walk for ranked AND with a common term

### DIFF
--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -319,6 +319,17 @@ pub(super) const OR_COUNT_ANCHOR_DOMINANCE: u64 = 8;
 /// `total_df >= max_doc / N`.
 pub(super) const OR_COUNT_BITSET_DENSITY_DIVISOR: u64 = 16;
 
+/// Rarest-term sparsity gate for the ranked-AND membership walk
+/// (`FtsReader::and_membership_scored`): route there only when the rarest term
+/// covers less than `1/N` of the doc-id space. The membership walk drives the
+/// rarest term's *entire* list (bit-testing the others) and gives up the
+/// flat-merge's block-max heap-bar skip, so it only pays when that list is
+/// genuinely short. A looser `1/16` (the count path's divisor) let moderately
+/// sparse rarest terms through and regressed the ranked tail (p99), where the
+/// bar-skip was doing real work; `1/64` restricts it to the clearly-rare∧common
+/// shape the walk targets. Bench-calibrated against the ranked-AND tail.
+pub(super) const AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR: u64 = 64;
+
 /// Multi-term OR dispatch floor. A 2-term OR is already sub-millisecond
 /// on MaxScore, so the window's per-window bookkeeping isn't worth it
 /// below this many terms. `pub(crate)`: the supertable fan-out reuses

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -459,10 +459,13 @@ impl FtsReader {
     /// and scored. This skips the flat-merge's per-leader-doc `skip_to` that
     /// fully decodes a common term's 128-doc block to read one doc — the profiled
     /// cost on n≥3-term AND with a common term. Score is `Σ` per-term BM25 at the
-    /// doc, identical to the flat-merge; emitted through the sink, so it serves
-    /// both the pure-AND and must+should sinks. Gated to the v4 bitset case with
-    /// a sparse rarest term (see [`and_prefer_membership`]); the flat-merge stays
-    /// for v1–v3 and the all-dense case.
+    /// doc, identical to the flat-merge; emitted through the generic sink, so the
+    /// walk is written against any [`AndSink`]. Only the pure-AND path
+    /// ([`run_and_intersect`](Self::run_and_intersect), a `ScoreSink`) routes here
+    /// today; must+should keeps the flat-merge so its should-clause scoring stays
+    /// in one place. Gated to the v4 bitset case with a sparse rarest term (see
+    /// [`and_prefer_membership`]); the flat-merge stays for v1–v3 and the
+    /// all-dense case.
     fn and_membership_scored<S: AndSink>(
         &self,
         mut cursors: Vec<TermCursor>,

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -102,6 +102,35 @@ fn block_max_and_bound(
     (ub, window_end)
 }
 
+/// Route a ranked AND to the membership walk ([`FtsReader::and_membership_scored`])
+/// instead of the block flat-merge. True only for v4 blobs — where a common
+/// term's blocks are bitset-encoded, so [`TermCursor::contains`] is an O(1)
+/// bit-test — with **≥3 terms** and a **very sparse rarest term**: driving the
+/// rarest doc-by-doc is then cheap and bit-testing the common others beats
+/// decoding their blocks to align them.
+///
+/// Two guards keep it off the shapes where it regressed the ranked tail:
+/// - **≥3 terms**: a 2-term AND keeps the specialized `and_flat_merge_2term`
+///   (two-pointer merge over the decoded blocks), which the membership walk was
+///   losing to.
+/// - **rarest < 1/`AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR`**: the walk gives up the
+///   flat-merge's heap-bar block skip, so it only pays when the rarest list is
+///   genuinely short. A looser bound regressed p99 where the bar-skip was
+///   working.
+fn and_prefer_membership(has_bitset_blocks: bool, cursors: &[TermCursor]) -> bool {
+    if !has_bitset_blocks || cursors.len() < 3 {
+        return false;
+    }
+    let max_doc = cursors
+        .iter()
+        .filter_map(|c| c.blocks.last())
+        .map(|b| b.last_doc_id)
+        .max()
+        .unwrap_or(0);
+    let min_df = cursors.iter().map(|c| c.df).min().unwrap_or(0);
+    min_df.saturating_mul(AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR) < u64::from(max_doc)
+}
+
 impl FtsReader {
     /// Multi-term OR via WAND + BlockMaxWAND.
     ///
@@ -399,11 +428,6 @@ impl FtsReader {
         let col_meta = &self.columns[column_id as usize];
         let dl_norm_k1 = &col_meta.dl_norm_k1;
 
-        // Smallest-df cursor at index 0 = leader. The remaining order
-        // doesn't matter for correctness but ascending-df reduces the
-        // expected number of leapfrog bumps per candidate.
-        cursors.sort_by_key(|c| c.block_count());
-
         let initial_cap = top_k_initial_capacity(k, u64::from(self.n_docs), None);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
         let mut sink = ScoreSink {
@@ -412,8 +436,66 @@ impl FtsReader {
             filter,
             floor_eff,
         };
-        self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
+        if and_prefer_membership(self.has_bitset_blocks, &cursors) {
+            // Rarest-driven membership walk: bit-test the common terms instead
+            // of decoding their blocks to align them (the flat-merge's dominant
+            // cost on rare∧common). See `and_membership_scored`.
+            self.and_membership_scored(cursors, dl_norm_k1, &mut sink);
+        } else {
+            // Smallest-df cursor at index 0 = leader. Ascending-df order reduces
+            // the expected number of leapfrog bumps per candidate.
+            cursors.sort_by_key(|c| c.block_count());
+            self.and_flat_merge(&mut cursors, dl_norm_k1, &mut sink);
+        }
         Ok(drain_top_k_desc(heap))
+    }
+
+    /// Ranked AND via the same rarest-driven membership walk that the unranked
+    /// count path uses ([`count_and_intersect_membership`]), but scoring the
+    /// matches. Iterate the rarest term; for each of its docs, probe the others
+    /// with [`TermCursor::contains`] — a **bitset bit-test with no block decode**
+    /// — short-circuiting on the first miss. Only a doc present in *every* term
+    /// is materialized (decoded + positioned via [`TermCursor::materialize_at`])
+    /// and scored. This skips the flat-merge's per-leader-doc `skip_to` that
+    /// fully decodes a common term's 128-doc block to read one doc — the profiled
+    /// cost on n≥3-term AND with a common term. Score is `Σ` per-term BM25 at the
+    /// doc, identical to the flat-merge; emitted through the sink, so it serves
+    /// both the pure-AND and must+should sinks. Gated to the v4 bitset case with
+    /// a sparse rarest term (see [`and_prefer_membership`]); the flat-merge stays
+    /// for v1–v3 and the all-dense case.
+    fn and_membership_scored<S: AndSink>(
+        &self,
+        mut cursors: Vec<TermCursor>,
+        dl_norm_k1: &NormTable,
+        sink: &mut S,
+    ) {
+        let driver_idx = cursors
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, c)| c.block_count())
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        let mut driver = cursors.swap_remove(driver_idx);
+        let mut others = cursors;
+        while !driver.is_exhausted() {
+            let doc = driver.current_doc_id();
+            if others.iter_mut().all(|o| o.contains(doc)) {
+                let score = if sink.needs_score() {
+                    let norm = dl_norm_k1.get(doc);
+                    let mut s =
+                        bm25::score_with_dl_norm_k1(driver.idf_x_k1p1, driver.current_tf(), norm);
+                    for o in others.iter_mut() {
+                        o.materialize_at(doc);
+                        s += bm25::score_with_dl_norm_k1(o.idf_x_k1p1, o.current_tf(), norm);
+                    }
+                    s
+                } else {
+                    0.0
+                };
+                sink.emit(doc, score);
+            }
+            driver.next();
+        }
     }
 
     /// Ranked must+should walk: the match set is the musts'

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -549,6 +549,69 @@ async fn oracle_and_scores_match_brute_force_ordering() {
 }
 
 #[tokio::test]
+async fn oracle_and_membership_path_matches_brute_force() {
+    // Force the ranked-AND rarest-driven membership walk (the path taken on v4
+    // blobs when the rarest term is sparse). `common` appears in every doc, so
+    // its blocks are dense and bitset-encoded — that both makes the reader's
+    // `has_bitset_blocks` true and makes `contains` an O(1) bit-test. `beta`
+    // (every 100th doc, df 10 < N/64) is the very-sparse rarest term, so the
+    // sparsity gate routes to `and_membership_scored`, not the flat-merge. The membership
+    // walk must return the same intersection and the same BM25 scores as textbook
+    // brute force — a bitset block that the flat-merge would decode is instead
+    // bit-tested, and only matches are materialized to score.
+    const N: u64 = 1000; // multi-block ⇒ `common` forms bitset blocks
+    let owned: Vec<(u64, String)> = (0..N)
+        .map(|i| {
+            let mut s = String::from("common");
+            if i % 4 == 0 {
+                s.push_str(" alpha");
+            }
+            if i % 100 == 0 {
+                s.push_str(" beta"); // df = 10 < N/64 ⇒ very-sparse rarest ⇒ membership
+            }
+            // Distinctive per-doc filler varies doc length so BM25 dl-norm (and
+            // thus the scores) differ across the intersection.
+            (i, format!("{s} f{}", i % 13))
+        })
+        .collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let infino = build_infino_superfile(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+
+    // k exceeds the intersection size (docs divisible by 100 = 10), so the whole
+    // match set is returned and checkable exactly (no top-k tie ambiguity).
+    let k = 64usize;
+    let got: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "common alpha beta", k, BoolMode::And)
+        .await
+        .expect("AND search")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    let want_set: HashSet<u64> = (0..N).filter(|i| i % 100 == 0).collect();
+    let got_set: HashSet<u64> = got.iter().map(|&(d, _)| d).collect();
+    assert_eq!(
+        got_set, want_set,
+        "membership-path AND must return exactly the intersection (docs divisible by 100)"
+    );
+    // Per-doc scores match textbook BM25 (tie-robust: compare via a doc→score map).
+    let terms = [
+        "common".to_string(),
+        "alpha".to_string(),
+        "beta".to_string(),
+    ];
+    let want: HashMap<u64, f32> = oracle.top_k_terms_and(&terms, k).into_iter().collect();
+    for (d, s) in &got {
+        let w = want[d];
+        assert!(
+            (s - w).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "membership-path score mismatch on doc {d}: infino={s} oracle={w}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn oracle_and_single_term_routed_consistently() {
     // BoolMode::And with a single term must route the same as
     // BoolMode::Or (both fall through to the single-term BMW path).

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -612,6 +612,106 @@ async fn oracle_and_membership_path_matches_brute_force() {
 }
 
 #[tokio::test]
+async fn oracle_and_membership_rejects_partial_matches() {
+    // Companion to `oracle_and_membership_path_matches_brute_force`, which
+    // planted the rarest term as a *subset* of the others — so every driver doc
+    // co-occurred and `others.all(contains)` was always true. That leaves the
+    // membership walk's reject path (a driver doc *absent* from some other term,
+    // short-circuited out and never emitted) untested. Here the driver term
+    // deliberately only *partially* overlaps the selective co-term, so most
+    // driver docs must be rejected — the walk has to bit-test, find a miss, and
+    // exclude the doc. The result set must be exactly the true 3-way
+    // intersection (not the whole driver list), and the scores must match.
+    const N: u64 = 2000; // multi-block ⇒ `common` forms bitset blocks
+    // `rare` drives (i % 80 == 0, df 25 < N/64 ⇒ sparse rarest ⇒ membership).
+    // `sel` (i % 3 == 0) is a dense bit-tested other. A driver doc is in the
+    // intersection only when it is also divisible by 3, i.e. i % 240 == 0 — so
+    // 16 of the 25 driver docs lack `sel` and must be rejected.
+    let owned: Vec<(u64, String)> = (0..N)
+        .map(|i| {
+            let mut s = String::from("common");
+            if i % 3 == 0 {
+                s.push_str(" sel");
+            }
+            if i % 80 == 0 {
+                s.push_str(" rare");
+            }
+            (i, format!("{s} f{}", i % 13))
+        })
+        .collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let infino = build_infino_superfile(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+
+    // k exceeds the intersection size (9 docs, i % 240 == 0), so the whole match
+    // set is returned and checkable exactly.
+    let k = 64usize;
+    let got: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "common sel rare", k, BoolMode::And)
+        .await
+        .expect("AND search")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    let want_set: HashSet<u64> = (0..N).filter(|i| i % 240 == 0).collect();
+    let got_set: HashSet<u64> = got.iter().map(|&(d, _)| d).collect();
+    assert_eq!(
+        got_set, want_set,
+        "membership-path AND must reject driver docs missing a co-term \
+         (result = i%240==0, not the whole rare list i%80==0)"
+    );
+    // The rejects are real: the driver list is larger than the result set, so the
+    // reject branch actually fired (guards against a future change that stops
+    // driving the rarest term or drops the co-occurrence check).
+    let driver_len = (0..N).filter(|i| i % 80 == 0).count();
+    assert!(
+        driver_len > want_set.len(),
+        "test would not exercise rejects: driver list ({driver_len}) must exceed \
+         the intersection ({})",
+        want_set.len()
+    );
+    // Per-doc scores match textbook BM25 (tie-robust via a doc→score map).
+    let terms = ["common".to_string(), "sel".to_string(), "rare".to_string()];
+    let want: HashMap<u64, f32> = oracle.top_k_terms_and(&terms, k).into_iter().collect();
+    for (d, s) in &got {
+        let w = want[d];
+        assert!(
+            (s - w).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "membership-path score mismatch on doc {d}: infino={s} oracle={w}"
+        );
+    }
+
+    // Truncated top-k on the membership route (k < intersection size): the
+    // ScoreSink heap must keep the k highest-scoring matches. Compare score
+    // multisets so a tie at the k-th place doesn't make the assertion flaky.
+    let k_trunc = 4usize;
+    let got_trunc: Vec<f32> = infino
+        .bm25_hits_async("title", "common sel rare", k_trunc, BoolMode::And)
+        .await
+        .expect("truncated AND search")
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect();
+    assert_eq!(
+        got_trunc.len(),
+        k_trunc,
+        "truncated AND must return exactly k"
+    );
+    let want_trunc: Vec<f32> = oracle
+        .top_k_terms_and(&terms, k_trunc)
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect();
+    for (g, w) in got_trunc.iter().zip(want_trunc.iter()) {
+        assert!(
+            (g - w).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "truncated membership-path score mismatch: infino={g} oracle={w}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn oracle_and_single_term_routed_consistently() {
     // BoolMode::And with a single term must route the same as
     // BoolMode::Or (both fall through to the single-term BMW path).


### PR DESCRIPTION
## Summary

Ranked AND (`BoolMode::And`) over a set of terms where one term is common and
the rarest is very sparse spends most of its time in the wrong place: for each
doc of the rarest term, the block flat-merge does a `skip_to` that **fully
decodes a common term's 128-doc block just to read one doc**. Profiling the
`n≥3`-term AND-with-a-common-term shape put that per-candidate block decode at
the top.

This adds a **rarest-driven membership walk** for that shape: iterate the rarest
term, and for each of its docs probe the other terms with `TermCursor::contains`
— an **O(1) bitset bit-test, no block decode** — short-circuiting on the first
miss. Only a doc present in *every* term is then materialized (decoded +
positioned) and scored. It reuses the same idea the unranked count path already
uses (`count_and_intersect_membership`), but scores the matches; the BM25 sum is
identical to the flat-merge, emitted through the same `ScoreSink`.

## Gating (deliberately narrow)

Routing is behind `and_prefer_membership`, true only when all hold:

- **v4 bitset blocks present** (`has_bitset_blocks`) — the common term's blocks
  are bitset-encoded, so `contains` is a real bit-test rather than a
  binary-search + decode.
- **≥3 terms** — a 2-term AND keeps the specialized `and_flat_merge_2term`
  two-pointer merge, which the walk was measurably losing to.
- **rarest term df < max_doc / 64** — the walk gives up the flat-merge's
  block-max heap-bar skip, so it only pays when the rarest list is genuinely
  short. A looser bound regressed the ranked tail (p99) where the bar-skip was
  doing real work.

Everything outside that shape — 2-term AND, non-sparse rarest, the all-dense /
pre-v4 case, and must+should (which keeps the flat-merge so its should-clause
scoring stays in one place) — is unchanged.

## Performance

Internal same-box A/B against the current main baseline (min-of-runs per query,
warmup + 15 iterations, same index and machine for both binaries), infino-only:

| bucket | avg | p50 | p90 |
|---|---|---|---|
| **≥3-term intersection (the target)** | **−13%** | **−16 to −18%** | **−18%** |
| 2-term intersection (gated out) | ~0% (neutral) | ~0% | ~0% |
| union (untouched path) | ~0% (neutral) | ~0% | ~0% |

The win is confined to the targeted shape; the paths the change does not touch
(2-term intersection, union) measure neutral on the same box, confirming no
collateral. No latency, throughput, or cost regression elsewhere.

## Testing

Two brute-force BM25 oracle tests (scores compared against the textbook formula,
no shared code with the optimized walk):

- `oracle_and_membership_path_matches_brute_force` — forces the walk (dense
  common term ⇒ bitset blocks; very-sparse rarest ⇒ sparsity gate) and checks
  the intersection set and every per-doc score against brute force.
- `oracle_and_membership_rejects_partial_matches` — the companion that exercises
  the **reject branch**: the rarest driver term only partially overlaps a
  selective co-term, so most driver docs must be bit-tested, found missing, and
  excluded. Asserts the result is the true 3-way intersection (not the whole
  driver list), that rejects actually fired, and adds a `k < match-count`
  truncation check on the same route.

`make ci` (fmt, clippy, tests) green.
