### PR TITLE
size the build reserve by rows, not by the buffer they share

### DIFF
--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -384,6 +384,19 @@ pub struct SupertableWriter {
     /// allocation. (`buffer_vector_bytes` is the exact f32 payload on
     /// either reading; slices share nothing wider than their rows.)
     buffer_fts_bytes: usize,
+    /// Visible (slice-aware) scalar bytes across `buffer`: what a build
+    /// will actually read, rather than the allocation the buffer holds.
+    ///
+    /// Separate from `buffer_scalar_bytes` because the two answer
+    /// different questions and the right measure is opposite for each.
+    /// Held memory is capacity: a slice pins its parent's whole buffer,
+    /// so that *is* the resident cost, and the auto-flush threshold
+    /// should see it. Build scratch scales with the rows the builder
+    /// touches, so it must not. Feeding capacity to the reserve made a
+    /// batch decoded from an Arrow IPC stream look ~160x its size,
+    /// because that decode points every child array at one shared
+    /// message buffer and capacity bills each child for all of it.
+    buffer_scalar_visible_bytes: usize,
     /// Ingested work for the batches sitting in `buffer`, computed at
     /// `append` time from the caller's own batch and held here until the
     /// commit that publishes them returns `Ok`. Counting at append time is
@@ -1001,6 +1014,7 @@ impl Supertable {
                 buffer_scalar_bytes: 0,
                 buffer_vector_bytes: 0,
                 buffer_fts_bytes: 0,
+                buffer_scalar_visible_bytes: 0,
                 pending_ingest: IngestTally::default(),
                 pending_updates: Vec::new(),
                 pending_deletes: Vec::new(),
@@ -1149,6 +1163,11 @@ impl SupertableWriter {
         self.buffer_scalar_bytes += scalar_bytes;
         self.buffer_vector_bytes += vector_bytes;
         self.buffer_fts_bytes += fts_bytes;
+        // `ingested_byte_legs` measured this already, on `scalar_no_id`. The
+        // engine-minted `_id` column is left out: 16 bytes a row against a
+        // payload measured in kilobytes, and counting it here would mean
+        // measuring a second batch to no purpose.
+        self.buffer_scalar_visible_bytes += scalar_bytes_u64 as usize;
 
         // Per-op work stats: the write's input shape, counted here from
         // the caller's batch — before any shard split or commit retry — so
@@ -1793,7 +1812,7 @@ impl SupertableWriter {
         // Held until this function returns, i.e. past `publish_superfiles` below.
         let _build_guard = reserve_build_scratch(
             &self.inner.options.connection_memory_budget,
-            self.buffer_scalar_bytes,
+            self.buffer_scalar_visible_bytes,
             self.buffer_vector_bytes,
             self.buffer_fts_bytes,
         )?;
@@ -1803,11 +1822,13 @@ impl SupertableWriter {
         let saved_scalar = self.buffer_scalar_bytes;
         let saved_vector = self.buffer_vector_bytes;
         let saved_fts = self.buffer_fts_bytes;
+        let saved_scalar_visible = self.buffer_scalar_visible_bytes;
         let saved_ingest = mem::take(&mut self.pending_ingest);
         let buffer = mem::take(&mut self.buffer);
         self.buffer_scalar_bytes = 0;
         self.buffer_vector_bytes = 0;
         self.buffer_fts_bytes = 0;
+        self.buffer_scalar_visible_bytes = 0;
 
         match self.commit_appends_with_taken_buffer(&buffer) {
             Ok(()) => {
@@ -1829,6 +1850,7 @@ impl SupertableWriter {
                 self.buffer_scalar_bytes = saved_scalar;
                 self.buffer_vector_bytes = saved_vector;
                 self.buffer_fts_bytes = saved_fts;
+                self.buffer_scalar_visible_bytes = saved_scalar_visible;
                 self.pending_ingest = saved_ingest;
                 Err(e)
             }
@@ -2162,7 +2184,12 @@ impl ShardOutput {
     }
 }
 
-/// Reserve the build's estimated transient heap:
+/// Reserve the build's estimated transient heap.
+///
+/// Every leg is visible bytes, not buffer capacity: this sizes work the build
+/// is about to do, so it has to follow the rows the builder will touch rather
+/// than whatever allocation those rows happen to sit inside.
+///
 ///
 /// estimate = (2.5*scalar_raw_bytes + 6.5*vector_raw_bytes + 1.5*fts_text_raw_bytes)
 ///

--- a/tests/nested_types.rs
+++ b/tests/nested_types.rs
@@ -14,12 +14,15 @@
 
 use std::{io::Cursor, sync::Arc, time::Duration};
 
-use arrow::json::ReaderBuilder;
+use arrow::{
+    ipc::{reader::StreamReader, writer::StreamWriter},
+    json::ReaderBuilder,
+};
 use infino::{
-    Bm25SearchOptions, BoolMode, Connection, IndexSpec, OptimizeOptions,
+    Bm25SearchOptions, BoolMode, ConnectOptions, Connection, IndexSpec, OptimizeOptions,
     arrow_array::{Array, Int64Array, ListArray, RecordBatch, StructArray},
     arrow_schema::{DataType, Field, Fields, Schema, SchemaRef, TimeUnit},
-    connect,
+    connect, connect_with,
 };
 use tempfile::TempDir;
 
@@ -388,4 +391,93 @@ fn nested_schema_survives_reopen_compaction_and_gc() {
         TALLEST_IMAGE_HEIGHT,
         "nested values must survive the rewrite unchanged"
     );
+}
+
+/// Rows enough that the shared-buffer effect is unmistakable rather than noise.
+const BUDGET_FIXTURE_ROWS: usize = 400;
+
+/// One nested row, repeated, as newline-delimited JSON.
+fn many_nested_rows(rows: usize) -> String {
+    let mut out = String::new();
+    for i in 0..rows {
+        out.push_str(&format!(
+            r#"{{"title":"article {i}","image":{{"content_url":"https://example.test/{i}.png","height":{i}}},"entities":[{{"identifier":"Q{i}","url":"https://example.test/Q{i}"}}],"updated":"2026-01-02T03:04:05Z"}}"#
+        ));
+        if i + 1 < rows {
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Send a batch through an Arrow IPC stream and back, the way a hosted append
+/// reaches the engine.
+fn ipc_round_trip(batch: &RecordBatch) -> RecordBatch {
+    let mut buf = Vec::new();
+    {
+        let mut w = StreamWriter::try_new(&mut buf, &batch.schema()).expect("ipc writer");
+        w.write(batch).expect("ipc write");
+        w.finish().expect("ipc finish");
+    }
+    StreamReader::try_new(Cursor::new(buf), None)
+        .expect("ipc reader")
+        .next()
+        .expect("one batch")
+        .expect("decodable")
+}
+
+/// Visible bytes of a batch: the rows it spans, not the allocation they sit in.
+fn visible_bytes(batch: &RecordBatch) -> usize {
+    batch
+        .columns()
+        .iter()
+        .map(|c| c.to_data().get_slice_memory_size().unwrap_or(0))
+        .sum()
+}
+
+#[test]
+fn build_budget_measures_rows_not_the_buffer_they_share() {
+    // An Arrow IPC decode points every child array at one shared message
+    // buffer. A nested schema has many children, and measuring buffer capacity
+    // bills each of them for the whole message, so the batch reads as orders of
+    // magnitude larger than it is. The build reserve then refuses a batch that
+    // fits comfortably -- and only over a hosted connection, since decoding
+    // parquet locally gives each column buffers of its own.
+    let schema = nested_schema();
+    let decoded = ipc_round_trip(&batch_from_json(
+        schema.clone(),
+        &many_nested_rows(BUDGET_FIXTURE_ROWS),
+    ));
+
+    let visible = visible_bytes(&decoded);
+    let capacity = decoded.get_array_memory_size();
+    assert!(
+        capacity > visible * 4,
+        "fixture must exhibit the inflation it is testing: \
+         capacity {capacity} B vs visible {visible} B"
+    );
+
+    // A budget of one capacity-measure. Reserving 2.5x the visible size fits
+    // inside it; reserving 2.5x the capacity cannot.
+    let dir = TempDir::new().expect("tempdir");
+    let db = connect_with(
+        dir.path().to_str().expect("utf-8 path"),
+        ConnectOptions::new().with_connection_memory_budget_bytes(capacity as u64),
+    )
+    .expect("connect");
+    let table = db
+        .create_table(TABLE, schema, IndexSpec::new().fts("title"))
+        .expect("create_table");
+
+    table
+        .append(&decoded)
+        .expect("a batch this size must fit the budget");
+
+    let rows: usize = db
+        .query_sql(&format!("SELECT title FROM {TABLE}"))
+        .expect("query_sql")
+        .iter()
+        .map(RecordBatch::num_rows)
+        .sum();
+    assert_eq!(rows, BUDGET_FIXTURE_ROWS, "every row must be committed");
 }


### PR DESCRIPTION
## Why

`buffer_scalar_bytes` answers two questions, and the correct measure is opposite for each:

- **How much memory is held?** Capacity. A slice pins its parent's whole allocation, so that is genuinely resident, and the auto-flush threshold should see it.
- **How much scratch will the build need?** Not capacity. It scales with the rows a builder reads, so billing a shared allocation overstates it.

The build reserve was reading the held-memory figure.

Over an Arrow IPC stream that is catastrophic. The decode points every child array at one shared message buffer, and `get_array_memory_size` bills each child for all of it, so a nested schema with many children reports its message size multiplied by the number of children.

Measured on a 65-column document corpus with several nested levels (`list<struct<...>>`, `struct<struct<...>>`):

| | |
| --- | --- |
| batch on the wire | 23.7 MiB |
| `get_array_memory_size` after IPC decode | **3771.5 MiB** (~160x) |
| reserve asks (2.5x) | 9.21 GiB |
| connection budget | 5.40 GiB |

So a batch that fits comfortably is refused. Reported from the field as a 413 on `append` against a hosted table, with the figure not moving when the input shrank from a directory to a single file.

**Only remote tables were affected.** Decoding parquet locally gives each column buffers of its own, so capacity runs about 1.4x visible there. The reporter's loads against local object storage worked throughout, which is what pointed at the decode rather than the data.

## What changed

The visible figure was already being computed and discarded. `ingested_byte_legs` returns it for the priced legs, and the comment there already makes the argument for the FTS leg:

> The FTS leg moves with the priced legs deliberately: it weights the build-scratch reserve, and the builder's scratch scales with the text it will actually index — a slice's visible rows — not with the parent allocation the slice shares.

That argument covers the scalar leg identically. It is now tracked alongside the others and handed to the reserve. Held-memory accounting stays on capacity, where the same comment says it belongs.

No new measurement, no new helper, and the multipliers are untouched: the FTS leg has been visible-based with its own multiplier for a while, so there is in-tree precedent that the constants work against visible bytes.

## Test

Appends an IPC-decoded nested batch under a budget of exactly one capacity-measure, so 2.5x the visible size fits inside it and 2.5x the capacity cannot. The fixture asserts it actually exhibits the inflation before relying on it.

Reverting just the one changed argument makes it fail with the reported error:

```
OverBudget("append: during ingest, over connection memory budget:
requested 1235555 B with 0 B in use of a 434908 B limit")
```

`make check` clean. Full suite 2317 passed; the single failure is
`reader_synchronous_with_storage_upgrades_lazy_hidden_entry`, which passes in
isolation and is unrelated to this diff — it appears to be an existing
order-dependent flake and is worth a separate look.

## Left alone

`writer.rs` also measures capacity for the superfile fanout heuristic. Its comment says capacity is "fine for a fanout heuristic that is clamped to the pool anyway", which still reads as true, so it is unchanged.

The visible figure is measured on the caller's columns, without the engine-minted `_id`. That omits 16 bytes a row of `Decimal128` against a payload measured in kilobytes; measuring a second batch to recover it would cost more than it is worth.
