### PR TITLE
node: point the hosted connect example at the endpoint that resolves

### DIFF
--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -529,7 +529,7 @@ export class Connection {
  * // local
  * const db = connect("./data");
  * // Infino Cloud
- * const cloud = connect("https://api.platform.infino.ai/my-app", { apiKey: "inf_…" });
+ * const cloud = connect("https://api.platform.infino.ws/my-app", { apiKey: "inf_…" });
  * ```
  */
 export function connect(uri: string, options?: ConnectOptions): Connection {


### PR DESCRIPTION
The `connect()` doc-comment shows `https://api.platform.infino.ai/my-app`, which does not resolve — the hosted service publishes at `api.platform.infino.ws`.

This one reaches readers before any documentation does: it is what an editor surfaces on hover over `connect`, and it ships inside the published package.

Only `index.ts` changes; `index.d.ts` is generated by `tsc` at build time and is not tracked. The Python and Rust surfaces carry no hosted-endpoint example, so there is nothing to correct there.

Found by the drift dashboard's finder. The same dead host was in infino-mcp's README, fixed separately.