### PR TITLE
superfile/vector: checked span arithmetic; the bracket guard counts

### DIFF
--- a/src/runtime_metrics/op_stats.rs
+++ b/src/runtime_metrics/op_stats.rs
@@ -528,21 +528,24 @@ pub(crate) fn outer_bracket_active() -> bool {
 
 /// Marks this thread as inside an outer CPU bracket until dropped.
 ///
-/// Restores the previous depth on drop, unwind included: a poll that
-/// panicked out of a raised depth would otherwise leave the thread
+/// A real counter, so the guard holds without a LIFO argument: overlapping
+/// lifetimes each add one and remove one, and the depth is zero exactly
+/// when no bracket is live. Decrements on drop, unwind included — a poll
+/// that panicked out of a raised depth would otherwise leave the thread
 /// permanently silenced, and every later query scheduled onto that worker
 /// would fold nothing.
-pub(crate) struct OuterBracketGuard(u32);
+pub(crate) struct OuterBracketGuard;
 
 impl OuterBracketGuard {
     pub(crate) fn enter() -> Self {
-        Self(OUTER_BRACKET_DEPTH.with(|d| d.replace(1)))
+        OUTER_BRACKET_DEPTH.with(|d| d.set(d.get().saturating_add(1)));
+        Self
     }
 }
 
 impl Drop for OuterBracketGuard {
     fn drop(&mut self) {
-        OUTER_BRACKET_DEPTH.with(|d| d.set(self.0));
+        OUTER_BRACKET_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
     }
 }
 

--- a/src/superfile/vector/reader.rs
+++ b/src/superfile/vector/reader.rs
@@ -5046,7 +5046,14 @@ async fn build_shortlist(
             // `local * stride` offset built from it then points far past
             // the block. Checking the lookups is not enough on its own —
             // the arithmetic derived from them needs the same guard.
-            let end = off.saturating_add(cnt);
+            // Checked, not saturating: a saturated end masks a corrupt
+            // span by letting near-MAX positions pass the very bound the
+            // check exists to enforce.
+            let end = off.checked_add(cnt).ok_or_else(|| {
+                VectorError::InconsistentIndex(format!(
+                    "cluster {cluster_id}'s span overflows: off={off}, cnt={cnt}"
+                ))
+            })?;
             if pos < off || pos >= end {
                 return Err(VectorError::InconsistentIndex(format!(
                     "shortlist position {pos} falls outside cluster {cluster_id}'s \


### PR DESCRIPTION
Two review fixes committed while #640 was merging, which missed the squash.

The shortlist position bound computed its end with `saturating_add`, which masks exactly the corruption the bound exists to reject: a span whose `off + cnt` overflows saturates to u32::MAX, so every near-MAX position passes the check unchallenged. `checked_add` now, with the overflow surfaced as `InconsistentIndex` like the bound itself.

`OuterBracketGuard` was named a depth and implemented as a boolean snapshot — `replace(1)` on enter, restore-prior on drop. That is correct only under a LIFO argument: stack locals drop in scope order, and a nested poll never enters because the depth check returns early. A real increment/decrement counter holds without needing that argument, and makes the name honest.