### PR TITLE
fts: trim ranked-path decode/walk overhead + batch boolean-clause atom build

### DIFF
--- a/src/superfile/fts/posting.rs
+++ b/src/superfile/fts/posting.rs
@@ -54,21 +54,11 @@
 //!   `assert!` preconditions plus the caller's contract carry safety
 //!   in production.
 
-use std::sync::LazyLock;
-
 use bitpacking::{BitPacker, BitPacker4x};
 
 /// Number of `(doc_id, tf)` pairs per encoded block. Fixed at 128 to
 /// match `BitPacker4x::BLOCK_LEN`.
 pub const BLOCK_LEN: usize = BitPacker4x::BLOCK_LEN;
-
-/// Process-wide bit-unpacking dispatcher, built once. `BitPacker4x::new()`
-/// runs a runtime SIMD-feature probe and is not `#[inline]`, so calling it
-/// per block was an out-of-line call on every decode — twice per full
-/// scoring decode (doc ids + tfs), in the hottest read path. The selected
-/// instruction set is process-invariant, so resolve it a single time and
-/// reuse the (one-byte, `Copy`) dispatcher.
-static BITPACKER: LazyLock<BitPacker4x> = LazyLock::new(BitPacker4x::new);
 
 /// Header size in bytes (doc_count + delta_bits + tf_bits + encoding +
 /// base_doc_id).
@@ -266,7 +256,7 @@ pub fn decode_block(bytes: &[u8], dest_doc_ids: &mut [u32], dest_tfs: &mut [u32]
         HEADER_SIZE + tfs_size
     );
     let tfs_start = bytes.len() - tfs_size;
-    BITPACKER.decompress(
+    BitPacker4x::new().decompress(
         &bytes[tfs_start..tfs_start + tfs_size],
         &mut dest_tfs[..BLOCK_LEN],
         tf_bits,
@@ -294,7 +284,7 @@ pub fn decode_block_tfs(bytes: &[u8], dest_tfs: &mut [u32]) {
         "decode_block_tfs: bytes shorter than header+tfs"
     );
     let tfs_start = bytes.len() - tfs_size;
-    BITPACKER.decompress(
+    BitPacker4x::new().decompress(
         &bytes[tfs_start..tfs_start + tfs_size],
         &mut dest_tfs[..BLOCK_LEN],
         tf_bits,
@@ -379,7 +369,7 @@ pub fn decode_block_doc_ids(bytes: &[u8], dest_doc_ids: &mut [u32]) -> usize {
         HEADER_SIZE + deltas_size
     );
 
-    BITPACKER.decompress_sorted(
+    BitPacker4x::new().decompress_sorted(
         base_doc_id,
         &bytes[HEADER_SIZE..HEADER_SIZE + deltas_size],
         &mut dest_doc_ids[..BLOCK_LEN],

--- a/src/superfile/fts/posting.rs
+++ b/src/superfile/fts/posting.rs
@@ -54,11 +54,21 @@
 //!   `assert!` preconditions plus the caller's contract carry safety
 //!   in production.
 
+use std::sync::LazyLock;
+
 use bitpacking::{BitPacker, BitPacker4x};
 
 /// Number of `(doc_id, tf)` pairs per encoded block. Fixed at 128 to
 /// match `BitPacker4x::BLOCK_LEN`.
 pub const BLOCK_LEN: usize = BitPacker4x::BLOCK_LEN;
+
+/// Process-wide bit-unpacking dispatcher, built once. `BitPacker4x::new()`
+/// runs a runtime SIMD-feature probe and is not `#[inline]`, so calling it
+/// per block was an out-of-line call on every decode — twice per full
+/// scoring decode (doc ids + tfs), in the hottest read path. The selected
+/// instruction set is process-invariant, so resolve it a single time and
+/// reuse the (one-byte, `Copy`) dispatcher.
+static BITPACKER: LazyLock<BitPacker4x> = LazyLock::new(BitPacker4x::new);
 
 /// Header size in bytes (doc_count + delta_bits + tf_bits + encoding +
 /// base_doc_id).
@@ -256,7 +266,7 @@ pub fn decode_block(bytes: &[u8], dest_doc_ids: &mut [u32], dest_tfs: &mut [u32]
         HEADER_SIZE + tfs_size
     );
     let tfs_start = bytes.len() - tfs_size;
-    BitPacker4x::new().decompress(
+    BITPACKER.decompress(
         &bytes[tfs_start..tfs_start + tfs_size],
         &mut dest_tfs[..BLOCK_LEN],
         tf_bits,
@@ -284,7 +294,7 @@ pub fn decode_block_tfs(bytes: &[u8], dest_tfs: &mut [u32]) {
         "decode_block_tfs: bytes shorter than header+tfs"
     );
     let tfs_start = bytes.len() - tfs_size;
-    BitPacker4x::new().decompress(
+    BITPACKER.decompress(
         &bytes[tfs_start..tfs_start + tfs_size],
         &mut dest_tfs[..BLOCK_LEN],
         tf_bits,
@@ -369,7 +379,7 @@ pub fn decode_block_doc_ids(bytes: &[u8], dest_doc_ids: &mut [u32]) -> usize {
         HEADER_SIZE + deltas_size
     );
 
-    BitPacker4x::new().decompress_sorted(
+    BITPACKER.decompress_sorted(
         base_doc_id,
         &bytes[HEADER_SIZE..HEADER_SIZE + deltas_size],
         &mut dest_doc_ids[..BLOCK_LEN],

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1083,12 +1083,19 @@ impl FtsReader {
         }
         let mut dict_ranges = 0u64;
         let mut out: Vec<Option<AnyCursor>> = Vec::with_capacity(terms.len() + phrases.len());
-        for term in terms {
-            let mut cursors = self
-                .build_term_cursors(column_id, &[term], global_idf, false)
+        // All bare terms in one FST open + one parallel postings fan-out
+        // (arity-preserving: each term maps to its own slot, `None` when
+        // absent), rather than a serial per-term build that re-fetched the
+        // dictionary and issued a separate range wave for each. One planned
+        // dictionary range for the whole batch.
+        if !terms.is_empty() {
+            let term_cursors = self
+                .build_term_cursors_opt(column_id, terms, global_idf, false)
                 .await?;
             dict_ranges += 1;
-            out.push(cursors.pop().map(AnyCursor::Term));
+            for cursor in term_cursors {
+                out.push(cursor.map(AnyCursor::Term));
+            }
         }
         for phrase in phrases {
             let member_refs: Vec<&str> = phrase.iter().map(|t| t.as_str()).collect();

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -719,8 +719,10 @@ impl TermCursor {
         // Decode this block's tf array once (doc order), reused across a run of
         // candidates in the same block; the doc ids are never expanded.
         if self.tf_decoded_block != self.current_block {
-            let bytes = &self.bytes[block.block_byte_offset..block.block_byte_end];
-            posting::decode_block_tfs(bytes, &mut self.block_tfs);
+            // Reuse `raw` (still borrowing this block's bytes, disjoint from
+            // the `&mut self.block_tfs` decode target) rather than recomputing
+            // the same subslice and its bounds check.
+            posting::decode_block_tfs(raw, &mut self.block_tfs);
             self.tf_decoded_block = self.current_block;
         }
         Some(self.block_tfs[rank as usize])
@@ -742,9 +744,16 @@ impl TermCursor {
 
     #[inline(always)]
     pub(super) fn current_doc_id(&self) -> u32 {
-        if self.is_exhausted() || self.pos >= self.block_n {
+        if self.is_exhausted() {
             u32::MAX
         } else {
+            // A live cursor always has `pos < block_n` — every mutator
+            // (`next`, `advance_by`, `skip_to`, `advance_block`) restores it
+            // or marks the cursor exhausted (see the `pos` field doc). The
+            // extra `pos >= block_n` guard was dead on this hot walk
+            // primitive; the debug tripwire fires if a future change breaks
+            // the invariant.
+            debug_assert!(self.pos < self.block_n);
             self.block_doc_ids[self.pos]
         }
     }

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -1508,21 +1508,20 @@ impl FtsReader {
                     }
                     let pos = c.pos;
                     if pos + bm25::SCORE_SIMD_LANES <= c.block_n {
-                        let doc_ids = [
-                            c.block_doc_ids[pos],
-                            c.block_doc_ids[pos + 1],
-                            c.block_doc_ids[pos + 2],
-                            c.block_doc_ids[pos + 3],
-                        ];
+                        // Bind the 4-wide window as one subslice per array:
+                        // the guard proves `pos + LANES <= block_n <= len`,
+                        // so this is a single range check and the lane reads
+                        // off the fixed-length-4 slice carry none — replacing
+                        // the eight separate element bounds checks the direct
+                        // `block_doc_ids[pos+i]` / `block_tfs[pos+i]` indexing
+                        // emitted in this per-block SIMD group.
+                        let dids = &c.block_doc_ids[pos..pos + bm25::SCORE_SIMD_LANES];
+                        let doc_ids = [dids[0], dids[1], dids[2], dids[3]];
                         if doc_ids[bm25::SCORE_SIMD_LANES - 1] < window_end {
+                            let tfs = &c.block_tfs[pos..pos + bm25::SCORE_SIMD_LANES];
                             let contributions = bm25::score_one_term_x4(
                                 c.idf_x_k1p1,
-                                [
-                                    c.block_tfs[pos],
-                                    c.block_tfs[pos + 1],
-                                    c.block_tfs[pos + 2],
-                                    c.block_tfs[pos + 3],
-                                ],
+                                [tfs[0], tfs[1], tfs[2], tfs[3]],
                                 [
                                     dl_norm_k1.get(doc_ids[0]),
                                     dl_norm_k1.get(doc_ids[1]),
@@ -1823,21 +1822,20 @@ impl FtsReader {
                     }
                     let pos = c.pos;
                     if pos + bm25::SCORE_SIMD_LANES <= c.block_n {
-                        let doc_ids = [
-                            c.block_doc_ids[pos],
-                            c.block_doc_ids[pos + 1],
-                            c.block_doc_ids[pos + 2],
-                            c.block_doc_ids[pos + 3],
-                        ];
+                        // Bind the 4-wide window as one subslice per array:
+                        // the guard proves `pos + LANES <= block_n <= len`,
+                        // so this is a single range check and the lane reads
+                        // off the fixed-length-4 slice carry none — replacing
+                        // the eight separate element bounds checks the direct
+                        // `block_doc_ids[pos+i]` / `block_tfs[pos+i]` indexing
+                        // emitted in this per-block SIMD group.
+                        let dids = &c.block_doc_ids[pos..pos + bm25::SCORE_SIMD_LANES];
+                        let doc_ids = [dids[0], dids[1], dids[2], dids[3]];
                         if doc_ids[bm25::SCORE_SIMD_LANES - 1] < window_end {
+                            let tfs = &c.block_tfs[pos..pos + bm25::SCORE_SIMD_LANES];
                             let contributions = bm25::score_one_term_x4(
                                 c.idf_x_k1p1,
-                                [
-                                    c.block_tfs[pos],
-                                    c.block_tfs[pos + 1],
-                                    c.block_tfs[pos + 2],
-                                    c.block_tfs[pos + 3],
-                                ],
+                                [tfs[0], tfs[1], tfs[2], tfs[3]],
                                 [
                                     dl_norm_k1.get(doc_ids[0]),
                                     dl_norm_k1.get(doc_ids[1]),

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -936,8 +936,13 @@ impl FtsReader {
             }
             let m = m_want.min(cand.len());
             cand.select_nth_unstable_by(m.saturating_sub(1), |a, b| b.0.total_cmp(&a.0));
-            // Decode those blocks, score, keep a k-sized seed heap.
-            let mut seed_heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(k);
+            // Decode those blocks, score, keep a k-sized seed heap. Clamp the
+            // preallocation to the corpus size: `k` is caller-controlled and may
+            // be `usize::MAX` (an unbounded "return everything" request), which
+            // would overflow `with_capacity`. The heap never holds more than the
+            // docs in scope anyway.
+            let mut seed_heap: BinaryHeap<TopKEntry> =
+                BinaryHeap::with_capacity(top_k_initial_capacity(k, u64::from(self.n_docs), None));
             for &(_, bi) in &cand[..m] {
                 let (_, off, _) = term_meta.skip_entry(postings, bi);
                 let end = term_meta.block_end_in_term(postings, bi);

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -878,8 +878,12 @@ impl FtsReader {
         // that makes `peek()` the current kth-best score.
         let mut heap: BinaryHeap<TopKEntry> =
             BinaryHeap::with_capacity(k.min(term_meta.num_blocks * BLOCK_LEN).max(1));
-        let mut buf_d = vec![0u32; BLOCK_LEN];
-        let mut buf_t = vec![0u32; BLOCK_LEN];
+        // Stack-resident decode scratch: `BLOCK_LEN` is a compile-time
+        // const and these never cross an await (the whole scoring walk
+        // below is synchronous), so they stay off the heap — no per-query
+        // malloc/free on the most common query shape.
+        let mut buf_d = [0u32; BLOCK_LEN];
+        let mut buf_t = [0u32; BLOCK_LEN];
 
         let coarse_span = format::fts::COARSE_BLOCK_MAX_SPAN;
         // The coarse block-max table exists only on V5 blobs; on V1–V4 the

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -1088,6 +1088,11 @@ impl FtsReader {
     /// Missing terms (FST miss) are silently dropped — fine for OR
     /// semantics where a missing term contributes nothing. Returned
     /// `Vec` may be empty (all terms missed) or shorter than `terms`.
+    ///
+    /// A thin wrapper over [`Self::build_term_cursors_opt`] that discards
+    /// the per-term slot positions; callers that need to know *which*
+    /// term missed (bare-atom builds, which keep a `None` slot for it)
+    /// use the `_opt` form directly.
     pub(super) async fn build_term_cursors(
         &self,
         column_id: u32,
@@ -1095,6 +1100,27 @@ impl FtsReader {
         global_idf: Option<&GlobalTermIdf>,
         count_only: bool,
     ) -> Result<Vec<TermCursor>, FtsError> {
+        Ok(self
+            .build_term_cursors_opt(column_id, terms, global_idf, count_only)
+            .await?
+            .into_iter()
+            .flatten()
+            .collect())
+    }
+
+    /// Build a `TermCursor` for every term, **preserving input order and
+    /// arity**: the result has one slot per input term, `None` where the
+    /// term is absent from the FST. One FST open and one parallel postings
+    /// fan-out for the whole batch — so a multi-term build costs a single
+    /// dictionary fetch and a single overlapped range wave, not one of each
+    /// per term.
+    pub(super) async fn build_term_cursors_opt(
+        &self,
+        column_id: u32,
+        terms: &[&str],
+        global_idf: Option<&GlobalTermIdf>,
+        count_only: bool,
+    ) -> Result<Vec<Option<TermCursor>>, FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
         let dict = DictReader::open(&fst_bytes).map_err(|e| {
             FtsError::Read(ReadError::MalformedVersion(format!(
@@ -1103,14 +1129,14 @@ impl FtsReader {
         })?;
         let col_meta = &self.columns[column_id as usize];
 
-        // Resolve each present term to either an inline (df=1) value or
-        // a PFOR metadata offset, preserving query order. FST misses
-        // are dropped (fine for OR; AND callers length-check). Collect
-        // the PFOR offsets so all their byte ranges can be fetched in
-        // one parallel fan-out below — never the whole postings region.
-        // Each resolved entry carries its term's global idf (when in
-        // `Bm25Stats::Global`) so the cursor is built with the global
-        // value; `None` per term falls back to this superfile's local idf.
+        // Resolve each term to an inline (df=1) value, a PFOR metadata
+        // offset, or a miss — preserving query order and arity (a miss is a
+        // `None` slot, so the caller can tell which term was absent). Collect
+        // the PFOR offsets so all their byte ranges can be fetched in one
+        // parallel fan-out below — never the whole postings region. Each
+        // resolved entry carries its term's global idf (when in
+        // `Bm25Stats::Global`) so the cursor is built with the global value;
+        // `None` per term falls back to this superfile's local idf.
         enum Resolved {
             Inline {
                 doc_id: u32,
@@ -1122,17 +1148,18 @@ impl FtsReader {
                 header_probed: bool,
             },
         }
-        let mut resolved: Vec<Resolved> = Vec::with_capacity(terms.len());
+        let mut resolved: Vec<Option<Resolved>> = Vec::with_capacity(terms.len());
         let mut pfor_offsets: Vec<(usize, Option<usize>)> = Vec::new();
         for term in terms {
             let key = make_key(&col_meta.name, term);
             let Some(packed) = dict.lookup(&key) else {
+                resolved.push(None);
                 continue;
             };
             let gidf = global_idf.and_then(|m| m.get(*term).copied());
             match FstValue::unpack(packed) {
                 FstValue::Inline { doc_id, tf } => {
-                    resolved.push(Resolved::Inline { doc_id, tf, gidf });
+                    resolved.push(Some(Resolved::Inline { doc_id, tf, gidf }));
                 }
                 FstValue::Pfor {
                     metadata_offset,
@@ -1145,10 +1172,10 @@ impl FtsReader {
                     // A hint-less slot (21-bit length overflow) costs a
                     // header probe BEFORE the body fetch — two planned
                     // ranges, recorded on the cursor for the tallies.
-                    resolved.push(Resolved::Pfor {
+                    resolved.push(Some(Resolved::Pfor {
                         gidf,
                         header_probed: postings_length_hint.is_none(),
-                    });
+                    }));
                 }
             }
         }
@@ -1156,10 +1183,11 @@ impl FtsReader {
         let pfor_bytes = self.fetch_term_postings(&pfor_offsets).await?;
         let mut pfor_iter = pfor_bytes.into_iter();
 
-        let mut cursors: Vec<TermCursor> = Vec::with_capacity(resolved.len());
+        let mut cursors: Vec<Option<TermCursor>> = Vec::with_capacity(resolved.len());
         for r in resolved {
             match r {
-                Resolved::Inline { doc_id, tf, gidf } => {
+                None => cursors.push(None),
+                Some(Resolved::Inline { doc_id, tf, gidf }) => {
                     // On a positional column the inline slot carries
                     // the term's single position, tf implied 1 — the
                     // builder only inlines tf == 1 postings there.
@@ -1171,20 +1199,20 @@ impl FtsReader {
                         false => tf,
                     };
                     let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
-                    cursors.push(TermCursor::new_inline(
+                    cursors.push(Some(TermCursor::new_inline(
                         doc_id,
                         tf,
                         self.n_docs as u64,
                         dl_norm_k1,
                         gidf,
-                    ));
+                    )));
                 }
-                Resolved::Pfor {
+                Some(Resolved::Pfor {
                     gidf,
                     header_probed,
-                } => {
+                }) => {
                     let term_bytes = pfor_iter.next().expect("one fetched range per PFOR term");
-                    cursors.push(TermCursor::new(
+                    cursors.push(Some(TermCursor::new(
                         term_bytes,
                         self.n_docs as u64,
                         col_meta.positions,
@@ -1192,7 +1220,7 @@ impl FtsReader {
                         header_probed,
                         count_only,
                         self.has_coarse_block_max,
-                    )?);
+                    )?));
                 }
             }
         }

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -412,6 +412,30 @@ async fn oracle_single_term_seed_scale_matches_brute_force() {
     }
 }
 
+#[tokio::test]
+async fn oracle_single_term_seed_scale_unbounded_k_does_not_overflow() {
+    // Regression: the threshold-first seed heap preallocated `with_capacity(k)`
+    // with no clamp. An unbounded request — `k == usize::MAX`, the "return
+    // everything" sentinel a brute-force comparison passes — then asked for a
+    // `usize::MAX`-capacity heap and panicked with "capacity overflow". The
+    // seed path only fires past its `MIN_BLOCKS = 256` gate, so the small
+    // oracles never reached it; this 35k-doc corpus puts `common` in every doc
+    // (~273 blocks), so the seed runs. With the capacity clamped to the corpus
+    // size the search must complete and return every matching doc.
+    let corp = seed_scale_single_term_corpus();
+    let corp_refs: Vec<(u64, &str)> = corp.iter().map(|(d, s)| (*d, s.as_str())).collect();
+    let infino = build_infino_superfile(&corp_refs);
+    let hits = infino
+        .bm25_hits_async("title", "common", usize::MAX, BoolMode::Or)
+        .await
+        .expect("unbounded-k BM25 search must not panic");
+    assert_eq!(
+        hits.len(),
+        corp.len(),
+        "unbounded-k search must return every doc containing the term"
+    );
+}
+
 /// Corpus where a common non-essential ("hot") has a high block-max only in a
 /// *mid-range* block. Five anchors in block 10 (ids 1281..1289) carry `lead` +
 /// `hot`×{10,9,8,7,6} — strictly-decreasing scores far above the bulk (bulk hot


### PR DESCRIPTION
## Summary

Two behavior-preserving optimizations on the BM25 top-k read path, plus one
attempt that was measured, reverted, and kept in history for the record. No
format or public-API change; results are bit-identical (gated by the existing
oracles).

## Changes

### 1. Batch the boolean-clause atom build
The must / should / negation path (and the count path) built its bare term
cursors **one term at a time** — each reopening the FST dictionary and issuing
its own serialized postings-range fetch. A k-term clause list therefore paid
**k dictionary opens and k serial fetch waves.**

A new arity-preserving core, `build_term_cursors_opt`, resolves every term
against **one FST open** and fetches all their posting ranges in a **single
parallel fan-out**, returning one slot per input term (`None` where a term is
absent, so callers still know which one missed). `build_term_cursors` keeps its
miss-dropping contract as a thin wrapper, so its many callers are unchanged.
The clause path now resolves all bare terms through one batched call — cutting
the planned dictionary ranges from one-per-term to one and overlapping the
fetches. Term order and absent-term (`None`) slots are preserved exactly.

### 2. Trim per-decode and per-walk overhead
Small hot-path cleanups on the top-k read path:
- **Single-term walk** (the most common query shape): keep its two per-query
  block decode buffers on the **stack** — they are `BLOCK_LEN`-sized and never
  cross an await, so the per-query heap alloc/free was needless.
- **Windowed MaxScore accumulate**: bind the four-wide SIMD window as one
  **subslice** per array, so the fixed-length lane reads drop their bounds
  checks (eight element checks become two range checks in the per-block inner
  loop).
- **Ranked-OR cursor**: reuse the block-bytes slice already held in the tf
  probe instead of recomputing the same subslice for the tf decode.
- Drop a **dead `pos >= block_n` guard** from `current_doc_id` (a live cursor
  always satisfies it; a debug assertion keeps the tripwire), so the hottest
  walk accessor does one comparison, not two.

### Reverted (kept in history): the cached unpacking dispatcher
An earlier commit built the `BitPacker4x` unpacking dispatcher once in a process
static. It was reverted: release builds pin `target-cpu`, so the feature-detect
folds to a compile-time constant and the per-call constructor already inlines
away to nothing — routing every decode through a `LazyLock` only **added** an
atomic-guarded init check to the hot path. Benchmarking the ranked path
confirmed it regressed, so it's out; the cleanups above stay. Kept as a commit
so the history shows the measurement.

## Why it's correct

Every change is **behavior-preserving** — same posting decode, same term
resolution, same clause semantics, same top-k. This is enforced, not just
argued:
- **Brute-force BM25 oracles** — top-k compared against the textbook BM25
  formula on planted (multi-block) corpora, sharing no code with the optimized
  walks.
- **Property-test fuzz oracle** — random corpora and random clause/phrase
  queries diffed against brute-force (exact set + per-doc scores).
- The batched atom build additionally preserves the **planned-range op-stats
  pins** (which assert the dictionary/postings fetch plan) — so the
  one-open/one-fan-out change is verified to keep the same term order and
  absent-term slots.
- `make ci` (fmt, clippy `-D warnings`, the test lanes).

## Performance

These remove work from the hottest read path rather than change any algorithm's
result: per-query heap allocations, per-block SIMD bounds checks, a redundant
subslice recompute, and a redundant walk-accessor comparison. The batched atom
build is the one structural win — a k-term boolean clause goes from **k FST
opens + k serial fetch waves to one open + one parallel fan-out.** The single
piece that benchmarked *negative* (the cached dispatcher) was reverted, so the
net is neutral-to-positive on the ranked path with the structural win on
multi-term clause building.
