### PR TITLE
superfile/vector: re-derive fine-cluster count when merging cells

### DIFF
--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -109,8 +109,9 @@ use crate::superfile::{
         cell_posting::{CellPostingBuilder, MaterializedIvfRow},
         distance::Metric,
         ivf_merge::{
-            MergedIvfSubsection, Sq8IvfMergeInput, merge_sq8_ivf_subsections,
-            merge_sq8_ivf_subsections_from_parsed, stable_ids_in_merged_local_order,
+            MergedIvfSubsection, Sq8IvfMergeInput, fine_run_target_n_cent,
+            merge_sq8_ivf_subsections, merge_sq8_ivf_subsections_from_parsed,
+            stable_ids_in_merged_local_order,
         },
         layout::VectorLayout,
         reader::{ColumnReader, VectorReader},
@@ -970,9 +971,10 @@ impl SuperfileBuilder {
 
         if any_tombstones {
             // Materialize → filter by file-local tombstone id → rebuild per cell.
-            // Also track the max fine-cluster count seen per cell so rebuilds
-            // keep the source IVF width (empty clusters stay empty).
-            let mut by_cell: HashMap<u32, (usize, Vec<MaterializedIvfRow>)> = HashMap::new();
+            // The fine-cluster count is re-derived from the surviving row count at
+            // rebuild time (see the build loop) so a merged cell is re-clustered
+            // to the fine-run byte target rather than inheriting a source width.
+            let mut by_cell: HashMap<u32, Vec<MaterializedIvfRow>> = HashMap::new();
             for (reader_idx, (reader, deleted)) in readers.iter().enumerate() {
                 let v = reader.vec().ok_or(BuildError::VectorReadError)?;
                 let superseded = superseded_per_reader.get(reader_idx);
@@ -995,20 +997,19 @@ impl SuperfileBuilder {
                     if rows.is_empty() {
                         continue;
                     }
-                    let entry = by_cell.entry(cell_id).or_insert_with(|| (0, Vec::new()));
-                    entry.0 = entry.0.max(col.n_cent as usize);
-                    entry.1.extend(rows);
+                    by_cell.entry(cell_id).or_default().extend(rows);
                 }
             }
 
             let mut cell_ids: Vec<u32> = by_cell.keys().copied().collect();
             cell_ids.sort_unstable();
             for cell_id in cell_ids {
-                let (n_cent, mut rows) = by_cell.remove(&cell_id).expect("cell present");
+                let mut rows = by_cell.remove(&cell_id).expect("cell present");
                 for (i, row) in rows.iter_mut().enumerate() {
                     row.local_doc_id = i as u32;
                 }
                 let stable_ids: Vec<i128> = rows.iter().map(|r| r.stable_id).collect();
+                let n_cent = fine_run_target_n_cent(vec_cfg.dim, vec_cfg.rerank_codec, rows.len());
                 let merged = build_merged_subsection_from_materialized(
                     vec_cfg.clone(),
                     n_cent.max(1),
@@ -1051,7 +1052,23 @@ impl SuperfileBuilder {
                 let same_shape = sources
                     .windows(2)
                     .all(|pair| pair[0].2.n_cent == pair[1].2.n_cent);
-                if same_shape {
+                // Byte-splice concatenates cluster-i with cluster-i positionally,
+                // so it emits the SOURCE fine-cluster count. That stays near the
+                // fine-run byte target only while the merged union still fits that
+                // many clusters; once the union crosses the target the spliced
+                // clusters fatten, their summary centroids drift to the blob's
+                // center of mass, and cell routing misranks (recall caps, cold
+                // reads balloon). Take the fast splice only when the union still
+                // fits the source width; otherwise fall through to the rebuild
+                // path, which re-clusters to the re-derived width.
+                let merged_docs: usize =
+                    sources.iter().map(|(_, _, inp)| inp.n_docs as usize).sum();
+                let fits_target = fine_run_target_n_cent(
+                    sources[0].2.dim,
+                    sources[0].2.rerank_codec,
+                    merged_docs,
+                ) <= sources[0].2.n_cent;
+                if same_shape && fits_target {
                     let mut inputs: Vec<Sq8IvfMergeInput> =
                         sources.into_iter().map(|(_, _, inp)| inp).collect();
                     let mut doc_base = 0u32;
@@ -1072,15 +1089,12 @@ impl SuperfileBuilder {
                     packed_cells.push((cell_id, merged));
                     continue;
                 }
-                // Same cell, different fine `n_cent` (a small delta drain
-                // merging into a larger base): byte-splice is positional per
-                // cluster, so rebuild this cell from materialized rows at the
-                // widest source width — same path the tombstone branch uses.
-                let n_cent = sources
-                    .iter()
-                    .map(|(_, _, inp)| inp.n_cent)
-                    .max()
-                    .unwrap_or(1);
+                // Reached when the sources disagree on fine `n_cent` (a small
+                // delta drain merging into a larger base) OR agree but their
+                // union no longer fits that width. Byte-splice is positional per
+                // cluster, so rebuild this cell from materialized rows and
+                // re-cluster to the fine-run byte target re-derived from the
+                // merged row count — same path the tombstone branch uses.
                 let mut rows: Vec<MaterializedIvfRow> = Vec::new();
                 for (reader_idx, ci, _) in sources {
                     let v = readers[reader_idx]
@@ -1093,6 +1107,7 @@ impl SuperfileBuilder {
                     row.local_doc_id = i as u32;
                 }
                 let stable_ids: Vec<i128> = rows.iter().map(|r| r.stable_id).collect();
+                let n_cent = fine_run_target_n_cent(vec_cfg.dim, vec_cfg.rerank_codec, rows.len());
                 let merged = build_merged_subsection_from_materialized(
                     vec_cfg.clone(),
                     n_cent.max(1),
@@ -4389,12 +4404,20 @@ mod tests {
         cells: &[(u32, usize, usize)],
         rerank_codec: RerankCodec,
     ) -> Arc<SuperfileReader> {
+        pack_cells_superfile_with_codec_dim(id_base, cells, rerank_codec, 16)
+    }
+
+    fn pack_cells_superfile_with_codec_dim(
+        id_base: i128,
+        cells: &[(u32, usize, usize)],
+        rerank_codec: RerankCodec,
+        dim: usize,
+    ) -> Arc<SuperfileReader> {
         use crate::superfile::vector::{
             builder::build_merged_subsection_from_materialized,
             cell_posting::{EncodedCellRow, MaterializedIvfRow},
         };
 
-        let dim = 16usize;
         let make_rows = |cell: u32, n: usize| -> Vec<MaterializedIvfRow> {
             let (scale, offset): (Arc<[f32]>, Arc<[f32]>) =
                 if rerank_codec == RerankCodec::Sq8FixedResidual {
@@ -4603,7 +4626,10 @@ mod tests {
     /// Base drain and a small delta drain legitimately pack the same global
     /// cell at different fine widths (fine `n_cent` is sized by packed bytes).
     /// The merge must rebuild such cells from materialized rows instead of
-    /// failing the byte-splice `n_cent` equality check.
+    /// failing the byte-splice `n_cent` equality check — and it re-derives the
+    /// fine width from the merged row count, not the widest source, so a small
+    /// merged cell collapses to a single fine run (8 rows fit far inside one
+    /// fine-run byte target) instead of inheriting the source's 4.
     #[test]
     fn multi_cell_merge_rebuilds_cells_with_mismatched_fine_width() {
         // Cell 0 disagrees on width (4 vs 1); cell 1 agrees (splice path).
@@ -4620,10 +4646,60 @@ mod tests {
         let v = merged.vec().expect("vec");
         assert_eq!(v.packed_cell_ids(), &[0, 1]);
         let cols: Vec<_> = v.vector_columns_config().collect();
-        assert_eq!(cols[0].n_docs, 8); // 6 + 2 rebuilt at the widest width
-        assert_eq!(cols[0].n_cent, 4);
-        assert_eq!(cols[1].n_docs, 5); // 2 + 3 byte-spliced
+        assert_eq!(cols[0].n_docs, 8); // 6 + 2 rebuilt from materialized rows
+        assert_eq!(cols[0].n_cent, 1); // re-derived to the byte target, not max(4,1)
+        assert_eq!(cols[1].n_docs, 5); // 2 + 3 byte-spliced (union fits width 2)
         assert_eq!(cols[1].n_cent, 2);
+    }
+
+    /// Regression: two fragments of the SAME cell that agree on fine `n_cent`
+    /// take the byte-splice path, which concatenates cluster-i with cluster-i
+    /// and emits the *source* fine-cluster count. When their union outgrows the
+    /// fine-run byte target the merge must instead re-cluster to the re-derived
+    /// width — otherwise the merged cell keeps a too-coarse count, its summary
+    /// centroids drift, and cell routing scans far more of the corpus than it
+    /// should. Before the fix this byte-spliced to the source width (1) for a
+    /// union that needs several fine runs.
+    #[test]
+    fn multi_cell_merge_resplits_when_union_exceeds_fine_run_target() {
+        // A wide vector inflates the per-row stride so a small, fast corpus
+        // still crosses the real fine-run byte target.
+        let dim = 512usize;
+        let codec = RerankCodec::Sq8Residual;
+        // Largest row count that still fits one fine run, then a union that
+        // spans several runs.
+        let rows_per_run = (1..)
+            .find(|&n| fine_run_target_n_cent(dim, codec, n) > 1)
+            .expect("threshold")
+            - 1;
+        let left_rows = rows_per_run + rows_per_run / 2;
+        let right_rows = rows_per_run + rows_per_run / 2;
+        let total = left_rows + right_rows;
+        let expected_n_cent = fine_run_target_n_cent(dim, codec, total);
+        assert!(
+            expected_n_cent > 1,
+            "test corpus must exceed one fine run (rows_per_run={rows_per_run})"
+        );
+
+        // Both fragments pack cell 0 at fine width 1 → same_shape → byte-splice
+        // candidate; the union exceeds one run and must be re-clustered.
+        let a = pack_cells_superfile_with_codec_dim(1_000, &[(0, left_rows, 1)], codec, dim);
+        let b = pack_cells_superfile_with_codec_dim(9_000, &[(0, right_rows, 1)], codec, dim);
+
+        let (merged_bytes, stats) =
+            SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(&[(a, None), (b, None)], &[])
+                .expect("merge over-target same-shape cell");
+        assert_eq!(stats.n_docs as usize, total);
+
+        let merged = SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged");
+        let v = merged.vec().expect("vec");
+        let cols: Vec<_> = v.vector_columns_config().collect();
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].n_docs as usize, total);
+        assert_eq!(
+            cols[0].n_cent as usize, expected_n_cent,
+            "merged cell must re-cluster to the byte-target width, not the source width 1"
+        );
     }
 
     #[test]

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -109,7 +109,7 @@ use crate::superfile::{
         cell_posting::{CellPostingBuilder, MaterializedIvfRow},
         distance::Metric,
         ivf_merge::{
-            MergedIvfSubsection, Sq8IvfMergeInput, fine_run_target_n_cent,
+            MergedIvfSubsection, Sq8IvfMergeInput, effective_fine_n_cent,
             merge_sq8_ivf_subsections, merge_sq8_ivf_subsections_from_parsed,
             stable_ids_in_merged_local_order,
         },
@@ -1009,7 +1009,7 @@ impl SuperfileBuilder {
                     row.local_doc_id = i as u32;
                 }
                 let stable_ids: Vec<i128> = rows.iter().map(|r| r.stable_id).collect();
-                let n_cent = fine_run_target_n_cent(vec_cfg.dim, vec_cfg.rerank_codec, rows.len());
+                let n_cent = effective_fine_n_cent(vec_cfg.dim, vec_cfg.rerank_codec, rows.len());
                 let merged = build_merged_subsection_from_materialized(
                     vec_cfg.clone(),
                     n_cent.max(1),
@@ -1060,14 +1060,18 @@ impl SuperfileBuilder {
                 // center of mass, and cell routing misranks (recall caps, cold
                 // reads balloon). Take the fast splice only when the union still
                 // fits the source width; otherwise fall through to the rebuild
-                // path, which re-clusters to the re-derived width.
+                // path, which re-clusters to the re-derived width. Compare
+                // against the EFFECTIVE count the build would store (byte target
+                // passed through the small-cell cap), not the raw byte target —
+                // a sub-threshold cell whose byte target exceeds the cap stores
+                // the capped count, so a raw-target gate would reject the splice
+                // and rebuild it on every compaction only to re-derive that same
+                // capped count.
                 let merged_docs: usize =
                     sources.iter().map(|(_, _, inp)| inp.n_docs as usize).sum();
-                let fits_target = fine_run_target_n_cent(
-                    sources[0].2.dim,
-                    sources[0].2.rerank_codec,
-                    merged_docs,
-                ) <= sources[0].2.n_cent;
+                let fits_target =
+                    effective_fine_n_cent(sources[0].2.dim, sources[0].2.rerank_codec, merged_docs)
+                        <= sources[0].2.n_cent;
                 if same_shape && fits_target {
                     let mut inputs: Vec<Sq8IvfMergeInput> =
                         sources.into_iter().map(|(_, _, inp)| inp).collect();
@@ -1107,7 +1111,7 @@ impl SuperfileBuilder {
                     row.local_doc_id = i as u32;
                 }
                 let stable_ids: Vec<i128> = rows.iter().map(|r| r.stable_id).collect();
-                let n_cent = fine_run_target_n_cent(vec_cfg.dim, vec_cfg.rerank_codec, rows.len());
+                let n_cent = effective_fine_n_cent(vec_cfg.dim, vec_cfg.rerank_codec, rows.len());
                 let merged = build_merged_subsection_from_materialized(
                     vec_cfg.clone(),
                     n_cent.max(1),
@@ -4669,13 +4673,15 @@ mod tests {
         // Largest row count that still fits one fine run, then a union that
         // spans several runs.
         let rows_per_run = (1..)
-            .find(|&n| fine_run_target_n_cent(dim, codec, n) > 1)
+            .find(|&n| effective_fine_n_cent(dim, codec, n) > 1)
             .expect("threshold")
             - 1;
         let left_rows = rows_per_run + rows_per_run / 2;
         let right_rows = rows_per_run + rows_per_run / 2;
         let total = left_rows + right_rows;
-        let expected_n_cent = fine_run_target_n_cent(dim, codec, total);
+        // The stored width is the byte target passed through the small-cell cap;
+        // at this corpus size the target is well under the cap, so they agree.
+        let expected_n_cent = effective_fine_n_cent(dim, codec, total);
         assert!(
             expected_n_cent > 1,
             "test corpus must exceed one fine run (rows_per_run={rows_per_run})"

--- a/src/superfile/vector/builder.rs
+++ b/src/superfile/vector/builder.rs
@@ -167,6 +167,25 @@ fn n_cent_row_count_cap(n_docs: usize) -> usize {
     }
 }
 
+/// The fine-cluster `n_cent` a cell pack actually stores for `requested_n_cent`
+/// at `n_docs` rows. The cap switches at the consolidated-cell boundary (see
+/// [`CONSOLIDATED_CELL_ROWS_THRESHOLD`]): consolidated cells keep the byte-target
+/// count uncapped; smaller cells clamp to the banded [`n_cent_row_count_cap`]
+/// the measured 1M/10M cold-GET layout depends on. Both build clamp sites and
+/// the merge splice-gate ([`effective_fine_n_cent`]) route through this one
+/// function, so the gate can never target a count the build will not store —
+/// which would otherwise rebuild a sub-threshold, above-cap cell on every
+/// compaction only to land back on the same capped count.
+pub(crate) fn effective_cell_n_cent(requested_n_cent: usize, n_docs: usize) -> usize {
+    let base = requested_n_cent.max(1);
+    let capped = if n_docs > CONSOLIDATED_CELL_ROWS_THRESHOLD {
+        base
+    } else {
+        base.min(n_cent_row_count_cap(n_docs))
+    };
+    capped.min(n_docs.max(1))
+}
+
 /// Target rows per IVF cluster for a STREAMING user-superfile build.
 /// Matches the layout the banded cap produces at its design points
 /// (1M rows / 1024 clusters = 976; the drain's fine-cluster p50 sits
@@ -1239,15 +1258,7 @@ fn materialized_centroids(
     // measured shape. Oversized fine-run splitting always runs — the
     // cap alone does not stop Lloyd from parking 2×-skewed runs that
     // flatten fine-first p=1 recall below 0.99.
-    let consolidated = n_docs > CONSOLIDATED_CELL_ROWS_THRESHOLD;
-    let requested = if consolidated {
-        requested_n_cent.max(1).min(n_docs.max(1))
-    } else {
-        requested_n_cent
-            .max(1)
-            .min(n_cent_row_count_cap(n_docs))
-            .min(n_docs.max(1))
-    };
+    let requested = effective_cell_n_cent(requested_n_cent, n_docs);
     // Keep the final Lloyd assignments — `split_oversized_fine_runs`
     // consumes them for the first bound check so a balanced pack (the
     // common commit-cell case) does not pay a redundant full sample
@@ -2204,17 +2215,9 @@ pub(crate) fn build_cell_subsection_from_source(
             }
         }
     }
-    // Mirrors the `materialized_centroids` `n_cent` cap switch so the
-    // sample is sized for the runs actually trained: consolidated cells
-    // uncapped, sub-threshold cells under the legacy row-count cap.
-    let effective_n_cent = if n_docs > CONSOLIDATED_CELL_ROWS_THRESHOLD {
-        requested_n_cent.max(1).min(n_docs)
-    } else {
-        requested_n_cent
-            .max(1)
-            .min(n_cent_row_count_cap(n_docs))
-            .min(n_docs)
-    };
+    // Sample is sized for the runs actually trained; the cap switch lives in
+    // the shared `effective_cell_n_cent`.
+    let effective_n_cent = effective_cell_n_cent(requested_n_cent, n_docs);
     let sample_size = if cfg.provided_centroids.is_some() {
         0
     } else {

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -52,6 +52,33 @@ fn stable_id_at(sids: &[i128], src_local: u32) -> Result<i128, BuildError> {
     })
 }
 
+/// Target encoded-byte size for one fine run (a sub-IVF cluster's rows). The
+/// fine-cluster count is derived from this so each run holds roughly this many
+/// bytes of encoded rows. Held identical at drain time (per fragment) and at
+/// merge time (per merged cell) so a cell's fine clusters stay near target as
+/// it grows through drains and compactions, instead of fattening past it.
+pub(crate) const FINE_RUN_TARGET_BYTES: usize = 2 * 1024 * 1024;
+
+/// The fine-cluster count (`n_cent`) that keeps each run near
+/// [`FINE_RUN_TARGET_BYTES`] of encoded rows for `n_rows` vectors of `dim`
+/// under `rerank_codec`. Re-derived from the *current* row count at every drain
+/// and every merge, so compaction re-clusters to fit instead of carrying a
+/// stale, too-coarse source count forward. `row_stride` mirrors the encoded
+/// per-row layout: 1-bit RaBitQ code + doc id + rerank code + stable id + the
+/// per-row f32 norm.
+pub(crate) fn fine_run_target_n_cent(
+    dim: usize,
+    rerank_codec: RerankCodec,
+    n_rows: usize,
+) -> usize {
+    let rabitq_bytes = dim.div_ceil(u8::BITS as usize);
+    let rerank_bytes = rerank_codec.per_vector_bytes(dim);
+    let row_stride =
+        rabitq_bytes + DOC_ID_BYTES + rerank_bytes + STABLE_ID_BYTES + size_of::<f32>();
+    let rows_per_run = (FINE_RUN_TARGET_BYTES / row_stride.max(1)).max(1);
+    n_rows.div_ceil(rows_per_run).clamp(1, n_rows.max(1))
+}
+
 /// One input superfile column for byte-splice merge.
 pub(crate) struct Sq8IvfMergeInput {
     pub sub: Vec<u8>,
@@ -908,6 +935,59 @@ mod tests {
     const N_CENT: usize = 4;
     /// Rows per merge input.
     const ROWS: usize = 6;
+
+    /// Fine-run sizing is re-derived from the current row count: under one run's
+    /// worth of rows yields a single fine cluster, and crossing the byte target
+    /// adds runs as `ceil(rows / rows_per_run)`. This is the single contract both
+    /// drain and merge apply, so a merge can never carry a stale, too-coarse
+    /// count forward.
+    #[test]
+    fn fine_run_target_n_cent_tracks_row_count() {
+        let dim = 512;
+        let codec = RerankCodec::Sq8Residual;
+        assert_eq!(
+            fine_run_target_n_cent(dim, codec, 0),
+            1,
+            "never zero clusters"
+        );
+        assert_eq!(fine_run_target_n_cent(dim, codec, 1), 1);
+        let rows_per_run = (1..)
+            .find(|&n| fine_run_target_n_cent(dim, codec, n) > 1)
+            .expect("threshold")
+            - 1;
+        assert!(rows_per_run > 1, "a wide vector fits many rows per run");
+        assert_eq!(
+            fine_run_target_n_cent(dim, codec, rows_per_run),
+            1,
+            "exactly one run at the boundary"
+        );
+        assert_eq!(
+            fine_run_target_n_cent(dim, codec, rows_per_run + 1),
+            2,
+            "one past the boundary needs a second run"
+        );
+        assert_eq!(
+            fine_run_target_n_cent(dim, codec, rows_per_run * 3),
+            3,
+            "three runs' worth of rows needs three clusters"
+        );
+        // Monotonic non-decreasing as the row count grows.
+        let mut prev = 0;
+        for n in [
+            1,
+            rows_per_run,
+            rows_per_run + 1,
+            rows_per_run * 5,
+            rows_per_run * 50,
+        ] {
+            let cur = fine_run_target_n_cent(dim, codec, n);
+            assert!(
+                cur >= prev,
+                "n_cent shrank as rows grew: {n} -> {cur} < {prev}"
+            );
+            prev = cur;
+        }
+    }
 
     /// Build one fixed-codec cell subsection whose rows all land in cluster 0
     /// of a provided 4-centroid grid, leaving clusters 1..3 empty (count 0)

--- a/src/superfile/vector/ivf_merge.rs
+++ b/src/superfile/vector/ivf_merge.rs
@@ -25,7 +25,7 @@ use crate::superfile::{
     vector::{
         builder::{
             IvfSubsectionLayout, alloc_ivf_subsection_with_header, centroid_storage_order,
-            fixed_sq8_quantizer, write_ivf_cluster_blocks,
+            effective_cell_n_cent, fixed_sq8_quantizer, write_ivf_cluster_blocks,
         },
         cell_posting::{EncodedCellRow, sq8_quant_params_equal},
         distance::{
@@ -77,6 +77,18 @@ pub(crate) fn fine_run_target_n_cent(
         rabitq_bytes + DOC_ID_BYTES + rerank_bytes + STABLE_ID_BYTES + size_of::<f32>();
     let rows_per_run = (FINE_RUN_TARGET_BYTES / row_stride.max(1)).max(1);
     n_rows.div_ceil(rows_per_run).clamp(1, n_rows.max(1))
+}
+
+/// The fine-cluster `n_cent` a merged or rebuilt cell of `n_rows` (dimension
+/// `dim`, codec `rerank_codec`) will actually store: the fine-run byte target
+/// from [`fine_run_target_n_cent`] passed through the same cap the build
+/// applies ([`effective_cell_n_cent`]). The merge splice-gate compares against
+/// THIS, not the raw byte target — otherwise a cell whose byte target sits
+/// above the small-cell cap while its rows stay under the consolidated
+/// threshold never satisfies the gate, and every compaction rebuilds it only to
+/// re-derive the same capped count.
+pub(crate) fn effective_fine_n_cent(dim: usize, rerank_codec: RerankCodec, n_rows: usize) -> usize {
+    effective_cell_n_cent(fine_run_target_n_cent(dim, rerank_codec, n_rows), n_rows)
 }
 
 /// One input superfile column for byte-splice merge.
@@ -986,6 +998,46 @@ mod tests {
                 "n_cent shrank as rows grew: {n} -> {cur} < {prev}"
             );
             prev = cur;
+        }
+    }
+
+    /// The splice-gate sizing passes the byte target through the small-cell cap
+    /// the build actually applies. A cell whose raw byte target exceeds the cap
+    /// (64) but whose rows stay under the consolidated threshold (80,000) is
+    /// sized at the cap, matching what the build stores — so a same-shape merge
+    /// that stays in that band satisfies the gate instead of rebuilding every
+    /// compaction. Above the threshold the byte target applies uncapped.
+    #[test]
+    fn effective_fine_n_cent_applies_the_small_cell_cap() {
+        // dim 1024 / Sq8Residual puts the ~61K–80K row band above the 64 cap:
+        // 70,000 rows -> byte target 74 -> stored 64 after the small-cell cap.
+        let dim = 1024;
+        let codec = RerankCodec::Sq8Residual;
+        let banded_rows = 70_000;
+        assert!(
+            fine_run_target_n_cent(dim, codec, banded_rows) > 64,
+            "precondition: the raw byte target must exceed the small-cell cap"
+        );
+        assert_eq!(
+            effective_fine_n_cent(dim, codec, banded_rows),
+            64,
+            "a sub-threshold cell is stored at the capped count, so the gate \
+             accepts a same-shape splice against a cell already at 64"
+        );
+
+        // Just above the consolidated threshold the byte target is uncapped.
+        let consolidated_rows = 90_000;
+        let raw = fine_run_target_n_cent(dim, codec, consolidated_rows);
+        assert!(raw > 64, "precondition: consolidated cell exceeds the cap");
+        assert_eq!(
+            effective_fine_n_cent(dim, codec, consolidated_rows),
+            raw,
+            "a consolidated cell keeps the uncapped byte-target count"
+        );
+
+        // The effective count never exceeds the raw byte target at any size.
+        for n in [1, 1_000, banded_rows, consolidated_rows, 200_000] {
+            assert!(effective_fine_n_cent(dim, codec, n) <= fine_run_target_n_cent(dim, codec, n));
         }
     }
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -135,9 +135,9 @@ use crate::{
             fts::{HEADER_SIZE_V1_LEGACY as FTS_HEADER_SIZE, U64_BYTES, hdr},
             kv,
             vec::{
-                CELL_DIR_ENTRY_SIZE, CLUSTER_IDX_ENTRY_BYTES, DIR_ENTRY_SIZE, DOC_ID_BYTES,
-                OUTER_HEADER_SIZE, STABLE_ID_BYTES, SUB_HEADER_SIZE, U32_BYTES, cell_dir_entry,
-                dir_entry, outer_hdr, sub_hdr,
+                CELL_DIR_ENTRY_SIZE, CLUSTER_IDX_ENTRY_BYTES, DIR_ENTRY_SIZE, OUTER_HEADER_SIZE,
+                STABLE_ID_BYTES, SUB_HEADER_SIZE, U32_BYTES, cell_dir_entry, dir_entry, outer_hdr,
+                sub_hdr,
             },
         },
         reader::vector_layout_from_kv,
@@ -151,7 +151,8 @@ use crate::{
             distance::Metric,
             hnsw::PayloadKind,
             ivf_merge::{
-                MergedIvfSubsection, merge_fragment_subsections, route_clusters_into_cells,
+                MergedIvfSubsection, fine_run_target_n_cent, merge_fragment_subsections,
+                route_clusters_into_cells,
             },
             kmeans::kmeans_with_assignments,
             layout::VectorLayout,
@@ -188,11 +189,6 @@ use crate::{
         },
     },
 };
-
-/// Target bytes per fine IVF run inside one global cell. Fine-centroid count
-/// is derived from this target; it is not copied from the outer/global grid or
-/// repeated as a fixed count for every small commit delta.
-const DRAIN_FINE_RUN_TARGET_BYTES: usize = 2 * 1024 * 1024;
 
 /// Multipart chunk size for large superfile uploads.
 const SUPERFILE_MULTIPART_PART_BYTES: usize = 8 * (1 << 20);
@@ -5558,28 +5554,19 @@ fn assign_cells<'a>(
     Ok(out)
 }
 
-/// Size one cell's fine IVF so one run is approximately
-/// [`DRAIN_FINE_RUN_TARGET_BYTES`]. The stride counts every per-row byte in
-/// the packed IVF: RaBitQ estimate code, local id, Sq8+epsilon rerank bytes,
-/// inline stable id, and the conservative norm word.
 /// Per-cell drain config plus the centroid count derived for that cell. The
-/// count sizes each fine run to ~`DRAIN_FINE_RUN_TARGET_BYTES` of encoded
-/// rows against the cell's row count (independent of any caller knob), and is
-/// passed alongside the config into the cell-pack build.
+/// count sizes each fine run to the fine-run byte target of encoded rows against
+/// the cell's row count (independent of any caller knob), via the shared
+/// [`fine_run_target_n_cent`] — the same sizing merge re-applies, so a cell's
+/// fine runs stay near target through drains and compactions alike.
 fn drain_cell_vector_config(cfg: &VectorConfig, n_rows: usize) -> (VectorConfig, usize) {
     debug_assert!(n_rows > 0);
-    let dim = cfg.dim;
     let rerank_codec = if cfg.rerank_codec.is_ivf_mergeable() {
         cfg.rerank_codec
     } else {
         RerankCodec::Sq8Residual
     };
-    let rabitq_bytes = dim.div_ceil(u8::BITS as usize);
-    let rerank_bytes = rerank_codec.per_vector_bytes(dim);
-    let row_stride =
-        rabitq_bytes + DOC_ID_BYTES + rerank_bytes + STABLE_ID_BYTES + mem::size_of::<f32>();
-    let rows_per_run = (DRAIN_FINE_RUN_TARGET_BYTES / row_stride.max(1)).max(1);
-    let n_cent = n_rows.div_ceil(rows_per_run).clamp(1, n_rows);
+    let n_cent = fine_run_target_n_cent(cfg.dim, rerank_codec, n_rows);
     let cell_cfg = VectorConfig {
         rerank_codec,
         provided_centroids: None,


### PR DESCRIPTION
## Problem

Vector search over a large table can end up scanning most of the corpus on a cold query. The root cause is in hidden-index compaction: when per-cell fragments merge, the merged cell kept the *source* fine-cluster count instead of re-deriving it from the merged row count.

Fine clusters (the sub-IVF runs within a cell) are sized so each holds about one fine-run byte target of encoded rows; at drain time the count is `ceil(rows / rows_per_run)`. But merge had two escape hatches:

- same-shape fragments **byte-splice** cluster-*i* onto cluster-*i* and keep the source `n_cent`, so the merged clusters hold the *sum* of both sources' rows;
- the rebuild paths used `n_cent = max(sources)`.

Neither re-fit the target, so a cell's fine clusters fatten as it grows through drain generations. A fat cluster's summary centroid drifts to the blob's center of mass, far from its boundary rows, so cell routing misranks it — recall caps out and cold reads balloon.

## Fix

One shared `fine_run_target_n_cent(dim, codec, n_rows)` is now the single sizing authority for both drain and merge. The byte-splice fast path is gated: it runs only when the merged union still fits the source width (`fine_run_target_n_cent(merged_rows) <= source n_cent`) — two under-target clusters legitimately merge into one. When the union crosses the target, the merge falls through to the rebuild path and re-clusters to the re-derived width. Both rebuild branches (different-shape and tombstone) re-derive `n_cent` from the merged row count.

## Correctness / recall

On the streaming-ingest recall bench (200K docs, two drains with a synchronous optimize between them, synthetic 1024-d Sq16, fine-run target scaled down so a small corpus exercises the multi-cluster merge path):

| checkpoint | recall@10 | over-target fine clusters |
| --- | --- | --- |
| after 1 drain | 1.000 | 0 |
| after 2 drains + merge | 0.992 | 0 |

Before the fix, the same run left hundreds of merged cells byte-spliced to a single fat cluster. After, every over-target merge re-clusters to `ceil(rows / rows_per_run)`, no fine cluster exceeds the target (`over_cap = 0`), and recall@10 holds at 0.992 (≥ the 0.99 bar).

## Tests

- `multi_cell_merge_resplits_when_union_exceeds_fine_run_target` — two same-shape fragments whose union outgrows the fine-run target; byte-splices to `n_cent=1` on the old code, re-clusters to the target width on the fix.
- `fine_run_target_n_cent_tracks_row_count` — pins the sizing contract (under target → 1, crossing → `ceil`, monotonic).
- Updated `multi_cell_merge_rebuilds_cells_with_mismatched_fine_width` — a small merged cell now re-derives to a single fine run instead of inheriting the widest source count.

## Performance / cost

The gate adds one `ceil` per merged cell. Over-target same-shape cells now take the rebuild path (k-means re-cluster) instead of the byte-splice — extra work only for cells that were being mis-sized, and it is exactly what restores routing accuracy and cuts the cold read.

The change makes a cell's fine clusters *finer and closer to target* as it grows; finer sub-IVF runs sharpen cell routing rather than degrade it, so the direction of the recall effect is positive. Recall@10 holds at 0.992 in the streaming-ingest bench above, and CI's `supertable_vector` (1M) bench plus the recall test exercise the drain+merge path at scale.
