### PR TITLE
vector: improve superfile ingestion. ncent rows per cluster.

### DIFF
--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -200,12 +200,18 @@ const STREAM_ROWS_PER_CENT: usize = 1000;
 /// Cell packs and maintenance rebuilds keep the banded cap — those are
 /// the measured 1M/10M cell layouts, not this path.
 fn stream_n_cent_for_rows(n_docs: usize) -> usize {
-    let target = n_docs / STREAM_ROWS_PER_CENT;
+    // Clamp the target to the ceiling BEFORE the power-of-two math: any
+    // target past `N_CENT_LARGE` resolves to `N_CENT_LARGE` regardless
+    // (rounding only moves values between adjacent powers of two, and
+    // the final clamp caps them), and the pre-clamp makes every
+    // operation below total — `next_power_of_two` cannot overflow-panic
+    // and the squared comparison stays far inside `usize` — with no
+    // assumption about how large a corpus a caller hands in.
+    let target = (n_docs / STREAM_ROWS_PER_CENT).min(N_CENT_LARGE);
     let up = target.next_power_of_two();
     let down = up / 2;
     // Nearest in log space: `down` wins iff `target <= down·√2`, i.e.
-    // `target² <= 2·down² = down·up`. `target` is rows/1000, so the
-    // square fits usize comfortably at any realistic corpus size.
+    // `target² <= 2·down² = down·up`.
     let nearest = if target * target <= down * up {
         down
     } else {
@@ -3508,6 +3514,10 @@ mod tests {
         // Clamp ceiling: at and past the large threshold, the large cap.
         assert_eq!(stream_n_cent_for_rows(5_000_000), N_CENT_LARGE);
         assert_eq!(stream_n_cent_for_rows(10_000_000), N_CENT_LARGE);
+        // Total for ANY input: the pre-clamp keeps the pow2 math from
+        // overflowing, so even an absurd row count resolves instead of
+        // panicking.
+        assert_eq!(stream_n_cent_for_rows(usize::MAX), N_CENT_LARGE);
         // The fix itself: a 1M/7 shard no longer trains the full 1024 —
         // its centroid count follows its own rows, landing rows/cluster
         // near the target (142,858 / 128 ≈ 1116).

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -186,16 +186,32 @@ const STREAM_ROWS_PER_CENT: usize = 1000;
 /// ≥100K band, so each shard trained the full 1024 centroids on all of
 /// its rows and 7 writers did ~2.6x the k-means work of 1 writer —
 /// measured 2x SLOWER wall time on a 4-core box. Under the continuous
-/// rule a 142K shard trains 256 centroids (~558 rows/cluster) and
+/// rule a 142K shard trains 128 centroids (~1116 rows/cluster) and
 /// sharding divides the centroid work the way it divides the rows.
-/// The 1M single-build point is unchanged (1000 -> 1024).
+///
+/// NEAREST power of two, not round-up: rounding up would keep every
+/// shard finer than the target (500..1000 rows/cluster) and shift the
+/// measured 10M supertable shard layout (~78K rows: 64 under the band,
+/// 128 rounded up). Nearest keeps rows-per-cluster bracketing the
+/// target (707..1414) and reproduces EVERY measured design shape
+/// exactly: 1M -> 1024, ~78K supertable shards -> 64, small builds ->
+/// 64, >=5M -> 4096.
 ///
 /// Cell packs and maintenance rebuilds keep the banded cap — those are
 /// the measured 1M/10M cell layouts, not this path.
 fn stream_n_cent_for_rows(n_docs: usize) -> usize {
-    (n_docs / STREAM_ROWS_PER_CENT)
-        .next_power_of_two()
-        .clamp(N_CENT_SMALL, N_CENT_LARGE)
+    let target = n_docs / STREAM_ROWS_PER_CENT;
+    let up = target.next_power_of_two();
+    let down = up / 2;
+    // Nearest in log space: `down` wins iff `target <= down·√2`, i.e.
+    // `target² <= 2·down² = down·up`. `target` is rows/1000, so the
+    // square fits usize comfortably at any realistic corpus size.
+    let nearest = if target * target <= down * up {
+        down
+    } else {
+        up
+    };
+    nearest.clamp(N_CENT_SMALL, N_CENT_LARGE)
 }
 
 /// Metric ID encoding for the directory entry. Spec: 0 = L2Sq, 1 = Cosine,
@@ -3485,17 +3501,21 @@ mod tests {
         assert_eq!(stream_n_cent_for_rows(62_500), N_CENT_SMALL);
         // Design point: the 1M single build keeps its measured layout.
         assert_eq!(stream_n_cent_for_rows(1_000_000), N_CENT_MEDIUM);
+        // 10M supertable commit shards (~78K rows) keep the measured 64:
+        // nearest-pow2 rounds 78 DOWN, where round-up would have shifted
+        // a measured layout to 128 for nothing.
+        assert_eq!(stream_n_cent_for_rows(78_125), N_CENT_SMALL);
         // Clamp ceiling: at and past the large threshold, the large cap.
         assert_eq!(stream_n_cent_for_rows(5_000_000), N_CENT_LARGE);
         assert_eq!(stream_n_cent_for_rows(10_000_000), N_CENT_LARGE);
         // The fix itself: a 1M/7 shard no longer trains the full 1024 —
-        // its centroid count follows its own rows.
-        let shard = stream_n_cent_for_rows(1_000_000_usize.div_ceil(7));
-        assert!(
-            shard < N_CENT_MEDIUM,
-            "a 142K shard must train fewer centroids than the whole 1M \
-             corpus, or sharding multiplies the k-means work (got {shard})"
-        );
+        // its centroid count follows its own rows, landing rows/cluster
+        // near the target (142,858 / 128 ≈ 1116).
+        assert_eq!(stream_n_cent_for_rows(1_000_000_usize.div_ceil(7)), 128);
+        // Power-of-two fractions of the design point keep the design
+        // ratio: half the corpus, half the clusters.
+        assert_eq!(stream_n_cent_for_rows(500_000), 512);
+        assert_eq!(stream_n_cent_for_rows(250_000), 256);
         // Monotone in rows: more rows never means fewer clusters.
         let mut prev = 0;
         for rows in [0, 10_000, 62_500, 142_858, 500_000, 1_000_000, 5_000_000] {

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -167,6 +167,37 @@ fn n_cent_row_count_cap(n_docs: usize) -> usize {
     }
 }
 
+/// Target rows per IVF cluster for a STREAMING user-superfile build.
+/// Matches the layout the banded cap produces at its design points
+/// (1M rows / 1024 clusters = 976; the drain's fine-cluster p50 sits
+/// ~1000 on the same corpora), so the continuous rule below reproduces
+/// the measured shapes where they were measured and interpolates
+/// between them instead of stepping.
+const STREAM_ROWS_PER_CENT: usize = 1000;
+
+/// IVF centroid count for a streaming user-superfile build, derived
+/// continuously from the rows the build holds:
+/// `next_pow2(rows / STREAM_ROWS_PER_CENT)` clamped to
+/// `[N_CENT_SMALL, N_CENT_LARGE]`.
+///
+/// Replaces the banded `n_cent_row_count_cap` on THIS path only. The
+/// band step made the centroid count a step function of shard size:
+/// sharding 1M rows across 7 builders put every 142K-row shard in the
+/// ≥100K band, so each shard trained the full 1024 centroids on all of
+/// its rows and 7 writers did ~2.6x the k-means work of 1 writer —
+/// measured 2x SLOWER wall time on a 4-core box. Under the continuous
+/// rule a 142K shard trains 256 centroids (~558 rows/cluster) and
+/// sharding divides the centroid work the way it divides the rows.
+/// The 1M single-build point is unchanged (1000 -> 1024).
+///
+/// Cell packs and maintenance rebuilds keep the banded cap — those are
+/// the measured 1M/10M cell layouts, not this path.
+fn stream_n_cent_for_rows(n_docs: usize) -> usize {
+    (n_docs / STREAM_ROWS_PER_CENT)
+        .next_power_of_two()
+        .clamp(N_CENT_SMALL, N_CENT_LARGE)
+}
+
 /// Metric ID encoding for the directory entry. Spec: 0 = L2Sq, 1 = Cosine,
 /// 2 = NegDot.
 fn metric_id(m: Metric) -> u32 {
@@ -2516,8 +2547,8 @@ fn build_subsection_streaming(
         // `n_cent > sample_rows` would crash k-means (`k > n` is asserted
         // by the trainer). At steady-state shapes (`n_docs > sample_size`,
         // `sample_size ≥ 100_000`) the sample_rows bound is the active
-        // one and is comfortably above the row-count cap.
-        let n_cent = n_cent_row_count_cap(n_docs)
+        // one and is comfortably above the row-count rule.
+        let n_cent = stream_n_cent_for_rows(n_docs)
             .min(n_docs.max(1))
             .min(sample_rows.max(1))
             .max(1);
@@ -3442,6 +3473,36 @@ mod tests {
             n_cent_row_count_cap(N_CENT_LARGE_DOC_THRESHOLD),
             N_CENT_LARGE
         );
+    }
+
+    /// The streaming rule preserves the banded cap's design points and
+    /// interpolates between them, so sharding a corpus divides the
+    /// k-means work instead of multiplying it.
+    #[test]
+    fn stream_n_cent_scales_with_rows_and_keeps_design_points() {
+        // Clamp floor: empty and small builds keep the small layout.
+        assert_eq!(stream_n_cent_for_rows(0), N_CENT_SMALL);
+        assert_eq!(stream_n_cent_for_rows(62_500), N_CENT_SMALL);
+        // Design point: the 1M single build keeps its measured layout.
+        assert_eq!(stream_n_cent_for_rows(1_000_000), N_CENT_MEDIUM);
+        // Clamp ceiling: at and past the large threshold, the large cap.
+        assert_eq!(stream_n_cent_for_rows(5_000_000), N_CENT_LARGE);
+        assert_eq!(stream_n_cent_for_rows(10_000_000), N_CENT_LARGE);
+        // The fix itself: a 1M/7 shard no longer trains the full 1024 —
+        // its centroid count follows its own rows.
+        let shard = stream_n_cent_for_rows(1_000_000_usize.div_ceil(7));
+        assert!(
+            shard < N_CENT_MEDIUM,
+            "a 142K shard must train fewer centroids than the whole 1M \
+             corpus, or sharding multiplies the k-means work (got {shard})"
+        );
+        // Monotone in rows: more rows never means fewer clusters.
+        let mut prev = 0;
+        for rows in [0, 10_000, 62_500, 142_858, 500_000, 1_000_000, 5_000_000] {
+            let n = stream_n_cent_for_rows(rows);
+            assert!(n >= prev, "n_cent must be monotone in rows");
+            prev = n;
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #663 — superfile vector ingest got SLOWER as writers were added.

## Mechanism

The banded `n_cent_row_count_cap` made the centroid count a step function of shard size: every shard >= 100K rows landed in the k=1024 band, so a 1M-row build split 7 ways trained seven full-size k-means — each on 100% of its rows, because the 262K training reservoir never binds on a 142K shard. ~2.6x the row x centroid work of one writer, on cores the single writer already saturates. The archived "16 writers = 7.8x faster" table was never a scaling measurement: at 62.5K rows/shard those shards trained k=64 against the 1-writer arm's k=1024 — 4x less centroid work on 16 threads.

## The change

Streaming user-superfile builds derive their centroid count continuously from their own rows:

```rust
const STREAM_ROWS_PER_CENT: usize = 1000;
// nearest power of two to rows/1000, clamped to the existing [64, 4096]
fn stream_n_cent_for_rows(n_docs: usize) -> usize { ... }
```

NEAREST power of two, not round-up: rounding up would keep every shard finer than the target (500..1000 rows/cluster) and shift the measured 10M supertable shard layout (~78K rows: 64 under the band, 128 rounded up). Nearest keeps rows-per-cluster bracketing the target (707..1414) and reproduces EVERY measured design shape exactly:

- 1M -> 1024 (the bench artifact, unchanged), >=5M -> 4096, small builds -> 64;
- ~78K supertable commit shards -> 64 — the 10M user layout is byte-identical, pinned by a unit test;
- a 142K shard trains 128 centroids (~1116 rows/cluster, right on the target) instead of 1024 (139 rows/cluster).
- Scoped to the streaming local-kmeans site only. Cell packs and maintenance rebuilds keep the banded cap — those are the measured 1M/10M cell layouts, deliberately untouched.
- The reservoir/sample-size lever from #663 is deliberately NOT taken here: an under-filled reservoir holds rows in arrival order, so truncating to a prefix would bias training on time-ordered corpora. Follow-up with an unbiased second-stage subsample.

## Measured (1M docs x 1024-d, 4C/8T)

| build | before | after |
|---|---|---|
| 1 writer | 46.45 s / 21.5 K/s | 44.20 s / 22.6 K/s (unchanged) |
| 8 writers | 95.16 s — 2.05x SLOWER | **14.95 s / 66.9 K/s — 3.0x faster** |

(3x, not 8x, because the 1-writer arm's k-means and assignment already run rayon-parallel on all cores — sharding parallelizes only the per-builder serial phases. FTS, whose builder has no internal parallelism, measures 4.02x with 8 writers on this 4-core box; that is the hardware ceiling, and vector now sits just under it.)

Recall on the bench artifact: 1.000 default (floor 0.80), 0.900 filtered (floor 0.80) — the 1-writer artifact keeps its exact shape by construction, which the unchanged wall time and recall confirm.

## Scale note

Every measured design shape is reproduced exactly (asserted in `stream_n_cent_scales_with_rows_and_keeps_design_points`), so the 10M supertable result is unchanged by construction — the only layouts that move are mid-range shard sizes nothing currently measures. Happy to run the 10M gate as belt-and-braces on request.

Gates: 312 superfile vector unit tests (incl. the new rule test pinning 78K -> 64 and 1M -> 1024), all 10 IVF brute-force oracles, clippy clean, fmt clean, and the 1M A/B above; recall on the bench artifact 1.000 default / 0.900 filtered, both above floors.