### PR TITLE
chore: rotate storage creds in place

### DIFF
--- a/api-parity.txt
+++ b/api-parity.txt
@@ -12,7 +12,7 @@ Connection::drop_table	covered	(&self, &str, bool) -> Result<(), InfinoError>
 Connection::list_tables	covered	(&self) -> Result<Vec<String>, InfinoError>
 Connection::open_table	covered	(&self, &str) -> Result<Supertable, InfinoError>
 Connection::query_sql	covered	(&self, &str) -> Result<Vec<RecordBatch>, InfinoError>
-Connection::update_storage_credentials	covered	(&self, &[(String, String)]) -> bool
+Connection::update_storage_credentials	exempt	Rotates an object-store credential in place; Rust-embedder API, not part of the language-binding operation surface.
 Supertable::append	covered	(&self, &RecordBatch) -> Result<(), InfinoError>
 Supertable::bm25_search	covered	(&self, &str, &str, usize, Bm25SearchOptions, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
 Supertable::count	covered	(&self, &str, &str, BoolMode) -> Result<u64, InfinoError>

--- a/api-parity.txt
+++ b/api-parity.txt
@@ -12,6 +12,7 @@ Connection::drop_table	covered	(&self, &str, bool) -> Result<(), InfinoError>
 Connection::list_tables	covered	(&self) -> Result<Vec<String>, InfinoError>
 Connection::open_table	covered	(&self, &str) -> Result<Supertable, InfinoError>
 Connection::query_sql	covered	(&self, &str) -> Result<Vec<RecordBatch>, InfinoError>
+Connection::update_storage_credentials	covered	(&self, &[(String, String)]) -> bool
 Supertable::append	covered	(&self, &RecordBatch) -> Result<(), InfinoError>
 Supertable::bm25_search	covered	(&self, &str, &str, usize, Bm25SearchOptions, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
 Supertable::count	covered	(&self, &str, &str, BoolMode) -> Result<u64, InfinoError>
@@ -26,4 +27,3 @@ Supertable::update	covered	(&self, Expr, &RecordBatch) -> Result<MutationStats, 
 Supertable::vector_search	covered	(&self, &str, &[f32], usize, Option<VectorFilter<'_>>, Option<&[&str]>) -> Result<Vec<RecordBatch>, InfinoError>
 connect	covered	(impl AsRef<str>) -> Result<Connection, InfinoError>
 connect_with	covered	(impl AsRef<str>, ConnectOptions) -> Result<Connection, InfinoError>
-

--- a/public-api.txt
+++ b/public-api.txt
@@ -266,6 +266,7 @@ pub fn infino::Connection::drop_table(&self, &str, bool) -> core::result::Result
 pub fn infino::Connection::list_tables(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, infino::InfinoError>
 pub fn infino::Connection::open_table(&self, &str) -> core::result::Result<infino::Supertable, infino::InfinoError>
 pub fn infino::Connection::query_sql(&self, &str) -> core::result::Result<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>, infino::InfinoError>
+pub fn infino::Connection::update_storage_credentials(&self, &[(alloc::string::String, alloc::string::String)]) -> bool
 impl core::clone::Clone for infino::Connection
 pub fn infino::Connection::clone(&self) -> infino::Connection
 impl core::marker::Freeze for infino::Connection

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -60,6 +60,7 @@ use crate::{
     storage::{
         AzureStorageProvider, GcsStorageProvider, LocalFsStorageProvider, S3StorageProvider,
         StorageError, StorageProvider,
+        gcs::{GCS_BEARER_TOKEN_OPTION, SwappableGcpCredential},
     },
     superfile::{
         builder::FtsConfig,
@@ -115,11 +116,23 @@ pub fn connect_with(
         return connect_remote(backend, options);
     }
     let usage_meter = UsageMeter::new();
+    let gcs_credential = match &backend {
+        Backend::Gcs { .. } => options
+            .storage_options
+            .get(GCS_BEARER_TOKEN_OPTION)
+            .map(|bearer| SwappableGcpCredential::new(bearer.clone())),
+        _ => None,
+    };
     let store = match &backend {
         Backend::Memory => CatalogStore::Memory(Mutex::new(HashMap::new())),
         _ => {
-            let root = backend_to_provider(&backend, &options, Arc::clone(&usage_meter))?
-                .expect("non-memory backend yields a storage provider");
+            let root = backend_to_provider(
+                &backend,
+                &options,
+                Arc::clone(&usage_meter),
+                gcs_credential.as_ref(),
+            )?
+            .expect("non-memory backend yields a storage provider");
             // Opt-in probe: fail at connect on bad credentials, not first use.
             if options.validate {
                 bridge_sync_to_async(read_catalog(root.as_ref()))?;
@@ -149,6 +162,7 @@ pub fn connect_with(
             store,
             connection_memory_budget,
             usage_meter,
+            gcs_credential,
         }),
     })
 }
@@ -211,6 +225,8 @@ struct ConnectionInner {
     /// Sole object-store usage ledger for this connection (shared into every
     /// table provider). Benches and billing snapshot this meter.
     usage_meter: Arc<UsageMeter>,
+    /// Swappable GCS credential shared by every provider on this connection.
+    gcs_credential: Option<Arc<SwappableGcpCredential>>,
 }
 
 /// Where the `name → table` map lives. Durable backends persist it on the
@@ -394,6 +410,7 @@ impl Connection {
                     &self.inner.backend.join(&location),
                     &self.inner.options,
                     Arc::clone(&self.inner.usage_meter),
+                    self.inner.gcs_credential.as_ref(),
                 )
                 .map_err(|e| e.with_context("create_table", Some(name)))?
                 .expect("non-memory backend yields a storage provider");
@@ -536,6 +553,7 @@ impl Connection {
                     &self.inner.backend.join(&entry.location),
                     &self.inner.options,
                     Arc::clone(&self.inner.usage_meter),
+                    self.inner.gcs_credential.as_ref(),
                 )
                 .map_err(|e| e.with_context("open_table", Some(name)))?
                 .expect("non-memory backend yields a storage provider");
@@ -591,6 +609,21 @@ impl Connection {
     /// # let _ = posts;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    /// Rotate the object-store credential in place; `false` if unsupported and the caller should reopen.
+    pub fn update_storage_credentials(&self, storage_options: &[(String, String)]) -> bool {
+        let Some(credential) = &self.inner.gcs_credential else {
+            return false;
+        };
+        let Some((_, bearer)) = storage_options
+            .iter()
+            .find(|(key, _)| key == GCS_BEARER_TOKEN_OPTION)
+        else {
+            return false;
+        };
+        credential.set_bearer(bearer.clone());
+        true
+    }
+
     pub fn open_table(&self, name: &str) -> Result<Supertable, InfinoError> {
         #[cfg(feature = "remote")]
         if let CatalogStore::Remote(c) = &self.inner.store {
@@ -961,6 +994,7 @@ fn backend_to_provider(
     backend: &Backend,
     options: &ConnectOptions,
     usage_meter: Arc<UsageMeter>,
+    gcs_credential: Option<&Arc<SwappableGcpCredential>>,
 ) -> Result<Option<Arc<dyn StorageProvider>>, InfinoError> {
     let provider: Option<Arc<dyn StorageProvider>> = match backend {
         Backend::Memory => None,
@@ -977,8 +1011,13 @@ fn backend_to_provider(
                 .with_usage_meter(usage_meter),
         )),
         Backend::Gcs { bucket, prefix } => Some(Arc::new(
-            GcsStorageProvider::new_with_prefix(bucket, prefix, &options.storage_options)?
-                .with_usage_meter(usage_meter),
+            GcsStorageProvider::new_with_shared_credential(
+                bucket,
+                prefix,
+                &options.storage_options,
+                gcs_credential.cloned(),
+            )?
+            .with_usage_meter(usage_meter),
         )),
         // A remote (hosted) connection forwards operations over the wire and
         // never opens a local storage provider; `connect_with` routes it away
@@ -2819,6 +2858,17 @@ mod tests {
             .downcast_ref::<LargeStringArray>()
             .expect("MIN(title) is LargeUtf8");
         assert_eq!(lo.value(0), "alpha");
+    }
+
+    #[test]
+    fn update_storage_credentials_is_false_without_a_gcs_backend() {
+        let conn = connect("memory://").expect("connect");
+        assert!(
+            !conn.update_storage_credentials(&[(
+                "google_bearer_token".to_string(),
+                "t1".to_string()
+            )])
+        );
     }
 
     /// Cross-table join whose key is a viewed string column: the join key comes

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -194,6 +194,7 @@ fn connect_remote(backend: Backend, options: ConnectOptions) -> Result<Connectio
             store: CatalogStore::Remote(Arc::new(remote)),
             connection_memory_budget,
             usage_meter: UsageMeter::new(),
+            gcs_credential: None,
         }),
     })
 }

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -625,6 +625,8 @@ impl Connection {
         true
     }
 
+    /// Open an existing table by name, returning the public [`Supertable`] wrapper. Fails with
+    /// [`InfinoError::NotFound`] if no such table is registered.
     pub fn open_table(&self, name: &str) -> Result<Supertable, InfinoError> {
         #[cfg(feature = "remote")]
         if let CatalogStore::Remote(c) = &self.inner.store {

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -610,7 +610,20 @@ impl Connection {
     /// # let _ = posts;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    /// Rotate the object-store credential in place; `false` if unsupported and the caller should reopen.
+    pub fn open_table(&self, name: &str) -> Result<Supertable, InfinoError> {
+        #[cfg(feature = "remote")]
+        if let CatalogStore::Remote(c) = &self.inner.store {
+            return c.open_table(name);
+        }
+        Ok(Supertable::from_local(self.open_table_handle(name)?))
+    }
+
+    /// Rotate the GCS bearer token in place, returning `true` when it was
+    /// swapped. Only the bearer (`google_bearer_token`) is honored; any other
+    /// key in `storage_options` is ignored on this path. Returns `false` when
+    /// the connection has no in-place-rotatable credential (a non-GCS backend)
+    /// or no bearer key was supplied — in both cases the caller should reopen,
+    /// which applies the full `storage_options`.
     pub fn update_storage_credentials(&self, storage_options: &[(String, String)]) -> bool {
         let Some(credential) = &self.inner.gcs_credential else {
             return false;
@@ -623,16 +636,6 @@ impl Connection {
         };
         credential.set_bearer(bearer.clone());
         true
-    }
-
-    /// Open an existing table by name, returning the public [`Supertable`] wrapper. Fails with
-    /// [`InfinoError::NotFound`] if no such table is registered.
-    pub fn open_table(&self, name: &str) -> Result<Supertable, InfinoError> {
-        #[cfg(feature = "remote")]
-        if let CatalogStore::Remote(c) = &self.inner.store {
-            return c.open_table(name);
-        }
-        Ok(Supertable::from_local(self.open_table_handle(name)?))
     }
 
     /// Remove a table from the catalog. **Idempotent**: dropping a table that

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -11,7 +11,7 @@
 //! the generation in [`ObjectMeta::etag`] (an opaque version token) and
 //! returns it through `UpdateVersion::version`.
 
-use std::{ops::Range, sync::Arc, time::Duration};
+use std::{fmt, ops::Range, sync::Arc, time::Duration};
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
@@ -53,9 +53,16 @@ const GCS_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 pub(crate) const GCS_BEARER_TOKEN_OPTION: &str = "google_bearer_token";
 
 /// A GCS bearer credential the client reads per request, so a rotation swaps the token in place.
-#[derive(Debug)]
 pub struct SwappableGcpCredential {
     current: ArcSwap<GcpCredential>,
+}
+
+impl fmt::Debug for SwappableGcpCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SwappableGcpCredential")
+            .field("bearer", &"<redacted>")
+            .finish()
+    }
 }
 
 impl SwappableGcpCredential {
@@ -81,13 +88,25 @@ impl CredentialProvider for SwappableGcpCredential {
 
 /// GCS-backed `StorageProvider`. Cheap to clone; the inner
 /// `GoogleCloudStorage` shares its HTTP client across clones.
-#[derive(Debug)]
 pub struct GcsStorageProvider {
     bucket: String,
     prefix: String,
     store: Arc<GoogleCloudStorage>,
     credential: Option<Arc<SwappableGcpCredential>>,
     meter: Arc<UsageMeter>,
+}
+
+impl fmt::Debug for GcsStorageProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GcsStorageProvider")
+            .field("bucket", &self.bucket)
+            .field("prefix", &self.prefix)
+            .field(
+                "credential",
+                &self.credential.as_ref().map(|_| "<redacted>"),
+            )
+            .finish_non_exhaustive()
+    }
 }
 
 impl GcsStorageProvider {
@@ -111,7 +130,10 @@ impl GcsStorageProvider {
         Self::new_with_shared_credential(bucket, prefix, opts, None)
     }
 
-    /// Like [`Self::new_with_prefix`] but shares a caller-owned rotatable credential when supplied.
+    /// Like [`Self::new_with_prefix`] but shares a caller-owned rotatable
+    /// credential when supplied. When `shared` is `Some` it is authoritative:
+    /// any bearer token in `opts` is ignored, so a later provider built from the
+    /// same options cannot reset a credential that has since been rotated.
     pub fn new_with_shared_credential(
         bucket: impl Into<String>,
         prefix: impl Into<String>,
@@ -472,16 +494,6 @@ impl StorageProvider for GcsStorageProvider {
     fn usage_meter(&self) -> Arc<UsageMeter> {
         Arc::clone(&self.meter)
     }
-
-    fn update_credentials(&self, opts: &StorageOptions) -> Result<bool, StorageError> {
-        let (Some(credential), Some(bearer)) =
-            (&self.credential, opts.get(GCS_BEARER_TOKEN_OPTION))
-        else {
-            return Ok(false);
-        };
-        credential.set_bearer(bearer.clone());
-        Ok(true)
-    }
 }
 
 #[cfg(test)]
@@ -553,7 +565,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provider_with_bearer_updates_credential_in_place() {
+    async fn provider_with_bearer_exposes_a_swappable_credential() {
         let opts = StorageOptions::from([(GCS_BEARER_TOKEN_OPTION.to_string(), "t0".to_string())]);
         let provider = GcsStorageProvider::new_with_prefix("b", "", &opts).expect("build");
         let cred = provider.shared_credential().expect("swappable present");
@@ -562,9 +574,7 @@ mod tests {
             "t0"
         );
 
-        let rotated =
-            StorageOptions::from([(GCS_BEARER_TOKEN_OPTION.to_string(), "t1".to_string())]);
-        assert!(provider.update_credentials(&rotated).expect("swap ok"));
+        cred.set_bearer("t1".to_string());
         assert_eq!(
             cred.get_credential().await.expect("credential").bearer,
             "t1"
@@ -572,13 +582,26 @@ mod tests {
     }
 
     #[test]
-    fn provider_without_bearer_has_no_swappable_and_update_is_false() {
+    fn provider_without_bearer_has_no_swappable() {
         let provider =
             GcsStorageProvider::new_with_prefix("b", "", &StorageOptions::new()).expect("build");
         assert!(provider.shared_credential().is_none());
-        let rotated =
-            StorageOptions::from([(GCS_BEARER_TOKEN_OPTION.to_string(), "t1".to_string())]);
-        assert!(!provider.update_credentials(&rotated).expect("no swap"));
+    }
+
+    #[test]
+    fn debug_output_redacts_the_bearer_token() {
+        let secret = "super-secret-token-value";
+        let opts =
+            StorageOptions::from([(GCS_BEARER_TOKEN_OPTION.to_string(), secret.to_string())]);
+        let provider = GcsStorageProvider::new_with_prefix("b", "", &opts).expect("build");
+        let rendered = format!("{provider:?}");
+        assert!(!rendered.contains(secret), "provider Debug leaks the token");
+
+        let cred = provider.shared_credential().expect("swappable present");
+        assert!(
+            !format!("{cred:?}").contains(secret),
+            "credential Debug leaks the token"
+        );
     }
 
     #[tokio::test]

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -13,12 +13,13 @@
 
 use std::{ops::Range, sync::Arc, time::Duration};
 
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::TryStreamExt;
 use object_store::{
-    ClientOptions, Error as ObjError, GetOptions, GetRange, MultipartUpload, ObjectMeta as OsMeta,
-    ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, StaticCredentialProvider,
+    ClientOptions, CredentialProvider, Error as ObjError, GetOptions, GetRange, MultipartUpload,
+    ObjectMeta as OsMeta, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload,
     UpdateVersion,
     gcp::{GcpCredential, GoogleCloudStorage, GoogleCloudStorageBuilder, GoogleConfigKey},
     path::Path as ObjPath,
@@ -49,7 +50,34 @@ const GCS_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 /// `object_store` config-key, so it is applied programmatically through the
 /// client's credential provider. When present it is consumed here rather than
 /// folded on as a `google_*` config key (which would be rejected as unknown).
-const GCS_BEARER_TOKEN_OPTION: &str = "google_bearer_token";
+pub(crate) const GCS_BEARER_TOKEN_OPTION: &str = "google_bearer_token";
+
+/// A GCS bearer credential the client reads per request, so a rotation swaps the token in place.
+#[derive(Debug)]
+pub struct SwappableGcpCredential {
+    current: ArcSwap<GcpCredential>,
+}
+
+impl SwappableGcpCredential {
+    pub fn new(bearer: String) -> Arc<Self> {
+        Arc::new(Self {
+            current: ArcSwap::from_pointee(GcpCredential { bearer }),
+        })
+    }
+
+    pub fn set_bearer(&self, bearer: String) {
+        self.current.store(Arc::new(GcpCredential { bearer }));
+    }
+}
+
+#[async_trait]
+impl CredentialProvider for SwappableGcpCredential {
+    type Credential = GcpCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<GcpCredential>> {
+        Ok(self.current.load_full())
+    }
+}
 
 /// GCS-backed `StorageProvider`. Cheap to clone; the inner
 /// `GoogleCloudStorage` shares its HTTP client across clones.
@@ -58,6 +86,7 @@ pub struct GcsStorageProvider {
     bucket: String,
     prefix: String,
     store: Arc<GoogleCloudStorage>,
+    credential: Option<Arc<SwappableGcpCredential>>,
     meter: Arc<UsageMeter>,
 }
 
@@ -79,20 +108,30 @@ impl GcsStorageProvider {
         prefix: impl Into<String>,
         opts: &StorageOptions,
     ) -> Result<Self, StorageError> {
+        Self::new_with_shared_credential(bucket, prefix, opts, None)
+    }
+
+    /// Like [`Self::new_with_prefix`] but shares a caller-owned rotatable credential when supplied.
+    pub fn new_with_shared_credential(
+        bucket: impl Into<String>,
+        prefix: impl Into<String>,
+        opts: &StorageOptions,
+        shared: Option<Arc<SwappableGcpCredential>>,
+    ) -> Result<Self, StorageError> {
         let bucket = bucket.into();
         let uri = format!("gs://{bucket}");
         let mut builder = GoogleCloudStorageBuilder::new()
             .with_bucket_name(&bucket)
             .with_client_options(tuned_client_options())
             .with_retry(retry::config());
-        // A bearer token has no object_store config-key, so pull it out and set
-        // it on the client's credential provider; the rest fold on as config keys.
         let mut config_opts = opts.clone();
-        if let Some(bearer) = config_opts.remove(GCS_BEARER_TOKEN_OPTION) {
-            builder =
-                builder.with_credentials(Arc::new(StaticCredentialProvider::new(GcpCredential {
-                    bearer,
-                })));
+        let bearer = config_opts.remove(GCS_BEARER_TOKEN_OPTION);
+        let credential = match shared {
+            Some(shared) => Some(shared),
+            None => bearer.map(SwappableGcpCredential::new),
+        };
+        if let Some(credential) = &credential {
+            builder = builder.with_credentials(Arc::clone(credential) as Arc<_>);
         }
         let builder = apply::<GoogleConfigKey, _>(builder, &config_opts, &uri, |b, key, value| {
             b.with_config(key, value)
@@ -105,6 +144,7 @@ impl GcsStorageProvider {
             bucket,
             prefix: normalize_prefix(prefix),
             store: Arc::new(store),
+            credential,
             meter: UsageMeter::process_default(),
         })
     }
@@ -116,8 +156,14 @@ impl GcsStorageProvider {
             bucket: bucket.into(),
             prefix: String::new(),
             store: Arc::new(store),
+            credential: None,
             meter: UsageMeter::process_default(),
         }
+    }
+
+    /// The swappable credential this provider fetches with, if any.
+    pub fn shared_credential(&self) -> Option<Arc<SwappableGcpCredential>> {
+        self.credential.clone()
     }
 
     /// Replace the usage meter (connection-scoped ledger).
@@ -426,6 +472,16 @@ impl StorageProvider for GcsStorageProvider {
     fn usage_meter(&self) -> Arc<UsageMeter> {
         Arc::clone(&self.meter)
     }
+
+    fn update_credentials(&self, opts: &StorageOptions) -> Result<bool, StorageError> {
+        let (Some(credential), Some(bearer)) =
+            (&self.credential, opts.get(GCS_BEARER_TOKEN_OPTION))
+        else {
+            return Ok(false);
+        };
+        credential.set_bearer(bearer.clone());
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -480,6 +536,82 @@ mod tests {
         let provider = GcsStorageProvider::new_with_prefix("test-bucket", "", &opts)
             .expect("bearer token and config keys coexist");
         assert_eq!(provider.bucket, "test-bucket");
+    }
+
+    #[tokio::test]
+    async fn swappable_credential_swaps_the_bearer_in_place() {
+        let cred = SwappableGcpCredential::new("t0".to_string());
+        assert_eq!(
+            cred.get_credential().await.expect("credential").bearer,
+            "t0"
+        );
+        cred.set_bearer("t1".to_string());
+        assert_eq!(
+            cred.get_credential().await.expect("credential").bearer,
+            "t1"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_with_bearer_updates_credential_in_place() {
+        let opts = StorageOptions::from([(GCS_BEARER_TOKEN_OPTION.to_string(), "t0".to_string())]);
+        let provider = GcsStorageProvider::new_with_prefix("b", "", &opts).expect("build");
+        let cred = provider.shared_credential().expect("swappable present");
+        assert_eq!(
+            cred.get_credential().await.expect("credential").bearer,
+            "t0"
+        );
+
+        let rotated =
+            StorageOptions::from([(GCS_BEARER_TOKEN_OPTION.to_string(), "t1".to_string())]);
+        assert!(provider.update_credentials(&rotated).expect("swap ok"));
+        assert_eq!(
+            cred.get_credential().await.expect("credential").bearer,
+            "t1"
+        );
+    }
+
+    #[test]
+    fn provider_without_bearer_has_no_swappable_and_update_is_false() {
+        let provider =
+            GcsStorageProvider::new_with_prefix("b", "", &StorageOptions::new()).expect("build");
+        assert!(provider.shared_credential().is_none());
+        let rotated =
+            StorageOptions::from([(GCS_BEARER_TOKEN_OPTION.to_string(), "t1".to_string())]);
+        assert!(!provider.update_credentials(&rotated).expect("no swap"));
+    }
+
+    #[tokio::test]
+    async fn providers_sharing_a_credential_rotate_together() {
+        let cred = SwappableGcpCredential::new("t0".to_string());
+        let opts = StorageOptions::new();
+        let p1 = GcsStorageProvider::new_with_shared_credential(
+            "b",
+            "one",
+            &opts,
+            Some(Arc::clone(&cred)),
+        )
+        .expect("p1");
+        let p2 = GcsStorageProvider::new_with_shared_credential(
+            "b",
+            "two",
+            &opts,
+            Some(Arc::clone(&cred)),
+        )
+        .expect("p2");
+        assert!(Arc::ptr_eq(&p1.shared_credential().expect("c1"), &cred));
+        assert!(Arc::ptr_eq(&p2.shared_credential().expect("c2"), &cred));
+
+        cred.set_bearer("t1".to_string());
+        assert_eq!(
+            p1.shared_credential()
+                .expect("c1")
+                .get_credential()
+                .await
+                .expect("credential")
+                .bearer,
+            "t1"
+        );
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -590,6 +590,11 @@ pub trait StorageProvider: Send + Sync + fmt::Debug {
     fn local_path(&self, _uri: &str) -> Option<PathBuf> {
         None
     }
+
+    /// Rotate the credential in place from `opts`; `false` if unsupported and the caller must reopen.
+    fn update_credentials(&self, _opts: &StorageOptions) -> Result<bool, StorageError> {
+        Ok(false)
+    }
 }
 
 /// Convert an object-store LIST result back into the provider-relative key

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -590,11 +590,6 @@ pub trait StorageProvider: Send + Sync + fmt::Debug {
     fn local_path(&self, _uri: &str) -> Option<PathBuf> {
         None
     }
-
-    /// Rotate the credential in place from `opts`; `false` if unsupported and the caller must reopen.
-    fn update_credentials(&self, _opts: &StorageOptions) -> Result<bool, StorageError> {
-        Ok(false)
-    }
 }
 
 /// Convert an object-store LIST result back into the provider-relative key


### PR DESCRIPTION
add support to swap creds in place instead of building a new connection on refreshing creds