### PR TITLE
vector: widen the pre-drain cell probe past p=1

### DIFF
--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -981,7 +981,14 @@ fn open_consumer(modality: Modality, built: &supertable::IngestResult) -> (TempD
 /// whole-cell at <5M (cells ~6 MiB), 2–4 islands at 10M.
 const VECTOR_COLD_GET_CEILINGS_FIRST: &[(&str, u64, u64)] = &[
     ("post-drain", 4, 8),
-    ("post-delta", 6, 10),
+    // post-delta is the only state that serves an UNDRAINED user tail
+    // beside the drained bulk, and the user table never carries a probe
+    // law -- the laws describe the hidden table. That tail therefore
+    // probes up to `UNDRAINED_CELL_NPROBE_MAX` (8) cells rather than the
+    // single cell these ceilings were calibrated against, measured at 8
+    // user + 1 hidden GET at 1M. Budget the widened tail; the hidden
+    // side of the same query is unchanged.
+    ("post-delta", 14, 18),
     ("post-compact", 4, 8),
 ];
 /// Per-state `(label, <5M ceiling, 5M–20M ceiling)` on the SECOND
@@ -993,7 +1000,8 @@ const VECTOR_COLD_GET_CEILINGS_FIRST: &[(&str, u64, u64)] = &[
 /// shard generations after a budgeted optimize).
 const VECTOR_COLD_GET_CEILINGS_SECOND: &[(&str, u64, u64)] = &[
     ("post-drain", 1, 4),
-    ("post-delta", 2, 5),
+    // Same undrained-tail allowance as the first-query table above.
+    ("post-delta", 10, 13),
     ("post-compact", 1, 5),
 ];
 /// Doc-count cutoffs for the two ceiling columns (exclusive upper

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -63,34 +63,21 @@ pub(crate) const BIRTH_VERSION_AGGREGATE_COLUMN: &str = "__infino_birth_version"
 /// bounded manifest cost.
 const MAX_EXACT_VALUE_COUNTS: usize = 256;
 
-/// Cells probed per query at minimum — the grid-nearest. One cell fetch
-/// stays the common case: the widening below fires only on genuine
-/// near-ties, so decisive geometry still serves at exactly one cell.
+/// Cells probed per query — exactly one, the grid-nearest. The p=1 read
+/// shape is the design point (one cell fetch, ~fine_nprobe × 2 MiB runs).
+///
+/// This is the SHARED fallback: every path that has no stamped law and
+/// no caller override lands here, drained or not. The undrained probe
+/// needs to reach further than one cell on real embeddings, but that is
+/// scoped to the undrained routing branch itself
+/// (`UNDRAINED_CELL_NPROBE_MAX` in `supertable::query::vector`) rather
+/// than widened here, so a drained table that stamped a width of one
+/// cell keeps its single cell.
 const DEFAULT_CELL_NPROBE_MIN: usize = 1;
-/// Hard cap on cells probed per query — the bound on the near-tie
-/// widening [`DEFAULT_CELL_SLACK`] governs.
-///
-/// This was equal to the floor (widening off) on the premise that
-/// coverage past one cell is bought at drain time by boundary
-/// replication rather than by probing wider. That compensator ships
-/// disabled — `vector.drain_replica_target_factor = 1.0`, replication
-/// having measured a net loss at 10M — so on the PRE-drain path nothing
-/// covered the gap: the width laws are stamped by the drain and do not
-/// exist yet, and there are no replicas. Measured on real Cohere
-/// embeddings at p=1: recall@10 0.367, where the synthetic
-/// planted-cluster corpus (whose clusters align to the grid) reads
-/// ~0.99 and hides the difference. Post-drain serving is unaffected —
-/// it is law-served and pins its own width.
-///
-/// The value matches the filtered path's own default probe width
-/// (`FILTERED_DEFAULT_NPROBE`), so the two paths bound fan-out alike.
-///
-/// This is a floor for the undrained state, not a substitute for
-/// measurement: it costs one constant and no ingest time. A table that
-/// wants the measured laws calls `optimize()`, whose drain stamps width,
-/// fine depth, and rerank budget from the whole corpus and serves them
-/// from the hidden manifest.
-const DEFAULT_CELL_NPROBE_MAX: usize = 8;
+/// Hard cap on cells probed per query. Equal to the floor: adaptive
+/// widening is off by default — see [`DEFAULT_CELL_NPROBE_MIN`] for
+/// where the undrained path opts into a wider cap.
+const DEFAULT_CELL_NPROBE_MAX: usize = 1;
 /// Margin on the distance-ratio probe threshold (`τ = d*·(1+slack)`).
 /// With `nprobe_max > nprobe_min` this is what decides how far the probe
 /// set actually widens: cliff geometry stops at the first cell, diffuse

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -63,17 +63,38 @@ pub(crate) const BIRTH_VERSION_AGGREGATE_COLUMN: &str = "__infino_birth_version"
 /// bounded manifest cost.
 const MAX_EXACT_VALUE_COUNTS: usize = 256;
 
-/// Cells probed per query — exactly one, the grid-nearest. The p=1 read
-/// shape is the design point (one cell fetch, ~fine_nprobe × 2 MiB runs);
-/// recall past its coverage ceiling is bought with boundary replication at
-/// drain time, never by widening the probe set.
+/// Cells probed per query at minimum — the grid-nearest. One cell fetch
+/// stays the common case: the widening below fires only on genuine
+/// near-ties, so decisive geometry still serves at exactly one cell.
 const DEFAULT_CELL_NPROBE_MIN: usize = 1;
-/// Hard cap on cells probed per query. Equal to the floor: adaptive
-/// widening is off — coverage is a drain-side (replication) concern.
-const DEFAULT_CELL_NPROBE_MAX: usize = 1;
+/// Hard cap on cells probed per query — the bound on the near-tie
+/// widening [`DEFAULT_CELL_SLACK`] governs.
+///
+/// This was equal to the floor (widening off) on the premise that
+/// coverage past one cell is bought at drain time by boundary
+/// replication rather than by probing wider. That compensator ships
+/// disabled — `vector.drain_replica_target_factor = 1.0`, replication
+/// having measured a net loss at 10M — so on the PRE-drain path nothing
+/// covered the gap: the width laws are stamped by the drain and do not
+/// exist yet, and there are no replicas. Measured on real Cohere
+/// embeddings at p=1: recall@10 0.367, where the synthetic
+/// planted-cluster corpus (whose clusters align to the grid) reads
+/// ~0.99 and hides the difference. Post-drain serving is unaffected —
+/// it is law-served and pins its own width.
+///
+/// The value matches the filtered path's own default probe width
+/// (`FILTERED_DEFAULT_NPROBE`), so the two paths bound fan-out alike.
+///
+/// This is a floor for the undrained state, not a substitute for
+/// measurement: it costs one constant and no ingest time. A table that
+/// wants the measured laws calls `optimize()`, whose drain stamps width,
+/// fine depth, and rerank budget from the whole corpus and serves them
+/// from the hidden manifest.
+const DEFAULT_CELL_NPROBE_MAX: usize = 8;
 /// Margin on the distance-ratio probe threshold (`τ = d*·(1+slack)`).
-/// Inert while `nprobe_max == nprobe_min`; acts only when a table
-/// explicitly widens its persisted routing.
+/// With `nprobe_max > nprobe_min` this is what decides how far the probe
+/// set actually widens: cliff geometry stops at the first cell, diffuse
+/// real-embedding geometry follows its near-ties to the cap.
 const DEFAULT_CELL_SLACK: f32 = 1.0;
 
 // ---------- Public in-memory shapes ----------

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -175,15 +175,20 @@ const USER_FINE_RUNS_PER_FRAGMENT: usize = 8;
 /// Explicit caller `nprobe` overrides; the per-run width sweep keeps the
 /// trade measured.
 const FILTERED_USER_CELL_NPROBE: usize = 4;
-/// Cells the UNDRAINED probe may widen to under the near-tie slack.
+/// Cells the UNDRAINED probe may widen to under the near-tie slack,
+/// COSINE columns only.
 ///
 /// Bounds the one path with no measurement behind it: until the drain
 /// stamps a width law, nothing has looked at this table's geometry, and
 /// the shared one-cell default is calibrated for planted clusters.
 /// Real embeddings need more — recall@10 0.623 -> 0.932 at 9.4M Cohere,
-/// 0.367 -> 0.844 at 200K — and the widening is bounded so an undrained
-/// table cannot fan out across the grid while it waits for `optimize()`.
-/// Drained serving never reads this: it pins the stamped width.
+/// 0.367 -> 0.844 at 200K, both cosine — and the widening is bounded so
+/// an undrained table cannot fan out across the grid while it waits for
+/// `optimize()`. Non-cosine metrics keep the one-cell default: the
+/// near-tie window is metric-sensitive, and under L2 it admits second
+/// cells on decisive geometry (measured +100% warm p90 on synthetic
+/// l2sq for zero recall gain). Drained serving never reads this: it
+/// pins the stamped width.
 const UNDRAINED_CELL_NPROBE_MAX: usize = 8;
 
 // The admit window keeps the shared
@@ -2868,7 +2873,7 @@ impl SupertableReader {
                     nprobe_max: FILTERED_USER_CELL_NPROBE,
                     ..CellRoutingParams::default()
                 }
-            } else {
+            } else if metric == Metric::Cosine {
                 // UNDRAINED tail: no drain has run, so no law has been
                 // stamped and nothing has measured this table's geometry.
                 // The shipped one-cell probe is calibrated against
@@ -2882,6 +2887,18 @@ impl SupertableReader {
                     nprobe_max: UNDRAINED_CELL_NPROBE_MAX,
                     ..CellRoutingParams::default()
                 }
+            } else {
+                // Non-cosine UNDRAINED tail keeps the one-cell default.
+                // The near-tie window (`τ = d*·(1+slack)`) is
+                // metric-sensitive: under L2 the second-nearest cells sit
+                // within the window on decisive geometry far more often
+                // than under cosine, so the widened cap fires where it
+                // buys nothing -- measured +100% warm p90 on the synthetic
+                // l2sq lane (5.40 -> 10.81 ms) at unchanged ~0.99 recall.
+                // The collapse the cap exists to cover (0.367 / 0.623)
+                // was measured on cosine embeddings only; widening another
+                // metric's undrained tail takes its own measurement first.
+                CellRoutingParams::default()
             };
             // Per-table probe-width law: when the drain calibrated one and
             // the caller passed nothing, the law's width for this `k` acts

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -174,6 +174,7 @@ const USER_FINE_RUNS_PER_FRAGMENT: usize = 8;
 /// complete at 4 runs (drain-diag: p4=1.000) and the default keeps 8.
 /// Explicit caller `nprobe` overrides; the per-run width sweep keeps the
 /// trade measured.
+const FILTERED_USER_CELL_NPROBE: usize = 4;
 /// Cells the UNDRAINED probe may widen to under the near-tie slack.
 ///
 /// Bounds the one path with no measurement behind it: until the drain
@@ -184,7 +185,6 @@ const USER_FINE_RUNS_PER_FRAGMENT: usize = 8;
 /// table cannot fan out across the grid while it waits for `optimize()`.
 /// Drained serving never reads this: it pins the stamped width.
 const UNDRAINED_CELL_NPROBE_MAX: usize = 8;
-const FILTERED_USER_CELL_NPROBE: usize = 4;
 
 // The admit window keeps the shared
 // `manifest::RABITQ_ADMIT_CELL_SHORTLIST_FRACTION` (20%) slice of the
@@ -5461,11 +5461,6 @@ mod tests {
         assert_eq!(admit_shortlist_window(241), 49);
     }
 
-    /// The self-measured admit extension (#515) follows the query's own
-    /// evidence: with a flat estimate spectrum and an observed
-    /// estimate-to-exact residual, the near-tie run past the write
-    /// window qualifies; a cliff-scored spectrum admits nothing. The
-    /// residual floor is measured from already-scored cells, so with no
     /// The wider undrained probe stays scoped to the undrained branch.
     ///
     /// Widening `CellRoutingParams::default()` instead would reach every
@@ -5490,6 +5485,11 @@ mod tests {
         );
     }
 
+    /// The self-measured admit extension (#515) follows the query's own
+    /// evidence: with a flat estimate spectrum and an observed
+    /// estimate-to-exact residual, the near-tie run past the write
+    /// window qualifies; a cliff-scored spectrum admits nothing. The
+    /// residual floor is measured from already-scored cells, so with no
     /// exact scores in hand the round admits nothing (no guess).
     #[test]
     fn admit_extension_round_follows_evidence() {

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -174,6 +174,16 @@ const USER_FINE_RUNS_PER_FRAGMENT: usize = 8;
 /// complete at 4 runs (drain-diag: p4=1.000) and the default keeps 8.
 /// Explicit caller `nprobe` overrides; the per-run width sweep keeps the
 /// trade measured.
+/// Cells the UNDRAINED probe may widen to under the near-tie slack.
+///
+/// Bounds the one path with no measurement behind it: until the drain
+/// stamps a width law, nothing has looked at this table's geometry, and
+/// the shared one-cell default is calibrated for planted clusters.
+/// Real embeddings need more — recall@10 0.623 -> 0.932 at 9.4M Cohere,
+/// 0.367 -> 0.844 at 200K — and the widening is bounded so an undrained
+/// table cannot fan out across the grid while it waits for `optimize()`.
+/// Drained serving never reads this: it pins the stamped width.
+const UNDRAINED_CELL_NPROBE_MAX: usize = 8;
 const FILTERED_USER_CELL_NPROBE: usize = 4;
 
 // The admit window keeps the shared
@@ -2859,7 +2869,19 @@ impl SupertableReader {
                     ..CellRoutingParams::default()
                 }
             } else {
-                CellRoutingParams::default()
+                // UNDRAINED tail: no drain has run, so no law has been
+                // stamped and nothing has measured this table's geometry.
+                // The shipped one-cell probe is calibrated against
+                // planted-cluster geometry and collapses on real
+                // embeddings -- measured recall@10 0.623 at 9.4M Cohere,
+                // 0.367 at 200K. Let the near-tie widening reach further
+                // HERE ONLY: a drained table serves its stamped width
+                // instead, so a table whose law says one cell keeps its
+                // single cell rather than being widened by a default.
+                CellRoutingParams {
+                    nprobe_max: UNDRAINED_CELL_NPROBE_MAX,
+                    ..CellRoutingParams::default()
+                }
             };
             // Per-table probe-width law: when the drain calibrated one and
             // the caller passed nothing, the law's width for this `k` acts
@@ -5444,6 +5466,30 @@ mod tests {
     /// estimate-to-exact residual, the near-tie run past the write
     /// window qualifies; a cliff-scored spectrum admits nothing. The
     /// residual floor is measured from already-scored cells, so with no
+    /// The wider undrained probe stays scoped to the undrained branch.
+    ///
+    /// Widening `CellRoutingParams::default()` instead would reach every
+    /// path that falls back to it — including a DRAINED table whose
+    /// stamped width law is one cell, where the law filters to `None`
+    /// (`LAW_WIDTH_WITHIN_DEFAULT`), no pin happens, and the default is
+    /// what serves. That regression is invisible to recall (planted
+    /// clusters already serve ~1.0) and shows up only as cold-GET fan,
+    /// which is why it is asserted here rather than left to a bench.
+    #[test]
+    fn undrained_cap_is_scoped_and_wider_than_the_shared_default() {
+        let shared = CellRoutingParams::default();
+        assert_eq!(
+            (shared.nprobe_min, shared.nprobe_max),
+            (1, 1),
+            "the shared routing fallback must stay a one-cell probe"
+        );
+        assert!(
+            super::UNDRAINED_CELL_NPROBE_MAX > shared.nprobe_max,
+            "the undrained cap must exceed the shared default, or the \
+             undrained branch widens nothing"
+        );
+    }
+
     /// exact scores in hand the round admits nothing (no guess).
     #[test]
     fn admit_extension_round_follows_evidence() {


### PR DESCRIPTION
The cell routing default capped `nprobe_max` at the `nprobe_min` floor, so the slack-based near-tie widening the query path already implements was inert: every table served exactly one cell until the drain stamped its width laws. The justification for that cap was that coverage past one cell is bought at drain time by boundary replication — but replication ships disabled (`vector.drain_replica_target_factor = 1.0`, a measured net loss at 10M), so nothing covered the undrained path: no laws yet, and no replicas.

Synthetic planted clusters hid it, because their clusters align to the grid a single probe lands in. On real embeddings it is the difference between serving and not.

## What changed

The widening is scoped to the UNDRAINED routing branch of COSINE columns — not to the shared default, and not to other metrics.

- `DEFAULT_CELL_NPROBE_MAX` in `manifest/list.rs` stays at 1. It is the shared fallback for every path with no stamped law and no caller override — and it is also what `handle.rs` stamps into a hidden vector-index table's routing at create time, so raising it reached post-drain serving on any table whose stamped width is one cell. A first cut did raise it, and the st-vec lane caught exactly that.
- `UNDRAINED_CELL_NPROBE_MAX = 8` in `query/vector.rs` is applied to the `CellRoutingParams` built in the undrained arm of user-table routing, cosine columns only. `nprobe_min` stays 1, so decisive geometry still serves at exactly one cell; only genuine near-ties widen, bounded.
- Non-cosine metrics keep the one-cell default. The near-tie window (`τ = d*·(1+slack)`) is metric-sensitive: under L2 the second-nearest cells sit within the window on decisive geometry far more often than under cosine, so the cap fired on the synthetic l2sq lane for zero recall gain (warm p90 5.40 -> 10.81 ms at unchanged ~0.99). The collapse this cap covers was measured on cosine embeddings; widening another metric's undrained tail takes its own measurement first.
- Drained serving is untouched: it pins its width from the stamped law.
- `undrained_cap_is_scoped_and_wider_than_the_shared_default` pins `CellRoutingParams::default()` at `(1, 1)`, because this regression class is invisible to recall and shows up only as cold-GET fan.

## Recall (pre-drain, default config, 100 queries, cosine)

| corpus | shared p=1 | undrained cap 8 |
|---|---|---|
| Cohere 9.4M x 768 | 0.623 | 0.932 |
| Cohere 1M x 768 | — | 0.910 |
| Cohere 200K x 768 | 0.367 | 0.844 |
| synthetic 200K x 1024 | 0.999 | 0.999 |

## Cold-GET budget

post-delta is the only state that serves an undrained user tail beside the drained bulk, and the user table never carries a probe law — the laws describe the hidden table. That tail probes up to 8 cells where these ceilings were calibrated against one. Narrowing it back gives up the recall this PR exists to recover, on exactly the rows that need it, so the two post-delta ceilings in `benches/utils/supertable.rs` are rebudgeted (6 -> 14 first query, 2 -> 10 steady). post-drain and post-compact are untouched.

Re-measured, synthetic 1M on Azure, all four states:

| state | first cold query | steady cold query | ceiling (first / steady) | recall@10 |
|---|---|---|---|---|
| post-drain | 2 GET (1 hidden data + 1 hidden manifest) | 1 GET | 4 / 1 unchanged | 0.992 |
| post-delta | 10 GET (8 user data + 1 hidden data + 1 hidden manifest) | 8 GET (7 user + 1 hidden) | 14 / 10 rebudgeted | 0.995 |
| post-compact | 2 GET | 1 GET | 4 / 1 unchanged | — |

Gates: 68 supertable vector unit tests, full supertable vector suite at 1M synthetic on Azure clean, clippy clean, fmt clean.
