### PR TITLE
vector: serve the stamped width and depth laws on the filtered path

### DIFF
--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2878,20 +2878,38 @@ impl SupertableReader {
             // exactly where a flat config floor was measured scale-fragile:
             // 10M post-drain 0.982 at floor 4 vs 0.996 at 8, identical
             // latency).
+            // The stamped fine-depth law applies to FILTERED queries too.
+            // It is consumed as a floor (`max`), so it can only deepen a
+            // read, never narrow one — and an allow-set needs at least the
+            // unfiltered depth, not less: only a fraction of what a cell
+            // yields is eligible, so the matching neighbours sit deeper in
+            // the fine ranking than the unfiltered top-k ever has to reach.
+            // Filtered was pinned to the fixed FILTERED_HIDDEN_FINE_NPROBE
+            // floor while the drain's own measurement sat unused, which is
+            // the shape of the loss on real corpora (measured post-drain on
+            // Cohere: 0.793 at 200K falling to 0.630 at 9.4M as cells grow,
+            // against 0.997 unfiltered on the same table).
             if hidden_vector_index
-                && !filtered
                 && let Some(fine) = hidden_routing.and_then(|r| r.fine_for_k_at(k))
             {
                 cell_routing.fine_nprobe = cell_routing.fine_nprobe.max(fine);
             }
-            let law_width: Option<usize> =
-                if hidden_vector_index && !filtered && options.nprobe.is_none() {
-                    hidden_routing
-                        .and_then(|r| r.width_for_k_at(k))
-                        .filter(|w| *w > LAW_WIDTH_WITHIN_DEFAULT)
-                } else {
-                    None
-                };
+            // The stamped width law serves FILTERED queries too. Sweeping
+            // every cell (`FILTERED_HIDDEN_CELL_NPROBE`) was a fallback for
+            // not consulting it: wide-and-shallow costs more reads than the
+            // law's cell set AND misses, because an allow-set's eligible
+            // neighbours sit deeper in the fine ranking rather than in
+            // farther cells. With the fine-depth law above now applying,
+            // this serves filtered in the same shape as the unfiltered
+            // default — law floor at whole-cell depth, extended by the
+            // near-tie window below.
+            let law_width: Option<usize> = if hidden_vector_index && options.nprobe.is_none() {
+                hidden_routing
+                    .and_then(|r| r.width_for_k_at(k))
+                    .filter(|w| *w > LAW_WIDTH_WITHIN_DEFAULT)
+            } else {
+                None
+            };
             // Depth the DEFAULT (unpinned) path would read per cell — the
             // stamped fine-depth law over the routing base. Captured before
             // the pin lifts `fine_nprobe` to MAX: #515 serve-window

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2900,9 +2900,10 @@ impl SupertableReader {
             // law's cell set AND misses, because an allow-set's eligible
             // neighbours sit deeper in the fine ranking rather than in
             // farther cells. With the fine-depth law above now applying,
-            // this serves filtered in the same shape as the unfiltered
-            // default — law floor at whole-cell depth, extended by the
-            // near-tie window below.
+            // filtered reads the law's cell set at whole-cell depth. It
+            // stops there: the near-tie serve window below is gated on
+            // `law_default`, which keeps its `!filtered` condition, so no
+            // extension cells are added for filtered.
             let law_width: Option<usize> = if hidden_vector_index && options.nprobe.is_none() {
                 hidden_routing
                     .and_then(|r| r.width_for_k_at(k))


### PR DESCRIPTION
Filtered vector search consulted none of the laws the drain stamps. They were gated behind `!filtered`, so an allow-set query fell back to fixed constants -- sweep every cell (FILTERED_HIDDEN_CELL_NPROBE = 256) at a fixed depth of 16 fine runs -- while the manifest carried a measured width of ~21 and a measured fine depth of ~62 for the same k.

Wide-and-shallow is the wrong trade for an allow-set. Only a fraction of what a probed run yields is eligible, so the matching neighbours sit deeper in each cell's fine ranking rather than in farther cells, and the deficit grows with cell size. That is the measured shape: post-drain filtered recall@10 on real Cohere was 0.793 at 200K and 0.630 at 9.4M, against 0.995 unfiltered on the same table with the same queries.

Serve the stamped width and fine-depth laws on this path. The depth law is consumed as a floor (`max`), so it can only deepen a read.

Measured, 9.4M Cohere, post-drain, ~10% selectivity:

  recall@10  0.630 -> 0.993
  p50        4.01 ms -> 12.31 ms

Two laws stay gated off, both deliberately:

- The rerank law, because its measured budget (1066 rows at k=10) is SMALLER than the k x rerank_mult constant it would replace, and an allow-set needs that shortlist widened rather than narrowed.
- The #515 near-tie serve window, which #525 scoped out of filtered search on purpose. Measured here for completeness: admitting it as well moves recall 0.993 -> 0.998 and p50 12.31 -> 16.95 ms. Whether that trade is worth reopening the exclusion is a separate decision and is not taken here.

Known and unexplained: this serves ~21 cells read in full (~534K rows) where the constants swept ~256 cells at 16 of ~36 fine runs (~2.9M rows) -- five times less data for three times the latency. The cost is therefore not the volume read, and the mechanism behind it is worth finding on its own; it is not specific to filtered search.

Cell and fine selection remain allow-blind -- routing ranks cells by vector proximity and filters rows only once inside a probed run -- so a selectivity-aware admit is still the deeper fix. `|allow|` is already on hand before routing for whoever writes it.