### PR TITLE
[1/n] improv tracing: include OpType in tracing spans

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -46,6 +46,8 @@ use tokio::runtime::Runtime;
 use tracing::{debug, info};
 use uri::{Backend, parse_uri};
 
+#[cfg(feature = "detailed-tracing")]
+use crate::utils::trace::OpOrigin;
 use crate::{
     InfinoError,
     config::DEFAULT_CONNECTION_BUDGET_BYTES,
@@ -765,7 +767,9 @@ impl Connection {
     /// ```
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(sql = sql))
+        // Connection-level entry: no table handle yet, so no `role` — the
+        // per-table spans beneath this one carry it.
+        tracing::instrument(skip_all, fields(sql = sql, origin = OpOrigin::Query.as_str()))
     )]
     pub fn query_sql(&self, sql: &str) -> Result<Vec<RecordBatch>, InfinoError> {
         debug!(sql, "running sql query");

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -38,6 +38,8 @@ use super::{
     },
     options::SupertableOptions,
 };
+#[cfg(feature = "detailed-tracing")]
+use crate::utils::trace::OpOrigin;
 use crate::{
     config,
     runtime_bridge::{bridge_on_runtime, bridge_sync_to_async, shared_io_runtime},
@@ -65,6 +67,7 @@ use crate::{
             recovery::{RecoveryError, RecoveryReport, scan_and_recover},
         },
     },
+    utils::trace::TableRole,
 };
 
 /// Top-level handle. Cheap to clone (one `Arc::clone`); all clones
@@ -81,6 +84,14 @@ pub struct Supertable {
 /// commit and to manipulate `writer_outstanding` for the
 /// single-writer slot enforcement.
 pub(super) struct SupertableInner {
+    /// Which of the two tables this handle drives — the user's own rows,
+    /// or the derived vector index. Both run the same code, so without
+    /// this the two are indistinguishable in a trace. Recorded as the
+    /// `role` field on the spans this handle roots. Immutable for the
+    /// handle's lifetime. Only read by the span sites, which are behind
+    /// `detailed-tracing`.
+    #[cfg_attr(not(feature = "detailed-tracing"), allow(dead_code))]
+    pub(super) role: TableRole,
     /// Schema, FTS columns, vector columns, tokenizer, thread
     /// pools, superfile store, commit threshold. Immutable for
     /// the supertable's lifetime; shared via Arc so readers,
@@ -462,7 +473,14 @@ impl Supertable {
                         .await
                     {
                         Ok(hidden_manifest) => {
-                            match open_table_async(hidden_arc, hidden_manifest, None).await {
+                            match open_table_async(
+                                hidden_arc,
+                                hidden_manifest,
+                                None,
+                                TableRole::VectorIndex,
+                            )
+                            .await
+                            {
                                 Ok(t) => (Some(Arc::new(t)), None),
                                 Err(e) => {
                                     warn!(
@@ -485,16 +503,19 @@ impl Supertable {
                 // correct — queries fall back to the user fan until a writer
                 // handle materializes the index.
                 Ok(None) if options_arc.summary_centroids_from_superfiles => (None, None),
-                Ok(None) => match create_table_async(hidden_opts, None, None).await {
-                    Ok(table) => (Some(Arc::new(table)), None),
-                    Err(e) => {
-                        // Surface a genuine bootstrap failure as Broken (carry the
-                        // error) rather than Absent, matching the sibling arms —
-                        // otherwise a storage fault silently degrades to full scan.
-                        warn!("supertable: hidden vector-index bootstrap-create failed: {e}");
-                        (None, Some(e.to_string()))
+                Ok(None) => {
+                    match create_table_async(hidden_opts, None, None, TableRole::VectorIndex).await
+                    {
+                        Ok(table) => (Some(Arc::new(table)), None),
+                        Err(e) => {
+                            // Surface a genuine bootstrap failure as Broken (carry the
+                            // error) rather than Absent, matching the sibling arms —
+                            // otherwise a storage fault silently degrades to full scan.
+                            warn!("supertable: hidden vector-index bootstrap-create failed: {e}");
+                            (None, Some(e.to_string()))
+                        }
                     }
-                },
+                }
                 Err(e) => {
                     warn!("supertable: hidden vector-index pointer unreadable: {e}");
                     (None, Some(e.to_string()))
@@ -503,7 +524,8 @@ impl Supertable {
         } else {
             (None, None)
         };
-        let handle = open_table_async(options_arc, manifest, vector_index_table).await?;
+        let handle =
+            open_table_async(options_arc, manifest, vector_index_table, TableRole::User).await?;
         if let Some(err) = hidden_index_broken {
             let _ = handle.inner.hidden_index_open_error.set(err);
         }
@@ -543,7 +565,13 @@ impl Supertable {
                 build_vector_index_options(&options, None, Some(prefix.as_str()))
             {
                 Some(Arc::new(
-                    create_table_async(hidden_opts, None, Some(prefix.clone())).await?,
+                    create_table_async(
+                        hidden_opts,
+                        None,
+                        Some(prefix.clone()),
+                        TableRole::VectorIndex,
+                    )
+                    .await?,
                 ))
             } else {
                 None
@@ -551,7 +579,13 @@ impl Supertable {
         } else {
             None
         };
-        create_table_async(options, vector_index_table, vector_index_storage_prefix).await
+        create_table_async(
+            options,
+            vector_index_table,
+            vector_index_storage_prefix,
+            TableRole::User,
+        )
+        .await
     }
 
     /// Re-read the manifest pointer from storage and advance this supertable to whatever it names.
@@ -632,6 +666,12 @@ impl Supertable {
             inner: Arc::clone(&self.inner),
             op_stats,
         }
+    }
+
+    /// Which table this handle drives, for the `role` span field.
+    #[cfg_attr(not(feature = "detailed-tracing"), allow(dead_code))]
+    pub(crate) fn role(&self) -> TableRole {
+        self.inner.role
     }
 
     test_visible! {
@@ -1580,16 +1620,25 @@ fn build_vector_index_options(
 }
 
 /// Build one supertable handle. Leaf — never creates a hidden sibling.
+#[cfg_attr(
+    feature = "detailed-tracing",
+    tracing::instrument(
+        skip_all,
+        fields(role = role.as_str(), origin = OpOrigin::Open.as_str())
+    )
+)]
 async fn build_handle(
     options: Arc<SupertableOptions>,
     manifest: Arc<ManifestSnapshot>,
     vector_index_table: Option<Arc<Supertable>>,
+    role: TableRole,
 ) -> Result<Supertable, OpenError> {
     let tombstone_cache = build_tombstone_cache(&options, &manifest);
     let id_generator = crate::supertable::utils::idgen::IdGenerator::new();
     let handle_id = crate::supertable::wal::state_doc::SupertableHandleId(id_generator.next_id());
     let inner = Arc::new(SupertableInner {
         options,
+        role,
         manifest: ArcSwap::new(manifest),
         writer_outstanding: AtomicBool::new(false),
         compaction_outstanding: AtomicBool::new(false),
@@ -1627,6 +1676,7 @@ async fn create_table_async(
     options: SupertableOptions,
     vector_index_table: Option<Arc<Supertable>>,
     vector_index_storage_prefix: Option<String>,
+    role: TableRole,
 ) -> Result<Supertable, OpenError> {
     let options = Arc::new(options);
     // A durable create *persists* the initial empty manifest — its list plus
@@ -1671,7 +1721,7 @@ async fn create_table_async(
             vector_index_table,
         )
     };
-    build_handle(options, manifest, vector_index_table).await
+    build_handle(options, manifest, vector_index_table, role).await
 }
 
 /// After a lost create-race, open (or bootstrap) the hidden vector-index
@@ -1695,7 +1745,7 @@ async fn reconcile_vector_index_table_to_manifest(
             let hidden_manifest =
                 ManifestSnapshot::load(None, hidden_storage, Some(hidden_arc.clone())).await?;
             Ok(Some(Arc::new(
-                open_table_async(hidden_arc, hidden_manifest, None).await?,
+                open_table_async(hidden_arc, hidden_manifest, None, TableRole::VectorIndex).await?,
             )))
         }
         Ok(None) => {
@@ -1724,7 +1774,7 @@ async fn reconcile_vector_index_table_to_manifest(
                 ))
             };
             Ok(Some(Arc::new(
-                build_handle(hidden_arc, manifest, None).await?,
+                build_handle(hidden_arc, manifest, None, TableRole::VectorIndex).await?,
             )))
         }
         Err(e) => Err(OpenError::Storage(StorageError::Permanent {
@@ -1739,8 +1789,9 @@ async fn open_table_async(
     options: Arc<SupertableOptions>,
     manifest: Arc<ManifestSnapshot>,
     vector_index_table: Option<Arc<Supertable>>,
+    role: TableRole,
 ) -> Result<Supertable, OpenError> {
-    build_handle(options, manifest, vector_index_table).await
+    build_handle(options, manifest, vector_index_table, role).await
 }
 
 fn install_disk_cache_pinning(inner: &Arc<SupertableInner>) {
@@ -1883,6 +1934,12 @@ impl SupertableReader {
     /// reader-vs-writer visibility ordering in tests.
     pub fn manifest_id(&self) -> u64 {
         self.manifest.manifest_id
+    }
+
+    /// Which table this reader queries, for the `role` span field.
+    #[cfg_attr(not(feature = "detailed-tracing"), allow(dead_code))]
+    pub(crate) fn role(&self) -> TableRole {
+        self.inner.role
     }
 
     /// Sync→async bridge for this reader's public query surface.
@@ -6246,6 +6303,50 @@ mod tests {
             !stamped,
             "an all-zero width law must not trigger calibration"
         );
+    }
+
+    /// The derived vector-index table runs the same code as the user table,
+    /// so its spans are only distinguishable by the `role` tag threaded
+    /// through handle construction. Assert the two handles disagree — a
+    /// regression here silently merges both tables into one trace.
+    #[test]
+    fn hidden_vector_index_handle_carries_the_vector_index_role() {
+        let dim = 16usize;
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "emb",
+            DataType::FixedSizeList(item_field, dim as i32),
+            false,
+        )]));
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let options = SupertableOptions::new(
+            schema,
+            vec![],
+            vec![VectorConfig {
+                column: "emb".into(),
+                dim,
+                rot_seed: 7,
+                metric: Metric::Cosine,
+                rerank_codec: RerankCodec::Sq8FixedResidual,
+                provided_centroids: None,
+            }],
+            Some(crate::test_helpers::default_tokenizer()),
+        )
+        .expect("valid options")
+        .with_storage(storage);
+
+        let st = Supertable::create(options).expect("create");
+        assert_eq!(st.role(), TableRole::User);
+
+        let hidden = st
+            .reader()
+            .expect("reader")
+            .vector_index_table()
+            .expect("a vector column means a hidden index handle")
+            .clone();
+        assert_eq!(hidden.role(), TableRole::VectorIndex);
     }
 
     /// The cleared-law repair, end to end through the PUBLIC `optimize()`:

--- a/src/supertable/optimize/mod.rs
+++ b/src/supertable/optimize/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
+#[cfg(feature = "detailed-tracing")]
+use crate::utils::trace::OpOrigin;
 use crate::{
     config::OptimizeOptions,
     supertable::{
@@ -17,6 +19,16 @@ impl Supertable {
     /// arrow sidecars). Pass [`OptimizeOptions::default`] for engine
     /// defaults. Requires durable storage.
     #[doc(alias = "compact")]
+    // Shares every step below with the detached background sweeps, so the
+    // span tags it `optimize`: same code, but a caller is blocked on it and
+    // the latency is theirs.
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(
+            skip_all,
+            fields(role = self.role().as_str(), origin = OpOrigin::Optimize.as_str())
+        )
+    )]
     pub fn optimize(&self, opts: &OptimizeOptions) -> Result<(), OptimizeError> {
         self.drain_hidden_vector_cells_sync()
             .map_err(|e| OptimizeError::Build(e.to_string()))?;

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -64,6 +64,8 @@ use datafusion::{
 use futures::{future, stream};
 use tracing::debug;
 
+#[cfg(feature = "detailed-tracing")]
+use crate::utils::trace::OpOrigin;
 use crate::{
     InfinoError,
     runtime_metrics::op_stats,
@@ -131,7 +133,7 @@ impl SupertableReader {
     #[allow(clippy::too_many_arguments)]
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(text_col = text_col, vec_col = vec_col, k = k, mode = ?mode))
+        tracing::instrument(skip_all, fields(text_col = text_col, vec_col = vec_col, k = k, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub(crate) async fn hybrid_search_async(
         &self,
@@ -194,7 +196,7 @@ impl Supertable {
     #[allow(clippy::too_many_arguments)]
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(text_col = text_col, vec_col = vec_col, k = k, mode = ?mode))
+        tracing::instrument(skip_all, fields(text_col = text_col, vec_col = vec_col, k = k, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub fn hybrid_search(
         &self,

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -114,6 +114,8 @@ const RANGED_KERNEL_POOL_MIN_TERMS: usize = OR_WINDOW_MIN_TERMS;
 const UNRANGED_KERNEL_POOL_MIN_MASS: u64 = 20_000;
 
 pub use crate::superfile::fts::reader::BoolMode;
+#[cfg(feature = "detailed-tracing")]
+use crate::utils::trace::OpOrigin;
 use crate::{
     InfinoError,
     runtime_bridge::run_on_pool,
@@ -314,7 +316,7 @@ impl SupertableReader {
     /// [`AsciiLowerTokenizer`]: crate::superfile::fts::tokenize::AsciiLowerTokenizer
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode))
+        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub(crate) async fn bm25_search_async(
         &self,
@@ -1079,7 +1081,7 @@ impl SupertableReader {
     /// [`SupertableReader::token_match`].
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column, mode = ?mode))
+        tracing::instrument(skip_all, fields(column = column, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub(crate) async fn token_match_async(
         &self,
@@ -1834,7 +1836,7 @@ impl Supertable {
     /// ```
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode))
+        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub fn bm25_search(
         &self,
@@ -1866,7 +1868,7 @@ impl Supertable {
     /// `bm25_search`.
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column, mode = ?mode))
+        tracing::instrument(skip_all, fields(column = column, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub fn token_match(
         &self,
@@ -1893,7 +1895,7 @@ impl Supertable {
     /// `bm25_search`.
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column))
+        tracing::instrument(skip_all, fields(column = column, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub fn exact_match(
         &self,

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -66,6 +66,8 @@ use datafusion::{
     logical_expr::{Expr, LogicalPlan},
 };
 
+#[cfg(feature = "detailed-tracing")]
+use crate::utils::trace::OpOrigin;
 use crate::{
     memory::budgeted_session_context,
     runtime_metrics::op_stats::{self, OpStatsCollector},
@@ -231,7 +233,7 @@ impl SupertableReader {
     #[cfg(any(test, feature = "test-helpers"))]
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(sql = sql))
+        tracing::instrument(skip_all, fields(sql = sql, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub fn query_sql(&self, sql: &str) -> Result<Vec<RecordBatch>, QueryError> {
         let _foreground = ForegroundQueryGuard::enter();

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -95,6 +95,8 @@ use super::{
 pub use crate::superfile::reader::VectorSearchOptions;
 #[cfg(feature = "test-helpers")]
 use crate::test_helpers::{admit_trace, served_shortlist_probe};
+#[cfg(feature = "detailed-tracing")]
+use crate::utils::trace::OpOrigin;
 use crate::{
     config,
     runtime_bridge::run_on_pool,
@@ -4073,7 +4075,7 @@ impl SupertableReader {
     /// `vector_search` with a filter; this drives the cross-superfile fan-out.
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column, k = k, dim = query.len()))
+        tracing::instrument(skip_all, fields(column = column, k = k, dim = query.len(), role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub(crate) async fn vector_hits_filtered_async(
         &self,
@@ -5481,7 +5483,7 @@ impl Supertable {
     /// ```
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column, k = k, dim = query.len()))
+        tracing::instrument(skip_all, fields(column = column, k = k, dim = query.len(), role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub fn vector_search(
         &self,

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -33,7 +33,7 @@ use tokio::{
     sync::{Notify, OnceCell, Semaphore, oneshot},
     task::{JoinHandle, spawn_blocking},
 };
-use tracing::Instrument;
+use tracing::{Instrument, debug_span};
 
 use super::{
     block_source::BlockCachedSource,
@@ -53,6 +53,7 @@ use crate::{
         StorageRangeSource,
         manifest::{SubsectionOffsets, SuperfileUri},
     },
+    utils::trace::{OpOrigin, detached},
 };
 
 /// Parquet footer tail-speculation length for cold opens. Must match
@@ -1296,6 +1297,16 @@ impl DiskCacheStore {
         let tmp_owned = tmp.clone();
         let final_owned = final_path.clone();
         let file_owned = Arc::clone(&file);
+        // Detached: the finalizer outlives the fetch that spawned it, so it
+        // gets a root of its own that merely follows from the caller. See
+        // `trace::detached` for why inheriting the caller's span here would
+        // corrupt that span's reported duration.
+        let finalize_span = detached(debug_span!(
+            "cache.finalize_fill",
+            uri = %uri_owned.0,
+            bytes = size,
+            origin = OpOrigin::Maintenance.as_str(),
+        ));
         tokio::spawn(
             async move {
                 let _ = finalize_to_mmap(
@@ -1310,7 +1321,7 @@ impl DiskCacheStore {
                 )
                 .await;
             }
-            .in_current_span(),
+            .instrument(finalize_span),
         );
 
         Ok(entry)
@@ -1417,6 +1428,16 @@ impl DiskCacheStore {
         let uri_owned = *uri;
         let storage_uri_owned = Self::storage_path(uri);
         let fetch_storage = self.resolve_storage(storage);
+        // Detached, and deliberately long-lived: the fill waits for the
+        // foreground's lazy readers to release before it downloads. Parenting
+        // it to the query that happened to trigger it would bill the query for
+        // every second of that wait.
+        let fill_span = detached(debug_span!(
+            "cache.background_fill",
+            uri = %uri_owned.0,
+            bytes = size,
+            origin = OpOrigin::Maintenance.as_str(),
+        ));
         tokio::spawn(
             async move {
                 if needs_reserve {
@@ -1439,7 +1460,7 @@ impl DiskCacheStore {
                 )
                 .await;
             }
-            .in_current_span(),
+            .instrument(fill_span),
         );
     }
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -111,6 +111,8 @@ use super::{
         },
     },
 };
+#[cfg(feature = "detailed-tracing")]
+use crate::utils::trace::OpOrigin;
 use crate::{
     InfinoError,
     config::{self, CentroidAlignment, DrainConsolidate, ThreadCount},
@@ -823,7 +825,7 @@ impl Supertable {
     /// ```
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(rows = batch.num_rows()))
+        tracing::instrument(skip_all, fields(rows = batch.num_rows(), role = self.role().as_str(), origin = OpOrigin::Ingest.as_str()))
     )]
     pub fn append(&self, batch: &RecordBatch) -> Result<(), InfinoError> {
         let mut w = self
@@ -862,7 +864,7 @@ impl Supertable {
     /// ```
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(new_rows = new_rows.num_rows()))
+        tracing::instrument(skip_all, fields(new_rows = new_rows.num_rows(), role = self.role().as_str(), origin = OpOrigin::Ingest.as_str()))
     )]
     pub fn update(
         &self,
@@ -906,7 +908,10 @@ impl Supertable {
     /// assert_eq!(stats.n_tombstoned(), 1);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    #[cfg_attr(feature = "detailed-tracing", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(role = self.role().as_str(), origin = OpOrigin::Ingest.as_str()))
+    )]
     pub fn delete(&self, predicate: Expr) -> Result<MutationStats, InfinoError> {
         let mut w = self
             .writer()
@@ -1040,7 +1045,7 @@ impl SupertableWriter {
     /// id column at position 0.
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(rows = batch.num_rows(), buffered = self.buffer.len()))
+        tracing::instrument(skip_all, fields(rows = batch.num_rows(), buffered = self.buffer.len(), role = self.inner.role.as_str(), origin = OpOrigin::Ingest.as_str()))
     )]
     pub fn append(&mut self, batch: &RecordBatch) -> Result<(), BuildError> {
         let options = &self.inner.options;
@@ -1386,6 +1391,8 @@ impl SupertableWriter {
             buffered = self.buffer.len(),
             updates = self.pending_updates.len(),
             deletes = self.pending_deletes.len(),
+            role = self.inner.role.as_str(),
+            origin = OpOrigin::Ingest.as_str(),
         ))
     )]
     pub fn commit(&mut self) -> Result<CommitResult, CommitError> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
 pub(crate) mod schema;
+pub(crate) mod trace;

--- a/src/utils/trace.rs
+++ b/src/utils/trace.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Shared vocabulary for the tracing spans the engine emits.
+//!
+//! The same functions run on behalf of very different callers:
+//! `ManifestSnapshot::load` can serve a foreground query, a commit, an
+//! explicit `optimize()`, or a detached background sweep, and it can run
+//! against either the user table or the derived vector-index table. A
+//! span name alone can't tell those apart, so each operation's root span
+//! carries two low-cardinality tags:
+//!
+//! * [`OpOrigin`] — what kind of operation is driving the work.
+//! * [`TableRole`] — which of the two tables the work is touching.
+//!
+//! Note these are recorded on the root, not repeated on every descendant:
+//! `tracing` fields do not inherit. A descendant is attributed by walking
+//! its parent chain, which is what the `fmt` subscriber prints as the
+//! span stack. The one root without a `role` is the connection-level SQL
+//! entry, which has no table handle yet.
+//!
+//! Both render as `&'static str`, so recording one is a pointer copy and
+//! never allocates. The field names are spelled `origin` and `role` at
+//! each span site: `tracing`'s macros take field names as literal
+//! tokens, so a shared constant can't stand in for them.
+//!
+//! What is deliberately *not* here is any notion of the calling
+//! application's own roles. A caller that wants its own label installs a
+//! span before calling in; because the public API is synchronous, that
+//! span is the ambient parent and `#[instrument]` picks it up with no
+//! engine-side code. The engine's job is only to never orphan the chain
+//! — see the thread hand-off helpers in `runtime_bridge`.
+
+use tracing::Span;
+
+/// What kind of operation a span's work is being done for.
+///
+/// Recorded on the root of each operation, so a shared helper's span can
+/// be attributed to the caller that triggered it by walking up to the
+/// root. The distinction that motivates the enum is
+/// `Optimize` vs `Maintenance`: both run the identical compaction code,
+/// but one blocks a caller and one does not.
+///
+/// Only `Maintenance` is constructed without `detailed-tracing`: the
+/// detached background spans are always compiled (they cost a disabled
+/// callsite check once per cold fetch), while the per-operation spans
+/// that carry the other variants are behind the feature.
+#[cfg_attr(not(feature = "detailed-tracing"), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OpOrigin {
+    /// A read: search or SQL, driven by a caller waiting on the result.
+    Query,
+    /// A write: append, update, delete, or the commit that publishes it.
+    Ingest,
+    /// An explicit `optimize()` call. Runs the same compaction and sweep
+    /// code as [`Self::Maintenance`], but synchronously, with a caller
+    /// blocked on it — so its latency is user-visible and its cost
+    /// belongs to the caller.
+    Optimize,
+    /// Detached background work: compaction, gc, hidden-index drain, and
+    /// the disk cache's background fills. Nobody is waiting on it, but it
+    /// competes for the same pools as the foreground.
+    Maintenance,
+    /// Connect, create, or open — including the open-time recovery and gc
+    /// sweeps that run before a handle is returned.
+    Open,
+}
+
+impl OpOrigin {
+    /// The span-field rendering. `&'static str` so recording is free.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Query => "query",
+            Self::Ingest => "ingest",
+            Self::Optimize => "optimize",
+            Self::Maintenance => "maintenance",
+            Self::Open => "open",
+        }
+    }
+}
+
+/// Which table a span's work is touching.
+///
+/// A table with vector columns owns a second, derived supertable holding
+/// the cell-ordered vector index. It runs the same code as the user
+/// table, so without this tag its spans are indistinguishable from the
+/// user table's — two `manifest.load` spans per query, same name,
+/// different table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TableRole {
+    /// The user's own table: the append-only, time-ordered rows.
+    User,
+    /// The derived, cell-ordered vector index that accelerates vector
+    /// search over [`Self::User`].
+    VectorIndex,
+}
+
+impl TableRole {
+    /// The span-field rendering. `&'static str` so recording is free.
+    /// Only read by the span sites, which are behind `detailed-tracing`.
+    #[cfg_attr(not(feature = "detailed-tracing"), allow(dead_code))]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::VectorIndex => "vector_index",
+        }
+    }
+}
+
+/// Turn `span` into the root of a *detached* unit of work that was
+/// merely triggered by the current span, rather than awaited by it.
+///
+/// The distinction matters for timing. A fire-and-forget task that
+/// inherits the triggering span as its parent keeps that span alive
+/// until the task finishes, so the span's recorded duration absorbs
+/// background work the caller never waited for — a query that returned
+/// in 5 ms reports the seconds its background cache fill went on to
+/// take. `follows_from` records the same causal link without the
+/// parent-child timing relationship, so both durations stay honest.
+///
+/// Use it at every `tokio::spawn` whose `JoinHandle` is dropped. Awaited
+/// fan-out is the opposite case and should keep `in_current_span`: the
+/// caller really is waiting, so the time really is the caller's.
+pub(crate) fn detached(span: Span) -> Span {
+    span.follows_from(Span::current());
+    span
+}


### PR DESCRIPTION
### What does this PR do?
- augments the current spans to include the type of operation which triggers this ( query / maintenance / optimize etc )
- For queries, includes what type of table the queries run on ( main user table or hidden vector table )

### Why do we need this change
- Better tracing and debugging