### PR TITLE
feat tracing: propagate trace_ids across tokio and rayon threads

### DIFF
--- a/src/runtime_bridge.rs
+++ b/src/runtime_bridge.rs
@@ -44,6 +44,7 @@ use tokio::{
     sync::oneshot,
     task::block_in_place,
 };
+use tracing::{Instrument, Span};
 
 /// Fallback worker count for [`build_query_runtime`] when the host's available
 /// parallelism can't be determined.
@@ -112,18 +113,39 @@ where
         Ok(handle) if matches!(handle.runtime_flavor(), runtime::RuntimeFlavor::MultiThread) => {
             block_in_place(|| handle.block_on(fut))
         }
-        Ok(_) => thread::spawn(move || build_current_thread_runtime().block_on(fut))
-            .join()
-            .expect("sync→async bridge worker thread panicked"),
+        Ok(_) => {
+            let fut = fut.in_current_span();
+            thread::spawn(move || build_current_thread_runtime().block_on(fut))
+                .join()
+                .expect("sync→async bridge worker thread panicked")
+        }
         Err(_) => build_current_thread_runtime().block_on(fut),
     }
 }
 
 /// Async→rayon bridge: dispatch CPU work onto the configured reader pool
 pub(crate) fn spawn_on<F: FnOnce() + Send + 'static>(pool: Option<&ThreadPool>, f: F) {
+    let f = carry_span(f);
     match pool {
         Some(pool) => pool.spawn(f),
         None => rayon::spawn(f),
+    }
+}
+
+/// Wrap `f` so it runs inside the caller's tracing span on whatever thread ends
+/// up executing it.
+///
+/// A pool or thread hop does not carry the span with it, so without this the log
+/// lines a unit of work emits lose the context of the operation that scheduled
+/// it. Use it at every hand-off to another thread.
+pub(crate) fn carry_span<T, F>(f: F) -> impl FnOnce() -> T + Send
+where
+    F: FnOnce() -> T + Send,
+{
+    let span = Span::current();
+    move || {
+        let _entered = span.enter();
+        f()
     }
 }
 
@@ -206,7 +228,62 @@ fn build_current_thread_runtime() -> runtime::Runtime {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc;
+
     use super::*;
+
+    /// A span is only resolvable from another thread when the subscriber is the
+    /// process-wide default — a thread-local one is invisible to a pool worker,
+    /// which is also why these assertions would pass vacuously without it.
+    /// Installed once for the binary; nothing else here sets one.
+    fn assign_span_ids() {
+        static INSTALLED: OnceLock<()> = OnceLock::new();
+        INSTALLED.get_or_init(|| {
+            let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+        });
+    }
+
+    #[test]
+    fn pool_work_runs_inside_the_span_that_dispatched_it() {
+        assign_span_ids();
+        let span = tracing::info_span!("dispatching");
+        let _entered = span.enter();
+        let dispatcher = Span::current().id();
+        assert!(dispatcher.is_some(), "span ids must be assigned");
+
+        let (tx, rx) = mpsc::channel();
+        spawn_on(None, move || {
+            let _ = tx.send(Span::current().id());
+        });
+
+        assert_eq!(
+            rx.recv().expect("pool task ran"),
+            dispatcher,
+            "a rayon hop must not drop the caller's span"
+        );
+    }
+
+    #[test]
+    fn carry_span_restores_the_span_on_a_plain_thread() {
+        assign_span_ids();
+        let span = tracing::info_span!("scheduling");
+        let _entered = span.enter();
+        let scheduler = Span::current().id();
+        assert!(scheduler.is_some(), "span ids must be assigned");
+
+        let observe = carry_span(|| Span::current().id());
+        assert_eq!(
+            thread::spawn(observe).join().expect("thread ran"),
+            scheduler
+        );
+    }
+
+    #[test]
+    fn carry_span_is_harmless_with_no_span_entered() {
+        assign_span_ids();
+        let observe = carry_span(|| Span::current().id());
+        assert_eq!(thread::spawn(observe).join().expect("thread ran"), None);
+    }
 
     /// The regression this pins: `bridge_on_runtime` once preferred the
     /// AMBIENT runtime when one was present, driving the future on a

--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -29,7 +29,7 @@ use object_store::{
 };
 
 use super::{ObjectMeta, StorageError, StorageProvider, counting};
-use crate::runtime_metrics::io::UsageMeter;
+use crate::{runtime_bridge::carry_span, runtime_metrics::io::UsageMeter};
 
 #[derive(Debug)]
 pub struct LocalFsStorageProvider {
@@ -336,9 +336,9 @@ impl StorageProvider for LocalFsStorageProvider {
                     })?;
                 // `flock` is a blocking syscall; run it on the
                 // blocking pool so it can't stall a tokio worker.
-                let lock_file = tokio::task::spawn_blocking(move || {
+                let lock_file = tokio::task::spawn_blocking(carry_span(move || {
                     lock_file.lock_exclusive().map(|_| lock_file)
-                })
+                }))
                 .await
                 .map_err(|e| StorageError::Permanent {
                     uri: uri.into(),

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -27,7 +27,7 @@ use arrow_schema::SchemaRef;
 use chrono::Utc;
 use datafusion::{execution::context::SessionContext, logical_expr::LogicalPlan};
 use tokio::runtime::Runtime;
-use tracing::{debug, warn};
+use tracing::{Instrument, debug, warn};
 
 use super::{
     error::{BuildError, CommitError, OpenError},
@@ -1185,7 +1185,7 @@ impl Supertable {
                             true,
                         )
                         .await
-                    })
+                    }.in_current_span())
                 })
                 .collect();
             for h in handles {

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -61,6 +61,7 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use super::options::SupertableOptions;
 use crate::{
+    runtime_bridge::carry_span,
     storage::{StorageError, StorageProvider},
     superfile::{
         builder::VectorConfig,
@@ -913,7 +914,7 @@ impl ManifestSnapshot {
                 prewarm_summary_admit_slabs(&entries, &vector_columns, &pool);
                 entries
             };
-            all_superfiles = match spawn_blocking(prewarm).await {
+            all_superfiles = match spawn_blocking(carry_span(prewarm)).await {
                 Ok(entries) => entries,
                 Err(join_error) => {
                     return Err(ManifestLoadError::SlowStateHydration(format!(
@@ -2252,7 +2253,7 @@ impl UserCentroidCache {
 /// `spawn_blocking` keeps the runtime free to drive the remaining
 /// fetches while decodes run in parallel on the blocking pool.
 async fn decode_part_off_thread(bytes: Bytes) -> Result<ManifestPart, ManifestLoadError> {
-    match spawn_blocking(move || part::decode(&bytes)).await {
+    match spawn_blocking(carry_span(move || part::decode(&bytes))).await {
         Ok(result) => Ok(result?),
         Err(join_error) => Err(ManifestLoadError::Parse(part::PartParseError::Avro(
             format!("part decode task failed: {join_error}"),
@@ -2277,7 +2278,7 @@ async fn verify_and_decode_part_off_thread(
         }
         part::decode(&bytes).map_err(ManifestLoadError::from)
     };
-    match spawn_blocking(verify_then_decode).await {
+    match spawn_blocking(carry_span(verify_then_decode)).await {
         Ok(result) => result,
         Err(join_error) => Err(ManifestLoadError::Parse(part::PartParseError::Avro(
             format!("part verify/decode task failed: {join_error}"),

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -44,7 +44,7 @@ use std::{collections::HashSet, future::Future, sync::Arc, time::Instant};
 use arrow_array::Decimal128Array;
 use futures::future::try_join_all;
 use roaring::RoaringBitmap;
-use tracing::trace;
+use tracing::{Instrument, trace};
 use uuid::Uuid;
 
 use super::SuperfileHit;
@@ -598,18 +598,21 @@ where
         let tombstone_cache = tombstone_cache.clone();
         let body = body.clone();
         let vector_columns = Arc::clone(&vector_columns);
-        let handle = tokio::spawn(async move {
-            let r = open_reader(
-                &store,
-                disk_cache.as_ref(),
-                storage.as_ref(),
-                &entry,
-                allow_background_fill,
-            )
-            .await?;
-            verify_superfile_vector_codecs(&r, &vector_columns)?;
-            body(r, entry, tombstone_cache, now, params).await
-        });
+        let handle = tokio::spawn(
+            async move {
+                let r = open_reader(
+                    &store,
+                    disk_cache.as_ref(),
+                    storage.as_ref(),
+                    &entry,
+                    allow_background_fill,
+                )
+                .await?;
+                verify_superfile_vector_codecs(&r, &vector_columns)?;
+                body(r, entry, tombstone_cache, now, params).await
+            }
+            .in_current_span(),
+        );
         // Flatten the join error into a QueryError so `try_join_all`
         // short-circuits on the first failing superfile.
         async move {

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -33,6 +33,7 @@ use tokio::{
     sync::{Notify, OnceCell, Semaphore, oneshot},
     task::{JoinHandle, spawn_blocking},
 };
+use tracing::Instrument;
 
 use super::{
     block_source::BlockCachedSource,
@@ -40,6 +41,7 @@ use super::{
 };
 use crate::{
     config::global as global_config,
+    runtime_bridge::carry_span,
     runtime_metrics::io::scope_background,
     storage::{StorageError, StorageProvider},
     superfile::{
@@ -1207,26 +1209,32 @@ impl DiskCacheStore {
             let (write_tx, write_rx) = oneshot::channel::<JoinHandle<Result<(), DiskCacheError>>>();
             write_handles.push(write_rx);
 
-            fetch_handles.push(tokio::spawn(async move {
-                let bytes = storage.get_range(&uri_s, start..end).await?;
-                // Save Bytes for the foreground.
-                {
-                    let mut guard = chunks.lock().await;
-                    guard[i as usize] = Some((start, bytes.clone()));
-                }
-                // Spawn the pwrite as a fire-and-forget task.
-                // Its JoinHandle goes to the background
-                // finalizer (via oneshot) so the foreground
-                // doesn't wait for it.
-                let pwrite_handle = tokio::spawn(async move {
-                    let mut guard = file.lock().await;
-                    guard.seek(SeekFrom::Start(start)).await?;
-                    guard.write_all(&bytes).await?;
+            fetch_handles.push(tokio::spawn(
+                async move {
+                    let bytes = storage.get_range(&uri_s, start..end).await?;
+                    // Save Bytes for the foreground.
+                    {
+                        let mut guard = chunks.lock().await;
+                        guard[i as usize] = Some((start, bytes.clone()));
+                    }
+                    // Spawn the pwrite as a fire-and-forget task.
+                    // Its JoinHandle goes to the background
+                    // finalizer (via oneshot) so the foreground
+                    // doesn't wait for it.
+                    let pwrite_handle = tokio::spawn(
+                        async move {
+                            let mut guard = file.lock().await;
+                            guard.seek(SeekFrom::Start(start)).await?;
+                            guard.write_all(&bytes).await?;
+                            Ok::<(), DiskCacheError>(())
+                        }
+                        .in_current_span(),
+                    );
+                    let _ = write_tx.send(pwrite_handle);
                     Ok::<(), DiskCacheError>(())
-                });
-                let _ = write_tx.send(pwrite_handle);
-                Ok::<(), DiskCacheError>(())
-            }));
+                }
+                .in_current_span(),
+            ));
         }
 
         // 2. Await all fetches (NOT pwrites). Foreground bytes
@@ -1288,19 +1296,22 @@ impl DiskCacheStore {
         let tmp_owned = tmp.clone();
         let final_owned = final_path.clone();
         let file_owned = Arc::clone(&file);
-        tokio::spawn(async move {
-            let _ = finalize_to_mmap(
-                store,
-                uri_owned,
-                tmp_owned,
-                final_owned,
-                file_owned,
-                write_handles,
-                size,
-                reserved_bytes,
-            )
-            .await;
-        });
+        tokio::spawn(
+            async move {
+                let _ = finalize_to_mmap(
+                    store,
+                    uri_owned,
+                    tmp_owned,
+                    final_owned,
+                    file_owned,
+                    write_handles,
+                    size,
+                    reserved_bytes,
+                )
+                .await;
+            }
+            .in_current_span(),
+        );
 
         Ok(entry)
     }
@@ -1406,27 +1417,30 @@ impl DiskCacheStore {
         let uri_owned = *uri;
         let storage_uri_owned = Self::storage_path(uri);
         let fetch_storage = self.resolve_storage(storage);
-        tokio::spawn(async move {
-            if needs_reserve {
-                let Some(s) = store.upgrade() else {
-                    return;
-                };
-                if s.reserve_manual(size).await.is_err() {
-                    return;
+        tokio::spawn(
+            async move {
+                if needs_reserve {
+                    let Some(s) = store.upgrade() else {
+                        return;
+                    };
+                    if s.reserve_manual(size).await.is_err() {
+                        return;
+                    }
                 }
+                let _ = lazy_background_fill(
+                    store,
+                    reader,
+                    uri_owned,
+                    storage_uri_owned,
+                    size,
+                    size,
+                    fetch_storage,
+                    skip_vec,
+                )
+                .await;
             }
-            let _ = lazy_background_fill(
-                store,
-                reader,
-                uri_owned,
-                storage_uri_owned,
-                size,
-                size,
-                fetch_storage,
-                skip_vec,
-            )
-            .await;
-        });
+            .in_current_span(),
+        );
     }
 
     /// Lazy cold-fetch path. Foreground builds a reader via
@@ -1921,22 +1935,25 @@ impl DiskCacheStore {
             let file = Arc::clone(&file);
             let uri = storage_uri.to_string();
             let stream_sem = Arc::clone(&stream_sem);
-            joins.push(tokio::spawn(async move {
-                let _permit = stream_sem.acquire_owned().await.map_err(|e| {
-                    DiskCacheError::SuperfileOpen(format!("stream semaphore closed: {e}"))
-                })?;
-                let bytes = storage.get_range(&uri, start..end).await?;
-                spawn_blocking(move || file.write_all_at(&bytes, start))
-                    .await
-                    .map_err(|e| DiskCacheError::SuperfileOpen(format!("write join: {e}")))??;
-                Ok::<(), DiskCacheError>(())
-            }));
+            joins.push(tokio::spawn(
+                async move {
+                    let _permit = stream_sem.acquire_owned().await.map_err(|e| {
+                        DiskCacheError::SuperfileOpen(format!("stream semaphore closed: {e}"))
+                    })?;
+                    let bytes = storage.get_range(&uri, start..end).await?;
+                    spawn_blocking(carry_span(move || file.write_all_at(&bytes, start)))
+                        .await
+                        .map_err(|e| DiskCacheError::SuperfileOpen(format!("write join: {e}")))??;
+                    Ok::<(), DiskCacheError>(())
+                }
+                .in_current_span(),
+            ));
         }
         for h in joins {
             h.await
                 .map_err(|e| DiskCacheError::SuperfileOpen(format!("join error: {e}")))??;
         }
-        spawn_blocking(move || file.sync_all())
+        spawn_blocking(carry_span(move || file.sync_all()))
             .await
             .map_err(|e| DiskCacheError::SuperfileOpen(format!("fsync join: {e}")))??;
         Ok(())
@@ -2242,7 +2259,7 @@ async fn cold_fetch_to_disk_cancelable(
                     let bytes =
                         scope_background(storage.get_range(&uri, range_start..range_end)).await?;
                     let file = Arc::clone(&file);
-                    spawn_blocking(move || file.write_all_at(&bytes, range_start))
+                    spawn_blocking(carry_span(move || file.write_all_at(&bytes, range_start)))
                         .await
                         .map_err(|error| {
                             DiskCacheError::SuperfileOpen(format!("write join: {error}"))
@@ -2296,7 +2313,7 @@ async fn cold_fetch_to_disk_cancelable(
     if reader_blocks_background_fill(reader) {
         return Ok(BackgroundFillOutcome::Paused);
     }
-    spawn_blocking(move || file.sync_all())
+    spawn_blocking(carry_span(move || file.sync_all()))
         .await
         .map_err(|error| DiskCacheError::SuperfileOpen(format!("fsync join: {error}")))??;
     Ok(BackgroundFillOutcome::Complete)

--- a/src/supertable/slow_vector_state.rs
+++ b/src/supertable/slow_vector_state.rs
@@ -33,6 +33,7 @@ use uuid::Uuid;
 
 use crate::{
     config,
+    runtime_bridge::carry_span,
     storage::{StorageError, StorageProvider},
     superfile::vector::hnsw,
     supertable::{
@@ -735,12 +736,12 @@ pub(crate) async fn load_full_state(
     // blake3 over the whole blob plus the Avro parse is a CPU wave
     // (multi-GiB at 100M docs); run it on the blocking pool so the
     // runtime keeps driving I/O instead of stalling behind the decode.
-    match spawn_blocking(move || {
+    match spawn_blocking(carry_span(move || {
         if ContentHash::of(bytes.as_ref()) != expected {
             return Err(SlowVectorStateError::HashMismatch);
         }
         decode_state(bytes.as_ref())
-    })
+    }))
     .await
     {
         Ok(result) => result,

--- a/src/supertable/wal/lease.rs
+++ b/src/supertable/wal/lease.rs
@@ -62,6 +62,7 @@ use std::{
 use chrono::{DateTime, Utc};
 use thiserror::Error;
 use tokio::task::JoinHandle;
+use tracing::Instrument;
 
 use crate::supertable::wal::{
     persistence::{Etag, WalStore, WalStoreError},
@@ -422,35 +423,38 @@ pub fn spawn_heartbeat(
     let tracker_for_task = Arc::clone(&tracker);
     let stuck_threshold = lease_duration / 2;
 
-    let join = tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(interval);
-        // First tick fires immediately (default); skip it so
-        // the work thread has a chance to do at least one
-        // storage op before we evaluate progress.
-        ticker.tick().await;
-        loop {
+    let join = tokio::spawn(
+        async move {
+            let mut ticker = tokio::time::interval(interval);
+            // First tick fires immediately (default); skip it so
+            // the work thread has a chance to do at least one
+            // storage op before we evaluate progress.
             ticker.tick().await;
-            if tracker_for_task.stop_requested() {
-                return;
-            }
-            // Stuck-worker check.
-            let last = tracker_for_task.last_progress_at();
-            if let Ok(elapsed) = SystemTime::now().duration_since(last)
-                && elapsed > stuck_threshold
-            {
-                tracker_for_task.request_stop();
-                return;
-            }
-            // Lease extension.
-            match try_heartbeat(&store, wal_id, owner, Utc::now(), lease_duration).await {
-                Ok(_) => {}
-                Err(_) => {
+            loop {
+                ticker.tick().await;
+                if tracker_for_task.stop_requested() {
+                    return;
+                }
+                // Stuck-worker check.
+                let last = tracker_for_task.last_progress_at();
+                if let Ok(elapsed) = SystemTime::now().duration_since(last)
+                    && elapsed > stuck_threshold
+                {
                     tracker_for_task.request_stop();
                     return;
                 }
+                // Lease extension.
+                match try_heartbeat(&store, wal_id, owner, Utc::now(), lease_duration).await {
+                    Ok(_) => {}
+                    Err(_) => {
+                        tracker_for_task.request_stop();
+                        return;
+                    }
+                }
             }
         }
-    });
+        .in_current_span(),
+    );
 
     HeartbeatHandle {
         join: Some(join),


### PR DESCRIPTION
### What does this PR do?
- Propagates the trace_id across tokio and rayon boundaries

### Why do we need this change?
- To help debugging, by using the trace_id to exactly figure out issues