### PR TITLE
fts: borrow block bytes in the union bitset-OR (drop a per-block atomic refcount)

### DIFF
--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1692,8 +1692,11 @@ pub(super) fn or_cursor_into_bitset(
         return;
     }
     for block in c.blocks.iter() {
-        let bytes = c.bytes.slice(block.block_byte_offset..block.block_byte_end);
-        let bytes = bytes.as_ref();
+        // Borrow the block bytes in place rather than `.slice()` them: a
+        // per-block `.slice()` bumps and drops an atomic refcount on `c.bytes`
+        // for every block of the union, while a borrowed subslice needs none —
+        // the same fix already applied to the membership `contains` path.
+        let bytes = &c.bytes[block.block_byte_offset..block.block_byte_end];
         if bytes[posting::ENCODING_OFF] == ENCODING_BITSET {
             // Word-OR the presence bitset in at its aligned base word.
             // Tfs trail; the bitset is everything between them.


### PR DESCRIPTION
`or_cursor_into_bitset` sliced the shared `Bytes` for every block of a union — each `.slice()` bumps and drops an atomic refcount. The loop only needs a `&[u8]`, so borrow a subslice (`&c.bytes[range]`) instead. Same fix already applied to the membership `contains` path.

**Measured:** −3.1% on union COUNT (multi-term, same-box min-of-7); the ranked path is flat (it doesn't call this function). Union counts are bit-identical to before; the full FTS oracle suite (103 tests, incl. count/union brute-force) passes. `cargo fmt` clean.

One-file, localized change; no format or API change.