### PR TITLE
fix: move logs from eprintln to tracing lib

### DIFF
--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -492,14 +492,27 @@ fn parse_args() -> Selection {
 }
 
 fn main() {
+    // Every bench run installs a subscriber, unconditionally
+    // `RUST_LOG` overrides; unset, default to `infino=debug` so the engine's
+    // own diagnostics always surface in CI without a caller having to know
+    // the right directive.
+    //
     // Span-timing diagnosis: with a `--features detailed-tracing` build,
-    // `INFINO_TRACE_SPANS=1` (+ `RUST_LOG=infino=info`) prints every
-    // instrumented span's busy time on close — per-stage attribution for
-    // query-path latency without touching engine code.
+    // `INFINO_TRACE_SPANS=1` additionally prints every instrumented span's
+    // busy time on close — per-stage attribution for query-path latency
+    // without touching engine code.
+    let env_filter = || {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,infino=debug"))
+    };
     if std::env::var("INFINO_TRACE_SPANS").is_ok() {
         tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
+            .with_env_filter(env_filter())
             .with_span_events(FmtSpan::CLOSE)
+            .with_writer(std::io::stderr)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter())
             .with_writer(std::io::stderr)
             .init();
     }

--- a/src/runtime_metrics/rss.rs
+++ b/src/runtime_metrics/rss.rs
@@ -22,6 +22,8 @@ use std::{
     time::Duration,
 };
 
+use tracing::debug;
+
 /// Force the global allocator (mimalloc, default-on) to return freed-but-
 /// retained arenas to the OS. No-op when mimalloc is not the global allocator.
 pub fn purge_allocator() {
@@ -217,7 +219,7 @@ pub fn log_rss_breakdown(label: &str) {
     let Some((rss, anon, file_backed, shmem)) = settled_rss_breakdown() else {
         return;
     };
-    eprintln!(
+    debug!(
         "[rss-breakdown] {label}: rss={} anonymous={} file_backed={} shmem={}",
         fmt_bytes(rss),
         fmt_bytes(anon),

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -88,6 +88,7 @@ use bumpalo::Bump;
 use hashbrown::hash_map::{HashMap as HbHashMap, RawEntryMut};
 use memmap2::Mmap;
 use rustc_hash::{FxBuildHasher, FxHashMap};
+use tracing::debug;
 
 use crate::superfile::{
     BuildError,
@@ -2907,7 +2908,7 @@ impl FtsBuilder {
                         let merge_total = merge_profile_start.elapsed();
                         let encode_total = finish_profile.encode_total - encode_total_before;
                         let non_encode = merge_total.saturating_sub(encode_total);
-                        eprintln!(
+                        debug!(
                             "[fts-profile] col='{}' merge_total={:.3}s non_encode_merge={:.3}s encode_total={:.3}s calls={} df1={} pfor={} block_build={:.3}s meta_write={:.3}s skip_write={:.3}s block_write={:.3}s fst_insert={:.3}s",
                             col_name,
                             merge_total.as_secs_f64(),
@@ -3321,7 +3322,7 @@ fn assemble_and_write_blob<W: Write>(
     }
 
     if finish_profile.enabled {
-        eprintln!(
+        debug!(
             "[fts-finish] partition_flush={:.3}s lex_rank={:.3}s partition_sort={:.3}s mmap_open={:.3}s scratch_cleanup={:.3}s postings_close={:.3}s fst_close={:.3}s doc_lengths_emit={:.3}s blob_copy={:.3}s",
             finish_profile.partition_flush.as_secs_f64(),
             finish_profile.lex_rank_build.as_secs_f64(),

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -456,7 +456,7 @@ impl Supertable {
 
         let clamped_components = transcode_clamped_components() - transcode_clamp_baseline;
         if clamped_components > 0 {
-            eprintln!(
+            warn!(
                 "[supertable compaction] BUG: {clamped_components} component(s) saturated \
                  their destination quantizer during this pass's merges/splits — a \
                  destination grid failed to cover its inputs; affected rows' recall \

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -56,6 +56,7 @@ use futures::future;
 pub use list::{FtsSummaryAgg, GlobalVectorIndex, RoutingRef, ScalarStatsAgg};
 use rayon::{ThreadPool, prelude::*};
 use tokio::{sync::OnceCell, task::spawn_blocking};
+use tracing::warn;
 use uuid::Uuid;
 use xxhash_rust::xxh3::xxh3_64;
 
@@ -1598,7 +1599,7 @@ impl ManifestSnapshot {
                 Some(cache)
             }
             Err(error) => {
-                eprintln!(
+                warn!(
                     "[supertable] full-part centroid hydration unavailable ({error}); falling \
                      back to per-superfile centroid reads"
                 );

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -1955,7 +1955,7 @@ impl SupertableWriter {
                 stats.add_planned_commit_requests(planned_data_objects(payload_bytes));
             }
             if crate::storage::io_counters::timeline_enabled() {
-                eprintln!(
+                info!(
                     "[supertable commit] build {:.1}ms ({:.1} MiB output) + prepare {:.1}ms + \
                      publish {:.1}ms ({:.1} MiB data PUT)",
                     build_elapsed.as_secs_f64() * 1e3,
@@ -3632,7 +3632,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
     }
     let batch_cfg = drain_batch_superfiles(&user_inner.options);
     if batch_cfg == 0 {
-        eprintln!("[supertable drain] skipped (drain_batch_superfiles = 0)");
+        info!("[supertable drain] skipped (drain_batch_superfiles = 0)");
         return Ok(());
     }
 
@@ -3742,7 +3742,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             .cloned()
             .collect();
         if selected.is_empty() {
-            eprintln!(
+            info!(
                 "[supertable drain] nothing to drain: all {} user superfile(s) already drained",
                 sources.len()
             );
@@ -4040,7 +4040,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             } else {
                 0.0
             };
-            eprintln!(
+            info!(
                 "[supertable drain] batch {}/{} materialize I/O: {} object reads, {:.1} MiB, wall {:.1}ms, Σdur {:.1}ms, implied concurrency {:.1}x ({} range-gets)",
                 batch_idx + 1,
                 n_batches,
@@ -4296,7 +4296,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             DrainTestFailurePhase::AfterBatch,
             local_checkpoint.batches_done,
         )?;
-        eprintln!(
+        info!(
             "[supertable drain] batch {}/{} ({} sf, {batch_log})",
             batch_idx + 1,
             n_batches,
@@ -4759,7 +4759,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         {
             tracing::warn!("drain local checkpoint cleanup failed: {error}");
         }
-        eprintln!(
+        info!(
             "[supertable drain] cell build: {} row(s), {} cell(s) -> {} packed shard superfile(s) for {} worker(s), {:.1}ms",
             total_rows,
             n_cells_total,
@@ -4770,13 +4770,13 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
         if crate::superfile::vector::builder::build_phase_timers::enabled() {
             let (train_ms, assign_ms, calib_ms) =
                 crate::superfile::vector::builder::build_phase_timers::snapshot_ms();
-            eprintln!(
+            info!(
                 "[supertable drain] cell build phases (summed CPU, {n_cells_total} cells): train {train_ms:.1}ms + assign {assign_ms:.1}ms + calibrate {calib_ms:.1}ms",
             );
         }
     }
 
-    eprintln!(
+    info!(
         "[supertable drain] done ({}, {} batch(es), budget {} sf): total {:.1}ms; RSS {} -> {} MiB",
         match consolidate {
             DrainConsolidate::Kmeans => "kmeans",
@@ -4794,7 +4794,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
     );
     let clamped_components = transcode_clamped_components() - transcode_clamp_baseline;
     if clamped_components > 0 {
-        eprintln!(
+        warn!(
             "[supertable drain] BUG: {clamped_components} component(s) saturated their \
              destination quantizer during this drain's re-encodes. Cosine: an ingest \
              path bypassed normalization; L2/NegDot: a destination grid failed to \
@@ -5842,7 +5842,7 @@ fn commit_shards_via_drain(
         .saturating_sub(flatten_elapsed)
         .saturating_sub(assign_elapsed);
     if crate::storage::io_counters::timeline_enabled() {
-        eprintln!(
+        info!(
             "[supertable commit] flatten {:.1}ms + assign {:.1}ms + shard pack/finish {:.1}ms",
             flatten_elapsed.as_secs_f64() * 1e3,
             assign_elapsed.as_secs_f64() * 1e3,


### PR DESCRIPTION
Some logs were set to be routes to std out via eprintln, so tracing library didn't push those logs to logging platform. 
This PR fixes the same.