### PR TITLE
fts: fix capacity-overflow panic on unbounded-k ranked search

### DIFF
--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -932,8 +932,13 @@ impl FtsReader {
             }
             let m = m_want.min(cand.len());
             cand.select_nth_unstable_by(m.saturating_sub(1), |a, b| b.0.total_cmp(&a.0));
-            // Decode those blocks, score, keep a k-sized seed heap.
-            let mut seed_heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(k);
+            // Decode those blocks, score, keep a k-sized seed heap. Clamp the
+            // preallocation to the corpus size: `k` is caller-controlled and may
+            // be `usize::MAX` (an unbounded "return everything" request), which
+            // would overflow `with_capacity`. The heap never holds more than the
+            // docs in scope anyway.
+            let mut seed_heap: BinaryHeap<TopKEntry> =
+                BinaryHeap::with_capacity(top_k_initial_capacity(k, u64::from(self.n_docs), None));
             for &(_, bi) in &cand[..m] {
                 let (_, off, _) = term_meta.skip_entry(postings, bi);
                 let end = term_meta.block_end_in_term(postings, bi);

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -412,6 +412,30 @@ async fn oracle_single_term_seed_scale_matches_brute_force() {
     }
 }
 
+#[tokio::test]
+async fn oracle_single_term_seed_scale_unbounded_k_does_not_overflow() {
+    // Regression: the threshold-first seed heap preallocated `with_capacity(k)`
+    // with no clamp. An unbounded request — `k == usize::MAX`, the "return
+    // everything" sentinel a brute-force comparison passes — then asked for a
+    // `usize::MAX`-capacity heap and panicked with "capacity overflow". The
+    // seed path only fires past its `MIN_BLOCKS = 256` gate, so the small
+    // oracles never reached it; this 35k-doc corpus puts `common` in every doc
+    // (~273 blocks), so the seed runs. With the capacity clamped to the corpus
+    // size the search must complete and return every matching doc.
+    let corp = seed_scale_single_term_corpus();
+    let corp_refs: Vec<(u64, &str)> = corp.iter().map(|(d, s)| (*d, s.as_str())).collect();
+    let infino = build_infino_superfile(&corp_refs);
+    let hits = infino
+        .bm25_hits_async("title", "common", usize::MAX, BoolMode::Or)
+        .await
+        .expect("unbounded-k BM25 search must not panic");
+    assert_eq!(
+        hits.len(),
+        corp.len(),
+        "unbounded-k search must return every doc containing the term"
+    );
+}
+
 /// Corpus where a common non-essential ("hot") has a high block-max only in a
 /// *mid-range* block. Five anchors in block 10 (ids 1281..1289) carry `lead` +
 /// `hot`×{10,9,8,7,6} — strictly-decreasing scores far above the bulk (bulk hot


### PR DESCRIPTION
## Problem

The single-term ranked BM25 path panics with `capacity overflow` when called with a very large `k`. The threshold-first seed heap preallocated `BinaryHeap::with_capacity(k)` with no clamp; `k` is caller-controlled and may be `usize::MAX` (the unbounded "return everything" request a brute-force top-k comparison passes), so the allocation overflows and aborts the query.

```
thread 'main' panicked at library/alloc/src/raw_vec/mod.rs:28:5:
capacity overflow
```

This is a live crash on `main`: the superfile FTS bench runs a `BMW==brute-force` correctness check that issues an unbounded-`k` search, so the bench aborts before producing results.

## Fix

Clamp the seed heap's preallocation to the corpus size via the existing `top_k_initial_capacity` helper — the same clamp every sibling top-k heap already uses. The seed heap never holds more than the docs in scope, so this only bounds the up-front allocation; behavior is otherwise unchanged.

## Test

Adds a regression test that runs an unbounded-`k` search over a corpus large enough to engage the seed path (a term in every one of 35k docs, ~273 blocks, past the seed's `MIN_BLOCKS = 256` gate). It reproduces the exact `capacity overflow` panic before the fix and passes after.