### PR TITLE
vector: improve supertable ingestion. bound the fp32 pack's chunk scratch by the call's rows

### DIFF
--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -1757,7 +1757,13 @@ fn stream_fp32_rows_to_buckets(
                 .expect("residual-family codec has divisor"),
         )
     });
-    let chunk_rows = materialized_chunk_rows_for_dim(dim);
+    // Bound the chunk by the rows this call actually holds: the budgeted
+    // chunk is 32K rows (~128 MiB per fp32 buffer at dim=1024), and the
+    // commit path reaches here once per small per-cell subsection — sizing
+    // the scratch to the budget regardless of `n_docs` zeroed ~320 MiB per
+    // call to process a few hundred rows. Measured: 46% of supertable
+    // vector ingest wall was memset under these allocations.
+    let chunk_rows = materialized_chunk_rows_for_dim(dim).min(n_docs.max(1));
     let mut chunk_rotated = vec![0.0f32; chunk_rows * dim];
     // Cosine rows must be unit before ANY consumer below sees them: the
     // fixed cosine grid spans [-1, 1], so a non-unit component saturates at


### PR DESCRIPTION
stream_fp32_rows_to_buckets sized its chunk scratch from the memory budget alone -- 32K rows, ~320 MiB of zeroed buffers per call at 1024-d cosine (rotated + unit + payload) -- regardless of how many rows the call holds. The commit path reaches it once per small per-cell subsection, so supertable vector ingest spent 46% of its wall in memset under these allocations (perf, 1M x 1024-d, 199 Hz dwarf).

Bound the chunk by min(budget rows, n_docs). Output is byte-identical: for n_docs <= 32K the loop processed one chunk before and processes the same one chunk now, minus the zeroing; above 32K the bound never binds.

Measured, supertable vector ingest 1M x 1024-d on Azure, 16 commits: 59.3s -> 31.6s (16.9 -> 31.6 K/s), shard pack 2280ms -> 577ms per commit, peak RSS 2.64 -> 1.11 GiB. Stored bytes identical (2.13 GiB) both runs.