### PR TITLE
vector: time the deferred warm scan; fix the width-pin filtered doc

### DIFF
--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -3690,9 +3690,20 @@ impl VectorReader {
                         budget,
                     };
                     let coarse_limit = k.saturating_mul(rerank_mult);
+                    // Timed like the immediate path's shortlist below: this
+                    // warm deferred scan is the read the width pin certifies
+                    // (whole-cell depth), which made it the dominant span of
+                    // `vec.fanout_wall` — ~9 of an 11 ms filtered query at
+                    // 9.4M — while carrying no phase label at all, so a
+                    // phase table showed ~2 ms of timed work inside a 10 ms
+                    // wall and read as a scheduling mystery.
+                    let shortlist_t0 = io_counters::phase_start();
                     let (shortlist, scan_kernel_ns) =
                         scan_shortlist(col, cb, &cluster_meta, &blocks, true, coarse_limit, &ctx)
                             .await?;
+                    if let Some(t0) = shortlist_t0 {
+                        io_counters::phase_record("vec.shortlist", t0.elapsed().as_micros() as u64);
+                    }
                     tally.kernel_cpu_ns += scan_kernel_ns;
                     let cands = shortlist
                         .into_iter()

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -4963,11 +4963,15 @@ fn rerank_mult_from_law(
 /// fine-first depth contributes only each cell's first runs — measured
 /// ~0.83 recall@100 on Cohere-1M REGARDLESS of width, a dial that
 /// widened without deepening. The per-fragment gate still clamps to
-/// each fragment's real run count. FILTERED queries keep their own fine
-/// floors (already applied to `routing` by the base branch) and never
-/// engage `sweep_width`: a sparse allow-set's shortlist divided across
-/// cells starves. `populated_cells` clamps the width the budget divide
-/// splits by — never more than the cells that actually carry postings.
+/// each fragment's real run count. FILTERED splits by arm: the LAW arm
+/// serves filtered exactly like unfiltered — same pin, same whole-cell
+/// depth (measured filtered recall@10 0.630 -> 0.993 on Cohere-9.4M) —
+/// while an explicit caller `nprobe` on a filtered query pins the width
+/// but returns `None` without lifting depth, so no sweep engages: a
+/// sparse allow-set's shortlist divided across caller-widened cells
+/// starves at the persisted fine floor. `populated_cells` clamps the
+/// width the budget divide splits by — never more than the cells that
+/// actually carry postings.
 fn apply_width_pin(
     routing: &mut CellRoutingParams,
     caller_nprobe: Option<usize>,


### PR DESCRIPTION
Observability follow-up to #638; no behaviour change.

**The deferred warm scan gets a phase timer.** The deferred-rerank path's warm 1-bit scan — the read the width pin certifies at whole-cell depth — carried no phase label: on the Cohere-9.4M filtered battery it was ~9 ms of an 11 ms query, all landing in `vec.fanout_wall` unlabeled. A phase table showed ~2 ms of timed work inside a 10 ms wall, which reads as a scheduling problem when the answer is scan volume (laws-off filtered kept 16 fine runs pooled table-wide, ~17K rows; laws-on reads the stamped width at whole-cell depth, ~0.5-0.8M rows — the recall is bought with exactly that read). Recorded as `vec.shortlist`, mirroring the immediate path's existing timer.

**`apply_width_pin`'s doc-comment catches up with #638.** It still said filtered queries never engage `sweep_width`. Since #638 the law arm pins filtered exactly like unfiltered (measured filtered recall@10 0.630 -> 0.993 on Cohere-9.4M); only the explicit caller-`nprobe` arm keeps the no-sweep behaviour. The comment now states the split per arm.

Two files, one `phase_record` plus comments. The timer only fires under `INFINO_TRACE_VECTOR_WARM_PHASES=1` plumbing (`phase_start` returns `None` otherwise), so the untraced hot path is unchanged.

Gates: fmt clean, clippy clean, 308 superfile vector + 67 supertable query vector unit tests.