### PR TITLE
superfile/vector: SQ8 int8-VNNI hnsw walk with Sq16 refine

### DIFF
--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -239,6 +239,20 @@ vector:
   # demand near-target recall from the graph or step aside to ivf.
   hnsw_recall_slack: 0.01
 
+  # For search_mode = hnsw_ivf: navigate the resident graph on an int8 (SQ8)
+  # plane derived at load from the Sq16 codes' high byte (scored with an
+  # int8-VNNI kernel where present), then re-rank the final beam on full Sq16.
+  # Roughly halves warm hnsw latency at unchanged recall; costs an extra
+  # resident plane (~1 byte/dim/row, ~50% over the Sq16 plane), built only when
+  # enabled. false walks entirely on Sq16 (no extra plane).
+  hnsw_sq8_walk: true
+
+  # For search_mode = hnsw_ivf with hnsw_sq8_walk: how many of the SQ8 walk's
+  # nearest candidates to re-rank on full Sq16 before returning the top k.
+  # Clamped to [k, ef]. Recall saturates well below ef (256 is the knee for
+  # k <= 100); wider only adds tail cost.
+  hnsw_refine_k: 256
+
   # For search_mode = hnsw_ivf: scale ceiling for the per-row DATA graph. The
   # resident data HNSW is built at drain and persisted only when the table's
   # doc count is at or below this; above it, only the (much smaller) centroid

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -318,6 +318,15 @@ const DEFAULT_VECTOR_TARGET_RECALL: f64 = 0.99;
 /// more hard high-dim tables on the graph; tighten it to demand near-target
 /// recall from the graph or step aside to ivf.
 const DEFAULT_VECTOR_HNSW_RECALL_SLACK: f64 = 0.01;
+/// Default for `hnsw_sq8_walk`: on. The int8 walk roughly halves warm hnsw
+/// latency at unchanged recall; the extra resident SQ8 plane (~50% over the
+/// Sq16 plane) is the accepted trade. Set `false` to reclaim that memory and
+/// walk on Sq16.
+const DEFAULT_VECTOR_HNSW_SQ8_WALK: bool = true;
+/// Default for `hnsw_refine_k`: re-rank the SQ8 walk's top 256 on full Sq16.
+/// The knee for k ≤ 100 — recall matches the Sq16 walk and saturates here, so
+/// a wider refine only adds tail cost.
+const DEFAULT_VECTOR_HNSW_REFINE_K: usize = 256;
 /// Base-layer degree candidates the drain calibrator sweeps (ascending).
 pub const HNSW_M0_CANDIDATES: &[usize] = &[32, 64, 128, 256];
 /// Query-beam (`ef`) candidates the drain calibrator sweeps (ascending),
@@ -540,6 +549,23 @@ pub struct VectorSettings {
     /// Recall shortfall below `target_recall` the hnsw graph is still accepted
     /// at before the drain gives up and serves ivf (`floor = target - this`).
     pub hnsw_recall_slack: f64,
+    /// For `search_mode = hnsw_ivf`: navigate the resident graph on an int8
+    /// (SQ8) plane derived at load from the Sq16 codes' high byte — scored with
+    /// an int8 dot kernel (AVX-512 VNNI where present) — then re-rank the final
+    /// beam on full Sq16. The walk dominates query cost (tens of thousands of
+    /// distance evals, far more than `ef`), so the cheaper int8 kernel roughly
+    /// halves warm latency at unchanged recall. Cost: an extra resident plane
+    /// (`+1 byte/dim/row`, ~50% on top of the Sq16 plane) — built only when
+    /// this is set. `false` walks entirely on Sq16 (no extra plane). Ignored
+    /// under any other search mode.
+    pub hnsw_sq8_walk: bool,
+    /// For `search_mode = hnsw_ivf` with `hnsw_sq8_walk`: how many of the SQ8
+    /// walk's nearest candidates to re-rank on full Sq16 before returning the
+    /// top `k`. Clamped to `[k, ef]`. Wider recovers more of the int8 walk's
+    /// ranking loss but adds Sq16 scores to the tail; recall saturates well
+    /// below `ef` (256 is the knee for k ≤ 100). Ignored when `hnsw_sq8_walk`
+    /// is off or under any other search mode.
+    pub hnsw_refine_k: usize,
     /// For `search_mode = hnsw_ivf`: scale ceiling for the per-row **data**
     /// graph. The resident data HNSW is built at drain and persisted only
     /// when the table's doc count ≤ this; above it, only the centroid graph
@@ -628,6 +654,8 @@ impl Default for VectorSettings {
             hnsw_ef_construction: DEFAULT_VECTOR_HNSW_EF_CONSTRUCTION,
             hnsw_m0: DEFAULT_VECTOR_HNSW_M0,
             hnsw_recall_slack: DEFAULT_VECTOR_HNSW_RECALL_SLACK,
+            hnsw_sq8_walk: DEFAULT_VECTOR_HNSW_SQ8_WALK,
+            hnsw_refine_k: DEFAULT_VECTOR_HNSW_REFINE_K,
             hnsw_max_docs: DEFAULT_VECTOR_HNSW_MAX_DOCS,
             hnsw_probe_max_docs: DEFAULT_VECTOR_HNSW_PROBE_MAX_DOCS,
             cell_split_doc_cap: DEFAULT_VECTOR_CELL_SPLIT_DOC_CAP,

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -1215,6 +1215,76 @@ fn sq16_cross(q_prime: &[f32], code_bytes: &[u8]) -> f32 {
     sq16_cross_wide(q_prime, code_bytes)
 }
 
+/// SQ8 walk dot: `Σ_d code_u8[d] · q_i8[d]` (unsigned code byte × signed int8
+/// query), int32. A *ranking proxy* for the graph walk only — the per-query
+/// offset baseline (`Σ 128·q_i8`) is a constant that doesn't change intra-query
+/// order, so it's dropped; exact scores come from the Sq16 refine afterward.
+/// `code_u8` is the contiguous high byte of each Sq16 code. int8 products over
+/// ≤768 dims stay far inside int32. Runtime-dispatched to AVX-512-VNNI
+/// `vpdpbusd`, else a scalar fallback. `code_u8.len() == q_i8.len() == dim`.
+pub(crate) fn sq8_walk_dot(code_u8: &[u8], q_i8: &[i8]) -> i32 {
+    debug_assert_eq!(code_u8.len(), q_i8.len());
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("avx512f")
+            && is_x86_feature_detected!("avx512bw")
+            && is_x86_feature_detected!("avx512vnni")
+        {
+            // SAFETY: gated on avx512f+bw+vnni (the features the kernel
+            // enables). Each iteration reads 64 `code_u8` and 64 `q_i8`
+            // strictly below `dim - dim % 64`; the scalar tail covers the
+            // remainder — no out-of-bounds access.
+            return unsafe { sq8_dot_vnni(code_u8, q_i8) };
+        }
+    }
+    sq8_dot_scalar(code_u8, q_i8)
+}
+
+fn sq8_dot_scalar(code_u8: &[u8], q_i8: &[i8]) -> i32 {
+    code_u8
+        .iter()
+        .zip(q_i8)
+        .map(|(&c, &q)| c as i32 * q as i32)
+        .sum()
+}
+
+/// AVX-512-VNNI `vpdpbusd` tier of [`sq8_walk_dot`]: 64 unsigned code bytes ×
+/// 64 signed int8 query values per instruction, int32 accumulate.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
+unsafe fn sq8_dot_vnni(code_u8: &[u8], q_i8: &[i8]) -> i32 {
+    use core::arch::x86_64::{
+        _mm512_dpbusd_epi32, _mm512_loadu_epi8, _mm512_reduce_add_epi32, _mm512_setzero_si512,
+    };
+    let dim = q_i8.len();
+    let mut acc = _mm512_setzero_si512();
+    let mut d = 0usize;
+    while d + 64 <= dim {
+        let a = _mm512_loadu_epi8(code_u8.as_ptr().add(d) as *const i8);
+        let b = _mm512_loadu_epi8(q_i8.as_ptr().add(d));
+        acc = _mm512_dpbusd_epi32(acc, a, b);
+        d += 64;
+    }
+    let mut s = _mm512_reduce_add_epi32(acc);
+    while d < dim {
+        s += code_u8[d] as i32 * q_i8[d] as i32;
+        d += 1;
+    }
+    s
+}
+
+/// Quantize a query to signed int8 for [`sq8_walk_dot`]: scale by the query's
+/// own max magnitude so the largest component maps to ±127. The scale is a
+/// per-query constant, so it doesn't affect the walk's intra-query ranking.
+pub(crate) fn quantize_query_i8(query: &[f32]) -> Vec<i8> {
+    let max = query.iter().fold(0.0f32, |m, &q| m.max(q.abs())).max(1e-12);
+    let qs = 127.0 / max;
+    query
+        .iter()
+        .map(|&q| (q * qs).round().clamp(-127.0, 127.0) as i8)
+        .collect()
+}
+
 /// Safe `wide` tier of [`sq16_cross`]: fixed-size 16-byte chunks so the
 /// u16 conversions compile without per-byte bounds checks.
 fn sq16_cross_wide(q_prime: &[f32], code_bytes: &[u8]) -> f32 {
@@ -2319,6 +2389,44 @@ mod tests {
 
     fn approx(a: f32, b: f32, eps: f32) -> bool {
         (a - b).abs() < eps
+    }
+
+    /// The SQ8 walk kernel's SIMD tier must match its scalar reference exactly
+    /// (integer dot — bit-exact, no float slack). Covers a 64-aligned width and
+    /// widths with a scalar tail (`dim % 64 != 0`).
+    #[test]
+    fn sq8_walk_dot_simd_matches_scalar() {
+        let mut st = 0x1234_5678_9abc_def0u64;
+        let mut next = || {
+            st ^= st << 13;
+            st ^= st >> 7;
+            st ^= st << 17;
+            st
+        };
+        for dim in [64usize, 100, 768] {
+            let code: Vec<u8> = (0..dim).map(|_| (next() & 0xff) as u8).collect();
+            let q: Vec<i8> = (0..dim)
+                .map(|_| ((next() % 255) as i32 - 127) as i8)
+                .collect();
+            let scalar = sq8_dot_scalar(&code, &q);
+            assert_eq!(
+                sq8_walk_dot(&code, &q),
+                scalar,
+                "runtime-dispatched sq8_walk_dot != scalar at dim={dim}"
+            );
+            #[cfg(target_arch = "x86_64")]
+            if is_x86_feature_detected!("avx512f")
+                && is_x86_feature_detected!("avx512bw")
+                && is_x86_feature_detected!("avx512vnni")
+            {
+                // SAFETY: gated on the exact features `sq8_dot_vnni` enables.
+                let vnni = unsafe { sq8_dot_vnni(&code, &q) };
+                assert_eq!(
+                    vnni, scalar,
+                    "avx512-vnni sq8 kernel != scalar at dim={dim}"
+                );
+            }
+        }
     }
 
     fn scalar_nearest_two_centroids(

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -1237,10 +1237,10 @@ pub(crate) fn sq8_walk_dot(code_u8: &[u8], q_i8: &[i8]) -> i32 {
             return unsafe { sq8_dot_vnni(code_u8, q_i8) };
         }
     }
-    sq8_dot_scalar(code_u8, q_i8)
+    sq8_walk_dot_scalar(code_u8, q_i8)
 }
 
-fn sq8_dot_scalar(code_u8: &[u8], q_i8: &[i8]) -> i32 {
+fn sq8_walk_dot_scalar(code_u8: &[u8], q_i8: &[i8]) -> i32 {
     code_u8
         .iter()
         .zip(q_i8)
@@ -2413,7 +2413,7 @@ mod tests {
             let q: Vec<i8> = (0..dim)
                 .map(|_| ((next() % 255) as i32 - 127) as i8)
                 .collect();
-            let scalar = sq8_dot_scalar(&code, &q);
+            let scalar = sq8_walk_dot_scalar(&code, &q);
             assert_eq!(
                 sq8_walk_dot(&code, &q),
                 scalar,

--- a/src/superfile/vector/distance.rs
+++ b/src/superfile/vector/distance.rs
@@ -1256,21 +1256,26 @@ unsafe fn sq8_dot_vnni(code_u8: &[u8], q_i8: &[i8]) -> i32 {
     use core::arch::x86_64::{
         _mm512_dpbusd_epi32, _mm512_loadu_epi8, _mm512_reduce_add_epi32, _mm512_setzero_si512,
     };
-    let dim = q_i8.len();
-    let mut acc = _mm512_setzero_si512();
-    let mut d = 0usize;
-    while d + 64 <= dim {
-        let a = _mm512_loadu_epi8(code_u8.as_ptr().add(d) as *const i8);
-        let b = _mm512_loadu_epi8(q_i8.as_ptr().add(d));
-        acc = _mm512_dpbusd_epi32(acc, a, b);
-        d += 64;
+    // SAFETY: called only after avx512f+bw+vnni detection. Each iteration loads
+    // 64 bytes from `code_u8` and `q_i8` strictly below `dim - dim % 64`; the
+    // scalar tail covers the remainder — no read past either slice.
+    unsafe {
+        let dim = q_i8.len();
+        let mut acc = _mm512_setzero_si512();
+        let mut d = 0usize;
+        while d + 64 <= dim {
+            let a = _mm512_loadu_epi8(code_u8.as_ptr().add(d) as *const i8);
+            let b = _mm512_loadu_epi8(q_i8.as_ptr().add(d));
+            acc = _mm512_dpbusd_epi32(acc, a, b);
+            d += 64;
+        }
+        let mut s = _mm512_reduce_add_epi32(acc);
+        while d < dim {
+            s += code_u8[d] as i32 * q_i8[d] as i32;
+            d += 1;
+        }
+        s
     }
-    let mut s = _mm512_reduce_add_epi32(acc);
-    while d < dim {
-        s += code_u8[d] as i32 * q_i8[d] as i32;
-        d += 1;
-    }
-    s
 }
 
 /// Quantize a query to signed int8 for [`sq8_walk_dot`]: scale by the query's

--- a/src/superfile/vector/hnsw.rs
+++ b/src/superfile/vector/hnsw.rs
@@ -46,7 +46,7 @@ use std::{
 use rayon::prelude::*;
 
 use crate::superfile::vector::distance::{
-    Metric, Sq16Kernel, dequantize_sq16_into, dot, encode_sq16_row,
+    Metric, Sq16Kernel, dequantize_sq16_into, dot, encode_sq16_row, quantize_query_i8, sq8_walk_dot,
 };
 
 /// Per-node distance the graph is generic over. Lower = nearer.
@@ -1176,6 +1176,11 @@ pub(crate) struct HnswIndex {
     /// different column (→ ivf) rather than silently answer it from this
     /// column's neighbors.
     pub column: String,
+    /// Resident contiguous SQ8 walk plane (`n × dim` bytes) — the high byte of
+    /// each Sq16 code, derived here at load, never persisted (no writer/bundle
+    /// change). Used by [`HnswIndex::search_sq8_refine`] for a cheap int8-VNNI
+    /// walk; the exact ranking comes from the Sq16 refine over `scorer`.
+    pub sq8_plane: Vec<u8>,
 }
 
 /// Serialize a `hnsw` index to a persistable byte bundle: header,
@@ -1216,7 +1221,7 @@ pub(crate) fn encode_hnsw(
 /// Rebuild a resident [`HnswIndex`] from [`encode_hnsw`].
 /// Returns `None` on any malformation so the caller falls back to the lazy
 /// build or scan path rather than failing the query.
-pub(crate) fn decode_hnsw(bytes: &[u8]) -> Option<HnswIndex> {
+pub(crate) fn decode_hnsw(bytes: &[u8], sq8_walk: bool) -> Option<HnswIndex> {
     let mut c = Cursor::new(bytes);
     if c.take(HNSW_DATA_MAGIC.len())? != HNSW_DATA_MAGIC {
         return None;
@@ -1251,6 +1256,19 @@ pub(crate) fn decode_hnsw(bytes: &[u8]) -> Option<HnswIndex> {
     if graph.len() != n {
         return None;
     }
+    // Resident SQ8 walk plane: the high byte of each little-endian u16 code,
+    // laid out contiguously (n × dim). Reader-side only — derived from the
+    // Sq16 plane, never persisted. Built only when SQ8-walk serving is on;
+    // empty otherwise, so the plane costs no memory when disabled and serving
+    // falls back to the Sq16 walk.
+    let sq8_plane: Vec<u8> = if sq8_walk {
+        // High byte of each little-endian u16 code — the second byte of every
+        // 2-byte pair. `chunks_exact(2)` elides the per-element bounds check on
+        // this `n × dim` hydration loop.
+        plane.chunks_exact(2).map(|w| w[1]).collect()
+    } else {
+        Vec::new()
+    };
     let scorer = Sq16Scorer::from_codes(plane, dim, n);
     Some(HnswIndex {
         scorer,
@@ -1259,7 +1277,104 @@ pub(crate) fn decode_hnsw(bytes: &[u8]) -> Option<HnswIndex> {
         dim,
         ef_search,
         column,
+        sq8_plane,
     })
+}
+
+/// Prepared query for [`Sq8WalkScorer`]: the int8 query plus the constant
+/// `128·Σq_i8` baseline subtracted at score time.
+pub(crate) struct Sq8Query {
+    q: Vec<i8>,
+    /// `128·Σq_i8`. The stored code byte is unsigned in `[0, 255]`, centered
+    /// near 128, so subtracting this baseline turns the raw dot `Σ code·q` into
+    /// the centered dot `Σ(code−128)·q` — the same ranking (a per-query
+    /// constant shift), but small enough to stay in f32's exact-integer range.
+    /// The raw u8·i8 dot can reach `dim·255·127` (> 2^24 for `dim ≳ 519`, e.g.
+    /// 768-dim), where distinct dots would collapse to the same f32 in the beam
+    /// heap and mis-order candidates before the Sq16 refine sees them.
+    baseline: i32,
+}
+
+/// Walk scorer over the resident SQ8 plane: ranks candidates by the int8-VNNI
+/// dot `-Σ(code−128)·q_i8` (NegDot — lower is nearer). A coarse *navigation*
+/// proxy; exact ranking is restored by the Sq16 refine in
+/// [`HnswIndex::search_sq8_refine`].
+pub(crate) struct Sq8WalkScorer<'a> {
+    plane: &'a [u8],
+    dim: usize,
+    len: usize,
+}
+
+impl Sq8WalkScorer<'_> {
+    #[inline]
+    fn row(&self, node: u32) -> &[u8] {
+        let s = node as usize * self.dim;
+        &self.plane[s..s + self.dim]
+    }
+}
+
+impl NodeScorer for Sq8WalkScorer<'_> {
+    type Prepared = Sq8Query;
+    fn len(&self) -> usize {
+        self.len
+    }
+    fn dim(&self) -> usize {
+        self.dim
+    }
+    fn prepare(&self, query: &[f32]) -> Sq8Query {
+        let q = quantize_query_i8(query);
+        let baseline = 128 * q.iter().map(|&x| x as i32).sum::<i32>();
+        Sq8Query { q, baseline }
+    }
+    fn prepare_node(&self, node: u32) -> Sq8Query {
+        // Node-as-query for build-time node-to-node distance; unused by the
+        // search-only walk. Center the stored bytes into signed int8.
+        let q: Vec<i8> = self
+            .row(node)
+            .iter()
+            .map(|&c| (c as i16 - 128) as i8)
+            .collect();
+        let baseline = 128 * q.iter().map(|&x| x as i32).sum::<i32>();
+        Sq8Query { q, baseline }
+    }
+    #[inline]
+    fn score(&self, q: &Sq8Query, node: u32) -> f32 {
+        // Centered dot: raw `Σ code·q` minus the `128·Σq` baseline — see
+        // `Sq8Query::baseline` for why the centering is needed for f32 exactness.
+        -((sq8_walk_dot(self.row(node), &q.q) - q.baseline) as f32)
+    }
+}
+
+impl HnswIndex {
+    /// SQ8 walk + Sq16 refine: navigate the graph scoring the cheap int8 plane
+    /// (returning the top `refine_k` by SQ8), then re-score those on the exact
+    /// Sq16 plane and return the true top-`k`. Reader-side; no bundle change.
+    pub(crate) fn search_sq8_refine(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef: usize,
+        refine_k: usize,
+    ) -> Vec<(u32, f32)> {
+        let sq8 = Sq8WalkScorer {
+            plane: &self.sq8_plane,
+            dim: self.dim,
+            len: self.graph.len(),
+        };
+        // Refine the top `refine_k` of the SQ8 beam on Sq16, clamped to
+        // `[k, ef]`: at least `k` (so there are enough to return) and at most
+        // the beam width `ef` (nothing beyond it was explored).
+        let shortlist = refine_k.max(k).min(ef);
+        let beam = self.graph.search(&sq8, query, shortlist, ef);
+        let prepared = self.scorer.prepare(query);
+        let mut refined: Vec<(u32, f32)> = beam
+            .into_iter()
+            .map(|(node, _)| (node, self.scorer.score(&prepared, node)))
+            .collect();
+        refined.sort_by(|a, b| a.1.total_cmp(&b.1));
+        refined.truncate(k);
+        refined
+    }
 }
 
 /// On-disk magic for the combined graph bundle (one slow-state section
@@ -2277,7 +2392,7 @@ mod tests {
         let graph = Hnsw::build(&scorer, HnswParams::default());
 
         let bytes = encode_hnsw(&codes, &doc_ids, &graph, dim, 256, "emb");
-        let idx = decode_hnsw(&bytes).expect("decode bundle");
+        let idx = decode_hnsw(&bytes, true).expect("decode bundle");
         assert_eq!(idx.dim, dim);
         assert_eq!(idx.doc_ids, doc_ids);
         assert_eq!(idx.graph.len(), n);
@@ -2297,7 +2412,7 @@ mod tests {
                 assert_eq!(idx.doc_ids[*node as usize], doc_ids[*node as usize]);
             }
         }
-        assert!(decode_hnsw(b"short").is_none());
+        assert!(decode_hnsw(b"short", true).is_none());
 
         // A corrupt node count must degrade to None, not drive a huge
         // `with_capacity` alloc-abort. Overwrite the `n` word (right after the
@@ -2306,8 +2421,80 @@ mod tests {
         poisoned[HNSW_DATA_MAGIC.len()..HNSW_DATA_MAGIC.len() + 8]
             .copy_from_slice(&u64::MAX.to_le_bytes());
         assert!(
-            decode_hnsw(&poisoned).is_none(),
+            decode_hnsw(&poisoned, true).is_none(),
             "a corrupt node count must decode to None, not attempt a giant alloc"
+        );
+    }
+
+    /// SQ8 walk + Sq16 refine returns essentially the same top-k as the Sq16
+    /// walk. Both are measured against the brute-force exact-Sq16 top-k so the
+    /// test asserts the PR's core claim directly: navigating on the cheap int8
+    /// plane then refining on Sq16 costs no meaningful recall versus walking on
+    /// Sq16 throughout.
+    #[test]
+    fn search_sq8_refine_matches_sq16_walk() {
+        use crate::superfile::vector::distance::encode_sq16_row;
+        let dim = 32;
+        let n = 1000;
+        let k = 10;
+        let ef = 64;
+        let vectors = random_unit_vectors(n, dim, 0xA11CE);
+        let stride = dim * 2;
+        let mut codes = vec![0u8; n * stride];
+        for (i, v) in vectors.iter().enumerate() {
+            encode_sq16_row(v, &mut codes[i * stride..(i + 1) * stride]);
+        }
+        let doc_ids: Vec<i128> = (0..n as i128).collect();
+        let scorer = Sq16Scorer::from_codes(codes.clone(), dim, n);
+        let graph = Hnsw::build(&scorer, HnswParams::default());
+        let bytes = encode_hnsw(&codes, &doc_ids, &graph, dim, ef, "emb");
+        let idx = decode_hnsw(&bytes, true).expect("decode bundle");
+        assert!(
+            !idx.sq8_plane.is_empty(),
+            "sq8 plane must be built when sq8_walk=true"
+        );
+
+        let queries = random_unit_vectors(50, dim, 0xB0B);
+        let mut sq16_hits = 0usize;
+        let mut sq8_hits = 0usize;
+        for q in &queries {
+            // Brute-force exact-Sq16 top-k ground truth (NegDot: lower nearer).
+            let prep = scorer.prepare(q);
+            let mut all: Vec<(u32, f32)> = (0..n as u32)
+                .map(|node| (node, scorer.score(&prep, node)))
+                .collect();
+            all.sort_by(|a, b| a.1.total_cmp(&b.1));
+            let gt: std::collections::HashSet<u32> =
+                all.iter().take(k).map(|(node, _)| *node).collect();
+
+            let sq16: Vec<u32> = graph
+                .search(&scorer, q, k, ef)
+                .into_iter()
+                .map(|(node, _)| node)
+                .collect();
+            // refine_k == ef refines the whole beam — the widest refine.
+            let sq8: Vec<u32> = idx
+                .search_sq8_refine(q, k, ef, ef)
+                .into_iter()
+                .map(|(node, _)| node)
+                .collect();
+            sq16_hits += sq16.iter().filter(|node| gt.contains(node)).count();
+            sq8_hits += sq8.iter().filter(|node| gt.contains(node)).count();
+        }
+        let denom = (queries.len() * k) as f32;
+        let sq16_recall = sq16_hits as f32 / denom;
+        let sq8_recall = sq8_hits as f32 / denom;
+        // The SQ8 walk navigates a slightly different beam, but refining on
+        // Sq16 recovers the ranking: its recall tracks the Sq16 walk within a
+        // small margin (not a lower fixed floor, which would pass even on a
+        // broken walk that always trailed).
+        assert!(
+            sq16_recall > 0.9,
+            "sanity: Sq16 walk recall {sq16_recall:.4} unexpectedly low"
+        );
+        assert!(
+            sq8_recall >= sq16_recall - 0.03,
+            "SQ8 refine recall {sq8_recall:.4} trails Sq16 walk {sq16_recall:.4} by too much"
         );
     }
 

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2220,6 +2220,10 @@ impl SupertableReader {
         let manifest = self.manifest();
         let sections_for_walk = Arc::clone(&sections);
         let query_owned = query.to_vec();
+        // SQ8 int8-VNNI walk + Sq16 refine when the SQ8 plane is resident
+        // (built at decode under `vector.hnsw_sq8_walk`); otherwise walk on
+        // Sq16 directly. `hnsw_refine_k` is the re-rank width.
+        let refine_k = config::global().vector.hnsw_refine_k;
         let hits: Vec<SuperfileHit> = run_on_pool(
             Some(&manifest.options.reader_pool),
             "hnsw serving walk: reader pool dropped result",
@@ -2228,8 +2232,12 @@ impl SupertableReader {
                     .data
                     .as_ref()
                     .expect("data present: checked before dispatch");
-                data.graph
-                    .search(&data.scorer, &query_owned, k_fetch, ef)
+                let walked = if data.sq8_plane.is_empty() {
+                    data.graph.search(&data.scorer, &query_owned, k_fetch, ef)
+                } else {
+                    data.search_sq8_refine(&query_owned, k_fetch, ef, refine_k)
+                };
+                walked
                     .into_iter()
                     .filter_map(|(node, dist)| {
                         // Shift the graph's `−dot` onto the ivf/scan arm's
@@ -7823,8 +7831,8 @@ mod tests {
             let bundle = block_on(super::assemble_hnsw_sections(manifest, "emb", &None))
                 .expect("assemble ok")
                 .expect("sq16 rows must assemble into a graph");
-            let decoded =
-                crate::superfile::vector::hnsw::decode_hnsw(&bundle).expect("decode data bundle");
+            let decoded = crate::superfile::vector::hnsw::decode_hnsw(&bundle, true)
+                .expect("decode data bundle");
             assert_eq!(
                 decoded.graph.len(),
                 decoded.doc_ids.len(),

--- a/src/supertable/slow_vector_state.rs
+++ b/src/supertable/slow_vector_state.rs
@@ -32,6 +32,7 @@ use tokio::task::spawn_blocking;
 use uuid::Uuid;
 
 use crate::{
+    config,
     storage::{StorageError, StorageProvider},
     superfile::vector::hnsw,
     supertable::manifest::{
@@ -596,7 +597,14 @@ pub(crate) async fn fetch_graph_sections(
     let raw = fetch_graph_section(storage, reference).await?;
     let bundle = hnsw::decode_graph_bundle(&raw)
         .ok_or_else(|| SlowVectorStateError::Parse("graph bundle frame".into()))?;
-    let data = bundle.data_bundle.as_deref().and_then(hnsw::decode_hnsw);
+    // Build the resident SQ8 walk plane only when SQ8-walk serving is enabled
+    // (it costs ~1 byte/dim/row on top of the Sq16 plane); otherwise serving
+    // walks on Sq16 and the plane stays empty.
+    let sq8_walk = config::global().vector.hnsw_sq8_walk;
+    let data = bundle
+        .data_bundle
+        .as_deref()
+        .and_then(|b| hnsw::decode_hnsw(b, sq8_walk));
     if let Some(idx) = &data {
         // Surface the stamped params every time the resident graph hydrates,
         // so serving always shows what a table's graph is actually running.


### PR DESCRIPTION
## What

For `search_mode = hnsw_ivf`, navigate the resident HNSW graph on a cheap int8 (SQ8) plane derived at load from the Sq16 codes' high byte — scored with an AVX-512-VNNI `vpdpbusd` kernel where present, scalar fallback otherwise — then re-rank the final beam on the exact Sq16 codes before returning the top `k`. The graph walk dominates query cost (tens of thousands of distance evals, far more than `ef`), so making the per-node kernel ~3× cheaper roughly halves warm latency while the Sq16 refine restores exact ranking.

Two new knobs under `vector:` (both `#[serde(default)]`, so existing `config.yaml` files keep working):

- `hnsw_sq8_walk` (default `true`) — walk on the SQ8 plane + Sq16 refine. `false` walks entirely on Sq16 (the prior behavior), no extra plane.
- `hnsw_refine_k` (default `256`) — how many of the SQ8 walk's nearest candidates to re-rank on Sq16 before returning `k`. Clamped to `[k, ef]`.

Reader-side only: the SQ8 plane is derived when a graph bundle is hydrated, never persisted — no writer, bundle-format, or on-disk change. The plane is built only when `hnsw_sq8_walk` is on, so the feature costs no memory when disabled.

## Why / results

Warm p95 on a 1M-row, 768-dim cosine corpus, comparing the Sq16 walk against SQ8 walk + Sq16 refine **at matched recall** (same graph, swept `ef`):

**k=100**

| recall | Sq16 walk p95 | SQ8 + refine p95 | speedup |
| ------ | ------------- | ---------------- | ------- |
| ~0.982 | 3.2 ms        | 1.8 ms           | 1.78×   |
| ~0.993 | 5.5 ms        | 2.9 ms           | 1.90×   |
| ~0.997 | 9.4 ms        | 4.9 ms           | 1.92×   |

**k=10**

| recall | Sq16 walk p95 | SQ8 + refine p95 | speedup |
| ------ | ------------- | ---------------- | ------- |
| ~0.990 | 1.9 ms        | 0.9 ms           | 2.11×   |
| ~0.996 | 3.0 ms        | 1.5 ms           | 2.00×   |

Recall matches the Sq16 walk to within ~0.001 at every `ef`; the win is 1.8–2.0× lower warm p95. The `refine_k` default of 256 is the knee: k=10 saturates by refine_k≈32, k=100 by refine_k≈256; at the higher `ef` used for 0.99 recall, 256 sits well below `ef` and fully saturates.

### 10M scale

Same corpus family at 10M rows (same-graph flip, stamped ef=512):

| k | Sq16 walk recall / p95 | SQ8 + refine recall / p95 | speedup |
| - | ---------------------- | ------------------------- | ------- |
| 100 | 0.9826 / 8.8 ms | 0.9823 / 5.9 ms | 1.49× |
| 10 | 0.9887 / 5.5 ms | 0.9880 / 3.8 ms | 1.45× |

Recall stays within 0.0007 of the Sq16 walk at 10M. The speedup is smaller than at 1M because the larger resident graph is more DRAM-bandwidth-bound (the int8 kernel's compute advantage is partly masked by memory-stall time), but it remains a recall-neutral 1.45–1.49× on warm p95.

## Cost / trade-off

The SQ8 plane is an extra resident array of `~1 byte/dim/row` — about 50% on top of the Sq16 plane — for each hydrated data graph, built only while `hnsw_sq8_walk` is on. This is the deliberate trade for the ~2× latency win; `hnsw_sq8_walk: false` reclaims the memory and walks on Sq16.

## Correctness

- The SQ8 walk is a **navigation proxy** only; the exact top-`k` always comes from the Sq16 refine. The walk kernel scores the *centered* dot `Σ(code−128)·q` (a per-query constant shift off the raw `u8·i8` dot), which keeps the value inside f32's exact-integer range at high dim.
- New unit tests: the VNNI kernel is asserted bit-exact against its scalar reference across 64-aligned and tail widths; `search_sq8_refine` is asserted to track the Sq16 walk's recall (both measured against brute-force exact Sq16) within a small margin.
- `cargo fmt`, `clippy`, and the vector unit + integration tests pass.
