### PR TITLE
supertable/query: attach the row-filter predicate once; keep LIMIT out of filtered scans

### DIFF
--- a/src/supertable/query/exec/metered_exec.rs
+++ b/src/supertable/query/exec/metered_exec.rs
@@ -74,6 +74,11 @@ use crate::runtime_metrics::{
 pub(crate) struct MeteredExec {
     input: Arc<dyn ExecutionPlan>,
     op_stats: Option<Arc<OpStatsCollector>>,
+    /// Whether the planner may carry a `LIMIT` fetch past this node into
+    /// the child. The one place this is `false` is the meter the table
+    /// provider wraps around a scan that carries filters — see
+    /// [`Self::without_limit_pushdown`].
+    limit_pushdown: bool,
 }
 
 impl MeteredExec {
@@ -85,7 +90,42 @@ impl MeteredExec {
         input: Arc<dyn ExecutionPlan>,
         op_stats: Option<Arc<OpStatsCollector>>,
     ) -> Self {
-        Self { input, op_stats }
+        Self {
+            input,
+            op_stats,
+            limit_pushdown: true,
+        }
+    }
+
+    /// Wrap `input` and stop `LimitPushdown` from embedding a fetch below
+    /// this node. The table provider uses this around a filtered scan:
+    /// its access plans carry tombstone (and index-candidate) row
+    /// selections, and a scan-level limit lets the Parquet opener's limit
+    /// pruning replace those selections with whole row groups that the
+    /// predicate's statistics prove "fully matching" — returning deleted
+    /// rows. With the `FilterExec` folded into the scan as a row filter,
+    /// nothing else above the scan would hold the fetch, so this node
+    /// refuses it and DataFusion keeps a limit node above instead. The
+    /// provider pushes its own scan-level limit only for filter-less
+    /// scans, where no predicate can mark a row group fully matching.
+    pub(crate) fn without_limit_pushdown(
+        input: Arc<dyn ExecutionPlan>,
+        op_stats: Option<Arc<OpStatsCollector>>,
+    ) -> Self {
+        Self {
+            input,
+            op_stats,
+            limit_pushdown: false,
+        }
+    }
+
+    /// A meter over `input` with this node's collector and limit policy.
+    fn rewrap(&self, input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        Arc::new(MeteredExec {
+            input,
+            op_stats: self.op_stats.clone(),
+            limit_pushdown: self.limit_pushdown,
+        })
     }
 }
 
@@ -122,10 +162,7 @@ impl ExecutionPlan for MeteredExec {
                 children.len()
             )));
         }
-        Ok(Arc::new(MeteredExec::new(
-            children.swap_remove(0),
-            self.op_stats.clone(),
-        )))
+        Ok(self.rewrap(children.swap_remove(0)))
     }
 
     // ---- Everything below is delegation. See the module header: a meter
@@ -153,15 +190,17 @@ impl ExecutionPlan for MeteredExec {
         // makes the planner insert a `RepartitionExec` *below* this node
         // instead, which both adds an exchange and moves the Parquet decode
         // into a spawned task where this node's thread clock cannot see it.
-        Ok(self.input.repartitioned(target_partitions, config)?.map(
-            |input| -> Arc<dyn ExecutionPlan> {
-                Arc::new(MeteredExec::new(input, self.op_stats.clone()))
-            },
-        ))
+        Ok(self
+            .input
+            .repartitioned(target_partitions, config)?
+            .map(|input| self.rewrap(input)))
     }
 
     fn supports_limit_pushdown(&self) -> bool {
-        true
+        // `false` makes `LimitPushdown` keep its limit node above this
+        // meter instead of walking into the scan; see
+        // [`Self::without_limit_pushdown`].
+        self.limit_pushdown
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
@@ -172,11 +211,10 @@ impl ExecutionPlan for MeteredExec {
         &self,
         projection: &ProjectionExec,
     ) -> DfResult<Option<Arc<dyn ExecutionPlan>>> {
-        Ok(self.input.try_swapping_with_projection(projection)?.map(
-            |input| -> Arc<dyn ExecutionPlan> {
-                Arc::new(MeteredExec::new(input, self.op_stats.clone()))
-            },
-        ))
+        Ok(self
+            .input
+            .try_swapping_with_projection(projection)?
+            .map(|input| self.rewrap(input)))
     }
 
     fn gather_filters_for_pushdown(
@@ -211,15 +249,12 @@ impl ExecutionPlan for MeteredExec {
         // default answer is `Unsupported`, which stops the pushdown walk
         // dead for any shape where the sort cannot sink, and a blocked
         // walk costs that shape its row-group reorder and reverse scan.
-        let rewrap = |input| -> Arc<dyn ExecutionPlan> {
-            Arc::new(MeteredExec::new(input, self.op_stats.clone()))
-        };
         Ok(match self.input.try_pushdown_sort(order)? {
             SortOrderPushdownResult::Exact { inner } => SortOrderPushdownResult::Exact {
-                inner: rewrap(inner),
+                inner: self.rewrap(inner),
             },
             SortOrderPushdownResult::Inexact { inner } => SortOrderPushdownResult::Inexact {
-                inner: rewrap(inner),
+                inner: self.rewrap(inner),
             },
             SortOrderPushdownResult::Unsupported => SortOrderPushdownResult::Unsupported,
         })
@@ -230,18 +265,18 @@ impl ExecutionPlan for MeteredExec {
     }
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
-        // Not consulted on today's plan shapes: `supports_limit_pushdown`
-        // above routes the LimitPushdown walk into the child directly, so
-        // the fetch reaches the source either way (verified by A/B EXPLAIN
-        // — the plans are identical with this pair deleted). Kept because
-        // the module contract is that every planner question is answered
-        // by the child: a shape or rule that does consult this must get
-        // the source's answer, not a meter defaulting to `None`.
-        self.input
-            .with_fetch(limit)
-            .map(|input| -> Arc<dyn ExecutionPlan> {
-                Arc::new(MeteredExec::new(input, self.op_stats.clone()))
-            })
+        // When the walk may pass, `supports_limit_pushdown` above routes
+        // `LimitPushdown` into the child directly and this is rarely
+        // consulted; it still delegates so a shape or rule that does ask
+        // gets the source's answer, not a meter defaulting to `None`. When
+        // the walk may not pass, this is exactly the question that must
+        // be refused: with no fetch-capable node here, `LimitPushdown`
+        // keeps a limit node above the meter (see
+        // [`Self::without_limit_pushdown`]).
+        if !self.limit_pushdown {
+            return None;
+        }
+        self.input.with_fetch(limit).map(|input| self.rewrap(input))
     }
 
     fn with_preserve_order(&self, preserve_order: bool) -> Option<Arc<dyn ExecutionPlan>> {
@@ -254,9 +289,7 @@ impl ExecutionPlan for MeteredExec {
         // skip row groups, not from a meter defaulting to `None`.
         self.input
             .with_preserve_order(preserve_order)
-            .map(|input| -> Arc<dyn ExecutionPlan> {
-                Arc::new(MeteredExec::new(input, self.op_stats.clone()))
-            })
+            .map(|input| self.rewrap(input))
     }
 
     fn execute(

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -21,11 +21,13 @@
 //!      `vector_centroid_skip`.
 //!   2. **Row-group / page skip (DataFusion).** The surviving
 //!      superfiles' Parquet bytes are exposed to a DataFusion
-//!      `ParquetSource` via an in-memory object store. The same
-//!      predicate is handed to DataFusion as a physical expression
-//!      so `PruningPredicate` prunes row groups and pages, then
-//!      projects + limits. We deliberately do **not** reimplement
-//!      this commodity layer.
+//!      `ParquetSource` via an in-memory object store. DataFusion's
+//!      own filter pushdown hands the `FilterExec` predicate to that
+//!      source, where `PruningPredicate` prunes row groups and pages;
+//!      when the index could not bound the rows, [`scan`] also turns
+//!      on Parquet row filters so the same predicate decodes the
+//!      filter columns first and only surviving rows materialize.
+//!      We deliberately do **not** reimplement this commodity layer.
 //!
 //! Correctness is independent of either tier: every pushed filter
 //! is reported [`TableProviderFilterPushDown::Inexact`], so
@@ -59,7 +61,7 @@ use bytes::Bytes;
 use dashmap::DashMap;
 use datafusion::{
     catalog::{Session, TableProvider},
-    common::{ColumnStatistics, DFSchema, Statistics, stats::Precision},
+    common::{ColumnStatistics, Statistics, stats::Precision},
     datasource::{
         listing::PartitionedFile,
         physical_plan::{
@@ -72,7 +74,6 @@ use datafusion::{
     execution::object_store::ObjectStoreUrl,
     logical_expr::{Expr, Operator, TableProviderFilterPushDown, TableType},
     object_store::path::Path as ObjPath,
-    physical_expr::PhysicalExpr,
     physical_plan::{ExecutionPlan, empty::EmptyExec, metrics::ExecutionPlanMetricsSet},
     scalar::ScalarValue,
 };
@@ -122,9 +123,8 @@ use crate::{
 };
 
 /// Logical name the supertable is registered under in the
-/// DataFusion `SessionContext`. Callers reference it as
-/// `FROM supertable`; we also use it as the schema qualifier when
-/// resolving filter columns to a physical pruning predicate.
+/// DataFusion `SessionContext`; callers reference it as
+/// `FROM supertable`.
 pub(crate) const TABLE_NAME: &str = "supertable";
 
 /// Distance between the endpoints of a min/max range that covers a
@@ -772,9 +772,9 @@ impl TableProvider for SupertableProvider {
     }
 
     /// Report every filter as `Inexact`: DataFusion hands us the
-    /// predicates (for both pruning tiers) **and** keeps a
-    /// `FilterExec` above the scan, so correctness never depends on
-    /// our conservative pruning. The `FilterExec` also does the
+    /// predicates (for the superfile skip and the index bound) **and**
+    /// keeps a `FilterExec` above the scan, so correctness never depends
+    /// on our conservative pruning. The `FilterExec` also does the
     /// candidate-superset verification in the same scan pass as the
     /// projection (one decode), which a self-verifying `exact_match`
     /// candidate would split into an extra pass — measured slower.
@@ -956,17 +956,27 @@ impl TableProvider for SupertableProvider {
         // so the predicate columns are decoded first and only surviving
         // rows materialize.
         //
+        // The predicate itself is not attached here. Every filter is
+        // reported `Inexact`, so DataFusion keeps a `FilterExec` above the
+        // scan, and its physical filter-pushdown rule then offers that
+        // node's predicate to the source: with row filters enabled the
+        // source accepts it once and the `FilterExec` is dropped; with them
+        // disabled the source still keeps it for statistics pruning and the
+        // node stays. Attaching our own copy of the same conjunction as
+        // well made the row filter `p AND p` — a second evaluation of the
+        // predicate over every row the first pass kept, which on a dense
+        // predicate is most of them.
+        //
         // When the index *did* bound the rows, the per-superfile access plan
         // already selects exactly the candidate rows and the `FilterExec`
-        // above (filters are `Inexact`) verifies the exact predicate over
-        // that tiny set. So we attach the pushdown predicate only on the
-        // unbounded path.
-        let index_bounded = !matches!(candidate_plan, CandidatePlan::Unbounded);
-        let predicate = if !index_bounded {
-            row_group_predicate(state, filters, &self.schema)
-        } else {
-            None
-        };
+        // verifies the exact predicate over that tiny set, so row filters
+        // stay off.
+        // A scan with no filters at all also lowers to `Unbounded`; it has
+        // no predicate to filter rows by and gets no row filter — otherwise
+        // DataFusion's post-optimization dynamic filters (TopK, join probe
+        // side, aggregate) would start running as Parquet row filters on
+        // filter-less scans, a change nothing has measured.
+        let row_filter = !filters.is_empty() && matches!(candidate_plan, CandidatePlan::Unbounded);
 
         // Only push the LIMIT into the scan when there are no filters:
         // with an `Inexact` filter re-applied above, a scan-level limit
@@ -975,9 +985,8 @@ impl TableProvider for SupertableProvider {
         let effective_limit = if filters.is_empty() { limit } else { None };
 
         let mut source = ParquetSource::new(Arc::clone(&self.schema));
-        if let Some(predicate) = predicate.as_ref() {
+        if row_filter {
             source = source
-                .with_predicate(Arc::clone(predicate))
                 .with_pushdown_filters(true)
                 .with_reorder_filters(true);
         }
@@ -1582,25 +1591,6 @@ fn flip_op(op: ScalarOp) -> ScalarOp {
         ScalarOp::Gt => ScalarOp::Lt,
         ScalarOp::GtEq => ScalarOp::LtEq,
     }
-}
-
-/// Lower the conjunction of `filters` into a single physical
-/// predicate for DataFusion's row-group pruning, or `None` if the
-/// filters are empty or can't be lowered (column-resolution /
-/// planning failure → skip pruning, never incorrect).
-fn row_group_predicate(
-    state: &dyn Session,
-    filters: &[Expr],
-    schema: &SchemaRef,
-) -> Option<Arc<dyn PhysicalExpr>> {
-    let combined = filters.iter().cloned().reduce(|a, b| a.and(b))?;
-    // Filter columns may arrive qualified (`supertable.col`) or
-    // bare depending on the plan; try the qualified schema first,
-    // then the unqualified one.
-    let df_schema = DFSchema::try_from_qualified_schema(TABLE_NAME, schema.as_ref())
-        .or_else(|_| DFSchema::try_from(schema.as_ref().clone()))
-        .ok()?;
-    state.create_physical_expr(combined, &df_schema).ok()
 }
 
 #[cfg(test)]

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -1033,10 +1033,20 @@ impl TableProvider for SupertableProvider {
         // reports operator time as wall-clock `elapsed_compute` and does not
         // report Parquet decode at all, so without this a SQL query's CPU is
         // both mis-clocked and missing its dominant leg.
-        Ok(Arc::new(MeteredExec::new(
-            DataSourceExec::from_data_source(config),
-            self.scan_store.op_stats(),
-        )))
+        //
+        // A filtered scan also refuses a scan-level `LIMIT` through the
+        // meter: the access plans above carry tombstone selections, and the
+        // Parquet opener's limit pruning would swap them for whole row
+        // groups the predicate's statistics prove fully matching, returning
+        // deleted rows. `effective_limit` above pushes our own limit only
+        // when there are no filters, for the same reason.
+        let scan = DataSourceExec::from_data_source(config);
+        let op_stats = self.scan_store.op_stats();
+        Ok(if filters.is_empty() {
+            Arc::new(MeteredExec::new(scan, op_stats))
+        } else {
+            Arc::new(MeteredExec::without_limit_pushdown(scan, op_stats))
+        })
     }
 }
 

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -548,11 +548,11 @@ fn extract_id_column(batches: &[RecordBatch]) -> Result<Vec<i128>, QueryError> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::HashSet, sync::Arc};
 
     use arrow_array::{
-        Array, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array, LargeStringArray,
-        RecordBatch, StringArray, StringViewArray,
+        Array, ArrayRef, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array,
+        LargeStringArray, RecordBatch, StringArray, StringViewArray,
     };
     use arrow_schema::{DataType, Field, Schema};
 
@@ -691,6 +691,88 @@ mod tests {
             .downcast_ref::<Int64Array>()
             .expect("count column is Int64");
         n.value(0)
+    }
+
+    /// Value `i` of a string column of whichever Arrow string width
+    /// DataFusion chose for it (EXPLAIN's columns are not coerced the way
+    /// user columns are).
+    fn string_at(column: &ArrayRef, i: usize) -> String {
+        let any = column.as_any();
+        if let Some(a) = any.downcast_ref::<StringArray>() {
+            a.value(i).to_owned()
+        } else if let Some(a) = any.downcast_ref::<LargeStringArray>() {
+            a.value(i).to_owned()
+        } else if let Some(a) = any.downcast_ref::<StringViewArray>() {
+            a.value(i).to_owned()
+        } else {
+            panic!("not a string column: {:?}", column.data_type());
+        }
+    }
+
+    /// The physical plan DataFusion prints for `sql`.
+    fn explain_physical(st: &Supertable, sql: &str) -> String {
+        let batches = st
+            .reader()
+            .expect("reader")
+            .query_sql(&format!("EXPLAIN {sql}"))
+            .expect("explain");
+        for batch in &batches {
+            for i in 0..batch.num_rows() {
+                if string_at(batch.column(0), i) == "physical_plan" {
+                    return string_at(batch.column(1), i);
+                }
+            }
+        }
+        panic!("no physical plan in EXPLAIN output");
+    }
+
+    #[test]
+    fn query_sql_row_filter_carries_the_predicate_once() {
+        // A predicate the index cannot bound (a scalar column) runs as a
+        // Parquet row filter: DataFusion's filter pushdown offers the
+        // `FilterExec` predicate to the scan, the scan accepts it, and the
+        // node is dropped. The provider used to attach its own copy of the
+        // same conjunction first, so the row filter read `p AND p` and
+        // evaluated the predicate twice. The scan line must carry exactly
+        // one `predicate=` with no self-conjunction, and the `FilterExec`
+        // must be gone.
+        let st = seeded(&["x", "y", "y"], &["alpha", "beta", "gamma"]);
+        let plan = explain_physical(&st, "SELECT title FROM supertable WHERE category = 'y'");
+        let scan = plan
+            .lines()
+            .find(|l| l.contains("DataSourceExec"))
+            .expect("a DataSourceExec in the physical plan");
+        assert!(!plan.contains("FilterExec"), "{plan}");
+        // The row-filter predicate prints as `, predicate=<expr>`, ahead of
+        // the statistics `pruning_predicate=` DataFusion derives from it.
+        let predicate = scan
+            .split_once(", predicate=")
+            .map(|(_, rest)| rest.split(", pruning_predicate=").next().unwrap_or(rest))
+            .expect("a predicate on the scan");
+        assert!(
+            predicate.starts_with("category@")
+                && predicate.ends_with("= y")
+                && !predicate.contains(" AND "),
+            "{scan}"
+        );
+        // The single-copy row filter still returns exactly the matching
+        // rows. (A `COUNT(*)` would not do here: the covered-aggregate
+        // rewrite answers it from manifest value counts without a scan.)
+        let rows: HashSet<String> = st
+            .reader()
+            .expect("reader")
+            .query_sql("SELECT title FROM supertable WHERE category = 'y'")
+            .expect("query")
+            .iter()
+            .flat_map(|b| (0..b.num_rows()).map(|i| string_at(b.column(0), i)))
+            .collect();
+        assert_eq!(rows, HashSet::from(["beta".to_owned(), "gamma".to_owned()]));
+
+        // Control: an index-bounded predicate keeps the `FilterExec` and
+        // the scan gets no row filter of ours; the `predicate=` DataFusion
+        // stores there is for statistics pruning only.
+        let bounded = explain_physical(&st, "SELECT title FROM supertable WHERE title = 'beta'");
+        assert!(bounded.contains("FilterExec"), "{bounded}");
     }
 
     /// `extract_id_column` collects non-null Decimal128 `_id`s from single-column
@@ -949,20 +1031,9 @@ mod tests {
             .expect("count is Int64");
         // DataFusion may materialize the GROUP BY key as Utf8,
         // LargeUtf8, or StringView depending on hash-aggregate
-        // type promotion; accept all three.
-        let extract = |i: usize| -> String {
-            if let Some(a) = cat_col.as_any().downcast_ref::<LargeStringArray>() {
-                a.value(i).to_string()
-            } else if let Some(a) = cat_col.as_any().downcast_ref::<StringArray>() {
-                a.value(i).to_string()
-            } else if let Some(a) = cat_col.as_any().downcast_ref::<StringViewArray>() {
-                a.value(i).to_string()
-            } else {
-                panic!("unexpected category column type: {:?}", cat_col.data_type())
-            }
-        };
+        // type promotion; `string_at` accepts all three.
         let mut got: Vec<(String, i64)> = (0..cat_col.len())
-            .map(|i| (extract(i), counts.value(i)))
+            .map(|i| (string_at(cat_col, i), counts.value(i)))
             .collect();
         got.sort();
         assert_eq!(

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -24,7 +24,7 @@
 use std::sync::Arc;
 
 use arrow_array::{
-    Array, ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch,
+    Array, ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch, StringArray,
 };
 use arrow_schema::{DataType, Field, Schema};
 use chrono::Utc;
@@ -61,6 +61,24 @@ const RAYON_POOL_THREADS: usize = 1;
 const VECTOR_ROT_SEED: u64 = 42;
 /// Vector-search top-k for the tombstone-filtered ANN query.
 const VECTOR_SEARCH_K: usize = 5;
+/// Rows in the `LIMIT` fixture. With [`LIMIT_FIXTURE_TITLE_LEN`]-character
+/// pseudo-random titles the superfile (Parquet pages plus the embedded
+/// term index over as many distinct terms) passes DataFusion's 10 MiB
+/// `repartition_file_min_size`, so the scan is split into byte ranges
+/// across partitions — the production shape — instead of getting a
+/// round-robin `RepartitionExec` that would stop a `LIMIT` short of the
+/// scan and hide the bug under test. The test asserts that shape.
+const LIMIT_FIXTURE_ROWS: usize = 60_000;
+/// Characters per pseudo-random title in the `LIMIT` fixture.
+const LIMIT_FIXTURE_TITLE_LEN: usize = 128;
+/// `LIMIT` small enough that one fully matching row group satisfies it.
+const LIMIT_FIXTURE_FETCH: usize = 3;
+/// Multiplier of the LCG that draws the `LIMIT` fixture's titles.
+const TITLE_LCG_MULT: u64 = 6_364_136_223_846_793_005;
+/// Alphabet the `LIMIT` fixture's titles are drawn from: one token per
+/// title under the default analyzer, and dense enough that Parquet's
+/// compression cannot shrink the file under the split threshold.
+const TITLE_ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
 
 fn build_delete_wal(target_id: i128, wal_id_value: i128) -> WalStateDoc {
     WalStateDoc {
@@ -208,6 +226,114 @@ async fn sql_query_excludes_tombstoned_row() {
         })
         .collect();
     assert_eq!(titles, vec!["bb", "dd"]);
+}
+
+/// `n` distinct pseudo-random titles of [`LIMIT_FIXTURE_TITLE_LEN`]
+/// characters, reproducible from `seed`.
+fn pseudo_random_titles(n: usize, seed: u64) -> Vec<String> {
+    let mut state = seed;
+    (0..n)
+        .map(|_| {
+            (0..LIMIT_FIXTURE_TITLE_LEN)
+                .map(|_| {
+                    state = state.wrapping_mul(TITLE_LCG_MULT).wrapping_add(1);
+                    TITLE_ALPHABET[(state >> 33) as usize % TITLE_ALPHABET.len()] as char
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// The `title` values of `batches`, in order.
+fn title_values(batches: &[RecordBatch]) -> Vec<String> {
+    batches
+        .iter()
+        .flat_map(|b| {
+            let col = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("title column");
+            (0..col.len()).map(move |i| col.value(i).to_owned())
+        })
+        .collect()
+}
+
+/// The physical plan DataFusion prints for `sql` (EXPLAIN's columns are
+/// plain `Utf8`, not the `LargeUtf8` user columns come back as).
+fn physical_plan(st: &Supertable, sql: &str) -> String {
+    let batches = st
+        .reader()
+        .expect("reader")
+        .query_sql(&format!("EXPLAIN {sql}"))
+        .expect("explain");
+    for batch in &batches {
+        let kinds = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("plan_type column");
+        let plans = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("plan column");
+        for i in 0..kinds.len() {
+            if kinds.value(i) == "physical_plan" {
+                return plans.value(i).to_owned();
+            }
+        }
+    }
+    panic!("no physical plan in EXPLAIN output");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sql_limit_under_a_row_filter_keeps_deleted_rows_out() {
+    // A predicate the index cannot bound (`_id > 0`) runs as a Parquet row
+    // filter with the `FilterExec` folded into the scan, so nothing above
+    // the scan would hold a `LIMIT`'s fetch — and a scan-level limit lets
+    // the Parquet opener's limit pruning replace the tombstone row
+    // selection with whole row groups the predicate's statistics prove
+    // fully matching, handing back deleted rows. The provider's meter
+    // refuses the fetch, a limit node stays above the scan, and the
+    // deleted first row stays out of the first three.
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+    let st = Supertable::create(default_supertable_options().with_storage(Arc::clone(&storage)))
+        .expect("create");
+
+    let titles = pseudo_random_titles(LIMIT_FIXTURE_ROWS, 7);
+    let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+    let mut w = st.writer().expect("writer");
+    w.append(&build_title_batch(&refs)).expect("append");
+    w.commit().expect("commit");
+    drop(w);
+
+    let deleted = titles[0].as_str();
+    let stats = st.delete(col("title").eq(lit(deleted))).expect("delete");
+    assert_eq!(stats.n_tombstoned(), 1);
+
+    let sql = format!("SELECT title FROM supertable WHERE _id > 0 LIMIT {LIMIT_FIXTURE_FETCH}");
+    let got = title_values(&st.reader().expect("reader").query_sql(&sql).expect("sql"));
+    assert_eq!(got.len(), LIMIT_FIXTURE_FETCH);
+    assert!(
+        !got.iter().any(|t| t == deleted),
+        "the deleted row came back under LIMIT: {got:?}"
+    );
+
+    // The shape that makes the check above load-bearing: byte-range
+    // partitions (no repartition node between the limit and the scan), the
+    // filter folded into the scan as a row filter, and the fetch held
+    // above the scan rather than inside it.
+    let plan = physical_plan(&st, &sql);
+    assert!(!plan.contains("RepartitionExec"), "{plan}");
+    assert!(!plan.contains("FilterExec"), "{plan}");
+    let scan = plan
+        .lines()
+        .find(|l| l.contains("DataSourceExec"))
+        .expect("a DataSourceExec in the physical plan");
+    assert!(!scan.contains("limit="), "{scan}");
 }
 
 // Deleting the row nearest a query must not shrink an unfiltered result


### PR DESCRIPTION
Fixes #705 , fixes #706.

**Commit 1 — attach the row-filter predicate once.** On the unbounded scan path the provider set its own copy of the predicate on the `ParquetSource` and enabled row filters; DataFusion's filter pushdown then conjoined the `FilterExec`'s identical predicate onto it, so the Parquet row filter evaluated `p AND p` — a second pass of `p` over every row the first kept. The provider now only enables row filters there and lets DataFusion supply the predicate once; the hand-built predicate and its helper are gone. Row filters stay off for filter-less scans (an empty filter list also lowers to `Unbounded`), so DataFusion's dynamic TopK/join/aggregate filters keep their pruning-only role there, as on `main`. Test: `query_sql_row_filter_carries_the_predicate_once` — EXPLAIN of `WHERE category = 'y'` shows one predicate with no self-conjunction and no `FilterExec`, the rows come back exactly, and the bounded control keeps its `FilterExec`.

**Commit 2 — keep a `LIMIT` out of a filtered scan's access plans.** Pre-existing: with the `FilterExec` folded into the scan, `LimitPushdown` embedded the fetch in the scan and the Parquet opener's limit pruning replaced the tombstone row selection with whole "fully matching" row groups, returning deleted rows. The meter around a filtered scan now refuses the fetch, so DataFusion keeps its limit node above the scan. Test: `sql_limit_under_a_row_filter_keeps_deleted_rows_out` — a superfile past the 10 MiB byte-range split threshold, first row deleted, `WHERE _id > 0 LIMIT 3` excludes it; the plan shape that makes the check load-bearing is asserted; verified to fail without the guard.

Bench: the CI Benchmark checks on this PR are the comparison against `main`. Commit 1 should move the dense scalar scans in `supertable_sql` (`AVG(rating) WHERE category=?`, `SUM(rating) bucket IN (all)`) down; commit 2 touches only `LIMIT` queries with a `WHERE`, where the limit node now sits above the scan instead of inside it. No format, manifest or public-API change.