### PR TITLE
Expand FTS BM25 correctness oracle coverage

### DIFF
--- a/tests/superfile/fts/edge_and_unranked.rs
+++ b/tests/superfile/fts/edge_and_unranked.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Edge-case matrix and the unranked match spine.
+//!
+//! * **Edge cases** the fuzz oracle doesn't reach by construction: `k =
+//!   0`, a single-doc corpus, a degenerate all-equal-length corpus
+//!   (constant dl-norm), and duplicate query terms (the fuzz generator
+//!   dedups atoms, so this pins whatever the parser + scorer actually do
+//!   with a repeated term, against the same parsed clauses).
+//! * **The unranked spine** (`token_match` / `token_match_count`): a
+//!   separate path from ranked search that must never prune. Pinned
+//!   against corpus truth for both modes, with the ordering and
+//!   `count == ids.len()` invariants, plus the cross-spine invariant
+//!   that a ranked search returning every match (`k ≥ n`) has exactly
+//!   `token_match_count` hits.
+
+use std::collections::HashSet;
+
+use infino::{
+    superfile::{SuperfileReader, fts::reader::BoolMode},
+    test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer},
+};
+
+use crate::fts::brute_force_oracle::{build_infino_superfile, corpus};
+
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+const K_ALL: usize = 64;
+
+/// Doc-ids whose text contains `term` as a whitespace token.
+fn docs_with(corp: &[(u64, &str)], term: &str) -> HashSet<u64> {
+    corp.iter()
+        .filter(|(_, t)| t.split_whitespace().any(|w| w == term))
+        .map(|(i, _)| *i)
+        .collect()
+}
+
+async fn ranked_ids(reader: &SuperfileReader, query: &str, k: usize, mode: BoolMode) -> Vec<u64> {
+    reader
+        .bm25_hits_async("title", query, k, mode)
+        .await
+        .expect("bm25 search")
+        .into_iter()
+        .map(|(d, _)| d as u64)
+        .collect()
+}
+
+// ── edge cases ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn k_zero_returns_empty() {
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    // A query that otherwise matches many docs; k=0 must short-circuit to
+    // empty across OR and AND.
+    assert!(ranked_ids(&r, "rust", 0, BoolMode::Or).await.is_empty());
+    assert!(
+        ranked_ids(&r, "rust web", 0, BoolMode::And)
+            .await
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn k_one_returns_single_best() {
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    let hits = ranked_ids(&r, "rare-token-zzz", 1, BoolMode::Or).await;
+    assert_eq!(hits, vec![17], "k=1 returns the single unique match");
+    // A common term: k=1 must return a top-scoring doc that the oracle
+    // also ranks first (score-wise; tie-break may pick either doc).
+    let got = ranked_ids(&r, "rust", 1, BoolMode::Or).await;
+    assert_eq!(got.len(), 1);
+    let top_score = oracle
+        .top_k("rust", 1, tok.as_ref())
+        .first()
+        .expect("oracle top-1")
+        .1;
+    // The returned doc's score must equal the oracle's best score.
+    let got_score = reader_score(&r, "rust", got[0]).await;
+    assert!(
+        (got_score - top_score).abs() <= SCORE_ABS_TOLERANCE,
+        "k=1 score {got_score} != oracle best {top_score}"
+    );
+}
+
+/// Score of a specific doc for a single-term query (via a k=all search).
+async fn reader_score(reader: &SuperfileReader, query: &str, doc: u64) -> f32 {
+    reader
+        .bm25_hits_async("title", query, K_ALL, BoolMode::Or)
+        .await
+        .expect("search")
+        .into_iter()
+        .find(|(d, _)| *d as u64 == doc)
+        .map(|(_, s)| s)
+        .expect("doc present")
+}
+
+#[tokio::test]
+async fn k_far_exceeds_matches_returns_all() {
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    // "rust" matches a known number of docs; k a thousand times larger
+    // must return exactly that set, not panic or pad.
+    let want = docs_with(&corp, "rust");
+    let got: HashSet<u64> = ranked_ids(&r, "rust", 100_000, BoolMode::Or)
+        .await
+        .into_iter()
+        .collect();
+    assert_eq!(got, want, "k >> n must return exactly the match set");
+}
+
+#[tokio::test]
+async fn single_doc_corpus() {
+    // Degenerate corpus of one doc: avgdl == dl, so the length norm is
+    // exactly 1 - b + b = 1. A matching query returns [0]; a non-matching
+    // one returns empty.
+    let corp = vec![(0u64, "rust async runtime tokio")];
+    let r = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+
+    let hits = ranked_hits(&r, "rust", K_ALL).await;
+    assert_eq!(hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(), vec![0]);
+    let want = oracle.top_k("rust", K_ALL, tok.as_ref());
+    assert_eq!(want.len(), 1);
+    assert!((hits[0].1 - want[0].1).abs() <= SCORE_ABS_TOLERANCE);
+
+    assert!(
+        ranked_ids(&r, "zzz-absent", K_ALL, BoolMode::Or)
+            .await
+            .is_empty(),
+        "non-matching query on a single-doc corpus is empty"
+    );
+}
+
+#[tokio::test]
+async fn all_equal_length_docs_constant_norm() {
+    // Every doc is exactly 3 tokens, so dl == avgdl and the length norm
+    // is constant across docs; ranking then depends only on tf and idf.
+    // Cross-check the full ranking against the oracle so the constant-norm
+    // regime is pinned (a dl-norm bug that cancels on varied lengths could
+    // hide here otherwise).
+    let corp = vec![
+        (0u64, "rust rust rust"), // tf=3
+        (1, "rust rust alpha"),   // tf=2
+        (2, "rust alpha beta"),   // tf=1
+        (3, "alpha beta gamma"),  // tf=0
+        (4, "rust rust rust"),    // tf=3 (ties doc 0)
+    ];
+    let r = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    let got = ranked_hits(&r, "rust", K_ALL).await;
+    let want = oracle.top_k("rust", K_ALL, tok.as_ref());
+
+    // Same match set.
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();
+    let want_ids: HashSet<u64> = want.iter().map(|(d, _)| *d).collect();
+    assert_eq!(got_ids, want_ids, "constant-norm match set");
+    // Per-doc scores agree.
+    let want_scores: std::collections::HashMap<u64, f32> = want.into_iter().collect();
+    for (d, s) in &got {
+        assert!((s - want_scores[d]).abs() <= SCORE_ABS_TOLERANCE);
+    }
+}
+
+#[tokio::test]
+async fn duplicate_query_term_matches_parsed_clauses() {
+    // The fuzz generator dedups atoms, so a repeated term is never
+    // generated. Pin whatever the parser + scorer actually do with
+    // "rust rust" by scoring the *same parsed clauses* through the oracle
+    // — the reader must agree with its own clause interpretation, so a
+    // duplicate that double-counts in one path but not the other is
+    // caught.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+
+    let query = "rust rust";
+    let clauses = tok.parse(query).into_clauses(BoolMode::Or);
+    let shoulds: Vec<String> = clauses.shoulds.iter().map(|t| t.to_string()).collect();
+    let want = oracle.top_k_clauses(&[], &shoulds, &[], K_ALL);
+
+    let got = ranked_hits(&r, query, K_ALL).await;
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();
+    let want_ids: HashSet<u64> = want.iter().map(|(d, _)| *d).collect();
+    assert_eq!(got_ids, want_ids, "duplicate-term match set");
+    let want_scores: std::collections::HashMap<u64, f32> = want.into_iter().collect();
+    for (d, s) in &got {
+        assert!(
+            (s - want_scores[d]).abs() <= SCORE_ABS_TOLERANCE,
+            "duplicate-term score on doc {d}: reader={s} oracle={}",
+            want_scores[d]
+        );
+    }
+}
+
+/// Ranked search returning `(doc, score)` pairs.
+async fn ranked_hits(reader: &SuperfileReader, query: &str, k: usize) -> Vec<(u64, f32)> {
+    reader
+        .bm25_hits_async("title", query, k, BoolMode::Or)
+        .await
+        .expect("search")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect()
+}
+
+// ── unranked spine ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn token_match_matches_corpus_truth() {
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+
+    // OR: union of the two terms' docs.
+    let or_ids = r
+        .token_match("title", &["rust", "python"], BoolMode::Or)
+        .await
+        .expect("token_match")
+        .0;
+    let or_want: HashSet<u64> = docs_with(&corp, "rust")
+        .union(&docs_with(&corp, "python"))
+        .copied()
+        .collect();
+    assert_eq!(
+        or_ids.iter().map(|d| *d as u64).collect::<HashSet<_>>(),
+        or_want,
+        "token_match OR"
+    );
+    // Ascending order is part of the contract.
+    let mut sorted = or_ids.clone();
+    sorted.sort_unstable();
+    assert_eq!(or_ids, sorted, "token_match must return ascending ids");
+
+    // AND: intersection.
+    let and_ids = r
+        .token_match("title", &["rust", "async"], BoolMode::And)
+        .await
+        .expect("token_match")
+        .0;
+    let and_want: HashSet<u64> = docs_with(&corp, "rust")
+        .intersection(&docs_with(&corp, "async"))
+        .copied()
+        .collect();
+    assert_eq!(
+        and_ids.iter().map(|d| *d as u64).collect::<HashSet<_>>(),
+        and_want,
+        "token_match AND"
+    );
+}
+
+#[tokio::test]
+async fn token_match_count_equals_ids_len() {
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    for (tokens, mode) in [
+        (vec!["rust"], BoolMode::Or),
+        (vec!["rust", "python"], BoolMode::Or),
+        (vec!["rust", "async"], BoolMode::And),
+        (vec!["rust", "web", "framework"], BoolMode::And),
+        (vec!["definitely-absent"], BoolMode::Or),
+    ] {
+        let ids = r
+            .token_match("title", &tokens, mode)
+            .await
+            .expect("token_match")
+            .0;
+        let count = r
+            .token_match_count("title", &tokens, mode)
+            .await
+            .expect("token_match_count")
+            .0;
+        assert_eq!(
+            count as usize,
+            ids.len(),
+            "count must equal ids len for {tokens:?} {mode:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn ranked_hits_count_equals_unranked_count_when_k_covers_all() {
+    // Cross-spine invariant: a ranked search with k >= n returns every
+    // match, so its hit count must equal the unranked token_match_count
+    // for the same tokens and mode.
+    let corp = corpus();
+    let r = build_infino_superfile(&corp);
+    for (query, tokens, mode) in [
+        ("rust", vec!["rust"], BoolMode::Or),
+        ("rust python", vec!["rust", "python"], BoolMode::Or),
+        ("rust async", vec!["rust", "async"], BoolMode::And),
+    ] {
+        let ranked = ranked_ids(&r, query, K_ALL, mode).await;
+        let count = r
+            .token_match_count("title", &tokens, mode)
+            .await
+            .expect("token_match_count")
+            .0;
+        assert_eq!(
+            ranked.len(),
+            count as usize,
+            "ranked hits ({}) != unranked count ({count}) for {query:?} {mode:?}",
+            ranked.len()
+        );
+    }
+}

--- a/tests/superfile/fts/fuzz_oracle.rs
+++ b/tests/superfile/fts/fuzz_oracle.rs
@@ -123,6 +123,22 @@ fn corpus_strategy() -> impl Strategy<Value = Vec<Vec<usize>>> {
     prop::collection::vec(doc, 1..=max_docs())
 }
 
+/// Like [`corpus_strategy`] but with a **skewed** token distribution:
+/// the first two vocab terms dominate (dense, bitset-encoded posting
+/// lists) while the other eight are rare. A uniform vocabulary produces
+/// near-equal document frequencies, so it rarely exercises the
+/// df-ratio-gated router branches — the 2-term WAND rare-anchor
+/// (`hi_df ≥ lo_df·16`) and the anchored OR count (`max_df ≥
+/// others·8`). Skewing the frequencies makes those branches fire.
+fn skewed_corpus_strategy() -> impl Strategy<Value = Vec<Vec<usize>>> {
+    let token = prop_oneof![
+        12 => 0usize..2,
+        1 => 2usize..VOCAB.len(),
+    ];
+    let doc = prop::collection::vec(token, 1..=max_doc_len());
+    prop::collection::vec(doc, 1..=max_docs())
+}
+
 fn atoms_strategy() -> impl Strategy<Value = Vec<Atom>> {
     let atom = (0u8..3u8, prop::collection::vec(0..VOCAB.len(), 1..=3))
         .prop_map(|(polarity, tokens)| Atom { polarity, tokens });
@@ -332,6 +348,20 @@ proptest! {
     #[test]
     fn fuzz_bm25_matches_brute_force(
         corpus in corpus_strategy(),
+        atoms in atoms_strategy(),
+        and_mode in any::<bool>(),
+        k in 1usize..=(max_docs() + 16),
+    ) {
+        run_case(&corpus, &atoms, and_mode, k)?;
+    }
+
+    /// Same agreement contract as [`fuzz_bm25_matches_brute_force`], but
+    /// over a skewed corpus so the rare-anchor and dominant-term router
+    /// branches — which a uniform vocabulary rarely triggers — are
+    /// exercised against the same brute-force reference.
+    #[test]
+    fn fuzz_bm25_skewed_vocab_matches_brute_force(
+        corpus in skewed_corpus_strategy(),
         atoms in atoms_strategy(),
         and_mode in any::<bool>(),
         k in 1usize..=(max_docs() + 16),

--- a/tests/superfile/fts/fuzz_oracle.rs
+++ b/tests/superfile/fts/fuzz_oracle.rs
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Property-based BM25 correctness oracle for the superfile FTS
+//! pipeline.
+//!
+//! The hand-planted oracles in [`super::brute_force_oracle`] pin
+//! individual kernels with carefully chosen mod-arithmetic corpora —
+//! coverage is only as good as the cases someone thought to write, and
+//! the router's branch *boundaries* (the exact df/k where dispatch
+//! flips kernel) are lightly exercised. This module instead generates
+//! random corpora and random clause/phrase queries and diffs the
+//! reader against the textbook [`BruteForceBm25`] reference on every
+//! case, so coverage tracks the router's actual behaviour space rather
+//! than an enumerated list.
+//!
+//! ## Why this stays exact (no quantization slack)
+//!
+//! Production scores read a *quantized* length-norm table, so the
+//! kernel oracles carry a `1e-3` tolerance. Here every generated doc
+//! is capped at [`MAX_DOC_LEN_HARD`] (< `LEN_QUANT_EXACT_MAX = 16`)
+//! tokens, which lands entirely in the norm table's exact region — the
+//! reader and the oracle then compute the *same* length norm, and the
+//! only residual is f64-vs-f32 idf rounding plus BM25 sum operand
+//! order, both far under the `1e-3` bar. Norm quantization on long
+//! docs is a separate concern, pinned by
+//! [`super::brute_force_oracle::quantized_norms_preserve_topk_ranking_on_long_docs`].
+//!
+//! ## Comparison contract
+//!
+//! The query is generated as a *string* and both sides interpret it
+//! through the same parser (`parse` + `into_clauses(mode)`), so clause
+//! semantics can never diverge by construction. Then:
+//!
+//! * the returned match set is always a subset of the oracle's full
+//!   match set, and its size is exactly `min(k, match_count)`;
+//! * when `k` covers every match, the match sets are equal and each
+//!   doc's score matches the oracle within tolerance;
+//! * when `k` truncates, the *multiset* of returned scores equals the
+//!   oracle's top-`k` scores within tolerance — robust to tie
+//!   reordering at the head and at the k-boundary, which is the only
+//!   place the reader and a doc-id-tie-breaking oracle may legitimately
+//!   pick different docs for the same score.
+//!
+//! ## Scale (env-tunable)
+//!
+//! The default corpus/case sizes are capped so the suite stays fast in
+//! CI; a deeper run is on-demand via env overrides (there is no nightly
+//! lane): `PROPTEST_CASES`, `INFINO_FTS_FUZZ_MAX_DOCS`,
+//! `INFINO_FTS_FUZZ_MAX_DOC_LEN` (hard-capped at 15 to keep norms
+//! exact), `INFINO_FTS_FUZZ_MAX_ATOMS`.
+
+use std::collections::HashSet;
+
+use infino::{
+    superfile::{SuperfileReader, fts::reader::BoolMode},
+    test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer},
+};
+use proptest::{prelude::*, test_runner::TestCaseError};
+
+use crate::fts::brute_force_oracle::build_infino_superfile_positional;
+
+/// Small shared vocabulary. Kept short so terms co-occur, intersect,
+/// and (across enough docs) form dense bitset blocks — the shapes the
+/// router branches on — instead of every doc being disjoint.
+const VOCAB: &[&str] = &[
+    "alpha", "beta", "gamma", "delta", "rust", "async", "web", "tokio", "go", "data",
+];
+
+/// Absolute ceiling on generated doc length. Must stay `<
+/// LEN_QUANT_EXACT_MAX` (16) so every doc's length norm is stored
+/// exactly and the reader/oracle norms agree bit-for-bit.
+const MAX_DOC_LEN_HARD: usize = 15;
+
+/// Score-equality tolerance. The two scorers share the identical BM25
+/// formula and (with exact norms) identical inputs; this only absorbs
+/// f64-vs-f32 idf rounding and sum operand order.
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+
+/// Read a `usize` cap from an env var, falling back to `default`.
+fn env_cap(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+/// Default proptest case count — modest for CI, overridable via the
+/// standard `PROPTEST_CASES` env var.
+fn cases() -> u32 {
+    env_cap("PROPTEST_CASES", 96) as u32
+}
+
+/// Max docs per generated corpus. Default crosses several 128-doc PFOR
+/// blocks so block-crossing kernels are reached organically.
+fn max_docs() -> usize {
+    env_cap("INFINO_FTS_FUZZ_MAX_DOCS", 400).clamp(1, 4096)
+}
+
+/// Max tokens per generated doc — hard-clamped to keep norms exact.
+fn max_doc_len() -> usize {
+    env_cap("INFINO_FTS_FUZZ_MAX_DOC_LEN", 12).clamp(1, MAX_DOC_LEN_HARD)
+}
+
+/// Max clause atoms per generated query.
+fn max_atoms() -> usize {
+    env_cap("INFINO_FTS_FUZZ_MAX_ATOMS", 4).clamp(1, 6)
+}
+
+/// One generated query atom: a polarity (`+`/bare/`-`) and 1..=3 vocab
+/// tokens (one token ⇒ a term, more ⇒ a phrase).
+#[derive(Clone, Debug)]
+struct Atom {
+    /// 0 = must (`+`), 1 = should (bare), 2 = negative (`-`).
+    polarity: u8,
+    /// Indices into [`VOCAB`].
+    tokens: Vec<usize>,
+}
+
+/// A corpus is `n_docs` docs, each a bag of vocab-token indices.
+fn corpus_strategy() -> impl Strategy<Value = Vec<Vec<usize>>> {
+    let doc = prop::collection::vec(0..VOCAB.len(), 1..=max_doc_len());
+    prop::collection::vec(doc, 1..=max_docs())
+}
+
+fn atoms_strategy() -> impl Strategy<Value = Vec<Atom>> {
+    let atom = (0u8..3u8, prop::collection::vec(0..VOCAB.len(), 1..=3))
+        .prop_map(|(polarity, tokens)| Atom { polarity, tokens });
+    prop::collection::vec(atom, 1..=max_atoms())
+}
+
+/// Render an atom to its query-string form (`+term`, `term`, `-term`,
+/// or the quoted-phrase variants).
+fn render_atom(a: &Atom) -> String {
+    let body = if a.tokens.len() == 1 {
+        VOCAB[a.tokens[0]].to_string()
+    } else {
+        let words: Vec<&str> = a.tokens.iter().map(|&i| VOCAB[i]).collect();
+        format!("\"{}\"", words.join(" "))
+    };
+    match a.polarity {
+        0 => format!("+{body}"),
+        2 => format!("-{body}"),
+        _ => body,
+    }
+}
+
+/// Build a well-formed query string from generated atoms: dedup
+/// identical rendered atoms (repeated-term scoring is a deliberately
+/// separate concern), and guarantee at least one positive clause so
+/// the query never trips the `NegationOnly` error.
+fn build_query(atoms: &[Atom]) -> String {
+    let mut atoms = atoms.to_vec();
+    // Guarantee a positive: if every atom is a negative, flip the first
+    // to a bare should.
+    if atoms.iter().all(|a| a.polarity == 2) {
+        atoms[0].polarity = 1;
+    }
+    let mut seen = HashSet::new();
+    let mut rendered = Vec::new();
+    for a in &atoms {
+        let r = render_atom(a);
+        if seen.insert(r.clone()) {
+            rendered.push(r);
+        }
+    }
+    rendered.join(" ")
+}
+
+/// Shared tokio runtime — one per test-fn invocation, reused across all
+/// proptest cases (each case only awaits I/O-free in-memory reads).
+fn rt() -> &'static tokio::runtime::Runtime {
+    use std::sync::OnceLock;
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build fuzz runtime")
+    })
+}
+
+/// Run one generated (corpus, query, mode, k) case and assert the
+/// reader agrees with the brute-force oracle.
+fn run_case(
+    corpus_idx: &[Vec<usize>],
+    atoms: &[Atom],
+    and_mode: bool,
+    k: usize,
+) -> Result<(), TestCaseError> {
+    // Materialize the corpus text; doc_id == row index so the reader's
+    // local_doc_id is the user id (the invariant the oracle assumes).
+    let owned: Vec<(u64, String)> = corpus_idx
+        .iter()
+        .enumerate()
+        .map(|(i, toks)| {
+            let text = toks.iter().map(|&t| VOCAB[t]).collect::<Vec<_>>().join(" ");
+            (i as u64, text)
+        })
+        .collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+
+    let reader: SuperfileReader = build_infino_superfile_positional(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+
+    let query = build_query(atoms);
+    let mode = if and_mode {
+        BoolMode::And
+    } else {
+        BoolMode::Or
+    };
+
+    // Reader result.
+    let got: Vec<(u64, f32)> = rt()
+        .block_on(reader.bm25_hits_async("title", &query, k, mode))
+        .map_err(|e| {
+            TestCaseError::fail(format!(
+                "reader error on {query:?} (mode={mode:?}, k={k}): {e}"
+            ))
+        })?
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+
+    // Oracle full match set (k = n) via the same parsed clauses, so the
+    // clause interpretation can never diverge from the reader's.
+    let clauses = tok.parse(&query).into_clauses(mode);
+    let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
+        v.into_iter().map(|t| t.into_owned()).collect()
+    };
+    let own_ph = |v: Vec<Vec<std::borrow::Cow<'_, str>>>| -> Vec<Vec<String>> {
+        v.into_iter()
+            .map(|p| p.into_iter().map(|t| t.into_owned()).collect())
+            .collect()
+    };
+    let want_full = oracle.top_k_atoms(
+        &own(clauses.musts),
+        &own_ph(clauses.must_phrases),
+        &own(clauses.shoulds),
+        &own_ph(clauses.should_phrases),
+        &own(clauses.negatives),
+        &own_ph(clauses.negative_phrases),
+        owned.len(),
+    );
+
+    let want_ids: HashSet<u64> = want_full.iter().map(|(d, _)| *d).collect();
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();
+
+    // Cardinality: the reader returns exactly the k highest matches (no
+    // floor here), i.e. min(k, match_count).
+    let expected_len = k.min(want_full.len());
+    prop_assert_eq!(
+        got.len(),
+        expected_len,
+        "hit count: query={:?} mode={:?} k={} matches={}",
+        query,
+        mode,
+        k,
+        want_full.len()
+    );
+
+    // Every returned doc is a real match.
+    prop_assert!(
+        got_ids.is_subset(&want_ids),
+        "returned docs not all matches: query={:?} mode={:?} k={} extra={:?}",
+        query,
+        mode,
+        k,
+        got_ids.difference(&want_ids).collect::<Vec<_>>()
+    );
+
+    if k >= want_full.len() {
+        // Full result: exact set + per-doc score.
+        prop_assert_eq!(
+            &got_ids,
+            &want_ids,
+            "full-result set mismatch: query={:?} mode={:?}",
+            query,
+            mode
+        );
+        let want_scores: std::collections::HashMap<u64, f32> = want_full.iter().copied().collect();
+        for (d, s) in &got {
+            let w = want_scores[d];
+            prop_assert!(
+                (s - w).abs() <= SCORE_ABS_TOLERANCE,
+                "score mismatch on doc {}: reader={} oracle={} query={:?} mode={:?}",
+                d,
+                s,
+                w,
+                query,
+                mode
+            );
+        }
+    }
+
+    // Score multiset (both regimes): the returned scores, sorted
+    // descending, equal the oracle's top-k scores sorted descending,
+    // within tolerance. Ties may reorder docs but never scores.
+    let mut got_scores: Vec<f32> = got.iter().map(|(_, s)| *s).collect();
+    got_scores.sort_unstable_by(|a, b| b.partial_cmp(a).expect("finite scores"));
+    let mut want_scores: Vec<f32> = want_full.iter().map(|(_, s)| *s).collect();
+    want_scores.sort_unstable_by(|a, b| b.partial_cmp(a).expect("finite scores"));
+    want_scores.truncate(k);
+    prop_assert_eq!(
+        got_scores.len(),
+        want_scores.len(),
+        "score-vec length: query={:?} mode={:?} k={}",
+        query,
+        mode,
+        k
+    );
+    for (g, w) in got_scores.iter().zip(&want_scores) {
+        prop_assert!(
+            (g - w).abs() <= SCORE_ABS_TOLERANCE,
+            "top-k score mismatch: reader={} oracle={} query={:?} mode={:?} k={}",
+            g,
+            w,
+            query,
+            mode,
+            k
+        );
+    }
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: cases(), ..ProptestConfig::default() })]
+
+    /// The reader's BM25 search agrees with textbook brute-force BM25
+    /// on every generated (corpus, clause/phrase query, mode, k).
+    #[test]
+    fn fuzz_bm25_matches_brute_force(
+        corpus in corpus_strategy(),
+        atoms in atoms_strategy(),
+        and_mode in any::<bool>(),
+        k in 1usize..=(max_docs() + 16),
+    ) {
+        run_case(&corpus, &atoms, and_mode, k)?;
+    }
+}

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -10,4 +10,5 @@ pub mod negation;
 pub mod phrase;
 pub mod pipeline;
 pub mod prefix_and_floor;
+pub mod standard_tokenizer;
 pub mod uses_spill_builder;

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
 pub mod brute_force_oracle;
+pub mod edge_and_unranked;
 pub mod fuzz_oracle;
 pub mod multi_column;
 pub mod must_should;

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
 pub mod brute_force_oracle;
+pub mod fuzz_oracle;
 pub mod must_should;
 pub mod negation;
 pub mod phrase;

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -8,4 +8,5 @@ pub mod must_should;
 pub mod negation;
 pub mod phrase;
 pub mod pipeline;
+pub mod prefix_and_floor;
 pub mod uses_spill_builder;

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod brute_force_oracle;
 pub mod fuzz_oracle;
+pub mod multi_column;
 pub mod must_should;
 pub mod negation;
 pub mod phrase;

--- a/tests/superfile/fts/multi_column.rs
+++ b/tests/superfile/fts/multi_column.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Oracle tests for multi-column weighted BM25 (`bm25_search_multi`,
+//! "most fields" semantics: each column is scored independently and the
+//! per-column scores are summed by weight).
+//!
+//! The pipeline test only checks *membership* of the multi-column
+//! result. This module pins the *scores*: a doc's combined score must
+//! equal `Σ_col weight_col · bm25_col(doc, query)`, where each column's
+//! BM25 uses that column's own df / avgdl / doc-length — the surface no
+//! single-column oracle can reach. The reference is two independent
+//! [`BruteForceBm25`] indices (one per column) combined by the same
+//! weighted sum, cross-checked against the reader across several weight
+//! configurations.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use arrow_array::{LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use bytes::Bytes;
+use infino::{
+    superfile::{
+        SuperfileReader,
+        builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
+        fts::reader::BoolMode,
+    },
+    test_helpers::{brute_force_bm25::BruteForceBm25, decimal128_ids, default_tokenizer},
+};
+
+/// Score-equality tolerance between the two BM25 scorers.
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+
+/// Build a two-FTS-column superfile (`title`, `body`) from a corpus of
+/// `(doc_id, title_text, body_text)`. `doc_id` == row index, so the
+/// reader's `local_doc_id` is the user id.
+fn build_two_column(corpus: &[(u64, &str, &str)]) -> SuperfileReader {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("doc_id", DataType::Decimal128(38, 0), false),
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("body", DataType::LargeUtf8, false),
+    ]));
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![
+            FtsConfig {
+                column: "title".into(),
+                positions: false,
+            },
+            FtsConfig {
+                column: "body".into(),
+                positions: false,
+            },
+        ],
+        vec![],
+        Some(default_tokenizer()),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let ids = decimal128_ids(corpus.iter().map(|(i, _, _)| *i));
+    let titles = LargeStringArray::from(corpus.iter().map(|(_, t, _)| *t).collect::<Vec<_>>());
+    let bodies = LargeStringArray::from(corpus.iter().map(|(_, _, b)| *b).collect::<Vec<_>>());
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(ids), Arc::new(titles), Arc::new(bodies)],
+    )
+    .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    SuperfileReader::open(bytes).expect("open superfile")
+}
+
+/// The "most fields" oracle: per-doc `Σ_col weight · bm25_col(doc)`,
+/// where each column's per-doc score comes from an independent
+/// brute-force index over that column's text. A doc is in the result
+/// iff it matches the query in at least one column. Returns descending
+/// by score, doc-id tie-break — matching the reader's contract.
+fn multi_column_oracle(
+    per_column: &[(f32, &BruteForceBm25)],
+    query: &str,
+    k: usize,
+) -> Vec<(u64, f32)> {
+    let tok = default_tokenizer();
+    let mut summed: HashMap<u64, f32> = HashMap::new();
+    for (weight, oracle) in per_column {
+        // k = n_docs ⇒ every matching doc in this column, fully scored.
+        for (doc, score) in oracle.top_k(query, oracle.n_docs() as usize, tok.as_ref()) {
+            *summed.entry(doc).or_insert(0.0) += weight * score;
+        }
+    }
+    let mut scored: Vec<(u64, f32)> = summed.into_iter().collect();
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0))
+    });
+    scored.truncate(k);
+    scored
+}
+
+/// Planted two-column corpus. `rust` appears in various title/body
+/// combinations so the weighting is observable: some docs match only in
+/// title, some only in body, some in both, with different tfs and doc
+/// lengths per column.
+fn corpus() -> Vec<(u64, &'static str, &'static str)> {
+    vec![
+        (0, "rust async runtime", "tokio reactor loop"), // title-only match for "rust"
+        (1, "python data tools", "rust ffi bindings safe"), // body-only match
+        (2, "rust web framework", "rust actix axum tower"), // both columns
+        (3, "go concurrency model", "channels select goroutine"), // no match
+        (4, "rust rust systems", "low level rust rust rust"), // high tf both columns
+        (5, "java spring boot", "enterprise beans only"), // no match
+        (6, "rust", "a b c d e f g h rust"),             // short title vs long body (dl-norm)
+        (7, "embedded rust firmware", "rust"),           // long title vs short body
+    ]
+}
+
+/// Cross-check the reader's `bm25_search_multi` against the weighted
+/// two-column oracle for a query at several weight configs.
+async fn assert_multi_matches_oracle(
+    reader: &SuperfileReader,
+    title_oracle: &BruteForceBm25,
+    body_oracle: &BruteForceBm25,
+    query: &str,
+    title_w: f32,
+    body_w: f32,
+    k: usize,
+) {
+    let got = reader
+        .bm25_search_multi(
+            &[("title", title_w), ("body", body_w)],
+            query,
+            k,
+            BoolMode::Or,
+        )
+        .await
+        .expect("bm25_search_multi");
+    let want = multi_column_oracle(&[(title_w, title_oracle), (body_w, body_oracle)], query, k);
+
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d as u64).collect();
+    let want_ids: HashSet<u64> = want.iter().map(|(d, _)| *d).collect();
+    // Full k (k >= match count): the sets must be identical.
+    if k >= want.len() {
+        assert_eq!(
+            got_ids, want_ids,
+            "multi({title_w},{body_w}) {query:?}: match sets disagree"
+        );
+    } else {
+        assert!(
+            got_ids.is_subset(&want_ids),
+            "multi({title_w},{body_w}) {query:?}: returned a non-match"
+        );
+    }
+
+    // Per-doc weighted score must match the oracle within tolerance.
+    let want_scores: HashMap<u64, f32> = want.iter().map(|(d, s)| (*d, *s)).collect();
+    for (d, s) in &got {
+        let w = want_scores[&(*d as u64)];
+        assert!(
+            (s - w).abs() <= SCORE_ABS_TOLERANCE,
+            "multi({title_w},{body_w}) {query:?} doc {d}: reader={s} oracle={w}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn multi_column_weighted_scores_match_oracle() {
+    let corp = corpus();
+    let reader = build_two_column(&corp);
+    let tok = default_tokenizer();
+    let title_corpus: Vec<(u64, &str)> = corp.iter().map(|(i, t, _)| (*i, *t)).collect();
+    let body_corpus: Vec<(u64, &str)> = corp.iter().map(|(i, _, b)| (*i, *b)).collect();
+    let title_oracle = BruteForceBm25::index(&title_corpus, tok.as_ref());
+    let body_oracle = BruteForceBm25::index(&body_corpus, tok.as_ref());
+
+    // Several weightings, including the asymmetric and degenerate (0)
+    // cases, so the weight actually drives the combined score and rank.
+    for (tw, bw) in [(1.0, 1.0), (2.0, 1.0), (1.0, 3.0), (5.0, 0.0), (0.0, 1.0)] {
+        for k in [8usize, 3] {
+            assert_multi_matches_oracle(&reader, &title_oracle, &body_oracle, "rust", tw, bw, k)
+                .await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn multi_column_multi_term_query_scores_match_oracle() {
+    // A two-term query so each column contributes an OR union that the
+    // weighted sum must combine correctly across columns.
+    let corp = corpus();
+    let reader = build_two_column(&corp);
+    let tok = default_tokenizer();
+    let title_corpus: Vec<(u64, &str)> = corp.iter().map(|(i, t, _)| (*i, *t)).collect();
+    let body_corpus: Vec<(u64, &str)> = corp.iter().map(|(i, _, b)| (*i, *b)).collect();
+    let title_oracle = BruteForceBm25::index(&title_corpus, tok.as_ref());
+    let body_oracle = BruteForceBm25::index(&body_corpus, tok.as_ref());
+
+    for (tw, bw) in [(1.0, 1.0), (3.0, 1.0), (1.0, 2.0)] {
+        assert_multi_matches_oracle(
+            &reader,
+            &title_oracle,
+            &body_oracle,
+            "rust async",
+            tw,
+            bw,
+            8,
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn multi_column_weight_scales_single_column_match_linearly() {
+    // Doc 0 matches "rust" only in its title ("rust async runtime"); its
+    // body ("tokio reactor loop") has no "rust", so the body column
+    // contributes exactly 0 to doc 0's combined score. The combined
+    // score therefore equals `title_weight · title_score(doc 0)`, and
+    // must scale *linearly* with the title weight — a direct proof the
+    // weight is multiplied in, not ignored, that needs no oracle.
+    let corp = corpus();
+    let reader = build_two_column(&corp);
+
+    let score_of = |hits: Vec<(u32, f32)>, doc: u32| -> f32 {
+        hits.iter()
+            .find(|(d, _)| *d == doc)
+            .map(|(_, s)| *s)
+            .expect("doc present in results")
+    };
+
+    let s1 = score_of(
+        reader
+            .bm25_search_multi(&[("title", 1.0), ("body", 1.0)], "rust", 8, BoolMode::Or)
+            .await
+            .expect("w=1"),
+        0,
+    );
+    let s2 = score_of(
+        reader
+            .bm25_search_multi(&[("title", 2.0), ("body", 1.0)], "rust", 8, BoolMode::Or)
+            .await
+            .expect("w=2"),
+        0,
+    );
+    // Body contributes 0 to doc 0, so doubling the title weight doubles
+    // the whole combined score.
+    assert!(
+        (s2 - 2.0 * s1).abs() <= SCORE_ABS_TOLERANCE,
+        "title-only doc 0: score must scale with title weight — s(w=1)={s1}, s(w=2)={s2}"
+    );
+    assert!(s1 > 0.0, "doc 0 must score for a title match");
+}

--- a/tests/superfile/fts/prefix_and_floor.rs
+++ b/tests/superfile/fts/prefix_and_floor.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Oracle tests for two reader surfaces the single-column term/phrase
+//! oracles don't exercise:
+//!
+//! * **Prefix search** (`bm25_search_prefix`): the FST expands the
+//!   prefix to every indexed term that starts with it and runs an OR
+//!   over the expansion. Cross-checked against the brute-force OR of the
+//!   same expansion computed from corpus truth.
+//! * **Score-floor pruning** (`bm25_search_pretokenized_with_floor`):
+//!   the floor is a work-pruning hint the supertable fan-out uses to
+//!   share the global kth-best across segments. Verified by its
+//!   load-bearing contract — a floor set at the unfloored kth-best score
+//!   must preserve the top-k exactly (same docs, same scores) — rather
+//!   than as an exact output filter, which it is not: under a large k a
+//!   kernel may still emit some below-floor docs (they lose in the
+//!   global merge).
+
+use std::collections::HashSet;
+
+use infino::{
+    superfile::{SuperfileReader, fts::reader::BoolMode},
+    test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer},
+};
+
+use crate::fts::brute_force_oracle::{build_infino_superfile, build_multi_block_corpus};
+
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+const K_ALL: usize = 64;
+
+// ── prefix search ─────────────────────────────────────────────────────
+
+/// Corpus with deliberate shared prefixes so an expansion is non-trivial:
+/// `run`, `runtime`, `running`, `rust`, `rustacean` all share `ru`, and
+/// `rust*` is its own sub-group. `python`/`pandas` share `p` but never
+/// `ru`/`rust`.
+fn prefix_corpus() -> Vec<(u64, &'static str)> {
+    vec![
+        (0, "run the loop"),
+        (1, "runtime scheduler tokio"),
+        (2, "running fast async"),
+        (3, "rust systems language"),
+        (4, "rustacean community crate"),
+        (5, "rust runtime bindings"), // two ru*-terms in one doc → OR sums both
+        (6, "python data pipeline"),
+        (7, "pandas dataframe numpy"),
+        (8, "go concurrency channels"),
+    ]
+}
+
+/// Distinct indexed terms (whitespace tokens, lowercased) beginning with
+/// `prefix` — the set the FST expansion must reproduce.
+fn expansion(corp: &[(u64, &str)], prefix: &str) -> Vec<String> {
+    let mut terms: HashSet<String> = HashSet::new();
+    for (_, text) in corp {
+        for w in text.split_whitespace() {
+            if w.starts_with(prefix) {
+                terms.insert(w.to_string());
+            }
+        }
+    }
+    terms.into_iter().collect()
+}
+
+async fn assert_prefix_matches_oracle(
+    reader: &SuperfileReader,
+    oracle: &BruteForceBm25,
+    corp: &[(u64, &str)],
+    prefix: &str,
+    k: usize,
+) {
+    let got = reader
+        .bm25_search_prefix("title", prefix, k)
+        .await
+        .expect("prefix search")
+        .0;
+    let terms = expansion(corp, prefix);
+    let want = oracle.top_k_terms(&terms, k);
+
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d as u64).collect();
+    let want_ids: HashSet<u64> = want.iter().map(|(d, _)| *d).collect();
+    if k >= want.len() {
+        assert_eq!(got_ids, want_ids, "prefix {prefix:?}: match sets disagree");
+    } else {
+        assert!(
+            got_ids.is_subset(&want_ids),
+            "prefix {prefix:?}: returned a non-match"
+        );
+    }
+    let want_scores: std::collections::HashMap<u64, f32> = want.into_iter().collect();
+    for (d, s) in &got {
+        let w = want_scores[&(*d as u64)];
+        assert!(
+            (s - w).abs() <= SCORE_ABS_TOLERANCE,
+            "prefix {prefix:?} doc {d}: reader={s} oracle={w}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn prefix_expansion_matches_brute_force_or() {
+    let corp = prefix_corpus();
+    let reader = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+
+    // Broad ("ru*" = run/runtime/running/rust/rustacean), narrower
+    // ("rust*" = rust/rustacean), and single-term ("runt*" = runtime).
+    for prefix in ["ru", "run", "rust", "runt", "p"] {
+        assert_prefix_matches_oracle(&reader, &oracle, &corp, prefix, K_ALL).await;
+    }
+    // Truncated top-k over the broad expansion keeps the pruning bar live.
+    assert_prefix_matches_oracle(&reader, &oracle, &corp, "ru", 2).await;
+}
+
+#[tokio::test]
+async fn prefix_uppercase_is_normalized() {
+    // The prefix is lowercased before FST lookup, so "RU" and "ru" expand
+    // to the same terms.
+    let corp = prefix_corpus();
+    let reader = build_infino_superfile(&corp);
+    let upper = reader
+        .bm25_search_prefix("title", "RU", K_ALL)
+        .await
+        .expect("upper")
+        .0;
+    let lower = reader
+        .bm25_search_prefix("title", "ru", K_ALL)
+        .await
+        .expect("lower")
+        .0;
+    assert_eq!(upper, lower, "prefix must be case-normalized");
+    assert!(!lower.is_empty(), "ru* must expand to something");
+}
+
+#[tokio::test]
+async fn prefix_no_match_returns_empty() {
+    let corp = prefix_corpus();
+    let reader = build_infino_superfile(&corp);
+    let hits = reader
+        .bm25_search_prefix("title", "zzz", K_ALL)
+        .await
+        .expect("prefix search")
+        .0;
+    assert!(hits.is_empty(), "no term starts with zzz");
+}
+
+// ── score-floor pruning ───────────────────────────────────────────────
+
+/// Verify the score floor's load-bearing contract: **top-k preservation
+/// under a floor at the kth-best score**. The supertable fan-out seeds
+/// each segment's floor with the global kth-best so segments skip work
+/// on docs that can't make the global top-k; correctness requires that a
+/// floor at or below the true kth-best never removes a doc that belongs
+/// in the top-k. (The floor is a work-pruning hint, not an output
+/// filter — under a large k a kernel like MaxScore may still emit some
+/// below-floor docs — so "the output shrinks" is not a valid universal
+/// assertion; top-k preservation is.)
+///
+/// Concretely: take the unfloored top-k, set the floor to its kth score,
+/// re-run floored, and require an identical top-k (same docs, same
+/// scores). A floor that drops a top-k doc, or that treats "equal to the
+/// floor" as pruned, backfills with a lower-scoring doc and diverges.
+/// `terms` is pre-tokenized; `mode` selects the kernel family.
+async fn assert_floor_preserves_topk(reader: &SuperfileReader, terms: &[&str], mode: BoolMode) {
+    const K: usize = 16;
+    let full = reader
+        .bm25_search_pretokenized_with_floor("title", terms, K, mode, f32::NEG_INFINITY)
+        .await
+        .expect("unfloored top-k");
+    assert_eq!(
+        full.len(),
+        K,
+        "corpus must supply more than K matches for {terms:?} {mode:?}"
+    );
+
+    // Floor at the kth-best score — an active, load-bearing value: the
+    // kernels prune every block whose max can't reach it, yet the full
+    // top-k must still come back because all K docs are at or above it.
+    let kth = full.last().expect("k>0").1;
+    let floored = reader
+        .bm25_search_pretokenized_with_floor("title", terms, K, mode, kth)
+        .await
+        .expect("floored top-k");
+
+    let full_ids: HashSet<u64> = full.iter().map(|(d, _)| *d as u64).collect();
+    let got_ids: HashSet<u64> = floored.iter().map(|(d, _)| *d as u64).collect();
+    assert_eq!(
+        got_ids, full_ids,
+        "floor={kth} on {terms:?} {mode:?}: floored top-k dropped/added a doc vs unfloored"
+    );
+
+    // Scores identical (compare per doc; the floor must not perturb them).
+    let full_scores: std::collections::HashMap<u64, f32> =
+        full.iter().map(|(d, s)| (*d as u64, *s)).collect();
+    for (d, s) in &floored {
+        let w = full_scores[&(*d as u64)];
+        assert!(
+            (s - w).abs() <= SCORE_ABS_TOLERANCE,
+            "floor perturbed a top-k score on doc {d}: floored={s} unfloored={w}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn floor_single_term_bmw_preserves_topk() {
+    // Single term ⇒ the BMW kernel; the floor seeds its threshold.
+    let owned = build_multi_block_corpus();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let reader = build_infino_superfile(&refs);
+    assert_floor_preserves_topk(&reader, &["alpha"], BoolMode::Or).await;
+}
+
+#[tokio::test]
+async fn floor_multi_term_maxscore_preserves_topk() {
+    // Multi-term OR ⇒ MaxScore+BMM; the floor lifts the initial bar.
+    let owned = build_multi_block_corpus();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let reader = build_infino_superfile(&refs);
+    assert_floor_preserves_topk(&reader, &["alpha", "beta", "gamma"], BoolMode::Or).await;
+}
+
+#[tokio::test]
+async fn floor_and_intersection_preserves_topk() {
+    // AND intersection ⇒ block-max-AND skips seeded from the floor.
+    let owned = build_multi_block_corpus();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let reader = build_infino_superfile(&refs);
+    assert_floor_preserves_topk(&reader, &["alpha", "beta"], BoolMode::And).await;
+}

--- a/tests/superfile/fts/standard_tokenizer.rs
+++ b/tests/superfile/fts/standard_tokenizer.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! BM25 oracle for the `standard` (UAX#29) analyzer.
+//!
+//! Every other oracle in this suite builds and queries under the
+//! default `ascii_lower` tokenizer. This module builds the superfile
+//! *and* indexes the brute-force reference under [`StandardTokenizer`],
+//! over a corpus whose text (non-ASCII letters, punctuation, digits)
+//! the two analyzers segment differently — so the reader's standard
+//! query+doc tokenization and scoring are pinned against a reference
+//! that tokenizes the same way, and a bug specific to the standard path
+//! (wrong analyzer selected, query tokenized under a different analyzer
+//! than the docs) diverges from the oracle.
+
+use std::{collections::HashSet, sync::Arc};
+
+use arrow_array::{LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use bytes::Bytes;
+use infino::{
+    superfile::{
+        SuperfileReader,
+        builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
+        fts::{
+            reader::BoolMode,
+            tokenize::{StandardTokenizer, Tokenizer},
+        },
+    },
+    test_helpers::{brute_force_bm25::BruteForceBm25, decimal128_ids},
+};
+
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+const K_ALL: usize = 64;
+
+/// Build a single-FTS-column superfile under the `standard` analyzer.
+/// `doc_id` == row index.
+fn build_standard(corpus: &[(u64, &str)]) -> SuperfileReader {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("doc_id", DataType::Decimal128(38, 0), false),
+        Field::new("title", DataType::LargeUtf8, false),
+    ]));
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        vec![],
+        Some(Arc::new(StandardTokenizer)),
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let ids = decimal128_ids(corpus.iter().map(|(i, _)| *i));
+    let titles = LargeStringArray::from(corpus.iter().map(|(_, t)| *t).collect::<Vec<_>>());
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
+        .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    SuperfileReader::open(bytes).expect("open superfile")
+}
+
+/// Corpus with text the `standard` analyzer segments differently from
+/// `ascii_lower`: accented letters, apostrophes, digits, punctuation.
+fn corpus() -> Vec<(u64, &'static str)> {
+    vec![
+        (0, "rust async runtime"),
+        (1, "café résumé naïve"), // non-ASCII: dropped entirely by ascii_lower
+        (2, "the rust programming café"), // "café" co-occurs with "rust"
+        (3, "version 2 point 0 release"),
+        (4, "rust systems programming"),
+        (5, "async await futures rust"),
+        (6, "python data café pipeline"), // "café" without "rust"
+        (7, "naïve bayes classifier"),    // "naïve" again
+    ]
+}
+
+/// Reader vs standard-tokenizer oracle for `query`: identical match set
+/// (at k=all) and per-doc scores within tolerance.
+async fn assert_matches_oracle(
+    reader: &SuperfileReader,
+    oracle: &BruteForceBm25,
+    query: &str,
+    mode: BoolMode,
+) {
+    let got: Vec<(u64, f32)> = reader
+        .bm25_hits_async("title", query, K_ALL, mode)
+        .await
+        .expect("bm25 search")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    // Score the same clauses the reader parsed, so the comparison can't
+    // diverge on tokenization of the query string itself.
+    let tok = StandardTokenizer;
+    let clauses = tok.parse(query).into_clauses(mode);
+    let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
+        v.into_iter().map(|t| t.into_owned()).collect()
+    };
+    let want = oracle.top_k_clauses(
+        &own(clauses.musts),
+        &own(clauses.shoulds),
+        &own(clauses.negatives),
+        K_ALL,
+    );
+
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();
+    let want_ids: HashSet<u64> = want.iter().map(|(d, _)| *d).collect();
+    assert_eq!(
+        got_ids, want_ids,
+        "standard {query:?} {mode:?}: match sets disagree"
+    );
+    let want_scores: std::collections::HashMap<u64, f32> = want.into_iter().collect();
+    for (d, s) in &got {
+        let w = want_scores[d];
+        assert!(
+            (s - w).abs() <= SCORE_ABS_TOLERANCE,
+            "standard {query:?} doc {d}: reader={s} oracle={w}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn standard_tokenizer_agrees_with_oracle() {
+    let corp = corpus();
+    let reader = build_standard(&corp);
+    let oracle = BruteForceBm25::index(&corp, &StandardTokenizer as &dyn Tokenizer);
+    for (query, mode) in [
+        ("rust", BoolMode::Or),
+        ("café", BoolMode::Or),
+        ("rust café", BoolMode::Or),
+        ("rust café", BoolMode::And),
+        ("naïve", BoolMode::Or),
+        ("+rust café", BoolMode::Or),
+        ("rust -café", BoolMode::Or),
+    ] {
+        assert_matches_oracle(&reader, &oracle, query, mode).await;
+    }
+}
+
+#[tokio::test]
+async fn standard_tokenizer_indexes_non_ascii_terms() {
+    // Discriminating check that the standard analyzer is actually in
+    // force: "café" and "naïve" contain non-ASCII bytes that the default
+    // `ascii_lower` tokenizer drops entirely. Under `standard` they are
+    // real, searchable terms — so a non-empty result here proves the
+    // build/query path used the standard analyzer, not a silent
+    // ascii_lower fallback.
+    let corp = corpus();
+    let reader = build_standard(&corp);
+
+    let cafe = reader
+        .bm25_hits_async("title", "café", K_ALL, BoolMode::Or)
+        .await
+        .expect("search café");
+    let cafe_ids: HashSet<u64> = cafe.iter().map(|(d, _)| *d as u64).collect();
+    assert_eq!(
+        cafe_ids,
+        HashSet::from([1, 2, 6]),
+        "café is indexed as a term under the standard analyzer"
+    );
+
+    let naive = reader
+        .bm25_hits_async("title", "naïve", K_ALL, BoolMode::Or)
+        .await
+        .expect("search naïve");
+    let naive_ids: HashSet<u64> = naive.iter().map(|(d, _)| *d as u64).collect();
+    assert_eq!(
+        naive_ids,
+        HashSet::from([1, 7]),
+        "naïve indexed under standard"
+    );
+}


### PR DESCRIPTION
Expands the FTS BM25 correctness coverage so the optimized search
kernels can't silently drift from correct BM25. All changes are
test-only — no engine code is touched.

## What's added

- **Property-based oracle** (`fuzz_oracle.rs`): generates random corpora
  and random clause/phrase/mode/k query strings and diffs the reader
  against the textbook brute-force BM25 reference on every case. Both
  sides interpret the same generated query through the same parser, so
  clause semantics can't diverge by construction. Documents are capped
  below the length-norm table's exact region, so the comparison needs no
  quantization slack. A second variant uses a skewed vocabulary to drive
  the rare-anchor and dominant-term routing branches that a uniform
  vocabulary rarely produces. Corpus and case sizes are env-tunable and
  capped by default to keep CI fast.

- **Multi-column weighted search** (`multi_column.rs`): pins the per-doc
  score of `bm25_search_multi` against a weighted two-column reference
  (previously only membership was checked).

- **Prefix and score floor** (`prefix_and_floor.rs`): prefix expansion
  vs the brute-force OR of the same expansion; the score floor verified
  by top-k preservation across the single-term, multi-term and
  intersection kernels.

- **Edge cases and the unranked spine** (`edge_and_unranked.rs`): k=0,
  single-doc, all-equal-length (constant length norm), and duplicate
  query terms; `token_match` / `token_match_count` against corpus truth
  with the ordering and `count == ids.len()` invariants, plus the
  cross-check that a ranked search covering all matches has exactly
  `token_match_count` hits.

- **Standard (UAX#29) tokenizer** (`standard_tokenizer.rs`): builds and
  references under the standard analyzer over text with non-ASCII
  letters, apostrophes and digits, and confirms non-ASCII terms are
  indexed and searchable.

## Verification

`cargo fmt` clean, `clippy` clean, and the full FTS integration suite
(103 tests) passes, including fuzz stress runs of several thousand cases.
