### PR TITLE
supertable/query: answer LIKE on FTS columns from the term dictionary

### DIFF
--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -2805,6 +2805,10 @@ pub mod sql {
     pub fn scan_battery(sample_key: &str, sample_title: &str) -> Vec<(&'static str, String)> {
         let k = sample_key.replace('\'', "''");
         let t = sample_title.replace('\'', "''");
+        // Titles are `doc{id:07} term… term…`: the leading doc token is
+        // unique per row and space-delimited, so a `LIKE 'doc… %'` pattern
+        // names one complete term the index can resolve directly.
+        let doc_token = t.split(' ').next().unwrap_or(t.as_str());
         vec![
             (
                 "WHERE key = ? (point lookup, unsorted col)",
@@ -2817,6 +2821,23 @@ pub mod sql {
             (
                 BULK_RANGE_SCAN,
                 "SELECT title, rating FROM supertable WHERE rating < 10".to_string(),
+            ),
+            (
+                // The pattern's only token is closed on both sides (pattern
+                // start, then a space), so it is answered from the index
+                // under any analyzer — one row, no column scan.
+                "WHERE title LIKE 'doc… %' (leading complete token, index-bounded)",
+                format!("SELECT key, rating FROM supertable WHERE title LIKE '{doc_token} %'"),
+            ),
+            (
+                // An open-edged token under the default `ascii_lower`
+                // analyzer cannot be bounded (a run holding a non-ASCII byte
+                // is dropped whole), so this stays a DataFusion column scan;
+                // `term09999` sits at the Zipf tail (the FTS battery's
+                // `single_rare` term), so the result stays small and the
+                // cost is the scan itself.
+                "WHERE title LIKE '%term…%' (substring, ascii_lower ⇒ scan)",
+                "SELECT key, rating FROM supertable WHERE title LIKE '%term09999%'".to_string(),
             ),
         ]
     }

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -2646,14 +2646,19 @@ pub mod sql {
     /// family split can never drift apart.
     pub const BULK_RANGE_SCAN: &str = "WHERE rating < N (range scan, returns rows)";
     pub const BULK_TOKEN_MATCH_ALL: &str = "token_match (all rows)";
+    /// A substring `LIKE` the default `ascii_lower` analyzer cannot bound:
+    /// a full column scan whose cost is the scan, not the rows it returns.
+    /// Classified with the bulk shapes so it never averages into the
+    /// point-lookup family the serving cost model prices per row.
+    pub const BULK_LIKE_SCAN: &str = "WHERE title LIKE '%term…%' (substring scan, ascii_lower)";
 
-    /// The one classification of a bulk row-set shape by name. Both the
-    /// warm/cold query table (this module) and the serving-cost family
+    /// The one classification of a bulk / scan-priced shape by name. Both
+    /// the warm/cold query table (this module) and the serving-cost family
     /// split (`supertable.rs`) call this rather than each re-deriving the
-    /// same `name == BULK_RANGE_SCAN || name == BULK_TOKEN_MATCH_ALL` check,
-    /// so the two tables can never classify the same shape differently.
+    /// same name check, so the two tables can never classify the same shape
+    /// differently.
     pub fn is_bulk_shape(name: &str) -> bool {
-        name == BULK_RANGE_SCAN || name == BULK_TOKEN_MATCH_ALL
+        name == BULK_RANGE_SCAN || name == BULK_TOKEN_MATCH_ALL || name == BULK_LIKE_SCAN
     }
 
     /// Scan-backed aggregates — realistic analytics shapes that provably
@@ -2836,7 +2841,7 @@ pub mod sql {
                 // `term09999` sits at the Zipf tail (the FTS battery's
                 // `single_rare` term), so the result stays small and the
                 // cost is the scan itself.
-                "WHERE title LIKE '%term…%' (substring, ascii_lower ⇒ scan)",
+                BULK_LIKE_SCAN,
                 "SELECT key, rating FROM supertable WHERE title LIKE '%term09999%'".to_string(),
             ),
         ]

--- a/docs/architecture/superfile.md
+++ b/docs/architecture/superfile.md
@@ -125,7 +125,10 @@ resolve the query tokens to their posting lists and intersect them (all
 tokens present) or union them (any token present) to get the matching
 document set, with no BM25 scoring. This is the boolean retrieval the
 table layer's SQL `WHERE` pushdown builds on; ranking and matching share
-one set of posting lists.
+one set of posting lists. The ordered term dictionary adds **term
+expansion**: a walk over one column's keys widens a prefix, suffix, or
+substring to every indexed term it covers, which is how a SQL `LIKE`
+fragment becomes a union of posting lists instead of a column scan.
 
 Document identifiers in the index are local to the superfile.
 

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -110,7 +110,7 @@ stored text is large against its vocabulary; otherwise that token is
 left to the scan. `ILIKE` is bounded the same way for ASCII tokens,
 comparing dictionary terms with the two non-ASCII characters Unicode
 case folding places in an ASCII letter's class (the long s `ſ` with
-`s`, the Kelvin sign `K` with `k`) folded to that letter; non-ASCII
+`s`, the Kelvin sign U+212A with `k`) folded to that letter; non-ASCII
 tokens under `ILIKE`, and `NOT LIKE`, scan. Search is
 also reachable from SQL through table-valued functions, so a query can
 filter, project, join, and order search results alongside scalar

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -104,7 +104,10 @@ tails, or sits inside) — with the exact predicate re-checked over the
 candidate rows. The default `ascii_lower` analyzer drops any token
 holding a non-ASCII byte, so under it only tokens the pattern closes on
 both sides can be required; the `standard` analyzer supports prefix,
-suffix, and substring patterns. `NOT LIKE` and `ILIKE` scan. Search is
+suffix, and substring patterns. `ILIKE` is bounded the same way for
+ASCII tokens, comparing dictionary terms with the two letters Unicode
+case folding widens past lowercasing (`ſ` as `s`, `K` as `k`) folded
+back; non-ASCII tokens under `ILIKE`, and `NOT LIKE`, scan. Search is
 also reachable from SQL through table-valued functions, so a query can
 filter, project, join, and order search results alongside scalar
 columns:

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -104,10 +104,14 @@ tails, or sits inside) — with the exact predicate re-checked over the
 candidate rows. The default `ascii_lower` analyzer drops any token
 holding a non-ASCII byte, so under it only tokens the pattern closes on
 both sides can be required; the `standard` analyzer supports prefix,
-suffix, and substring patterns. `ILIKE` is bounded the same way for
-ASCII tokens, comparing dictionary terms with the two letters Unicode
-case folding widens past lowercasing (`ſ` as `s`, `K` as `k`) folded
-back; non-ASCII tokens under `ILIKE`, and `NOT LIKE`, scan. Search is
+suffix, and substring patterns. A suffix or substring token needs a walk
+of the column's whole dictionary, taken only where the superfile's
+stored text is large against its vocabulary; otherwise that token is
+left to the scan. `ILIKE` is bounded the same way for ASCII tokens,
+comparing dictionary terms with the two non-ASCII characters Unicode
+case folding places in an ASCII letter's class (the long s `ſ` with
+`s`, the Kelvin sign `K` with `k`) folded to that letter; non-ASCII
+tokens under `ILIKE`, and `NOT LIKE`, scan. Search is
 also reachable from SQL through table-valued functions, so a query can
 filter, project, join, and order search results alongside scalar
 columns:

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -94,9 +94,20 @@ is verified against the raw string — so it never scans the whole
 column. Tokenization is used only to prune; the match itself is a
 raw-string comparison. Also unranked.
 - **SQL.** A SQL query over the table's scalar and full-text columns,
-returning the matching rows. Search is also reachable from SQL
-through table-valued functions, so a query can filter, project, join,
-and order search results alongside scalar columns:
+returning the matching rows. A `WHERE` clause on a full-text column is
+answered from the inverted index wherever the index can bound it
+soundly — equality and `IN` through the literal's terms, `LIKE` through
+the term dictionary (each literal fragment of the pattern is tokenized;
+a token the fragment closes on both sides is required as itself, and a
+token bordering a wildcard is widened to the indexed terms it heads,
+tails, or sits inside) — with the exact predicate re-checked over the
+candidate rows. The default `ascii_lower` analyzer drops any token
+holding a non-ASCII byte, so under it only tokens the pattern closes on
+both sides can be required; the `standard` analyzer supports prefix,
+suffix, and substring patterns. `NOT LIKE` and `ILIKE` scan. Search is
+also reachable from SQL through table-valued functions, so a query can
+filter, project, join, and order search results alongside scalar
+columns:
   - `vector_search(column, query, k)` — vector kNN as a relation.
   - `bm25_search(column, query, k)` and
   `bm25_search_prefix(column, prefix, k)` — full-text / prefix BM25.

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -204,6 +204,15 @@ pub enum FtsError {
     )]
     PositionsUnavailable { column: String },
 
+    /// A dictionary walk handed to the reader pool dropped its result
+    /// channel without sending. The reader pool installs no panic handler,
+    /// so a panic inside the walk aborts the process before the awaiting
+    /// task can see this; the variant covers a sender lost any other way
+    /// (a pool torn down mid-query) and fails that one query, the FTS twin
+    /// of the vector path's variant.
+    #[error("dictionary walk dropped its result during {0}")]
+    TaskDropped(&'static str),
+
     #[error("read error: {0}")]
     Read(#[from] ReadError),
 }

--- a/src/superfile/fts/dict.rs
+++ b/src/superfile/fts/dict.rs
@@ -210,14 +210,26 @@ impl<'a> DictReader<'a> {
     /// query paths use [`Self::lookup`].
     pub fn iter_prefix(&self, prefix: &[u8]) -> Vec<(Vec<u8>, u64)> {
         let mut out = Vec::new();
+        self.for_each_prefix(prefix, |key, value| {
+            out.push((key.to_vec(), value));
+            true
+        });
+        out
+    }
+
+    /// Visit every `(key, value)` pair whose key starts with `prefix`, in
+    /// lexicographic order, until `visit` returns `false`. The same range
+    /// scan as [`Self::iter_prefix`] without materializing the keys, for a
+    /// caller that keeps only a filtered subset or stops early — a `LIKE`
+    /// expansion walks a column's whole vocabulary this way and gives up
+    /// once too many terms qualify.
+    pub fn for_each_prefix(&self, prefix: &[u8], mut visit: impl FnMut(&[u8], u64) -> bool) {
         let mut stream = self.fst.range().ge(prefix).into_stream();
         while let Some((key, value)) = stream.next() {
-            if !key.starts_with(prefix) {
+            if !key.starts_with(prefix) || !visit(key, value) {
                 break;
             }
-            out.push((key.to_vec(), value));
         }
-        out
     }
 }
 

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1387,10 +1387,11 @@ impl FtsReader {
     /// `column` whose bytes begin with `term_prefix`, in lex order.
     ///
     /// Mirrors [`Self::iter_column_terms`] but bounds the walk to a
-    /// prefix range instead of the whole column. Used by
-    /// [`SuperfileReader::bm25_search_prefix`] to expand a
-    /// prefix into the concrete terms list before delegating to
-    /// `search` in OR mode.
+    /// prefix range instead of the whole column. This is the synchronous,
+    /// commit-time form (the writer's term summary reaches it through
+    /// `iter_column_terms`); the query path's prefix search expands through
+    /// [`Self::terms_with_prefix`], which walks the same dictionary on the
+    /// reader pool.
     ///
     /// `term_prefix` is the prefix as it appears in the FST — the
     /// caller is responsible for any tokenizer-level normalization
@@ -1402,23 +1403,38 @@ impl FtsReader {
         column: &str,
         term_prefix: &[u8],
     ) -> Result<Vec<Vec<u8>>, FtsError> {
-        if !self.column_id_by_name.contains_key(column) {
+        if !self.has_column(column) {
             return Ok(Vec::new());
         }
-        let mut full_prefix = column.as_bytes().to_vec();
-        full_prefix.push(FST_SEPARATOR);
-        let column_prefix_len = full_prefix.len();
-        full_prefix.extend_from_slice(term_prefix);
-        let fst_bytes = self
-            .dict_bytes()
-            .expect("FST bytes must be available for term iteration");
-        let dict = Self::open_dict(&fst_bytes)?;
-        let pairs = dict.iter_prefix(&full_prefix);
-        Ok(pairs
-            .into_iter()
-            .map(|(key, _)| key[column_prefix_len..].to_vec())
-            .collect())
+        let fst_bytes = self.dict_bytes()?;
+        collect_terms_with_prefix(&fst_bytes, column, term_prefix)
     }
+
+    /// Whether `column` is registered as an FTS column in this superfile.
+    pub(super) fn has_column(&self, column: &str) -> bool {
+        self.column_id_by_name.contains_key(column)
+    }
+}
+
+/// Every key of `column`'s dictionary that begins with `term_prefix`, in
+/// lex order, with the column key prefix stripped. The CPU half shared by
+/// the sync commit-time walk ([`FtsReader::iter_terms_with_prefix`]) and
+/// the query path's pooled one (`FtsReader::terms_with_prefix`).
+pub(super) fn collect_terms_with_prefix(
+    fst_bytes: &[u8],
+    column: &str,
+    term_prefix: &[u8],
+) -> Result<Vec<Vec<u8>>, FtsError> {
+    let mut full_prefix = column.as_bytes().to_vec();
+    full_prefix.push(FST_SEPARATOR);
+    let column_prefix_len = full_prefix.len();
+    full_prefix.extend_from_slice(term_prefix);
+    let dict = FtsReader::open_dict(fst_bytes)?;
+    let pairs = dict.iter_prefix(&full_prefix);
+    Ok(pairs
+        .into_iter()
+        .map(|(key, _)| key[column_prefix_len..].to_vec())
+        .collect())
 }
 
 /// One query's built OR cursors for one superfile: the postings fetch

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -935,6 +935,16 @@ impl FtsReader {
         fetch_source_range(&self.source, self.fst_range.clone(), "fts/dict")
     }
 
+    /// Open the term dictionary over fetched FST bytes, mapping an FST
+    /// parse failure to the reader's malformed-blob error.
+    pub(super) fn open_dict(fst_bytes: &[u8]) -> Result<DictReader<'_>, FtsError> {
+        DictReader::open(fst_bytes).map_err(|e| {
+            FtsError::Read(ReadError::MalformedVersion(format!(
+                "FST parse failed: {e}"
+            )))
+        })
+    }
+
     /// Async FST-dictionary fetch for the query path. Resolves
     /// zero-copy for in-memory / warm sources; for a cold `Lazy`
     /// source it `await`s the object-store range on the caller's
@@ -1410,11 +1420,7 @@ impl FtsReader {
         let fst_bytes = self
             .dict_bytes()
             .expect("FST bytes must be available for term iteration");
-        let dict = DictReader::open(&fst_bytes).map_err(|e| {
-            FtsError::Read(ReadError::MalformedVersion(format!(
-                "FST parse failed: {e}"
-            )))
-        })?;
+        let dict = Self::open_dict(&fst_bytes)?;
         let pairs = dict.iter_prefix(&full_prefix);
         Ok(pairs
             .into_iter()

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1179,11 +1179,7 @@ impl FtsReader {
                     true => {
                         dict_ranges += 1;
                         let fst_bytes = self.dict_bytes_async().await?;
-                        let dict = DictReader::open(&fst_bytes).map_err(|e| {
-                            FtsError::Read(ReadError::MalformedVersion(format!(
-                                "FST parse failed: {e}"
-                            )))
-                        })?;
+                        let dict = Self::open_dict(&fst_bytes)?;
                         let key = make_key(&col_meta.name, term);
                         let packed = dict
                             .lookup(&key)
@@ -1253,11 +1249,7 @@ impl FtsReader {
         let positions_region = self.positions_range.clone();
 
         let fst_bytes = self.dict_bytes()?;
-        let dict = DictReader::open(&fst_bytes).map_err(|e| {
-            FtsError::Read(ReadError::MalformedVersion(format!(
-                "FST parse failed: {e}"
-            )))
-        })?;
+        let dict = Self::open_dict(&fst_bytes)?;
 
         // Column-scoped FST keys are `column_name <FST_SEPARATOR> term`;
         // `iter_prefix` yields `(key, packed_value)` in lex term order, so we

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -19,11 +19,7 @@ use crate::{
         ReadError,
         error::FtsError,
         format::fts::U32_BYTES,
-        fts::{
-            builder::TERM_META_SIZE,
-            dict::{DictReader, make_key},
-            fst_value::FstValue,
-        },
+        fts::{builder::TERM_META_SIZE, dict::make_key, fst_value::FstValue},
     },
 };
 
@@ -324,11 +320,7 @@ impl FtsReader {
             return Ok((Vec::new(), MatchWork::default()));
         }
         let fst_bytes = self.dict_bytes_async().await?;
-        let dict = DictReader::open(&fst_bytes).map_err(|e| {
-            FtsError::Read(ReadError::MalformedVersion(format!(
-                "FST parse failed: {e}"
-            )))
-        })?;
+        let dict = Self::open_dict(&fst_bytes)?;
         let col_meta = &self.columns[column_id as usize];
 
         // First pass — pure in-memory FST lookups. Absent and inline

--- a/src/superfile/fts/reader/expand.rs
+++ b/src/superfile/fts/reader/expand.rs
@@ -7,10 +7,25 @@
 //! instead of a column scan. Its own `impl FtsReader` block, split from
 //! the reader `core`.
 
-use std::str;
+use std::{borrow::Cow, str};
 
 use super::{core::*, work::MatchWork};
 use crate::superfile::{error::FtsError, fts::dict::make_key};
+
+/// The ASCII letter whose Unicode case-folding class holds a character
+/// `to_lowercase` keeps as itself: `s`, folded together with the long s
+/// [`LONG_S`]. An `ILIKE` token holding it may be spelled with `ſ` in a
+/// matching row's indexed term, so only a dictionary walk can find it.
+pub(crate) const LONG_S_ASCII: char = 's';
+
+/// Long s (U+017F). Simple case folding puts it in `s`'s class;
+/// `to_lowercase` leaves it, so an indexed term can carry it.
+const LONG_S: char = 'ſ';
+
+/// Kelvin sign (U+212A), folded with `k`. `to_lowercase` maps it to `k`
+/// before indexing, so a term never carries it; folded here anyway so the
+/// comparison does not depend on that.
+const KELVIN_SIGN: char = 'K';
 
 /// How one `LIKE` fragment token constrains an indexed term. The text is
 /// already the column tokenizer's output (lowercased, split), so it
@@ -29,15 +44,44 @@ pub(crate) enum TermPattern<'a> {
     Contains(&'a str),
 }
 
+/// How much of the dictionary a pattern has to see.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Walk {
+    /// The token is its own expansion.
+    None,
+    /// Only the keys sharing the token's prefix.
+    Subtree,
+    /// Every key of the column: the walk shared by all such patterns.
+    Full,
+}
+
 impl TermPattern<'_> {
-    /// A pattern whose start may sit mid-term. It cannot be bounded to a
-    /// dictionary subtree, so it is tested against every key of the
-    /// column's range — one shared walk serves all such patterns.
-    fn is_open_left(&self) -> bool {
-        matches!(self, TermPattern::Suffix(_) | TermPattern::Contains(_))
+    fn text(&self) -> &str {
+        match self {
+            TermPattern::Exact(text)
+            | TermPattern::Prefix(text)
+            | TermPattern::Suffix(text)
+            | TermPattern::Contains(text) => text,
+        }
     }
 
-    /// Whether an indexed `term` is covered by this pattern.
+    /// Which walk resolves this pattern. Under `fold` (`ILIKE`) an exact
+    /// or prefix token holding `s` may be spelled with `ſ`, which sorts
+    /// elsewhere in the dictionary, so its subtree bound is lost and it
+    /// joins the full walk.
+    fn walk(&self, fold: bool) -> Walk {
+        let long_s = fold && self.text().contains(LONG_S_ASCII);
+        match self {
+            TermPattern::Exact(_) if long_s => Walk::Full,
+            TermPattern::Exact(_) => Walk::None,
+            TermPattern::Prefix(_) if long_s => Walk::Full,
+            TermPattern::Prefix(_) => Walk::Subtree,
+            TermPattern::Suffix(_) | TermPattern::Contains(_) => Walk::Full,
+        }
+    }
+
+    /// Whether `term` (already folded when the leaf is an `ILIKE`) is
+    /// covered by this pattern.
     fn covers(&self, term: &str) -> bool {
         match self {
             TermPattern::Exact(text) => term == *text,
@@ -45,6 +89,25 @@ impl TermPattern<'_> {
             TermPattern::Suffix(text) => term.ends_with(text),
             TermPattern::Contains(text) => term.contains(text),
         }
+    }
+}
+
+/// A dictionary term with `ſ` and `K` folded to the ASCII members of
+/// their case-folding classes — the view an `ILIKE` token is compared
+/// against. Borrowed when nothing folds.
+fn fold_term(term: &str) -> Cow<'_, str> {
+    if term.contains([LONG_S, KELVIN_SIGN]) {
+        Cow::Owned(
+            term.chars()
+                .map(|c| match c {
+                    LONG_S => 's',
+                    KELVIN_SIGN => 'k',
+                    other => other,
+                })
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(term)
     }
 }
 
@@ -91,8 +154,11 @@ impl FtsReader {
     /// token walks only its own subtree. Every suffix or infix token is
     /// tested against each key of one shared walk over the column's whole
     /// range, so a multi-fragment `LIKE` pays for the vocabulary once, not
-    /// once per token. The FST is fetched once when any pattern needs it
-    /// (one planned range, like a match's build).
+    /// once per token. Under `fold` (`ILIKE`) terms are compared with `ſ`
+    /// and `K` folded to `s` and `k`, and an exact or prefix token holding
+    /// an `s` joins the shared walk (its `ſ` spelling sorts elsewhere).
+    /// The FST is fetched once when any pattern needs it (one planned
+    /// range, like a match's build).
     ///
     /// Errors with `FtsError::UnknownColumn` when `column` is not
     /// FTS-indexed in this superfile, like [`Self::token_match`].
@@ -100,12 +166,14 @@ impl FtsReader {
         &self,
         column: &str,
         patterns: &[TermPattern<'_>],
+        fold: bool,
         max_terms: usize,
     ) -> Result<(Vec<Option<Vec<String>>>, MatchWork), FtsError> {
         self.resolve_column_id(column)?;
+        let walks: Vec<Walk> = patterns.iter().map(|p| p.walk(fold)).collect();
         let mut collected: Vec<Collected> = patterns.iter().map(|_| Collected::new()).collect();
         let mut work = MatchWork::default();
-        if patterns.iter().any(|p| !matches!(p, TermPattern::Exact(_))) {
+        if walks.iter().any(|w| *w != Walk::None) {
             let fst_bytes = self.dict_bytes_async().await?;
             let dict = Self::open_dict(&fst_bytes)?;
             work.planned_ranges += 1;
@@ -114,9 +182,9 @@ impl FtsReader {
             // output, so the conversion holds by construction; a key that
             // fails it is skipped rather than trusted.
             let term_start = make_key(column, "").len();
-            for (slot, pattern) in collected.iter_mut().zip(patterns) {
-                if let TermPattern::Prefix(text) = pattern {
-                    dict.for_each_prefix(&make_key(column, text), |key, _| {
+            for ((slot, pattern), walk) in collected.iter_mut().zip(patterns).zip(&walks) {
+                if *walk == Walk::Subtree {
+                    dict.for_each_prefix(&make_key(column, pattern.text()), |key, _| {
                         match str::from_utf8(&key[term_start..]) {
                             Ok(term) => slot.admit(term, max_terms),
                             Err(_) => true,
@@ -124,26 +192,31 @@ impl FtsReader {
                     });
                 }
             }
-            let mut open_left: Vec<usize> = (0..patterns.len())
-                .filter(|&i| patterns[i].is_open_left())
+            let mut full: Vec<usize> = (0..patterns.len())
+                .filter(|&i| walks[i] == Walk::Full)
                 .collect();
-            if !open_left.is_empty() {
+            if !full.is_empty() {
                 dict.for_each_prefix(&make_key(column, ""), |key, _| {
                     if let Ok(term) = str::from_utf8(&key[term_start..]) {
-                        open_left.retain(|&i| {
-                            !patterns[i].covers(term) || collected[i].admit(term, max_terms)
+                        let view = if fold {
+                            fold_term(term)
+                        } else {
+                            Cow::Borrowed(term)
+                        };
+                        full.retain(|&i| {
+                            !patterns[i].covers(&view) || collected[i].admit(term, max_terms)
                         });
                     }
-                    // Stop once every open-left pattern has hit its cap.
-                    !open_left.is_empty()
+                    // Stop once every full-walk pattern has hit its cap.
+                    !full.is_empty()
                 });
             }
         }
         let mut out = Vec::with_capacity(patterns.len());
-        for (slot, pattern) in collected.into_iter().zip(patterns) {
-            out.push(match pattern {
-                TermPattern::Exact(term) => Some(vec![(*term).to_owned()]),
-                _ => slot.finish(),
+        for ((slot, pattern), walk) in collected.into_iter().zip(patterns).zip(&walks) {
+            out.push(match walk {
+                Walk::None => Some(vec![pattern.text().to_owned()]),
+                Walk::Subtree | Walk::Full => slot.finish(),
             });
         }
         Ok((out, work))
@@ -152,7 +225,10 @@ impl FtsReader {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::test_util::build_blob, *};
+    use super::{
+        super::test_util::{build_blob, build_standard_fold_blob},
+        *,
+    };
 
     /// Generous cap so a test never trips the too-many fallback by accident.
     const MAX_TERMS: usize = 64;
@@ -160,15 +236,20 @@ mod tests {
     fn expand_all(
         r: &FtsReader,
         patterns: &[TermPattern<'_>],
+        fold: bool,
         max_terms: usize,
     ) -> (Vec<Option<Vec<String>>>, MatchWork) {
         let rt = tokio::runtime::Runtime::new().expect("runtime");
-        rt.block_on(r.expand_terms("body", patterns, max_terms))
+        rt.block_on(r.expand_terms("body", patterns, fold, max_terms))
             .expect("expand_terms")
     }
 
     fn expand(r: &FtsReader, pattern: TermPattern<'_>, max_terms: usize) -> Option<Vec<String>> {
-        expand_all(r, &[pattern], max_terms).0.remove(0)
+        expand_all(r, &[pattern], false, max_terms).0.remove(0)
+    }
+
+    fn expand_fold(r: &FtsReader, pattern: TermPattern<'_>) -> Option<Vec<String>> {
+        expand_all(r, &[pattern], true, MAX_TERMS).0.remove(0)
     }
 
     fn owned(terms: &[&str]) -> Option<Vec<String>> {
@@ -219,6 +300,7 @@ mod tests {
                 TermPattern::Exact("rust"),
                 TermPattern::Prefix("ja"),
             ],
+            false,
             MAX_TERMS,
         );
         assert_eq!(
@@ -231,6 +313,56 @@ mod tests {
             ]
         );
         assert_eq!(work.planned_ranges, 1, "one FST fetch for the whole leaf");
+    }
+
+    #[test]
+    fn folding_finds_the_long_s_spellings_a_case_insensitive_match_admits() {
+        // Terms: k, kelvin, riſe, rise, set, sun, sunset, ſun (lex order
+        // puts `ſ…` after every ASCII-initial term).
+        let (blob, json) = build_standard_fold_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        // Case-sensitive: byte-exact, the long-s spellings are not covered
+        // (`ſun` shares the bytes `un`, not `su`).
+        assert_eq!(
+            expand(&r, TermPattern::Prefix("su"), MAX_TERMS),
+            owned(&["sun", "sunset"])
+        );
+        assert_eq!(
+            expand(&r, TermPattern::Contains("su"), MAX_TERMS),
+            owned(&["sun", "sunset"])
+        );
+        assert_eq!(
+            expand(&r, TermPattern::Exact("sun"), MAX_TERMS),
+            owned(&["sun"])
+        );
+        // Folded: every shape sees `ſ` as `s`.
+        assert_eq!(
+            expand_fold(&r, TermPattern::Exact("sun")),
+            owned(&["sun", "ſun"]),
+            "an exact token holding `s` walks for its `ſ` spelling"
+        );
+        assert_eq!(
+            expand_fold(&r, TermPattern::Prefix("su")),
+            owned(&["sun", "sunset", "ſun"])
+        );
+        assert_eq!(
+            expand_fold(&r, TermPattern::Suffix("se")),
+            owned(&["rise", "riſe"])
+        );
+        assert_eq!(
+            expand_fold(&r, TermPattern::Contains("su")),
+            owned(&["sun", "sunset", "ſun"])
+        );
+        // The Kelvin sign was lowercased to `k` at index time, so a folded
+        // token without an `s` needs no walk at all.
+        let (out, work) = expand_all(&r, &[TermPattern::Exact("kelvin")], true, MAX_TERMS);
+        assert_eq!(out, vec![owned(&["kelvin"])]);
+        assert_eq!(work.planned_ranges, 0);
+        assert_eq!(
+            expand_fold(&r, TermPattern::Suffix("k")),
+            owned(&["k"]),
+            "the indexed term is already `k`"
+        );
     }
 
     #[test]
@@ -250,6 +382,7 @@ mod tests {
         let (out, _) = expand_all(
             &r,
             &[TermPattern::Contains(""), TermPattern::Contains("zz")],
+            false,
             2,
         );
         assert_eq!(out, vec![None, Some(Vec::new())]);
@@ -259,9 +392,9 @@ mod tests {
     fn a_dictionary_walk_reports_its_fetch_but_an_exact_token_does_not() {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
-        let (_, walked) = expand_all(&r, &[TermPattern::Prefix("ru")], MAX_TERMS);
+        let (_, walked) = expand_all(&r, &[TermPattern::Prefix("ru")], false, MAX_TERMS);
         assert_eq!(walked.planned_ranges, 1, "one FST fetch per walk");
-        let (_, exact) = expand_all(&r, &[TermPattern::Exact("rust")], MAX_TERMS);
+        let (_, exact) = expand_all(&r, &[TermPattern::Exact("rust")], false, MAX_TERMS);
         assert_eq!(exact.planned_ranges, 0, "no dictionary needed");
     }
 
@@ -271,7 +404,7 @@ mod tests {
         let r = FtsReader::open(blob, &json).expect("open");
         let rt = tokio::runtime::Runtime::new().expect("runtime");
         let err = rt
-            .block_on(r.expand_terms("nope", &[TermPattern::Prefix("ru")], MAX_TERMS))
+            .block_on(r.expand_terms("nope", &[TermPattern::Prefix("ru")], false, MAX_TERMS))
             .expect_err("unknown column");
         assert!(matches!(err, FtsError::UnknownColumn(_)));
     }

--- a/src/superfile/fts/reader/expand.rs
+++ b/src/superfile/fts/reader/expand.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Term-dictionary expansion on [`FtsReader`]: widen one `LIKE` fragment
+//! token to the indexed terms it covers, so the table layer's SQL `WHERE`
+//! pushdown can answer a substring predicate from posting lists instead of
+//! a column scan. Its own `impl FtsReader` block, split from the reader
+//! `core`.
+
+use std::str;
+
+use super::{core::*, work::MatchWork};
+use crate::superfile::{error::FtsError, fts::dict::make_key};
+
+/// How one `LIKE` fragment token constrains an indexed term. The text is
+/// already the column tokenizer's output (lowercased, split), so it
+/// compares byte-for-byte against dictionary keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TermPattern<'a> {
+    /// The term itself — a token the fragment closes on both sides.
+    Exact(&'a str),
+    /// Terms beginning with the text: the token's end may sit mid-term
+    /// (`'abc%'`).
+    Prefix(&'a str),
+    /// Terms ending with the text: the token's start may sit mid-term
+    /// (`'%abc'`).
+    Suffix(&'a str),
+    /// Terms containing the text: both ends may sit mid-term (`'%abc%'`).
+    Contains(&'a str),
+}
+
+impl TermPattern<'_> {
+    /// The dictionary range the walk is bounded to. A prefix pattern walks
+    /// only its own subtree; a suffix or infix pattern has to see the
+    /// column's whole vocabulary, since any term may end with or contain
+    /// the text.
+    fn walk_prefix(&self) -> &str {
+        match self {
+            TermPattern::Prefix(text) => text,
+            TermPattern::Exact(_) | TermPattern::Suffix(_) | TermPattern::Contains(_) => "",
+        }
+    }
+
+    /// Whether an indexed `term` is covered by this pattern.
+    fn covers(&self, term: &str) -> bool {
+        match self {
+            TermPattern::Exact(text) => term == *text,
+            // The walk already stayed inside the prefix subtree.
+            TermPattern::Prefix(_) => true,
+            TermPattern::Suffix(text) => term.ends_with(text),
+            TermPattern::Contains(text) => term.contains(text),
+        }
+    }
+}
+
+impl FtsReader {
+    /// Expand `pattern` into the indexed terms of `column` it covers, in
+    /// lex order. `Ok((None, work))` says more than `max_terms` terms
+    /// qualify — the pattern is too broad for a posting-list answer and
+    /// the caller falls back to scanning. An [`TermPattern::Exact`] token
+    /// is its own expansion and costs no dictionary fetch; every other
+    /// shape fetches the FST once (one planned range, like a match's
+    /// build) and walks the column's key range.
+    ///
+    /// Errors with `FtsError::UnknownColumn` when `column` is not
+    /// FTS-indexed in this superfile, like [`Self::token_match`].
+    pub(crate) async fn expand_terms(
+        &self,
+        column: &str,
+        pattern: TermPattern<'_>,
+        max_terms: usize,
+    ) -> Result<(Option<Vec<String>>, MatchWork), FtsError> {
+        self.resolve_column_id(column)?;
+        if let TermPattern::Exact(term) = pattern {
+            return Ok((Some(vec![term.to_owned()]), MatchWork::default()));
+        }
+        let fst_bytes = self.dict_bytes_async().await?;
+        let dict = Self::open_dict(&fst_bytes)?;
+        let key_prefix = make_key(column, pattern.walk_prefix());
+        // Every key in the walk starts with `<column>\x1F`; the term is
+        // what follows.
+        let term_start = make_key(column, "").len();
+        let mut terms = Vec::new();
+        let mut too_many = false;
+        dict.for_each_prefix(&key_prefix, |key, _| {
+            // Keys are the tokenizer's UTF-8 output, so the conversion
+            // holds by construction; a key that fails it is skipped rather
+            // than trusted.
+            if let Ok(term) = str::from_utf8(&key[term_start..])
+                && pattern.covers(term)
+            {
+                if terms.len() == max_terms {
+                    too_many = true;
+                    return false;
+                }
+                terms.push(term.to_owned());
+            }
+            true
+        });
+        let work = MatchWork {
+            planned_ranges: 1,
+            ..MatchWork::default()
+        };
+        Ok(((!too_many).then_some(terms), work))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::test_util::build_blob, *};
+
+    /// Generous cap so a test never trips the too-many fallback by accident.
+    const MAX_TERMS: usize = 64;
+
+    fn expand(r: &FtsReader, pattern: TermPattern<'_>, max_terms: usize) -> Option<Vec<String>> {
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(r.expand_terms("body", pattern, max_terms))
+            .expect("expand_terms")
+            .0
+    }
+
+    #[test]
+    fn each_pattern_shape_covers_the_right_terms() {
+        // Vocabulary: a, async, boot, is, java, runtime, rust, spring, tokio.
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        assert_eq!(
+            expand(&r, TermPattern::Prefix("ru"), MAX_TERMS),
+            Some(vec!["runtime".to_owned(), "rust".to_owned()]),
+            "a prefix walks only its subtree, in lex order"
+        );
+        assert_eq!(
+            expand(&r, TermPattern::Suffix("me"), MAX_TERMS),
+            Some(vec!["runtime".to_owned()])
+        );
+        assert_eq!(
+            expand(&r, TermPattern::Contains("o"), MAX_TERMS),
+            Some(vec!["boot".to_owned(), "tokio".to_owned()])
+        );
+        assert_eq!(
+            expand(&r, TermPattern::Exact("rust"), MAX_TERMS),
+            Some(vec!["rust".to_owned()]),
+            "an exact token is its own expansion"
+        );
+        assert_eq!(
+            expand(&r, TermPattern::Contains("zzz"), MAX_TERMS),
+            Some(Vec::new()),
+            "nothing qualifies ⇒ an empty (not absent) expansion"
+        );
+    }
+
+    #[test]
+    fn expansion_past_the_cap_is_reported_as_too_many() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        // Nine terms contain a vowel-or-consonant anywhere; a cap of two
+        // cannot hold them.
+        assert_eq!(expand(&r, TermPattern::Contains(""), 2), None);
+        // Exactly at the cap still fits.
+        assert_eq!(
+            expand(&r, TermPattern::Prefix("ru"), 2),
+            Some(vec!["runtime".to_owned(), "rust".to_owned()])
+        );
+    }
+
+    #[test]
+    fn a_dictionary_walk_reports_its_fetch_but_an_exact_token_does_not() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let (_, walked) = rt
+            .block_on(r.expand_terms("body", TermPattern::Prefix("ru"), MAX_TERMS))
+            .expect("expand");
+        assert_eq!(walked.planned_ranges, 1, "one FST fetch per walk");
+        let (_, exact) = rt
+            .block_on(r.expand_terms("body", TermPattern::Exact("rust"), MAX_TERMS))
+            .expect("expand");
+        assert_eq!(exact.planned_ranges, 0, "no dictionary needed");
+    }
+
+    #[test]
+    fn unknown_column_errors_like_a_match_would() {
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let err = rt
+            .block_on(r.expand_terms("nope", TermPattern::Prefix("ru"), MAX_TERMS))
+            .expect_err("unknown column");
+        assert!(matches!(err, FtsError::UnknownColumn(_)));
+    }
+}

--- a/src/superfile/fts/reader/expand.rs
+++ b/src/superfile/fts/reader/expand.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
-//! Term-dictionary expansion on [`FtsReader`]: widen one `LIKE` fragment
-//! token to the indexed terms it covers, so the table layer's SQL `WHERE`
-//! pushdown can answer a substring predicate from posting lists instead of
-//! a column scan. Its own `impl FtsReader` block, split from the reader
-//! `core`.
+//! Term-dictionary expansion on [`FtsReader`]: widen the tokens of one
+//! `LIKE` leaf to the indexed terms they cover, so the table layer's SQL
+//! `WHERE` pushdown can answer a substring predicate from posting lists
+//! instead of a column scan. Its own `impl FtsReader` block, split from
+//! the reader `core`.
 
 use std::str;
 
@@ -30,78 +30,123 @@ pub(crate) enum TermPattern<'a> {
 }
 
 impl TermPattern<'_> {
-    /// The dictionary range the walk is bounded to. A prefix pattern walks
-    /// only its own subtree; a suffix or infix pattern has to see the
-    /// column's whole vocabulary, since any term may end with or contain
-    /// the text.
-    fn walk_prefix(&self) -> &str {
-        match self {
-            TermPattern::Prefix(text) => text,
-            TermPattern::Exact(_) | TermPattern::Suffix(_) | TermPattern::Contains(_) => "",
-        }
+    /// A pattern whose start may sit mid-term. It cannot be bounded to a
+    /// dictionary subtree, so it is tested against every key of the
+    /// column's range — one shared walk serves all such patterns.
+    fn is_open_left(&self) -> bool {
+        matches!(self, TermPattern::Suffix(_) | TermPattern::Contains(_))
     }
 
     /// Whether an indexed `term` is covered by this pattern.
     fn covers(&self, term: &str) -> bool {
         match self {
             TermPattern::Exact(text) => term == *text,
-            // The walk already stayed inside the prefix subtree.
-            TermPattern::Prefix(_) => true,
+            TermPattern::Prefix(text) => term.starts_with(text),
             TermPattern::Suffix(text) => term.ends_with(text),
             TermPattern::Contains(text) => term.contains(text),
         }
     }
 }
 
+/// One pattern's terms as a walk collects them, with the cap it may not
+/// exceed. Past the cap the pattern is too broad for a posting-list
+/// answer and its collection stops.
+struct Collected {
+    terms: Vec<String>,
+    too_many: bool,
+}
+
+impl Collected {
+    fn new() -> Self {
+        Self {
+            terms: Vec::new(),
+            too_many: false,
+        }
+    }
+
+    /// Record `term`; `false` once the cap is hit (the caller stops
+    /// feeding this pattern).
+    fn admit(&mut self, term: &str, max_terms: usize) -> bool {
+        if self.terms.len() == max_terms {
+            self.too_many = true;
+            return false;
+        }
+        self.terms.push(term.to_owned());
+        true
+    }
+
+    fn finish(self) -> Option<Vec<String>> {
+        (!self.too_many).then_some(self.terms)
+    }
+}
+
 impl FtsReader {
-    /// Expand `pattern` into the indexed terms of `column` it covers, in
-    /// lex order. `Ok((None, work))` says more than `max_terms` terms
-    /// qualify — the pattern is too broad for a posting-list answer and
-    /// the caller falls back to scanning. An [`TermPattern::Exact`] token
-    /// is its own expansion and costs no dictionary fetch; every other
-    /// shape fetches the FST once (one planned range, like a match's
-    /// build) and walks the column's key range.
+    /// Expand each of `patterns` into the indexed terms of `column` it
+    /// covers, in lex order, in one pass over the dictionary. A slot is
+    /// `None` when more than `max_terms` terms qualify for its pattern —
+    /// too broad for a posting-list answer; the caller falls back to
+    /// scanning for that token.
+    ///
+    /// An [`TermPattern::Exact`] token is its own expansion. A prefix
+    /// token walks only its own subtree. Every suffix or infix token is
+    /// tested against each key of one shared walk over the column's whole
+    /// range, so a multi-fragment `LIKE` pays for the vocabulary once, not
+    /// once per token. The FST is fetched once when any pattern needs it
+    /// (one planned range, like a match's build).
     ///
     /// Errors with `FtsError::UnknownColumn` when `column` is not
     /// FTS-indexed in this superfile, like [`Self::token_match`].
     pub(crate) async fn expand_terms(
         &self,
         column: &str,
-        pattern: TermPattern<'_>,
+        patterns: &[TermPattern<'_>],
         max_terms: usize,
-    ) -> Result<(Option<Vec<String>>, MatchWork), FtsError> {
+    ) -> Result<(Vec<Option<Vec<String>>>, MatchWork), FtsError> {
         self.resolve_column_id(column)?;
-        if let TermPattern::Exact(term) = pattern {
-            return Ok((Some(vec![term.to_owned()]), MatchWork::default()));
-        }
-        let fst_bytes = self.dict_bytes_async().await?;
-        let dict = Self::open_dict(&fst_bytes)?;
-        let key_prefix = make_key(column, pattern.walk_prefix());
-        // Every key in the walk starts with `<column>\x1F`; the term is
-        // what follows.
-        let term_start = make_key(column, "").len();
-        let mut terms = Vec::new();
-        let mut too_many = false;
-        dict.for_each_prefix(&key_prefix, |key, _| {
-            // Keys are the tokenizer's UTF-8 output, so the conversion
-            // holds by construction; a key that fails it is skipped rather
-            // than trusted.
-            if let Ok(term) = str::from_utf8(&key[term_start..])
-                && pattern.covers(term)
-            {
-                if terms.len() == max_terms {
-                    too_many = true;
-                    return false;
+        let mut collected: Vec<Collected> = patterns.iter().map(|_| Collected::new()).collect();
+        let mut work = MatchWork::default();
+        if patterns.iter().any(|p| !matches!(p, TermPattern::Exact(_))) {
+            let fst_bytes = self.dict_bytes_async().await?;
+            let dict = Self::open_dict(&fst_bytes)?;
+            work.planned_ranges += 1;
+            // Every key in the column's range starts with `<column>\x1F`;
+            // the term is what follows. Keys are the tokenizer's UTF-8
+            // output, so the conversion holds by construction; a key that
+            // fails it is skipped rather than trusted.
+            let term_start = make_key(column, "").len();
+            for (slot, pattern) in collected.iter_mut().zip(patterns) {
+                if let TermPattern::Prefix(text) = pattern {
+                    dict.for_each_prefix(&make_key(column, text), |key, _| {
+                        match str::from_utf8(&key[term_start..]) {
+                            Ok(term) => slot.admit(term, max_terms),
+                            Err(_) => true,
+                        }
+                    });
                 }
-                terms.push(term.to_owned());
             }
-            true
-        });
-        let work = MatchWork {
-            planned_ranges: 1,
-            ..MatchWork::default()
-        };
-        Ok(((!too_many).then_some(terms), work))
+            let mut open_left: Vec<usize> = (0..patterns.len())
+                .filter(|&i| patterns[i].is_open_left())
+                .collect();
+            if !open_left.is_empty() {
+                dict.for_each_prefix(&make_key(column, ""), |key, _| {
+                    if let Ok(term) = str::from_utf8(&key[term_start..]) {
+                        open_left.retain(|&i| {
+                            !patterns[i].covers(term) || collected[i].admit(term, max_terms)
+                        });
+                    }
+                    // Stop once every open-left pattern has hit its cap.
+                    !open_left.is_empty()
+                });
+            }
+        }
+        let mut out = Vec::with_capacity(patterns.len());
+        for (slot, pattern) in collected.into_iter().zip(patterns) {
+            out.push(match pattern {
+                TermPattern::Exact(term) => Some(vec![(*term).to_owned()]),
+                _ => slot.finish(),
+            });
+        }
+        Ok((out, work))
     }
 }
 
@@ -112,11 +157,22 @@ mod tests {
     /// Generous cap so a test never trips the too-many fallback by accident.
     const MAX_TERMS: usize = 64;
 
-    fn expand(r: &FtsReader, pattern: TermPattern<'_>, max_terms: usize) -> Option<Vec<String>> {
+    fn expand_all(
+        r: &FtsReader,
+        patterns: &[TermPattern<'_>],
+        max_terms: usize,
+    ) -> (Vec<Option<Vec<String>>>, MatchWork) {
         let rt = tokio::runtime::Runtime::new().expect("runtime");
-        rt.block_on(r.expand_terms("body", pattern, max_terms))
+        rt.block_on(r.expand_terms("body", patterns, max_terms))
             .expect("expand_terms")
-            .0
+    }
+
+    fn expand(r: &FtsReader, pattern: TermPattern<'_>, max_terms: usize) -> Option<Vec<String>> {
+        expand_all(r, &[pattern], max_terms).0.remove(0)
+    }
+
+    fn owned(terms: &[&str]) -> Option<Vec<String>> {
+        Some(terms.iter().map(|t| (*t).to_owned()).collect())
     }
 
     #[test]
@@ -126,20 +182,20 @@ mod tests {
         let r = FtsReader::open(blob, &json).expect("open");
         assert_eq!(
             expand(&r, TermPattern::Prefix("ru"), MAX_TERMS),
-            Some(vec!["runtime".to_owned(), "rust".to_owned()]),
+            owned(&["runtime", "rust"]),
             "a prefix walks only its subtree, in lex order"
         );
         assert_eq!(
             expand(&r, TermPattern::Suffix("me"), MAX_TERMS),
-            Some(vec!["runtime".to_owned()])
+            owned(&["runtime"])
         );
         assert_eq!(
             expand(&r, TermPattern::Contains("o"), MAX_TERMS),
-            Some(vec!["boot".to_owned(), "tokio".to_owned()])
+            owned(&["boot", "tokio"])
         );
         assert_eq!(
             expand(&r, TermPattern::Exact("rust"), MAX_TERMS),
-            Some(vec!["rust".to_owned()]),
+            owned(&["rust"]),
             "an exact token is its own expansion"
         );
         assert_eq!(
@@ -150,31 +206,62 @@ mod tests {
     }
 
     #[test]
+    fn several_patterns_expand_in_one_dictionary_pass() {
+        // Two open-left tokens, a prefix and an exact token: one FST fetch,
+        // each slot exactly what the single-pattern calls return.
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let (out, work) = expand_all(
+            &r,
+            &[
+                TermPattern::Contains("o"),
+                TermPattern::Suffix("me"),
+                TermPattern::Exact("rust"),
+                TermPattern::Prefix("ja"),
+            ],
+            MAX_TERMS,
+        );
+        assert_eq!(
+            out,
+            vec![
+                owned(&["boot", "tokio"]),
+                owned(&["runtime"]),
+                owned(&["rust"]),
+                owned(&["java"]),
+            ]
+        );
+        assert_eq!(work.planned_ranges, 1, "one FST fetch for the whole leaf");
+    }
+
+    #[test]
     fn expansion_past_the_cap_is_reported_as_too_many() {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
-        // Nine terms contain a vowel-or-consonant anywhere; a cap of two
-        // cannot hold them.
+        // Every term contains the empty string; a cap of two cannot hold
+        // nine of them.
         assert_eq!(expand(&r, TermPattern::Contains(""), 2), None);
         // Exactly at the cap still fits.
         assert_eq!(
             expand(&r, TermPattern::Prefix("ru"), 2),
-            Some(vec!["runtime".to_owned(), "rust".to_owned()])
+            owned(&["runtime", "rust"])
         );
+        // In a shared walk one pattern hitting its cap leaves the others
+        // collecting.
+        let (out, _) = expand_all(
+            &r,
+            &[TermPattern::Contains(""), TermPattern::Contains("zz")],
+            2,
+        );
+        assert_eq!(out, vec![None, Some(Vec::new())]);
     }
 
     #[test]
     fn a_dictionary_walk_reports_its_fetch_but_an_exact_token_does_not() {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
-        let rt = tokio::runtime::Runtime::new().expect("runtime");
-        let (_, walked) = rt
-            .block_on(r.expand_terms("body", TermPattern::Prefix("ru"), MAX_TERMS))
-            .expect("expand");
+        let (_, walked) = expand_all(&r, &[TermPattern::Prefix("ru")], MAX_TERMS);
         assert_eq!(walked.planned_ranges, 1, "one FST fetch per walk");
-        let (_, exact) = rt
-            .block_on(r.expand_terms("body", TermPattern::Exact("rust"), MAX_TERMS))
-            .expect("expand");
+        let (_, exact) = expand_all(&r, &[TermPattern::Exact("rust")], MAX_TERMS);
         assert_eq!(exact.planned_ranges, 0, "no dictionary needed");
     }
 
@@ -184,7 +271,7 @@ mod tests {
         let r = FtsReader::open(blob, &json).expect("open");
         let rt = tokio::runtime::Runtime::new().expect("runtime");
         let err = rt
-            .block_on(r.expand_terms("nope", TermPattern::Prefix("ru"), MAX_TERMS))
+            .block_on(r.expand_terms("nope", &[TermPattern::Prefix("ru")], MAX_TERMS))
             .expect_err("unknown column");
         assert!(matches!(err, FtsError::UnknownColumn(_)));
     }

--- a/src/superfile/fts/reader/expand.rs
+++ b/src/superfile/fts/reader/expand.rs
@@ -9,8 +9,13 @@
 
 use std::{borrow::Cow, str};
 
+use rayon::ThreadPool;
+
 use super::{core::*, work::MatchWork};
-use crate::superfile::{error::FtsError, fts::dict::make_key};
+use crate::{
+    runtime_bridge::run_on_pool,
+    superfile::{error::FtsError, fts::dict::make_key},
+};
 
 /// Long s (U+017F). Simple case folding puts it in `s`'s class;
 /// `to_lowercase` leaves it, so an indexed term can carry it.
@@ -106,6 +111,38 @@ impl TermPattern<'_> {
     }
 }
 
+/// A [`TermPattern`] with its text owned, so a leaf's patterns can move
+/// onto the reader pool with the dictionary walk.
+#[derive(Debug, Clone)]
+enum OwnedPattern {
+    Exact(String),
+    Prefix(String),
+    Suffix(String),
+    Contains(String),
+}
+
+impl OwnedPattern {
+    fn borrow(&self) -> TermPattern<'_> {
+        match self {
+            OwnedPattern::Exact(text) => TermPattern::Exact(text),
+            OwnedPattern::Prefix(text) => TermPattern::Prefix(text),
+            OwnedPattern::Suffix(text) => TermPattern::Suffix(text),
+            OwnedPattern::Contains(text) => TermPattern::Contains(text),
+        }
+    }
+}
+
+impl TermPattern<'_> {
+    fn into_owned(self) -> OwnedPattern {
+        match self {
+            TermPattern::Exact(text) => OwnedPattern::Exact(text.to_owned()),
+            TermPattern::Prefix(text) => OwnedPattern::Prefix(text.to_owned()),
+            TermPattern::Suffix(text) => OwnedPattern::Suffix(text.to_owned()),
+            TermPattern::Contains(text) => OwnedPattern::Contains(text.to_owned()),
+        }
+    }
+}
+
 /// A dictionary term with `ſ` and `K` folded to the ASCII members of
 /// their case-folding classes — the view an `ILIKE` token is compared
 /// against. Borrowed when nothing folds.
@@ -174,6 +211,11 @@ impl FtsReader {
     /// The FST is fetched once when any pattern needs it (one planned
     /// range, like a match's build).
     ///
+    /// The FST fetch is I/O and stays on the calling runtime; the walk
+    /// itself is CPU — up to the column's whole vocabulary — and runs on
+    /// `pool` (the configured reader pool, or rayon's global pool when
+    /// `None`) behind a oneshot, so no tokio worker sits under it.
+    ///
     /// Errors with `FtsError::UnknownColumn` when `column` is not
     /// FTS-indexed in this superfile, like [`Self::token_match`].
     pub(crate) async fn expand_terms(
@@ -183,53 +225,36 @@ impl FtsReader {
         fold: bool,
         max_terms: usize,
         allow_full_walk: bool,
+        pool: Option<&ThreadPool>,
     ) -> Result<(Vec<Option<Vec<String>>>, MatchWork), FtsError> {
         self.resolve_column_id(column)?;
         let walks: Vec<Walk> = patterns.iter().map(|p| p.walk(fold)).collect();
-        let mut collected: Vec<Collected> = patterns.iter().map(|_| Collected::new()).collect();
         let mut work = MatchWork::default();
         let needs_dict = walks
             .iter()
             .any(|w| *w == Walk::Subtree || (*w == Walk::Full && allow_full_walk));
-        if needs_dict {
+        let collected = if needs_dict {
             let fst_bytes = self.dict_bytes_async().await?;
-            let dict = Self::open_dict(&fst_bytes)?;
             work.planned_ranges += 1;
-            // Every key in the column's range starts with `<column>\x1F`;
-            // the term is what follows. Keys are the tokenizer's UTF-8
-            // output, so the conversion holds by construction; a key that
-            // fails it is skipped rather than trusted.
-            let term_start = make_key(column, "").len();
-            for ((slot, pattern), walk) in collected.iter_mut().zip(patterns).zip(&walks) {
-                if *walk == Walk::Subtree {
-                    dict.for_each_prefix(&make_key(column, pattern.text()), |key, _| {
-                        match str::from_utf8(&key[term_start..]) {
-                            Ok(term) => slot.admit(term, max_terms),
-                            Err(_) => true,
-                        }
-                    });
-                }
-            }
-            let mut full: Vec<usize> = (0..patterns.len())
-                .filter(|&i| walks[i] == Walk::Full && allow_full_walk)
-                .collect();
-            if !full.is_empty() {
-                dict.for_each_prefix(&make_key(column, ""), |key, _| {
-                    if let Ok(term) = str::from_utf8(&key[term_start..]) {
-                        let view = if fold {
-                            fold_term(term)
-                        } else {
-                            Cow::Borrowed(term)
-                        };
-                        full.retain(|&i| {
-                            !patterns[i].covers(&view) || collected[i].admit(term, max_terms)
-                        });
-                    }
-                    // Stop once every full-walk pattern has hit its cap.
-                    !full.is_empty()
-                });
-            }
-        }
+            let column = column.to_owned();
+            let owned: Vec<OwnedPattern> = patterns.iter().map(|p| p.into_owned()).collect();
+            let walks = walks.clone();
+            run_on_pool(pool, "like expansion", move || {
+                walk_dictionary(
+                    &fst_bytes,
+                    &column,
+                    &owned,
+                    &walks,
+                    fold,
+                    max_terms,
+                    allow_full_walk,
+                )
+            })
+            .await
+            .map_err(|_| FtsError::TaskDropped("like expansion"))??
+        } else {
+            patterns.iter().map(|_| Collected::new()).collect()
+        };
         let mut out = Vec::with_capacity(patterns.len());
         for ((slot, pattern), walk) in collected.into_iter().zip(patterns).zip(&walks) {
             out.push(match walk {
@@ -240,6 +265,85 @@ impl FtsReader {
         }
         Ok((out, work))
     }
+
+    /// Every indexed term of `column` that begins with `term_prefix` (the
+    /// prefix as it appears in the FST — the caller lowercases it for the
+    /// column's analyzer), in lex order, without the column key prefix.
+    /// The prefix search's expansion. The FST fetch stays on the calling
+    /// runtime; the subtree walk runs on `pool` behind a oneshot, like
+    /// [`Self::expand_terms`]. Empty when `column` is not FTS-indexed here
+    /// or no term matches.
+    pub(crate) async fn terms_with_prefix(
+        &self,
+        column: &str,
+        term_prefix: &[u8],
+        pool: Option<&ThreadPool>,
+    ) -> Result<Vec<Vec<u8>>, FtsError> {
+        if !self.has_column(column) {
+            return Ok(Vec::new());
+        }
+        let fst_bytes = self.dict_bytes_async().await?;
+        let column = column.to_owned();
+        let term_prefix = term_prefix.to_vec();
+        run_on_pool(pool, "prefix expansion", move || {
+            collect_terms_with_prefix(&fst_bytes, &column, &term_prefix)
+        })
+        .await
+        .map_err(|_| FtsError::TaskDropped("prefix expansion"))?
+    }
+}
+
+/// The CPU half of [`FtsReader::expand_terms`]: one pass over the fetched
+/// dictionary that fills every pattern's collector. Runs on the reader
+/// pool, so it takes owned inputs.
+fn walk_dictionary(
+    fst_bytes: &[u8],
+    column: &str,
+    patterns: &[OwnedPattern],
+    walks: &[Walk],
+    fold: bool,
+    max_terms: usize,
+    allow_full_walk: bool,
+) -> Result<Vec<Collected>, FtsError> {
+    let dict = FtsReader::open_dict(fst_bytes)?;
+    let mut collected: Vec<Collected> = patterns.iter().map(|_| Collected::new()).collect();
+    // Every key in the column's range starts with `<column>\x1F`; the
+    // term is what follows. `for_each_prefix` only visits keys carrying
+    // the prefix it was given, and every prefix below begins with that
+    // column key, so the slice never runs past a key. Keys are the
+    // tokenizer's UTF-8 output, so the conversion holds by construction; a
+    // key that fails it is skipped rather than trusted.
+    let term_start = make_key(column, "").len();
+    for ((slot, pattern), walk) in collected.iter_mut().zip(patterns).zip(walks) {
+        if *walk == Walk::Subtree {
+            dict.for_each_prefix(&make_key(column, pattern.borrow().text()), |key, _| {
+                match str::from_utf8(&key[term_start..]) {
+                    Ok(term) => slot.admit(term, max_terms),
+                    Err(_) => true,
+                }
+            });
+        }
+    }
+    let mut full: Vec<usize> = (0..patterns.len())
+        .filter(|&i| walks[i] == Walk::Full && allow_full_walk)
+        .collect();
+    if !full.is_empty() {
+        dict.for_each_prefix(&make_key(column, ""), |key, _| {
+            if let Ok(term) = str::from_utf8(&key[term_start..]) {
+                let view = if fold {
+                    fold_term(term)
+                } else {
+                    Cow::Borrowed(term)
+                };
+                full.retain(|&i| {
+                    !patterns[i].borrow().covers(&view) || collected[i].admit(term, max_terms)
+                });
+            }
+            // Stop once every full-walk pattern has hit its cap.
+            !full.is_empty()
+        });
+    }
+    Ok(collected)
 }
 
 #[cfg(test)]
@@ -261,7 +365,7 @@ mod tests {
         max_terms: usize,
     ) -> (Vec<Option<Vec<String>>>, MatchWork) {
         let rt = Runtime::new().expect("runtime");
-        rt.block_on(r.expand_terms("body", patterns, fold, max_terms, true))
+        rt.block_on(r.expand_terms("body", patterns, fold, max_terms, true, None))
             .expect("expand_terms")
     }
 
@@ -357,6 +461,7 @@ mod tests {
                 false,
                 MAX_TERMS,
                 false,
+                None,
             ))
             .expect("expand_terms");
         assert_eq!(out, vec![None, None, owned(&["java"]), owned(&["rust"])]);
@@ -369,6 +474,7 @@ mod tests {
                 false,
                 MAX_TERMS,
                 false,
+                None,
             ))
             .expect("expand_terms");
         assert_eq!(out, vec![None]);
@@ -464,7 +570,14 @@ mod tests {
         let r = FtsReader::open(blob, &json).expect("open");
         let rt = Runtime::new().expect("runtime");
         let err = rt
-            .block_on(r.expand_terms("nope", &[TermPattern::Prefix("ru")], false, MAX_TERMS, true))
+            .block_on(r.expand_terms(
+                "nope",
+                &[TermPattern::Prefix("ru")],
+                false,
+                MAX_TERMS,
+                true,
+                None,
+            ))
             .expect_err("unknown column");
         assert!(matches!(err, FtsError::UnknownColumn(_)));
     }

--- a/src/superfile/fts/reader/expand.rs
+++ b/src/superfile/fts/reader/expand.rs
@@ -12,20 +12,34 @@ use std::{borrow::Cow, str};
 use super::{core::*, work::MatchWork};
 use crate::superfile::{error::FtsError, fts::dict::make_key};
 
-/// The ASCII letter whose Unicode case-folding class holds a character
-/// `to_lowercase` keeps as itself: `s`, folded together with the long s
-/// [`LONG_S`]. An `ILIKE` token holding it may be spelled with `ſ` in a
-/// matching row's indexed term, so only a dictionary walk can find it.
-pub(crate) const LONG_S_ASCII: char = 's';
-
 /// Long s (U+017F). Simple case folding puts it in `s`'s class;
 /// `to_lowercase` leaves it, so an indexed term can carry it.
 const LONG_S: char = 'ſ';
 
 /// Kelvin sign (U+212A), folded with `k`. `to_lowercase` maps it to `k`
 /// before indexing, so a term never carries it; folded here anyway so the
-/// comparison does not depend on that.
-const KELVIN_SIGN: char = 'K';
+/// comparison does not depend on that. Written as an escape: the glyph is
+/// indistinguishable from an ASCII `K` in most fonts, and an ASCII `K`
+/// here would make the fold a no-op without any test noticing.
+const KELVIN_SIGN: char = '\u{212A}';
+
+/// Every non-ASCII character Unicode simple case folding puts in an ASCII
+/// letter's class, paired with that letter. These are the only spellings
+/// an `ILIKE` on an ASCII token can match that `to_lowercase` of ASCII
+/// text never produces; every fold rule in the crate derives from this
+/// table so the pairs are written once.
+pub(crate) const FOLD_PAIRS: &[(char, char)] = &[(LONG_S, 's'), (KELVIN_SIGN, 'k')];
+
+/// The ASCII letter whose fold partner an indexed term can actually
+/// carry: `s` (the long s survives `to_lowercase`; the Kelvin sign does
+/// not). An `ILIKE` token holding it may be spelled with `ſ` in a
+/// matching row's term, so only a dictionary walk can find it.
+pub(crate) const LONG_S_ASCII: char = FOLD_PAIRS[0].1;
+
+/// Whether `c` is an ASCII letter with a non-ASCII fold partner.
+pub(crate) fn has_fold_partner(c: char) -> bool {
+    FOLD_PAIRS.iter().any(|&(_, ascii)| ascii == c)
+}
 
 /// How one `LIKE` fragment token constrains an indexed term. The text is
 /// already the column tokenizer's output (lowercased, split), so it
@@ -96,16 +110,14 @@ impl TermPattern<'_> {
 /// their case-folding classes — the view an `ILIKE` token is compared
 /// against. Borrowed when nothing folds.
 fn fold_term(term: &str) -> Cow<'_, str> {
-    if term.contains([LONG_S, KELVIN_SIGN]) {
-        Cow::Owned(
-            term.chars()
-                .map(|c| match c {
-                    LONG_S => 's',
-                    KELVIN_SIGN => 'k',
-                    other => other,
-                })
-                .collect(),
-        )
+    let fold = |c: char| {
+        FOLD_PAIRS
+            .iter()
+            .find(|&&(from, _)| from == c)
+            .map(|&(_, to)| to)
+    };
+    if term.chars().any(|c| fold(c).is_some()) {
+        Cow::Owned(term.chars().map(|c| fold(c).unwrap_or(c)).collect())
     } else {
         Cow::Borrowed(term)
     }

--- a/src/superfile/fts/reader/expand.rs
+++ b/src/superfile/fts/reader/expand.rs
@@ -146,9 +146,11 @@ impl Collected {
 impl FtsReader {
     /// Expand each of `patterns` into the indexed terms of `column` it
     /// covers, in lex order, in one pass over the dictionary. A slot is
-    /// `None` when more than `max_terms` terms qualify for its pattern —
-    /// too broad for a posting-list answer; the caller falls back to
-    /// scanning for that token.
+    /// `None` when its pattern cannot be answered from the dictionary:
+    /// more than `max_terms` terms qualify (too broad for a posting-list
+    /// answer), or it needs the whole column walked and `allow_full_walk`
+    /// is off (the caller judged that walk dearer than the scan it would
+    /// replace). The caller falls back to scanning for that token.
     ///
     /// An [`TermPattern::Exact`] token is its own expansion. A prefix
     /// token walks only its own subtree. Every suffix or infix token is
@@ -168,12 +170,16 @@ impl FtsReader {
         patterns: &[TermPattern<'_>],
         fold: bool,
         max_terms: usize,
+        allow_full_walk: bool,
     ) -> Result<(Vec<Option<Vec<String>>>, MatchWork), FtsError> {
         self.resolve_column_id(column)?;
         let walks: Vec<Walk> = patterns.iter().map(|p| p.walk(fold)).collect();
         let mut collected: Vec<Collected> = patterns.iter().map(|_| Collected::new()).collect();
         let mut work = MatchWork::default();
-        if walks.iter().any(|w| *w != Walk::None) {
+        let needs_dict = walks
+            .iter()
+            .any(|w| *w == Walk::Subtree || (*w == Walk::Full && allow_full_walk));
+        if needs_dict {
             let fst_bytes = self.dict_bytes_async().await?;
             let dict = Self::open_dict(&fst_bytes)?;
             work.planned_ranges += 1;
@@ -193,7 +199,7 @@ impl FtsReader {
                 }
             }
             let mut full: Vec<usize> = (0..patterns.len())
-                .filter(|&i| walks[i] == Walk::Full)
+                .filter(|&i| walks[i] == Walk::Full && allow_full_walk)
                 .collect();
             if !full.is_empty() {
                 dict.for_each_prefix(&make_key(column, ""), |key, _| {
@@ -216,6 +222,7 @@ impl FtsReader {
         for ((slot, pattern), walk) in collected.into_iter().zip(patterns).zip(&walks) {
             out.push(match walk {
                 Walk::None => Some(vec![pattern.text().to_owned()]),
+                Walk::Full if !allow_full_walk => None,
                 Walk::Subtree | Walk::Full => slot.finish(),
             });
         }
@@ -225,6 +232,8 @@ impl FtsReader {
 
 #[cfg(test)]
 mod tests {
+    use tokio::runtime::Runtime;
+
     use super::{
         super::test_util::{build_blob, build_standard_fold_blob},
         *,
@@ -239,8 +248,8 @@ mod tests {
         fold: bool,
         max_terms: usize,
     ) -> (Vec<Option<Vec<String>>>, MatchWork) {
-        let rt = tokio::runtime::Runtime::new().expect("runtime");
-        rt.block_on(r.expand_terms("body", patterns, fold, max_terms))
+        let rt = Runtime::new().expect("runtime");
+        rt.block_on(r.expand_terms("body", patterns, fold, max_terms, true))
             .expect("expand_terms")
     }
 
@@ -313,6 +322,45 @@ mod tests {
             ]
         );
         assert_eq!(work.planned_ranges, 1, "one FST fetch for the whole leaf");
+    }
+
+    #[test]
+    fn a_disallowed_full_walk_leaves_the_pattern_unanswered() {
+        // The caller judged the whole-column walk dearer than the scan: the
+        // suffix and infix tokens come back `None`, the prefix token still
+        // walks its subtree, the exact token is untouched, and the FST is
+        // still fetched once for the subtree walk.
+        let (blob, json) = build_blob();
+        let r = FtsReader::open(blob, &json).expect("open");
+        let rt = Runtime::new().expect("runtime");
+        let (out, work) = rt
+            .block_on(r.expand_terms(
+                "body",
+                &[
+                    TermPattern::Contains("o"),
+                    TermPattern::Suffix("me"),
+                    TermPattern::Prefix("ja"),
+                    TermPattern::Exact("rust"),
+                ],
+                false,
+                MAX_TERMS,
+                false,
+            ))
+            .expect("expand_terms");
+        assert_eq!(out, vec![None, None, owned(&["java"]), owned(&["rust"])]);
+        assert_eq!(work.planned_ranges, 1);
+        // Nothing but full-walk patterns: no dictionary fetch at all.
+        let (out, work) = rt
+            .block_on(r.expand_terms(
+                "body",
+                &[TermPattern::Contains("o")],
+                false,
+                MAX_TERMS,
+                false,
+            ))
+            .expect("expand_terms");
+        assert_eq!(out, vec![None]);
+        assert_eq!(work.planned_ranges, 0);
     }
 
     #[test]
@@ -402,9 +450,9 @@ mod tests {
     fn unknown_column_errors_like_a_match_would() {
         let (blob, json) = build_blob();
         let r = FtsReader::open(blob, &json).expect("open");
-        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let rt = Runtime::new().expect("runtime");
         let err = rt
-            .block_on(r.expand_terms("nope", &[TermPattern::Prefix("ru")], false, MAX_TERMS))
+            .block_on(r.expand_terms("nope", &[TermPattern::Prefix("ru")], false, MAX_TERMS, true))
             .expect_err("unknown column");
         assert!(matches!(err, FtsError::UnknownColumn(_)));
     }

--- a/src/superfile/fts/reader/mod.rs
+++ b/src/superfile/fts/reader/mod.rs
@@ -22,7 +22,7 @@ mod work;
 
 pub use core::*;
 
-pub(crate) use expand::TermPattern;
+pub(crate) use expand::{LONG_S_ASCII, TermPattern};
 pub use metadata::OpenOptions;
 pub use options::{Bm25SearchOptions, Bm25Stats, BoolMode};
 pub use work::MatchWork;

--- a/src/superfile/fts/reader/mod.rs
+++ b/src/superfile/fts/reader/mod.rs
@@ -22,7 +22,7 @@ mod work;
 
 pub use core::*;
 
-pub(crate) use expand::{LONG_S_ASCII, TermPattern};
+pub(crate) use expand::{LONG_S_ASCII, TermPattern, has_fold_partner};
 pub use metadata::OpenOptions;
 pub use options::{Bm25SearchOptions, Bm25Stats, BoolMode};
 pub use work::MatchWork;

--- a/src/superfile/fts/reader/mod.rs
+++ b/src/superfile/fts/reader/mod.rs
@@ -8,6 +8,7 @@
 mod core;
 mod count;
 mod cursor;
+mod expand;
 mod filter;
 mod metadata;
 mod options;
@@ -21,6 +22,7 @@ mod work;
 
 pub use core::*;
 
+pub(crate) use expand::TermPattern;
 pub use metadata::OpenOptions;
 pub use options::{Bm25SearchOptions, Bm25Stats, BoolMode};
 pub use work::MatchWork;

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -28,12 +28,11 @@ use crate::{
         op_stats::{metering_active, timed_section},
     },
     superfile::{
-        ReadError,
         error::FtsError,
         format,
         fts::{
             bm25,
-            dict::{DictReader, make_key},
+            dict::make_key,
             fst_value::FstValue,
             posting::{BLOCK_LEN, decode_block},
         },
@@ -836,11 +835,7 @@ impl FtsReader {
         floor_eff: f32,
     ) -> Result<(Vec<(u32, f32)>, MatchWork, u64), FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
-        let dict = DictReader::open(&fst_bytes).map_err(|e| {
-            FtsError::Read(ReadError::MalformedVersion(format!(
-                "FST parse failed: {e}"
-            )))
-        })?;
+        let dict = Self::open_dict(&fst_bytes)?;
         let col_meta = &self.columns[column_id as usize];
         let key = make_key(&col_meta.name, term);
         let Some(packed) = dict.lookup(&key) else {
@@ -1175,11 +1170,7 @@ impl FtsReader {
         qtf: Option<&[u32]>,
     ) -> Result<Vec<Option<TermCursor>>, FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
-        let dict = DictReader::open(&fst_bytes).map_err(|e| {
-            FtsError::Read(ReadError::MalformedVersion(format!(
-                "FST parse failed: {e}"
-            )))
-        })?;
+        let dict = Self::open_dict(&fst_bytes)?;
         let col_meta = &self.columns[column_id as usize];
 
         // Resolve each term to an inline (df=1) value, a PFOR metadata

--- a/src/superfile/fts/reader/test_util.rs
+++ b/src/superfile/fts/reader/test_util.rs
@@ -8,7 +8,27 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 
-use crate::superfile::fts::{builder::FtsBuilder, tokenize::AsciiLowerTokenizer};
+use crate::superfile::fts::{
+    builder::FtsBuilder,
+    tokenize::{AsciiLowerTokenizer, StandardTokenizer},
+};
+
+/// A `standard`-analyzer corpus whose vocabulary carries the two letters
+/// Unicode case folding widens past lowercasing: `ſ` (long s, kept by
+/// `to_lowercase`) and the Kelvin sign `K` (lowercased to `k` at index).
+/// Terms: k, kelvin, riſe, rise, set, sun, sunset, ſun.
+pub(super) fn build_standard_fold_blob() -> (Bytes, String) {
+    let mut b = FtsBuilder::new(Arc::new(StandardTokenizer));
+    b.register_column("body".into(), false)
+        .expect("register column");
+    b.add_doc(0, 0, "ſun riſe").expect("add doc");
+    b.add_doc(0, 1, "SUN set").expect("add doc");
+    b.add_doc(0, 2, "sunset rise").expect("add doc");
+    b.add_doc(0, 3, "Kelvin K").expect("add doc");
+    let bytes = b.finish().expect("finish");
+    let json = r#"[{"name":"body","tokenizer":"standard"}]"#;
+    (Bytes::from(bytes), json.to_string())
+}
 
 pub(super) fn build_blob() -> (Bytes, String) {
     // 3 docs, 1 column.

--- a/src/superfile/fts/reader/test_util.rs
+++ b/src/superfile/fts/reader/test_util.rs
@@ -15,7 +15,7 @@ use crate::superfile::fts::{
 
 /// A `standard`-analyzer corpus whose vocabulary carries the two letters
 /// Unicode case folding widens past lowercasing: `ſ` (long s, kept by
-/// `to_lowercase`) and the Kelvin sign `K` (lowercased to `k` at index).
+/// `to_lowercase`) and the Kelvin sign U+212A (lowercased to `k` at index).
 /// Terms: k, kelvin, riſe, rise, set, sun, sunset, ſun.
 pub(super) fn build_standard_fold_blob() -> (Bytes, String) {
     let mut b = FtsBuilder::new(Arc::new(StandardTokenizer));
@@ -24,7 +24,7 @@ pub(super) fn build_standard_fold_blob() -> (Bytes, String) {
     b.add_doc(0, 0, "ſun riſe").expect("add doc");
     b.add_doc(0, 1, "SUN set").expect("add doc");
     b.add_doc(0, 2, "sunset rise").expect("add doc");
-    b.add_doc(0, 3, "Kelvin K").expect("add doc");
+    b.add_doc(0, 3, "Kelvin \u{212A}").expect("add doc");
     let bytes = b.finish().expect("finish");
     let json = r#"[{"name":"body","tokenizer":"standard"}]"#;
     (Bytes::from(bytes), json.to_string())

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1202,19 +1202,23 @@ impl SuperfileReader {
 
     /// Widen the tokens of one `LIKE` leaf to the indexed terms of
     /// `column` each covers, in one dictionary pass (a slot is `None` when
-    /// more than `max_terms` qualify); `fold` compares terms under the
-    /// `ILIKE` folding. Delegates to [`FtsReader::expand_terms`].
+    /// more than `max_terms` qualify, or when it needs the whole column
+    /// walked and `allow_full_walk` is off); `fold` compares terms under
+    /// the `ILIKE` folding. Delegates to [`FtsReader::expand_terms`].
     pub(crate) async fn expand_terms(
         &self,
         column: &str,
         patterns: &[TermPattern<'_>],
         fold: bool,
         max_terms: usize,
+        allow_full_walk: bool,
     ) -> Result<(Vec<Option<Vec<String>>>, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
-        Ok(fts.expand_terms(column, patterns, fold, max_terms).await?)
+        Ok(fts
+            .expand_terms(column, patterns, fold, max_terms, allow_full_walk)
+            .await?)
     }
 
     /// Unranked token-match **count**: the number of `local_doc_id`s

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -54,7 +54,7 @@ use crate::{
         fts::{
             reader::{
                 self as fts_reader, BoolMode, ClauseLists, FtsReader, MatchWork, OrCursorSet,
-                PreparedClauses,
+                PreparedClauses, TermPattern,
             },
             tokenize::{AsciiLowerTokenizer, Tokenizer},
         },
@@ -1198,6 +1198,21 @@ impl SuperfileReader {
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
         Ok(fts.token_match(column, tokens, mode).await?)
+    }
+
+    /// Widen one `LIKE` fragment token to the indexed terms of `column`
+    /// it covers (`None` when more than `max_terms` qualify). Delegates to
+    /// [`FtsReader::expand_terms`].
+    pub(crate) async fn expand_terms(
+        &self,
+        column: &str,
+        pattern: TermPattern<'_>,
+        max_terms: usize,
+    ) -> Result<(Option<Vec<String>>, MatchWork), ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.expand_terms(column, pattern, max_terms).await?)
     }
 
     /// Unranked token-match **count**: the number of `local_doc_id`s

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1212,12 +1212,13 @@ impl SuperfileReader {
         fold: bool,
         max_terms: usize,
         allow_full_walk: bool,
+        pool: Option<&ThreadPool>,
     ) -> Result<(Vec<Option<Vec<String>>>, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
         Ok(fts
-            .expand_terms(column, patterns, fold, max_terms, allow_full_walk)
+            .expand_terms(column, patterns, fold, max_terms, allow_full_walk, pool)
             .await?)
     }
 
@@ -1433,6 +1434,7 @@ impl SuperfileReader {
         column: &str,
         prefix: &str,
         k: usize,
+        pool: Option<&ThreadPool>,
     ) -> Result<(Vec<(u32, f32)>, MatchWork), ReadError> {
         let fts = self
             .fts()
@@ -1441,7 +1443,11 @@ impl SuperfileReader {
             return Ok((Vec::new(), MatchWork::default()));
         }
         let lowered = prefix.to_ascii_lowercase();
-        let term_bytes = fts.iter_terms_with_prefix(column, lowered.as_bytes())?;
+        // The dictionary walk is CPU work and runs on the reader pool; the
+        // FST fetch it needs stays on this runtime.
+        let term_bytes = fts
+            .terms_with_prefix(column, lowered.as_bytes(), pool)
+            .await?;
         if term_bytes.is_empty() {
             return Ok((Vec::new(), MatchWork::default()));
         }
@@ -1541,12 +1547,15 @@ impl SuperfileReader {
         &self,
         column: &str,
         prefix: &str,
+        pool: Option<&ThreadPool>,
     ) -> Result<OrCursorSet, ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
         let lowered = prefix.to_ascii_lowercase();
-        let term_bytes = fts.iter_terms_with_prefix(column, lowered.as_bytes())?;
+        let term_bytes = fts
+            .terms_with_prefix(column, lowered.as_bytes(), pool)
+            .await?;
         // FST keys are valid UTF-8 by construction (AsciiLower
         // tokenizer only emits ASCII bytes); the from_utf8 below
         // is a typed pass-through, not a re-validation cost.
@@ -1589,11 +1598,12 @@ impl SuperfileReader {
         k: usize,
         doc_id_start: u32,
         doc_id_end: u32,
+        pool: Option<&ThreadPool>,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
         if k == 0 || doc_id_start >= doc_id_end {
             return Ok(Vec::new());
         }
-        let set = self.bm25_prefix_cursor_set(column, prefix).await?;
+        let set = self.bm25_prefix_cursor_set(column, prefix, pool).await?;
         self.bm25_search_or_range_prebuilt(&set, k, doc_id_start, doc_id_end, f32::NEG_INFINITY)
     }
 
@@ -2767,7 +2777,7 @@ mod tests {
         let r = SuperfileReader::open(bytes).expect("open");
         // "rust" is a prefix of "rust" (docs 0,2); "ru" expands to it too.
         let (hits, work) = r
-            .bm25_search_prefix("title", "ru", 5)
+            .bm25_search_prefix("title", "ru", 5, None)
             .await
             .expect("prefix search");
         assert!(
@@ -2779,7 +2789,7 @@ mod tests {
         assert!(ids.contains(&2));
         // No indexed term begins with "zz".
         assert!(
-            r.bm25_search_prefix("title", "zz", 5)
+            r.bm25_search_prefix("title", "zz", 5, None)
                 .await
                 .expect("prefix")
                 .0
@@ -2787,7 +2797,7 @@ mod tests {
         );
         // k == 0 short-circuits.
         assert!(
-            r.bm25_search_prefix("title", "ru", 0)
+            r.bm25_search_prefix("title", "ru", 0, None)
                 .await
                 .expect("zero k")
                 .0
@@ -2834,7 +2844,7 @@ mod tests {
         let r = SuperfileReader::open(bytes).expect("open");
         // "ru" expands to "rust" (docs 0,2); restrict to [0,2) ⇒ doc 0.
         let hits = r
-            .bm25_search_prefix_range("title", "ru", 10, 0, 2)
+            .bm25_search_prefix_range("title", "ru", 10, 0, 2, None)
             .await
             .expect("prefix range");
         let ids: HashSet<u32> = hits.iter().map(|(d, _)| *d).collect();
@@ -2842,13 +2852,13 @@ mod tests {
         assert!(!ids.contains(&2));
         // Degenerate range / k short-circuits.
         assert!(
-            r.bm25_search_prefix_range("title", "ru", 0, 0, 2)
+            r.bm25_search_prefix_range("title", "ru", 0, 0, 2, None)
                 .await
                 .expect("zero k")
                 .is_empty()
         );
         assert!(
-            r.bm25_search_prefix_range("title", "ru", 10, 2, 2)
+            r.bm25_search_prefix_range("title", "ru", 10, 2, 2, None)
                 .await
                 .expect("empty range")
                 .is_empty()
@@ -3145,7 +3155,7 @@ mod tests {
         let bytes = build_simple_fts_only_superfile();
         let r = SuperfileReader::open(bytes).expect("open");
         let hits = r
-            .bm25_search_prefix_range("title", "zz", 10, 0, 4)
+            .bm25_search_prefix_range("title", "zz", 10, 0, 4, None)
             .await
             .expect("prefix range");
         assert!(hits.is_empty());

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1202,18 +1202,19 @@ impl SuperfileReader {
 
     /// Widen the tokens of one `LIKE` leaf to the indexed terms of
     /// `column` each covers, in one dictionary pass (a slot is `None` when
-    /// more than `max_terms` qualify). Delegates to
-    /// [`FtsReader::expand_terms`].
+    /// more than `max_terms` qualify); `fold` compares terms under the
+    /// `ILIKE` folding. Delegates to [`FtsReader::expand_terms`].
     pub(crate) async fn expand_terms(
         &self,
         column: &str,
         patterns: &[TermPattern<'_>],
+        fold: bool,
         max_terms: usize,
     ) -> Result<(Vec<Option<Vec<String>>>, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
-        Ok(fts.expand_terms(column, patterns, max_terms).await?)
+        Ok(fts.expand_terms(column, patterns, fold, max_terms).await?)
     }
 
     /// Unranked token-match **count**: the number of `local_doc_id`s

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1200,19 +1200,20 @@ impl SuperfileReader {
         Ok(fts.token_match(column, tokens, mode).await?)
     }
 
-    /// Widen one `LIKE` fragment token to the indexed terms of `column`
-    /// it covers (`None` when more than `max_terms` qualify). Delegates to
+    /// Widen the tokens of one `LIKE` leaf to the indexed terms of
+    /// `column` each covers, in one dictionary pass (a slot is `None` when
+    /// more than `max_terms` qualify). Delegates to
     /// [`FtsReader::expand_terms`].
     pub(crate) async fn expand_terms(
         &self,
         column: &str,
-        pattern: TermPattern<'_>,
+        patterns: &[TermPattern<'_>],
         max_terms: usize,
-    ) -> Result<(Option<Vec<String>>, MatchWork), ReadError> {
+    ) -> Result<(Vec<Option<Vec<String>>>, MatchWork), ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
-        Ok(fts.expand_terms(column, pattern, max_terms).await?)
+        Ok(fts.expand_terms(column, patterns, max_terms).await?)
     }
 
     /// Unranked token-match **count**: the number of `local_doc_id`s

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -47,8 +47,12 @@
 //! head or tail of a longer indexed term and is widened, per superfile,
 //! to every term that starts with / ends with / contains it. Which edges
 //! count as closed, and which open tokens can be used at all, depends on
-//! the analyzer — see `Analyzer`. `NOT LIKE` and `ILIKE` stay
-//! `Unbounded`.
+//! the analyzer — see `Analyzer`. `ILIKE` is bounded the same way for
+//! ASCII tokens: Arrow folds case under Unicode simple case folding, so
+//! a matching row may spell `s` as `ſ` and `k` as `K`, and the expansion
+//! compares dictionary terms with those folded back (`fold_term`). Tokens
+//! with non-ASCII characters are not bounded under `ILIKE`. `NOT LIKE`
+//! stays `Unbounded`.
 
 use std::{collections::HashSet, mem, sync::Arc};
 
@@ -66,7 +70,7 @@ use crate::{
     superfile::{
         ReadError, SuperfileReader,
         fts::{
-            reader::{BoolMode, MatchWork, TermPattern},
+            reader::{BoolMode, LONG_S_ASCII, MatchWork, TermPattern},
             tokenize::{ASCII_LOWER_TOKENIZER, STANDARD_TOKENIZER, Tokenizer},
         },
     },
@@ -106,6 +110,13 @@ const WORD_JOINERS: &[char] = &['\'', '"', '.', ':', ',', ';', '_'];
 /// lowercasing.
 const FINAL_SIGMA: char = 'ς';
 
+/// ASCII letters whose Unicode simple case-folding class has a non-ASCII
+/// member: `s` folds together with `ſ` (U+017F) and `k` with the Kelvin
+/// sign `K` (U+212A). Under `ILIKE` a matching row may hold those forms;
+/// the `ascii_lower` analyzer drops the run holding one, so a token with
+/// either letter cannot be required of it.
+const FOLD_TO_ASCII: &[char] = &['s', 'k'];
+
 /// A superfile-independent boolean plan over FTS term retrievals, lowered
 /// once from a SQL `WHERE` clause and [`evaluate`](CandidatePlan::evaluate)d
 /// per superfile to a superset of the rows satisfying the FTS-resolvable
@@ -133,10 +144,13 @@ pub(crate) enum CandidatePlan {
     /// an open-edged one as some term it is the head / tail / infix of.
     /// [`expand`](Self::expand) turns it into an `And` of `TermsAny` per
     /// superfile; `evaluate` / `estimate` do the same inline when handed
-    /// the unexpanded leaf.
+    /// the unexpanded leaf. `fold` marks an `ILIKE`: dictionary terms are
+    /// compared with `ſ` / `K` folded back to `s` / `k`, the two ASCII
+    /// letters whose case-folding class Arrow widens past lowercasing.
     TermsLike {
         column: String,
         tokens: Vec<LikeToken>,
+        fold: bool,
     },
     /// Intersection of children (logical `AND`).
     And(Vec<CandidatePlan>),
@@ -229,8 +243,12 @@ impl CandidatePlan {
                     let (docs, work) = reader.token_match(column, &refs, BoolMode::Or).await?;
                     Ok((Some(docs.into_iter().collect()), work))
                 }
-                CandidatePlan::TermsLike { column, tokens } => {
-                    let (expanded, mut work) = expand_like(reader, column, tokens).await?;
+                CandidatePlan::TermsLike {
+                    column,
+                    tokens,
+                    fold,
+                } => {
+                    let (expanded, mut work) = expand_like(reader, column, tokens, *fold).await?;
                     let (docs, eval_work) = expanded.evaluate(reader).await?;
                     work.merge(eval_work);
                     Ok((docs, work))
@@ -363,14 +381,23 @@ impl CandidatePlan {
                 }
                 true
             }
-            CandidatePlan::TermsLike { column, tokens } => {
+            CandidatePlan::TermsLike {
+                column,
+                tokens,
+                fold,
+            } => {
                 // A complete token must be present as itself → term bloom;
                 // a token open only on the right must head some term → lex
                 // term-range overlap. A token open on the left bounds no
-                // manifest summary.
+                // manifest summary. Under `ILIKE` a token holding `s` may
+                // be spelled with `ſ` in the dictionary, so neither summary
+                // can be asked about it (`k` is safe: `K` lowercases to
+                // `k` before indexing).
+                let summarizable = |t: &&LikeToken| !*fold || !t.text.contains(LONG_S_ASCII);
                 let complete: Vec<String> = tokens
                     .iter()
                     .filter(|t| t.is_complete())
+                    .filter(summarizable)
                     .map(|t| t.text.clone())
                     .collect();
                 if !complete.is_empty() {
@@ -380,7 +407,11 @@ impl CandidatePlan {
                         mode: BoolMode::And,
                     });
                 }
-                for token in tokens.iter().filter(|t| !t.open_left && t.open_right) {
+                for token in tokens
+                    .iter()
+                    .filter(|t| !t.open_left && t.open_right)
+                    .filter(summarizable)
+                {
                     leaves.push(PruneLeaf::Prefix {
                         column: column.clone(),
                         prefix: token.text.as_bytes().to_vec(),
@@ -438,8 +469,12 @@ impl CandidatePlan {
                     let sum = dfs.into_iter().fold(0u64, u64::saturating_add);
                     Ok((sum.min(n_docs), work))
                 }
-                CandidatePlan::TermsLike { column, tokens } => {
-                    let (expanded, mut work) = expand_like(reader, column, tokens).await?;
+                CandidatePlan::TermsLike {
+                    column,
+                    tokens,
+                    fold,
+                } => {
+                    let (expanded, mut work) = expand_like(reader, column, tokens, *fold).await?;
                     let (rows, est_work) = expanded.estimate(reader).await?;
                     work.merge(est_work);
                     Ok((rows, work))
@@ -498,9 +533,11 @@ impl CandidatePlan {
     ) -> BoxFuture<'a, Result<(CandidatePlan, MatchWork), ReadError>> {
         Box::pin(async move {
             match self {
-                CandidatePlan::TermsLike { column, tokens } => {
-                    expand_like(reader, column, tokens).await
-                }
+                CandidatePlan::TermsLike {
+                    column,
+                    tokens,
+                    fold,
+                } => expand_like(reader, column, tokens, *fold).await,
                 CandidatePlan::And(children) => {
                     let (expanded, work) = expand_children(reader, children).await?;
                     Ok((and_combine(expanded), work))
@@ -533,16 +570,18 @@ async fn expand_children(
 /// Bind one `TermsLike` leaf to a superfile: the `AND` of each token's
 /// expansion. A token widening past [`LIKE_MAX_TERMS`] contributes no
 /// constraint (`Unbounded`, which `and_combine` drops); every token too
-/// wide ⇒ the leaf is `Unbounded` and the superfile scans.
+/// wide ⇒ the leaf is `Unbounded` and the superfile scans. `fold` is the
+/// leaf's `ILIKE` flag.
 async fn expand_like(
     reader: &SuperfileReader,
     column: &str,
     tokens: &[LikeToken],
+    fold: bool,
 ) -> Result<(CandidatePlan, MatchWork), ReadError> {
     // One dictionary pass widens every token of the leaf.
     let patterns: Vec<TermPattern<'_>> = tokens.iter().map(LikeToken::pattern).collect();
     let (expansions, work) = reader
-        .expand_terms(column, &patterns, LIKE_MAX_TERMS)
+        .expand_terms(column, &patterns, fold, LIKE_MAX_TERMS)
         .await?;
     let parts = expansions
         .into_iter()
@@ -620,26 +659,29 @@ fn in_list_leaf(
     or_combine(branches)
 }
 
-/// Lower `col LIKE 'pattern'` on an FTS column. The pattern's literal
-/// fragments are tokenized with the column's analyzer; every token the
-/// analyzer can bound soundly becomes a constraint (see `Analyzer::admits`).
-/// All-complete tokens are the same term-AND an equality lowers to;
-/// otherwise the leaf waits for a superfile's dictionary. `Unbounded` for
-/// `NOT LIKE`, `ILIKE`, a non-column or non-literal operand, a non-FTS
-/// column, an escape other than `\`, or a pattern with no usable token.
+/// Lower `col LIKE 'pattern'` / `col ILIKE 'pattern'` on an FTS column.
+/// The pattern's literal fragments are tokenized with the column's
+/// analyzer; every token the analyzer can bound soundly becomes a
+/// constraint (see `Analyzer::admits`). All-complete tokens are the same
+/// term-AND an equality lowers to, unless an `ILIKE` token holds an `s`
+/// (its `ſ` spelling needs the dictionary); otherwise the leaf waits for
+/// a superfile's dictionary. `Unbounded` for `NOT LIKE`, a non-column or
+/// non-literal operand, a non-FTS column, an escape other than `\`, or a
+/// pattern with no usable token.
 fn like_leaf(
     like: &Like,
     fts_cols: &HashSet<&str>,
     resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
 ) -> CandidatePlan {
-    // `NOT LIKE` excludes rows — no term set bounds an exclusion. `ILIKE`
-    // matches under Unicode simple case folding, which is wider than the
-    // analyzers' lowercasing (`ſ` folds to `s`; `to_lowercase` keeps it),
-    // so a folded match could hide behind a term the pattern's lowercased
-    // token never reaches.
-    if like.negated || like.case_insensitive {
+    // `NOT LIKE` excludes rows — no term set bounds an exclusion.
+    if like.negated {
         return CandidatePlan::Unbounded;
     }
+    // `ILIKE`: Arrow compares under Unicode simple case folding (ASCII
+    // fast paths aside), so the analyzers' lowercasing does not reproduce
+    // every match — `fold` carries that to the token rules and the
+    // expansion.
+    let fold = like.case_insensitive;
     // Arrow's kernel reads `\` as the escape; the executor rejects others.
     if like.escape_char.is_some_and(|c| c != LIKE_ESCAPE) {
         return CandidatePlan::Unbounded;
@@ -662,12 +704,16 @@ fn like_leaf(
     };
     let tokens: Vec<LikeToken> = fragments
         .iter()
-        .flat_map(|fragment| fragment.tokens(tok.as_ref(), analyzer))
+        .flat_map(|fragment| fragment.tokens(tok.as_ref(), analyzer, fold))
         .collect();
     if tokens.is_empty() {
         return CandidatePlan::Unbounded;
     }
-    if tokens.iter().all(LikeToken::is_complete) {
+    // Complete tokens are exact terms — unless `ILIKE` may have spelled
+    // an `s` as `ſ`, which only the dictionary walk can find.
+    let exact_terms = tokens.iter().all(LikeToken::is_complete)
+        && !(fold && tokens.iter().any(|t| t.text.contains(LONG_S_ASCII)));
+    if exact_terms {
         return CandidatePlan::TermsAll {
             column: c.name.clone(),
             tokens: tokens.into_iter().map(|t| t.text).collect(),
@@ -676,6 +722,7 @@ fn like_leaf(
     CandidatePlan::TermsLike {
         column: c.name.clone(),
         tokens,
+        fold,
     }
 }
 
@@ -697,8 +744,9 @@ impl Fragment {
     /// is a hard separator (the token began after it); the last token
     /// likewise on the right. Any other edge may continue into the text a
     /// wildcard stands for. Tokens the analyzer cannot bound soundly are
-    /// dropped — a dropped constraint keeps a superset.
-    fn tokens(&self, tok: &dyn Tokenizer, analyzer: Analyzer) -> Vec<LikeToken> {
+    /// dropped — a dropped constraint keeps a superset. `fold` is the
+    /// `ILIKE` flag.
+    fn tokens(&self, tok: &dyn Tokenizer, analyzer: Analyzer, fold: bool) -> Vec<LikeToken> {
         let texts: Vec<String> = tok.tokenize(&self.text).collect();
         let n = texts.len();
         let left_closed = self.at_start
@@ -717,11 +765,14 @@ impl Fragment {
             .into_iter()
             .enumerate()
             .filter_map(|(i, text)| {
-                analyzer.admits(LikeToken {
-                    text,
-                    open_left: i == 0 && !left_closed,
-                    open_right: i + 1 == n && !right_closed,
-                })
+                analyzer.admits(
+                    LikeToken {
+                        text,
+                        open_left: i == 0 && !left_closed,
+                        open_right: i + 1 == n && !right_closed,
+                    },
+                    fold,
+                )
             })
             .collect()
     }
@@ -799,14 +850,26 @@ impl Analyzer {
         }
     }
 
-    /// Whether the index can soundly require `token` of a matching row.
-    fn admits(self, token: LikeToken) -> Option<LikeToken> {
+    /// Whether the index can soundly require `token` of a matching row;
+    /// `fold` is the `ILIKE` flag.
+    fn admits(self, token: LikeToken, fold: bool) -> Option<LikeToken> {
+        // Under `ILIKE`, Arrow folds case with Unicode simple case folding
+        // (through a regex whenever the column or the pattern is not pure
+        // ASCII). A non-ASCII token then matches spellings `to_lowercase`
+        // never produces (`ς` for a medial `σ`, `ϐ` for `β`), so only an
+        // ASCII token can be required.
+        if fold && !token.text.is_ascii() {
+            return None;
+        }
         match self {
             // A run holding any non-ASCII byte is dropped whole, so a term
             // that merely *contains* a fragment token may not exist
             // (`Firefox—the` indexes nothing). Only a token the fragment
             // closes on both sides is guaranteed indexed as itself.
             Analyzer::AsciiLower if !token.is_complete() => None,
+            // …and under `ILIKE` a row may spell `s` as `ſ` or `k` as `K`
+            // — non-ASCII bytes that drop the whole run.
+            Analyzer::AsciiLower if fold && token.text.contains(FOLD_TO_ASCII) => None,
             // `to_lowercase` spells a word-final `Σ` as `ς` and a medial
             // one as `σ`, so a token whose end may sit mid-word has two
             // possible spellings in the dictionary.
@@ -1147,6 +1210,15 @@ mod tests {
         CandidatePlan::TermsLike {
             column: "title".into(),
             tokens,
+            fold: false,
+        }
+    }
+
+    fn terms_ilike(tokens: Vec<LikeToken>) -> CandidatePlan {
+        CandidatePlan::TermsLike {
+            column: "title".into(),
+            tokens,
+            fold: true,
         }
     }
 
@@ -1286,15 +1358,95 @@ mod tests {
     }
 
     #[test]
-    fn negated_and_case_insensitive_like_are_unbounded() {
+    fn negated_like_is_unbounded() {
         assert_eq!(
             standard_plan(col("title").not_like(lit("rust%"))),
             CandidatePlan::Unbounded
         );
         assert_eq!(
-            standard_plan(col("title").ilike(lit("rust%"))),
+            standard_plan(col("title").not_ilike(lit("rust%"))),
             CandidatePlan::Unbounded
         );
+    }
+
+    #[test]
+    fn ilike_lowers_like_like_with_the_fold_flag() {
+        // The pattern's own case is irrelevant (the analyzer lowercases);
+        // the leaf carries `fold` so the dictionary walk folds `ſ`.
+        assert_eq!(
+            standard_plan(col("title").ilike(lit("%FoX%"))),
+            terms_ilike(vec![like_token("fox", true, true)])
+        );
+        // Complete tokens without an `s` are exact terms, as under LIKE.
+        assert_eq!(
+            standard_plan(col("title").ilike(lit("% Quick Fox %"))),
+            terms_all(&["quick", "fox"])
+        );
+        // A complete token holding an `s` may be spelled `ſ` in a matching
+        // row's term, so it needs the dictionary even though it is complete.
+        assert_eq!(
+            standard_plan(col("title").ilike(lit("% rust %"))),
+            terms_ilike(vec![like_token("rust", false, false)])
+        );
+    }
+
+    #[test]
+    fn ilike_bounds_only_ascii_tokens() {
+        // Arrow's fold widens non-ASCII letters past `to_lowercase`
+        // (medial `σ` matches `ς`), so the token cannot be required.
+        assert_eq!(
+            standard_plan(col("title").ilike(lit("%ΟΔΟΣ%"))),
+            CandidatePlan::Unbounded
+        );
+        // A mixed pattern keeps the ASCII token and drops the other.
+        assert_eq!(
+            standard_plan(col("title").ilike(lit("%fox%süd%"))),
+            terms_ilike(vec![like_token("fox", true, true)])
+        );
+    }
+
+    #[test]
+    fn ilike_under_ascii_lower_excludes_tokens_that_can_fold_to_non_ascii() {
+        // `ſ` / `K` in a matching row are non-ASCII bytes, which drop the
+        // run under `ascii_lower`; a complete token holding `s` or `k` is
+        // therefore not guaranteed indexed. Others still are.
+        assert_eq!(
+            plan(col("title").ilike(lit("% rust %"))),
+            CandidatePlan::Unbounded
+        );
+        assert_eq!(
+            plan(col("title").ilike(lit("% quick %"))),
+            CandidatePlan::Unbounded
+        );
+        assert_eq!(
+            plan(col("title").ilike(lit("% fox %"))),
+            terms_all(&["fox"])
+        );
+        assert_eq!(
+            plan(col("title").ilike(lit("%fox%"))),
+            CandidatePlan::Unbounded
+        );
+    }
+
+    #[test]
+    fn ilike_prune_leaves_skip_tokens_that_may_be_spelled_with_a_long_s() {
+        // `fox` is a safe bloom term; `rust`'s dictionary spelling may be
+        // `ruſt`, so no summary is asked about it; `quic` prefix is safe.
+        let leaves = like_prune_leaves(
+            &[col("title").ilike(lit("quic% rust fox %"))],
+            &fts_cols(),
+            &standard_resolver,
+        );
+        assert_eq!(leaves.len(), 2);
+        assert!(matches!(
+            &leaves[0],
+            PruneLeaf::TermPresence { terms, mode: BoolMode::And, .. }
+                if *terms == ["fox".to_owned()]
+        ));
+        assert!(matches!(
+            &leaves[1],
+            PruneLeaf::Prefix { prefix, .. } if prefix == b"quic"
+        ));
     }
 
     #[test]

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -64,6 +64,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use futures::future::BoxFuture;
+use rayon::ThreadPool;
 use roaring::RoaringBitmap;
 
 use crate::{
@@ -213,10 +214,12 @@ impl CandidatePlan {
     /// `token_match(.., And)`; `And`/`Or` intersect/union children.
     /// The second element sums the posting-walk work of every `TermsAll`
     /// leaf the evaluation touched (an early-out keeps the work already
-    /// done), so the caller can flush it per superfile.
+    /// done), so the caller can flush it per superfile. `pool` is the
+    /// reader pool a `LIKE` leaf's dictionary walk runs on.
     pub(crate) fn evaluate<'a>(
         &'a self,
         reader: &'a SuperfileReader,
+        pool: Option<&'a ThreadPool>,
     ) -> BoxFuture<'a, Result<(Option<RoaringBitmap>, MatchWork), ReadError>> {
         Box::pin(async move {
             match self {
@@ -242,8 +245,8 @@ impl CandidatePlan {
                     fold,
                 } => {
                     let (expanded, mut work) =
-                        expand_like(reader, column, tokens, *fold, true).await?;
-                    let (docs, eval_work) = expanded.evaluate(reader).await?;
+                        expand_like(reader, column, tokens, *fold, true, pool).await?;
+                    let (docs, eval_work) = expanded.evaluate(reader, pool).await?;
                     work.merge(eval_work);
                     Ok((docs, work))
                 }
@@ -251,7 +254,7 @@ impl CandidatePlan {
                     let mut acc: Option<RoaringBitmap> = None;
                     let mut work = MatchWork::default();
                     for c in children {
-                        let (child, child_work) = c.evaluate(reader).await?;
+                        let (child, child_work) = c.evaluate(reader, pool).await?;
                         work.merge(child_work);
                         if let Some(bm) = child {
                             acc = Some(match acc {
@@ -270,7 +273,7 @@ impl CandidatePlan {
                     let mut acc = RoaringBitmap::new();
                     let mut work = MatchWork::default();
                     for c in children {
-                        let (child, child_work) = c.evaluate(reader).await?;
+                        let (child, child_work) = c.evaluate(reader, pool).await?;
                         work.merge(child_work);
                         match child {
                             Some(bm) => acc |= bm,
@@ -436,6 +439,7 @@ impl CandidatePlan {
     pub(crate) fn estimate<'a>(
         &'a self,
         reader: &'a SuperfileReader,
+        pool: Option<&'a ThreadPool>,
     ) -> BoxFuture<'a, Result<(u64, MatchWork), ReadError>> {
         Box::pin(async move {
             let n_docs = reader.n_docs();
@@ -469,8 +473,8 @@ impl CandidatePlan {
                     fold,
                 } => {
                     let (expanded, mut work) =
-                        expand_like(reader, column, tokens, *fold, true).await?;
-                    let (rows, est_work) = expanded.estimate(reader).await?;
+                        expand_like(reader, column, tokens, *fold, true, pool).await?;
+                    let (rows, est_work) = expanded.estimate(reader, pool).await?;
                     work.merge(est_work);
                     Ok((rows, work))
                 }
@@ -478,7 +482,7 @@ impl CandidatePlan {
                     let mut m = n_docs;
                     let mut work = MatchWork::default();
                     for c in children {
-                        let (child, child_work) = c.estimate(reader).await?;
+                        let (child, child_work) = c.estimate(reader, pool).await?;
                         work.merge(child_work);
                         m = m.min(child);
                     }
@@ -488,7 +492,7 @@ impl CandidatePlan {
                     let mut sum: u64 = 0;
                     let mut work = MatchWork::default();
                     for c in children {
-                        let (child, child_work) = c.estimate(reader).await?;
+                        let (child, child_work) = c.estimate(reader, pool).await?;
                         work.merge(child_work);
                         sum = sum.saturating_add(child);
                     }
@@ -528,6 +532,7 @@ impl CandidatePlan {
         &'a self,
         reader: &'a SuperfileReader,
         full_walk_pays: &'a (dyn Fn(&str) -> bool + Sync),
+        pool: Option<&'a ThreadPool>,
     ) -> BoxFuture<'a, Result<(CandidatePlan, MatchWork), ReadError>> {
         Box::pin(async move {
             match self {
@@ -535,15 +540,15 @@ impl CandidatePlan {
                     column,
                     tokens,
                     fold,
-                } => expand_like(reader, column, tokens, *fold, full_walk_pays(column)).await,
+                } => expand_like(reader, column, tokens, *fold, full_walk_pays(column), pool).await,
                 CandidatePlan::And(children) => {
                     let (expanded, work) =
-                        expand_children(reader, children, full_walk_pays).await?;
+                        expand_children(reader, children, full_walk_pays, pool).await?;
                     Ok((and_combine(expanded), work))
                 }
                 CandidatePlan::Or(children) => {
                     let (expanded, work) =
-                        expand_children(reader, children, full_walk_pays).await?;
+                        expand_children(reader, children, full_walk_pays, pool).await?;
                     Ok((or_combine(expanded), work))
                 }
                 leaf => Ok((leaf.clone(), MatchWork::default())),
@@ -557,11 +562,12 @@ async fn expand_children(
     reader: &SuperfileReader,
     children: &[CandidatePlan],
     full_walk_pays: &(dyn Fn(&str) -> bool + Sync),
+    pool: Option<&ThreadPool>,
 ) -> Result<(Vec<CandidatePlan>, MatchWork), ReadError> {
     let mut expanded = Vec::with_capacity(children.len());
     let mut work = MatchWork::default();
     for child in children {
-        let (plan, child_work) = child.expand(reader, full_walk_pays).await?;
+        let (plan, child_work) = child.expand(reader, full_walk_pays, pool).await?;
         work.merge(child_work);
         expanded.push(plan);
     }
@@ -573,18 +579,26 @@ async fn expand_children(
 /// the whole dictionary walked while `allow_full_walk` is off, contributes
 /// no constraint (`Unbounded`, which `and_combine` drops); every token
 /// unanswered ⇒ the leaf is `Unbounded` and the superfile scans. `fold`
-/// is the leaf's `ILIKE` flag.
+/// is the leaf's `ILIKE` flag; the dictionary walk runs on `pool`.
 async fn expand_like(
     reader: &SuperfileReader,
     column: &str,
     tokens: &[LikeToken],
     fold: bool,
     allow_full_walk: bool,
+    pool: Option<&ThreadPool>,
 ) -> Result<(CandidatePlan, MatchWork), ReadError> {
     // One dictionary pass widens every token of the leaf.
     let patterns: Vec<TermPattern<'_>> = tokens.iter().map(LikeToken::pattern).collect();
     let (expansions, work) = reader
-        .expand_terms(column, &patterns, fold, LIKE_MAX_TERMS, allow_full_walk)
+        .expand_terms(
+            column,
+            &patterns,
+            fold,
+            LIKE_MAX_TERMS,
+            allow_full_walk,
+            pool,
+        )
         .await?;
     let parts = expansions
         .into_iter()

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -311,7 +311,11 @@ impl CandidatePlan {
         }
     }
 
-    /// Append one `OR` branch as a single conjunctive leaf group.
+    /// Append one `OR` branch as a single conjunctive leaf group. A branch
+    /// that yields no leaf at all (a `LIKE` whose tokens are all open on
+    /// the left — no summary bounds a suffix or infix) constrains no
+    /// superfile, so the whole disjunction has no gate: `false`, not an
+    /// empty group, which the caller would read as "nothing survives".
     fn collect_survival_or_branch(&self, groups: &mut Vec<Vec<PruneLeaf>>) -> bool {
         match self {
             CandidatePlan::Unbounded => false,
@@ -320,7 +324,7 @@ impl CandidatePlan {
                 .all(|child| child.collect_survival_or_branch(groups)),
             other => {
                 let mut leaves = Vec::new();
-                if !other.append_prune_leaves(&mut leaves) {
+                if !other.append_prune_leaves(&mut leaves) || leaves.is_empty() {
                     return false;
                 }
                 groups.push(leaves);
@@ -1338,6 +1342,32 @@ mod tests {
             PruneLeaf::TermPresence { terms, mode: BoolMode::And, .. }
                 if *terms == ["quick".to_owned(), "fox".to_owned()]
         ));
+    }
+
+    #[test]
+    fn a_like_with_only_open_left_tokens_has_no_survival_gate() {
+        // `%fox%` bounds no manifest summary (no bloom term, no prefix), so
+        // the plan must report "no gate" — an empty leaf group would read as
+        // "no superfile survives" and silently drop every match.
+        let contains = terms_like(vec![like_token("fox", true, true)]);
+        let mut groups = Vec::new();
+        assert!(!contains.collect_survival_or_groups(&mut groups));
+        assert!(groups.is_empty());
+        // The same leaf under an OR disables the whole disjunction's gate.
+        let mut groups = Vec::new();
+        assert!(
+            !CandidatePlan::Or(vec![terms_all(&["alpha"]), contains.clone()])
+                .collect_survival_or_groups(&mut groups)
+        );
+        // Under an AND, the sibling's leaf still gates (a superset stays
+        // sound: every match has `alpha`).
+        let mut groups = Vec::new();
+        assert!(
+            CandidatePlan::And(vec![terms_all(&["alpha"]), contains])
+                .collect_survival_or_groups(&mut groups)
+        );
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 1);
     }
 
     #[test]

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -248,7 +248,8 @@ impl CandidatePlan {
                     tokens,
                     fold,
                 } => {
-                    let (expanded, mut work) = expand_like(reader, column, tokens, *fold).await?;
+                    let (expanded, mut work) =
+                        expand_like(reader, column, tokens, *fold, true).await?;
                     let (docs, eval_work) = expanded.evaluate(reader).await?;
                     work.merge(eval_work);
                     Ok((docs, work))
@@ -474,7 +475,8 @@ impl CandidatePlan {
                     tokens,
                     fold,
                 } => {
-                    let (expanded, mut work) = expand_like(reader, column, tokens, *fold).await?;
+                    let (expanded, mut work) =
+                        expand_like(reader, column, tokens, *fold, true).await?;
                     let (rows, est_work) = expanded.estimate(reader).await?;
                     work.merge(est_work);
                     Ok((rows, work))
@@ -525,11 +527,14 @@ impl CandidatePlan {
     /// superfile: each fragment token becomes the
     /// [`TermsAny`](Self::TermsAny) of the indexed terms it covers, or
     /// `Unbounded` (dropping out of its `AND`) when more than
-    /// [`LIKE_MAX_TERMS`] qualify. Every other node is copied. The work is
-    /// the dictionary fetches performed.
+    /// [`LIKE_MAX_TERMS`] qualify or when the token needs the column's
+    /// whole dictionary walked and `full_walk_pays(column)` says that walk
+    /// is dearer than the scan it would replace. Every other node is
+    /// copied. The work is the dictionary fetches performed.
     pub(crate) fn expand<'a>(
         &'a self,
         reader: &'a SuperfileReader,
+        full_walk_pays: &'a (dyn Fn(&str) -> bool + Sync),
     ) -> BoxFuture<'a, Result<(CandidatePlan, MatchWork), ReadError>> {
         Box::pin(async move {
             match self {
@@ -537,13 +542,15 @@ impl CandidatePlan {
                     column,
                     tokens,
                     fold,
-                } => expand_like(reader, column, tokens, *fold).await,
+                } => expand_like(reader, column, tokens, *fold, full_walk_pays(column)).await,
                 CandidatePlan::And(children) => {
-                    let (expanded, work) = expand_children(reader, children).await?;
+                    let (expanded, work) =
+                        expand_children(reader, children, full_walk_pays).await?;
                     Ok((and_combine(expanded), work))
                 }
                 CandidatePlan::Or(children) => {
-                    let (expanded, work) = expand_children(reader, children).await?;
+                    let (expanded, work) =
+                        expand_children(reader, children, full_walk_pays).await?;
                     Ok((or_combine(expanded), work))
                 }
                 leaf => Ok((leaf.clone(), MatchWork::default())),
@@ -556,11 +563,12 @@ impl CandidatePlan {
 async fn expand_children(
     reader: &SuperfileReader,
     children: &[CandidatePlan],
+    full_walk_pays: &(dyn Fn(&str) -> bool + Sync),
 ) -> Result<(Vec<CandidatePlan>, MatchWork), ReadError> {
     let mut expanded = Vec::with_capacity(children.len());
     let mut work = MatchWork::default();
     for child in children {
-        let (plan, child_work) = child.expand(reader).await?;
+        let (plan, child_work) = child.expand(reader, full_walk_pays).await?;
         work.merge(child_work);
         expanded.push(plan);
     }
@@ -568,20 +576,22 @@ async fn expand_children(
 }
 
 /// Bind one `TermsLike` leaf to a superfile: the `AND` of each token's
-/// expansion. A token widening past [`LIKE_MAX_TERMS`] contributes no
-/// constraint (`Unbounded`, which `and_combine` drops); every token too
-/// wide ⇒ the leaf is `Unbounded` and the superfile scans. `fold` is the
-/// leaf's `ILIKE` flag.
+/// expansion. A token widening past [`LIKE_MAX_TERMS`], or one that needs
+/// the whole dictionary walked while `allow_full_walk` is off, contributes
+/// no constraint (`Unbounded`, which `and_combine` drops); every token
+/// unanswered ⇒ the leaf is `Unbounded` and the superfile scans. `fold`
+/// is the leaf's `ILIKE` flag.
 async fn expand_like(
     reader: &SuperfileReader,
     column: &str,
     tokens: &[LikeToken],
     fold: bool,
+    allow_full_walk: bool,
 ) -> Result<(CandidatePlan, MatchWork), ReadError> {
     // One dictionary pass widens every token of the leaf.
     let patterns: Vec<TermPattern<'_>> = tokens.iter().map(LikeToken::pattern).collect();
     let (expansions, work) = reader
-        .expand_terms(column, &patterns, fold, LIKE_MAX_TERMS)
+        .expand_terms(column, &patterns, fold, LIKE_MAX_TERMS, allow_full_walk)
         .await?;
     let parts = expansions
         .into_iter()

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -220,8 +220,11 @@ impl CandidatePlan {
                     Ok((Some(docs.into_iter().collect()), work))
                 }
                 CandidatePlan::TermsAny { column, terms } => {
-                    // No qualifying term in this superfile ⇒ no row; the
-                    // match returns the empty set for an empty term list.
+                    // No qualifying term in this superfile ⇒ no row, decided
+                    // here rather than left to the match's empty-input rule.
+                    if terms.is_empty() {
+                        return Ok((Some(RoaringBitmap::new()), MatchWork::default()));
+                    }
                     let refs: Vec<&str> = terms.iter().map(String::as_str).collect();
                     let (docs, work) = reader.token_match(column, &refs, BoolMode::Or).await?;
                     Ok((Some(docs.into_iter().collect()), work))
@@ -536,21 +539,21 @@ async fn expand_like(
     column: &str,
     tokens: &[LikeToken],
 ) -> Result<(CandidatePlan, MatchWork), ReadError> {
-    let mut parts = Vec::with_capacity(tokens.len());
-    let mut work = MatchWork::default();
-    for token in tokens {
-        let (terms, expand_work) = reader
-            .expand_terms(column, token.pattern(), LIKE_MAX_TERMS)
-            .await?;
-        work.merge(expand_work);
-        parts.push(match terms {
+    // One dictionary pass widens every token of the leaf.
+    let patterns: Vec<TermPattern<'_>> = tokens.iter().map(LikeToken::pattern).collect();
+    let (expansions, work) = reader
+        .expand_terms(column, &patterns, LIKE_MAX_TERMS)
+        .await?;
+    let parts = expansions
+        .into_iter()
+        .map(|terms| match terms {
             Some(terms) => CandidatePlan::TermsAny {
                 column: column.to_owned(),
                 terms,
             },
             None => CandidatePlan::Unbounded,
-        });
-    }
+        })
+        .collect();
     Ok((and_combine(parts), work))
 }
 

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -36,13 +36,27 @@
 //! one — the exact equality is verified in pass 2. `AND` with an
 //! un-boundable child drops that child (keeps more rows — still a
 //! superset); `OR` with any un-boundable child is itself `Unbounded`;
-//! `NOT`, non-FTS columns, range ops, and `LIKE` are `Unbounded` (a
-//! word-token index can't soundly bound substring / negation).
+//! `NOT`, non-FTS columns, and range ops are `Unbounded` (a word-token
+//! index can't soundly bound negation or ordering).
+//!
+//! `LIKE` is bounded through the term dictionary. The pattern is split
+//! at its wildcards into literal fragments and each fragment is tokenized
+//! with the column's analyzer. A token the fragment closes on both sides
+//! (a separator inside the fragment, or the pattern's own start / end)
+//! must be indexed as itself; a token bordering a wildcard may be the
+//! head or tail of a longer indexed term and is widened, per superfile,
+//! to every term that starts with / ends with / contains it. Which edges
+//! count as closed, and which open tokens can be used at all, depends on
+//! the analyzer — see `Analyzer`. `NOT LIKE` and `ILIKE` stay
+//! `Unbounded`.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, mem, sync::Arc};
 
 use datafusion::{
-    logical_expr::{Expr, Operator},
+    logical_expr::{
+        Expr, Operator,
+        expr::{InList, Like},
+    },
     scalar::ScalarValue,
 };
 use futures::future::BoxFuture;
@@ -52,8 +66,8 @@ use crate::{
     superfile::{
         ReadError, SuperfileReader,
         fts::{
-            reader::{BoolMode, MatchWork},
-            tokenize::Tokenizer,
+            reader::{BoolMode, MatchWork, TermPattern},
+            tokenize::{ASCII_LOWER_TOKENIZER, STANDARD_TOKENIZER, Tokenizer},
         },
     },
     supertable::{
@@ -62,6 +76,35 @@ use crate::{
         query::prune::{PruneLeaf, select_superfiles},
     },
 };
+
+/// Most indexed terms one `LIKE` fragment token may widen to before the
+/// index gives up on it. Each expanded term costs a df probe and a
+/// posting walk, and a token this broad matches enough rows that the
+/// scan wins anyway — the provider's selectivity gate would send it there
+/// after paying for the probes. Sibling of the provider's `PUSHDOWN_*`
+/// gates.
+pub(crate) const LIKE_MAX_TERMS: usize = 1024;
+
+/// `LIKE` wildcard matching any run of characters, including none.
+const LIKE_ANY: char = '%';
+
+/// `LIKE` wildcard matching exactly one character.
+const LIKE_ONE: char = '_';
+
+/// The escape Arrow's `LIKE` kernel reads: the character after it is
+/// literal, whatever it is.
+const LIKE_ESCAPE: char = '\\';
+
+/// ASCII characters UAX #29 lets join two words — apostrophe, quote,
+/// full stop, colon, comma, semicolon, underscore (`don't`, `3.5`,
+/// `a:b`, `1,000`, `x_y`, a Hebrew `"`). Any other ASCII non-alphanumeric
+/// is a hard word break under the `standard` analyzer.
+const WORD_JOINERS: &[char] = &['\'', '"', '.', ':', ',', ';', '_'];
+
+/// Lowercase final sigma: `to_lowercase` spells a word-final `Σ` this way
+/// and a medial one `σ` — the one context-sensitive mapping in Unicode
+/// lowercasing.
+const FINAL_SIGMA: char = 'ς';
 
 /// A superfile-independent boolean plan over FTS term retrievals, lowered
 /// once from a SQL `WHERE` clause and [`evaluate`](CandidatePlan::evaluate)d
@@ -79,12 +122,59 @@ pub(crate) enum CandidatePlan {
     /// rejected: it decodes the predicate column in its own pass 2, once
     /// per `OR`/`IN` branch, on top of the scan — multi-decode.)
     TermsAll { column: String, tokens: Vec<String> },
+    /// Rows whose `column` contains any one of `terms` (term-OR): one
+    /// `LIKE` fragment token bound to a superfile's vocabulary by
+    /// [`expand`](Self::expand). Resolved by a single `token_match(.., Or)`;
+    /// empty `terms` (nothing in that superfile's dictionary qualifies)
+    /// matches no row, so the superfile is skipped without a scan.
+    TermsAny { column: String, terms: Vec<String> },
+    /// Rows whose `column` satisfies every `LIKE` fragment token, before
+    /// the superfile is known: a complete token must be indexed as itself,
+    /// an open-edged one as some term it is the head / tail / infix of.
+    /// [`expand`](Self::expand) turns it into an `And` of `TermsAny` per
+    /// superfile; `evaluate` / `estimate` do the same inline when handed
+    /// the unexpanded leaf.
+    TermsLike {
+        column: String,
+        tokens: Vec<LikeToken>,
+    },
     /// Intersection of children (logical `AND`).
     And(Vec<CandidatePlan>),
     /// Union of children (logical `OR`).
     Or(Vec<CandidatePlan>),
     /// No usable bound: scan the superfile and let `FilterExec` verify.
     Unbounded,
+}
+
+/// One token of a `LIKE` fragment, as the column's analyzer produced it,
+/// with which of its ends may sit mid-term in a matching row's text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LikeToken {
+    /// The analyzer's token text (already split and lowercased).
+    pub(crate) text: String,
+    /// A wildcard precedes the token with no separator in between, so a
+    /// matching row may hold it as the tail of a longer term.
+    pub(crate) open_left: bool,
+    /// A wildcard follows the token with no separator in between, so a
+    /// matching row may hold it as the head of a longer term.
+    pub(crate) open_right: bool,
+}
+
+impl LikeToken {
+    /// Closed on both sides: the token must be indexed exactly as itself.
+    fn is_complete(&self) -> bool {
+        !self.open_left && !self.open_right
+    }
+
+    /// The dictionary shape the open edges call for.
+    fn pattern(&self) -> TermPattern<'_> {
+        match (self.open_left, self.open_right) {
+            (false, false) => TermPattern::Exact(&self.text),
+            (false, true) => TermPattern::Prefix(&self.text),
+            (true, false) => TermPattern::Suffix(&self.text),
+            (true, true) => TermPattern::Contains(&self.text),
+        }
+    }
 }
 
 impl CandidatePlan {
@@ -128,6 +218,19 @@ impl CandidatePlan {
                     let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
                     let (docs, work) = reader.token_match(column, &refs, BoolMode::And).await?;
                     Ok((Some(docs.into_iter().collect()), work))
+                }
+                CandidatePlan::TermsAny { column, terms } => {
+                    // No qualifying term in this superfile ⇒ no row; the
+                    // match returns the empty set for an empty term list.
+                    let refs: Vec<&str> = terms.iter().map(String::as_str).collect();
+                    let (docs, work) = reader.token_match(column, &refs, BoolMode::Or).await?;
+                    Ok((Some(docs.into_iter().collect()), work))
+                }
+                CandidatePlan::TermsLike { column, tokens } => {
+                    let (expanded, mut work) = expand_like(reader, column, tokens).await?;
+                    let (docs, eval_work) = expanded.evaluate(reader).await?;
+                    work.merge(eval_work);
+                    Ok((docs, work))
                 }
                 CandidatePlan::And(children) => {
                     let mut acc: Option<RoaringBitmap> = None;
@@ -243,6 +346,41 @@ impl CandidatePlan {
                 });
                 true
             }
+            CandidatePlan::TermsAny { column, terms } => {
+                if !terms.is_empty() {
+                    leaves.push(PruneLeaf::TermPresence {
+                        column: column.clone(),
+                        terms: terms.clone(),
+                        mode: BoolMode::Or,
+                    });
+                }
+                true
+            }
+            CandidatePlan::TermsLike { column, tokens } => {
+                // A complete token must be present as itself → term bloom;
+                // a token open only on the right must head some term → lex
+                // term-range overlap. A token open on the left bounds no
+                // manifest summary.
+                let complete: Vec<String> = tokens
+                    .iter()
+                    .filter(|t| t.is_complete())
+                    .map(|t| t.text.clone())
+                    .collect();
+                if !complete.is_empty() {
+                    leaves.push(PruneLeaf::TermPresence {
+                        column: column.clone(),
+                        terms: complete,
+                        mode: BoolMode::And,
+                    });
+                }
+                for token in tokens.iter().filter(|t| !t.open_left && t.open_right) {
+                    leaves.push(PruneLeaf::Prefix {
+                        column: column.clone(),
+                        prefix: token.text.as_bytes().to_vec(),
+                    });
+                }
+                true
+            }
             CandidatePlan::And(children) => children
                 .iter()
                 .all(|child| child.append_prune_leaves(leaves)),
@@ -254,14 +392,15 @@ impl CandidatePlan {
     /// in `reader`'s superfile, computed from per-term `df` only (no
     /// `token_match`, no posting decode). The bound follows the boolean
     /// tree: a term-`AND` can't exceed the **smallest** term's `df`
-    /// (`min`); an `OR`/`IN` union can't exceed the **sum** of branch
-    /// estimates (capped at `n_docs`); `Unbounded` is `n_docs` (no
-    /// bound). The provider uses this to skip the index pushdown when a
-    /// predicate would match a large fraction of the superfile — there the
-    /// matches saturate the data pages so an index `RowSelection` can't
-    /// skip any, and a plain scan is cheaper.
+    /// (`min`); a term-`OR` (an expanded `LIKE` token) and an `OR`/`IN`
+    /// union can't exceed the **sum** of their parts (capped at `n_docs`);
+    /// `Unbounded` is `n_docs` (no bound). The provider uses this to skip
+    /// the index pushdown when a predicate would match a large fraction of
+    /// the superfile — there the matches saturate the data pages so an
+    /// index `RowSelection` can't skip any, and a plain scan is cheaper.
     /// The second element sums the header-fetch work of every leaf df
-    /// probe, so the caller can flush it per superfile.
+    /// probe (and the dictionary walk of an unexpanded `LIKE` leaf), so
+    /// the caller can flush it per superfile.
     pub(crate) fn estimate<'a>(
         &'a self,
         reader: &'a SuperfileReader,
@@ -281,6 +420,22 @@ impl CandidatePlan {
                     let (dfs, work) = reader.term_dfs(column, &refs).await?;
                     let min_df = dfs.into_iter().min().unwrap_or(u64::MAX);
                     Ok((min_df.min(n_docs), work))
+                }
+                CandidatePlan::TermsAny { column, terms } => {
+                    if terms.is_empty() {
+                        return Ok((0, MatchWork::default()));
+                    }
+                    // Union ≤ the sum of the terms' dfs.
+                    let refs: Vec<&str> = terms.iter().map(String::as_str).collect();
+                    let (dfs, work) = reader.term_dfs(column, &refs).await?;
+                    let sum = dfs.into_iter().fold(0u64, u64::saturating_add);
+                    Ok((sum.min(n_docs), work))
+                }
+                CandidatePlan::TermsLike { column, tokens } => {
+                    let (expanded, mut work) = expand_like(reader, column, tokens).await?;
+                    let (rows, est_work) = expanded.estimate(reader).await?;
+                    work.merge(est_work);
+                    Ok((rows, work))
                 }
                 CandidatePlan::And(children) => {
                     let mut m = n_docs;
@@ -307,6 +462,94 @@ impl CandidatePlan {
     }
 }
 
+impl CandidatePlan {
+    /// Whether any leaf still needs a superfile's dictionary
+    /// ([`TermsLike`](Self::TermsLike)). The provider expands such a plan
+    /// once per superfile and estimates / evaluates the result, instead of
+    /// paying the dictionary walk in both steps.
+    pub(crate) fn has_like(&self) -> bool {
+        match self {
+            CandidatePlan::TermsLike { .. } => true,
+            CandidatePlan::And(children) | CandidatePlan::Or(children) => {
+                children.iter().any(CandidatePlan::has_like)
+            }
+            CandidatePlan::TermsAll { .. }
+            | CandidatePlan::TermsAny { .. }
+            | CandidatePlan::Unbounded => false,
+        }
+    }
+
+    /// Bind every [`TermsLike`](Self::TermsLike) leaf to `reader`'s
+    /// superfile: each fragment token becomes the
+    /// [`TermsAny`](Self::TermsAny) of the indexed terms it covers, or
+    /// `Unbounded` (dropping out of its `AND`) when more than
+    /// [`LIKE_MAX_TERMS`] qualify. Every other node is copied. The work is
+    /// the dictionary fetches performed.
+    pub(crate) fn expand<'a>(
+        &'a self,
+        reader: &'a SuperfileReader,
+    ) -> BoxFuture<'a, Result<(CandidatePlan, MatchWork), ReadError>> {
+        Box::pin(async move {
+            match self {
+                CandidatePlan::TermsLike { column, tokens } => {
+                    expand_like(reader, column, tokens).await
+                }
+                CandidatePlan::And(children) => {
+                    let (expanded, work) = expand_children(reader, children).await?;
+                    Ok((and_combine(expanded), work))
+                }
+                CandidatePlan::Or(children) => {
+                    let (expanded, work) = expand_children(reader, children).await?;
+                    Ok((or_combine(expanded), work))
+                }
+                leaf => Ok((leaf.clone(), MatchWork::default())),
+            }
+        })
+    }
+}
+
+/// Expand each child in order, summing the dictionary work.
+async fn expand_children(
+    reader: &SuperfileReader,
+    children: &[CandidatePlan],
+) -> Result<(Vec<CandidatePlan>, MatchWork), ReadError> {
+    let mut expanded = Vec::with_capacity(children.len());
+    let mut work = MatchWork::default();
+    for child in children {
+        let (plan, child_work) = child.expand(reader).await?;
+        work.merge(child_work);
+        expanded.push(plan);
+    }
+    Ok((expanded, work))
+}
+
+/// Bind one `TermsLike` leaf to a superfile: the `AND` of each token's
+/// expansion. A token widening past [`LIKE_MAX_TERMS`] contributes no
+/// constraint (`Unbounded`, which `and_combine` drops); every token too
+/// wide ⇒ the leaf is `Unbounded` and the superfile scans.
+async fn expand_like(
+    reader: &SuperfileReader,
+    column: &str,
+    tokens: &[LikeToken],
+) -> Result<(CandidatePlan, MatchWork), ReadError> {
+    let mut parts = Vec::with_capacity(tokens.len());
+    let mut work = MatchWork::default();
+    for token in tokens {
+        let (terms, expand_work) = reader
+            .expand_terms(column, token.pattern(), LIKE_MAX_TERMS)
+            .await?;
+        work.merge(expand_work);
+        parts.push(match terms {
+            Some(terms) => CandidatePlan::TermsAny {
+                column: column.to_owned(),
+                terms,
+            },
+            None => CandidatePlan::Unbounded,
+        });
+    }
+    Ok((and_combine(parts), work))
+}
+
 /// Lower one `Expr` node.
 fn lower(
     expr: &Expr,
@@ -329,7 +572,9 @@ fn lower(
         },
         // `IN (a, b, …)` on an FTS column is an OR of equalities.
         Expr::InList(il) if !il.negated => in_list_leaf(il, fts_cols, resolve),
-        // NOT, LIKE, IS NULL, functions, etc. — not soundly term-bounded.
+        // `LIKE` on an FTS column is bounded through the term dictionary.
+        Expr::Like(like) => like_leaf(like, fts_cols, resolve),
+        // NOT, IS NULL, functions, etc. — not soundly term-bounded.
         _ => CandidatePlan::Unbounded,
     }
 }
@@ -351,7 +596,7 @@ fn eq_leaf(
 
 /// Lower `col IN ('a', 'b', …)` on an FTS column to an OR of term-ANDs.
 fn in_list_leaf(
-    il: &datafusion::logical_expr::expr::InList,
+    il: &InList,
     fts_cols: &HashSet<&str>,
     resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
 ) -> CandidatePlan {
@@ -366,6 +611,202 @@ fn in_list_leaf(
         branches.push(terms_all(&c.name, v, fts_cols, resolve));
     }
     or_combine(branches)
+}
+
+/// Lower `col LIKE 'pattern'` on an FTS column. The pattern's literal
+/// fragments are tokenized with the column's analyzer; every token the
+/// analyzer can bound soundly becomes a constraint (see `Analyzer::admits`).
+/// All-complete tokens are the same term-AND an equality lowers to;
+/// otherwise the leaf waits for a superfile's dictionary. `Unbounded` for
+/// `NOT LIKE`, `ILIKE`, a non-column or non-literal operand, a non-FTS
+/// column, an escape other than `\`, or a pattern with no usable token.
+fn like_leaf(
+    like: &Like,
+    fts_cols: &HashSet<&str>,
+    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+) -> CandidatePlan {
+    // `NOT LIKE` excludes rows — no term set bounds an exclusion. `ILIKE`
+    // matches under Unicode simple case folding, which is wider than the
+    // analyzers' lowercasing (`ſ` folds to `s`; `to_lowercase` keeps it),
+    // so a folded match could hide behind a term the pattern's lowercased
+    // token never reaches.
+    if like.negated || like.case_insensitive {
+        return CandidatePlan::Unbounded;
+    }
+    // Arrow's kernel reads `\` as the escape; the executor rejects others.
+    if like.escape_char.is_some_and(|c| c != LIKE_ESCAPE) {
+        return CandidatePlan::Unbounded;
+    }
+    let (Expr::Column(c), Expr::Literal(v, _)) = (like.expr.as_ref(), like.pattern.as_ref()) else {
+        return CandidatePlan::Unbounded;
+    };
+    if !fts_cols.contains(c.name.as_str()) {
+        return CandidatePlan::Unbounded;
+    }
+    let Some(pattern) = scalar_str(v) else {
+        return CandidatePlan::Unbounded;
+    };
+    let tok = resolve(&c.name);
+    let Some(analyzer) = Analyzer::of(tok.as_ref()) else {
+        return CandidatePlan::Unbounded;
+    };
+    let Some(fragments) = like_fragments(pattern) else {
+        return CandidatePlan::Unbounded;
+    };
+    let tokens: Vec<LikeToken> = fragments
+        .iter()
+        .flat_map(|fragment| fragment.tokens(tok.as_ref(), analyzer))
+        .collect();
+    if tokens.is_empty() {
+        return CandidatePlan::Unbounded;
+    }
+    if tokens.iter().all(LikeToken::is_complete) {
+        return CandidatePlan::TermsAll {
+            column: c.name.clone(),
+            tokens: tokens.into_iter().map(|t| t.text).collect(),
+        };
+    }
+    CandidatePlan::TermsLike {
+        column: c.name.clone(),
+        tokens,
+    }
+}
+
+/// One maximal run of literal (non-wildcard) pattern characters, and
+/// whether the pattern's own start / end bounds it (no wildcard before /
+/// after it).
+#[derive(Debug, PartialEq, Eq)]
+struct Fragment {
+    text: String,
+    at_start: bool,
+    at_end: bool,
+}
+
+impl Fragment {
+    /// Tokenize the fragment with the column's analyzer and mark each
+    /// token's open edges. An interior token is bordered by separators
+    /// inside the fragment on both sides. The first token is closed on the
+    /// left when the pattern starts here or the fragment's first character
+    /// is a hard separator (the token began after it); the last token
+    /// likewise on the right. Any other edge may continue into the text a
+    /// wildcard stands for. Tokens the analyzer cannot bound soundly are
+    /// dropped — a dropped constraint keeps a superset.
+    fn tokens(&self, tok: &dyn Tokenizer, analyzer: Analyzer) -> Vec<LikeToken> {
+        let texts: Vec<String> = tok.tokenize(&self.text).collect();
+        let n = texts.len();
+        let left_closed = self.at_start
+            || self
+                .text
+                .chars()
+                .next()
+                .is_some_and(|c| analyzer.hard_separator(c));
+        let right_closed = self.at_end
+            || self
+                .text
+                .chars()
+                .next_back()
+                .is_some_and(|c| analyzer.hard_separator(c));
+        texts
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, text)| {
+                analyzer.admits(LikeToken {
+                    text,
+                    open_left: i == 0 && !left_closed,
+                    open_right: i + 1 == n && !right_closed,
+                })
+            })
+            .collect()
+    }
+}
+
+/// Split a `LIKE` pattern at its wildcards into literal fragments,
+/// unescaping `\x` to a literal `x`. `None` for a trailing `\`, which the
+/// executor rejects — nothing to plan.
+fn like_fragments(pattern: &str) -> Option<Vec<Fragment>> {
+    let mut fragments = Vec::new();
+    let mut text = String::new();
+    // No wildcard seen yet: the next fragment starts where the pattern does.
+    let mut at_start = true;
+    let mut chars = pattern.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            LIKE_ESCAPE => text.push(chars.next()?),
+            LIKE_ANY | LIKE_ONE => {
+                if !text.is_empty() {
+                    fragments.push(Fragment {
+                        text: mem::take(&mut text),
+                        at_start,
+                        at_end: false,
+                    });
+                }
+                at_start = false;
+            }
+            other => text.push(other),
+        }
+    }
+    if !text.is_empty() {
+        fragments.push(Fragment {
+            text,
+            at_start,
+            at_end: true,
+        });
+    }
+    Some(fragments)
+}
+
+/// Which shipped analyzer indexed a column. It decides which fragment
+/// edges are closed and which open tokens the index can bound at all; an
+/// analyzer this module does not know keeps `LIKE` `Unbounded`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Analyzer {
+    /// `ascii_lower`: `[A-Za-z0-9]` runs, every other ASCII byte a
+    /// separator, a run holding any non-ASCII byte dropped whole.
+    AsciiLower,
+    /// `standard`: UAX #29 words, lowercased with `to_lowercase`.
+    Standard,
+}
+
+impl Analyzer {
+    fn of(tok: &dyn Tokenizer) -> Option<Analyzer> {
+        match tok.name() {
+            ASCII_LOWER_TOKENIZER => Some(Analyzer::AsciiLower),
+            STANDARD_TOKENIZER => Some(Analyzer::Standard),
+            _ => None,
+        }
+    }
+
+    /// A character that ends a token wherever it appears, so a token next
+    /// to it inside a fragment has the same boundary in any row's text.
+    fn hard_separator(self, c: char) -> bool {
+        match self {
+            // Every ASCII byte outside `[A-Za-z0-9]` splits a run; a
+            // non-ASCII byte extends (and poisons) one instead.
+            Analyzer::AsciiLower => c.is_ascii() && !c.is_ascii_alphanumeric(),
+            // UAX #29 may join a word across a `WORD_JOINERS` character
+            // (`don't`); every other ASCII non-alphanumeric always breaks.
+            // Non-ASCII punctuation is left open rather than classified.
+            Analyzer::Standard => {
+                c.is_ascii() && !c.is_ascii_alphanumeric() && !WORD_JOINERS.contains(&c)
+            }
+        }
+    }
+
+    /// Whether the index can soundly require `token` of a matching row.
+    fn admits(self, token: LikeToken) -> Option<LikeToken> {
+        match self {
+            // A run holding any non-ASCII byte is dropped whole, so a term
+            // that merely *contains* a fragment token may not exist
+            // (`Firefox—the` indexes nothing). Only a token the fragment
+            // closes on both sides is guaranteed indexed as itself.
+            Analyzer::AsciiLower if !token.is_complete() => None,
+            // `to_lowercase` spells a word-final `Σ` as `ς` and a medial
+            // one as `σ`, so a token whose end may sit mid-word has two
+            // possible spellings in the dictionary.
+            Analyzer::Standard if token.open_right && token.text.ends_with(FINAL_SIGMA) => None,
+            _ => Some(token),
+        }
+    }
 }
 
 /// Build a `TermsAll` leaf for `column = value`, or `Unbounded` if the
@@ -440,6 +881,45 @@ fn collapse(mut flat: Vec<CandidatePlan>, is_and: bool) -> CandidatePlan {
         1 => flat.pop().expect("len checked == 1"),
         _ if is_and => CandidatePlan::And(flat),
         _ => CandidatePlan::Or(flat),
+    }
+}
+
+/// Manifest prune leaves for the `LIKE` predicates in `filters`: the same
+/// lowering as the candidate plan, reduced to what a superfile summary can
+/// answer — a term bloom for complete tokens and a lex-range check for a
+/// prefix token. Descends `AND` and aliases; anything else contributes
+/// nothing (the superfile is kept).
+pub(crate) fn like_prune_leaves(
+    filters: &[Expr],
+    fts_cols: &HashSet<&str>,
+    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+) -> Vec<PruneLeaf> {
+    let mut out = Vec::new();
+    for filter in filters {
+        collect_like_leaves(filter, fts_cols, resolve, &mut out);
+    }
+    out
+}
+
+/// Walk one filter expression for `LIKE` nodes, lowering each to its
+/// prune leaves.
+fn collect_like_leaves(
+    expr: &Expr,
+    fts_cols: &HashSet<&str>,
+    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    out: &mut Vec<PruneLeaf>,
+) {
+    match expr {
+        Expr::Alias(a) => collect_like_leaves(&a.expr, fts_cols, resolve, out),
+        Expr::BinaryExpr(be) if be.op == Operator::And => {
+            collect_like_leaves(&be.left, fts_cols, resolve, out);
+            collect_like_leaves(&be.right, fts_cols, resolve, out);
+        }
+        Expr::Like(like) => {
+            // A single leaf is always one conjunctive group.
+            like_leaf(like, fts_cols, resolve).append_prune_leaves(out);
+        }
+        _ => {}
     }
 }
 
@@ -639,12 +1119,240 @@ mod tests {
         );
     }
 
+    /// Resolver for the Unicode-aware analyzer.
+    fn standard_resolver(_col: &str) -> Arc<dyn Tokenizer> {
+        Arc::new(StandardTokenizer)
+    }
+
+    fn standard_plan(expr: Expr) -> CandidatePlan {
+        CandidatePlan::from_filters(&[expr], &fts_cols(), &standard_resolver)
+    }
+
+    fn like_token(text: &str, open_left: bool, open_right: bool) -> LikeToken {
+        LikeToken {
+            text: text.into(),
+            open_left,
+            open_right,
+        }
+    }
+
+    fn terms_like(tokens: Vec<LikeToken>) -> CandidatePlan {
+        CandidatePlan::TermsLike {
+            column: "title".into(),
+            tokens,
+        }
+    }
+
+    fn terms_all(tokens: &[&str]) -> CandidatePlan {
+        CandidatePlan::TermsAll {
+            column: "title".into(),
+            tokens: tokens.iter().map(|t| (*t).into()).collect(),
+        }
+    }
+
     #[test]
-    fn like_is_unbounded() {
+    fn like_without_wildcards_is_the_equality_term_and() {
+        // `title LIKE 'rust async'` admits only the exact value, whose
+        // tokens are the literal's — the same superset equality lowers to.
+        assert_eq!(
+            plan(col("title").like(lit("rust async"))),
+            terms_all(&["rust", "async"])
+        );
+    }
+
+    #[test]
+    fn like_open_edges_lower_to_dictionary_shapes_under_standard() {
+        assert_eq!(
+            standard_plan(col("title").like(lit("rust%"))),
+            terms_like(vec![like_token("rust", false, true)])
+        );
+        assert_eq!(
+            standard_plan(col("title").like(lit("%rust"))),
+            terms_like(vec![like_token("rust", true, false)])
+        );
+        assert_eq!(
+            standard_plan(col("title").like(lit("%rust%"))),
+            terms_like(vec![like_token("rust", true, true)])
+        );
+        // `_` is a wildcard too: `ab` closed on the left by the pattern
+        // start and open on the right; `cd` open on both sides.
+        assert_eq!(
+            standard_plan(col("title").like(lit("ab_cd%"))),
+            terms_like(vec![
+                like_token("ab", false, true),
+                like_token("cd", true, true)
+            ])
+        );
+    }
+
+    #[test]
+    fn like_separators_inside_the_fragment_close_a_token() {
+        // Spaces are hard breaks: both tokens are complete, and an
+        // all-complete pattern is the plain term-AND.
+        assert_eq!(
+            standard_plan(col("title").like(lit("% quick fox %"))),
+            terms_all(&["quick", "fox"])
+        );
+        // The hyphen closes `fox` on the left; the wildcard leaves the
+        // right open.
+        assert_eq!(
+            standard_plan(col("title").like(lit("%-fox%"))),
+            terms_like(vec![like_token("fox", false, true)])
+        );
+    }
+
+    #[test]
+    fn like_word_joiners_leave_an_edge_open_under_standard() {
+        // `'` can join `don` to what follows (`don't`), so the token may be
+        // the head of a longer term; `.` likewise keeps `fox` open on the
+        // left (`a.fox`), while the trailing space closes its right.
+        assert_eq!(
+            standard_plan(col("title").like(lit("%don'%"))),
+            terms_like(vec![like_token("don", true, true)])
+        );
+        assert_eq!(
+            standard_plan(col("title").like(lit("%.fox %"))),
+            terms_like(vec![like_token("fox", true, false)])
+        );
+    }
+
+    #[test]
+    fn like_final_sigma_open_right_is_dropped_under_standard() {
+        // `ΟΔΟΣ` lowercases to `οδος` on its own but to `οδοσ…` mid-word,
+        // so an open-right token has two spellings and cannot be required.
+        assert_eq!(
+            standard_plan(col("title").like(lit("%ΟΔΟΣ%"))),
+            CandidatePlan::Unbounded
+        );
+        // Closed on the right the word really ends there: kept as a suffix.
+        assert_eq!(
+            standard_plan(col("title").like(lit("%ΟΔΟΣ"))),
+            terms_like(vec![like_token("οδος", true, false)])
+        );
+    }
+
+    #[test]
+    fn like_under_ascii_lower_keeps_only_complete_tokens() {
+        // The default analyzer drops any run holding a non-ASCII byte, so
+        // a token that may be the head or tail of a longer run is not
+        // guaranteed indexed: open-edged tokens drop out, and a pattern
+        // made only of them is Unbounded.
+        assert_eq!(
+            plan(col("title").like(lit("%rust%"))),
+            CandidatePlan::Unbounded
+        );
         assert_eq!(
             plan(col("title").like(lit("rust%"))),
             CandidatePlan::Unbounded
         );
+        // A token closed by separators inside the fragment is exact.
+        assert_eq!(
+            plan(col("title").like(lit("%(rust)%"))),
+            terms_all(&["rust"])
+        );
+        // Mixed: the complete token stays, the open one drops.
+        assert_eq!(
+            plan(col("title").like(lit("rust async%"))),
+            terms_all(&["rust"])
+        );
+    }
+
+    #[test]
+    fn like_escape_makes_a_wildcard_literal() {
+        // `\%` is a literal percent sign: no wildcard, so the value must be
+        // exactly `100% sure` and its tokens bound it.
+        assert_eq!(
+            plan(col("title").like(lit("100\\% sure"))),
+            terms_all(&["100", "sure"])
+        );
+        // The literal `%` is itself a separator, so `100` is complete even
+        // though a real wildcard follows the fragment.
+        assert_eq!(
+            standard_plan(col("title").like(lit("100\\%%"))),
+            terms_all(&["100"])
+        );
+        // A trailing backslash is a pattern the executor rejects.
+        assert_eq!(
+            plan(col("title").like(lit("rust\\"))),
+            CandidatePlan::Unbounded
+        );
+    }
+
+    #[test]
+    fn negated_and_case_insensitive_like_are_unbounded() {
+        assert_eq!(
+            standard_plan(col("title").not_like(lit("rust%"))),
+            CandidatePlan::Unbounded
+        );
+        assert_eq!(
+            standard_plan(col("title").ilike(lit("rust%"))),
+            CandidatePlan::Unbounded
+        );
+    }
+
+    #[test]
+    fn like_needs_an_fts_column_and_a_literal_pattern() {
+        assert_eq!(
+            standard_plan(col("category").like(lit("rust%"))),
+            CandidatePlan::Unbounded
+        );
+        assert_eq!(
+            standard_plan(col("title").like(col("category"))),
+            CandidatePlan::Unbounded
+        );
+        // Wildcards only: no fragment, nothing to bound.
+        assert_eq!(
+            standard_plan(col("title").like(lit("%_%"))),
+            CandidatePlan::Unbounded
+        );
+    }
+
+    #[test]
+    fn like_prunes_with_a_bloom_for_complete_tokens_and_a_range_for_a_prefix() {
+        // `rust` heads a term → lex range; `quick`, `fox` are complete →
+        // one bloom AND; `tail` is open on the left → no summary bounds it.
+        let leaves = like_prune_leaves(
+            &[col("title").like(lit("rust% quick fox %tail"))],
+            &fts_cols(),
+            &standard_resolver,
+        );
+        assert_eq!(leaves.len(), 2);
+        assert!(matches!(
+            &leaves[0],
+            PruneLeaf::TermPresence { column, terms, mode: BoolMode::And }
+                if column == "title" && *terms == ["quick".to_owned(), "fox".to_owned()]
+        ));
+        assert!(matches!(
+            &leaves[1],
+            PruneLeaf::Prefix { column, prefix } if column == "title" && prefix == b"rust"
+        ));
+        // Under the default analyzer only the complete tokens survive.
+        let leaves = like_prune_leaves(
+            &[col("title").like(lit("rust% quick fox %tail"))],
+            &fts_cols(),
+            &ascii_resolver,
+        );
+        assert_eq!(leaves.len(), 1);
+        assert!(matches!(
+            &leaves[0],
+            PruneLeaf::TermPresence { terms, mode: BoolMode::And, .. }
+                if *terms == ["quick".to_owned(), "fox".to_owned()]
+        ));
+    }
+
+    #[test]
+    fn has_like_finds_a_dictionary_leaf_anywhere_in_the_tree() {
+        assert!(standard_plan(col("title").like(lit("rust%"))).has_like());
+        assert!(
+            standard_plan(
+                col("title")
+                    .eq(lit("alpha"))
+                    .or(col("title").like(lit("%beta")))
+            )
+            .has_like()
+        );
+        assert!(!plan(col("title").eq(lit("alpha"))).has_like());
+        assert!(!CandidatePlan::Unbounded.has_like());
     }
 
     #[test]

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -70,7 +70,7 @@ use crate::{
     superfile::{
         ReadError, SuperfileReader,
         fts::{
-            reader::{BoolMode, LONG_S_ASCII, MatchWork, TermPattern},
+            reader::{BoolMode, LONG_S_ASCII, MatchWork, TermPattern, has_fold_partner},
             tokenize::{ASCII_LOWER_TOKENIZER, STANDARD_TOKENIZER, Tokenizer},
         },
     },
@@ -109,13 +109,6 @@ const WORD_JOINERS: &[char] = &['\'', '"', '.', ':', ',', ';', '_'];
 /// and a medial one `σ` — the one context-sensitive mapping in Unicode
 /// lowercasing.
 const FINAL_SIGMA: char = 'ς';
-
-/// ASCII letters whose Unicode simple case-folding class has a non-ASCII
-/// member: `s` folds together with `ſ` (U+017F) and `k` with the Kelvin
-/// sign `K` (U+212A). Under `ILIKE` a matching row may hold those forms;
-/// the `ascii_lower` analyzer drops the run holding one, so a token with
-/// either letter cannot be required of it.
-const FOLD_TO_ASCII: &[char] = &['s', 'k'];
 
 /// A superfile-independent boolean plan over FTS term retrievals, lowered
 /// once from a SQL `WHERE` clause and [`evaluate`](CandidatePlan::evaluate)d
@@ -879,7 +872,7 @@ impl Analyzer {
             Analyzer::AsciiLower if !token.is_complete() => None,
             // …and under `ILIKE` a row may spell `s` as `ſ` or `k` as `K`
             // — non-ASCII bytes that drop the whole run.
-            Analyzer::AsciiLower if fold && token.text.contains(FOLD_TO_ASCII) => None,
+            Analyzer::AsciiLower if fold && token.text.chars().any(has_fold_partner) => None,
             // `to_lowercase` spells a word-final `Σ` as `ς` and a medial
             // one as `σ`, so a token whose end may sit mid-word has two
             // possible spellings in the dictionary.
@@ -1432,6 +1425,12 @@ mod tests {
             plan(col("title").ilike(lit("% fox %"))),
             terms_all(&["fox"])
         );
+        // The drop is per token: a sibling without `s` or `k` stays
+        // required, so the leaf narrows instead of vanishing.
+        assert_eq!(
+            plan(col("title").ilike(lit("% rust fox %"))),
+            terms_all(&["fox"])
+        );
         assert_eq!(
             plan(col("title").ilike(lit("%fox%"))),
             CandidatePlan::Unbounded
@@ -1456,6 +1455,20 @@ mod tests {
         assert!(matches!(
             &leaves[1],
             PruneLeaf::Prefix { prefix, .. } if prefix == b"quic"
+        ));
+        // An open-right token holding `s` loses its term-range leaf too:
+        // its `ſ` spelling sorts nowhere near the prefix. Only the safe
+        // complete token is left to ask about.
+        let leaves = like_prune_leaves(
+            &[col("title").ilike(lit("sun% fox %"))],
+            &fts_cols(),
+            &standard_resolver,
+        );
+        assert_eq!(leaves.len(), 1);
+        assert!(matches!(
+            &leaves[0],
+            PruneLeaf::TermPresence { terms, mode: BoolMode::And, .. }
+                if *terms == ["fox".to_owned()]
         ));
     }
 

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -567,9 +567,13 @@ mod tests {
     use crate::{
         superfile::{
             builder::{FtsConfig, VectorConfig},
+            fts::tokenize::{StandardTokenizer, Tokenizer},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
-        supertable::{Supertable, SupertableOptions, manifest::ManifestSnapshot},
+        supertable::{
+            Supertable, SupertableOptions, manifest::ManifestSnapshot,
+            query::candidate::LIKE_MAX_TERMS,
+        },
         test_helpers::default_tokenizer as tok,
     };
 
@@ -586,6 +590,15 @@ mod tests {
     }
 
     fn options_one_superfile_per_commit(dim: usize) -> SupertableOptions {
+        options_one_superfile_per_commit_with(dim, tok())
+    }
+
+    /// [`options_one_superfile_per_commit`] with `title` analyzed by
+    /// `tokenizer`.
+    fn options_one_superfile_per_commit_with(
+        dim: usize,
+        tokenizer: Arc<dyn Tokenizer>,
+    ) -> SupertableOptions {
         let pool = Arc::new(
             ThreadPoolBuilder::new()
                 .num_threads(1)
@@ -610,7 +623,7 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
+            Some(tokenizer),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -656,14 +669,27 @@ mod tests {
     /// `title = 'rare'` over the global top-k would underflow, which is
     /// exactly what the pushdown must avoid. Requires `dim >= 2`.
     fn supertable_for_pushdown(dim: usize, n: usize, n_common: usize) -> Supertable {
-        let st = Supertable::create(options_one_superfile_per_commit(dim)).expect("create");
+        let titles: Vec<String> = (0..n)
+            .map(|i| if i < n_common { "common" } else { "rare" }.to_owned())
+            .collect();
+        supertable_ranked_by_index(dim, &titles, tok())
+    }
+
+    /// Single-superfile table where doc `i` carries `titles[i]` and the
+    /// vector `[1, i, 0, …]`, so distance to the query `[1, 0, …]` ranks by
+    /// index (see [`supertable_for_pushdown`]). `title` is analyzed with
+    /// `tokenizer`. Requires `dim >= 2`.
+    fn supertable_ranked_by_index(
+        dim: usize,
+        titles: &[String],
+        tokenizer: Arc<dyn Tokenizer>,
+    ) -> Supertable {
+        let n = titles.len();
+        let st = Supertable::create(options_one_superfile_per_commit_with(dim, tokenizer))
+            .expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
-        let titles = LargeStringArray::from(
-            (0..n)
-                .map(|i| if i < n_common { "common" } else { "rare" })
-                .collect::<Vec<_>>(),
-        );
+        let titles = LargeStringArray::from(titles.iter().map(String::as_str).collect::<Vec<_>>());
         let mut flat = Vec::<f32>::with_capacity(n * dim);
         for i in 0..n {
             for d in 0..dim {
@@ -940,6 +966,89 @@ mod tests {
             .expect("query_sql");
         let total: usize = rows.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, k, "unbounded predicate falls back to plain kNN");
+    }
+
+    /// Titles across `batches`, in hit order.
+    fn titles_of(batches: &[RecordBatch]) -> Vec<String> {
+        batches
+            .iter()
+            .flat_map(|b| {
+                let t = col_str(b, "title");
+                (0..t.len())
+                    .map(|i| t.value(i).to_owned())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn vector_search_tvf_where_like_contains_ranks_among_matching() {
+        // `%fox%` bounds no manifest summary (no bloom term, no prefix), so
+        // the plan must keep every superfile and bound the rows from each
+        // superfile's dictionary — the three nearest titles containing
+        // `fox` come back, not zero rows and not the unfiltered top-k.
+        let dim = 16;
+        let k = 3;
+        let titles: Vec<String> = [
+            "common",
+            "common",
+            "common",
+            "firefox browser",
+            "outfoxed",
+            "plain",
+            "fox",
+            "nothing",
+        ]
+        .iter()
+        .map(|t| (*t).to_owned())
+        .collect();
+        let st = supertable_ranked_by_index(dim, &titles, Arc::new(StandardTokenizer));
+        let q = csv_one_hot(dim, 0);
+        let filtered = st
+            .reader()
+            .expect("reader")
+            .query_sql(&format!(
+                "SELECT title, score FROM vector_search('emb', '{q}', {k}) WHERE title LIKE '%fox%'"
+            ))
+            .expect("query_sql");
+        assert_eq!(
+            titles_of(&filtered),
+            vec!["firefox browser", "outfoxed", "fox"],
+            "the k nearest rows whose title contains `fox`, by distance"
+        );
+    }
+
+    #[test]
+    fn vector_search_tvf_where_like_token_over_the_cap_keeps_every_row() {
+        // Every title is a distinct term containing `zz`, more of them than
+        // a LIKE token may widen to, so the index bounds nothing in this
+        // superfile. That must fall back to ranking every row (the
+        // FilterExec re-checks the pattern), never to an error or to an
+        // empty candidate set.
+        let dim = 16;
+        let k = 3;
+        let titles: Vec<String> = (0..LIKE_MAX_TERMS + 8).map(|i| format!("w{i}zz")).collect();
+        let st = supertable_ranked_by_index(dim, &titles, Arc::new(StandardTokenizer));
+        let q = csv_one_hot(dim, 0);
+        // Contains: no manifest gate at all.
+        let contains = st
+            .reader()
+            .expect("reader")
+            .query_sql(&format!(
+                "SELECT title, score FROM vector_search('emb', '{q}', {k}) WHERE title LIKE '%zz%'"
+            ))
+            .expect("query_sql");
+        assert_eq!(titles_of(&contains), vec!["w0zz", "w1zz", "w2zz"]);
+        // Prefix: the term-range gate keeps the superfile, then the same
+        // over-cap fallback applies.
+        let prefix = st
+            .reader()
+            .expect("reader")
+            .query_sql(&format!(
+                "SELECT title, score FROM vector_search('emb', '{q}', {k}) WHERE title LIKE 'w%'"
+            ))
+            .expect("query_sql");
+        assert_eq!(titles_of(&prefix), vec!["w0zz", "w1zz", "w2zz"]);
     }
 
     #[test]

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -873,7 +873,11 @@ impl SupertableReader {
                         let set = cell
                             .get_or_try_init(|| async {
                                 let set = r
-                                    .bm25_prefix_cursor_set(&column_arc, &prefix_arc)
+                                    .bm25_prefix_cursor_set(
+                                        &column_arc,
+                                        &prefix_arc,
+                                        Some(&reader_pool),
+                                    )
                                     .await
                                     .map_err(fts_read_error)?;
                                 // Flushed inside the OnceCell init so slices
@@ -924,7 +928,7 @@ impl SupertableReader {
                     }
                     None => {
                         let (hits, work) = r
-                            .bm25_search_prefix(&column_arc, &prefix_arc, k)
+                            .bm25_search_prefix(&column_arc, &prefix_arc, k, Some(&reader_pool))
                             .await
                             .map_err(fts_read_error)?;
                         if let Some(stats) = &op_stats {
@@ -2808,7 +2812,7 @@ mod tests {
         }
 
         let oracle = build_oracle_superfile(&titles);
-        let oracle_hits = block_on(oracle.bm25_search_prefix("title", "rust", 5))
+        let oracle_hits = block_on(oracle.bm25_search_prefix("title", "rust", 5, None))
             .expect("oracle")
             .0;
         let oracle_globals: HashSet<u32> = oracle_hits.iter().map(|(d, _)| *d).collect();

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -100,7 +100,7 @@ use crate::{
     superfile::{
         SuperfileReader,
         fts::{
-            reader::BoolMode,
+            reader::{BoolMode, MatchWork},
             tokenize::{Tokenizer, unique_tokens},
         },
     },
@@ -109,7 +109,7 @@ use crate::{
         manifest::{ManifestSnapshot, add_sum_arrays, hll::HllSketch, list::ScalarValueCounts},
         options::{DECIMAL128_PRECISION, DECIMAL128_SCALE},
         query::{
-            candidate::CandidatePlan,
+            candidate::{CandidatePlan, like_prune_leaves},
             df_object_store::SuperfileObjectStore,
             exec::metered_exec::MeteredExec,
             prune::{PruneLeaf, select_superfiles},
@@ -429,6 +429,12 @@ impl SupertableProvider {
             &self.fts_cols_set(),
             &|col| opts.fts_tokenizer_for(col),
         ));
+
+        // `LIKE` on an FTS column: a term bloom for the pattern's complete
+        // tokens and a lex-range check for a prefix token.
+        leaves.extend(like_prune_leaves(filters, &self.fts_cols_set(), &|col| {
+            opts.fts_tokenizer_for(col)
+        }));
 
         leaves.extend(exprs_to_null_leaves(filters, &self.schema));
 
@@ -852,6 +858,9 @@ impl TableProvider for SupertableProvider {
         let candidate_plan = CandidatePlan::from_filters(filters, &self.fts_cols_set(), &|col| {
             opts.fts_tokenizer_for(col)
         });
+        // A `LIKE` leaf is bound to each superfile's dictionary once, up
+        // front, so the estimate and the evaluation below share one walk.
+        let needs_expansion = candidate_plan.has_like();
         let prepared_files =
             try_join_all(survivors.iter().map(|entry| self.prepared_scan_file(entry))).await?;
 
@@ -878,18 +887,31 @@ impl TableProvider for SupertableProvider {
             // overhead. The floor keeps the pushdown active on small
             // superfiles; the density cap binds even under the floor so
             // an all-matching predicate never takes the index path.
-            let (est, est_work) = candidate_plan
+            let mut predicate_work = MatchWork::default();
+            let expanded;
+            let plan = if needs_expansion {
+                let (plan, expand_work) = candidate_plan
+                    .expand(prepared.reader.as_ref())
+                    .await
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                predicate_work.merge(expand_work);
+                expanded = plan;
+                &expanded
+            } else {
+                &candidate_plan
+            };
+            let (est, est_work) = plan
                 .estimate(prepared.reader.as_ref())
                 .await
                 .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            predicate_work.merge(est_work);
             let gate = ((prepared.reader.n_docs() as f64 * PUSHDOWN_MAX_FRACTION) as u64)
                 .max(PUSHDOWN_MIN_ROWS);
             let density_cap = (prepared.reader.n_docs() as f64 * PUSHDOWN_MAX_DENSITY) as u64;
-            let mut predicate_work = est_work;
             let candidates = if est > gate || est >= density_cap {
                 None
             } else {
-                let (bitmap, eval_work) = candidate_plan
+                let (bitmap, eval_work) = plan
                     .evaluate(prepared.reader.as_ref())
                     .await
                     .map_err(|e| DataFusionError::Execution(e.to_string()))?;
@@ -951,21 +973,23 @@ impl TableProvider for SupertableProvider {
 
         // Tier 2 - DataFusion-owned row-group / page pruning + row-level
         // filter pushdown, used **only when the index could not bound the
-        // rows** (`Unbounded` candidate plan). In that fallback the
+        // rows** of some superfile: an `Unbounded` candidate plan, a `LIKE`
+        // token too wide for that superfile's dictionary, or a superfile
+        // the selectivity gate sent to a scan. In that fallback the
         // predicate becomes a Parquet `RowFilter` (`with_pushdown_filters`)
         // so the predicate columns are decoded first and only surviving
         // rows materialize.
         //
-        // When the index *did* bound the rows, the per-superfile access plan
+        // When the index bounded *every* superfile, each access plan
         // already selects exactly the candidate rows and the `FilterExec`
         // above (filters are `Inexact`) verifies the exact predicate over
-        // that tiny set. So we attach the pushdown predicate only on the
-        // unbounded path.
-        let index_bounded = !matches!(candidate_plan, CandidatePlan::Unbounded);
-        let predicate = if !index_bounded {
-            row_group_predicate(state, filters, &self.schema)
-        } else {
+        // that tiny set. So we attach the pushdown predicate only when some
+        // superfile scans.
+        let all_bounded = superfiles.iter().all(|seg| seg.candidates.is_some());
+        let predicate = if all_bounded {
             None
+        } else {
+            row_group_predicate(state, filters, &self.schema)
         };
 
         // Only push the LIMIT into the scan when there are no filters:
@@ -2267,13 +2291,13 @@ mod tests {
         .expect("batch")
     }
 
-    #[test]
-    fn superfile_prune_index_helps_vs_does_not() {
+    /// Three superfiles whose `title` lexicographic ranges all span
+    /// "mango" — so scalar min/max prunes none of them — while only the
+    /// middle one actually holds the token. Returns the provider and a
+    /// runtime to drive its async surface.
+    fn provider_over_mango_superfiles() -> (SupertableProvider, runtime::Runtime) {
         let st = Supertable::create(cat_title_opts()).expect("create");
         let mut w = st.writer().expect("writer");
-        // Three superfiles. Every superfile's `title` lexicographic range
-        // spans "mango", so scalar min/max can prune none of them — but
-        // only the middle superfile actually holds the token.
         w.append(&cat_title_batch(&["lang", "lang"], &["aardvark", "zebra"]))
             .expect("a1");
         w.commit().expect("c1");
@@ -2297,6 +2321,12 @@ mod tests {
             .enable_all()
             .build()
             .expect("rt");
+        (provider, rt)
+    }
+
+    #[test]
+    fn superfile_prune_index_helps_vs_does_not() {
+        let (provider, rt) = provider_over_mango_superfiles();
 
         // Index HELPS: the term bloom prunes the two wide-range superfiles
         // that min/max could not, leaving only the real holder.
@@ -2320,6 +2350,34 @@ mod tests {
             rt.block_on(provider.surviving_superfile_count(&[col("category").eq(lit("lang"))])),
             3,
             "non-FTS predicate matching all superfiles prunes nothing"
+        );
+    }
+
+    #[test]
+    fn superfile_prune_bounds_like_by_its_complete_tokens() {
+        let (provider, rt) = provider_over_mango_superfiles();
+
+        // A `LIKE` whose only token the pattern closes on both sides is a
+        // term the bloom can test: the two superfiles without `mango` are
+        // pruned before any byte is read.
+        assert_eq!(
+            rt.block_on(provider.surviving_superfile_count(&[col("title").like(lit("% mango %"))])),
+            1,
+            "a complete LIKE token prunes through the term bloom"
+        );
+        // A wildcard-free pattern is the equality case and prunes the same.
+        assert_eq!(
+            rt.block_on(provider.surviving_superfile_count(&[col("title").like(lit("mango"))])),
+            1,
+            "a wildcard-free LIKE prunes like the equality"
+        );
+        // Under the default `ascii_lower` analyzer an open-edged token
+        // cannot be required (a run holding a non-ASCII byte is dropped
+        // whole), so a substring pattern keeps every superfile.
+        assert_eq!(
+            rt.block_on(provider.surviving_superfile_count(&[col("title").like(lit("%mango%"))])),
+            3,
+            "an open-edged LIKE token under ascii_lower prunes nothing"
         );
     }
 

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -909,104 +909,146 @@ impl TableProvider for SupertableProvider {
             prepared: Arc<PreparedScanFile>,
             candidates: Option<RoaringBitmap>,
             tombstones: Arc<RoaringBitmap>,
+            /// This superfile's plan came out `Unbounded` — the whole plan
+            /// is, or a `LIKE` token found no bound in its dictionary.
+            unbounded: bool,
+            /// The pushdown predicate's df probes, dictionary walks and
+            /// posting walks on this superfile.
+            predicate_work: MatchWork,
         }
-        let mut superfiles: Vec<SuperfileScan> = Vec::with_capacity(survivors.len());
-        // Whether some superfile's plan came out `Unbounded` — the whole
-        // plan is, or a `LIKE` token found no bound in that superfile's
-        // dictionary. Decides whether DataFusion's row filter is attached
-        // below; a superfile the selectivity gate sends to a scan is not
-        // counted (see there).
-        let mut any_plan_unbounded = matches!(candidate_plan, CandidatePlan::Unbounded);
         // The plan's dictionary walks (a `LIKE` leaf's expansion) are CPU
         // work and run on the reader pool behind a oneshot; only their FST
         // fetches stay on this runtime.
         let reader_pool: &ThreadPool = &self.manifest.options.reader_pool;
 
-        for (entry, prepared) in survivors.iter().zip(prepared_files) {
-            // Pass 1 (per superfile): resolve candidate rows from the
-            // index. `None` => no usable bound, scan the superfile.
-            //
-            // Selectivity gate: estimate the match count from per-term
-            // `df` first (cheap, header-only). If a predicate would match
-            // more than `PUSHDOWN_MAX_FRACTION` of this superfile, skip the
-            // index path and let DataFusion scan: at that match density
-            // the rows saturate the data pages, so an index `RowSelection`
-            // can't skip any page and only adds posting-walk + selection
-            // overhead. The floor keeps the pushdown active on small
-            // superfiles; the density cap binds even under the floor so
-            // an all-matching predicate never takes the index path.
-            let mut predicate_work = MatchWork::default();
-            let expanded;
-            let plan = if needs_expansion {
-                // A whole-dictionary walk pays only when the column's
-                // stored text is large next to its vocabulary; judged per
-                // column from the manifest's term count and the Parquet
-                // footer's column size, neither of which costs a read.
-                let meta = self
-                    .scan_metas
-                    .get(&prepared.path)
-                    .map(|m| Arc::clone(m.value()));
-                let full_walk_pays = |column: &str| {
-                    let terms = entry
-                        .fts_summary
-                        .get(column)
-                        .map_or(0, |summary| summary.n_terms_distinct);
-                    let bytes = meta
-                        .as_ref()
-                        .and_then(|m| column_stored_bytes(m, column))
-                        .unwrap_or(0);
-                    full_walk_pays(terms, bytes)
-                };
-                let (plan, expand_work) = candidate_plan
-                    .expand(prepared.reader.as_ref(), &full_walk_pays, Some(reader_pool))
-                    .await
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-                predicate_work.merge(expand_work);
-                expanded = plan;
-                &expanded
-            } else {
-                &candidate_plan
-            };
-            any_plan_unbounded |= matches!(plan, CandidatePlan::Unbounded);
-            let (est, est_work) = plan
-                .estimate(prepared.reader.as_ref(), Some(reader_pool))
-                .await
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-            predicate_work.merge(est_work);
-            let gate = ((prepared.reader.n_docs() as f64 * PUSHDOWN_MAX_FRACTION) as u64)
-                .max(PUSHDOWN_MIN_ROWS);
-            let density_cap = (prepared.reader.n_docs() as f64 * PUSHDOWN_MAX_DENSITY) as u64;
-            let candidates = if est > gate || est >= density_cap {
-                None
-            } else {
-                let (bitmap, eval_work) = plan
-                    .evaluate(prepared.reader.as_ref(), Some(reader_pool))
-                    .await
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-                predicate_work.merge(eval_work);
-                bitmap
-            };
-            // The pushdown predicate's df probes + posting walks, flushed
-            // through the same collector that meters this scan's pages.
-            if let Some(stats) = self.scan_store.op_stats() {
-                stats.add_fts_postings_bytes(predicate_work.postings_bytes);
-                stats.add_planned_read_ranges(predicate_work.planned_ranges);
-                stats.add_kernel_cpu_ns(predicate_work.kernel_cpu_ns);
+        // Pass 1 (per superfile), fanned out: every survivor resolves its
+        // candidate rows in its own future and `try_join_all` drives them
+        // together, so one superfile's dictionary fetch overlaps another's
+        // walk on the reader pool and a third's posting reads, instead of
+        // each superfile waiting for the one before it. The futures share
+        // this task rather than being spawned — the CPU is on the pool and
+        // the I/O is awaited, so the task only polls, and nothing here is
+        // `'static`. `try_join_all` keeps survivor order, so the file list
+        // below stays deterministic in manifest order, and the first
+        // error (in time) ends the scan.
+        let superfiles: Vec<SuperfileScan> = try_join_all(
+            survivors
+                .iter()
+                .zip(prepared_files)
+                .map(|(entry, prepared)| {
+                    let candidate_plan = &candidate_plan;
+                    async move {
+                        // Resolve candidate rows from the index. `None` => no
+                        // usable bound, scan the superfile.
+                        //
+                        // Selectivity gate: estimate the match count from
+                        // per-term `df` first (cheap, header-only). If a
+                        // predicate would match more than
+                        // `PUSHDOWN_MAX_FRACTION` of this superfile, skip the
+                        // index path and let DataFusion scan: at that match
+                        // density the rows saturate the data pages, so an index
+                        // `RowSelection` can't skip any page and only adds
+                        // posting-walk + selection overhead. The floor keeps
+                        // the pushdown active on small superfiles; the density
+                        // cap binds even under the floor so an all-matching
+                        // predicate never takes the index path.
+                        let mut predicate_work = MatchWork::default();
+                        let expanded;
+                        let plan = if needs_expansion {
+                            // A whole-dictionary walk pays only when the
+                            // column's stored text is large next to its
+                            // vocabulary; judged per column from the manifest's
+                            // term count and the Parquet footer's column size,
+                            // neither of which costs a read.
+                            let meta = self
+                                .scan_metas
+                                .get(&prepared.path)
+                                .map(|m| Arc::clone(m.value()));
+                            let full_walk_pays = |column: &str| {
+                                let terms = entry
+                                    .fts_summary
+                                    .get(column)
+                                    .map_or(0, |summary| summary.n_terms_distinct);
+                                let bytes = meta
+                                    .as_ref()
+                                    .and_then(|m| column_stored_bytes(m, column))
+                                    .unwrap_or(0);
+                                full_walk_pays(terms, bytes)
+                            };
+                            let (plan, expand_work) = candidate_plan
+                                .expand(
+                                    prepared.reader.as_ref(),
+                                    &full_walk_pays,
+                                    Some(reader_pool),
+                                )
+                                .await
+                                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                            predicate_work.merge(expand_work);
+                            expanded = plan;
+                            &expanded
+                        } else {
+                            candidate_plan
+                        };
+                        let unbounded = matches!(plan, CandidatePlan::Unbounded);
+                        let (est, est_work) = plan
+                            .estimate(prepared.reader.as_ref(), Some(reader_pool))
+                            .await
+                            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                        predicate_work.merge(est_work);
+                        let gate = ((prepared.reader.n_docs() as f64 * PUSHDOWN_MAX_FRACTION)
+                            as u64)
+                            .max(PUSHDOWN_MIN_ROWS);
+                        let density_cap =
+                            (prepared.reader.n_docs() as f64 * PUSHDOWN_MAX_DENSITY) as u64;
+                        let candidates = if est > gate || est >= density_cap {
+                            None
+                        } else {
+                            let (bitmap, eval_work) = plan
+                                .evaluate(prepared.reader.as_ref(), Some(reader_pool))
+                                .await
+                                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                            predicate_work.merge(eval_work);
+                            bitmap
+                        };
+
+                        // This superfile's tombstoned rows (empty when no
+                        // overlay); the batch prefetch above already resolved
+                        // them, so this is a cache read.
+                        let tombstones = match self.tombstone_cache.as_ref() {
+                            Some(cache) => {
+                                cache.bitmap_for(entry.superfile_id, now).map_err(|e| {
+                                    DataFusionError::Execution(format!("tombstone cache: {e}"))
+                                })?
+                            }
+                            None => Arc::new(RoaringBitmap::new()),
+                        };
+
+                        Ok::<SuperfileScan, DataFusionError>(SuperfileScan {
+                            prepared,
+                            candidates,
+                            tombstones,
+                            unbounded,
+                            predicate_work,
+                        })
+                    }
+                }),
+        )
+        .await?;
+
+        // Whether some superfile's plan came out `Unbounded`. Decides
+        // whether DataFusion's row filter is attached below; a superfile
+        // the selectivity gate sends to a scan is not counted (see there).
+        let any_plan_unbounded = superfiles.iter().any(|seg| seg.unbounded);
+        // The pushdown predicates' df probes, dictionary walks and posting
+        // walks, flushed through the same collector that meters this
+        // scan's pages — once the fan-out is in, so the tallies land in
+        // manifest order whatever order the superfiles finished in.
+        if let Some(stats) = self.scan_store.op_stats() {
+            for seg in &superfiles {
+                stats.add_fts_postings_bytes(seg.predicate_work.postings_bytes);
+                stats.add_planned_read_ranges(seg.predicate_work.planned_ranges);
+                stats.add_kernel_cpu_ns(seg.predicate_work.kernel_cpu_ns);
             }
-
-            // This superfile's tombstoned rows (empty when no overlay).
-            let tombstones = match self.tombstone_cache.as_ref() {
-                Some(cache) => cache
-                    .bitmap_for(entry.superfile_id, now)
-                    .map_err(|e| DataFusionError::Execution(format!("tombstone cache: {e}")))?,
-                None => Arc::new(RoaringBitmap::new()),
-            };
-
-            superfiles.push(SuperfileScan {
-                prepared,
-                candidates,
-                tombstones,
-            });
         }
 
         // The single object store DataFusion reads every survivor through.

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -184,6 +184,18 @@ const PUSHDOWN_MIN_ROWS: u64 = 4096;
 /// plain scan.
 const PUSHDOWN_MAX_DENSITY: f64 = 0.5;
 
+/// Gate for a `LIKE` token that needs a superfile's whole dictionary
+/// walked (a suffix or infix, or an `ILIKE` token that may be spelled
+/// with `ſ`): the walk is taken only when the column holds at least this
+/// many stored bytes per distinct term, i.e. when the scan it replaces is
+/// large next to the vocabulary. Measured on a 127,600-row news corpus
+/// split into 40 superfiles (55 bytes of text per dictionary key), the
+/// walk path ran at 1.8× the plain scan: a key visit costs about as much
+/// as scanning 45 bytes, so break-even sits near 45 bytes per term and
+/// 128 keeps the walk under ~35% of the scan. A superfile without a term
+/// count passes (nothing to judge by).
+const LIKE_WALK_MIN_BYTES_PER_TERM: u64 = 128;
+
 /// A [`TableProvider`] over a pinned supertable snapshot.
 ///
 /// Cheap to build (just `Arc` clones); all real work happens in
@@ -758,6 +770,31 @@ fn spans_full_domain(min: &ScalarValue, max: &ScalarValue) -> bool {
         && max.distance(min).map(|d| d as u64) == Some(FULL_DOMAIN_ENDPOINT_DISTANCE)
 }
 
+/// Whether walking a column's whole dictionary (`terms` distinct terms) is
+/// worth it against scanning its `bytes` of stored text — see
+/// [`LIKE_WALK_MIN_BYTES_PER_TERM`]. A missing term count (0) passes.
+fn full_walk_pays(terms: u64, bytes: u64) -> bool {
+    terms == 0 || bytes / terms >= LIKE_WALK_MIN_BYTES_PER_TERM
+}
+
+/// Stored (uncompressed) bytes of `column`'s data pages across a
+/// superfile's row groups — the volume a scan of that column decodes.
+/// `None` when the footer has no leaf column of that name.
+fn column_stored_bytes(meta: &ParquetMetaData, column: &str) -> Option<u64> {
+    let index = meta
+        .file_metadata()
+        .schema_descr()
+        .columns()
+        .iter()
+        .position(|descr| descr.name() == column)?;
+    Some(
+        meta.row_groups()
+            .iter()
+            .map(|rg| rg.column(index).uncompressed_size().max(0) as u64)
+            .sum(),
+    )
+}
+
 /// Extract a UTF-8 string literal from a scalar value, if it is one.
 /// Used to tokenize an equality literal for FTS-bloom pruning.
 fn scalar_as_str(v: &ScalarValue) -> Option<&str> {
@@ -873,6 +910,12 @@ impl TableProvider for SupertableProvider {
             tombstones: Arc<RoaringBitmap>,
         }
         let mut superfiles: Vec<SuperfileScan> = Vec::with_capacity(survivors.len());
+        // Whether some superfile's plan came out `Unbounded` — the whole
+        // plan is, or a `LIKE` token found no bound in that superfile's
+        // dictionary. Decides whether DataFusion's row filter is attached
+        // below; a superfile the selectivity gate sends to a scan is not
+        // counted (see there).
+        let mut any_plan_unbounded = matches!(candidate_plan, CandidatePlan::Unbounded);
 
         for (entry, prepared) in survivors.iter().zip(prepared_files) {
             // Pass 1 (per superfile): resolve candidate rows from the
@@ -890,8 +933,27 @@ impl TableProvider for SupertableProvider {
             let mut predicate_work = MatchWork::default();
             let expanded;
             let plan = if needs_expansion {
+                // A whole-dictionary walk pays only when the column's
+                // stored text is large next to its vocabulary; judged per
+                // column from the manifest's term count and the Parquet
+                // footer's column size, neither of which costs a read.
+                let meta = self
+                    .scan_metas
+                    .get(&prepared.path)
+                    .map(|m| Arc::clone(m.value()));
+                let full_walk_pays = |column: &str| {
+                    let terms = entry
+                        .fts_summary
+                        .get(column)
+                        .map_or(0, |summary| summary.n_terms_distinct);
+                    let bytes = meta
+                        .as_ref()
+                        .and_then(|m| column_stored_bytes(m, column))
+                        .unwrap_or(0);
+                    full_walk_pays(terms, bytes)
+                };
                 let (plan, expand_work) = candidate_plan
-                    .expand(prepared.reader.as_ref())
+                    .expand(prepared.reader.as_ref(), &full_walk_pays)
                     .await
                     .map_err(|e| DataFusionError::Execution(e.to_string()))?;
                 predicate_work.merge(expand_work);
@@ -900,6 +962,7 @@ impl TableProvider for SupertableProvider {
             } else {
                 &candidate_plan
             };
+            any_plan_unbounded |= matches!(plan, CandidatePlan::Unbounded);
             let (est, est_work) = plan
                 .estimate(prepared.reader.as_ref())
                 .await
@@ -973,23 +1036,25 @@ impl TableProvider for SupertableProvider {
 
         // Tier 2 - DataFusion-owned row-group / page pruning + row-level
         // filter pushdown, used **only when the index could not bound the
-        // rows** of some superfile: an `Unbounded` candidate plan, a `LIKE`
-        // token too wide for that superfile's dictionary, or a superfile
-        // the selectivity gate sent to a scan. In that fallback the
-        // predicate becomes a Parquet `RowFilter` (`with_pushdown_filters`)
-        // so the predicate columns are decoded first and only surviving
-        // rows materialize.
+        // rows** of some superfile: an `Unbounded` candidate plan, or a
+        // `LIKE` token that found no bound in that superfile's dictionary.
+        // In that fallback the predicate becomes a Parquet `RowFilter`
+        // (`with_pushdown_filters`) so the predicate columns are decoded
+        // first and only surviving rows materialize.
         //
-        // When the index bounded *every* superfile, each access plan
-        // already selects exactly the candidate rows and the `FilterExec`
-        // above (filters are `Inexact`) verifies the exact predicate over
-        // that tiny set. So we attach the pushdown predicate only when some
-        // superfile scans.
-        let all_bounded = superfiles.iter().all(|seg| seg.candidates.is_some());
-        let predicate = if all_bounded {
-            None
-        } else {
+        // When the index bounded the rows, each access plan already selects
+        // exactly the candidate rows and the `FilterExec` above (filters
+        // are `Inexact`) verifies the exact predicate over that tiny set.
+        // A superfile the selectivity gate sent to a scan deliberately gets
+        // no row filter either: the gate fires when the predicate matches
+        // most rows, and a row filter that keeps most rows only adds its
+        // own decode pass on top of the scan — measured on the 1M-row SQL
+        // bench, `bucket IN (all)` and a majority `category` aggregate ran
+        // 1.6–3× slower with it attached.
+        let predicate = if any_plan_unbounded {
             row_group_predicate(state, filters, &self.schema)
+        } else {
+            None
         };
 
         // Only push the LIMIT into the scan when there are no filters:
@@ -2379,6 +2444,25 @@ mod tests {
             3,
             "an open-edged LIKE token under ascii_lower prunes nothing"
         );
+    }
+
+    #[test]
+    fn a_whole_dictionary_walk_pays_only_when_text_dwarfs_vocabulary() {
+        // Below the bytes-per-term floor the scan is cheaper than the walk
+        // (the measured news-corpus shape sits at 55 bytes per term).
+        assert!(!full_walk_pays(452_011, 24_700_000));
+        // Long documents over a small vocabulary: the walk is a rounding
+        // error next to the scan.
+        assert!(full_walk_pays(10_000, 8 * 1024 * 1024));
+        // Exactly at the floor passes; one byte under does not.
+        let terms = 1_000;
+        assert!(full_walk_pays(terms, terms * LIKE_WALK_MIN_BYTES_PER_TERM));
+        assert!(!full_walk_pays(
+            terms,
+            terms * LIKE_WALK_MIN_BYTES_PER_TERM - 1
+        ));
+        // No term count to judge by ⇒ the walk is allowed.
+        assert!(full_walk_pays(0, 0));
     }
 
     /// Build a provider over a freshly-committed two-superfile table

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -92,6 +92,7 @@ use parquet::{
     errors,
     file::metadata::ParquetMetaData,
 };
+use rayon::ThreadPool;
 use roaring::RoaringBitmap;
 use tokio::sync::OnceCell;
 use uuid::Uuid;
@@ -916,6 +917,10 @@ impl TableProvider for SupertableProvider {
         // below; a superfile the selectivity gate sends to a scan is not
         // counted (see there).
         let mut any_plan_unbounded = matches!(candidate_plan, CandidatePlan::Unbounded);
+        // The plan's dictionary walks (a `LIKE` leaf's expansion) are CPU
+        // work and run on the reader pool behind a oneshot; only their FST
+        // fetches stay on this runtime.
+        let reader_pool: &ThreadPool = &self.manifest.options.reader_pool;
 
         for (entry, prepared) in survivors.iter().zip(prepared_files) {
             // Pass 1 (per superfile): resolve candidate rows from the
@@ -953,7 +958,7 @@ impl TableProvider for SupertableProvider {
                     full_walk_pays(terms, bytes)
                 };
                 let (plan, expand_work) = candidate_plan
-                    .expand(prepared.reader.as_ref(), &full_walk_pays)
+                    .expand(prepared.reader.as_ref(), &full_walk_pays, Some(reader_pool))
                     .await
                     .map_err(|e| DataFusionError::Execution(e.to_string()))?;
                 predicate_work.merge(expand_work);
@@ -964,7 +969,7 @@ impl TableProvider for SupertableProvider {
             };
             any_plan_unbounded |= matches!(plan, CandidatePlan::Unbounded);
             let (est, est_work) = plan
-                .estimate(prepared.reader.as_ref())
+                .estimate(prepared.reader.as_ref(), Some(reader_pool))
                 .await
                 .map_err(|e| DataFusionError::Execution(e.to_string()))?;
             predicate_work.merge(est_work);
@@ -975,7 +980,7 @@ impl TableProvider for SupertableProvider {
                 None
             } else {
                 let (bitmap, eval_work) = plan
-                    .evaluate(prepared.reader.as_ref())
+                    .evaluate(prepared.reader.as_ref(), Some(reader_pool))
                     .await
                     .map_err(|e| DataFusionError::Execution(e.to_string()))?;
                 predicate_work.merge(eval_work);

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -548,14 +548,15 @@ fn extract_id_column(batches: &[RecordBatch]) -> Result<Vec<i128>, QueryError> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, sync::Arc};
+    use std::{collections::HashSet, iter::repeat_n, sync::Arc};
 
     use arrow_array::{
-        Array, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray,
-        RecordBatch, StringArray, StringViewArray,
+        Array, ArrayRef, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array,
+        LargeStringArray, RecordBatch, StringArray, StringViewArray,
     };
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::{datasource::MemTable, prelude::SessionContext};
+    use tokio::runtime::Runtime;
 
     use crate::{
         memory::ConnectionMemoryBudget,
@@ -1738,12 +1739,14 @@ mod tests {
             let name = tokenizer.name();
             let st = Supertable::create(options_id_cat_title_with(tokenizer)).expect("create");
             let mut w = st.writer().expect("writer");
-            let cats: Vec<&str> = LIKE_TITLES.iter().map(|_| "x").collect();
-            w.append(&build_cat_batch(0, &cats, LIKE_TITLES))
+            let titles = with_walk_filler(LIKE_TITLES);
+            let title_refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+            let cats: Vec<&str> = title_refs.iter().map(|_| "x").collect();
+            w.append(&build_cat_batch(0, &cats, &title_refs))
                 .expect("append");
             w.commit().expect("commit");
             for pattern in LIKE_PATTERNS {
-                let expected: HashSet<&str> = LIKE_TITLES
+                let expected: HashSet<&str> = title_refs
                     .iter()
                     .copied()
                     .filter(|title| like_oracle(title, pattern))
@@ -1770,12 +1773,14 @@ mod tests {
         // decide — including the long s and the Kelvin sign that Unicode
         // case folding matches against `s` and `k` — the index-bounded
         // plan must return exactly that, under both analyzers.
-        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let rt = Runtime::new().expect("runtime");
         let analyzers: [Arc<dyn Tokenizer>; 2] = [tok(), Arc::new(StandardTokenizer)];
         for tokenizer in analyzers {
             let name = tokenizer.name();
-            let cats: Vec<&str> = FOLD_TITLES.iter().map(|_| "x").collect();
-            let batch = build_cat_batch(0, &cats, FOLD_TITLES);
+            let titles = with_walk_filler(FOLD_TITLES);
+            let title_refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+            let cats: Vec<&str> = title_refs.iter().map(|_| "x").collect();
+            let batch = build_cat_batch(0, &cats, &title_refs);
 
             let st = Supertable::create(options_id_cat_title_with(tokenizer)).expect("create");
             let mut w = st.writer().expect("writer");
@@ -1800,33 +1805,106 @@ mod tests {
         }
     }
 
-    #[test]
-    fn query_sql_like_mixes_bounded_and_unbounded_superfiles() {
-        // Two superfiles under the `standard` analyzer. The first holds
-        // more distinct terms containing `zz` than a LIKE token may widen
-        // to, so `%zz%` is unbounded there and that superfile scans with
-        // the row filter; the second holds two such terms and is bounded.
-        // One query spans both paths and must still be exact. A prefix
-        // pattern flips the roles: bounded in the first, empty in the
-        // second (no term starts with `q1`), which skips it outright.
-        const OVER_CAP_ROWS: usize = LIKE_MAX_TERMS + 76;
+    /// Rows of the wide superfile in [`mixed_like_table`]: more distinct
+    /// terms containing `zz` than a LIKE token may widen to.
+    const OVER_CAP_ROWS: usize = LIKE_MAX_TERMS + 76;
+
+    /// Prose appended to every wide-superfile title, and standing alone
+    /// as the filler rows of [`with_walk_filler`], so a superfile's stored
+    /// text dwarfs its vocabulary and a suffix or substring token takes
+    /// the whole-dictionary walk (the walk-vs-scan gate compares the two;
+    /// a handful of short titles on their own sit far under it and would
+    /// only ever exercise the scan).
+    const WALK_FILLER: &str = " lorem ipsum dolor sit amet consectetur adipiscing elit sed do \
+                                eiusmod tempor incididunt ut labore et dolore magna aliqua \
+                                lorem ipsum dolor sit amet consectetur adipiscing elit sed do \
+                                eiusmod tempor incididunt ut labore et dolore magna aliqua";
+
+    /// Filler rows [`with_walk_filler`] adds: enough copies of
+    /// [`WALK_FILLER`] to hold well over the gate's bytes-per-term floor
+    /// against the fixture titles' vocabulary.
+    const WALK_FILLER_ROWS: usize = 64;
+
+    /// `titles` followed by [`WALK_FILLER_ROWS`] rows of [`WALK_FILLER`].
+    /// The oracles judge the filler rows like any other, so they may add
+    /// to a pattern's expected set (`%` matches them all).
+    fn with_walk_filler(titles: &[&str]) -> Vec<String> {
+        titles
+            .iter()
+            .map(|t| (*t).to_owned())
+            .chain(repeat_n(WALK_FILLER.trim().to_owned(), WALK_FILLER_ROWS))
+            .collect()
+    }
+
+    /// Two superfiles under the `standard` analyzer: a wide one whose
+    /// `q{i}zz` titles hold more distinct `zz` terms than the cap, and a
+    /// narrow one with two such terms (plus the filler rows that let it
+    /// walk its dictionary).
+    fn mixed_like_table() -> Supertable {
         let st = Supertable::create(options_id_cat_title_with(Arc::new(StandardTokenizer)))
             .expect("create");
         let mut w = st.writer().expect("writer");
-        let wide: Vec<String> = (0..OVER_CAP_ROWS).map(|i| format!("q{i}zz")).collect();
+        let wide: Vec<String> = (0..OVER_CAP_ROWS)
+            .map(|i| format!("q{i}zz{WALK_FILLER}"))
+            .collect();
         let wide_refs: Vec<&str> = wide.iter().map(String::as_str).collect();
         let cats: Vec<&str> = wide_refs.iter().map(|_| "x").collect();
         w.append(&build_cat_batch(0, &cats, &wide_refs))
             .expect("append wide");
         w.commit().expect("commit wide");
-        w.append(&build_cat_batch(
-            0,
-            &["y", "y", "y"],
-            &["buzz lightyear", "fizz", "plain"],
-        ))
-        .expect("append narrow");
+        let narrow = with_walk_filler(&["buzz lightyear", "fizz", "plain"]);
+        let narrow_refs: Vec<&str> = narrow.iter().map(String::as_str).collect();
+        let cats: Vec<&str> = narrow_refs.iter().map(|_| "y").collect();
+        w.append(&build_cat_batch(0, &cats, &narrow_refs))
+            .expect("append narrow");
         w.commit().expect("commit narrow");
         assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
+        st
+    }
+
+    /// Value `i` of a string column of whichever Arrow string width
+    /// DataFusion chose for it (EXPLAIN's columns are not coerced the way
+    /// user columns are).
+    fn string_at(column: &ArrayRef, i: usize) -> String {
+        let any = column.as_any();
+        if let Some(a) = any.downcast_ref::<StringArray>() {
+            a.value(i).to_owned()
+        } else if let Some(a) = any.downcast_ref::<LargeStringArray>() {
+            a.value(i).to_owned()
+        } else if let Some(a) = any.downcast_ref::<StringViewArray>() {
+            a.value(i).to_owned()
+        } else {
+            panic!("not a string column: {:?}", column.data_type());
+        }
+    }
+
+    /// The physical plan DataFusion prints for `sql`.
+    fn explain_physical(st: &Supertable, sql: &str) -> String {
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(&format!("EXPLAIN {sql}"))
+            .expect("explain");
+        for batch in &batches {
+            for i in 0..batch.num_rows() {
+                if string_at(batch.column(0), i) == "physical_plan" {
+                    return string_at(batch.column(1), i);
+                }
+            }
+        }
+        panic!("no physical plan in EXPLAIN output");
+    }
+
+    #[test]
+    fn query_sql_like_mixes_bounded_and_unbounded_superfiles() {
+        // The first superfile holds more distinct terms containing `zz`
+        // than a LIKE token may widen to, so `%zz%` is unbounded there and
+        // that superfile scans with the row filter; the second holds two
+        // such terms and is bounded. One query spans both paths and must
+        // still be exact. A prefix pattern flips the roles: bounded in the
+        // first, empty in the second (no term starts with `q1`), which
+        // skips it outright.
+        let st = mixed_like_table();
 
         // Contains: unbounded in the wide superfile, bounded in the narrow.
         assert_eq!(
@@ -1852,6 +1930,46 @@ mod tests {
             ),
             2,
         );
+    }
+
+    #[test]
+    fn query_sql_row_filter_attaches_only_where_a_plan_is_unbounded() {
+        // DataFusion's Parquet row filter pays only when the index found
+        // no bound: a LIKE token past the cap in some superfile, or a plan
+        // that was never bounded. A bounded plan leaves it off, and so
+        // does a plan the selectivity gate sends to a scan for being
+        // dense — there the filter would keep nearly every row and only
+        // add its own decode pass.
+        //
+        // The witness is the `FilterExec` node: with the row filter on,
+        // DataFusion pushes the filter into the scan (the source accepts
+        // row filters) and drops the node; with it off the node stays
+        // above the scan. The scan prints `predicate=` either way — every
+        // filter is kept there for statistics pruning — so that text
+        // proves nothing. The probes project a column so no query folds
+        // to a manifest count without a scan.
+        let st = mixed_like_table();
+        let expect_row_filter = |sql: &str, on: bool| {
+            let plan = explain_physical(&st, sql);
+            assert!(plan.contains("DataSourceExec"), "{sql}\n{plan}");
+            assert_eq!(!plan.contains("FilterExec"), on, "{sql}\n{plan}");
+        };
+        // Over the cap in the wide superfile ⇒ on.
+        expect_row_filter("SELECT title FROM supertable WHERE title LIKE '%zz%'", true);
+        // Bounded in both superfiles (prefix subtree walk; empty in the
+        // narrow one) ⇒ off.
+        expect_row_filter("SELECT title FROM supertable WHERE title LIKE 'q1%'", false);
+        // Equality on the FTS column, bounded ⇒ off.
+        expect_row_filter("SELECT title FROM supertable WHERE title = 'fizz'", false);
+        // A dense predicate nearly every row of both superfiles satisfies
+        // (`lorem` is in every filler row): the gate sends them to a scan,
+        // and the row filter stays off.
+        expect_row_filter(
+            "SELECT title FROM supertable WHERE title IN ('lorem', 'plain')",
+            false,
+        );
+        // Never bounded (a non-FTS column) ⇒ on, as before.
+        expect_row_filter("SELECT title FROM supertable WHERE category = 'y'", true);
     }
 
     #[test]

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -548,7 +548,7 @@ fn extract_id_column(batches: &[RecordBatch]) -> Result<Vec<i128>, QueryError> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::HashSet, sync::Arc};
 
     use arrow_array::{
         Array, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray,
@@ -561,6 +561,7 @@ mod tests {
         storage::{LocalFsStorageProvider, StorageProvider},
         superfile::{
             builder::{FtsConfig, VectorConfig},
+            fts::tokenize::{StandardTokenizer, Tokenizer},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{
@@ -572,6 +573,69 @@ mod tests {
     /// One more than the manifest's exact-value cardinality cap.
     const HIGH_CARDINALITY_ROWS: usize = 257;
 
+    /// Titles for the `LIKE` oracle, chosen so the index superset and the
+    /// exact match differ: `fox` as a whole word, as a head (`foxes`), a
+    /// tail (`firefox`), an infix (`outfoxed`), glued to punctuation the
+    /// analyzers treat differently (`a.fox.b`, `don't`), capitalised
+    /// (`LIKE` is case-sensitive, the index is not), inside a run the
+    /// default analyzer drops (`Firefox—the`), and a Greek word whose final
+    /// sigma lowercases by position.
+    const LIKE_TITLES: &[&str] = &[
+        "firefox browser",
+        "the fox jumped",
+        "foxes are quick",
+        "Firefox—the browser",
+        "fox",
+        "outfoxed again",
+        "a.fox.b",
+        "don't stop",
+        "100% sure",
+        "quick brown fox",
+        "nothing here",
+        "ΟΔΟΣ ΟΔΟΣΑ",
+    ];
+
+    /// Patterns for the `LIKE` oracle: prefix, suffix, infix, case, an
+    /// interior complete token, `_`, joiner punctuation, no match, match
+    /// all, no wildcard, Greek, two fragments, and parenthesised.
+    const LIKE_PATTERNS: &[&str] = &[
+        "fox%",
+        "%fox",
+        "%fox%",
+        "%Fox%",
+        "% fox %",
+        "%fox jumped",
+        "fo_ %",
+        "%foxe_%",
+        "%don'%",
+        "%.fox.%",
+        "%zzq%",
+        "%",
+        "fox",
+        "%ΟΔΟΣ%",
+        "%ΟΔΟΣ",
+        "%brown%fox%",
+        "%(fox)%",
+        "%100%",
+    ];
+
+    /// Textbook `LIKE`: `%` any run, `_` one character, everything else
+    /// byte-exact (the fixture patterns carry no escapes). Deliberately
+    /// shares nothing with the engine's lowering.
+    fn like_oracle(value: &str, pattern: &str) -> bool {
+        fn go(v: &[char], p: &[char]) -> bool {
+            match p.split_first() {
+                None => v.is_empty(),
+                Some(('%', rest)) => (0..=v.len()).any(|i| go(&v[i..], rest)),
+                Some(('_', rest)) => !v.is_empty() && go(&v[1..], rest),
+                Some((c, rest)) => v.first() == Some(c) && go(&v[1..], rest),
+            }
+        }
+        let v: Vec<char> = value.chars().collect();
+        let p: Vec<char> = pattern.chars().collect();
+        go(&v, &p)
+    }
+
     /// Schema with id + scalar + FTS column. No vector; query_sql
     /// is scalar-only by design.
     fn schema_id_cat_title() -> Arc<Schema> {
@@ -582,6 +646,11 @@ mod tests {
     }
 
     fn options_id_cat_title() -> SupertableOptions {
+        options_id_cat_title_with(tok())
+    }
+
+    /// [`options_id_cat_title`] with `title` analyzed by `tokenizer`.
+    fn options_id_cat_title_with(tokenizer: Arc<dyn Tokenizer>) -> SupertableOptions {
         // Single-threaded writer pool so each commit produces
         // exactly one superfile — keeps assertions on per-superfile
         // counts deterministic.
@@ -598,7 +667,7 @@ mod tests {
                 positions: false,
             }],
             vec![],
-            Some(tok()),
+            Some(tokenizer),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -1592,6 +1661,56 @@ mod tests {
             ),
             2,
         );
+    }
+
+    #[test]
+    fn query_sql_like_matches_a_brute_force_oracle_under_both_analyzers() {
+        // The index bounds a LIKE differently per analyzer (the default
+        // one only through complete tokens, `standard` through prefix /
+        // suffix / infix expansion), and every bound is a superset the
+        // FilterExec narrows. Whatever the plan, the rows must be exactly
+        // the textbook LIKE matches — checked against an independent
+        // oracle for every pattern under both analyzers.
+        let analyzers: [Arc<dyn Tokenizer>; 2] = [tok(), Arc::new(StandardTokenizer)];
+        for tokenizer in analyzers {
+            let name = tokenizer.name();
+            let st = Supertable::create(options_id_cat_title_with(tokenizer)).expect("create");
+            let mut w = st.writer().expect("writer");
+            let cats: Vec<&str> = LIKE_TITLES.iter().map(|_| "x").collect();
+            w.append(&build_cat_batch(0, &cats, LIKE_TITLES))
+                .expect("append");
+            w.commit().expect("commit");
+            for pattern in LIKE_PATTERNS {
+                let expected: HashSet<&str> = LIKE_TITLES
+                    .iter()
+                    .copied()
+                    .filter(|title| like_oracle(title, pattern))
+                    .collect();
+                let quoted = pattern.replace('\'', "''");
+                let batches = st
+                    .reader()
+                    .expect("reader")
+                    .query_sql(&format!(
+                        "SELECT title FROM supertable WHERE title LIKE '{quoted}'"
+                    ))
+                    .expect("query");
+                let got: Vec<String> = batches
+                    .iter()
+                    .flat_map(|b| {
+                        let titles = b
+                            .column(0)
+                            .as_any()
+                            .downcast_ref::<LargeStringArray>()
+                            .expect("title column");
+                        (0..titles.len())
+                            .map(|i| titles.value(i).to_owned())
+                            .collect::<Vec<_>>()
+                    })
+                    .collect();
+                let got: HashSet<&str> = got.iter().map(String::as_str).collect();
+                assert_eq!(got, expected, "LIKE {pattern:?} under {name}");
+            }
+        }
     }
 
     #[test]

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -565,7 +565,9 @@ mod tests {
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{
-            Supertable, SupertableOptions, error::QueryError, query::sql::build_sql_schemas,
+            Supertable, SupertableOptions,
+            error::QueryError,
+            query::{candidate::LIKE_MAX_TERMS, sql::build_sql_schemas},
         },
         test_helpers::default_tokenizer as tok,
     };
@@ -1711,6 +1713,60 @@ mod tests {
                 assert_eq!(got, expected, "LIKE {pattern:?} under {name}");
             }
         }
+    }
+
+    #[test]
+    fn query_sql_like_mixes_bounded_and_unbounded_superfiles() {
+        // Two superfiles under the `standard` analyzer. The first holds
+        // more distinct terms containing `zz` than a LIKE token may widen
+        // to, so `%zz%` is unbounded there and that superfile scans with
+        // the row filter; the second holds two such terms and is bounded.
+        // One query spans both paths and must still be exact. A prefix
+        // pattern flips the roles: bounded in the first, empty in the
+        // second (no term starts with `q1`), which skips it outright.
+        const OVER_CAP_ROWS: usize = LIKE_MAX_TERMS + 76;
+        let st = Supertable::create(options_id_cat_title_with(Arc::new(StandardTokenizer)))
+            .expect("create");
+        let mut w = st.writer().expect("writer");
+        let wide: Vec<String> = (0..OVER_CAP_ROWS).map(|i| format!("q{i}zz")).collect();
+        let wide_refs: Vec<&str> = wide.iter().map(String::as_str).collect();
+        let cats: Vec<&str> = wide_refs.iter().map(|_| "x").collect();
+        w.append(&build_cat_batch(0, &cats, &wide_refs))
+            .expect("append wide");
+        w.commit().expect("commit wide");
+        w.append(&build_cat_batch(
+            0,
+            &["y", "y", "y"],
+            &["buzz lightyear", "fizz", "plain"],
+        ))
+        .expect("append narrow");
+        w.commit().expect("commit narrow");
+        assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
+
+        // Contains: unbounded in the wide superfile, bounded in the narrow.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE title LIKE '%zz%'"
+            ),
+            (OVER_CAP_ROWS + 2) as i64,
+        );
+        // Prefix: `q1`, `q10`..`q19`, `q100`..`q199`, `q1000`..`q1099`.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE title LIKE 'q1%'"
+            ),
+            1 + 10 + 100 + 100,
+        );
+        // Both, with a scalar conjunct the index cannot bound.
+        assert_eq!(
+            run_count(
+                &st,
+                "SELECT COUNT(*) FROM supertable WHERE title LIKE '%zz%' AND category = 'y'"
+            ),
+            2,
+        );
     }
 
     #[test]

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -555,6 +555,7 @@ mod tests {
         RecordBatch, StringArray, StringViewArray,
     };
     use arrow_schema::{DataType, Field, Schema};
+    use datafusion::{datasource::MemTable, prelude::SessionContext};
 
     use crate::{
         memory::ConnectionMemoryBudget,
@@ -620,6 +621,65 @@ mod tests {
         "%(fox)%",
         "%100%",
     ];
+
+    /// Titles whose case-folding is where `ILIKE` and lowercasing part
+    /// ways: a long s (`ſun riſe`, which Arrow matches against `sun`), a
+    /// Kelvin sign (`Kelvin K`, matched against `k`), and Greek with a
+    /// final sigma, beside plain mixed case.
+    const FOLD_TITLES: &[&str] = &[
+        "sun set",
+        "SUN RISE",
+        "ſun riſe",
+        "Kelvin K",
+        "sunset boulevard",
+        "a sun",
+        "Peter Parker",
+        "PETER PARKER",
+        "nothing here",
+        "ΟΔΟΣ ΟΔΟΣΑ",
+        "οδος",
+    ];
+
+    /// `(operator, pattern)` pairs judged against DataFusion itself.
+    const FOLD_PATTERNS: &[(&str, &str)] = &[
+        ("LIKE", "sun%"),
+        ("LIKE", "%K"),
+        ("ILIKE", "sun%"),
+        ("ILIKE", "%sun%"),
+        ("ILIKE", "%sun"),
+        ("ILIKE", "sun set"),
+        ("ILIKE", "% sun %"),
+        ("ILIKE", "%SUN RISE"),
+        ("ILIKE", "k %"),
+        ("ILIKE", "%kelvin%"),
+        ("ILIKE", "%k"),
+        ("ILIKE", "peter %"),
+        ("ILIKE", "%parker"),
+        ("ILIKE", "%PARKER"),
+        ("ILIKE", "%ri_e"),
+        ("ILIKE", "%riſe"),
+        ("ILIKE", "%οδος%"),
+        ("ILIKE", "ΟΔΟΣ%"),
+        ("ILIKE", "%"),
+        ("ILIKE", "%zzq%"),
+    ];
+
+    /// The `title` values across `batches`, as a set.
+    fn title_set(batches: &[RecordBatch]) -> HashSet<String> {
+        batches
+            .iter()
+            .flat_map(|b| {
+                let titles = b
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<LargeStringArray>()
+                    .expect("title column");
+                (0..titles.len())
+                    .map(|i| titles.value(i).to_owned())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
 
     /// Textbook `LIKE`: `%` any run, `_` one character, everything else
     /// byte-exact (the fixture patterns carry no escapes). Deliberately
@@ -1696,21 +1756,46 @@ mod tests {
                         "SELECT title FROM supertable WHERE title LIKE '{quoted}'"
                     ))
                     .expect("query");
-                let got: Vec<String> = batches
-                    .iter()
-                    .flat_map(|b| {
-                        let titles = b
-                            .column(0)
-                            .as_any()
-                            .downcast_ref::<LargeStringArray>()
-                            .expect("title column");
-                        (0..titles.len())
-                            .map(|i| titles.value(i).to_owned())
-                            .collect::<Vec<_>>()
-                    })
-                    .collect();
+                let got = title_set(&batches);
                 let got: HashSet<&str> = got.iter().map(String::as_str).collect();
                 assert_eq!(got, expected, "LIKE {pattern:?} under {name}");
+            }
+        }
+    }
+
+    #[test]
+    fn query_sql_like_and_ilike_match_datafusion_on_a_memtable() {
+        // The oracle here is DataFusion itself over the same rows in a
+        // plain in-memory table: whatever Arrow's `LIKE` / `ILIKE` kernels
+        // decide — including the long s and the Kelvin sign that Unicode
+        // case folding matches against `s` and `k` — the index-bounded
+        // plan must return exactly that, under both analyzers.
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let analyzers: [Arc<dyn Tokenizer>; 2] = [tok(), Arc::new(StandardTokenizer)];
+        for tokenizer in analyzers {
+            let name = tokenizer.name();
+            let cats: Vec<&str> = FOLD_TITLES.iter().map(|_| "x").collect();
+            let batch = build_cat_batch(0, &cats, FOLD_TITLES);
+
+            let st = Supertable::create(options_id_cat_title_with(tokenizer)).expect("create");
+            let mut w = st.writer().expect("writer");
+            w.append(&batch).expect("append");
+            w.commit().expect("commit");
+
+            let ctx = SessionContext::new();
+            let mem = MemTable::try_new(schema_id_cat_title(), vec![vec![batch]]).expect("mem");
+            ctx.register_table("supertable", Arc::new(mem))
+                .expect("register");
+
+            for (op, pattern) in FOLD_PATTERNS {
+                let quoted = pattern.replace('\'', "''");
+                let sql = format!("SELECT title FROM supertable WHERE title {op} '{quoted}'");
+                let expected = title_set(
+                    &rt.block_on(async { ctx.sql(&sql).await?.collect().await })
+                        .expect("datafusion oracle"),
+                );
+                let got = title_set(&st.reader().expect("reader").query_sql(&sql).expect("query"));
+                assert_eq!(got, expected, "{op} {pattern:?} under {name}");
             }
         }
     }

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -548,7 +548,7 @@ fn extract_id_column(batches: &[RecordBatch]) -> Result<Vec<i128>, QueryError> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, iter::repeat_n, sync::Arc};
+    use std::{collections::HashSet, sync::Arc};
 
     use arrow_array::{
         Array, ArrayRef, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array,
@@ -625,13 +625,18 @@ mod tests {
 
     /// Titles whose case-folding is where `ILIKE` and lowercasing part
     /// ways: a long s (`ſun riſe`, which Arrow matches against `sun`), a
-    /// Kelvin sign (`Kelvin K`, matched against `k`), and Greek with a
-    /// final sigma, beside plain mixed case.
+    /// Kelvin sign U+212A (written as an escape — the glyph passes for an
+    /// ASCII `K`, which would make every Kelvin case here vacuous: `Kelvin
+    /// K`, matched against `k`; `K b`, whose only `k` is the sign — under
+    /// `ascii_lower` that run is dropped and only `b` is indexed, so
+    /// requiring `k` of the row would lose it), and Greek with a final
+    /// sigma, beside plain mixed case.
     const FOLD_TITLES: &[&str] = &[
         "sun set",
         "SUN RISE",
         "ſun riſe",
-        "Kelvin K",
+        "Kelvin \u{212A}",
+        "\u{212A} b",
         "sunset boulevard",
         "a sun",
         "Peter Parker",
@@ -641,14 +646,35 @@ mod tests {
         "οδος",
     ];
 
+    /// The row committed as a second superfile of the `ILIKE` oracle:
+    /// `ſun ſet`, spelled only in forms an ASCII token never names. Every
+    /// term of the file sorts after `sun`, so a term-range leaf asked
+    /// about `sun` would prune the file, and a bloom asked for `sun` or
+    /// `set` finds neither — either unsound leaf loses a row Arrow
+    /// matches. Nothing here may put a term below `sun` into the file's
+    /// range, which is why `K b` sits in [`FOLD_TITLES`] instead.
+    const FOLD_TITLES_APART: &[&str] = &["ſun ſet"];
+
+    /// Filler words for that second superfile (see [`filler_rows`]): each
+    /// sorts after every probed ASCII prefix and holds neither `s` nor
+    /// `k`, so the rows keep the file's whole term range clear of `sun`
+    /// while still letting its dictionary walk pay.
+    const FOLD_FILLER_WORDS: &[&str] = &[
+        "tango", "tempo", "tiger", "timber", "toga", "torch", "total", "tower", "trade", "treaty",
+        "trophy", "tulip", "tundra", "tunnel", "turbo", "ultra", "umbra", "uncle", "under",
+        "union", "unity", "upper", "urban", "utter", "valley", "vapor", "velvet", "venue",
+        "verdant", "vertex", "violet", "viper",
+    ];
+
     /// `(operator, pattern)` pairs judged against DataFusion itself.
     const FOLD_PATTERNS: &[(&str, &str)] = &[
         ("LIKE", "sun%"),
-        ("LIKE", "%K"),
+        ("LIKE", "%\u{212A}"),
         ("ILIKE", "sun%"),
         ("ILIKE", "%sun%"),
         ("ILIKE", "%sun"),
         ("ILIKE", "sun set"),
+        ("ILIKE", "SUN SET"),
         ("ILIKE", "% sun %"),
         ("ILIKE", "%SUN RISE"),
         ("ILIKE", "k %"),
@@ -659,7 +685,10 @@ mod tests {
         ("ILIKE", "%PARKER"),
         ("ILIKE", "%ri_e"),
         ("ILIKE", "%riſe"),
+        ("ILIKE", "%ſet"),
+        ("LIKE", "ſun%"),
         ("ILIKE", "%οδος%"),
+        ("ILIKE", "%οδοσ%"),
         ("ILIKE", "ΟΔΟΣ%"),
         ("ILIKE", "%"),
         ("ILIKE", "%zzq%"),
@@ -1781,14 +1810,25 @@ mod tests {
             let title_refs: Vec<&str> = titles.iter().map(String::as_str).collect();
             let cats: Vec<&str> = title_refs.iter().map(|_| "x").collect();
             let batch = build_cat_batch(0, &cats, &title_refs);
+            let apart = with_filler_rows(FOLD_TITLES_APART, FOLD_FILLER_WORDS);
+            let apart_refs: Vec<&str> = apart.iter().map(String::as_str).collect();
+            let apart_cats: Vec<&str> = apart_refs.iter().map(|_| "x").collect();
+            let apart_batch = build_cat_batch(0, &apart_cats, &apart_refs);
 
+            // Two superfiles: the second holds only rows whose every
+            // spelling an ASCII token misses, so an unsound term-bloom or
+            // term-range leaf would prune it whole and lose its rows.
             let st = Supertable::create(options_id_cat_title_with(tokenizer)).expect("create");
             let mut w = st.writer().expect("writer");
             w.append(&batch).expect("append");
             w.commit().expect("commit");
+            w.append(&apart_batch).expect("append apart");
+            w.commit().expect("commit apart");
+            assert_eq!(st.reader().expect("reader").n_superfiles(), 2);
 
             let ctx = SessionContext::new();
-            let mem = MemTable::try_new(schema_id_cat_title(), vec![vec![batch]]).expect("mem");
+            let mem = MemTable::try_new(schema_id_cat_title(), vec![vec![batch, apart_batch]])
+                .expect("mem");
             ctx.register_table("supertable", Arc::new(mem))
                 .expect("register");
 
@@ -1809,31 +1849,85 @@ mod tests {
     /// terms containing `zz` than a LIKE token may widen to.
     const OVER_CAP_ROWS: usize = LIKE_MAX_TERMS + 76;
 
-    /// Prose appended to every wide-superfile title, and standing alone
-    /// as the filler rows of [`with_walk_filler`], so a superfile's stored
+    /// Prose words appended to every wide-superfile title, and making up
+    /// the filler rows of [`with_walk_filler`], so a superfile's stored
     /// text dwarfs its vocabulary and a suffix or substring token takes
     /// the whole-dictionary walk (the walk-vs-scan gate compares the two;
     /// a handful of short titles on their own sit far under it and would
     /// only ever exercise the scan).
-    const WALK_FILLER: &str = " lorem ipsum dolor sit amet consectetur adipiscing elit sed do \
-                                eiusmod tempor incididunt ut labore et dolore magna aliqua \
-                                lorem ipsum dolor sit amet consectetur adipiscing elit sed do \
-                                eiusmod tempor incididunt ut labore et dolore magna aliqua";
+    const WALK_FILLER_WORDS: &[&str] = &[
+        "lorem",
+        "ipsum",
+        "dolor",
+        "amet",
+        "consectetur",
+        "adipiscing",
+        "elit",
+        "eiusmod",
+        "tempor",
+        "incididunt",
+        "labore",
+        "dolore",
+        "magna",
+        "aliqua",
+        "enim",
+        "minim",
+        "veniam",
+        "quis",
+        "nostrud",
+        "exercitation",
+        "ullamco",
+        "laboris",
+        "nisi",
+        "aliquip",
+        "commodo",
+        "consequat",
+        "duis",
+        "aute",
+        "irure",
+        "reprehenderit",
+        "voluptate",
+        "velit",
+    ];
 
-    /// Filler rows [`with_walk_filler`] adds: enough copies of
-    /// [`WALK_FILLER`] to hold well over the gate's bytes-per-term floor
-    /// against the fixture titles' vocabulary.
+    /// Filler rows [`filler_rows`] builds: enough to hold well over the
+    /// gate's bytes-per-term floor against the fixture titles' vocabulary.
+    /// Twice the word count, so every row is a distinct ordering.
     const WALK_FILLER_ROWS: usize = 64;
 
-    /// `titles` followed by [`WALK_FILLER_ROWS`] rows of [`WALK_FILLER`].
-    /// The oracles judge the filler rows like any other, so they may add
-    /// to a pattern's expected set (`%` matches them all).
-    fn with_walk_filler(titles: &[&str]) -> Vec<String> {
+    /// [`WALK_FILLER_ROWS`] rows over `words`, each a different ordering
+    /// (the rotations, then the reversed rotations). The rows must differ:
+    /// Parquet dictionary-encodes a repeated string as one entry and the
+    /// gate reads the column's encoded size, so identical rows would
+    /// weigh as one. Real prose rows are distinct; these are too.
+    fn filler_rows(words: &[&str]) -> Vec<String> {
+        assert!(WALK_FILLER_ROWS <= 2 * words.len(), "orderings run out");
+        (0..WALK_FILLER_ROWS)
+            .map(|i| {
+                let mut row = words.to_vec();
+                row.rotate_left(i % words.len());
+                if i >= words.len() {
+                    row.reverse();
+                }
+                row.join(" ")
+            })
+            .collect()
+    }
+
+    /// `titles` followed by the [`filler_rows`] over `words`. The oracles
+    /// judge the filler rows like any other, so they may add to a
+    /// pattern's expected set (`%` matches them all).
+    fn with_filler_rows(titles: &[&str], words: &[&str]) -> Vec<String> {
         titles
             .iter()
             .map(|t| (*t).to_owned())
-            .chain(repeat_n(WALK_FILLER.trim().to_owned(), WALK_FILLER_ROWS))
+            .chain(filler_rows(words))
             .collect()
+    }
+
+    /// [`with_filler_rows`] over the [`WALK_FILLER_WORDS`] prose.
+    fn with_walk_filler(titles: &[&str]) -> Vec<String> {
+        with_filler_rows(titles, WALK_FILLER_WORDS)
     }
 
     /// Two superfiles under the `standard` analyzer: a wide one whose
@@ -1844,8 +1938,9 @@ mod tests {
         let st = Supertable::create(options_id_cat_title_with(Arc::new(StandardTokenizer)))
             .expect("create");
         let mut w = st.writer().expect("writer");
+        let filler = WALK_FILLER_WORDS.join(" ");
         let wide: Vec<String> = (0..OVER_CAP_ROWS)
-            .map(|i| format!("q{i}zz{WALK_FILLER}"))
+            .map(|i| format!("q{i}zz {filler}"))
             .collect();
         let wide_refs: Vec<&str> = wide.iter().map(String::as_str).collect();
         let cats: Vec<&str> = wide_refs.iter().map(|_| "x").collect();

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -5581,12 +5581,16 @@ impl SupertableReader {
     ) -> Result<HashMap<SuperfileUri, Arc<RoaringBitmap>>, QueryError> {
         let plan_arc = Arc::new(plan.clone());
         let op_stats = self.op_stats.clone();
+        // A `LIKE` leaf's dictionary walk is CPU work: it runs on the reader
+        // pool, not on the tokio worker driving this fan-out.
+        let reader_pool = Arc::clone(&self.manifest().options.reader_pool);
         self.fanout_candidate_bitmaps(superfiles, move |r, _entry| {
             let plan = Arc::clone(&plan_arc);
             let op_stats = op_stats.clone();
+            let reader_pool = Arc::clone(&reader_pool);
             async move {
                 let (bitmap, work) = plan
-                    .evaluate(r.as_ref())
+                    .evaluate(r.as_ref(), Some(&reader_pool))
                     .await
                     .map_err(|e| QueryError::Parquet(e.to_string()))?;
                 // The SQL predicate's posting walks, summed across the

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -5567,9 +5567,13 @@ impl SupertableReader {
     /// them. Tombstoned rows are dropped by the shared `fanout` (a deleted
     /// row must never be a kNN candidate).
     ///
-    /// The caller passes only a bounded plan, so `evaluate` returns
-    /// `Some(bitmap)` per superfile; a defensive `None` (unbounded) is
-    /// treated as the empty set, skipping that superfile.
+    /// The caller passes a plan that is bounded as lowered, but a `LIKE`
+    /// leaf is bound per superfile: a token that widens past the
+    /// dictionary cap in *this* superfile makes `evaluate` return `None`
+    /// there. `None` means the index constrains nothing for that
+    /// superfile, so every one of its rows stays a kNN candidate — the
+    /// `FilterExec` above the TVF re-applies the exact predicate. Treating
+    /// it as the empty set would drop matching rows.
     async fn candidate_bitmaps_from_plan(
         &self,
         superfiles: &[Arc<SuperfileEntry>],
@@ -5592,11 +5596,11 @@ impl SupertableReader {
                     stats.add_planned_read_ranges(work.planned_ranges);
                     stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                 }
-                bitmap.ok_or_else(|| {
-                    QueryError::Execute(
-                        "bounded CandidatePlan evaluated to Unbounded — planner bug".into(),
-                    )
-                })
+                Ok(bitmap.unwrap_or_else(|| {
+                    let mut all = RoaringBitmap::new();
+                    all.insert_range(0..r.n_docs() as u32);
+                    all
+                }))
             }
         })
         .await

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -5567,10 +5567,12 @@ impl SupertableReader {
     /// them. Tombstoned rows are dropped by the shared `fanout` (a deleted
     /// row must never be a kNN candidate).
     ///
-    /// The caller passes a plan that is bounded as lowered, but a `LIKE`
-    /// leaf is bound per superfile: a token that widens past the
-    /// dictionary cap in *this* superfile makes `evaluate` return `None`
-    /// there. `None` means the index constrains nothing for that
+    /// The caller passes a plan that is bounded as lowered, and for a plan
+    /// without a `LIKE` leaf `evaluate` therefore returns `Some(bitmap)`
+    /// for every superfile — a `None` there is a planner bug and is
+    /// reported as one. A `LIKE` leaf is bound per superfile: a token that
+    /// widens past the dictionary cap in *this* superfile makes `evaluate`
+    /// return `None` there, meaning the index constrains nothing for that
     /// superfile, so every one of its rows stays a kNN candidate — the
     /// `FilterExec` above the TVF re-applies the exact predicate. Treating
     /// it as the empty set would drop matching rows.
@@ -5580,6 +5582,7 @@ impl SupertableReader {
         plan: &CandidatePlan,
     ) -> Result<HashMap<SuperfileUri, Arc<RoaringBitmap>>, QueryError> {
         let plan_arc = Arc::new(plan.clone());
+        let unbounded_is_legitimate = plan.has_like();
         let op_stats = self.op_stats.clone();
         // A `LIKE` leaf's dictionary walk is CPU work: it runs on the reader
         // pool, not on the tokio worker driving this fan-out.
@@ -5600,11 +5603,17 @@ impl SupertableReader {
                     stats.add_planned_read_ranges(work.planned_ranges);
                     stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
                 }
-                Ok(bitmap.unwrap_or_else(|| {
-                    let mut all = RoaringBitmap::new();
-                    all.insert_range(0..r.n_docs() as u32);
-                    all
-                }))
+                match bitmap {
+                    Some(bitmap) => Ok(bitmap),
+                    None if unbounded_is_legitimate => {
+                        let mut all = RoaringBitmap::new();
+                        all.insert_range(0..r.n_docs() as u32);
+                        Ok(all)
+                    }
+                    None => Err(QueryError::Execute(
+                        "bounded CandidatePlan evaluated to Unbounded — planner bug".into(),
+                    )),
+                }
             }
         })
         .await

--- a/tests/superfile/fts/prefix_and_floor.rs
+++ b/tests/superfile/fts/prefix_and_floor.rs
@@ -71,7 +71,7 @@ async fn assert_prefix_matches_oracle(
     k: usize,
 ) {
     let got = reader
-        .bm25_search_prefix("title", prefix, k)
+        .bm25_search_prefix("title", prefix, k, None)
         .await
         .expect("prefix search")
         .0;
@@ -121,12 +121,12 @@ async fn prefix_uppercase_is_normalized() {
     let corp = prefix_corpus();
     let reader = build_infino_superfile(&corp);
     let upper = reader
-        .bm25_search_prefix("title", "RU", K_ALL)
+        .bm25_search_prefix("title", "RU", K_ALL, None)
         .await
         .expect("upper")
         .0;
     let lower = reader
-        .bm25_search_prefix("title", "ru", K_ALL)
+        .bm25_search_prefix("title", "ru", K_ALL, None)
         .await
         .expect("lower")
         .0;
@@ -139,7 +139,7 @@ async fn prefix_no_match_returns_empty() {
     let corp = prefix_corpus();
     let reader = build_infino_superfile(&corp);
     let hits = reader
-        .bm25_search_prefix("title", "zzz", K_ALL)
+        .bm25_search_prefix("title", "zzz", K_ALL, None)
         .await
         .expect("prefix search")
         .0;

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -23,7 +23,10 @@ use infino::{
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
         builder::{FtsConfig, VectorConfig},
-        fts::reader::{Bm25Stats, BoolMode},
+        fts::{
+            reader::{Bm25Stats, BoolMode},
+            tokenize::STANDARD_TOKENIZER,
+        },
         vector::rerank_codec::RerankCodec,
     },
     supertable::{
@@ -850,6 +853,125 @@ fn scoped_sql_stats(db: &Connection, sql: &str) -> OpStats {
     let (batches, stats) = with_op_stats(|| db.query_sql(sql).expect("query_sql"));
     assert!(!batches.is_empty(), "fixture SQL {sql:?} must return");
     stats
+}
+
+/// Rows in the `LIKE` fixture. Large enough that every writer shard holds
+/// at least two needle rows: a term with df = 1 in a superfile is stored
+/// inline in the dictionary with no posting bytes, which would make the
+/// posting-work assertion vacuous.
+const LIKE_ROWS: usize = 512;
+/// Every this-many-th row of the `LIKE` fixture carries the needle.
+const LIKE_NEEDLE_STRIDE: usize = 4;
+
+/// A `standard`-analyzer table for the `LIKE` pushdown: the substring
+/// `nimble` occurs only inside the term `nimblefox`, planted in every
+/// [`LIKE_NEEDLE_STRIDE`]-th row.
+fn sql_like_fixture(dir: &TempDir) -> Connection {
+    let db = connect(dir.path().to_str().expect("utf-8 path")).expect("connect");
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("rating", DataType::Int64, false),
+    ]));
+    let docs = db
+        .create_table(
+            "docs",
+            schema.clone(),
+            IndexSpec::new().fts_with_analyzer("title", STANDARD_TOKENIZER),
+        )
+        .expect("create_table");
+    let titles: Vec<String> = (0..LIKE_ROWS)
+        .map(|i| {
+            if i % LIKE_NEEDLE_STRIDE == 0 {
+                format!("filler{i} nimblefox")
+            } else {
+                format!("filler{i} rust")
+            }
+        })
+        .collect();
+    let title_arr: ArrayRef = Arc::new(LargeStringArray::from(
+        titles.iter().map(String::as_str).collect::<Vec<_>>(),
+    ));
+    let ratings: ArrayRef = Arc::new(Int64Array::from((0..LIKE_ROWS as i64).collect::<Vec<_>>()));
+    let batch = RecordBatch::try_new(schema, vec![title_arr, ratings]).expect("batch");
+    docs.append(&batch).expect("append");
+    db
+}
+
+#[test]
+fn a_like_predicate_is_answered_from_the_index() {
+    // `%nimble%` widens through each superfile's dictionary to the one
+    // term containing it and the scan decodes only that term's rows —
+    // FTS work the counters must show. The same query used to decode
+    // every row of `title` to test the substring.
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_like_fixture(&dir);
+    let stats = scoped_sql_stats(&db, "SELECT title FROM docs WHERE title LIKE '%nimble%'");
+    assert!(
+        stats.fts_postings_bytes > 0,
+        "the LIKE resolves through posting lists; got 0"
+    );
+    assert_eq!(
+        stats.rows_materialized,
+        (LIKE_ROWS / LIKE_NEEDLE_STRIDE) as u64,
+        "only the candidate rows decode"
+    );
+
+    // A prefix pattern widens through the dictionary too. No stored value
+    // starts with `nimble` (they all start with `filler`), so the answer is
+    // empty — but the index still hands the scan the rows holding a term
+    // that starts with it, and only the FilterExec rejects them. Decoding
+    // exactly those candidates is the signature of the index path: a plain
+    // scan with the row filter inside it would decode none.
+    let (batches, prefix) = with_op_stats(|| {
+        db.query_sql("SELECT title FROM docs WHERE title LIKE 'nimble%'")
+            .expect("query_sql")
+    });
+    assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 0);
+    assert!(
+        prefix.fts_postings_bytes > 0,
+        "the prefix expansion resolves through posting lists; got 0"
+    );
+    assert_eq!(
+        prefix.rows_materialized,
+        (LIKE_ROWS / LIKE_NEEDLE_STRIDE) as u64,
+        "the candidate rows decode before the exact check rejects them"
+    );
+
+    // A substring no indexed term contains expands to nothing: every
+    // superfile's access plan selects no row, so no data page is read.
+    let (batches, none) = with_op_stats(|| {
+        db.query_sql("SELECT title FROM docs WHERE title LIKE '%zzq%'")
+            .expect("query_sql")
+    });
+    assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 0);
+    assert_eq!(
+        none.sql_page_bytes, 0,
+        "an empty expansion reads no Parquet pages"
+    );
+    assert_eq!(
+        none.rows_materialized, 0,
+        "an empty expansion decodes nothing"
+    );
+}
+
+#[test]
+fn an_open_edged_like_under_the_default_analyzer_still_scans() {
+    // `ascii_lower` drops any run holding a non-ASCII byte, so a term that
+    // merely contains `rust` may not exist for a row that does — the
+    // index cannot bound `%rust%` there and the column scans instead.
+    // Control for the test above: no posting work, same answer.
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_fixture(&dir);
+    let stats = scoped_sql_stats(&db, "SELECT title FROM docs WHERE title LIKE '%rust%'");
+    assert_eq!(
+        stats.fts_postings_bytes, 0,
+        "no index bound under ascii_lower; got {}",
+        stats.fts_postings_bytes
+    );
+    assert!(
+        stats.sql_page_bytes > 0,
+        "the scan reads the column's pages"
+    );
 }
 
 #[test]

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -855,10 +855,11 @@ fn scoped_sql_stats(db: &Connection, sql: &str) -> OpStats {
     stats
 }
 
-/// Rows in the `LIKE` fixture. Large enough that every writer shard holds
-/// at least two needle rows: a term with df = 1 in a superfile is stored
-/// inline in the dictionary with no posting bytes, which would make the
-/// posting-work assertion vacuous.
+/// Rows in the `LIKE` fixture. The needle term must reach df ≥ 2 in its
+/// superfile: a df = 1 term is stored inline in the dictionary with no
+/// posting bytes, which would make the posting-work assertion vacuous.
+/// One batch this small commits as a single superfile, so the stride
+/// below gives the needle a df well clear of that.
 const LIKE_ROWS: usize = 512;
 /// Every this-many-th row of the `LIKE` fixture carries the needle.
 const LIKE_NEEDLE_STRIDE: usize = 4;
@@ -955,11 +956,66 @@ fn a_like_predicate_is_answered_from_the_index() {
 }
 
 #[test]
+fn a_like_inside_a_boolean_tree_keeps_its_bound() {
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_like_fixture(&dir);
+    let needle_rows = (LIKE_ROWS / LIKE_NEEDLE_STRIDE) as u64;
+
+    // Two fragments: `filler1` names the rows whose filler term starts
+    // with 1 (1, 10..19, 100..199), `nimble` the needle rows. The
+    // expansions must intersect — a union would decode 212 rows, either
+    // token alone 111 or 128.
+    let filler1_rows: u64 = (0..LIKE_ROWS)
+        .filter(|i| i.to_string().starts_with('1'))
+        .count() as u64;
+    let both: u64 = (0..LIKE_ROWS)
+        .filter(|i| i.to_string().starts_with('1') && i % LIKE_NEEDLE_STRIDE == 0)
+        .count() as u64;
+    let stats = scoped_sql_stats(
+        &db,
+        "SELECT title FROM docs WHERE title LIKE '%filler1%nimble%'",
+    );
+    assert!(both < filler1_rows && both < needle_rows);
+    assert_eq!(
+        stats.rows_materialized, both,
+        "the two tokens' expansions intersect"
+    );
+
+    // AND with a scalar conjunct the index cannot bound: the LIKE still
+    // bounds the candidates (every needle row decodes), and the rating
+    // check is verified above the scan.
+    let (batches, and_stats) = with_op_stats(|| {
+        db.query_sql(&format!(
+            "SELECT title FROM docs WHERE title LIKE '%nimble%' AND rating >= {}",
+            LIKE_ROWS / 2
+        ))
+        .expect("query_sql")
+    });
+    assert_eq!(
+        batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+        LIKE_ROWS / 2 / LIKE_NEEDLE_STRIDE
+    );
+    assert_eq!(and_stats.rows_materialized, needle_rows);
+
+    // OR with an equality: both branches bound, the candidates are their
+    // union (the prefix `nimble%` matches no value but its expansion still
+    // names the needle rows), and one row survives the exact check.
+    let (batches, or_stats) = with_op_stats(|| {
+        db.query_sql("SELECT title FROM docs WHERE title LIKE 'nimble%' OR title = 'filler3 rust'")
+            .expect("query_sql")
+    });
+    assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+    assert_eq!(or_stats.rows_materialized, needle_rows + 1);
+}
+
+#[test]
 fn an_open_edged_like_under_the_default_analyzer_still_scans() {
-    // `ascii_lower` drops any run holding a non-ASCII byte, so a term that
-    // merely contains `rust` may not exist for a row that does — the
-    // index cannot bound `%rust%` there and the column scans instead.
-    // Control for the test above: no posting work, same answer.
+    // Under `ascii_lower` an open-edged token is never required, whatever
+    // the data: the analyzer drops any run holding a non-ASCII byte whole,
+    // so in general a term merely containing `rust` may not exist for a
+    // row that matches. `%rust%` therefore scans here even though this
+    // corpus is pure ASCII. Control for the tests above: no posting work,
+    // same answer.
     let dir = TempDir::new().expect("tempdir");
     let db = sql_fixture(&dir);
     let stats = scoped_sql_stats(&db, "SELECT title FROM docs WHERE title LIKE '%rust%'");

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -863,11 +863,19 @@ fn scoped_sql_stats(db: &Connection, sql: &str) -> OpStats {
 const LIKE_ROWS: usize = 512;
 /// Every this-many-th row of the `LIKE` fixture carries the needle.
 const LIKE_NEEDLE_STRIDE: usize = 4;
+/// Prose appended to every row of the padded `LIKE` fixture: a handful of
+/// words repeated, so the column's stored text dwarfs its vocabulary and
+/// the whole-dictionary walk passes the walk-vs-scan gate. The unpadded
+/// fixture (one unique filler word per row) sits far under it.
+const LIKE_PADDING: &str = " the quick brown fox jumps over the lazy dog again and again \
+                            the quick brown fox jumps over the lazy dog again and again \
+                            the quick brown fox jumps over the lazy dog again and again";
 
 /// A `standard`-analyzer table for the `LIKE` pushdown: the substring
 /// `nimble` occurs only inside the term `nimblefox`, planted in every
-/// [`LIKE_NEEDLE_STRIDE`]-th row.
-fn sql_like_fixture(dir: &TempDir) -> Connection {
+/// [`LIKE_NEEDLE_STRIDE`]-th row. `padded` appends [`LIKE_PADDING`] to
+/// every row.
+fn sql_like_fixture(dir: &TempDir, padded: bool) -> Connection {
     let db = connect(dir.path().to_str().expect("utf-8 path")).expect("connect");
     let schema = Arc::new(Schema::new(vec![
         Field::new("title", DataType::LargeUtf8, false),
@@ -880,12 +888,13 @@ fn sql_like_fixture(dir: &TempDir) -> Connection {
             IndexSpec::new().fts_with_analyzer("title", STANDARD_TOKENIZER),
         )
         .expect("create_table");
+    let padding = if padded { LIKE_PADDING } else { "" };
     let titles: Vec<String> = (0..LIKE_ROWS)
         .map(|i| {
             if i % LIKE_NEEDLE_STRIDE == 0 {
-                format!("filler{i} nimblefox")
+                format!("filler{i} nimblefox{padding}")
             } else {
-                format!("filler{i} rust")
+                format!("filler{i} rust{padding}")
             }
         })
         .collect();
@@ -905,7 +914,7 @@ fn a_like_predicate_is_answered_from_the_index() {
     // FTS work the counters must show. The same query used to decode
     // every row of `title` to test the substring.
     let dir = TempDir::new().expect("tempdir");
-    let db = sql_like_fixture(&dir);
+    let db = sql_like_fixture(&dir, true);
     let stats = scoped_sql_stats(&db, "SELECT title FROM docs WHERE title LIKE '%nimble%'");
     assert!(
         stats.fts_postings_bytes > 0,
@@ -956,9 +965,45 @@ fn a_like_predicate_is_answered_from_the_index() {
 }
 
 #[test]
+fn a_whole_dictionary_walk_is_skipped_when_the_scan_is_cheaper() {
+    // One unique word per row makes the vocabulary as large as the column
+    // (a few bytes of text per distinct term), so walking the dictionary
+    // for `%nimble%` would cost more than scanning: the token is left
+    // unbounded, no posting list is read, and the scan still answers
+    // exactly. The prefix `nimble%` walks only its own subtree, which the
+    // gate does not touch, so it stays index-bounded.
+    let dir = TempDir::new().expect("tempdir");
+    let db = sql_like_fixture(&dir, false);
+    let stats = scoped_sql_stats(&db, "SELECT title FROM docs WHERE title LIKE '%nimble%'");
+    assert_eq!(
+        stats.fts_postings_bytes, 0,
+        "the contains token is not expanded when the walk would not pay"
+    );
+    let (batches, _) = with_op_stats(|| {
+        db.query_sql("SELECT COUNT(*) FROM docs WHERE title LIKE '%nimble%'")
+            .expect("query_sql")
+    });
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("count")
+        .value(0);
+    assert_eq!(count, (LIKE_ROWS / LIKE_NEEDLE_STRIDE) as i64);
+    let (_, prefix) = with_op_stats(|| {
+        db.query_sql("SELECT title FROM docs WHERE title LIKE 'nimble%'")
+            .expect("query_sql")
+    });
+    assert!(
+        prefix.fts_postings_bytes > 0,
+        "a prefix token's subtree walk is not gated"
+    );
+}
+
+#[test]
 fn a_like_inside_a_boolean_tree_keeps_its_bound() {
     let dir = TempDir::new().expect("tempdir");
-    let db = sql_like_fixture(&dir);
+    let db = sql_like_fixture(&dir, true);
     let needle_rows = (LIKE_ROWS / LIKE_NEEDLE_STRIDE) as u64;
 
     // Two fragments: `filler1` names the rows whose filler term starts
@@ -1001,8 +1046,11 @@ fn a_like_inside_a_boolean_tree_keeps_its_bound() {
     // union (the prefix `nimble%` matches no value but its expansion still
     // names the needle rows), and one row survives the exact check.
     let (batches, or_stats) = with_op_stats(|| {
-        db.query_sql("SELECT title FROM docs WHERE title LIKE 'nimble%' OR title = 'filler3 rust'")
-            .expect("query_sql")
+        db.query_sql(&format!(
+            "SELECT title FROM docs WHERE title LIKE 'nimble%' \
+             OR title = 'filler3 rust{LIKE_PADDING}'"
+        ))
+        .expect("query_sql")
     });
     assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
     assert_eq!(or_stats.rows_materialized, needle_rows + 1);

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -926,6 +926,19 @@ fn a_like_predicate_is_answered_from_the_index() {
         "only the candidate rows decode"
     );
 
+    // `ILIKE` takes the same path: the token is compared folded against
+    // every dictionary key, and the needle rows are all that decode.
+    let folded = scoped_sql_stats(&db, "SELECT title FROM docs WHERE title ILIKE '%NIMBLE%'");
+    assert!(
+        folded.fts_postings_bytes > 0,
+        "the ILIKE resolves through posting lists; got 0"
+    );
+    assert_eq!(
+        folded.rows_materialized,
+        (LIKE_ROWS / LIKE_NEEDLE_STRIDE) as u64,
+        "only the candidate rows decode under ILIKE"
+    );
+
     // A prefix pattern widens through the dictionary too. No stored value
     // starts with `nimble` (they all start with `filler`), so the answer is
     // empty — but the index still hands the scan the rows holding a term


### PR DESCRIPTION
Fixes #702 

A SQL WHERE equality or IN on a full-text column is bounded by the index; LIKE on the same column ran as a full column scan. Models and people write LIKE constantly (174 of 772 agent loops on BIRD, hundreds on DataAgentBench), every one a scan of a column that carried an index built for exactly that lookup.

The pattern is split at its wildcards into literal fragments, each fragment is tokenized with the column's analyzer, and every token becomes a constraint: a token the fragment closes on both sides (a separator inside the fragment, or the pattern's own start / end) must be indexed as itself; a token bordering a wildcard is widened, per superfile, to the indexed terms it heads, tails, or sits inside by a streamed walk over the column's dictionary range. The union of those terms' postings is a superset of the matching rows and the FilterExec above the scan re-checks the exact predicate, as for equality. A token widening past LIKE_MAX_TERMS contributes no constraint (the scan wins there anyway); one that widens to nothing skips the superfile.

What each analyzer can bound: `standard` supports exact, prefix, suffix and substring tokens, with two edge rules — an ASCII word joiner (' " . : , ; _) leaves a fragment edge open, and an open-right token ending in a final sigma is dropped because `to_lowercase` spells a word-final Σ differently from a medial one. `ascii_lower` drops any run holding a non-ASCII byte whole, so a term merely containing a fragment token may not exist for a row that matches; under it only tokens the pattern closes on both sides are required, and `%fox%` still scans. NOT LIKE and ILIKE stay unbounded (ILIKE folds wider than lowercasing). Complete tokens prune superfiles through the term bloom, prefix tokens through the lex term range.

The provider expands a LIKE plan once per superfile so the estimate and the evaluation share one dictionary walk, and now attaches DataFusion's row-filter predicate whenever any superfile scans, not only for a wholly unbounded plan — a gate-rejected superfile previously had neither bound.

Tests: per-analyzer lowering, escape handling and prune leaves in candidate.rs; dictionary expansion in expand.rs; an end-to-end oracle comparing every LIKE shape against a textbook matcher under both analyzers; op-stats proving the index is consulted, only candidate rows decode, and an empty expansion reads no pages; a provider-level prune test. The supertable SQL bench gains a leading-complete-token LIKE shape (index-bounded under any analyzer) and a substring LIKE shape (scan under the default).

Commits: 

- keep a LIKE filter sound on the vector_search TVF path. Review found two bugs: a LIKE token that widened past the cap made evaluate return None per superfile and the TVF aborted the query as a "planner bug"; a pattern whose tokens are all open on the left (%fox%) produced an empty prune-leaf group, which the survival gate read as "no superfile survives" and the query silently returned no rows. A branch that yields no leaf now disables the gate; a superfile whose plan evaluates to None keeps every row as a kNN candidate and the FilterExec re-checks. Also applies the shared dictionary-open helper to the five remaining identical sites, moves the substring LIKE bench shape into the scan-priced family, and adds the missing tests (vector_search + LIKE, a two-superfile mixed bounded/unbounded LIKE, multi-token and AND/OR op-stats).

- one dictionary pass per LIKE leaf instead of one per token (the bot's per-token comment), and an expansion that finds no term evaluates to the empty set itself (the bot's TermsAny comment).

- ILIKE bounded for ASCII tokens. Arrow's ILIKE folds under Unicode simple case folding whenever the column or pattern is not pure ASCII; the two places that reach ASCII letters are ſ (folds with s) and the Kelvin sign K (folds with k). The expansion compares dictionary terms with those folded back, an exact/prefix token holding s joins the full walk, no bloom/range summary is asked about such a token, and under ascii_lower a token holding s or k is not required at all (the ſ/K spelling is a non-ASCII byte that drops the run). Non-ASCII ILIKE tokens are not bounded. Oracle: every LIKE/ILIKE pattern run through DataFusion itself on an in-memory table with ſun riſe, Kelvin K, Greek final sigma and mixed case, under both analyzers.

- the ILIKE rules get end-to-end witnesses, and a bug the review turned up on the way: the Kelvin sign was an ASCII K everywhere it appeared (the fold table constant, the reader fixture, the oracle rows), so the fold's Kelvin entry was a no-op and every Kelvin test passed on an ordinary letter. Shipped behaviour was still right (the k rule under ascii_lower never depended on the constant; the index lowercases a real Kelvin sign to k), but it is now a \u{212A} escape. Also found by mutation: the oracle's filler rows were identical strings, which Parquet dictionary-encodes as one entry, so the walk-vs-scan gate read 463 bytes for a 15 KB column and every suffix/substring pattern in the oracle was quietly taking the scan path — the rows are now distinct orderings of the same words. Each soundness rule was then checked by removing it and watching the oracle fail: the prefix-leaf skip (a second superfile of ſun ſet, whose whole term range sorts past sun), the ascii_lower k rule (K b, real sign), the non-ASCII rule (%riſe compared byte-for-byte against folded terms; %οδοσ%, which the final-sigma rule does not catch).

Measured after the gate (agnews, 127,600 rows, 40 superfiles, 12 LIKE/ILIKE shapes, four interleaved passes of three cells: v0.5.12 engine on the ascii_lower store, this branch on the same store, this branch on a standard store): every query within noise across the three cells, 50–55 ms against a 45–48 ms COUNT(*) floor; the 100 ms substring LIKE on standard from before the gate is gone. One shape, ILIKE '%microsoft%', runs at ~103 ms in all three cells including the baseline — that is Arrow's regex path for a case-insensitive match over a non-ASCII column, not this change.

- the dictionary walks now run on the reader pool. The LIKE expansion walked the FST inline in an async fn on the tokio worker that awaited the fetch, copying the shape of the prefix search, which did the same; both are CPU waves under the crate's concurrency contract. Both now fetch the FST on the runtime and walk it on the reader pool behind a oneshot (run_on_pool), the pool threaded from the provider, the vector TVF fan-out and the prefix kernel; a dropped pool task is FtsError::TaskDropped, the FTS twin of the vector variant.

Known follow-ups, not in this PR: a per-superfile "no run dropped" bit so ascii_lower columns can bound open-edged tokens too (format change, own issue).