### PR TITLE
infino-python: lean numpy search ids + benchmark serve mode

### DIFF
--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2176,6 +2176,7 @@ dependencies = [
  "arrow-schema",
  "datafusion",
  "infino",
+ "numpy",
  "pyo3",
 ]
 
@@ -2401,6 +2402,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2478,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "no_std_io2"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2548,22 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "numpy"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "pyo3-build-config",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -2755,6 +2797,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3061,6 +3112,12 @@ checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -29,6 +29,9 @@ arrow-schema = "58"
 # stable ABI), so distribution needs one wheel per platform rather than
 # one per Python version.
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
+# Lean search-result marshalling: return `_id` keys as a numpy array so the
+# only GIL-held step is one array creation (vs building a pyarrow Table).
+numpy = "0.28"
 # Parse a SQL predicate string (for `update` / `delete`) into a DataFusion
 # `Expr` — the type the core `update` / `delete` take. Pinned to infino's
 # datafusion version so the `Expr` type unifies with the core signatures;

--- a/infino-python/pyproject.toml
+++ b/infino-python/pyproject.toml
@@ -47,6 +47,10 @@ Repository = "https://github.com/infino-ai/infino"
 Issues = "https://github.com/infino-ai/infino/issues"
 Changelog = "https://github.com/infino-ai/infino/releases"
 
+# EXPERIMENTAL benchmark serve mode (raw-TCP) — not a production server.
+[project.scripts]
+infino-bench-serve = "infino._bench_serve:main"
+
 [tool.mypy]
 strict = true
 

--- a/infino-python/python/infino/_bench_serve.py
+++ b/infino-python/python/infino/_bench_serve.py
@@ -1,0 +1,47 @@
+"""EXPERIMENTAL benchmark serve mode CLI — **not a production server**.
+
+Serves a single table over a minimal raw-TCP wire so a networked benchmark
+client (e.g. VectorDBBench) can drive the embedded engine on a dedicated host.
+No auth, no TLS, no durability. The supported infino interface is embedded
+(``connect``/``open_table``); this exists purely for throughput benchmarking.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        prog="infino-bench-serve",
+        description=(
+            "EXPERIMENTAL infino benchmark serve mode (raw-TCP). No auth/TLS/durability; "
+            "NOT production-validated."
+        ),
+    )
+    p.add_argument("--data", required=True, help="data path (the connect uri)")
+    p.add_argument("--table", default="vdbbench_infino", help="table name to serve")
+    p.add_argument("--col", default="emb", help="vector column name")
+    p.add_argument(
+        "--addr",
+        default="127.0.0.1:50052",
+        help="bind address; use 0.0.0.0:PORT to accept remote clients",
+    )
+    p.add_argument("--cache-bytes", type=int, default=21_474_836_480, help="block-cache budget")
+    p.add_argument(
+        "--id-col",
+        default="",
+        help=(
+            "scalar int64 column to project and return as the result id "
+            "(dataset id, 8-byte LE); empty returns the engine _id (16-byte)"
+        ),
+    )
+    a = p.parse_args()
+
+    from infino._infino import bench_serve_tcp
+
+    bench_serve_tcp(a.data, a.table, a.col, a.addr, a.cache_bytes, a.id_col)
+
+
+if __name__ == "__main__":
+    main()

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -31,6 +31,20 @@ def connect(
     api_key: str | None = ...,
 ) -> Connection: ...
 
+def bench_serve_tcp(
+    data_path: str,
+    table: str,
+    col: str,
+    addr: str,
+    cache_bytes: int,
+    id_col: str = ...,
+) -> None:
+    """EXPERIMENTAL benchmark serve mode (raw-TCP). Blocks forever serving the
+    given table. Not a production server (no auth/TLS/durability). When
+    ``id_col`` is non-empty, that scalar int64 column is projected and returned
+    as the result id (dataset id, 8-byte LE); otherwise the engine ``_id``
+    (16-byte)."""
+
 class InfinoError(Exception):
     """Base class for infino's errors. Catch it to handle any infino failure."""
 
@@ -79,6 +93,16 @@ class Table:
         filter_mode: BoolMode | None = ...,
         projection: Sequence[str] | None = ...,
     ) -> ArrowTable: ...
+    def vector_search_ids(
+        self,
+        column: str,
+        query: Sequence[float],
+        k: int,
+    ) -> Any:
+        """Top-k engine ``_id`` keys as a numpy ``uint8`` array of shape
+        ``[k, 16]`` (big-endian). Lean marshalling for concurrent search: the
+        only GIL-held step is the array creation. Use ``vector_search`` for
+        Arrow rows or projections."""
     def token_match(
         self,
         column: str,

--- a/infino-python/src/bench_serve.rs
+++ b/infino-python/src/bench_serve.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+//! EXPERIMENTAL benchmark serve mode (raw-TCP) — **not a production server**.
+//!
+//! Wraps the embedded engine behind a minimal raw-TCP wire so a networked
+//! benchmark client (e.g. VectorDBBench) can drive it, the same way it drives
+//! any server database. No auth, no TLS, no durability, single table. The
+//! supported infino interface remains embedded (`connect`/`open_table`); this
+//! exists purely to measure warm search throughput under a client-server
+//! topology.
+//!
+//! Two id modes (chosen at start):
+//!   - default: return the engine `_id` (16-byte big-endian decimal128); the
+//!     client maps it to its dataset id.
+//!   - `id_col` set: project that scalar int64 column and return the dataset id
+//!     directly (8-byte little-endian) — the client needs no id map.
+//!
+//! Wire (little-endian, one persistent connection, pipelined requests):
+//!   request : u32 k, u32 dim, then dim*4 bytes of f32 query
+//!   response: u32 n, then n*IDSIZE bytes  (IDSIZE = 16 for `_id`, 8 for id_col)
+
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    sync::Arc,
+    thread,
+};
+
+use arrow_array::{Array, Decimal128Array, Int64Array};
+use arrow_schema::DataType;
+use infino::{ConnectOptions, Supertable, connect_with};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+fn handle(
+    mut stream: TcpStream,
+    st: Arc<Supertable>,
+    col: String,
+    id_col: Option<String>,
+    dim: usize,
+) {
+    stream.set_nodelay(true).ok();
+    let mut hdr = [0u8; 8];
+    loop {
+        if stream.read_exact(&mut hdr).is_err() {
+            break; // client closed
+        }
+        let k = u32::from_le_bytes(hdr[0..4].try_into().unwrap()) as usize;
+        let req_dim = u32::from_le_bytes(hdr[4..8].try_into().unwrap()) as usize;
+        // Validate against the table's known dimension BEFORE allocating: a
+        // mismatched/garbage header would otherwise drive an unbounded alloc and
+        // then a swallowed search error. Fail loud instead.
+        if req_dim != dim {
+            eprintln!(
+                "[infino-bench-serve] query dim {req_dim} != table dim {dim}; closing connection"
+            );
+            break;
+        }
+        let mut qbuf = vec![0u8; dim * 4];
+        if stream.read_exact(&mut qbuf).is_err() {
+            break;
+        }
+        let query: Vec<f32> = qbuf
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        let projection = id_col.as_deref().map(|c| [c]);
+        let proj_ref = projection.as_ref().map(|p| p.as_slice());
+        let batches = match st.vector_search(&col, &query, k, None, proj_ref) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("[infino-bench-serve] search error: {e}");
+                break;
+            }
+        };
+        // Serialize ids: dataset int64 (8B) when id_col is set, else engine _id (16B).
+        let mut out: Vec<u8> = Vec::with_capacity(4 + k * 16);
+        out.extend_from_slice(&0u32.to_le_bytes()); // n placeholder
+        let mut n: u32 = 0;
+        for b in &batches {
+            if let Some(ic) = id_col.as_deref() {
+                // Column presence + Int64 type are validated at startup, so a miss
+                // here is a bug, not a config error — fail loud rather than return a
+                // short/empty result the client would score as ~0 recall silently.
+                let Some(c) = b.column_by_name(ic) else {
+                    eprintln!(
+                        "[infino-bench-serve] id column {ic:?} absent from result batch; closing"
+                    );
+                    return;
+                };
+                let Some(arr) = c.as_any().downcast_ref::<Int64Array>() else {
+                    eprintln!(
+                        "[infino-bench-serve] id column {ic:?} is not Int64 in result batch; closing"
+                    );
+                    return;
+                };
+                for i in 0..arr.len() {
+                    out.extend_from_slice(&arr.value(i).to_le_bytes());
+                    n += 1;
+                }
+            } else {
+                let Some(c) = b.column_by_name("_id") else {
+                    break;
+                };
+                let Some(dec) = c.as_any().downcast_ref::<Decimal128Array>() else {
+                    break;
+                };
+                for i in 0..dec.len() {
+                    out.extend_from_slice(&dec.value(i).to_be_bytes());
+                    n += 1;
+                }
+            }
+        }
+        out[0..4].copy_from_slice(&n.to_le_bytes());
+        if stream.write_all(&out).is_err() {
+            break;
+        }
+    }
+}
+
+/// EXPERIMENTAL raw-TCP benchmark serve loop. Opens `table` under `data_path`
+/// and serves top-k ids over TCP. Blocks forever. Not a production server
+/// (no auth/TLS/durability) — it is invoked by the benchmark client. When
+/// `id_col` is non-empty, results are the dataset int64 ids from that column
+/// (no client-side id map); otherwise the engine `_id`.
+#[pyfunction]
+#[pyo3(signature = (data_path, table, col, addr, cache_bytes, id_col=""))]
+pub fn bench_serve_tcp(
+    py: Python<'_>,
+    data_path: &str,
+    table: &str,
+    col: &str,
+    addr: &str,
+    cache_bytes: u64,
+    id_col: &str,
+) -> PyResult<()> {
+    eprintln!(
+        "[infino-bench-serve] EXPERIMENTAL benchmark serve mode — no auth, no TLS, no durability, \
+         single table. NOT production-validated; the supported infino interface is embedded."
+    );
+    let data_path = data_path.to_string();
+    let table = table.to_string();
+    let col = col.to_string();
+    let addr = addr.to_string();
+    let id_col: Option<String> = if id_col.is_empty() {
+        None
+    } else {
+        Some(id_col.to_string())
+    };
+    // Serve with the GIL released — the loop is pure Rust (no Python).
+    py.detach(move || -> Result<(), String> {
+        let opts = ConnectOptions::new()
+            .with_cache_budget_bytes(cache_bytes)
+            .with_cache_dir(format!("{data_path}/cache"));
+        let conn = connect_with(&data_path, opts).map_err(|e| e.to_string())?;
+        let st = Arc::new(conn.open_table(&table).map_err(|e| e.to_string())?);
+        // Read the fixed vector dimension from the schema so the warm-up query and
+        // the per-request length check use the table's real dim (not a hard-coded
+        // one), and confirm the id column is the Int64 the wire format assumes —
+        // both are startup invariants, so a mismatch should fail here, loudly,
+        // not silently mid-benchmark.
+        let schema = st.schema();
+        let vfield = schema
+            .field_with_name(&col)
+            .map_err(|e| format!("vector column {col:?} not in schema: {e}"))?;
+        let dim = match vfield.data_type() {
+            DataType::FixedSizeList(_, n) => *n as usize,
+            other => return Err(format!("vector column {col:?} is {other:?}, expected FixedSizeList<Float32>")),
+        };
+        if let Some(ic) = id_col.as_deref() {
+            let ifield = schema
+                .field_with_name(ic)
+                .map_err(|e| format!("id column {ic:?} not in schema: {e}"))?;
+            if !matches!(ifield.data_type(), DataType::Int64) {
+                return Err(format!("id column {ic:?} is {:?}, expected Int64", ifield.data_type()));
+            }
+        }
+        let warm = vec![0.0f32; dim];
+        let _ = st.vector_search(&col, &warm, 10, None, None);
+        let listener = TcpListener::bind(&addr).map_err(|e| e.to_string())?;
+        eprintln!(
+            "[infino-bench-serve] table={table} dim={dim} listening={addr} id_col={} cache={cache_bytes} — ready",
+            id_col.as_deref().unwrap_or("_id")
+        );
+        for stream in listener.incoming() {
+            match stream {
+                Ok(s) => {
+                    let st = st.clone();
+                    let col = col.clone();
+                    let id_col = id_col.clone();
+                    thread::spawn(move || handle(s, st, col, id_col, dim));
+                }
+                Err(e) => eprintln!("[infino-bench-serve] accept error: {e}"),
+            }
+        }
+        Ok(())
+    })
+    .map_err(PyRuntimeError::new_err)?;
+    Ok(())
+}

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -20,11 +20,12 @@ use std::time::Duration;
 
 use arrow::compute::concat_batches;
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
-use arrow_array::RecordBatch;
+use arrow_array::{Array, Decimal128Array, RecordBatch};
 use arrow_schema::Schema;
 use datafusion::common::DFSchema;
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::Expr;
+use numpy::{IntoPyArray, PyArrayMethods};
 use pyo3::create_exception;
 use pyo3::exceptions::{PyException, PyKeyError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -38,6 +39,8 @@ use infino::{
 // the engine's public API and reachable only under `infino/test-helpers`.
 #[cfg(feature = "diagnostics")]
 use infino::VectorSearchOptions;
+
+mod bench_serve;
 
 // Typed exception surface for the bindings. `InfinoError` is the base for every
 // infino error, so a caller can catch the whole family with one `except` or
@@ -535,7 +538,11 @@ impl Table {
         filter_mode: Option<&str>,
         projection: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let filter = parse_filter(filter_column.as_deref(), filter_query.as_deref(), filter_mode)?;
+        let filter = parse_filter(
+            filter_column.as_deref(),
+            filter_query.as_deref(),
+            filter_mode,
+        )?;
         let batches = py
             .detach(|| {
                 let names = projection_refs(&projection);
@@ -544,6 +551,40 @@ impl Table {
             })
             .map_err(py_err)?;
         batches_to_pyarrow_table(py, batches)
+    }
+
+    /// Lean search: return only the top-k `_id`s as a numpy `uint8[k, 16]`
+    /// (big-endian decimal128 keys). The search runs GIL-free (`detach`); the
+    /// only GIL-held step is creating one numpy array — no pyarrow Table, no
+    /// per-row Python objects — so the per-query GIL-serialized marshalling is
+    /// minimized for high-concurrency serving.
+    #[pyo3(signature = (column, query, k))]
+    fn vector_search_ids<'py>(
+        &self,
+        py: Python<'py>,
+        column: &str,
+        query: Vec<f32>,
+        k: usize,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let batches = py
+            .detach(|| self.inner.vector_search(column, &query, k, None, None))
+            .map_err(py_err)?;
+        let mut bytes: Vec<u8> = Vec::with_capacity(k * 16);
+        for b in &batches {
+            let col = b
+                .column_by_name("_id")
+                .ok_or_else(|| PyRuntimeError::new_err("vector_search result missing _id"))?;
+            let dec = col
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .ok_or_else(|| PyRuntimeError::new_err("_id column is not decimal128"))?;
+            for i in 0..dec.len() {
+                bytes.extend_from_slice(&dec.value(i).to_be_bytes());
+            }
+        }
+        let rows = bytes.len() / 16;
+        let arr = bytes.into_pyarray(py).reshape([rows, 16])?;
+        Ok(arr.into_any())
     }
 
     /// Diagnostic build only: `nprobe` / `rerank_mult` overrides for
@@ -572,12 +613,22 @@ impl Table {
         if let Some(n) = rerank_mult {
             opts = opts.with_rerank_mult(n);
         }
-        let filter = parse_filter(filter_column.as_deref(), filter_query.as_deref(), filter_mode)?;
+        let filter = parse_filter(
+            filter_column.as_deref(),
+            filter_query.as_deref(),
+            filter_mode,
+        )?;
         let batches = py
             .detach(|| {
                 let names = projection_refs(&projection);
-                self.inner
-                    .vector_search_with_options(column, &query, k, opts, filter, names.as_deref())
+                self.inner.vector_search_with_options(
+                    column,
+                    &query,
+                    k,
+                    opts,
+                    filter,
+                    names.as_deref(),
+                )
             })
             .map_err(py_err)?;
         batches_to_pyarrow_table(py, batches)
@@ -965,6 +1016,7 @@ fn coerce_to_record_batch(
 #[pyo3(name = "_infino")]
 fn infino_ext(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(connect, m)?)?;
+    m.add_function(wrap_pyfunction!(bench_serve::bench_serve_tcp, m)?)?;
     m.add_class::<Connection>()?;
     m.add_class::<Table>()?;
     m.add_class::<IndexSpec>()?;


### PR DESCRIPTION
## What

Two additions to the Python binding, both aimed at driving the engine at higher throughput under a concurrent / networked benchmark client:

1. **`vector_search_ids`** — returns the top-k engine `_id` keys as a numpy array (uint8 `[k, 16]`, big-endian) instead of building a pyarrow `Table`. The only GIL-held step becomes one array creation.
2. **`bench_serve` mode** (`infino-bench-serve`) — an **experimental** raw-TCP serve loop wrapping the embedded engine, so a networked benchmark client can drive it in a client-server topology. Optional `--id-col` projects a scalar int64 column and returns the dataset id directly (8-byte LE), so the client needs no id map; unset returns the engine `_id` (16-byte BE).

## Why

Warm concurrent search throughput from Python is bottlenecked in the **marshalling layer, not the engine**. Building a pyarrow `Table` + `to_pylist()` per query dominates GIL-held time; and the embedded call path can't be measured in the client-server shape that networked databases are benchmarked in. These two additions remove the marshalling cost and enable the client-server measurement, without touching scoring (recall is unchanged).

## Numbers — Cohere-1M, 16 vCPU, recall@10 = 0.9327

| Path | Warm QPS |
|---|---|
| pyarrow `Table` marshalling (before) | ~4,000 |
| `vector_search_ids` (lean numpy) | **8,690** (~2.2×) |
| raw-TCP serve mode | **9,751** (+12% over embedded lean) |
| native, no-Python ceiling (reference) | ~15,700 |

Measured at ef=128; the deltas hold across the recall/throughput range. Recall is unaffected — both changes are marshalling/transport only, not scoring.

## Design rationale: why raw TCP, and the throughput ceiling

**Why not gRPC.** The first serve prototype used gRPC — it pulls `tonic`/`prost`/`protoc` build deps and adds per-call framing + protobuf (de)serialization on the hot path. Replacing it with a fixed-layout raw-TCP frame (one persistent, pipelined connection) removed those dependencies and cut the transport overhead to ~7% over the embedded call. For a benchmark harness measuring the engine, the minimal dependency-free transport is the right tool; gRPC's generality buys nothing here.

**Why serve beats embedded, and why it can't reach native.** Serve mode (9,751) *beats* embedded lean-py (8,690) because moving the search into a separate process lets it run **GIL-free** while the Python clients block on sockets (the GIL is released across socket I/O). It **can't reach the ~15,700 native ceiling** because a Python client is still in the loop: per-query `struct.pack`/`frombuffer`, socket syscalls, and framing that a pure-Rust in-process caller never pays. Native is the ceiling only when nothing but Rust touches the query.

## What this is **not**

`bench_serve` is **experimental and not a production server**: no auth, no TLS, no durability, single table. The supported infino interface remains embedded (`connect`/`open_table`). It ships as the `infino-bench-serve` console entry point purely for throughput benchmarking.

## Design notes

- Serve wire (little-endian, one persistent connection, pipelined): request = `u32 k, u32 dim, dim*4 f32`; response = `u32 n, n*IDSIZE` (`IDSIZE` = 16 for `_id`, 8 for `--id-col` int64).
- The server reads the vector dimension from the table schema and validates the `--id-col` type at startup, and rejects a mismatched per-request dim — a wrong column/dim fails loud rather than returning a short result the client would silently score as ~0 recall.
- `--id-col` does `vector_search(projection=[col])` and returns the stored dataset id directly.

## Testing

- fmt + clippy clean (no new warnings).
- Serve correctness: returns **byte-identical** ids to embedded `vector_search(projection=[id])` across queries (raw-TCP smoke test, including the `--id-col` int64 path).

## Alternatives considered

- **gRPC serve** — needs `tonic`/`prost`/`protoc` build deps; raw TCP is dependency-free and lower-overhead for a benchmark harness.
- **Keep returning pyarrow** — the pyarrow build is exactly the GIL cost being removed.
