### PR TITLE
catalog/remote: carry the FTS analyzer in create_table requests

### DIFF
--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -68,9 +68,9 @@ impl IndexSpec {
 
     /// Mark `column` as full-text (BM25) indexed with a named analyzer
     /// (`"ascii_lower"` or `"standard"` — the Unicode-aware UAX #29
-    /// tokenizer that keeps non-ASCII text). All FTS columns in a table
-    /// must use the same analyzer; a table mixing analyzers is rejected
-    /// at [`create_table`](crate::Connection::create_table).
+    /// tokenizer that keeps non-ASCII text). The analyzer is per column:
+    /// each FTS column is tokenized with its own, so columns in one table
+    /// may use different analyzers.
     pub fn fts_with_analyzer(
         mut self,
         column: impl Into<String>,

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -22,8 +22,7 @@ use arrow_schema::Schema;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use serde_json::{Value, json};
 
-use crate::superfile::fts::tokenize::ASCII_LOWER_TOKENIZER;
-use crate::{IndexSpec, InfinoError, Metric};
+use crate::{IndexSpec, InfinoError, Metric, superfile::fts::tokenize::ASCII_LOWER_TOKENIZER};
 
 /// Content type for an Arrow IPC streaming body — the encoding for `append`
 /// bodies and read responses.

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -22,6 +22,7 @@ use arrow_schema::Schema;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use serde_json::{Value, json};
 
+use crate::superfile::fts::tokenize::ASCII_LOWER_TOKENIZER;
 use crate::{IndexSpec, InfinoError, Metric};
 
 /// Content type for an Arrow IPC streaming body — the encoding for `append`
@@ -43,13 +44,30 @@ pub(crate) fn metric_str(metric: Metric) -> &'static str {
 }
 
 /// An [`IndexSpec`] as the `indexes` object of a create-table request:
-/// `{fts: [col, …], vector: [{column, dim, metric}, …]}`. Absent index kinds
+/// `{fts: [entry, …], vector: [{column, dim, metric}, …]}`. Absent index kinds
 /// are omitted (the server treats a missing key as "none").
+///
+/// Each FTS entry is a bare column name when it uses the default `ascii_lower`
+/// analyzer, or a `{column, analyzer}` object when it names a different one, so
+/// the chosen analyzer reaches the server rather than being dropped. The bare
+/// form for the default keeps the request identical to what older servers
+/// expect.
 pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
     let mut indexes = serde_json::Map::new();
-    let fts = spec.fts_columns();
-    if !fts.is_empty() {
-        indexes.insert("fts".to_string(), json!(fts));
+    let columns = spec.fts_columns();
+    if !columns.is_empty() {
+        let fts: Vec<Value> = columns
+            .iter()
+            .zip(spec.fts_analyzers())
+            .map(|(column, analyzer)| {
+                if analyzer == ASCII_LOWER_TOKENIZER {
+                    json!(column)
+                } else {
+                    json!({ "column": column, "analyzer": analyzer })
+                }
+            })
+            .collect();
+        indexes.insert("fts".to_string(), Value::Array(fts));
     }
     let vectors: Vec<Value> = spec
         .vector_indexes()
@@ -161,6 +179,31 @@ mod tests {
             json["vector"][0],
             json!({"column": "embedding", "dim": 384, "metric": "cosine"})
         );
+    }
+
+    #[test]
+    fn index_spec_json_carries_a_non_default_analyzer() {
+        // A named analyzer must cross the wire as a {column, analyzer} object,
+        // so the server builds the index with it rather than the default. A
+        // default-analyzer column alongside it stays a bare string, so only the
+        // columns that need the object form pay for it.
+        let spec = IndexSpec::new()
+            .fts("title")
+            .fts_with_analyzer("body", "standard");
+        let json = index_spec_to_json(&spec);
+        assert_eq!(
+            json["fts"],
+            json!(["title", {"column": "body", "analyzer": "standard"}])
+        );
+    }
+
+    #[test]
+    fn index_spec_json_bare_form_for_the_default_analyzer() {
+        // An explicit ascii_lower is the default, so it serializes identically to
+        // a bare column name — no needless object form, and byte-identical to
+        // what an older server expects.
+        let spec = IndexSpec::new().fts_with_analyzer("body", "ascii_lower");
+        assert_eq!(index_spec_to_json(&spec)["fts"], json!(["body"]));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The remote transport encoded an `IndexSpec`'s FTS indexes as bare column names
(`"fts": ["body"]`), using only `fts_columns()` and never `fts_analyzers()`. So
a non-default analyzer chosen at create time —
`IndexSpec::new().fts_with_analyzer("body", "standard")` — was dropped on the
wire, and the server built the column with the default `ascii_lower` analyzer.
Non-ASCII query terms against a remote table then returned no rows, while the
same table over a local connection (which passes the `IndexSpec` straight to
the engine) honored the analyzer.

## Fix

Encode each FTS entry as a `{column, analyzer}` object when it uses a
non-default analyzer, and keep the bare column-name form for the default
(`ascii_lower`):

```json
"fts": ["title", {"column": "body", "analyzer": "standard"}]
```

Keeping the bare form for the default means a default-analyzer request is
byte-identical to before, so a server that predates the object form is
unaffected for the common case; only a request that actually asks for a
non-default analyzer uses the new shape.

## Testing

- `index_spec_json_carries_a_non_default_analyzer` — a `standard` column
  serializes as `{"column","analyzer"}` while a sibling default column stays a
  bare string.
- `index_spec_json_bare_form_for_the_default_analyzer` — an explicit
  `ascii_lower` serializes identically to a bare column name.
- The existing `index_spec_json_shape` (default analyzer → `["body"]`) is
  unchanged.
- `cargo fmt --check` clean; `cargo test --features remote catalog::remote::wire`
  green.
