### PR TITLE
fts: score block-max upper bound with the reader's quantized doc length

### DIFF
--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -3360,11 +3360,13 @@ struct TermScratch {
     doc_ids: Vec<u32>,
     /// Per-block tf column, same lifecycle as `doc_ids`.
     tfs: Vec<u32>,
-    /// Per-block BM25 upper bound for the skip table — the **exact**
-    /// maximum per-doc contribution over the block's docs (not the looser
-    /// `score(max_tf, min_dl)`, whose best-case tf and best-case dl need
-    /// not co-occur in one doc). A tighter bound lets the reader's
-    /// block-skip fire more often.
+    /// Per-block BM25 upper bound for the skip table — the maximum per-doc
+    /// contribution over the block's docs, scored with the same quantized
+    /// document length the reader uses (not the looser `score(max_tf,
+    /// min_dl)`, whose best-case tf and best-case dl need not co-occur in
+    /// one doc). Scoring against the quantized length keeps the bound a
+    /// true upper bound over query-time scores; a tighter bound lets the
+    /// reader's block-skip fire more often.
     block_ub_per_block: Vec<f32>,
     /// Per-term list of encoded blocks held across the meta + skip-
     /// table + block-bytes emit stages.
@@ -3637,16 +3639,29 @@ fn encode_and_emit_term<W: Write>(
             block_tfs.clear();
             block_doc_ids.extend(chunk.iter().map(|&(d, _)| d));
             block_tfs.extend(chunk.iter().map(|&(_, t)| t));
-            // Exact per-block BM25 upper bound: the max actual per-doc
-            // contribution over the block. score() rises with tf and falls
-            // with dl, so the looser `score(max_tf, min_dl)` over-estimates
-            // when the highest-tf doc isn't also the shortest. Computing the
-            // real max here (build-time, off the query path) tightens the
-            // skip-table bound so the reader skips more blocks.
+            // Tight per-block BM25 upper bound: the max per-doc contribution
+            // over the block. score() rises with tf and falls with dl, so the
+            // looser `score(max_tf, min_dl)` over-estimates when the
+            // highest-tf doc isn't also the shortest. Computing the real max
+            // here (build-time, off the query path) tightens the skip-table
+            // bound so the reader skips more blocks.
+            //
+            // Score against the *quantized* length the reader scores with —
+            // the resident norm table stores each length as a one-byte
+            // bucket and scores from its dequantized representative, which
+            // truncates the length downward. A shorter length means a
+            // smaller norm and thus a *higher* BM25 score, so bounding
+            // against the exact length would leave the stored max below the
+            // query-time score of that same doc and let the block-max skip
+            // drop a qualifying document.
             let block_ub = block_doc_ids
                 .iter()
                 .zip(block_tfs.iter())
-                .map(|(&d, &t)| bm25::score(idf_t, t, col_doc_lengths[d as usize], avgdl))
+                .map(|(&d, &t)| {
+                    let reader_dl =
+                        bm25::dequantize_len(bm25::quantize_len(col_doc_lengths[d as usize]));
+                    bm25::score(idf_t, t, reader_dl, avgdl)
+                })
                 .fold(0.0f32, f32::max);
             block_ub_per_block.push(block_ub);
             let block = Block {

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -817,3 +817,111 @@ impl TermCursor {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+
+    use crate::superfile::fts::{
+        bm25, builder::FtsBuilder, reader::FtsReader, tokenize::AsciiLowerTokenizer,
+    };
+
+    /// The per-block BM25 upper bound stored in the skip table must be a
+    /// valid upper bound over the *query-time* score of every document in
+    /// that block. Query-time scoring reads each document's length from the
+    /// byte-quantized norm table, which truncates the length downward — and
+    /// a shorter length yields a *higher* BM25 score. If the stored block
+    /// max is computed from the exact (un-truncated) length, it lands below
+    /// the query score of a doc whose length quantizes down, and the
+    /// block-max skip in the ranked-OR walk drops that doc from the top-k.
+    ///
+    /// This plants a term spanning several 128-doc blocks whose documents
+    /// all have a length in the quantize-down region, then walks the term's
+    /// cursor and asserts `block_max >= query_score` for every posting.
+    /// Without the length-consistent block bound the assertion fires on the
+    /// highest-tf doc in each block; a small-doc corpus (every length in the
+    /// exact-quantization region) never exercises it.
+    #[tokio::test]
+    async fn block_max_bounds_query_time_score() {
+        // A length that truncates under the one-byte length quantizer:
+        // `dequantize_len(quantize_len(200)) == 192`, so a length-200 doc is
+        // scored as if length 192 and scores *higher* than at its true
+        // length.
+        const DOC_LEN: usize = 200;
+        assert!(
+            bm25::dequantize_len(bm25::quantize_len(DOC_LEN as u32)) < DOC_LEN as u32,
+            "corpus doc length must quantize downward to exercise the bound"
+        );
+        // The term under test lives in this many docs — enough to span
+        // multiple 128-doc blocks so the block-max skip engages.
+        const TERM_DOCS: u32 = 260;
+        // Total corpus size. Kept well above `TERM_DOCS` so the term's IDF
+        // is large enough that the quantization-induced score gap clears the
+        // skip table's fixed-point rounding and the assertion is decisive.
+        const N_DOCS: u32 = 1300;
+
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false)
+            .expect("register column");
+        for doc_id in 0..N_DOCS {
+            // Every doc is `DOC_LEN` tokens long (so `avgdl == DOC_LEN` and
+            // every length quantizes down identically). The term docs carry
+            // `common` with a term frequency of 1..=3 — a genuine per-block
+            // spread of scores whose maximum is the highest-tf doc — padded
+            // with a filler token; the rest are filler only.
+            let common_tf = if doc_id < TERM_DOCS {
+                1 + (doc_id % 3) as usize
+            } else {
+                0
+            };
+            let mut text = String::with_capacity(DOC_LEN * 5);
+            for _ in 0..common_tf {
+                text.push_str("common ");
+            }
+            for _ in 0..(DOC_LEN - common_tf) {
+                text.push_str("pad ");
+            }
+            b.add_doc(0, doc_id, text.trim_end()).expect("add doc");
+        }
+        let bytes = Bytes::from(b.finish().expect("finish builder"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let reader = FtsReader::open(bytes, json).expect("open FtsReader");
+
+        let mut cursors = reader
+            .build_term_cursors(0, &["common"], None, false)
+            .await
+            .expect("build term cursors");
+        let cursor = cursors.first_mut().expect("`common` present in dictionary");
+        assert!(
+            cursor.blocks.len() >= 2,
+            "term must span multiple blocks so the block-max skip engages \
+             (got {} block(s))",
+            cursor.blocks.len()
+        );
+        let col_meta = &reader.columns[0];
+
+        let mut checked = 0u32;
+        while !cursor.is_exhausted() {
+            let doc = cursor.current_doc_id();
+            let tf = cursor.current_tf();
+            let query_score =
+                bm25::score_with_dl_norm_k1(cursor.idf_x_k1p1, tf, col_meta.dl_norm_k1.get(doc));
+            let block_max = cursor.current_block_max_bm25();
+            assert!(
+                block_max >= query_score,
+                "stored block max {block_max} < query-time score {query_score} for \
+                 doc {doc} (tf={tf}): the per-block BM25 bound under-estimates a \
+                 document in its own block, so the ranked-OR block-max skip can drop it",
+            );
+            checked += 1;
+            cursor.next();
+        }
+        assert_eq!(
+            checked, TERM_DOCS,
+            "every posting for the term must be visited"
+        );
+    }
+}


### PR DESCRIPTION
## What

Fixes #624. Block-Max WAND/MaxScore returned a wrong ranked multi-term OR top-k at scale — it dropped tied-score documents and substituted lower-scoring ones. The bench's BMW-vs-brute-force oracle catches it at 1M docs (`benches/utils/superfile.rs`), so the superfile bench tier aborted before emitting any report.

## Root cause

Query-time BM25 scores each document from the byte-quantized doc-length norm table, which stores every length as a one-byte bucket and scores from its dequantized representative — **truncating the length downward**. A shorter length yields a smaller norm and thus a *higher* BM25 score.

The builder, however, computed each block's stored max-BM25 upper bound from the document's **exact** length. For any document whose length quantizes down (length ≥ 16), its query-time score exceeds the stored per-block bound. Nothing consumed that bound tightly per-document until the block-max non-essential skip in the ranked-OR MaxScore fast path — which then pruned a block that still held a qualifying document, dropping it from the top-k. The failure is silent in production: the returned list is plausible and correctly ordered; only a brute-force oracle reveals the missing documents.

Small-length corpora (every length in the exact-quantization region) never exercise this, which is why the existing unit oracles passed while the large-scale bench oracle failed.

## Fix

Score the per-block upper bound with the same quantized length the reader uses — `dequantize_len(quantize_len(dl))` — instead of the exact length. The bound stays tight (it still equals the block's true query-time maximum) and is once again a valid upper bound over query-time scores. No on-disk format-layout change: the fixed-point store of the bound is unchanged.

## Testing

- **1M-doc bench oracle now passes:** `INFINO_BENCH_SUPERFILE_DOCS=1000000 cargo bench --bench bench -- superfile fts` reports `correctness OK: self-consistent + 7 queries BMW==brute-force` (previously panicked with a BMW-vs-brute-force divergence).
- **New regression test** `superfile::fts::reader::cursor::tests::block_max_bounds_query_time_score`: plants a term spanning several 128-doc blocks whose documents have lengths in the quantize-down region, then asserts `block_max >= query_score` for every posting. It **fails without this fix** (stored block max ~2.529 vs query score ~2.549, a gap well above the skip table's fixed-point rounding) and **passes with it**. This runs at unit-test speed and targets the invariant directly, unlike the 1M bench.
- `cargo fmt --check` and `cargo clippy --lib --all-features` are clean.

## Performance / cost

Bounds are unchanged in the common case (lengths in the exact-quantization region) and become the correct, still-tight per-block maximum elsewhere — no loosening of the block-max skip, so no pruning-effectiveness or latency regression. The change is one extra quantize/dequantize per block during build (off the query path).