### PR TITLE
Bench: add per-k sweep

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1614,6 +1614,21 @@ pub mod vector {
             let rank = (pct * sorted.len()).div_ceil(100);
             sorted[rank.saturating_sub(1).min(sorted.len() - 1)].as_nanos() as f64
         };
+        // Enforced, not just documented: a measurement helper must fail
+        // fast on malformed inputs rather than publish skewed numbers —
+        // zip would silently drop unmatched rows while the division still
+        // used the full count, and clipping a shallow oracle row would
+        // inflate recall at the deep knots.
+        assert_eq!(
+            queries.len(),
+            truth_deep.len(),
+            "one ground-truth row per query"
+        );
+        let max_k = ks.iter().copied().max().unwrap_or(0);
+        assert!(
+            truth_deep.iter().all(|truth| truth.len() >= max_k),
+            "every ground-truth row must be at least as deep as the largest k ({max_k})"
+        );
         ks.iter()
             .map(|&k| {
                 let mut latencies = Vec::with_capacity(queries.len());
@@ -1622,7 +1637,7 @@ pub mod vector {
                     let started = Instant::now();
                     let hits = search(query, k);
                     latencies.push(started.elapsed());
-                    recall_sum += corpus::recall_at_k(&hits, &truth[..k.min(truth.len())]);
+                    recall_sum += corpus::recall_at_k(&hits, &truth[..k]);
                 }
                 latencies.sort_unstable();
                 PerKCell {
@@ -1633,6 +1648,48 @@ pub mod vector {
                 }
             })
             .collect()
+    }
+
+    #[cfg(test)]
+    mod per_k_sweep_tests {
+        use super::*;
+
+        /// Queries carry their own index in coordinate 0, so the closure
+        /// can answer each from its matching truth row: an ideal engine,
+        /// which must grade exactly 1.0 at every knot.
+        #[test]
+        fn an_ideal_engine_grades_one_at_every_knot() {
+            let queries: Vec<Vec<f32>> = (0..3).map(|q| vec![q as f32; 4]).collect();
+            let truth: Vec<Vec<u32>> = (0..3u32).map(|q| (q * 10..q * 10 + 10).collect()).collect();
+            let truth_for_closure = truth.clone();
+            let cells = per_k_sweep(&queries, &truth, &[1, 10], |query, k| {
+                let row = &truth_for_closure[query[0] as usize];
+                row[..k].iter().map(|&id| (id, 0.0)).collect()
+            });
+            assert_eq!(cells.len(), 2);
+            for cell in &cells {
+                assert_eq!(cell.recall, 1.0, "ideal engine at k={}", cell.k);
+            }
+        }
+
+        /// The enforced input contract: a ground-truth row shallower than
+        /// the deepest knot must fail fast, never inflate recall.
+        #[test]
+        #[should_panic(expected = "at least as deep")]
+        fn a_shallow_oracle_row_fails_fast() {
+            let queries = vec![vec![0.0f32; 4]];
+            let truth = vec![vec![0u32; 5]];
+            per_k_sweep(&queries, &truth, &[10], |_, _| Vec::new());
+        }
+
+        /// One truth row per query, enforced.
+        #[test]
+        #[should_panic(expected = "one ground-truth row per query")]
+        fn mismatched_lengths_fail_fast() {
+            let queries = vec![vec![0.0f32; 4]; 2];
+            let truth = vec![vec![0u32; 10]];
+            per_k_sweep(&queries, &truth, &[10], |_, _| Vec::new());
+        }
     }
 
     impl VectorRead for SuperfileReader {

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1603,6 +1603,12 @@ pub mod vector {
         mut search: impl FnMut(&[f32], usize) -> Vec<corpus::Hit>,
     ) -> Vec<PerKCell> {
         let percentile = |sorted: &[Duration], pct: usize| -> f64 {
+            // Empty input yields 0 rather than an underflowing index: the
+            // recall side already tolerates an empty query set, and a
+            // helper must not have a narrower domain than its caller.
+            if sorted.is_empty() {
+                return 0.0;
+            }
             let rank = (pct * sorted.len()).div_ceil(100);
             sorted[rank.saturating_sub(1).min(sorted.len() - 1)].as_nanos() as f64
         };

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1362,7 +1362,11 @@ pub mod fts {
 }
 
 pub mod vector {
-    use std::{collections::HashMap, hint::black_box};
+    use std::{
+        collections::HashMap,
+        hint::black_box,
+        time::{Duration, Instant},
+    };
 
     use infino::{
         storage::io_counters,
@@ -1373,8 +1377,6 @@ pub mod vector {
     };
 
     use super::*;
-    use std::time::{Duration, Instant};
-
     use crate::{
         corpus::{self, Calibrated},
         cpu,

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -1373,6 +1373,8 @@ pub mod vector {
     };
 
     use super::*;
+    use std::time::{Duration, Instant};
+
     use crate::{
         corpus::{self, Calibrated},
         cpu,
@@ -1569,6 +1571,60 @@ pub mod vector {
         ) -> Option<f64> {
             None
         }
+    }
+
+    /// One row of [`per_k_sweep`]: recall and latency at a single `k`.
+    #[derive(Clone, Copy, Debug)]
+    pub struct PerKCell {
+        pub k: usize,
+        pub recall: f32,
+        pub p50_ns: f64,
+        pub p95_ns: f64,
+    }
+
+    /// Median percentile rank for [`per_k_sweep`] latency columns.
+    const SWEEP_P50: usize = 50;
+    /// Tail percentile rank for [`per_k_sweep`] latency columns.
+    const SWEEP_P95: usize = 95;
+
+    /// Per-`k` recall/latency sweep over ONE search surface — the single
+    /// measurement loop every comparison arm shares. `search` is the
+    /// engine's own call (its public API where it has one: a supertable
+    /// arm passes a closure over `vector_search` via
+    /// [`SupertableVectorRead`], a library peer passes its `search`);
+    /// this function owns the timing, the recall division against the
+    /// deep oracle's `k`-prefix, and the percentile math, so no battery
+    /// re-implements any of them. `truth_deep` rows are rank-sorted and
+    /// at least as deep as the largest `k`.
+    pub fn per_k_sweep(
+        queries: &[Vec<f32>],
+        truth_deep: &[Vec<u32>],
+        ks: &[usize],
+        mut search: impl FnMut(&[f32], usize) -> Vec<corpus::Hit>,
+    ) -> Vec<PerKCell> {
+        let percentile = |sorted: &[Duration], pct: usize| -> f64 {
+            let rank = (pct * sorted.len()).div_ceil(100);
+            sorted[rank.saturating_sub(1).min(sorted.len() - 1)].as_nanos() as f64
+        };
+        ks.iter()
+            .map(|&k| {
+                let mut latencies = Vec::with_capacity(queries.len());
+                let mut recall_sum = 0.0_f32;
+                for (query, truth) in queries.iter().zip(truth_deep) {
+                    let started = Instant::now();
+                    let hits = search(query, k);
+                    latencies.push(started.elapsed());
+                    recall_sum += corpus::recall_at_k(&hits, &truth[..k.min(truth.len())]);
+                }
+                latencies.sort_unstable();
+                PerKCell {
+                    k,
+                    recall: recall_sum / queries.len().max(1) as f32,
+                    p50_ns: percentile(&latencies, SWEEP_P50),
+                    p95_ns: percentile(&latencies, SWEEP_P95),
+                }
+            })
+            .collect()
     }
 
     impl VectorRead for SuperfileReader {

--- a/benches/utils/harness/infino_engine.rs
+++ b/benches/utils/harness/infino_engine.rs
@@ -140,6 +140,7 @@ impl FtsEngine for InfinoFtsEngine {
             vector: true,
             sql: true,
             hybrid: true,
+            ..Default::default()
         }
     }
 

--- a/benches/utils/harness/infino_sql_engine.rs
+++ b/benches/utils/harness/infino_sql_engine.rs
@@ -242,6 +242,7 @@ impl SqlEngine for InfinoSqlEngine {
             vector: true,
             sql: true,
             hybrid: true,
+            ..Default::default()
         }
     }
 

--- a/benches/utils/harness/infino_vector_engine.rs
+++ b/benches/utils/harness/infino_vector_engine.rs
@@ -90,6 +90,14 @@ pub struct InfinoVectorIndex {
     metric: VectorMetric,
     bytes: Option<Vec<u8>>,
     reader: Option<SuperfileReader>,
+    /// Retained fp32 source vectors, kept ONLY so `insert`/`remove` can
+    /// rebuild the superfile from an updated corpus — infino superfiles
+    /// are immutable once `finish()` is called (see
+    /// `src/superfile/builder.rs`), so there is no in-place add/remove at
+    /// this tier. Retaining the full fp32 source is a bench-only cost no
+    /// shipping caller would pay; `load` deliberately leaves this `None`
+    /// since a loaded index has no fp32 source to reconstruct from.
+    source_vectors: Option<Vec<f32>>,
 }
 
 impl InfinoVectorIndex {
@@ -115,6 +123,14 @@ impl VectorEngine for InfinoVectorEngine {
             vector: true,
             sql: true,
             hybrid: true,
+            // Honest but heavy: infino has no in-place insert/remove at
+            // the superfile tier, so both are implemented as a full
+            // incremental rebuild — see `insert`/`remove` below.
+            vector_insert: true,
+            vector_remove: true,
+            // Genuinely cheap and native: `finish()` already returns
+            // final bytes, `SuperfileReader::open` already reopens them.
+            vector_save_load: true,
         }
     }
 
@@ -125,6 +141,7 @@ impl VectorEngine for InfinoVectorEngine {
             metric,
             bytes: None,
             reader: None,
+            source_vectors: None,
         }
     }
 
@@ -133,6 +150,7 @@ impl VectorEngine for InfinoVectorEngine {
         index.reader =
             Some(SuperfileReader::open(Bytes::from(bytes.clone())).expect("open SuperfileReader"));
         index.bytes = Some(bytes);
+        index.source_vectors = Some(vectors.to_vec());
     }
 
     fn parallel_write(
@@ -195,5 +213,91 @@ impl VectorEngine for InfinoVectorEngine {
 
     fn delete(_index: Self::Index) {
         // Dropping the in-memory bytes/reader releases the artifact.
+    }
+
+    /// NOT a true append-to-served-index. Infino superfiles are
+    /// immutable once `finish()` is called — there is no insert-after
+    /// -seal operation anywhere in the crate. What this measures instead
+    /// is the cost of growing the corpus by `vectors.len() / dim` rows and
+    /// re-sealing from scratch: it appends to the retained fp32 source
+    /// (see [`InfinoVectorIndex::source_vectors`]) and re-`finish()`s a
+    /// fresh superfile. This is the honest number for "how much does
+    /// growing an infino superfile by n rows cost", which is a different
+    /// (and for infino, much heavier) question than "insert latency"
+    /// implies for a mutable-index engine.
+    fn insert(index: &mut Self::Index, vectors: &[f32], next_id: u64) -> bool {
+        let existing = index
+            .source_vectors
+            .as_ref()
+            .expect("insert requires InfinoVectorIndex::source_vectors retained from write()");
+        // Ids are always 0..n_docs by construction (see `build_superfile`'s
+        // `id_base`), so `next_id` is validated rather than threaded
+        // through — this reference impl does not support inserting at an
+        // arbitrary sparse id.
+        let expected_next_id = (existing.len() / index.dim) as u64;
+        assert_eq!(
+            next_id, expected_next_id,
+            "InfinoVectorEngine::insert only supports appending at the current doc count"
+        );
+        let mut combined = existing.clone();
+        combined.extend_from_slice(vectors);
+        let rebuilt = build_superfile(&index.column, &combined, index.dim, index.metric, 0);
+        index.reader = Some(
+            SuperfileReader::open(Bytes::from(rebuilt.clone())).expect("open SuperfileReader"),
+        );
+        index.bytes = Some(rebuilt);
+        index.source_vectors = Some(combined);
+        true
+    }
+
+    /// Same honesty caveat as `insert`: no remove-by-id exists at the
+    /// superfile tier. This filters the retained source vectors by id and
+    /// rebuilds — a full rebuild minus the removed rows, not an in-place
+    /// tombstone. `ids` are the `0..n_docs` positional ids `write`/`insert`
+    /// assign, so this filters by index position directly.
+    fn remove(index: &mut Self::Index, ids: &[u64]) -> bool {
+        let existing = index
+            .source_vectors
+            .as_ref()
+            .expect("remove requires InfinoVectorIndex::source_vectors retained from write()");
+        let dim = index.dim;
+        let drop_set: std::collections::HashSet<u64> = ids.iter().copied().collect();
+        let n_docs = existing.len() / dim;
+        let mut kept = Vec::with_capacity(existing.len());
+        for doc in 0..n_docs {
+            if !drop_set.contains(&(doc as u64)) {
+                kept.extend_from_slice(&existing[doc * dim..(doc + 1) * dim]);
+            }
+        }
+        let rebuilt = build_superfile(&index.column, &kept, dim, index.metric, 0);
+        index.reader = Some(
+            SuperfileReader::open(Bytes::from(rebuilt.clone())).expect("open SuperfileReader"),
+        );
+        index.bytes = Some(rebuilt);
+        index.source_vectors = Some(kept);
+        true
+    }
+
+    /// This one is real: `finish()` already returns final bytes.
+    fn save(index: &Self::Index) -> Option<Vec<u8>> {
+        Some(index.bytes().to_vec())
+    }
+
+    /// This one is real: `SuperfileReader::open` already reopens from
+    /// bytes. `source_vectors` is deliberately left `None` — a loaded
+    /// index has no fp32 source to reconstruct, so `insert`/`remove`
+    /// after `load` will panic until the source is re-supplied by a
+    /// caller that tracks it independently.
+    fn load(column: &str, dim: usize, metric: VectorMetric, bytes: &[u8]) -> Option<Self::Index> {
+        let owned = Bytes::from(bytes.to_vec());
+        let reader = SuperfileReader::open(owned.clone()).expect("open SuperfileReader");
+        Some(InfinoVectorIndex {
+            column: column.to_string(),
+            dim,
+            metric,
+            bytes: Some(owned.to_vec()),
+            reader: Some(reader),
+            source_vectors: None,
+        })
     }
 }

--- a/benches/utils/harness/infino_vector_engine.rs
+++ b/benches/utils/harness/infino_vector_engine.rs
@@ -319,6 +319,9 @@ impl VectorEngine for InfinoVectorEngine {
             index.dim
         );
         let added = vectors.len() / index.dim;
+        // A `next_id` near u64::MAX would make this range wrap EMPTY (not
+        // duplicate ids), and the builder's one-`_id`-per-row assert then
+        // fails loudly on the length mismatch — no silent state exists.
         row_ids.extend(next_id..next_id + added as u64);
         let mut combined = existing.clone();
         combined.extend_from_slice(vectors);

--- a/benches/utils/harness/infino_vector_engine.rs
+++ b/benches/utils/harness/infino_vector_engine.rs
@@ -44,6 +44,23 @@ fn build_superfile(
     id_base: usize,
 ) -> Vec<u8> {
     let n_docs = vectors.len() / dim;
+    let ids: Vec<u64> = (id_base as u64..(id_base + n_docs) as u64).collect();
+    build_superfile_with_ids(column, vectors, dim, metric, &ids)
+}
+
+/// [`build_superfile`] with explicit per-row `_id`s — the engine's own
+/// stable-id mechanism (the `_id` column every superfile carries), used by
+/// the insert/remove rebuilds so surviving rows keep the ids the caller
+/// already holds instead of being renumbered positionally.
+fn build_superfile_with_ids(
+    column: &str,
+    vectors: &[f32],
+    dim: usize,
+    metric: VectorMetric,
+    row_ids: &[u64],
+) -> Vec<u8> {
+    let n_docs = vectors.len() / dim;
+    assert_eq!(row_ids.len(), n_docs, "one _id per row");
     let metric = map_metric(metric);
     let schema = Arc::new(Schema::new(vec![Field::new(
         ID_COLUMN,
@@ -68,8 +85,9 @@ fn build_superfile(
     let mut offset = 0;
     while offset < n_docs {
         let len = WRITE_CHUNK.min(n_docs - offset);
-        let ids: Decimal128Array = ((id_base + offset) as u64..(id_base + offset + len) as u64)
-            .map(|i| Some(i as i128))
+        let ids: Decimal128Array = row_ids[offset..offset + len]
+            .iter()
+            .map(|&i| Some(i as i128))
             .collect::<Decimal128Array>()
             .with_precision_and_scale(38, 0)
             .expect("decimal128 precision/scale");
@@ -80,6 +98,24 @@ fn build_superfile(
         offset += len;
     }
     builder.finish().expect("SuperfileBuilder::finish")
+}
+
+/// Every row's stable `_id`, in local-doc order, read from the artifact's
+/// own id column — the same local→stable resolution the supertable layer
+/// performs (`take_by_local_doc_ids` on the id column). The superfile IS
+/// the id map; no side state to drift.
+fn stable_ids_of(reader: &SuperfileReader) -> Vec<u64> {
+    let n_docs = reader.n_docs() as u32;
+    let locals: Vec<u32> = (0..n_docs).collect();
+    let batch = reader
+        .take_by_local_doc_ids(&locals, &[reader.id_column()])
+        .expect("read the _id column");
+    let ids = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Decimal128Array>()
+        .expect("_id column is Decimal128");
+    (0..ids.len()).map(|i| ids.value(i) as u64).collect()
 }
 
 pub struct InfinoVectorEngine;
@@ -98,6 +134,12 @@ pub struct InfinoVectorIndex {
     /// shipping caller would pay; `load` deliberately leaves this `None`
     /// since a loaded index has no fp32 source to reconstruct from.
     source_vectors: Option<Vec<f32>>,
+    /// Whether insert/remove ever ran. A freshly written artifact has
+    /// dense `_id`s equal to local ids, so `read` skips the id resolve on
+    /// the unmutated path and its timing is unchanged; after a mutation,
+    /// hits resolve through the artifact's id column like any caller's
+    /// would.
+    mutated: bool,
 }
 
 impl InfinoVectorIndex {
@@ -142,6 +184,7 @@ impl VectorEngine for InfinoVectorEngine {
             bytes: None,
             reader: None,
             source_vectors: None,
+            mutated: false,
         }
     }
 
@@ -199,9 +242,35 @@ impl VectorEngine for InfinoVectorEngine {
                 .vector_hits_async(&index.column, query, k, opts),
         )
         .expect("vector_search");
+        if !index.mutated {
+            // Freshly written artifacts have `_id == local` by
+            // construction; skip the resolve so the mainline cells'
+            // timing is byte-identical to before mutations existed.
+            return hits
+                .into_iter()
+                .map(|(doc_id, distance)| VectorHit {
+                    doc_id: u64::from(doc_id),
+                    distance,
+                })
+                .collect();
+        }
+        // After a mutation, locals are renumbered by the rebuild; resolve
+        // to stable `_id`s through the artifact's own id column, the same
+        // resolution any caller's hits go through.
+        let locals: Vec<u32> = hits.iter().map(|(doc_id, _)| *doc_id).collect();
+        let batch = index
+            .reader()
+            .take_by_local_doc_ids(&locals, &[index.reader().id_column()])
+            .expect("resolve hit _ids");
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .expect("_id column is Decimal128");
         hits.into_iter()
-            .map(|(doc_id, distance)| VectorHit {
-                doc_id: u64::from(doc_id),
+            .enumerate()
+            .map(|(i, (_, distance))| VectorHit {
+                doc_id: ids.value(i) as u64,
                 distance,
             })
             .collect()
@@ -230,31 +299,38 @@ impl VectorEngine for InfinoVectorEngine {
             .source_vectors
             .as_ref()
             .expect("insert requires InfinoVectorIndex::source_vectors retained from write()");
-        // Ids are always 0..n_docs by construction (see `build_superfile`'s
-        // `id_base`), so `next_id` is validated rather than threaded
-        // through — this reference impl does not support inserting at an
-        // arbitrary sparse id.
-        let expected_next_id = (existing.len() / index.dim) as u64;
-        assert_eq!(
-            next_id, expected_next_id,
-            "InfinoVectorEngine::insert only supports appending at the current doc count"
+        // The artifact's own `_id` column is the id authority: new rows get
+        // `next_id..`, survivors keep the ids they already carry, and the
+        // trait's uniqueness contract is checked against the real ids
+        // rather than assumed from a positional count.
+        let mut row_ids = stable_ids_of(index.reader());
+        let max_id = row_ids.iter().copied().max().unwrap_or(0);
+        assert!(
+            row_ids.is_empty() || next_id > max_id,
+            "InfinoVectorEngine::insert: next_id {next_id} must exceed the max stored _id {max_id}"
         );
+        let added = vectors.len() / index.dim;
+        row_ids.extend(next_id..next_id + added as u64);
         let mut combined = existing.clone();
         combined.extend_from_slice(vectors);
-        let rebuilt = build_superfile(&index.column, &combined, index.dim, index.metric, 0);
+        let rebuilt =
+            build_superfile_with_ids(&index.column, &combined, index.dim, index.metric, &row_ids);
         index.reader = Some(
             SuperfileReader::open(Bytes::from(rebuilt.clone())).expect("open SuperfileReader"),
         );
         index.bytes = Some(rebuilt);
         index.source_vectors = Some(combined);
+        index.mutated = true;
         true
     }
 
     /// Same honesty caveat as `insert`: no remove-by-id exists at the
-    /// superfile tier. This filters the retained source vectors by id and
+    /// superfile tier. This filters the retained source vectors and
     /// rebuilds — a full rebuild minus the removed rows, not an in-place
-    /// tombstone. `ids` are the `0..n_docs` positional ids `write`/`insert`
-    /// assign, so this filters by index position directly.
+    /// tombstone. `ids` name stable `_id`s (the artifact's own id column),
+    /// and survivors KEEP their ids across the rebuild, so a later
+    /// insert/remove/search still means the rows the caller thinks it
+    /// means.
     fn remove(index: &mut Self::Index, ids: &[u64]) -> bool {
         let existing = index
             .source_vectors
@@ -262,19 +338,24 @@ impl VectorEngine for InfinoVectorEngine {
             .expect("remove requires InfinoVectorIndex::source_vectors retained from write()");
         let dim = index.dim;
         let drop_set: std::collections::HashSet<u64> = ids.iter().copied().collect();
+        let row_ids = stable_ids_of(index.reader());
         let n_docs = existing.len() / dim;
+        assert_eq!(row_ids.len(), n_docs, "source vectors track the artifact");
         let mut kept = Vec::with_capacity(existing.len());
-        for doc in 0..n_docs {
-            if !drop_set.contains(&(doc as u64)) {
+        let mut kept_ids = Vec::with_capacity(row_ids.len());
+        for (doc, &stable) in row_ids.iter().enumerate() {
+            if !drop_set.contains(&stable) {
                 kept.extend_from_slice(&existing[doc * dim..(doc + 1) * dim]);
+                kept_ids.push(stable);
             }
         }
-        let rebuilt = build_superfile(&index.column, &kept, dim, index.metric, 0);
+        let rebuilt = build_superfile_with_ids(&index.column, &kept, dim, index.metric, &kept_ids);
         index.reader = Some(
             SuperfileReader::open(Bytes::from(rebuilt.clone())).expect("open SuperfileReader"),
         );
         index.bytes = Some(rebuilt);
         index.source_vectors = Some(kept);
+        index.mutated = true;
         true
     }
 
@@ -298,6 +379,88 @@ impl VectorEngine for InfinoVectorEngine {
             bytes: Some(owned.to_vec()),
             reader: Some(reader),
             source_vectors: None,
+            mutated: false,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Rows planted on distinct axes so nearest-neighbor identity is exact.
+    const TEST_DIM: usize = 16;
+    /// Enough rows that removing two from the middle genuinely renumbers
+    /// the locals behind them.
+    const TEST_ROWS: usize = 8;
+
+    fn axis_rows(n: usize) -> Vec<f32> {
+        let mut flat = vec![0.0f32; n * TEST_DIM];
+        for row in 0..n {
+            flat[row * TEST_DIM + row % TEST_DIM] = 1.0;
+        }
+        flat
+    }
+
+    fn query_for(row: usize) -> Vec<f32> {
+        let mut q = vec![0.0f32; TEST_DIM];
+        q[row % TEST_DIM] = 1.0;
+        q
+    }
+
+    fn top1(index: &InfinoVectorIndex, row: usize) -> u64 {
+        InfinoVectorEngine::read(
+            index,
+            &query_for(row),
+            1,
+            VectorSearch {
+                nprobe: usize::MAX,
+                rerank_mult: 4,
+            },
+        )
+        .first()
+        .expect("one hit")
+        .doc_id
+    }
+
+    /// The regression the id column exists to prevent: removing middle
+    /// rows renumbers locals, but hits and later mutations must keep
+    /// speaking stable `_id`s. Before the fix, removing {2, 5} made row 7
+    /// answer as 5, and a follow-up remove would have deleted the wrong
+    /// rows.
+    #[test]
+    fn remove_preserves_surviving_ids_and_insert_continues_them() {
+        let mut index = InfinoVectorEngine::create("emb", TEST_DIM, VectorMetric::Cosine);
+        InfinoVectorEngine::write(&mut index, &axis_rows(TEST_ROWS));
+        assert_eq!(top1(&index, 7), 7, "fresh artifact: local == stable");
+
+        assert!(InfinoVectorEngine::remove(&mut index, &[2, 5]));
+        assert_eq!(
+            top1(&index, 7),
+            7,
+            "row 7 keeps _id 7 though its local id shrank by two"
+        );
+        assert_eq!(top1(&index, 3), 3, "row 3 keeps _id 3 behind one removal");
+
+        // The trait's running-counter contract: the caller hands the next
+        // unused id, and it lands verbatim.
+        let mut extra = vec![0.0f32; TEST_DIM];
+        extra[TEST_DIM - 1] = 1.0;
+        assert!(InfinoVectorEngine::insert(
+            &mut index,
+            &extra,
+            TEST_ROWS as u64
+        ));
+        assert_eq!(
+            top1(&index, TEST_DIM - 1),
+            TEST_ROWS as u64,
+            "inserted row answers with the caller-assigned id"
+        );
+
+        // Removing by a STABLE id after the renumbering removes the right
+        // row: _id 7 (now at a shifted local position) disappears, and the
+        // axis-7 query falls to some other row, never a phantom 7.
+        assert!(InfinoVectorEngine::remove(&mut index, &[7]));
+        assert_ne!(top1(&index, 7), 7, "_id 7 is gone, not renumbered onto");
     }
 }

--- a/benches/utils/harness/infino_vector_engine.rs
+++ b/benches/utils/harness/infino_vector_engine.rs
@@ -295,10 +295,13 @@ impl VectorEngine for InfinoVectorEngine {
     /// (and for infino, much heavier) question than "insert latency"
     /// implies for a mutable-index engine.
     fn insert(index: &mut Self::Index, vectors: &[f32], next_id: u64) -> bool {
-        let existing = index
-            .source_vectors
-            .as_ref()
-            .expect("insert requires InfinoVectorIndex::source_vectors retained from write()");
+        // A LOADED index retains no fp32 source, so the rebuild that
+        // implements mutation here is impossible for it. Static
+        // capabilities cannot express state-dependent support; `false` is
+        // the trait's channel for it, and callers assert on the return.
+        let Some(existing) = index.source_vectors.as_ref() else {
+            return false;
+        };
         // The artifact's own `_id` column is the id authority: new rows get
         // `next_id..`, survivors keep the ids they already carry, and the
         // trait's uniqueness contract is checked against the real ids
@@ -308,6 +311,12 @@ impl VectorEngine for InfinoVectorEngine {
         assert!(
             row_ids.is_empty() || next_id > max_id,
             "InfinoVectorEngine::insert: next_id {next_id} must exceed the max stored _id {max_id}"
+        );
+        assert!(
+            vectors.len().is_multiple_of(index.dim),
+            "insert buffer must be whole rows: {} floats at dim {}",
+            vectors.len(),
+            index.dim
         );
         let added = vectors.len() / index.dim;
         row_ids.extend(next_id..next_id + added as u64);
@@ -332,10 +341,11 @@ impl VectorEngine for InfinoVectorEngine {
     /// insert/remove/search still means the rows the caller thinks it
     /// means.
     fn remove(index: &mut Self::Index, ids: &[u64]) -> bool {
-        let existing = index
-            .source_vectors
-            .as_ref()
-            .expect("remove requires InfinoVectorIndex::source_vectors retained from write()");
+        // Same state-dependent unsupport as `insert`: no retained source,
+        // no rebuild.
+        let Some(existing) = index.source_vectors.as_ref() else {
+            return false;
+        };
         let dim = index.dim;
         let drop_set: std::collections::HashSet<u64> = ids.iter().copied().collect();
         let row_ids = stable_ids_of(index.reader());
@@ -379,7 +389,13 @@ impl VectorEngine for InfinoVectorEngine {
             bytes: Some(owned.to_vec()),
             reader: Some(reader),
             source_vectors: None,
-            mutated: false,
+            // Forced on: these bytes may have been saved AFTER an
+            // insert/remove, so their `_id`s need not equal locals, and
+            // density cannot be checked without an O(n) id-column scan
+            // inside the timed load. Resolving hits through the id column
+            // is also what production reads do — the identity fast path is
+            // provably safe only for artifacts this process built fresh.
+            mutated: true,
         })
     }
 }
@@ -462,5 +478,34 @@ mod tests {
         // axis-7 query falls to some other row, never a phantom 7.
         assert!(InfinoVectorEngine::remove(&mut index, &[7]));
         assert_ne!(top1(&index, 7), 7, "_id 7 is gone, not renumbered onto");
+    }
+
+    /// A save/load round trip after mutations must keep answering with
+    /// stable `_id`s (the saved bytes carry non-dense ids), and mutating
+    /// the loaded index — which retains no fp32 source — must report
+    /// unsupported instead of panicking.
+    #[test]
+    fn loaded_index_resolves_saved_ids_and_declines_mutation() {
+        let mut index = InfinoVectorEngine::create("emb", TEST_DIM, VectorMetric::Cosine);
+        InfinoVectorEngine::write(&mut index, &axis_rows(TEST_ROWS));
+        assert!(InfinoVectorEngine::remove(&mut index, &[2, 5]));
+        let saved = InfinoVectorEngine::save(&index).expect("superfile bytes");
+
+        let mut loaded = InfinoVectorEngine::load("emb", TEST_DIM, VectorMetric::Cosine, &saved)
+            .expect("reopen saved bytes");
+        assert_eq!(
+            top1(&loaded, 7),
+            7,
+            "the loaded artifact's non-dense _ids resolve, not its locals"
+        );
+        let extra = vec![0.0f32; TEST_DIM];
+        assert!(
+            !InfinoVectorEngine::insert(&mut loaded, &extra, TEST_ROWS as u64),
+            "no retained source: insert reports unsupported"
+        );
+        assert!(
+            !InfinoVectorEngine::remove(&mut loaded, &[7]),
+            "no retained source: remove reports unsupported"
+        );
     }
 }

--- a/benches/utils/harness/mod.rs
+++ b/benches/utils/harness/mod.rs
@@ -82,6 +82,19 @@ pub struct Capabilities {
     pub vector: bool,
     pub sql: bool,
     pub hybrid: bool,
+    /// Engine can add vectors to an existing index without a full rebuild.
+    /// See [`VectorEngine::insert`] — an immutable-artifact engine may
+    /// still advertise this if it implements `insert` as an honest, if
+    /// heavier, incremental build; the capability flag alone does not
+    /// promise a cheap in-place add.
+    pub vector_insert: bool,
+    /// Engine can remove vectors from an existing index by id, without a
+    /// full rebuild. See [`VectorEngine::remove`].
+    pub vector_remove: bool,
+    /// Engine can serialize its index to bytes and reopen it — i.e. has a
+    /// real save/load boundary distinct from "keep the in-process handle".
+    /// See [`VectorEngine::save`] / [`VectorEngine::load`].
+    pub vector_save_load: bool,
 }
 
 /// A full-text retrieval engine under comparison.
@@ -182,6 +195,43 @@ pub trait VectorEngine {
     fn close(index: &mut Self::Index);
 
     fn delete(index: Self::Index);
+
+    /// Add `vectors` (a flat buffer of `vectors.len() / dim` new rows) to
+    /// an already-built, queryable index. Ids are assigned starting at
+    /// `next_id` (the caller tracks the running id counter so ids stay
+    /// unique across insert calls). Returns `false` if unsupported —
+    /// callers must check [`Capabilities::vector_insert`] before calling
+    /// and treat a `false` return as a harness bug, not a normal outcome.
+    ///
+    /// Deliberately vague about *how* the engine achieves "add to a
+    /// queryable index": an immutable-artifact engine may implement this
+    /// as an incremental rebuild rather than a true append-to-served
+    /// -index. Implementors must document which they do.
+    fn insert(_index: &mut Self::Index, _vectors: &[f32], _next_id: u64) -> bool {
+        false
+    }
+
+    /// Remove the rows named by `ids` from the index. Returns `false` if
+    /// unsupported (see [`VectorEngine::insert`]'s return-value contract).
+    fn remove(_index: &mut Self::Index, _ids: &[u64]) -> bool {
+        false
+    }
+
+    /// Serialize the index to bytes. `None` if unsupported.
+    fn save(_index: &Self::Index) -> Option<Vec<u8>> {
+        None
+    }
+
+    /// Reopen an index from bytes previously produced by [`VectorEngine::save`].
+    /// `None` if unsupported.
+    fn load(
+        _column: &str,
+        _dim: usize,
+        _metric: VectorMetric,
+        _bytes: &[u8],
+    ) -> Option<Self::Index> {
+        None
+    }
 }
 
 /// A scalar row ingested by SQL engines.

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -645,13 +645,23 @@ pub fn build_local_for_serving(
 /// arithmetic re-derived in bench code. `None` when no resident index
 /// was published (ivf mode, above the scale ceiling, or a declined
 /// register probe).
-pub fn served_index_blob_bytes(st: &Supertable, storage: &Arc<dyn StorageProvider>) -> Option<u64> {
+pub fn served_index_blob_bytes(st: &Supertable) -> Option<u64> {
     let hidden = st.vector_index_table()?;
     let reference = hidden
         .pinned_reader()
         .manifest()
         .resident_vector_index_blob_ref()?;
-    let meta = tiers::block_on(storage.head(&reference.uri)).ok()?;
+    // The ref's URI is relative to the HIDDEN table's (prefixed) provider,
+    // so head through that handle — heading the user-root provider turns
+    // "blob exists" into NotFound. A manifest that names a blob the store
+    // cannot head is corruption, not absence: fail loudly, never `None`.
+    let storage = hidden
+        .options()
+        .storage
+        .as_ref()
+        .expect("hidden table with a published blob has storage attached");
+    let meta = tiers::block_on(storage.head(&reference.uri))
+        .expect("head the resident-index blob the hidden manifest references");
     Some(meta.size)
 }
 

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -11,14 +11,16 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use infino::{
+    config::OptimizeOptions,
     superfile::{
         builder::{FtsConfig, VectorConfig},
         fts::tokenize::Tokenizer,
         vector::distance::Metric,
     },
-    supertable::{Supertable, SupertableOptions, storage::StorageProvider},
+    supertable::{LocalFsStorageProvider, Supertable, SupertableOptions, storage::StorageProvider},
     test_helpers::default_tokenizer,
 };
+use tempfile::TempDir;
 
 use crate::{
     corpus::{self, MmapTextCorpus, MmapVectorCorpus, dim},
@@ -597,6 +599,62 @@ fn text_delta_batch(modality: Modality, corpus: &PreparedCorpus) -> RecordBatch 
 /// dead weight. SQL's extra columns are derived inline from `doc_id`.
 /// The text/vector corpus is identical across modalities (same seeds),
 /// so each shape is directly comparable to its single-modality competitor.
+/// Build a LOCAL vector supertable from the prepared corpus's first
+/// `n_docs` rows and run the standard lifecycle — chunked appends,
+/// commits, then `optimize()` — so whatever serving index the process
+/// config selects (`vector.search_mode`: the stamped ivf laws, the
+/// resident graph, or the resident flat plane) is built, calibrated,
+/// and serving before the handle is returned.
+///
+/// For in-process comparisons against RAM-resident library peers: the
+/// backing store is a LocalFs tempdir (returned as the guard, dropped
+/// with the table), so the deploy story stays "cargo bench" with no
+/// object-store daemon, while a resident serving index answers from RAM
+/// exactly as it would over any backend.
+pub fn build_local_for_serving(
+    corpus: &PreparedCorpus,
+    n_docs: usize,
+) -> (Supertable, Arc<dyn StorageProvider>, TempDir) {
+    let dir = TempDir::new().expect("local supertable tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("LocalFs provider"));
+    let st = Supertable::create(options_for(Modality::Vector, Some(Arc::clone(&storage))))
+        .expect("create local supertable");
+    let schema = schema_for(Modality::Vector);
+    let commits = n_commits();
+    let chunk_size = n_docs.div_ceil(commits);
+    let mut w = st.writer().expect("writer");
+    for start in (0..n_docs).step_by(chunk_size) {
+        let end = (start + chunk_size).min(n_docs);
+        let batch = chunk_batch(Modality::Vector, corpus, &schema, start, end, end - start);
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+    }
+    drop(w);
+    // The full maintenance pass: drain to the hidden index, compact,
+    // calibrate the serving laws, and build whichever resident index the
+    // config opts into. Serving state after this is what a caller gets.
+    st.optimize(&OptimizeOptions::default())
+        .expect("optimize local supertable");
+    (st, storage, dir)
+}
+
+/// Serialized size of the resident vector-index blob the drain published
+/// (flat plane or graph bundle), by `head()`ing the object the hidden
+/// manifest references — the engine's own accounting, not plane
+/// arithmetic re-derived in bench code. `None` when no resident index
+/// was published (ivf mode, above the scale ceiling, or a declined
+/// register probe).
+pub fn served_index_blob_bytes(st: &Supertable, storage: &Arc<dyn StorageProvider>) -> Option<u64> {
+    let hidden = st.vector_index_table()?;
+    let reference = hidden
+        .pinned_reader()
+        .manifest()
+        .resident_vector_index_blob_ref()?;
+    let meta = tiers::block_on(storage.head(&reference.uri)).ok()?;
+    Some(meta.size)
+}
+
 pub fn build_on_storage(modality: Modality, corpus: &PreparedCorpus) -> IngestResult {
     let n_docs = n_docs();
     let commits = n_commits();

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -621,6 +621,11 @@ pub fn build_local_for_serving(
     let st = Supertable::create(options_for(Modality::Vector, Some(Arc::clone(&storage))))
         .expect("create local supertable");
     let schema = schema_for(Modality::Vector);
+    // A zero-doc build is a caller bug, named here rather than surfacing
+    // as `step_by(0)`'s opaque panic; an empty table also has nothing for
+    // `optimize()` to calibrate, so tolerating it would return a handle
+    // that serves no mode meaningfully.
+    assert!(n_docs > 0, "build_local_for_serving needs at least one row");
     let commits = n_commits();
     let chunk_size = n_docs.div_ceil(commits);
     let mut w = st.writer().expect("writer");

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -1237,6 +1237,17 @@ impl ManifestSnapshot {
         self.list.as_ref()?.slow_vector_state_graphs.as_ref()
     }
 
+    test_visible! {
+        /// Bench/test introspection for the published resident vector-index
+        /// blob (the flat plane or graph bundle the drain persisted): its
+        /// storage ref, so a bench can `head()` the object and report the
+        /// engine's own serialized size instead of re-deriving plane
+        /// arithmetic from internals.
+        fn resident_vector_index_blob_ref(&self) -> Option<RoutingRef> {
+            self.resident_vector_index_blob().cloned()
+        }
+    }
+
     /// Stamp (or replace) the hidden index's consolidated deleted-user-`_id`
     /// bytes in the manifest list. Bumps `manifest_id` like a normal commit
     /// without touching superfiles or parts.


### PR DESCRIPTION
## What

- **`bench/vector: shared per-k recall/latency sweep`** — `per_k_sweep`: recall + p50/p95 at each `k` knot through one timed closure, so every arm in a battery is graded by literally the same loop instead of per-arm copies of it. 56 lines in `benches/utils/executors.rs`. (Stranded on the old `vector/sq4-plane-cell-families` lineage when #651/#672 squash-merged; same story for the lifecycle commit below.)
- **`bench/harness: add vector insert/remove/save-load to VectorEngine`** — lifecycle cells (insert into a warm index, remove by id, save/load round-trip) as optional trait members, with the infino reference implementation.
- **`bench/vector: build a local table through the config-selected serving mode`** — `build_local_for_serving`: a vector supertable built by the standard public lifecycle (chunked appends → commits → `optimize()`) against a LocalFs tempdir, so whatever `vector.search_mode` the config selects (stamped ivf laws, resident graph, resident flat plane) is built, calibrated, and serving before the handle returns. Plus `served_index_blob_bytes`: the published resident-index blob's size by `head()`ing the object the hidden manifest references — the engine's own serialized accounting rather than plane arithmetic re-derived in bench code. The manifest ref accessor is the one `src/` change, `test_visible!` per the existing bench-introspection pattern (off the public API; the `cargo-public-api` snapshot is taken without `test-helpers`).
- **`bench/vector: head the resident blob through the hidden table's provider`** — the blob ref's URI is relative to the hidden table's prefixed provider; heading the user-root provider turned "blob exists" into `NotFound`, and an `.ok()?` collapsed that into "no index published". Now heads through the hidden table's own handle, and a ref the store cannot head is a loud panic (a manifest naming a missing object is corruption, not absence).

## Verified

`build_local_for_serving` under `vector.search_mode: flat_ivf` on dbpedia-1536 at 100K serves the resident plane end to end: recall@10 0.934 at 1.51 ms warm p50 (box-threads; 1.53 ms single-thread — the scan is DRAM-bound), resident blob 74.8 MiB (784 B/vec: plane + ruler + id map). The register gate is exercised too: on the synthetic bench corpus the plane measures 0.26 and the drain correctly declines and serves ivf — which is exactly the case the loud-decline path in the last commit exists for.

## Gates

Benches-only surface: `cargo build -p infino-bench-utils` and the full bench target compile clean, fmt clean, clippy clean. No engine behavior changes; `public-api.txt` unchanged (the accessor is feature-gated). The default bench path is untouched — the new helpers run only when a battery calls them.