### PR TITLE
fts: faster ranked rare∧common AND via a rarest-driven bitset-probe walk

### DIFF
--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -326,20 +326,47 @@ pub(super) const OR_COUNT_ANCHOR_DOMINANCE: u64 = 8;
 /// `total_df >= max_doc / N`.
 pub(super) const OR_COUNT_BITSET_DENSITY_DIVISOR: u64 = 16;
 
-/// Rarest-term sparsity gate for the ranked-AND membership walk
-/// (`FtsReader::and_membership_scored`): route there only when the rarest term
-/// covers less than `1/N` of the doc-id space. The membership walk drives the
-/// rarest term's *entire* list, bit-testing the others, so it only pays when
-/// that list is genuinely short relative to the corpus. It previously *also*
-/// gave up the flat-merge's block-max heap-bar skip, which forced a strict
-/// `1/64` gate — a looser `1/16` let moderately sparse rarest terms through and
-/// regressed the ranked tail (p99) where the bar-skip was doing real work. The
-/// walk now carries that same Block-Max-AND skip itself, so a moderately-sparse
-/// rarest term (rare∧common — one discriminating term plus stopwords, the
-/// common multi-term shape) can route here and still skip windows the bar rules
-/// out. Set to the count path's `1/16`; the all-dense case (every term a
-/// stopword) stays above the gate and keeps the flat-merge.
+/// Ranked-AND membership-walk routing (`FtsReader::and_membership_scored`) uses
+/// two sparsity tiers for the rarest term, plus a density check on the middle
+/// tier. All thresholds are `1/N` fractions of the doc-id space.
+///
+/// - **Rarest < `1/AND_MEMBERSHIP_ALWAYS_DIVISOR`** (very sparse): always route
+///   to the walk. Driving so short a list, bit-testing the others, is cheaper
+///   than the flat-merge regardless of the others' density — this is the tier
+///   the walk always served.
+/// - **Rarest in `[1/ALWAYS, 1/AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR)`**
+///   (moderately sparse): route only when the others are collectively dense
+///   enough (see [`AND_MEMBERSHIP_OTHERS_DENSITY_MULT`]). This is the band the
+///   walk newly reaches — a discriminating term plus common ones — and the one
+///   that needs the density guard, because a moderately-sparse rarest with only
+///   moderately-common companions is handled better by the flat-merge's block
+///   decode + block-max skip.
+/// - **Rarest ≥ `1/RAREST_SPARSE_DIVISOR`**: never; the all-dense case (every
+///   term common) keeps the flat-merge.
+///
+/// The walk now carries the flat-merge's own Block-Max-AND heap-bar skip, so the
+/// middle tier no longer regresses the ranked tail (p99) the way a skip-less
+/// walk did when this was a flat `1/16` gate.
+pub(super) const AND_MEMBERSHIP_ALWAYS_DIVISOR: u64 = 64;
+
+/// Upper sparsity bound for the density-gated middle routing tier — see
+/// [`AND_MEMBERSHIP_ALWAYS_DIVISOR`]. A rarest term denser than `1/16` of the
+/// corpus never routes to the membership walk.
 pub(super) const AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR: u64 = 16;
+
+/// Density guard for the middle routing tier: the *other* terms must be
+/// collectively at least this many times denser than the driver (their combined
+/// df ≥ `MULT` × the rarest df). The walk's win is skipping the flat-merge's
+/// decode of the common terms' blocks; that only outweighs iterating the whole
+/// driver list when those others are much denser than the driver. When they are
+/// only moderately denser (e.g. three mid-frequency terms), the flat-merge's
+/// block decode is already cheap and its block-max skip prunes the driver, so it
+/// wins — routing such a query to the walk regressed it. Sparsity alone can't
+/// tell the two apart (same rarest term, different companions), so this ratio is
+/// the discriminator. Calibrated on the ranked-AND intersection set: middle-tier
+/// wins sit at ≥ ~38× and the one regression at ~4.5×, so `8` separates them
+/// with margin on both sides. (The very-sparse tier skips this check.)
+pub(super) const AND_MEMBERSHIP_OTHERS_DENSITY_MULT: u64 = 8;
 
 /// Multi-term OR dispatch floor. A 2-term OR is already sub-millisecond
 /// on MaxScore, so the window's per-window bookkeeping isn't worth it

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -329,13 +329,17 @@ pub(super) const OR_COUNT_BITSET_DENSITY_DIVISOR: u64 = 16;
 /// Rarest-term sparsity gate for the ranked-AND membership walk
 /// (`FtsReader::and_membership_scored`): route there only when the rarest term
 /// covers less than `1/N` of the doc-id space. The membership walk drives the
-/// rarest term's *entire* list (bit-testing the others) and gives up the
-/// flat-merge's block-max heap-bar skip, so it only pays when that list is
-/// genuinely short. A looser `1/16` (the count path's divisor) let moderately
-/// sparse rarest terms through and regressed the ranked tail (p99), where the
-/// bar-skip was doing real work; `1/64` restricts it to the clearly-rare∧common
-/// shape the walk targets. Bench-calibrated against the ranked-AND tail.
-pub(super) const AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR: u64 = 64;
+/// rarest term's *entire* list, bit-testing the others, so it only pays when
+/// that list is genuinely short relative to the corpus. It previously *also*
+/// gave up the flat-merge's block-max heap-bar skip, which forced a strict
+/// `1/64` gate — a looser `1/16` let moderately sparse rarest terms through and
+/// regressed the ranked tail (p99) where the bar-skip was doing real work. The
+/// walk now carries that same Block-Max-AND skip itself, so a moderately-sparse
+/// rarest term (rare∧common — one discriminating term plus stopwords, the
+/// common multi-term shape) can route here and still skip windows the bar rules
+/// out. Set to the count path's `1/16`; the all-dense case (every term a
+/// stopword) stays above the gate and keeps the flat-merge.
+pub(super) const AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR: u64 = 16;
 
 /// Multi-term OR dispatch floor. A 2-term OR is already sub-millisecond
 /// on MaxScore, so the window's per-window bookkeeping isn't worth it

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -728,54 +728,6 @@ impl TermCursor {
         Some(self.block_tfs[rank as usize])
     }
 
-    /// Tf for `doc` on a cursor a preceding [`Self::contains(doc)`] just confirmed
-    /// present. `contains` already advanced `current_block` to `doc`'s block (and,
-    /// on a PACKED block, decoded it), so this skips the block-advance and the
-    /// presence bit-test that [`Self::bitset_probe_tf`] repeats, doing only the tf
-    /// lookup: a popcount-rank into the tf array on a bitset block, or a binary
-    /// search over the decoded doc ids on a PACKED one. Only valid immediately
-    /// after `contains(doc)` returned `true` with no intervening advance.
-    pub(super) fn tf_at_contained(&mut self, doc: u32) -> u32 {
-        // Inline (df=1) cursor: single pre-decoded posting.
-        if self.bytes.is_empty() {
-            return self.block_tfs[0];
-        }
-        let block = self.blocks[self.current_block];
-        let raw = &self.bytes[block.block_byte_offset..block.block_byte_end];
-        if raw[posting::ENCODING_OFF] == posting::ENCODING_BITSET {
-            let base = read_u32_le(&raw[4..8]);
-            let bit = (doc - base) as usize;
-            let tf_bits = raw[2] as usize;
-            let tfs_size = BLOCK_LEN * tf_bits / 8;
-            let bitset_end = raw.len() - tfs_size;
-            let word_idx = bit / 64;
-            let word_at = posting::HEADER_SIZE + word_idx * 8;
-            let word = u64::from_le_bytes(raw[word_at..word_at + 8].try_into().expect("8 bytes"));
-            let presence = &raw[posting::HEADER_SIZE..bitset_end];
-            let mut rank: u32 = 0;
-            for w in presence[..word_idx * 8].chunks_exact(8) {
-                rank += u64::from_le_bytes(w.try_into().expect("8 bytes")).count_ones();
-            }
-            let below = if bit.is_multiple_of(64) {
-                0u64
-            } else {
-                (1u64 << (bit % 64)) - 1
-            };
-            rank += (word & below).count_ones();
-            if self.tf_decoded_block != self.current_block {
-                posting::decode_block_tfs(raw, &mut self.block_tfs);
-                self.tf_decoded_block = self.current_block;
-            }
-            self.block_tfs[rank as usize]
-        } else {
-            // PACKED: `contains` decoded this block's doc ids and tfs. Locate doc.
-            let pos = self.block_doc_ids[..self.block_n]
-                .binary_search(&doc)
-                .expect("contains(doc) confirmed presence");
-            self.block_tfs[pos]
-        }
-    }
-
     pub(super) fn is_exhausted(&self) -> bool {
         self.current_block >= self.blocks.len()
     }
@@ -1019,6 +971,59 @@ impl TermCursor {
             if self.current_block < self.blocks.len() {
                 self.decode_current_block();
             }
+        }
+    }
+
+    /// Tf for `doc` on a cursor a preceding [`Self::contains(doc)`] just confirmed
+    /// present. `contains` already advanced `current_block` to `doc`'s block (and,
+    /// on a PACKED block, decoded it), so this skips the block-advance and the
+    /// presence bit-test that [`Self::bitset_probe_tf`] repeats, doing only the tf
+    /// lookup: a popcount-rank into the tf array on a bitset block, or a binary
+    /// search over the decoded doc ids on a PACKED one. Only valid immediately
+    /// after `contains(doc)` returned `true` with no intervening advance.
+    ///
+    /// Kept at the end of the impl, past the doc-cursor hot methods
+    /// (`skip_to`, `next`, `decode_current_block`, `current_doc_id`), so adding
+    /// it doesn't shift their code offsets — those methods drive the flat-merge
+    /// AND path, which is measurably sensitive to its own instruction layout.
+    pub(super) fn tf_at_contained(&mut self, doc: u32) -> u32 {
+        // Inline (df=1) cursor: single pre-decoded posting.
+        if self.bytes.is_empty() {
+            return self.block_tfs[0];
+        }
+        let block = self.blocks[self.current_block];
+        let raw = &self.bytes[block.block_byte_offset..block.block_byte_end];
+        if raw[posting::ENCODING_OFF] == posting::ENCODING_BITSET {
+            let base = read_u32_le(&raw[4..8]);
+            let bit = (doc - base) as usize;
+            let tf_bits = raw[2] as usize;
+            let tfs_size = BLOCK_LEN * tf_bits / 8;
+            let bitset_end = raw.len() - tfs_size;
+            let word_idx = bit / 64;
+            let word_at = posting::HEADER_SIZE + word_idx * 8;
+            let word = u64::from_le_bytes(raw[word_at..word_at + 8].try_into().expect("8 bytes"));
+            let presence = &raw[posting::HEADER_SIZE..bitset_end];
+            let mut rank: u32 = 0;
+            for w in presence[..word_idx * 8].chunks_exact(8) {
+                rank += u64::from_le_bytes(w.try_into().expect("8 bytes")).count_ones();
+            }
+            let below = if bit.is_multiple_of(64) {
+                0u64
+            } else {
+                (1u64 << (bit % 64)) - 1
+            };
+            rank += (word & below).count_ones();
+            if self.tf_decoded_block != self.current_block {
+                posting::decode_block_tfs(raw, &mut self.block_tfs);
+                self.tf_decoded_block = self.current_block;
+            }
+            self.block_tfs[rank as usize]
+        } else {
+            // PACKED: `contains` decoded this block's doc ids and tfs. Locate doc.
+            let pos = self.block_doc_ids[..self.block_n]
+                .binary_search(&doc)
+                .expect("contains(doc) confirmed presence");
+            self.block_tfs[pos]
         }
     }
 }

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -658,6 +658,28 @@ impl TermCursor {
     /// (the doc ids must be decoded to locate the doc), so it falls back to
     /// `skip_to` + `current_tf`. Like [`Self::contains`] it advances
     /// `current_block`, so a cursor probed this way must not also be iterated.
+    /// Rank of the doc at in-block position `bit` among a bitset block's presence
+    /// bits — the count of set bits before `bit`, i.e. that doc's index into the
+    /// block's doc-order tf array. `word` is the presence word already loaded at
+    /// `bit`'s position; `bitset_end` is the end of the presence bitmap (start of
+    /// the tf array). Shared by [`Self::bitset_probe_tf`] (which first checks the
+    /// bit is set) and [`Self::tf_at_contained`] (which knows it is).
+    #[inline]
+    fn bitset_tf_rank(raw: &[u8], bit: usize, word: u64, bitset_end: usize) -> u32 {
+        let word_idx = bit / 64;
+        let presence = &raw[posting::HEADER_SIZE..bitset_end];
+        let mut rank: u32 = 0;
+        for w in presence[..word_idx * 8].chunks_exact(8) {
+            rank += u64::from_le_bytes(w.try_into().expect("8 bytes")).count_ones();
+        }
+        let below = if bit.is_multiple_of(64) {
+            0u64
+        } else {
+            (1u64 << (bit % 64)) - 1
+        };
+        rank + (word & below).count_ones()
+    }
+
     pub(super) fn bitset_probe_tf(&mut self, doc: u32) -> Option<u32> {
         while self.current_block < self.blocks.len()
             && self.blocks[self.current_block].last_doc_id < doc
@@ -702,20 +724,8 @@ impl TermCursor {
         if (word >> (bit % 64)) & 1 == 0 {
             return None; // doc not present in this block
         }
-        // Present. `rank` = number of set bits before `bit` = popcount of the
-        // whole presence words ahead of this one + popcount of this word below
-        // `bit`. The r-th set bit (doc) maps to the r-th tf in doc order.
-        let presence = &raw[posting::HEADER_SIZE..bitset_end];
-        let mut rank: u32 = 0;
-        for w in presence[..word_idx * 8].chunks_exact(8) {
-            rank += u64::from_le_bytes(w.try_into().expect("8 bytes")).count_ones();
-        }
-        let below = if bit.is_multiple_of(64) {
-            0u64
-        } else {
-            (1u64 << (bit % 64)) - 1
-        };
-        rank += (word & below).count_ones();
+        // Present: the r-th set bit (doc) maps to the r-th tf in doc order.
+        let rank = Self::bitset_tf_rank(raw, bit, word, bitset_end);
         // Decode this block's tf array once (doc order), reused across a run of
         // candidates in the same block; the doc ids are never expanded.
         if self.tf_decoded_block != self.current_block {
@@ -1002,17 +1012,7 @@ impl TermCursor {
             let word_idx = bit / 64;
             let word_at = posting::HEADER_SIZE + word_idx * 8;
             let word = u64::from_le_bytes(raw[word_at..word_at + 8].try_into().expect("8 bytes"));
-            let presence = &raw[posting::HEADER_SIZE..bitset_end];
-            let mut rank: u32 = 0;
-            for w in presence[..word_idx * 8].chunks_exact(8) {
-                rank += u64::from_le_bytes(w.try_into().expect("8 bytes")).count_ones();
-            }
-            let below = if bit.is_multiple_of(64) {
-                0u64
-            } else {
-                (1u64 << (bit % 64)) - 1
-            };
-            rank += (word & below).count_ones();
+            let rank = Self::bitset_tf_rank(raw, bit, word, bitset_end);
             if self.tf_decoded_block != self.current_block {
                 posting::decode_block_tfs(raw, &mut self.block_tfs);
                 self.tf_decoded_block = self.current_block;

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -728,6 +728,54 @@ impl TermCursor {
         Some(self.block_tfs[rank as usize])
     }
 
+    /// Tf for `doc` on a cursor a preceding [`Self::contains(doc)`] just confirmed
+    /// present. `contains` already advanced `current_block` to `doc`'s block (and,
+    /// on a PACKED block, decoded it), so this skips the block-advance and the
+    /// presence bit-test that [`Self::bitset_probe_tf`] repeats, doing only the tf
+    /// lookup: a popcount-rank into the tf array on a bitset block, or a binary
+    /// search over the decoded doc ids on a PACKED one. Only valid immediately
+    /// after `contains(doc)` returned `true` with no intervening advance.
+    pub(super) fn tf_at_contained(&mut self, doc: u32) -> u32 {
+        // Inline (df=1) cursor: single pre-decoded posting.
+        if self.bytes.is_empty() {
+            return self.block_tfs[0];
+        }
+        let block = self.blocks[self.current_block];
+        let raw = &self.bytes[block.block_byte_offset..block.block_byte_end];
+        if raw[posting::ENCODING_OFF] == posting::ENCODING_BITSET {
+            let base = read_u32_le(&raw[4..8]);
+            let bit = (doc - base) as usize;
+            let tf_bits = raw[2] as usize;
+            let tfs_size = BLOCK_LEN * tf_bits / 8;
+            let bitset_end = raw.len() - tfs_size;
+            let word_idx = bit / 64;
+            let word_at = posting::HEADER_SIZE + word_idx * 8;
+            let word = u64::from_le_bytes(raw[word_at..word_at + 8].try_into().expect("8 bytes"));
+            let presence = &raw[posting::HEADER_SIZE..bitset_end];
+            let mut rank: u32 = 0;
+            for w in presence[..word_idx * 8].chunks_exact(8) {
+                rank += u64::from_le_bytes(w.try_into().expect("8 bytes")).count_ones();
+            }
+            let below = if bit.is_multiple_of(64) {
+                0u64
+            } else {
+                (1u64 << (bit % 64)) - 1
+            };
+            rank += (word & below).count_ones();
+            if self.tf_decoded_block != self.current_block {
+                posting::decode_block_tfs(raw, &mut self.block_tfs);
+                self.tf_decoded_block = self.current_block;
+            }
+            self.block_tfs[rank as usize]
+        } else {
+            // PACKED: `contains` decoded this block's doc ids and tfs. Locate doc.
+            let pos = self.block_doc_ids[..self.block_n]
+                .binary_search(&doc)
+                .expect("contains(doc) confirmed presence");
+            self.block_tfs[pos]
+        }
+    }
+
     pub(super) fn is_exhausted(&self) -> bool {
         self.current_block >= self.blocks.len()
     }

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -1026,6 +1026,25 @@ impl TermCursor {
             self.block_tfs[pos]
         }
     }
+
+    /// Whether this term's postings are stored in the dense **bitset** encoding,
+    /// sampled from the first block's encoding byte (a dense term's blocks are
+    /// uniformly bitset). When true, [`Self::contains`] answers by an O(1)
+    /// bit-test instead of a block decode — the signal a 2-term AND uses to
+    /// decide the membership walk beats the flat-merge's block expansion.
+    pub(super) fn is_bitset_dense(&self) -> bool {
+        if self.bytes.is_empty() {
+            return false; // inline df=1 cursor: no postings bytes
+        }
+        match self.blocks.first() {
+            Some(block) => {
+                self.bytes
+                    .get(block.block_byte_offset + posting::ENCODING_OFF)
+                    == Some(&posting::ENCODING_BITSET)
+            }
+            None => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -1032,6 +1032,10 @@ impl TermCursor {
     /// uniformly bitset). When true, [`Self::contains`] answers by an O(1)
     /// bit-test instead of a block decode — the signal a 2-term AND uses to
     /// decide the membership walk beats the flat-merge's block expansion.
+    ///
+    /// `#[cold]`: called once per query at dispatch, not in a per-doc loop —
+    /// out-of-line so it stays clear of the hot doc-cursor methods' layout.
+    #[cold]
     pub(super) fn is_bitset_dense(&self) -> bool {
         if self.bytes.is_empty() {
             return false; // inline df=1 cursor: no postings bytes

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -241,16 +241,20 @@ fn block_max_and_bound(
 /// and a **sparse rarest term**: driving the rarest doc-by-doc is then cheap and
 /// bit-testing the common others beats decoding their blocks to align them.
 ///
-/// Two guards keep it off the shapes where the flat-merge is cheaper:
+/// Guards keep it off the shapes where the flat-merge is cheaper:
 /// - **≥3 terms**: a 2-term AND keeps the specialized `and_flat_merge_2term`
 ///   (two-pointer merge over the decoded blocks), which the membership walk was
 ///   losing to.
-/// - **rarest < 1/`AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR`**: the walk drives the
-///   rarest term's whole list, so it only pays when that list is short relative
-///   to the corpus. The walk now carries the flat-merge's Block-Max-AND heap-bar
-///   skip itself, so this gate can sit at `1/16` (a discriminating term plus
-///   stopwords) without the p99 regression a skip-less walk had; an all-dense
-///   AND stays above the gate on the flat-merge.
+/// - **rarest-term sparsity, in two tiers** (see [`AND_MEMBERSHIP_ALWAYS_DIVISOR`]):
+///   a very sparse rarest (`< 1/64`) always routes here — driving so short a list
+///   beats the flat-merge whatever the others' density. A moderately-sparse
+///   rarest (`[1/64, 1/16)`) routes only when the others are collectively much
+///   denser than it ([`AND_MEMBERSHIP_OTHERS_DENSITY_MULT`]), because that is
+///   where skipping their block decode outweighs iterating the driver; a
+///   moderately-sparse rarest with only moderately-common companions is left on
+///   the flat-merge. A rarest denser than `1/16` (the all-dense AND) also stays
+///   on the flat-merge. The walk carries the flat-merge's own Block-Max-AND
+///   heap-bar skip, so the middle tier doesn't regress the ranked tail (p99).
 fn and_prefer_membership(has_bitset_blocks: bool, cursors: &[TermCursor]) -> bool {
     if !has_bitset_blocks || cursors.len() < 3 {
         return false;
@@ -262,7 +266,19 @@ fn and_prefer_membership(has_bitset_blocks: bool, cursors: &[TermCursor]) -> boo
         .max()
         .unwrap_or(0);
     let min_df = cursors.iter().map(|c| c.df).min().unwrap_or(0);
-    min_df.saturating_mul(AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR) < u64::from(max_doc)
+    // Very sparse rarest term: always cheaper to drive it, whatever the others.
+    if min_df.saturating_mul(AND_MEMBERSHIP_ALWAYS_DIVISOR) < u64::from(max_doc) {
+        return true;
+    }
+    // Moderately sparse rarest term: only when the others are collectively much
+    // denser than it, so skipping their block decode is worth iterating the whole
+    // driver list. A denser rarest than this stays on the flat-merge.
+    if min_df.saturating_mul(AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR) < u64::from(max_doc) {
+        let total_df: u64 = cursors.iter().map(|c| c.df).sum();
+        let others_df = total_df.saturating_sub(min_df);
+        return others_df >= min_df.saturating_mul(AND_MEMBERSHIP_OTHERS_DENSITY_MULT);
+    }
+    false
 }
 
 impl FtsReader {
@@ -588,24 +604,35 @@ impl FtsReader {
     /// for each of its docs, probe every other term with
     /// [`TermCursor::bitset_probe_tf`] — a **bitset bit-test that also reads the
     /// matching tf by popcount-rank, with no doc-id block decode** — short-
-    /// circuiting on the first miss. A doc present in *every* term is scored by
-    /// `Σ` per-term BM25 (identical to the flat-merge) and emitted through the
+    /// circuiting on the first miss. Only a doc present in *every* term is scored
+    /// (`Σ` per-term BM25, identical to the flat-merge) and emitted through the
     /// generic sink. This skips the flat-merge's per-leader-doc `skip_to` that
     /// fully decodes a common term's 128-doc block just to align it — the
     /// profiled cost on an n≥3-term AND with a common term.
     ///
-    /// Unlike a plain membership walk, this keeps the flat-merge's **Block-Max-AND
-    /// heap-bar skip**: at each driver doc the driver's block-max plus each
-    /// other's block-max at that doc (read off the inspect pointer, no decode)
-    /// bound the window's best possible score; if it can't beat the kth-best,
-    /// the driver skips the whole window. That's what lets a moderately-sparse
-    /// rarest term (not just an extremely sparse one) route here without
-    /// forfeiting the pruning that protects the ranked tail — see
-    /// [`and_prefer_membership`]. Only the pure-AND path
-    /// ([`run_and_intersect`](Self::run_and_intersect), a `ScoreSink`) routes
-    /// here; must+should keeps the flat-merge so its should-clause scoring stays
-    /// in one place. Gated to the v4/v5 bitset case; the flat-merge stays for
-    /// v1–v3 and the all-dense case.
+    /// Two properties keep it competitive across the sparsity range the gate
+    /// ([`and_prefer_membership`]) admits:
+    /// - **Presence is tested before any tf is read.** A selective AND misses on
+    ///   most driver docs, and a miss can come after several common terms have
+    ///   already matched. Membership is checked with [`TermCursor::contains`]
+    ///   (a bitset bit-test) across all others first; only on a *full* match are
+    ///   the tfs read with [`TermCursor::bitset_probe_tf`] and the score summed.
+    ///   Reading the tf eagerly per matching term instead — a popcount-rank plus
+    ///   a one-time tf-array decode — is wasted whenever a later term misses, and
+    ///   on 5–7-term ANDs that waste dominated.
+    /// - **It keeps the flat-merge's Block-Max-AND heap-bar skip**, amortized
+    ///   over a window: the driver's block-max plus each other's block-max at the
+    ///   driver doc (inspect pointer, no decode) bound every score in
+    ///   `[doc, window_end]` (the smallest block boundary across the cursors); if
+    ///   that can't beat the kth-best the driver skips the whole window. Without
+    ///   it a moderately-sparse rarest term with a large intersection (small-`k`)
+    ///   would score every match; with it the walk keeps the tail protection that
+    ///   let the routing gate loosen.
+    ///
+    /// Only the pure-AND path ([`run_and_intersect`](Self::run_and_intersect), a
+    /// `ScoreSink`) routes here; must+should keeps the flat-merge so its
+    /// should-clause scoring stays in one place. Gated to the v4/v5 bitset case;
+    /// the flat-merge stays for v1–v3 and the all-dense case.
     fn and_membership_scored<S: AndSink>(
         &self,
         mut cursors: Vec<TermCursor>,
@@ -624,52 +651,71 @@ impl FtsReader {
         while !driver.is_exhausted() {
             let doc = driver.current_doc_id();
 
-            // Block-Max-AND pruning over [doc, window_end]: the driver's
+            // Block-Max-AND pruning, amortized over a window: the driver's
             // block-max plus each other term's block-max at `doc` (inspect
-            // pointer, no decode) upper-bounds every score in the window. If it
-            // can't beat the heap bar, skip the driver past the window. Same
-            // bound the flat-merge uses, so the walk keeps its heap-bar skip.
-            let bar = sink.bar();
-            if bar > f32::NEG_INFINITY {
+            // pointer, no decode) upper-bounds every score in `[doc, window_end]`,
+            // where `window_end` is the smallest block boundary across the
+            // cursors. If it can't beat the heap bar, skip the driver past the
+            // window; otherwise process every driver doc up to `window_end`
+            // before recomputing, so a sparse driver pays the bound per block,
+            // not per doc.
+            let window_end = if sink.bar() > f32::NEG_INFINITY {
                 let (ub, window_end) = block_max_and_bound(
                     driver.current_block_max_bm25(),
                     driver.current_block_last_doc_id(),
                     &mut others,
                     doc,
                 );
-                if ub <= bar {
+                if ub <= sink.bar() {
                     driver.skip_to(window_end.saturating_add(1));
                     continue;
                 }
-            }
-
-            // Probe each other term: a bitset bit-test that also reads the tf by
-            // popcount-rank, never expanding the block's doc ids. Any miss drops
-            // the doc from the intersection; short-circuit on it.
-            let norm = dl_norm_k1.get(doc);
-            let mut score = if need_score {
-                bm25::score_with_dl_norm_k1(driver.idf_x_k1p1, driver.current_tf(), norm)
+                window_end
             } else {
-                0.0
+                // No live bar (heap not yet full, or an unranked sink): nothing to
+                // prune against. Bound the batch to the driver's current block;
+                // the probes cross the others' blocks on their own.
+                driver.current_block_last_doc_id()
             };
-            let mut all_match = true;
-            for o in others.iter_mut() {
-                match o.bitset_probe_tf(doc) {
-                    Some(tf) => {
-                        if need_score {
-                            score += bm25::score_with_dl_norm_k1(o.idf_x_k1p1, tf, norm);
-                        }
-                    }
-                    None => {
+
+            loop {
+                let d = driver.current_doc_id();
+                // Cheap presence pass: bitset bit-test every other, short-circuit
+                // on the first miss. No tf is read here — a miss after k matching
+                // common terms would waste k popcount-rank + tf decodes.
+                let mut all_match = true;
+                for o in others.iter_mut() {
+                    if !o.contains(d) {
                         all_match = false;
                         break;
                     }
                 }
+                if all_match {
+                    let score = if need_score {
+                        let norm = dl_norm_k1.get(d);
+                        let mut s = bm25::score_with_dl_norm_k1(
+                            driver.idf_x_k1p1,
+                            driver.current_tf(),
+                            norm,
+                        );
+                        // Full match: now read each tf (bit-test + popcount-rank,
+                        // no doc-id decode). `contains` already positioned each
+                        // cursor on `d`'s block, so this doesn't re-seek.
+                        for o in others.iter_mut() {
+                            let tf = o.bitset_probe_tf(d).unwrap_or(0);
+                            s += bm25::score_with_dl_norm_k1(o.idf_x_k1p1, tf, norm);
+                        }
+                        s
+                    } else {
+                        0.0
+                    };
+                    sink.emit(d, score);
+                }
+                driver.next();
+                if driver.is_exhausted() || driver.current_doc_id() > window_end {
+                    break;
+                }
             }
-            if all_match {
-                sink.emit(doc, score);
-            }
-            driver.next();
         }
     }
 

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -242,9 +242,12 @@ fn block_max_and_bound(
 /// bit-testing the common others beats decoding their blocks to align them.
 ///
 /// Guards keep it off the shapes where the flat-merge is cheaper:
-/// - **≥3 terms**: a 2-term AND keeps the specialized `and_flat_merge_2term`
-///   (two-pointer merge over the decoded blocks), which the membership walk was
-///   losing to.
+/// - **2-term**: routes only when the common (denser) term is bitset-encoded
+///   ([`TermCursor::is_bitset_dense`]) and the rarer one is not — then `contains`
+///   bit-tests the common term instead of the specialized `and_flat_merge_2term`
+///   expanding its blocks (the ranked cost on `+the +X`). A PFOR common term
+///   keeps that two-pointer merge, which the walk doesn't beat when the probe
+///   must still decode. The sparsity tiers below are for **≥3 terms** only.
 /// - **rarest-term sparsity, in two tiers** (see [`AND_MEMBERSHIP_ALWAYS_DIVISOR`]):
 ///   a very sparse rarest (`< 1/64`) always routes here — driving so short a list
 ///   beats the flat-merge whatever the others' density. A moderately-sparse
@@ -256,7 +259,7 @@ fn block_max_and_bound(
 ///   on the flat-merge. The walk carries the flat-merge's own Block-Max-AND
 ///   heap-bar skip, so the middle tier doesn't regress the ranked tail (p99).
 fn and_prefer_membership(has_bitset_blocks: bool, cursors: &[TermCursor]) -> bool {
-    if !has_bitset_blocks || cursors.len() < 3 {
+    if !has_bitset_blocks || cursors.len() < 2 {
         return false;
     }
     let max_doc = cursors
@@ -265,6 +268,20 @@ fn and_prefer_membership(has_bitset_blocks: bool, cursors: &[TermCursor]) -> boo
         .map(|b| b.last_doc_id)
         .max()
         .unwrap_or(0);
+    if cursors.len() == 2 {
+        // 2-term: route only when the common (denser) term is bitset-encoded, so
+        // `contains` bit-tests it instead of the flat-merge expanding its blocks —
+        // the ranked cost on `+the +X`. A PFOR common (e.g. `+american +funds`)
+        // keeps the specialized 2-term two-pointer merge, which the walk doesn't
+        // beat when the probe must still decode. The rarer term must not itself be
+        // bitset-dense: an all-dense 2-term is left to the flat-merge/count kernels.
+        let (rare, common) = if cursors[0].df <= cursors[1].df {
+            (&cursors[0], &cursors[1])
+        } else {
+            (&cursors[1], &cursors[0])
+        };
+        return common.is_bitset_dense() && !rare.is_bitset_dense();
+    }
     let min_df = cursors.iter().map(|c| c.df).min().unwrap_or(0);
     // Very sparse rarest term: always cheaper to drive it, whatever the others.
     if min_df.saturating_mul(AND_MEMBERSHIP_ALWAYS_DIVISOR) < u64::from(max_doc) {

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -600,46 +600,33 @@ impl FtsReader {
         Ok(drain_top_k_desc(heap))
     }
 
-    /// Ranked AND via a rarest-driven membership walk. Iterate the rarest term;
-    /// for each of its docs, probe every other term with
-    /// [`TermCursor::bitset_probe_tf`] — a **bitset bit-test that also reads the
-    /// matching tf by popcount-rank, with no doc-id block decode** — short-
-    /// circuiting on the first miss. Only a doc present in *every* term is scored
-    /// (`Σ` per-term BM25, identical to the flat-merge) and emitted through the
-    /// generic sink. This skips the flat-merge's per-leader-doc `skip_to` that
-    /// fully decodes a common term's 128-doc block just to align it — the
-    /// profiled cost on an n≥3-term AND with a common term.
+    /// Ranked AND via a rarest-driven membership walk, for the rare∧common shape the
+    /// gate ([`and_prefer_membership`]) routes here. Example: `+the +book +of +life`
+    /// — drive `book` (the rarest term) and, for each of its docs, bit-test the
+    /// common terms (`the`, `of`, `life`) for presence. This avoids the flat-merge's
+    /// per-doc `skip_to`, which fully decodes a common term's 128-doc posting block
+    /// just to align it — the profiled cost when a rare term is AND-ed with common ones.
     ///
-    /// Two properties keep it competitive across the sparsity range the gate
-    /// ([`and_prefer_membership`]) admits:
-    /// - **Presence is tested before any tf is read.** A selective AND misses on
-    ///   most driver docs, and a miss can come after several common terms have
-    ///   already matched. Membership is checked with [`TermCursor::contains`]
-    ///   (a bitset bit-test) across all others first; only on a *full* match are
-    ///   the tfs read with [`TermCursor::tf_at_contained`] (reusing the block
-    ///   position `contains` left, no re-probe) and the score summed.
-    ///   Reading the tf eagerly per matching term instead — a popcount-rank plus
-    ///   a one-time tf-array decode — is wasted whenever a later term misses, and
-    ///   on 5–7-term ANDs that waste dominated.
-    /// - **It keeps the flat-merge's Block-Max-AND heap-bar skip**, amortized
-    ///   over a window: the driver's block-max plus each other's block-max at the
-    ///   driver doc (inspect pointer, no decode) bound every score in
-    ///   `[doc, window_end]` (the smallest block boundary across the cursors); if
-    ///   that can't beat the kth-best the driver skips the whole window. Without
-    ///   it a moderately-sparse rarest term with a large intersection (small-`k`)
-    ///   would score every match; with it the walk keeps the tail protection that
-    ///   let the routing gate loosen.
+    /// Per driver doc: [`TermCursor::contains`] each other term (an O(1) bitset
+    /// bit-test), short-circuiting on the first miss. Only a doc present in *every*
+    /// term is scored — `Σ` per-term BM25, the same score the flat-merge computes —
+    /// and emitted through the sink.
     ///
-    /// Only the pure-AND path ([`run_and_intersect`](Self::run_and_intersect), a
-    /// `ScoreSink`) routes here; must+should keeps the flat-merge so its
-    /// should-clause scoring stays in one place. Gated to the v4/v5 bitset case;
-    /// the flat-merge stays for v1–v3 and the all-dense case.
+    /// Two details make it pay off:
+    /// - **tf is read only on a full match**, via [`TermCursor::tf_at_contained`]
+    ///   (reusing the block position `contains` just left). Reading it during the
+    ///   presence probe instead wastes a popcount-rank whenever a later term misses —
+    ///   which dominated on 5–7-term ANDs.
+    /// - **the flat-merge's Block-Max-AND heap-bar skip is kept**, amortized per block
+    ///   window: if the driver's block-max plus each other's block-max at the driver
+    ///   doc can't beat the k-th best score, the driver skips the whole window.
+    ///   Without it a large intersection at small `k` would score every match.
     ///
-    /// `#[cold]` places this out of line, so growing it doesn't shift the layout
-    /// of the flat-merge scorers it shares this module with. The flat-merge AND
-    /// path is measurably sensitive to its own instruction placement, and moving
-    /// this walk aside kept an all-dense conjunction (which never routes here)
-    /// off the regression this code's size would otherwise have caused it.
+    /// Only [`run_and_intersect`](Self::run_and_intersect) (pure AND, a `ScoreSink`)
+    /// routes here; must+should stays on the flat-merge. `#[cold]` keeps this out of
+    /// line: the flat-merge shares this module and is sensitive to its own
+    /// instruction placement, so growing this walk must not shift it (an all-dense
+    /// conjunction that never routes here regressed purely from the code shift).
     #[cold]
     fn and_membership_scored<S: AndSink>(
         &self,

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -258,6 +258,10 @@ fn block_max_and_bound(
 ///   the flat-merge. A rarest denser than `1/16` (the all-dense AND) also stays
 ///   on the flat-merge. The walk carries the flat-merge's own Block-Max-AND
 ///   heap-bar skip, so the middle tier doesn't regress the ranked tail (p99).
+// `#[cold]`: this is a once-per-query dispatch decision, not per-doc hot code, so
+// place it out of line — keeping its size (and edits to it) from shifting the
+// layout of the flat-merge/membership scorers it shares this module with.
+#[cold]
 fn and_prefer_membership(has_bitset_blocks: bool, cursors: &[TermCursor]) -> bool {
     if !has_bitset_blocks || cursors.len() < 2 {
         return false;

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -634,6 +634,13 @@ impl FtsReader {
     /// `ScoreSink`) routes here; must+should keeps the flat-merge so its
     /// should-clause scoring stays in one place. Gated to the v4/v5 bitset case;
     /// the flat-merge stays for v1–v3 and the all-dense case.
+    ///
+    /// `#[cold]` places this out of line, so growing it doesn't shift the layout
+    /// of the flat-merge scorers it shares this module with. The flat-merge AND
+    /// path is measurably sensitive to its own instruction placement, and moving
+    /// this walk aside kept an all-dense conjunction (which never routes here)
+    /// off the regression this code's size would otherwise have caused it.
+    #[cold]
     fn and_membership_scored<S: AndSink>(
         &self,
         mut cursors: Vec<TermCursor>,

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -616,7 +616,8 @@ impl FtsReader {
     ///   most driver docs, and a miss can come after several common terms have
     ///   already matched. Membership is checked with [`TermCursor::contains`]
     ///   (a bitset bit-test) across all others first; only on a *full* match are
-    ///   the tfs read with [`TermCursor::bitset_probe_tf`] and the score summed.
+    ///   the tfs read with [`TermCursor::tf_at_contained`] (reusing the block
+    ///   position `contains` left, no re-probe) and the score summed.
     ///   Reading the tf eagerly per matching term instead — a popcount-rank plus
     ///   a one-time tf-array decode — is wasted whenever a later term misses, and
     ///   on 5–7-term ANDs that waste dominated.
@@ -702,7 +703,7 @@ impl FtsReader {
                         // no doc-id decode). `contains` already positioned each
                         // cursor on `d`'s block, so this doesn't re-seek.
                         for o in others.iter_mut() {
-                            let tf = o.bitset_probe_tf(d).unwrap_or(0);
+                            let tf = o.tf_at_contained(d);
                             s += bm25::score_with_dl_norm_k1(o.idf_x_k1p1, tf, norm);
                         }
                         s

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -235,20 +235,22 @@ fn block_max_and_bound(
 }
 
 /// Route a ranked AND to the membership walk ([`FtsReader::and_membership_scored`])
-/// instead of the block flat-merge. True only for v4 blobs — where a common
-/// term's blocks are bitset-encoded, so [`TermCursor::contains`] is an O(1)
-/// bit-test — with **≥3 terms** and a **very sparse rarest term**: driving the
-/// rarest doc-by-doc is then cheap and bit-testing the common others beats
-/// decoding their blocks to align them.
+/// instead of the block flat-merge. True only for v4/v5 blobs — where a common
+/// term's blocks are bitset-encoded, so a membership probe is an O(1) bit-test
+/// (plus a popcount-rank for the tf) with no doc-id decode — with **≥3 terms**
+/// and a **sparse rarest term**: driving the rarest doc-by-doc is then cheap and
+/// bit-testing the common others beats decoding their blocks to align them.
 ///
-/// Two guards keep it off the shapes where it regressed the ranked tail:
+/// Two guards keep it off the shapes where the flat-merge is cheaper:
 /// - **≥3 terms**: a 2-term AND keeps the specialized `and_flat_merge_2term`
 ///   (two-pointer merge over the decoded blocks), which the membership walk was
 ///   losing to.
-/// - **rarest < 1/`AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR`**: the walk gives up the
-///   flat-merge's heap-bar block skip, so it only pays when the rarest list is
-///   genuinely short. A looser bound regressed p99 where the bar-skip was
-///   working.
+/// - **rarest < 1/`AND_MEMBERSHIP_RAREST_SPARSE_DIVISOR`**: the walk drives the
+///   rarest term's whole list, so it only pays when that list is short relative
+///   to the corpus. The walk now carries the flat-merge's Block-Max-AND heap-bar
+///   skip itself, so this gate can sit at `1/16` (a discriminating term plus
+///   stopwords) without the p99 regression a skip-less walk had; an all-dense
+///   AND stays above the gate on the flat-merge.
 fn and_prefer_membership(has_bitset_blocks: bool, cursors: &[TermCursor]) -> bool {
     if !has_bitset_blocks || cursors.len() < 3 {
         return false;
@@ -582,22 +584,28 @@ impl FtsReader {
         Ok(drain_top_k_desc(heap))
     }
 
-    /// Ranked AND via the same rarest-driven membership walk that the unranked
-    /// count path uses ([`count_and_intersect_membership`]), but scoring the
-    /// matches. Iterate the rarest term; for each of its docs, probe the others
-    /// with [`TermCursor::contains`] — a **bitset bit-test with no block decode**
-    /// — short-circuiting on the first miss. Only a doc present in *every* term
-    /// is materialized (decoded + positioned via [`TermCursor::materialize_at`])
-    /// and scored. This skips the flat-merge's per-leader-doc `skip_to` that
-    /// fully decodes a common term's 128-doc block to read one doc — the profiled
-    /// cost on n≥3-term AND with a common term. Score is `Σ` per-term BM25 at the
-    /// doc, identical to the flat-merge; emitted through the generic sink, so the
-    /// walk is written against any [`AndSink`]. Only the pure-AND path
-    /// ([`run_and_intersect`](Self::run_and_intersect), a `ScoreSink`) routes here
-    /// today; must+should keeps the flat-merge so its should-clause scoring stays
-    /// in one place. Gated to the v4 bitset case with a sparse rarest term (see
-    /// [`and_prefer_membership`]); the flat-merge stays for v1–v3 and the
-    /// all-dense case.
+    /// Ranked AND via a rarest-driven membership walk. Iterate the rarest term;
+    /// for each of its docs, probe every other term with
+    /// [`TermCursor::bitset_probe_tf`] — a **bitset bit-test that also reads the
+    /// matching tf by popcount-rank, with no doc-id block decode** — short-
+    /// circuiting on the first miss. A doc present in *every* term is scored by
+    /// `Σ` per-term BM25 (identical to the flat-merge) and emitted through the
+    /// generic sink. This skips the flat-merge's per-leader-doc `skip_to` that
+    /// fully decodes a common term's 128-doc block just to align it — the
+    /// profiled cost on an n≥3-term AND with a common term.
+    ///
+    /// Unlike a plain membership walk, this keeps the flat-merge's **Block-Max-AND
+    /// heap-bar skip**: at each driver doc the driver's block-max plus each
+    /// other's block-max at that doc (read off the inspect pointer, no decode)
+    /// bound the window's best possible score; if it can't beat the kth-best,
+    /// the driver skips the whole window. That's what lets a moderately-sparse
+    /// rarest term (not just an extremely sparse one) route here without
+    /// forfeiting the pruning that protects the ranked tail — see
+    /// [`and_prefer_membership`]. Only the pure-AND path
+    /// ([`run_and_intersect`](Self::run_and_intersect), a `ScoreSink`) routes
+    /// here; must+should keeps the flat-merge so its should-clause scoring stays
+    /// in one place. Gated to the v4/v5 bitset case; the flat-merge stays for
+    /// v1–v3 and the all-dense case.
     fn and_membership_scored<S: AndSink>(
         &self,
         mut cursors: Vec<TermCursor>,
@@ -612,21 +620,53 @@ impl FtsReader {
             .unwrap_or(0);
         let mut driver = cursors.swap_remove(driver_idx);
         let mut others = cursors;
+        let need_score = sink.needs_score();
         while !driver.is_exhausted() {
             let doc = driver.current_doc_id();
-            if others.iter_mut().all(|o| o.contains(doc)) {
-                let score = if sink.needs_score() {
-                    let norm = dl_norm_k1.get(doc);
-                    let mut s =
-                        bm25::score_with_dl_norm_k1(driver.idf_x_k1p1, driver.current_tf(), norm);
-                    for o in others.iter_mut() {
-                        o.materialize_at(doc);
-                        s += bm25::score_with_dl_norm_k1(o.idf_x_k1p1, o.current_tf(), norm);
+
+            // Block-Max-AND pruning over [doc, window_end]: the driver's
+            // block-max plus each other term's block-max at `doc` (inspect
+            // pointer, no decode) upper-bounds every score in the window. If it
+            // can't beat the heap bar, skip the driver past the window. Same
+            // bound the flat-merge uses, so the walk keeps its heap-bar skip.
+            let bar = sink.bar();
+            if bar > f32::NEG_INFINITY {
+                let (ub, window_end) = block_max_and_bound(
+                    driver.current_block_max_bm25(),
+                    driver.current_block_last_doc_id(),
+                    &mut others,
+                    doc,
+                );
+                if ub <= bar {
+                    driver.skip_to(window_end.saturating_add(1));
+                    continue;
+                }
+            }
+
+            // Probe each other term: a bitset bit-test that also reads the tf by
+            // popcount-rank, never expanding the block's doc ids. Any miss drops
+            // the doc from the intersection; short-circuit on it.
+            let norm = dl_norm_k1.get(doc);
+            let mut score = if need_score {
+                bm25::score_with_dl_norm_k1(driver.idf_x_k1p1, driver.current_tf(), norm)
+            } else {
+                0.0
+            };
+            let mut all_match = true;
+            for o in others.iter_mut() {
+                match o.bitset_probe_tf(doc) {
+                    Some(tf) => {
+                        if need_score {
+                            score += bm25::score_with_dl_norm_k1(o.idf_x_k1p1, tf, norm);
+                        }
                     }
-                    s
-                } else {
-                    0.0
-                };
+                    None => {
+                        all_match = false;
+                        break;
+                    }
+                }
+            }
+            if all_match {
                 sink.emit(doc, score);
             }
             driver.next();

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -942,6 +942,75 @@ async fn oracle_and_membership_middle_tier_multiblock_matches_brute_force() {
 }
 
 #[tokio::test]
+async fn oracle_and_membership_reads_tf_above_one() {
+    // `tf_at_contained` reads a matched *non-leader* term's tf on a full match —
+    // by popcount-rank on a bitset block, or binary-search on a PACKED block. The
+    // other membership oracles plant each term once per doc (tf = 1), so a read
+    // that ignored the tf array and returned a constant would pass them. Here the
+    // two non-leader terms appear a *varying* number of times in the matched docs,
+    // so a wrong tf read gives a wrong BM25 score. `common` (df = N, fully dense ⇒
+    // bitset blocks) exercises the rank path; `mid` (df ≈ N/4 ⇒ PFOR blocks) the
+    // binary-search path. `rare` is the sparse leader (df 10 < N/64 ⇒ membership).
+    const N: u64 = 1000; // multi-block; `common` forms bitset blocks
+    let common_tf = |g: u64| 1 + g % 4; // 1..4 across the 10 matched docs
+    let mid_tf = |g: u64| 1 + g % 3; // 1..3 across the 10 matched docs
+    let owned: Vec<(u64, String)> = (0..N)
+        .map(|i| {
+            let g = i / 100;
+            let mut s = String::new();
+            for _ in 0..common_tf(g) {
+                s.push_str("common ");
+            }
+            if i % 4 == 0 {
+                for _ in 0..mid_tf(g) {
+                    s.push_str("mid ");
+                }
+            }
+            if i % 100 == 0 {
+                s.push_str("rare ");
+            }
+            // Keep doc length < `bm25::LEN_QUANT_EXACT_MAX` (16) so the length norm
+            // is lossless and infino's scores equal textbook BM25 exactly.
+            s.push_str(&format!("f{}", i % 7));
+            (i, s)
+        })
+        .collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let infino = build_infino_superfile(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+    let terms = ["common".to_string(), "mid".to_string(), "rare".to_string()];
+
+    let k = 64usize; // > intersection (10) ⇒ whole match set, checkable exactly
+    let got: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "common mid rare", k, BoolMode::And)
+        .await
+        .expect("AND search")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    // rare docs (i % 100 == 0) also carry common and mid (i % 100 == 0 ⇒ i % 4 ==
+    // 0), so the intersection is exactly the 10 rare docs.
+    let want_set: HashSet<u64> = (0..N).filter(|i| i % 100 == 0).collect();
+    let got_set: HashSet<u64> = got.iter().map(|&(d, _)| d).collect();
+    assert_eq!(got_set, want_set, "intersection must be the 10 rare docs");
+    // At least one matched doc has a non-leader tf > 1 — otherwise the test would
+    // not exercise the tf read at all (guards against a future corpus change).
+    assert!(
+        (0..N).any(|i| i % 100 == 0 && (common_tf(i / 100) > 1 || mid_tf(i / 100) > 1)),
+        "corpus must plant tf > 1 on a matched non-leader term"
+    );
+    let want: HashMap<u64, f32> = oracle.top_k_terms_and(&terms, k).into_iter().collect();
+    for (d, s) in &got {
+        assert!(
+            (s - want[d]).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "membership tf>1 score mismatch on doc {d}: infino={s} oracle={}",
+            want[d]
+        );
+    }
+}
+
+#[tokio::test]
 async fn oracle_and_single_term_routed_consistently() {
     // BoolMode::And with a single term must route the same as
     // BoolMode::Or (both fall through to the single-term BMW path).

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -846,7 +846,7 @@ async fn oracle_and_membership_middle_tier_multiblock_matches_brute_force() {
     // 3..=15 assigned by a permutation (5 coprime to 13) so score order is shuffled
     // relative to doc id. Every other mid doc is a filler (dl 40).
     let winner_pad = |j: u64| -> Option<usize> {
-        if j >= 15 && j % 15 == 0 && j / 15 <= WINNERS {
+        if j >= 15 && j.is_multiple_of(15) && j / 15 <= WINNERS {
             Some((((j / 15 - 1) * 5) % 13) as usize) // 0..12 ⇒ dl 3..=15, distinct, lossless
         } else {
             None

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -816,6 +816,98 @@ async fn oracle_and_membership_rejects_partial_matches() {
 }
 
 #[tokio::test]
+async fn oracle_and_membership_middle_tier_multiblock_matches_brute_force() {
+    // The middle routing tier: a *moderately*-sparse rarest term (df in
+    // [max_doc/64, max_doc/16)) reaches `and_membership_scored` only because the
+    // other terms are collectively >= 8x denser — the `+the +book +of +life`
+    // shape, a route the very-sparse membership oracles above never take. Its
+    // intersection also spans many posting blocks, so the walk's amortized
+    // Block-Max-AND window skip has to cross blocks correctly: the very-sparse
+    // oracles prune over a <=9-doc intersection, so a window-skip that
+    // miscomputed its end (dropping a valid top-k doc) would show up here, not
+    // there.
+    const N: u64 = 4000; // ~32 posting blocks of 128
+    // `common` and `also` are in every doc: dense, bitset-encoded, df = N each.
+    // `mid` (every 20th doc, df 200) is the rarest: above N/64 = 62 (so not the
+    // always-take tier) and below N/16 = 250, with others' df (2N) >= 8 * 200, so
+    // the density-gated middle tier routes it to the walk.
+    let owned: Vec<(u64, String)> = (0..N)
+        .map(|i| {
+            let mut s = String::from("common also");
+            if i % 20 == 0 {
+                s.push_str(" mid");
+            }
+            // Vary doc length so BM25 dl-norm (and thus scores) differ across the
+            // intersection, giving the truncated top-k something to rank.
+            (i, format!("{s} f{}", i % 13))
+        })
+        .collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let infino = build_infino_superfile(&refs);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&refs, tok.as_ref());
+    let terms = ["common".to_string(), "also".to_string(), "mid".to_string()];
+
+    // Full match set (k exceeds the 200-doc intersection): exact intersection + scores.
+    let k_full = 300usize;
+    let got: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "common also mid", k_full, BoolMode::And)
+        .await
+        .expect("AND search")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    let want_set: HashSet<u64> = (0..N).filter(|i| i % 20 == 0).collect();
+    let got_set: HashSet<u64> = got.iter().map(|&(d, _)| d).collect();
+    assert_eq!(
+        got_set, want_set,
+        "middle-tier membership AND must return exactly the intersection (docs divisible by 20)"
+    );
+    assert!(
+        want_set.len() > 128,
+        "intersection ({}) must span multiple posting blocks to exercise cross-block pruning",
+        want_set.len()
+    );
+    let want: HashMap<u64, f32> = oracle.top_k_terms_and(&terms, k_full).into_iter().collect();
+    for (d, s) in &got {
+        assert!(
+            (s - want[d]).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "middle-tier score mismatch on doc {d}: infino={s} oracle={}",
+            want[d]
+        );
+    }
+
+    // Truncated top-k, k << intersection: the heap fills, the bar rises, and the
+    // Block-Max-AND window skip fires repeatedly across blocks. It must still keep
+    // the k highest-scoring matches. Compare score multisets so a tie at the k-th
+    // place isn't flaky.
+    let k_trunc = 5usize;
+    let got_trunc: Vec<f32> = infino
+        .bm25_hits_async("title", "common also mid", k_trunc, BoolMode::And)
+        .await
+        .expect("truncated AND search")
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect();
+    assert_eq!(
+        got_trunc.len(),
+        k_trunc,
+        "truncated AND must return exactly k"
+    );
+    let want_trunc: Vec<f32> = oracle
+        .top_k_terms_and(&terms, k_trunc)
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect();
+    for (g, w) in got_trunc.iter().zip(want_trunc.iter()) {
+        assert!(
+            (g - w).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "middle-tier truncated score mismatch: infino={g} oracle={w}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn oracle_and_single_term_routed_consistently() {
     // BoolMode::And with a single term must route the same as
     // BoolMode::Or (both fall through to the single-term BMW path).

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -821,25 +821,50 @@ async fn oracle_and_membership_middle_tier_multiblock_matches_brute_force() {
     // [max_doc/64, max_doc/16)) reaches `and_membership_scored` only because the
     // other terms are collectively >= 8x denser — the `+the +book +of +life`
     // shape, a route the very-sparse membership oracles above never take. Its
-    // intersection also spans many posting blocks, so the walk's amortized
-    // Block-Max-AND window skip has to cross blocks correctly: the very-sparse
-    // oracles prune over a <=9-doc intersection, so a window-skip that
-    // miscomputed its end (dropping a valid top-k doc) would show up here, not
-    // there.
-    const N: u64 = 4000; // ~32 posting blocks of 128
-    // `common` and `also` are in every doc: dense, bitset-encoded, df = N each.
-    // `mid` (every 20th doc, df 200) is the rarest: above N/64 = 62 (so not the
-    // always-take tier) and below N/16 = 250, with others' df (2N) >= 8 * 200, so
-    // the density-gated middle tier routes it to the walk.
+    // 200-doc intersection is spread across the whole doc-id range, so the walk's
+    // amortized Block-Max-AND window skip re-bounds across the common terms' ~32
+    // posting blocks (the very-sparse oracles prune over a <=9-doc intersection).
+    //
+    // To make the skip's correctness observable, 13 of the intersecting docs are
+    // "winners" with DISTINCT short lengths, placed at scattered doc ids; the rest
+    // are longer, uniformly lower-scoring fillers. Distinct lengths give distinct
+    // scores, so a small-k top-k has a well-defined answer; scattering the winners
+    // means the walk must fill the heap (bar rises, skip fires) yet still reach
+    // every winner — a skip that jumped past a winner's block would return the
+    // wrong doc-id SET, which the exact set check below catches.
+    //
+    // Lengths are kept < `bm25::LEN_QUANT_EXACT_MAX` (16): in that region infino's
+    // one-byte length norm is lossless, so winner scores equal textbook BM25
+    // exactly. Filler lengths sit above it (byte-quantized, ~6% error), so their
+    // scores are intentionally not compared to the exact-length oracle.
+    const N: u64 = 4000; // common/also span ~32 posting blocks of 128
+    const WINNERS: u64 = 13; // 13 distinct lengths fit the lossless region (dl 3..=15)
+    // `common`/`also`: every doc, dense bitset lists, df = N. `mid`: every 20th doc
+    // (df 200) — above N/64 = 62 (not the always tier) and below N/16 = 250, with
+    // others' df (2N) >= 8 * 200, so the density-gated middle tier routes here.
+    // Winner at every 15th mid doc (j = i/20 in 15,30,..,195): a distinct length
+    // 3..=15 assigned by a permutation (5 coprime to 13) so score order is shuffled
+    // relative to doc id. Every other mid doc is a filler (dl 40).
+    let winner_pad = |j: u64| -> Option<usize> {
+        if j >= 15 && j % 15 == 0 && j / 15 <= WINNERS {
+            Some((((j / 15 - 1) * 5) % 13) as usize) // 0..12 ⇒ dl 3..=15, distinct, lossless
+        } else {
+            None
+        }
+    };
     let owned: Vec<(u64, String)> = (0..N)
         .map(|i| {
             let mut s = String::from("common also");
             if i % 20 == 0 {
                 s.push_str(" mid");
+                let pad = winner_pad(i / 20).unwrap_or(37); // filler ⇒ dl 40 (quantized, low)
+                for _ in 0..pad {
+                    s.push_str(" pad");
+                }
+            } else {
+                s.push_str(&format!(" f{}", i % 13));
             }
-            // Vary doc length so BM25 dl-norm (and thus scores) differ across the
-            // intersection, giving the truncated top-k something to rank.
-            (i, format!("{s} f{}", i % 13))
+            (i, s)
         })
         .collect();
     let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
@@ -848,7 +873,8 @@ async fn oracle_and_membership_middle_tier_multiblock_matches_brute_force() {
     let oracle = BruteForceBm25::index(&refs, tok.as_ref());
     let terms = ["common".to_string(), "also".to_string(), "mid".to_string()];
 
-    // Full match set (k exceeds the 200-doc intersection): exact intersection + scores.
+    // Full match set (k exceeds the 200-doc intersection): the walk must return
+    // exactly the intersection, regardless of scores.
     let k_full = 300usize;
     let got: Vec<(u64, f32)> = infino
         .bm25_hits_async("title", "common also mid", k_full, BoolMode::And)
@@ -868,43 +894,51 @@ async fn oracle_and_membership_middle_tier_multiblock_matches_brute_force() {
         "intersection ({}) must span multiple posting blocks to exercise cross-block pruning",
         want_set.len()
     );
-    let want: HashMap<u64, f32> = oracle.top_k_terms_and(&terms, k_full).into_iter().collect();
-    for (d, s) in &got {
+
+    // The winners are in the lossless length region, so their scores must match
+    // textbook BM25 exactly (fillers' quantized scores are not checked).
+    let infino_score: HashMap<u64, f32> = got.iter().copied().collect();
+    let oracle_score: HashMap<u64, f32> =
+        oracle.top_k_terms_and(&terms, k_full).into_iter().collect();
+    let winners: Vec<u64> = (0..N)
+        .filter(|&i| i % 20 == 0 && winner_pad(i / 20).is_some())
+        .collect();
+    assert_eq!(
+        winners.len(),
+        WINNERS as usize,
+        "expected {WINNERS} winners"
+    );
+    for d in &winners {
+        let (inf, orc) = (infino_score[d], oracle_score[d]);
         assert!(
-            (s - want[d]).abs() < BM25_SCORE_ABS_TOLERANCE,
-            "middle-tier score mismatch on doc {d}: infino={s} oracle={}",
-            want[d]
+            (inf - orc).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "middle-tier winner score mismatch on doc {d}: infino={inf} oracle={orc}"
         );
     }
 
-    // Truncated top-k, k << intersection: the heap fills, the bar rises, and the
-    // Block-Max-AND window skip fires repeatedly across blocks. It must still keep
-    // the k highest-scoring matches. Compare score multisets so a tie at the k-th
-    // place isn't flaky.
-    let k_trunc = 5usize;
-    let got_trunc: Vec<f32> = infino
-        .bm25_hits_async("title", "common also mid", k_trunc, BoolMode::And)
+    // Truncated top-k, k < WINNERS < intersection: the heap fills, the bar rises,
+    // and the Block-Max-AND window skip fires across the range. The winners are the
+    // only distinct-score docs and outscore every filler, so the top-k is exactly
+    // the k highest winners — assert that doc-id SET against textbook. A skip that
+    // dropped a scattered winner would return the wrong set.
+    let k = 10usize;
+    let got_topk: HashSet<u64> = infino
+        .bm25_hits_async("title", "common also mid", k, BoolMode::And)
         .await
         .expect("truncated AND search")
         .into_iter()
-        .map(|(_, s)| s)
+        .map(|(d, _)| d as u64)
         .collect();
-    assert_eq!(
-        got_trunc.len(),
-        k_trunc,
-        "truncated AND must return exactly k"
-    );
-    let want_trunc: Vec<f32> = oracle
-        .top_k_terms_and(&terms, k_trunc)
+    let want_topk: HashSet<u64> = oracle
+        .top_k_terms_and(&terms, k)
         .into_iter()
-        .map(|(_, s)| s)
+        .map(|(d, _)| d)
         .collect();
-    for (g, w) in got_trunc.iter().zip(want_trunc.iter()) {
-        assert!(
-            (g - w).abs() < BM25_SCORE_ABS_TOLERANCE,
-            "middle-tier truncated score mismatch: infino={g} oracle={w}"
-        );
-    }
+    assert_eq!(got_topk.len(), k, "truncated AND must return exactly k");
+    assert_eq!(
+        got_topk, want_topk,
+        "middle-tier truncated top-{k} must return the exact highest-scoring doc set"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

A ranked multi-term AND that mixes one discriminating term with common ones
(`+the +book +of +life`, `+secretary +of +state`, `+lord +of +the +rings`) runs
the block flat-merge, which decodes each common term's 128-doc posting block just
to align it against the rare term — the dominant cost on these queries, since the
common terms' blocks are large and mostly irrelevant.

## Change

Route those conjunctions to a rarest-driven membership walk instead: drive the
rarest term, and for each of its docs test the common terms for presence with a
bitset bit-test (`contains`), reading a term's frequency only on a full match via
a popcount-rank (`tf_at_contained`) — **never decoding the common terms' doc-id
blocks.** The walk keeps the flat-merge's Block-Max-AND heap-bar skip (amortized
per window), so it doesn't forfeit top-k pruning.

Routing (`and_prefer_membership`) is two-tier on the rarest term's document
frequency: a very sparse rarest (< 1/64 of the corpus) always takes the walk; a
moderately-sparse rarest ([1/64, 1/16)) takes it only when the other terms are
collectively ≥ 8× denser, which is exactly when skipping their block decode beats
iterating the driver. Denser-rarest and all-common conjunctions stay on the
flat-merge, unchanged.

The same idea extends to the **2-term** case (`+the +X`): when the common term is
bitset-encoded (`is_bitset_dense`) and the rarer one is not, the walk bit-tests
the common term instead of the specialized two-pointer merge expanding its dense
blocks. A PFOR common term (e.g. `+american +funds`) keeps that two-pointer merge,
which the walk doesn't beat when the probe must still decode.

## Results

Measured on a 5M-document English-Wikipedia full-text index (single compacted
segment), ranked TOP-k, branch vs. `main`, same index:

- `+the +book +of +life`: TOP_10 **-39%**, TOP_100 **-39%**, TOP_1000 **-37%**
- 300 distinct intersection queries, TOP_1000: 3-term **-19%**, 4-term **-29%**,
  aggregate **-10%**
- 2-term `+the +X` (bitset common): `+the +book` TOP_1000 **-51%**,
  `+the +incredibles` **-27%**, `+the +who` TOP_1000 **-21%**.
- PFOR-common 2-term (`+american +funds`, `+body +painting`) and all-common
  conjunctions (`+to +be +or +not +to +be`): at parity — they stay on the
  flat-merge.

`COUNT` and every match set are byte-for-byte identical to `main`.

## Testing

Read-path only — no format change, and no new `unsafe`.

The walk is checked against a textbook BM25 brute-force scorer (independent of the
optimized walks):

- The existing membership-path oracles exercise the walk end to end — the
  presence probe and its reject/short-circuit path, the per-match term-frequency
  read on **both** block encodings (bitset popcount-rank and PFOR binary-search),
  multi-`other` scoring, and the Block-Max-AND heap-bar skip on a truncated top-k.
- New oracle `oracle_and_membership_middle_tier_multiblock_matches_brute_force`
  covers what those didn't: the **density-gated middle routing tier** (a
  moderately-sparse rarest term with much-denser companions — the shape this PR
  targets, which the pre-existing oracles never routed to) over a **200-doc
  intersection spanning ~32 posting blocks**, so the window-skip pruning has to
  cross blocks correctly. Both the full match set and a truncated top-k are
  compared to brute force.
- The property-fuzz BM25 oracle (uniform and skewed vocabularies) exercises the
  router branches across randomized corpora and queries.

The routing *decision* (walk vs. flat-merge) is a performance choice — both paths
return identical results — so it is guarded by the benchmarks above rather than
the correctness oracles.

## Note on code placement

The membership walk shares its module with the block flat-merge, whose hot
doc-walk is measurably sensitive to its own instruction placement. `#[cold]` on
the walk and keeping `tf_at_contained` past the hot cursor methods hold that
layout steady, so an all-common conjunction — which never routes to the walk —
stays at parity rather than drifting from the added code.
