### PR TITLE
fix(wal): cap id-type alignment at 8 to avoid a movaps #GP on x86_64-apple-darwin

### DIFF
--- a/src/supertable/wal/state_doc.rs
+++ b/src/supertable/wal/state_doc.rs
@@ -63,15 +63,47 @@ pub enum IdParseError {
 macro_rules! define_id_type {
     ($(#[$meta:meta])* $name:ident) => {
         $(#[$meta])*
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(Clone, Copy)]
+        // Cap the field alignment at 8. `i128` is 16-byte aligned on x86, and an
+        // `i128` carried through a large `async` state machine can land on an
+        // 8-aligned frame slot that the compiler then writes with a 16-byte
+        // *aligned* SSE move (`movaps`) — a general-protection fault, seen only on
+        // x86_64-apple-darwin. Capping alignment at 8 makes the compiler use
+        // unaligned moves instead, so the value moves correctly at any offset.
+        // The id stays 128 bits and the hex wire form is unchanged.
+        #[repr(C, packed(8))]
         pub struct $name(pub i128);
+
+        // `#[derive]` for these traits borrows the field (`&self.0`), which is
+        // illegal on a packed struct; hand-write them reading a *copy* instead.
+        impl PartialEq for $name {
+            fn eq(&self, other: &Self) -> bool {
+                let a = self.0;
+                let b = other.0;
+                a == b
+            }
+        }
+        impl Eq for $name {}
+        impl std::hash::Hash for $name {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                let v = self.0;
+                v.hash(state);
+            }
+        }
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let v = self.0;
+                write!(f, "{}({})", stringify!($name), v)
+            }
+        }
 
         impl $name {
             /// 32-char zero-padded lowercase hex of `self.0.to_be_bytes()`.
             /// Stable across releases — JSON payload format, so any
             /// change here is a wire-format change.
             pub fn to_hex(self) -> String {
-                let bytes = self.0.to_be_bytes();
+                let v = self.0;
+                let bytes = v.to_be_bytes();
                 let mut out = String::with_capacity(ID_HEX_LEN);
                 for b in bytes {
                     // `{:02x}` always emits two lowercase hex digits.


### PR DESCRIPTION
## What

Cap the alignment of the `define_id_type!` id newtypes (`WalId`, `RowId`, `SupertableHandleId`) at 8 with `#[repr(packed(8))]`, so the compiler never emits a 16-byte *aligned* SSE store (`movaps`) for the inner `i128`.

Fixes the release blocker in #697.

> **The failure this fixes:** the `publish-python` run that blocked the 0.5.9 release — [run 33503914534](https://github.com/infino-ai/infino/actions/runs/33503914534) ([`wheel x86_64-apple-darwin` job](https://github.com/infino-ai/infino/actions/runs/33503914534/job/99896810539)) — segfaulted in `test_delete_by_predicate`, so the wheels never uploaded and PyPI is stuck at 0.5.7.

## Why — and what actually tripped

`publish-python` fails with a segfault on the `x86_64-apple-darwin` wheel only (linux-x86, linux-aarch64, and macOS-aarch64 all pass the same test). Native lldb on `macos-15-intel` pinned it to:

```
stop reason = EXC_BAD_ACCESS (EXC_I386_GPFLT)
-> movaps %xmm0, -0xa8(%rbp)     ; rbp is 16-aligned, rbp-0xa8 is only 8-aligned
   in do_tombstone_apply (async) at pipeline.rs
```

`i128` is 16-byte aligned on x86, and `movaps` **requires** a 16-byte-aligned memory operand or it raises `#GP`.

**The specific trigger.** `do_tombstone_apply` ends with:

```rust
Ok((TombstonePhaseOutcome::Applied { n_tombstoned, n_not_found }, wal_cur, etag_cur))
```

`wal_cur` is a `WalStateDoc`, which holds `i128` ids (`WalId`, and `RowId`s nested in `tombstone_progress`). It is **held across `.await` and returned by value**. That return is the `movaps` site: the compiler moves an `i128` field out of the **coroutine state** into a stack temporary for the return value, and on the `x86_64-apple-darwin` target it allocates an 8-aligned slot for that temporary and writes it with the 16-byte *aligned* move — faulting.

So the ingredient that surfaced the bug is *"a large `async fn` that carries an `i128`-bearing value through its state machine and moves it out at an await-spanning return."* The id **type was never changed** — `RowId`/`WalId` have always been `i128`. What changed is the newly-added `do_tombstone_apply` batched-tombstone sweep is the first place an `i128` lives inside a big coroutine state on this path. It reproduces only on the `x86_64-apple-darwin` frame layout; ARM has no `movaps`, and the other x86 targets lay the value out 16-aligned or use an unaligned move. This is a latent, target-specific `i128`/coroutine-frame alignment miscompile in the toolchain, not a logic bug in #652.

## The fix

`#[repr(packed(8))]` caps the field alignment at 8, so LLVM treats the `i128` as 8-aligned and uses unaligned moves (`movups` / two `movq`) — valid at any address, including the 8-aligned frame slot. The value is still 128 bits and the hex wire form is byte-for-byte unchanged.

Because `#[derive(PartialEq, Eq, Hash, Debug)]` generates code that borrows the field (`&self.0`), which is illegal on a packed struct, those four are hand-written to read a *copy* of the field first (`let v = self.0`). `Clone`/`Copy` stay derived. `.0`-by-value reads (including the `sort_by_key(|w| w.0)` time-ordering) keep full `i128` semantics, so no call sites change.

### Why fix the type, not the function

The crash can also be dodged at the call site — e.g. return `Box<WalStateDoc>` so the move-out copies an 8-byte pointer instead of the `i128`; or extract the return construction into a non-async `#[inline(never)]` helper so the move happens in a normal (correctly-aligned) stack frame rather than the coroutine layout. Both were rejected: they only work by accident of layout, so a compiler bump or a one-line edit to the function could silently re-trip it — and it would only resurface on Intel-Mac at *publish* time. Capping the id's alignment removes the 16-alignment *requirement* itself, so `movaps` can never be selected for these ids in **any** function shape — it fixes the whole class, not this one call site.

An alternative type fix — storing `[u64; 2]` (align 8, keeps the derives) — was also rejected: it changes the field type and would touch ~158 `.0` / `Name(x)` call sites; the packed route is the minimal diff.

## Update: the crash is already masked on `main` — which is the whole point

Since this PR was opened, the `0.5.10` python wheel **published successfully from `main` without this fix** — `test_delete_by_predicate` passed on the `x86_64-apple-darwin` runner and the wheel shipped. The fix is not in that build; `state_doc.rs` still carries the plain derives.

This is not a resolution — it's a demonstration of the hazard. The only changes in that window were unrelated to deletes (adding tracing spans on other paths, a vector estimator fix); one of them perturbed the coroutine stack layout just enough that the aligned move no longer lands on the 8-aligned slot, so the `#GP` disappeared. That is exactly the *"works only by accident of layout"* failure mode described above. The latent miscompile is unchanged: a future unrelated edit — a new field, a different inlining decision, a toolchain bump — can shift the layout back and silently re-trip the crash, again surfacing only at publish time on Intel-Mac.

Capping the alignment removes the 16-alignment *requirement* itself, so the fault cannot recur regardless of how the frame is laid out. That is why this is still worth merging even though the immediate release is unblocked.

## Validation

Built the `x86_64-apple-darwin` wheel and ran the full `infino-python/tests` suite on `macos-15-intel` (the failing runner):

```
infino-python/tests/test_smoke.py::test_delete_by_predicate PASSED
======================== 43 passed, 17 skipped ========================
```

`cargo check` clean (no `&id.0` sites).

## Follow-up (separate)

macOS-x86 is only smoke-tested at publish time, so this class of target-specific miscompile can't surface in PR CI. A follow-up should add a `macos-15-intel` wheel-build + `infino-python/tests` job to PR CI to catch it earlier.

