### PR TITLE
improv error: add error variant for permission error

### DIFF
--- a/public-api.txt
+++ b/public-api.txt
@@ -118,6 +118,7 @@ pub infino::InfinoError::Conflict(alloc::string::String)
 pub infino::InfinoError::Io(alloc::string::String)
 pub infino::InfinoError::NotFound(alloc::string::String)
 pub infino::InfinoError::OverBudget(alloc::string::String)
+pub infino::InfinoError::PermissionDenied(alloc::string::String)
 pub infino::InfinoError::Query(alloc::string::String)
 pub infino::InfinoError::Schema(alloc::string::String)
 impl core::error::Error for infino::InfinoError

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,10 @@ pub enum InfinoError {
     #[error("io: {0}")]
     Io(String),
 
+    /// The storage backend refused the credentials in use (HTTP 403 / 401).
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+
     /// SQL planning or execution failure.
     #[error("query: {0}")]
     Query(String),
@@ -118,6 +122,7 @@ impl InfinoError {
             Self::Schema(m) => Self::Schema(format!("{prefix}: {m}")),
             Self::Cardinality(m) => Self::Cardinality(format!("{prefix}: {m}")),
             Self::Io(m) => Self::Io(format!("{prefix}: {m}")),
+            Self::PermissionDenied(m) => Self::PermissionDenied(format!("{prefix}: {m}")),
             Self::Query(m) => Self::Query(format!("{prefix}: {m}")),
             Self::OverBudget(m) => Self::OverBudget(format!("{prefix}: {m}")),
             Self::Conflict(m) => Self::Conflict(format!("{prefix}: {m}")),
@@ -133,6 +138,7 @@ impl From<StorageError> for InfinoError {
         match e {
             StorageError::NotFound { .. } => InfinoError::NotFound(msg),
             StorageError::PreconditionFailed { .. } => InfinoError::Conflict(msg),
+            StorageError::PermissionDenied { .. } => InfinoError::PermissionDenied(msg),
             StorageError::TransientExhausted { .. } | StorageError::Permanent { .. } => {
                 InfinoError::Io(msg)
             }
@@ -145,6 +151,9 @@ impl From<QueryError> for InfinoError {
         if let Some(msg) = e.over_budget() {
             return InfinoError::OverBudget(msg.to_string());
         }
+        if e.is_permission_denied() {
+            return InfinoError::PermissionDenied(e.to_string());
+        }
         InfinoError::Query(e.to_string())
     }
 }
@@ -152,6 +161,9 @@ impl From<QueryError> for InfinoError {
 impl From<ManifestLoadError> for InfinoError {
     fn from(e: ManifestLoadError) -> Self {
         let msg = e.to_string();
+        if e.is_permission_denied() {
+            return InfinoError::PermissionDenied(msg);
+        }
         match e {
             // The table this handle was reading has been dropped and purged, so
             // the name it was opened under no longer resolves to anything —
@@ -187,6 +199,9 @@ impl From<SupertableBuildError> for InfinoError {
         if let Some(msg) = e.over_budget() {
             return InfinoError::OverBudget(msg.to_string());
         }
+        if e.is_permission_denied() {
+            return InfinoError::PermissionDenied(e.to_string());
+        }
         if e.is_conflict() {
             return InfinoError::Conflict(e.to_string());
         }
@@ -203,6 +218,9 @@ impl From<SupertableBuildError> for InfinoError {
 impl From<SupertableCommitError> for InfinoError {
     fn from(e: SupertableCommitError) -> Self {
         let msg = e.to_string();
+        if e.is_permission_denied() {
+            return InfinoError::PermissionDenied(msg);
+        }
         match e {
             // Reached by commit paths that surface the typed error directly
             // (the append path converts to `BuildError::TableGone` first).
@@ -216,6 +234,9 @@ impl From<SupertableCommitError> for InfinoError {
 
 impl From<OpenError> for InfinoError {
     fn from(e: OpenError) -> Self {
+        if e.is_permission_denied() {
+            return InfinoError::PermissionDenied(e.to_string());
+        }
         if e.is_conflict() {
             return InfinoError::Conflict(e.to_string());
         }
@@ -228,6 +249,9 @@ impl From<MutationError> for InfinoError {
         let msg = e.to_string();
         if e.is_conflict() {
             return InfinoError::Conflict(msg);
+        }
+        if e.is_permission_denied() {
+            return InfinoError::PermissionDenied(msg);
         }
         match e {
             // Routes over-budget through From<QueryError> when the predicate
@@ -251,6 +275,9 @@ impl From<MutationCommitError> for InfinoError {
         }
         if e.is_conflict() {
             return InfinoError::Conflict(e.to_string());
+        }
+        if e.is_permission_denied() {
+            return InfinoError::PermissionDenied(e.to_string());
         }
         // `Supertable::append` lands here, so this is the arm that decides what
         // appending to a purged table reports. Narrow on purpose: every other
@@ -360,6 +387,73 @@ mod tests {
         assert!(matches!(
             InfinoError::from(SupertableBuildError::NoDocsToBuild),
             InfinoError::Schema(_)
+        ));
+    }
+
+    #[test]
+    fn refused_credentials_route_to_permission_denied_through_every_wrapper() {
+        // The condition a caller reacts to by supplying fresh credentials, so
+        // it must not arrive as a generic Io/Backend/Query fault on any path.
+        let denied = || StorageError::PermissionDenied { uri: "u".into() };
+
+        // Direct storage op.
+        assert!(matches!(
+            InfinoError::from(denied()),
+            InfinoError::PermissionDenied(_)
+        ));
+        // Manifest / part load — otherwise a retryable Io.
+        assert!(matches!(
+            InfinoError::from(ManifestLoadError::Storage(denied())),
+            InfinoError::PermissionDenied(_)
+        ));
+        // Open, build, and commit paths — otherwise Backend or Schema.
+        assert!(matches!(
+            InfinoError::from(OpenError::Storage(denied())),
+            InfinoError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(SupertableBuildError::StorageConstruction(denied())),
+            InfinoError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(SupertableCommitError::Storage(denied())),
+            InfinoError::PermissionDenied(_)
+        ));
+        // Mutation and its commit wrapper — otherwise Backend.
+        assert!(matches!(
+            InfinoError::from(MutationError::Storage(denied())),
+            InfinoError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(MutationCommitError::AppendFlush(
+                SupertableBuildError::StorageConstruction(denied())
+            )),
+            InfinoError::PermissionDenied(_)
+        ));
+        // Query path — otherwise a caller-fault Query (a 400 at an HTTP
+        // boundary), which is the one mislabel that hides the real cause.
+        assert!(matches!(
+            InfinoError::from(QueryError::PermissionDenied("q".into())),
+            InfinoError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            InfinoError::from(QueryError::ManifestLoad(ManifestLoadError::Storage(
+                denied()
+            ))),
+            InfinoError::PermissionDenied(_)
+        ));
+    }
+
+    #[test]
+    fn an_ordinary_storage_fault_is_still_io_not_permission_denied() {
+        // The near miss: a permanent storage fault is not a credential
+        // problem, and fresh credentials would not fix it.
+        assert!(matches!(
+            InfinoError::from(StorageError::Permanent {
+                uri: "u".into(),
+                source: "bad region".into(),
+            }),
+            InfinoError::Io(_)
         ));
     }
 

--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -181,6 +181,11 @@ fn translate(uri: &str, e: ObjError) -> StorageError {
         ObjError::AlreadyExists { .. } | ObjError::Precondition { .. } => {
             StorageError::PreconditionFailed { uri: uri.into() }
         }
+        // Refused credentials, kept apart from `Permanent`: the URI is
+        // fine and the same call with valid credentials can succeed.
+        ObjError::PermissionDenied { .. } | ObjError::Unauthenticated { .. } => {
+            StorageError::PermissionDenied { uri: uri.into() }
+        }
         ObjError::Generic { source, .. } => StorageError::TransientExhausted {
             uri: uri.into(),
             source,
@@ -504,6 +509,26 @@ mod tests {
         match err {
             StorageError::TransientExhausted { uri, .. } => assert_eq!(uri, "k"),
             other => panic!("expected TransientExhausted; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_refused_credentials_to_permission_denied() {
+        // 403 and 401 both mean the credentials were refused: kept apart from
+        // `Permanent` so a caller can supply fresh ones and reissue instead of
+        // treating the URI as broken.
+        for e in [
+            ObjError::PermissionDenied {
+                path: "k".into(),
+                source: "forbidden".into(),
+            },
+            ObjError::Unauthenticated {
+                path: "k".into(),
+                source: "expired".into(),
+            },
+        ] {
+            let err = translate("k", e);
+            assert!(matches!(err, StorageError::PermissionDenied { uri } if uri == "k"));
         }
     }
 

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -184,6 +184,11 @@ fn translate(uri: &str, e: ObjError) -> StorageError {
         ObjError::AlreadyExists { .. } | ObjError::Precondition { .. } => {
             StorageError::PreconditionFailed { uri: uri.into() }
         }
+        // Refused credentials, kept apart from `Permanent`: the URI is
+        // fine and the same call with valid credentials can succeed.
+        ObjError::PermissionDenied { .. } | ObjError::Unauthenticated { .. } => {
+            StorageError::PermissionDenied { uri: uri.into() }
+        }
         ObjError::Generic { source, .. } => StorageError::TransientExhausted {
             uri: uri.into(),
             source,
@@ -533,6 +538,26 @@ mod tests {
             },
         );
         assert!(matches!(err, StorageError::TransientExhausted { uri, .. } if uri == "k"));
+    }
+
+    #[test]
+    fn translate_refused_credentials_to_permission_denied() {
+        // 403 and 401 both mean the credentials were refused: kept apart from
+        // `Permanent` so a caller can supply fresh ones and reissue instead of
+        // treating the URI as broken.
+        for e in [
+            ObjError::PermissionDenied {
+                path: "k".into(),
+                source: "forbidden".into(),
+            },
+            ObjError::Unauthenticated {
+                path: "k".into(),
+                source: "expired".into(),
+            },
+        ] {
+            let err = translate("k", e);
+            assert!(matches!(err, StorageError::PermissionDenied { uri } if uri == "k"));
+        }
     }
 
     #[test]

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -145,6 +145,11 @@ fn translate(uri: &str, e: ObjError) -> StorageError {
         ObjError::AlreadyExists { .. } | ObjError::Precondition { .. } => {
             StorageError::PreconditionFailed { uri: uri.into() }
         }
+        // Refused credentials, kept apart from `Permanent`: the URI is
+        // fine and the same call with valid credentials can succeed.
+        ObjError::PermissionDenied { .. } | ObjError::Unauthenticated { .. } => {
+            StorageError::PermissionDenied { uri: uri.into() }
+        }
         ObjError::Generic { source, .. } => StorageError::TransientExhausted {
             uri: uri.into(),
             source,
@@ -936,6 +941,26 @@ mod tests {
             matches!(mapped, StorageError::TransientExhausted { .. }),
             "expected TransientExhausted, got {mapped:?}"
         );
+    }
+
+    #[test]
+    fn translate_refused_credentials_to_permission_denied() {
+        // 403 and 401 both mean the credentials were refused: kept apart from
+        // `Permanent` so a caller can supply fresh ones and reissue instead of
+        // treating the URI as broken.
+        for e in [
+            ObjError::PermissionDenied {
+                path: "k".into(),
+                source: "forbidden".into(),
+            },
+            ObjError::Unauthenticated {
+                path: "k".into(),
+                source: "expired".into(),
+            },
+        ] {
+            let err = translate("k", e);
+            assert!(matches!(err, StorageError::PermissionDenied { uri } if uri == "k"));
+        }
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -99,9 +99,21 @@ pub enum StorageError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    /// Permanent failure (auth, schema/region mismatch,
-    /// corrupted response, malformed URI). Callers do **not**
-    /// retry.
+    /// The credentials in use were refused: the backend rejected the
+    /// request as unauthorized or unauthenticated (HTTP 403 / 401).
+    ///
+    /// Permanent for the credentials that produced it, but *not*
+    /// permanent for the URI: the same operation with valid
+    /// credentials can succeed, which is why this is its own variant
+    /// rather than a [`Self::Permanent`]. Callers do not retry with
+    /// the same credentials.
+    #[error("permission denied: {uri}")]
+    PermissionDenied { uri: String },
+
+    /// Permanent failure (schema/region mismatch, corrupted
+    /// response, malformed URI). Callers do **not** retry.
+    /// Refused credentials have their own variant — see
+    /// [`Self::PermissionDenied`].
     #[error("permanent error: {uri} — {source}")]
     Permanent {
         uri: String,
@@ -123,6 +135,33 @@ impl StorageError {
     pub(crate) fn is_conflict(&self) -> bool {
         matches!(self, StorageError::PreconditionFailed { .. })
     }
+
+    /// True when the backend refused the credentials in use.
+    ///
+    /// The distinguishing property is that neither retrying nor
+    /// reissuing against fresh state helps — only different
+    /// credentials do. Every layer above has its own
+    /// `is_permission_denied` that funnels into this one, and the
+    /// public boundary turns the answer into
+    /// [`InfinoError::PermissionDenied`](crate::InfinoError::PermissionDenied).
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        matches!(self, StorageError::PermissionDenied { .. })
+    }
+}
+
+/// True when `e` or anything in its source chain is a refused-credentials
+/// storage error.
+///
+/// For layers that stringify their source when converting (the query path
+/// carries formatted messages, not typed sources) — this reads the chain
+/// *before* it is flattened, so the classification stays typed rather than
+/// matching on message text. Every link in the chain must declare its
+/// `#[source]` / `#[from]` for the walk to reach the bottom.
+pub(crate) fn permission_denied_in_chain(e: &(dyn std::error::Error + 'static)) -> bool {
+    std::iter::successors(Some(e), |e| e.source()).any(|link| {
+        link.downcast_ref::<StorageError>()
+            .is_some_and(StorageError::is_permission_denied)
+    })
 }
 
 /// I/O diagnostics that are not the usage ledger: timeline and phase spans.
@@ -697,6 +736,32 @@ mod tests {
 
     /// Fixed etag the mock reports for any stored object.
     const MOCK_ETAG: &str = "mock-etag";
+
+    /// A two-link error chain over a source, standing in for the wrappers a
+    /// storage error picks up on its way through the query path.
+    #[derive(Debug, thiserror::Error)]
+    #[error("outer")]
+    struct Wrapper(#[source] Box<dyn Error + Send + Sync + 'static>);
+
+    #[test]
+    fn permission_denied_is_found_through_a_wrapped_source_chain() {
+        // The read path stringifies its source when converting, so the
+        // classification has to happen off the typed chain while it still
+        // exists — however deeply the storage error is nested.
+        let nested = Wrapper(Box::new(Wrapper(Box::new(
+            StorageError::PermissionDenied { uri: "u".into() },
+        ))));
+        assert!(permission_denied_in_chain(&nested));
+
+        // A chain with no storage error in it, and one whose storage error is
+        // a different condition, both read as false.
+        assert!(!permission_denied_in_chain(&Wrapper(Box::new(
+            StorageError::NotFound { uri: "u".into() }
+        ))));
+        assert!(!permission_denied_in_chain(&Wrapper(Box::new(
+            std::io::Error::other("disk")
+        ))));
+    }
 
     #[test]
     fn logical_list_key_strips_exact_provider_root() {

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -331,6 +331,11 @@ fn translate(uri: &str, e: ObjError) -> StorageError {
         ObjError::AlreadyExists { .. } | ObjError::Precondition { .. } => {
             StorageError::PreconditionFailed { uri: uri.into() }
         }
+        // Refused credentials, kept apart from `Permanent`: the URI is
+        // fine and the same call with valid credentials can succeed.
+        ObjError::PermissionDenied { .. } | ObjError::Unauthenticated { .. } => {
+            StorageError::PermissionDenied { uri: uri.into() }
+        }
         ObjError::Generic { source, .. } => StorageError::TransientExhausted {
             uri: uri.into(),
             source,
@@ -686,6 +691,26 @@ mod tests {
         match err {
             StorageError::TransientExhausted { uri, .. } => assert_eq!(uri, "k"),
             other => panic!("expected TransientExhausted; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_refused_credentials_to_permission_denied() {
+        // 403 and 401 both mean the credentials were refused: kept apart from
+        // `Permanent` so a caller can supply fresh ones and reissue instead of
+        // treating the URI as broken.
+        for e in [
+            ObjError::PermissionDenied {
+                path: "k".into(),
+                source: "forbidden".into(),
+            },
+            ObjError::Unauthenticated {
+                path: "k".into(),
+                source: "expired".into(),
+            },
+        ] {
+            let err = translate("k", e);
+            assert!(matches!(err, StorageError::PermissionDenied { uri } if uri == "k"));
         }
     }
 

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::{
-    storage::StorageError,
+    storage::{StorageError, permission_denied_in_chain},
     superfile::error::BuildError as SuperfileBuildError,
     supertable::{ManifestLoadError, manifest::part},
 };
@@ -115,6 +115,15 @@ pub enum BuildError {
     #[error("superfile store: {0}")]
     Store(String),
 
+    /// The storage backend refused the credentials in use. Carried as its own
+    /// variant rather than folded into [`Self::Store`] for the same reason as
+    /// [`Self::TableGone`] and [`Self::WriteContention`]: a stringified error
+    /// can't be matched on, and the public mapping must report refused
+    /// credentials rather than a backend fault. See
+    /// `From<CommitError> for BuildError`.
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+
     /// The table was dropped and purged while this handle was open, so the
     /// commit had no pointer to fence against. Carried as its own variant
     /// rather than folded into [`Self::Store`] so the public mapping can
@@ -181,6 +190,15 @@ impl BuildError {
             _ => false,
         }
     }
+
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            BuildError::PermissionDenied(_) => true,
+            BuildError::StorageConstruction(e) => e.is_permission_denied(),
+            _ => false,
+        }
+    }
 }
 
 impl From<CommitError> for BuildError {
@@ -193,6 +211,9 @@ impl From<CommitError> for BuildError {
         match e {
             CommitError::PointerVanished => BuildError::TableGone,
             other if other.is_conflict() => BuildError::WriteContention,
+            other if other.is_permission_denied() => {
+                BuildError::PermissionDenied(other.to_string())
+            }
             other => BuildError::Store(other.to_string()),
         }
     }
@@ -255,6 +276,15 @@ impl CommitError {
             CommitError::WriteContentionExhausted => true,
             CommitError::Storage(e) => e.is_conflict(),
             CommitError::Build(b) => b.is_conflict(),
+            _ => false,
+        }
+    }
+
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            CommitError::Storage(e) => e.is_permission_denied(),
+            CommitError::Build(b) => b.is_permission_denied(),
             _ => false,
         }
     }
@@ -357,6 +387,21 @@ impl OpenError {
             OpenError::PointerUnreadable(e) | OpenError::Storage(e) => e.is_conflict(),
             OpenError::Build(b) => b.is_conflict(),
             OpenError::Commit(c) => c.is_conflict(),
+            _ => false,
+        }
+    }
+
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            OpenError::PointerUnreadable(e) | OpenError::Storage(e) => e.is_permission_denied(),
+            OpenError::Build(b) => b.is_permission_denied(),
+            OpenError::Commit(c) => c.is_permission_denied(),
+            OpenError::ManifestLoadError(e) => e.is_permission_denied(),
+            // The part loader boxes its source, so read the chain.
+            OpenError::ManifestPartLoad { source, .. } => {
+                permission_denied_in_chain(source.as_ref())
+            }
             _ => false,
         }
     }
@@ -530,6 +575,12 @@ pub enum QueryError {
 
     #[error("manifest load error: {0}")]
     ManifestLoad(ManifestLoadError),
+
+    /// The storage backend refused the credentials in use. Classified at the
+    /// boundary — like [`Self::OverBudget`] — because the variants above carry
+    /// stringified sources; routes to `InfinoError::PermissionDenied`.
+    #[error("permission denied during query: {0}")]
+    PermissionDenied(String),
 }
 
 impl QueryError {
@@ -539,5 +590,53 @@ impl QueryError {
             QueryError::OverBudget(m) => Some(m),
             _ => None,
         }
+    }
+
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            QueryError::PermissionDenied(_) => true,
+            QueryError::ManifestLoad(e) => e.is_permission_denied(),
+            _ => false,
+        }
+    }
+
+    /// Classify a storage-backed query failure whose source is about to be
+    /// stringified: refused credentials get their own variant, everything else
+    /// stays a [`Self::Store`]. `message` is the text the caller would have
+    /// used either way, so no message changes shape.
+    pub(crate) fn build(message: String, source: &(dyn std::error::Error + 'static)) -> Self {
+        if permission_denied_in_chain(source) {
+            return QueryError::PermissionDenied(message);
+        }
+        QueryError::Store(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supertable::reader_cache::disk::DiskCacheError;
+
+    #[test]
+    fn a_refused_credential_is_classified_through_the_disk_cache_wrapper() {
+        // The read path's real shape: the query layer stringifies whatever the
+        // disk cache hands it, so the classification has to read the typed
+        // chain through that wrapper. Anything else on the same path stays a
+        // store error.
+        let refused = DiskCacheError::Storage(StorageError::PermissionDenied { uri: "u".into() });
+        assert!(matches!(
+            QueryError::build(refused.to_string(), &refused),
+            QueryError::PermissionDenied(_)
+        ));
+
+        let transient = DiskCacheError::Storage(StorageError::TransientExhausted {
+            uri: "u".into(),
+            source: "boom".into(),
+        });
+        assert!(matches!(
+            QueryError::build(transient.to_string(), &transient),
+            QueryError::Store(_)
+        ));
     }
 }

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -2341,6 +2341,16 @@ pub enum ManifestLoadError {
     SlowStateHydration(String),
 }
 
+impl ManifestLoadError {
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            ManifestLoadError::Storage(e) => e.is_permission_denied(),
+            _ => false,
+        }
+    }
+}
+
 /// One superfile's metadata + skip-pruning summaries. The bytes that
 /// back the superfile live in the superfile store keyed by `uri` —
 /// `superfile_id` is for debugging / observability, `uri` is for

--- a/src/supertable/mutations.rs
+++ b/src/supertable/mutations.rs
@@ -232,6 +232,19 @@ impl MutationError {
             _ => false,
         }
     }
+
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            MutationError::Storage(e) => e.is_permission_denied(),
+            MutationError::WalStore(e) => e.is_permission_denied(),
+            MutationError::AppendPhase(e) => e.is_permission_denied(),
+            MutationError::TombstonePhase(e) => e.is_permission_denied(),
+            MutationError::PredicateEval(q) => q.is_permission_denied(),
+            MutationError::TargetResolve(e) => e.is_permission_denied(),
+            _ => false,
+        }
+    }
 }
 
 /// Value returned from [`SupertableWriter::update`]. Carries the
@@ -330,6 +343,16 @@ impl CommitError {
         match self {
             CommitError::AppendFlush(b) => b.is_conflict(),
             CommitError::PartialCommit { cause, .. } => cause.is_conflict(),
+        }
+    }
+
+    /// True when the backend refused the credentials in use. On
+    /// `PartialCommit` this reports the *cause* of the stop, as `is_conflict`
+    /// does.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            CommitError::AppendFlush(b) => b.is_permission_denied(),
+            CommitError::PartialCommit { cause, .. } => cause.is_permission_denied(),
         }
     }
 }

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -90,7 +90,7 @@ pub(crate) async fn open_reader(
         allow_background_fill,
     )
     .await
-    .map_err(|e| QueryError::Store(e.to_string()))
+    .map_err(|e| QueryError::build(e.to_string(), &e))
 }
 
 /// Verify that each configured vector column is present in this superfile and
@@ -178,7 +178,7 @@ pub(crate) async fn open_compaction_input(
             let reader = cache
                 .reader_synchronous_with_storage(&entry.uri, Arc::clone(storage))
                 .await
-                .map_err(|e| QueryError::Store(e.to_string()));
+                .map_err(|e| QueryError::build(e.to_string(), &e));
             // Fully-resident only: a promoted hybrid reader exposes parquet
             // bytes but leaves the vector blob sparse, and the Sq8 merge
             // below reads real vector bytes synchronously.
@@ -194,8 +194,9 @@ pub(crate) async fn open_compaction_input(
         let (bytes, _) = storage
             .get(&path)
             .await
-            .map_err(|e| QueryError::Store(e.to_string()))?;
-        let reader = SuperfileReader::open(bytes).map_err(|e| QueryError::Store(e.to_string()))?;
+            .map_err(|e| QueryError::build(e.to_string(), &e))?;
+        let reader =
+            SuperfileReader::open(bytes).map_err(|e| QueryError::build(e.to_string(), &e))?;
         return Ok(Arc::new(reader));
     }
     // Compaction is not a query modality; allow fill so inputs can promote.
@@ -234,7 +235,7 @@ pub(crate) fn tombstone_deny_set(
 ) -> Result<Option<Arc<RoaringBitmap>>, QueryError> {
     let bitmap = cache
         .bitmap_for(superfile_id, now)
-        .map_err(|e| QueryError::Store(format!("tombstone cache: {e}")))?;
+        .map_err(|e| QueryError::build(format!("tombstone cache: {e}"), &e))?;
     Ok((!bitmap.is_empty()).then_some(bitmap))
 }
 
@@ -380,7 +381,7 @@ pub(crate) async fn apply_resolved_tombstone_filter(
     };
     let bitmap = cache
         .bitmap_for(entry.superfile_id, now)
-        .map_err(|e| QueryError::Store(format!("tombstone cache: {e}")))?;
+        .map_err(|e| QueryError::build(format!("tombstone cache: {e}"), &e))?;
     if bitmap.is_empty() {
         return Ok(());
     }

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1229,9 +1229,9 @@ impl SupertableReader {
                     // Tombstone bitmap for this superfile (None = no deletes).
                     let tomb = match tombstone_cache.as_ref() {
                         Some(c) => {
-                            let b = c
-                                .bitmap_for(entry.superfile_id, now)
-                                .map_err(|e| QueryError::Store(format!("tombstone cache: {e}")))?;
+                            let b = c.bitmap_for(entry.superfile_id, now).map_err(|e| {
+                                QueryError::build(format!("tombstone cache: {e}"), &e)
+                            })?;
                             if b.is_empty() { None } else { Some(b) }
                         }
                         None => None,

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -68,6 +68,7 @@ use datafusion::{
 use crate::{
     memory::budgeted_session_context,
     runtime_metrics::op_stats,
+    storage::permission_denied_in_chain,
     supertable::{
         error::QueryError,
         handle::{Supertable, SupertableReader},
@@ -155,10 +156,18 @@ fn cacheable_scalar_plan(plan: &LogicalPlan) -> bool {
 }
 
 /// Classify a SQL execution error: budget exhaustion -> [`QueryError::OverBudget`]
-/// (the catalog surfaces it as `InfinoError::OverBudget`), else an execute error.
+/// (the catalog surfaces it as `InfinoError::OverBudget`), refused credentials
+/// -> [`QueryError::PermissionDenied`], else an execute error.
+///
+/// The credential check reads the error's source chain rather than its message:
+/// a scan failure reaches DataFusion wrapped, and the underlying storage error
+/// is still typed inside it.
 fn exec_query_error(e: DataFusionError) -> QueryError {
     match e {
         DataFusionError::ResourcesExhausted(msg) => QueryError::OverBudget(msg),
+        other if permission_denied_in_chain(&other) => {
+            QueryError::PermissionDenied(other.to_string())
+        }
         other => QueryError::Execute(other.to_string()),
     }
 }

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -4894,7 +4894,7 @@ fn subtract_tombstones(
     if let Some(cache) = tombstone_cache {
         let deleted = cache
             .bitmap_for(entry.superfile_id, now)
-            .map_err(|e| QueryError::Store(format!("tombstone cache: {e}")))?;
+            .map_err(|e| QueryError::build(format!("tombstone cache: {e}"), &e))?;
         if !deleted.is_empty() {
             *bm -= &*deleted;
         }

--- a/src/supertable/wal/persistence.rs
+++ b/src/supertable/wal/persistence.rs
@@ -145,6 +145,14 @@ impl WalStoreError {
             _ => false,
         }
     }
+
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            WalStoreError::Storage { source, .. } => source.is_permission_denied(),
+            _ => false,
+        }
+    }
 }
 
 /// Storage prefix for WAL state-doc + sidecar objects.

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -207,6 +207,16 @@ impl AppendPhaseError {
             _ => false,
         }
     }
+
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            AppendPhaseError::ManifestCommit(e) => e.is_permission_denied(),
+            AppendPhaseError::Storage(e) => e.is_permission_denied(),
+            AppendPhaseError::WalStore(e) => e.is_permission_denied(),
+            _ => false,
+        }
+    }
 }
 
 /// Drive one UPDATE WAL from `Intent` to `Appended`.
@@ -781,6 +791,16 @@ impl TombstonePhaseError {
             TombstonePhaseError::ManifestStamp(e) => e.is_conflict(),
             TombstonePhaseError::Storage(e) => e.is_conflict(),
             TombstonePhaseError::WalStore(e) => e.is_conflict(),
+            _ => false,
+        }
+    }
+
+    /// True when the backend refused the credentials in use.
+    pub(crate) fn is_permission_denied(&self) -> bool {
+        match self {
+            TombstonePhaseError::ManifestStamp(e) => e.is_permission_denied(),
+            TombstonePhaseError::Storage(e) => e.is_permission_denied(),
+            TombstonePhaseError::WalStore(e) => e.is_permission_denied(),
             _ => false,
         }
     }

--- a/src/test_helpers/fault_storage.rs
+++ b/src/test_helpers/fault_storage.rs
@@ -57,6 +57,11 @@ pub enum FaultKind {
     /// allowed to treat as contention, so tests use it to drive a CAS-loss
     /// to its retry budget and check what the caller finally sees.
     Precondition,
+    /// [`StorageError::PermissionDenied`] — the backend refused the
+    /// credentials in use. Neither a retry nor a reissue helps, so tests use
+    /// it to check that the condition survives every wrapper it passes
+    /// through instead of arriving as a generic fault.
+    PermissionDenied,
 }
 
 /// One armed fault: the next `remaining` calls of `op` whose URI
@@ -146,6 +151,9 @@ impl FaultStorage {
                         source: Box::new(IoError::other("injected fault")),
                     },
                     FaultKind::Precondition => StorageError::PreconditionFailed {
+                        uri: uri.to_string(),
+                    },
+                    FaultKind::PermissionDenied => StorageError::PermissionDenied {
                         uri: uri.to_string(),
                     },
                 });

--- a/tests/supertable/storage/fault_surfacing.rs
+++ b/tests/supertable/storage/fault_surfacing.rs
@@ -149,6 +149,49 @@ fn commit_surfaces_pointer_cas_fault_without_publishing() {
     assert_eq!(st.reader().expect("reader").n_superfiles(), 1);
 }
 
+/// A refused credential must reach the caller as
+/// [`InfinoError::PermissionDenied`], not as the generic backend fault a
+/// transient failure produces: the two call for different responses — retry
+/// the transient one, supply fresh credentials for this one — so collapsing
+/// them leaves a caller with no way to react.
+///
+/// The commit path is the one that erased it hardest: the condition crosses
+/// four wrappers (storage -> commit -> build -> append flush) on its way out.
+#[test]
+fn a_refused_credential_surfaces_as_permission_denied_not_a_generic_fault() {
+    // The superfile PUT is refused mid-commit.
+    let (st, faults, _dir) = faulted_table();
+    faults.fail_with(FaultKind::PermissionDenied, FaultOp::PutAtomic, "data/", 1);
+    let mut w = st.writer().expect("writer");
+    w.append(&build_title_batch(&["second commit beta"]))
+        .expect("append");
+    let err = InfinoError::from(w.commit().expect_err("a refused PUT must fail the commit"));
+    assert!(
+        matches!(err, InfinoError::PermissionDenied(_)),
+        "commit reported {err:?}"
+    );
+    assert_eq!(st.manifest_id(), 1, "nothing published");
+}
+
+/// Open reads the pointer before anything else, so a refused credential
+/// there is the first thing a caller sees.
+#[test]
+fn open_surfaces_a_refused_credential_as_permission_denied() {
+    let (st, faults, _dir) = faulted_table();
+    drop(st);
+
+    faults.fail_with(FaultKind::PermissionDenied, FaultOp::Get, POINTER_PATH, 1);
+    let storage: Arc<dyn StorageProvider> = Arc::<FaultStorage>::clone(&faults);
+    let err = InfinoError::from(
+        Supertable::open(default_supertable_options().with_storage(storage))
+            .expect_err("a refused pointer GET must fail the open"),
+    );
+    assert!(
+        matches!(err, InfinoError::PermissionDenied(_)),
+        "open reported {err:?}"
+    );
+}
+
 #[test]
 fn open_surfaces_pointer_get_fault_and_recovers() {
     let (st, faults, _dir) = faulted_table();


### PR DESCRIPTION
### What does this PR do?
- Exposes a new error variant for "Permission" related errors. Previously, these errors were treated as Io errors

### Why do we need this change?
- Permission errors are different from Io errors, in the sense that retries will not fix them. The user needs to explicitly update the credentials and try again.
- Exposing the error as a separate variant makes it easy for consumers to catch these kind of errors, update their credentials and try again.

### How do we do this change?
- All error variants ( which may fail due to permission errors ) now have a way to throw a Permission Error enum variant. ( For certain errors, we need to iterate over the error chain )
- This error is propagated to the consumers