### PR TITLE
superfile/vector: mmap the graph bundle; SQ8 as a bundle section

### DIFF
--- a/src/storage/local_fs.rs
+++ b/src/storage/local_fs.rs
@@ -463,6 +463,23 @@ impl StorageProvider for LocalFsStorageProvider {
     fn usage_meter(&self) -> Arc<UsageMeter> {
         Arc::clone(&self.meter)
     }
+
+    fn local_path(&self, uri: &str) -> Option<PathBuf> {
+        // The provider root is baked into the store; the object key is the bare
+        // (normalized) uri. Rebuild the on-disk path so a caller can mmap the
+        // file directly. `object_store`'s `LocalFileSystem` maps each *decoded*
+        // path segment to a filesystem component, so we join the decoded parts
+        // (`PathPart::as_ref`), not `ObjPath::to_string()` (which re-emits the
+        // percent-ENCODED form and would diverge for keys needing encoding).
+        // Parsing through `ObjPath` first applies the same normalization the
+        // read/write paths use.
+        let path = Self::path(uri).ok()?;
+        let mut fs_path = self.root.clone();
+        for part in path.parts() {
+            fs_path.push(part.as_ref());
+        }
+        Some(fs_path)
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,7 +30,7 @@
 //! specifically, re-reads the pointer to capture the winner's
 //! state, and retries the commit on top of it.
 
-use std::{fmt, ops::Range, sync::Arc, time::SystemTime};
+use std::{fmt, ops::Range, path::PathBuf, sync::Arc, time::SystemTime};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -580,6 +580,16 @@ pub trait StorageProvider: Send + Sync + fmt::Debug {
     fn usage_meter(&self) -> Arc<UsageMeter> {
         UsageMeter::process_default()
     }
+
+    /// Filesystem path this `uri` maps to, when the provider is backed by a
+    /// local directory (LocalFs). `Some(path)` lets an open-time caller mmap a
+    /// large immutable object zero-copy — sharing one physical page-cache copy
+    /// across processes — instead of assembling it into private heap via
+    /// range-GETs. `None` for object-store backends (S3/Azure/GCS) and test
+    /// doubles; those callers keep the buffered fetch path.
+    fn local_path(&self, _uri: &str) -> Option<PathBuf> {
+        None
+    }
 }
 
 /// Convert an object-store LIST result back into the provider-relative key
@@ -722,6 +732,10 @@ impl StorageProvider for PrefixedStorageProvider {
 
     fn usage_meter(&self) -> Arc<UsageMeter> {
         self.inner.usage_meter()
+    }
+
+    fn local_path(&self, uri: &str) -> Option<PathBuf> {
+        self.inner.local_path(&self.prefixed(uri))
     }
 }
 

--- a/src/superfile/vector/hnsw.rs
+++ b/src/superfile/vector/hnsw.rs
@@ -43,6 +43,7 @@ use std::{
     sync::{Mutex, RwLock},
 };
 
+use bytes::Bytes;
 use rayon::prelude::*;
 
 use crate::superfile::vector::distance::{
@@ -85,6 +86,39 @@ pub(crate) trait NodeScorer {
     fn score(&self, q: &Self::Prepared, node: u32) -> f32;
 }
 
+/// Backing store for a serving byte plane (the Sq16 code plane or the derived
+/// SQ8 walk plane): either owned heap (`Vec`) or a zero-copy slice of the
+/// memory-mapped graph bundle (`Bytes`). [`Plane::bytes`] hands out a
+/// contiguous `&[u8]` either way, so the scoring / VNNI kernels are unchanged.
+///
+/// The mapped variant keeps its backing `Bytes` alive: when the bundle is
+/// served via `mmap` (the default for local backends, see
+/// `slow_vector_state::fetch_graph_section`), the Sq16 and SQ8 planes are
+/// `slice_ref` views of that one mapping — one physical page-cache copy shared
+/// across every process, and no per-open heap copy of the multi-GiB planes.
+pub(crate) enum Plane {
+    Owned(Vec<u8>),
+    Shared(Bytes),
+}
+
+impl Plane {
+    #[inline]
+    pub(crate) fn bytes(&self) -> &[u8] {
+        match self {
+            Plane::Owned(v) => v,
+            Plane::Shared(b) => b,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.bytes().len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.bytes().is_empty()
+    }
+}
+
 /// Sq16 node scorer: one `u16` code per dimension on the fixed cosine
 /// grid, scored with the existing fused-dequant [`Sq16Kernel`] under the
 /// [`Metric::NegDot`] convention (`score = −dot`, so smaller is nearer).
@@ -92,8 +126,9 @@ pub(crate) trait NodeScorer {
 /// The codes are stored row-major (`dim × 2` bytes per node) and scored
 /// straight from the code bytes — no per-candidate decode buffer.
 pub(crate) struct Sq16Scorer {
-    /// `len × dim × 2` little-endian `u16` codes, row-major.
-    codes: Vec<u8>,
+    /// `len × dim × 2` little-endian `u16` codes, row-major — owned heap, or a
+    /// zero-copy slice of the mapped graph bundle.
+    codes: Plane,
     dim: usize,
     len: usize,
 }
@@ -110,7 +145,7 @@ impl Sq16Scorer {
             encode_sq16_row(v, &mut codes[i * stride..(i + 1) * stride]);
         }
         Self {
-            codes,
+            codes: Plane::Owned(codes),
             dim,
             len: vectors.len(),
         }
@@ -121,6 +156,19 @@ impl Sq16Scorer {
     /// on-disk `full[]` Sq16 plane. No decode/re-encode round trip.
     pub(crate) fn from_codes(codes: Vec<u8>, dim: usize, len: usize) -> Self {
         debug_assert_eq!(codes.len(), len * dim * 2);
+        Self {
+            codes: Plane::Owned(codes),
+            dim,
+            len,
+        }
+    }
+
+    /// Adopt an already-backed Sq16 code plane verbatim: the plane holds
+    /// exactly the `len × dim × 2` on-disk bytes, whether that is a zero-copy
+    /// slice of the mapped bundle (`Plane::Shared`) or an owned buffer. No
+    /// decode/re-encode round trip and, for the shared variant, no heap copy.
+    pub(crate) fn from_plane(codes: Plane, dim: usize, len: usize) -> Self {
+        debug_assert_eq!(codes.len(), len * dim * 2);
         Self { codes, dim, len }
     }
 
@@ -128,14 +176,14 @@ impl Sq16Scorer {
     /// concatenate the prior codes with a freshly-drained delta into one
     /// combined scorer.
     pub(crate) fn codes(&self) -> &[u8] {
-        &self.codes
+        self.codes.bytes()
     }
 
     #[inline]
     fn row(&self, node: u32) -> &[u8] {
         let stride = self.dim * 2;
         let start = node as usize * stride;
-        &self.codes[start..start + stride]
+        &self.codes.bytes()[start..start + stride]
     }
 }
 
@@ -1152,12 +1200,30 @@ impl Hnsw {
     }
 }
 
-/// On-disk magic for a persisted `hnsw` bundle (graph + node→doc-id
-/// map + node-ordered Sq16 plane), the self-contained payload a resident
-/// data index is rebuilt from at open. `02` carries the stamped column
-/// name; an older `01` bundle (no column) decodes to `None` so the query
-/// falls back to ivf until the next drain rebuilds it.
-const HNSW_DATA_MAGIC: &[u8; 8] = b"INFDDG02";
+/// On-disk magic for a persisted `hnsw` data bundle (graph + node→doc-id map +
+/// node-ordered Sq16 plane), the self-contained payload a resident data index
+/// is rebuilt from at open.
+///
+/// `v03` is the current format: it appends the derived SQ8 walk plane (`n ×
+/// dim` high bytes) as a section right after the Sq16 plane, so a mapped bundle
+/// serves *both* planes as zero-copy slices — no per-open derive of the ~0.77
+/// GiB SQ8 plane. `v02` (pre-existing bundles) carries only the Sq16 plane; it
+/// is still decoded, with the SQ8 plane derived on read as before — the
+/// backward-compatible fallback, so no forced rebuild. `v03` and `v02` share
+/// an identical header/doc-id/Sq16/graph framing; they differ only by the
+/// presence of the SQ8 section (and thus the magic). An older `01` bundle (no
+/// column) is neither, so it decodes to `None` and the query falls back to ivf
+/// until the next drain rebuilds it.
+const HNSW_DATA_MAGIC_V2: &[u8; 8] = b"INFDDG02";
+const HNSW_DATA_MAGIC_V3: &[u8; 8] = b"INFDDG03";
+/// Both magics are 8 bytes; the shared byte width of the leading tag.
+const HNSW_DATA_MAGIC_LEN: usize = HNSW_DATA_MAGIC_V3.len();
+/// Byte size of the fixed frame of a data bundle: magic(8) + n(u64) + dim(u32)
+/// + ef(u32) + col_len(u32) + graph_len(u64). The variable-length column name,
+/// doc-id map, Sq16/SQ8 planes, and graph bytes are added on top; naming it
+/// keeps the `encode_hnsw` capacity hint exact so the final `graph_len` extend
+/// after the multi-GiB planes cannot trigger a full-buffer realloc at drain.
+const HNSW_DATA_FIXED_BYTES: usize = HNSW_DATA_MAGIC_LEN + 8 + 4 + 4 + 4 + 8;
 
 /// A `hnsw` resident index rebuilt from a persisted bundle: the Sq16
 /// scorer over the node-ordered code plane, the walkable graph, and the
@@ -1177,16 +1243,20 @@ pub(crate) struct HnswIndex {
     /// column's neighbors.
     pub column: String,
     /// Resident contiguous SQ8 walk plane (`n × dim` bytes) — the high byte of
-    /// each Sq16 code, derived here at load, never persisted (no writer/bundle
-    /// change). Used by [`HnswIndex::search_sq8_refine`] for a cheap int8-VNNI
-    /// walk; the exact ranking comes from the Sq16 refine over `scorer`.
-    pub sq8_plane: Vec<u8>,
+    /// each Sq16 code. On a `v03` bundle it is a zero-copy slice of the mapped
+    /// bundle (persisted as a section); on a `v02` bundle it is derived on read
+    /// into owned heap. Empty when SQ8-walk serving is off, so it costs no
+    /// memory when disabled and serving falls back to the Sq16 walk. Used by
+    /// [`HnswIndex::search_sq8_refine`] for a cheap int8-VNNI walk; the exact
+    /// ranking comes from the Sq16 refine over `scorer`.
+    pub sq8_plane: Plane,
 }
 
-/// Serialize a `hnsw` index to a persistable byte bundle: header,
-/// the `node -> stable doc id` map, the node-ordered Sq16 code plane, and
-/// the graph section. The Sq16 plane is carried inline so the bundle is
-/// self-contained — reopening needs nothing but these bytes.
+/// Serialize a `hnsw` index to a persistable byte bundle (`v03`): header,
+/// the `node -> stable doc id` map, the node-ordered Sq16 code plane, the
+/// derived SQ8 walk plane, and the graph section. Both planes are carried
+/// inline so the bundle is self-contained — reopening needs nothing but these
+/// bytes, and a mapped bundle serves both planes zero-copy.
 pub(crate) fn encode_hnsw(
     sq16_codes: &[u8],
     doc_ids: &[i128],
@@ -1199,9 +1269,12 @@ pub(crate) fn encode_hnsw(
     debug_assert_eq!(sq16_codes.len(), n * dim * 2);
     let graph_bytes = graph.to_bytes();
     let col = column.as_bytes();
-    let mut out =
-        Vec::with_capacity(32 + col.len() + n * 16 + sq16_codes.len() + graph_bytes.len());
-    out.extend_from_slice(HNSW_DATA_MAGIC);
+    // The SQ8 section is `n × dim` bytes (the high byte of each u16 Sq16 code).
+    let sq8_len = n * dim;
+    let mut out = Vec::with_capacity(
+        HNSW_DATA_FIXED_BYTES + col.len() + n * 16 + sq16_codes.len() + sq8_len + graph_bytes.len(),
+    );
+    out.extend_from_slice(HNSW_DATA_MAGIC_V3);
     out.extend_from_slice(&(n as u64).to_le_bytes());
     out.extend_from_slice(&(dim as u32).to_le_bytes());
     // Was reserved / alignment; now the stamped query beam (u32).
@@ -1213,19 +1286,58 @@ pub(crate) fn encode_hnsw(
         out.extend_from_slice(&id.to_le_bytes());
     }
     out.extend_from_slice(sq16_codes);
+    // SQ8 walk plane, derived from the Sq16 plane just written. Persisting it
+    // (rather than deriving on read) lets a mapped bundle serve it as a
+    // zero-copy slice. Shares the derivation with the v02 read-time fallback so
+    // the two can't drift.
+    extend_sq8_plane(&mut out, sq16_codes);
     out.extend_from_slice(&(graph_bytes.len() as u64).to_le_bytes());
     out.extend_from_slice(&graph_bytes);
+    out
+}
+
+/// Append the derived SQ8 walk plane — the high byte of each little-endian
+/// `u16` Sq16 code — to `out`. The single source of truth for the derivation,
+/// shared by [`encode_hnsw`] (persisting the v03 section) and
+/// [`derive_sq8_plane`] (the v02 read-time fallback) so the two can't drift.
+/// `chunks_exact(2)` elides the per-element bounds check on this hydration loop.
+fn extend_sq8_plane(out: &mut Vec<u8>, sq16_plane: &[u8]) {
+    out.extend(sq16_plane.chunks_exact(2).map(|w| w[1]));
+}
+
+/// The derived SQ8 walk plane as an owned buffer (`n × dim`). A pure function
+/// of the Sq16 plane — used to serve a `v02` bundle that has no persisted SQ8
+/// section.
+fn derive_sq8_plane(sq16_plane: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(sq16_plane.len() / 2);
+    extend_sq8_plane(&mut out, sq16_plane);
     out
 }
 
 /// Rebuild a resident [`HnswIndex`] from [`encode_hnsw`].
 /// Returns `None` on any malformation so the caller falls back to the lazy
 /// build or scan path rather than failing the query.
-pub(crate) fn decode_hnsw(bytes: &[u8], sq8_walk: bool) -> Option<HnswIndex> {
+///
+/// `bundle` owns the encoded bytes. When it is the memory-mapped graph bundle
+/// (the default local serving path), the Sq16 plane — and, on a `v03` bundle,
+/// the SQ8 plane — are served as zero-copy [`Bytes::slice_ref`] slices of it,
+/// with no heap copy, and the returned index keeps the mapping alive. A `v02`
+/// bundle has no SQ8 section, so the SQ8 plane is derived on read into owned
+/// heap when SQ8-walk serving is on.
+pub(crate) fn decode_hnsw(bundle: &Bytes, sq8_walk: bool) -> Option<HnswIndex> {
+    let bytes: &[u8] = bundle.as_ref();
     let mut c = Cursor::new(bytes);
-    if c.take(HNSW_DATA_MAGIC.len())? != HNSW_DATA_MAGIC {
+    let magic = c.take(HNSW_DATA_MAGIC_LEN)?;
+    // `v03` carries the SQ8 walk plane as an inline section; `v02` (pre-existing
+    // bundles) does not, so it is derived on read below. Any other tag (e.g. a
+    // legacy `01`) is unsupported → `None`, and the query falls back to ivf.
+    let has_sq8_section = if magic == HNSW_DATA_MAGIC_V3 {
+        true
+    } else if magic == HNSW_DATA_MAGIC_V2 {
+        false
+    } else {
         return None;
-    }
+    };
     let n = c.u64()? as usize;
     let dim = c.u32()? as usize;
     let ef_search = c.u32()? as usize; // 0 on older bundles (was reserved)
@@ -1249,27 +1361,37 @@ pub(crate) fn decode_hnsw(bytes: &[u8], sq8_walk: bool) -> Option<HnswIndex> {
     for _ in 0..n {
         doc_ids.push(c.i128()?);
     }
-    let plane = c.take(n.checked_mul(dim)?.checked_mul(2)?)?.to_vec();
+    // Sq16 plane as a zero-copy slice of `bundle`: `c.take` yields a subslice of
+    // `bytes` (= `bundle.as_ref()`), so `slice_ref` recovers the owning `Bytes`
+    // view without copying — a mapped bundle never copies the ~1.5 GiB plane
+    // into this process's heap.
+    let sq16_slice = c.take(n.checked_mul(dim)?.checked_mul(2)?)?;
+    let sq16_plane = bundle.slice_ref(sq16_slice);
+    // SQ8 walk plane. On `v03` it is the next inline section — sliced zero-copy
+    // out of `bundle` exactly like Sq16; the cursor consumes it either way
+    // (the section is always present) so the graph section that follows is
+    // reachable. On `v02` it is derived on read from the Sq16 high byte. Empty
+    // when SQ8-walk serving is off, so it costs no memory when disabled and
+    // serving falls back to the Sq16 walk.
+    let sq8_plane: Plane = if has_sq8_section {
+        let sq8_slice = c.take(n.checked_mul(dim)?)?;
+        if sq8_walk {
+            Plane::Shared(bundle.slice_ref(sq8_slice))
+        } else {
+            Plane::Owned(Vec::new())
+        }
+    } else if sq8_walk {
+        Plane::Owned(derive_sq8_plane(sq16_slice))
+    } else {
+        Plane::Owned(Vec::new())
+    };
     let graph_len = c.u64()? as usize;
     let graph_bytes = c.take(graph_len)?;
     let graph = Hnsw::from_bytes(graph_bytes)?;
     if graph.len() != n {
         return None;
     }
-    // Resident SQ8 walk plane: the high byte of each little-endian u16 code,
-    // laid out contiguously (n × dim). Reader-side only — derived from the
-    // Sq16 plane, never persisted. Built only when SQ8-walk serving is on;
-    // empty otherwise, so the plane costs no memory when disabled and serving
-    // falls back to the Sq16 walk.
-    let sq8_plane: Vec<u8> = if sq8_walk {
-        // High byte of each little-endian u16 code — the second byte of every
-        // 2-byte pair. `chunks_exact(2)` elides the per-element bounds check on
-        // this `n × dim` hydration loop.
-        plane.chunks_exact(2).map(|w| w[1]).collect()
-    } else {
-        Vec::new()
-    };
-    let scorer = Sq16Scorer::from_codes(plane, dim, n);
+    let scorer = Sq16Scorer::from_plane(Plane::Shared(sq16_plane), dim, n);
     Some(HnswIndex {
         scorer,
         graph,
@@ -1357,7 +1479,7 @@ impl HnswIndex {
         refine_k: usize,
     ) -> Vec<(u32, f32)> {
         let sq8 = Sq8WalkScorer {
-            plane: &self.sq8_plane,
+            plane: self.sq8_plane.bytes(),
             dim: self.dim,
             len: self.graph.len(),
         };
@@ -1412,7 +1534,12 @@ pub(crate) struct GraphBundle {
     /// Largest stable doc id the graph covers (the append-delta boundary).
     pub high_water_id: i128,
     pub centroid_graph: Vec<u8>,
-    pub data_bundle: Option<Vec<u8>>,
+    /// The [`encode_hnsw`] payload, as a zero-copy slice of the input `Bytes`
+    /// (`raw.slice_ref`). When the input is the mapped bundle this is the
+    /// multi-GiB data section with no heap copy — the open-time transient the
+    /// mmap serving path removes; [`decode_hnsw`] then slices the Sq16 and SQ8
+    /// planes straight out of it.
+    pub data_bundle: Option<Bytes>,
 }
 
 /// Read the `(population_key, high_water_id)` header from a bundle's first
@@ -1450,14 +1577,6 @@ fn put_opt_section(out: &mut Vec<u8>, section: Option<&[u8]>) {
     }
 }
 
-fn take_opt_section(c: &mut Cursor<'_>) -> Option<Option<Vec<u8>>> {
-    if c.take(1)?[0] == 0 {
-        return Some(None);
-    }
-    let len = c.u64()? as usize;
-    Some(Some(c.take(len)?.to_vec()))
-}
-
 /// Frame the graph sections into one slow-state blob, stamping the
 /// `(high_water_id, count)` watermark into the fixed-offset header. The
 /// data bundle and its provenance are omitted (a `0` flag) above the
@@ -1481,7 +1600,20 @@ pub(crate) fn encode_graph_bundle(
 /// Parse an [`encode_graph_bundle`] blob into its raw sections + header.
 /// `None` on a bad magic or truncation, so a corrupt bundle degrades to a
 /// fallback.
-pub(crate) fn decode_graph_bundle(bytes: &[u8]) -> Option<GraphBundle> {
+///
+/// `mmap_backed` picks how the large `data_bundle` section is returned:
+/// - `true` (the local serving path, `raw` is the shared file mmap): a
+///   zero-copy `raw.slice_ref` — the multi-GiB payload never touches heap and
+///   the returned index keeps the one mapping alive.
+/// - `false` (remote/object-store, `raw` is a striped *heap* blob): the data
+///   section is copied out into its own `Bytes`, so `raw` — which also holds
+///   the centroid section and framing — is freed once this returns instead of
+///   being pinned for the index's whole lifetime.
+///
+/// The small `centroid_graph` (present at every scale, modest size) is always
+/// copied out into owned heap.
+pub(crate) fn decode_graph_bundle(raw: &Bytes, mmap_backed: bool) -> Option<GraphBundle> {
+    let bytes: &[u8] = raw.as_ref();
     let mut c = Cursor::new(bytes);
     if c.take(GRAPH_BUNDLE_MAGIC.len())? != GRAPH_BUNDLE_MAGIC {
         return None;
@@ -1490,7 +1622,21 @@ pub(crate) fn decode_graph_bundle(bytes: &[u8]) -> Option<GraphBundle> {
     let high_water_id = c.i128()?;
     let centroid_len = c.u64()? as usize;
     let centroid_graph = c.take(centroid_len)?.to_vec();
-    let data_bundle = take_opt_section(&mut c)?;
+    // Optional length-prefixed data-bundle section (`0` flag ⇒ absent). `c.take`
+    // yields a subslice of `bytes` (= `raw`): on the mmap path `slice_ref`
+    // shares that mapping zero-copy; on the heap path we copy it out so `raw`
+    // (the full striped blob) frees.
+    let data_bundle = if c.take(1)?[0] == 0 {
+        None
+    } else {
+        let len = c.u64()? as usize;
+        let section = c.take(len)?;
+        Some(if mmap_backed {
+            raw.slice_ref(section)
+        } else {
+            Bytes::copy_from_slice(section)
+        })
+    };
     Some(GraphBundle {
         population_key,
         high_water_id,
@@ -2392,7 +2538,12 @@ mod tests {
         let graph = Hnsw::build(&scorer, HnswParams::default());
 
         let bytes = encode_hnsw(&codes, &doc_ids, &graph, dim, 256, "emb");
-        let idx = decode_hnsw(&bytes, true).expect("decode bundle");
+        assert_eq!(
+            &bytes[..HNSW_DATA_MAGIC_LEN],
+            HNSW_DATA_MAGIC_V3,
+            "encode_hnsw stamps the v03 data magic"
+        );
+        let idx = decode_hnsw(&Bytes::from(bytes.clone()), true).expect("decode bundle");
         assert_eq!(idx.dim, dim);
         assert_eq!(idx.doc_ids, doc_ids);
         assert_eq!(idx.graph.len(), n);
@@ -2412,18 +2563,89 @@ mod tests {
                 assert_eq!(idx.doc_ids[*node as usize], doc_ids[*node as usize]);
             }
         }
-        assert!(decode_hnsw(b"short", true).is_none());
+        assert!(decode_hnsw(&Bytes::from_static(b"short"), true).is_none());
 
         // A corrupt node count must degrade to None, not drive a huge
         // `with_capacity` alloc-abort. Overwrite the `n` word (right after the
         // 8-byte magic) with an absurd value and confirm the decode declines.
         let mut poisoned = bytes.clone();
-        poisoned[HNSW_DATA_MAGIC.len()..HNSW_DATA_MAGIC.len() + 8]
+        poisoned[HNSW_DATA_MAGIC_LEN..HNSW_DATA_MAGIC_LEN + 8]
             .copy_from_slice(&u64::MAX.to_le_bytes());
         assert!(
-            decode_hnsw(&poisoned, true).is_none(),
+            decode_hnsw(&Bytes::from(poisoned), true).is_none(),
             "a corrupt node count must decode to None, not attempt a giant alloc"
         );
+    }
+
+    /// A `v03` bundle serves the SQ8 plane as a persisted section that is a
+    /// zero-copy slice of the same backing bytes as the Sq16 plane, and a
+    /// pre-existing `v02` bundle (Sq16 only) still decodes with the SQ8 plane
+    /// derived on read — the backward-compatible fallback. Both paths must
+    /// yield byte-identical planes and identical search results.
+    #[test]
+    fn sq8_section_v03_matches_derived_v02() {
+        use crate::superfile::vector::distance::encode_sq16_row;
+        let dim = 24;
+        let n = 400;
+        let vectors = random_unit_vectors(n, dim, 0x5EC7);
+        let stride = dim * 2;
+        let mut codes = vec![0u8; n * stride];
+        for (i, v) in vectors.iter().enumerate() {
+            encode_sq16_row(v, &mut codes[i * stride..(i + 1) * stride]);
+        }
+        let doc_ids: Vec<i128> = (0..n as i128).collect();
+        let scorer = Sq16Scorer::from_codes(codes.clone(), dim, n);
+        let graph = Hnsw::build(&scorer, HnswParams::default());
+
+        // Current encoder → v03 (SQ8 section present).
+        let v3 = encode_hnsw(&codes, &doc_ids, &graph, dim, 128, "emb");
+        assert_eq!(&v3[..HNSW_DATA_MAGIC_LEN], HNSW_DATA_MAGIC_V3);
+
+        // Synthesize a pre-existing v02 bundle: identical framing but no SQ8
+        // section (Sq16 plane runs straight into the graph section) and the v02
+        // magic. Built by re-laying the wire so the fixture matches exactly what
+        // an old drain wrote.
+        let mut v2 = Vec::new();
+        v2.extend_from_slice(HNSW_DATA_MAGIC_V2);
+        v2.extend_from_slice(&(n as u64).to_le_bytes());
+        v2.extend_from_slice(&(dim as u32).to_le_bytes());
+        v2.extend_from_slice(&128u32.to_le_bytes());
+        let col = b"emb";
+        v2.extend_from_slice(&(col.len() as u32).to_le_bytes());
+        v2.extend_from_slice(col);
+        for &id in &doc_ids {
+            v2.extend_from_slice(&id.to_le_bytes());
+        }
+        v2.extend_from_slice(&codes);
+        let graph_bytes = graph.to_bytes();
+        v2.extend_from_slice(&(graph_bytes.len() as u64).to_le_bytes());
+        v2.extend_from_slice(&graph_bytes);
+
+        let idx_v3 = decode_hnsw(&Bytes::from(v3), true).expect("decode v03");
+        let idx_v2 = decode_hnsw(&Bytes::from(v2), true).expect("decode v02");
+
+        // The SQ8 plane the persisted section carries must equal the one derived
+        // from the Sq16 high byte.
+        let derived = derive_sq8_plane(&codes);
+        assert_eq!(idx_v3.sq8_plane.bytes(), derived.as_slice());
+        assert_eq!(idx_v2.sq8_plane.bytes(), derived.as_slice());
+        assert_eq!(idx_v3.sq8_plane.len(), n * dim);
+
+        // Sq16 plane and searches identical across both bundle versions.
+        assert_eq!(idx_v3.scorer.codes(), idx_v2.scorer.codes());
+        let queries = random_unit_vectors(30, dim, 0x1CE);
+        for q in &queries {
+            let a = idx_v3.search_sq8_refine(q, 10, 64, 32);
+            let b = idx_v2.search_sq8_refine(q, 10, 64, 32);
+            assert_eq!(a, b, "v03 section vs v02 derive diverged");
+        }
+
+        // With SQ8-walk off, a v03 bundle still consumes the section (so the
+        // graph is reachable) and serves correctly with an empty SQ8 plane.
+        let v3_again = encode_hnsw(&codes, &doc_ids, &graph, dim, 128, "emb");
+        let idx_off = decode_hnsw(&Bytes::from(v3_again), false).expect("decode v03 sq8-off");
+        assert!(idx_off.sq8_plane.is_empty());
+        assert_eq!(idx_off.graph.len(), n);
     }
 
     /// SQ8 walk + Sq16 refine returns essentially the same top-k as the Sq16
@@ -2448,7 +2670,7 @@ mod tests {
         let scorer = Sq16Scorer::from_codes(codes.clone(), dim, n);
         let graph = Hnsw::build(&scorer, HnswParams::default());
         let bytes = encode_hnsw(&codes, &doc_ids, &graph, dim, ef, "emb");
-        let idx = decode_hnsw(&bytes, true).expect("decode bundle");
+        let idx = decode_hnsw(&Bytes::from(bytes), true).expect("decode bundle");
         assert!(
             !idx.sq8_plane.is_empty(),
             "sq8 plane must be built when sq8_walk=true"
@@ -2507,11 +2729,25 @@ mod tests {
         let centroid = vec![1u8, 2, 3, 4, 5];
         let data = vec![9u8; 300];
         let blob = encode_graph_bundle(0xDEAD_BEEF_1234, 987_654_321, &centroid, Some(&data));
-        let got = decode_graph_bundle(&blob).expect("decode full");
-        assert_eq!(got.population_key, 0xDEAD_BEEF_1234);
-        assert_eq!(got.high_water_id, 987_654_321);
-        assert_eq!(got.centroid_graph, centroid);
-        assert_eq!(got.data_bundle.as_deref(), Some(&data[..]));
+        // Both modes recover identical sections; only the data-section backing
+        // differs (zero-copy slice of `raw` vs an owned copy).
+        for mmap_backed in [true, false] {
+            let raw = Bytes::from(blob.clone());
+            let got = decode_graph_bundle(&raw, mmap_backed).expect("decode full");
+            assert_eq!(got.population_key, 0xDEAD_BEEF_1234);
+            assert_eq!(got.high_water_id, 987_654_321);
+            assert_eq!(got.centroid_graph, centroid);
+            assert_eq!(got.data_bundle.as_deref(), Some(&data[..]));
+            // On the heap path the data section must be an independent copy, not
+            // a view into `raw`, so `raw` can be freed.
+            if !mmap_backed {
+                let db = got.data_bundle.as_ref().expect("data present");
+                assert!(
+                    !raw.as_ref().as_ptr_range().contains(&db.as_ptr()),
+                    "heap-path data_bundle must not alias raw"
+                );
+            }
+        }
         // The header reads from the fixed-offset prefix alone (a tiny range
         // GET at settle time — no need for the multi-GiB body).
         assert_eq!(
@@ -2521,11 +2757,11 @@ mod tests {
 
         // Data-less bundle (above the scale ceiling): empty centroid, no data.
         let blob = encode_graph_bundle(0, 0, &[], None);
-        let got = decode_graph_bundle(&blob).expect("decode empty");
+        let got = decode_graph_bundle(&Bytes::from(blob), true).expect("decode empty");
         assert!(got.centroid_graph.is_empty());
         assert!(got.data_bundle.is_none());
 
-        assert!(decode_graph_bundle(b"bad").is_none());
+        assert!(decode_graph_bundle(&Bytes::from_static(b"bad"), true).is_none());
         assert!(graph_bundle_header(b"short").is_none());
     }
 

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -7850,8 +7850,9 @@ mod tests {
             let bundle = block_on(super::assemble_hnsw_sections(manifest, "emb", &None))
                 .expect("assemble ok")
                 .expect("sq16 rows must assemble into a graph");
-            let decoded = crate::superfile::vector::hnsw::decode_hnsw(&bundle, true)
-                .expect("decode data bundle");
+            let decoded =
+                crate::superfile::vector::hnsw::decode_hnsw(&bytes::Bytes::from(bundle), true)
+                    .expect("decode data bundle");
             assert_eq!(
                 decoded.graph.len(),
                 decoded.doc_ids.len(),

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -2308,17 +2308,18 @@ impl SupertableReader {
                 return Some(Arc::clone(sections));
             }
         }
-        let sections = match fetch_graph_sections(storage.as_ref(), &reference).await {
-            Ok(sections) => Arc::new(sections),
-            Err(error) => {
-                tracing::warn!(
-                    "hnsw graph sections {} unavailable ({error}); falling back to \
+        let sections =
+            match fetch_graph_sections(storage.as_ref(), &reference, /* need_sq8 */ true).await {
+                Ok(sections) => Arc::new(sections),
+                Err(error) => {
+                    tracing::warn!(
+                        "hnsw graph sections {} unavailable ({error}); falling back to \
                      the ivf scan",
-                    reference.uri
-                );
-                return None;
-            }
-        };
+                        reference.uri
+                    );
+                    return None;
+                }
+            };
         // Publish under the cache lock. The gate makes this the only in-flight
         // hydration, so it installs the uri it just fetched.
         {

--- a/src/supertable/slow_vector_state.rs
+++ b/src/supertable/slow_vector_state.rs
@@ -35,11 +35,14 @@ use crate::{
     config,
     storage::{StorageError, StorageProvider},
     superfile::vector::hnsw,
-    supertable::manifest::{
-        SuperfileEntry, VectorSummary,
-        encoding::SummaryWireMode,
-        list::RoutingRef,
-        part::{self, ContentHash, ManifestPart, PartId},
+    supertable::{
+        manifest::{
+            SuperfileEntry, VectorSummary,
+            encoding::SummaryWireMode,
+            list::RoutingRef,
+            part::{self, ContentHash, ManifestPart, PartId},
+        },
+        reader_cache::disk,
     },
 };
 
@@ -554,20 +557,67 @@ pub(crate) async fn write_graph_section(
 }
 
 /// Fetch a graph section written by [`write_graph_section`], verifying its
-/// bytes hash to `reference.content_hash`. Returns the raw section bytes
-/// (the caller decodes them with `hnsw::decode_hnsw` /
-/// `Hnsw::from_bytes`). Striped like every other slow-state fetch. Callers
-/// fall back to the lazy build / scan path on any error — a bad or missing
-/// graph blob must never fail an open or a query.
+/// bytes hash to `reference.content_hash`. Returns the verified section bytes as
+/// a [`Bytes`] handed straight to the decoder (no `to_vec` copy) plus whether
+/// the backing is an `mmap` (the caller decodes with `hnsw::decode_hnsw` /
+/// `Hnsw::from_bytes`).
+///
+/// A local bundle file is loaded as a zero-copy `mmap`-backed `Bytes` (one
+/// faulted read for the hash check, then the mapping is what the resident
+/// graph holds), so the multi-GiB open-time transient never touches heap and N
+/// processes share one physical page-cache copy — the default serving path.
+/// Every non-local backend (`local_path` is `None`, i.e. S3/Azure/GCS) keeps
+/// the striped heap fetch, so remote correctness is unchanged. Callers fall
+/// back to the lazy build / scan path on any error — a bad or missing graph
+/// blob must never fail an open or a query.
+///
+/// The hash verification faults the whole (possibly multi-GiB, mmap-backed)
+/// bundle in synchronously — a CPU/IO wave that must not run on a tokio worker
+/// (the runtime anti-pattern). It runs on the blocking pool, mirroring
+/// [`load_full_state`].
 pub(crate) async fn fetch_graph_section(
     storage: &dyn StorageProvider,
     reference: &RoutingRef,
-) -> Result<Vec<u8>, SlowVectorStateError> {
-    let bytes = fetch_blob_striped(storage, &reference.uri, STRIPED_FETCH_CHUNK_BYTES).await?;
-    if ContentHash::of(bytes.as_ref()) != reference.content_hash {
-        return Err(SlowVectorStateError::HashMismatch);
+) -> Result<(Bytes, bool), SlowVectorStateError> {
+    let (bytes, is_mmap) = fetch_graph_bytes(storage, reference).await?;
+    let expected = reference.content_hash;
+    let bytes = spawn_blocking(move || {
+        if ContentHash::of(bytes.as_ref()) != expected {
+            return Err(SlowVectorStateError::HashMismatch);
+        }
+        Ok(bytes)
+    })
+    .await
+    .map_err(|join_error| {
+        SlowVectorStateError::Parse(format!("graph section hash task failed: {join_error}"))
+    })??;
+    Ok((bytes, is_mmap))
+}
+
+/// The bundle bytes for [`fetch_graph_section`] plus whether the backing is an
+/// `mmap`: `mmap`-backed for a local file (the default), else striped from
+/// storage into a heap buffer for remote backends. A local mmap failure is
+/// non-fatal — it falls through to the striped fetch so an open never fails on
+/// it. The mmap acquisition itself is cheap (no fault); only the hash + decode
+/// over the map are CPU/IO-heavy, and those run on the blocking pool.
+async fn fetch_graph_bytes(
+    storage: &dyn StorageProvider,
+    reference: &RoutingRef,
+) -> Result<(Bytes, bool), SlowVectorStateError> {
+    if let Some(path) = storage.local_path(&reference.uri)
+        && path.exists()
+    {
+        match disk::mmap_readonly_bytes(&path) {
+            Ok(bytes) => return Ok((bytes, true)),
+            Err(error) => tracing::warn!(
+                uri = reference.uri,
+                %error,
+                "graph bundle mmap failed; falling back to striped heap fetch"
+            ),
+        }
     }
-    Ok(bytes.to_vec())
+    let bytes = fetch_blob_striped(storage, &reference.uri, STRIPED_FETCH_CHUNK_BYTES).await?;
+    Ok((bytes, false))
 }
 
 /// The graph sections of one published generation, decoded resident. Held
@@ -594,17 +644,29 @@ pub(crate) async fn fetch_graph_sections(
     storage: &dyn StorageProvider,
     reference: &RoutingRef,
 ) -> Result<ResidentGraphSections, SlowVectorStateError> {
-    let raw = fetch_graph_section(storage, reference).await?;
-    let bundle = hnsw::decode_graph_bundle(&raw)
-        .ok_or_else(|| SlowVectorStateError::Parse("graph bundle frame".into()))?;
-    // Build the resident SQ8 walk plane only when SQ8-walk serving is enabled
-    // (it costs ~1 byte/dim/row on top of the Sq16 plane); otherwise serving
-    // walks on Sq16 and the plane stays empty.
+    let (raw, mmap_backed) = fetch_graph_section(storage, reference).await?;
+    // Serve the resident SQ8 walk plane only when SQ8-walk serving is enabled;
+    // otherwise serving walks on Sq16 and the plane stays empty.
     let sq8_walk = config::global().vector.hnsw_sq8_walk;
-    let data = bundle
-        .data_bundle
-        .as_deref()
-        .and_then(|b| hnsw::decode_hnsw(b, sq8_walk));
+    // Decoding faults the (mmap-backed) plane pages in and parses the graph — a
+    // CPU/IO wave that must stay off the tokio workers (the runtime
+    // anti-pattern), so it runs on the blocking pool. On a mapped bundle the
+    // Sq16/SQ8 planes are zero-copy slices of `raw` and the returned index keeps
+    // the mapping alive; on the heap path the data section is copied out so
+    // `raw` frees.
+    let (high_water_id, data) = spawn_blocking(move || {
+        let bundle = hnsw::decode_graph_bundle(&raw, mmap_backed)
+            .ok_or_else(|| SlowVectorStateError::Parse("graph bundle frame".into()))?;
+        let data = bundle
+            .data_bundle
+            .as_ref()
+            .and_then(|b| hnsw::decode_hnsw(b, sq8_walk));
+        Ok::<_, SlowVectorStateError>((bundle.high_water_id, data))
+    })
+    .await
+    .map_err(|join_error| {
+        SlowVectorStateError::Parse(format!("graph bundle decode task failed: {join_error}"))
+    })??;
     if let Some(idx) = &data {
         // Surface the stamped params every time the resident graph hydrates,
         // so serving always shows what a table's graph is actually running.
@@ -618,7 +680,7 @@ pub(crate) async fn fetch_graph_sections(
     }
     Ok(ResidentGraphSections {
         uri: reference.uri.clone(),
-        high_water_id: bundle.high_water_id,
+        high_water_id,
         data,
     })
 }
@@ -911,10 +973,20 @@ mod tests {
             .expect("republish");
         assert_eq!(reference, again);
 
-        let fetched = fetch_graph_section(&storage, &reference)
+        // LocalFs → `local_path` is `Some`, so this exercises the mmap serving
+        // path; the bytes must round-trip byte-exact through the mapping.
+        let (fetched, is_mmap) = fetch_graph_section(&storage, &reference)
             .await
             .expect("fetch graph section");
-        assert_eq!(fetched, bytes, "graph section must round-trip byte-exact");
+        assert!(
+            is_mmap,
+            "LocalFs graph section must serve from the mmap path"
+        );
+        assert_eq!(
+            fetched.as_ref(),
+            bytes.as_slice(),
+            "graph section must round-trip byte-exact"
+        );
 
         let tampered = RoutingRef {
             uri: reference.uri.clone(),

--- a/src/supertable/slow_vector_state.rs
+++ b/src/supertable/slow_vector_state.rs
@@ -643,11 +643,14 @@ pub(crate) struct ResidentGraphSections {
 pub(crate) async fn fetch_graph_sections(
     storage: &dyn StorageProvider,
     reference: &RoutingRef,
+    need_sq8: bool,
 ) -> Result<ResidentGraphSections, SlowVectorStateError> {
     let (raw, mmap_backed) = fetch_graph_section(storage, reference).await?;
-    // Serve the resident SQ8 walk plane only when SQ8-walk serving is enabled;
-    // otherwise serving walks on Sq16 and the plane stays empty.
-    let sq8_walk = config::global().vector.hnsw_sq8_walk;
+    // Serve the resident SQ8 walk plane only when SQ8-walk serving is enabled
+    // AND the caller needs it. The drain/incremental-append maintenance path
+    // hydrates the graph but never walks the SQ8 plane, so it passes
+    // `need_sq8 = false` and skips the plane build entirely.
+    let sq8_walk = need_sq8 && config::global().vector.hnsw_sq8_walk;
     // Decoding faults the (mmap-backed) plane pages in and parses the graph — a
     // CPU/IO wave that must stay off the tokio workers (the runtime
     // anti-pattern), so it runs on the blocking pool. On a mapped bundle the

--- a/src/supertable/slow_vector_state.rs
+++ b/src/supertable/slow_vector_state.rs
@@ -594,26 +594,52 @@ pub(crate) async fn fetch_graph_section(
     Ok((bytes, is_mmap))
 }
 
+/// Whether an `mmap` failure signals resource exhaustion (`ENOMEM`: address
+/// space, `vm.max_map_count`, or an `mmap` rlimit) rather than a benign,
+/// per-file error. On such a failure the striped heap fallback would pull the
+/// whole bundle into heap — strictly more memory than the mapping that just
+/// failed — so the caller surfaces the error instead of masking the pressure.
+fn is_mmap_resource_exhaustion(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::OutOfMemory
+}
+
 /// The bundle bytes for [`fetch_graph_section`] plus whether the backing is an
 /// `mmap`: `mmap`-backed for a local file (the default), else striped from
-/// storage into a heap buffer for remote backends. A local mmap failure is
-/// non-fatal — it falls through to the striped fetch so an open never fails on
-/// it. The mmap acquisition itself is cheap (no fault); only the hash + decode
-/// over the map are CPU/IO-heavy, and those run on the blocking pool.
+/// storage into a heap buffer for remote backends. A *benign* local mmap
+/// failure (missing/moved file, permissions) is non-fatal — it falls through to
+/// the striped fetch so an open never fails on it. A *resource-exhaustion*
+/// failure (see [`is_mmap_resource_exhaustion`]) is surfaced instead: the
+/// striped fallback would consume strictly more memory than the mapping that
+/// just failed, so masking it would turn mapping pressure into a likely OOM;
+/// the caller then degrades to the ivf scan (serving) or a full rebuild (drain).
+/// The `exists` + `mmap` syscalls run on the blocking pool, off the tokio
+/// workers (the striped remote fetch is async and yields on its own); only the
+/// hash + decode over the map are the heavy CPU/IO wave, also on the pool.
 async fn fetch_graph_bytes(
     storage: &dyn StorageProvider,
     reference: &RoutingRef,
 ) -> Result<(Bytes, bool), SlowVectorStateError> {
-    if let Some(path) = storage.local_path(&reference.uri)
-        && path.exists()
-    {
-        match disk::mmap_readonly_bytes(&path) {
-            Ok(bytes) => return Ok((bytes, true)),
-            Err(error) => tracing::warn!(
+    if let Some(path) = storage.local_path(&reference.uri) {
+        let mapped =
+            spawn_blocking(move || path.exists().then(|| disk::mmap_readonly_bytes(&path)))
+                .await
+                .map_err(|join_error| {
+                    SlowVectorStateError::Parse(format!("graph mmap task failed: {join_error}"))
+                })?;
+        match mapped {
+            Some(Ok(bytes)) => return Ok((bytes, true)),
+            Some(Err(error)) if is_mmap_resource_exhaustion(&error) => {
+                return Err(SlowVectorStateError::Storage(format!(
+                    "graph bundle mmap exhausted resources ({error}); \
+                     refusing the heavier striped heap fetch"
+                )));
+            }
+            Some(Err(error)) => tracing::warn!(
                 uri = reference.uri,
                 %error,
                 "graph bundle mmap failed; falling back to striped heap fetch"
             ),
+            None => {}
         }
     }
     let bytes = fetch_blob_striped(storage, &reference.uri, STRIPED_FETCH_CHUNK_BYTES).await?;
@@ -804,6 +830,24 @@ mod tests {
             vector_layout: VectorLayout::Ivf,
             subsection_offsets: None,
         })
+    }
+
+    #[test]
+    fn mmap_resource_exhaustion_is_distinguished_from_benign_errors() {
+        // Only resource exhaustion (ENOMEM: address space / vm.max_map_count /
+        // rlimit) must be surfaced; the striped heap fallback would use more
+        // memory than the mapping that failed.
+        assert!(is_mmap_resource_exhaustion(&io::Error::from(
+            io::ErrorKind::OutOfMemory
+        )));
+        // Benign per-file failures fall through to the striped fetch so an open
+        // never fails on them.
+        assert!(!is_mmap_resource_exhaustion(&io::Error::from(
+            io::ErrorKind::NotFound
+        )));
+        assert!(!is_mmap_resource_exhaustion(&io::Error::from(
+            io::ErrorKind::PermissionDenied
+        )));
     }
 
     /// Dim for the routing-sibling fixture's vector summary.

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -7914,7 +7914,8 @@ async fn build_hnsw_graph_ref(
     // Incremental append: extend the prior persisted graph with only the new
     // rows, cloning it (fetch + decode) rather than mutating a serving graph.
     if let Some(prior_ref) = manifest.slow_vector_state_graphs_blob()
-        && let Ok(sections) = slow_vector_state::fetch_graph_sections(storage, prior_ref).await
+        && let Ok(sections) =
+            slow_vector_state::fetch_graph_sections(storage, prior_ref, /* need_sq8 */ false).await
         && let Some(prior_data) = sections.data
     {
         let prior_count = prior_data.doc_ids.len();
@@ -9175,11 +9176,15 @@ mod tests {
         let ref1 = build_hnsw_graph_ref(storage.as_ref(), reader1.manifest())
             .await
             .expect("full build registers a graph");
-        let prior = slow_vector_state::fetch_graph_sections(storage.as_ref(), &ref1)
-            .await
-            .expect("fetch built graph")
-            .data
-            .expect("data graph present after full build");
+        let prior = slow_vector_state::fetch_graph_sections(
+            storage.as_ref(),
+            &ref1,
+            /* need_sq8 */ false,
+        )
+        .await
+        .expect("fetch built graph")
+        .data
+        .expect("data graph present after full build");
         assert!(
             nearest(&prior, 1) < 0.05,
             "full-build graph must serve a batch-1 row"


### PR DESCRIPTION
Implements #636. Stacks on #629 (merged).

## What

For `search_mode = hnsw_ivf`, the resident graph is now served from an **mmap of the graph bundle** instead of being decoded into private per-process heap:

- **mmap is the default** (no config flag). Local backends map the bundle file directly (via the disk cache's `mmap_readonly_bytes`); object-store backends keep the existing striped fetch; heap fallback on any mmap I/O error. The Sq16 plane and doc-ids are **zero-copy slices** of the one mapping, and the resident index holds the mapping alive.
- **The SQ8 walk plane becomes a persisted data-bundle section**, not a per-open derivation — data-bundle magic **`INFDDG02` → `INFDDG03`**. On `INFDDG03` the SQ8 plane is a zero-copy slice of the same mapping; on older `INFDDG02` bundles it is derived on read (the prior behavior) — **backward-compatible, no forced rebuild**.
- Hydration (hash-verify + decode over the mapping) runs on the **blocking pool**, off the tokio workers (per the runtime concurrency contract).
- 2nd commit (review follow-up): the **drain / incremental-append** maintenance path hydrates the graph but never walks SQ8, so it now passes `need_sq8 = false` and **skips the SQ8 plane entirely** — no wasted derivation/slice in the background path. (Serving-neutral: serving passes `true`, i.e. the prior behavior.)

## Why

The resident graph decoded into **private per-process heap** — so every process/reader that opened a table loaded its own full copy (multi-GB), which OOMs on memory-constrained or multi-process serving. Mapping the bundle shares **one physical copy across all readers via the page cache** (reclaimable, not pinned heap), and open becomes a `~seconds` map instead of a multi-GB decode. And even single-process it is not a trade-off — warm serving is marginally *faster* than the heap decode (see below), so there is no latency cost to pay for the memory win.

This also lays the groundwork for two follow-ups tracked in #632:
- **Multi-node / multi-replica serving** — several serving processes or replicas on one host share a single physical bundle copy via the page cache, instead of N× the graph in private heap.
- **Unpinning the resident graph from RAM** — page-cache pages are reclaimable under memory pressure (they re-fault from NVMe on demand), unlike the decoded graph which is pinned on the heap for the handle's lifetime. That is exactly the reclaimable-graph-cache goal, and mapping the bundle is the enabler.

## Verification (1M Cohere, 768-dim, az2 x86_64)

**Correctness — recall bit-identical to the pre-mmap (heap) path**: same result-id `sha256` (`e43090b2…`) on a shared `INFDDG02` table. Rebuilt `INFDDG03` table serves healthy recall:

| metric | value |
| ------ | ----- |
| recall@10 | 0.9928 |
| recall@100 | 0.9765 |

**Throughput — mmap unlocks concurrent serving the heap path couldn't reach.** With a private per-process graph copy, concurrent multi-process serving OOM'd before it got useful — it hung/crashed past a handful of readers (heap dies at N≈6, see the memory table). The shared mapping removes that wall, so concurrent throughput scales and holds through N=40 (direct probe, `hnsw_ivf`, 8 cores):

| readers (N) | 8 | 16 | 24 | 40 |
| ----------- | -- | -- | -- | -- |
| heap | ❌ OOM | ❌ OOM | ❌ OOM | ❌ OOM |
| mmap QPS | 6102 | 6209 | 6360 | 6217 |

So this goes from *"single/low-concurrency only, crashes when scaled"* to **sustained ~6.2K QPS across the concurrency an 8-core host saturates at (~N=16)**. (The section-in-bundle layout itself is perf-neutral — QPS matches a plain mmap of the planes; it's the shared mapping that buys the scaling.)

**Warm latency, single process (N=1, 3000 warmed queries, K=100)** — mmap is not just heap-class, it is **consistently a touch faster** across every percentile (a warm mmap read is a plain RAM load, and the single shared copy has tighter cache residency than a private heap copy):

| percentile | heap | mmap |
| ---------- | ---- | ---- |
| p50 | 0.620 ms | 0.590 ms |
| p95 | 0.775 ms | 0.738 ms |
| p99 | 0.873 ms | 0.837 ms |

<sub>(heap-vs-mmap A/B captured via a development-time toggle; the shipped build maps unconditionally on local backends.)</sub>

**Multi-process memory (8-core / 32 GB budget, pure multi-process ladder)** — mmap shares one physical bundle copy, so many readers fit where the heap path OOMs:

| readers (N) | heap | mmap (#636) |
| ----------- | ---- | ----------- |
| 4 | ✅ | ✅ |
| 6 | ✅ (~25 GB) | ✅ |
| 8 | ❌ OOM | ✅ |
| 40 | ❌ | ✅ (~20 GB peak) |

Max readers survived: **heap = 6, mmap = 40** (~6.7×), ~0.5 GB/process incremental (the ~2.8 GB Sq16+SQ8 planes are mapped once, `smaps` `Pss_File` ≈ shared/N).

**Backward-compat**: the new build serving a pre-existing `INFDDG02` table returns identical results via derive-on-read. **`INFDDG03` bundle** produced by a drop-old rebuild (no temp files).

## Notes

- On-disk **format bump `INFDDG02` → `INFDDG03`** — additive, backward-compatible via derive-on-read; no forced rebuild.
- The HNSW **adjacency stays decoded in heap** (small — ~128 MB — and not the bottleneck at the concurrency an 8-core host saturates at); flattening it is deliberately out of scope.
- `cargo fmt` / `clippy --all-targets` / `check -D warnings` clean; 305 vector + 9 slow_vector_state + 67 writer lib tests pass, incl. new `INFDDG03` round-trip + `INFDDG02` backward-compat + heap-path-doesn't-alias tests.
