### PR TITLE
superfile/vector: reuse a per-thread visited set in hnsw search

### DIFF
--- a/src/superfile/vector/hnsw.rs
+++ b/src/superfile/vector/hnsw.rs
@@ -770,6 +770,15 @@ impl VisitedSet {
         }
     }
 
+    /// Grow the stamp array to cover at least `n` nodes, preserving existing
+    /// stamps. New slots are 0, which reads as unvisited under any live epoch
+    /// (epochs start at 1 after the first `clear`).
+    fn ensure(&mut self, n: usize) {
+        if self.stamp.len() < n {
+            self.stamp.resize(n, 0);
+        }
+    }
+
     /// Mark `node` visited; return whether it was already visited.
     #[inline]
     fn test_and_set(&mut self, node: u32) -> bool {
@@ -1071,8 +1080,24 @@ impl Hnsw {
         k: usize,
         ef: usize,
     ) -> Vec<(u32, f32)> {
-        let mut visited = VisitedSet::new(self.len);
-        self.search_scratch(scorer, query, k, ef, &mut visited)
+        // Reuse a per-thread visited set instead of allocating (then zeroing,
+        // then freeing) an O(n) buffer on every query — 40 MB at 10M nodes.
+        // That per-query alloc+memset dominated warm latency at scale and,
+        // worse, serialized concurrent queries on the allocator's arena locks,
+        // capping QPS. `search_layer` epoch-clears the set on entry, so a dirty
+        // carry-over from the prior query is correct; serving is multi-threaded,
+        // so the scratch is thread-local: grown to the thread's largest index
+        // seen and then reused for the thread's lifetime (a bounded, one-time
+        // cost — no per-query allocation, no cross-thread contention).
+        thread_local! {
+            static SEARCH_VISITED: std::cell::RefCell<VisitedSet> =
+                std::cell::RefCell::new(VisitedSet::new(0));
+        }
+        SEARCH_VISITED.with(|cell| {
+            let mut visited = cell.borrow_mut();
+            visited.ensure(self.len);
+            self.search_scratch(scorer, query, k, ef, &mut visited)
+        })
     }
 
     /// [`search`](Self::search) reusing a caller-owned visited set. The set is


### PR DESCRIPTION
## What

Serving HNSW `search()` allocated, zeroed, and freed a fresh O(n) `VisitedSet` on **every query**. `VisitedSet` is a `Vec<u32>` stamp array, so at 10M nodes that is a **40 MB alloc + `memset` + free per query**. The epoch stamp already makes *reset* O(1) — only the buffer itself was being re-allocated each call.

This dominated warm-search latency at scale and, worse, **serialized concurrent queries on the allocator's arena locks**, so QPS saturated far below linear scaling with cores.

## Fix

Reuse a **thread-local** `VisitedSet` through the existing `search_scratch` path. `search_layer` epoch-clears the set on entry, so a dirty carry-over from the previous query is correct — the `calibrate_ef_curve` path already reuses one set for exactly this reason. Per-thread scope avoids cross-thread contention. Added `VisitedSet::ensure` to grow the buffer once per thread.

Recall is unchanged: `search()` already delegated to `search_scratch`; this only changes where the visited buffer comes from (same reset semantics).

## Impact

Measured with the native concurrency probe (`examples/concurrent_probe.rs`, one 16-vCPU host, Cohere-768, `hnsw_ivf`, ef=256), before vs after:

**10M**

| concurrency | QPS (before → after) | p50 ms (before → after) |
|---|---|---|
| 1  | 369 → **800**     | 2.71 → **1.25** |
| 8  | 1,291 → **6,067** | 5.96 → **1.29** |
| 16 | 1,291 → **8,469** | 12.1 → **1.83** |

**1M**

| concurrency | QPS (before → after) | p50 ms (before → after) |
|---|---|---|
| 1  | 935 → **1,058**    | 1.05 → **0.92** |
| 16 | 8,872 → **12,086** | 1.73 → **1.26** |

At 10M the baseline saturated at ~1,300 QPS (allocator-arena contention); the fix scales near-linearly to the host's physical cores. The win is scale-proportional — a larger index means a larger per-query buffer, so a bigger saving. A `perf` profile before the change spent ~54% of warm-query time in allocator page management + `memset`; afterward that is gone and the walk is bound by the `sq8` distance kernel, as expected.

## Test

`cargo fmt` clean; `cargo clippy` clean; hnsw unit tests pass. Recall is preserved by construction (identical `search_scratch` semantics).