### PR TITLE
metering/writes: track write resource usage 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,7 @@ dependencies = [
  "reqwest",
  "roaring",
  "rustc-hash",
+ "rustix",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,11 @@ mimalloc = { version = "0.1", default-features = false, optional = true }
 libmimalloc-sys = { version = "0.1", features = ["extended"], optional = true }
 bumpalo = { version = "3", features = ["collections"] }
 rustc-hash = "2"
+# Safe `clock_gettime` wrapper, for the per-thread CPU clock the per-op
+# meter brackets with. Already in the dependency graph (tempfile, fs4),
+# so this adds a direct edge rather than new supply-chain surface, and
+# its safe API keeps the syscall out of `unsafe`.
+rustix = { version = "1", features = ["time"] }
 static_assertions = "1"
 
 # Tokenization: UAX#29 word segmentation for the Unicode-aware standard

--- a/benches/README.md
+++ b/benches/README.md
@@ -70,10 +70,11 @@ INFINO_BENCH_UPDATE_README=1 cargo bench -- superfile fts
 
 # Diagnostics (standalone programs in the same binary; never implied by
 # `all` or a bare `cargo bench`).
-cargo bench -- diagnostic                  # all five
+cargo bench -- diagnostic                  # all nine
 cargo bench -- diagnostic scale tombstone  # a subset, grouped
 cargo bench -- tombstone                   # bare names also work
-# Names: scale | tombstone | update | sql-diag | object-store
+# Names: scale | tombstone | update | sql-diag | fts-diag | object-store
+#        | concurrent | disk-warm | write-diag
 ```
 
 ## Object-store backends
@@ -184,6 +185,7 @@ ingest/, fixture/           supertable object-store helpers
 scale.rs, sql_diag.rs       diagnostics (recall gates, SQL dispatch tax)
 tombstone_overhead.rs       diagnostics (delete/tombstone query overhead)
 supertable_update.rs        diagnostics (update/delete pipeline)
+write_diag.rs               diagnostics (per-write-op cost by shape)
 unified_object_store.rs     diagnostics (cold lazy-fetch request shape)
 ```
 

--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -16,7 +16,7 @@
 //! cargo bench -- supertable vector build cold
 //!
 //! # Diagnostics (standalone programs, same binary):
-//! cargo bench -- diagnostic              # all eight
+//! cargo bench -- diagnostic              # all nine
 //! cargo bench -- diagnostic scale        # a subset, grouped
 //! cargo bench -- tombstone               # bare names also work
 //!
@@ -34,9 +34,9 @@
 //!   `all`       : explicit "every tier × modality × phase" (the default).
 //!                 Matrix only — diagnostics are NEVER implied by `all` or
 //!                 by a bare `cargo bench`.
-//!   diagnostic  : `scale` | `tombstone` | `update` | `sql-diag` | `fts-diag` | `object-store` | `concurrent` | `disk-warm`,
+//!   diagnostic  : `scale` | `tombstone` | `update` | `sql-diag` | `fts-diag` | `object-store` | `concurrent` | `disk-warm` | `write-diag`,
 //!                 by name, or grouped under the `diagnostic` keyword —
-//!                 `cargo bench -- diagnostic` runs all eight,
+//!                 `cargo bench -- diagnostic` runs all nine,
 //!                 `cargo bench -- diagnostic scale tombstone` a subset.
 //!
 //! The matrix tests run = (selected tiers) × (selected modalities).
@@ -72,6 +72,7 @@ enum Diagnostic {
     Concurrent,
     DiskWarm,
     RecallWhileIngest,
+    WriteDiag,
 }
 
 impl Diagnostic {
@@ -86,6 +87,7 @@ impl Diagnostic {
             Diagnostic::Concurrent => "concurrent",
             Diagnostic::DiskWarm => "disk-warm",
             Diagnostic::RecallWhileIngest => "recall_while_ingest",
+            Diagnostic::WriteDiag => "write-diag",
         }
     }
 
@@ -108,6 +110,7 @@ impl Diagnostic {
                 );
             }
             Diagnostic::RecallWhileIngest => infino_bench_utils::recall_while_ingest::run(),
+            Diagnostic::WriteDiag => infino_bench_utils::write_diag::run(),
         }
     }
 }
@@ -425,6 +428,7 @@ fn parse_args() -> Selection {
             "concurrent" => diagnostics.push(Diagnostic::Concurrent),
             "disk-warm" | "disk_warm" => diagnostics.push(Diagnostic::DiskWarm),
             "recall_while_ingest" => diagnostics.push(Diagnostic::RecallWhileIngest),
+            "write-diag" | "write_diag" => diagnostics.push(Diagnostic::WriteDiag),
             "diagnostic" | "diagnostics" => want_diagnostics = true,
             other => match other.split_once('=') {
                 Some(("corpus", spec)) => corpus_spec = Some(spec.to_string()),
@@ -465,6 +469,7 @@ fn parse_args() -> Selection {
             Diagnostic::ObjectStore,
             Diagnostic::Concurrent,
             Diagnostic::DiskWarm,
+            Diagnostic::WriteDiag,
         ];
     }
 

--- a/benches/utils/cost.rs
+++ b/benches/utils/cost.rs
@@ -731,6 +731,40 @@ pub fn cold_cell_per_million(
     }
 }
 
+/// Full DIRECT cost of one write op, in dollars: compute billed at the
+/// binding leg — pool CPU or peak-RSS share of RAM, whichever is larger —
+/// over the op's wall window, plus its object-store request dollars.
+/// `None` when the op's CPU was unsampled (never a $0 guess — the same
+/// rule the phase and query cells follow).
+///
+/// "Direct" is deliberate: deferred maintenance the write will later
+/// cause (hidden-index drain merges, compaction) is excluded here and
+/// is already inside the amortized `write_per_million_docs` figure.
+/// Per-op cells exist to compare write shapes against each other on the
+/// work the op itself performed.
+pub fn write_op_usd(
+    cpu_s: Option<f64>,
+    wall_s: f64,
+    peak_rss_bytes: Option<u64>,
+    io: &ObjectStoreMeter,
+) -> Option<f64> {
+    cpu_s.map(|cpu| {
+        let inst = Instance::current();
+        inst.compute_usd(inst.phase_vcpu_seconds(cpu, wall_s, peak_rss_bytes)) + request_usd(io)
+    })
+}
+
+/// "$X/write ($Y/1M)" cell text for one write op's direct cost.
+pub fn write_cell(per_op: f64) -> String {
+    format!("{}/write ({})", usd(per_op), usd_per_million(per_op))
+}
+
+/// Plain "$X" cell text for an already-scaled dollar figure (e.g. a
+/// per-1M-rows value a caller computed from a per-op cost).
+pub fn usd_text(v: f64) -> String {
+    usd(v)
+}
+
 fn fmt_vcpu_seconds(s: f64) -> String {
     if s >= 10.0 {
         format!("{s:.1}")

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -41,3 +41,4 @@ pub mod sql_diag;
 pub mod supertable_update;
 pub mod tombstone_overhead;
 pub mod unified_object_store;
+pub mod write_diag;

--- a/benches/utils/rustfs_server.rs
+++ b/benches/utils/rustfs_server.rs
@@ -1317,15 +1317,26 @@ fn create_bucket(
     // 409, which means the bucket already exists and is success for us.
     let deadline = Instant::now() + Duration::from_secs(BUCKET_READY_TIMEOUT_SECS);
     loop {
-        let response = client
+        let sent = client
             .put(&url)
             .header("host", &host)
             .header("x-amz-date", &amz_date)
             .header("x-amz-content-sha256", &payload_hash)
             .header("authorization", authorization.clone())
             .body(Vec::<u8>::new())
-            .send()
-            .map_err(|e| e.to_string())?;
+            .send();
+        let response = match sent {
+            Ok(response) => response,
+            // A transport error is the earlier half of the same startup
+            // race: before rustfs is ready enough to answer 503 it can
+            // refuse or reset the connection outright. Retry those on the
+            // same deadline, or the loop still gives up too early.
+            Err(_) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(BUCKET_READY_POLL_INTERVAL_MS));
+                continue;
+            }
+            Err(e) => return Err(format!("CreateBucket failed for {bucket}: {e}")),
+        };
         let status = response.status();
         if status.is_success() || status.as_u16() == 409 {
             return Ok(());

--- a/benches/utils/rustfs_server.rs
+++ b/benches/utils/rustfs_server.rs
@@ -1316,7 +1316,6 @@ fn create_bucket(
     // genuine error (bad auth, bad name) and fails immediately — except
     // 409, which means the bucket already exists and is success for us.
     let deadline = Instant::now() + Duration::from_secs(BUCKET_READY_TIMEOUT_SECS);
-    let mut last = String::new();
     loop {
         let response = client
             .put(&url)
@@ -1331,13 +1330,12 @@ fn create_bucket(
         if status.is_success() || status.as_u16() == 409 {
             return Ok(());
         }
-        last = format!(
-            "CreateBucket failed for {bucket}: HTTP {} {:?}",
-            status,
-            response.text().ok()
-        );
         if !status.is_server_error() || Instant::now() >= deadline {
-            return Err(last);
+            return Err(format!(
+                "CreateBucket failed for {bucket}: HTTP {} {:?}",
+                status,
+                response.text().ok()
+            ));
         }
         std::thread::sleep(Duration::from_millis(BUCKET_READY_POLL_INTERVAL_MS));
     }

--- a/benches/utils/rustfs_server.rs
+++ b/benches/utils/rustfs_server.rs
@@ -49,6 +49,19 @@ const RUSTFS_REGION: &str = "us-east-1";
 pub const RUSTFS_BENCH_BUCKET: &str = "infino-bench";
 /// Milliseconds between health polls while RustFS starts.
 const HEALTH_POLL_INTERVAL_MS: u64 = 200;
+
+/// How long `CreateBucket` keeps retrying a 5xx before giving up.
+///
+/// `/health` going green means the socket is serving, not that the object
+/// layer finished initializing — rustfs answers `503 Service not ready`
+/// in that window. Under load (a 10M-doc corpus generation immediately
+/// before the spawn) the gap is wide enough that the first bucket create
+/// lands inside it and the whole bench cell is skipped for what is a
+/// startup race, not a failure.
+const BUCKET_READY_TIMEOUT_SECS: u64 = 60;
+
+/// Backoff between `CreateBucket` retries while the object layer warms up.
+const BUCKET_READY_POLL_INTERVAL_MS: u64 = 250;
 /// Maximum time to wait for RustFS `/health` after spawn.
 const HEALTH_TIMEOUT_SECS: u64 = 60;
 /// Grace period after SIGKILL before a second kill attempt during teardown.
@@ -1298,24 +1311,36 @@ fn create_bucket(
         secret_key,
         region,
     })?;
-    let response = client
-        .put(&url)
-        .header("host", &host)
-        .header("x-amz-date", &amz_date)
-        .header("x-amz-content-sha256", &payload_hash)
-        .header("authorization", authorization)
-        .body(Vec::<u8>::new())
-        .send()
-        .map_err(|e| e.to_string())?;
-    let status = response.status();
-    if status.is_success() || status.as_u16() == 409 {
-        return Ok(());
+    // Retry through the post-health startup window: a 5xx here is rustfs
+    // still bringing its object layer up, not a real rejection. 4xx is a
+    // genuine error (bad auth, bad name) and fails immediately — except
+    // 409, which means the bucket already exists and is success for us.
+    let deadline = Instant::now() + Duration::from_secs(BUCKET_READY_TIMEOUT_SECS);
+    let mut last = String::new();
+    loop {
+        let response = client
+            .put(&url)
+            .header("host", &host)
+            .header("x-amz-date", &amz_date)
+            .header("x-amz-content-sha256", &payload_hash)
+            .header("authorization", authorization.clone())
+            .body(Vec::<u8>::new())
+            .send()
+            .map_err(|e| e.to_string())?;
+        let status = response.status();
+        if status.is_success() || status.as_u16() == 409 {
+            return Ok(());
+        }
+        last = format!(
+            "CreateBucket failed for {bucket}: HTTP {} {:?}",
+            status,
+            response.text().ok()
+        );
+        if !status.is_server_error() || Instant::now() >= deadline {
+            return Err(last);
+        }
+        std::thread::sleep(Duration::from_millis(BUCKET_READY_POLL_INTERVAL_MS));
     }
-    Err(format!(
-        "CreateBucket failed for {bucket}: HTTP {} {:?}",
-        status,
-        response.text().ok()
-    ))
 }
 
 fn delete_bucket(

--- a/benches/utils/write_diag.rs
+++ b/benches/utils/write_diag.rs
@@ -243,9 +243,8 @@ fn shape_row(label: &str, rows_per_op: usize, ops: usize, m: &OpMeasure) -> Vec<
         .scalar_bytes_written
         .saturating_add(m.stats.vector_bytes_written) as f64
         / ops_f;
-    let per_gib = per_op_usd.and_then(|usd| {
-        (logical_bytes > 0.0).then(|| usd / (logical_bytes / BYTES_PER_GIB_F64))
-    });
+    let per_gib = per_op_usd
+        .and_then(|usd| (logical_bytes > 0.0).then(|| usd / (logical_bytes / BYTES_PER_GIB_F64)));
     let wall_ns = wall_s * NS_PER_SEC;
     vec![
         text(label),

--- a/benches/utils/write_diag.rs
+++ b/benches/utils/write_diag.rs
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Per-write-op cost cells — the write-side equivalent of the per-query
+//! read cost cells ([`crate::cost::warm_cell_per_million`] /
+//! [`crate::cost::cold_cell_per_million`]).
+//!
+//! The read path reports a cost cell per query *shape*, so the spread
+//! across shapes is visible. The write path only had one whole-run
+//! aggregate (`write_per_million_docs`, dollars per doc averaged over
+//! ingest, drain and compaction alike), which hides the two axes that
+//! dominate per-op write cost:
+//!
+//! - **Batch size.** A 1-row append pays the full fixed commit cost —
+//!   superfile build overhead, manifest json, pointer CAS — that a
+//!   100k-row append amortizes 100 000 ways. Per-row those differ by
+//!   orders of magnitude.
+//! - **Modality.** A vector append encodes and places 1024-dim
+//!   embeddings; a text append builds postings; the same byte count
+//!   does very different work.
+//!
+//! This diagnostic measures each write shape as an individual committed
+//! op against a seeded table, prices it with the same instance cost
+//! model the read cells use (compute at the binding CPU/RAM leg +
+//! object-store request dollars), and reports $/write, $/1M writes and
+//! $/1M rows per shape.
+//!
+//! **Direct cost only, deliberately.** Deferred maintenance a write
+//! later causes (hidden-index drain merges, compaction) is excluded
+//! here; it is already inside the amortized `write_per_million_docs`
+//! figure. These cells exist to compare shapes against each other on
+//! the work the op itself performed. Engine-attributed counters (rows, planned
+//! PUTs vs actual PUTs) are reported alongside so the priced billing
+//! legs can be reconciled against the measured dollars.
+//!
+//! Corpus text/vectors come from the standard synthetic generator
+//! ([`SequentialSyntheticCorpus`], same seeds and distributions as the
+//! main bench corpus). SQL-schema appends are deferred to a follow-up;
+//! the FTS and vector shapes carry the modality spread.
+//!
+//! Invoked as `cargo bench -- write-diag`.
+
+use std::{env, sync::Arc, time::Duration};
+
+use arrow_array::{LargeStringArray, RecordBatch};
+use datafusion::prelude::{col, lit};
+use infino::{
+    runtime_metrics::op_stats::{OpStats, with_op_stats},
+    storage::{LocalFsStorageProvider, StorageProvider},
+    supertable::Supertable,
+};
+use tempfile::TempDir;
+
+use crate::{
+    corpus::{self, SequentialSyntheticCorpus},
+    cost, cpu,
+    ingest::supertable::{
+        CORPUS_VEC_SEED, Modality, TEXT_COLUMN, options_for, schema_for, vector_array,
+        vector_filter_bucket_term,
+    },
+    markdown::{fmt_count, fmt_time},
+    report::{Better, Block, Cell, Report, Section, metric, text},
+    rss::{self, PeakSampler},
+    storage_meter::{self, MeteredStorage, ObjectStoreMeter},
+};
+
+/// Rows pre-loaded into each table before any measured op, so shapes run
+/// against a real manifest rather than an empty table. Override with
+/// `INFINO_BENCH_WRITE_DIAG_SEED_DOCS`.
+const DEFAULT_SEED_DOCS: usize = 100_000;
+
+/// Largest measured append, in rows. The ladder is fixed at
+/// {1, 1_000, this} so the small/large amortization cliff is always
+/// visible. Override with `INFINO_BENCH_WRITE_DIAG_DOCS`.
+const DEFAULT_TOP_APPEND_ROWS: usize = 100_000;
+
+/// Mid rung of the append ladder.
+const MID_APPEND_ROWS: usize = 1_000;
+
+/// Single-row mutations averaged per mutation cell — enough iterations
+/// that the process-CPU sampler sees a measurable delta over the loop.
+const N_MUTATIONS: usize = 8;
+
+/// Text seed for the streamed corpus — must match the vector seed policy
+/// of the main corpus (both derive from the same base seed).
+const CORPUS_TEXT_SEED: u64 = 1;
+
+/// Nanoseconds per second, for latency markdown.
+const NS_PER_SEC: f64 = 1e9;
+
+fn seed_docs() -> usize {
+    env::var("INFINO_BENCH_WRITE_DIAG_SEED_DOCS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_SEED_DOCS)
+}
+
+fn top_append_rows() -> usize {
+    env::var("INFINO_BENCH_WRITE_DIAG_DOCS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_TOP_APPEND_ROWS)
+}
+
+/// One measured write op (or averaged loop of ops): wall, CPU, peak RSS,
+/// object-store window, and the engine's own per-op counters.
+struct OpMeasure {
+    wall: Duration,
+    cpu_s: Option<f64>,
+    peak_rss_bytes: u64,
+    io: ObjectStoreMeter,
+    stats: OpStats,
+}
+
+/// Bracket `f` with the same instruments the read cells use — process
+/// CPU, wall, peak RSS, the provider's request meter — plus the engine's
+/// per-op work scope.
+fn measure(ms: &MeteredStorage, f: impl FnOnce()) -> OpMeasure {
+    let before = ms.snapshot();
+    let sampler = PeakSampler::start_default();
+    let (((), stats), wall, cpu_s) = cpu::timed(|| with_op_stats(f));
+    let peak_rss_bytes = sampler.stop_stats().peak_rss_bytes;
+    let io = ms.snapshot().since(&before);
+    OpMeasure {
+        wall,
+        cpu_s,
+        peak_rss_bytes,
+        io,
+        stats,
+    }
+}
+
+/// Fresh streamed generator positioned at doc 0.
+fn corpus_stream(total_docs: usize) -> DocStream {
+    DocStream {
+        stream: SequentialSyntheticCorpus::new(
+            corpus::n_cent(total_docs),
+            CORPUS_VEC_SEED,
+            CORPUS_TEXT_SEED,
+            true,
+        ),
+        next_doc: 0,
+    }
+}
+
+/// The synthetic stream plus its running doc position — the vector
+/// schema's filter-bucket terms derive from each row's global doc id,
+/// exactly as the bulk ingest path stamps them.
+struct DocStream {
+    stream: SequentialSyntheticCorpus,
+    next_doc: usize,
+}
+
+/// Next `len` rows off the stream as a batch for `modality` (Fts => the
+/// text column; Vector => bucket + embedding, matching `schema_for`'s
+/// field order).
+fn next_batch(src: &mut DocStream, modality: Modality, len: usize) -> RecordBatch {
+    let mut titles: Vec<String> = Vec::new();
+    let mut flat: Vec<f32> = Vec::new();
+    let (gen_text, gen_vec) = match modality {
+        Modality::Fts => (true, false),
+        Modality::Vector => (false, true),
+        _ => unreachable!("write-diag drives Fts and Vector shapes only"),
+    };
+    src.stream
+        .fill_chunk_modality(len, &mut titles, &mut flat, gen_text, gen_vec);
+    let doc_base = src.next_doc;
+    src.next_doc += len;
+    let schema = schema_for(modality);
+    match modality {
+        Modality::Fts => {
+            let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+            RecordBatch::try_new(schema, vec![Arc::new(LargeStringArray::from(refs))])
+                .expect("fts RecordBatch")
+        }
+        Modality::Vector => {
+            let buckets: Vec<String> = (doc_base..doc_base + len)
+                .map(vector_filter_bucket_term)
+                .collect();
+            let bucket_refs: Vec<&str> = buckets.iter().map(String::as_str).collect();
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(LargeStringArray::from(bucket_refs)),
+                    vector_array(&flat),
+                ],
+            )
+            .expect("vector RecordBatch")
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// A seeded table of `modality` on a metered local store.
+fn seeded_table(
+    modality: Modality,
+    stream: &mut DocStream,
+    n_seed: usize,
+) -> (TempDir, MeteredStorage, Supertable) {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let ms = storage_meter::wrap(Arc::clone(&storage));
+    let st = Supertable::create(options_for(modality, Some(storage))).expect("create supertable");
+    if n_seed > 0 {
+        let batch = next_batch(stream, modality, n_seed);
+        st.append(&batch).expect("seed append");
+    }
+    (dir, ms, st)
+}
+
+/// Report cells for one measured shape. `ops` is how many ops the
+/// measurement window covered (1 for the appends, `N_MUTATIONS` for the
+/// averaged mutation loops); every per-op figure divides by it.
+fn shape_row(label: &str, rows_per_op: usize, ops: usize, m: &OpMeasure) -> Vec<Cell> {
+    let ops_f = ops as f64;
+    let wall_s = m.wall.as_secs_f64() / ops_f;
+    let cpu_s = m.cpu_s.map(|c| c / ops_f);
+    let per_op_usd =
+        cost::write_op_usd(m.cpu_s, m.wall.as_secs_f64(), Some(m.peak_rss_bytes), &m.io)
+            .map(|total| total / ops_f);
+    let per_million_rows = per_op_usd.map(|usd| usd / (rows_per_op.max(1) as f64) * 1e6);
+    let wall_ns = wall_s * NS_PER_SEC;
+    vec![
+        text(label),
+        metric(rows_per_op as f64, fmt_count(rows_per_op), Better::Higher),
+        metric(wall_ns, fmt_time(wall_ns), Better::Lower),
+        match cpu_s {
+            Some(c) => metric(c, format!("{c:.4}"), Better::Lower),
+            None => text("—"),
+        },
+        metric(
+            m.peak_rss_bytes as f64,
+            rss::fmt_bytes(m.peak_rss_bytes),
+            Better::Lower,
+        ),
+        metric(
+            m.io.put_count as f64 / ops_f,
+            format!("{:.0}", m.io.put_count as f64 / ops_f),
+            Better::Lower,
+        ),
+        metric(
+            m.stats.planned_write_requests as f64 / ops_f,
+            format!("{:.0}", m.stats.planned_write_requests as f64 / ops_f),
+            Better::Lower,
+        ),
+        metric(
+            m.io.get_count as f64 / ops_f,
+            format!("{:.0}", m.io.get_count as f64 / ops_f),
+            Better::Lower,
+        ),
+        match per_op_usd {
+            Some(usd) => metric(usd, cost::write_cell(usd), Better::Lower),
+            None => text("—"),
+        },
+        match per_million_rows {
+            Some(usd) => metric(usd, cost::usd_text(usd), Better::Lower),
+            None => text("—"),
+        },
+    ]
+}
+
+pub fn run() {
+    let n_seed = seed_docs();
+    let top = top_append_rows();
+    let append_ladder: [usize; 3] = [1, MID_APPEND_ROWS, top];
+    let total_docs = n_seed + append_ladder.iter().sum::<usize>() + N_MUTATIONS;
+    eprintln!(
+        "[write-diag] seed {} docs/table, appends {:?}, {} single-row mutations...",
+        fmt_count(n_seed),
+        append_ladder,
+        N_MUTATIONS
+    );
+
+    let mut rows: Vec<Vec<Cell>> = Vec::new();
+
+    // ── Appends: the batch-size ladder, per modality ──────────────────
+    for modality in [Modality::Fts, Modality::Vector] {
+        let label = match modality {
+            Modality::Fts => "fts",
+            Modality::Vector => "vector",
+            _ => unreachable!(),
+        };
+        let mut stream = corpus_stream(total_docs);
+        let (_dir, ms, st) = seeded_table(modality, &mut stream, n_seed);
+        for &n_rows in &append_ladder {
+            let batch = next_batch(&mut stream, modality, n_rows);
+            let m = measure(&ms, || {
+                st.append(&batch).expect("measured append");
+            });
+            assert_eq!(
+                m.stats.rows_written, n_rows as u64,
+                "the engine's per-op counter must see exactly the appended rows"
+            );
+            rows.push(shape_row(
+                &format!("append_{label}_{}_rows", fmt_count(n_rows)),
+                n_rows,
+                1,
+                &m,
+            ));
+        }
+    }
+
+    // ── Single-row mutations, averaged over N_MUTATIONS ops ───────────
+    // Marker rows appended (uncounted) so predicates hit exactly one row
+    // each against the seeded corpus table.
+    let mut stream = corpus_stream(total_docs);
+    let (_dir, ms, st) = seeded_table(Modality::Fts, &mut stream, n_seed);
+    let markers: Vec<String> = (0..N_MUTATIONS)
+        .map(|i| format!("write-diag-marker-{i:04}"))
+        .collect();
+    {
+        let refs: Vec<&str> = markers.iter().map(String::as_str).collect();
+        let batch = RecordBatch::try_new(
+            schema_for(Modality::Fts),
+            vec![Arc::new(LargeStringArray::from(refs))],
+        )
+        .expect("marker batch");
+        st.append(&batch).expect("marker append");
+    }
+
+    let update_m = measure(&ms, || {
+        for marker in &markers {
+            let replacement = RecordBatch::try_new(
+                schema_for(Modality::Fts),
+                vec![Arc::new(LargeStringArray::from(vec![marker.as_str()]))],
+            )
+            .expect("replacement batch");
+            st.update(col(TEXT_COLUMN).eq(lit(marker.as_str())), &replacement)
+                .expect("measured update");
+        }
+    });
+    rows.push(shape_row("update_1_row", 1, N_MUTATIONS, &update_m));
+
+    let delete_m = measure(&ms, || {
+        for marker in &markers {
+            st.delete(col(TEXT_COLUMN).eq(lit(marker.as_str())))
+                .expect("measured delete");
+        }
+    });
+    rows.push(shape_row("delete_1_row", 1, N_MUTATIONS, &delete_m));
+
+    let mut report = Report::load("write-diag");
+    report.emit(&Section {
+        anchor: "bench/write_diag/shapes".into(),
+        title: format!(
+            "Per-write-op cost by shape ({} seed docs/table)",
+            fmt_count(n_seed)
+        ),
+        note: "Each shape is one committed op (mutations averaged over a small loop) against a \
+               seeded local-store table, priced with the same instance cost model as the read \
+               cells: compute at the binding CPU/RAM leg + request dollars. Direct cost only — \
+               deferred drain/compaction is excluded here and amortized into the \
+               `write_per_million_docs` anchor. `PUT plan` is the engine's priceable \
+               `planned_write_requests`; `PUT act` is the provider meter's actual count. \
+               Δ is vs the previous run."
+            .into(),
+        blocks: vec![Block {
+            subtitle: String::new(),
+            headers: vec![
+                "Shape".into(),
+                "Rows/op".into(),
+                "Wall/op".into(),
+                "CPU s/op".into(),
+                "Peak RSS".into(),
+                "PUT act".into(),
+                "PUT plan".into(),
+                "GET".into(),
+                "$/write".into(),
+                "$/1M rows".into(),
+            ],
+            rows,
+        }],
+    });
+    report.save();
+}

--- a/benches/utils/write_diag.rs
+++ b/benches/utils/write_diag.rs
@@ -77,6 +77,14 @@ const DEFAULT_TOP_APPEND_ROWS: usize = 100_000;
 /// Mid rung of the append ladder.
 const MID_APPEND_ROWS: usize = 1_000;
 
+/// Per-commit row cap while seeding. The ingest working set scales with
+/// the commit's doc count, not the table's (see the ingest path's
+/// MAX_DOCS_PER_COMMIT rationale), so a large seed lands as several
+/// modest commits — which also matches how a real table gets to that
+/// size. Measured ops are never chunked: an append shape's batch size
+/// IS the thing being measured.
+const SEED_CHUNK_ROWS: usize = 250_000;
+
 /// Single-row mutations averaged per mutation cell — enough iterations
 /// that the process-CPU sampler sees a measurable delta over the loop.
 const N_MUTATIONS: usize = 8;
@@ -202,9 +210,12 @@ fn seeded_table(
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let ms = storage_meter::wrap(Arc::clone(&storage));
     let st = Supertable::create(options_for(modality, Some(storage))).expect("create supertable");
-    if n_seed > 0 {
-        let batch = next_batch(stream, modality, n_seed);
+    let mut remaining = n_seed;
+    while remaining > 0 {
+        let chunk = remaining.min(SEED_CHUNK_ROWS);
+        let batch = next_batch(stream, modality, chunk);
         st.append(&batch).expect("seed append");
+        remaining -= chunk;
     }
     (dir, ms, st)
 }

--- a/benches/utils/write_diag.rs
+++ b/benches/utils/write_diag.rs
@@ -96,6 +96,9 @@ const CORPUS_TEXT_SEED: u64 = 1;
 /// Nanoseconds per second, for latency markdown.
 const NS_PER_SEC: f64 = 1e9;
 
+/// Bytes per GiB, as a float for the per-GiB cost division.
+const BYTES_PER_GIB_F64: f64 = (1u64 << 30) as f64;
+
 fn seed_docs() -> usize {
     env::var("INFINO_BENCH_WRITE_DIAG_SEED_DOCS")
         .ok()
@@ -231,6 +234,18 @@ fn shape_row(label: &str, rows_per_op: usize, ops: usize, m: &OpMeasure) -> Vec<
         cost::write_op_usd(m.cpu_s, m.wall.as_secs_f64(), Some(m.peak_rss_bytes), &m.io)
             .map(|total| total / ops_f);
     let per_million_rows = per_op_usd.map(|usd| usd / (rows_per_op.max(1) as f64) * 1e6);
+    // Logical payload this op ingested — the caller's own bytes, before
+    // any index or replication expansion. Carrying it here is what lets a
+    // per-op cost convert to $/GiB, so cost per byte is comparable across
+    // shapes whose row sizes differ.
+    let logical_bytes = m
+        .stats
+        .scalar_bytes_written
+        .saturating_add(m.stats.vector_bytes_written) as f64
+        / ops_f;
+    let per_gib = per_op_usd.and_then(|usd| {
+        (logical_bytes > 0.0).then(|| usd / (logical_bytes / BYTES_PER_GIB_F64))
+    });
     let wall_ns = wall_s * NS_PER_SEC;
     vec![
         text(label),
@@ -265,6 +280,15 @@ fn shape_row(label: &str, rows_per_op: usize, ops: usize, m: &OpMeasure) -> Vec<
             None => text("—"),
         },
         match per_million_rows {
+            Some(usd) => metric(usd, cost::usd_text(usd), Better::Lower),
+            None => text("—"),
+        },
+        metric(
+            logical_bytes,
+            rss::fmt_bytes(logical_bytes as u64),
+            Better::Higher,
+        ),
+        match per_gib {
             Some(usd) => metric(usd, cost::usd_text(usd), Better::Lower),
             None => text("—"),
         },
@@ -364,6 +388,8 @@ pub fn run() {
                deferred drain/compaction is excluded here and amortized into the \
                `write_per_million_docs` anchor. `PUT plan` is the engine's priceable \
                `planned_write_requests`; `PUT act` is the provider meter's actual count. \
+               `Logical` is the payload the caller sent, so `$/GiB logical` makes cost \
+               per byte comparable across shapes with different row sizes. \
                Δ is vs the previous run."
             .into(),
         blocks: vec![Block {
@@ -379,6 +405,8 @@ pub fn run() {
                 "GET".into(),
                 "$/write".into(),
                 "$/1M rows".into(),
+                "Logical".into(),
+                "$/GiB logical".into(),
             ],
             rows,
         }],

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2156,6 +2156,7 @@ dependencies = [
  "rayon",
  "roaring",
  "rustc-hash",
+ "rustix",
  "serde",
  "serde_json",
  "static_assertions",

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2151,6 +2151,7 @@ dependencies = [
  "rayon",
  "roaring",
  "rustc-hash",
+ "rustix",
  "serde",
  "serde_json",
  "static_assertions",

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -71,10 +71,7 @@ use crate::{
     supertable::{
         Supertable as SupertableHandle,
         options::SupertableOptions,
-        query::{
-            covered_agg::CoveredAggregateRewrite,
-            exec::{common::harvest_datafusion_metrics, metered_exec::MeteredExec},
-        },
+        query::exec::{common::harvest_datafusion_metrics, metered_exec::MeteredExec},
         reader_cache::{DiskCacheConfig, DiskCacheError, DiskCacheStore},
     },
 };
@@ -788,12 +785,6 @@ impl Connection {
         // working set (sort / aggregate / join), so its pool is the gate.
         let ctx = budgeted_session_context(&self.inner.connection_memory_budget)
             .map_err(|e| InfinoError::Query(e.to_string()).with_context("query_sql", None))?;
-        // Answer covered aggregates from manifest statistics instead of
-        // scanning for them. The rule was only ever registered on the
-        // reader-level session, which is test-gated — so on the surface
-        // real users call, a fully-covered aggregate scanned every
-        // superfile, and per-op metering now bills that scan.
-        ctx.add_optimizer_rule(Arc::new(CoveredAggregateRewrite));
 
         // Resolve the relations the query names and register each that is a
         // catalog table. Unknown names (CTEs, search TVFs, aliases) are

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -71,7 +71,10 @@ use crate::{
     supertable::{
         Supertable as SupertableHandle,
         options::SupertableOptions,
-        query::exec::{common::harvest_datafusion_metrics, metered_exec::MeteredExec},
+        query::{
+            covered_agg::CoveredAggregateRewrite,
+            exec::{common::harvest_datafusion_metrics, metered_exec::MeteredExec},
+        },
         reader_cache::{DiskCacheConfig, DiskCacheError, DiskCacheStore},
     },
 };
@@ -785,6 +788,12 @@ impl Connection {
         // working set (sort / aggregate / join), so its pool is the gate.
         let ctx = budgeted_session_context(&self.inner.connection_memory_budget)
             .map_err(|e| InfinoError::Query(e.to_string()).with_context("query_sql", None))?;
+        // Answer covered aggregates from manifest statistics instead of
+        // scanning for them. The rule was only ever registered on the
+        // reader-level session, which is test-gated — so on the surface
+        // real users call, a fully-covered aggregate scanned every
+        // superfile, and per-op metering now bills that scan.
+        ctx.add_optimizer_rule(Arc::new(CoveredAggregateRewrite));
 
         // Resolve the relations the query names and register each that is a
         // catalog table. Unknown names (CTEs, search TVFs, aliases) are

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -34,7 +34,11 @@ use std::{
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
 use dashmap::DashMap;
-use datafusion::{config::Dialect, error::DataFusionError, physical_plan::collect as collect_plan};
+use datafusion::{
+    config::Dialect,
+    error::DataFusionError,
+    physical_plan::{ExecutionPlan, collect as collect_plan},
+};
 use futures::future::try_join_all;
 pub use index_spec::IndexSpec;
 use manifest::{
@@ -67,7 +71,7 @@ use crate::{
     supertable::{
         Supertable as SupertableHandle,
         options::SupertableOptions,
-        query::exec::common::harvest_datafusion_metrics,
+        query::exec::{common::harvest_datafusion_metrics, metered_exec::MeteredExec},
         reader_cache::{DiskCacheConfig, DiskCacheError, DiskCacheStore},
     },
 };
@@ -837,6 +841,13 @@ impl Connection {
                 .create_physical_plan()
                 .await
                 .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;
+            // Meter the whole plan, not just its scans: aggregation, sort
+            // and join work sits above the scan and is this query's CPU
+            // too. The scan wrapper still counts on spawned partitions,
+            // where the root's thread never runs; MeteredExec's depth
+            // guard keeps a single-partition plan from counting both.
+            let plan: Arc<dyn ExecutionPlan> =
+                Arc::new(MeteredExec::new(Arc::clone(&plan), op_stats.clone()));
             let batches = collect_plan(Arc::clone(&plan), task_ctx)
                 .await
                 .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -34,11 +34,7 @@ use std::{
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
 use dashmap::DashMap;
-use datafusion::{
-    config::Dialect,
-    error::DataFusionError,
-    physical_plan::{ExecutionPlan, collect as collect_plan},
-};
+use datafusion::{config::Dialect, error::DataFusionError};
 use futures::future::try_join_all;
 pub use index_spec::IndexSpec;
 use manifest::{
@@ -71,7 +67,7 @@ use crate::{
     supertable::{
         Supertable as SupertableHandle,
         options::SupertableOptions,
-        query::exec::{common::harvest_datafusion_metrics, metered_exec::MeteredExec},
+        query::exec::common::collect_plan_metered,
         reader_cache::{DiskCacheConfig, DiskCacheError, DiskCacheStore},
     },
 };
@@ -841,17 +837,15 @@ impl Connection {
                 .create_physical_plan()
                 .await
                 .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;
-            // Meter the whole plan, not just its scans: aggregation, sort
-            // and join work sits above the scan and is this query's CPU
-            // too. The scan wrapper still counts on spawned partitions,
-            // where the root's thread never runs; MeteredExec's depth
-            // guard keeps a single-partition plan from counting both.
-            let plan: Arc<dyn ExecutionPlan> =
-                Arc::new(MeteredExec::new(Arc::clone(&plan), op_stats.clone()));
-            let batches = collect_plan(Arc::clone(&plan), task_ctx)
+            // The shared meter-collect-harvest step: the root wrapper
+            // meters the whole plan (aggregation, sort and join work sits
+            // above the scan and is this query's CPU too), the scan
+            // wrapper still counts on spawned partitions where the root's
+            // thread never runs, and the shared bracket depth keeps a
+            // single-partition plan from counting both.
+            let batches = collect_plan_metered(&plan, task_ctx, &op_stats)
                 .await
                 .map_err(|e| sql_exec_error(e).with_context("query_sql", None))?;
-            harvest_datafusion_metrics(&plan, &op_stats);
             if batches.is_empty() {
                 // An empty Vec carries no schema, so hand back one empty batch
                 // instead. Its schema comes from the physical plan, not the

--- a/src/runtime_metrics/cpu.rs
+++ b/src/runtime_metrics/cpu.rs
@@ -28,6 +28,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(target_os = "linux")]
+use rustix::time::{ClockId, clock_gettime};
+
 /// Process stat file containing cumulative user/system CPU ticks.
 const PROC_SELF_STAT: &str = "/proc/self/stat";
 /// POSIX clock-tick query used once per process.
@@ -84,17 +87,37 @@ pub fn cpu_seconds_since(start_ns: Option<u128>) -> Option<f64> {
     Some(end.saturating_sub(start) as f64 / NS_PER_SEC as f64)
 }
 
-/// Thread-local schedstat path (Linux): first field is this thread's
-/// cumulative on-CPU nanoseconds.
-const PROC_THREAD_SELF_SCHEDSTAT: &str = "/proc/thread-self/schedstat";
-
-/// The calling thread's own on-CPU nanoseconds (ns resolution, unlike the
-/// process-wide tick counter), or `None` off Linux procfs. Two reads
-/// bracket one synchronous kernel section for per-query CPU attribution;
-/// only valid when both reads happen on the same thread.
+/// The calling thread's own on-CPU nanoseconds, or `None` where no
+/// per-thread CPU clock exists. Two reads bracket one synchronous kernel
+/// section for per-query CPU attribution; only valid when both reads
+/// happen on the same thread.
+///
+/// Reads `CLOCK_THREAD_CPUTIME_ID` rather than
+/// `/proc/thread-self/schedstat`. procfs prints the scheduler's stored
+/// `sum_exec_runtime` without refreshing it first, so for a thread that
+/// is currently running the value is stale until the next scheduler tick
+/// — measured on this host as exactly 1 ms steps. That made any bracket
+/// shorter than a tick read either 0 or a full millisecond, and made a
+/// bracket straddling a tick collect whatever else had run on the thread
+/// before it, so the estimate drifted toward "CPU accrued during the
+/// wall-clock windows the brackets covered" rather than "CPU this
+/// section burned". The POSIX clock is updated when it is read, so it
+/// resolves the section actually bracketed. It is also a vDSO read
+/// rather than opening and parsing a procfs file, which matters because
+/// the meter brackets every poll of every partition.
+#[cfg(target_os = "linux")]
 pub(crate) fn thread_cpu_ns() -> Option<u128> {
-    let raw = fs::read_to_string(PROC_THREAD_SELF_SCHEDSTAT).ok()?;
-    raw.split_whitespace().next()?.parse().ok()
+    let ts = clock_gettime(ClockId::ThreadCPUTime);
+    let secs = u128::try_from(ts.tv_sec).ok()?;
+    let nanos = u128::try_from(ts.tv_nsec).ok()?;
+    Some(secs * NS_PER_SEC + nanos)
+}
+
+/// No per-thread CPU clock: every bracket reports zero rather than an
+/// error, the same contract [`thread_cpu_delta_ns`] documents.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn thread_cpu_ns() -> Option<u128> {
+    None
 }
 
 /// On-CPU nanoseconds this thread accrued since `start` (a prior
@@ -148,6 +171,43 @@ mod tests {
     const TEST_WORKER_BUSY_WINDOW: Duration = Duration::from_millis(50);
     /// Minimum process CPU seconds from exited workers.
     const TEST_MIN_EXITED_WORKER_CPU_S: f64 = 0.01;
+    /// Busy window short enough that a tick-quantized clock could not
+    /// resolve it at all.
+    const SUB_TICK_BUSY_WINDOW: Duration = Duration::from_micros(100);
+    /// One scheduler tick at the common `CONFIG_HZ=1000`, in ns — the
+    /// granularity the old schedstat reading was pinned to.
+    const NS_PER_SCHEDULER_TICK: u64 = 1_000_000;
+
+    /// The per-thread clock must resolve work far shorter than a
+    /// scheduler tick. `/proc/thread-self/schedstat` prints a value the
+    /// scheduler refreshes only at ticks, so this same section read
+    /// either 0 or a full millisecond there — measured at exactly 1 ms
+    /// steps — which is what let short brackets collect a whole tick of
+    /// whatever else had run on the thread. Guards against going back.
+    #[test]
+    fn the_thread_clock_resolves_sub_tick_work() {
+        let Some(start) = thread_cpu_ns() else {
+            return;
+        };
+        let t = Instant::now();
+        let mut acc = 0u64;
+        while t.elapsed() < SUB_TICK_BUSY_WINDOW {
+            for i in 0..TEST_BUSY_INNER_ITERS {
+                acc = acc.wrapping_add(i.wrapping_mul(TEST_BUSY_MIX_CONST));
+            }
+        }
+        black_box(acc);
+        let measured = thread_cpu_delta_ns(Some(start));
+        assert!(
+            measured > 0,
+            "a busy section must register on-CPU time, not round to zero"
+        );
+        assert!(
+            measured < NS_PER_SCHEDULER_TICK,
+            "a {SUB_TICK_BUSY_WINDOW:?} section must not read as a whole \
+             scheduler tick; got {measured}ns"
+        );
+    }
     #[test]
     fn on_cpu_time_excludes_sleep() {
         let Some(start_busy) = thread_cpu_ns() else {

--- a/src/runtime_metrics/ingest.rs
+++ b/src/runtime_metrics/ingest.rs
@@ -58,11 +58,14 @@ pub fn classify_batch_bytes(batch: &RecordBatch) -> (u64, u64) {
 ///   values array — the over-count this function exists to avoid. Lists
 ///   size the child window their offsets actually name.
 ///
-/// `Dictionary` — and `Map`, which shares its entries child the same way
-/// — keeps the over-count for a slice (the whole shared child is counted
-/// per chunk) and is left alone deliberately: the child genuinely is
-/// shared, so amortizing it across chunks needs a policy rather than a
-/// measurement.
+/// `Dictionary` keeps the over-count for a slice (every chunk counts the
+/// whole dictionary) and is left alone deliberately: its values are
+/// content-shared — arbitrary keys reference arbitrary value rows, so no
+/// per-chunk window exists and amortizing needs a policy rather than a
+/// measurement. `Map` also keeps the over-count today, but for the other
+/// reason: its entries child is offset-addressed exactly like a list, so
+/// the same window measurement would apply — it is simply not wired, and
+/// no Map ingest path exists to feed it.
 pub(crate) fn visible_array_bytes(column: &dyn Array) -> u64 {
     match column.data_type() {
         DataType::Utf8View | DataType::BinaryView => view_visible_bytes(column),

--- a/src/runtime_metrics/ingest.rs
+++ b/src/runtime_metrics/ingest.rs
@@ -110,7 +110,18 @@ fn view_visible_bytes(column: &dyn Array) -> u64 {
     };
     ((column.len() * VIEW_STRIDE) as u64)
         .saturating_add(payload)
-        .saturating_add(column.nulls().map_or(0, |n| n.buffer().len() as u64))
+        .saturating_add(null_bitmap_visible_bytes(column))
+}
+
+/// Visible bytes of a column's null bitmap: one bit per visible row,
+/// rounded up — never the backing buffer's length, which a slice shares
+/// with its parent the same way it shares value buffers.
+fn null_bitmap_visible_bytes(column: &dyn Array) -> u64 {
+    if column.nulls().is_some() {
+        column.len().div_ceil(8) as u64
+    } else {
+        0
+    }
 }
 
 /// Slice-aware size for a type whose own layout describes it fully.
@@ -134,8 +145,7 @@ fn list_window_bytes<O: OffsetSizeTrait>(column: &dyn Array) -> u64 {
         (Some(first), Some(last)) => (first.as_usize(), last.as_usize()),
         _ => (0, 0),
     };
-    let own =
-        mem::size_of_val(offsets) as u64 + list.nulls().map_or(0, |n| n.buffer().len() as u64);
+    let own = mem::size_of_val(offsets) as u64 + null_bitmap_visible_bytes(column);
     let child = if end > start {
         visible_array_bytes(list.values().slice(start, end - start).as_ref())
     } else {

--- a/src/runtime_metrics/ingest.rs
+++ b/src/runtime_metrics/ingest.rs
@@ -58,10 +58,11 @@ pub fn classify_batch_bytes(batch: &RecordBatch) -> (u64, u64) {
 ///   values array — the over-count this function exists to avoid. Lists
 ///   size the child window their offsets actually name.
 ///
-/// `Dictionary` keeps the same over-count for a slice (the whole
-/// dictionary is counted per chunk) and is left alone deliberately: the
-/// dictionary genuinely is shared, so amortizing it across chunks needs a
-/// policy rather than a measurement.
+/// `Dictionary` — and `Map`, which shares its entries child the same way
+/// — keeps the over-count for a slice (the whole shared child is counted
+/// per chunk) and is left alone deliberately: the child genuinely is
+/// shared, so amortizing it across chunks needs a policy rather than a
+/// measurement.
 pub(crate) fn visible_array_bytes(column: &dyn Array) -> u64 {
     match column.data_type() {
         DataType::Utf8View | DataType::BinaryView => view_visible_bytes(column),

--- a/src/runtime_metrics/ingest.rs
+++ b/src/runtime_metrics/ingest.rs
@@ -7,7 +7,11 @@
 //! Vector columns are Arrow [`DataType::FixedSizeList`] (the engine's vector
 //! column shape); every other column counts as text/scalar.
 
-use arrow_array::{Array, RecordBatch};
+use std::mem;
+
+use arrow_array::{
+    Array, BinaryViewArray, GenericListArray, OffsetSizeTrait, RecordBatch, StringViewArray,
+};
 use arrow_schema::DataType;
 
 /// Split `batch`'s visible column footprint into `(text_bytes, vector_bytes)`.
@@ -33,26 +37,208 @@ pub fn classify_batch_bytes(batch: &RecordBatch) -> (u64, u64) {
 /// One array's *visible* footprint: slice-aware, so an array that is a
 /// zero-copy window into a larger buffer is billed for the rows it
 /// actually carries rather than for its parent's whole allocation.
-/// Falls back to the capacity-based size only if slice sizing fails.
 ///
 /// This is the right measure wherever bytes are *priced*. It is the wrong
 /// one for held-memory accounting (an auto-flush threshold, a scratch
 /// reserve), where the parent allocation really is what is resident.
+///
+/// Two families need handling of their own, because Arrow's slice-aware
+/// sizing is not uniformly slice-aware:
+///
+/// - **View types.** `get_slice_memory_size` walks only the buffers a
+///   type's layout declares, and the view layout declares one 16-byte
+///   view buffer with the payload buffers marked variadic — those are
+///   never visited. A `Utf8View` column would price at 16 bytes a row
+///   whatever it carries, roughly 13x under a `LargeUtf8` column of the
+///   same strings. The capacity-based size is the closer answer, so these
+///   use it. This matters here and not only in theory: the SQL provider
+///   retypes non-FTS string columns to `Utf8View` for the scan.
+/// - **Offset-addressed children.** `ArrayData::slice` recurses into
+///   children only for `Struct`, so a sliced `List` bills its whole shared
+///   values array — the over-count this function exists to avoid. Lists
+///   size the child window their offsets actually name.
+///
+/// `Dictionary` keeps the same over-count for a slice (the whole
+/// dictionary is counted per chunk) and is left alone deliberately: the
+/// dictionary genuinely is shared, so amortizing it across chunks needs a
+/// policy rather than a measurement.
 pub(crate) fn visible_array_bytes(column: &dyn Array) -> u64 {
+    match column.data_type() {
+        DataType::Utf8View | DataType::BinaryView => view_visible_bytes(column),
+        DataType::List(_) => list_window_bytes::<i32>(column),
+        DataType::LargeList(_) => list_window_bytes::<i64>(column),
+        _ => flat_visible_bytes(column),
+    }
+}
+
+/// A view column's visible footprint: the fixed 16-byte view per row plus
+/// the payload of every value too long to live inline in it.
+///
+/// Neither of Arrow's two sizing calls works here. `get_slice_memory_size`
+/// visits only the declared view buffer and reports 16 bytes a row however
+/// much text the column carries; `get_array_memory_size` counts the
+/// variadic buffers' whole *capacity*, and their allocator over-allocates
+/// in large blocks — a four-row column of long strings measured 16,560
+/// bytes against 196 for the same strings as `LargeUtf8`. Walking the
+/// values is O(rows), which is affordable on a path that is about to
+/// encode the batch anyway, and it is right for a slice as well as a whole
+/// array.
+fn view_visible_bytes(column: &dyn Array) -> u64 {
+    /// Bytes each view occupies in the fixed-width buffer.
+    const VIEW_STRIDE: usize = 16;
+    /// Payload up to this length is stored inside the view itself.
+    const INLINE_CAPACITY: usize = 12;
+
+    let out_of_line = |lengths: &mut dyn Iterator<Item = usize>| -> u64 {
+        lengths
+            .filter(|len| *len > INLINE_CAPACITY)
+            .map(|len| len as u64)
+            .sum()
+    };
+    let payload = if let Some(view) = column.as_any().downcast_ref::<StringViewArray>() {
+        out_of_line(&mut view.iter().flatten().map(str::len))
+    } else if let Some(view) = column.as_any().downcast_ref::<BinaryViewArray>() {
+        out_of_line(&mut view.iter().flatten().map(<[u8]>::len))
+    } else {
+        // Not a shape we can walk; the declared-buffer size is at least a
+        // floor rather than a guess.
+        return flat_visible_bytes(column);
+    };
+    ((column.len() * VIEW_STRIDE) as u64)
+        .saturating_add(payload)
+        .saturating_add(column.nulls().map_or(0, |n| n.buffer().len() as u64))
+}
+
+/// Slice-aware size for a type whose own layout describes it fully.
+fn flat_visible_bytes(column: &dyn Array) -> u64 {
     column
         .to_data()
         .get_slice_memory_size()
         .unwrap_or_else(|_| column.get_array_memory_size()) as u64
 }
 
+/// A list column's own buffers plus only the slice of its values array
+/// that this window addresses.
+fn list_window_bytes<O: OffsetSizeTrait>(column: &dyn Array) -> u64 {
+    let Some(list) = column.as_any().downcast_ref::<GenericListArray<O>>() else {
+        return flat_visible_bytes(column);
+    };
+    let offsets = list.value_offsets();
+    // An empty window addresses no child rows; its own offset buffer still
+    // costs something, which `own` below covers.
+    let (start, end) = match (offsets.first(), offsets.last()) {
+        (Some(first), Some(last)) => (first.as_usize(), last.as_usize()),
+        _ => (0, 0),
+    };
+    let own =
+        mem::size_of_val(offsets) as u64 + list.nulls().map_or(0, |n| n.buffer().len() as u64);
+    let child = if end > start {
+        visible_array_bytes(list.values().slice(start, end - start).as_ref())
+    } else {
+        0
+    };
+    own.saturating_add(child)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+    use arrow_array::{
+        Array, FixedSizeListArray, Float32Array, LargeStringArray, ListArray, RecordBatch,
+        StringViewArray,
+        builder::{ListBuilder, StringBuilder},
+    };
     use arrow_schema::{DataType, Field, Schema};
 
-    use super::classify_batch_bytes;
+    use super::{classify_batch_bytes, visible_array_bytes};
+
+    /// Strings long enough to live outside a view's inline 12-byte prefix,
+    /// which is the only case where the view layout hides its payload.
+    const OUT_OF_LINE: [&str; 4] = [
+        "a string comfortably past the inline prefix",
+        "another string comfortably past the prefix",
+        "a third string that will not fit inline",
+        "a fourth string that will not fit inline",
+    ];
+    /// Widest gap tolerated between the two encodings of the same strings.
+    const VIEW_VS_LARGE_UTF8_TOLERANCE: u64 = 4;
+
+    #[test]
+    fn a_view_column_is_not_billed_at_its_inline_stride() {
+        // Arrow's slice-aware sizing visits only the buffers a layout
+        // declares, and the view layout declares one 16-byte view buffer
+        // with the payload buffers variadic — so a view column priced that
+        // way reports 16 bytes a row however much text it carries. The SQL
+        // provider retypes non-FTS string columns to Utf8View, so this is
+        // a shape the engine really sees.
+        let view = StringViewArray::from(OUT_OF_LINE.to_vec());
+        let large = LargeStringArray::from(OUT_OF_LINE.to_vec());
+        let view_bytes = visible_array_bytes(&view);
+        let large_bytes = visible_array_bytes(&large);
+        let payload: u64 = OUT_OF_LINE.iter().map(|s| s.len() as u64).sum();
+        assert!(
+            view_bytes > payload,
+            "the same strings must cost at least their payload: {view_bytes} vs {payload}"
+        );
+        assert!(
+            view_bytes * VIEW_VS_LARGE_UTF8_TOLERANCE > large_bytes
+                && large_bytes * VIEW_VS_LARGE_UTF8_TOLERANCE > view_bytes,
+            "two encodings of the same strings must price within a small \
+             factor: view={view_bytes} large_utf8={large_bytes}"
+        );
+    }
+
+    #[test]
+    fn a_sliced_list_bills_only_the_child_window_it_addresses() {
+        // `ArrayData::slice` recurses into children only for structs, so a
+        // sliced list would otherwise carry its whole shared values array
+        // — the exact over-count this sizing exists to avoid, on the
+        // nested column shape the engine ingests.
+        let mut builder = ListBuilder::new(StringBuilder::new());
+        for row in 0..64 {
+            for item in 0..8 {
+                builder
+                    .values()
+                    .append_value(format!("row {row} item {item}"));
+            }
+            builder.append(true);
+        }
+        let full = builder.finish();
+        let window = full.slice(0, 2);
+        let window = window
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("still a list");
+        let full_bytes = visible_array_bytes(&full);
+        let window_bytes = visible_array_bytes(window);
+        assert!(
+            window_bytes * 4 < full_bytes,
+            "two rows of sixty-four must cost a fraction of the whole: \
+             window={window_bytes} full={full_bytes}"
+        );
+    }
+
+    #[test]
+    fn a_slice_taken_from_the_middle_is_billed_like_a_standalone_batch() {
+        // Chunked ingest slices at 0, then at len, then at 2*len — every
+        // chunk after the first carries a non-zero `ArrayData.offset`. A
+        // sizing that honoured length but ignored offset would pass an
+        // offset-zero test and still over-bill every later chunk.
+        const OFFSET: usize = 200;
+        const ROWS: usize = 10;
+        let titles: Vec<String> = (0..1_000)
+            .map(|i| format!("row {i} with some text"))
+            .collect();
+        let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+        let middle = LargeStringArray::from(refs.clone()).slice(OFFSET, ROWS);
+        let standalone = LargeStringArray::from(refs[OFFSET..OFFSET + ROWS].to_vec());
+        assert_eq!(
+            visible_array_bytes(&middle),
+            visible_array_bytes(&standalone),
+            "a mid-array window must price like the same rows standing alone"
+        );
+    }
 
     #[test]
     fn splits_text_and_vector_columns() {

--- a/src/runtime_metrics/ingest.rs
+++ b/src/runtime_metrics/ingest.rs
@@ -30,7 +30,15 @@ pub fn classify_batch_bytes(batch: &RecordBatch) -> (u64, u64) {
     (text_bytes, vector_bytes)
 }
 
-fn visible_array_bytes(column: &dyn Array) -> u64 {
+/// One array's *visible* footprint: slice-aware, so an array that is a
+/// zero-copy window into a larger buffer is billed for the rows it
+/// actually carries rather than for its parent's whole allocation.
+/// Falls back to the capacity-based size only if slice sizing fails.
+///
+/// This is the right measure wherever bytes are *priced*. It is the wrong
+/// one for held-memory accounting (an auto-flush threshold, a scratch
+/// reserve), where the parent allocation really is what is resident.
+pub(crate) fn visible_array_bytes(column: &dyn Array) -> u64 {
     column
         .to_data()
         .get_slice_memory_size()

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -321,18 +321,26 @@ impl OpStatsCollector {
             .fetch_add(fts_terms, Ordering::Relaxed);
     }
 
-    /// Flush the PUTs one committed publish *planned*, from the bytes it
-    /// sealed and the table's target object size. Called beside
-    /// [`Self::add_commit_outputs`], under the same post-Ok discipline, so
-    /// a failed or retried publish never counts.
-    pub(crate) fn add_planned_write_requests(&self, sealed_bytes: u64, target_bytes: u64) {
-        let objects = if target_bytes == 0 {
-            0
-        } else {
-            sealed_bytes.div_ceil(target_bytes)
-        };
-        self.planned_write_requests
-            .fetch_add(objects.saturating_add(MANIFEST_PUTS_PER_COMMIT), Ordering::Relaxed);
+    /// Flush the PUTs one committed publish *planned*: the data objects
+    /// the caller derived from its input shape, plus the manifest json +
+    /// pointer every manifest commit publishes. Called beside the other
+    /// commit flushes, under the same post-Ok discipline, so a failed or
+    /// retried publish never counts.
+    ///
+    /// Callers state their own object term because it is shape-specific:
+    /// a buffered append plans `ceil(sealed bytes / target object size)`;
+    /// an update plans exactly 1 (its replacement rows land in the WAL's
+    /// single preallocated superfile by design). A delete flushes nothing
+    /// here — it commits no manifest, and its per-superfile tombstone
+    /// CAS-writes (like the WAL state-doc writes of both mutations) stay
+    /// recorded-only in `put_requests` for now: their count follows where
+    /// the target rows live, a table-state quantity a later change can
+    /// plan from the resolve — deliberately not guessed at today.
+    pub(crate) fn add_planned_commit_requests(&self, data_objects: u64) {
+        self.planned_write_requests.fetch_add(
+            data_objects.saturating_add(MANIFEST_PUTS_PER_COMMIT),
+            Ordering::Relaxed,
+        );
     }
 
     /// The counters accumulated so far.

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -72,7 +72,7 @@
 //! `pool.install` for the whole fan-out.
 
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     sync::{
         Arc,
         atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -300,6 +300,16 @@ impl OpStatsCollector {
 
     /// Flush one bracketed kernel section's on-CPU nanoseconds.
     pub(crate) fn add_kernel_cpu_ns(&self, ns: u64) {
+        // An enclosing bracket on this thread is already measuring this
+        // work, so folding here too would charge the same nanoseconds
+        // twice. That is not hypothetical: a search TVF invoked through
+        // SQL runs its kernel inline inside the plan root's poll, and
+        // both brackets reported it — measured at roughly 59% of what a
+        // vector query through the TVF appeared to cost, against the
+        // identical operation called directly.
+        if outer_bracket_active() {
+            return;
+        }
         self.kernel_cpu_ns.fetch_add(ns, Ordering::Relaxed);
     }
 
@@ -480,6 +490,51 @@ pub(crate) fn timed_kernel<T>(
     value
 }
 
+thread_local! {
+    /// Depth of live outer CPU brackets on this thread.
+    ///
+    /// `MeteredExec` brackets a whole DataFusion poll, and DataFusion is
+    /// pull-based, so that poll synchronously drives the operator subtree
+    /// beneath it — including the search kernels, which bracket their own
+    /// sections. Tokio runs one task at a time per thread, so a raised
+    /// depth means exactly "this thread is already inside a bracket that
+    /// covers whatever runs next", and the inner folds must stand down
+    /// and let the outermost one report.
+    ///
+    /// This lives here rather than beside `MeteredExec` because the fold
+    /// it guards is here: every CPU nanosecond reaches the collector
+    /// through [`OpStatsCollector::add_kernel_cpu_ns`], whether it came
+    /// from `timed_kernel` or from a `timed_section` value a caller
+    /// folded by hand. Gating one choke point covers them all.
+    static OUTER_BRACKET_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// True while an enclosing CPU bracket on this thread is already
+/// measuring, so an inner fold would double-charge.
+pub(crate) fn outer_bracket_active() -> bool {
+    OUTER_BRACKET_DEPTH.with(|d| d.get()) > 0
+}
+
+/// Marks this thread as inside an outer CPU bracket until dropped.
+///
+/// Restores the previous depth on drop, unwind included: a poll that
+/// panicked out of a raised depth would otherwise leave the thread
+/// permanently silenced, and every later query scheduled onto that worker
+/// would fold nothing.
+pub(crate) struct OuterBracketGuard(u32);
+
+impl OuterBracketGuard {
+    pub(crate) fn enter() -> Self {
+        Self(OUTER_BRACKET_DEPTH.with(|d| d.replace(1)))
+    }
+}
+
+impl Drop for OuterBracketGuard {
+    fn drop(&mut self) {
+        OUTER_BRACKET_DEPTH.with(|d| d.set(self.0));
+    }
+}
+
 /// Bracket one synchronous section with the thread-CPU clock, gated on
 /// [`metering_active`] so an unmetered process pays one relaxed load and
 /// no procfs reads. For the superfile layers, which have no collector —
@@ -518,6 +573,43 @@ mod tests {
         assert_eq!(value, 7);
         assert_eq!(stats.fts_postings_bytes, 123);
         assert!(current().is_none(), "scope uninstalls its collector");
+    }
+
+    #[test]
+    fn an_inner_fold_stands_down_inside_an_outer_bracket() {
+        // `MeteredExec` brackets a whole DataFusion poll, and that poll
+        // drives the search kernels inline — they bracket their own
+        // sections, so without this both fold the same nanoseconds. It was
+        // roughly 59% of what a vector query through the SQL TVF appeared
+        // to cost against the identical direct call.
+        let (_, stats) = with_op_stats(|| {
+            let c = current().expect("collector installed");
+            c.add_kernel_cpu_ns(100);
+            {
+                let _outer = OuterBracketGuard::enter();
+                c.add_kernel_cpu_ns(500);
+            }
+            c.add_kernel_cpu_ns(7);
+        });
+        assert_eq!(
+            stats.kernel_cpu_ns, 107,
+            "the fold inside the outer bracket is the outer bracket's to \
+             report; folds resume once it drops"
+        );
+    }
+
+    #[test]
+    fn an_outer_bracket_restores_its_depth_on_unwind() {
+        // A poll that panicked out of a raised depth would silence every
+        // later query scheduled onto that worker.
+        let _ = catch_unwind(|| {
+            let _outer = OuterBracketGuard::enter();
+            panic!("poll blew up");
+        });
+        assert!(
+            !outer_bracket_active(),
+            "the guard must restore the depth even when the poll unwinds"
+        );
     }
 
     #[test]

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -300,16 +300,14 @@ impl OpStatsCollector {
 
     /// Flush one bracketed kernel section's on-CPU nanoseconds.
     pub(crate) fn add_kernel_cpu_ns(&self, ns: u64) {
-        // An enclosing bracket on this thread is already measuring this
-        // work, so folding here too would charge the same nanoseconds
-        // twice. That is not hypothetical: a search TVF invoked through
-        // SQL runs its kernel inline inside the plan root's poll, and
-        // both brackets reported it — measured at roughly 59% of what a
-        // vector query through the TVF appeared to cost, against the
-        // identical operation called directly.
-        if outer_bracket_active() {
-            return;
-        }
+        // Unconditional by design. Much of what reaches here was measured
+        // on a rayon worker and carried back as data — the resident decode
+        // wave, the per-cell probes — and the poll-level bracket reads only
+        // its own thread's clock, so it never contained those nanoseconds.
+        // Suppressing them here would not de-duplicate, it would delete.
+        // De-duplication happens where the measurement happens, in
+        // [`timed_kernel`] and [`timed_section`], which run on the same
+        // thread as the bracket that would otherwise cover them.
         self.kernel_cpu_ns.fetch_add(ns, Ordering::Relaxed);
     }
 
@@ -484,6 +482,16 @@ pub(crate) fn timed_kernel<T>(
     let Some(stats) = collector else {
         return f();
     };
+    // An enclosing bracket on THIS thread already covers whatever `f`
+    // does — DataFusion is pull-based, so a poll drives its subtree
+    // synchronously on the polling thread. Measuring again here would
+    // charge the same nanoseconds twice; it was roughly 59% of what a
+    // vector query through the SQL TVF appeared to cost against the
+    // identical direct call. Same-thread by construction, which is why
+    // the check belongs here and not at the collector's sink.
+    if outer_bracket_active() {
+        return f();
+    }
     let start = cpu::thread_cpu_ns();
     let value = f();
     stats.add_kernel_cpu_ns(cpu::thread_cpu_delta_ns(start));
@@ -540,6 +548,14 @@ impl Drop for OuterBracketGuard {
 /// no procfs reads. For the superfile layers, which have no collector —
 /// the ns travel back to the supertable as data.
 pub(crate) fn timed_section<R>(f: impl FnOnce() -> R) -> (R, u64) {
+    // Zero when an enclosing bracket on this thread already covers the
+    // section, so the caller's later fold adds nothing. A section running
+    // on a rayon worker sees depth 0 — thread-locals are per-thread — and
+    // reports its real time, which is exactly right: the poll-level
+    // bracket never measured that worker's CPU.
+    if outer_bracket_active() {
+        return (f(), 0);
+    }
     let start = metering_active().then(cpu::thread_cpu_ns).flatten();
     let out = f();
     (out, cpu::thread_cpu_delta_ns(start))
@@ -576,25 +592,47 @@ mod tests {
     }
 
     #[test]
-    fn an_inner_fold_stands_down_inside_an_outer_bracket() {
+    fn a_same_thread_measurement_stands_down_inside_an_outer_bracket() {
         // `MeteredExec` brackets a whole DataFusion poll, and that poll
         // drives the search kernels inline — they bracket their own
-        // sections, so without this both fold the same nanoseconds. It was
-        // roughly 59% of what a vector query through the SQL TVF appeared
-        // to cost against the identical direct call.
+        // sections, so without this both measure the same nanoseconds. It
+        // was roughly 59% of what a vector query through the SQL TVF
+        // appeared to cost against the identical direct call.
         let (_, stats) = with_op_stats(|| {
-            let c = current().expect("collector installed");
-            c.add_kernel_cpu_ns(100);
-            {
-                let _outer = OuterBracketGuard::enter();
-                c.add_kernel_cpu_ns(500);
-            }
-            c.add_kernel_cpu_ns(7);
+            let collector = current();
+            let mut ran = 0u32;
+            let _outer = OuterBracketGuard::enter();
+            timed_kernel(&collector, || ran += 1);
+            let (_, section_ns) = timed_section(|| ran += 1);
+            assert_eq!(ran, 2, "the work still runs; only the clock stands down");
+            assert_eq!(
+                section_ns, 0,
+                "a section the enclosing bracket already covers reports \
+                 nothing for its caller to fold"
+            );
         });
         assert_eq!(
-            stats.kernel_cpu_ns, 107,
-            "the fold inside the outer bracket is the outer bracket's to \
-             report; folds resume once it drops"
+            stats.kernel_cpu_ns, 0,
+            "the enclosing bracket is the one that reports this thread's CPU"
+        );
+    }
+
+    #[test]
+    fn a_carried_measurement_folds_even_under_an_outer_bracket() {
+        // The counterpart, and the reason the check cannot live at the
+        // collector's sink: nanoseconds measured on a rayon worker and
+        // carried back as data were never inside the poll-level bracket,
+        // which reads only its own thread's clock. Dropping them would not
+        // de-duplicate, it would delete — measured at 0.25-1.16 ms per
+        // query on the search TVF path.
+        let (_, stats) = with_op_stats(|| {
+            let collector = current().expect("collector installed");
+            let _outer = OuterBracketGuard::enter();
+            collector.add_kernel_cpu_ns(4_242);
+        });
+        assert_eq!(
+            stats.kernel_cpu_ns, 4_242,
+            "a value measured elsewhere must still reach the collector"
         );
     }
 

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -65,10 +65,11 @@
 //! [`super::io::UsageMeter`] ledger keeps the actuals); the deferred
 //! storage-reclaim sweep and ingest-triggered hidden-index maintenance
 //! (detached tasks never pick up a collector, so they are excluded by
-//! the mint discipline); and per-shard build CPU (the caller's thread
-//! blocks in `pool.install` while the writer pool burns the CPU, so a
-//! calling-thread bracket cannot see it — a consumer's process-level
-//! CPU accounting carries the compute leg).
+//! the mint discipline). Per-shard build CPU IS measured: the bracket
+//! sits inside each shard's pool closure (`fanout_shards_metered`) and
+//! the WAL update's build step, on the thread doing the work — a
+//! calling-thread bracket would see nothing, since the caller blocks in
+//! `pool.install` for the whole fan-out.
 
 use std::{
     cell::RefCell,

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -148,10 +148,13 @@ pub struct OpStats {
     pub sql_page_bytes: u64,
     /// Rows decoded from stored columns to build results — the scalar
     /// projection decode (`resolve_columns`, including the `_id` stamping
-    /// fallback it serves) plus, for SQL, the scan operators' output rows
-    /// from DataFusion's own metrics. The id-score arithmetic fast path
-    /// decodes nothing and counts nothing; remap/tombstone-internal id
-    /// reads count planned ranges only, never rows.
+    /// fallback it serves); for SQL, the scan operators' output rows from
+    /// DataFusion's own metrics; and filter-side verify decodes
+    /// (`exact_match` decodes one row per candidate to compare values,
+    /// counted once whichever take served the batch). The id-score
+    /// arithmetic fast path decodes nothing and counts nothing;
+    /// remap/tombstone-internal id reads count planned ranges only, never
+    /// rows.
     pub rows_materialized: u64,
     /// Nanoseconds of the query's bracketed synchronous kernel sections.
     /// One clock everywhere: the thread-CPU clock (schedstat). Engine

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -208,8 +208,8 @@ pub struct OpStats {
     /// into and how many times a contended publish retried. This counts
     /// instead what the data itself requires, which neither varies with:
     ///
-    /// - the objects the committed bytes occupy at the table's target
-    ///   superfile size, and
+    /// - the objects the commit's *ingested payload* occupies at the
+    ///   table's target superfile size, and
     /// - the manifest json + pointer that every commit must publish
     ///   ([`MANIFEST_PUTS_PER_COMMIT`]), counted once per successful
     ///   commit rather than once per OCC attempt.
@@ -218,12 +218,15 @@ pub struct OpStats {
     /// the superfile count, so they carry the same width-dependence the
     /// priced legs exist to avoid.
     ///
-    /// One honest caveat: the object term is derived from the commit's
-    /// *sealed* bytes, which carry a per-superfile overhead that does
-    /// scale with shard count. Against a gibibyte-scale target that
-    /// overhead is kilobytes, so it cannot move the ceiling except on a
-    /// knife-edge boundary; `write_stats_are_invariant_to_writer_pool_width`
-    /// compares this counter across widths and would catch it if it did.
+    /// The object term is derived from the buffered input rather than the
+    /// sealed output, and that distinction is load-bearing rather than
+    /// cosmetic. Per-superfile overhead is not a fixed footer: every shard
+    /// carries its own dictionary, FST and index headers, so on a corpus
+    /// whose vocabulary is shared across rows the same input seals to
+    /// roughly four times more bytes at pool width 16 than at width 1.
+    /// Dividing that by the target would make an identical append plan
+    /// more requests on a wider host — the exact width-dependence this
+    /// counter exists to avoid.
     ///
     /// Requests are a real and material share of write cost — a PUT is
     /// 12.5x a GET in the bench cost model, and unlike a warm read's
@@ -335,7 +338,7 @@ impl OpStatsCollector {
     /// retried publish never counts.
     ///
     /// Callers state their own object term because it is shape-specific:
-    /// a buffered append plans `ceil(sealed bytes / target object size)`;
+    /// a buffered append plans `ceil(ingested payload / target object size)`;
     /// an update plans exactly 1 (its replacement rows land in the WAL's
     /// single preallocated superfile by design). A delete flushes nothing
     /// here — it commits no manifest, and its per-superfile tombstone

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -154,12 +154,18 @@ pub struct OpStats {
     /// reads count planned ranges only, never rows.
     pub rows_materialized: u64,
     /// Nanoseconds of the query's bracketed synchronous kernel sections.
-    /// Engine kernels use the thread-CPU clock; SQL operator sections use
-    /// DataFusion's own `elapsed_compute` instrumentation (an `Instant`
-    /// timer around synchronous poll work — approximately on-CPU for
-    /// compute-bound operators, excluding async I/O waits). A refinement
-    /// of — not a replacement for — a consumer's own process-level CPU
-    /// accounting: fan-out glue and async awaits are outside the brackets.
+    /// One clock everywhere: the thread-CPU clock (schedstat). Engine
+    /// kernels bracket their own sections; SQL scans are bracketed per
+    /// poll by `MeteredExec`, which measures on whichever worker polls
+    /// that partition. DataFusion's `elapsed_compute` is deliberately not
+    /// used — it is wall time and omits Parquet decode — so a SQL query
+    /// and a search query are priced on the same basis.
+    ///
+    /// Coverage is not total: orchestration between kernels and async
+    /// awaits sit outside the brackets, so this reads lower than a
+    /// process-level measurement of the same op. Measured on the standard
+    /// vector bench, then closed toward completeness — the remaining gap
+    /// is what a consumer must calibrate its reference against.
     pub kernel_cpu_ns: u64,
 
     // ---- Write-side work (see the module's write-side determinism

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -1,17 +1,39 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Per-query execution work stats — deterministic counters of the physical
-//! work one query performs, independent of cache temperature.
+//! Per-op execution work stats — deterministic counters of the physical
+//! work one query **or one write** performs, independent of cache
+//! temperature (reads) and of pool width / commit contention (writes).
 //!
 //! Parallel to [`super::io`] (connection-scoped I/O ledger) and [`super::cpu`]
-//! (process CPU): this module scopes to a **single query**. A caller wraps a
-//! search in [`with_op_stats`]; the reader minted for that query picks the
-//! collector up ([`current`]) and threads it through the fan-out, and each
-//! kernel flushes its work counters into it. The same query against the same
-//! table state reports the same numbers whether the cache was warm or cold —
-//! these count what the plan *did*, not what the storage layer happened to
-//! fetch (the [`super::io::UsageMeter`] ledger keeps counting actuals).
+//! (process CPU): this module scopes to a **single op**. A caller wraps a
+//! search or a write in [`with_op_stats`]; the reader or writer minted for
+//! that op picks the collector up ([`current`]) and threads it through the
+//! fan-out, and each kernel flushes its work counters into it. The same query
+//! against the same table state reports the same numbers whether the cache
+//! was warm or cold — these count what the plan *did*, not what the storage
+//! layer happened to fetch (the [`super::io::UsageMeter`] ledger keeps
+//! counting actuals).
+//!
+//! One struct serves both directions deliberately: `update` and `delete`
+//! resolve their predicate through a real reader, so a mutation's scan leg
+//! reports read counters and its commit leg reports write counters — one
+//! scope, one snapshot, both halves of the op's physical work. That scan
+//! is the same work a `SELECT` would do and should be priced as read work
+//! (exempting it would let `SELECT`-then-delete-by-id dodge the meter).
+//!
+//! ## Write-side determinism
+//!
+//! Two things vary on the write path through no fault of the caller: the
+//! shard split follows the writer pool's width, and a contended commit
+//! retries its publish. The write counters split accordingly:
+//! [`OpStats::rows_written`], the three ingested-byte counters, and
+//! [`OpStats::rows_tombstoned`] are functions of the batch, the predicate,
+//! and the table state alone — one thread or sixteen, first-attempt commit
+//! or third. [`OpStats::superfiles_written`],
+//! [`OpStats::superfile_bytes_written`], and [`OpStats::fts_terms_indexed`]
+//! are width-dependent execution observations, recorded for reconciliation
+//! and never to be priced.
 //!
 //! With no collector installed the per-flush cost is one `Option` check,
 //! and the superfile-level kernel-CPU brackets gate their procfs reads on
@@ -36,6 +58,17 @@
 //! invariantly). Their expected cost is recovered through a consumer's
 //! calibrated rates, never surcharged on the query that happened to pay
 //! them.
+//!
+//! Write-side exclusions, same reasoning: object-store PUT count/bytes
+//! (OCC retries, multipart fan-out, and manifest-part rewrites are our
+//! contention and our config, not the caller's — the
+//! [`super::io::UsageMeter`] ledger keeps the actuals); the deferred
+//! storage-reclaim sweep and ingest-triggered hidden-index maintenance
+//! (detached tasks never pick up a collector, so they are excluded by
+//! the mint discipline); and per-shard build CPU (the caller's thread
+//! blocks in `pool.install` while the writer pool burns the CPU, so a
+//! calling-thread bracket cannot see it — a consumer's process-level
+//! CPU accounting carries the compute leg).
 
 use std::{
     cell::RefCell,
@@ -49,13 +82,16 @@ use serde::{Deserialize, Serialize};
 
 use super::cpu;
 
-/// Physical work one query performed. Every field except
-/// [`Self::kernel_cpu_ns`] (measured time, varies run to run) and
+/// Physical work one op performed — read counters for its query legs,
+/// write counters for its commit legs (a pure query leaves the write
+/// block zero and vice versa; a mutation fills both). Every read field
+/// except [`Self::kernel_cpu_ns`] (measured time, varies run to run) and
 /// [`Self::vector_rows_reranked`] (actual execution rows — the deferred
 /// path reranks cold cells in place, so the count can shift with cache
 /// temperature) is a deterministic plan count: same query, same table
-/// state → same value, warm or cold. The struct is `#[non_exhaustive]`
-/// because counters land modality by modality.
+/// state → same value, warm or cold. The write block splits the same way
+/// (see the module's write-side determinism note). The struct is
+/// `#[non_exhaustive]` because counters land modality by modality.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct OpStats {
@@ -124,9 +160,45 @@ pub struct OpStats {
     /// of — not a replacement for — a consumer's own process-level CPU
     /// accounting: fan-out glue and async awaits are outside the brackets.
     pub kernel_cpu_ns: u64,
+
+    // ---- Write-side work (see the module's write-side determinism
+    // note; every counter below is a value the commit path already
+    // computes, harvested rather than instrumented) ----
+    /// Rows the op durably indexed: appended rows plus an update's
+    /// replacement rows. Counted from the caller's batch at buffering
+    /// time, before any fan-out — invariant to shard count and OCC
+    /// retries.
+    pub rows_written: u64,
+    /// Arrow footprint of the op's scalar/text columns — the payload the
+    /// commit encodes to Parquet. Deterministic (input-shaped).
+    pub scalar_bytes_written: u64,
+    /// f32 payload bytes of the op's vector columns (`rows × dim × 4`) —
+    /// the input to rotation, k-means, and quantized encode.
+    /// Deterministic (input-shaped).
+    pub vector_bytes_written: u64,
+    /// Arrow footprint of the FTS-indexed text columns, a subset of
+    /// [`Self::scalar_bytes_written`], not additional payload: the
+    /// tokenize → dictionary → postings build scales with it.
+    /// Deterministic (input-shaped).
+    pub fts_text_bytes_written: u64,
+    /// Rows an update or delete tombstoned (sidecar bits set; excludes
+    /// not-found ids). A function of the predicate and table state.
+    pub rows_tombstoned: u64,
+    /// New superfile objects this op published. Host-width dependent —
+    /// the shard split follows the writer pool — so recorded for
+    /// reconciliation, never to be priced.
+    pub superfiles_written: u64,
+    /// On-storage bytes of those superfiles (sealed bodies, excluding
+    /// manifest parts and the pointer). Per-superfile fixed overhead
+    /// scales with shard count, so width-dependent; recorded only.
+    pub superfile_bytes_written: u64,
+    /// Distinct FTS terms built, summed per column across this op's new
+    /// superfiles. A term present in k shards counts k times, so
+    /// width-dependent; recorded only.
+    pub fts_terms_indexed: u64,
 }
 
-/// Accumulates one query's work counters across its fan-out (tokio unit
+/// Accumulates one op's work counters across its fan-out (tokio unit
 /// tasks and rayon kernel waves both add through the same `Arc`).
 #[derive(Debug, Default)]
 pub(crate) struct OpStatsCollector {
@@ -138,6 +210,14 @@ pub(crate) struct OpStatsCollector {
     sql_page_bytes: AtomicU64,
     rows_materialized: AtomicU64,
     kernel_cpu_ns: AtomicU64,
+    rows_written: AtomicU64,
+    scalar_bytes_written: AtomicU64,
+    vector_bytes_written: AtomicU64,
+    fts_text_bytes_written: AtomicU64,
+    rows_tombstoned: AtomicU64,
+    superfiles_written: AtomicU64,
+    superfile_bytes_written: AtomicU64,
+    fts_terms_indexed: AtomicU64,
 }
 
 impl OpStatsCollector {
@@ -180,6 +260,34 @@ impl OpStatsCollector {
         self.kernel_cpu_ns.fetch_add(ns, Ordering::Relaxed);
     }
 
+    /// Flush one buffered append's input shape — rows plus the three
+    /// ingested-byte legs, computed together at the buffering site.
+    pub(crate) fn add_ingested_write(&self, rows: u64, scalar: u64, vector: u64, fts_text: u64) {
+        self.rows_written.fetch_add(rows, Ordering::Relaxed);
+        self.scalar_bytes_written
+            .fetch_add(scalar, Ordering::Relaxed);
+        self.vector_bytes_written
+            .fetch_add(vector, Ordering::Relaxed);
+        self.fts_text_bytes_written
+            .fetch_add(fts_text, Ordering::Relaxed);
+    }
+
+    /// Flush a mutation's tombstoned-row count.
+    pub(crate) fn add_rows_tombstoned(&self, rows: u64) {
+        self.rows_tombstoned.fetch_add(rows, Ordering::Relaxed);
+    }
+
+    /// Flush one committed publish batch's output shape (after the
+    /// commit returns Ok, so a failed or retried publish never counts).
+    pub(crate) fn add_commit_outputs(&self, superfiles: u64, bytes: u64, fts_terms: u64) {
+        self.superfiles_written
+            .fetch_add(superfiles, Ordering::Relaxed);
+        self.superfile_bytes_written
+            .fetch_add(bytes, Ordering::Relaxed);
+        self.fts_terms_indexed
+            .fetch_add(fts_terms, Ordering::Relaxed);
+    }
+
     /// The counters accumulated so far.
     pub(crate) fn snapshot(&self) -> OpStats {
         OpStats {
@@ -191,6 +299,14 @@ impl OpStatsCollector {
             sql_page_bytes: self.sql_page_bytes.load(Ordering::Relaxed),
             rows_materialized: self.rows_materialized.load(Ordering::Relaxed),
             kernel_cpu_ns: self.kernel_cpu_ns.load(Ordering::Relaxed),
+            rows_written: self.rows_written.load(Ordering::Relaxed),
+            scalar_bytes_written: self.scalar_bytes_written.load(Ordering::Relaxed),
+            vector_bytes_written: self.vector_bytes_written.load(Ordering::Relaxed),
+            fts_text_bytes_written: self.fts_text_bytes_written.load(Ordering::Relaxed),
+            rows_tombstoned: self.rows_tombstoned.load(Ordering::Relaxed),
+            superfiles_written: self.superfiles_written.load(Ordering::Relaxed),
+            superfile_bytes_written: self.superfile_bytes_written.load(Ordering::Relaxed),
+            fts_terms_indexed: self.fts_terms_indexed.load(Ordering::Relaxed),
         }
     }
 }

--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -192,6 +192,38 @@ pub struct OpStats {
     /// manifest parts and the pointer). Per-superfile fixed overhead
     /// scales with shard count, so width-dependent; recorded only.
     pub superfile_bytes_written: u64,
+    /// Object-store PUTs this op's *plan* implies — the write-side twin
+    /// of [`Self::planned_read_ranges`], and priceable for the same
+    /// reason.
+    ///
+    /// Actual PUTs ([`Self::put_requests`]) are ours, not the caller's:
+    /// they scale with how many shards the writer pool split the commit
+    /// into and how many times a contended publish retried. This counts
+    /// instead what the data itself requires, which neither varies with:
+    ///
+    /// - the objects the committed bytes occupy at the table's target
+    ///   superfile size, and
+    /// - the manifest json + pointer that every commit must publish
+    ///   ([`MANIFEST_PUTS_PER_COMMIT`]), counted once per successful
+    ///   commit rather than once per OCC attempt.
+    ///
+    /// Manifest *parts* are excluded deliberately: their count follows
+    /// the superfile count, so they carry the same width-dependence the
+    /// priced legs exist to avoid.
+    ///
+    /// One honest caveat: the object term is derived from the commit's
+    /// *sealed* bytes, which carry a per-superfile overhead that does
+    /// scale with shard count. Against a gibibyte-scale target that
+    /// overhead is kilobytes, so it cannot move the ceiling except on a
+    /// knife-edge boundary; `write_stats_are_invariant_to_writer_pool_width`
+    /// compares this counter across widths and would catch it if it did.
+    ///
+    /// Requests are a real and material share of write cost — a PUT is
+    /// 12.5x a GET in the bench cost model, and unlike a warm read's
+    /// ranges they never resolve from residency, so a commit always pays
+    /// them. A consumer that accounts for write cost without a request
+    /// term would understate every write by that share.
+    pub planned_write_requests: u64,
     /// Distinct FTS terms built, summed per column across this op's new
     /// superfiles. A term present in k shards counts k times, so
     /// width-dependent; recorded only.
@@ -216,6 +248,7 @@ pub(crate) struct OpStatsCollector {
     fts_text_bytes_written: AtomicU64,
     rows_tombstoned: AtomicU64,
     superfiles_written: AtomicU64,
+    planned_write_requests: AtomicU64,
     superfile_bytes_written: AtomicU64,
     fts_terms_indexed: AtomicU64,
 }
@@ -288,6 +321,20 @@ impl OpStatsCollector {
             .fetch_add(fts_terms, Ordering::Relaxed);
     }
 
+    /// Flush the PUTs one committed publish *planned*, from the bytes it
+    /// sealed and the table's target object size. Called beside
+    /// [`Self::add_commit_outputs`], under the same post-Ok discipline, so
+    /// a failed or retried publish never counts.
+    pub(crate) fn add_planned_write_requests(&self, sealed_bytes: u64, target_bytes: u64) {
+        let objects = if target_bytes == 0 {
+            0
+        } else {
+            sealed_bytes.div_ceil(target_bytes)
+        };
+        self.planned_write_requests
+            .fetch_add(objects.saturating_add(MANIFEST_PUTS_PER_COMMIT), Ordering::Relaxed);
+    }
+
     /// The counters accumulated so far.
     pub(crate) fn snapshot(&self) -> OpStats {
         OpStats {
@@ -305,6 +352,7 @@ impl OpStatsCollector {
             fts_text_bytes_written: self.fts_text_bytes_written.load(Ordering::Relaxed),
             rows_tombstoned: self.rows_tombstoned.load(Ordering::Relaxed),
             superfiles_written: self.superfiles_written.load(Ordering::Relaxed),
+            planned_write_requests: self.planned_write_requests.load(Ordering::Relaxed),
             superfile_bytes_written: self.superfile_bytes_written.load(Ordering::Relaxed),
             fts_terms_indexed: self.fts_terms_indexed.load(Ordering::Relaxed),
         }
@@ -319,6 +367,12 @@ thread_local! {
     /// so spawned tasks and pool closures never consult this slot.
     static CURRENT: RefCell<Option<Arc<OpStatsCollector>>> = const { RefCell::new(None) };
 }
+
+/// PUTs every successful commit publishes regardless of shape: the
+/// manifest json and the pointer file, one each. Manifest *parts* are
+/// excluded — their count follows the superfile count, which is
+/// width-dependent (see [`OpStats::planned_write_requests`]).
+const MANIFEST_PUTS_PER_COMMIT: u64 = 2;
 
 /// Live [`with_op_stats`] scopes, process-wide. Superfile-layer kernel
 /// brackets gate their procfs reads on this instead of a collector they

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -241,6 +241,14 @@ pub enum VectorError {
     /// panicking the process.
     #[error("vector compute task dropped its result during {0}")]
     TaskDropped(&'static str),
+
+    /// The warmed cluster-block span map is missing a cluster that the
+    /// rerank shortlist references. An internal inconsistency rather
+    /// than bad user input; surfaced as an error on the same reasoning
+    /// as [`VectorError::TaskDropped`], so one query fails instead of
+    /// the process panicking on a map index.
+    #[error("vector index inconsistency: {0}")]
+    InconsistentIndex(String),
 }
 
 impl VectorError {

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -366,21 +366,26 @@ impl FtsReader {
         if !header_ranges.is_empty() {
             let fetched = self.fetch_term_postings(&header_ranges).await?;
             work.planned_ranges += header_ranges.len() as u64;
-            for (fetched_idx, &slot) in pfor_slots.iter().enumerate() {
-                let header = fetched.get(fetched_idx).ok_or_else(|| {
-                    FtsError::Read(ReadError::MalformedVersion(
-                        "term_dfs: fetched fewer headers than requested".into(),
-                    ))
-                })?;
-                work.postings_bytes += header.len() as u64;
-                let header_bytes = header.as_ref();
-                if header_bytes.len() < U32_BYTES {
-                    return Err(FtsError::Read(ReadError::MalformedVersion(
-                        "term_dfs: short postings header".into(),
-                    )));
+            let (decoded, decode_ns) = timed_section(|| {
+                for (fetched_idx, &slot) in pfor_slots.iter().enumerate() {
+                    let header = fetched.get(fetched_idx).ok_or_else(|| {
+                        FtsError::Read(ReadError::MalformedVersion(
+                            "term_dfs: fetched fewer headers than requested".into(),
+                        ))
+                    })?;
+                    work.postings_bytes += header.len() as u64;
+                    let header_bytes = header.as_ref();
+                    if header_bytes.len() < U32_BYTES {
+                        return Err(FtsError::Read(ReadError::MalformedVersion(
+                            "term_dfs: short postings header".into(),
+                        )));
+                    }
+                    dfs[slot] = read_u32_le(&header_bytes[0..U32_BYTES]) as u64;
                 }
-                dfs[slot] = read_u32_le(&header_bytes[0..U32_BYTES]) as u64;
-            }
+                Ok(())
+            });
+            decoded?;
+            work.kernel_cpu_ns += decode_ns;
         }
         Ok((dfs, work))
     }

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -4836,6 +4836,22 @@ pub struct ProbeTally {
     pub kernel_cpu_ns: u64,
 }
 
+impl ScanOutcome {
+    /// The scan's five work tallies in the shared carrier, so every
+    /// supertable fold site prices the same field set through one
+    /// function — a sixth tally added here is a compile error at the
+    /// fold, not a silent gap at one of three call sites.
+    pub(crate) fn work(&self) -> ProbeTally {
+        ProbeTally {
+            cells_scanned: self.cells_scanned,
+            candidates_scanned: self.candidates_scanned,
+            ranges_requested: self.ranges_requested,
+            rows_reranked: self.rows_reranked,
+            kernel_cpu_ns: self.kernel_cpu_ns,
+        }
+    }
+}
+
 /// Result of a deferred-rerank scan over one superfile
 /// ([`VectorReader::search_clusters_scan_async`]).
 pub(crate) struct ScanOutcome {

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3468,7 +3468,15 @@ impl VectorReader {
         // selection; at a wide sweep that is the whole probed set.
         let (per_cell, resolve_ns) = timed_section(|| self.resolve_cells_for_clusters(clusters));
         if per_cell.is_empty() {
-            return Ok((Vec::new(), ProbeTally::default()));
+            // The resolve itself was real work; a zero-hit probe still
+            // reports the CPU it spent finding that out.
+            return Ok((
+                Vec::new(),
+                ProbeTally {
+                    kernel_cpu_ns: resolve_ns,
+                    ..ProbeTally::default()
+                },
+            ));
         }
 
         // One rotation for every probed cell: it is seeded once per column,
@@ -3481,17 +3489,27 @@ impl VectorReader {
         // out of range and take the process with it. Validate the whole
         // set here rather than just the first: the fan-out closure below
         // indexes `self.columns` per cell and is a `filter_map`, so it has
-        // no way to report an error partway through the wave.
+        // no way to report an error partway through the wave. Layout
+        // agreement is part of the same validation — sharing one rotated
+        // query across cells is only correct while every cell carries the
+        // column's dim and table-wide rotation seed, and a mismatch would
+        // otherwise score silently wrong rather than fail.
+        let first_col = self.column_at(per_cell[0].0)?;
         for &(cell_idx, ..) in &per_cell {
-            self.column_at(cell_idx)?;
+            let cell_col = self.column_at(cell_idx)?;
+            if cell_col.dim != first_col.dim || cell_col.rot_seed != first_col.rot_seed {
+                return Err(VectorError::InconsistentIndex(format!(
+                    "cell {cell_idx} disagrees with the column's layout \
+                     (dim {} seed {}, expected dim {} seed {})",
+                    cell_col.dim, cell_col.rot_seed, first_col.dim, first_col.rot_seed
+                )));
+            }
         }
-        let (q_rot_shared, rot_ns) = timed_section(|| -> Result<Vec<f32>, VectorError> {
-            let first_col = self.column_at(per_cell[0].0)?;
+        let (q_rot_shared, rot_ns) = timed_section(|| {
             let mut q_rot = vec![0f32; first_col.dim];
             first_col.rot.apply(query, &mut q_rot);
-            Ok(q_rot)
+            q_rot
         });
-        let q_rot_shared = q_rot_shared?;
         let q_rot_shared = &q_rot_shared;
 
         // Probe the selected cells CONCURRENTLY — the same wave shape the
@@ -3670,7 +3688,6 @@ impl VectorReader {
         // REQUESTED column's seed (every cell of one column shares it),
         // not `columns[0]`'s — a multi-column file's first column can be
         // a different column with a different rotation.
-        outcome.rot_seed = self.column_at(per_cell[0].0)?.rot_seed;
         // Rotate the query once per superfile: every cell of a column
         // shares the table-wide rotation seed (cross-cell estimate pooling
         // depends on it), so per-cell re-rotation is duplicate work — at a
@@ -3678,11 +3695,20 @@ impl VectorReader {
         // ~1.3ms of wall per query.
         // Same reasoning as the multi-cell probe path: the scan closure
         // below indexes `self.columns` for every cell and cannot return an
-        // error, so the whole resolved set is validated up front.
-        for &(cell_idx, ..) in &per_cell {
-            self.column_at(cell_idx)?;
-        }
+        // error, so the whole resolved set — indices and layout agreement
+        // both — is validated up front.
         let first_col = self.column_at(per_cell[0].0)?;
+        for &(cell_idx, ..) in &per_cell {
+            let cell_col = self.column_at(cell_idx)?;
+            if cell_col.dim != first_col.dim || cell_col.rot_seed != first_col.rot_seed {
+                return Err(VectorError::InconsistentIndex(format!(
+                    "cell {cell_idx} disagrees with the column's layout \
+                     (dim {} seed {}, expected dim {} seed {})",
+                    cell_col.dim, cell_col.rot_seed, first_col.dim, first_col.rot_seed
+                )));
+            }
+        }
+        outcome.rot_seed = first_col.rot_seed;
         let (q_rot_shared, rot_ns) = timed_section(|| {
             let mut q_rot = vec![0f32; first_col.dim];
             first_col.rot.apply(query, &mut q_rot);
@@ -3718,9 +3744,11 @@ impl VectorReader {
                 let ((cluster_meta, prefix_ranges), meta_ns) =
                     timed_section(|| chosen_cluster_meta(col, &cluster_idx, &locals));
                 if cluster_meta.is_empty() {
-                    // The cluster-index read itself was one planned range.
+                    // The cluster-index read itself was one planned range,
+                    // and the metadata walk was real CPU.
                     let tally = ProbeTally {
                         ranges_requested: 1,
+                        kernel_cpu_ns: meta_ns,
                         ..ProbeTally::default()
                     };
                     return Ok((Vec::new(), Vec::new(), tally));
@@ -3960,7 +3988,27 @@ impl VectorReader {
                                                 cand.cluster_id
                                             ))
                                         })?;
-                                    Ok(region.slice(range.start - base..range.end - base))
+                                    // Checked arithmetic for the same reason
+                                    // the lookup is checked: a stale span
+                                    // base underflows the subtraction and a
+                                    // short region fails the slice — both
+                                    // are index inconsistency, not a reason
+                                    // to abort the process.
+                                    let (start, end) = range
+                                        .start
+                                        .checked_sub(*base)
+                                        .zip(range.end.checked_sub(*base))
+                                        .filter(|&(s, e)| s <= e && e <= region.len())
+                                        .ok_or_else(|| {
+                                            VectorError::InconsistentIndex(format!(
+                                                "survivor range {:?} falls outside cluster {}'s \
+                                                 warmed span (base {base}, len {})",
+                                                range,
+                                                cand.cluster_id,
+                                                region.len()
+                                            ))
+                                        })?;
+                                    Ok(region.slice(start..end))
                                 })
                                 .collect::<Result<Vec<_>, VectorError>>()
                         });
@@ -4035,7 +4083,14 @@ impl VectorReader {
         let ((cluster_meta, cluster_prefix_ranges), meta_ns) =
             timed_section(|| chosen_cluster_meta(col, cluster_idx, chosen));
         if cluster_meta.is_empty() {
-            return Ok((Vec::new(), ProbeTally::default()));
+            // The metadata walk was real work; keep its CPU on the tally.
+            return Ok((
+                Vec::new(),
+                ProbeTally {
+                    kernel_cpu_ns: meta_ns,
+                    ..ProbeTally::default()
+                },
+            ));
         }
         // Plan tallies, fixed before the warm/cold fetch branch: both arms
         // scan the same clusters and request one prefix/block range each

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3681,7 +3681,11 @@ impl VectorReader {
                     .await
                     .map_err(|e| VectorError::LazySource(e.to_string()))?;
                 let cb = col.quant.code_bytes();
-                let (cluster_meta, prefix_ranges) = chosen_cluster_meta(col, &cluster_idx, &locals);
+                // Per-cell metadata assembly: a pass over this cell's chosen
+                // clusters, on the worker that probes it. Scales with probe
+                // width, so at a wide sweep it is paid once per cell.
+                let ((cluster_meta, prefix_ranges), meta_ns) =
+                    timed_section(|| chosen_cluster_meta(col, &cluster_idx, &locals));
                 if cluster_meta.is_empty() {
                     // The cluster-index read itself was one planned range.
                     let tally = ProbeTally {
@@ -3705,6 +3709,7 @@ impl VectorReader {
                     rows_reranked: 0,
                     kernel_cpu_ns: 0,
                 };
+                tally.kernel_cpu_ns += meta_ns;
                 // Warm fast path: every prefix resident -> defer rerank.
                 // The resident-range assembly is a real memcpy per cell
                 // (codes + doc-ids blocks), so it counts as this query's
@@ -3987,7 +3992,8 @@ impl VectorReader {
         chosen: &[usize],
     ) -> Result<(Vec<(u32, f32)>, ProbeTally), VectorError> {
         let cb = col.quant.code_bytes();
-        let (cluster_meta, cluster_prefix_ranges) = chosen_cluster_meta(col, cluster_idx, chosen);
+        let ((cluster_meta, cluster_prefix_ranges), meta_ns) =
+            timed_section(|| chosen_cluster_meta(col, cluster_idx, chosen));
         if cluster_meta.is_empty() {
             return Ok((Vec::new(), ProbeTally::default()));
         }
@@ -4006,6 +4012,7 @@ impl VectorReader {
             rows_reranked: 0,
             kernel_cpu_ns: 0,
         };
+        tally.kernel_cpu_ns += meta_ns;
         // Warm fast path: every prefix already resident → sync zero-copy.
         let prefix_blocks_sync: Option<Vec<Bytes>> = cluster_prefix_ranges
             .iter()

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3449,7 +3449,9 @@ impl VectorReader {
             return Ok((Vec::new(), ProbeTally::default()));
         }
 
-        let per_cell = self.resolve_cells_for_clusters(clusters);
+        // Mapping the selected flat clusters onto cells is a pass over the
+        // selection; at a wide sweep that is the whole probed set.
+        let (per_cell, resolve_ns) = timed_section(|| self.resolve_cells_for_clusters(clusters));
         if per_cell.is_empty() {
             return Ok((Vec::new(), ProbeTally::default()));
         }
@@ -3532,7 +3534,7 @@ impl VectorReader {
             .try_collect()
             .await?;
         let mut tally = ProbeTally::default();
-        tally.kernel_cpu_ns += rot_ns;
+        tally.kernel_cpu_ns += rot_ns.saturating_add(resolve_ns);
         for (_, cell_tally) in &per_cell {
             tally.cells_scanned += cell_tally.cells_scanned;
             tally.candidates_scanned += cell_tally.candidates_scanned;

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3916,16 +3916,25 @@ impl VectorReader {
                 let (survivor_rows, gather_ns) = match spans {
                     // Warm: slice survivors straight out of the spans
                     // already in hand — a per-survivor pass, so bracketed.
-                    Some(spans) => timed_section(|| {
-                        rerank_cands
-                            .iter()
-                            .zip(&ranges)
-                            .map(|(cand, range)| {
-                                let (base, region) = &spans[&cand.cluster_id];
-                                region.slice(range.start - base..range.end - base)
-                            })
-                            .collect::<Vec<_>>()
-                    }),
+                    Some(spans) => {
+                        let (rows, ns) = timed_section(|| {
+                            rerank_cands
+                                .iter()
+                                .zip(&ranges)
+                                .map(|(cand, range)| {
+                                    let (base, region) =
+                                        spans.get(&cand.cluster_id).ok_or_else(|| {
+                                            VectorError::InconsistentIndex(format!(
+                                                "no warmed survivor span for cluster {}",
+                                                cand.cluster_id
+                                            ))
+                                        })?;
+                                    Ok(region.slice(range.start - base..range.end - base))
+                                })
+                                .collect::<Result<Vec<_>, VectorError>>()
+                        });
+                        (rows?, ns)
+                    }
                     None => get_survivor_ranges_coalesced_async(&self.source, &ranges)
                         .await
                         .map_err(|e| VectorError::LazySource(e.to_string()))?,

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3270,8 +3270,11 @@ impl VectorReader {
         let centroid_scores = score_centroids(&centroids, col, query, nprobe_eff);
 
         // 3. Rotate query once for the 1-bit code estimator.
-        let mut q_rot = vec![0f32; col.dim];
-        col.rot.apply(query, &mut q_rot);
+        let (q_rot, rot_ns) = timed_section(|| {
+            let mut q_rot = vec![0f32; col.dim];
+            col.rot.apply(query, &mut q_rot);
+            q_rot
+        });
 
         // 4. Probe the centroid-scored clusters through the shared tail
         //    (also used by the externally-selected
@@ -3290,6 +3293,7 @@ impl VectorReader {
         let (hits, mut tally) = self
             .probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
             .await?;
+        tally.kernel_cpu_ns += rot_ns;
         // The centroid + cluster-index span above was one planned range.
         tally.ranges_requested += 1;
         Ok((hits, tally))
@@ -3346,8 +3350,11 @@ impl VectorReader {
             .range_async(idx_start..idx_end)
             .await
             .map_err(|e| VectorError::LazySource(e.to_string()))?;
-        let mut q_rot = vec![0f32; col.dim];
-        col.rot.apply(query, &mut q_rot);
+        let (q_rot, rot_ns) = timed_section(|| {
+            let mut q_rot = vec![0f32; col.dim];
+            col.rot.apply(query, &mut q_rot);
+            q_rot
+        });
         let chosen: Vec<usize> = clusters.iter().map(|&c| c as usize).collect();
         // No inverse-selectivity rerank inflation on the fan path: the
         // shortlist heap admits MATCHING rows only (the allow test runs
@@ -3372,6 +3379,7 @@ impl VectorReader {
         let (hits, mut tally) = self
             .probe_clusters_async(col, query, &ctx, &cluster_idx, &chosen)
             .await?;
+        tally.kernel_cpu_ns += rot_ns;
         // The cluster-index fetch above was one planned range.
         tally.ranges_requested += 1;
         Ok((hits, tally))
@@ -3446,6 +3454,19 @@ impl VectorReader {
             return Ok((Vec::new(), ProbeTally::default()));
         }
 
+        // One rotation for every probed cell: it is seeded once per column,
+        // table-wide (that is what makes estimates comparable across cells),
+        // so recomputing it per cell — as this path used to — repeated the
+        // same O(dim^2) transform once per probed cell, unmetered. Hoisted
+        // and bracketed, mirroring the scan path's shared rotation.
+        let (q_rot_shared, rot_ns) = timed_section(|| {
+            let first_col = &self.columns[per_cell[0].0];
+            let mut q_rot = vec![0f32; first_col.dim];
+            first_col.rot.apply(query, &mut q_rot);
+            q_rot
+        });
+        let q_rot_shared = &q_rot_shared;
+
         // Probe the selected cells CONCURRENTLY — the same wave shape the
         // supertable's cross-superfile fan-out (and FTS) already uses, one
         // level down. A width sweep selects many cells inside one packed
@@ -3479,10 +3500,8 @@ impl VectorReader {
                     .range_async(idx_start..idx_end)
                     .await
                     .map_err(|e| VectorError::LazySource(e.to_string()))?;
-                let mut q_rot = vec![0f32; col.dim];
-                col.rot.apply(query, &mut q_rot);
                 let ctx = ProbeCtx {
-                    q_rot: &q_rot,
+                    q_rot: q_rot_shared,
                     k,
                     rerank_mult,
                     allow: cell_allow,
@@ -3513,6 +3532,7 @@ impl VectorReader {
             .try_collect()
             .await?;
         let mut tally = ProbeTally::default();
+        tally.kernel_cpu_ns += rot_ns;
         for (_, cell_tally) in &per_cell {
             tally.cells_scanned += cell_tally.cells_scanned;
             tally.candidates_scanned += cell_tally.candidates_scanned;
@@ -3520,12 +3540,18 @@ impl VectorReader {
             tally.rows_reranked += cell_tally.rows_reranked;
             tally.kernel_cpu_ns += cell_tally.kernel_cpu_ns;
         }
-        let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flat_map(|(hits, _)| hits).collect();
-        // Distance ascending (smaller = closer), matching every other vector
-        // search path. Descending here kept the farthest k hits and collapsed
-        // packed-shard recall to ~0.
-        merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
-        merged.truncate(k);
+        // The cross-cell merge is this query's CPU too.
+        let (merged, merge_ns) = timed_section(|| {
+            let mut merged: Vec<(u32, f32)> =
+                per_cell.into_iter().flat_map(|(hits, _)| hits).collect();
+            // Distance ascending (smaller = closer), matching every other
+            // vector search path. Descending here kept the farthest k hits
+            // and collapsed packed-shard recall to ~0.
+            merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+            merged.truncate(k);
+            merged
+        });
+        tally.kernel_cpu_ns += merge_ns;
         Ok((merged, tally))
     }
 
@@ -3624,8 +3650,12 @@ impl VectorReader {
         // ~60-cell width sweep the repeated 768x768 applies measured
         // ~1.3ms of wall per query.
         let first_col = &self.columns[per_cell[0].0];
-        let mut q_rot_shared = vec![0f32; first_col.dim];
-        first_col.rot.apply(query, &mut q_rot_shared);
+        let (q_rot_shared, rot_ns) = timed_section(|| {
+            let mut q_rot = vec![0f32; first_col.dim];
+            first_col.rot.apply(query, &mut q_rot);
+            q_rot
+        });
+        outcome.kernel_cpu_ns += rot_ns;
         let q_rot_shared = &q_rot_shared;
         let cell_scans = per_cell.into_iter().filter_map(|(cell_idx, base, locals)| {
             let col = &self.columns[cell_idx];
@@ -3674,10 +3704,16 @@ impl VectorReader {
                     kernel_cpu_ns: 0,
                 };
                 // Warm fast path: every prefix resident -> defer rerank.
-                let prefix_blocks: Option<Vec<Bytes>> = prefix_ranges
-                    .iter()
-                    .map(|range| self.source.try_get_range_sync(range.clone()))
-                    .collect();
+                // The resident-range assembly is a real memcpy per cell
+                // (codes + doc-ids blocks), so it counts as this query's
+                // CPU like the scan it feeds.
+                let (prefix_blocks, fetch_ns) = timed_section(|| {
+                    prefix_ranges
+                        .iter()
+                        .map(|range| self.source.try_get_range_sync(range.clone()))
+                        .collect::<Option<Vec<Bytes>>>()
+                });
+                tally.kernel_cpu_ns += fetch_ns;
                 let rabitq_only = matches!(col.rerank_codec, RerankCodec::RabitqOnly);
                 if let (Some(blocks), false) = (prefix_blocks, rabitq_only) {
                     let ctx = ProbeCtx {

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3477,8 +3477,14 @@ impl VectorReader {
         // same O(dim^2) transform once per probed cell, unmetered. Hoisted
         // and bracketed, mirroring the scan path's shared rotation.
         // `per_cell` is non-empty (guarded above), so [0] is safe; the
-        // column index it names is not — a corrupt cell map would index
-        // out of range and take the process with it.
+        // column indices it names are not — a corrupt cell map would index
+        // out of range and take the process with it. Validate the whole
+        // set here rather than just the first: the fan-out closure below
+        // indexes `self.columns` per cell and is a `filter_map`, so it has
+        // no way to report an error partway through the wave.
+        for &(cell_idx, ..) in &per_cell {
+            self.column_at(cell_idx)?;
+        }
         let (q_rot_shared, rot_ns) = timed_section(|| -> Result<Vec<f32>, VectorError> {
             let first_col = self.column_at(per_cell[0].0)?;
             let mut q_rot = vec![0f32; first_col.dim];
@@ -3670,6 +3676,12 @@ impl VectorReader {
         // depends on it), so per-cell re-rotation is duplicate work — at a
         // ~60-cell width sweep the repeated 768x768 applies measured
         // ~1.3ms of wall per query.
+        // Same reasoning as the multi-cell probe path: the scan closure
+        // below indexes `self.columns` for every cell and cannot return an
+        // error, so the whole resolved set is validated up front.
+        for &(cell_idx, ..) in &per_cell {
+            self.column_at(cell_idx)?;
+        }
         let first_col = self.column_at(per_cell[0].0)?;
         let (q_rot_shared, rot_ns) = timed_section(|| {
             let mut q_rot = vec![0f32; first_col.dim];
@@ -4955,6 +4967,19 @@ async fn build_shortlist(
                     "block index {bi} out of range for cluster {cluster_id}"
                 ))
             })?;
+            // `pos` is a cluster-order position and must fall inside this
+            // cluster's own span. These are u32: a position below `off`
+            // wraps to near-u32::MAX instead of going negative, and the
+            // `local * stride` offset built from it then points far past
+            // the block. Checking the lookups is not enough on its own —
+            // the arithmetic derived from them needs the same guard.
+            let end = off.saturating_add(cnt);
+            if pos < off || pos >= end {
+                return Err(VectorError::InconsistentIndex(format!(
+                    "shortlist position {pos} falls outside cluster {cluster_id}'s \
+                     span [{off}, {end})"
+                )));
+            }
             let full_start = (cnt as usize) * cb + (cnt as usize) * 4;
             let local = (pos - off) as usize;
             let full_idx = if let Some(ranges) = survivor_full_ranges.as_mut() {

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -358,6 +358,20 @@ pub struct VectorReader {
 }
 
 impl VectorReader {
+    /// The column at `idx`, or a typed error. Cell maps resolve to column
+    /// indices by construction, so a miss is inconsistent index state
+    /// rather than bad input — surfaced as an error, on the same
+    /// reasoning as the warmed survivor spans, so one query fails instead
+    /// of the process panicking on a slice index.
+    fn column_at(&self, idx: usize) -> Result<&ColumnReader, VectorError> {
+        self.columns.get(idx).ok_or_else(|| {
+            VectorError::InconsistentIndex(format!(
+                "cell resolved to column index {idx}, past the {} this superfile carries",
+                self.columns.len()
+            ))
+        })
+    }
+
     /// Test-only accessor: the per-doc dequantized-norm table this
     /// reader loaded from a column's `codec_meta` region (residual
     /// family or `Sq16`). Returns `None` for a codec that carries no
@@ -3462,12 +3476,16 @@ impl VectorReader {
         // so recomputing it per cell — as this path used to — repeated the
         // same O(dim^2) transform once per probed cell, unmetered. Hoisted
         // and bracketed, mirroring the scan path's shared rotation.
-        let (q_rot_shared, rot_ns) = timed_section(|| {
-            let first_col = &self.columns[per_cell[0].0];
+        // `per_cell` is non-empty (guarded above), so [0] is safe; the
+        // column index it names is not — a corrupt cell map would index
+        // out of range and take the process with it.
+        let (q_rot_shared, rot_ns) = timed_section(|| -> Result<Vec<f32>, VectorError> {
+            let first_col = self.column_at(per_cell[0].0)?;
             let mut q_rot = vec![0f32; first_col.dim];
             first_col.rot.apply(query, &mut q_rot);
-            q_rot
+            Ok(q_rot)
         });
+        let q_rot_shared = q_rot_shared?;
         let q_rot_shared = &q_rot_shared;
 
         // Probe the selected cells CONCURRENTLY — the same wave shape the
@@ -3646,13 +3664,13 @@ impl VectorReader {
         // REQUESTED column's seed (every cell of one column shares it),
         // not `columns[0]`'s — a multi-column file's first column can be
         // a different column with a different rotation.
-        outcome.rot_seed = self.columns[per_cell[0].0].rot_seed;
+        outcome.rot_seed = self.column_at(per_cell[0].0)?.rot_seed;
         // Rotate the query once per superfile: every cell of a column
         // shares the table-wide rotation seed (cross-cell estimate pooling
         // depends on it), so per-cell re-rotation is duplicate work — at a
         // ~60-cell width sweep the repeated 768x768 applies measured
         // ~1.3ms of wall per query.
-        let first_col = &self.columns[per_cell[0].0];
+        let first_col = self.column_at(per_cell[0].0)?;
         let (q_rot_shared, rot_ns) = timed_section(|| {
             let mut q_rot = vec![0f32; first_col.dim];
             first_col.rot.apply(query, &mut q_rot);
@@ -4912,7 +4930,8 @@ async fn build_shortlist(
     // One index build + one pass over every survivor, per probed cell. At
     // a wide sweep that is the cell count times the shortlist width, all of
     // it this query's CPU.
-    let ((candidates, survivor_full_ranges), refs_ns) = timed_section(|| {
+    type ShortlistRefs = (Vec<RerankCandidate>, Option<Vec<Range<usize>>>);
+    let (built, refs_ns) = timed_section(|| -> Result<ShortlistRefs, VectorError> {
         let mut block_by_cid: HashMap<u32, usize> = HashMap::with_capacity(cluster_meta.len());
         for (bi, &(c, _, _)) in cluster_meta.iter().enumerate() {
             block_by_cid.insert(c as u32, bi);
@@ -4924,8 +4943,18 @@ async fn build_shortlist(
             None
         };
         for &(did, _, pos, cluster_id) in &shortlist {
-            let bi = block_by_cid[&cluster_id];
-            let (_, off, cnt) = cluster_meta[bi];
+            // A shortlist entry naming a cluster the block metadata does
+            // not carry is an index inconsistency, not a user error.
+            let &bi = block_by_cid.get(&cluster_id).ok_or_else(|| {
+                VectorError::InconsistentIndex(format!(
+                    "shortlist cluster {cluster_id} is absent from the block metadata"
+                ))
+            })?;
+            let &(_, off, cnt) = cluster_meta.get(bi).ok_or_else(|| {
+                VectorError::InconsistentIndex(format!(
+                    "block index {bi} out of range for cluster {cluster_id}"
+                ))
+            })?;
             let full_start = (cnt as usize) * cb + (cnt as usize) * 4;
             let local = (pos - off) as usize;
             let full_idx = if let Some(ranges) = survivor_full_ranges.as_mut() {
@@ -4944,8 +4973,9 @@ async fn build_shortlist(
                 full_idx,
             });
         }
-        (candidates, survivor_full_ranges)
+        Ok((candidates, survivor_full_ranges))
     });
+    let (candidates, survivor_full_ranges) = built?;
     Ok((
         ShortlistOutcome::Rerank {
             candidates,

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -4839,8 +4839,10 @@ pub struct ProbeTally {
 impl ScanOutcome {
     /// The scan's five work tallies in the shared carrier, so every
     /// supertable fold site prices the same field set through one
-    /// function — a sixth tally added here is a compile error at the
-    /// fold, not a silent gap at one of three call sites.
+    /// function. A new `ProbeTally` field is a compile error here (this
+    /// literal is exhaustive) and at the fold's destructure; a new
+    /// `ScanOutcome`-side tally still has to be threaded through this one
+    /// mapping, which is the single place to look.
     pub(crate) fn work(&self) -> ProbeTally {
         ProbeTally {
             cells_scanned: self.cells_scanned,

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3906,26 +3906,31 @@ impl VectorReader {
                             .map(|bytes| (cid, (span.start, bytes)))
                     })
                     .collect();
-                let survivor_rows = match spans {
-                    Some(spans) => rerank_cands
-                        .iter()
-                        .zip(&ranges)
-                        .map(|(cand, range)| {
-                            let (base, region) = &spans[&cand.cluster_id];
-                            region.slice(range.start - base..range.end - base)
-                        })
-                        .collect(),
+                let (survivor_rows, gather_ns) = match spans {
+                    // Warm: slice survivors straight out of the spans
+                    // already in hand — a per-survivor pass, so bracketed.
+                    Some(spans) => timed_section(|| {
+                        rerank_cands
+                            .iter()
+                            .zip(&ranges)
+                            .map(|(cand, range)| {
+                                let (base, region) = &spans[&cand.cluster_id];
+                                region.slice(range.start - base..range.end - base)
+                            })
+                            .collect::<Vec<_>>()
+                    }),
                     None => get_survivor_ranges_coalesced_async(&self.source, &ranges)
                         .await
                         .map_err(|e| VectorError::LazySource(e.to_string()))?,
                 };
+
                 if let Some(t0) = survivor_t0 {
                     io_counters::phase_record(
                         "vec.survivor_fetch",
                         t0.elapsed().as_micros() as u64,
                     );
                 }
-                io_counters::phase_timed_async("vec.rerank", async {
+                let (hits, rerank_ns) = io_counters::phase_timed_async("vec.rerank", async {
                     rerank_candidates_from_blocks(
                         &self.source,
                         meta_bytes.as_ref(),
@@ -3939,7 +3944,11 @@ impl VectorReader {
                     )
                     .await
                 })
-                .await
+                .await?;
+                Ok::<(Vec<(u32, f32)>, u64), VectorError>((
+                    hits,
+                    rerank_ns.saturating_add(gather_ns),
+                ))
             })
         });
         let max_in_flight = pool_wave_cap(pool.as_deref());
@@ -3948,10 +3957,14 @@ impl VectorReader {
             .try_collect()
             .await?;
         let kernel_ns: u64 = per_cell.iter().map(|(_, ns)| ns).sum();
-        let mut merged: Vec<(u32, f32)> = per_cell.into_iter().flat_map(|(hits, _)| hits).collect();
-        merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
-        merged.truncate(k);
-        Ok((merged, kernel_ns))
+        let (merged, merge_ns) = timed_section(|| {
+            let mut merged: Vec<(u32, f32)> =
+                per_cell.into_iter().flat_map(|(hits, _)| hits).collect();
+            merged.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+            merged.truncate(k);
+            merged
+        });
+        Ok((merged, kernel_ns.saturating_add(merge_ns)))
     }
 
     /// Shared async tail of the IVF probe: given a chosen set of cluster
@@ -4113,11 +4126,13 @@ impl VectorReader {
         // runtime; warm ranges resolve sync/zero-copy with no await.
         let survivor_t0 = io_counters::phase_start();
         let survivor_full_rows = match survivor_full_ranges {
-            Some(ranges) => Some(
-                get_survivor_ranges_coalesced_async(&self.source, &ranges)
+            Some(ranges) => {
+                let (rows, gather_ns) = get_survivor_ranges_coalesced_async(&self.source, &ranges)
                     .await
-                    .map_err(|e| VectorError::LazySource(e.to_string()))?,
-            ),
+                    .map_err(|e| VectorError::LazySource(e.to_string()))?;
+                tally.kernel_cpu_ns += gather_ns;
+                Some(rows)
+            }
             None => None,
         };
         if let Some(t0) = survivor_t0 {
@@ -4856,15 +4871,16 @@ async fn build_shortlist(
         // deterministically here exactly as it does on the multi-cell
         // merge path — otherwise the two paths diverge on top-k for a
         // corrupt/degenerate score.
-        shortlist.sort_unstable_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        let (done, sort_ns) = timed_section(|| {
+            shortlist.sort_unstable_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            shortlist
+                .into_iter()
+                .map(|(did, est, _pos, _c)| (did, -est))
+                .collect::<Vec<_>>()
+        });
         return Ok((
-            ShortlistOutcome::Done(
-                shortlist
-                    .into_iter()
-                    .map(|(did, est, _pos, _c)| (did, -est))
-                    .collect(),
-            ),
-            scan_kernel_ns,
+            ShortlistOutcome::Done(done),
+            scan_kernel_ns.saturating_add(sort_ns),
         ));
     }
 
@@ -4873,44 +4889,50 @@ async fn build_shortlist(
     // Each block's `full_chunk` follows its `[codes][doc_ids]` prefix;
     // the candidate at cluster-order position `pos` lives at in-block
     // offset `cnt*cb + cnt*4 + local*stride`.
-    let mut block_by_cid: HashMap<u32, usize> = HashMap::with_capacity(cluster_meta.len());
-    for (bi, &(c, _, _)) in cluster_meta.iter().enumerate() {
-        block_by_cid.insert(c as u32, bi);
-    }
     let stride = full_vec_bytes;
-    let mut candidates = Vec::with_capacity(shortlist.len());
-    let mut survivor_full_ranges = if survivor_only_rerank_fetch {
-        Some(Vec::with_capacity(shortlist.len()))
-    } else {
-        None
-    };
-    for &(did, _, pos, cluster_id) in &shortlist {
-        let bi = block_by_cid[&cluster_id];
-        let (_, off, cnt) = cluster_meta[bi];
-        let full_start = (cnt as usize) * cb + (cnt as usize) * 4;
-        let local = (pos - off) as usize;
-        let full_idx = if let Some(ranges) = survivor_full_ranges.as_mut() {
-            let idx = ranges.len();
-            ranges.push(col.cluster_rerank_row_range(off, cnt, local));
-            Some(idx)
+    // One index build + one pass over every survivor, per probed cell. At
+    // a wide sweep that is the cell count times the shortlist width, all of
+    // it this query's CPU.
+    let ((candidates, survivor_full_ranges), refs_ns) = timed_section(|| {
+        let mut block_by_cid: HashMap<u32, usize> = HashMap::with_capacity(cluster_meta.len());
+        for (bi, &(c, _, _)) in cluster_meta.iter().enumerate() {
+            block_by_cid.insert(c as u32, bi);
+        }
+        let mut candidates = Vec::with_capacity(shortlist.len());
+        let mut survivor_full_ranges = if survivor_only_rerank_fetch {
+            Some(Vec::with_capacity(shortlist.len()))
         } else {
             None
         };
-        candidates.push(RerankCandidate {
-            did,
-            pos,
-            cluster_id,
-            block_idx: bi,
-            full_off: full_start + local * stride,
-            full_idx,
-        });
-    }
+        for &(did, _, pos, cluster_id) in &shortlist {
+            let bi = block_by_cid[&cluster_id];
+            let (_, off, cnt) = cluster_meta[bi];
+            let full_start = (cnt as usize) * cb + (cnt as usize) * 4;
+            let local = (pos - off) as usize;
+            let full_idx = if let Some(ranges) = survivor_full_ranges.as_mut() {
+                let idx = ranges.len();
+                ranges.push(col.cluster_rerank_row_range(off, cnt, local));
+                Some(idx)
+            } else {
+                None
+            };
+            candidates.push(RerankCandidate {
+                did,
+                pos,
+                cluster_id,
+                block_idx: bi,
+                full_off: full_start + local * stride,
+                full_idx,
+            });
+        }
+        (candidates, survivor_full_ranges)
+    });
     Ok((
         ShortlistOutcome::Rerank {
             candidates,
             survivor_full_ranges,
         },
-        scan_kernel_ns,
+        scan_kernel_ns.saturating_add(refs_ns),
     ))
 }
 
@@ -6180,25 +6202,35 @@ fn get_survivor_ranges_coalesced(
 }
 
 /// Async sibling of [`get_survivor_ranges_coalesced`].
+/// Returns the gathered survivor blocks plus the on-CPU nanoseconds its
+/// synchronous halves cost: planning the coalesce (a sort plus a merge
+/// pass over every survivor range) and restoring per-survivor slices out
+/// of the fetched spans. Both scale with survivor count times probed
+/// cells, so at a wide sweep they are a real share of the query — and
+/// neither is inside the fetch's await, which is I/O wait and correctly
+/// uncounted.
 async fn get_survivor_ranges_coalesced_async(
     source: &Source,
     ranges: &[Range<usize>],
-) -> Result<Vec<Bytes>, LazyByteSourceError> {
+) -> Result<(Vec<Bytes>, u64), LazyByteSourceError> {
     if ranges.is_empty() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), 0));
     }
     if ranges.len() == 1 {
-        return source.get_ranges_parallel_async(ranges).await;
+        return Ok((source.get_ranges_parallel_async(ranges).await?, 0));
     }
-    let plan = RangeCoalescePlan::new(
-        ranges,
-        SURVIVOR_RANGE_COALESCE_MAX_GAP,
-        SURVIVOR_RANGE_COALESCE_MAX_OVERFETCH,
-    );
+    let (plan, plan_ns) = timed_section(|| {
+        RangeCoalescePlan::new(
+            ranges,
+            SURVIVOR_RANGE_COALESCE_MAX_GAP,
+            SURVIVOR_RANGE_COALESCE_MAX_OVERFETCH,
+        )
+    });
     let fetched = source
         .get_ranges_parallel_async(plan.fetch_ranges())
         .await?;
-    Ok(plan.restore(&fetched))
+    let (restored, restore_ns) = timed_section(|| plan.restore(&fetched));
+    Ok((restored, plan_ns.saturating_add(restore_ns)))
 }
 
 /// Best-effort sync byte fetch with a typed error. Used throughout

--- a/src/supertable/build.rs
+++ b/src/supertable/build.rs
@@ -22,7 +22,11 @@
 //! the pool width (`n_shards ≤ n_threads`); intra-shard work fills cores
 //! as shards drain.
 
+use std::sync::Arc;
+
 use rayon::{ThreadPool, prelude::*};
+
+use crate::runtime_metrics::op_stats::{OpStatsCollector, timed_kernel};
 
 /// Run shard build tasks on `pool`, preserving input order.
 ///
@@ -63,4 +67,33 @@ where
         return Ok(Vec::new());
     }
     tasks.par_iter().map(&build_one).collect()
+}
+
+/// [`fanout_shards`] with each task's on-CPU time folded into `op_stats`.
+///
+/// The bracket sits *inside* the per-task closure, on the pool thread that
+/// runs it — the calling thread blocks in `install` for the whole fan-out,
+/// so a bracket around the call would measure nothing. Concurrent tasks
+/// fold concurrently; the collector's counters are atomics.
+///
+/// Use this for shard builds that are a caller op's own work (an append's
+/// commit build, a vector commit's drain-pack). Maintenance fan-outs
+/// (hidden-index drain merges, compaction) keep the unmetered variant —
+/// their cost is deliberately not attributed to any op.
+pub(crate) fn fanout_shards_metered<T, O, E, F>(
+    pool: &ThreadPool,
+    op_stats: &Option<Arc<OpStatsCollector>>,
+    tasks: &[T],
+    build_one: F,
+) -> Result<Vec<O>, E>
+where
+    T: Sync,
+    O: Send,
+    E: Send,
+    F: Fn(&T) -> Result<O, E> + Sync,
+{
+    let stats = op_stats.clone();
+    fanout_shards(pool, tasks, move |task| {
+        timed_kernel(&stats, || build_one(task))
+    })
 }

--- a/src/supertable/query/covered_agg.rs
+++ b/src/supertable/query/covered_agg.rs
@@ -171,25 +171,22 @@ fn try_rewrite(plan: &LogicalPlan) -> DfResult<Option<LogicalPlan>> {
             };
             partials.push(partial);
         }
-        let out_names: Vec<String> = agg
-            .schema
-            .fields()
-            .iter()
-            .map(|field| field.name().clone())
-            .collect();
         let mut expressions = Vec::with_capacity(kinds.len());
-        for ((kind, partial), name) in kinds.iter().zip(&partials).zip(out_names) {
+        for (i, (kind, partial)) in kinds.iter().zip(&partials).enumerate() {
+            let field = agg.schema.field(i);
             let expression = match (kind, partial) {
                 (AggKind::CountStar, Partial::Count(count)) => lit(*count),
                 (AggKind::Sum(_), Partial::Sum(value))
                 | (AggKind::Min(_), Partial::Bound(value))
-                | (AggKind::Max(_), Partial::Bound(value)) => lit(value.clone()),
+                | (AggKind::Max(_), Partial::Bound(value)) => {
+                    covered_literal(value, field.data_type())
+                }
                 (AggKind::Avg(_), Partial::Avg { sum, count }) => {
                     cast(lit(sum.clone()), DataType::Float64) / cast(lit(*count), DataType::Float64)
                 }
                 _ => return Ok(None),
             };
-            expressions.push(expression.alias(name));
+            expressions.push(expression.alias(field.name().clone()));
         }
         let rewritten = LogicalPlanBuilder::empty(true)
             .project(expressions)?
@@ -305,7 +302,14 @@ fn try_rewrite(plan: &LogicalPlan) -> DfResult<Option<LogicalPlan>> {
                 partial_exprs.push(max(col(column)).alias(format!("__resid_{i}_max")));
             }
             AggKind::Avg(column) => {
-                partial_exprs.push(sum(col(column)).alias(format!("__resid_{i}_sum")));
+                // Explicitly cast: the analyzer's coercion pass has already
+                // run, so a bare `sum(col)` over a numeric narrower than
+                // the sum accumulator (Int32, Float32, ...) is untypeable
+                // here. Float64 matches the cast the planner had put on
+                // the original AVG argument, which parse_aggregates peeled.
+                partial_exprs.push(
+                    sum(cast(col(column), DataType::Float64)).alias(format!("__resid_{i}_sum")),
+                );
                 partial_exprs.push(count(col(column)).alias(format!("__resid_{i}_cnt")));
             }
         }
@@ -315,15 +319,10 @@ fn try_rewrite(plan: &LogicalPlan) -> DfResult<Option<LogicalPlan>> {
     // Final projection: combine each residual partial with its covered
     // literal, aliased to the original aggregate's output name so the
     // rewritten plan's schema matches the original node's exactly.
-    let out_names: Vec<String> = agg
-        .schema
-        .fields()
-        .iter()
-        .map(|f| f.name().clone())
-        .collect();
     let mut final_exprs: Vec<Expr> = Vec::with_capacity(kinds.len());
     for (i, (kind, partial)) in kinds.iter().zip(&partials).enumerate() {
-        let name = &out_names[i];
+        let field = agg.schema.field(i);
+        let name = field.name().clone();
         let expr = match (kind, partial) {
             (AggKind::CountStar, Partial::Count(n)) => {
                 // COUNT over an empty residual is 0, never NULL.
@@ -334,19 +333,25 @@ fn try_rewrite(plan: &LogicalPlan) -> DfResult<Option<LogicalPlan>> {
                 (coalesce(vec![col(format!("__resid_{i}_sum")), lit(zero)]) + lit(value.clone()))
                     .alias(name)
             }
-            (AggKind::Min(_), Partial::Bound(value)) => {
-                least(vec![col(format!("__resid_{i}_min")), lit(value.clone())]).alias(name)
-            }
-            (AggKind::Max(_), Partial::Bound(value)) => {
-                greatest(vec![col(format!("__resid_{i}_max")), lit(value.clone())]).alias(name)
-            }
+            (AggKind::Min(_), Partial::Bound(value)) => least(vec![
+                col(format!("__resid_{i}_min")),
+                covered_literal(value, field.data_type()),
+            ])
+            .alias(name),
+            (AggKind::Max(_), Partial::Bound(value)) => greatest(vec![
+                col(format!("__resid_{i}_max")),
+                covered_literal(value, field.data_type()),
+            ])
+            .alias(name),
             (AggKind::Avg(_), Partial::Avg { sum, count }) => {
-                let zero = typed_zero(sum)?;
-                let total_sum =
-                    coalesce(vec![col(format!("__resid_{i}_sum")), lit(zero)]) + lit(sum.clone());
+                // The residual partial is Float64 by construction (its sum
+                // is over an explicit cast), so the whole combiner stays in
+                // Float64 — the coalesce zero and the covered sum must
+                // match it, since nothing coerces after this rule.
+                let total_sum = coalesce(vec![col(format!("__resid_{i}_sum")), lit(0.0_f64)])
+                    + cast(lit(sum.clone()), DataType::Float64);
                 let total_cnt = col(format!("__resid_{i}_cnt")) + lit(*count);
-                (cast(total_sum, DataType::Float64) / cast(total_cnt, DataType::Float64))
-                    .alias(name)
+                (total_sum / cast(total_cnt, DataType::Float64)).alias(name)
             }
             _ => return Ok(None),
         };
@@ -355,6 +360,22 @@ fn try_rewrite(plan: &LogicalPlan) -> DfResult<Option<LogicalPlan>> {
 
     let rewritten = builder.project(final_exprs)?.build()?;
     Ok(Some(rewritten))
+}
+
+/// The covered statistic as a literal, cast to the aggregate's own output
+/// type when the stored value's type differs. Optimizer rules run after
+/// the analyzer's type-coercion pass, so nothing downstream repairs a
+/// mismatch — and one exists for every non-FTS string column: the scan
+/// serves it as `Utf8View` while the manifest stores its bounds as
+/// `LargeUtf8`. Uncast, the bound fails arrow's comparison kernel at
+/// execution (filtered arm) or breaks the rewritten plan's schema
+/// (unfiltered arm).
+fn covered_literal(value: &ScalarValue, output: &DataType) -> Expr {
+    if &value.data_type() == output {
+        lit(value.clone())
+    } else {
+        cast(lit(value.clone()), output.clone())
+    }
 }
 
 fn rewrite_grouped_count_from_value_counts(aggregate: &Aggregate) -> DfResult<Option<LogicalPlan>> {
@@ -569,7 +590,10 @@ fn parse_aggregates(exprs: &[Expr]) -> Option<Vec<AggKind>> {
             ("max", [Expr::Column(c)]) => AggKind::Max(c.name.clone()),
             // AVG's int arguments arrive wrapped in a coercion cast to
             // Float64; peeling it is safe here (and only here) because
-            // the combiner re-casts both totals to Float64 itself.
+            // the residual partial re-applies the cast explicitly and the
+            // combiner works in Float64 throughout — no coercion pass runs
+            // after an optimizer rule, so every expression this rewrite
+            // emits must arrive fully typed.
             ("avg", [arg]) => AggKind::Avg(avg_column(arg)?),
             _ => return None,
         };

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -89,15 +89,18 @@ pub(crate) fn search_query_df_error(e: QueryError) -> DataFusionError {
 /// by every public row-returning search method (`bm25_search`,
 /// `vector_search`, `token_match`, `exact_match`); `what` labels error
 /// messages with the calling method.
-/// Fold DataFusion's own operator instrumentation into the per-query
-/// stats after a SQL plan has executed. Every operator's
-/// `elapsed_compute` (DataFusion brackets its synchronous poll sections
-/// with an `Instant` timer — approximately on-CPU for compute-bound
-/// operators, and excluding async I/O waits) sums into the kernel
-/// counter; leaf (source) operators' `output_rows` sum into
+/// Fold DataFusion's row instrumentation into the per-query stats after a
+/// SQL plan has executed: leaf (source) operators' `output_rows` sum into
 /// `rows_materialized` — the rows the scans decoded from storage.
-/// Infino's own TVF exec nodes report no DataFusion metrics (their
-/// kernels bracket and flush internally), so nothing double-counts.
+///
+/// Deliberately NOT `elapsed_compute`. That is an `Instant` timer around
+/// synchronous poll sections — wall time, so on a busy host it counts
+/// whatever the thread was descheduled for, the exact contention bleed
+/// per-op metering exists to remove. It also omits Parquet decode
+/// entirely. CPU now comes from
+/// [`MeteredExec`](crate::supertable::query::exec::metered_exec::MeteredExec),
+/// which brackets each scan poll with the same thread-CPU clock the
+/// search kernels use, so SQL and search are priced on one clock.
 pub(crate) fn harvest_datafusion_metrics(
     plan: &Arc<dyn ExecutionPlan>,
     op_stats: &Option<Arc<OpStatsCollector>>,
@@ -105,37 +108,26 @@ pub(crate) fn harvest_datafusion_metrics(
     // Deduped by node identity: plans are trees in practice, but nothing
     // forbids an operator `Arc` appearing under two parents, and a shared
     // node's metrics must not be added once per path.
-    fn walk(
-        node: &Arc<dyn ExecutionPlan>,
-        seen: &mut HashSet<usize>,
-        compute_ns: &mut u64,
-        leaf_rows: &mut u64,
-    ) {
+    fn walk(node: &Arc<dyn ExecutionPlan>, seen: &mut HashSet<usize>, leaf_rows: &mut u64) {
         if !seen.insert(Arc::as_ptr(node) as *const () as usize) {
             return;
         }
-        if let Some(metrics) = node.metrics() {
-            if let Some(ns) = metrics.elapsed_compute() {
-                *compute_ns += ns as u64;
-            }
-            if node.children().is_empty()
-                && let Some(rows) = metrics.output_rows()
-            {
-                *leaf_rows += rows as u64;
-            }
+        if let Some(metrics) = node.metrics()
+            && node.children().is_empty()
+            && let Some(rows) = metrics.output_rows()
+        {
+            *leaf_rows += rows as u64;
         }
         for child in node.children() {
-            walk(child, seen, compute_ns, leaf_rows);
+            walk(child, seen, leaf_rows);
         }
     }
     let Some(stats) = op_stats else {
         return;
     };
     let mut seen = HashSet::new();
-    let mut compute_ns = 0u64;
     let mut leaf_rows = 0u64;
-    walk(plan, &mut seen, &mut compute_ns, &mut leaf_rows);
-    stats.add_kernel_cpu_ns(compute_ns);
+    walk(plan, &mut seen, &mut leaf_rows);
     stats.add_rows_materialized(leaf_rows);
 }
 

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -83,26 +83,6 @@ pub(crate) fn search_query_df_error(e: QueryError) -> DataFusionError {
     }
 }
 
-/// Resolve `hits` to one `RecordBatch`, with `projection` naming the
-/// output columns (any of `_id`, the visible scalar columns, or the
-/// trailing `score`); `None` returns the engine-native `_id` + `score`
-/// pair. Names are resolved to output-schema indices and forwarded to
-/// [`resolve_hits`], which decodes only the projected columns. Shared
-/// by every public row-returning search method (`bm25_search`,
-/// `vector_search`, `token_match`, `exact_match`); `what` labels error
-/// messages with the calling method.
-/// Fold DataFusion's row instrumentation into the per-query stats after a
-/// SQL plan has executed: leaf (source) operators' `output_rows` sum into
-/// `rows_materialized` — the rows the scans decoded from storage.
-///
-/// Deliberately NOT `elapsed_compute`. That is an `Instant` timer around
-/// synchronous poll sections — wall time, so on a busy host it counts
-/// whatever the thread was descheduled for, the exact contention bleed
-/// per-op metering exists to remove. It also omits Parquet decode
-/// entirely. CPU now comes from
-/// [`MeteredExec`](crate::supertable::query::exec::metered_exec::MeteredExec),
-/// which brackets each scan poll with the same thread-CPU clock the
-/// search kernels use, so SQL and search are priced on one clock.
 /// Meter, execute and account for one physical plan: wrap the root in
 /// [`MeteredExec`], collect, then harvest the executed plan's own
 /// metrics. The three steps belong together — a site that collects
@@ -127,6 +107,18 @@ pub(crate) async fn collect_plan_metered(
     Ok(batches)
 }
 
+/// Fold DataFusion's row instrumentation into the per-query stats after a
+/// SQL plan has executed: leaf (source) operators' `output_rows` sum into
+/// `rows_materialized` — the rows the scans decoded from storage.
+///
+/// Deliberately NOT `elapsed_compute`. That is an `Instant` timer around
+/// synchronous poll sections — wall time, so on a busy host it counts
+/// whatever the thread was descheduled for, the exact contention bleed
+/// per-op metering exists to remove. It also omits Parquet decode
+/// entirely. CPU now comes from
+/// [`MeteredExec`](crate::supertable::query::exec::metered_exec::MeteredExec),
+/// which brackets each scan poll with the same thread-CPU clock the
+/// search kernels use, so SQL and search are priced on one clock.
 pub(crate) fn harvest_datafusion_metrics(
     plan: &Arc<dyn ExecutionPlan>,
     op_stats: &Option<Arc<OpStatsCollector>>,
@@ -157,6 +149,14 @@ pub(crate) fn harvest_datafusion_metrics(
     stats.add_rows_materialized(leaf_rows);
 }
 
+/// Resolve `hits` to one `RecordBatch`, with `projection` naming the
+/// output columns (any of `_id`, the visible scalar columns, or the
+/// trailing `score`); `None` returns the engine-native `_id` + `score`
+/// pair. Names are resolved to output-schema indices and forwarded to
+/// [`resolve_hits`], which decodes only the projected columns. Shared
+/// by every public row-returning search method (`bm25_search`,
+/// `vector_search`, `token_match`, `exact_match`); `what` labels error
+/// messages with the calling method.
 pub(crate) async fn resolve_hits_named(
     reader: &SupertableReader,
     hits: &[SuperfileHit],

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -23,8 +23,9 @@ use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use bytes::Bytes;
 use datafusion::{
     error::{DataFusionError, Result as DfResult},
+    execution::TaskContext,
     logical_expr::Expr,
-    physical_plan::ExecutionPlan,
+    physical_plan::{ExecutionPlan, collect},
     scalar::ScalarValue,
 };
 use futures::{
@@ -57,7 +58,8 @@ use crate::{
         manifest::SuperfileUri,
         options::{DECIMAL128_PRECISION, DECIMAL128_SCALE},
         query::{
-            SuperfileHit, superfile_reader::superfile_reader, vector::row_id_from_manifest_entry,
+            SuperfileHit, exec::metered_exec::MeteredExec, superfile_reader::superfile_reader,
+            vector::row_id_from_manifest_entry,
         },
     },
 };
@@ -101,6 +103,30 @@ pub(crate) fn search_query_df_error(e: QueryError) -> DataFusionError {
 /// [`MeteredExec`](crate::supertable::query::exec::metered_exec::MeteredExec),
 /// which brackets each scan poll with the same thread-CPU clock the
 /// search kernels use, so SQL and search are priced on one clock.
+/// Meter, execute and account for one physical plan: wrap the root in
+/// [`MeteredExec`], collect, then harvest the executed plan's own
+/// metrics. The three steps belong together — a site that collects
+/// without harvesting reports CPU, page bytes and ranges with no row
+/// count beside them, which is how the mutation predicate resolve once
+/// reported zero decoded rows for a scan it genuinely paid for. Every
+/// SQL execution site (catalog, reader-level, predicate resolve) goes
+/// through here; error mapping stays with the caller, whose surface it
+/// belongs to.
+pub(crate) async fn collect_plan_metered(
+    plan: &Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+    op_stats: &Option<Arc<OpStatsCollector>>,
+) -> DfResult<Vec<RecordBatch>> {
+    let metered: Arc<dyn ExecutionPlan> =
+        Arc::new(MeteredExec::new(Arc::clone(plan), op_stats.clone()));
+    let batches = collect(metered, task_ctx).await?;
+    // Harvesting the unwrapped plan and the wrapped one reach the same
+    // leaves — the walk dedupes by node identity and sums childless nodes
+    // only, and the meter delegates `execute` to this same tree.
+    harvest_datafusion_metrics(plan, op_stats);
+    Ok(batches)
+}
+
 pub(crate) fn harvest_datafusion_metrics(
     plan: &Arc<dyn ExecutionPlan>,
     op_stats: &Option<Arc<OpStatsCollector>>,

--- a/src/supertable/query/exec/metered_exec.rs
+++ b/src/supertable/query/exec/metered_exec.rs
@@ -204,11 +204,13 @@ impl ExecutionPlan for MeteredExec {
         &self,
         order: &[PhysicalSortExpr],
     ) -> DfResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
-        // The default answer is `Unsupported`, which stops the pushdown
-        // walk dead. A meter sitting between a sort and the scan would
-        // then cost the query its row-group reorder, its reverse scan and
-        // any sort elimination — turning an early-terminating TopK into a
-        // full scan plus a full sort.
+        // On today's plans the sort sinks BELOW this node —
+        // `maintains_input_order` above is what lets EnforceSorting do
+        // that — so the reorder and reverse-scan wins come from that hook
+        // and this one is rarely consulted. It still must delegate: the
+        // default answer is `Unsupported`, which stops the pushdown walk
+        // dead for any shape where the sort cannot sink, and a blocked
+        // walk costs that shape its row-group reorder and reverse scan.
         let rewrap = |input| -> Arc<dyn ExecutionPlan> {
             Arc::new(MeteredExec::new(input, self.op_stats.clone()))
         };
@@ -223,10 +225,27 @@ impl ExecutionPlan for MeteredExec {
         })
     }
 
+    fn fetch(&self) -> Option<usize> {
+        self.input.fetch()
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        // A limit the child can absorb must reach it through the meter, or
+        // the Exact arm of the sort pushdown above preserves an order whose
+        // early-termination fetch never arrives at the source.
+        self.input
+            .with_fetch(limit)
+            .map(|input| -> Arc<dyn ExecutionPlan> {
+                Arc::new(MeteredExec::new(input, self.op_stats.clone()))
+            })
+    }
+
     fn with_preserve_order(&self, preserve_order: bool) -> Option<Arc<dyn ExecutionPlan>> {
-        // Order-sensitivity has to reach the data source, which decides
-        // whether it may skip row groups. Defaulting to `None` silently
-        // drops that signal at the meter.
+        // Completeness rather than a measured win: no optimizer path in
+        // this DataFusion reaches a wrapper here (both call sites target
+        // sources and unions). If a rewrite ever does ask, the answer must
+        // come from the source that decides whether it may skip row
+        // groups, not from a meter defaulting to `None`.
         self.input
             .with_preserve_order(preserve_order)
             .map(|input| -> Arc<dyn ExecutionPlan> {

--- a/src/supertable/query/exec/metered_exec.rs
+++ b/src/supertable/query/exec/metered_exec.rs
@@ -25,7 +25,9 @@
 //! neither alone is enough: DataFusion spawns a task per partition, so a
 //! root-only bracket misses work under an internal spawn boundary, while a
 //! scan-only bracket misses the aggregation and sort work above it. The
-//! `POLL_DEPTH` guard below keeps the overlap from counting twice. The
+//! shared bracket depth in `op_stats` keeps the overlap from counting
+//! twice — it gates every CPU fold, including the search kernels' own
+//! brackets, which a poll of this node drives inline. The
 //! collector's counters are atomics, so concurrent partitions fold safely.
 //!
 //! Everything the planner asks of this node is delegated to the child. A
@@ -37,7 +39,6 @@
 //! change the query.
 
 use std::{
-    cell::Cell,
     fmt,
     pin::Pin,
     sync::Arc,
@@ -65,27 +66,8 @@ use futures::Stream;
 
 use crate::runtime_metrics::{
     cpu,
-    op_stats::{OpStatsCollector, metering_active},
+    op_stats::{OpStatsCollector, OuterBracketGuard, metering_active, outer_bracket_active},
 };
-
-thread_local! {
-    /// Depth of live [`MeteredStream`] polls on this thread.
-    ///
-    /// The node is placed both at the plan root and around each table
-    /// scan, because neither alone is enough: DataFusion spawns a task per
-    /// partition, so a root-only bracket misses every spawned partition,
-    /// while a scan-only bracket misses the aggregation and sort work
-    /// above it. With both, a single-partition plan would poll the scan
-    /// *inside* the root's poll on the same thread and count that time
-    /// twice.
-    ///
-    /// So only the outermost bracket on a given thread measures. On a
-    /// spawned partition the scan is outermost on its own thread and
-    /// counts there; on the coalescing thread the root counts, and the
-    /// nested scan defers to it. Each thread's CPU is attributed exactly
-    /// once.
-    static POLL_DEPTH: Cell<u32> = const { Cell::new(0) };
-}
 
 /// Wraps `input`, metering every partition's poll time into `op_stats`.
 #[derive(Debug)]
@@ -266,18 +248,6 @@ impl ExecutionPlan for MeteredExec {
     }
 }
 
-/// Restores `POLL_DEPTH` on unwind as well as on the normal path. A poll
-/// that panicked out of a raised depth would leave the thread-local set
-/// forever, and every later query polled on that worker would treat its
-/// outermost bracket as nested and bill zero CPU.
-struct PollDepthGuard(u32);
-
-impl Drop for PollDepthGuard {
-    fn drop(&mut self) {
-        POLL_DEPTH.with(|d| d.set(self.0));
-    }
-}
-
 /// Per-poll CPU bracket around one partition's stream.
 struct MeteredStream {
     inner: SendableRecordBatchStream,
@@ -297,10 +267,13 @@ impl Stream for MeteredStream {
         }
         // Nested inside another bracket on this thread: that one is already
         // measuring this poll, so counting here would double-charge it.
-        if POLL_DEPTH.with(|d| d.get()) > 0 {
+        if outer_bracket_active() {
             return Pin::new(&mut self.inner).poll_next(cx);
         }
-        let restore = PollDepthGuard(POLL_DEPTH.with(|d| d.replace(1)));
+        // Raised for the duration of the poll so the kernels this poll
+        // drives stand down; dropped before the fold below, which is this
+        // bracket's own and must not be gated by it.
+        let restore = OuterBracketGuard::enter();
         let start = cpu::thread_cpu_ns();
         let out = Pin::new(&mut self.inner).poll_next(cx);
         let delta = cpu::thread_cpu_delta_ns(start);

--- a/src/supertable/query/exec/metered_exec.rs
+++ b/src/supertable/query/exec/metered_exec.rs
@@ -28,6 +28,7 @@
 //! counters are atomics, so concurrent partitions fold safely.
 
 use std::{
+    cell::Cell,
     fmt,
     pin::Pin,
     sync::Arc,
@@ -50,6 +51,25 @@ use crate::runtime_metrics::{
     cpu,
     op_stats::{OpStatsCollector, metering_active},
 };
+
+thread_local! {
+    /// Depth of live [`MeteredStream`] polls on this thread.
+    ///
+    /// The node is placed both at the plan root and around each table
+    /// scan, because neither alone is enough: DataFusion spawns a task per
+    /// partition, so a root-only bracket misses every spawned partition,
+    /// while a scan-only bracket misses the aggregation and sort work
+    /// above it. With both, a single-partition plan would poll the scan
+    /// *inside* the root's poll on the same thread and count that time
+    /// twice.
+    ///
+    /// So only the outermost bracket on a given thread measures. On a
+    /// spawned partition the scan is outermost on its own thread and
+    /// counts there; on the coalescing thread the root counts, and the
+    /// nested scan defers to it. Each thread's CPU is attributed exactly
+    /// once.
+    static POLL_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
 
 /// Wraps `input`, metering every partition's poll time into `op_stats`.
 #[derive(Debug)]
@@ -136,9 +156,17 @@ impl Stream for MeteredStream {
         if !metering_active() {
             return Pin::new(&mut self.inner).poll_next(cx);
         }
+        // Nested inside another bracket on this thread: that one is already
+        // measuring this poll, so counting here would double-charge it.
+        if POLL_DEPTH.with(|d| d.get()) > 0 {
+            return Pin::new(&mut self.inner).poll_next(cx);
+        }
+        POLL_DEPTH.with(|d| d.set(1));
         let start = cpu::thread_cpu_ns();
         let out = Pin::new(&mut self.inner).poll_next(cx);
-        stats.add_kernel_cpu_ns(cpu::thread_cpu_delta_ns(start));
+        let delta = cpu::thread_cpu_delta_ns(start);
+        POLL_DEPTH.with(|d| d.set(0));
+        stats.add_kernel_cpu_ns(delta);
         out
     }
 }

--- a/src/supertable/query/exec/metered_exec.rs
+++ b/src/supertable/query/exec/metered_exec.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! [`MeteredExec`] — a pass-through `ExecutionPlan` that charges its
+//! child's on-CPU time to the op that ran the query.
+//!
+//! DataFusion reports per-operator time as `elapsed_compute`, an `Instant`
+//! timer around synchronous poll sections. That is *wall* time: on a busy
+//! host it includes whatever the thread was descheduled for, which is the
+//! same contention bleed that per-op metering exists to remove — and the
+//! Parquet decode inside a scan node is not in it at all. Search paths, by
+//! contrast, fold `thread_cpu_ns` (schedstat). Pricing both through one
+//! meter while they read different clocks makes a SQL query and a vector
+//! query incomparable.
+//!
+//! This node closes that: it wraps a child plan and brackets **each poll**
+//! of each output partition with the thread-CPU clock, folding the delta
+//! into the query's own collector. DataFusion is pull-based, so a poll
+//! synchronously drives that partition's operator subtree — decode
+//! included — on the polling thread. An `await` on I/O yields out of the
+//! poll, so waiting is excluded and only real on-CPU time is counted,
+//! which is exactly the contract the search kernels already meet.
+//!
+//! Placed around the table scan rather than the plan root on purpose:
+//! DataFusion spawns a task per partition, so a root-level bracket would
+//! see only the coalescing thread. Wrapping the scan means each partition
+//! is measured on whichever worker actually polls it; the collector's
+//! counters are atomics, so concurrent partitions fold safely.
+
+use std::{
+    fmt,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use datafusion::{
+    error::Result as DfResult,
+    execution::TaskContext,
+    physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
+        SendableRecordBatchStream,
+    },
+};
+use futures::Stream;
+
+use crate::runtime_metrics::{
+    cpu,
+    op_stats::{OpStatsCollector, metering_active},
+};
+
+/// Wraps `input`, metering every partition's poll time into `op_stats`.
+#[derive(Debug)]
+pub(crate) struct MeteredExec {
+    input: Arc<dyn ExecutionPlan>,
+    op_stats: Option<Arc<OpStatsCollector>>,
+}
+
+impl MeteredExec {
+    /// Wrap `input`. With no collector this is still a pass-through node —
+    /// the per-poll bracket short-circuits on the same `metering_active`
+    /// gate the kernels use, so an unmetered query pays one relaxed load
+    /// per poll and no procfs reads.
+    pub(crate) fn new(
+        input: Arc<dyn ExecutionPlan>,
+        op_stats: Option<Arc<OpStatsCollector>>,
+    ) -> Self {
+        Self { input, op_stats }
+    }
+}
+
+impl DisplayAs for MeteredExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MeteredExec")
+    }
+}
+
+impl ExecutionPlan for MeteredExec {
+    fn name(&self) -> &'static str {
+        "MeteredExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        self.input.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        // Optimizer rewrites keep the meter attached to whatever the child
+        // became; dropping it here would silently unmeter the scan.
+        Ok(Arc::new(MeteredExec::new(
+            children
+                .into_iter()
+                .next()
+                .unwrap_or(Arc::clone(&self.input)),
+            self.op_stats.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DfResult<SendableRecordBatchStream> {
+        let inner = self.input.execute(partition, context)?;
+        Ok(Box::pin(MeteredStream {
+            schema: inner.schema(),
+            inner,
+            op_stats: self.op_stats.clone(),
+        }))
+    }
+}
+
+/// Per-poll CPU bracket around one partition's stream.
+struct MeteredStream {
+    inner: SendableRecordBatchStream,
+    schema: SchemaRef,
+    op_stats: Option<Arc<OpStatsCollector>>,
+}
+
+impl Stream for MeteredStream {
+    type Item = DfResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let Some(stats) = self.op_stats.clone() else {
+            return Pin::new(&mut self.inner).poll_next(cx);
+        };
+        if !metering_active() {
+            return Pin::new(&mut self.inner).poll_next(cx);
+        }
+        let start = cpu::thread_cpu_ns();
+        let out = Pin::new(&mut self.inner).poll_next(cx);
+        stats.add_kernel_cpu_ns(cpu::thread_cpu_delta_ns(start));
+        out
+    }
+}
+
+impl RecordBatchStream for MeteredStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}

--- a/src/supertable/query/exec/metered_exec.rs
+++ b/src/supertable/query/exec/metered_exec.rs
@@ -21,11 +21,20 @@
 //! poll, so waiting is excluded and only real on-CPU time is counted,
 //! which is exactly the contract the search kernels already meet.
 //!
-//! Placed around the table scan rather than the plan root on purpose:
-//! DataFusion spawns a task per partition, so a root-level bracket would
-//! see only the coalescing thread. Wrapping the scan means each partition
-//! is measured on whichever worker actually polls it; the collector's
-//! counters are atomics, so concurrent partitions fold safely.
+//! Placed at BOTH the plan root and around each table scan, because
+//! neither alone is enough: DataFusion spawns a task per partition, so a
+//! root-only bracket misses work under an internal spawn boundary, while a
+//! scan-only bracket misses the aggregation and sort work above it. The
+//! `POLL_DEPTH` guard below keeps the overlap from counting twice. The
+//! collector's counters are atomics, so concurrent partitions fold safely.
+//!
+//! Everything the planner asks of this node is delegated to the child. A
+//! wrapper that answers those questions for itself is not transparent: the
+//! `ExecutionPlan` defaults report unknown statistics and refuse filter
+//! pushdown, and sitting between an aggregate and the scan that way stops
+//! `COUNT`/`MIN`/`MAX` folding from manifest statistics and turns an O(1)
+//! manifest read into a full columnar scan. Measuring a query must not
+//! change the query.
 
 use std::{
     cell::Cell,
@@ -38,11 +47,18 @@ use std::{
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use datafusion::{
-    error::Result as DfResult,
+    common::{Statistics, config::ConfigOptions},
+    error::{DataFusionError, Result as DfResult},
     execution::TaskContext,
+    physical_expr::PhysicalExpr,
     physical_plan::{
         DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
         SendableRecordBatchStream,
+        execution_plan::CardinalityEffect,
+        filter_pushdown::{
+            ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
+        },
+        projection::ProjectionExec,
     },
 };
 use futures::Stream;
@@ -112,17 +128,94 @@ impl ExecutionPlan for MeteredExec {
 
     fn with_new_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DfResult<Arc<dyn ExecutionPlan>> {
         // Optimizer rewrites keep the meter attached to whatever the child
-        // became; dropping it here would silently unmeter the scan.
+        // became; dropping it here would silently unmeter the scan. A unary
+        // node handed anything but one child is a broken rewrite — say so,
+        // rather than papering over it by keeping the stale subtree.
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "MeteredExec requires exactly one child; got {}",
+                children.len()
+            )));
+        }
         Ok(Arc::new(MeteredExec::new(
-            children
-                .into_iter()
-                .next()
-                .unwrap_or(Arc::clone(&self.input)),
+            children.swap_remove(0),
             self.op_stats.clone(),
         )))
+    }
+
+    // ---- Everything below is delegation. See the module header: a meter
+    // that answers the planner for itself changes the plan it measures. ----
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        // Rows leave in the order the child produced them.
+        vec![true; self.children().len()]
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> DfResult<Arc<Statistics>> {
+        // The default is `Statistics::new_unknown`, which would hide the
+        // manifest statistics the provider attaches and stop the aggregate
+        // rule folding COUNT/MIN/MAX into a constant.
+        self.input.partition_statistics(partition)
+    }
+
+    fn repartitioned(
+        &self,
+        target_partitions: usize,
+        config: &ConfigOptions,
+    ) -> DfResult<Option<Arc<dyn ExecutionPlan>>> {
+        // A scan that can split itself across partitions should still do so
+        // with the meter on. Refusing here doesn't prevent parallelism — it
+        // makes the planner insert a `RepartitionExec` *below* this node
+        // instead, which both adds an exchange and moves the Parquet decode
+        // into a spawned task where this node's thread clock cannot see it.
+        Ok(self.input.repartitioned(target_partitions, config)?.map(
+            |input| -> Arc<dyn ExecutionPlan> {
+                Arc::new(MeteredExec::new(input, self.op_stats.clone()))
+            },
+        ))
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+
+    fn try_swapping_with_projection(
+        &self,
+        projection: &ProjectionExec,
+    ) -> DfResult<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(self.input.try_swapping_with_projection(projection)?.map(
+            |input| -> Arc<dyn ExecutionPlan> {
+                Arc::new(MeteredExec::new(input, self.op_stats.clone()))
+            },
+        ))
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> DfResult<FilterDescription> {
+        // The default bars every parent filter, which leaves a redundant
+        // `FilterExec` above a scan that could have pushed the predicate
+        // down into the Parquet reader.
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> DfResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
     }
 
     fn execute(
@@ -136,6 +229,18 @@ impl ExecutionPlan for MeteredExec {
             inner,
             op_stats: self.op_stats.clone(),
         }))
+    }
+}
+
+/// Restores `POLL_DEPTH` on unwind as well as on the normal path. A poll
+/// that panicked out of a raised depth would leave the thread-local set
+/// forever, and every later query polled on that worker would treat its
+/// outermost bracket as nested and bill zero CPU.
+struct PollDepthGuard(u32);
+
+impl Drop for PollDepthGuard {
+    fn drop(&mut self) {
+        POLL_DEPTH.with(|d| d.set(self.0));
     }
 }
 
@@ -161,11 +266,11 @@ impl Stream for MeteredStream {
         if POLL_DEPTH.with(|d| d.get()) > 0 {
             return Pin::new(&mut self.inner).poll_next(cx);
         }
-        POLL_DEPTH.with(|d| d.set(1));
+        let restore = PollDepthGuard(POLL_DEPTH.with(|d| d.replace(1)));
         let start = cpu::thread_cpu_ns();
         let out = Pin::new(&mut self.inner).poll_next(cx);
         let delta = cpu::thread_cpu_delta_ns(start);
-        POLL_DEPTH.with(|d| d.set(0));
+        drop(restore);
         stats.add_kernel_cpu_ns(delta);
         out
     }

--- a/src/supertable/query/exec/metered_exec.rs
+++ b/src/supertable/query/exec/metered_exec.rs
@@ -230,9 +230,13 @@ impl ExecutionPlan for MeteredExec {
     }
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
-        // A limit the child can absorb must reach it through the meter, or
-        // the Exact arm of the sort pushdown above preserves an order whose
-        // early-termination fetch never arrives at the source.
+        // Not consulted on today's plan shapes: `supports_limit_pushdown`
+        // above routes the LimitPushdown walk into the child directly, so
+        // the fetch reaches the source either way (verified by A/B EXPLAIN
+        // — the plans are identical with this pair deleted). Kept because
+        // the module contract is that every planner question is answered
+        // by the child: a shape or rule that does consult this must get
+        // the source's answer, not a meter defaulting to `None`.
         self.input
             .with_fetch(limit)
             .map(|input| -> Arc<dyn ExecutionPlan> {
@@ -241,11 +245,13 @@ impl ExecutionPlan for MeteredExec {
     }
 
     fn with_preserve_order(&self, preserve_order: bool) -> Option<Arc<dyn ExecutionPlan>> {
-        // Completeness rather than a measured win: no optimizer path in
-        // this DataFusion reaches a wrapper here (both call sites target
-        // sources and unions). If a rewrite ever does ask, the answer must
-        // come from the source that decides whether it may skip row
-        // groups, not from a meter defaulting to `None`.
+        // Reachable, not theoretical: LimitPushdown embeds a fetch into
+        // whatever fetch-capable non-pushdown node carries it — a residual
+        // `FilterExec` directly above a metered scan is an ordinary shape
+        // on this engine — and then calls `with_preserve_order` on that
+        // node, which delegates into its input, i.e. into this meter. The
+        // answer must come from the source that decides whether it may
+        // skip row groups, not from a meter defaulting to `None`.
         self.input
             .with_preserve_order(preserve_order)
             .map(|input| -> Arc<dyn ExecutionPlan> {

--- a/src/supertable/query/exec/metered_exec.rs
+++ b/src/supertable/query/exec/metered_exec.rs
@@ -50,10 +50,10 @@ use datafusion::{
     common::{Statistics, config::ConfigOptions},
     error::{DataFusionError, Result as DfResult},
     execution::TaskContext,
-    physical_expr::PhysicalExpr,
+    physical_expr::{PhysicalExpr, PhysicalSortExpr},
     physical_plan::{
         DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
-        SendableRecordBatchStream,
+        SendableRecordBatchStream, SortOrderPushdownResult,
         execution_plan::CardinalityEffect,
         filter_pushdown::{
             ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
@@ -216,6 +216,40 @@ impl ExecutionPlan for MeteredExec {
         _config: &ConfigOptions,
     ) -> DfResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
         Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DfResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        // The default answer is `Unsupported`, which stops the pushdown
+        // walk dead. A meter sitting between a sort and the scan would
+        // then cost the query its row-group reorder, its reverse scan and
+        // any sort elimination — turning an early-terminating TopK into a
+        // full scan plus a full sort.
+        let rewrap = |input| -> Arc<dyn ExecutionPlan> {
+            Arc::new(MeteredExec::new(input, self.op_stats.clone()))
+        };
+        Ok(match self.input.try_pushdown_sort(order)? {
+            SortOrderPushdownResult::Exact { inner } => SortOrderPushdownResult::Exact {
+                inner: rewrap(inner),
+            },
+            SortOrderPushdownResult::Inexact { inner } => SortOrderPushdownResult::Inexact {
+                inner: rewrap(inner),
+            },
+            SortOrderPushdownResult::Unsupported => SortOrderPushdownResult::Unsupported,
+        })
+    }
+
+    fn with_preserve_order(&self, preserve_order: bool) -> Option<Arc<dyn ExecutionPlan>> {
+        // Order-sensitivity has to reach the data source, which decides
+        // whether it may skip row groups. Defaulting to `None` silently
+        // drops that signal at the meter.
+        self.input
+            .with_preserve_order(preserve_order)
+            .map(|input| -> Arc<dyn ExecutionPlan> {
+                Arc::new(MeteredExec::new(input, self.op_stats.clone()))
+            })
     }
 
     fn execute(

--- a/src/supertable/query/exec/mod.rs
+++ b/src/supertable/query/exec/mod.rs
@@ -16,4 +16,5 @@ pub mod common;
 pub mod fts_exec;
 pub mod hybrid_exec;
 pub mod match_exec;
+pub mod metered_exec;
 pub mod vector_exec;

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1425,6 +1425,13 @@ impl SupertableReader {
                 })?;
                 let batch = match warm_batch {
                     Some(batch) => batch,
+                    // Cold: the fetch and its Parquet decode are interleaved
+                    // inside the async reader, so the decode leg is not
+                    // separable here and goes uncharged. Bracketing the await
+                    // itself would be worse than leaving it at zero — a thread
+                    // clock spanning an await bills whatever else the runtime
+                    // ran on this thread to this query. The verify comparison
+                    // below is charged on both arms.
                     None => take_rows_byte_source(&r, &candidates, &[column_arc.as_str()])
                         .await
                         .map_err(|e| QueryError::Execute(e.to_string()))?,

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1394,9 +1394,9 @@ impl SupertableReader {
                         .token_match(&column_arc, &refs, BoolMode::And)
                         .await
                         .map_err(fts_read_error)?;
-                    // The prune pass's posting walk. The verify pass's
-                    // row reads count through the take path's own
-                    // collector accounting below.
+                    // The prune pass's posting walk. The verify pass's own
+                    // decode is folded into `rows_materialized` below; its
+                    // byte and range legs ride the take path's accounting.
                     if let Some(stats) = &op_stats {
                         stats.add_fts_postings_bytes(work.postings_bytes);
                         stats.add_planned_read_ranges(work.planned_ranges);
@@ -1410,10 +1410,9 @@ impl SupertableReader {
                 // The verify pass — candidate decode + string compare — is
                 // this query's dominant CPU (a token-less value decodes the
                 // whole column), so it is bracketed like any other kernel.
-                // The warm take runs synchronously and is inside the bracket;
-                // the cold take awaits I/O, so only its post-fetch decode
-                // portion registers on this thread's clock, which is the
-                // on-CPU share and exactly what should.
+                // Only the warm take is inside this bracket; the cold arm's
+                // decode is not separable from the fetch it is interleaved
+                // with, which the comment on that arm explains.
                 let warm_batch = op_stats::timed_kernel(&op_stats, || {
                     if r.can_take_by_local_doc_ids() {
                         r.take_by_local_doc_ids(&candidates, &[column_arc.as_str()])
@@ -1436,6 +1435,12 @@ impl SupertableReader {
                         .await
                         .map_err(|e| QueryError::Execute(e.to_string()))?,
                 };
+                // The verify decode materialized one row per candidate,
+                // on either arm. Folding it here rather than per-arm keeps
+                // the count invariant to which take served the batch.
+                if let Some(stats) = &op_stats {
+                    stats.add_rows_materialized(candidates.len() as u64);
+                }
                 let hits = op_stats::timed_kernel(&op_stats, || {
                     let values = batch
                         .column(0)

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1407,37 +1407,57 @@ impl SupertableReader {
                 if candidates.is_empty() {
                     return Ok(Vec::new());
                 }
-                let batch = if r.can_take_by_local_doc_ids() {
-                    r.take_by_local_doc_ids(&candidates, &[column_arc.as_str()])
-                        .map_err(|e| QueryError::Parquet(e.to_string()))?
-                } else {
-                    take_rows_byte_source(&r, &candidates, &[column_arc.as_str()])
+                // The verify pass — candidate decode + string compare — is
+                // this query's dominant CPU (a token-less value decodes the
+                // whole column), so it is bracketed like any other kernel.
+                // The warm take runs synchronously and is inside the bracket;
+                // the cold take awaits I/O, so only its post-fetch decode
+                // portion registers on this thread's clock, which is the
+                // on-CPU share and exactly what should.
+                let warm_batch = op_stats::timed_kernel(&op_stats, || {
+                    if r.can_take_by_local_doc_ids() {
+                        r.take_by_local_doc_ids(&candidates, &[column_arc.as_str()])
+                            .map(Some)
+                            .map_err(|e| QueryError::Parquet(e.to_string()))
+                    } else {
+                        Ok(None)
+                    }
+                })?;
+                let batch = match warm_batch {
+                    Some(batch) => batch,
+                    None => take_rows_byte_source(&r, &candidates, &[column_arc.as_str()])
                         .await
-                        .map_err(|e| QueryError::Execute(e.to_string()))?
+                        .map_err(|e| QueryError::Execute(e.to_string()))?,
                 };
-                let values = batch
-                    .column(0)
-                    .as_any()
-                    .downcast_ref::<LargeStringArray>()
-                    .ok_or_else(|| {
-                        QueryError::Execute(format!(
-                            "exact_match column '{}' is not LargeUtf8",
-                            column_arc
-                        ))
-                    })?;
-                let mut hits: Vec<SuperfileHit> = candidates
-                    .iter()
-                    .enumerate()
-                    .filter(|(index, _)| {
-                        !values.is_null(*index) && values.value(*index) == value_arc.as_str()
-                    })
-                    .map(|(_, &local_doc_id)| SuperfileHit {
-                        superfile: entry.uri,
-                        local_doc_id,
-                        score: 0.0,
-                        stable_id: None,
-                    })
-                    .collect();
+                let hits = op_stats::timed_kernel(&op_stats, || {
+                    let values = batch
+                        .column(0)
+                        .as_any()
+                        .downcast_ref::<LargeStringArray>()
+                        .ok_or_else(|| {
+                            QueryError::Execute(format!(
+                                "exact_match column '{}' is not LargeUtf8",
+                                column_arc
+                            ))
+                        })?;
+                    Ok::<_, QueryError>(
+                        candidates
+                            .iter()
+                            .enumerate()
+                            .filter(|(index, _)| {
+                                !values.is_null(*index)
+                                    && values.value(*index) == value_arc.as_str()
+                            })
+                            .map(|(_, &local_doc_id)| SuperfileHit {
+                                superfile: entry.uri,
+                                local_doc_id,
+                                score: 0.0,
+                                stable_id: None,
+                            })
+                            .collect::<Vec<SuperfileHit>>(),
+                    )
+                });
+                let mut hits: Vec<SuperfileHit> = hits?;
                 dispatch::apply_tombstone_filter(tombstone_cache.as_ref(), &entry, &mut hits, now)?;
                 Ok(hits)
             }

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1396,7 +1396,9 @@ impl SupertableReader {
                         .map_err(fts_read_error)?;
                     // The prune pass's posting walk. The verify pass's own
                     // decode is folded into `rows_materialized` below; its
-                    // byte and range legs ride the take path's accounting.
+                    // byte and range legs are deliberately unpriced — both
+                    // take paths report no planned ranges by design, so the
+                    // counter stays identical warm or cold.
                     if let Some(stats) = &op_stats {
                         stats.add_fts_postings_bytes(work.postings_bytes);
                         stats.add_planned_read_ranges(work.planned_ranges);

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -111,6 +111,7 @@ use crate::{
         query::{
             candidate::CandidatePlan,
             df_object_store::SuperfileObjectStore,
+            exec::metered_exec::MeteredExec,
             prune::{PruneLeaf, select_superfiles},
             skip::{ScalarOp, ScalarPredicate},
             superfile_reader::superfile_reader,
@@ -1019,7 +1020,14 @@ impl TableProvider for SupertableProvider {
             .with_projection_indices(projection.cloned())?
             .with_limit(effective_limit)
             .build();
-        Ok(DataSourceExec::from_data_source(config))
+        // Meter the scan's own poll time on the thread clock. DataFusion
+        // reports operator time as wall-clock `elapsed_compute` and does not
+        // report Parquet decode at all, so without this a SQL query's CPU is
+        // both mis-clocked and missing its dominant leg.
+        Ok(Arc::new(MeteredExec::new(
+            DataSourceExec::from_data_source(config),
+            self.scan_store.op_stats(),
+        )))
     }
 }
 

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -63,6 +63,7 @@ use datafusion::{
     error::DataFusionError,
     execution::context::SessionContext,
     logical_expr::{Expr, LogicalPlan},
+    physical_plan::{ExecutionPlan, collect as collect_physical},
 };
 
 use crate::{
@@ -77,7 +78,8 @@ use crate::{
             covered_agg::CoveredAggregateRewrite,
             exec::{
                 fts_exec::register_bm25, hybrid_exec::register_hybrid_search,
-                match_exec::register_match, vector_exec::register_vector_search,
+                match_exec::register_match, metered_exec::MeteredExec,
+                vector_exec::register_vector_search,
             },
             provider::{SupertableProvider, TABLE_NAME, view_string_schema},
         },
@@ -248,6 +250,12 @@ impl SupertableReader {
         });
         let cached_plan = self.cached_sql_logical_plan(sql);
         let cache_reader = self.clone();
+        // Picked up on the caller's thread, like reader mint: the drive
+        // future polls on runtime threads where the scope's slot is
+        // invisible. This is what lets the cached, collector-detached
+        // context still report the plan's CPU — the meter rides the
+        // wrapper below, not the context.
+        let op_stats = op_stats::current();
 
         let sql = sql.to_owned();
         let drive = async move {
@@ -279,7 +287,19 @@ impl SupertableReader {
                     df
                 }
             };
-            df.collect().await.map_err(exec_query_error)
+            // Meter the executed plan on the thread-CPU clock, the same
+            // way the catalog path does. The context is cached and
+            // deliberately carries no collector, so without this the
+            // reader-level SQL surface reports nothing at all.
+            let plan = df
+                .create_physical_plan()
+                .await
+                .map_err(|e| QueryError::Plan(e.to_string()))?;
+            let metered: Arc<dyn ExecutionPlan> =
+                Arc::new(MeteredExec::new(Arc::clone(&plan), op_stats));
+            collect_physical(metered, ctx.task_ctx())
+                .await
+                .map_err(exec_query_error)
         };
 
         // Drive through the shared sync→async bridge: ambient

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -220,9 +220,10 @@ impl SupertableReader {
     /// Not metered: this entry runs on the cached, collector-detached
     /// [`SessionContext`] (see [`Self::sql_session_context`]), so a
     /// surrounding `with_op_stats` scope reports zero SQL work for it.
-    /// The metered SQL surface is the catalog `Connection::query_sql`,
-    /// which builds a fresh per-query provider that carries the scope's
-    /// collector.
+    /// The metered SQL surfaces are the catalog `Connection::query_sql`,
+    /// which builds a fresh per-query provider carrying the scope's
+    /// collector, and mutation predicate resolves, which go through
+    /// [`Self::metered_session_context`] for the same reason.
     // Single-table SQL — off the public surface; catalog-level SQL is the
     // public entry point. Reachable from tests/benches via `test-helpers`.
     #[cfg(any(test, feature = "test-helpers"))]
@@ -327,20 +328,49 @@ impl SupertableReader {
             return Ok(ctx.clone());
         }
 
+        let ctx = op_stats::suppressed(|| self.build_session_context(reader))?;
+        *guard = Some((Arc::clone(&manifest), ctx.clone()));
+        Ok(ctx)
+    }
+
+    /// A context bound to **this** reader, collector and all, built fresh
+    /// on every call and never cached.
+    ///
+    /// [`Self::sql_session_context`] detaches the collector because its
+    /// context is shared across queries, and one that captured a live
+    /// collector would attribute later queries' work back into an old
+    /// scope. That makes it unusable for anything whose work should be
+    /// reported: a caller running through it measures zero no matter how
+    /// much it scans.
+    ///
+    /// Not caching is what makes carrying the collector safe — nothing
+    /// outlives the scope that created it — and it is the same trade the
+    /// catalog's `Connection::query_sql` already makes, building a fresh
+    /// provider per query so the scope's collector rides along.
+    fn metered_session_context(&self) -> Result<SessionContext, QueryError> {
+        self.build_session_context(Arc::new(self.clone()))
+    }
+
+    /// Assemble a context over `reader`'s pinned snapshot: pushdown-aware
+    /// provider, the covered-aggregate rewrite, and the search TVFs.
+    ///
+    /// Whether the result may be cached is the caller's call, and it turns
+    /// entirely on whether `reader` carries a work collector — see the two
+    /// callers above.
+    fn build_session_context(&self, reader: Arc<Self>) -> Result<SessionContext, QueryError> {
+        let manifest = Arc::clone(reader.manifest());
         let store = Arc::clone(&self.options().store);
         let disk_cache = self.options().disk_cache.as_ref().map(Arc::clone);
         // Cached per-table schemas: the provider scans the string-viewed `scan`
         // schema; the TVFs bind to the plain `scalar` schema.
         let schemas = self.sql_schemas();
-        let provider = op_stats::suppressed(|| {
-            SupertableProvider::new(
-                schemas.scan().clone(),
-                Arc::clone(&manifest),
-                store,
-                disk_cache,
-                reader.tombstone_cache.clone(),
-            )
-        });
+        let provider = SupertableProvider::new(
+            schemas.scan().clone(),
+            Arc::clone(&manifest),
+            store,
+            disk_cache,
+            reader.tombstone_cache.clone(),
+        );
 
         // Gate SQL heap on the connection budget (shared across contexts, so
         // this reader's SQL counts against the same ceiling as the rest).
@@ -363,8 +393,6 @@ impl SupertableReader {
         // Unranked token / exact match TVFs (siblings of bm25_search).
         register_match(&ctx, Arc::clone(&reader), schemas.scalar().clone());
         register_hybrid_search(&ctx, Arc::clone(&reader), schemas.scalar().clone());
-
-        *guard = Some((Arc::clone(&manifest), ctx.clone()));
 
         Ok(ctx)
     }
@@ -393,7 +421,10 @@ impl SupertableReader {
         // Resolve against this reader's pinned snapshot. Callers that need
         // current-state semantics create a fresh reader immediately before
         // invoking this helper.
-        let ctx = self.sql_session_context()?;
+        // Metered deliberately: this scan is real read work the caller
+        // asked for, and routing it through the cached context would
+        // report zero for an arbitrarily large table scan.
+        let ctx = self.metered_session_context()?;
         let id_column = self.options().id_column.clone();
 
         let drive = async move {

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -77,9 +77,9 @@ use crate::{
         query::{
             covered_agg::CoveredAggregateRewrite,
             exec::{
-                fts_exec::register_bm25, hybrid_exec::register_hybrid_search,
-                match_exec::register_match, metered_exec::MeteredExec,
-                vector_exec::register_vector_search,
+                common::harvest_datafusion_metrics, fts_exec::register_bm25,
+                hybrid_exec::register_hybrid_search, match_exec::register_match,
+                metered_exec::MeteredExec, vector_exec::register_vector_search,
             },
             provider::{SupertableProvider, TABLE_NAME, view_string_schema},
         },
@@ -296,10 +296,18 @@ impl SupertableReader {
                 .await
                 .map_err(|e| QueryError::Plan(e.to_string()))?;
             let metered: Arc<dyn ExecutionPlan> =
-                Arc::new(MeteredExec::new(Arc::clone(&plan), op_stats));
-            collect_physical(metered, ctx.task_ctx())
+                Arc::new(MeteredExec::new(Arc::clone(&plan), op_stats.clone()));
+            let batches = collect_physical(metered, ctx.task_ctx())
                 .await
-                .map_err(exec_query_error)
+                .map_err(exec_query_error)?;
+            // The cached context carries no collector by design, so the
+            // scan-level wrappers are inert here and `rows_materialized`
+            // would otherwise stay at zero while `kernel_cpu_ns` did not.
+            // Harvesting walks the executed plan and takes the collector
+            // explicitly, so it needs neither a metered context nor a
+            // cache bypass.
+            harvest_datafusion_metrics(&plan, &op_stats);
+            Ok(batches)
         };
 
         // Drive through the shared sync→async bridge: ambient

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -59,16 +59,17 @@ use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, Decimal128Array};
 use arrow_schema::SchemaRef;
 use datafusion::{
+    dataframe::DataFrame,
     datasource::DefaultTableSource,
     error::DataFusionError,
-    execution::context::SessionContext,
+    execution::{TaskContext, context::SessionContext},
     logical_expr::{Expr, LogicalPlan},
     physical_plan::{ExecutionPlan, collect as collect_physical},
 };
 
 use crate::{
     memory::budgeted_session_context,
-    runtime_metrics::op_stats,
+    runtime_metrics::op_stats::{self, OpStatsCollector},
     storage::permission_denied_in_chain,
     supertable::{
         error::QueryError,
@@ -291,23 +292,7 @@ impl SupertableReader {
             // way the catalog path does. The context is cached and
             // deliberately carries no collector, so without this the
             // reader-level SQL surface reports nothing at all.
-            let plan = df
-                .create_physical_plan()
-                .await
-                .map_err(|e| QueryError::Plan(e.to_string()))?;
-            let metered: Arc<dyn ExecutionPlan> =
-                Arc::new(MeteredExec::new(Arc::clone(&plan), op_stats.clone()));
-            let batches = collect_physical(metered, ctx.task_ctx())
-                .await
-                .map_err(exec_query_error)?;
-            // The cached context carries no collector by design, so the
-            // scan-level wrappers are inert here and `rows_materialized`
-            // would otherwise stay at zero while `kernel_cpu_ns` did not.
-            // Harvesting walks the executed plan and takes the collector
-            // explicitly, so it needs neither a metered context nor a
-            // cache bypass.
-            harvest_datafusion_metrics(&plan, &op_stats);
-            Ok(batches)
+            Self::collect_metered_df(df, ctx.task_ctx(), &op_stats).await
         };
 
         // Drive through the shared sync→async bridge: ambient
@@ -438,6 +423,35 @@ impl SupertableReader {
     /// large-table delete/update predicate never materializes every
     /// superfile into memory.
     ///
+    /// Plan, meter, execute and account for one DataFrame.
+    ///
+    /// The four steps belong together: a site that collects without
+    /// harvesting reports CPU, page bytes and ranges with no row count
+    /// beside them, which is how the mutation predicate resolve came to
+    /// report zero decoded rows for a scan it genuinely paid for. Keeping
+    /// them in one helper means a later call site cannot execute a plan
+    /// and quietly skip the accounting.
+    async fn collect_metered_df(
+        df: DataFrame,
+        task_ctx: Arc<TaskContext>,
+        op_stats: &Option<Arc<OpStatsCollector>>,
+    ) -> Result<Vec<RecordBatch>, QueryError> {
+        let plan = df
+            .create_physical_plan()
+            .await
+            .map_err(|e| QueryError::Plan(e.to_string()))?;
+        let metered: Arc<dyn ExecutionPlan> =
+            Arc::new(MeteredExec::new(Arc::clone(&plan), op_stats.clone()));
+        let batches = collect_physical(metered, task_ctx)
+            .await
+            .map_err(exec_query_error)?;
+        // Walks the executed plan and takes the collector explicitly, so
+        // it needs neither a metered context nor a cache bypass — the
+        // cached context carries no collector by design.
+        harvest_datafusion_metrics(&plan, op_stats);
+        Ok(batches)
+    }
+
     /// Note: the resolution is against the **current** manifest
     /// snapshot, exactly like a contemporaneous `query_sql` would
     /// see. Rows that newly match `expr` between this call and
@@ -445,6 +459,9 @@ impl SupertableReader {
     /// captured-at-call semantics match SQL `UPDATE WHERE` /
     /// `DELETE WHERE`.
     pub(crate) fn scan_ids_matching(&self, expr: Expr) -> Result<Vec<i128>, QueryError> {
+        // Picked up on the caller's thread, before any runtime hop, so the
+        // harvest below folds into this op's collector.
+        let op_stats = op_stats::current();
         let _foreground = ForegroundQueryGuard::enter();
         // Resolve against this reader's pinned snapshot. Callers that need
         // current-state semantics create a fresh reader immediately before
@@ -464,7 +481,12 @@ impl SupertableReader {
                 .map_err(|e| QueryError::Plan(e.to_string()))?
                 .select_columns(&[id_column.as_str()])
                 .map_err(|e| QueryError::Plan(e.to_string()))?;
-            let batches = df.collect().await.map_err(exec_query_error)?;
+            // Same three steps as `query_sql`, and for the same reason:
+            // this scan's rows are real decoded rows. Collecting the
+            // DataFrame directly reported CPU, page bytes and ranges for a
+            // mutation's predicate resolve while leaving its row count at
+            // zero.
+            let batches = Self::collect_metered_df(df, ctx.task_ctx(), &op_stats).await?;
             extract_id_column(&batches)
         };
 

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -64,7 +64,6 @@ use datafusion::{
     error::DataFusionError,
     execution::{TaskContext, context::SessionContext},
     logical_expr::{Expr, LogicalPlan},
-    physical_plan::{ExecutionPlan, collect as collect_physical},
 };
 
 use crate::{
@@ -78,9 +77,9 @@ use crate::{
         query::{
             covered_agg::CoveredAggregateRewrite,
             exec::{
-                common::harvest_datafusion_metrics, fts_exec::register_bm25,
+                common::collect_plan_metered, fts_exec::register_bm25,
                 hybrid_exec::register_hybrid_search, match_exec::register_match,
-                metered_exec::MeteredExec, vector_exec::register_vector_search,
+                vector_exec::register_vector_search,
             },
             provider::{SupertableProvider, TABLE_NAME, view_string_schema},
         },
@@ -410,6 +409,23 @@ impl SupertableReader {
         Ok(ctx)
     }
 
+    /// Plan one DataFrame, then run it through the shared
+    /// meter-collect-harvest step every SQL execution site uses
+    /// ([`collect_plan_metered`]).
+    async fn collect_metered_df(
+        df: DataFrame,
+        task_ctx: Arc<TaskContext>,
+        op_stats: &Option<Arc<OpStatsCollector>>,
+    ) -> Result<Vec<RecordBatch>, QueryError> {
+        let plan = df
+            .create_physical_plan()
+            .await
+            .map_err(|e| QueryError::Plan(e.to_string()))?;
+        collect_plan_metered(&plan, task_ctx, op_stats)
+            .await
+            .map_err(exec_query_error)
+    }
+
     /// Resolve a predicate to the matching `_id` values. Used by
     /// the writer's `delete()` / `update()` entry points to
     /// capture the target-id set at call time (step 0a in the
@@ -423,35 +439,6 @@ impl SupertableReader {
     /// large-table delete/update predicate never materializes every
     /// superfile into memory.
     ///
-    /// Plan, meter, execute and account for one DataFrame.
-    ///
-    /// The four steps belong together: a site that collects without
-    /// harvesting reports CPU, page bytes and ranges with no row count
-    /// beside them, which is how the mutation predicate resolve came to
-    /// report zero decoded rows for a scan it genuinely paid for. Keeping
-    /// them in one helper means a later call site cannot execute a plan
-    /// and quietly skip the accounting.
-    async fn collect_metered_df(
-        df: DataFrame,
-        task_ctx: Arc<TaskContext>,
-        op_stats: &Option<Arc<OpStatsCollector>>,
-    ) -> Result<Vec<RecordBatch>, QueryError> {
-        let plan = df
-            .create_physical_plan()
-            .await
-            .map_err(|e| QueryError::Plan(e.to_string()))?;
-        let metered: Arc<dyn ExecutionPlan> =
-            Arc::new(MeteredExec::new(Arc::clone(&plan), op_stats.clone()));
-        let batches = collect_physical(metered, task_ctx)
-            .await
-            .map_err(exec_query_error)?;
-        // Walks the executed plan and takes the collector explicitly, so
-        // it needs neither a metered context nor a cache bypass — the
-        // cached context carries no collector by design.
-        harvest_datafusion_metrics(&plan, op_stats);
-        Ok(batches)
-    }
-
     /// Note: the resolution is against the **current** manifest
     /// snapshot, exactly like a contemporaneous `query_sql` would
     /// see. Rows that newly match `expr` between this call and

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2592,6 +2592,9 @@ impl SupertableReader {
                 )
                 .await
                 .map_err(|e| QueryError::Execute(e.to_string()))?;
+            if let Some(stats) = &self.op_stats {
+                stats.add_kernel_cpu_ns(scan.kernel_cpu_ns);
+            }
             // Cold cells rerank in-scan; take their exact hits directly.
             if !scan.hits.is_empty() {
                 let mut tagged = dispatch::tag_hits(entry, scan.hits);
@@ -2615,10 +2618,13 @@ impl SupertableReader {
             for (si, selected) in by_seg {
                 let entry = &superfiles[si];
                 let reader = readers[si].as_ref();
-                let (hits, _ns) = reader
+                let (hits, rerank_ns) = reader
                     .vector_rerank_selected(column, query, k, selected, None)
                     .await
                     .map_err(|e| QueryError::Execute(e.to_string()))?;
+                if let Some(stats) = &self.op_stats {
+                    stats.add_kernel_cpu_ns(rerank_ns);
+                }
                 let mut tagged = dispatch::tag_hits(entry, hits);
                 dispatch::attach_stable_ids(reader, entry, &mut tagged, false, &self.op_stats)
                     .await?;

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -258,13 +258,22 @@ fn fold_probe_work(op_stats: &Option<Arc<OpStatsCollector>>, work: &ProbeTally) 
     let Some(stats) = op_stats else {
         return;
     };
-    stats.add_vector_scan(work.cells_scanned, work.candidates_scanned);
+    // Exhaustive on purpose: a field added to `ProbeTally` fails to
+    // compile here until someone decides how it is priced.
+    let ProbeTally {
+        cells_scanned,
+        candidates_scanned,
+        ranges_requested,
+        rows_reranked,
+        kernel_cpu_ns,
+    } = *work;
+    stats.add_vector_scan(cells_scanned, candidates_scanned);
     // Request-shaped ranges only (cluster index + prefixes/blocks + Sq8
     // meta). Rerank rows are diagnostics; their cost rides the priced CPU
     // watermark.
-    stats.add_planned_read_ranges(work.ranges_requested);
-    stats.add_vector_rows_reranked(work.rows_reranked);
-    stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
+    stats.add_planned_read_ranges(ranges_requested);
+    stats.add_vector_rows_reranked(rows_reranked);
+    stats.add_kernel_cpu_ns(kernel_cpu_ns);
 }
 
 /// Build the fine-cluster probe set, then refill globally (best score first)

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -265,6 +265,27 @@ const FILTERED_HIDDEN_FINE_NPROBE: usize = 16;
 ///   fragment, so each fragment of a selected cell is probed (accepted read
 ///   amplification), and a small fragment is not crowded out by a larger
 ///   sibling in the same cell.
+/// Fold one superfile scan's work into the op's collector.
+///
+/// Both vector fan-outs produce a [`ScanOutcome`] and both must report the
+/// same five values. The global-fine path once folded only the CPU leg,
+/// which left its cells, candidates, cluster-index/block ranges and rerank
+/// rows unpriced while the stamped path counted them. One function, so a
+/// sixth field cannot be added to the struct and wired up at only one of
+/// the two sites.
+fn fold_scan_outcome(op_stats: &Option<Arc<OpStatsCollector>>, scan: &ScanOutcome) {
+    let Some(stats) = op_stats else {
+        return;
+    };
+    stats.add_vector_scan(scan.cells_scanned, scan.candidates_scanned);
+    // Request-shaped ranges only (cluster index + prefixes/blocks + Sq8
+    // meta). Rerank rows are diagnostics; their cost rides the priced CPU
+    // watermark.
+    stats.add_planned_read_ranges(scan.ranges_requested);
+    stats.add_vector_rows_reranked(scan.rows_reranked);
+    stats.add_kernel_cpu_ns(scan.kernel_cpu_ns);
+}
+
 fn gate_fine_candidates_by_fragment(
     candidates: Vec<(usize, u32, f32, Option<u32>, u64)>,
     selected: &HashSet<u32>,
@@ -2728,12 +2749,13 @@ impl SupertableReader {
         for (si, scan) in scans {
             let entry = &superfiles[si];
             let reader = readers[si].as_ref();
-            // The scan wave above already ran; fold each superfile's scan
-            // kernel time in here, on the calling thread, now that the
-            // concurrent block has been collected.
-            if let Some(stats) = &self.op_stats {
-                stats.add_kernel_cpu_ns(scan.kernel_cpu_ns);
-            }
+            // The scan wave above already ran; fold each superfile's work
+            // in here, on the calling thread, now that the concurrent block
+            // has been collected. This folded only the CPU leg and dropped
+            // the other four, so the cells, candidates and cluster-index /
+            // block ranges every probed cluster requested went unpriced on
+            // this path while the stamped one counted them.
+            fold_scan_outcome(&self.op_stats, &scan);
             // Cold cells rerank in-scan; take their exact hits directly.
             if !scan.hits.is_empty() {
                 let mut tagged = dispatch::tag_hits(entry, scan.hits);
@@ -3745,16 +3767,7 @@ impl SupertableReader {
                             )
                             .await
                             .map_err(vector_read_query_error)?;
-                        if let Some(stats) = &op_stats {
-                            stats.add_vector_scan(scan.cells_scanned, scan.candidates_scanned);
-                            // Request-shaped ranges only (cluster index +
-                            // prefixes/blocks + Sq8 meta). Rerank rows are
-                            // diagnostics; their cost rides the priced
-                            // CPU watermark.
-                            stats.add_planned_read_ranges(scan.ranges_requested);
-                            stats.add_vector_rows_reranked(scan.rows_reranked);
-                            stats.add_kernel_cpu_ns(scan.kernel_cpu_ns);
-                        }
+                        fold_scan_outcome(&op_stats, &scan);
                         max_replica_overhead
                             .fetch_max(replica_overhead as u64, atomic::Ordering::Relaxed);
                         if !scan.candidates.is_empty() {

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2978,31 +2978,36 @@ impl SupertableReader {
                 .collect();
             // Round 0: the pre-#515 write-window slice plus the grid's
             // must-include picks, exactly scored.
-            let admit_ranking = estimate_admit_ranking(
-                &superfiles,
-                column,
-                query.len(),
-                metric,
-                &admit_q,
-                allow_ref,
-                superseded,
-            )?;
+            let admit_ranking = op_stats::timed_kernel(&self.op_stats, || {
+                estimate_admit_ranking(
+                    &superfiles,
+                    column,
+                    query.len(),
+                    metric,
+                    &admit_q,
+                    allow_ref,
+                    superseded,
+                )
+            })?;
             let mut admitted: HashSet<u32> = admit_ranking
                 .iter()
                 .take(admit_shortlist_window(admit_ranking.len()))
                 .map(|(cell, _)| *cell)
                 .collect();
             admitted.extend(must_include.iter().copied());
-            let (mut candidates, deferred) = score_fine_candidates(
-                &superfiles,
-                column,
-                query,
-                metric,
-                Some(&admitted),
-                true,
-                allow_ref,
-                superseded,
-            )?;
+            let (candidates, deferred) = op_stats::timed_kernel(&self.op_stats, || {
+                score_fine_candidates(
+                    &superfiles,
+                    column,
+                    query,
+                    metric,
+                    Some(&admitted),
+                    true,
+                    allow_ref,
+                    superseded,
+                )
+            })?;
+            let mut candidates = candidates;
             if !deferred.is_empty() {
                 self.rescore_deferred_cells(
                     &superfiles,
@@ -3025,7 +3030,9 @@ impl SupertableReader {
             let law_default = !filtered && options.nprobe.is_none() && law_width.is_some();
             if law_default {
                 loop {
-                    let fine_ranked_now = cells_ranked_by_fine_score(&candidates);
+                    let fine_ranked_now = op_stats::timed_kernel(&self.op_stats, || {
+                        cells_ranked_by_fine_score(&candidates)
+                    });
                     let Some(&(_, best_exact)) = fine_ranked_now.first() else {
                         break;
                     };
@@ -3043,16 +3050,20 @@ impl SupertableReader {
                     }
                     let delta: HashSet<u32> = round.into_iter().collect();
                     admitted.extend(delta.iter().copied());
-                    let (mut delta_candidates, delta_deferred) = score_fine_candidates(
-                        &superfiles,
-                        column,
-                        query,
-                        metric,
-                        Some(&delta),
-                        false,
-                        allow_ref,
-                        superseded,
-                    )?;
+                    let (delta_candidates, delta_deferred) =
+                        op_stats::timed_kernel(&self.op_stats, || {
+                            score_fine_candidates(
+                                &superfiles,
+                                column,
+                                query,
+                                metric,
+                                Some(&delta),
+                                false,
+                                allow_ref,
+                                superseded,
+                            )
+                        })?;
+                    let mut delta_candidates = delta_candidates;
                     if !delta_deferred.is_empty() {
                         self.rescore_deferred_cells(
                             &superfiles,
@@ -3077,7 +3088,9 @@ impl SupertableReader {
                 .as_ref()
                 .expect("ranked cell ids exist with scored ranking");
             if hidden_vector_index {
-                let fine_ranked = cells_ranked_by_fine_score(&candidates);
+                let fine_ranked = op_stats::timed_kernel(&self.op_stats, || {
+                    cells_ranked_by_fine_score(&candidates)
+                });
                 #[cfg(feature = "test-helpers")]
                 admit_trace::record_fine(fine_ranked.clone());
                 // Default path: fine-first p=1, the same selection the user
@@ -3173,7 +3186,9 @@ impl SupertableReader {
             } else {
                 // Fine-first p=1 over all scored fines. Explicit nprobe /
                 // filtered search keep the grid/fine union.
-                let fine_ranked = cells_ranked_by_fine_score(&candidates);
+                let fine_ranked = op_stats::timed_kernel(&self.op_stats, || {
+                    cells_ranked_by_fine_score(&candidates)
+                });
                 let default_p1 = !filtered && options.nprobe.is_none() && cutoff == 1;
                 let mut selected_cells: Vec<u32> = if default_p1 && !fine_ranked.is_empty() {
                     fine_first_cell_selection(&fine_ranked, ranked.first().copied())
@@ -3219,16 +3234,19 @@ impl SupertableReader {
             // (legacy flat path, no prefilter). Stripped summaries defer to
             // the exact rescore — untagged legacy tables have no per-cell
             // gating to absorb estimate noise.
-            let (mut candidates, deferred) = score_fine_candidates(
-                &superfiles,
-                column,
-                query,
-                metric,
-                None,
-                true,
-                allow_ref,
-                superseded,
-            )?;
+            let (candidates, deferred) = op_stats::timed_kernel(&self.op_stats, || {
+                score_fine_candidates(
+                    &superfiles,
+                    column,
+                    query,
+                    metric,
+                    None,
+                    true,
+                    allow_ref,
+                    superseded,
+                )
+            })?;
+            let mut candidates = candidates;
             if !deferred.is_empty() {
                 self.rescore_deferred_cells(
                     &superfiles,

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -108,7 +108,7 @@ use crate::{
             distance::{Metric, distance, normalize, relative_score_window},
             hnsw::{self, HnswParams, Sq16Scorer, encode_hnsw},
             layout::VectorLayout,
-            reader::{ScanCandidate, ScanOutcome},
+            reader::{ProbeTally, ScanCandidate, ScanOutcome},
         },
     },
     supertable::{
@@ -245,6 +245,28 @@ const FILTERED_HIDDEN_CELL_NPROBE: usize = 256;
 /// is in-cell loss, recovered by probing deeper, not wider.
 const FILTERED_HIDDEN_FINE_NPROBE: usize = 16;
 
+/// Fold one probe's work tallies into the op's collector.
+///
+/// Three fan-out sites produce the same five tallies — the stamped scan
+/// (as a [`ScanOutcome`], via [`ScanOutcome::work`]), the filtered scan
+/// (as a [`ProbeTally`] directly), and the global-fine scan. All three
+/// must price the same field set; the global-fine path once folded only
+/// the CPU leg, which left its cells, candidates, cluster-index/block
+/// ranges and rerank rows unpriced while the stamped path counted them.
+/// One function, so a sixth tally cannot be wired up at only one site.
+fn fold_probe_work(op_stats: &Option<Arc<OpStatsCollector>>, work: &ProbeTally) {
+    let Some(stats) = op_stats else {
+        return;
+    };
+    stats.add_vector_scan(work.cells_scanned, work.candidates_scanned);
+    // Request-shaped ranges only (cluster index + prefixes/blocks + Sq8
+    // meta). Rerank rows are diagnostics; their cost rides the priced CPU
+    // watermark.
+    stats.add_planned_read_ranges(work.ranges_requested);
+    stats.add_vector_rows_reranked(work.rows_reranked);
+    stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
+}
+
 /// Build the fine-cluster probe set, then refill globally (best score first)
 /// toward `gated_target` postings. Candidates without a cell go to `scored`
 /// for the flat (non-cell) path.
@@ -265,27 +287,6 @@ const FILTERED_HIDDEN_FINE_NPROBE: usize = 16;
 ///   fragment, so each fragment of a selected cell is probed (accepted read
 ///   amplification), and a small fragment is not crowded out by a larger
 ///   sibling in the same cell.
-/// Fold one superfile scan's work into the op's collector.
-///
-/// Both vector fan-outs produce a [`ScanOutcome`] and both must report the
-/// same five values. The global-fine path once folded only the CPU leg,
-/// which left its cells, candidates, cluster-index/block ranges and rerank
-/// rows unpriced while the stamped path counted them. One function, so a
-/// sixth field cannot be added to the struct and wired up at only one of
-/// the two sites.
-fn fold_scan_outcome(op_stats: &Option<Arc<OpStatsCollector>>, scan: &ScanOutcome) {
-    let Some(stats) = op_stats else {
-        return;
-    };
-    stats.add_vector_scan(scan.cells_scanned, scan.candidates_scanned);
-    // Request-shaped ranges only (cluster index + prefixes/blocks + Sq8
-    // meta). Rerank rows are diagnostics; their cost rides the priced CPU
-    // watermark.
-    stats.add_planned_read_ranges(scan.ranges_requested);
-    stats.add_vector_rows_reranked(scan.rows_reranked);
-    stats.add_kernel_cpu_ns(scan.kernel_cpu_ns);
-}
-
 fn gate_fine_candidates_by_fragment(
     candidates: Vec<(usize, u32, f32, Option<u32>, u64)>,
     selected: &HashSet<u32>,
@@ -2751,11 +2752,10 @@ impl SupertableReader {
             let reader = readers[si].as_ref();
             // The scan wave above already ran; fold each superfile's work
             // in here, on the calling thread, now that the concurrent block
-            // has been collected. This folded only the CPU leg and dropped
-            // the other four, so the cells, candidates and cluster-index /
-            // block ranges every probed cluster requested went unpriced on
-            // this path while the stamped one counted them.
-            fold_scan_outcome(&self.op_stats, &scan);
+            // has been collected. Note this whole path sits behind
+            // `vector.ivf_router = centroid_graph` (experimental, off by
+            // default) and is not exercised by the test suite.
+            fold_probe_work(&self.op_stats, &scan.work());
             // Cold cells rerank in-scan; take their exact hits directly.
             if !scan.hits.is_empty() {
                 let mut tagged = dispatch::tag_hits(entry, scan.hits);
@@ -2775,6 +2775,15 @@ impl SupertableReader {
             let mut by_seg: HashMap<usize, Vec<ScanCandidate>> = HashMap::new();
             for (si, c) in winners {
                 by_seg.entry(si).or_default().push(c);
+            }
+            if let Some(stats) = &self.op_stats {
+                // Actual winner rows, folded once for the whole phase-C
+                // rerank. The scan-time tallies carry only the cold arm's
+                // immediate reranks; on this deferred design the phase-C
+                // winners are the dominant rerank leg, and the stamped
+                // fan-out already counts its equivalent.
+                let rows: u64 = by_seg.values().map(|sel| sel.len() as u64).sum();
+                stats.add_vector_rows_reranked(rows);
             }
             for (si, selected) in by_seg {
                 let entry = &superfiles[si];
@@ -3767,7 +3776,7 @@ impl SupertableReader {
                             )
                             .await
                             .map_err(vector_read_query_error)?;
-                        fold_scan_outcome(&op_stats, &scan);
+                        fold_probe_work(&op_stats, &scan.work());
                         max_replica_overhead
                             .fetch_max(replica_overhead as u64, atomic::Ordering::Relaxed);
                         if !scan.candidates.is_empty() {
@@ -3784,17 +3793,7 @@ impl SupertableReader {
                             )
                             .await
                             .map_err(vector_read_query_error)?;
-                        if let Some(stats) = &op_stats {
-                            stats.add_vector_scan(tally.cells_scanned, tally.candidates_scanned);
-                            // Request-shaped ranges only — rerank rows are
-                            // diagnostics; their cost rides the priced CPU
-                            // watermark (survivor fetches coalesce into a
-                            // handful of real requests, so counting one
-                            // range per row would not be request-shaped).
-                            stats.add_planned_read_ranges(tally.ranges_requested);
-                            stats.add_vector_rows_reranked(tally.rows_reranked);
-                            stats.add_kernel_cpu_ns(tally.kernel_cpu_ns);
-                        }
+                        fold_probe_work(&op_stats, &tally);
                         hits
                     };
                     let mut tagged = dispatch::tag_hits(&entry, hits);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2816,8 +2816,11 @@ impl SupertableReader {
         // their dead on-disk blocks are never selected or fetched.
         let empty_superseded = BTreeMap::new();
         let superseded = manifest.get_superseded_cells().unwrap_or(&empty_superseded);
-        let (postings_by_cell, any_tagged) =
-            postings_by_cell_from_summaries(&superfiles, column, allow_ref, superseded);
+        // A pass over every superfile's per-cell summaries — the routing
+        // input, and pure CPU this query asked for.
+        let (postings_by_cell, any_tagged) = op_stats::timed_kernel(&self.op_stats, || {
+            postings_by_cell_from_summaries(&superfiles, column, allow_ref, superseded)
+        });
 
         let mut gated = Vec::new();
         let mut scored = Vec::new();

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -406,8 +406,13 @@ async fn do_apply(
     let scalar_with_id = prepend_id_column(&scalar_no_id, &flat_ids, &inner.options)?;
 
     // ---- Step 4: Build the superfile bytes ----
-    // The replacement superfile's build is the update's own CPU, measured
-    // on this thread (the build below is synchronous).
+    // The replacement superfile's build is the update's own CPU. It is
+    // synchronous, and it runs on whichever thread drives this future:
+    // `update` reaches here through `bridge_on_runtime`, so that is the
+    // caller's own thread inside `block_on` — or, with an ambient
+    // multi-thread runtime, a worker already inside `block_in_place`.
+    // Either way no runtime worker is silently starved behind it, and this
+    // thread's clock is the build's on-CPU time.
     let bytes = timed_kernel(&op_stats, || {
         let mut builder = SuperfileBuilder::new(inner.options.builder_options()).map_err(|e| {
             AppendPhaseError::SuperfileBuild {

--- a/src/supertable/wal/pipeline.rs
+++ b/src/supertable/wal/pipeline.rs
@@ -66,6 +66,7 @@ use uuid::Uuid;
 
 use crate::{
     runtime_bridge::bridge_sync_to_async,
+    runtime_metrics::op_stats::{OpStatsCollector, timed_kernel},
     storage::StorageError,
     superfile::{ReadError, SuperfileReader, builder::SuperfileBuilder},
     supertable::{
@@ -242,11 +243,16 @@ impl AppendPhaseError {
 /// end state because every step is idempotent on replay (steps
 /// 1-4) or content-addressed (step 5's manifest writes go
 /// through the normal CAS).
-pub async fn run_append_phase(
+pub(crate) async fn run_append_phase(
     supertable: &Supertable,
     wal_store: &WalStore,
     wal_doc: &WalStateDoc,
     wal_etag: &Etag,
+    // The mutation's per-op collector, passed explicitly: this runs on the
+    // runtime's thread, so the caller's thread-local scope cannot reach it.
+    // The recovery sweep passes None — a recovered WAL is maintenance, not
+    // any live op's work.
+    op_stats: Option<Arc<OpStatsCollector>>,
 ) -> Result<(AppendPhaseOutcome, WalStateDoc, Etag), AppendPhaseError> {
     // Pre-condition: only UPDATE has an append phase.
     if wal_doc.op_kind != OpKind::Update {
@@ -286,6 +292,7 @@ pub async fn run_append_phase(
         wal_doc,
         wal_etag,
         preallocated_superfile_id,
+        op_stats,
     )
     .await?;
     Ok((AppendPhaseOutcome::Applied, new_wal, new_etag))
@@ -329,6 +336,7 @@ async fn do_apply(
     wal_doc: &WalStateDoc,
     wal_etag: &Etag,
     preallocated_superfile_id: Uuid,
+    op_stats: Option<Arc<OpStatsCollector>>,
 ) -> Result<(WalStateDoc, Etag), AppendPhaseError> {
     let inner = supertable.inner();
     let storage = inner
@@ -398,7 +406,9 @@ async fn do_apply(
     let scalar_with_id = prepend_id_column(&scalar_no_id, &flat_ids, &inner.options)?;
 
     // ---- Step 4: Build the superfile bytes ----
-    let bytes = {
+    // The replacement superfile's build is the update's own CPU, measured
+    // on this thread (the build below is synchronous).
+    let bytes = timed_kernel(&op_stats, || {
         let mut builder = SuperfileBuilder::new(inner.options.builder_options()).map_err(|e| {
             AppendPhaseError::SuperfileBuild {
                 message: format!("builder construction: {e}"),
@@ -414,8 +424,8 @@ async fn do_apply(
             .map_err(|e| AppendPhaseError::SuperfileBuild {
                 message: format!("finish: {e}"),
             })?;
-        Bytes::from(raw)
-    };
+        Ok::<_, AppendPhaseError>(Bytes::from(raw))
+    })?;
 
     // ---- Step 5: Per-superfile summaries + SuperfileEntry ----
     //
@@ -1394,7 +1404,7 @@ mod tests {
     async fn rejects_delete_wal_with_typed_error() {
         let (_dir, st, ws, mut wal, etag) = fixture().await;
         wal.op_kind = OpKind::Delete;
-        let err = run_append_phase(&st, &ws, &wal, &etag)
+        let err = run_append_phase(&st, &ws, &wal, &etag, None)
             .await
             .expect_err("must error");
         assert!(matches!(err, AppendPhaseError::NotAnUpdateWal), "{err:?}");
@@ -1404,7 +1414,7 @@ mod tests {
     async fn rejects_wal_missing_preallocated_superfile_id() {
         let (_dir, st, ws, mut wal, etag) = fixture().await;
         wal.preallocated_superfile_id = None;
-        let err = run_append_phase(&st, &ws, &wal, &etag)
+        let err = run_append_phase(&st, &ws, &wal, &etag, None)
             .await
             .expect_err("must error");
         assert!(
@@ -1538,7 +1548,7 @@ mod tests {
             fixture_with_ipc_payload(&["alpha bravo", "charlie delta"], 7, 5_000).await;
         let pre_uuid = wal.preallocated_superfile_id.expect("set in fixture");
 
-        let (outcome, new_wal, new_etag) = run_append_phase(&st, &ws, &wal, &etag)
+        let (outcome, new_wal, new_etag) = run_append_phase(&st, &ws, &wal, &etag, None)
             .await
             .expect("append phase");
 
@@ -1571,14 +1581,14 @@ mod tests {
             fixture_with_ipc_payload(&["alpha", "beta"], 11, 6_000).await;
 
         let (first_outcome, after_first, etag_after_first) =
-            run_append_phase(&st, &ws, &wal, &etag)
+            run_append_phase(&st, &ws, &wal, &etag, None)
                 .await
                 .expect("first");
         assert_eq!(first_outcome, AppendPhaseOutcome::Applied);
         assert_eq!(after_first.state, WalState::Appended);
 
         let (second_outcome, after_second, etag_after_second) =
-            run_append_phase(&st, &ws, &after_first, &etag_after_first)
+            run_append_phase(&st, &ws, &after_first, &etag_after_first, None)
                 .await
                 .expect("second");
         // The second run is a no-op on the state doc (WAL was
@@ -1605,8 +1615,9 @@ mod tests {
         // injecting a fault in persist_commit; using a
         // successful run + a manually-reset WAL is equivalent
         // and easier to reason about.)
-        let (_outcome, _new_wal, _new_etag) =
-            run_append_phase(&st, &ws, &wal, &etag).await.expect("seed");
+        let (_outcome, _new_wal, _new_etag) = run_append_phase(&st, &ws, &wal, &etag, None)
+            .await
+            .expect("seed");
 
         // Manually reset the WAL state to Intent — simulating
         // a crash that landed the manifest swap but lost the
@@ -1628,7 +1639,7 @@ mod tests {
         // superfile, takes the AlreadyApplied path, advances
         // the WAL state to Appended.
         let (outcome, recovered, recovered_etag) =
-            run_append_phase(&st, &ws, &intent_wal, &intent_etag)
+            run_append_phase(&st, &ws, &intent_wal, &intent_etag, None)
                 .await
                 .expect("recovered");
         assert_eq!(outcome, AppendPhaseOutcome::AlreadyApplied);
@@ -1651,7 +1662,7 @@ mod tests {
 
         // First run: drive through the orchestrator, capture
         // the superfile's bytes from storage.
-        let (_o, _new_wal, _new_etag) = run_append_phase(&st1, &ws1, &wal, &etag1)
+        let (_o, _new_wal, _new_etag) = run_append_phase(&st1, &ws1, &wal, &etag1, None)
             .await
             .expect("first run");
         let manifest1 = st1.inner().manifest.load_full();
@@ -1673,7 +1684,7 @@ mod tests {
         // helper, so the entire WAL state doc matches.
         let (_dir2, st2, ws2, wal2, etag2) =
             fixture_with_ipc_payload(&["determinism check"], 17, 8_000).await;
-        run_append_phase(&st2, &ws2, &wal2, &etag2)
+        run_append_phase(&st2, &ws2, &wal2, &etag2, None)
             .await
             .expect("second run");
         let storage2 = st2.inner().options.storage.as_ref().expect("storage");
@@ -1710,7 +1721,7 @@ mod tests {
             .await
             .expect("re-cas with bad hash");
 
-        let err = run_append_phase(&st, &ws, &wal, &bad_etag)
+        let err = run_append_phase(&st, &ws, &wal, &bad_etag, None)
             .await
             .expect_err("must error on hash mismatch");
         assert!(
@@ -1761,7 +1772,7 @@ mod tests {
             }],
         };
         let etag = ws.create(&wal_doc).await.expect("create");
-        let err = run_append_phase(&st, &ws, &wal_doc, &etag)
+        let err = run_append_phase(&st, &ws, &wal_doc, &etag, None)
             .await
             .expect_err("must error without storage");
         assert!(
@@ -1778,7 +1789,7 @@ mod tests {
             .update_with_etag(wal.wal_id, &etag, &wal)
             .await
             .expect("re-cas");
-        let err = run_append_phase(&st, &ws, &wal, &bad_etag)
+        let err = run_append_phase(&st, &ws, &wal, &bad_etag, None)
             .await
             .expect_err("must error");
         assert!(
@@ -1806,7 +1817,7 @@ mod tests {
             .update_with_etag(wal.wal_id, &etag, &wal)
             .await
             .expect("re-cas");
-        let err = run_append_phase(&st, &ws, &wal, &bad_etag)
+        let err = run_append_phase(&st, &ws, &wal, &bad_etag, None)
             .await
             .expect_err("must error");
         assert!(
@@ -1861,7 +1872,7 @@ mod tests {
             }],
         };
         let etag = ws.create(&wal_doc).await.expect("create");
-        let err = run_append_phase(&st, &ws, &wal_doc, &etag)
+        let err = run_append_phase(&st, &ws, &wal_doc, &etag, None)
             .await
             .expect_err("must error on bad ipc");
         assert!(matches!(err, AppendPhaseError::IpcDecode { .. }), "{err:?}");
@@ -2100,7 +2111,7 @@ mod tests {
     ) -> (TempDir, Supertable, WalStore, Uuid, i128, i128) {
         let (dir, st, ws, wal, etag) = fixture_with_ipc_payload(titles, 101, minted_first).await;
         let pre_uuid = wal.preallocated_superfile_id.expect("set");
-        run_append_phase(&st, &ws, &wal, &etag)
+        run_append_phase(&st, &ws, &wal, &etag, None)
             .await
             .expect("append phase");
         let n = titles.len() as i128;

--- a/src/supertable/wal/recovery.rs
+++ b/src/supertable/wal/recovery.rs
@@ -275,7 +275,9 @@ async fn drive_to_complete(
 ) -> Result<OneWalOutcome, SweepStep> {
     let (post_doc, post_etag, append_ran) = match (doc.op_kind, doc.state) {
         (OpKind::Update, WalState::Intent) => {
-            match pipeline::run_append_phase(supertable, wal_store, &doc, &etag).await {
+            // Recovery is maintenance — a recovered WAL's build is not any
+            // live op's work, so no collector.
+            match pipeline::run_append_phase(supertable, wal_store, &doc, &etag, None).await {
                 Ok((_, d, e)) => (d, e, true),
                 Err(AppendPhaseError::WalStore(WalStoreError::CasFailed { .. })) => {
                     return Err(SweepStep::CasLost);

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -2934,9 +2934,14 @@ fn commit_target_object_bytes() -> u64 {
 /// pricing off them would make the same append cost different amounts on
 /// different hosts. See [`buffered_payload_bytes`].
 fn planned_data_objects(payload_bytes: u64) -> u64 {
+    if payload_bytes == 0 {
+        return 0;
+    }
     let target = commit_target_object_bytes();
     if target == 0 {
-        0
+        // A zero target is a misconfiguration, not a license to write for
+        // free: any committed payload occupies at least one object.
+        1
     } else {
         payload_bytes.div_ceil(target)
     }

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -116,7 +116,10 @@ use crate::{
     config::{self, CentroidAlignment, DrainConsolidate, ThreadCount},
     memory::{ConnectionMemoryBudget, Reservation},
     runtime_bridge::{bridge_on_runtime, run_on_pool},
-    runtime_metrics::op_stats::{self, OpStatsCollector},
+    runtime_metrics::{
+        ingest::visible_array_bytes,
+        op_stats::{self, OpStatsCollector},
+    },
     storage::{StorageError, StorageProvider},
     superfile::{
         BuildError as SuperfileBuildError, ReadError, SuperfileReader,
@@ -2879,13 +2882,25 @@ fn ingested_byte_legs(
     vector_elems: usize,
     options: &SupertableOptions,
 ) -> (u64, u64, u64) {
-    let scalar_bytes = scalar.get_array_memory_size() as u64;
+    // Visible bytes, not buffer capacity. `get_array_memory_size` sums
+    // `Buffer::capacity()` — the whole shared allocation — and is blind to
+    // an array's offset and length, so a zero-copy slice reports its
+    // parent's footprint. Chunked ingest (read one large batch, append it
+    // as N slices) is the ordinary pattern arrow-rs makes cheap precisely
+    // because slices share buffers, and it would bill N times the whole
+    // batch. Capacity is still the right answer for the held-memory
+    // tallies and the build-scratch reserve, which is why those keep it.
+    let scalar_bytes = scalar
+        .columns()
+        .iter()
+        .map(|c| visible_array_bytes(c.as_ref()))
+        .sum::<u64>();
     let vector_bytes = (vector_elems * mem::size_of::<f32>()) as u64;
     let fts_bytes = options
         .fts_columns
         .iter()
         .filter_map(|fc| scalar.schema().index_of(&fc.column).ok())
-        .map(|idx| scalar.column(idx).get_array_memory_size() as u64)
+        .map(|idx| visible_array_bytes(scalar.column(idx).as_ref()))
         .sum::<u64>();
     (scalar_bytes, vector_bytes, fts_bytes)
 }
@@ -2925,7 +2940,11 @@ fn buffered_payload_bytes(buffer: &[BufferedBatch]) -> u64 {
     buffer
         .iter()
         .map(|b| {
-            b.scalar.get_array_memory_size() as u64
+            b.scalar
+                .columns()
+                .iter()
+                .map(|c| visible_array_bytes(c.as_ref()))
+                .sum::<u64>()
                 + b.vectors
                     .iter()
                     .map(|v| (v.len() * mem::size_of::<f32>()) as u64)

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1539,6 +1539,13 @@ impl SupertableWriter {
         if let Some(stats) = &self.op_stats {
             stats.add_ingested_write(u64::from(entry.new_row_count), 0, 0, 0);
             stats.add_rows_tombstoned(n_tombstoned as u64);
+            // An update commits a manifest (replacement superfile +
+            // manifest json + pointer); a pure delete does not — its
+            // tombstone CAS-writes stay recorded-only, see
+            // `add_planned_commit_requests`.
+            if entry.new_row_count > 0 {
+                stats.add_planned_commit_requests(UPDATE_PLANNED_DATA_OBJECTS);
+            }
         }
         Ok(MutationStats {
             wal_id: entry.wal_id,
@@ -1823,7 +1830,7 @@ impl SupertableWriter {
                 (&self.op_stats, output_stats)
             {
                 stats.add_commit_outputs(superfiles, bytes, fts_terms);
-                stats.add_planned_write_requests(bytes, commit_target_object_bytes());
+                stats.add_planned_commit_requests(planned_data_objects(bytes));
             }
             if crate::storage::io_counters::timeline_enabled() {
                 eprintln!(
@@ -1965,7 +1972,7 @@ impl SupertableWriter {
             (&self.op_stats, output_stats)
         {
             stats.add_commit_outputs(n_superfiles, bytes, fts_terms);
-            stats.add_planned_write_requests(bytes, commit_target_object_bytes());
+            stats.add_planned_commit_requests(planned_data_objects(bytes));
         }
         if self.inner.options.storage.is_some() {
             schedule_background_storage_reclaim(Arc::clone(&self.inner));
@@ -2786,6 +2793,21 @@ fn commit_target_object_bytes() -> u64 {
         .target_superfile_size_mb
         .saturating_mul(1024 * 1024)
 }
+
+/// Data objects a buffered append's plan implies: the objects its sealed
+/// bytes occupy at the target object size.
+fn planned_data_objects(sealed_bytes: u64) -> u64 {
+    let target = commit_target_object_bytes();
+    if target == 0 {
+        0
+    } else {
+        sealed_bytes.div_ceil(target)
+    }
+}
+
+/// Data objects an update's plan implies: its replacement rows land in
+/// the WAL's single preallocated superfile, always exactly one.
+const UPDATE_PLANNED_DATA_OBJECTS: u64 = 1;
 
 fn commit_output_stats(batch: &SuperfilePublishBatch) -> (u64, u64, u64) {
     let superfiles = batch.new_entries.len() as u64;

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -116,6 +116,7 @@ use crate::{
     config::{self, CentroidAlignment, DrainConsolidate, ThreadCount},
     memory::{ConnectionMemoryBudget, Reservation},
     runtime_bridge::{bridge_on_runtime, run_on_pool},
+    runtime_metrics::op_stats::{self, OpStatsCollector},
     storage::{StorageError, StorageProvider},
     superfile::{
         BuildError as SuperfileBuildError, ReadError, SuperfileReader,
@@ -379,6 +380,15 @@ pub struct SupertableWriter {
     /// `wal_id`; `commit()` builds the WAL state doc and drives
     /// the tombstone phase.
     pending_deletes: Vec<PendingDeleteEntry>,
+    /// Per-op work collector, captured at construction — the writer is
+    /// minted on the caller's thread inside its [`with_op_stats`]
+    /// scope (the same pickup contract as the reader), and the write
+    /// counters flush through this `Arc` from wherever the commit
+    /// runs. `None` outside a scope: every flush is one `Option`
+    /// check.
+    ///
+    /// [`with_op_stats`]: crate::runtime_metrics::op_stats::with_op_stats
+    op_stats: Option<Arc<OpStatsCollector>>,
 }
 
 /// One buffered update. Resources here are all reserved at the
@@ -915,6 +925,7 @@ impl Supertable {
                 buffer_fts_bytes: 0,
                 pending_updates: Vec::new(),
                 pending_deletes: Vec::new(),
+                op_stats: op_stats::current(),
             }),
             Err(_) => Err(BuildError::SupertableInUse),
         }
@@ -1078,6 +1089,19 @@ impl SupertableWriter {
         self.buffer_scalar_bytes += scalar_bytes;
         self.buffer_vector_bytes += vector_bytes;
         self.buffer_fts_bytes += fts_bytes;
+
+        // Per-op work stats: the write's input shape, counted here from
+        // the caller's batch — before any shard split or commit retry —
+        // so the counters are deterministic by construction (see the
+        // op_stats module's write-side determinism note).
+        if let Some(stats) = &self.op_stats {
+            stats.add_ingested_write(
+                n_rows as u64,
+                scalar_bytes as u64,
+                vector_bytes as u64,
+                fts_bytes as u64,
+            );
+        }
 
         // Auto-flush on held bytes (scalar + vector); the FTS weighting is a
         // reserve-time concern, not held memory.
@@ -1508,6 +1532,14 @@ impl SupertableWriter {
             Ok::<_, MutationError>((n_t, n_nf))
         };
         let (n_tombstoned, n_not_found) = bridge_on_runtime(drive, &self.inner.query_runtime())?;
+        // Per-op work stats: the update's replacement rows are appended
+        // through the WAL pipeline (not the buffered append above), so
+        // they count here — after the drive returns Ok — alongside the
+        // rows its tombstone phase retired.
+        if let Some(stats) = &self.op_stats {
+            stats.add_ingested_write(u64::from(entry.new_row_count), 0, 0, 0);
+            stats.add_rows_tombstoned(n_tombstoned as u64);
+        }
         Ok(MutationStats {
             wal_id: entry.wal_id,
             matched: entry.target_ids.len(),
@@ -1631,6 +1663,11 @@ impl SupertableWriter {
             Ok::<_, MutationError>((n_t, n_nf))
         };
         let (n_tombstoned, n_not_found) = bridge_on_runtime(drive, &self.inner.query_runtime())?;
+        // Per-op work stats: rows this delete retired, after the drive
+        // returns Ok.
+        if let Some(stats) = &self.op_stats {
+            stats.add_rows_tombstoned(n_tombstoned as u64);
+        }
         Ok(MutationStats {
             wal_id: entry.wal_id,
             matched: entry.target_ids.len(),
@@ -1770,11 +1807,23 @@ impl SupertableWriter {
                 .iter()
                 .map(|(_, bytes)| bytes.len())
                 .sum();
+            // Computed before the batch moves into the publish future;
+            // flushed only after Ok below, so a failed or retried commit
+            // never counts.
+            let output_stats = self
+                .op_stats
+                .as_ref()
+                .map(|_| commit_output_stats(&user_batch));
             let publish_t0 = time::Instant::now();
             bridge_on_runtime(
                 persist_superfile_publish_batch_async(&self.inner, user_batch, list_metadata),
                 &self.inner.query_runtime(),
             )?;
+            if let (Some(stats), Some((superfiles, bytes, fts_terms))) =
+                (&self.op_stats, output_stats)
+            {
+                stats.add_commit_outputs(superfiles, bytes, fts_terms);
+            }
             if crate::storage::io_counters::timeline_enabled() {
                 eprintln!(
                     "[supertable commit] build {:.1}ms ({:.1} MiB output) + prepare {:.1}ms + \
@@ -1902,10 +1951,20 @@ impl SupertableWriter {
         })?;
         let superfiles = outputs.len();
         let user_batch = prepare_user_superfile_batch(&self.inner, outputs, cell_hints)?;
+        // Same pre-move / post-Ok discipline as the vector arm above.
+        let output_stats = self
+            .op_stats
+            .as_ref()
+            .map(|_| commit_output_stats(&user_batch));
         bridge_on_runtime(
             persist_superfile_publish_batch_async(&user_inner, user_batch, list_metadata),
             &self.inner.query_runtime(),
         )?;
+        if let (Some(stats), Some((n_superfiles, bytes, fts_terms))) =
+            (&self.op_stats, output_stats)
+        {
+            stats.add_commit_outputs(n_superfiles, bytes, fts_terms);
+        }
         if self.inner.options.storage.is_some() {
             schedule_background_storage_reclaim(Arc::clone(&self.inner));
         }
@@ -2706,6 +2765,30 @@ fn collect_prepared_superfiles(
         pending_cache_inserts,
         pending_store_inserts,
     })
+}
+
+/// One committed publish batch's output shape for the per-op work stats:
+/// superfile count, sealed on-storage bytes (from each entry's own
+/// `SubsectionOffsets::total_size`, so the figure is identical across
+/// storage backends), and the distinct-FTS-term sum across the new
+/// entries. Callers compute this before the batch moves into the publish
+/// future and flush it only after the commit returns Ok, so a failed or
+/// retried publish never counts.
+fn commit_output_stats(batch: &SuperfilePublishBatch) -> (u64, u64, u64) {
+    let superfiles = batch.new_entries.len() as u64;
+    let bytes: u64 = batch
+        .new_entries
+        .iter()
+        .filter_map(|entry| entry.subsection_offsets.as_ref())
+        .map(|offsets| offsets.total_size)
+        .sum();
+    let fts_terms: u64 = batch
+        .new_entries
+        .iter()
+        .flat_map(|entry| entry.fts_summary.values())
+        .map(|agg| agg.n_terms_distinct)
+        .sum();
+    (superfiles, bytes, fts_terms)
 }
 
 fn apply_pending_store_inserts(inner: &SupertableInner, inserts: Vec<(SuperfileUri, Bytes)>) {

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1079,9 +1079,19 @@ impl SupertableWriter {
         // Arrow buffer allocations (rough but good enough); the vector payload is
         // its exact f32 size. The FTS text columns are a subset of the scalar
         // columns, summed separately only to weight the build-scratch reserve.
-        let (scalar_bytes_u64, vector_bytes_u64, fts_bytes_u64) =
-            ingested_byte_legs(&scalar, vectors.iter().map(|v| v.len()).sum(), options);
-        let scalar_bytes = scalar_bytes_u64 as usize;
+        //
+        // The priced legs measure `scalar_no_id` — the caller's own columns,
+        // without the engine-minted `_id`. `update` meters the same shape, so
+        // an update and an equivalent append report identical payload bytes
+        // instead of the update looking artificially cheaper.
+        let (scalar_bytes_u64, vector_bytes_u64, fts_bytes_u64) = ingested_byte_legs(
+            &scalar_no_id,
+            vectors.iter().map(|v| v.len()).sum(),
+            options,
+        );
+        // Buffer accounting is a different question — held memory — and the
+        // buffer owns `scalar`, ids included, so it measures that instead.
+        let scalar_bytes = scalar.get_array_memory_size();
         let vector_bytes = vector_bytes_u64 as usize;
         let fts_bytes = fts_bytes_u64 as usize;
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1823,6 +1823,7 @@ impl SupertableWriter {
                 (&self.op_stats, output_stats)
             {
                 stats.add_commit_outputs(superfiles, bytes, fts_terms);
+                stats.add_planned_write_requests(bytes, commit_target_object_bytes());
             }
             if crate::storage::io_counters::timeline_enabled() {
                 eprintln!(
@@ -1964,6 +1965,7 @@ impl SupertableWriter {
             (&self.op_stats, output_stats)
         {
             stats.add_commit_outputs(n_superfiles, bytes, fts_terms);
+            stats.add_planned_write_requests(bytes, commit_target_object_bytes());
         }
         if self.inner.options.storage.is_some() {
             schedule_background_storage_reclaim(Arc::clone(&self.inner));
@@ -2774,6 +2776,17 @@ fn collect_prepared_superfiles(
 /// entries. Callers compute this before the batch moves into the publish
 /// future and flush it only after the commit returns Ok, so a failed or
 /// retried publish never counts.
+/// The object size a table's data converges to — compaction's target, in
+/// bytes. Used to turn a commit's sealed bytes into the number of objects
+/// the data itself occupies, independent of how many shards this
+/// particular commit happened to split into.
+fn commit_target_object_bytes() -> u64 {
+    crate::config::global()
+        .compaction
+        .target_superfile_size_mb
+        .saturating_mul(1024 * 1024)
+}
+
 fn commit_output_stats(batch: &SuperfilePublishBatch) -> (u64, u64, u64) {
     let superfiles = batch.new_entries.len() as u64;
     let bytes: u64 = batch

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -371,7 +371,10 @@ pub struct SupertableWriter {
     /// Byte size of the FTS-indexed text columns within `buffer`. A
     /// subset of `buffer_scalar_bytes`, not extra held memory; tracked
     /// only to weight the build-scratch reserve, since the FTS index
-    /// structures built at commit scale with the text input.
+    /// structures built at commit scale with the text input. Measured as
+    /// visible (slice-aware) bytes — what the build will actually index —
+    /// unlike the two held-memory tallies above, which measure resident
+    /// allocation.
     buffer_fts_bytes: usize,
     /// Ingested work for the batches sitting in `buffer`, computed at
     /// `append` time from the caller's own batch and held here until the
@@ -2889,7 +2892,12 @@ fn ingested_byte_legs(
     // as N slices) is the ordinary pattern arrow-rs makes cheap precisely
     // because slices share buffers, and it would bill N times the whole
     // batch. Capacity is still the right answer for the held-memory
-    // tallies and the build-scratch reserve, which is why those keep it.
+    // tallies (`buffer_scalar_bytes`, `buffer_vector_bytes`), which
+    // measure resident allocation and keep `get_array_memory_size`. The
+    // FTS leg moves with the priced legs deliberately: it weights the
+    // build-scratch reserve, and the builder's scratch scales with the
+    // text it will actually index — a slice's visible rows — not with the
+    // parent allocation the slice shares.
     let scalar_bytes = scalar
         .columns()
         .iter()

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -88,7 +88,7 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use super::{
-    build::fanout_shards,
+    build::{fanout_shards, fanout_shards_metered},
     error::BuildError,
     handle::{GLOBAL_VECTOR_KMEANS_ITERS, GLOBAL_VECTOR_KMEANS_SEED, Supertable, SupertableInner},
     manifest::{
@@ -1500,6 +1500,7 @@ impl SupertableWriter {
         let wal_id = entry.wal_id;
         let ipc_bytes = entry.ipc_bytes.clone();
         let owner = self.inner.handle_id;
+        let drive_op_stats = self.op_stats.clone();
         let drive = async move {
             wal_store
                 .put_arrow(wal_id, ipc_bytes)
@@ -1509,7 +1510,14 @@ impl SupertableWriter {
                 .create(&wal_doc)
                 .await
                 .map_err(MutationError::WalStore)?;
-            let append = pipeline::run_append_phase(&supertable, &wal_store, &wal_doc, &etag).await;
+            let append = pipeline::run_append_phase(
+                &supertable,
+                &wal_store,
+                &wal_doc,
+                &etag,
+                drive_op_stats,
+            )
+            .await;
             let (_outcome, doc_after_append, etag_after_append) = match append {
                 Ok(appended) => appended,
                 Err(cause) => {
@@ -1824,7 +1832,7 @@ impl SupertableWriter {
                 .map(|vc| vc.metric)
                 .unwrap_or(Metric::L2Sq);
             let (outputs, cell_hints) =
-                commit_shards_via_drain(buffer, &self.inner, &pack_grid, metric)?;
+                commit_shards_via_drain(buffer, &self.inner, &pack_grid, metric, &self.op_stats)?;
             let build_elapsed = commit_t0.elapsed();
             let output_bytes: usize = outputs.iter().map(|output| output.bytes.len()).sum();
             let user_batch = prepare_user_superfile_batch(&self.inner, outputs, cell_hints)?;
@@ -1969,7 +1977,9 @@ impl SupertableWriter {
         // Phase B: user-only build + publish. No hidden incoming build/publish;
         // the hidden cell index is drained later straight from these user
         // superfiles, and pre-drain queries fall back to them.
-        let outputs = fanout_shards(&writer_pool, &shards, |slice| {
+        // The shard build is the append's own CPU — measured on the pool
+        // threads that run it, folded into the op's collector.
+        let outputs = fanout_shards_metered(&writer_pool, &self.op_stats, &shards, |slice| {
             build_one_shard_with_layout(
                 slice.as_slice(),
                 &user_options,
@@ -5570,6 +5580,7 @@ fn commit_shards_via_drain(
     inner: &SupertableInner,
     clusters: &ClusterCentroids,
     metric: Metric,
+    op_stats: &Option<Arc<OpStatsCollector>>,
 ) -> Result<(Vec<ShardOutput>, Vec<Option<u32>>), BuildError> {
     let stage_t0 = time::Instant::now();
     let vc = inner
@@ -5663,18 +5674,23 @@ fn commit_shards_via_drain(
         group_cells_by_packed_shard(assigned_cells, packed_cell_shard_count(&inner.options));
 
     let options = &inner.options;
-    let shard_outputs = fanout_shards(&inner.options.writer_pool, &packed_shards, |task| {
-        let (shard_id, cells) = task;
-        build_one_packed_shard_via_drain(
-            cells,
-            &source_scalar,
-            &vector_views,
-            &local_by_id,
-            options,
-            &vc,
-        )
-        .map(|output| output.map(|output| (*shard_id, output)))
-    })?;
+    let shard_outputs = fanout_shards_metered(
+        &inner.options.writer_pool,
+        op_stats,
+        &packed_shards,
+        |task| {
+            let (shard_id, cells) = task;
+            build_one_packed_shard_via_drain(
+                cells,
+                &source_scalar,
+                &vector_views,
+                &local_by_id,
+                options,
+                &vc,
+            )
+            .map(|output| output.map(|output| (*shard_id, output)))
+        },
+    )?;
     let fanout_elapsed = stage_t0
         .elapsed()
         .saturating_sub(flatten_elapsed)

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -373,8 +373,9 @@ pub struct SupertableWriter {
     /// only to weight the build-scratch reserve, since the FTS index
     /// structures built at commit scale with the text input. Measured as
     /// visible (slice-aware) bytes — what the build will actually index —
-    /// unlike the two held-memory tallies above, which measure resident
-    /// allocation.
+    /// unlike `buffer_scalar_bytes` above, which measures resident
+    /// allocation. (`buffer_vector_bytes` is the exact f32 payload on
+    /// either reading; slices share nothing wider than their rows.)
     buffer_fts_bytes: usize,
     /// Ingested work for the batches sitting in `buffer`, computed at
     /// `append` time from the caller's own batch and held here until the
@@ -2891,13 +2892,14 @@ fn ingested_byte_legs(
     // parent's footprint. Chunked ingest (read one large batch, append it
     // as N slices) is the ordinary pattern arrow-rs makes cheap precisely
     // because slices share buffers, and it would bill N times the whole
-    // batch. Capacity is still the right answer for the held-memory
-    // tallies (`buffer_scalar_bytes`, `buffer_vector_bytes`), which
-    // measure resident allocation and keep `get_array_memory_size`. The
-    // FTS leg moves with the priced legs deliberately: it weights the
-    // build-scratch reserve, and the builder's scratch scales with the
-    // text it will actually index — a slice's visible rows — not with the
-    // parent allocation the slice shares.
+    // batch. Capacity remains right for `buffer_scalar_bytes`, which
+    // measures resident allocation and keeps `get_array_memory_size`;
+    // `buffer_vector_bytes` was never capacity-based — it reuses this
+    // function's exact f32 payload (`elems * 4`). The FTS leg moves with
+    // the priced legs deliberately: it weights the build-scratch reserve,
+    // and the builder's scratch scales with the text it will actually
+    // index — a slice's visible rows — not with the parent allocation the
+    // slice shares.
     let scalar_bytes = scalar
         .columns()
         .iter()

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -370,6 +370,16 @@ pub struct SupertableWriter {
     /// only to weight the build-scratch reserve, since the FTS index
     /// structures built at commit scale with the text input.
     buffer_fts_bytes: usize,
+    /// Ingested work for the batches sitting in `buffer`, computed at
+    /// `append` time from the caller's own batch and held here until the
+    /// commit that publishes them returns `Ok`. Counting at append time is
+    /// what keeps the values invariant to the shard split and to OCC
+    /// retries; holding them until the publish succeeds is what keeps a
+    /// failed or abandoned commit from reporting rows nobody stored. Every
+    /// other write counter already follows this discipline — the update
+    /// path stashes on `PendingUpdateEntry`, the commit outputs and
+    /// `rows_tombstoned` flush after `Ok`.
+    pending_ingest: IngestTally,
     /// Pending update entries, in buffer order. Each is
     /// fully-resolved at `update()` call time (predicate
     /// captured, `_id` range minted, IPC sidecar bytes encoded);
@@ -436,6 +446,17 @@ impl fmt::Debug for SupertableWriter {
 struct BufferedBatch {
     scalar: RecordBatch,
     vectors: Vec<Arc<Float32Array>>,
+}
+
+/// Ingested work accumulated across the buffered appends of one commit.
+/// Input-shaped by construction, so it is the same at every writer-pool
+/// width; published into the collector only once the commit succeeds.
+#[derive(Default, Clone, Copy)]
+struct IngestTally {
+    rows: u64,
+    scalar_bytes: u64,
+    vector_bytes: u64,
+    fts_text_bytes: u64,
 }
 
 /// Zero-copy view of one vector column across the buffered batches:
@@ -929,6 +950,7 @@ impl Supertable {
                 buffer_scalar_bytes: 0,
                 buffer_vector_bytes: 0,
                 buffer_fts_bytes: 0,
+                pending_ingest: IngestTally::default(),
                 pending_updates: Vec::new(),
                 pending_deletes: Vec::new(),
                 op_stats: op_stats::current(),
@@ -1101,17 +1123,16 @@ impl SupertableWriter {
         self.buffer_fts_bytes += fts_bytes;
 
         // Per-op work stats: the write's input shape, counted here from
-        // the caller's batch — before any shard split or commit retry —
-        // so the counters are deterministic by construction (see the
-        // op_stats module's write-side determinism note).
-        if let Some(stats) = &self.op_stats {
-            stats.add_ingested_write(
-                n_rows as u64,
-                scalar_bytes_u64,
-                vector_bytes_u64,
-                fts_bytes_u64,
-            );
-        }
+        // the caller's batch — before any shard split or commit retry — so
+        // the values are deterministic by construction (see the op_stats
+        // module's write-side determinism note). They are held on the
+        // writer rather than published now: nothing is durable until the
+        // commit below returns Ok, and a counter that says "rows written"
+        // must not describe rows that were dropped with the buffer.
+        self.pending_ingest.rows += n_rows as u64;
+        self.pending_ingest.scalar_bytes += scalar_bytes_u64;
+        self.pending_ingest.vector_bytes += vector_bytes_u64;
+        self.pending_ingest.fts_text_bytes += fts_bytes_u64;
 
         // Auto-flush on held bytes (scalar + vector); the FTS weighting is a
         // reserve-time concern, not held memory.
@@ -1752,18 +1773,33 @@ impl SupertableWriter {
         let saved_scalar = self.buffer_scalar_bytes;
         let saved_vector = self.buffer_vector_bytes;
         let saved_fts = self.buffer_fts_bytes;
+        let saved_ingest = mem::take(&mut self.pending_ingest);
         let buffer = mem::take(&mut self.buffer);
         self.buffer_scalar_bytes = 0;
         self.buffer_vector_bytes = 0;
         self.buffer_fts_bytes = 0;
 
         match self.commit_appends_with_taken_buffer(&buffer) {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                // Durable now, so the ingested work is real work. An
+                // all-empty-batch commit publishes nothing and reports
+                // nothing.
+                if let (Some(stats), true) = (&self.op_stats, saved_ingest.rows > 0) {
+                    stats.add_ingested_write(
+                        saved_ingest.rows,
+                        saved_ingest.scalar_bytes,
+                        saved_ingest.vector_bytes,
+                        saved_ingest.fts_text_bytes,
+                    );
+                }
+                Ok(())
+            }
             Err(e) => {
                 self.buffer = buffer;
                 self.buffer_scalar_bytes = saved_scalar;
                 self.buffer_vector_bytes = saved_vector;
                 self.buffer_fts_bytes = saved_fts;
+                self.pending_ingest = saved_ingest;
                 Err(e)
             }
         }
@@ -1807,6 +1843,18 @@ impl SupertableWriter {
         if total_rows == 0 {
             return Ok(());
         }
+
+        // The commit's payload, read off the taken buffer before either
+        // shard-count helper is consulted, so both arms price the same
+        // number. Deliberately not the sealed output: every shard carries
+        // its own dictionary, FST and index headers, so sealed bytes scale
+        // with the shard split — and the split follows the writer pool's
+        // width. On a shared-vocabulary corpus the same input seals to
+        // roughly four times more bytes at width 16 than at width 1, so
+        // pricing off sealed bytes makes an identical append plan more
+        // requests on a wider host, which is precisely what the write-side
+        // determinism contract forbids.
+        let payload_bytes = buffered_payload_bytes(buffer);
 
         let list_metadata = CommitListMetadata {
             partition_strategy: None,
@@ -1868,7 +1916,7 @@ impl SupertableWriter {
                 (&self.op_stats, output_stats)
             {
                 stats.add_commit_outputs(superfiles, bytes, fts_terms);
-                stats.add_planned_commit_requests(planned_data_objects(bytes));
+                stats.add_planned_commit_requests(planned_data_objects(payload_bytes));
             }
             if crate::storage::io_counters::timeline_enabled() {
                 eprintln!(
@@ -2012,7 +2060,7 @@ impl SupertableWriter {
             (&self.op_stats, output_stats)
         {
             stats.add_commit_outputs(n_superfiles, bytes, fts_terms);
-            stats.add_planned_commit_requests(planned_data_objects(bytes));
+            stats.add_planned_commit_requests(planned_data_objects(payload_bytes));
         }
         if self.inner.options.storage.is_some() {
             schedule_background_storage_reclaim(Arc::clone(&self.inner));
@@ -2816,17 +2864,6 @@ fn collect_prepared_superfiles(
     })
 }
 
-/// One committed publish batch's output shape for the per-op work stats:
-/// superfile count, sealed on-storage bytes (from each entry's own
-/// `SubsectionOffsets::total_size`, so the figure is identical across
-/// storage backends), and the distinct-FTS-term sum across the new
-/// entries. Callers compute this before the batch moves into the publish
-/// future and flush it only after the commit returns Ok, so a failed or
-/// retried publish never counts.
-/// The object size a table's data converges to — compaction's target, in
-/// bytes. Used to turn a commit's sealed bytes into the number of objects
-/// the data itself occupies, independent of how many shards this
-/// particular commit happened to split into.
 /// The three ingested-byte legs of one caller batch: scalar footprint,
 /// exact vector payload, and the FTS text subset of the scalar columns.
 ///
@@ -2853,6 +2890,10 @@ fn ingested_byte_legs(
     (scalar_bytes, vector_bytes, fts_bytes)
 }
 
+/// The object size a table's data converges to — compaction's target, in
+/// bytes. The divisor that turns a commit's ingested payload into the
+/// number of objects the data itself occupies, independent of how many
+/// shards this particular commit happened to split into.
 fn commit_target_object_bytes() -> u64 {
     crate::config::global()
         .compaction
@@ -2860,21 +2901,51 @@ fn commit_target_object_bytes() -> u64 {
         .saturating_mul(1024 * 1024)
 }
 
-/// Data objects a buffered append's plan implies: the objects its sealed
-/// bytes occupy at the target object size.
-fn planned_data_objects(sealed_bytes: u64) -> u64 {
+/// Data objects a buffered append's plan implies: the objects its
+/// ingested payload occupies at the target object size.
+///
+/// Takes the payload, never the sealed output. Sealed bytes are a
+/// function of the shard split, which follows the writer pool's width, so
+/// pricing off them would make the same append cost different amounts on
+/// different hosts. See [`buffered_payload_bytes`].
+fn planned_data_objects(payload_bytes: u64) -> u64 {
     let target = commit_target_object_bytes();
     if target == 0 {
         0
     } else {
-        sealed_bytes.div_ceil(target)
+        payload_bytes.div_ceil(target)
     }
+}
+
+/// Bytes a taken buffer will write: the Arrow scalar footprint (the
+/// engine-minted `_id` included — it is stored too) plus the exact f32
+/// vector payload. Input-shaped, so it reads the same at every
+/// writer-pool width and across an OCC retry, which re-uses this buffer.
+fn buffered_payload_bytes(buffer: &[BufferedBatch]) -> u64 {
+    buffer
+        .iter()
+        .map(|b| {
+            b.scalar.get_array_memory_size() as u64
+                + b.vectors
+                    .iter()
+                    .map(|v| (v.len() * mem::size_of::<f32>()) as u64)
+                    .sum::<u64>()
+        })
+        .sum()
 }
 
 /// Data objects an update's plan implies: its replacement rows land in
 /// the WAL's single preallocated superfile, always exactly one.
 const UPDATE_PLANNED_DATA_OBJECTS: u64 = 1;
 
+/// One committed publish batch's output shape for the per-op work stats:
+/// superfile count, sealed on-storage bytes (from each entry's own
+/// `SubsectionOffsets::total_size`, so the figure is identical across
+/// storage backends), and the distinct-FTS-term sum across the new
+/// entries. All three are width-dependent and recorded-only — the shard
+/// split decides them. Callers compute this before the batch moves into
+/// the publish future and flush it only after the commit returns Ok, so a
+/// failed or retried publish never counts.
 fn commit_output_stats(batch: &SuperfilePublishBatch) -> (u64, u64, u64) {
     let superfiles = batch.new_entries.len() as u64;
     let bytes: u64 = batch
@@ -10294,6 +10365,54 @@ mod tests {
             scalar_plus_fts > scalar_only,
             "the FTS term is additive on top of scalar ({scalar_plus_fts} vs {scalar_only})"
         );
+    }
+
+    #[test]
+    fn planned_data_objects_counts_objects_at_the_target_boundary() {
+        // Every integration fixture seals three orders of magnitude below
+        // the shipped target, so `div_ceil` is 1 at every writer-pool width
+        // there and the arithmetic itself never runs. Pin it directly, or
+        // the counter could be replaced by a hardcoded 1 and every
+        // width-invariance assertion would still pass.
+        let target = commit_target_object_bytes();
+        assert!(target > 0, "the shipped config defines a target size");
+        assert_eq!(
+            planned_data_objects(0),
+            0,
+            "an empty payload plans no data object"
+        );
+        assert_eq!(planned_data_objects(1), 1);
+        assert_eq!(
+            planned_data_objects(target),
+            1,
+            "exactly one target's worth fills exactly one object"
+        );
+        assert_eq!(
+            planned_data_objects(target + 1),
+            2,
+            "one byte past the target spills into a second object"
+        );
+        assert_eq!(planned_data_objects(target.saturating_mul(3)), 3);
+    }
+
+    #[test]
+    fn a_refused_append_reports_no_ingested_work() {
+        // `rows_written` means rows the op durably indexed. A commit that
+        // never published must report nothing, or a failed write counts
+        // rows that do not exist. The 1-byte budget floors the build gate
+        // to 0, so the buffered commit is refused before anything seals.
+        let mut opts = options_id_title_serial();
+        opts.connection_memory_budget = ConnectionMemoryBudget::with_limit(1);
+        let st = Supertable::create(opts).expect("create");
+        let (result, stats) = op_stats::with_op_stats(|| st.append(&build_simple_batch(0, 8)));
+        assert!(result.is_err(), "a 0-byte gate refuses the build");
+        assert_eq!(
+            stats.rows_written, 0,
+            "a refused append durably indexed no rows"
+        );
+        assert_eq!(stats.scalar_bytes_written, 0);
+        assert_eq!(stats.vector_bytes_written, 0);
+        assert_eq!(stats.fts_text_bytes_written, 0);
     }
 
     #[test]

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -403,6 +403,12 @@ struct PendingUpdateEntry {
     new_row_count: u32,
     new_row_content_hash: String,
     ipc_bytes: Bytes,
+    /// Ingested-byte legs of the replacement batch, measured at call time
+    /// the same way an append measures its own — the batch itself is
+    /// dropped once IPC-encoded, so they cannot be recomputed at commit.
+    scalar_bytes_written: u64,
+    vector_bytes_written: u64,
+    fts_text_bytes_written: u64,
 }
 
 /// One buffered delete. Just the call-time resolved target_ids
@@ -1073,17 +1079,11 @@ impl SupertableWriter {
         // Arrow buffer allocations (rough but good enough); the vector payload is
         // its exact f32 size. The FTS text columns are a subset of the scalar
         // columns, summed separately only to weight the build-scratch reserve.
-        let scalar_bytes = scalar.get_array_memory_size();
-        let vector_bytes = vectors
-            .iter()
-            .map(|v| v.len() * mem::size_of::<f32>())
-            .sum::<usize>();
-        let fts_bytes = options
-            .fts_columns
-            .iter()
-            .filter_map(|fc| scalar.schema().index_of(&fc.column).ok())
-            .map(|idx| scalar.column(idx).get_array_memory_size())
-            .sum::<usize>();
+        let (scalar_bytes_u64, vector_bytes_u64, fts_bytes_u64) =
+            ingested_byte_legs(&scalar, vectors.iter().map(|v| v.len()).sum(), options);
+        let scalar_bytes = scalar_bytes_u64 as usize;
+        let vector_bytes = vector_bytes_u64 as usize;
+        let fts_bytes = fts_bytes_u64 as usize;
 
         self.buffer.push(BufferedBatch { scalar, vectors });
         self.buffer_scalar_bytes += scalar_bytes;
@@ -1097,9 +1097,9 @@ impl SupertableWriter {
         if let Some(stats) = &self.op_stats {
             stats.add_ingested_write(
                 n_rows as u64,
-                scalar_bytes as u64,
-                vector_bytes as u64,
-                fts_bytes as u64,
+                scalar_bytes_u64,
+                vector_bytes_u64,
+                fts_bytes_u64,
             );
         }
 
@@ -1285,6 +1285,18 @@ impl SupertableWriter {
         // call time (rather than commit time) means the caller
         // can drop the `RecordBatch` immediately — the buffer
         // owns the bytes from here on.
+        // Measure the replacement payload before the batch is dropped: the
+        // entry keeps only the IPC bytes from here on, so this is the last
+        // point the byte legs can be derived. Same helper `append` uses, so
+        // an updated row is measured exactly like an appended one.
+        let (upd_scalar_bytes, upd_vector_bytes, upd_fts_bytes) = {
+            let options = &self.inner.options;
+            let (scalar_no_id, vector_slices) =
+                split_vectors(&new_rows, options).map_err(MutationError::InvalidNewRows)?;
+            let elems = vector_slices.iter().map(|v| v.len()).sum();
+            ingested_byte_legs(&scalar_no_id, elems, options)
+        };
+
         let ipc_bytes = encode_record_batch_ipc(&new_rows).map_err(|e| {
             MutationError::Storage(StorageError::Permanent {
                 uri: "ipc encode".into(),
@@ -1301,6 +1313,9 @@ impl SupertableWriter {
             new_row_count: matched as u32,
             new_row_content_hash: content_hash,
             ipc_bytes,
+            scalar_bytes_written: upd_scalar_bytes,
+            vector_bytes_written: upd_vector_bytes,
+            fts_text_bytes_written: upd_fts_bytes,
         });
         Ok(PendingUpdate { matched })
     }
@@ -1537,7 +1552,12 @@ impl SupertableWriter {
         // they count here — after the drive returns Ok — alongside the
         // rows its tombstone phase retired.
         if let Some(stats) = &self.op_stats {
-            stats.add_ingested_write(u64::from(entry.new_row_count), 0, 0, 0);
+            stats.add_ingested_write(
+                u64::from(entry.new_row_count),
+                entry.scalar_bytes_written,
+                entry.vector_bytes_written,
+                entry.fts_text_bytes_written,
+            );
             stats.add_rows_tombstoned(n_tombstoned as u64);
             // An update commits a manifest (replacement superfile +
             // manifest json + pointer); a pure delete does not — its
@@ -2787,6 +2807,32 @@ fn collect_prepared_superfiles(
 /// bytes. Used to turn a commit's sealed bytes into the number of objects
 /// the data itself occupies, independent of how many shards this
 /// particular commit happened to split into.
+/// The three ingested-byte legs of one caller batch: scalar footprint,
+/// exact vector payload, and the FTS text subset of the scalar columns.
+///
+/// Shared by `append` and `update` so a replacement batch is measured the
+/// same way an appended one is — the update path reported zeros for all
+/// three before this existed, which under-counted every non-empty update.
+/// `vector_elems` is the total f32 count across the batch's vector
+/// columns — taken as a count rather than the arrays themselves because
+/// the two callers hold different representations of the same payload
+/// (`append` has built `Float32Array`s, `update` still has raw slices).
+fn ingested_byte_legs(
+    scalar: &RecordBatch,
+    vector_elems: usize,
+    options: &SupertableOptions,
+) -> (u64, u64, u64) {
+    let scalar_bytes = scalar.get_array_memory_size() as u64;
+    let vector_bytes = (vector_elems * mem::size_of::<f32>()) as u64;
+    let fts_bytes = options
+        .fts_columns
+        .iter()
+        .filter_map(|fc| scalar.schema().index_of(&fc.column).ok())
+        .map(|idx| scalar.column(idx).get_array_memory_size() as u64)
+        .sum::<u64>();
+    (scalar_bytes, vector_bytes, fts_bytes)
+}
+
 fn commit_target_object_bytes() -> u64 {
     crate::config::global()
         .compaction

--- a/tests/supertable/commit/mod.rs
+++ b/tests/supertable/commit/mod.rs
@@ -11,3 +11,4 @@ pub mod persistence;
 pub mod pointer_atomic;
 pub mod same_handle_query;
 pub mod stats;
+pub mod write_stats;

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -35,6 +35,20 @@ use tempfile::TempDir;
 /// pool below, so `n_shards = min(width, rows)` is genuinely
 /// width-bound and the shard split really differs between widths.
 const WIDTH_TEST_ROWS: usize = 40;
+
+/// Superfile split size for the cross-width fixtures, in MiB.
+///
+/// Shard count is `min(ceil(buffered_bytes / split), pool_threads, rows)`
+/// — bytes first, pool width only as a cap. At the shipped split a test
+/// batch would always be one shard, so the widest pool would produce the
+/// same single superfile as the narrowest and the invariance assertions
+/// would pass vacuously. Squeezing the split makes the pool width the
+/// binding term, which is the thing under test.
+const WIDTH_TEST_SPLIT_MB: u64 = 1;
+
+/// Rows for the fixtures that must span several shards: enough Arrow
+/// footprint to clear `WIDTH_TEST_SPLIT_MB` several times over.
+const SHARDING_TEST_ROWS: usize = 40_000;
 /// Writer-pool widths the invariance test compares.
 const POOL_WIDTHS: [usize; 3] = [1, 2, 8];
 /// Vector fixture dimensionality (engine minimum is 16).
@@ -75,6 +89,7 @@ fn options_with_pool_width(n_threads: usize) -> SupertableOptions {
     )
     .expect("valid options")
     .with_writer_pool(pool)
+    .with_superfile_buffer_split_mb(WIDTH_TEST_SPLIT_MB)
 }
 
 /// The width-test corpus: same titles every call, so every width builds
@@ -82,6 +97,17 @@ fn options_with_pool_width(n_threads: usize) -> SupertableOptions {
 fn width_test_batch() -> RecordBatch {
     let titles: Vec<String> = (0..WIDTH_TEST_ROWS)
         .map(|i| format!("row{i:03} common tokens"))
+        .collect();
+    let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+    build_title_batch(&refs)
+}
+
+/// A batch big enough to split across the widest pool: each row carries a
+/// kibibyte of title text, so 40k rows clear the 1 MiB split many times.
+fn sharding_test_batch() -> RecordBatch {
+    let filler = "lorem ipsum dolor sit amet ".repeat(38);
+    let titles: Vec<String> = (0..SHARDING_TEST_ROWS)
+        .map(|i| format!("row{i:06} common tokens {filler}"))
         .collect();
     let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
     build_title_batch(&refs)
@@ -101,7 +127,7 @@ fn scoped_append(options: SupertableOptions, batch: &RecordBatch) -> OpStats {
 fn write_stats_are_invariant_to_writer_pool_width() {
     // The load-bearing determinism test: the priced counters must not
     // depend on how many rayon threads happened to shard the build.
-    let batch = width_test_batch();
+    let batch = sharding_test_batch();
     let snapshots: Vec<OpStats> = POOL_WIDTHS
         .iter()
         .map(|&width| scoped_append(options_with_pool_width(width), &batch))
@@ -135,7 +161,7 @@ fn planned_write_requests_follow_the_data_not_the_shard_count() {
     // sharded and how often a contended publish retried. What is billed
     // is what the data requires: the objects it occupies at the target
     // size, plus the manifest json and pointer every commit publishes.
-    let batch = width_test_batch();
+    let batch = sharding_test_batch();
     let narrow = scoped_append(options_with_pool_width(POOL_WIDTHS[0]), &batch);
     let wide = scoped_append(options_with_pool_width(POOL_WIDTHS[2]), &batch);
 
@@ -304,6 +330,12 @@ fn a_delete_reports_its_tombstoned_rows_and_its_scan() {
         "the delete's write leg reports its retired rows"
     );
     assert_eq!(stats.rows_written, 0, "deletes index no new rows");
+    // A pure delete commits no manifest; its tombstone CAS-writes are
+    // recorded-only actuals, so the planned counter stays silent.
+    assert_eq!(
+        stats.planned_write_requests, 0,
+        "a delete plans no commit requests"
+    );
     // The predicate resolve runs on the reader's cached, collector-
     // detached SessionContext (the same deliberate suppression that
     // keeps a cached context from billing later queries into an old
@@ -339,6 +371,12 @@ fn an_update_reports_replacement_rows_and_tombstones() {
     assert_eq!(
         stats.rows_tombstoned, 1,
         "the update's retired rows count as tombstoned"
+    );
+    // An update's plan: its one WAL-preallocated replacement superfile
+    // plus the manifest json + pointer of its commit.
+    assert_eq!(
+        stats.planned_write_requests, 3,
+        "an update plans exactly one data object + the manifest pair"
     );
 }
 

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -153,6 +153,25 @@ fn write_stats_are_invariant_to_writer_pool_width() {
 }
 
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "per-thread CPU clock is Linux procfs (schedstat); off Linux kernel_cpu_ns is always 0"
+)]
+fn an_append_reports_its_build_cpu() {
+    // The write meter's CPU leg. Before the metered fan-out existed, every
+    // append reported zero kernel CPU and a consumer pricing that field
+    // billed the per-write floor regardless of size. The sharding fixture
+    // guarantees a real multi-shard build, whose k-means/encode work is far
+    // above the schedstat tick.
+    let batch = sharding_test_batch();
+    let stats = scoped_append(options_with_pool_width(POOL_WIDTHS[2]), &batch);
+    assert!(
+        stats.kernel_cpu_ns > 0,
+        "a {SHARDING_TEST_ROWS}-row append must report its build CPU; got 0"
+    );
+}
+
+#[test]
 fn planned_write_requests_follow_the_data_not_the_shard_count() {
     // The write-side twin of `planned_read_ranges`, and priceable for the
     // same reason: a PUT is 12.5x a GET in the cost model and never

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -349,6 +349,54 @@ fn a_dropped_writer_reports_nothing_it_never_committed() {
     assert_eq!(stats.superfiles_written, 0);
 }
 
+/// Rows in the parent batch the slice fixture carves from — large enough
+/// that billing its whole allocation is unmistakable.
+const SLICE_TEST_PARENT_ROWS: usize = 4_000;
+/// Rows the slice fixture actually appends.
+const SLICE_TEST_ROWS: usize = 10;
+
+/// Priced bytes measure the rows an append carries, not the allocation
+/// they happen to live in. Arrow slices share their parent's buffers, and
+/// `get_array_memory_size` sums buffer *capacity* while ignoring offset
+/// and length — so a 10-row slice of a 4,000-row batch reported the whole
+/// parent. Chunked ingest (read one large batch, append it in zero-copy
+/// slices) is exactly that pattern, and it billed every chunk for the
+/// entire batch.
+#[test]
+fn a_sliced_append_is_billed_for_its_own_rows() {
+    let titles: Vec<String> = (0..SLICE_TEST_PARENT_ROWS)
+        .map(|i| format!("row {i} carrying enough text to allocate a real buffer"))
+        .collect();
+    let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+    let sliced = build_title_batch(&refs).slice(0, SLICE_TEST_ROWS);
+    let standalone = build_title_batch(&refs[..SLICE_TEST_ROWS]);
+
+    let st_sliced = Supertable::create(options_with_pool_width(1)).expect("create");
+    let ((), from_slice) = with_op_stats(|| {
+        st_sliced.append(&sliced).expect("append the slice");
+    });
+    let st_standalone = Supertable::create(options_with_pool_width(1)).expect("create");
+    let ((), from_standalone) = with_op_stats(|| {
+        st_standalone
+            .append(&standalone)
+            .expect("append the standalone batch");
+    });
+
+    assert_eq!(
+        from_slice.rows_written, from_standalone.rows_written,
+        "both appends carry the same rows"
+    );
+    assert_eq!(
+        from_slice.scalar_bytes_written, from_standalone.scalar_bytes_written,
+        "the same rows must price the same whether they arrive as a slice \
+         of a larger batch or as a batch of their own"
+    );
+    assert_eq!(
+        from_slice.fts_text_bytes_written, from_standalone.fts_text_bytes_written,
+        "and so must the indexed-text leg"
+    );
+}
+
 /// A storage-backed table (mutations require storage for the WAL
 /// pipeline) with three committed rows.
 fn seeded_storage_table(dir: &TempDir) -> Supertable {
@@ -388,6 +436,14 @@ fn a_delete_reports_its_tombstoned_rows_and_its_scan() {
     assert!(
         stats.planned_read_ranges > 0,
         "the mutation's predicate scan must report its read work"
+    );
+    // The resolve decodes rows, and `rows_materialized` is the counter
+    // that says so. It sat at zero while the CPU, page-byte and range
+    // counters beside it all reported, because the resolve collected its
+    // DataFrame without harvesting DataFusion's leaf metrics.
+    assert!(
+        stats.rows_materialized > 0,
+        "the predicate scan's decoded rows must reach the counter"
     );
 }
 
@@ -485,14 +541,28 @@ fn optimize_does_not_re_bill_ingested_rows() {
     // A second commit gives compaction something to merge.
     st.append(&build_title_batch(&["delta", "echo"]))
         .expect("second append");
+    let before = st.reader().expect("reader").n_superfiles();
     let ((), stats) = with_op_stats(|| {
         st.optimize(&OptimizeOptions::compact(CompactionSettings {
+            // Without this the default is 50, so two superfiles never
+            // select a merge job and the zero assertions below hold
+            // because nothing ran.
+            min_superfiles_for_merge: 2,
             target_superfile_size_mb: 1,
             min_fill_percent: 1,
             ..CompactionSettings::default()
         }))
         .expect("optimize");
     });
+    // The zeros below only mean something if a merge actually ran. With
+    // the shipped `min_superfiles_for_merge` this fixture selected no job
+    // at all, so the assertions passed because nothing happened.
+    let after = st.reader().expect("reader").n_superfiles();
+    assert!(
+        after < before,
+        "the fixture must really merge ({before} -> {after}), or the \
+         zero assertions below prove nothing"
+    );
     assert_eq!(
         stats.rows_written, 0,
         "optimize must never re-count ingested rows"

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -374,6 +374,22 @@ fn an_update_reports_replacement_rows_and_tombstones() {
         stats.planned_write_requests, 3,
         "an update plans exactly one data object + the manifest pair"
     );
+    // The replacement payload is ingested work and must be measured the
+    // same way an append's is. This reported zero until the byte legs
+    // were captured at call time — the batch is dropped once IPC-encoded,
+    // so there is no second chance at commit.
+    assert!(
+        stats.scalar_bytes_written > 0,
+        "an update's replacement rows must report their ingested bytes"
+    );
+    assert!(
+        stats.fts_text_bytes_written > 0,
+        "the replacement's indexed text is part of that payload"
+    );
+    assert!(
+        stats.fts_text_bytes_written <= stats.scalar_bytes_written,
+        "the FTS leg is a subset of the scalar leg, not additional payload"
+    );
 }
 
 #[test]

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -336,19 +336,15 @@ fn a_delete_reports_its_tombstoned_rows_and_its_scan() {
         stats.planned_write_requests, 0,
         "a delete plans no commit requests"
     );
-    // The predicate resolve runs on the reader's cached, collector-
-    // detached SessionContext (the same deliberate suppression that
-    // keeps a cached context from billing later queries into an old
-    // scope), so the scan leg reports no read work today. Pinned here
-    // so a change to that exclusion is a visible decision, not drift:
-    // metering the mutation scan as read work closes a SELECT-then-
-    // delete-by-id arbitrage, but reopening the suppression design is
-    // its own discussion.
-    assert_eq!(
-        stats.planned_read_ranges, 0,
-        "the mutation's predicate scan is unmetered by design (cached \
-         detached context); if this starts reporting, the exclusion \
-         decision changed and the docs must follow"
+    // The predicate resolve is real read work the caller asked for, so
+    // it reports through the same scope as the write leg. It runs on a
+    // fresh, uncached context that carries the collector; routing it
+    // through the shared cached one would report zero for an
+    // arbitrarily large table scan, and would leave a SELECT-then-
+    // delete-by-id path costing more than the equivalent DELETE WHERE.
+    assert!(
+        stats.planned_read_ranges > 0,
+        "the mutation's predicate scan must report its read work"
     );
 }
 

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -25,6 +25,7 @@ use infino::{
     supertable::{Supertable, SupertableOptions},
     test_helpers::{
         build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
+        fault_storage::{FaultKind, FaultOp, FaultStorage},
         schema_id_title,
     },
 };
@@ -349,6 +350,13 @@ fn a_dropped_writer_reports_nothing_it_never_committed() {
     assert_eq!(stats.superfiles_written, 0);
 }
 
+/// The manifest pointer's URI fragment — the object whose conditional
+/// write is the commit's CAS, and so the one to fail to force a retry.
+const POINTER_URI_FRAGMENT: &str = "_supertable/current";
+/// Rows in the two-column fixture that separates the FTS leg from the
+/// scalar leg.
+const MIXED_SCHEMA_ROWS: usize = 32;
+
 /// Rows in the parent batch the slice fixture carves from — large enough
 /// that billing its whole allocation is unmistakable.
 const SLICE_TEST_PARENT_ROWS: usize = 4_000;
@@ -394,6 +402,116 @@ fn a_sliced_append_is_billed_for_its_own_rows() {
     assert_eq!(
         from_slice.fts_text_bytes_written, from_standalone.fts_text_bytes_written,
         "and so must the indexed-text leg"
+    );
+}
+
+/// The determinism contract covers commit retries as well as pool width,
+/// and the collector promises the manifest pair is counted once per
+/// successful commit rather than once per OCC attempt. Only the width
+/// half had a test. A lost pointer CAS drives the retry deterministically,
+/// so this does not depend on winning a race.
+#[test]
+fn write_stats_are_invariant_to_a_commit_retry() {
+    let uncontended_dir = TempDir::new().expect("tempdir");
+    let uncontended: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(uncontended_dir.path()).expect("provider"));
+    let baseline_table =
+        Supertable::create(default_supertable_options().with_storage(uncontended)).expect("create");
+    let ((), baseline) = with_op_stats(|| {
+        baseline_table
+            .append(&width_test_batch())
+            .expect("uncontended append");
+    });
+
+    let contended_dir = TempDir::new().expect("tempdir");
+    let local: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(contended_dir.path()).expect("provider"));
+    let faults = FaultStorage::wrap(local);
+    let storage: Arc<dyn StorageProvider> = Arc::<FaultStorage>::clone(&faults);
+    let retried_table =
+        Supertable::create(default_supertable_options().with_storage(storage)).expect("create");
+    // Lose the pointer CAS exactly once: the commit must reissue and still
+    // report its work a single time.
+    faults.fail_with(
+        FaultKind::Precondition,
+        FaultOp::PutIfMatch,
+        POINTER_URI_FRAGMENT,
+        1,
+    );
+    let ((), retried) = with_op_stats(|| {
+        retried_table
+            .append(&width_test_batch())
+            .expect("append survives one lost CAS");
+    });
+
+    assert!(
+        faults.fired() > 0,
+        "the fixture must actually lose a CAS, or the retry half is untested"
+    );
+    assert_eq!(
+        retried.rows_written, baseline.rows_written,
+        "a retried commit indexes the same rows once"
+    );
+    assert_eq!(retried.scalar_bytes_written, baseline.scalar_bytes_written);
+    assert_eq!(
+        retried.fts_text_bytes_written,
+        baseline.fts_text_bytes_written
+    );
+    assert_eq!(
+        retried.planned_write_requests, baseline.planned_write_requests,
+        "the manifest pair counts once per successful commit, not once per \
+         attempt"
+    );
+}
+
+/// The FTS leg is documented as a subset of the scalar leg rather than
+/// additional payload. Every other fixture here has exactly one user
+/// column and it *is* the FTS column, so the two counters come out equal
+/// by construction and the subset relation is never actually exercised.
+/// This one carries an unindexed column too, so the inequality is strict.
+#[test]
+fn the_fts_leg_is_a_strict_subset_when_a_column_is_unindexed() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("rating", DataType::Int64, false),
+    ]));
+    let titles: Vec<String> = (0..MIXED_SCHEMA_ROWS)
+        .map(|i| format!("document {i} about rust and search"))
+        .collect();
+    let title_col: ArrayRef = Arc::new(LargeStringArray::from(
+        titles.iter().map(String::as_str).collect::<Vec<_>>(),
+    ));
+    let rating_col: ArrayRef = Arc::new(arrow_array::Int64Array::from(
+        (0..MIXED_SCHEMA_ROWS as i64).collect::<Vec<_>>(),
+    ));
+    let batch =
+        RecordBatch::try_new(Arc::clone(&schema), vec![title_col, rating_col]).expect("batch");
+
+    let options = SupertableOptions::new(
+        Arc::clone(&schema),
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        Vec::new(),
+        Some(default_tokenizer()),
+    )
+    .expect("valid options");
+    let st = Supertable::create(options).expect("create");
+    let ((), stats) = with_op_stats(|| {
+        st.append(&batch).expect("append");
+    });
+
+    assert!(
+        stats.fts_text_bytes_written > 0,
+        "the indexed column carries text"
+    );
+    assert!(
+        stats.fts_text_bytes_written < stats.scalar_bytes_written,
+        "the FTS leg counts only the indexed column, so an unindexed \
+         column must make it a strict subset: fts={} scalar={}",
+        stats.fts_text_bytes_written,
+        stats.scalar_bytes_written
     );
 }
 

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -325,6 +325,30 @@ fn a_writer_minted_outside_the_scope_records_nothing() {
     assert_eq!(stats.superfiles_written, 0);
 }
 
+/// A writer holds its ingested work until the commit that publishes it
+/// returns Ok. Dropping the writer discards the buffer without committing
+/// — silently and by design — so it must discard the counters with it.
+/// Every call here returns Ok, which is what makes this the one path a
+/// "failed ops return Err" argument does not cover.
+#[test]
+fn a_dropped_writer_reports_nothing_it_never_committed() {
+    let st = Supertable::create(options_with_pool_width(1)).expect("create");
+    let batch = width_test_batch();
+    let ((), stats) = with_op_stats(|| {
+        let mut w = st.writer().expect("writer");
+        w.append(&batch).expect("append");
+        drop(w);
+    });
+    assert_eq!(
+        stats.rows_written, 0,
+        "the buffer was dropped, so no row was durably indexed"
+    );
+    assert_eq!(stats.scalar_bytes_written, 0);
+    assert_eq!(stats.vector_bytes_written, 0);
+    assert_eq!(stats.fts_text_bytes_written, 0);
+    assert_eq!(stats.superfiles_written, 0);
+}
+
 /// A storage-backed table (mutations require storage for the WAL
 /// pipeline) with three committed rows.
 fn seeded_storage_table(dir: &TempDir) -> Supertable {

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -362,6 +362,9 @@ const MIXED_SCHEMA_ROWS: usize = 32;
 const SLICE_TEST_PARENT_ROWS: usize = 4_000;
 /// Rows the slice fixture actually appends.
 const SLICE_TEST_ROWS: usize = 10;
+/// Mid-array offset for the second slice arm — far enough in that a
+/// sizing blind to offsets would visibly bill the wrong window.
+const SLICE_TEST_OFFSET: usize = 1_700;
 
 /// Priced bytes measure the rows an append carries, not the allocation
 /// they happen to live in. Arrow slices share their parent's buffers, and
@@ -376,33 +379,41 @@ fn a_sliced_append_is_billed_for_its_own_rows() {
         .map(|i| format!("row {i} carrying enough text to allocate a real buffer"))
         .collect();
     let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
-    let sliced = build_title_batch(&refs).slice(0, SLICE_TEST_ROWS);
-    let standalone = build_title_batch(&refs[..SLICE_TEST_ROWS]);
+    // Two windows: one at offset 0 and one from the middle. Chunked
+    // ingest slices at 0, then len, then 2*len — every chunk after the
+    // first carries a non-zero offset, and a sizing that honoured length
+    // while ignoring offset would pass the first arm and still over-bill
+    // every later chunk.
+    for offset in [0, SLICE_TEST_OFFSET] {
+        let sliced = build_title_batch(&refs).slice(offset, SLICE_TEST_ROWS);
+        let standalone = build_title_batch(&refs[offset..offset + SLICE_TEST_ROWS]);
 
-    let st_sliced = Supertable::create(options_with_pool_width(1)).expect("create");
-    let ((), from_slice) = with_op_stats(|| {
-        st_sliced.append(&sliced).expect("append the slice");
-    });
-    let st_standalone = Supertable::create(options_with_pool_width(1)).expect("create");
-    let ((), from_standalone) = with_op_stats(|| {
-        st_standalone
-            .append(&standalone)
-            .expect("append the standalone batch");
-    });
+        let st_sliced = Supertable::create(options_with_pool_width(1)).expect("create");
+        let ((), from_slice) = with_op_stats(|| {
+            st_sliced.append(&sliced).expect("append the slice");
+        });
+        let st_standalone = Supertable::create(options_with_pool_width(1)).expect("create");
+        let ((), from_standalone) = with_op_stats(|| {
+            st_standalone
+                .append(&standalone)
+                .expect("append the standalone batch");
+        });
 
-    assert_eq!(
-        from_slice.rows_written, from_standalone.rows_written,
-        "both appends carry the same rows"
-    );
-    assert_eq!(
-        from_slice.scalar_bytes_written, from_standalone.scalar_bytes_written,
-        "the same rows must price the same whether they arrive as a slice \
-         of a larger batch or as a batch of their own"
-    );
-    assert_eq!(
-        from_slice.fts_text_bytes_written, from_standalone.fts_text_bytes_written,
-        "and so must the indexed-text leg"
-    );
+        assert_eq!(
+            from_slice.rows_written, from_standalone.rows_written,
+            "offset {offset}: both appends carry the same rows"
+        );
+        assert_eq!(
+            from_slice.scalar_bytes_written, from_standalone.scalar_bytes_written,
+            "offset {offset}: the same rows must price the same whether \
+             they arrive as a slice of a larger batch or as a batch of \
+             their own"
+        );
+        assert_eq!(
+            from_slice.fts_text_bytes_written, from_standalone.fts_text_bytes_written,
+            "offset {offset}: and so must the indexed-text leg"
+        );
+    }
 }
 
 /// The determinism contract covers commit retries as well as pool width,

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -127,6 +127,38 @@ fn write_stats_are_invariant_to_writer_pool_width() {
 }
 
 #[test]
+fn planned_write_requests_follow_the_data_not_the_shard_count() {
+    // The write-side twin of `planned_read_ranges`, and priceable for the
+    // same reason: a PUT is 12.5x a GET in the cost model and never
+    // resolves from residency, so requests are a real share of write
+    // COGS — but the ACTUAL PUTs are ours, rising with how wide the pool
+    // sharded and how often a contended publish retried. What is billed
+    // is what the data requires: the objects it occupies at the target
+    // size, plus the manifest json and pointer every commit publishes.
+    let batch = width_test_batch();
+    let narrow = scoped_append(options_with_pool_width(POOL_WIDTHS[0]), &batch);
+    let wide = scoped_append(options_with_pool_width(POOL_WIDTHS[2]), &batch);
+
+    assert!(
+        wide.superfiles_written > narrow.superfiles_written,
+        "the fixture must really shard wider ({} vs {}), or the invariance \
+         below proves nothing",
+        wide.superfiles_written,
+        narrow.superfiles_written
+    );
+    assert_eq!(
+        narrow.planned_write_requests, wide.planned_write_requests,
+        "more shards must not mean more planned requests"
+    );
+    assert!(
+        narrow.planned_write_requests >= 2,
+        "every commit publishes at least the manifest json and the pointer, \
+         got {}",
+        narrow.planned_write_requests
+    );
+}
+
+#[test]
 fn repeated_identical_appends_report_identical_counters() {
     // Same batch, same (fresh) table state, same pool width: the whole
     // masked snapshot matches, and the recorded superfile count does

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -411,6 +411,45 @@ fn an_update_reports_replacement_rows_and_tombstones() {
     );
 }
 
+/// An update's replacement payload and an append of the very same batch
+/// must price identically. Both are one row of the caller's own columns;
+/// the `_id` the engine mints belongs to neither. Append measured the
+/// id-bearing batch until this was pinned, so every update looked
+/// cheaper than the append that wrote the same data.
+#[test]
+fn an_update_and_an_equivalent_append_price_the_same_payload() {
+    let batch = build_title_batch(&["bravo-replacement"]);
+
+    let update_dir = TempDir::new().expect("tempdir");
+    let update_table = seeded_storage_table(&update_dir);
+    let (outcome, update_stats) = with_op_stats(|| {
+        update_table
+            .update(col("title").eq(lit("bravo")), &batch)
+            .expect("update")
+    });
+    assert_eq!(outcome.matched(), 1, "the fixture must match one row");
+
+    let append_dir = TempDir::new().expect("tempdir");
+    let append_table = seeded_storage_table(&append_dir);
+    let ((), append_stats) = with_op_stats(|| {
+        append_table.append(&batch).expect("append");
+    });
+
+    assert_eq!(
+        update_stats.rows_written, append_stats.rows_written,
+        "one replacement row is one written row, same as an append"
+    );
+    assert_eq!(
+        update_stats.scalar_bytes_written, append_stats.scalar_bytes_written,
+        "the same batch must price the same whether it arrives as an \
+         update's replacement or as a plain append"
+    );
+    assert_eq!(
+        update_stats.fts_text_bytes_written, append_stats.fts_text_bytes_written,
+        "and so must its indexed-text leg"
+    );
+}
+
 #[test]
 fn optimize_does_not_re_bill_ingested_rows() {
     // Compaction rewrites rows the caller already paid to ingest; if

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Per-op work stats over the write surface: a write wrapped in
+//! [`with_op_stats`] reports the rows and bytes it indexed,
+//! deterministically — the same batch into the same table state reports
+//! the same priced counters whether the writer pool is one thread or
+//! eight, and a writer minted outside a scope records nothing. The
+//! width-dependent output-shape counters (superfile count/bytes,
+//! distinct terms) are recorded-only and exempted from the invariance
+//! contract, exactly as the module documents.
+
+#![deny(clippy::unwrap_used)]
+
+use std::{mem, sync::Arc};
+
+use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use datafusion::prelude::{col, lit};
+use infino::{
+    config::{CompactionSettings, OptimizeOptions},
+    runtime_metrics::op_stats::{OpStats, with_op_stats},
+    storage::{LocalFsStorageProvider, StorageProvider},
+    superfile::builder::FtsConfig,
+    supertable::{Supertable, SupertableOptions},
+    test_helpers::{
+        build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
+        schema_id_title,
+    },
+};
+use rayon::ThreadPoolBuilder;
+use tempfile::TempDir;
+
+/// Rows in the width-invariance fixture — comfortably above the widest
+/// pool below, so `n_shards = min(width, rows)` is genuinely
+/// width-bound and the shard split really differs between widths.
+const WIDTH_TEST_ROWS: usize = 40;
+/// Writer-pool widths the invariance test compares.
+const POOL_WIDTHS: [usize; 3] = [1, 2, 8];
+/// Vector fixture dimensionality (engine minimum is 16).
+const DIM: usize = 16;
+/// Rows in the vector-bytes pin fixture.
+const VECTOR_ROWS: usize = 24;
+/// Random-rotation seed for the vector fixture.
+const VECTOR_ROT_SEED: u64 = 13;
+
+/// Zero the counters the write contract exempts: superfile count and
+/// the per-superfile overhead ride the writer pool's width, distinct
+/// terms double-count across shards, and kernel CPU is measured time.
+/// Serves the cross-width comparisons; everything left must be equal.
+fn deterministic_write(mut stats: OpStats) -> OpStats {
+    stats.superfiles_written = 0;
+    stats.superfile_bytes_written = 0;
+    stats.fts_terms_indexed = 0;
+    stats.kernel_cpu_ns = 0;
+    stats
+}
+
+/// The `title`-only options with an explicit writer-pool width.
+fn options_with_pool_width(n_threads: usize) -> SupertableOptions {
+    let pool = Arc::new(
+        ThreadPoolBuilder::new()
+            .num_threads(n_threads)
+            .build()
+            .expect("writer pool"),
+    );
+    SupertableOptions::new(
+        schema_id_title(),
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        Vec::new(),
+        Some(default_tokenizer()),
+    )
+    .expect("valid options")
+    .with_writer_pool(pool)
+}
+
+/// The width-test corpus: same titles every call, so every width builds
+/// from an identical batch.
+fn width_test_batch() -> RecordBatch {
+    let titles: Vec<String> = (0..WIDTH_TEST_ROWS)
+        .map(|i| format!("row{i:03} common tokens"))
+        .collect();
+    let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+    build_title_batch(&refs)
+}
+
+/// One scoped append+commit of `batch` into a fresh table built from
+/// `options`, returning the write's work stats.
+fn scoped_append(options: SupertableOptions, batch: &RecordBatch) -> OpStats {
+    let st = Supertable::create(options).expect("create");
+    let ((), stats) = with_op_stats(|| {
+        st.append(batch).expect("append");
+    });
+    stats
+}
+
+#[test]
+fn write_stats_are_invariant_to_writer_pool_width() {
+    // The load-bearing determinism test: the priced counters must not
+    // depend on how many rayon threads happened to shard the build.
+    let batch = width_test_batch();
+    let snapshots: Vec<OpStats> = POOL_WIDTHS
+        .iter()
+        .map(|&width| scoped_append(options_with_pool_width(width), &batch))
+        .collect();
+
+    let baseline = deterministic_write(snapshots[0]);
+    for (width, stats) in POOL_WIDTHS.iter().zip(&snapshots).skip(1) {
+        assert_eq!(
+            deterministic_write(*stats),
+            baseline,
+            "priced write counters must match width 1 at width {width}"
+        );
+    }
+    // The mask is load-bearing, not vacuous: the widest pool really did
+    // shard more than the single thread.
+    assert!(
+        snapshots[2].superfiles_written > snapshots[0].superfiles_written,
+        "width {} must produce more superfiles than width 1 ({} vs {})",
+        POOL_WIDTHS[2],
+        snapshots[2].superfiles_written,
+        snapshots[0].superfiles_written
+    );
+}
+
+#[test]
+fn repeated_identical_appends_report_identical_counters() {
+    // Same batch, same (fresh) table state, same pool width: the whole
+    // masked snapshot matches, and the recorded superfile count does
+    // too (it is width-dependent, not run-dependent).
+    let batch = width_test_batch();
+    let a = scoped_append(options_with_pool_width(2), &batch);
+    let b = scoped_append(options_with_pool_width(2), &batch);
+    assert_eq!(
+        deterministic_write(a),
+        deterministic_write(b),
+        "same batch, same table state, same work"
+    );
+    assert_eq!(
+        a.superfiles_written, b.superfiles_written,
+        "the shard split is a function of width and rows, not of the run"
+    );
+}
+
+#[test]
+fn an_append_pins_exact_rows_and_subset_fts_bytes() {
+    // Exact equality, not >0: a double flush would report 2x and pass a
+    // positivity check.
+    let batch = width_test_batch();
+    let stats = scoped_append(options_with_pool_width(1), &batch);
+    assert_eq!(
+        stats.rows_written, WIDTH_TEST_ROWS as u64,
+        "one committed row per input row"
+    );
+    assert_eq!(stats.rows_tombstoned, 0, "appends tombstone nothing");
+    assert!(
+        stats.scalar_bytes_written > 0,
+        "the scalar leg counts the buffered Arrow payload"
+    );
+    // The FTS leg is a subset of the scalar leg, not additional payload.
+    assert!(
+        stats.fts_text_bytes_written > 0
+            && stats.fts_text_bytes_written <= stats.scalar_bytes_written,
+        "fts bytes ({}) are a subset of scalar bytes ({})",
+        stats.fts_text_bytes_written,
+        stats.scalar_bytes_written
+    );
+    assert_eq!(
+        stats.vector_bytes_written, 0,
+        "no vector column in this fixture"
+    );
+    assert!(
+        stats.superfiles_written > 0 && stats.superfile_bytes_written > 0,
+        "a committed append published at least one superfile"
+    );
+}
+
+#[test]
+fn a_vector_append_pins_exact_payload_bytes() {
+    let item = Arc::new(Field::new("item", DataType::Float32, true));
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new(
+            "emb",
+            DataType::FixedSizeList(Arc::clone(&item), DIM as i32),
+            false,
+        ),
+    ]));
+    let options = SupertableOptions::new(
+        Arc::clone(&schema),
+        vec![FtsConfig {
+            column: "title".into(),
+            positions: false,
+        }],
+        vec![default_vector_config("emb", VECTOR_ROT_SEED)],
+        Some(default_tokenizer()),
+    )
+    .expect("valid options");
+
+    let flat: Vec<f32> = (0..VECTOR_ROWS * DIM).map(|i| i as f32 * 0.25).collect();
+    let titles: Vec<String> = (0..VECTOR_ROWS).map(|i| format!("vec row{i:03}")).collect();
+    let fsl = FixedSizeListArray::try_new(
+        item,
+        DIM as i32,
+        Arc::new(Float32Array::from(flat)) as ArrayRef,
+        None,
+    )
+    .expect("FSL");
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(LargeStringArray::from(titles)) as ArrayRef,
+            Arc::new(fsl),
+        ],
+    )
+    .expect("batch");
+
+    let st = Supertable::create(options).expect("create");
+    let ((), stats) = with_op_stats(|| {
+        st.append(&batch).expect("append");
+    });
+    assert_eq!(stats.rows_written, VECTOR_ROWS as u64);
+    assert_eq!(
+        stats.vector_bytes_written,
+        (VECTOR_ROWS * DIM * mem::size_of::<f32>()) as u64,
+        "the vector leg is exactly rows x dim x 4"
+    );
+}
+
+#[test]
+fn a_writer_minted_outside_the_scope_records_nothing() {
+    // Pickup happens at writer mint, not at commit time — the same
+    // contract the reader has.
+    let st = Supertable::create(options_with_pool_width(1)).expect("create");
+    let mut w = st.writer().expect("writer");
+    let batch = width_test_batch();
+    let ((), stats) = with_op_stats(|| {
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+    });
+    assert_eq!(
+        stats.rows_written, 0,
+        "pickup happens at writer mint, not inside the scope"
+    );
+    assert_eq!(stats.superfiles_written, 0);
+}
+
+/// A storage-backed table (mutations require storage for the WAL
+/// pipeline) with three committed rows.
+fn seeded_storage_table(dir: &TempDir) -> Supertable {
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st =
+        Supertable::create(default_supertable_options().with_storage(storage)).expect("create");
+    st.append(&build_title_batch(&["alpha", "bravo", "charlie"]))
+        .expect("seed append");
+    st
+}
+
+#[test]
+fn a_delete_reports_its_tombstoned_rows_and_its_scan() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = seeded_storage_table(&dir);
+    let (outcome, stats) =
+        with_op_stats(|| st.delete(col("title").eq(lit("bravo"))).expect("delete"));
+    assert_eq!(outcome.n_tombstoned(), 1);
+    assert_eq!(
+        stats.rows_tombstoned, 1,
+        "the delete's write leg reports its retired rows"
+    );
+    assert_eq!(stats.rows_written, 0, "deletes index no new rows");
+    // The predicate resolve runs on the reader's cached, collector-
+    // detached SessionContext (the same deliberate suppression that
+    // keeps a cached context from billing later queries into an old
+    // scope), so the scan leg reports no read work today. Pinned here
+    // so a change to that exclusion is a visible decision, not drift:
+    // metering the mutation scan as read work closes a SELECT-then-
+    // delete-by-id arbitrage, but reopening the suppression design is
+    // its own discussion.
+    assert_eq!(
+        stats.planned_read_ranges, 0,
+        "the mutation's predicate scan is unmetered by design (cached \
+         detached context); if this starts reporting, the exclusion \
+         decision changed and the docs must follow"
+    );
+}
+
+#[test]
+fn an_update_reports_replacement_rows_and_tombstones() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = seeded_storage_table(&dir);
+    let (outcome, stats) = with_op_stats(|| {
+        st.update(
+            col("title").eq(lit("bravo")),
+            &build_title_batch(&["bravo-replacement"]),
+        )
+        .expect("update")
+    });
+    assert_eq!(outcome.matched(), 1);
+    assert_eq!(
+        stats.rows_written, 1,
+        "the update's replacement rows count as written"
+    );
+    assert_eq!(
+        stats.rows_tombstoned, 1,
+        "the update's retired rows count as tombstoned"
+    );
+}
+
+#[test]
+fn optimize_does_not_re_bill_ingested_rows() {
+    // Compaction rewrites rows the caller already paid to ingest; if
+    // optimize() ever lands in rows_written, every optimize re-counts
+    // the whole table. Recorded output-shape counters may move; the
+    // priced input-shape counters must stay zero.
+    let dir = TempDir::new().expect("tempdir");
+    let st = seeded_storage_table(&dir);
+    // A second commit gives compaction something to merge.
+    st.append(&build_title_batch(&["delta", "echo"]))
+        .expect("second append");
+    let ((), stats) = with_op_stats(|| {
+        st.optimize(&OptimizeOptions::compact(CompactionSettings {
+            target_superfile_size_mb: 1,
+            min_fill_percent: 1,
+            ..CompactionSettings::default()
+        }))
+        .expect("optimize");
+    });
+    assert_eq!(
+        stats.rows_written, 0,
+        "optimize must never re-count ingested rows"
+    );
+    assert_eq!(stats.scalar_bytes_written, 0);
+    assert_eq!(stats.vector_bytes_written, 0);
+    assert_eq!(stats.fts_text_bytes_written, 0);
+}

--- a/tests/supertable/query/covered_agg.rs
+++ b/tests/supertable/query/covered_agg.rs
@@ -14,7 +14,9 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use arrow_array::{Array, Float64Array, Int64Array, LargeStringArray, RecordBatch};
+use arrow_array::{
+    Array, Float64Array, Int32Array, Int64Array, LargeStringArray, RecordBatch, StringViewArray,
+};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::prelude::{col, lit};
 use infino::{
@@ -108,6 +110,24 @@ fn scalar_i64(st: &Supertable, sql: &str) -> i64 {
         .downcast_ref::<Int64Array>()
         .expect("i64 result")
         .value(0)
+}
+
+/// First-row string result. The provider serves non-FTS string columns
+/// as `Utf8View`, so a covered bound comes back as a view array; the
+/// LargeUtf8 arm covers plans that kept the stored type.
+fn scalar_string(st: &Supertable, sql: &str) -> String {
+    let batches = st.reader().expect("reader").query_sql(sql).expect("sql");
+    let batch = batches.iter().find(|b| b.num_rows() > 0).expect("one row");
+    let column = batch.column(0);
+    if let Some(views) = column.as_any().downcast_ref::<StringViewArray>() {
+        return views.value(0).to_string();
+    }
+    column
+        .as_any()
+        .downcast_ref::<LargeStringArray>()
+        .expect("string result")
+        .value(0)
+        .to_string()
 }
 
 fn scalar_f64(st: &Supertable, sql: &str) -> f64 {
@@ -457,4 +477,90 @@ fn not_in_returns_the_complement() {
         "SELECT COUNT(*) AS n FROM supertable WHERE rating NOT IN (1, 2, 3, 1001)",
     );
     assert_eq!(n, total - 4);
+}
+
+/// MIN/MAX over a non-FTS string column: the scan serves it as
+/// `Utf8View` while the manifest stores its bounds as `LargeUtf8`, and no
+/// coercion pass runs after an optimizer rule — so an uncast covered
+/// bound fails arrow's comparison kernel at execution (filtered arm) or
+/// breaks the rewritten plan's schema (unfiltered arm). Both arms cast.
+#[test]
+fn string_min_max_survive_the_utf8view_retype() {
+    let st = build_table();
+
+    // Cuts into commit 2, so the residual least/greatest combiner runs.
+    let where_range = "rating BETWEEN 1000 AND 2025";
+    let min_sql = format!("SELECT MIN(category) FROM supertable WHERE {where_range}");
+    let max_sql = format!("SELECT MAX(category) FROM supertable WHERE {where_range}");
+    assert_eq!(scalar_string(&st, &min_sql), "cat1_000");
+    assert_eq!(scalar_string(&st, &max_sql), "cat2_025");
+    for sql in [&min_sql, &max_sql] {
+        let plan = explain(&st, sql);
+        assert!(
+            plan.contains("__resid_0"),
+            "{sql}: expected the covered/residual rewrite; plan was:\n{plan}"
+        );
+    }
+
+    // Unfiltered arm: fully covered, answered without any scan.
+    assert_eq!(
+        scalar_string(&st, "SELECT MIN(category) FROM supertable"),
+        "cat0_000"
+    );
+    assert_eq!(
+        scalar_string(&st, "SELECT MAX(category) FROM supertable"),
+        format!("cat{}_{:03}", COMMITS - 1, ROWS_PER_COMMIT - 1)
+    );
+    let plan = explain(&st, "SELECT MAX(category) FROM supertable");
+    assert!(
+        !plan.contains("DataSourceExec") && !plan.contains("Parquet"),
+        "manifest-only string bound must not retain a Parquet scan:\n{plan}"
+    );
+}
+
+/// Rows per commit in the narrow-numeric fixture.
+const NARROW_ROWS: usize = 40;
+
+/// AVG over a numeric narrower than the sum accumulator: the planner
+/// coerces `avg(int32_col)` to `avg(CAST(... AS Float64))` and the rule
+/// peels that cast — so the residual partial must re-apply it, because
+/// DataFusion's `sum` has no return type for Int32 and nothing coerces
+/// after an optimizer rule.
+#[test]
+fn narrow_numeric_avg_survives_the_peeled_cast() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "score",
+        DataType::Int32,
+        false,
+    )]));
+    let options =
+        SupertableOptions::new(Arc::clone(&schema), vec![], vec![], None).expect("valid options");
+    let st = Supertable::create(options).expect("create");
+    let mut w = st.writer().expect("writer");
+    for idx in 0..COMMITS {
+        let scores: Vec<i32> = (0..NARROW_ROWS).map(|r| (idx * 1000 + r) as i32).collect();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(scores))],
+        )
+        .expect("batch");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+    }
+    drop(w);
+
+    // Cuts into commit 2 -> commit 1 covered, commit 2 scanned residually.
+    let sql = "SELECT AVG(score) FROM supertable WHERE score BETWEEN 1000 AND 2019";
+    let values: Vec<f64> = (1000..1000 + NARROW_ROWS as i64)
+        .chain(2000..=2019)
+        .map(|v| v as f64)
+        .collect();
+    let expected = values.iter().sum::<f64>() / values.len() as f64;
+    let got = scalar_f64(&st, sql);
+    assert!((got - expected).abs() < 1e-9, "avg {got} vs {expected}");
+    let plan = explain(&st, sql);
+    assert!(
+        plan.contains("__resid_0"),
+        "expected the covered/residual rewrite; plan was:\n{plan}"
+    );
 }

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -843,9 +843,30 @@ fn a_scoped_sql_scan_reports_page_bytes() {
         stats.rows_materialized > 0,
         "the scan's decoded rows come from DataFusion's own metrics; got 0"
     );
+}
+
+#[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "per-thread CPU clock is Linux procfs (schedstat); off Linux kernel_cpu_ns is always 0"
+)]
+fn a_scoped_sql_scan_reports_kernel_cpu() {
+    // SQL CPU is bracketed per scan poll on the thread clock, like every
+    // other kernel — not DataFusion's `elapsed_compute`, which is wall
+    // time and omits Parquet decode. Same granularity handling as the
+    // BM25 and vector kernel-CPU tests: schedstat advances at scheduler
+    // events, so one sub-tick scan can legitimately read zero and only a
+    // batch is guaranteed to register.
+    const KERNEL_CPU_BATCH: usize = 200;
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_fixture(&dir);
+    let mut total = 0u64;
+    for _ in 0..KERNEL_CPU_BATCH {
+        total += scoped_sql_stats(&db, "SELECT rating FROM docs WHERE rating > 5").kernel_cpu_ns;
+    }
     assert!(
-        stats.kernel_cpu_ns > 0,
-        "the plan's elapsed compute comes from DataFusion's own metrics; got 0"
+        total > 0,
+        "the bracketed SQL scan reports on-CPU time over {KERNEL_CPU_BATCH} queries; got 0"
     );
 }
 

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -783,6 +783,29 @@ fn vector_work_stats_are_deterministic_across_cache_temperature() {
     assert_eq!(cold, warm, "same plan, same table state, same work");
 }
 
+/// The reader-level SQL surface (test/bench only) meters CPU through the
+/// plan root, but its session context is cached and deliberately carries
+/// no collector — so the scan-level wrappers are inert there and the
+/// row count has to come from DataFusion's own leaf metrics. Without
+/// that harvest the benches driving this surface got a CPU number with no
+/// row denominator to divide it by.
+#[test]
+fn the_reader_level_sql_surface_reports_materialized_rows() {
+    let st = demo_two_superfiles();
+    let (batches, stats) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .query_sql("SELECT title FROM supertable")
+            .expect("reader-level query_sql")
+    });
+    let returned: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
+    assert!(returned > 0, "the fixture must return rows");
+    assert_eq!(
+        stats.rows_materialized, returned,
+        "every row the scan decoded must reach the counter"
+    );
+}
+
 // ---- SQL: the per-query channel through the catalog `query_sql` path ----
 
 /// Rows in the SQL fixture.

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -845,6 +845,39 @@ fn a_scoped_sql_scan_reports_page_bytes() {
     );
 }
 
+/// A whole-table aggregate is answerable from statistics the provider
+/// attaches to the scan, so the planner folds it to a constant and never
+/// opens a page. Measuring must not change that. `MeteredExec` sits
+/// directly between the aggregate and the scan, and an `ExecutionPlan`
+/// wrapper that takes the trait defaults reports unknown statistics —
+/// which silently turns an O(1) manifest read into a full columnar scan
+/// that the customer is then billed for. This asserts the billing-visible
+/// consequence rather than a plan string, so it holds whichever rule does
+/// the folding.
+#[test]
+fn a_whole_table_aggregate_folds_instead_of_scanning() {
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_fixture(&dir);
+    for sql in [
+        "SELECT COUNT(*) FROM docs",
+        "SELECT MIN(rating), MAX(rating) FROM docs",
+    ] {
+        let stats = scoped_sql_stats(&db, sql);
+        assert_eq!(
+            stats.sql_page_bytes, 0,
+            "{sql} folds from statistics; it must not read Parquet pages"
+        );
+        assert_eq!(
+            stats.planned_read_ranges, 0,
+            "{sql} folds from statistics; it must not plan a read range"
+        );
+        assert_eq!(
+            stats.rows_materialized, 0,
+            "{sql} folds from statistics; it must not decode rows"
+        );
+    }
+}
+
 #[test]
 #[cfg_attr(
     not(target_os = "linux"),

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -220,16 +220,21 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
 }
 
 #[test]
-fn work_stats_are_deterministic_across_cache_temperature() {
-    // The first run decodes from a cold state, the repeat hits every
-    // warm structure — the whole point of the counter is that the
-    // reported work is identical either way. Compare the full masked
-    // snapshot (like the vector/SQL siblings), not just posting bytes,
-    // so a warm/cold divergence in any FTS counter is caught.
+fn fts_work_stats_repeat_identically_on_the_same_table_state() {
+    // Named for what it guards. It used to claim the first run decodes
+    // from a cold state and the repeat hits warm structures, but this
+    // fixture has no cache-temperature axis at all: `demo_two_superfiles`
+    // attaches no storage, so every published superfile's bytes sit in
+    // the table's in-memory reader cache for its lifetime and both runs
+    // are served from the same resident reader. What it really pins is
+    // run-to-run repeatability across the full masked snapshot, which is
+    // worth having — the genuine cold-open axis is covered by
+    // `sql_work_stats_do_not_depend_on_reader_open_shape` for SQL and by
+    // the reader-lifetime transposition in the vector sibling.
     let st = demo_two_superfiles();
-    let cold = deterministic(scoped_fts_stats(&st, "rust"));
-    let warm = deterministic(scoped_fts_stats(&st, "rust"));
-    assert_eq!(cold, warm, "same plan, same table state, same work");
+    let first = deterministic(scoped_fts_stats(&st, "rust"));
+    let second = deterministic(scoped_fts_stats(&st, "rust"));
+    assert_eq!(first, second, "same plan, same table state, same work");
 }
 
 #[test]

--- a/tests/supertable/query/query_surface.rs
+++ b/tests/supertable/query/query_surface.rs
@@ -347,3 +347,43 @@ fn explain_base_table_scan() {
     let plan = explain_text(&st, "SELECT title FROM supertable WHERE rating > 4");
     assert!(!plan.trim().is_empty(), "base-table EXPLAIN was empty");
 }
+
+/// The meter must be invisible to the planner: limit pushdown reaches the
+/// Parquet source and sort pushdown reorders/reverses row groups THROUGH
+/// [`MeteredExec`]. Guards the delegation surface as a whole — an
+/// `ExecutionPlan` wrapper that takes the trait defaults silently costs
+/// these plans their source-side limit and their reverse scan, the same
+/// class of bug whose `partition_statistics` variant once turned a
+/// whole-table `COUNT(*)` into a full columnar scan.
+#[test]
+fn metered_exec_is_invisible_to_limit_and_sort_pushdown() {
+    let st = demo_table();
+
+    let limit_plan = explain_text(&st, "SELECT rating FROM supertable LIMIT 5");
+    let source = limit_plan
+        .lines()
+        .find(|line| line.contains("DataSourceExec"))
+        .expect("physical plan has a source");
+    assert!(
+        source.contains("limit=5"),
+        "the limit must reach the source through the meter; plan was:\n{limit_plan}"
+    );
+    assert!(
+        !limit_plan.contains("GlobalLimitExec") && !limit_plan.contains("LocalLimitExec"),
+        "no residual limit node may sit above the meter; plan was:\n{limit_plan}"
+    );
+
+    let sort_plan = explain_text(
+        &st,
+        "SELECT rating FROM supertable ORDER BY _id DESC LIMIT 5",
+    );
+    let source = sort_plan
+        .lines()
+        .find(|line| line.contains("DataSourceExec"))
+        .expect("physical plan has a source");
+    assert!(
+        source.contains("reverse_row_groups=true") && source.contains("sort_order_for_reorder"),
+        "the DESC sort must reach the source as a reverse scan through the \
+         meter; plan was:\n{sort_plan}"
+    );
+}


### PR DESCRIPTION
## What

Per-op write work counters in the existing `OpStats` scope, so a completed append / update / delete / DDL reports the work it actually did — the write half of #550 — plus a fix for mutation predicate scans reporting no read work, and a diagnostic (`cargo bench -- write-diag`) that reports per-write-op cost the way the read benches report per-query cost.

## Why one scope, not two

`update` and `delete` resolve their predicate through a real reader, which picks the collector up at mint from the read scope's thread-local. A separate write scope would silently drop that read leg and force every consumer to nest two scopes and merge two snapshots. One scope means a mutation reports both halves of its work in one place.

## The determinism contract

The shard split follows the writer pool's width and a contended commit retries its publish — neither is the caller's doing. So the counters split, and the split is the API:

**Deterministic — invariant to pool width and commit retries:** `rows_written`, `scalar_bytes_written`, `vector_bytes_written`, `fts_text_bytes_written`, `rows_tombstoned`, and `planned_write_requests`. The first five are counted from the caller's batch at buffering time, before any fan-out.

`planned_write_requests` is the write-side twin of `planned_read_ranges`: the PUTs the op's *plan* implies — the objects its sealed bytes occupy at the table's target object size, plus the manifest json and pointer every manifest commit publishes. An update plans exactly one data object (its WAL-preallocated replacement superfile). A pure delete plans zero: it commits no manifest, and its per-superfile tombstone CAS-writes stay recorded-only until their count can be planned from the resolve rather than guessed.

Requests matter enough to have a deterministic counter: a PUT is 12.5× a GET in the bench cost model, and unlike a warm read's ranges they never resolve from residency — a commit always pays them.

**Recorded only — width/retry-dependent:** `superfiles_written`, `superfile_bytes_written`, `fts_terms_indexed`, and the actual PUT ledger. A term appearing in k shards counts k times; per-file overhead scales with shard count; actual PUTs carry our sharding and our OCC retries.

Also excluded, with reasons in the module docs: detached background work (the mint discipline — it never picks up a collector) and per-shard build CPU (the calling thread blocks in `pool.install`, so a calling-thread bracket cannot see it; a consumer's process-CPU watermark carries that leg, as it does for reads).

## Wiring

The writer picks the collector up at construction — one construction site, the same caller-thread pickup contract the reader uses — and flushes at five points: append buffering, both commit arms, the update drive, and the delete drive. Commit-side figures are computed **before** the batch moves into the publish future and flushed only after `Ok`, so a failed or retried commit never counts. Zero signature changes: the rayon fan-out closures capture the `Arc`. An unmetered write pays one `Option` check per site.

## write-diag

`benches/utils/cost.rs` reports a cost cell per query shape, but the write path had only one whole-run aggregate (`write_per_million_docs` — dollars per doc averaged over ingest, drain and compaction alike). That hides the two axes that dominate per-op write cost, both of which are large:

- **Batch size.** A 1-row FTS append costs ~$21 per million rows; a 1M-row append of the same data costs ~$0.0016 per million rows. A small commit pays the full fixed cost — superfile build, manifest json, pointer CAS, four object-store PUTs — that a large batch amortizes away.
- **Modality.** Per GiB of payload, a bulk vector append costs ~2.2× a bulk FTS append (k-means placement and encode vs postings).

`cargo bench -- write-diag` measures each write shape as an individual committed op against a seeded table — appends across a batch-size ladder per modality, single-row update and delete — and prices each with the same instance cost model the read cells use (compute at the binding CPU/RAM leg + object-store request dollars). It reports $/write, $/1M rows, the logical payload, and $/GiB, alongside the engine's own counters so planned PUTs reconcile against actuals in the same row.

Direct cost only, deliberately: deferred drain and compaction are already inside the amortized `write_per_million_docs` figure, so these cells compare shapes against each other on the work the op itself performed.

## Two bench fixes this stack needed

**The width-invariance test was passing vacuously.** Sharding is `min(ceil(bytes / split), pool_threads, rows)`, and the 40-row fixture never produced more than one superfile at any pool width — so the load-bearing determinism test compared a single-superfile commit against itself. Caught the first time the suite ran on a machine that could execute it: the guard assertion (width 8 must out-shard width 1) failed on 1 vs 1. The cross-width fixtures now append 40k kibibyte-scale rows against a 1 MiB buffer split, making pool width the binding term — the thing under test.

**RustFS `CreateBucket` had no retry.** A green `/health` means the socket is serving, not that the object layer finished initializing; in that window rustfs answers `503 Service not ready`. Generating a 10M-doc corpus immediately before the spawn widens the gap enough to hit reliably, and twice a 10M run lost its whole FTS cell to it. Worse, the parent *skips* the row rather than failing, so the suite still exits 0 and the cost report simply comes back missing that shape. Now retries any 5xx for up to 60s; 4xx still fails immediately and 409 stays success.

## Tests

`tests/supertable/commit/write_stats.rs`, 10 cases:

- **Pool-width invariance** at widths 1 / 2 / 8 on masked snapshots, with the guard above.
- **Planned requests follow the data, not the shard count**: a wider pool produces more superfiles and more actual PUTs without moving the planned count, and every commit plans at least the manifest pair.
- **Repeat-append equality** and **exact** row / vector-byte pins (equality, not `> 0` — a double flush would pass a positivity check).
- The **FTS-subset property** (`fts_text_bytes_written` ⊆ `scalar_bytes_written`).
- A writer minted **outside** a scope records nothing.
- Mutation contracts: an update plans one data object plus the manifest pair; a delete plans zero; delete/update row accounting; and a delete's predicate scan reports read work rather than zero.
- **`optimize` never re-counts ingested rows** — compaction rewrites rows already counted at ingest; this holds by construction, since the input-shape counters flush only at append buffering.

## Mutation predicate scans are now metered

`scan_ids_matching` — the resolve behind every `DELETE WHERE` / `UPDATE WHERE` — ran on the shared cached `SessionContext`, which is deliberately built around a collector-detached reader. That detachment is right for its own purpose: the context is reused across queries, so one that captured a live collector would attribute later queries' work back into an old scope. The side effect was that the resolve reported **zero** read work no matter how much it scanned — a full-table delete measured the same nothing as a single-row one, and resolving ids with a query before deleting by id reported *more* work than the equivalent `DELETE WHERE` doing the same scan.

Mutation resolves now build a fresh context carrying the scope's collector. Not caching it is what makes that safe — nothing outlives the scope that created it — and it is the trade the catalog's `Connection::query_sql` already makes, building a fresh provider per query for the same reason. Context assembly is now one shared function, so the cached and metered variants cannot drift apart.

The single-table `query_sql` entry keeps its cached, unmetered context; its doc now names both metered surfaces. Trade-off: a mutation pays provider construction and TVF registration instead of a cache hit. Mutations are not high-QPS and I would expect it to disappear into the WAL round-trips, but I have not measured it — happy to if you want the number.

## Gates

`cargo test` (307 supertable + 2260 lib), clippy 0 warnings, fmt clean, `public-api.txt` unchanged.

No full bench A/B: the change adds counter arithmetic behind an `Option` check on the commit path and touches no scoring, distance, codec, or manifest logic; write-diag is new measurement code that runs only when invoked. Happy to run the suite if you'd rather see it.