### PR TITLE
remote: carry the table schema as Arrow IPC

### DIFF
--- a/src/catalog/remote/mod.rs
+++ b/src/catalog/remote/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod wire;
 use std::{io::Read, sync::Arc};
 
 use arrow_array::RecordBatch;
-use arrow_schema::SchemaRef;
+use arrow_schema::{Schema, SchemaRef};
 use serde_json::{Value, json};
 
 use crate::{IndexSpec, InfinoError, Supertable};
@@ -119,7 +119,7 @@ impl RemoteCatalog {
     ) -> Result<Supertable, InfinoError> {
         let body = json!({
             "table_name": name,
-            "schema": wire::schema_to_json(&schema)?,
+            "schema_ipc": wire::schema_to_ipc_base64(&schema)?,
             "indexes": wire::index_spec_to_json(&indexes),
         });
         self.post_json("create_table", body)?;
@@ -133,12 +133,11 @@ impl RemoteCatalog {
     pub(crate) fn open_table(self: &Arc<Self>, name: &str) -> Result<Supertable, InfinoError> {
         // Fetch the schema: this validates the table exists (a missing table is
         // a 404 → NotFound) and caches the schema so `schema()` is infallible.
-        let response = self.post_json("schema", json!({ "table_name": name }))?;
-        let value = read_json("schema", response)?;
-        let fields = value.as_array().ok_or_else(|| {
-            InfinoError::Backend("schema response was not a JSON array".to_string())
-        })?;
-        let schema = Arc::new(wire::json_to_schema(fields)?);
+        let response = self.post_json(
+            "schema",
+            json!({ "table_name": name, "encoding": wire::IPC_ENCODING }),
+        )?;
+        let schema = Arc::new(read_arrow_schema("schema", response)?);
         Ok(Supertable::from_table(Arc::new(table::RemoteTable::new(
             Arc::clone(self),
             name.to_string(),
@@ -209,4 +208,16 @@ pub(crate) fn read_arrow(
         .read_to_end(&mut buf)
         .map_err(|e| InfinoError::Backend(format!("{op}: reading response: {e}")))?;
     wire::ipc_to_batches(&buf)
+}
+
+/// Read an Arrow-IPC response body into the schema it carries. The body is a
+/// schema message with no batches, so this cannot go through
+/// [`read_arrow`], which expects at least one batch to describe.
+pub(crate) fn read_arrow_schema(op: &str, response: ureq::Response) -> Result<Schema, InfinoError> {
+    let mut buf = Vec::new();
+    response
+        .into_reader()
+        .read_to_end(&mut buf)
+        .map_err(|e| InfinoError::Backend(format!("{op}: reading response: {e}")))?;
+    wire::ipc_to_schema(&buf)
 }

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -5,16 +5,21 @@
 //!
 //! Requests are JSON; read responses are Arrow IPC streams that decode straight
 //! into the engine's native `Vec<RecordBatch>`. This module owns the
-//! translations: an Arrow schema and an [`IndexSpec`] to their JSON request
-//! shapes, `RecordBatch`es to/from the Arrow IPC stream, and an HTTP status to
-//! an [`InfinoError`]. The string spellings mirror what the hosted service
-//! accepts.
+//! translations: a schema to and from Arrow's own IPC encoding, an
+//! [`IndexSpec`] to its JSON request shape, `RecordBatch`es to/from the Arrow
+//! IPC stream, and an HTTP status to an [`InfinoError`].
+//!
+//! The schema crosses as an Arrow IPC schema message rather than a hand-rolled
+//! JSON descriptor. That is Arrow's canonical encoding, so every type the
+//! engine can hold survives the trip, nested structs and lists included, and
+//! there is no per-type spelling table to keep in step with the service.
 
-use std::{io::Cursor, sync::Arc};
+use std::io::Cursor;
 
 use arrow::ipc::{reader::StreamReader, writer::StreamWriter};
 use arrow_array::RecordBatch;
-use arrow_schema::{DataType, Field, Schema};
+use arrow_schema::Schema;
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use serde_json::{Value, json};
 
 use crate::{IndexSpec, InfinoError, Metric};
@@ -23,55 +28,10 @@ use crate::{IndexSpec, InfinoError, Metric};
 /// bodies and read responses.
 pub(crate) const ARROW_STREAM_CONTENT_TYPE: &str = "application/vnd.apache.arrow.stream";
 
-/// Canonical wire spelling for a scalar Arrow type, matching what the hosted
-/// service accepts. Non-scalar types are rejected so a schema that can't cross
-/// the wire fails loudly at the client instead of diverging from local.
-fn scalar_type_str(data_type: &DataType) -> Result<&'static str, InfinoError> {
-    Ok(match data_type {
-        DataType::Utf8 => "utf8",
-        DataType::LargeUtf8 => "large_utf8",
-        DataType::Boolean => "bool",
-        DataType::Int32 => "i32",
-        DataType::Int64 => "i64",
-        DataType::UInt32 => "u32",
-        DataType::UInt64 => "u64",
-        DataType::Float32 => "f32",
-        DataType::Float64 => "f64",
-        other => {
-            return Err(InfinoError::Schema(format!(
-                "column type not supported over the remote transport: {other:?}"
-            )));
-        }
-    })
-}
-
-/// One Arrow field as its `{name, type, nullable}` JSON descriptor. `nullable`
-/// is always written explicitly (the server defaults an omitted value to
-/// `true`, which would silently flip a non-nullable column). A
-/// `FixedSizeList<Float32, dim>` maps to `{type: "vector", dim}`; a `List<T>`
-/// to `{type: "list", item}`.
-fn field_to_json(field: &Field) -> Result<Value, InfinoError> {
-    let name = field.name();
-    let nullable = field.is_nullable();
-    match field.data_type() {
-        DataType::FixedSizeList(item, dim) if *item.data_type() == DataType::Float32 => {
-            Ok(json!({ "name": name, "type": "vector", "dim": dim, "nullable": nullable }))
-        }
-        DataType::List(item) => Ok(json!({
-            "name": name,
-            "type": "list",
-            "item": scalar_type_str(item.data_type())?,
-            "nullable": nullable,
-        })),
-        other => Ok(json!({ "name": name, "type": scalar_type_str(other)?, "nullable": nullable })),
-    }
-}
-
-/// A schema as the JSON array of field descriptors the create-table request
-/// carries.
-pub(crate) fn schema_to_json(schema: &Schema) -> Result<Vec<Value>, InfinoError> {
-    schema.fields().iter().map(|f| field_to_json(f)).collect()
-}
+/// The `encoding` value that asks a schema response for Arrow IPC rather than
+/// the JSON column descriptors. Only IPC can carry a nested column type, so the
+/// client always asks for it.
+pub(crate) const IPC_ENCODING: &str = "ipc";
 
 /// The wire spelling for a vector distance metric.
 pub(crate) fn metric_str(metric: Metric) -> &'static str {
@@ -141,70 +101,29 @@ pub(crate) fn ipc_to_batches(bytes: &[u8]) -> Result<Vec<RecordBatch>, InfinoErr
         .map_err(|e| InfinoError::Backend(format!("arrow ipc read: {e}")))
 }
 
-/// The Arrow scalar type for a wire type spelling — the inverse of
-/// [`scalar_type_str`], accepting the same aliases the hosted service does.
-fn scalar_type_from_str(name: &str) -> Result<DataType, InfinoError> {
-    Ok(match name {
-        "utf8" | "string" => DataType::Utf8,
-        "large_utf8" | "large_string" => DataType::LargeUtf8,
-        "bool" | "boolean" => DataType::Boolean,
-        "i32" | "int32" => DataType::Int32,
-        "i64" | "int64" => DataType::Int64,
-        "u32" | "uint32" => DataType::UInt32,
-        "u64" | "uint64" => DataType::UInt64,
-        "f32" | "float32" => DataType::Float32,
-        "f64" | "float64" | "double" => DataType::Float64,
-        other => {
-            return Err(InfinoError::Schema(format!(
-                "unknown column type in schema response: {other}"
-            )));
-        }
-    })
+/// Encode a schema as the `schema_ipc` field of a create-table request: an
+/// Arrow IPC stream carrying only the schema message, base64 for the JSON body.
+///
+/// Base64 rather than a raw body because the request also carries `table_name`
+/// and the index spec, which belong in JSON; the overhead is irrelevant on a
+/// schema of a few kilobytes.
+pub(crate) fn schema_to_ipc_base64(schema: &Schema) -> Result<String, InfinoError> {
+    let mut out = Vec::new();
+    let mut writer = StreamWriter::try_new(&mut out, schema)
+        .map_err(|e| InfinoError::Backend(format!("arrow ipc schema writer: {e}")))?;
+    writer
+        .finish()
+        .map_err(|e| InfinoError::Backend(format!("arrow ipc schema finish: {e}")))?;
+    Ok(BASE64.encode(&out))
 }
 
-fn field_from_json(value: &Value) -> Result<Field, InfinoError> {
-    let name = value
-        .get("name")
-        .and_then(Value::as_str)
-        .ok_or_else(|| InfinoError::Schema("schema field missing `name`".to_string()))?;
-    let type_name = value
-        .get("type")
-        .and_then(Value::as_str)
-        .ok_or_else(|| InfinoError::Schema("schema field missing `type`".to_string()))?;
-    let nullable = value
-        .get("nullable")
-        .and_then(Value::as_bool)
-        .unwrap_or(true);
-    let data_type = match type_name {
-        "vector" => {
-            let dim = value
-                .get("dim")
-                .and_then(Value::as_u64)
-                .ok_or_else(|| InfinoError::Schema("vector column missing `dim`".to_string()))?;
-            let item = Arc::new(Field::new("item", DataType::Float32, true));
-            DataType::FixedSizeList(item, dim as i32)
-        }
-        "list" => {
-            let item_type = value
-                .get("item")
-                .and_then(Value::as_str)
-                .ok_or_else(|| InfinoError::Schema("list column missing `item`".to_string()))?;
-            let item = Arc::new(Field::new("item", scalar_type_from_str(item_type)?, true));
-            DataType::List(item)
-        }
-        other => scalar_type_from_str(other)?,
-    };
-    Ok(Field::new(name, data_type, nullable))
-}
-
-/// Decode a schema response (`[{name, type, nullable}, …]`) into an Arrow
-/// schema — the inverse of [`schema_to_json`].
-pub(crate) fn json_to_schema(fields: &[Value]) -> Result<Schema, InfinoError> {
-    let fields = fields
-        .iter()
-        .map(field_from_json)
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(Schema::new(fields))
+/// Decode a schema response body — an Arrow IPC stream whose schema message is
+/// the whole payload — into an Arrow schema. Raw bytes, not base64: the
+/// response body is the schema, so it needs no JSON envelope.
+pub(crate) fn ipc_to_schema(bytes: &[u8]) -> Result<Schema, InfinoError> {
+    let reader = StreamReader::try_new(Cursor::new(bytes), None)
+        .map_err(|e| InfinoError::Backend(format!("arrow ipc schema reader: {e}")))?;
+    Ok(reader.schema().as_ref().clone())
 }
 
 /// Map an HTTP error status to an [`InfinoError`]. Best-effort: only a few
@@ -230,47 +149,6 @@ mod tests {
     use arrow_schema::{DataType, Field, FieldRef, Fields, Schema};
 
     use super::*;
-
-    #[test]
-    fn schema_json_preserves_nullable_and_types() {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("body", DataType::LargeUtf8, true),
-        ]);
-        let json = schema_to_json(&schema).expect("schema to json");
-        assert_eq!(
-            json[0],
-            json!({"name": "id", "type": "i32", "nullable": false})
-        );
-        assert_eq!(
-            json[1],
-            json!({"name": "body", "type": "large_utf8", "nullable": true})
-        );
-    }
-
-    #[test]
-    fn schema_json_maps_vector_column() {
-        let item = Arc::new(Field::new("item", DataType::Float32, true));
-        let schema = Schema::new(vec![Field::new(
-            "embedding",
-            DataType::FixedSizeList(item, 384),
-            false,
-        )]);
-        let json = schema_to_json(&schema).expect("schema to json");
-        assert_eq!(
-            json[0],
-            json!({"name": "embedding", "type": "vector", "dim": 384, "nullable": false})
-        );
-    }
-
-    #[test]
-    fn schema_json_rejects_unsupported_type() {
-        let schema = Schema::new(vec![Field::new("ts", DataType::Date32, true)]);
-        assert!(matches!(
-            schema_to_json(&schema),
-            Err(InfinoError::Schema(_))
-        ));
-    }
 
     #[test]
     fn index_spec_json_shape() {
@@ -311,6 +189,35 @@ mod tests {
         let back = ipc_to_batches(&bytes).expect("decode");
         assert_eq!(back.len(), 1);
         assert_eq!(back[0], batch);
+    }
+
+    #[test]
+    fn schema_ipc_round_trips_a_nested_column() {
+        // A struct column is the case the previous JSON descriptors could not
+        // express at all, so it is the one worth pinning.
+        let inner: Fields = vec![
+            FieldRef::from(Field::new("url", DataType::Utf8, true)),
+            FieldRef::from(Field::new("height", DataType::Int64, true)),
+        ]
+        .into();
+        let schema = Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("image", DataType::Struct(inner), true),
+        ]);
+
+        let encoded = schema_to_ipc_base64(&schema).expect("encode schema");
+        let bytes = BASE64.decode(&encoded).expect("valid base64");
+        let back = ipc_to_schema(&bytes).expect("decode schema");
+
+        assert_eq!(back, schema, "the schema survives the round trip exactly");
+    }
+
+    #[test]
+    fn schema_ipc_rejects_a_body_that_is_not_an_ipc_stream() {
+        assert!(matches!(
+            ipc_to_schema(b"not arrow ipc"),
+            Err(InfinoError::Backend(_))
+        ));
     }
 
     #[test]

--- a/tests/fixtures/hosted-openapi.json
+++ b/tests/fixtures/hosted-openapi.json
@@ -40,6 +40,22 @@
             }
           }
         ],
+        "requestBody": {
+          "description": "The rows to append: a JSON `{\"data\": [...]}` envelope of rows keyed by column name (`application/json`), or an Arrow IPC stream of one record batch (`application/vnd.apache.arrow.stream`).",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RowsEnvelope"
+              }
+            },
+            "application/vnd.apache.arrow.stream": {
+              "schema": {
+                "$ref": "#/components/schemas/ArrowIpcRows"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Rows appended. Body is an Arrow IPC row stream (application/vnd.apache.arrow.stream), or a JSON `{\"data\": [...]}` envelope."
@@ -204,7 +220,7 @@
             "description": "Table created."
           },
           "400": {
-            "description": "Invalid request body."
+            "description": "Invalid request body, or a malformed table name — use non-empty [A-Za-z0-9_-], at most 128 characters, not starting with '_'."
           },
           "401": {
             "description": "Missing or invalid API key."
@@ -300,6 +316,16 @@
               }
             }
           },
+          "403": {
+            "description": "The API key may not address this database, or the account is not entitled to storage bindings (BYOB is an enterprise feature).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
           "409": {
             "description": "Database already exists.",
             "content": {
@@ -353,6 +379,67 @@
           },
           "412": {
             "description": "The database changed concurrently; retry the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/v1/databases/{name}/storage/verify": {
+      "post": {
+        "tags": [
+          "Databases"
+        ],
+        "summary": "Verify a storage binding",
+        "description": "Prove the database's bring-your-own-bucket grant end to end; workers start only after this passes.",
+        "operationId": "verify_database_storage",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The database name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The binding verified; workers may start."
+          },
+          "400": {
+            "description": "No binding, or the probe failed; the message names the failing stage.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No valid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such database.",
             "content": {
               "application/json": {
                 "schema": {
@@ -800,6 +887,22 @@
             }
           }
         ],
+        "requestBody": {
+          "description": "The replacement rows, 1:1 with the rows the predicate matches: a JSON `{\"data\": [...]}` envelope of rows keyed by column name (`application/json`), or an Arrow IPC stream of one record batch (`application/vnd.apache.arrow.stream`).",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RowsEnvelope"
+              }
+            },
+            "application/vnd.apache.arrow.stream": {
+              "schema": {
+                "$ref": "#/components/schemas/ArrowIpcRows"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Row counts as JSON `{matched, n_tombstoned, n_not_found}`. Body is the replacement rows as an Arrow IPC stream."
@@ -880,6 +983,11 @@
   },
   "components": {
     "schemas": {
+      "ArrowIpcRows": {
+        "type": "string",
+        "format": "binary",
+        "description": "A raw Arrow IPC stream request body: one record batch of rows, sent as\n`Content-Type: application/vnd.apache.arrow.stream`. The most efficient\ningest path — no JSON conversion; the batch's schema must match the\ntable's."
+      },
       "Bm25SearchRequest": {
         "type": "object",
         "description": "`POST /v1/bm25_search/{database}`. Projection is optional (absent ⇒ the\nengine-native `_id` + `score`).",
@@ -965,15 +1073,164 @@
           "name": {
             "type": "string",
             "description": "The database name, unique within the account."
+          },
+          "storage": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CreateDatabaseStorage",
+                "description": "Bring-your-own-bucket: where this database's data should live. Omitted\nmeans platform-hosted storage, exactly as before this field existed."
+              }
+            ]
           }
         }
+      },
+      "CreateDatabaseResponse": {
+        "type": "object",
+        "description": "Create-database response. Empty for a platform-hosted database; a bound\none carries what the caller needs to finish the handshake.",
+        "properties": {
+          "storage": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CreatedStorage",
+                "description": "Present when the database was created with a storage binding."
+              }
+            ]
+          }
+        }
+      },
+      "CreateDatabaseStorage": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Amazon S3 (or an S3-compatible store via `endpoint`).",
+            "required": [
+              "bucket",
+              "region",
+              "role_arn",
+              "provider"
+            ],
+            "properties": {
+              "bucket": {
+                "type": "string",
+                "description": "The customer's bucket."
+              },
+              "endpoint": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Custom endpoint for an S3-compatible store (https only)."
+              },
+              "prefix": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Root inside the bucket under which everything the platform writes\nlives. Omitted roots at the bucket."
+              },
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "s3"
+                ]
+              },
+              "region": {
+                "type": "string",
+                "description": "The bucket's region."
+              },
+              "requester_pays": {
+                "type": "boolean",
+                "description": "Whether the bucket has Requester Pays enabled."
+              },
+              "role_arn": {
+                "type": "string",
+                "description": "The customer-owned IAM role the platform will assume\n(`arn:aws:iam::<account>:role/<name>`)."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Google Cloud Storage: the customer grants the platform's service\naccount an object role on the bucket.",
+            "required": [
+              "bucket",
+              "region",
+              "provider"
+            ],
+            "properties": {
+              "bucket": {
+                "type": "string",
+                "description": "The customer's bucket."
+              },
+              "prefix": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Root inside the bucket. Omitted roots at the bucket."
+              },
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "gcs"
+                ]
+              },
+              "region": {
+                "type": "string",
+                "description": "The bucket's region."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Azure Blob Storage: the customer admin-consents the platform's Entra\napplication and grants it a data role on the storage account.",
+            "required": [
+              "container",
+              "region",
+              "tenant_id",
+              "provider"
+            ],
+            "properties": {
+              "container": {
+                "type": "string",
+                "description": "The customer's container."
+              },
+              "prefix": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Root inside the container. Omitted roots at the container."
+              },
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "azure"
+                ]
+              },
+              "region": {
+                "type": "string",
+                "description": "The storage account's region."
+              },
+              "tenant_id": {
+                "type": "string",
+                "description": "The customer's Entra tenant id."
+              }
+            }
+          }
+        ],
+        "description": "A requested storage binding, tagged by provider. Deliberately NOT the\nstored [`StorageBinding`] shape: the AWS external id is generated by the\nplatform during the create call and returned to the caller — accepting one\nfrom the request would let a caller reuse another binding's id and reopen\nthe confused-deputy hole the id exists to close."
       },
       "CreateTableRequest": {
         "type": "object",
         "description": "`POST /v1/create_table/{database}`.",
         "required": [
-          "table_name",
-          "schema"
+          "table_name"
         ],
         "properties": {
           "indexes": {
@@ -987,16 +1244,47 @@
             ]
           },
           "schema": {
-            "type": "array",
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "$ref": "#/components/schemas/SchemaField"
-            }
+            },
+            "description": "JSON column descriptors. Exactly one of `schema` or `schema_ipc` is\nrequired. Cannot express nested types; use `schema_ipc` for those."
+          },
+          "schema_ipc": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The table's Arrow schema as a base64-encoded Arrow IPC stream carrying\nonly the schema message. Exactly one of `schema` or `schema_ipc` is\nrequired. Carries any Arrow type the engine accepts, nested included."
           },
           "table_name": {
             "type": "string"
           }
         },
         "additionalProperties": false
+      },
+      "CreatedStorage": {
+        "type": "object",
+        "description": "The binding half of a create response.",
+        "required": [
+          "verified"
+        ],
+        "properties": {
+          "external_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "For AWS bindings: the external id to write into the role's trust\npolicy (`sts:ExternalId` condition). Returned exactly once, here."
+          },
+          "verified": {
+            "type": "boolean",
+            "description": "Always `false` at create. Call `POST /v1/databases/{name}/storage/verify`\nonce the grant is in place; workers will not start for this database\nuntil the binding verifies."
+          }
+        }
       },
       "DatabaseSummary": {
         "type": "object",
@@ -1019,7 +1307,7 @@
           },
           "state": {
             "type": "string",
-            "description": "Lifecycle state: `registered` (usable) or `purging` (being deleted)."
+            "description": "Lifecycle state: `registered` (usable), `purging` (being deleted), or\n`unreachable` (a bound database whose storage grant failed — restore\nthe grant and re-verify to restore service; the data is not lost)."
           }
         }
       },
@@ -1192,6 +1480,23 @@
           "and"
         ]
       },
+      "RowsEnvelope": {
+        "type": "object",
+        "description": "JSON row envelope for `POST /v1/append/{database}` and\n`POST /v1/update/{database}` — the `Content-Type: application/json`\nalternative to an Arrow IPC stream body. Rows are JSON objects keyed by\ncolumn name, converted server-side into one Arrow batch against the\ntable's schema.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "Rows as JSON objects keyed by column name."
+          }
+        },
+        "additionalProperties": false
+      },
       "SchemaField": {
         "type": "object",
         "description": "One column in a `create_table` schema. A scalar column is `{name, type}` where `type` is a scalar spelling (`\"i32\"`, `\"large_utf8\"`, …); a vector column is `{name, type: \"vector\", dim}`; a list column is `{name, type: \"list\", item}`. `dim` is required for `\"vector\"` and `item` for `\"list\"`.",
@@ -1205,8 +1510,9 @@
               "integer",
               "null"
             ],
-            "description": "Fixed length, required for `type: \"vector\"`.",
-            "minimum": 0
+            "description": "Fixed length, required for `type: \"vector\"`. Must be in [1, 4096].",
+            "maximum": 4096,
+            "minimum": 1
           },
           "item": {
             "type": [
@@ -1240,6 +1546,13 @@
           "table_name"
         ],
         "properties": {
+          "encoding": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Response encoding. Omitted (the default) returns the JSON column\ndescriptors; `\"ipc\"` returns an Arrow IPC schema message, which is the\nonly form that can carry a nested column type."
+          },
           "table_name": {
             "type": "string"
           }

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -11,11 +11,12 @@
 
 #![cfg(feature = "remote")]
 
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, io::Cursor, sync::Arc, time::Duration};
 
-use arrow::ipc::writer::StreamWriter;
+use arrow::ipc::{reader::StreamReader, writer::StreamWriter};
 use arrow_array::{Int32Array, RecordBatch};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use datafusion::prelude::{col, lit};
 use infino::{
     Bm25SearchOptions, BoolMode, ConnectOptions, IndexSpec, InfinoError, OptimizeError,
@@ -37,6 +38,17 @@ fn id_schema() -> SchemaRef {
 /// A one-column `id` batch, and its Arrow-IPC bytes (a canned search response).
 fn id_batch(ids: Vec<i32>) -> RecordBatch {
     RecordBatch::try_new(id_schema(), vec![Arc::new(Int32Array::from(ids))]).expect("batch")
+}
+
+/// A schema's Arrow-IPC bytes: a schema message and nothing else, which is what
+/// a describe response carries.
+fn schema_ipc_bytes(schema: &Schema) -> Vec<u8> {
+    let mut out = Vec::new();
+    {
+        let mut w = StreamWriter::try_new(&mut out, schema).expect("ipc schema writer");
+        w.finish().expect("ipc schema finish");
+    }
+    out
 }
 
 fn ipc_bytes(batch: &RecordBatch) -> Vec<u8> {
@@ -76,7 +88,6 @@ async fn create_table_posts_expected_shape() {
         .and(header("authorization", format!("Bearer {KEY}").as_str()))
         .and(body_partial_json(json!({
             "table_name": "posts",
-            "schema": [{"name": "id", "type": "i32", "nullable": false}],
             "indexes": {"fts": ["id"]},
         })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
@@ -89,6 +100,30 @@ async fn create_table_posts_expected_shape() {
             .expect("create_table");
     })
     .await;
+
+    // The schema travels as base64 Arrow IPC. Assert on what it decodes to
+    // rather than on exact bytes, so the test pins the contract and not the
+    // encoder's byte layout.
+    let requests = server
+        .received_requests()
+        .await
+        .expect("request recording is enabled");
+    let body: serde_json::Value =
+        serde_json::from_slice(&requests[0].body).expect("json request body");
+    let encoded = body["schema_ipc"]
+        .as_str()
+        .expect("schema_ipc is a base64 string");
+    let bytes = BASE64.decode(encoded).expect("valid base64");
+    let reader = StreamReader::try_new(Cursor::new(bytes), None).expect("an arrow ipc stream");
+    assert_eq!(
+        reader.schema().as_ref(),
+        id_schema().as_ref(),
+        "the posted schema decodes back to the declared one"
+    );
+    assert!(
+        body.get("schema").is_none(),
+        "the JSON descriptor form is no longer sent"
+    );
 }
 
 #[tokio::test]
@@ -97,9 +132,9 @@ async fn append_streams_arrow_body_with_table_query() {
     // open_table fetches the schema first.
     Mock::given(method("POST"))
         .and(path("/v1/schema/mydb"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-            {"name": "id", "type": "i32", "nullable": false}
-        ])))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(schema_ipc_bytes(&id_schema()), ARROW_CT),
+        )
         .mount(&server)
         .await;
     Mock::given(method("POST"))
@@ -124,9 +159,9 @@ async fn bm25_search_sends_json_and_decodes_arrow() {
     // open_table fetches the schema first.
     Mock::given(method("POST"))
         .and(path("/v1/schema/mydb"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-            {"name": "id", "type": "i32", "nullable": false}
-        ])))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(schema_ipc_bytes(&id_schema()), ARROW_CT),
+        )
         .mount(&server)
         .await;
     Mock::given(method("POST"))
@@ -216,9 +251,9 @@ async fn open_table_missing_maps_to_not_found() {
 async fn mount_schema(server: &MockServer) {
     Mock::given(method("POST"))
         .and(path("/v1/schema/mydb"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-            {"name": "id", "type": "i32", "nullable": false}
-        ])))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(schema_ipc_bytes(&id_schema()), ARROW_CT),
+        )
         .mount(server)
         .await;
 }


### PR DESCRIPTION
## Why

The JSON column descriptors the remote transport sent are flat. A column is `{name, type, nullable}` where the type is one of nine strings, plus bolted-on slots for `vector` and `list` whose `item` must itself be a scalar. There is no recursion, so a struct, a list of structs, or a timestamp cannot be written at all — and adding a tenth type string would not help.

The rejection happened **client-side**, in `scalar_type_str`, before a request was ever sent. So a caller with nested data got `column type not supported over the remote transport` even though the same schema works fine on a local or object-storage connection, where `create_table` takes the Arrow schema directly with no serialization. The limitation was manufactured entirely by the transport's choice of encoding.

## What changed

**`create_table` sends `schema_ipc`** — the schema as a base64-encoded Arrow IPC stream carrying only the schema message. Arrow's own canonical encoding, so every type the engine can hold survives the round trip and there is no per-type spelling table to keep in step with the service. Base64 inside the JSON body rather than a raw body, because the request also carries the table name and the index spec, which belong in JSON; the encoding overhead is irrelevant on a schema of a few kilobytes.

**Describe asks for the same encoding.** `POST /v1/schema/{database}` now carries `"encoding": "ipc"` and the schema is read straight from the response body. That body is raw IPC, not base64: it *is* the schema, so it needs no envelope. The asymmetry between the two directions is deliberate for that reason.

**Six functions deleted**, with their tests: `scalar_type_str`, `field_to_json`, `schema_to_json`, `scalar_type_from_str`, `field_from_json`, `json_to_schema`. The client no longer needs a JSON schema encoder or decoder in either direction, so `wire.rs` loses ~123 lines net.

**The node and python bindings inherit this for free** — both compile this transport with the `remote` feature, so there is nothing to change in either.

**The vendored hosted API spec is refreshed** from the deployed service, which publishes `schema_ipc` and `encoding`.

## Verification

- `cargo test --features remote --lib catalog::remote::wire` — 8/8, including a new test that a `Struct` column round-trips through base64 IPC byte-exactly, and one that a non-IPC body is rejected.
- `cargo test --features remote --test remote` — 17/17. `create_table_posts_expected_shape` now asserts by *decoding* the captured `schema_ipc` and comparing to the declared schema, rather than matching bytes, so it pins the contract and not the encoder's layout. It also asserts the JSON `schema` field is no longer sent.
- The drift test (`-- --ignored`) passes against the refreshed spec: both the operation set and the request signatures.
- `make check` clean. Full default suite green (2225 lib tests plus every integration target).
- Not run locally: `make coverage` and `make public-api`, for want of `cargo-llvm-cov` and `cargo-public-api` on this machine. The public surface is unaffected by inspection — everything touched is `pub(crate)` or private.
- **No benchmark run.** The `remote` feature is off by default, so none of this compiles into the shipped library, and the change touches no query, ingest, or storage path. Happy to run the suite if you would rather have the comparison on record.

## Ordering

The service already accepts both fields in production, so this is safe to land and release independently. A client on an older version keeps working: the JSON descriptor form is still accepted server-side, and only nested schemas need this change.
