### PR TITLE
fix: retain block cache on reopen

### DIFF
--- a/src/supertable/reader_cache/block_source.rs
+++ b/src/supertable/reader_cache/block_source.rs
@@ -175,14 +175,11 @@ impl BlockCachedSource {
         }
         self.state
             .get_or_init(|| {
-                // Publish a FRESH inode rather than truncating in place. Remove
-                // the old name first: a reader still holding the previous
-                // `.blocks` inode keeps its bytes (POSIX unlink-while-open),
-                // while this source gets its own inode to fill. `create_new`
-                // then refuses to reopen an existing inode, so a concurrent
-                // same-path source fails cleanly (degrading to a passthrough
-                // read) instead of truncating a live reader's blocks.
+                if let Some(adopted) = self.try_adopt(size) {
+                    return Some(adopted);
+                }
                 let _ = fs::remove_file(&self.path);
+                let _ = fs::remove_file(self.idx_path());
                 let file = fs::OpenOptions::new()
                     .read(true)
                     .write(true)
@@ -197,6 +194,58 @@ impl BlockCachedSource {
                 })
             })
             .as_ref()
+    }
+
+    fn idx_path(&self) -> PathBuf {
+        let mut p = self.path.clone().into_os_string();
+        p.push(".idx");
+        PathBuf::from(p)
+    }
+
+    /// Adopt a prior generation's sparse file when its persisted index proves
+    /// which ranges are valid (immutable superfile, so size-match is enough).
+    fn try_adopt(&self, size: u64) -> Option<BlockFile> {
+        let meta = fs::metadata(&self.path).ok()?;
+        if meta.len() != size {
+            return None;
+        }
+        let idx_bytes = fs::read(self.idx_path()).ok()?;
+        let bitmap = RoaringBitmap::deserialize_from(idx_bytes.as_slice()).ok()?;
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&self.path)
+            .ok()?;
+        let adopted_bytes: u64 = bitmap.iter().map(|b| Self::block_len(size, b)).sum();
+        if self.owns_accounting
+            && let Some(store) = self.store.upgrade()
+        {
+            store.account_adopted_bytes(adopted_bytes);
+        }
+        self.filled_bytes.store(adopted_bytes, Ordering::Release);
+        *self.filled.lock().expect("filled bitmap mutex poisoned") = bitmap;
+        Some(BlockFile {
+            file,
+            size,
+            mmap: OnceLock::new(),
+        })
+    }
+
+    /// Persist the filled-block bitmap, always after the blocks it describes so
+    /// the index never claims a block that was not written.
+    fn persist_idx(&self) {
+        let filled = self.filled.lock().expect("filled bitmap mutex poisoned");
+        let mut buf = Vec::with_capacity(filled.serialized_size());
+        if filled.serialize_into(&mut buf).is_err() {
+            return;
+        }
+        let idx = self.idx_path();
+        let mut tmp = idx.clone().into_os_string();
+        tmp.push(".tmp");
+        let tmp = PathBuf::from(tmp);
+        if fs::write(&tmp, &buf).is_ok() {
+            let _ = fs::rename(&tmp, &idx);
+        }
     }
 
     /// Byte length of block `b` (the trailing block may be partial).
@@ -302,6 +351,7 @@ impl BlockCachedSource {
         if !store.lazy_block_entry_is_current(&self.uri, &self.entry_token) {
             return Ok(false);
         }
+        let mut filled_any = false;
         for (rb0, rb1) in self.missing_runs(b0, b1) {
             let run_start = u64::from(rb0) * CACHE_BLOCK_BYTES;
             let run_end = (u64::from(rb1) + 1) * CACHE_BLOCK_BYTES;
@@ -327,11 +377,15 @@ impl BlockCachedSource {
             }
             let newly = self.mark_filled(bf.size, rb0, rb1);
             self.filled_bytes.fetch_add(newly, Ordering::AcqRel);
+            filled_any = true;
             if self.owns_accounting && newly < run_len {
                 // A concurrent filler beat us to some blocks; its accounting
                 // stands, ours is released.
                 store.release_block_bytes(run_len - newly);
             }
+        }
+        if filled_any {
+            self.persist_idx();
         }
         Ok(true)
     }
@@ -339,9 +393,7 @@ impl BlockCachedSource {
 
 impl Drop for BlockCachedSource {
     fn drop(&mut self) {
-        // Last reader over this source is gone (entry evicted/replaced and
-        // no in-flight queries): release the accounted bytes and remove the
-        // sparse file. The store may already be gone at process teardown.
+        // Release accounted bytes only; the file and index persist for adoption.
         if self.owns_accounting
             && let Some(store) = self.store.upgrade()
         {
@@ -349,9 +401,6 @@ impl Drop for BlockCachedSource {
             if filled > 0 {
                 store.release_block_bytes(filled);
             }
-        }
-        if self.state.get().is_some_and(|s| s.is_some()) {
-            let _ = fs::remove_file(&self.path);
         }
     }
 }
@@ -595,13 +644,121 @@ mod tests {
             "trailing partial block accounts its real length"
         );
 
-        // Drop the source: accounting released, blocks file unlinked.
+        // Drop the source: accounting released, but the sparse file and its
+        // index persist for a later generation to adopt.
         let path = dir.path().join("t.blocks");
         assert!(path.exists());
         store.remove_block_entry_for_test(&uri);
         drop(src);
         assert_eq!(store.stats().current_bytes, 0);
-        assert!(!path.exists());
+        assert!(path.exists(), "blocks file survives drop for adoption");
+        let mut idx = path.clone().into_os_string();
+        idx.push(".idx");
+        assert!(
+            std::path::PathBuf::from(idx).exists(),
+            "index sidecar persisted alongside the blocks file"
+        );
+    }
+
+    /// Reopen/reconnect warm survival: a fresh source adopts a prior
+    /// generation's persisted blocks and serves filled ranges with zero refetch.
+    #[tokio::test]
+    async fn adopt_reuses_blocks_across_source_generations() {
+        const OBJ: usize = 3 * CACHE_BLOCK_BYTES as usize + 1000;
+        let dir = tempdir().expect("tempdir");
+        let store = test_store(dir.path(), u64::MAX);
+        let uri = SuperfileUri::new_v4();
+        let path = dir.path().join("t.blocks");
+
+        let inner1 = Arc::new(CountingSource::new(OBJ));
+        let src1 = BlockCachedSource::new(
+            Arc::clone(&inner1) as Arc<dyn LazyByteSource>,
+            Arc::downgrade(&store),
+            uri,
+            path.clone(),
+        );
+        store.install_block_entry_for_test(uri, src1.filled_bytes_handle(), src1.entry_token());
+        let start = 100u64;
+        let len = 2 * CACHE_BLOCK_BYTES + 500;
+        let first = src1.range(start, len).await.expect("gen1 read");
+        assert_eq!(inner1.calls(), 1);
+        let filled = src1.filled_bytes_handle().load(Ordering::Acquire);
+
+        store.remove_block_entry_for_test(&uri);
+        drop(src1);
+        assert_eq!(store.stats().current_bytes, 0);
+        assert!(path.exists());
+
+        let inner2 = Arc::new(CountingSource::new(OBJ));
+        let src2 = BlockCachedSource::new(
+            Arc::clone(&inner2) as Arc<dyn LazyByteSource>,
+            Arc::downgrade(&store),
+            uri,
+            path.clone(),
+        );
+        store.install_block_entry_for_test(uri, src2.filled_bytes_handle(), src2.entry_token());
+
+        let again = src2.range(start, len).await.expect("gen2 read");
+        assert_eq!(again, first);
+        assert_eq!(inner2.calls(), 0, "adopted blocks serve without refetch");
+        assert_eq!(
+            src2.filled_bytes_handle().load(Ordering::Acquire),
+            filled,
+            "adopted footprint re-accounted"
+        );
+        assert_eq!(store.stats().current_bytes, filled);
+
+        let tail_start = 3 * CACHE_BLOCK_BYTES + 10;
+        let _ = src2.range(tail_start, 50).await.expect("gen2 tail");
+        assert_eq!(inner2.calls(), 1, "an unfilled range still fetches");
+    }
+
+    /// An absent index sidecar makes adoption fall back to a fresh file rather
+    /// than trust the sparse bytes blindly.
+    #[tokio::test]
+    async fn adopt_falls_back_to_fresh_when_index_is_missing() {
+        const OBJ: usize = 3 * CACHE_BLOCK_BYTES as usize + 1000;
+        let dir = tempdir().expect("tempdir");
+        let store = test_store(dir.path(), u64::MAX);
+        let uri = SuperfileUri::new_v4();
+        let path = dir.path().join("t.blocks");
+
+        let inner1 = Arc::new(CountingSource::new(OBJ));
+        let src1 = BlockCachedSource::new(
+            Arc::clone(&inner1) as Arc<dyn LazyByteSource>,
+            Arc::downgrade(&store),
+            uri,
+            path.clone(),
+        );
+        store.install_block_entry_for_test(uri, src1.filled_bytes_handle(), src1.entry_token());
+        let _ = src1
+            .range(100, 2 * CACHE_BLOCK_BYTES + 500)
+            .await
+            .expect("gen1");
+        store.remove_block_entry_for_test(&uri);
+        drop(src1);
+
+        let mut idx = path.clone().into_os_string();
+        idx.push(".idx");
+        std::fs::remove_file(PathBuf::from(idx)).expect("drop the index");
+
+        let inner2 = Arc::new(CountingSource::new(OBJ));
+        let src2 = BlockCachedSource::new(
+            Arc::clone(&inner2) as Arc<dyn LazyByteSource>,
+            Arc::downgrade(&store),
+            uri,
+            path.clone(),
+        );
+        store.install_block_entry_for_test(uri, src2.filled_bytes_handle(), src2.entry_token());
+        let _ = src2
+            .range(100, 2 * CACHE_BLOCK_BYTES + 500)
+            .await
+            .expect("gen2");
+        assert_eq!(
+            inner2.calls(),
+            1,
+            "no index means fresh fetch, not stale reuse"
+        );
     }
 
     /// Regression for the transient `Required field type_ is missing` decode

--- a/src/supertable/reader_cache/block_source.rs
+++ b/src/supertable/reader_cache/block_source.rs
@@ -26,13 +26,15 @@
 //! land — so eviction sees a lazy entry's true footprint. On budget
 //! exhaustion, or once this source's cache entry has been replaced (eviction
 //! / mmap promotion), reads degrade to plain uncached passthrough instead of
-//! failing. The source releases its accounted bytes and unlinks its file on
-//! `Drop` (i.e. when the last in-flight reader over it goes away).
+//! failing. The source releases its accounted bytes on `Drop` (i.e. when the
+//! last in-flight reader over it goes away); the sparse file and its persisted
+//! index stay on disk so a later generation can adopt them.
 
 use std::{
     fs,
     os::unix::fs::FileExt,
     path::PathBuf,
+    process,
     sync::{
         Arc, Mutex, OnceLock, Weak,
         atomic::{AtomicU64, Ordering},
@@ -57,7 +59,9 @@ use crate::{
 /// ~55K). Post-drain vector queries read ~0.25–2 MiB scan ranges, so
 /// 512 KiB keeps first-touch overshoot well under 2× while still
 /// coalescing a multi-MiB scan into a handful of blocks.
-const CACHE_BLOCK_BYTES: u64 = 512 * 1024;
+pub(super) const CACHE_BLOCK_BYTES: u64 = 512 * 1024;
+
+static PERSIST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Lazily-initialized sparse backing file. Created on the first cached read
 /// (the object size may only be known after the open-time `tail()` on
@@ -210,17 +214,16 @@ impl BlockCachedSource {
             return None;
         }
         let idx_bytes = fs::read(self.idx_path()).ok()?;
-        let bitmap = RoaringBitmap::deserialize_from(idx_bytes.as_slice()).ok()?;
+        let (bitmap, adopted_bytes) = indexed_filled_bytes(size, &idx_bytes)?;
         let file = fs::OpenOptions::new()
             .read(true)
             .write(true)
             .open(&self.path)
             .ok()?;
-        let adopted_bytes: u64 = bitmap.iter().map(|b| Self::block_len(size, b)).sum();
         if self.owns_accounting
             && let Some(store) = self.store.upgrade()
         {
-            store.account_adopted_bytes(adopted_bytes);
+            store.account_adopted_bytes(&self.uri, adopted_bytes);
         }
         self.filled_bytes.store(adopted_bytes, Ordering::Release);
         *self.filled.lock().expect("filled bitmap mutex poisoned") = bitmap;
@@ -234,14 +237,18 @@ impl BlockCachedSource {
     /// Persist the filled-block bitmap, always after the blocks it describes so
     /// the index never claims a block that was not written.
     fn persist_idx(&self) {
-        let filled = self.filled.lock().expect("filled bitmap mutex poisoned");
-        let mut buf = Vec::with_capacity(filled.serialized_size());
-        if filled.serialize_into(&mut buf).is_err() {
-            return;
-        }
+        let buf = {
+            let filled = self.filled.lock().expect("filled bitmap mutex poisoned");
+            let mut buf = Vec::with_capacity(filled.serialized_size());
+            if filled.serialize_into(&mut buf).is_err() {
+                return;
+            }
+            buf
+        };
         let idx = self.idx_path();
+        let seq = PERSIST_COUNTER.fetch_add(1, Ordering::Relaxed);
         let mut tmp = idx.clone().into_os_string();
-        tmp.push(".tmp");
+        tmp.push(format!(".tmp.{}.{seq}", process::id()));
         let tmp = PathBuf::from(tmp);
         if fs::write(&tmp, &buf).is_ok() {
             let _ = fs::rename(&tmp, &idx);
@@ -384,11 +391,24 @@ impl BlockCachedSource {
                 store.release_block_bytes(run_len - newly);
             }
         }
-        if filled_any {
+        if filled_any && bf.file.sync_data().is_ok() {
             self.persist_idx();
         }
         Ok(true)
     }
+}
+
+pub(super) fn indexed_filled_bytes(size: u64, idx_bytes: &[u8]) -> Option<(RoaringBitmap, u64)> {
+    let bitmap = RoaringBitmap::deserialize_from(idx_bytes).ok()?;
+    let n_blocks = size.div_ceil(CACHE_BLOCK_BYTES);
+    if bitmap.max().is_some_and(|m| u64::from(m) >= n_blocks) {
+        return None;
+    }
+    let filled = bitmap
+        .iter()
+        .map(|b| BlockCachedSource::block_len(size, b))
+        .sum();
+    Some((bitmap, filled))
 }
 
 impl Drop for BlockCachedSource {
@@ -759,6 +779,28 @@ mod tests {
             1,
             "no index means fresh fetch, not stale reuse"
         );
+    }
+
+    #[test]
+    fn indexed_filled_bytes_rejects_a_block_id_past_the_file() {
+        let size = 2 * CACHE_BLOCK_BYTES;
+        let mut bitmap = RoaringBitmap::new();
+        bitmap.insert(2);
+        let mut buf = Vec::new();
+        bitmap.serialize_into(&mut buf).expect("serialize");
+        assert!(indexed_filled_bytes(size, &buf).is_none());
+    }
+
+    #[test]
+    fn indexed_filled_bytes_sums_in_range_blocks() {
+        let size = 2 * CACHE_BLOCK_BYTES + 100;
+        let mut bitmap = RoaringBitmap::new();
+        bitmap.insert(0);
+        bitmap.insert(2);
+        let mut buf = Vec::new();
+        bitmap.serialize_into(&mut buf).expect("serialize");
+        let (_, filled) = indexed_filled_bytes(size, &buf).expect("valid index");
+        assert_eq!(filled, CACHE_BLOCK_BYTES + 100);
     }
 
     /// Regression for the transient `Required field type_ is missing` decode

--- a/src/supertable/reader_cache/block_source.rs
+++ b/src/supertable/reader_cache/block_source.rs
@@ -61,6 +61,10 @@ use crate::{
 /// coalescing a multi-MiB scan into a handful of blocks.
 pub(super) const CACHE_BLOCK_BYTES: u64 = 512 * 1024;
 
+const IDX_HEADER: [u8; 8] = CACHE_BLOCK_BYTES.to_le_bytes();
+
+const PERSIST_BYTES_THRESHOLD: u64 = 32 * 1024 * 1024;
+
 static PERSIST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Lazily-initialized sparse backing file. Created on the first cached read
@@ -102,6 +106,7 @@ pub(crate) struct BlockCachedSource {
     /// `size_bytes`, so eviction candidates report a lazy entry's real
     /// footprint as it grows.
     filled_bytes: Arc<AtomicU64>,
+    persisted_bytes: AtomicU64,
 }
 
 impl BlockCachedSource {
@@ -147,6 +152,7 @@ impl BlockCachedSource {
             state: OnceLock::new(),
             filled: Mutex::new(RoaringBitmap::new()),
             filled_bytes: Arc::new(AtomicU64::new(0)),
+            persisted_bytes: AtomicU64::new(0),
         })
     }
 
@@ -220,12 +226,15 @@ impl BlockCachedSource {
             .write(true)
             .open(&self.path)
             .ok()?;
-        if self.owns_accounting
-            && let Some(store) = self.store.upgrade()
-        {
-            store.account_adopted_bytes(&self.uri, adopted_bytes);
+        if let Some(store) = self.store.upgrade() {
+            if self.owns_accounting {
+                store.account_adopted_bytes(&self.uri, adopted_bytes);
+            } else {
+                store.release_scanned_block_file(&self.uri);
+            }
         }
         self.filled_bytes.store(adopted_bytes, Ordering::Release);
+        self.persisted_bytes.store(adopted_bytes, Ordering::Release);
         *self.filled.lock().expect("filled bitmap mutex poisoned") = bitmap;
         Some(BlockFile {
             file,
@@ -237,13 +246,12 @@ impl BlockCachedSource {
     /// Persist the filled-block bitmap, always after the blocks it describes so
     /// the index never claims a block that was not written.
     fn persist_idx(&self) {
+        if !self.path.exists() {
+            return;
+        }
         let buf = {
             let filled = self.filled.lock().expect("filled bitmap mutex poisoned");
-            let mut buf = Vec::with_capacity(filled.serialized_size());
-            if filled.serialize_into(&mut buf).is_err() {
-                return;
-            }
-            buf
+            serialize_index(&filled)
         };
         let idx = self.idx_path();
         let seq = PERSIST_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -391,15 +399,28 @@ impl BlockCachedSource {
                 store.release_block_bytes(run_len - newly);
             }
         }
-        if filled_any && bf.file.sync_data().is_ok() {
-            self.persist_idx();
+        if filled_any {
+            let filled = self.filled_bytes.load(Ordering::Acquire);
+            let unpersisted = filled.saturating_sub(self.persisted_bytes.load(Ordering::Acquire));
+            if unpersisted >= PERSIST_BYTES_THRESHOLD && bf.file.sync_data().is_ok() {
+                self.persist_idx();
+                self.persisted_bytes.store(filled, Ordering::Release);
+            }
         }
         Ok(true)
     }
 }
 
+pub(super) fn serialize_index(bitmap: &RoaringBitmap) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(IDX_HEADER.len() + bitmap.serialized_size());
+    buf.extend_from_slice(&IDX_HEADER);
+    let _ = bitmap.serialize_into(&mut buf);
+    buf
+}
+
 pub(super) fn indexed_filled_bytes(size: u64, idx_bytes: &[u8]) -> Option<(RoaringBitmap, u64)> {
-    let bitmap = RoaringBitmap::deserialize_from(idx_bytes).ok()?;
+    let body = idx_bytes.strip_prefix(&IDX_HEADER)?;
+    let bitmap = RoaringBitmap::deserialize_from(body).ok()?;
     let n_blocks = size.div_ceil(CACHE_BLOCK_BYTES);
     if bitmap.max().is_some_and(|m| u64::from(m) >= n_blocks) {
         return None;
@@ -413,6 +434,13 @@ pub(super) fn indexed_filled_bytes(size: u64, idx_bytes: &[u8]) -> Option<(Roari
 
 impl Drop for BlockCachedSource {
     fn drop(&mut self) {
+        if let Some(Some(bf)) = self.state.get() {
+            let filled = self.filled_bytes.load(Ordering::Acquire);
+            if filled > self.persisted_bytes.load(Ordering::Acquire) && bf.file.sync_data().is_ok()
+            {
+                self.persist_idx();
+            }
+        }
         // Release accounted bytes only; the file and index persist for adoption.
         if self.owns_accounting
             && let Some(store) = self.store.upgrade()
@@ -786,9 +814,7 @@ mod tests {
         let size = 2 * CACHE_BLOCK_BYTES;
         let mut bitmap = RoaringBitmap::new();
         bitmap.insert(2);
-        let mut buf = Vec::new();
-        bitmap.serialize_into(&mut buf).expect("serialize");
-        assert!(indexed_filled_bytes(size, &buf).is_none());
+        assert!(indexed_filled_bytes(size, &serialize_index(&bitmap)).is_none());
     }
 
     #[test]
@@ -797,10 +823,19 @@ mod tests {
         let mut bitmap = RoaringBitmap::new();
         bitmap.insert(0);
         bitmap.insert(2);
-        let mut buf = Vec::new();
-        bitmap.serialize_into(&mut buf).expect("serialize");
-        let (_, filled) = indexed_filled_bytes(size, &buf).expect("valid index");
+        let (_, filled) =
+            indexed_filled_bytes(size, &serialize_index(&bitmap)).expect("valid index");
         assert_eq!(filled, CACHE_BLOCK_BYTES + 100);
+    }
+
+    #[test]
+    fn indexed_filled_bytes_rejects_a_mismatched_header() {
+        let size = 2 * CACHE_BLOCK_BYTES;
+        let mut bitmap = RoaringBitmap::new();
+        bitmap.insert(0);
+        let mut bytes = serialize_index(&bitmap);
+        bytes[0] ^= 0xFF;
+        assert!(indexed_filled_bytes(size, &bytes).is_none());
     }
 
     /// Regression for the transient `Required field type_ is missing` decode

--- a/src/supertable/reader_cache/block_source.rs
+++ b/src/supertable/reader_cache/block_source.rs
@@ -243,22 +243,27 @@ impl BlockCachedSource {
         })
     }
 
-    /// Persist the filled-block bitmap, always after the blocks it describes so
-    /// the index never claims a block that was not written.
-    fn persist_idx(&self) {
+    /// Serialize the filled-block bitmap for persistence. Taken before the
+    /// `sync_data()` barrier so the persisted index only ever names blocks whose
+    /// writes the fsync already flushed — a concurrent fill that marks a new
+    /// block after this snapshot is simply absent (a safe undercount), never a
+    /// durably-claimed hole.
+    fn snapshot_index(&self) -> Vec<u8> {
+        let filled = self.filled.lock().expect("filled bitmap mutex poisoned");
+        serialize_index(&filled)
+    }
+
+    /// Write a pre-serialized index snapshot, only after its blocks are durable.
+    fn persist_idx(&self, snapshot: &[u8]) {
         if !self.path.exists() {
             return;
         }
-        let buf = {
-            let filled = self.filled.lock().expect("filled bitmap mutex poisoned");
-            serialize_index(&filled)
-        };
         let idx = self.idx_path();
         let seq = PERSIST_COUNTER.fetch_add(1, Ordering::Relaxed);
         let mut tmp = idx.clone().into_os_string();
         tmp.push(format!(".tmp.{}.{seq}", process::id()));
         let tmp = PathBuf::from(tmp);
-        if fs::write(&tmp, &buf).is_ok() {
+        if fs::write(&tmp, snapshot).is_ok() {
             let _ = fs::rename(&tmp, &idx);
         }
     }
@@ -402,9 +407,12 @@ impl BlockCachedSource {
         if filled_any {
             let filled = self.filled_bytes.load(Ordering::Acquire);
             let unpersisted = filled.saturating_sub(self.persisted_bytes.load(Ordering::Acquire));
-            if unpersisted >= PERSIST_BYTES_THRESHOLD && bf.file.sync_data().is_ok() {
-                self.persist_idx();
-                self.persisted_bytes.store(filled, Ordering::Release);
+            if unpersisted >= PERSIST_BYTES_THRESHOLD {
+                let snapshot = self.snapshot_index();
+                if bf.file.sync_data().is_ok() {
+                    self.persist_idx(&snapshot);
+                    self.persisted_bytes.store(filled, Ordering::Release);
+                }
             }
         }
         Ok(true)
@@ -436,9 +444,11 @@ impl Drop for BlockCachedSource {
     fn drop(&mut self) {
         if let Some(Some(bf)) = self.state.get() {
             let filled = self.filled_bytes.load(Ordering::Acquire);
-            if filled > self.persisted_bytes.load(Ordering::Acquire) && bf.file.sync_data().is_ok()
-            {
-                self.persist_idx();
+            if filled > self.persisted_bytes.load(Ordering::Acquire) {
+                let snapshot = self.snapshot_index();
+                if bf.file.sync_data().is_ok() {
+                    self.persist_idx(&snapshot);
+                }
             }
         }
         // Release accounted bytes only; the file and index persist for adoption.

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -83,6 +83,10 @@ const STORE_UPGRADE_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 /// Filename suffix for per-superfile sparse block-cache files.
 const BLOCKS_FILE_SUFFIX: &str = ".blocks";
 
+/// Filename suffix (appended after `.blocks`) for the persisted filled-block
+/// index sidecar.
+const BLOCKS_IDX_SUFFIX: &str = ".idx";
+
 /// How old an in-flight tempfile must be before the open-time scan reclaims it. A live cold
 /// fetch's tempfile is seconds old, so one this stale can only be a crashed fetch's leftover;
 /// deleting a live one would fail the owner's rename and cost it a retried fetch.
@@ -1127,8 +1131,7 @@ impl DiskCacheStore {
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
-            if name.ends_with(BLOCKS_FILE_SUFFIX) {
-                let _ = fs::remove_file(&path);
+            if name.ends_with(BLOCKS_IDX_SUFFIX) || name.ends_with(BLOCKS_FILE_SUFFIX) {
                 continue;
             }
 
@@ -1193,10 +1196,11 @@ impl DiskCacheStore {
     ) -> Result<Option<Arc<CachedEntry>>, DiskCacheError> {
         let path = self.cache_path(uri);
         let Ok(meta) = fs::metadata(&path) else {
-            // A counted file that is gone (deleted outside the engine) must stop counting now:
-            // left in place, its record double-counts against the fetched replacement and a later
-            // eviction of it would unlink the replacement's file.
-            self.discard_cache_file(uri);
+            // No whole-file copy; decrement a vanished counted one but leave any block cache intact.
+            if let Some((_, file)) = self.unindexed.remove(uri) {
+                self.current_bytes
+                    .fetch_sub(file.size_bytes, Ordering::Release);
+            }
             return Ok(None);
         };
 
@@ -1254,6 +1258,7 @@ impl DiskCacheStore {
 
         let _ = fs::remove_file(self.cache_path(uri));
         let _ = fs::remove_file(self.blocks_path(uri));
+        let _ = fs::remove_file(self.blocks_idx_path(uri));
     }
 
     /// Delete never-opened files, oldest first, until `bytes_needed` is freed. Returns the bytes
@@ -1302,6 +1307,20 @@ impl DiskCacheStore {
         self.config
             .cache_root
             .join(format!("{}{BLOCKS_FILE_SUFFIX}", uri.cache_filename()))
+    }
+
+    /// Path of the persisted filled-block index
+    fn blocks_idx_path(&self, uri: &SuperfileUri) -> PathBuf {
+        self.config.cache_root.join(format!(
+            "{}{BLOCKS_FILE_SUFFIX}{BLOCKS_IDX_SUFFIX}",
+            uri.cache_filename()
+        ))
+    }
+
+    /// Account bytes for an adopted block cache whose data is already on disk; a
+    /// later reservation evicts if this pushes the store over budget.
+    pub(super) fn account_adopted_bytes(&self, bytes: u64) {
+        self.current_bytes.fetch_add(bytes, Ordering::Release);
     }
 
     /// Build a per-URI tempfile path (sparse destination
@@ -2082,6 +2101,8 @@ impl DiskCacheStore {
             if let Some((_, entry)) = self.cached.remove(&uri) {
                 let path = self.cache_path(&uri);
                 let _ = fs::remove_file(&path);
+                let _ = fs::remove_file(self.blocks_path(&uri));
+                let _ = fs::remove_file(self.blocks_idx_path(&uri));
                 self.release_entry_accounting(&entry);
                 self.n_evictions.fetch_add(1, Ordering::AcqRel);
             }
@@ -2112,6 +2133,7 @@ impl DiskCacheStore {
         self.coordinators.remove(uri);
         let _ = fs::remove_file(self.cache_path(uri));
         let _ = fs::remove_file(self.blocks_path(uri));
+        let _ = fs::remove_file(self.blocks_idx_path(uri));
         if present {
             self.n_gc_drops.fetch_add(1, Ordering::AcqRel);
         }
@@ -2712,6 +2734,7 @@ async fn lazy_background_fill(
             }
         };
 
+        let block_source_retained = block_source.is_some();
         match store.cached.entry(uri) {
             Entry::Occupied(mut occupied) => {
                 *occupied.get_mut() = Arc::new(CachedEntry {
@@ -2724,6 +2747,10 @@ async fn lazy_background_fill(
                     fill_spawned: AtomicBool::new(true),
                     last_access_us: AtomicU64::new(store.now_us()),
                 });
+                if !block_source_retained {
+                    let _ = fs::remove_file(store.blocks_path(&uri));
+                    let _ = fs::remove_file(store.blocks_idx_path(&uri));
+                }
             }
             Entry::Vacant(_) => {
                 let _ = fs::remove_file(&final_path);
@@ -3354,6 +3381,38 @@ mod tests {
             "orphan file still unlinked"
         );
         assert_eq!(store.stats().n_gc_drops, 0);
+    }
+
+    #[tokio::test]
+    async fn erase_superfile_local_copy_unlinks_block_index() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        fs::write(store.blocks_path(&uri), b"blocks").expect("blocks");
+        fs::write(store.blocks_idx_path(&uri), b"idx").expect("idx");
+
+        store.erase_superfile_local_copy(&uri);
+
+        assert!(!store.blocks_path(&uri).exists());
+        assert!(!store.blocks_idx_path(&uri).exists());
+    }
+
+    #[tokio::test]
+    async fn restart_scan_preserves_block_cache_and_index() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        fs::write(store.blocks_path(&uri), b"sparse block bytes").expect("blocks");
+        fs::write(store.blocks_idx_path(&uri), b"index bytes").expect("idx");
+
+        let reopened = reopen_store(&store, |_| {});
+
+        assert!(
+            reopened.blocks_path(&uri).exists(),
+            "restart keeps the .blocks file for adoption"
+        );
+        assert!(
+            reopened.blocks_idx_path(&uri).exists(),
+            "restart keeps the .blocks.idx sidecar"
+        );
     }
 
     // ----- lazy open: cost scales with the working set, not the directory -----

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -1201,6 +1201,25 @@ impl DiskCacheStore {
         }
 
         self.current_bytes.fetch_add(total, Ordering::Release);
+        self.trim_cold_to_budget();
+    }
+
+    /// Evict never-opened files (whole-file copies, then retained block files) to
+    /// bring `current_bytes` back under budget. Only cold candidates are freed;
+    /// live cached entries are left to the async reservation path. Runs on paths
+    /// that add already-on-disk bytes without a reservation (restart scan, block
+    /// adoption), so a read-only reopen still self-corrects to budget.
+    fn trim_cold_to_budget(&self) {
+        let budget = self.disk_budget_bytes();
+        let cur = self.current_bytes.load(Ordering::Acquire);
+        if cur <= budget {
+            return;
+        }
+        let over = cur - budget;
+        let freed = self.evict_unindexed(over);
+        if freed < over {
+            self.evict_block_files(over - freed);
+        }
     }
 
     fn scan_block_file(&self, path: &Path, uri: &SuperfileUri) -> Option<u64> {
@@ -1409,12 +1428,15 @@ impl DiskCacheStore {
         }
     }
 
-    /// Account bytes for an adopted block cache whose data is already on disk; a
-    /// later reservation evicts if this pushes the store over budget. Bytes a
-    /// restart scan already counted for this file are released first.
+    /// Account bytes for an adopted block cache whose data is already on disk.
+    /// Bytes a restart scan already counted for this file are released first (so
+    /// a scanned-then-adopted file nets to zero), then any excess over budget is
+    /// trimmed from cold candidates rather than left for a reservation that a
+    /// read-only table never issues.
     pub(super) fn account_adopted_bytes(&self, uri: &SuperfileUri, bytes: u64) {
         self.release_scanned_block_file(uri);
         self.current_bytes.fetch_add(bytes, Ordering::Release);
+        self.trim_cold_to_budget();
     }
 
     /// Build a per-URI tempfile path (sparse destination
@@ -3667,6 +3689,24 @@ mod tests {
         );
         assert!(!reopened.blocks_path(&uri).exists());
         assert!(!reopened.blocks_idx_path(&uri).exists());
+    }
+
+    #[tokio::test]
+    async fn reopen_trims_retained_block_files_to_budget() {
+        let (_dir, store) = test_store();
+        let mut total = 0;
+        for _ in 0..4 {
+            let uri = SuperfileUri::new_v4();
+            total += seed_valid_block_file(&store, &uri, 3 * CACHE_BLOCK_BYTES, &[0, 1, 2]);
+        }
+
+        let budget = total / 2;
+        let reopened = reopen_store(&store, |cfg| cfg.disk_budget_bytes = budget);
+        assert!(
+            reopened.stats().current_bytes <= budget,
+            "a read-only reopen trims retained blocks to budget at scan, current={} budget={budget}",
+            reopened.stats().current_bytes
+        );
     }
 
     // ----- lazy open: cost scales with the working set, not the directory -----

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -87,6 +87,8 @@ const BLOCKS_FILE_SUFFIX: &str = ".blocks";
 /// index sidecar.
 const BLOCKS_IDX_SUFFIX: &str = ".idx";
 
+const BLOCKS_IDX_TMP_INFIX: &str = ".idx.tmp.";
+
 /// How old an in-flight tempfile must be before the open-time scan reclaims it. A live cold
 /// fetch's tempfile is seconds old, so one this stale can only be a crashed fetch's leftover;
 /// deleting a live one would fail the owner's rename and cost it a retried fetch.
@@ -1133,14 +1135,27 @@ impl DiskCacheStore {
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
+            if name.contains(BLOCKS_IDX_TMP_INFIX) {
+                let stale = entry
+                    .metadata()
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .and_then(|t| SystemTime::now().duration_since(t).ok())
+                    .is_some_and(|age| age >= TMP_RECLAIM_AGE);
+                if stale {
+                    let _ = fs::remove_file(&path);
+                }
+                continue;
+            }
             if name.ends_with(BLOCKS_IDX_SUFFIX) {
                 continue;
             }
             if let Some(body) = name.strip_suffix(BLOCKS_FILE_SUFFIX) {
-                if let Some(uri) = SuperfileUri::from_cache_filename(body)
-                    && let Some(bytes) = self.scan_block_file(&path, &uri)
-                {
-                    total += bytes;
+                if let Some(uri) = SuperfileUri::from_cache_filename(body) {
+                    match self.scan_block_file(&path, &uri) {
+                        Some(bytes) => total += bytes,
+                        None => self.drop_block_file(&uri),
+                    }
                 }
                 continue;
             }
@@ -1387,14 +1402,18 @@ impl DiskCacheStore {
         ))
     }
 
-    /// Account bytes for an adopted block cache whose data is already on disk; a
-    /// later reservation evicts if this pushes the store over budget. Bytes a
-    /// restart scan already counted for this file are released first.
-    pub(super) fn account_adopted_bytes(&self, uri: &SuperfileUri, bytes: u64) {
+    pub(super) fn release_scanned_block_file(&self, uri: &SuperfileUri) {
         if let Some((_, prior)) = self.block_files.remove(uri) {
             self.current_bytes
                 .fetch_sub(prior.size_bytes, Ordering::Release);
         }
+    }
+
+    /// Account bytes for an adopted block cache whose data is already on disk; a
+    /// later reservation evicts if this pushes the store over budget. Bytes a
+    /// restart scan already counted for this file are released first.
+    pub(super) fn account_adopted_bytes(&self, uri: &SuperfileUri, bytes: u64) {
+        self.release_scanned_block_file(uri);
         self.current_bytes.fetch_add(bytes, Ordering::Release);
     }
 
@@ -2825,8 +2844,7 @@ async fn lazy_background_fill(
                     last_access_us: AtomicU64::new(store.now_us()),
                 });
                 if !block_source_retained {
-                    let _ = fs::remove_file(store.blocks_path(&uri));
-                    let _ = fs::remove_file(store.blocks_idx_path(&uri));
+                    store.drop_block_file(&uri);
                 }
             }
             Entry::Vacant(_) => {
@@ -3011,7 +3029,10 @@ mod tests {
     use tempfile::TempDir;
     use tokio::{spawn, task::yield_now, time::timeout};
 
-    use super::{super::block_source::CACHE_BLOCK_BYTES, *};
+    use super::{
+        super::block_source::{CACHE_BLOCK_BYTES, serialize_index},
+        *,
+    };
     use crate::{
         storage::LocalFsStorageProvider,
         superfile::builder::{BuilderOptions, SuperfileBuilder},
@@ -3035,9 +3056,7 @@ mod tests {
         for &b in blocks {
             bitmap.insert(b);
         }
-        let mut buf = Vec::new();
-        bitmap.serialize_into(&mut buf).expect("serialize");
-        fs::write(store.blocks_idx_path(uri), &buf).expect("idx");
+        fs::write(store.blocks_idx_path(uri), serialize_index(&bitmap)).expect("idx");
         blocks
             .iter()
             .map(|&b| {
@@ -3507,8 +3526,7 @@ mod tests {
     async fn restart_scan_preserves_block_cache_and_index() {
         let (_dir, store) = test_store();
         let uri = SuperfileUri::new_v4();
-        fs::write(store.blocks_path(&uri), b"sparse block bytes").expect("blocks");
-        fs::write(store.blocks_idx_path(&uri), b"index bytes").expect("idx");
+        seed_valid_block_file(&store, &uri, 2 * CACHE_BLOCK_BYTES, &[0, 1]);
 
         let reopened = reopen_store(&store, |_| {});
 
@@ -3520,6 +3538,45 @@ mod tests {
             reopened.blocks_idx_path(&uri).exists(),
             "restart keeps the .blocks.idx sidecar"
         );
+    }
+
+    #[tokio::test]
+    async fn restart_scan_deletes_a_block_file_with_an_invalid_index() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        fs::write(store.blocks_path(&uri), b"sparse block bytes").expect("blocks");
+        fs::write(store.blocks_idx_path(&uri), b"not a valid index").expect("idx");
+
+        let reopened = reopen_store(&store, |_| {});
+
+        assert!(
+            !reopened.blocks_path(&uri).exists(),
+            "an un-adoptable block file is reclaimed, not leaked"
+        );
+        assert!(!reopened.blocks_idx_path(&uri).exists());
+        assert_eq!(reopened.stats().current_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn restart_scan_sweeps_stale_index_tempfiles_and_spares_fresh_ones() {
+        let (_dir, store) = test_store();
+        let idx = store.blocks_idx_path(&SuperfileUri::new_v4());
+        let stale = idx.with_extension("idx.tmp.4242.0");
+        let fresh = idx.with_extension("idx.tmp.4242.1");
+        let now = SystemTime::now();
+        for (path, mtime) in [(&stale, now - TMP_RECLAIM_AGE * 2), (&fresh, now)] {
+            fs::write(path, b"partial").expect("seed tmp");
+            fs::File::options()
+                .write(true)
+                .open(path)
+                .expect("open tmp")
+                .set_modified(mtime)
+                .expect("set mtime");
+        }
+
+        let _opened = reopen_store(&store, |_| {});
+        assert!(!stale.exists(), "stale index tempfile reclaimed");
+        assert!(fresh.exists(), "fresh index tempfile left for its owner");
     }
 
     #[tokio::test]
@@ -3538,7 +3595,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scan_skips_a_block_file_without_an_index() {
+    async fn scan_reclaims_a_block_file_without_an_index() {
         let (_dir, store) = test_store();
         let uri = SuperfileUri::new_v4();
         let f = fs::OpenOptions::new()
@@ -3550,14 +3607,27 @@ mod tests {
         f.set_len(4 * CACHE_BLOCK_BYTES).expect("set_len");
 
         let reopened = reopen_store(&store, |_| {});
+        assert_eq!(reopened.stats().current_bytes, 0);
+        assert!(
+            !reopened.blocks_path(&uri).exists(),
+            "a block file with no index cannot be adopted, so it is reclaimed"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_non_owning_adopt_releases_the_scanned_block_bytes() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let filled = seed_valid_block_file(&store, &uri, 2 * CACHE_BLOCK_BYTES, &[0, 1]);
+
+        let reopened = reopen_store(&store, |_| {});
+        assert_eq!(reopened.stats().current_bytes, filled);
+
+        reopened.release_scanned_block_file(&uri);
         assert_eq!(
             reopened.stats().current_bytes,
             0,
-            "a block file with no index is not counted"
-        );
-        assert!(
-            reopened.blocks_path(&uri).exists(),
-            "the un-adoptable block file is left in place"
+            "a promotion-path adopt drops the scan-counted bytes instead of double-counting"
         );
     }
 

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -36,7 +36,7 @@ use tokio::{
 use tracing::{Instrument, debug_span};
 
 use super::{
-    block_source::BlockCachedSource,
+    block_source::{BlockCachedSource, indexed_filled_bytes},
     config::{ColdFetchMode, DiskCacheConfig, EvictionCandidate},
 };
 use crate::{
@@ -281,6 +281,7 @@ pub struct DiskCacheStore {
     coordinators: DashMap<SuperfileUri, Coordinator>,
     /// Files on disk that no read has opened yet. Filled by `scan_cache_root`, drained by reuse or eviction.
     unindexed: DashMap<SuperfileUri, UnindexedFile>,
+    block_files: DashMap<SuperfileUri, UnindexedFile>,
     current_bytes: AtomicU64,
     /// Live disk budget in bytes, seeded from `config.disk_budget_bytes`.
     /// An engine-managed (auto-sized) budget is raised — never lowered —
@@ -367,6 +368,7 @@ impl DiskCacheStore {
             cached: DashMap::new(),
             coordinators: DashMap::new(),
             unindexed: DashMap::new(),
+            block_files: DashMap::new(),
             current_bytes: AtomicU64::new(0),
             budget_bytes: AtomicU64::new(configured_budget),
             budget_auto_sized: AtomicBool::new(false),
@@ -1131,7 +1133,15 @@ impl DiskCacheStore {
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
-            if name.ends_with(BLOCKS_IDX_SUFFIX) || name.ends_with(BLOCKS_FILE_SUFFIX) {
+            if name.ends_with(BLOCKS_IDX_SUFFIX) {
+                continue;
+            }
+            if let Some(body) = name.strip_suffix(BLOCKS_FILE_SUFFIX) {
+                if let Some(uri) = SuperfileUri::from_cache_filename(body)
+                    && let Some(bytes) = self.scan_block_file(&path, &uri)
+                {
+                    total += bytes;
+                }
                 continue;
             }
 
@@ -1176,6 +1186,27 @@ impl DiskCacheStore {
         }
 
         self.current_bytes.fetch_add(total, Ordering::Release);
+    }
+
+    fn scan_block_file(&self, path: &Path, uri: &SuperfileUri) -> Option<u64> {
+        let meta = fs::metadata(path).ok()?;
+        let size = meta.len();
+        if size == 0 {
+            return None;
+        }
+        let idx_bytes = fs::read(self.blocks_idx_path(uri)).ok()?;
+        let (_, filled) = indexed_filled_bytes(size, &idx_bytes)?;
+        if filled == 0 {
+            return None;
+        }
+        self.block_files.insert(
+            *uri,
+            UnindexedFile {
+                size_bytes: filled,
+                mtime_us: file_mtime_us(&meta),
+            },
+        );
+        Some(filled)
     }
 
     /// Serve `uri` from an existing cache file instead of fetching from storage. Runs before every
@@ -1241,7 +1272,7 @@ impl DiskCacheStore {
                     self.current_bytes.fetch_sub(size, Ordering::Release);
                 }
                 let _ = fs::remove_file(&path);
-                let _ = fs::remove_file(self.blocks_path(uri));
+                self.drop_block_file(uri);
                 Ok(None)
             }
         }
@@ -1257,6 +1288,14 @@ impl DiskCacheStore {
         }
 
         let _ = fs::remove_file(self.cache_path(uri));
+        self.drop_block_file(uri);
+    }
+
+    fn drop_block_file(&self, uri: &SuperfileUri) {
+        if let Some((_, file)) = self.block_files.remove(uri) {
+            self.current_bytes
+                .fetch_sub(file.size_bytes, Ordering::Release);
+        }
         let _ = fs::remove_file(self.blocks_path(uri));
         let _ = fs::remove_file(self.blocks_idx_path(uri));
     }
@@ -1287,7 +1326,38 @@ impl DiskCacheStore {
             // cannot double-count.
             if self.unindexed.remove(&uri).is_some() {
                 let _ = fs::remove_file(self.cache_path(&uri));
+                self.drop_block_file(&uri);
+                self.current_bytes.fetch_sub(size, Ordering::Release);
+                self.n_evictions.fetch_add(1, Ordering::AcqRel);
+                freed += size;
+            }
+        }
+
+        freed
+    }
+
+    fn evict_block_files(&self, bytes_needed: u64) -> u64 {
+        if self.block_files.is_empty() {
+            return 0;
+        }
+
+        let mut candidates: Vec<(SuperfileUri, u64, u64)> = self
+            .block_files
+            .iter()
+            .map(|e| (*e.key(), e.value().size_bytes, e.value().mtime_us))
+            .collect();
+
+        candidates.sort_by_key(|(_, _, mtime_us)| *mtime_us);
+
+        let mut freed: u64 = 0;
+        for (uri, size, _) in candidates {
+            if freed >= bytes_needed {
+                break;
+            }
+
+            if self.block_files.remove(&uri).is_some() {
                 let _ = fs::remove_file(self.blocks_path(&uri));
+                let _ = fs::remove_file(self.blocks_idx_path(&uri));
                 self.current_bytes.fetch_sub(size, Ordering::Release);
                 self.n_evictions.fetch_add(1, Ordering::AcqRel);
                 freed += size;
@@ -1318,8 +1388,13 @@ impl DiskCacheStore {
     }
 
     /// Account bytes for an adopted block cache whose data is already on disk; a
-    /// later reservation evicts if this pushes the store over budget.
-    pub(super) fn account_adopted_bytes(&self, bytes: u64) {
+    /// later reservation evicts if this pushes the store over budget. Bytes a
+    /// restart scan already counted for this file are released first.
+    pub(super) fn account_adopted_bytes(&self, uri: &SuperfileUri, bytes: u64) {
+        if let Some((_, prior)) = self.block_files.remove(uri) {
+            self.current_bytes
+                .fetch_sub(prior.size_bytes, Ordering::Release);
+        }
         self.current_bytes.fetch_add(bytes, Ordering::Release);
     }
 
@@ -2054,7 +2129,10 @@ impl DiskCacheStore {
     async fn evict_at_least(&self, bytes_needed: u64) -> Result<(), DiskCacheError> {
         // Never-opened files go first; freeing one cannot hurt a live reader.
         let freed = self.evict_unindexed(bytes_needed);
-
+        if freed >= bytes_needed {
+            return Ok(());
+        }
+        let freed = freed + self.evict_block_files(bytes_needed - freed);
         if freed >= bytes_needed {
             return Ok(());
         }
@@ -2132,8 +2210,7 @@ impl DiskCacheStore {
 
         self.coordinators.remove(uri);
         let _ = fs::remove_file(self.cache_path(uri));
-        let _ = fs::remove_file(self.blocks_path(uri));
-        let _ = fs::remove_file(self.blocks_idx_path(uri));
+        self.drop_block_file(uri);
         if present {
             self.n_gc_drops.fetch_add(1, Ordering::AcqRel);
         }
@@ -2930,15 +3007,45 @@ mod tests {
 
     use arrow_array::{LargeStringArray, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
+    use roaring::RoaringBitmap;
     use tempfile::TempDir;
     use tokio::{spawn, task::yield_now, time::timeout};
 
-    use super::*;
+    use super::{super::block_source::CACHE_BLOCK_BYTES, *};
     use crate::{
         storage::LocalFsStorageProvider,
         superfile::builder::{BuilderOptions, SuperfileBuilder},
         test_helpers::{decimal128_id_field, decimal128_ids},
     };
+
+    fn seed_valid_block_file(
+        store: &Arc<DiskCacheStore>,
+        uri: &SuperfileUri,
+        size: u64,
+        blocks: &[u32],
+    ) -> u64 {
+        let f = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(store.blocks_path(uri))
+            .expect("blocks");
+        f.set_len(size).expect("set_len");
+        let mut bitmap = RoaringBitmap::new();
+        for &b in blocks {
+            bitmap.insert(b);
+        }
+        let mut buf = Vec::new();
+        bitmap.serialize_into(&mut buf).expect("serialize");
+        fs::write(store.blocks_idx_path(uri), &buf).expect("idx");
+        blocks
+            .iter()
+            .map(|&b| {
+                let start = u64::from(b) * CACHE_BLOCK_BYTES;
+                (size - start).min(CACHE_BLOCK_BYTES)
+            })
+            .sum()
+    }
 
     /// Local-filesystem background promotion should finish well within this.
     const PROMOTE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -3413,6 +3520,83 @@ mod tests {
             reopened.blocks_idx_path(&uri).exists(),
             "restart keeps the .blocks.idx sidecar"
         );
+    }
+
+    #[tokio::test]
+    async fn restart_scan_counts_retained_block_files() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let size = 3 * CACHE_BLOCK_BYTES + 1000;
+        let filled = seed_valid_block_file(&store, &uri, size, &[0, 1, 3]);
+
+        let reopened = reopen_store(&store, |_| {});
+        assert_eq!(
+            reopened.stats().current_bytes,
+            filled,
+            "scan counts the retained block bytes against the budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_skips_a_block_file_without_an_index() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let f = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(store.blocks_path(&uri))
+            .expect("blocks");
+        f.set_len(4 * CACHE_BLOCK_BYTES).expect("set_len");
+
+        let reopened = reopen_store(&store, |_| {});
+        assert_eq!(
+            reopened.stats().current_bytes,
+            0,
+            "a block file with no index is not counted"
+        );
+        assert!(
+            reopened.blocks_path(&uri).exists(),
+            "the un-adoptable block file is left in place"
+        );
+    }
+
+    #[tokio::test]
+    async fn adopting_a_scanned_block_file_does_not_double_count() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let size = 2 * CACHE_BLOCK_BYTES + 500;
+        let filled = seed_valid_block_file(&store, &uri, size, &[0, 1]);
+
+        let reopened = reopen_store(&store, |_| {});
+        assert_eq!(reopened.stats().current_bytes, filled);
+
+        reopened.account_adopted_bytes(&uri, filled);
+        assert_eq!(
+            reopened.stats().current_bytes,
+            filled,
+            "adopt claims the scanned bytes rather than adding them again"
+        );
+    }
+
+    #[tokio::test]
+    async fn retained_block_files_are_evicted_under_budget_pressure() {
+        let (_dir, store) = test_store();
+        let uri = SuperfileUri::new_v4();
+        let size = 3 * CACHE_BLOCK_BYTES;
+        let filled = seed_valid_block_file(&store, &uri, size, &[0, 1, 2]);
+
+        let reopened = reopen_store(&store, |cfg| cfg.disk_budget_bytes = filled);
+        assert_eq!(reopened.stats().current_bytes, filled);
+
+        reopened.evict_at_least(filled).await.expect("evict");
+        assert_eq!(
+            reopened.stats().current_bytes,
+            0,
+            "the retained block file is evicted to reclaim budget"
+        );
+        assert!(!reopened.blocks_path(&uri).exists());
+        assert!(!reopened.blocks_idx_path(&uri).exists());
     }
 
     // ----- lazy open: cost scales with the working set, not the directory -----


### PR DESCRIPTION
## What is the change about?

During vector query we download block cache instead of fetching the entire hidden table superfile. We explicitly clear this valid cache file during reopen of table because we don't have the index (roaring bit map) persisted with the blocks. 

### how does this affect the performance

Without this change, every open/reopen/restart results in 1st vector query to be slow even if the files are part of cache dir
After this change the queries after open should be warm instead of cold.
