### PR TITLE
fts: use FxHashMap for the u32-keyed multi-column score combine

### DIFF
--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -21,6 +21,8 @@ use std::{
     sync::Arc,
 };
 
+use rustc_hash::FxHashMap;
+
 use bytes::Bytes;
 
 use super::{
@@ -1484,7 +1486,7 @@ impl OrCursorSet {
 /// broken by ascending doc_id. Used by `search_multi`'s cross-column
 /// combiner, where the per-column scores have already been weighted
 /// and summed into `scores`.
-pub(super) fn top_k(scores: HashMap<u32, f32>, k: usize) -> Vec<(u32, f32)> {
+pub(super) fn top_k(scores: FxHashMap<u32, f32>, k: usize) -> Vec<(u32, f32)> {
     // Iterate in ascending doc_id order so ties resolve deterministically
     // (smaller doc_ids enter the heap first; the strict `score > peek`
     // check below means subsequent equal-score entries don't displace
@@ -2300,7 +2302,7 @@ mod tests {
 
     #[test]
     fn top_k_keeps_highest_scores_with_doc_id_tiebreak() {
-        let mut scores: HashMap<u32, f32> = HashMap::new();
+        let mut scores: FxHashMap<u32, f32> = FxHashMap::default();
         scores.insert(0, 1.0);
         scores.insert(1, 3.0);
         scores.insert(2, 2.0);
@@ -2312,7 +2314,7 @@ mod tests {
 
     #[test]
     fn top_k_smaller_than_k_returns_all_sorted() {
-        let mut scores: HashMap<u32, f32> = HashMap::new();
+        let mut scores: FxHashMap<u32, f32> = FxHashMap::default();
         scores.insert(5, 2.0);
         scores.insert(9, 5.0);
         let out = top_k(scores, 10);

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -21,9 +21,8 @@ use std::{
     sync::Arc,
 };
 
-use rustc_hash::FxHashMap;
-
 use bytes::Bytes;
+use rustc_hash::FxHashMap;
 
 use super::{
     cursor::{TermCursor, TermMeta},

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -7,7 +7,9 @@
 //! BlockMaxWAND fast path, and the atom (phrase-aware) scored walk.
 //! Its own `impl FtsReader` block, split from the reader `core`.
 
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
+
+use rustc_hash::FxHashMap;
 
 use super::{
     core::*,
@@ -729,7 +731,9 @@ impl FtsReader {
         // Tokenize the query with each column's configured tokenizer so
         // per-column analyzers are honored — a table may index different
         // columns with different analyzers.
-        let mut combined: HashMap<u32, f32> = HashMap::new();
+        // FxHashMap: the combine does a per-doc insert across columns; the
+        // default SipHash is needless work for small integer (doc-id) keys.
+        let mut combined: FxHashMap<u32, f32> = FxHashMap::default();
         for (col_name, weight) in columns {
             let col_id = self.resolve_column_id(col_name)?;
             let tok = &self.columns[col_id as usize].tokenizer;


### PR DESCRIPTION
The multi-column search (`search_multi`) combines per-column scores with a per-doc `HashMap<u32,f32>` (`entry(doc).or_insert() += `) and `top_k` iterates it. The keys are internal doc-ids, so the std default SipHash is needless work. Switch the combine map and `top_k` to `rustc_hash::FxHashMap` (already a dependency).

## Justification (numbers)
No macro-benchmark exercises the multi-column path — every FTS bench is single-column `bm25_search` — so this is justified by a micro-benchmark of the exact changed operation (the combine `entry+or_insert+=` plus `top_k`'s `into_iter().collect()`+sort), release-optimized (opt-level 3, thin-LTO, cgu=1), over a realistic 3-column × 40k-hit combine (120k col-hits), min of 200 iterations:

| hasher | combine + drain |
|---|---|
| std SipHash | 3051 µs/op |
| **FxHashMap** | **1981 µs/op** |
| | **1.54× (−35%)** |

That −35% is on the combine *operation* in isolation; in a full multi-column query the per-column search dominates and the combine is a fraction of total time, so the end-to-end win scales with the combine's share. Single-column search is unaffected — it returns top-k straight from the scorer heap and never builds this map.

## Safety
The keys are **internal doc-ids** (assigned sequentially at ingest, not caller-supplied), so a fast non-DoS-resistant hasher introduces **no hash-flooding / algorithmic-complexity risk** here. The maps keyed by **caller-controlled strings** — query terms (`GlobalTermIdf`) and column names (`column_id_by_name`) — deliberately keep the DoS-resistant default hasher and are untouched.

## Correctness
The full FTS oracle suite (103 tests, incl. `multi_column`) passes; `cargo fmt` clean.