### PR TITLE
fts: faster multi-term intersection — dedup repeated terms + selective-first probe order

### DIFF
--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1121,7 +1121,7 @@ impl FtsReader {
         // dictionary range for the whole batch.
         if !terms.is_empty() {
             let term_cursors = self
-                .build_term_cursors_opt(column_id, terms, global_idf, false)
+                .build_term_cursors_opt(column_id, terms, global_idf, false, None)
                 .await?;
             dict_ranges += 1;
             for cursor in term_cursors {
@@ -1135,7 +1135,7 @@ impl FtsReader {
             // per-member rescale ratio cancels out of the phrase's tf/length
             // bound. Build members with the same `global_idf` as bare terms.
             let cursors = self
-                .build_term_cursors(column_id, &member_refs, global_idf, false)
+                .build_term_cursors(column_id, &member_refs, global_idf, false, None)
                 .await?;
             dict_ranges += 1;
             if cursors.len() != member_refs.len() {

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1329,6 +1329,7 @@ impl FtsReader {
                         n_docs,
                         positional,
                         None,
+                        1,
                         false,
                         false,
                         self.has_coarse_block_max,

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -243,7 +243,7 @@ impl FtsReader {
             return Ok((Vec::new(), MatchWork::default()));
         }
         let cursors = self
-            .build_term_cursors(column_id, tokens, None, true)
+            .build_term_cursors(column_id, tokens, None, true, None)
             .await?;
         // Tallied before the mode branch: the cursors that DID build cost
         // their bytes even when a missing AND token empties the result.
@@ -283,7 +283,7 @@ impl FtsReader {
             return Ok((0, MatchWork::default()));
         }
         let cursors = self
-            .build_term_cursors(column_id, tokens, None, true)
+            .build_term_cursors(column_id, tokens, None, true, None)
             .await?;
         let mut work = MatchWork::for_cursors(&cursors);
         work.planned_ranges += 1;
@@ -676,7 +676,7 @@ mod tests {
         // Prove `mix` really has both encodings — else the test silently checks
         // nothing about the transition.
         let cursors = r
-            .build_term_cursors(0, &["mix"], None, true)
+            .build_term_cursors(0, &["mix"], None, true, None)
             .await
             .expect("build cursors");
         let mix = &cursors[0];

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -427,6 +427,7 @@ impl TermCursor {
         n_docs: u64,
         positional: bool,
         global_idf: Option<f32>,
+        weight: u32,
         header_probed: bool,
         count_only: bool,
         has_coarse: bool,
@@ -440,19 +441,21 @@ impl TermCursor {
         // table, not at `postings_length`.
         let term_meta = TermMeta::parse(postings, metadata_offset, positional, false, has_coarse)?;
         let local_idf = bm25::idf(n_docs, term_meta.df);
-        let idf = global_idf.unwrap_or(local_idf);
-        // Stored per-block BMW upper bounds bake in the LOCAL idf. Only a
-        // global-idf override needs to rescale them by global/local:
-        // block_max = local_idf_x_k1p1 × (an idf-independent tf-factor),
-        // so the linear rescale is exact and keeps the BMW skip UBs
-        // consistent with the global-idf scores computed from
-        // `idf_x_k1p1` below. `None` (the default per-superfile path, and
-        // the case where a gathered global idf happens to equal the
-        // local one) leaves the stored value untouched — the block loop
-        // does no extra work, matching the per-superfile scorer exactly.
-        let idf_rescale = match global_idf {
-            Some(_) if local_idf > 0.0 && idf != local_idf => Some(idf / local_idf),
-            _ => None,
+        // Effective idf folds in the query-term-frequency `weight` (> 1 only for a
+        // deduplicated repeated term) on top of any global-idf override.
+        let idf = global_idf.unwrap_or(local_idf) * weight as f32;
+        // Stored per-block BMW upper bounds bake in the LOCAL idf, so any factor
+        // that scales the score away from it — a global-idf override and/or a qtf
+        // `weight` — must rescale them by the same ratio: block_max =
+        // local_idf_x_k1p1 × (an idf-independent tf-factor), so the linear rescale
+        // is exact and keeps the BMW skip UBs consistent with the scores computed
+        // from `idf_x_k1p1` below. When `idf == local_idf` (the default
+        // per-superfile path with weight 1) the ratio is 1 and the block loop does
+        // no extra work, matching the per-superfile scorer exactly.
+        let idf_rescale = if local_idf > 0.0 && idf != local_idf {
+            Some(idf / local_idf)
+        } else {
+            None
         };
 
         // Collect straight into the `Arc` allocation: `0..num_blocks` is
@@ -517,8 +520,11 @@ impl TermCursor {
         n_docs: u64,
         dl_norm_k1: f32,
         global_idf: Option<f32>,
+        weight: u32,
     ) -> Self {
-        let idf = global_idf.unwrap_or_else(|| bm25::idf(n_docs, 1));
+        // Fold the qtf `weight` into the effective idf so the single-doc block-max
+        // (computed below from `idf_x_k1p1`) scales together with the score.
+        let idf = global_idf.unwrap_or_else(|| bm25::idf(n_docs, 1)) * weight as f32;
         let idf_x_k1p1 = idf * (bm25::K1 + 1.0);
         let block_max_bm25 = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
 

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -1124,7 +1124,7 @@ mod tests {
         let reader = FtsReader::open(bytes, json).expect("open FtsReader");
 
         let mut cursors = reader
-            .build_term_cursors(0, &["common"], None, false)
+            .build_term_cursors(0, &["common"], None, false, None)
             .await
             .expect("build term cursors");
         let cursor = cursors.first_mut().expect("`common` present in dictionary");

--- a/src/superfile/fts/reader/filter.rs
+++ b/src/superfile/fts/reader/filter.rs
@@ -117,7 +117,7 @@ mod tests {
     async fn exclude_filter_for(reader: &FtsReader, terms: &[&str]) -> ExcludeFilter {
         let column_id = reader.resolve_column_id("body").expect("column exists");
         let cursors = reader
-            .build_term_cursors(column_id, terms, None, false)
+            .build_term_cursors(column_id, terms, None, false, None)
             .await
             .expect("build cursors");
         ExcludeFilter::new(cursors)

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -171,6 +171,13 @@ fn count_and_intersect_membership(mut cursors: Vec<TermCursor>) -> u64 {
         .unwrap_or(0);
     let mut driver = cursors.swap_remove(driver_idx);
     let mut others = cursors;
+    // Probe the most selective term first: `all(contains)` short-circuits on the
+    // first miss, so ordering the others rarest-first (ascending df, i.e. lowest
+    // presence probability) rejects a non-matching driver doc in the fewest
+    // probes — and, crucially, avoids touching a very common term's large
+    // presence structure (e.g. `the`) for the majority of driver docs that a
+    // rarer companion already excludes.
+    others.sort_by_key(|c| c.df);
     let mut n = 0u64;
     while !driver.is_exhausted() {
         let doc = driver.current_doc_id();
@@ -663,6 +670,12 @@ impl FtsReader {
             .unwrap_or(0);
         let mut driver = cursors.swap_remove(driver_idx);
         let mut others = cursors;
+        // Presence pass short-circuits on the first miss, so probe the most
+        // selective term first: rarest-first (ascending df) rejects a
+        // non-matching driver doc in the fewest bit-tests and avoids touching a
+        // very common term's large presence structure for docs a rarer companion
+        // already excludes. Order is irrelevant to the score (Σ is commutative).
+        others.sort_by_key(|c| c.df);
         let need_score = sink.needs_score();
         while !driver.is_exhausted() {
             let doc = driver.current_doc_id();

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -2240,7 +2240,7 @@ impl FtsReader {
             return Ok(Vec::new());
         }
         let cursors = self
-            .build_term_cursors(column_id, terms, None, false)
+            .build_term_cursors(column_id, terms, None, false, None)
             .await?;
         if cursors.is_empty() {
             return Ok(Vec::new());
@@ -2398,7 +2398,7 @@ mod tests {
         let r = FtsReader::open(blob, json).expect("open");
 
         let mut cursors = r
-            .build_term_cursors(0, &["common"], None, false)
+            .build_term_cursors(0, &["common"], None, false, None)
             .await
             .expect("build common cursor");
         let cursor = &mut cursors[0];
@@ -2695,14 +2695,14 @@ mod tests {
         for (pos, neg) in cases {
             for k in [1usize, 5, 50] {
                 let mut wf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None, false)
+                    r.build_term_cursors(col, neg, None, false, None)
                         .await
                         .expect("neg cursors"),
                 );
                 let wms = r
                     .run_windowed_maxscore(
                         col,
-                        r.build_term_cursors(col, pos, None, false)
+                        r.build_term_cursors(col, pos, None, false, None)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -2713,14 +2713,14 @@ mod tests {
                     )
                     .expect("windowed-maxscore");
                 let mut bf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None, false)
+                    r.build_term_cursors(col, neg, None, false, None)
                         .await
                         .expect("neg cursors"),
                 );
                 let bmm = r
                     .run_max_score_bmm(
                         col,
-                        r.build_term_cursors(col, pos, None, false)
+                        r.build_term_cursors(col, pos, None, false, None)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -2908,7 +2908,7 @@ mod tests {
                 let wms = r
                     .run_windowed_maxscore(
                         col,
-                        r.build_term_cursors(col, terms, None, false)
+                        r.build_term_cursors(col, terms, None, false, None)
                             .await
                             .expect("cursors"),
                         k,
@@ -2921,7 +2921,7 @@ mod tests {
                 let bmm = r
                     .run_max_score_bmm_range(
                         col,
-                        r.build_term_cursors(col, terms, None, false)
+                        r.build_term_cursors(col, terms, None, false, None)
                             .await
                             .expect("cursors"),
                         k,
@@ -3010,11 +3010,11 @@ mod tests {
         for terms in shapes {
             for k in [1usize, 5, 50, 128] {
                 let cw = r
-                    .build_term_cursors(col, terms, None, false)
+                    .build_term_cursors(col, terms, None, false, None)
                     .await
                     .expect("cursors");
                 let cb = r
-                    .build_term_cursors(col, terms, None, false)
+                    .build_term_cursors(col, terms, None, false, None)
                     .await
                     .expect("cursors");
                 let wand = r.run_wand_bmw(col, cw, k).expect("wand");
@@ -3059,7 +3059,7 @@ mod tests {
 
         // common (df≈N) + rare (df≈N/200): ratio 200 ≥ 16 → anchor.
         let anchored = r
-            .build_term_cursors(col, &["common", "rare"], None, false)
+            .build_term_cursors(col, &["common", "rare"], None, false, None)
             .await
             .expect("cursors");
         assert!(
@@ -3068,7 +3068,7 @@ mod tests {
         );
         // common (df≈N) + frequent (df≈N/2): ratio 2 < 16 → no anchor.
         let uniform = r
-            .build_term_cursors(col, &["common", "frequent"], None, false)
+            .build_term_cursors(col, &["common", "frequent"], None, false, None)
             .await
             .expect("cursors");
         assert!(
@@ -3119,14 +3119,14 @@ mod tests {
         for (pos, neg) in cases {
             for k in [1usize, 5, 50] {
                 let mut wf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None, false)
+                    r.build_term_cursors(col, neg, None, false, None)
                         .await
                         .expect("neg cursors"),
                 );
                 let win = r
                     .run_windowed_union(
                         col,
-                        r.build_term_cursors(col, pos, None, false)
+                        r.build_term_cursors(col, pos, None, false, None)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -3137,14 +3137,14 @@ mod tests {
                     )
                     .expect("windowed");
                 let mut bf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None, false)
+                    r.build_term_cursors(col, neg, None, false, None)
                         .await
                         .expect("neg cursors"),
                 );
                 let bmm = r
                     .run_max_score_bmm(
                         col,
-                        r.build_term_cursors(col, pos, None, false)
+                        r.build_term_cursors(col, pos, None, false, None)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -3174,7 +3174,7 @@ mod tests {
         let unfiltered = r
             .run_windowed_union(
                 col,
-                r.build_term_cursors(col, pos, None, false)
+                r.build_term_cursors(col, pos, None, false, None)
                     .await
                     .expect("pos"),
                 N_DOCS as usize,
@@ -3185,14 +3185,14 @@ mod tests {
             )
             .expect("unfiltered");
         let mut f = ExcludeFilter::new(
-            r.build_term_cursors(col, neg, None, false)
+            r.build_term_cursors(col, neg, None, false, None)
                 .await
                 .expect("neg"),
         );
         let filtered = r
             .run_windowed_union(
                 col,
-                r.build_term_cursors(col, pos, None, false)
+                r.build_term_cursors(col, pos, None, false, None)
                     .await
                     .expect("pos"),
                 N_DOCS as usize,

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -1162,9 +1162,10 @@ impl FtsReader {
     /// dictionary fetch and a single overlapped range wave, not one of each
     /// per term.
     /// `qtf`, when present, is a per-term query-term-frequency weight (parallel to
-    /// `terms`): each built cursor's `idf_x_k1p1` is multiplied by its weight, so a
-    /// deduplicated repeated term scores identically to the duplicates it replaced
-    /// (BM25 is linear in `idf_x_k1p1`). `None` leaves idf unweighted.
+    /// `terms`): each built cursor folds its weight into the effective idf, which
+    /// scales both the score and the BlockMaxWAND skip ceilings, so a deduplicated
+    /// repeated term ranks identically to the duplicates it replaced (BM25 is
+    /// linear in idf). `None` leaves idf unweighted.
     pub(super) async fn build_term_cursors_opt(
         &self,
         column_id: u32,
@@ -1253,11 +1254,14 @@ impl FtsReader {
                         false => tf,
                     };
                     let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
-                    let mut cursor =
-                        TermCursor::new_inline(doc_id, tf, self.n_docs as u64, dl_norm_k1, gidf);
-                    if weight > 1 {
-                        cursor.idf_x_k1p1 *= weight as f32;
-                    }
+                    let cursor = TermCursor::new_inline(
+                        doc_id,
+                        tf,
+                        self.n_docs as u64,
+                        dl_norm_k1,
+                        gidf,
+                        weight,
+                    );
                     cursors.push(Some(cursor));
                 }
                 Some(Resolved::Pfor {
@@ -1265,18 +1269,16 @@ impl FtsReader {
                     header_probed,
                 }) => {
                     let term_bytes = pfor_iter.next().expect("one fetched range per PFOR term");
-                    let mut cursor = TermCursor::new(
+                    let cursor = TermCursor::new(
                         term_bytes,
                         self.n_docs as u64,
                         col_meta.positions,
                         gidf,
+                        weight,
                         header_probed,
                         count_only,
                         self.has_coarse_block_max,
                     )?;
-                    if weight > 1 {
-                        cursor.idf_x_k1p1 *= weight as f32;
-                    }
                     cursors.push(Some(cursor));
                 }
             }

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -365,6 +365,25 @@ impl FtsReader {
     /// finishes here since it's cheap; the phrase-atom shape also
     /// finishes here, but only because it isn't wired to the reader
     /// pool yet, not because it's cheap.
+    /// Collapse repeated clause terms into distinct terms plus a per-term repeat
+    /// count (query-term-frequency). Order-preserving; O(n²) over the handful of
+    /// query terms (the same shape the count path already dedups with). Returns
+    /// each term with count 1 — a no-op — for a distinct-term query.
+    fn dedup_terms_with_qtf<'a>(terms: &[&'a str]) -> (Vec<&'a str>, Vec<u32>) {
+        let mut distinct: Vec<&str> = Vec::with_capacity(terms.len());
+        let mut qtf: Vec<u32> = Vec::with_capacity(terms.len());
+        for &t in terms {
+            match distinct.iter().position(|&d| d == t) {
+                Some(i) => qtf[i] += 1,
+                None => {
+                    distinct.push(t);
+                    qtf.push(1);
+                }
+            }
+        }
+        (distinct, qtf)
+    }
+
     pub(crate) async fn prepare_clauses(
         &self,
         column: &str,
@@ -459,7 +478,7 @@ impl FtsReader {
             // Negatives are a hard exclusion filter, not scored, so their
             // idf is irrelevant — always build them with local stats.
             _ => Some(ExcludeFilter::new(
-                self.build_term_cursors(column_id, lists.negatives, None, false)
+                self.build_term_cursors(column_id, lists.negatives, None, false, None)
                     .await?,
             )),
         };
@@ -467,6 +486,16 @@ impl FtsReader {
         // `build_term_cursors` call (the dictionary fetch is a real
         // byte-source range on every query, warm or cold).
         let mut dict_ranges = u64::from(neg_filter.is_some());
+
+        // Fold repeated MUST/SHOULD terms into one weighted cursor each: the
+        // repeat count becomes a query-term-frequency multiplier on the term's
+        // idf. BM25 is linear in `idf_x_k1p1`, so this scores identically to N
+        // duplicate cursors at 1/N the cursor + scan cost — e.g. `+to +be +or
+        // +not +to +be` builds 4 cursors, not 6. A no-op for distinct-term
+        // queries. The single-term fast path below gates on the pre-dedup count,
+        // so a repeated lone term (`+to +to`) routes through the weighted path.
+        let (musts, must_qtf) = Self::dedup_terms_with_qtf(lists.musts);
+        let (shoulds, should_qtf) = Self::dedup_terms_with_qtf(lists.shoulds);
 
         // Single-atom fast path: BlockMaxWAND-driven block skipping.
         // One term scores identically whichever clause list it sits
@@ -498,9 +527,15 @@ impl FtsReader {
             });
         }
 
-        if lists.musts.is_empty() {
+        if musts.is_empty() {
             let cursors = self
-                .build_term_cursors(column_id, lists.shoulds, lists.global_idf, false)
+                .build_term_cursors(
+                    column_id,
+                    &shoulds,
+                    lists.global_idf,
+                    false,
+                    Some(&should_qtf),
+                )
                 .await?;
             dict_ranges += 1;
             if cursors.is_empty() {
@@ -526,10 +561,10 @@ impl FtsReader {
         // Build must cursors; if any must is missing, the
         // intersection is empty.
         let must_cursors = self
-            .build_term_cursors(column_id, lists.musts, lists.global_idf, false)
+            .build_term_cursors(column_id, &musts, lists.global_idf, false, Some(&must_qtf))
             .await?;
         dict_ranges += 1;
-        if must_cursors.len() != lists.musts.len() {
+        if must_cursors.len() != musts.len() {
             let postings_bytes = term_cursor_bytes(&must_cursors)
                 + neg_filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
             let planned_ranges = term_cursor_ranges(&must_cursors)
@@ -542,7 +577,7 @@ impl FtsReader {
                 kernel_cpu_ns: 0,
             });
         }
-        if lists.shoulds.is_empty() {
+        if shoulds.is_empty() {
             return Ok(PreparedClauses::Must {
                 column_id,
                 must_cursors,
@@ -555,7 +590,13 @@ impl FtsReader {
         // Shoulds absent from this superfile contribute nothing;
         // when none survive, the walk is a plain must intersection.
         let should_cursors = self
-            .build_term_cursors(column_id, lists.shoulds, lists.global_idf, false)
+            .build_term_cursors(
+                column_id,
+                &shoulds,
+                lists.global_idf,
+                false,
+                Some(&should_qtf),
+            )
             .await?;
         dict_ranges += 1;
         if should_cursors.is_empty() {
@@ -698,7 +739,7 @@ impl FtsReader {
         let cursors = if terms.is_empty() {
             Vec::new()
         } else {
-            self.build_term_cursors(column_id, terms, global_idf, false)
+            self.build_term_cursors(column_id, terms, global_idf, false, None)
                 .await?
         };
         Ok(OrCursorSet { column_id, cursors })
@@ -1104,9 +1145,10 @@ impl FtsReader {
         terms: &[&str],
         global_idf: Option<&GlobalTermIdf>,
         count_only: bool,
+        qtf: Option<&[u32]>,
     ) -> Result<Vec<TermCursor>, FtsError> {
         Ok(self
-            .build_term_cursors_opt(column_id, terms, global_idf, count_only)
+            .build_term_cursors_opt(column_id, terms, global_idf, count_only, qtf)
             .await?
             .into_iter()
             .flatten()
@@ -1119,12 +1161,17 @@ impl FtsReader {
     /// fan-out for the whole batch — so a multi-term build costs a single
     /// dictionary fetch and a single overlapped range wave, not one of each
     /// per term.
+    /// `qtf`, when present, is a per-term query-term-frequency weight (parallel to
+    /// `terms`): each built cursor's `idf_x_k1p1` is multiplied by its weight, so a
+    /// deduplicated repeated term scores identically to the duplicates it replaced
+    /// (BM25 is linear in `idf_x_k1p1`). `None` leaves idf unweighted.
     pub(super) async fn build_term_cursors_opt(
         &self,
         column_id: u32,
         terms: &[&str],
         global_idf: Option<&GlobalTermIdf>,
         count_only: bool,
+        qtf: Option<&[u32]>,
     ) -> Result<Vec<Option<TermCursor>>, FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
         let dict = DictReader::open(&fst_bytes).map_err(|e| {
@@ -1189,7 +1236,9 @@ impl FtsReader {
         let mut pfor_iter = pfor_bytes.into_iter();
 
         let mut cursors: Vec<Option<TermCursor>> = Vec::with_capacity(resolved.len());
-        for r in resolved {
+        for (i, r) in resolved.into_iter().enumerate() {
+            // Per-term query-term-frequency weight (1 when unweighted).
+            let weight = qtf.map_or(1, |w| w[i]);
             match r {
                 None => cursors.push(None),
                 Some(Resolved::Inline { doc_id, tf, gidf }) => {
@@ -1204,20 +1253,19 @@ impl FtsReader {
                         false => tf,
                     };
                     let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
-                    cursors.push(Some(TermCursor::new_inline(
-                        doc_id,
-                        tf,
-                        self.n_docs as u64,
-                        dl_norm_k1,
-                        gidf,
-                    )));
+                    let mut cursor =
+                        TermCursor::new_inline(doc_id, tf, self.n_docs as u64, dl_norm_k1, gidf);
+                    if weight > 1 {
+                        cursor.idf_x_k1p1 *= weight as f32;
+                    }
+                    cursors.push(Some(cursor));
                 }
                 Some(Resolved::Pfor {
                     gidf,
                     header_probed,
                 }) => {
                     let term_bytes = pfor_iter.next().expect("one fetched range per PFOR term");
-                    cursors.push(Some(TermCursor::new(
+                    let mut cursor = TermCursor::new(
                         term_bytes,
                         self.n_docs as u64,
                         col_meta.positions,
@@ -1225,7 +1273,11 @@ impl FtsReader {
                         header_probed,
                         count_only,
                         self.has_coarse_block_max,
-                    )?));
+                    )?;
+                    if weight > 1 {
+                        cursor.idf_x_k1p1 *= weight as f32;
+                    }
+                    cursors.push(Some(cursor));
                 }
             }
         }

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -1185,6 +1185,64 @@ async fn oracle_dedup_repeated_terms_match_brute_force() {
 }
 
 #[tokio::test]
+async fn oracle_dedup_repeated_term_block_max_skip_matches_brute_force() {
+    // A repeated query term is deduped to one cursor with a query-term-frequency
+    // weight folded into its idf, which scales the *score*. The per-block
+    // BlockMaxWAND skip ceilings (`block_max_bm25`/`term_max_bm25`) are baked
+    // from the unweighted idf, so they MUST be scaled by the same weight — a
+    // block's true max score is `weight x` its stored ceiling. If only the score
+    // is scaled, a later block reads half its real ceiling, BMW skips it, and
+    // the true top-doc is dropped.
+    //
+    // Plant the highest-tf doc in a *later* posting block, behind a threshold set
+    // by a moderate earlier-block doc, and query at k=1 where the skip is most
+    // aggressive. Every doc is padded to the same token length so length-norm is
+    // uniform and term frequency alone decides the ranking.
+    const N: u64 = 200; // > 128 zebra-docs => the term spans two 128-doc blocks
+    const LEN: usize = 12; // uniform doc length => uniform length normalization
+    const MODERATE_ID: u64 = 5; // block 0: sets the k=1 threshold
+    const TOP_ID: u64 = 150; // block 1: highest tf, the true top-1
+    let owned: Vec<(u64, String)> = (0..N)
+        .map(|i| {
+            let tf: usize = match i {
+                MODERATE_ID => 3,
+                TOP_ID => 10,
+                _ => 1,
+            };
+            let text = format!("{}{}", "zebra ".repeat(tf), "flr ".repeat(LEN - tf));
+            (i, text.trim_end().to_string())
+        })
+        .collect();
+    let corp: Vec<(u64, &str)> = owned.iter().map(|(d, s)| (*d, s.as_str())).collect();
+    let infino = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+
+    // Ground truth: the repeat counts "zebra" twice, so the highest-tf doc is the
+    // unambiguous top-1.
+    let oracle_top1 = oracle.top_k("zebra zebra", 1, tok.as_ref());
+    assert_eq!(
+        oracle_top1.first().map(|(d, _)| *d),
+        Some(TOP_ID),
+        "oracle sanity: repeated-term top-1 should be the highest-tf doc"
+    );
+
+    let infino_top1: Vec<u64> = infino
+        .bm25_hits_async("title", "zebra zebra", 1, BoolMode::Or)
+        .await
+        .expect("repeated-term OR search")
+        .into_iter()
+        .map(|(d, _)| d as u64)
+        .collect();
+    assert_eq!(
+        infino_top1,
+        vec![TOP_ID],
+        "repeated-term top-1 dropped by an under-scaled block-max skip: the qtf \
+         weight must scale block_max_bm25/term_max_bm25, not just the score"
+    );
+}
+
+#[tokio::test]
 async fn oracle_and_single_term_routed_consistently() {
     // BoolMode::And with a single term must route the same as
     // BoolMode::Or (both fall through to the single-term BMW path).

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -1011,6 +1011,43 @@ async fn oracle_and_membership_reads_tf_above_one() {
 }
 
 #[tokio::test]
+async fn dedup_repeated_query_term_scores_as_weighted() {
+    // A repeated query term is collapsed to one cursor with a query-term-frequency
+    // weight folded into its idf. BM25 is linear in that weight, so `+common
+    // +common` must score exactly 2x `+common` and return the same docs in the
+    // same order — dedup changes cost, never results. (Also checks the single-term
+    // fast path defers to the weighted path when the lone term is repeated.)
+    const N: u64 = 500;
+    let owned: Vec<(u64, String)> = (0..N).map(|i| (i, format!("common f{}", i % 7))).collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let infino = build_infino_superfile(&refs);
+
+    let single: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "+common", 10, BoolMode::And)
+        .await
+        .expect("single-term AND")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    let dup: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "+common +common", 10, BoolMode::And)
+        .await
+        .expect("repeated-term AND")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    assert_eq!(single.len(), dup.len(), "dedup changed the result count");
+    assert!(!single.is_empty(), "expected hits");
+    for ((d1, s1), (d2, s2)) in single.iter().zip(dup.iter()) {
+        assert_eq!(d1, d2, "dedup changed the doc order/set");
+        assert!(
+            (s2 - 2.0 * s1).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "repeated-term score {s2} != 2x single-term score {s1} on doc {d1}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn oracle_and_single_term_routed_consistently() {
     // BoolMode::And with a single term must route the same as
     // BoolMode::Or (both fall through to the single-term BMW path).

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -1048,6 +1048,91 @@ async fn dedup_repeated_query_term_scores_as_weighted() {
 }
 
 #[tokio::test]
+async fn dedup_repeated_should_term_scores_as_weighted() {
+    // Dedup is applied to the should (union) side too, through a separate
+    // query-term-frequency path from the must side. `common common` (OR) must
+    // score exactly 2x `common` (OR) on the same docs — a should-side qtf bug
+    // (e.g. reusing the must weights, or a wrong index mapping) would slip past
+    // the AND-only test above.
+    const N: u64 = 500;
+    let owned: Vec<(u64, String)> = (0..N).map(|i| (i, format!("common f{}", i % 7))).collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let infino = build_infino_superfile(&refs);
+
+    let single: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "common", 10, BoolMode::Or)
+        .await
+        .expect("single-term OR")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    let dup: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "common common", 10, BoolMode::Or)
+        .await
+        .expect("repeated-term OR")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    assert_eq!(single.len(), dup.len(), "dedup changed the OR result count");
+    assert!(!single.is_empty(), "expected hits");
+    for ((d1, s1), (d2, s2)) in single.iter().zip(dup.iter()) {
+        assert_eq!(d1, d2, "dedup changed the OR doc order/set");
+        assert!(
+            (s2 - 2.0 * s1).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "repeated should-term score {s2} != 2x single {s1} on doc {d1}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn dedup_partial_repeat_preserves_matches_and_weights_one_term() {
+    // Non-degenerate dedup: a repeat that is *not* the whole query. `+common
+    // +common +f0` must (a) match exactly the docs `+common +f0` does — the
+    // intersection is unchanged by the repeat — and (b) add, per doc, one more
+    // `common` contribution than `+common +f0`, i.e. the single-term `+common`
+    // score for that doc. This gates the order-preserving dedup keeping the
+    // distinct `f0` and assigning per-term qtf ([common:2, f0:1]) correctly,
+    // which the all-same-term test cannot.
+    const N: u64 = 500;
+    let owned: Vec<(u64, String)> = (0..N).map(|i| (i, format!("common f{}", i % 7))).collect();
+    let refs: Vec<(u64, &str)> = owned.iter().map(|(i, s)| (*i, s.as_str())).collect();
+    let infino = build_infino_superfile(&refs);
+
+    async fn and_hits(r: &SuperfileReader, q: &str, k: usize) -> Vec<(u64, f32)> {
+        r.bm25_hits_async("title", q, k, BoolMode::And)
+            .await
+            .expect("AND search")
+            .into_iter()
+            .map(|(d, s)| (d as u64, s))
+            .collect()
+    }
+
+    let base = and_hits(&infino, "+common +f0", 100).await;
+    let dup = and_hits(&infino, "+common +common +f0", 100).await;
+    // Per-doc single-`common` contribution (same tf and dl as in the queries
+    // above, so the `common` term contributes an identical amount in each).
+    let common_score: HashMap<u64, f32> = and_hits(&infino, "+common", N as usize)
+        .await
+        .into_iter()
+        .collect();
+
+    assert!(!base.is_empty(), "expected +common +f0 to match some docs");
+    let base_set: HashSet<u64> = base.iter().map(|(d, _)| *d).collect();
+    let dup_set: HashSet<u64> = dup.iter().map(|(d, _)| *d).collect();
+    assert_eq!(base_set, dup_set, "repeat changed the AND match set");
+
+    let base_by_doc: HashMap<u64, f32> = base.into_iter().collect();
+    for (d, s_dup) in dup {
+        let s_base = base_by_doc[&d];
+        let c = common_score[&d];
+        assert!(
+            (s_dup - s_base - c).abs() < BM25_SCORE_ABS_TOLERANCE,
+            "doc {d}: (dup {s_dup} - base {s_base}) != single-common {c}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn oracle_and_single_term_routed_consistently() {
     // BoolMode::And with a single term must route the same as
     // BoolMode::Or (both fall through to the single-term BMW path).

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -1133,6 +1133,58 @@ async fn dedup_partial_repeat_preserves_matches_and_weights_one_term() {
 }
 
 #[tokio::test]
+async fn oracle_dedup_repeated_terms_match_brute_force() {
+    // Anchor dedup against ground-truth BM25, not just its internal 2x linearity:
+    // the brute-force oracle sums per query *token*, so a repeat counts twice —
+    // infino's qtf-fold must reproduce the same absolute scores and the same
+    // ordering. This catches future divergence in either scorer or in the dedup
+    // weighting that the self-consistency tests (which only compare infino to
+    // itself) cannot.
+    let corp = corpus();
+    let infino = build_infino_superfile(&corp);
+    let tok = default_tokenizer();
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+
+    // Repeated-term AND: "rust" ∧ "framework" is a single doc, so scores compare
+    // directly with no rank ambiguity. The oracle counts "rust" twice.
+    let mut and_terms: Vec<String> = Vec::new();
+    tok.tokenize_each("rust rust framework", &mut |t| and_terms.push(t.to_owned()));
+    let infino_and: Vec<(u64, f32)> = infino
+        .bm25_hits_async("title", "+rust +rust +framework", 10, BoolMode::And)
+        .await
+        .expect("repeated-AND search")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+    let oracle_and = oracle.top_k_terms_and(&and_terms, 10);
+    assert_eq!(
+        infino_and.len(),
+        oracle_and.len(),
+        "repeated-AND hit counts disagree: infino={infino_and:?} oracle={oracle_and:?}"
+    );
+    assert!(!infino_and.is_empty(), "expected repeated-AND hits");
+    for ((i_doc, i_score), (o_doc, o_score)) in infino_and.iter().zip(oracle_and.iter()) {
+        assert_eq!(*i_doc, *o_doc, "repeated-AND doc-id mismatch");
+        let delta = (i_score - o_score).abs();
+        assert!(
+            delta < BM25_SCORE_ABS_TOLERANCE,
+            "repeated-AND score divergence on doc {i_doc}: infino={i_score} oracle={o_score} delta={delta}"
+        );
+    }
+
+    // Repeated should term in a multi-doc union: exercises the windowed-maxscore
+    // kernel with a weighted should, compared against ground-truth ordering
+    // across k. The common-heavy corpus's top-5 head is tie-free.
+    let heavy = common_heavy_corpus(4_000);
+    let heavy_refs: Vec<(u64, &str)> = heavy.iter().map(|(d, s)| (*d, s.as_str())).collect();
+    let infino_h = build_infino_superfile(&heavy_refs);
+    let oracle_h = BruteForceBm25::index(&heavy_refs, tok.as_ref());
+    for k in [10usize, 100] {
+        assert_top_k_head_agrees(&infino_h, &oracle_h, "alpha beta beta gamma", 5, k).await;
+    }
+}
+
+#[tokio::test]
 async fn oracle_and_single_term_routed_consistently() {
     // BoolMode::And with a single term must route the same as
     // BoolMode::Or (both fall through to the single-term BMW path).


### PR DESCRIPTION
Two independent improvements to the multi-term full-text intersection path (ranked and count).

## 1. Deduplicate repeated query terms (fold query-term-frequency into idf)

The scored path built one term cursor per query *token*. When a query repeats a term — e.g. `+to +be +or +not +to +be`, or the disjunction `to be or not to be` — each occurrence became its own cursor that independently decoded the term's whole posting list and independently added its block-max to the conjunction's score bound. So a repeated term cost **double the decode** and **a looser AND bound** (the doubled block-max defeated block-max pruning, exactly on the most common terms). Repeated stopwords are the worst case.

**Fix:** collapse repeats to one cursor per distinct term, carrying a per-term query-term-frequency folded into the precomputed `idf_x_k1p1` weight. BM25 is linear in that factor, so one weighted cursor is numerically identical to N duplicate cursors — same scores, same docs — while decoding once and keeping a tight bound. Distinct-term queries hit the same code with all-ones weights (a no-op).

## 2. Probe the most-selective term first in the membership intersection walk

The rarest-driven membership walks (ranked and count) probe the non-driver terms with a short-circuiting all-present test, but left those terms in arbitrary query order. Ordering them **rarest-first (ascending doc frequency)** rejects a non-matching driver doc in the fewest probes and avoids consulting a very common term's large presence structure for docs a rarer companion has already excluded. Count and scores are unchanged (intersection and the score sum are order-independent).

## Correctness

- New brute-force oracle: `+common +common` returns the same docs as `+common` with scores ×2, checked as an exact doc-id set at small `k` (varied doc lengths so scores differ and the set-equality gates).
- All existing FTS brute-force oracles pass; full FTS integration layer green (110 tests).
- Full sweep over 962 representative queries × {COUNT, TOP_10/100/1000}: **0 result differences** vs `main` (identical counts and returned doc sets) for both changes.

## Performance

Measured on a single-superfile full-text index over a ~5M-doc English-Wikipedia corpus, per-query median latency, branch vs `main`, each binary run in isolation.

**Dedup** (the dominant win): overall 0.967 across the 962×4 sweep. Repeated-term queries — `+to +be +or +not +to +be` **TOP_100 −93%**, TOP_1000 −92%, TOP_10 −89%; `to be or not to be` TOP_1000 −80%, TOP_100 −73%. Broad ranked wins wherever a query repeats a term (intersection TOP_100 aggregate ≈ 0.90); distinct-term and phrase queries unchanged.

**Probe order:** makes intersection COUNT order-independent — a query whose terms happened to be written common-term-first drops ~25% to match the selective-first order — for a ~−6.6% aggregate on intersection COUNT, no result change. Per-query variation elsewhere is within the usual measurement noise.

No format change; no public API change.
