### PR TITLE
fts: locate ranked-OR non-essentials by bit-test, not block expansion

### DIFF
--- a/src/superfile/fts/posting.rs
+++ b/src/superfile/fts/posting.rs
@@ -265,6 +265,32 @@ pub fn decode_block(bytes: &[u8], dest_doc_ids: &mut [u32], dest_tfs: &mut [u32]
     count
 }
 
+/// Decode only the tf array of a block (the trailing tf-packed bytes) into
+/// `dest_tfs`, in doc order, skipping the doc-id half. The ranked-OR
+/// membership probe locates a bitset-block doc by bit-test + popcount-rank
+/// and needs only that doc's tf, never the expanded doc ids — so it decodes
+/// the tfs (which are BitPacker4x-packed and can't be single-value-indexed)
+/// once per block and reads the rank-th one, avoiding the doc-id expansion.
+pub fn decode_block_tfs(bytes: &[u8], dest_tfs: &mut [u32]) {
+    assert!(
+        dest_tfs.len() >= BLOCK_LEN,
+        "decode_block_tfs: dest_tfs must have at least {BLOCK_LEN} slots"
+    );
+    let tf_bits = bytes[2];
+    assert!(tf_bits <= 32, "decode_block_tfs: tf_bits {tf_bits} > 32");
+    let tfs_size = BLOCK_LEN * tf_bits as usize / 8;
+    assert!(
+        bytes.len() >= HEADER_SIZE + tfs_size,
+        "decode_block_tfs: bytes shorter than header+tfs"
+    );
+    let tfs_start = bytes.len() - tfs_size;
+    BitPacker4x::new().decompress(
+        &bytes[tfs_start..tfs_start + tfs_size],
+        &mut dest_tfs[..BLOCK_LEN],
+        tf_bits,
+    );
+}
+
 /// Decode only the doc ids of a posting block, skipping the term-frequency
 /// half entirely. Unranked counts (union, intersection) never look at
 /// `tf` — they tally doc ids — so decoding + reading the packed tfs is

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -653,7 +653,7 @@ impl TermCursor {
         for w in presence[..word_idx * 8].chunks_exact(8) {
             rank += u64::from_le_bytes(w.try_into().expect("8 bytes")).count_ones();
         }
-        let below = if bit % 64 == 0 {
+        let below = if bit.is_multiple_of(64) {
             0u64
         } else {
             (1u64 << (bit % 64)) - 1

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -353,6 +353,13 @@ pub(crate) struct TermCursor {
     /// PACKED block it already holds while probing membership across a
     /// run of ascending target docs.
     pub(super) decoded_block: usize,
+    /// Which block index has its tf array decoded into `block_tfs`
+    /// (`usize::MAX` = none). Set whenever `block_tfs` is filled — by a full
+    /// [`Self::decode_current_block`] (non-count) or by a tf-only decode in
+    /// [`Self::bitset_probe_tf`], which reads a single doc's tf by rank
+    /// without expanding the block's doc ids. Lets the probe reuse the
+    /// decoded tfs across a run of candidates landing in the same block.
+    pub(super) tf_decoded_block: usize,
 }
 
 impl TermCursor {
@@ -432,6 +439,7 @@ impl TermCursor {
             header_probed,
             count_only,
             decoded_block: usize::MAX,
+            tf_decoded_block: usize::MAX,
         };
         if !cursor.blocks.is_empty() {
             cursor.decode_current_block();
@@ -489,6 +497,7 @@ impl TermCursor {
             // never call `decode_current_block`, so the flag is inert.
             count_only: false,
             decoded_block: 0,
+            tf_decoded_block: 0,
         }
     }
 
@@ -505,6 +514,11 @@ impl TermCursor {
         };
         self.pos = 0;
         self.decoded_block = self.current_block;
+        // A non-count decode also fills `block_tfs` for this block, so the
+        // tf-only probe can reuse it without re-decoding.
+        if !self.count_only {
+            self.tf_decoded_block = self.current_block;
+        }
     }
 
     /// Membership probe: does this term contain `doc`? Advances the block
@@ -576,6 +590,83 @@ impl TermCursor {
         while self.pos < self.block_n && self.block_doc_ids[self.pos] < doc {
             self.pos += 1;
         }
+    }
+
+    /// Ranked-OR non-essential membership probe returning the doc's tf
+    /// **without expanding the block's doc ids**. On a dense (bitset) block it
+    /// bit-tests presence and, on a hit, reads the one tf by popcount-rank into
+    /// the tf array (decoded once per block) — never materializing the 128 doc
+    /// ids, which is the dominant cost of the ranked-OR non-essential
+    /// completion on common terms. On a PACKED block there is no rank shortcut
+    /// (the doc ids must be decoded to locate the doc), so it falls back to
+    /// `skip_to` + `current_tf`. Like [`Self::contains`] it advances
+    /// `current_block`, so a cursor probed this way must not also be iterated.
+    pub(super) fn bitset_probe_tf(&mut self, doc: u32) -> Option<u32> {
+        while self.current_block < self.blocks.len()
+            && self.blocks[self.current_block].last_doc_id < doc
+        {
+            self.current_block += 1;
+        }
+        if self.current_block >= self.blocks.len() {
+            return None;
+        }
+        // Inline (df=1) cursor: single pre-decoded posting, no postings bytes.
+        if self.bytes.is_empty() {
+            if self.block_n > 0 && self.block_doc_ids[0] == doc {
+                return Some(self.block_tfs[0]);
+            }
+            return None;
+        }
+        let block = self.blocks[self.current_block];
+        let raw = &self.bytes[block.block_byte_offset..block.block_byte_end];
+        if raw[posting::ENCODING_OFF] != posting::ENCODING_BITSET {
+            // PACKED: no rank shortcut — decode + locate like the old path.
+            self.skip_to(doc);
+            return if self.current_doc_id() == doc {
+                Some(self.current_tf())
+            } else {
+                None
+            };
+        }
+        let base = read_u32_le(&raw[4..8]);
+        if doc < base {
+            return None;
+        }
+        let bit = (doc - base) as usize;
+        let tf_bits = raw[2] as usize;
+        let tfs_size = BLOCK_LEN * tf_bits / 8;
+        let bitset_end = raw.len() - tfs_size;
+        let word_idx = bit / 64;
+        let word_at = posting::HEADER_SIZE + word_idx * 8;
+        if word_at + 8 > bitset_end {
+            return None; // past this block's presence bits ⇒ absent
+        }
+        let word = u64::from_le_bytes(raw[word_at..word_at + 8].try_into().expect("8 bytes"));
+        if (word >> (bit % 64)) & 1 == 0 {
+            return None; // doc not present in this block
+        }
+        // Present. `rank` = number of set bits before `bit` = popcount of the
+        // whole presence words ahead of this one + popcount of this word below
+        // `bit`. The r-th set bit (doc) maps to the r-th tf in doc order.
+        let presence = &raw[posting::HEADER_SIZE..bitset_end];
+        let mut rank: u32 = 0;
+        for w in presence[..word_idx * 8].chunks_exact(8) {
+            rank += u64::from_le_bytes(w.try_into().expect("8 bytes")).count_ones();
+        }
+        let below = if bit % 64 == 0 {
+            0u64
+        } else {
+            (1u64 << (bit % 64)) - 1
+        };
+        rank += (word & below).count_ones();
+        // Decode this block's tf array once (doc order), reused across a run of
+        // candidates in the same block; the doc ids are never expanded.
+        if self.tf_decoded_block != self.current_block {
+            let bytes = &self.bytes[block.block_byte_offset..block.block_byte_end];
+            posting::decode_block_tfs(bytes, &mut self.block_tfs);
+            self.tf_decoded_block = self.current_block;
+        }
+        Some(self.block_tfs[rank as usize])
     }
 
     pub(super) fn is_exhausted(&self) -> bool {

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1693,7 +1693,10 @@ mod tests {
 
     use super::{super::test_util::*, *};
     use crate::superfile::fts::{
-        builder::FtsBuilder, reader::BoolMode, tokenize::AsciiLowerTokenizer,
+        builder::FtsBuilder,
+        posting::{ENCODING_BITSET, ENCODING_OFF},
+        reader::BoolMode,
+        tokenize::AsciiLowerTokenizer,
     };
 
     #[tokio::test]
@@ -1777,6 +1780,71 @@ mod tests {
                 "score mismatch: bmm={s_bmm} exhaustive={s_exh}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn bitset_probe_tf_reads_correct_tf_across_presence_words() {
+        // Regression for the ranked-OR non-essential probe: `bitset_probe_tf`
+        // locates a doc in a dense (bitset) block by bit-test and reads its
+        // tf by popcount-rank — summing the popcounts of every 64-bit presence
+        // word ahead of the doc's word, then the set bits below it in its own
+        // word. The top-k oracle only exercised a 20-doc block, so every doc
+        // sat in presence word 0 (bit < 64) and the cross-word accumulation
+        // loop never ran. Plant a block where the probed docs sit at bit >= 64
+        // with a tf that differs from the rest, so a wrong cross-word popcount
+        // would land on the wrong tf.
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false)
+            .expect("register column");
+        // `common` is present at doc 0 and docs 100..=165. First-doc 0 word-
+        // aligns the bitset base to 0, so doc 100 -> bit 100 (presence word 1)
+        // and doc 165 -> bit 165 (presence word 2); the 0->100 gap widens the
+        // deltas enough that the block takes the bitset encoding, not PFOR. tf
+        // is 1 everywhere except 3 at doc 100 and 2 at doc 165.
+        for id in 0u32..=165 {
+            let text = match id {
+                0 => "common",
+                100 => "common common common",
+                165 => "common common",
+                101..=164 => "common",
+                _ => "filler", // 1..=99: present docs that don't carry `common`
+            };
+            b.add_doc(0, id, text).expect("add doc");
+        }
+        let blob = Bytes::from(b.finish().expect("finish"));
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(blob, json).expect("open");
+
+        let mut cursors = r
+            .build_term_cursors(0, &["common"], None, false)
+            .await
+            .expect("build common cursor");
+        let cursor = &mut cursors[0];
+
+        // Guard the test's own premise: the block must be a bitset, else the
+        // probe takes the PACKED fallback and the rank path under test is skipped.
+        let blk = cursor.blocks[0];
+        assert_eq!(
+            cursor.bytes[blk.block_byte_offset + ENCODING_OFF],
+            ENCODING_BITSET,
+            "corpus must produce a bitset block for this test to be meaningful"
+        );
+
+        // Probe in ascending doc order (the cursor advances forward only).
+        // doc 50 is absent; doc 100 needs word 0's popcount (rank 1); doc 165
+        // needs words 0 and 1 summed (rank 66) — the multi-word path.
+        assert_eq!(cursor.bitset_probe_tf(50), None, "doc 50 absent from bitset");
+        assert_eq!(
+            cursor.bitset_probe_tf(100),
+            Some(3),
+            "tf at doc 100 (bit 100, presence word 1)"
+        );
+        assert_eq!(
+            cursor.bitset_probe_tf(165),
+            Some(2),
+            "tf at doc 165 (bit 165, presence word 2)"
+        );
     }
 
     #[tokio::test]

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1834,7 +1834,11 @@ mod tests {
         // Probe in ascending doc order (the cursor advances forward only).
         // doc 50 is absent; doc 100 needs word 0's popcount (rank 1); doc 165
         // needs words 0 and 1 summed (rank 66) — the multi-word path.
-        assert_eq!(cursor.bitset_probe_tf(50), None, "doc 50 absent from bitset");
+        assert_eq!(
+            cursor.bitset_probe_tf(50),
+            None,
+            "doc 50 absent from bitset"
+        );
         assert_eq!(
             cursor.bitset_probe_tf(100),
             Some(3),

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1052,10 +1052,9 @@ impl FtsReader {
                     let mut packed = 1;
                     let mut score: f32 = 0.0;
                     for cursor in cursors.iter_mut().skip(1) {
-                        cursor.skip_to(candidate);
-                        if cursor.current_doc_id() == candidate {
+                        if let Some(tf) = cursor.bitset_probe_tf(candidate) {
                             idfs[packed] = cursor.idf_x_k1p1;
-                            tfs[packed] = cursor.current_tf() as f32;
+                            tfs[packed] = tf as f32;
                             packed += 1;
                             if packed == 4 {
                                 score += bm25::score_simd_x4(idfs, tfs, norm);
@@ -1221,13 +1220,12 @@ impl FtsReader {
                             if score + remaining_block_ub <= threshold {
                                 break;
                             }
-                            cursor.skip_to(candidate);
-                            if cursor.current_doc_id() == candidate {
-                                score += bm25::score_with_dl_norm_k1(
-                                    cursor.idf_x_k1p1,
-                                    cursor.current_tf(),
-                                    norm,
-                                );
+                            // Locate + score the non-essential without expanding
+                            // a dense block's doc ids: a bit-test + popcount-rank
+                            // tf read on a bitset block, decode-and-locate on a
+                            // PACKED one.
+                            if let Some(tf) = cursor.bitset_probe_tf(candidate) {
+                                score += bm25::score_with_dl_norm_k1(cursor.idf_x_k1p1, tf, norm);
                             }
                             remaining_block_ub -= block_ub;
                         }


### PR DESCRIPTION
## What

The ranked-OR MaxScore completion decoded a non-essential term's entire
128-doc posting block on **every candidate**, just to locate the candidate
doc and read its term frequency. On a dense (bitset-encoded) block — exactly
what common non-essential terms use — that expansion is a scalar set-bit loop
over 128 doc ids, and it dominated the non-essential completion cost.

This locates the candidate by a presence **bit-test** and reads its tf by
**popcount-rank** into the block's tf array (decoded once per block via the
new `decode_block_tfs`, reused across a run of candidates in the same block),
never expanding the doc ids. PACKED blocks keep the decode-and-locate path —
there is no rank shortcut when doc ids are delta-packed.

## Why it's correct

Top-k is unchanged: in a bitset block a doc's position in doc order equals its
popcount-rank, so the tf read is bit-for-bit the same value the old
`block_tfs[pos]` returned. The brute-force BM25 top-k oracle and the proptest
fuzz oracle pass unchanged, and exercise the new tf-only decode through the
ranked-OR path.

No on-disk format change — this is a read-path-only optimization.

## Performance

Internal A/B, this branch vs `main`, same host, both builds on this base
commit so the delta isolates this change. SBG-style metric (min across
repeated runs per query, then averaged), on a multi-term FTS query workload
over a large single-node index. `COUNT` is an unchanged-code drift control.

Improvement concentrates on multi-term ranked unions — the class that pays the
non-essential completion cost:

| query class      | TOP_10 | TOP_100 | TOP_1000 |
|------------------|-------:|--------:|---------:|
| 3-term union     | −7.0%  | −11.8%  | −5.2%    |
| 4+-term union    | −6.9%  |  −9.5%  | −7.9%    |

No query class regresses beyond the ±noise band that untouched paths
(intersection, phrase) show across commands. The one directional cost is
two-term unions at large k (TOP_1000, ~+3%): with only two terms and a large
candidate set the per-candidate popcount-rank isn't fully amortized. It sits
within run-to-run noise and is outweighed by the ≥3-term wins. Single-term,
phrase, intersection, and count workloads are unchanged within noise.

## Coverage

Existing brute-force + fuzz BM25 top-k oracles gate the scoring path and pass
unchanged (top-k identical). No new public surface; no new dependency.
