### PR TITLE
fix: proper offloading of tokio workers

### DIFF
--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -27,13 +27,13 @@ use futures::{
 };
 use roaring::RoaringBitmap;
 use tempfile::NamedTempFile;
-use tokio::time;
+use tokio::{task::spawn_blocking, time};
 use tracing::warn;
 use uuid::Uuid;
 
 use crate::{
     config::CompactionSettings,
-    runtime_bridge::bridge_on_runtime,
+    runtime_bridge::{bridge_on_runtime, carry_span},
     superfile::{
         builder::SuperfileBuilder,
         vector::{cell_posting::transcode_clamped_components, layout::VectorLayout},
@@ -540,16 +540,17 @@ impl Supertable {
             readers_with_tombstones.push((reader.clone(), bitmap));
         }
 
-        let (merged_bytes, superfile_stats): (Bytes, _) = {
-            let first_vec = readers_with_tombstones
-                .first()
-                .and_then(|(reader, _)| reader.vec());
-            let multi_cell = first_vec.is_some_and(|v| v.is_multi_cell());
-            let sq8_merge = first_vec.and_then(|v| {
-                v.vector_columns_config()
-                    .next()
-                    .map(|c| c.rerank_codec.is_ivf_mergeable())
-            });
+        let first_vec = readers_with_tombstones
+            .first()
+            .and_then(|(reader, _)| reader.vec());
+        let multi_cell = first_vec.is_some_and(|v| v.is_multi_cell());
+        let sq8_merge = first_vec.and_then(|v| {
+            v.vector_columns_config()
+                .next()
+                .map(|c| c.rerank_codec.is_ivf_mergeable())
+        });
+        let has_vector = first_vec.is_some();
+        let (merged_bytes, superfile_stats) = spawn_blocking(carry_span(move || {
             // Every merge kind streams its output to a temp file and mmaps it
             // back, so the corpus-sized merge output is never held as an anon
             // Vec — the allocation that OOMs compaction on a memory-tight host.
@@ -571,7 +572,7 @@ impl Supertable {
                         &readers_with_tombstones,
                         &mut writer,
                     )?
-                } else if first_vec.is_none() {
+                } else if !has_vector {
                     // FTS/scalar inputs (no vector index): carry each input's
                     // already-built posting lists across instead of
                     // re-tokenizing the whole corpus.
@@ -592,8 +593,10 @@ impl Supertable {
             };
             let bytes = mmap_readonly_bytes(output.path())
                 .map_err(|e| BuildError::Store(format!("merge mmap: {e}")))?;
-            (bytes, stats)
-        };
+            Ok::<(Bytes, _), BuildError>((bytes, stats))
+        }))
+        .await
+        .map_err(|e| BuildError::Store(format!("merge build join: {e}")))??;
 
         let shard = ShardOutput::new_with_params(
             merged_bytes,

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -1192,17 +1192,17 @@ impl DiskCacheStore {
         expected_size: Option<u64>,
     ) -> Result<Option<Arc<CachedEntry>>, DiskCacheError> {
         let path = self.cache_path(uri);
-        let Ok(meta) = fs::metadata(&path) else {
+        let Ok(meta) = tokio::fs::metadata(&path).await else {
             // A counted file that is gone (deleted outside the engine) must stop counting now:
             // left in place, its record double-counts against the fetched replacement and a later
             // eviction of it would unlink the replacement's file.
-            self.discard_cache_file(uri);
+            self.discard_cache_file(uri).await;
             return Ok(None);
         };
 
         let size = meta.len();
         if size == 0 || expected_size.is_some_and(|want| want != size) {
-            self.discard_cache_file(uri);
+            self.discard_cache_file(uri).await;
             return Ok(None);
         }
 
@@ -1236,8 +1236,8 @@ impl DiskCacheStore {
                 if counted {
                     self.current_bytes.fetch_sub(size, Ordering::Release);
                 }
-                let _ = fs::remove_file(&path);
-                let _ = fs::remove_file(self.blocks_path(uri));
+                let _ = tokio::fs::remove_file(&path).await;
+                let _ = tokio::fs::remove_file(self.blocks_path(uri)).await;
                 Ok(None)
             }
         }
@@ -1246,14 +1246,14 @@ impl DiskCacheStore {
     /// Delete an unusable cache file and give back the bytes the scan counted for it. Subtracts the
     /// record's own size, so the accounting balances even when the file on disk no longer matches
     /// what the scan saw (or is gone entirely).
-    fn discard_cache_file(&self, uri: &SuperfileUri) {
+    async fn discard_cache_file(&self, uri: &SuperfileUri) {
         if let Some((_, file)) = self.unindexed.remove(uri) {
             self.current_bytes
                 .fetch_sub(file.size_bytes, Ordering::Release);
         }
 
-        let _ = fs::remove_file(self.cache_path(uri));
-        let _ = fs::remove_file(self.blocks_path(uri));
+        let _ = tokio::fs::remove_file(self.cache_path(uri)).await;
+        let _ = tokio::fs::remove_file(self.blocks_path(uri)).await;
     }
 
     /// Delete never-opened files, oldest first, until `bytes_needed` is freed. Returns the bytes
@@ -2141,12 +2141,18 @@ impl DiskCacheStore {
         // so chunk writers can use positioned (`pwrite`) writes
         // off the async reactor without a shared file lock.
         let file = {
-            let f = fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(dest_path)?;
-            f.set_len(size)?;
+            let dest = dest_path.to_path_buf();
+            let f = spawn_blocking(carry_span(move || {
+                let f = fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&dest)?;
+                f.set_len(size)?;
+                Ok::<_, DiskCacheError>(f)
+            }))
+            .await
+            .map_err(|e| DiskCacheError::SuperfileOpen(format!("preallocate join: {e}")))??;
             Arc::new(f)
         };
 
@@ -2435,15 +2441,21 @@ async fn cold_fetch_to_disk_cancelable(
         filled.resize(n_chunks as usize, false);
     }
     let file = {
-        let mut opts = fs::OpenOptions::new();
-        opts.write(true).create(true);
-        if first_attempt {
-            opts.truncate(true);
-        }
-        let file = opts.open(dest_path)?;
-        if first_attempt {
-            file.set_len(size)?;
-        }
+        let dest = dest_path.to_path_buf();
+        let file = spawn_blocking(carry_span(move || {
+            let mut opts = fs::OpenOptions::new();
+            opts.write(true).create(true);
+            if first_attempt {
+                opts.truncate(true);
+            }
+            let file = opts.open(&dest)?;
+            if first_attempt {
+                file.set_len(size)?;
+            }
+            Ok::<_, DiskCacheError>(file)
+        }))
+        .await
+        .map_err(|e| DiskCacheError::SuperfileOpen(format!("preallocate join: {e}")))??;
         Arc::new(file)
     };
 


### PR DESCRIPTION
* some async function uses std::fs instead of tokio::Fs or doesn't use tokio::spawn_blocking where it should use. This PR attempts to fix couple of those issue so that throughput will improve.