### PR TITLE
fts: per-column stored flag; analyzer folded onto FtsConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.5.15"
+version = "0.6.0"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.5.15"
+version = "0.6.0"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -51,7 +51,6 @@ use infino::{
         vector::{distance::Metric, rerank_codec::RerankCodec},
     },
     supertable::{Supertable, SupertableOptions},
-    test_helpers::default_tokenizer,
 };
 use tempfile::TempDir;
 
@@ -241,11 +240,7 @@ fn build_batch(start: usize, n: usize) -> RecordBatch {
 fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOptions {
     SupertableOptions::new(
         concurrent_schema(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig {
             column: VEC_COLUMN.into(),
             dim: VEC_DIM,
@@ -254,7 +249,6 @@ fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOpti
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        Some(default_tokenizer()),
     )
     .expect("SupertableOptions with FTS + vector")
     .with_storage(storage)

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -244,6 +244,7 @@ fn build_supertable_options(storage: Arc<dyn StorageProvider>) -> SupertableOpti
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig {
             column: VEC_COLUMN.into(),

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -2486,11 +2486,7 @@ pub fn build_superfile(docs: &[String], vectors: &[f32]) -> Vec<u8> {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![SfVectorConfig {
             provided_centroids: None,
             column: "emb".into(),
@@ -2499,7 +2495,6 @@ pub fn build_superfile(docs: &[String], vectors: &[f32]) -> Vec<u8> {
             metric: Metric::Cosine,
             rerank_codec: bench_rerank_codec(Metric::Cosine),
         }],
-        Some(default_tokenizer()),
     );
 
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
@@ -2529,11 +2524,7 @@ pub fn build_superfile_with_metric(docs: &[String], vectors: &[f32], metric: Met
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![SfVectorConfig {
             provided_centroids: None,
             column: "emb".into(),
@@ -2542,7 +2533,6 @@ pub fn build_superfile_with_metric(docs: &[String], vectors: &[f32], metric: Met
             metric,
             rerank_codec: bench_rerank_codec(metric),
         }],
-        Some(default_tokenizer()),
     );
 
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -2489,6 +2489,7 @@ pub fn build_superfile(docs: &[String], vectors: &[f32]) -> Vec<u8> {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![SfVectorConfig {
             provided_centroids: None,
@@ -2531,6 +2532,7 @@ pub fn build_superfile_with_metric(docs: &[String], vectors: &[f32], metric: Met
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![SfVectorConfig {
             provided_centroids: None,

--- a/benches/utils/diag_common.rs
+++ b/benches/utils/diag_common.rs
@@ -124,6 +124,7 @@ pub fn diag_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: true,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/benches/utils/diag_common.rs
+++ b/benches/utils/diag_common.rs
@@ -24,7 +24,6 @@ use infino::{
     OptimizeOptions,
     superfile::builder::FtsConfig,
     supertable::{OptimizeError, Supertable, SupertableOptions},
-    test_helpers::default_tokenizer,
 };
 use rayon::ThreadPoolBuilder;
 
@@ -121,13 +120,8 @@ pub fn diag_schema() -> Arc<Schema> {
 pub fn diag_options() -> SupertableOptions {
     SupertableOptions::new(
         diag_schema(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: true,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title").positions(true)],
         vec![],
-        Some(default_tokenizer()),
     )
     .expect("diag supertable options")
 }

--- a/benches/utils/harness/infino_engine.rs
+++ b/benches/utils/harness/infino_engine.rs
@@ -14,13 +14,10 @@ use std::sync::Arc;
 use arrow_array::{Decimal128Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
-use infino::{
-    superfile::{
-        SuperfileReader,
-        builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
-        fts::reader::BoolMode as InfinoBoolMode,
-    },
-    test_helpers::default_tokenizer,
+use infino::superfile::{
+    SuperfileReader,
+    builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
+    fts::reader::BoolMode as InfinoBoolMode,
 };
 use rayon::prelude::*;
 
@@ -49,13 +46,8 @@ fn build_superfile(column: &str, docs: &[(u64, &str)], positions: bool) -> Vec<u
     let opts = BuilderOptions::new(
         schema.clone(),
         ID_COLUMN,
-        vec![FtsConfig {
-            column: column.to_string(),
-            positions,
-            stored: true,
-        }],
+        vec![FtsConfig::new(column.to_string()).positions(positions)],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut builder = SuperfileBuilder::new(opts).expect("SuperfileBuilder::new");
     for chunk in docs.chunks(WRITE_CHUNK) {

--- a/benches/utils/harness/infino_engine.rs
+++ b/benches/utils/harness/infino_engine.rs
@@ -52,6 +52,7 @@ fn build_superfile(column: &str, docs: &[(u64, &str)], positions: bool) -> Vec<u
         vec![FtsConfig {
             column: column.to_string(),
             positions,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/benches/utils/harness/infino_sql_engine.rs
+++ b/benches/utils/harness/infino_sql_engine.rs
@@ -125,18 +125,22 @@ pub fn sql_options() -> SupertableOptions {
             FtsConfig {
                 column: TITLE_COLUMN.into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: BUCKET_COLUMN.into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: KEY_COLUMN.into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: CATEGORY_COLUMN.into(),
                 positions: false,
+                stored: true,
             },
         ],
         vec![VectorConfig {
@@ -298,6 +302,7 @@ fn spec_options(spec: &SqlCorpusSpec) -> SupertableOptions {
         .map(|column| FtsConfig {
             column: column.clone(),
             positions: false,
+            stored: true,
         })
         .collect();
     let vectors = spec

--- a/benches/utils/harness/infino_sql_engine.rs
+++ b/benches/utils/harness/infino_sql_engine.rs
@@ -24,7 +24,6 @@ use infino::{
         vector::distance::Metric,
     },
     supertable::{Supertable, SupertableOptions},
-    test_helpers::default_tokenizer,
 };
 use rayon::prelude::*;
 
@@ -122,26 +121,10 @@ pub fn sql_options() -> SupertableOptions {
     SupertableOptions::new(
         schema(),
         vec![
-            FtsConfig {
-                column: TITLE_COLUMN.into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: BUCKET_COLUMN.into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: KEY_COLUMN.into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: CATEGORY_COLUMN.into(),
-                positions: false,
-                stored: true,
-            },
+            FtsConfig::new(TITLE_COLUMN),
+            FtsConfig::new(BUCKET_COLUMN),
+            FtsConfig::new(KEY_COLUMN),
+            FtsConfig::new(CATEGORY_COLUMN),
         ],
         vec![VectorConfig {
             provided_centroids: None,
@@ -151,7 +134,6 @@ pub fn sql_options() -> SupertableOptions {
             metric: Metric::Cosine,
             rerank_codec: corpus::bench_rerank_codec(Metric::Cosine),
         }],
-        Some(default_tokenizer()),
     )
     .expect("supertable sql options")
 }
@@ -299,11 +281,7 @@ fn spec_options(spec: &SqlCorpusSpec) -> SupertableOptions {
     let fts = spec
         .fts_columns
         .iter()
-        .map(|column| FtsConfig {
-            column: column.clone(),
-            positions: false,
-            stored: true,
-        })
+        .map(|column| FtsConfig::new(column.clone()))
         .collect();
     let vectors = spec
         .vector
@@ -317,13 +295,8 @@ fn spec_options(spec: &SqlCorpusSpec) -> SupertableOptions {
             rerank_codec: corpus::bench_rerank_codec(v.metric),
         })
         .collect();
-    SupertableOptions::new(
-        Arc::clone(&spec.schema),
-        fts,
-        vectors,
-        Some(default_tokenizer()),
-    )
-    .expect("invariant: schema-driven supertable options are well-formed")
+    SupertableOptions::new(Arc::clone(&spec.schema), fts, vectors)
+        .expect("invariant: schema-driven supertable options are well-formed")
 }
 
 /// Appends every batch to `table` and commits once — the write-side tail

--- a/benches/utils/harness/infino_vector_engine.rs
+++ b/benches/utils/harness/infino_vector_engine.rs
@@ -79,7 +79,6 @@ fn build_superfile_with_ids(
             metric,
             rerank_codec: corpus::bench_rerank_codec(metric),
         }],
-        None,
     );
     let mut builder = SuperfileBuilder::new(opts).expect("SuperfileBuilder::new");
     let mut offset = 0;

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -312,6 +312,7 @@ pub fn options_for(
         fts.push(FtsConfig {
             column: TEXT_COLUMN.into(),
             positions: true,
+            stored: true,
         });
     }
     if modality.has_vector_filter_bucket() {
@@ -320,6 +321,7 @@ pub fn options_for(
         fts.push(FtsConfig {
             column: VECTOR_FILTER_COLUMN.into(),
             positions: false,
+            stored: true,
         });
     }
     let vector = if modality.has_vector() {

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -14,11 +14,9 @@ use infino::{
     config::OptimizeOptions,
     superfile::{
         builder::{FtsConfig, VectorConfig},
-        fts::tokenize::Tokenizer,
         vector::distance::Metric,
     },
     supertable::{LocalFsStorageProvider, Supertable, SupertableOptions, storage::StorageProvider},
-    test_helpers::default_tokenizer,
 };
 use tempfile::TempDir;
 
@@ -306,23 +304,14 @@ pub fn options_for(
             .build()
             .expect("pool"),
     );
-    let tk: Arc<dyn Tokenizer> = default_tokenizer();
     let mut fts = Vec::new();
     if modality.has_fts() {
-        fts.push(FtsConfig {
-            column: TEXT_COLUMN.into(),
-            positions: true,
-            stored: true,
-        });
+        fts.push(FtsConfig::new(TEXT_COLUMN).positions(true));
     }
     if modality.has_vector_filter_bucket() {
         // Single token per row, equality-only predicates — positions buy
         // nothing and would triple the (tiny) index.
-        fts.push(FtsConfig {
-            column: VECTOR_FILTER_COLUMN.into(),
-            positions: false,
-            stored: true,
-        });
+        fts.push(FtsConfig::new(VECTOR_FILTER_COLUMN));
     }
     let vector = if modality.has_vector() {
         vec![VectorConfig {
@@ -336,7 +325,7 @@ pub fn options_for(
     } else {
         vec![]
     };
-    let mut opts = SupertableOptions::new(schema_for(modality), fts, vector, Some(tk))
+    let mut opts = SupertableOptions::new(schema_for(modality), fts, vector)
         .expect("opts")
         .with_reader_pool(pool.clone())
         .with_commit_threshold_size_mb(COMMIT_THRESHOLD_SIZE_MB)

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -112,7 +112,6 @@ use infino::{
         reader_cache::DiskCacheStore,
         storage::{S3StorageProvider, StorageProvider},
     },
-    test_helpers::default_tokenizer,
 };
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
@@ -235,11 +234,7 @@ fn build_superfile_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         ID_COLUMN,
-        vec![FtsConfig {
-            column: FTS_COLUMN.into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new(FTS_COLUMN)],
         vec![VectorConfig {
             provided_centroids: None,
             column: VEC_COLUMN.into(),
@@ -248,7 +243,6 @@ fn build_superfile_bytes() -> Bytes {
             metric: Metric::Cosine,
             rerank_codec: corpus::bench_rerank_codec(Metric::Cosine),
         }],
-        Some(default_tokenizer()),
     );
     let mut builder = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -1865,11 +1859,7 @@ pub(crate) mod diag {
         ]));
         SupertableOptions::new(
             schema,
-            vec![FtsConfig {
-                column: FTS_COLUMN.into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new(FTS_COLUMN)],
             vec![VectorConfig {
                 provided_centroids: None,
                 column: VEC_COLUMN.into(),
@@ -1878,7 +1868,6 @@ pub(crate) mod diag {
                 metric: Metric::Cosine,
                 rerank_codec: corpus::bench_rerank_codec(Metric::Cosine),
             }],
-            Some(default_tokenizer()),
         )
         .expect("real S3 supertable options")
     }

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -238,6 +238,7 @@ fn build_superfile_bytes() -> Bytes {
         vec![FtsConfig {
             column: FTS_COLUMN.into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig {
             provided_centroids: None,
@@ -1867,6 +1868,7 @@ pub(crate) mod diag {
             vec![FtsConfig {
                 column: FTS_COLUMN.into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 provided_centroids: None,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -84,6 +84,7 @@ fn demo_superfile() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig::new(
             "emb".into(),

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -30,9 +30,7 @@ use infino::{
         vector::distance::{Metric, normalize},
     },
     supertable::Supertable,
-    test_helpers::{
-        build_title_batch, decimal128_ids, default_supertable_options, default_tokenizer,
-    },
+    test_helpers::{build_title_batch, decimal128_ids, default_supertable_options},
 };
 use tempfile::NamedTempFile;
 
@@ -81,18 +79,13 @@ fn demo_superfile() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig::new(
             "emb".into(),
             EMB_DIM,
             DEMO_ROT_SEED,
             Metric::Cosine,
         )],
-        Some(default_tokenizer()),
     );
 
     let mut builder = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.5.15"
+version = "0.6.0"
 dependencies = [
  "apache-avro",
  "arc-swap",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "infino-node"
-version = "0.5.10"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-node/Cargo.toml
+++ b/infino-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-node"
-version = "0.5.10"
+version = "0.6.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.5.10",
+  "version": "0.6.0",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.5.10",
-    "infx-darwin-arm64": "0.5.10",
-    "infx-linux-x64-gnu": "0.5.10",
-    "infx-linux-arm64-gnu": "0.5.10",
-    "infx-linux-x64-musl": "0.5.10",
-    "infx-linux-arm64-musl": "0.5.10"
+    "infx-darwin-x64": "0.6.0",
+    "infx-darwin-arm64": "0.6.0",
+    "infx-linux-x64-gnu": "0.6.0",
+    "infx-linux-arm64-gnu": "0.6.0",
+    "infx-linux-x64-musl": "0.6.0",
+    "infx-linux-arm64-musl": "0.6.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -519,9 +519,25 @@ pub struct VectorFilter {
 #[napi]
 #[derive(Clone, Default)]
 pub struct IndexSpec {
-    fts: Vec<String>,
+    /// `(column, analyzer, stored)`; `analyzer` `None` means the default.
+    fts: Vec<(String, Option<String>, bool)>,
     /// `(column, dim, metric)`.
     vectors: Vec<(String, u32, String)>,
+}
+
+/// Per-column FTS options for `IndexSpec.fts`.
+#[napi(object)]
+#[derive(Clone, Default)]
+pub struct FtsOptions {
+    /// Tokenizer: `"ascii_lower"` (default — ASCII split + lowercase,
+    /// non-ASCII dropped) or `"standard"` (the Unicode-aware UAX #29
+    /// tokenizer that keeps non-ASCII text).
+    pub analyzer: Option<String>,
+    /// Keep the raw text in the table (default true). `false` makes the
+    /// column index-only: searchable, but the text is never stored, so
+    /// it cannot be selected, projected, or filtered on (append/update
+    /// batches still carry it).
+    pub stored: Option<bool>,
 }
 
 #[napi]
@@ -531,11 +547,14 @@ impl IndexSpec {
         Self::default()
     }
 
-    /// Mark `column` (a UTF-8 string column) as full-text indexed.
+    /// Mark `column` (a UTF-8 string column) as full-text indexed,
+    /// with optional per-column `options` (analyzer, stored).
     #[napi]
-    pub fn fts(&self, column: String) -> Self {
+    pub fn fts(&self, column: String, options: Option<FtsOptions>) -> Self {
         let mut next = self.clone();
-        next.fts.push(column);
+        let opts = options.unwrap_or_default();
+        next.fts
+            .push((column, opts.analyzer, opts.stored.unwrap_or(true)));
         next
     }
 
@@ -554,8 +573,12 @@ impl IndexSpec {
     /// Lower to the core `IndexSpec` builder.
     fn to_rust(&self) -> Result<infino::IndexSpec> {
         let mut spec = infino::IndexSpec::new();
-        for column in &self.fts {
-            spec = spec.fts(column.clone());
+        for (column, analyzer, stored) in &self.fts {
+            let mut field = infino::FtsField::new(column.clone()).stored(*stored);
+            if let Some(a) = analyzer {
+                field = field.analyzer(a.clone());
+            }
+            spec = spec.fts(field);
         }
         for (column, dim, metric) in &self.vectors {
             spec = spec.vector(column.clone(), *dim as usize, metric_from_str(metric)?);

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.5.15"
+version = "0.6.0"
 dependencies = [
  "apache-avro",
  "arc-swap",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "infino-python"
-version = "0.5.10"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-python"
-version = "0.5.10"
+version = "0.6.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -220,8 +220,8 @@ fn connect(
 #[pyclass(name = "IndexSpec", skip_from_py_object)]
 #[derive(Clone, Default)]
 struct IndexSpec {
-    /// `(column, analyzer)`; `analyzer` `None` means the default.
-    fts: Vec<(String, Option<String>)>,
+    /// `(column, analyzer, stored)`; `analyzer` `None` means the default.
+    fts: Vec<(String, Option<String>, bool)>,
     /// `(column, dim, metric)`.
     vectors: Vec<(String, usize, String)>,
 }
@@ -237,10 +237,13 @@ impl IndexSpec {
     /// `analyzer` selects the tokenizer: `"ascii_lower"` (default —
     /// ASCII split + lowercase, non-ASCII dropped) or `"standard"` (the
     /// Unicode-aware UAX #29 tokenizer that keeps non-ASCII text).
-    #[pyo3(signature = (column, analyzer = None))]
-    fn fts(&self, column: String, analyzer: Option<String>) -> Self {
+    /// `stored=False` makes the column index-only: searchable, but the
+    /// raw text is never kept in the table, so it cannot be selected,
+    /// projected, or filtered on (append/update batches still carry it).
+    #[pyo3(signature = (column, analyzer = None, stored = true))]
+    fn fts(&self, column: String, analyzer: Option<String>, stored: bool) -> Self {
         let mut next = self.clone();
-        next.fts.push((column, analyzer));
+        next.fts.push((column, analyzer, stored));
         next
     }
 
@@ -258,11 +261,12 @@ impl IndexSpec {
     /// Lower to the core `IndexSpec` builder.
     fn to_rust(&self) -> PyResult<infino::IndexSpec> {
         let mut spec = infino::IndexSpec::new();
-        for (column, analyzer) in &self.fts {
-            spec = match analyzer {
-                Some(a) => spec.fts_with_analyzer(column.clone(), a.clone()),
-                None => spec.fts(column.clone()),
-            };
+        for (column, analyzer, stored) in &self.fts {
+            let mut field = infino::FtsField::new(column.clone()).stored(*stored);
+            if let Some(a) = analyzer {
+                field = field.analyzer(a.clone());
+            }
+            spec = spec.fts(field);
         }
         for (column, dim, metric) in &self.vectors {
             spec = spec.vector(column.clone(), *dim, metric_from_str(metric)?);

--- a/public-api.txt
+++ b/public-api.txt
@@ -276,6 +276,26 @@ impl core::marker::Unpin for infino::Connection
 impl core::marker::UnsafeUnpin for infino::Connection
 impl !core::panic::unwind_safe::RefUnwindSafe for infino::Connection
 impl !core::panic::unwind_safe::UnwindSafe for infino::Connection
+pub struct infino::FtsField
+impl infino::FtsField
+pub fn infino::FtsField::analyzer(self, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn infino::FtsField::new(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn infino::FtsField::stored(self, bool) -> Self
+impl core::clone::Clone for infino::FtsField
+pub fn infino::FtsField::clone(&self) -> infino::FtsField
+impl core::convert::From<&str> for infino::FtsField
+pub fn infino::FtsField::from(&str) -> Self
+impl core::convert::From<alloc::string::String> for infino::FtsField
+pub fn infino::FtsField::from(alloc::string::String) -> Self
+impl core::fmt::Debug for infino::FtsField
+pub fn infino::FtsField::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for infino::FtsField
+impl core::marker::Send for infino::FtsField
+impl core::marker::Sync for infino::FtsField
+impl core::marker::Unpin for infino::FtsField
+impl core::marker::UnsafeUnpin for infino::FtsField
+impl core::panic::unwind_safe::RefUnwindSafe for infino::FtsField
+impl core::panic::unwind_safe::UnwindSafe for infino::FtsField
 pub struct infino::GcReport
 pub infino::GcReport::bytes_freed: u64
 pub infino::GcReport::delete_errors: u64
@@ -318,8 +338,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for infino::GcSettings
 impl core::panic::unwind_safe::UnwindSafe for infino::GcSettings
 pub struct infino::IndexSpec
 impl infino::IndexSpec
-pub fn infino::IndexSpec::fts(self, impl core::convert::Into<alloc::string::String>) -> Self
-pub fn infino::IndexSpec::fts_with_analyzer(self, impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn infino::IndexSpec::fts(self, impl core::convert::Into<infino::FtsField>) -> Self
 pub fn infino::IndexSpec::new() -> Self
 pub fn infino::IndexSpec::vector(self, impl core::convert::Into<alloc::string::String>, usize, infino::Metric) -> Self
 impl core::clone::Clone for infino::IndexSpec

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -175,17 +175,15 @@ impl IndexSpec {
 
     /// Lower to the internal `(FtsConfig, VectorConfig)` lists the
     /// supertable options take. `rot_seed` / `rerank_codec` are not part
-    /// of the public spec — defaults are applied here. The analyzer
-    /// choice rides on the options' shared tokenizer (resolved by
-    /// `table_tokenizer`), not on `FtsConfig`.
+    /// of the public spec — defaults are applied here.
     pub(crate) fn to_configs(&self) -> (Vec<FtsConfig>, Vec<VectorConfig>) {
         let fts = self
             .fts
             .iter()
-            .map(|f| FtsConfig {
-                column: f.column.clone(),
-                positions: false,
-                stored: f.stored,
+            .map(|f| {
+                FtsConfig::new(f.column.clone())
+                    .analyzer(f.analyzer.clone())
+                    .stored(f.stored)
             })
             .collect();
         let vectors = self

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -24,12 +24,73 @@ struct VectorIndex {
     metric: Metric,
 }
 
-/// A full-text index declaration: the column and the analyzer
-/// (tokenizer) name applied to it.
+/// One full-text (BM25) indexed column, with its per-column options.
+///
+/// Passed to [`IndexSpec::fts`]. A plain column name converts with all
+/// defaults (`ascii_lower` analyzer, stored text), so the common case
+/// stays `.fts("body")`; build a `FtsField` to change an option:
+///
+/// ```
+/// use infino::{FtsField, IndexSpec};
+/// let spec = IndexSpec::new()
+///     .fts("title")
+///     .fts(FtsField::new("body").analyzer("standard").stored(false));
+/// # let _ = spec;
+/// ```
 #[derive(Debug, Clone)]
-struct FtsIndex {
+pub struct FtsField {
     column: String,
     analyzer: String,
+    stored: bool,
+}
+
+impl FtsField {
+    /// Declare `column` as full-text indexed with the defaults: the
+    /// `ascii_lower` analyzer (ASCII split + lowercase, non-ASCII
+    /// dropped) and the raw text stored. The column must be a UTF-8
+    /// string column in the table schema.
+    pub fn new(column: impl Into<String>) -> Self {
+        Self {
+            column: column.into(),
+            analyzer: ASCII_LOWER_TOKENIZER.to_string(),
+            stored: true,
+        }
+    }
+
+    /// Pick the column's analyzer by name (`"ascii_lower"` or
+    /// `"standard"` — the Unicode-aware UAX #29 tokenizer that keeps
+    /// non-ASCII text). The analyzer is per column: each FTS column is
+    /// tokenized with its own, so columns in one table may use
+    /// different analyzers.
+    pub fn analyzer(mut self, name: impl Into<String>) -> Self {
+        self.analyzer = name.into();
+        self
+    }
+
+    /// Keep the raw text in the table (the default). Pass `false` for
+    /// an index-only column: the text is searchable (BM25, token and
+    /// phrase matching) but never stored, so it cannot be read back —
+    /// not in SQL results, not in a search projection, not in
+    /// predicates. `append` and `update` batches still carry the
+    /// column (the text has to arrive to be indexed); it is dropped at
+    /// write time. The trade is storage: large text that is only ever
+    /// searched skips the stored copy entirely.
+    pub fn stored(mut self, stored: bool) -> Self {
+        self.stored = stored;
+        self
+    }
+}
+
+impl From<&str> for FtsField {
+    fn from(column: &str) -> Self {
+        Self::new(column)
+    }
+}
+
+impl From<String> for FtsField {
+    fn from(column: String) -> Self {
+        Self::new(column)
+    }
 }
 
 /// Declares the search indexes to build over a table's columns.
@@ -47,7 +108,7 @@ struct FtsIndex {
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct IndexSpec {
-    fts: Vec<FtsIndex>,
+    fts: Vec<FtsField>,
     vectors: Vec<VectorIndex>,
 }
 
@@ -57,29 +118,19 @@ impl IndexSpec {
         Self::default()
     }
 
-    /// Mark `column` as full-text (BM25) indexed with the default
-    /// `ascii_lower` analyzer (ASCII split + lowercase, non-ASCII
-    /// dropped). The column must be a UTF-8 string column in the schema.
-    /// Use [`fts_with_analyzer`](Self::fts_with_analyzer) to pick a
-    /// different analyzer.
-    pub fn fts(self, column: impl Into<String>) -> Self {
-        self.fts_with_analyzer(column, ASCII_LOWER_TOKENIZER)
-    }
-
-    /// Mark `column` as full-text (BM25) indexed with a named analyzer
-    /// (`"ascii_lower"` or `"standard"` — the Unicode-aware UAX #29
-    /// tokenizer that keeps non-ASCII text). The analyzer is per column:
-    /// each FTS column is tokenized with its own, so columns in one table
-    /// may use different analyzers.
-    pub fn fts_with_analyzer(
-        mut self,
-        column: impl Into<String>,
-        analyzer: impl Into<String>,
-    ) -> Self {
-        self.fts.push(FtsIndex {
-            column: column.into(),
-            analyzer: analyzer.into(),
-        });
+    /// Mark a column as full-text (BM25) indexed. Takes a plain column
+    /// name for the defaults, or an [`FtsField`] to set the analyzer
+    /// and whether the raw text is stored:
+    ///
+    /// ```
+    /// use infino::{FtsField, IndexSpec};
+    /// let spec = IndexSpec::new()
+    ///     .fts("title")
+    ///     .fts(FtsField::new("body").analyzer("standard").stored(false));
+    /// # let _ = spec;
+    /// ```
+    pub fn fts(mut self, field: impl Into<FtsField>) -> Self {
+        self.fts.push(field.into());
         self
     }
 
@@ -107,6 +158,12 @@ impl IndexSpec {
         self.fts.iter().map(|f| f.analyzer.clone()).collect()
     }
 
+    /// FTS stored flags, in declaration order (parallel to
+    /// [`fts_columns`](Self::fts_columns)).
+    pub(crate) fn fts_stored(&self) -> Vec<bool> {
+        self.fts.iter().map(|f| f.stored).collect()
+    }
+
     /// Vector index declarations as `(column, dim, metric)`, in declaration
     /// order. Used by the remote transport to serialize the spec.
     #[cfg(feature = "remote")]
@@ -128,6 +185,7 @@ impl IndexSpec {
             .map(|f| FtsConfig {
                 column: f.column.clone(),
                 positions: false,
+                stored: f.stored,
             })
             .collect();
         let vectors = self

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -59,6 +59,12 @@ pub(crate) struct TableEntry {
     /// `ascii_lower` on reopen.
     #[serde(default)]
     pub(crate) fts_analyzers: Vec<String>,
+    /// FTS stored flags, parallel to `fts` (`false` = index-only, the
+    /// raw text is not kept in the table). Absent in catalogs written
+    /// before index-only columns existed; a missing or short entry
+    /// defaults to stored on reopen.
+    #[serde(default)]
+    pub(crate) fts_stored: Vec<bool>,
     /// Vector-indexed columns.
     pub(crate) vectors: Vec<VectorEntry>,
     /// Creation time, seconds since the Unix epoch.
@@ -174,6 +180,7 @@ mod tests {
             schema_ipc: schema_to_ipc(&sample_schema()).expect("ipc"),
             fts: vec!["title".into()],
             fts_analyzers: vec!["ascii_lower".into()],
+            fts_stored: vec![true],
             vectors: vec![VectorEntry {
                 column: "emb".into(),
                 dim: 8,
@@ -181,6 +188,20 @@ mod tests {
             }],
             created_at_unix: 0,
         }
+    }
+
+    /// A catalog entry written before `fts_stored` existed (the key is
+    /// absent from its JSON) deserializes to an empty vec — which the
+    /// open path reads as "every FTS column stored". Pins the serde
+    /// default, so old catalogs keep opening.
+    #[test]
+    fn table_entry_without_fts_stored_defaults_to_all_stored() {
+        let mut v = serde_json::to_value(sample_table_entry()).expect("encode");
+        let obj = v.as_object_mut().expect("object");
+        obj.remove("fts_stored");
+        assert!(!obj.contains_key("fts_stored"));
+        let entry: TableEntry = serde_json::from_value(v).expect("legacy entry decodes");
+        assert!(entry.fts_stored.is_empty(), "missing key ⇒ empty ⇒ stored");
     }
 
     // ---- read_catalog --------------------------------------------------

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -36,7 +36,7 @@ use arrow_schema::SchemaRef;
 use dashmap::DashMap;
 use datafusion::{config::Dialect, error::DataFusionError, execution::context::SQLOptions};
 use futures::future::try_join_all;
-pub use index_spec::IndexSpec;
+pub use index_spec::{FtsField, IndexSpec};
 use manifest::{
     TableEntry, VectorEntry, commit_catalog, read_catalog, schema_from_ipc, schema_to_ipc,
 };
@@ -411,6 +411,7 @@ impl Connection {
                         .map_err(|e| e.with_context("create_table", Some(name)))?,
                     fts: indexes.fts_columns(),
                     fts_analyzers: indexes.fts_analyzers(),
+                    fts_stored: indexes.fts_stored(),
                     vectors,
                     created_at_unix: now_unix(),
                 };
@@ -544,7 +545,15 @@ impl Connection {
                         .get(i)
                         .map(String::as_str)
                         .unwrap_or(ASCII_LOWER_TOKENIZER);
-                    spec = spec.fts_with_analyzer(column.clone(), analyzer);
+                    // Same back-compat rule for `fts_stored`: a catalog
+                    // written before index-only columns existed can only
+                    // mean the text is stored.
+                    let stored = entry.fts_stored.get(i).copied().unwrap_or(true);
+                    spec = spec.fts(
+                        FtsField::new(column.clone())
+                            .analyzer(analyzer)
+                            .stored(stored),
+                    );
                 }
                 for v in &entry.vectors {
                     spec = spec.vector(
@@ -1303,7 +1312,7 @@ mod tests {
             .create_table(
                 "std",
                 schema_id_title(),
-                IndexSpec::new().fts_with_analyzer("title", "standard"),
+                IndexSpec::new().fts(FtsField::new("title").analyzer("standard")),
             )
             .expect("create standard table");
         std_tbl
@@ -1323,7 +1332,7 @@ mod tests {
             .create_table(
                 "bad",
                 schema_id_title(),
-                IndexSpec::new().fts_with_analyzer("title", "nonesuch"),
+                IndexSpec::new().fts(FtsField::new("title").analyzer("nonesuch")),
             )
             .expect_err("unknown analyzer must be rejected");
         assert!(matches!(err, InfinoError::Config(_)), "got: {err:?}");
@@ -1361,8 +1370,8 @@ mod tests {
                 "docs",
                 schema.clone(),
                 IndexSpec::new()
-                    .fts_with_analyzer("title", "standard")
-                    .fts_with_analyzer("body", "ascii_lower"),
+                    .fts(FtsField::new("title").analyzer("standard"))
+                    .fts(FtsField::new("body").analyzer("ascii_lower")),
             )
             .expect("create_table");
         table
@@ -1409,8 +1418,8 @@ mod tests {
                     "docs",
                     schema.clone(),
                     IndexSpec::new()
-                        .fts_with_analyzer("title", "standard")
-                        .fts_with_analyzer("body", "ascii_lower"),
+                        .fts(FtsField::new("title").analyzer("standard"))
+                        .fts(FtsField::new("body").analyzer("ascii_lower")),
                 )
                 .expect("create_table");
             table
@@ -1439,6 +1448,85 @@ mod tests {
         assert_eq!(
             body_cafe, 0,
             "ascii_lower column still drops non-ASCII after reopen"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// An index-only column (`FtsField::stored(false)`) survives a
+    /// storage-backed reopen: the catalog records the flag, `open_table`
+    /// reconstructs it, and the reopened table both searches the column
+    /// and keeps rejecting it as a projection target.
+    #[test]
+    fn index_only_column_survives_reopen() {
+        let dir = std::env::temp_dir().join(format!("infino-idxonly-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let uri = format!("file://{}", dir.display());
+        let schema = schema_title_body();
+        {
+            let conn = connect(&uri).expect("connect");
+            let table = conn
+                .create_table(
+                    "docs",
+                    schema.clone(),
+                    IndexSpec::new()
+                        .fts("title")
+                        .fts(FtsField::new("body").stored(false)),
+                )
+                .expect("create_table");
+            table
+                .append(&title_body_batch(
+                    schema.clone(),
+                    "stored title",
+                    "hidden signal text",
+                ))
+                .expect("append");
+        }
+        let conn2 = connect(&uri).expect("reconnect");
+        let table = conn2.open_table("docs").expect("open_table");
+        // schema() keeps the ingest contract, index-only column included.
+        assert_eq!(
+            table
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect::<Vec<_>>(),
+            vec!["title", "body"],
+        );
+        // Searchable after reopen…
+        let hits = table
+            .bm25_search("body", "signal", TOP_K, Bm25SearchOptions::new(), None)
+            .expect("index-only search after reopen");
+        assert_eq!(n_rows(&hits), 1);
+        // …and still not readable: projecting it fails with a clean,
+        // caller-level error.
+        let err = table
+            .bm25_search(
+                "body",
+                "signal",
+                TOP_K,
+                Bm25SearchOptions::new(),
+                Some(&["_id", "body", "score"]),
+            )
+            .expect_err("index-only column must not be projectable after reopen");
+        let msg = err.to_string();
+        assert!(msg.contains("body"), "error names the column: {msg}");
+        assert!(!msg.contains("DataFusion"), "no engine internals: {msg}");
+        // Appends still require the column (it is part of the write
+        // contract even though it is never stored).
+        let title_only = Arc::new(Schema::new(vec![Field::new(
+            "title",
+            DataType::LargeUtf8,
+            false,
+        )]));
+        let short = RecordBatch::try_new(
+            title_only,
+            vec![Arc::new(LargeStringArray::from(vec!["no body"]))],
+        )
+        .expect("batch");
+        assert!(
+            table.append(&short).is_err(),
+            "append without the index-only column must be rejected"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -64,7 +64,7 @@ use crate::{
     },
     superfile::{
         builder::FtsConfig,
-        fts::tokenize::{ASCII_LOWER_TOKENIZER, Tokenizer, tokenizer_for_name},
+        fts::tokenize::ASCII_LOWER_TOKENIZER,
         vector::{builder::VectorConfig, distance::Metric},
     },
     supertable::{
@@ -347,8 +347,6 @@ impl Connection {
         validate_name(name).map_err(|e| e.with_context("create_table", Some(name)))?;
         validate_schema(&schema).map_err(|e| e.with_context("create_table", Some(name)))?;
         let (fts_cfg, vec_cfg) = indexes.to_configs();
-        let tokenizers =
-            table_tokenizers(&indexes).map_err(|e| e.with_context("create_table", Some(name)))?;
 
         match &self.inner.store {
             CatalogStore::Memory(map) => {
@@ -356,7 +354,6 @@ impl Connection {
                     schema,
                     fts_cfg,
                     vec_cfg,
-                    tokenizers,
                     None,
                     Arc::clone(&self.inner.connection_memory_budget),
                 )
@@ -434,7 +431,6 @@ impl Connection {
                     schema,
                     fts_cfg,
                     vec_cfg,
-                    tokenizers,
                     Some(table_storage),
                     Arc::clone(&self.inner.connection_memory_budget),
                 )
@@ -564,8 +560,6 @@ impl Connection {
                     );
                 }
                 let (fts_cfg, vec_cfg) = spec.to_configs();
-                let tokenizers = table_tokenizers(&spec)
-                    .map_err(|e| e.with_context("open_table", Some(name)))?;
 
                 let table_storage = backend_to_provider(
                     &self.inner.backend.join(&entry.location),
@@ -584,7 +578,6 @@ impl Connection {
                     schema,
                     fts_cfg,
                     vec_cfg,
-                    tokenizers,
                     Some(table_storage),
                     Arc::clone(&self.inner.connection_memory_budget),
                 )
@@ -970,16 +963,10 @@ fn build_options(
     schema: SchemaRef,
     fts: Vec<FtsConfig>,
     vectors: Vec<VectorConfig>,
-    tokenizers: Vec<Arc<dyn Tokenizer>>,
     storage: Option<Arc<dyn StorageProvider>>,
     connection_memory_budget: Arc<ConnectionMemoryBudget>,
 ) -> Result<SupertableOptions, InfinoError> {
-    // Seed the default tokenizer with the first column's analyzer (None
-    // when there are no FTS columns), then set the authoritative
-    // per-column tokenizers for per-field analysis.
-    let seed = tokenizers.first().cloned();
-    let mut opts =
-        SupertableOptions::new(schema, fts, vectors, seed)?.with_fts_tokenizers(tokenizers);
+    let mut opts = SupertableOptions::new(schema, fts, vectors)?;
     if let Some(s) = storage {
         opts = opts.with_storage(s);
     }
@@ -995,20 +982,6 @@ fn sql_exec_error(e: DataFusionError) -> InfinoError {
         DataFusionError::ResourcesExhausted(msg) => InfinoError::OverBudget(msg),
         other => InfinoError::Query(other.to_string()),
     }
-}
-
-/// Resolve each FTS column's analyzer name to a tokenizer instance,
-/// in declaration order (per-field analysis). Empty when there are no
-/// FTS columns. An unknown analyzer name is a configuration error.
-fn table_tokenizers(indexes: &IndexSpec) -> Result<Vec<Arc<dyn Tokenizer>>, InfinoError> {
-    indexes
-        .fts_analyzers()
-        .iter()
-        .map(|name| {
-            tokenizer_for_name(name)
-                .ok_or_else(|| InfinoError::Config(format!("unknown FTS analyzer: {name:?}")))
-        })
-        .collect()
 }
 
 /// Construct the storage provider for `backend` (None for `memory://`).

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -46,11 +46,11 @@ pub(crate) fn metric_str(metric: Metric) -> &'static str {
 /// `{fts: [entry, …], vector: [{column, dim, metric}, …]}`. Absent index kinds
 /// are omitted (the server treats a missing key as "none").
 ///
-/// Each FTS entry is a bare column name when it uses the default `ascii_lower`
-/// analyzer, or a `{column, analyzer}` object when it names a different one, so
-/// the chosen analyzer reaches the server rather than being dropped. The bare
-/// form for the default keeps the request identical to what older servers
-/// expect.
+/// Each FTS entry is a bare column name when every option is at its default
+/// (`ascii_lower` analyzer, stored text), or a `{column, …}` object carrying
+/// only the non-default options (`analyzer`, `stored: false`), so the chosen
+/// options reach the server rather than being dropped. The bare form for the
+/// defaults keeps the request identical to what older servers expect.
 pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
     let mut indexes = serde_json::Map::new();
     let columns = spec.fts_columns();
@@ -58,12 +58,20 @@ pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
         let fts: Vec<Value> = columns
             .iter()
             .zip(spec.fts_analyzers())
-            .map(|(column, analyzer)| {
-                if analyzer == ASCII_LOWER_TOKENIZER {
-                    json!(column)
-                } else {
-                    json!({ "column": column, "analyzer": analyzer })
+            .zip(spec.fts_stored())
+            .map(|((column, analyzer), stored)| {
+                if analyzer == ASCII_LOWER_TOKENIZER && stored {
+                    return json!(column);
                 }
+                let mut entry = serde_json::Map::new();
+                entry.insert("column".to_string(), json!(column));
+                if analyzer != ASCII_LOWER_TOKENIZER {
+                    entry.insert("analyzer".to_string(), json!(analyzer));
+                }
+                if !stored {
+                    entry.insert("stored".to_string(), json!(false));
+                }
+                Value::Object(entry)
             })
             .collect();
         indexes.insert("fts".to_string(), Value::Array(fts));
@@ -166,6 +174,7 @@ mod tests {
     use arrow_schema::{DataType, Field, FieldRef, Fields, Schema};
 
     use super::*;
+    use crate::FtsField;
 
     #[test]
     fn index_spec_json_shape() {
@@ -188,7 +197,7 @@ mod tests {
         // columns that need the object form pay for it.
         let spec = IndexSpec::new()
             .fts("title")
-            .fts_with_analyzer("body", "standard");
+            .fts(FtsField::new("body").analyzer("standard"));
         let json = index_spec_to_json(&spec);
         assert_eq!(
             json["fts"],
@@ -201,7 +210,7 @@ mod tests {
         // An explicit ascii_lower is the default, so it serializes identically to
         // a bare column name — no needless object form, and byte-identical to
         // what an older server expects.
-        let spec = IndexSpec::new().fts_with_analyzer("body", "ascii_lower");
+        let spec = IndexSpec::new().fts(FtsField::new("body").analyzer("ascii_lower"));
         assert_eq!(index_spec_to_json(&spec)["fts"], json!(["body"]));
     }
 

--- a/src/catalog/search_tvf.rs
+++ b/src/catalog/search_tvf.rs
@@ -107,7 +107,10 @@ impl TableResolver {
         reader.op_stats = self.op_stats.clone();
         let resolved = ResolvedTable {
             reader: Arc::new(reader),
-            scalar_schema: table.options().scalar_schema(),
+            // Stored shape: search TVF output columns resolve against
+            // what Parquet actually holds (index-only FTS columns are
+            // not projectable).
+            scalar_schema: table.options().stored_schema(),
         };
         self.cache
             .lock()

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -199,7 +199,13 @@ impl Supertable {
         Self { inner }
     }
 
-    /// The table's Arrow schema.
+    /// The table's Arrow schema — the shape `append` and `update`
+    /// batches must match.
+    ///
+    /// An FTS column declared with `stored(false)` appears here (its
+    /// text must arrive in every batch to be indexed) but is
+    /// write+search-only: it cannot be selected via SQL, named in a
+    /// search projection, or used in a predicate.
     pub fn schema(&self) -> SchemaRef {
         self.inner.schema()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -211,6 +211,12 @@ impl From<SupertableBuildError> for InfinoError {
         if matches!(e, SupertableBuildError::TableGone) {
             return InfinoError::NotFound(e.to_string());
         }
+        // A bad analyzer name is a configuration mistake, not a schema
+        // shape problem — surface it as the same class a bad connect
+        // option gets.
+        if matches!(e, SupertableBuildError::UnknownAnalyzer { .. }) {
+            return InfinoError::Config(e.to_string());
+        }
         InfinoError::Schema(e.to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,9 @@ pub use arrow_schema;
 pub use catalog::Supertable;
 /// Catalog entry points and handle: open a `Connection`, then create /
 /// open / drop / list tables.
-pub use catalog::{ColdFetchMode, ConnectOptions, Connection, IndexSpec, connect, connect_with};
+pub use catalog::{
+    ColdFetchMode, ConnectOptions, Connection, FtsField, IndexSpec, connect, connect_with,
+};
 pub use config::{CompactionSettings, GcSettings, OptimizeOptions};
 /// The single public error type for the curated API.
 pub use error::InfinoError;

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -73,14 +73,13 @@ use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fmt,
     io::{BufReader, BufWriter, Cursor, Error, Seek, SeekFrom, Write},
-    mem,
     str::from_utf8,
     sync::Arc,
 };
 
 use arrow::compute::{concat_batches, take};
 use arrow_array::{Array, ArrayRef, Decimal128Array, LargeStringArray, RecordBatch, UInt32Array};
-use arrow_schema::{DataType, Schema};
+use arrow_schema::{DataType, Field, Schema};
 use parquet::basic::{Compression, ZstdLevel};
 use roaring::RoaringBitmap;
 use tempfile::{NamedTempFile, tempfile};
@@ -130,6 +129,19 @@ pub struct FtsConfig {
     /// opt-in. Columns without positions answer phrase queries with a
     /// typed error, never a silent bag-of-words fallback.
     pub positions: bool,
+    /// Keep the raw text in the Parquet body (the default). When
+    /// `false` the column is index-only: it is tokenized into the FTS
+    /// blob but never written to Parquet, so it cannot be read back —
+    /// not via SQL, not via a search projection, not in predicates.
+    /// The trade is file size: large text corpora that are only ever
+    /// searched skip the raw-text copy entirely.
+    ///
+    /// At ingest the column must still be present in the builder
+    /// schema (the text has to arrive to be indexed); the builder
+    /// drops it from the Parquet-bound rows. When rebuilding from an
+    /// existing superfile the column is legitimately absent from the
+    /// stored schema and its postings are carried across instead.
+    pub stored: bool,
 }
 
 // `VectorConfig` (the per-column vector config used by
@@ -359,6 +371,7 @@ impl BuilderOptions {
                             FtsConfig {
                                 column: c.name.clone(),
                                 positions: c.positions,
+                                stored: c.stored,
                             },
                             Arc::clone(&c.tokenizer),
                         )
@@ -504,8 +517,22 @@ impl fmt::Debug for SuperfileBuilder {
 pub struct SuperfileBuilder {
     opts: BuilderOptions,
     /// Cached column indices for FTS columns, parallel to `opts.fts_columns`.
-    fts_col_idxs: Vec<usize>,
-    /// Accumulated input batches. Drained at `finish()`.
+    /// `None` for an unstored column absent from `opts.schema` — the
+    /// merge-source shape, where the column's postings arrive prebuilt
+    /// (see [`Self::carry_fts_from_reader`]) instead of being tokenized
+    /// from a batch.
+    fts_col_idxs: Vec<Option<usize>>,
+    /// The Parquet-bound shape: `opts.schema` minus unstored FTS
+    /// columns. `opts.schema` stays the ingest contract (an unstored
+    /// column's text must arrive to be indexed); this is what the body
+    /// encoder writes and what readers see as the stored schema.
+    parquet_schema: Arc<Schema>,
+    /// Indices of the `opts.schema` fields kept in the Parquet body;
+    /// `None` when every ingest column is stored (batches are pushed
+    /// as-is, no projection).
+    parquet_projection: Option<Vec<usize>>,
+    /// Accumulated input batches, already projected to
+    /// `parquet_schema`. Drained at `finish()`.
     batches: Vec<RecordBatch>,
     /// FtsBuilder accumulating tokens across every `add_batch`.
     /// `None` if `opts.fts_columns` is empty.
@@ -545,13 +572,23 @@ impl SuperfileBuilder {
             ));
         }
 
-        // 2. Each FTS column must exist and be LargeUtf8.
+        // 2. Each FTS column present in the schema must be LargeUtf8. A
+        //    stored column must be present (its text both feeds the index
+        //    and ships in Parquet). An unstored column may be absent —
+        //    that's the merge-source shape, where the stored schema never
+        //    had it and its postings are carried across prebuilt; when it
+        //    IS present (ingest shape) it's tokenized and then dropped
+        //    from the Parquet-bound rows.
         let mut fts_col_idxs = Vec::with_capacity(opts.fts_columns.len());
         for fc in &opts.fts_columns {
-            let idx = opts
-                .schema
-                .index_of(&fc.column)
-                .map_err(|_| BuildError::FtsColumnMissing(fc.column.clone()))?;
+            let idx = match opts.schema.index_of(&fc.column) {
+                Ok(idx) => idx,
+                Err(_) if !fc.stored => {
+                    fts_col_idxs.push(None);
+                    continue;
+                }
+                Err(_) => return Err(BuildError::FtsColumnMissing(fc.column.clone())),
+            };
             let f = opts.schema.field(idx);
             if f.data_type() != &DataType::LargeUtf8 {
                 return Err(BuildError::FtsColumnMustBeLargeUtf8 {
@@ -559,8 +596,30 @@ impl SuperfileBuilder {
                     actual: format!("{:?}", f.data_type()),
                 });
             }
-            fts_col_idxs.push(idx);
+            fts_col_idxs.push(Some(idx));
         }
+
+        // The Parquet body keeps every ingest column except unstored FTS
+        // columns; those exist only in the FTS blob.
+        let dropped: HashSet<usize> = opts
+            .fts_columns
+            .iter()
+            .zip(&fts_col_idxs)
+            .filter(|(fc, _)| !fc.stored)
+            .filter_map(|(_, idx)| *idx)
+            .collect();
+        let (parquet_schema, parquet_projection) = if dropped.is_empty() {
+            (Arc::clone(&opts.schema), None)
+        } else {
+            let kept: Vec<usize> = (0..opts.schema.fields().len())
+                .filter(|i| !dropped.contains(i))
+                .collect();
+            let fields: Vec<Arc<Field>> = kept
+                .iter()
+                .map(|&i| Arc::clone(&opts.schema.fields()[i]))
+                .collect();
+            (Arc::new(Schema::new(fields)), Some(kept))
+        };
 
         // 3. No reserved separator / prefix / duplication across the
         //    combined logical-name namespace (FTS + vector + any
@@ -641,6 +700,8 @@ impl SuperfileBuilder {
         Ok(Self {
             opts,
             fts_col_idxs,
+            parquet_schema,
+            parquet_projection,
             batches: Vec::new(),
             fts_builder,
             vec_builder,
@@ -669,6 +730,21 @@ impl SuperfileBuilder {
     /// buffer for `opts.vector_columns[i]`, length
     /// `batch.num_rows() * vector_columns[i].dim`.
     pub fn add_batch(&mut self, batch: &RecordBatch, vectors: &[&[f32]]) -> Result<(), BuildError> {
+        self.add_batch_inner(batch, vectors, true)
+    }
+
+    /// [`add_batch`](Self::add_batch) body with the FTS feed selectable:
+    /// ingest tokenizes the batch's text columns (`index_fts` true); the
+    /// reader-merge path feeds prebuilt postings out of band instead
+    /// ([`carry_fts_from_reader`](Self::carry_fts_from_reader)) and skips
+    /// tokenization here, so a merge never re-tokenizes — and never
+    /// silently under-indexes a column whose text isn't in the batch.
+    fn add_batch_inner(
+        &mut self,
+        batch: &RecordBatch,
+        vectors: &[&[f32]],
+        index_fts: bool,
+    ) -> Result<(), BuildError> {
         if batch.schema().fields() != self.opts.schema.fields() {
             return Err(BuildError::BatchSchemaMismatch {
                 batch: batch.schema().to_string(),
@@ -696,7 +772,9 @@ impl SuperfileBuilder {
         }
 
         // Route FTS columns. Pull each column's LargeStringArray once.
-        self.index_fts_batch(batch, n_rows)?;
+        if index_fts {
+            self.index_fts_batch(batch, n_rows)?;
+        }
 
         // Route vectors.
         if let Some(vb) = self.vec_builder.as_mut() {
@@ -718,12 +796,17 @@ impl SuperfileBuilder {
         }
 
         self.next_local_doc_id += n_rows;
-        self.batches.push(batch.clone());
+        self.push_parquet_batch(batch);
         Ok(())
     }
 
     /// Append a scalar-only batch (ids without vector payloads). Used when the
-    /// vector blob is supplied separately via a prebuilt IVF subsection.
+    /// vector blob is supplied separately via a prebuilt IVF subsection. The
+    /// FTS blob is likewise supplied out of band: merge callers carry each
+    /// input's prebuilt postings across ([`Self::carry_fts_from_reader`] /
+    /// [`Self::carry_fts_postings_with_remap`]) — this method never
+    /// tokenizes, so feeding it rows without also carrying their postings
+    /// under-indexes the file.
     pub(crate) fn add_batch_ids_only(&mut self, batch: &RecordBatch) -> Result<(), BuildError> {
         if batch.schema().fields() != self.opts.schema.fields() {
             return Err(BuildError::BatchSchemaMismatch {
@@ -731,15 +814,24 @@ impl SuperfileBuilder {
                 builder: self.opts.schema.to_string(),
             });
         }
-        // Sq8 / multi-cell merge paths supply the vector blob out of band, but
-        // any FTS columns still need to be indexed from the scalar batch —
-        // otherwise `finish` emits an empty FTS blob against a non-empty
-        // Parquet body (silent query corruption).
         let n_rows = batch.num_rows() as u32;
-        self.index_fts_batch(batch, n_rows)?;
         self.next_local_doc_id += n_rows;
-        self.batches.push(batch.clone());
+        self.push_parquet_batch(batch);
         Ok(())
+    }
+
+    /// Push a validated ingest batch onto the Parquet-bound accumulator,
+    /// projected down to `parquet_schema` (drops unstored FTS columns).
+    /// Identity-shape builders push the batch as-is — an `Arc` bump per
+    /// column, no copy.
+    fn push_parquet_batch(&mut self, batch: &RecordBatch) {
+        let stored = match &self.parquet_projection {
+            Some(kept) => batch
+                .project(kept)
+                .expect("projection indices are derived from the validated schema"),
+            None => batch.clone(),
+        };
+        self.batches.push(stored);
     }
 
     /// Index FTS text columns from `batch` starting at `self.next_local_doc_id`.
@@ -748,7 +840,12 @@ impl SuperfileBuilder {
         let Some(fb) = self.fts_builder.as_mut() else {
             return Ok(());
         };
-        for (col_id, &schema_idx) in self.fts_col_idxs.iter().enumerate() {
+        for (col_id, idx) in self.fts_col_idxs.iter().enumerate() {
+            // An unstored column absent from the schema (merge-source
+            // shape) has no text here; its postings arrive prebuilt.
+            let Some(schema_idx) = *idx else {
+                continue;
+            };
             let arr = batch.column(schema_idx);
             let strs = arr
                 .as_any()
@@ -763,6 +860,127 @@ impl SuperfileBuilder {
                 };
                 fb.add_doc(col_id as u32, local_doc_id, text)?;
             }
+        }
+        Ok(())
+    }
+
+    /// Carry one input superfile's already-built FTS postings into this
+    /// builder — the merge-path counterpart of [`Self::index_fts_batch`],
+    /// used by every reader merge so a merge never re-tokenizes (and an
+    /// unstored column, whose text isn't in Parquet at all, still merges
+    /// losslessly). Surviving input docs are remapped densely onto
+    /// `self.next_local_doc_id..`, matching the row order the caller
+    /// appends to the Parquet body; call this BEFORE the append advances
+    /// `next_local_doc_id`. Doc-lengths are carried from the input's
+    /// stored lengths, never recomputed.
+    fn carry_fts_from_reader(
+        &mut self,
+        reader: &SuperfileReader,
+        deleted: Option<&RoaringBitmap>,
+    ) -> Result<(), BuildError> {
+        let Some(fts) = reader.fts() else {
+            return Ok(());
+        };
+        if self.fts_builder.is_none() {
+            return Ok(());
+        }
+        // Map each input-local doc id to its output doc id. Survivors get
+        // dense ids `base + rank`; deleted docs map to `None`. `rank` walks
+        // local ids in order skipping tombstones, so it ends at the
+        // surviving row count — the same count and order as the caller's
+        // Parquet-bound batch.
+        let n_local = fts.n_docs();
+        let base = self.next_local_doc_id;
+        let mut remap: Vec<Option<u32>> = vec![None; n_local as usize];
+        let mut rank: u32 = 0;
+        for d in 0..n_local {
+            let is_deleted = deleted.is_some_and(|b| b.contains(d));
+            if !is_deleted {
+                remap[d as usize] = Some(base + rank);
+                rank += 1;
+            }
+        }
+        self.carry_fts_postings_with_remap(reader, &remap)?;
+
+        // Dense remap preserves input order, so the surviving lengths
+        // append in output order.
+        let n_fts_columns = self.opts.fts_columns.len() as u32;
+        for column_id in 0..n_fts_columns {
+            let dls = fts.read_doc_lengths(column_id).map_err(|e| {
+                BuildError::Io(Error::other(format!(
+                    "fts merge column {column_id}: read doc-lengths failed: {e}"
+                )))
+            })?;
+            let kept: Vec<u32> = dls
+                .iter()
+                .enumerate()
+                .filter(|(d, _)| remap[*d].is_some())
+                .map(|(_, &len)| len)
+                .collect();
+            self.fts_builder
+                .as_mut()
+                .expect("checked Some above")
+                .append_prebuilt_doc_lengths(column_id, &kept);
+        }
+        Ok(())
+    }
+
+    /// Stream one input's prebuilt postings into this builder's FTS
+    /// accumulator with input-local doc ids remapped through `remap`
+    /// (`None` = dropped row). Doc-lengths are NOT handled here — a
+    /// non-monotonic remap (the multi-cell merge's stable-id reorder)
+    /// must scatter them into output order itself, and must also force
+    /// the spilled accumulator first
+    /// ([`Self::set_fts_spill_threshold_bytes`] to 0): the spilled
+    /// finish sorts triples by `(term, doc)`, so feed order doesn't
+    /// matter there, while the in-RAM accumulator preserves insertion
+    /// order and requires per-term ascending doc ids.
+    fn carry_fts_postings_with_remap(
+        &mut self,
+        reader: &SuperfileReader,
+        remap: &[Option<u32>],
+    ) -> Result<(), BuildError> {
+        let Some(fts) = reader.fts() else {
+            return Ok(());
+        };
+        let n_fts_columns = self.opts.fts_columns.len() as u32;
+        for column_id in 0..n_fts_columns {
+            let fb = self
+                .fts_builder
+                .as_mut()
+                .ok_or(BuildError::BatchReadError)?;
+            // `for_each_term_posting` surfaces read errors as `FtsError`;
+            // a builder push error is a `BuildError`, so capture it out of
+            // band and re-raise after the walk (the sentinel `FtsError`
+            // only stops iteration).
+            let mut push_err: Option<BuildError> = None;
+            let walk = fts.for_each_term_posting(column_id, |term, local_doc, tf, positions| {
+                let Some(out_doc) = remap[local_doc as usize] else {
+                    return Ok(());
+                };
+                let term_str = from_utf8(term).map_err(|_| {
+                    FtsError::Read(ReadError::MalformedVersion(
+                        "non-utf8 term in FTS merge input".into(),
+                    ))
+                })?;
+                if let Err(e) =
+                    fb.add_prebuilt_term_posting(column_id, term_str, out_doc, tf, positions)
+                {
+                    push_err = Some(e);
+                    return Err(FtsError::Read(ReadError::MalformedVersion(
+                        "prebuilt push aborted".into(),
+                    )));
+                }
+                Ok(())
+            });
+            if let Some(e) = push_err {
+                return Err(e);
+            }
+            walk.map_err(|e| {
+                BuildError::Io(Error::other(format!(
+                    "fts merge column {column_id}: posting walk failed: {e}"
+                )))
+            })?;
         }
         Ok(())
     }
@@ -884,6 +1102,10 @@ impl SuperfileBuilder {
             let v = reader.vec().ok_or(BuildError::VectorReadError)?;
             merge_inputs.push((v, column.clone(), local_base));
 
+            // FTS rides out of band like the vector blob: carry the input's
+            // prebuilt postings (aligned with the surviving rows the batch
+            // holds) before the append advances the doc-id counter.
+            superfile_builder.carry_fts_from_reader(reader, deleted.as_deref())?;
             superfile_builder.add_batch_ids_only(&record_batch)?;
             local_base += record_batch.num_rows() as u32;
         }
@@ -1139,6 +1361,83 @@ impl SuperfileBuilder {
             return Ok(SuperfileStats::from_children(&[]));
         }
 
+        // Carry FTS postings across in the packed output order. Unlike the
+        // concatenating merges, output rows follow `all_stable_ids`
+        // (cell-directory order), so the remap is stable-id → output
+        // position and the per-input doc ids arrive OUT of order. The
+        // spilled FTS accumulator sorts triples by `(term, doc)` at finish,
+        // so force it on before feeding; the in-RAM accumulator preserves
+        // insertion order and would mis-sort the posting lists.
+        if superfile_builder.fts_builder.is_some() {
+            // 1 byte = the minimum allowed budget: the first push crosses
+            // it, so effectively the whole feed runs in spill mode.
+            superfile_builder.set_fts_spill_threshold_bytes(1);
+            let n_out = all_stable_ids.len();
+            // Claim map: each output row's postings come from exactly one
+            // input copy. A superseded parent cell and its drained
+            // replacement can both carry a stable id; whichever input
+            // claims it first feeds the (identical) row, the other maps to
+            // `None` — mirroring the single row the reordered scalar batch
+            // keeps.
+            let mut pos_of_id: HashMap<i128, u32> = HashMap::with_capacity(n_out);
+            for (pos, &sid) in all_stable_ids.iter().enumerate() {
+                pos_of_id.insert(sid, pos as u32);
+            }
+            let id_idx = scalar_schema
+                .index_of(&id_column)
+                .map_err(|_| BuildError::MissingIdColumn(id_column.clone()))?;
+            let n_fts_columns = superfile_builder.opts.fts_columns.len();
+            let mut out_lengths: Vec<Vec<u32>> = vec![vec![0; n_out]; n_fts_columns];
+            for (idx, (reader, deleted)) in readers.iter().enumerate() {
+                let Some(fts) = reader.fts() else {
+                    continue;
+                };
+                let ids = scalar_batches[idx]
+                    .column(id_idx)
+                    .as_any()
+                    .downcast_ref::<Decimal128Array>()
+                    .ok_or_else(|| BuildError::MissingIdColumn(id_column.clone()))?;
+                // Walk input-local doc ids; survivors line up with the
+                // tombstone-filtered batch rows (`rank`). A survivor whose
+                // stable id was already claimed (or whose cell was
+                // superseded out of the pack) maps to `None`.
+                let n_local = fts.n_docs();
+                let mut remap: Vec<Option<u32>> = vec![None; n_local as usize];
+                let mut rank: usize = 0;
+                for d in 0..n_local {
+                    let is_deleted = deleted.as_ref().is_some_and(|b| b.contains(d));
+                    if is_deleted {
+                        continue;
+                    }
+                    let sid = ids.value(rank);
+                    rank += 1;
+                    if let Some(pos) = pos_of_id.remove(&sid) {
+                        remap[d as usize] = Some(pos);
+                    }
+                }
+                for (col, lengths) in out_lengths.iter_mut().enumerate() {
+                    let dls = fts.read_doc_lengths(col as u32).map_err(|e| {
+                        BuildError::Io(Error::other(format!(
+                            "multi-cell merge input {idx} column {col}: read doc-lengths failed: {e}"
+                        )))
+                    })?;
+                    for (d, &len) in dls.iter().enumerate() {
+                        if let Some(pos) = remap[d] {
+                            lengths[pos as usize] = len;
+                        }
+                    }
+                }
+                superfile_builder.carry_fts_postings_with_remap(reader, &remap)?;
+            }
+            for (col, lengths) in out_lengths.iter().enumerate() {
+                superfile_builder
+                    .fts_builder
+                    .as_mut()
+                    .expect("checked Some above")
+                    .append_prebuilt_doc_lengths(col as u32, lengths);
+            }
+        }
+
         // Parquet rows must follow the same cell-directory order as the packed
         // IVF subsections. Hidden index files are `_id`-only; user MultiCell
         // files carry the full scalar schema (title, …) and must be reordered
@@ -1255,7 +1554,13 @@ impl SuperfileBuilder {
         }
 
         let slices: Vec<&[f32]> = vectors.iter().map(|row| row.as_slice()).collect();
-        self.add_batch(&record_batch, &slices)?;
+        // Carry the input's prebuilt postings across (before the append
+        // advances `next_local_doc_id`) instead of re-tokenizing its rows:
+        // the merge is cheaper, byte-faithful to the input's index, and an
+        // unstored column — whose text isn't in the batch at all — still
+        // merges losslessly.
+        self.carry_fts_from_reader(reader, deleted_docs_bitmap.as_deref())?;
+        self.add_batch_inner(&record_batch, &slices, false)?;
         Ok(superfile_stats)
     }
 
@@ -1321,9 +1626,6 @@ impl SuperfileBuilder {
     ) -> Result<SuperfileStats, BuildError> {
         let first = readers.first().ok_or(BuildError::BatchReadError)?;
         let builder_opts = BuilderOptions::new_from_reader(&first.0);
-        // FTS column ids run `0..n` in schema-declaration order, matching the
-        // reader's column order.
-        let n_fts_columns = builder_opts.fts_columns.len() as u32;
         let mut superfile_builder = SuperfileBuilder::new(builder_opts)?;
 
         // Encode the Parquet body incrementally: each input's surviving rows are
@@ -1336,17 +1638,14 @@ impl SuperfileBuilder {
                 superfile_builder.opts.id_page_size_limit,
             )];
             ParquetBodyEncoder::new(
-                &superfile_builder.opts.schema,
+                &superfile_builder.parquet_schema,
                 superfile_builder.opts.compression,
                 superfile_builder.opts.row_group_size,
                 &id_page_limit,
             )?
         };
 
-        // Per-column doc-lengths, concatenated across inputs in output-doc order.
-        let mut merged_doc_lengths: Vec<Vec<u32>> = vec![Vec::new(); n_fts_columns as usize];
         let mut stats_collector = Vec::with_capacity(readers.len());
-        let mut base: u32 = 0;
         // Stream the stable-id sidecar from the merged rows as they are written
         // to the body, in the same order — so the compacted superfile resolves
         // `_id` from the sidecar just like a fresh build. `ids_ok` clears on the
@@ -1375,74 +1674,10 @@ impl SuperfileBuilder {
                 &record_batch,
             )?);
 
-            // Map each input-local doc id to its output doc id. Survivors get
-            // dense ids `base + rank`; deleted docs map to `None`. `rank` walks
-            // local ids in order skipping tombstones, so it ends at the surviving
-            // row count — the same count and order as `record_batch`.
-            let fts = reader.fts();
-            let n_local = fts.map(|f| f.n_docs()).unwrap_or(reader.n_docs() as u32);
-            let mut remap: Vec<Option<u32>> = vec![None; n_local as usize];
-            let mut rank: u32 = 0;
-            for d in 0..n_local {
-                let is_deleted = deleted.as_ref().is_some_and(|b| b.contains(d));
-                if !is_deleted {
-                    remap[d as usize] = Some(base + rank);
-                    rank += 1;
-                }
-            }
-
-            if let Some(fts) = fts {
-                for column_id in 0..n_fts_columns {
-                    let fb = superfile_builder
-                        .fts_builder
-                        .as_mut()
-                        .ok_or(BuildError::BatchReadError)?;
-                    // `for_each_term_posting` surfaces read errors as `FtsError`;
-                    // a builder push error is a `BuildError`, so capture it out of
-                    // band and re-raise after the walk (the sentinel `FtsError`
-                    // only stops iteration).
-                    let mut push_err: Option<BuildError> = None;
-                    let walk =
-                        fts.for_each_term_posting(column_id, |term, local_doc, tf, positions| {
-                            let Some(out_doc) = remap[local_doc as usize] else {
-                                return Ok(());
-                            };
-                            let term_str = from_utf8(term).map_err(|_| {
-                                FtsError::Read(ReadError::MalformedVersion(
-                                    "non-utf8 term in FTS merge input".into(),
-                                ))
-                            })?;
-                            if let Err(e) = fb.add_prebuilt_term_posting(
-                                column_id, term_str, out_doc, tf, positions,
-                            ) {
-                                push_err = Some(e);
-                                return Err(FtsError::Read(ReadError::MalformedVersion(
-                                    "prebuilt push aborted".into(),
-                                )));
-                            }
-                            Ok(())
-                        });
-                    if let Some(e) = push_err {
-                        return Err(e);
-                    }
-                    walk.map_err(|e| {
-                        BuildError::Io(Error::other(format!(
-                            "fts merge input {idx} column {column_id}: posting walk failed: {e}"
-                        )))
-                    })?;
-
-                    let dls = fts.read_doc_lengths(column_id).map_err(|e| {
-                        BuildError::Io(Error::other(format!(
-                            "fts merge input {idx} column {column_id}: read doc-lengths failed: {e}"
-                        )))
-                    })?;
-                    for (d, &len) in dls.iter().enumerate() {
-                        if remap[d].is_some() {
-                            merged_doc_lengths[column_id as usize].push(len);
-                        }
-                    }
-                }
-            }
+            // Carry the input's prebuilt postings + doc-lengths across,
+            // remapped densely onto the output rows this batch is about to
+            // append (so it must run before `next_local_doc_id` advances).
+            superfile_builder.carry_fts_from_reader(reader, deleted.as_deref())?;
 
             // Stream this input's surviving rows straight into the Parquet body
             // and drop the batch — the corpus is never accumulated in RAM. The
@@ -1460,16 +1695,6 @@ impl SuperfileBuilder {
             }
             drop(record_batch);
             superfile_builder.next_local_doc_id += n_rows;
-            base += n_rows;
-        }
-
-        if let Some(fb) = superfile_builder.fts_builder.as_mut() {
-            for column_id in 0..n_fts_columns {
-                fb.set_prebuilt_doc_lengths(
-                    column_id,
-                    mem::take(&mut merged_doc_lengths[column_id as usize]),
-                );
-            }
         }
 
         // Every input fully tombstoned → no rows: match `finish_to`'s
@@ -1558,7 +1783,7 @@ impl SuperfileBuilder {
         let id_page_limit = [(self.opts.id_column.as_str(), self.opts.id_page_size_limit)];
         let encode_body = || {
             encode_parquet_body(
-                &self.opts.schema,
+                &self.parquet_schema,
                 &self.batches,
                 self.opts.compression,
                 self.opts.row_group_size,
@@ -1692,7 +1917,7 @@ impl SuperfileBuilder {
         let kvs = superfile_kvs(&self.opts, n_docs, Some(&cell_ids))?;
         let id_page_limit = [(self.opts.id_column.as_str(), self.opts.id_page_size_limit)];
         let body = encode_parquet_body(
-            &self.opts.schema,
+            &self.parquet_schema,
             &self.batches,
             self.opts.compression,
             self.opts.row_group_size,
@@ -2023,6 +2248,12 @@ fn fts_columns_json(cols: &[FtsConfig], tokenizers: &[Arc<dyn Tokenizer>]) -> St
         if c.positions {
             s.push_str(r#","positions":true"#);
         }
+        // Same only-when-set rule, inverted default: a stored column's
+        // JSON stays byte-identical to files written before index-only
+        // columns existed (the reader defaults a missing field to true).
+        if !c.stored {
+            s.push_str(r#","stored":false"#);
+        }
         s.push('}');
     }
     s.push(']');
@@ -2130,6 +2361,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2192,6 +2424,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![],
                 Some(default_tokenizer()),
@@ -2213,6 +2446,7 @@ mod tests {
             vec![FtsConfig {
                 column: "nope".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2233,6 +2467,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2249,6 +2484,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![default_vector_config("title", 1)],
             Some(default_tokenizer()),
@@ -2291,6 +2527,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             None,
@@ -2445,10 +2682,12 @@ mod tests {
             FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             },
         ];
         let toks: Vec<Arc<dyn Tokenizer>> =
@@ -2473,10 +2712,12 @@ mod tests {
             FtsConfig {
                 column: "title".into(),
                 positions: true,
+                stored: true,
             },
             FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             },
         ];
         let toks: Vec<Arc<dyn Tokenizer>> =
@@ -2500,10 +2741,12 @@ mod tests {
             FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             },
         ];
         let toks: Vec<Arc<dyn Tokenizer>> =
@@ -2517,6 +2760,309 @@ mod tests {
             s.contains(r#"{"name":"body","tokenizer":"ascii_lower"}"#),
             "body uses ascii_lower: {s}"
         );
+    }
+
+    /// The stored field appears only on index-only columns, and a mixed
+    /// declaration keeps the stored column's entry in the legacy shape.
+    #[test]
+    fn fts_columns_json_stored_emitted_only_when_false() {
+        let cols = vec![
+            FtsConfig {
+                column: "title".into(),
+                positions: false,
+                stored: true,
+            },
+            FtsConfig {
+                column: "body".into(),
+                positions: false,
+                stored: false,
+            },
+        ];
+        let toks: Vec<Arc<dyn Tokenizer>> =
+            vec![Arc::new(AsciiLowerTokenizer), Arc::new(AsciiLowerTokenizer)];
+        let s = fts_columns_json(&cols, &toks);
+        assert!(
+            s.contains(r#"{"name":"title","tokenizer":"ascii_lower"}"#),
+            "stored column stays in the legacy shape: {s}"
+        );
+        assert!(
+            s.contains(r#"{"name":"body","tokenizer":"ascii_lower","stored":false}"#),
+            "index-only column carries the flag: {s}"
+        );
+    }
+
+    /// An index-only FTS column: dropped from the Parquet body, present
+    /// in the FTS blob, recovered as unstored by `new_from_reader`.
+    #[tokio::test]
+    async fn unstored_column_dropped_from_parquet_but_searchable() {
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![
+                FtsConfig {
+                    column: "title".into(),
+                    positions: false,
+                    stored: true,
+                },
+                FtsConfig {
+                    column: "body".into(),
+                    positions: false,
+                    stored: false,
+                },
+            ],
+            vec![],
+            Some(default_tokenizer()),
+        );
+        let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        let schema = b.opts.schema.clone();
+        let batch = batch_two_rows(&schema);
+        b.add_batch(&batch, &[]).expect("add_batch");
+        let bytes = b.finish().expect("finish builder");
+
+        let kv = read_kv_metadata(&bytes).expect("read kv metadata");
+        assert!(
+            kv.get("inf.fts.columns")
+                .expect("fts columns kv")
+                .contains(r#""stored":false"#),
+            "index-only flag persists in the KV metadata"
+        );
+
+        let reader = SuperfileReader::open(Bytes::from(bytes)).expect("open");
+        // The Parquet body kept the stored columns only.
+        let names: Vec<&str> = reader
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(names, vec!["doc_id", "title"]);
+        // Both columns search; the index-only one indexed the batch text.
+        let hits = reader
+            .bm25_hits_async("body", "baz", 10, BoolMode::Or)
+            .await
+            .expect("search body");
+        assert_eq!(hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(), vec![1]);
+        let hits = reader
+            .bm25_hits_async("title", "hello", 10, BoolMode::Or)
+            .await
+            .expect("search title");
+        assert_eq!(hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(), vec![0]);
+        // A rebuild sees the column as index-only, absent from the schema.
+        let rebuilt = BuilderOptions::new_from_reader(&reader);
+        assert_eq!(rebuilt.fts_columns.len(), 2);
+        assert!(rebuilt.fts_columns[0].stored);
+        assert!(!rebuilt.fts_columns[1].stored);
+        assert!(rebuilt.schema.index_of("body").is_err());
+        // And such a rebuild builder accepts the reader as a merge input.
+        let mut mb = SuperfileBuilder::new(rebuilt).expect("merge builder");
+        mb.add_batch_from_reader(&reader, None).expect("merge in");
+        let merged = mb.finish().expect("finish merge");
+        let merged = SuperfileReader::open(Bytes::from(merged)).expect("open merged");
+        let hits = merged
+            .bm25_hits_async("body", "foo", 10, BoolMode::Or)
+            .await
+            .expect("search merged body");
+        assert_eq!(hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(), vec![0]);
+    }
+
+    /// Multi-cell merge reorders rows by stable id (cell-directory
+    /// order); the FTS carry must remap postings and doc-lengths into
+    /// that order. Two packed inputs sharing a cell id interleave, so
+    /// the output order differs from both inputs' local orders.
+    #[tokio::test]
+    async fn multi_cell_merge_carries_fts_postings_through_reorder() {
+        // Cells: input A has cells 1 and 3, input B has cells 2 and 3 —
+        // cell 3 interleaves both inputs after the cell-id sort.
+        let a = pack_cells_superfile_with_body(1000, &[(1, 3, 2), (3, 2, 2)], false);
+        let b = pack_cells_superfile_with_body(2000, &[(2, 2, 2), (3, 3, 2)], false);
+        assert_multi_cell_merge_fts(&a, &b).await;
+    }
+
+    /// Same reorder coverage with the FTS column index-only: the merge
+    /// has no Parquet text to fall back to, so a carry bug would surface
+    /// as an empty (or mis-mapped) index.
+    #[tokio::test]
+    async fn multi_cell_merge_carries_unstored_fts_postings() {
+        let a = pack_cells_superfile_with_body(1000, &[(1, 3, 2), (3, 2, 2)], true);
+        let b = pack_cells_superfile_with_body(2000, &[(2, 2, 2), (3, 3, 2)], true);
+        assert_multi_cell_merge_fts(&a, &b).await;
+    }
+
+    /// Merge `a` + `b` and assert every doc's unique body token finds
+    /// exactly its own row (postings remapped correctly), the shared
+    /// token finds every row (doc set complete), and the phrase probe
+    /// respects positions carried through the reorder.
+    async fn assert_multi_cell_merge_fts(a: &Arc<SuperfileReader>, b: &Arc<SuperfileReader>) {
+        let (merged, _) = SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(
+            &[(Arc::clone(a), None), (Arc::clone(b), None)],
+            &[BTreeSet::new(), BTreeSet::new()],
+        )
+        .expect("multi-cell merge");
+        let merged = SuperfileReader::open(Bytes::from(merged)).expect("open merged");
+
+        // stable id per merged-local row, from the Parquet body.
+        let batch = merged.get_record_batch(None).expect("merged batch");
+        let ids = batch
+            .column(batch.schema().index_of("doc_id").expect("id col"))
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .expect("decimal ids")
+            .clone();
+        let stable_of_local: Vec<i128> = (0..ids.len()).map(|i| ids.value(i)).collect();
+        let n = stable_of_local.len();
+        assert_eq!(n, 10, "3+2 + 2+3 rows survive the merge");
+
+        // Every row's unique token resolves to exactly its own stable id.
+        for (local, &sid) in stable_of_local.iter().enumerate() {
+            let hits = merged
+                .bm25_hits_async("body", &format!("tok{sid}"), 16, BoolMode::Or)
+                .await
+                .expect("unique-token search");
+            assert_eq!(
+                hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(),
+                vec![local as u32],
+                "tok{sid} must land on merged-local row {local}"
+            );
+        }
+        // The shared token finds every row.
+        let hits = merged
+            .bm25_hits_async("body", "shared", 16, BoolMode::Or)
+            .await
+            .expect("shared-token search");
+        assert_eq!(hits.len(), n, "shared token spans the whole merged corpus");
+        // Phrase probe: "alpha beta" was written contiguously only for
+        // even stable ids; positions must survive the reorder.
+        let hits = merged
+            .bm25_hits_async("body", "\"alpha beta\"", 16, BoolMode::Or)
+            .await
+            .expect("phrase search");
+        let mut got: Vec<i128> = hits
+            .iter()
+            .map(|(d, _)| stable_of_local[*d as usize])
+            .collect();
+        got.sort_unstable();
+        let mut want: Vec<i128> = stable_of_local
+            .iter()
+            .copied()
+            .filter(|sid| sid % 2 == 0)
+            .collect();
+        want.sort_unstable();
+        assert_eq!(got, want, "phrase matches exactly the contiguous docs");
+        // Doc-lengths were scattered into merged order: every body is
+        // exactly 4 tokens, so any misplacement shows as a wrong length.
+        let dls = merged
+            .fts()
+            .expect("fts reader")
+            .read_doc_lengths(0)
+            .expect("doc lengths");
+        assert_eq!(dls, vec![4u32; n]);
+    }
+
+    /// `pack_cells_superfile_with_codec_dim` variant whose scalar schema
+    /// carries a positional FTS `body` column next to the id. Body text
+    /// per row: `tok<stable_id> shared` plus `alpha beta` (contiguous)
+    /// for even stable ids or `beta alpha` for odd ones — 4 tokens each.
+    fn pack_cells_superfile_with_body(
+        id_base: i128,
+        cells: &[(u32, usize, usize)],
+        unstored: bool,
+    ) -> Arc<SuperfileReader> {
+        use crate::superfile::vector::{
+            builder::build_merged_subsection_from_materialized,
+            cell_posting::{EncodedCellRow, MaterializedIvfRow},
+        };
+
+        const DIM: usize = 16;
+        let make_rows = |cell: u32, n: usize| -> Vec<MaterializedIvfRow> {
+            let (scale, offset): (Arc<[f32]>, Arc<[f32]>) =
+                (Arc::from(vec![1.0f32; DIM]), Arc::from(vec![0.0f32; DIM]));
+            (0..n)
+                .map(|i| {
+                    let local = i as u32;
+                    let stable_id = id_base + (cell as i128) * 100 + local as i128;
+                    let mut codes = vec![0u8; DIM];
+                    codes[0] = (cell as u8).wrapping_add(i as u8);
+                    MaterializedIvfRow {
+                        local_doc_id: local,
+                        stable_id,
+                        cluster: 0,
+                        rabitq_code: vec![0u8; DIM.div_ceil(8)],
+                        encoded: EncodedCellRow {
+                            stable_id,
+                            rerank_codec: RerankCodec::Sq8Residual,
+                            scale: Arc::clone(&scale),
+                            offset: Arc::clone(&offset),
+                            codes,
+                            residuals: vec![0u8; DIM],
+                            norm_sq: Some(1.0),
+                        },
+                    }
+                })
+                .collect()
+        };
+        let vec_cfg = VectorConfig {
+            column: "emb".into(),
+            dim: DIM,
+            rot_seed: 1,
+            metric: Metric::L2Sq,
+            rerank_codec: RerankCodec::Sq8Residual,
+            provided_centroids: None,
+        };
+        let mut ids: Vec<i128> = Vec::new();
+        let mut packed = Vec::with_capacity(cells.len());
+        for &(cell_id, n_rows, n_cent) in cells {
+            let rows = make_rows(cell_id, n_rows);
+            ids.extend(rows.iter().map(|r| r.stable_id));
+            let sub = build_merged_subsection_from_materialized(vec_cfg.clone(), n_cent, rows)
+                .expect("cell subsection");
+            packed.push((cell_id, sub));
+        }
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("body", DataType::LargeUtf8, false),
+        ]));
+        let bodies: Vec<String> = ids
+            .iter()
+            .map(|sid| {
+                if sid % 2 == 0 {
+                    format!("tok{sid} shared alpha beta")
+                } else {
+                    format!("tok{sid} shared beta alpha")
+                }
+            })
+            .collect();
+        let id_array = Decimal128Array::from_iter_values(ids.iter().copied())
+            .with_precision_and_scale(38, 0)
+            .expect("decimal");
+        let body_array = LargeStringArray::from(bodies);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(id_array) as Arc<dyn Array>,
+                Arc::new(body_array) as Arc<dyn Array>,
+            ],
+        )
+        .expect("batch");
+        let opts = BuilderOptions::new(
+            schema,
+            "doc_id",
+            vec![FtsConfig {
+                column: "body".into(),
+                positions: true,
+                stored: !unstored,
+            }],
+            vec![vec_cfg],
+            Some(default_tokenizer()),
+        )
+        .with_vector_layout(VectorLayout::MultiCellIvf);
+        let mut b = SuperfileBuilder::new(opts).expect("builder");
+        let n_rows = batch.num_rows();
+        let flat = vec![0.0f32; n_rows * DIM];
+        b.add_batch(&batch, &[flat.as_slice()]).expect("add batch");
+        b.set_prebuilt_multi_cell_ivfs(packed).expect("pack");
+        let bytes = b.finish().expect("finish");
+        Arc::new(SuperfileReader::open(Bytes::from(bytes)).expect("open"))
     }
 
     #[test]
@@ -2557,6 +3103,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![default_vector_config("emb", 7)],
             Some(default_tokenizer()),
@@ -2680,6 +3227,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2787,6 +3335,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2839,6 +3388,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![default_vector_config("emb", 7)],
             Some(default_tokenizer()),
@@ -3022,6 +3572,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![default_vector_config("emb", 7)],
             Some(default_tokenizer()),
@@ -3110,6 +3661,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3156,6 +3708,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3221,6 +3774,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3350,6 +3904,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3466,6 +4021,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![default_vector_config("emb", 7)],
             Some(default_tokenizer()),
@@ -3520,6 +4076,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3591,6 +4148,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3646,6 +4204,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3700,6 +4259,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3841,6 +4401,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3913,6 +4474,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -3994,6 +4556,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -4091,6 +4654,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -4245,18 +4809,22 @@ mod tests {
             FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "bucket".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "key".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "category".into(),
                 positions: false,
+                stored: true,
             },
         ];
         let sq8_opts = BuilderOptions::new(
@@ -4325,6 +4893,81 @@ mod tests {
             !hits.is_empty(),
             "FTS must be rebuilt during Sq8 merge, got no hits for planted term"
         );
+    }
+
+    /// Sq8 byte-splice merge with an index-only FTS column: there is no
+    /// Parquet text to rebuild from, so the merge must carry the inputs'
+    /// prebuilt postings — a regression here shows as an empty index.
+    #[tokio::test]
+    async fn sq8_merge_carries_unstored_fts_postings() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc_id", DataType::Decimal128(38, 0), false),
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("body", DataType::LargeUtf8, false),
+        ]));
+        let fts = vec![
+            FtsConfig {
+                column: "title".into(),
+                positions: false,
+                stored: true,
+            },
+            FtsConfig {
+                column: "body".into(),
+                positions: false,
+                stored: false,
+            },
+        ];
+        let sq8_opts = BuilderOptions::new(
+            schema.clone(),
+            "doc_id",
+            fts,
+            vec![default_vector_config("emb", 7).with_rerank_codec(RerankCodec::Sq8Residual)],
+            Some(default_tokenizer()),
+        );
+        let make_file = |id0: u64, body: &str| {
+            let mut b = SuperfileBuilder::new(sq8_opts.clone()).expect("new SuperfileBuilder");
+            let ids = decimal128_ids(vec![id0, id0 + 1]);
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(ids),
+                    Arc::new(LargeStringArray::from(vec!["alpha", "gamma"])),
+                    Arc::new(LargeStringArray::from(vec![body, "filler text"])),
+                ],
+            )
+            .expect("batch");
+            let mut v: Vec<f32> = vec![0.0; 32];
+            v[0] = 1.0;
+            v[16 + 1] = 1.0;
+            b.add_batch(&batch, &[v.as_slice()]).expect("add_batch");
+            Bytes::from(b.finish().expect("finish"))
+        };
+        let r1 = Arc::new(SuperfileReader::open(make_file(10, "hellozzz")).expect("open"));
+        let r2 = Arc::new(SuperfileReader::open(make_file(20, "worldzzz")).expect("open"));
+        assert!(
+            r1.schema().index_of("body").is_err(),
+            "index-only column stays out of the source Parquet body"
+        );
+
+        let (merged_bytes, stats) =
+            SuperfileBuilder::build_from_sq8_ivf_readers(&[(Arc::clone(&r1), None), (r2, None)])
+                .expect("sq8 merge with an index-only column");
+        assert_eq!(stats.n_docs, 4);
+
+        let merged = SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged");
+        assert!(merged.schema().index_of("body").is_err());
+        // r1 rows land at merged-local 0..2, r2 at 2..4.
+        let hits = merged
+            .bm25_hits_async("body", "worldzzz", 10, BoolMode::Or)
+            .await
+            .expect("bm25 on carried index-only column");
+        assert_eq!(hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(), vec![2]);
+        // The stored column carried too (the same feed serves both).
+        let hits = merged
+            .bm25_hits_async("title", "gamma", 10, BoolMode::Or)
+            .await
+            .expect("bm25 on carried stored column");
+        assert_eq!(hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(), vec![1, 3]);
     }
 
     #[tokio::test]

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -97,7 +97,7 @@ use crate::superfile::{
     },
     fts::{
         builder::FtsBuilder,
-        tokenize::{AsciiLowerTokenizer, Tokenizer},
+        tokenize::{ASCII_LOWER_TOKENIZER, AsciiLowerTokenizer, tokenizer_for_name},
     },
     stats::SuperfileStats,
     vector::{
@@ -119,10 +119,21 @@ use crate::superfile::{
 };
 
 /// Per-column FTS configuration. The `column` must exist in
-/// `BuilderOptions.schema` and be `LargeUtf8`.
-#[derive(Clone)]
+/// `BuilderOptions.schema` and be `LargeUtf8` (an unstored column may
+/// be absent — the merge-source shape).
+///
+/// Built with [`FtsConfig::new`] plus the chained setters; this is the
+/// single in-memory record of a column's FTS options, mirroring the
+/// per-column entry persisted in the `inf.fts.columns` KV metadata.
+#[derive(Debug, Clone)]
 pub struct FtsConfig {
     pub column: String,
+    /// Analyzer (tokenizer) name applied to this column —
+    /// `"ascii_lower"` (the default) or `"standard"`. Resolved to a
+    /// tokenizer instance once, at builder construction; an unknown
+    /// name is a build error. Per column: each FTS column is tokenized
+    /// with its own analyzer, so columns in one table may differ.
+    pub analyzer: String,
     /// Record token positions for this column, enabling exact phrase
     /// queries against it. Off by default: positions roughly double
     /// the column's FTS index footprint, so the cost is a per-column
@@ -142,6 +153,37 @@ pub struct FtsConfig {
     /// existing superfile the column is legitimately absent from the
     /// stored schema and its postings are carried across instead.
     pub stored: bool,
+}
+
+impl FtsConfig {
+    /// Configuration with the defaults: `ascii_lower` analyzer, no
+    /// positions, text stored.
+    pub fn new(column: impl Into<String>) -> Self {
+        Self {
+            column: column.into(),
+            analyzer: ASCII_LOWER_TOKENIZER.to_string(),
+            positions: false,
+            stored: true,
+        }
+    }
+
+    /// Set the analyzer name (see the field docs).
+    pub fn analyzer(mut self, name: impl Into<String>) -> Self {
+        self.analyzer = name.into();
+        self
+    }
+
+    /// Record token positions (see the field docs).
+    pub fn positions(mut self, positions: bool) -> Self {
+        self.positions = positions;
+        self
+    }
+
+    /// Keep the raw text in the Parquet body (see the field docs).
+    pub fn stored(mut self, stored: bool) -> Self {
+        self.stored = stored;
+        self
+    }
 }
 
 // `VectorConfig` (the per-column vector config used by
@@ -218,13 +260,6 @@ pub struct BuilderOptions {
     /// fuses results from `bm25_search(text_col, ...)` and
     /// `vector_search(emb_col, ...)`.
     pub vector_columns: Vec<VectorConfig>,
-    /// Default tokenizer, required iff `fts_columns` is non-empty. Seeds
-    /// the per-column default for `fts_tokenizers`.
-    pub tokenizer: Option<Arc<dyn Tokenizer>>,
-    /// Per-column tokenizers, aligned to `fts_columns`. Defaults in
-    /// [`Self::new`] to `tokenizer` applied to every column;
-    /// [`Self::with_fts_tokenizers`] overrides for per-field analysis.
-    pub fts_tokenizers: Vec<Arc<dyn Tokenizer>>,
     /// Parquet target row-group size (number of rows).
     pub row_group_size: usize,
     /// Parquet column-chunk compression.
@@ -307,22 +342,12 @@ impl BuilderOptions {
         id_column: impl Into<String>,
         fts_columns: Vec<FtsConfig>,
         vector_columns: Vec<VectorConfig>,
-        tokenizer: Option<Arc<dyn Tokenizer>>,
     ) -> Self {
-        // Default per-column tokenizers: the single tokenizer applied to
-        // every FTS column (`with_fts_tokenizers` overrides for per-field
-        // analyzers).
-        let fts_tokenizers = match &tokenizer {
-            Some(t) => fts_columns.iter().map(|_| Arc::clone(t)).collect(),
-            None => Vec::new(),
-        };
         Self {
             schema,
             id_column: id_column.into(),
             fts_columns,
             vector_columns,
-            tokenizer,
-            fts_tokenizers,
             row_group_size: 65_536,
             compression: Compression::ZSTD(
                 ZstdLevel::try_new(3).expect("zstd level 3 is in the valid 1..=22 range"),
@@ -334,14 +359,6 @@ impl BuilderOptions {
 
     pub(crate) fn with_vector_layout(mut self, layout: VectorLayout) -> Self {
         self.vector_layout = layout;
-        self
-    }
-
-    /// Override the per-column FTS tokenizers (per-field analysis). Must
-    /// be aligned to `fts_columns` (one per FTS column, declaration
-    /// order).
-    pub(crate) fn with_fts_tokenizers(mut self, tokenizers: Vec<Arc<dyn Tokenizer>>) -> Self {
-        self.fts_tokenizers = tokenizers;
         self
     }
 
@@ -360,33 +377,21 @@ impl BuilderOptions {
     }
 
     pub fn new_from_reader(reader: &SuperfileReader) -> Self {
-        // Recover each FTS column's tokenizer from the source reader so a
-        // rebuild (compaction) re-indexes with the same analyzer it was
-        // built with, instead of defaulting to ASCII.
-        let (fts_columns, fts_tokenizers): (Vec<FtsConfig>, Vec<Arc<dyn Tokenizer>>) =
-            if let Some(fts) = &reader.fts() {
-                fts.fts_columns_config()
-                    .map(|c| {
-                        (
-                            FtsConfig {
-                                column: c.name.clone(),
-                                positions: c.positions,
-                                stored: c.stored,
-                            },
-                            Arc::clone(&c.tokenizer),
-                        )
-                    })
-                    .unzip()
-            } else {
-                (Vec::new(), Vec::new())
-            };
-        // Seed the single-tokenizer field with the first column's analyzer
-        // (ASCII default when there are no FTS columns); `fts_tokenizers`
-        // is authoritative for per-column indexing.
-        let tokenizer: Arc<dyn Tokenizer> = fts_tokenizers
-            .first()
-            .cloned()
-            .unwrap_or_else(|| Arc::new(AsciiLowerTokenizer));
+        // Recover each FTS column's analyzer from the source reader so a
+        // rebuild carries the analyzer it was built with, instead of
+        // defaulting to ASCII.
+        let fts_columns: Vec<FtsConfig> = if let Some(fts) = &reader.fts() {
+            fts.fts_columns_config()
+                .map(|c| {
+                    FtsConfig::new(c.name.clone())
+                        .analyzer(c.tokenizer.name())
+                        .positions(c.positions)
+                        .stored(c.stored)
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         let (vector_columns, vector_layout) = if let Some(vec) = &reader.vec() {
             if vec.is_multi_cell() {
@@ -422,9 +427,7 @@ impl BuilderOptions {
             reader.id_column(),
             fts_columns,
             vector_columns,
-            Some(tokenizer),
         )
-        .with_fts_tokenizers(fts_tokenizers)
         .with_vector_layout(vector_layout)
     }
 
@@ -642,37 +645,25 @@ impl SuperfileBuilder {
             }
         }
 
-        // 4. FTS requires a tokenizer.
-        if !opts.fts_columns.is_empty() && opts.tokenizer.is_none() {
-            return Err(BuildError::FtsColumnTypeInvalid {
-                column: opts.fts_columns[0].column.clone(),
-                actual: "missing tokenizer in BuilderOptions".to_string(),
-            });
-        }
-
-        // 5. Wire up the unified FTS + vector sub-builders.
+        // 4 + 5. Resolve each FTS column's analyzer name and wire up the
+        //        unified FTS + vector sub-builders. Resolution happens
+        //        once, here — `FtsConfig` carries the name (the same
+        //        record `inf.fts.columns` persists) and an unknown name
+        //        is a build error.
         let fts_builder = if opts.fts_columns.is_empty() {
             None
         } else {
-            let tk = opts
-                .tokenizer
-                .as_ref()
-                .expect("validated non-empty FTS implies Some tokenizer")
-                .clone();
-            debug_assert_eq!(
-                opts.fts_columns.len(),
-                opts.fts_tokenizers.len(),
-                "fts_tokenizers must align 1:1 with fts_columns"
-            );
-            let mut fb = FtsBuilder::new(tk);
-            // Register each column with its own analyzer (per-field
-            // analysis). `fts_tokenizers` is aligned to `fts_columns`.
-            for (fc, tok) in opts.fts_columns.iter().zip(&opts.fts_tokenizers) {
-                fb.register_column_with_tokenizer(
-                    fc.column.clone(),
-                    fc.positions,
-                    Arc::clone(tok),
-                )?;
+            // The constructor's default tokenizer is irrelevant: every
+            // column below registers its own analyzer explicitly.
+            let mut fb = FtsBuilder::new(Arc::new(AsciiLowerTokenizer));
+            for fc in &opts.fts_columns {
+                let tok = tokenizer_for_name(&fc.analyzer).ok_or_else(|| {
+                    BuildError::UnknownAnalyzer {
+                        column: fc.column.clone(),
+                        analyzer: fc.analyzer.clone(),
+                    }
+                })?;
+                fb.register_column_with_tokenizer(fc.column.clone(), fc.positions, tok)?;
             }
             Some(fb)
         };
@@ -1964,7 +1955,7 @@ fn superfile_kvs(
         // `fts_tokenizers` is aligned 1:1 with `fts_columns`.
         kvs.push((
             kv::FTS_COLUMNS.into(),
-            fts_columns_json(&options.fts_columns, &options.fts_tokenizers),
+            fts_columns_json(&options.fts_columns),
         ));
     }
     if !options.vector_columns.is_empty() {
@@ -2228,10 +2219,10 @@ fn check_user_column_name(name: &str) -> Result<(), BuildError> {
 /// Output shape per column:
 /// `{"name":"<escaped>","tokenizer":"<name>"}`.
 /// `tokenizer` is that column's analyzer name (`"ascii_lower"` or
-/// `"standard"`), taken from `tokenizers[i]` — the reader reconstructs
-/// the matching tokenizer from it for query-time tokenization.
-/// `tokenizers` is aligned 1:1 with `cols`.
-fn fts_columns_json(cols: &[FtsConfig], tokenizers: &[Arc<dyn Tokenizer>]) -> String {
+/// `"standard"`), straight from `FtsConfig.analyzer` — the reader
+/// reconstructs the matching tokenizer from it for query-time
+/// tokenization.
+fn fts_columns_json(cols: &[FtsConfig]) -> String {
     let mut s = String::from("[");
     for (i, c) in cols.iter().enumerate() {
         if i > 0 {
@@ -2240,7 +2231,7 @@ fn fts_columns_json(cols: &[FtsConfig], tokenizers: &[Arc<dyn Tokenizer>]) -> St
         s.push_str(r#"{"name":""#);
         s.push_str(&escape_json(&c.column));
         s.push_str(r#"","tokenizer":""#);
-        s.push_str(&escape_json(tokenizers[i].name()));
+        s.push_str(&escape_json(&c.analyzer));
         s.push('"');
         // Emitted only when set: a positionless column's JSON stays
         // byte-identical to files written before positions existed
@@ -2343,7 +2334,7 @@ mod tests {
             fts::reader::BoolMode,
             vector::rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
         },
-        test_helpers::{decimal128_ids, default_tokenizer, default_vector_config},
+        test_helpers::{decimal128_ids, default_vector_config},
     };
 
     fn schema_with_fts() -> Arc<Schema> {
@@ -2358,13 +2349,8 @@ mod tests {
         BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         )
     }
 
@@ -2418,17 +2404,7 @@ mod tests {
                 Field::new("doc_id", ty.clone(), false),
                 Field::new("title", DataType::LargeUtf8, false),
             ]));
-            let opts = BuilderOptions::new(
-                schema,
-                "doc_id",
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
-                vec![],
-                Some(default_tokenizer()),
-            );
+            let opts = BuilderOptions::new(schema, "doc_id", vec![FtsConfig::new("title")], vec![]);
             let err =
                 SuperfileBuilder::new(opts).expect_err(&format!("expected rejection for {ty:?}"));
             assert!(
@@ -2443,13 +2419,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "nope".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("nope")],
             vec![],
-            Some(default_tokenizer()),
         );
         let err = SuperfileBuilder::new(opts).expect_err("expected error");
         assert!(matches!(err, BuildError::FtsColumnMissing(_)));
@@ -2461,17 +2432,7 @@ mod tests {
             Field::new("doc_id", DataType::Decimal128(38, 0), false),
             Field::new("title", DataType::Utf8, false),
         ]));
-        let opts = BuilderOptions::new(
-            schema,
-            "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(default_tokenizer()),
-        );
+        let opts = BuilderOptions::new(schema, "doc_id", vec![FtsConfig::new("title")], vec![]);
         let err = SuperfileBuilder::new(opts).expect_err("expected error");
         assert!(matches!(err, BuildError::FtsColumnMustBeLargeUtf8 { .. }));
     }
@@ -2481,13 +2442,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![default_vector_config("title", 1)],
-            Some(default_tokenizer()),
         );
         let err = SuperfileBuilder::new(opts).expect_err("expected error");
         assert!(matches!(err, BuildError::DuplicateLogicalName(_)));
@@ -2500,7 +2456,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("body", 1)], // same name as a schema column
-            None,
         );
         let err = SuperfileBuilder::new(opts).expect_err("expected error");
         assert!(matches!(err, BuildError::DuplicateLogicalName(_)));
@@ -2513,27 +2468,21 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("inf.bad", 1)],
-            None,
         );
         let err = SuperfileBuilder::new(opts).expect_err("expected error");
         assert!(matches!(err, BuildError::ReservedPrefixInColumnName(_)));
     }
 
     #[test]
-    fn new_with_fts_requires_tokenizer() {
+    fn new_rejects_unknown_analyzer() {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title").analyzer("nonesuch")],
             vec![],
-            None,
         );
         let err = SuperfileBuilder::new(opts).expect_err("expected error");
-        assert!(matches!(err, BuildError::FtsColumnTypeInvalid { .. }));
+        assert!(matches!(err, BuildError::UnknownAnalyzer { .. }));
     }
 
     fn batch_two_rows(schema: &Arc<Schema>) -> RecordBatch {
@@ -2582,7 +2531,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 1)],
-            None,
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -2598,7 +2546,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 1)],
-            None,
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -2617,7 +2564,7 @@ mod tests {
             Field::new("doc_id", DataType::Decimal128(38, 0), false),
             Field::new("title", DataType::LargeUtf8, false),
         ]));
-        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let ids = decimal128_ids(vec![1u64, 2, 3]);
         let titles = LargeStringArray::from(vec!["a", "b", "c"]);
@@ -2657,7 +2604,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 7)],
-            None,
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -2678,21 +2624,8 @@ mod tests {
 
     #[test]
     fn fts_columns_json_round_trip_shape() {
-        let cols = vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            },
-        ];
-        let toks: Vec<Arc<dyn Tokenizer>> =
-            vec![Arc::new(AsciiLowerTokenizer), Arc::new(AsciiLowerTokenizer)];
-        let s = fts_columns_json(&cols, &toks);
+        let cols = vec![FtsConfig::new("title"), FtsConfig::new("body")];
+        let s = fts_columns_json(&cols);
         assert!(s.starts_with('['));
         assert!(s.contains(r#""name":"title""#));
         assert!(s.contains(r#""name":"body""#));
@@ -2709,20 +2642,10 @@ mod tests {
     #[test]
     fn fts_columns_json_positions_emitted_only_when_true() {
         let cols = vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: true,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            },
+            FtsConfig::new("title").positions(true),
+            FtsConfig::new("body"),
         ];
-        let toks: Vec<Arc<dyn Tokenizer>> =
-            vec![Arc::new(AsciiLowerTokenizer), Arc::new(AsciiLowerTokenizer)];
-        let s = fts_columns_json(&cols, &toks);
+        let s = fts_columns_json(&cols);
         assert!(
             s.contains(r#"{"name":"title","tokenizer":"ascii_lower","positions":true}"#),
             "positional column carries the flag: {s}"
@@ -2736,22 +2659,11 @@ mod tests {
     /// Per-column analyzers: each column records its own tokenizer name.
     #[test]
     fn fts_columns_json_per_column_analyzers() {
-        use crate::superfile::fts::tokenize::StandardTokenizer;
         let cols = vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            },
+            FtsConfig::new("title").analyzer("standard"),
+            FtsConfig::new("body"),
         ];
-        let toks: Vec<Arc<dyn Tokenizer>> =
-            vec![Arc::new(StandardTokenizer), Arc::new(AsciiLowerTokenizer)];
-        let s = fts_columns_json(&cols, &toks);
+        let s = fts_columns_json(&cols);
         assert!(
             s.contains(r#"{"name":"title","tokenizer":"standard"}"#),
             "title uses the standard analyzer: {s}"
@@ -2767,20 +2679,10 @@ mod tests {
     #[test]
     fn fts_columns_json_stored_emitted_only_when_false() {
         let cols = vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: false,
-            },
+            FtsConfig::new("title"),
+            FtsConfig::new("body").stored(false),
         ];
-        let toks: Vec<Arc<dyn Tokenizer>> =
-            vec![Arc::new(AsciiLowerTokenizer), Arc::new(AsciiLowerTokenizer)];
-        let s = fts_columns_json(&cols, &toks);
+        let s = fts_columns_json(&cols);
         assert!(
             s.contains(r#"{"name":"title","tokenizer":"ascii_lower"}"#),
             "stored column stays in the legacy shape: {s}"
@@ -2799,19 +2701,10 @@ mod tests {
             schema_with_fts(),
             "doc_id",
             vec![
-                FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                },
-                FtsConfig {
-                    column: "body".into(),
-                    positions: false,
-                    stored: false,
-                },
+                FtsConfig::new("title"),
+                FtsConfig::new("body").stored(false),
             ],
             vec![],
-            Some(default_tokenizer()),
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -3047,13 +2940,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema,
             "doc_id",
-            vec![FtsConfig {
-                column: "body".into(),
-                positions: true,
-                stored: !unstored,
-            }],
+            vec![FtsConfig::new("body").positions(true).stored(!unstored)],
             vec![vec_cfg],
-            Some(default_tokenizer()),
         )
         .with_vector_layout(VectorLayout::MultiCellIvf);
         let mut b = SuperfileBuilder::new(opts).expect("builder");
@@ -3100,13 +2988,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![default_vector_config("emb", 7)],
-            Some(default_tokenizer()),
         );
         let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
         let schema = b1.opts.schema.clone();
@@ -3224,13 +3107,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
         let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
         let schema = b1.opts.schema.clone();
@@ -3277,7 +3155,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 7)],
-            None,
         );
         let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
         let schema = b1.opts.schema.clone();
@@ -3332,13 +3209,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
         let mut b1 = SuperfileBuilder::new(opts.clone()).expect("new SuperfileBuilder");
         let schema = b1.opts.schema.clone();
@@ -3385,13 +3257,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![default_vector_config("emb", 7)],
-            Some(default_tokenizer()),
         );
 
         // Create first superfile
@@ -3486,7 +3353,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 7)],
-            None,
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -3546,7 +3412,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            None,
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -3569,13 +3434,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![default_vector_config("emb", 7)],
-            Some(default_tokenizer()),
         );
 
         // Create original superfile
@@ -3658,13 +3518,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -3705,13 +3560,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
 
         // Create first superfile
@@ -3771,13 +3621,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
         let schema = opts.schema.clone();
 
@@ -3901,13 +3746,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title").positions(positions)],
             vec![],
-            Some(default_tokenizer()),
         );
         let schema = opts.schema.clone();
 
@@ -4018,13 +3858,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![default_vector_config("emb", 7)],
-            Some(default_tokenizer()),
         );
 
         // Create superfile with both FTS and vectors
@@ -4073,13 +3908,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
         let schema = opts.schema.clone();
 
@@ -4145,13 +3975,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
 
         // Create superfile with FTS
@@ -4201,13 +4026,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
 
         let mut readers = Vec::with_capacity(NUM_FILES);
@@ -4256,13 +4076,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
 
         // Create three superfiles
@@ -4318,7 +4133,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 7)],
-            None,
         );
 
         // Create first superfile with only vectors (no FTS)
@@ -4398,13 +4212,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
 
         // Create first superfile with 2 rows (indices 0, 1)
@@ -4471,13 +4280,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -4553,13 +4357,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
 
         // Create first superfile with ids 10, 11, titles ["hello world", "rust async"]
@@ -4651,13 +4450,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
 
         // Create superfile with specific string values to validate min/max ordering
@@ -4734,7 +4528,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 7).with_rerank_codec(RerankCodec::Sq8Residual)],
-            None,
         );
         let mut b1 = SuperfileBuilder::new(sq8_opts.clone()).expect("new SuperfileBuilder");
         let schema = b1.opts.schema.clone();
@@ -4806,33 +4599,16 @@ mod tests {
             Field::new("rating", DataType::Int64, false),
         ]));
         let fts = vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "bucket".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "key".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "category".into(),
-                positions: false,
-                stored: true,
-            },
+            FtsConfig::new("title"),
+            FtsConfig::new("bucket"),
+            FtsConfig::new("key"),
+            FtsConfig::new("category"),
         ];
         let sq8_opts = BuilderOptions::new(
             schema.clone(),
             "doc_id",
             fts,
             vec![default_vector_config("emb", 7).with_rerank_codec(RerankCodec::Sq8Residual)],
-            Some(default_tokenizer()),
         );
 
         let make_file = |id0: u64, title: &str| {
@@ -4906,23 +4682,14 @@ mod tests {
             Field::new("body", DataType::LargeUtf8, false),
         ]));
         let fts = vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: false,
-            },
+            FtsConfig::new("title"),
+            FtsConfig::new("body").stored(false),
         ];
         let sq8_opts = BuilderOptions::new(
             schema.clone(),
             "doc_id",
             fts,
             vec![default_vector_config("emb", 7).with_rerank_codec(RerankCodec::Sq8Residual)],
-            Some(default_tokenizer()),
         );
         let make_file = |id0: u64, body: &str| {
             let mut b = SuperfileBuilder::new(sq8_opts.clone()).expect("new SuperfileBuilder");
@@ -4979,7 +4746,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 7)], // Fp32 is the default_vector_config codec
-            None,
         );
         let mut b = SuperfileBuilder::new(fp32_opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
@@ -5132,7 +4898,7 @@ mod tests {
         let batch =
             RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array) as Arc<dyn Array>])
                 .expect("batch");
-        let opts = BuilderOptions::new(schema, "doc_id", vec![], vec![make_cfg()], None)
+        let opts = BuilderOptions::new(schema, "doc_id", vec![], vec![make_cfg()])
             .with_vector_layout(VectorLayout::MultiCellIvf);
         let mut b = SuperfileBuilder::new(opts).expect("builder");
         b.add_batch_ids_only(&batch).expect("ids");

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -97,6 +97,7 @@ use crate::superfile::{
     },
     fts::{
         builder::FtsBuilder,
+        reader::ColumnMeta,
         tokenize::{ASCII_LOWER_TOKENIZER, AsciiLowerTokenizer, tokenizer_for_name},
     },
     stats::SuperfileStats,
@@ -431,11 +432,71 @@ impl BuilderOptions {
         .with_vector_layout(vector_layout)
     }
 
+    /// Verify a merge input's per-column FTS configuration is
+    /// carry-compatible with this builder's. Merges carry each input's
+    /// prebuilt postings across without re-tokenizing, so the inputs'
+    /// FTS shape must agree exactly — not just column names:
+    ///
+    /// - **presence**: an input without an FTS index merged into an
+    ///   FTS-declaring builder would silently contribute zero postings
+    ///   (and the reverse would silently drop the input's index);
+    /// - **analyzer**: the merged file records ONE analyzer per column,
+    ///   and queries tokenize with it — postings carried from an input
+    ///   built under a different analyzer would silently stop matching;
+    /// - **positions**: a positional column merged with a positionless
+    ///   input would declare phrase support that half its docs can't
+    ///   answer;
+    /// - **stored**: schema equality catches this indirectly (an
+    ///   unstored column is absent from the Parquet schema), but the
+    ///   explicit check names the actual disagreement.
+    ///
+    /// Inputs from one table can never disagree (the table's options
+    /// identity pins the per-column config), so every error here is a
+    /// misuse of the merge entry points — made loud instead of silent.
+    fn check_fts_carry_compat(&self, remote: Option<&[&ColumnMeta]>) -> Result<(), BuildError> {
+        let remote = remote.unwrap_or(&[]);
+        if self.fts_columns.len() != remote.len() {
+            return Err(BuildError::FTSSchemaMismatch(format!(
+                "mismatched column len. self {} vs other {}",
+                self.fts_columns.len(),
+                remote.len()
+            )));
+        }
+        for (own, other) in self.fts_columns.iter().zip(remote.iter()) {
+            if own.column != other.name {
+                return Err(BuildError::FTSSchemaMismatch(format!(
+                    "mismatched column name. self {} vs other {}",
+                    own.column, other.name
+                )));
+            }
+            let other_analyzer = other.tokenizer.name();
+            if own.analyzer != other_analyzer {
+                return Err(BuildError::FTSSchemaMismatch(format!(
+                    "column {}: mismatched analyzer. self {} vs other {}",
+                    own.column, own.analyzer, other_analyzer
+                )));
+            }
+            if own.positions != other.positions {
+                return Err(BuildError::FTSSchemaMismatch(format!(
+                    "column {}: mismatched positions flag. self {} vs other {}",
+                    own.column, own.positions, other.positions
+                )));
+            }
+            if own.stored != other.stored {
+                return Err(BuildError::FTSSchemaMismatch(format!(
+                    "column {}: mismatched stored flag. self {} vs other {}",
+                    own.column, own.stored, other.stored
+                )));
+            }
+        }
+        Ok(())
+    }
+
     fn check_mergeability(
         &self,
         remote_id_col: &str,
         remote_schema: &Arc<Schema>,
-        remote_fts_columns: Option<Vec<&str>>,
+        remote_fts_columns: Option<Vec<&ColumnMeta>>,
         remote_vector_columns: Option<Vec<&ColumnReader>>,
     ) -> Result<bool, BuildError> {
         if self.id_column != *remote_id_col {
@@ -452,26 +513,7 @@ impl BuilderOptions {
             });
         }
 
-        if let Some(remote_fts_columns) = remote_fts_columns {
-            let self_fts_columns = &self.fts_columns;
-            if self_fts_columns.len() != remote_fts_columns.len() {
-                return Err(BuildError::FTSSchemaMismatch(format!(
-                    "mismatched column len. self {} vs other {}",
-                    self_fts_columns.len(),
-                    remote_fts_columns.len()
-                )));
-            }
-            for (self_fts_column, remote_fts_column) in
-                self_fts_columns.iter().zip(remote_fts_columns.iter())
-            {
-                if self_fts_column.column != *remote_fts_column {
-                    return Err(BuildError::FTSSchemaMismatch(format!(
-                        "mismatched column name. self {} vs other {}",
-                        self_fts_column.column, remote_fts_column
-                    )));
-                }
-            }
-        }
+        self.check_fts_carry_compat(remote_fts_columns.as_deref())?;
 
         if let Some(remote_vector_columns) = remote_vector_columns {
             let self_vec_columns = &self.vector_columns;
@@ -869,6 +911,13 @@ impl SuperfileBuilder {
         reader: &SuperfileReader,
         deleted: Option<&RoaringBitmap>,
     ) -> Result<(), BuildError> {
+        // Config compatibility first, before any early return — a
+        // presence or per-column mismatch must fail loud, never carry
+        // partially (see `check_fts_carry_compat`).
+        let remote_cfg = reader
+            .fts()
+            .map(|f| f.fts_columns_config().collect::<Vec<_>>());
+        self.opts.check_fts_carry_compat(remote_cfg.as_deref())?;
         let Some(fts) = reader.fts() else {
             return Ok(());
         };
@@ -931,6 +980,12 @@ impl SuperfileBuilder {
         reader: &SuperfileReader,
         remap: &[Option<u32>],
     ) -> Result<(), BuildError> {
+        // Same compatibility gate as `carry_fts_from_reader`, so callers
+        // that feed this directly (the multi-cell merge) get it too.
+        let remote_cfg = reader
+            .fts()
+            .map(|f| f.fts_columns_config().collect::<Vec<_>>());
+        self.opts.check_fts_carry_compat(remote_cfg.as_deref())?;
         let Some(fts) = reader.fts() else {
             return Ok(());
         };
@@ -1176,6 +1231,15 @@ impl SuperfileBuilder {
                     "build_from_multi_cell_sq8_ivf_readers requires multi-cell inputs".into(),
                 ));
             }
+            // Per-input FTS config gate: the carry loop below skips
+            // FTS-less inputs, so check presence + per-column agreement
+            // here where every input passes through.
+            let remote_cfg = reader
+                .fts()
+                .map(|f| f.fts_columns_config().collect::<Vec<_>>());
+            superfile_builder
+                .opts
+                .check_fts_carry_compat(remote_cfg.as_deref())?;
             scalar_batches.push(record_batch);
         }
 
@@ -1489,7 +1553,9 @@ impl SuperfileBuilder {
         self.opts.check_mergeability(
             reader.id_column(),
             reader.schema(),
-            reader.fts().map(|f| f.fts_columns().collect::<Vec<_>>()),
+            reader
+                .fts()
+                .map(|f| f.fts_columns_config().collect::<Vec<_>>()),
             reader
                 .vec()
                 .map(|v| v.vector_columns_config().collect::<Vec<_>>()),
@@ -1650,7 +1716,9 @@ impl SuperfileBuilder {
             superfile_builder.opts.check_mergeability(
                 reader.id_column(),
                 reader.schema(),
-                reader.fts().map(|f| f.fts_columns().collect::<Vec<_>>()),
+                reader
+                    .fts()
+                    .map(|f| f.fts_columns_config().collect::<Vec<_>>()),
                 reader
                     .vec()
                     .map(|v| v.vector_columns_config().collect::<Vec<_>>()),

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -33,6 +33,12 @@ pub enum BuildError {
     #[error("duplicate column name {0:?}")]
     DuplicateColumnName(String),
 
+    #[error(
+        "FTS column {column:?}: unknown analyzer {analyzer:?} (valid: \
+         \"ascii_lower\", \"standard\")"
+    )]
+    UnknownAnalyzer { column: String, analyzer: String },
+
     #[error("logical name {0:?} duplicated across fts_columns and vector_columns")]
     DuplicateLogicalName(String),
 

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -12,7 +12,10 @@ pub mod footer;
 pub const PROJECT_MAGIC: &[u8; 3] = b"INF";
 
 /// File-format version. Semver string. Bump major to break compatibility.
-pub const FORMAT_VERSION: &str = "1.0.0";
+/// 1.1.0: `inf.fts.columns` entries may carry `"stored":false` (index-only
+/// FTS columns, absent from the Parquet body); the field is emitted only
+/// when false, and same-major readers default a missing field to true.
+pub const FORMAT_VERSION: &str = "1.1.0";
 
 /// CRC width in bytes (`u32` CRC-32C, little-endian) appended after a
 /// directory or after a subsection's payload. Defined once so the

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1784,23 +1784,26 @@ impl FtsBuilder {
         Ok(())
     }
 
-    /// Set a column's per-doc lengths directly (the compaction merge feeds the
-    /// inputs' already-clamped stored lengths rather than recomputing them
+    /// Append a run of per-doc lengths to a column (the compaction merge feeds
+    /// the inputs' already-clamped stored lengths rather than recomputing them
     /// from text) and advance the builder's doc count so `finish` sizes the
-    /// doc-lengths table and `n_docs` correctly.
+    /// doc-lengths table and `n_docs` correctly. Append (not replace) so the
+    /// prebuilt feed composes: with lengths a prior input already carried
+    /// across, and with lengths `add_doc` accumulated for docs tokenized into
+    /// the same builder — the merged lengths axis stays aligned with the
+    /// column's ascending local-doc-id axis either way.
     ///
-    /// Also recomputes `total_tokens` as the sum of the lengths. `finish`
+    /// Also accumulates `total_tokens` as the sum of the lengths. `finish`
     /// derives `avgdl = total_tokens / n_docs` from it, and a doc length *is*
     /// its token count (`add_doc` clamps only at `u32::MAX`, never reached in
     /// practice), so this sum equals what re-indexing the same corpus would
     /// accumulate — keeping merged BM25 scores identical to a fresh build.
-    pub(crate) fn set_prebuilt_doc_lengths(&mut self, column_id: u32, doc_lengths: Vec<u32>) {
-        let n = doc_lengths.len() as u32;
+    pub(crate) fn append_prebuilt_doc_lengths(&mut self, column_id: u32, doc_lengths: &[u32]) {
         let total_tokens: u64 = doc_lengths.iter().map(|&dl| u64::from(dl)).sum();
         let col = &mut self.columns[column_id as usize];
-        col.total_tokens = total_tokens;
-        col.doc_lengths = doc_lengths;
-        self.n_docs = self.n_docs.max(n);
+        col.total_tokens += total_tokens;
+        col.doc_lengths.extend_from_slice(doc_lengths);
+        self.n_docs = self.n_docs.max(col.doc_lengths.len() as u32);
     }
 
     /// Spilled-mode hot path. Per-token cost: intern lookup + dense-

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -887,6 +887,7 @@ impl FtsReader {
                 dl_norm_k1,
                 positions: col_cfg.positions,
                 tokenizer,
+                stored: col_cfg.stored,
             });
             column_id_by_name.insert(col_cfg.name.clone(), i as u32);
         }
@@ -1930,7 +1931,7 @@ mod tests {
             Ok(())
         })
         .expect("feed prebuilt postings");
-        b.set_prebuilt_doc_lengths(0, ra.read_doc_lengths(0).expect("doc lengths"));
+        b.append_prebuilt_doc_lengths(0, &ra.read_doc_lengths(0).expect("doc lengths"));
         let rb = FtsReader::open(Bytes::from(b.finish().expect("finish b")), json).expect("open b");
 
         // The two readers must expose identical postings (doc_ids, tfs,
@@ -1979,7 +1980,7 @@ mod tests {
             Ok(())
         })
         .expect("feed prebuilt postings");
-        b.set_prebuilt_doc_lengths(0, ra.read_doc_lengths(0).expect("doc lengths"));
+        b.append_prebuilt_doc_lengths(0, &ra.read_doc_lengths(0).expect("doc lengths"));
         let rb = FtsReader::open(Bytes::from(b.finish().expect("finish b")), json).expect("open b");
 
         let collect = |r: &FtsReader| {

--- a/src/superfile/fts/reader/metadata.rs
+++ b/src/superfile/fts/reader/metadata.rs
@@ -109,6 +109,11 @@ pub struct ColumnMeta {
     /// column must be tokenized with it to match how the column was
     /// indexed.
     pub tokenizer: Arc<dyn Tokenizer>,
+    /// Whether the column's raw text is kept in the Parquet body (from
+    /// `inf.fts.columns`). Index-only columns (`false`) are searchable
+    /// but absent from the stored schema, so they cannot be read back;
+    /// a rebuild carries their postings across instead of re-tokenizing.
+    pub stored: bool,
 }
 
 /// JSON-deserialized form of one entry in `inf.fts.columns`. The KV
@@ -128,10 +133,20 @@ pub struct FtsColumnConfig {
     /// deserializes to `false`.
     #[serde(default)]
     pub positions: bool,
+    /// Whether the raw text is kept in the Parquet body. Files written
+    /// before index-only columns existed lack the field, which can only
+    /// mean the text is stored — so a missing field deserializes to
+    /// `true` (the writer emits it only when `false`).
+    #[serde(default = "default_stored")]
+    pub stored: bool,
 }
 
 pub(super) fn default_tokenizer() -> String {
     "ascii_lower".to_string()
+}
+
+pub(super) fn default_stored() -> bool {
+    true
 }
 
 /// Per-open knobs for [`FtsReader::open_with`]. Mirrors the

--- a/src/superfile/fts/reader/mod.rs
+++ b/src/superfile/fts/reader/mod.rs
@@ -23,6 +23,6 @@ mod work;
 pub use core::*;
 
 pub(crate) use expand::{LONG_S_ASCII, TermPattern, has_fold_partner};
-pub use metadata::OpenOptions;
+pub use metadata::{ColumnMeta, OpenOptions};
 pub use options::{Bm25SearchOptions, Bm25Stats, BoolMode};
 pub use work::MatchWork;

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1984,6 +1984,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -2567,10 +2568,12 @@ mod tests {
                 FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 },
                 FtsConfig {
                     column: "body".into(),
                     positions: false,
+                    stored: true,
                 },
             ],
             vec![],

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1966,7 +1966,7 @@ mod tests {
             builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
             vector::distance::normalize,
         },
-        test_helpers::{decimal128_ids, default_tokenizer, default_vector_config},
+        test_helpers::{decimal128_ids, default_vector_config},
     };
 
     fn schema_with_text() -> Arc<Schema> {
@@ -1981,13 +1981,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema.clone(),
             "doc_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let ids = decimal128_ids(vec![10u64, 11, 12, 13]);
@@ -2062,7 +2057,7 @@ mod tests {
     /// in row order, which is the oracle's ground truth.
     fn build_shuffled_id_superfile() -> (Bytes, Vec<i128>) {
         let schema = schema_with_text();
-        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
         let ids: Vec<i128> = (0..SHUFFLED_ID_ROWS)
@@ -2127,7 +2122,7 @@ mod tests {
     #[test]
     fn id_lookup_many_takes_the_first_occurrence_of_a_repeated_id() {
         let schema = schema_with_text();
-        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         // Row 1 and row 3 carry the same `_id`.
         let ids = Decimal128Array::from_iter_values([70i128, 71, 72, 71, 73])
@@ -2395,7 +2390,7 @@ mod tests {
     async fn bm25_search_errors_when_no_fts() {
         // Build a superfile with no FTS, no vec.
         let schema = schema_with_text();
-        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let ids = decimal128_ids(vec![1u64]);
         let title = LargeStringArray::from(vec!["x"]);
@@ -2443,7 +2438,6 @@ mod tests {
             "doc_id",
             vec![],
             vec![default_vector_config("emb", 7)],
-            None,
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         // 4 unit-norm vectors so cosine is well-defined.
@@ -2564,20 +2558,8 @@ mod tests {
         let opts = BuilderOptions::new(
             schema.clone(),
             "doc_id",
-            vec![
-                FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                },
-                FtsConfig {
-                    column: "body".into(),
-                    positions: false,
-                    stored: true,
-                },
-            ],
+            vec![FtsConfig::new("title"), FtsConfig::new("body")],
             vec![],
-            Some(default_tokenizer()),
         );
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let ids = decimal128_ids(vec![1u64, 2, 3]);

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -975,9 +975,7 @@ mod tests {
             error::CompactionError,
             storage::{LocalFsStorageProvider, StorageProvider},
         },
-        test_helpers::{
-            build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
-        },
+        test_helpers::{build_title_batch, default_supertable_options, default_vector_config},
     };
 
     const DEFAULT_STALE_SEAL_TIMEOUT: std::time::Duration =
@@ -1882,13 +1880,8 @@ mod tests {
         // non-IVF-mergeable case, so compaction routes to the re-index branch.
         let opts = SupertableOptions::new(
             Arc::clone(&schema),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![default_vector_config("emb", 42)],
-            Some(default_tokenizer()),
         )
         .expect("options with an fp32 vector column")
         // One writer thread ⇒ one superfile per commit (deterministic doc-id

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -1885,6 +1885,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![default_vector_config("emb", 42)],
             Some(default_tokenizer()),

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -90,9 +90,10 @@ pub enum BuildError {
     ReservedPrefixInColumnName(String),
 
     #[error(
-        "FTS columns declared but no tokenizer supplied; tokenizer is required iff fts_columns is non-empty"
+        "FTS column {column:?}: unknown analyzer {analyzer:?} (valid: \
+         \"ascii_lower\", \"standard\")"
     )]
-    MissingTokenizer,
+    UnknownAnalyzer { column: String, analyzer: String },
 
     #[error("input RecordBatch schema does not match the supertable's declared schema")]
     BatchSchemaMismatch,

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -1598,13 +1598,8 @@ fn build_vector_index_options(
             ..vc.clone()
         })
         .collect();
-    let mut hidden_opts = SupertableOptions::new(
-        hidden_schema,
-        vec![],
-        hidden_vector_columns,
-        user_opts.tokenizer.clone(),
-    )
-    .ok()?;
+    let mut hidden_opts =
+        SupertableOptions::new(hidden_schema, vec![], hidden_vector_columns).ok()?;
     hidden_opts = hidden_opts
         .with_storage(Arc::clone(&sub_storage))
         .with_vector_layout(crate::superfile::vector::layout::VectorLayout::Ivf)
@@ -2195,18 +2190,9 @@ mod tests {
     }
 
     fn opts() -> SupertableOptions {
-        let tk = default_tokenizer();
-        SupertableOptions::new(
-            schema(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tk),
-        )
-        .expect("valid options")
+        let _tk = default_tokenizer();
+        SupertableOptions::new(schema(), vec![FtsConfig::new("title")], vec![])
+            .expect("valid options")
     }
 
     fn entry(n_docs: u64) -> Arc<SuperfileEntry> {
@@ -2527,11 +2513,7 @@ mod tests {
         let make_options = || {
             SupertableOptions::new(
                 schema.clone(),
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
+                vec![FtsConfig::new("title")],
                 vec![VectorConfig {
                     column: "emb".into(),
                     dim,
@@ -2540,7 +2522,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8FixedResidual,
                     provided_centroids: None,
                 }],
-                Some(crate::test_helpers::default_tokenizer()),
             )
             .expect("valid options")
             .with_storage(Arc::clone(&storage))
@@ -2764,7 +2745,7 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let base = SupertableOptions::new(schema, vec![], vec![], None).expect("options");
+        let base = SupertableOptions::new(schema, vec![], vec![]).expect("options");
         let overridden = base.with_vector_cell_counts(7, 9);
         assert_eq!(user_vector_cell_count(&overridden), 7);
         assert_eq!(hidden_vector_cell_count(&overridden), 9);
@@ -2821,11 +2802,7 @@ mod tests {
         let make_options = |from_superfiles: bool| {
             SupertableOptions::new(
                 schema.clone(),
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
+                vec![FtsConfig::new("title")],
                 vec![VectorConfig {
                     column: "emb".into(),
                     dim,
@@ -2834,7 +2811,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8FixedResidual,
                     provided_centroids: None,
                 }],
-                Some(crate::test_helpers::default_tokenizer()),
             )
             .expect("valid options")
             .with_storage(Arc::clone(&storage))
@@ -3037,11 +3013,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -3050,7 +3022,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8FixedResidual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -3140,11 +3111,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -3153,7 +3120,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -3245,11 +3211,7 @@ mod tests {
         // that routes the drain through materialized_ivf_rows_in_doc_order.
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -3258,7 +3220,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(Arc::clone(&storage))
@@ -3345,11 +3306,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim: DIM,
@@ -3358,7 +3315,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8FixedResidual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(Arc::clone(&storage))
@@ -3456,11 +3412,7 @@ mod tests {
 
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -3469,7 +3421,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8FixedResidual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(Arc::clone(&storage))
@@ -3581,7 +3532,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                None,
             )
             .expect("valid options")
             .with_storage(Arc::clone(&storage))
@@ -3704,7 +3654,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                None,
             )
             .expect("valid options")
             .with_storage(Arc::clone(&storage))
@@ -3817,11 +3766,7 @@ mod tests {
         let make_options = || {
             SupertableOptions::new(
                 schema.clone(),
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
+                vec![FtsConfig::new("title")],
                 vec![VectorConfig {
                     column: "emb".into(),
                     dim,
@@ -3830,7 +3775,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                Some(crate::test_helpers::default_tokenizer()),
             )
             .expect("valid options")
             .with_storage(Arc::clone(&storage))
@@ -4019,7 +3963,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                None,
             )
             .expect("valid options")
             .with_storage(Arc::clone(&storage))
@@ -4193,26 +4136,10 @@ mod tests {
             SupertableOptions::new(
                 schema.clone(),
                 vec![
-                    FtsConfig {
-                        column: "title".into(),
-                        positions: false,
-                        stored: true,
-                    },
-                    FtsConfig {
-                        column: "bucket".into(),
-                        positions: false,
-                        stored: true,
-                    },
-                    FtsConfig {
-                        column: "key".into(),
-                        positions: false,
-                        stored: true,
-                    },
-                    FtsConfig {
-                        column: "category".into(),
-                        positions: false,
-                        stored: true,
-                    },
+                    FtsConfig::new("title"),
+                    FtsConfig::new("bucket"),
+                    FtsConfig::new("key"),
+                    FtsConfig::new("category"),
                 ],
                 vec![VectorConfig {
                     column: "emb".into(),
@@ -4222,7 +4149,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                Some(default_tokenizer()),
             )
             .expect("valid options")
             .with_storage(Arc::clone(&storage))
@@ -4362,11 +4288,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -4375,7 +4297,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -4457,11 +4378,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -4470,7 +4387,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -4550,11 +4466,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -4563,7 +4475,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -4723,11 +4634,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -4736,7 +4643,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -4925,11 +4831,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -4938,7 +4840,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(Arc::clone(&storage))
@@ -5208,11 +5109,7 @@ mod tests {
         let storage: Arc<dyn StorageProvider> = Arc::clone(&failing) as Arc<dyn StorageProvider>;
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -5221,7 +5118,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -5368,11 +5264,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -5381,7 +5273,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -5472,11 +5363,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -5485,7 +5372,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -5590,11 +5476,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -5603,7 +5485,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -5758,11 +5639,7 @@ mod tests {
                 Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
             SupertableOptions::new(
                 schema.clone(),
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
+                vec![FtsConfig::new("title")],
                 vec![VectorConfig {
                     column: "emb".into(),
                     dim,
@@ -5771,7 +5648,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                Some(crate::test_helpers::default_tokenizer()),
             )
             .expect("valid options")
             .with_storage(storage)
@@ -5930,11 +5806,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -5943,7 +5815,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(Arc::clone(&storage))
@@ -6157,11 +6028,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -6170,7 +6037,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(Arc::clone(&storage))
@@ -6379,7 +6245,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8FixedResidual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage);
@@ -6443,11 +6308,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -6456,7 +6317,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(Arc::clone(&storage))
@@ -6633,11 +6493,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -6646,7 +6502,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -6814,11 +6669,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim: DIM,
@@ -6827,7 +6678,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -6944,11 +6794,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -6957,7 +6803,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -7072,11 +6917,7 @@ mod tests {
                 Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
             let options = SupertableOptions::new(
                 schema.clone(),
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
+                vec![FtsConfig::new("title")],
                 vec![VectorConfig {
                     column: "emb".into(),
                     dim,
@@ -7085,7 +6926,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                Some(crate::test_helpers::default_tokenizer()),
             )
             .expect("valid options")
             .with_storage(storage)
@@ -7200,11 +7040,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let mut options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -7213,7 +7049,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -7340,11 +7175,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -7353,7 +7184,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -7473,11 +7303,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -7486,7 +7312,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -7602,11 +7427,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -7615,7 +7436,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -7725,11 +7545,7 @@ mod tests {
                 Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
             SupertableOptions::new(
                 schema.clone(),
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
+                vec![FtsConfig::new("title")],
                 vec![VectorConfig {
                     column: "emb".into(),
                     dim,
@@ -7738,7 +7554,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                Some(crate::test_helpers::default_tokenizer()),
             )
             .expect("valid options")
             .with_storage(storage)
@@ -7904,11 +7719,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -7917,7 +7728,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)
@@ -8044,11 +7854,7 @@ mod tests {
             Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
         let options = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -8057,7 +7863,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(crate::test_helpers::default_tokenizer()),
         )
         .expect("valid options")
         .with_storage(storage)

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -2201,6 +2201,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tk),
@@ -2529,6 +2530,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![VectorConfig {
                     column: "emb".into(),
@@ -2822,6 +2824,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![VectorConfig {
                     column: "emb".into(),
@@ -3037,6 +3040,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -3139,6 +3143,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -3243,6 +3248,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -3342,6 +3348,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -3452,6 +3459,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -3812,6 +3820,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![VectorConfig {
                     column: "emb".into(),
@@ -4187,18 +4196,22 @@ mod tests {
                     FtsConfig {
                         column: "title".into(),
                         positions: false,
+                        stored: true,
                     },
                     FtsConfig {
                         column: "bucket".into(),
                         positions: false,
+                        stored: true,
                     },
                     FtsConfig {
                         column: "key".into(),
                         positions: false,
+                        stored: true,
                     },
                     FtsConfig {
                         column: "category".into(),
                         positions: false,
+                        stored: true,
                     },
                 ],
                 vec![VectorConfig {
@@ -4352,6 +4365,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -4446,6 +4460,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -4538,6 +4553,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -4710,6 +4726,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -4911,6 +4928,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -5193,6 +5211,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -5352,6 +5371,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -5455,6 +5475,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -5572,6 +5593,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -5739,6 +5761,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![VectorConfig {
                     column: "emb".into(),
@@ -5910,6 +5933,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -6136,6 +6160,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -6421,6 +6446,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -6610,6 +6636,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -6790,6 +6817,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -6919,6 +6947,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -7046,6 +7075,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![VectorConfig {
                     column: "emb".into(),
@@ -7173,6 +7203,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -7312,6 +7343,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -7444,6 +7476,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -7572,6 +7605,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -7694,6 +7728,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![VectorConfig {
                     column: "emb".into(),
@@ -7872,6 +7907,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -8011,6 +8047,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -4232,6 +4232,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![],
                 Some(tk),

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -4225,19 +4225,10 @@ mod tests {
     }
 
     fn opts() -> Arc<SupertableOptions> {
-        let tk = default_tokenizer();
+        let _tk = default_tokenizer();
         Arc::new(
-            SupertableOptions::new(
-                schema(),
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
-                vec![],
-                Some(tk),
-            )
-            .expect("valid options"),
+            SupertableOptions::new(schema(), vec![FtsConfig::new("title")], vec![])
+                .expect("valid options"),
         )
     }
 
@@ -4615,7 +4606,7 @@ mod tests {
                 DataType::LargeUtf8,
                 false,
             )]));
-            Arc::new(SupertableOptions::new(s, vec![], vec![], None).expect("opts"))
+            Arc::new(SupertableOptions::new(s, vec![], vec![]).expect("opts"))
         }
 
         fn build_manifest_with_loader(
@@ -5059,7 +5050,7 @@ mod tests {
     }
 
     fn make_opts() -> Arc<SupertableOptions> {
-        SupertableOptions::new(simple_schema(), vec![], vec![], None)
+        SupertableOptions::new(simple_schema(), vec![], vec![])
             .map(Arc::new)
             .expect("valid options")
     }
@@ -5550,7 +5541,7 @@ mod tests {
 
         let consumer_opts = |knob: bool| {
             Arc::new(
-                SupertableOptions::new(simple_schema(), vec![], vec![], None)
+                SupertableOptions::new(simple_schema(), vec![], vec![])
                     .expect("valid options")
                     .with_summary_centroids_from_superfiles(knob),
             )
@@ -5679,7 +5670,7 @@ mod tests {
     async fn consumer_mode_hydrates_parts_from_routing_sibling() {
         let consumer_opts = |knob: bool| {
             Arc::new(
-                SupertableOptions::new(simple_schema(), vec![], vec![], None)
+                SupertableOptions::new(simple_schema(), vec![], vec![])
                     .expect("valid options")
                     .with_summary_centroids_from_superfiles(knob),
             )
@@ -5974,7 +5965,7 @@ mod tests {
         // a loader — the second (removal) phase loads carried-over parts
         // (part_0, part_1) back from storage.
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = TARGET_SUPERFILES_PER_PART;
         let opts = Arc::new(base_opts.with_storage(storage.clone()));
 
@@ -6220,7 +6211,7 @@ mod tests {
     #[tokio::test]
     async fn update_rewrite_partition_within_target() {
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 3;
         let opts = Arc::new(base_opts);
 
@@ -6323,7 +6314,7 @@ mod tests {
     #[tokio::test]
     async fn update_split_partition_exceeds_target() {
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 2;
         let opts = Arc::new(base_opts);
 
@@ -6450,7 +6441,7 @@ mod tests {
     #[tokio::test]
     async fn update_split_partition_exceeds_size_threshold() {
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 10_000;
         // Any real encoded part is bigger than 1 byte, so the latest part is
         // always considered at-cap.
@@ -6562,7 +6553,7 @@ mod tests {
     #[tokio::test]
     async fn update_older_entry_preserved_when_latest_rewritten() {
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 2;
         let opts = Arc::new(base_opts);
 
@@ -6701,7 +6692,7 @@ mod tests {
         // the LAST existing part (the latest); the earlier part carries over
         // unchanged. Each superfile keeps its own partition_hint/partition_key.
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 3;
         let opts = Arc::new(base_opts);
 
@@ -6847,7 +6838,7 @@ mod tests {
         // the earlier part carries over with the exact URI and content_hash that
         // were written — no re-encode, no PUT.
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 3;
         let opts = Arc::new(base_opts);
 
@@ -6984,7 +6975,7 @@ mod tests {
         // entries. p0..p2 carry over unchanged. Each superfile keeps its own
         // partition_hint.
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 2;
         let opts = Arc::new(base_opts);
 
@@ -7190,7 +7181,7 @@ mod tests {
         // Under the default single-bucket Hash strategy the commit-time
         // partition_key stamped on every entry is bucket 0, regardless of hint.
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 8;
         let opts = Arc::new(base_opts);
 
@@ -7337,7 +7328,7 @@ mod tests {
         // in the same partition. The resulting part should contain the
         // surviving existing superfile plus the new one — not the removed one.
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 3;
         let opts = Arc::new(base_opts);
 
@@ -7581,7 +7572,7 @@ mod tests {
         // part_a_latest matches and is rewritten with only its surviving
         // superfile.
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 2;
         let opts = Arc::new(base_opts);
 
@@ -7916,7 +7907,7 @@ mod tests {
         // removed superfile; part_a_latest holds no matching id and carries over
         // unchanged. sf_a_old_keep and sf_a_latest survive.
         let mut base_opts =
-            SupertableOptions::new(simple_schema(), vec![], vec![], None).expect("valid options");
+            SupertableOptions::new(simple_schema(), vec![], vec![]).expect("valid options");
         base_opts.target_superfiles_per_part = 2;
         let opts = Arc::new(base_opts);
 

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -118,6 +118,18 @@ pub fn compute_options_hash(opts: &SupertableOptions, strategy: &PartitionStrate
             push_str(&mut buf, t.name());
         }
     }
+    // 3d. stored flags — same only-when-non-default rule: an all-stored
+    //     table's stream stays byte-identical to hashes stamped before
+    //     index-only columns existed, so pre-existing manifests keep
+    //     verifying; a table with an index-only column hashes
+    //     differently (its superfiles' Parquet bodies differ, so the
+    //     options identity must too).
+    if opts.fts_columns.iter().any(|c| !c.stored) {
+        push_tag(&mut buf, b"fts_stored");
+        for c in &opts.fts_columns {
+            buf.push(c.stored as u8);
+        }
+    }
 
     // 4. vector_columns (same declared-order rationale).
     push_tag(&mut buf, b"vector_columns");
@@ -293,6 +305,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -334,6 +347,7 @@ mod tests {
             vec![FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -359,6 +373,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),
@@ -386,10 +401,12 @@ mod tests {
                 FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 },
                 FtsConfig {
                     column: "subtitle".into(),
                     positions: false,
+                    stored: true,
                 },
             ],
             vec![],
@@ -417,10 +434,12 @@ mod tests {
                 FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 },
                 FtsConfig {
                     column: "subtitle".into(),
                     positions: false,
+                    stored: true,
                 },
             ],
             vec![],
@@ -433,10 +452,12 @@ mod tests {
                 FtsConfig {
                     column: "subtitle".into(),
                     positions: false,
+                    stored: true,
                 },
                 FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 },
             ],
             vec![],
@@ -470,10 +491,12 @@ mod tests {
                     FtsConfig {
                         column: "title".into(),
                         positions: title_pos,
+                        stored: true,
                     },
                     FtsConfig {
                         column: "subtitle".into(),
                         positions: subtitle_pos,
+                        stored: true,
                     },
                 ],
                 vec![],
@@ -492,6 +515,49 @@ mod tests {
         // same options. If this assertion ever fails, the encoding
         // drifted and every existing table would fail open-validation.
         let hex: String = h_ff.0.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(hex, ALL_FALSE_GOLDEN_HEX);
+    }
+
+    /// The stored flag follows the same only-when-non-default rule as
+    /// positions: an all-stored table's stream carries no `fts_stored`
+    /// block (its hash equals the pre-flag golden above, which the
+    /// positions test pins), an index-only column changes the hash, and
+    /// WHICH column is index-only matters.
+    #[test]
+    fn compute_options_hash_stored_flag() {
+        let schema_two = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new("subtitle", DataType::LargeUtf8, false),
+        ]));
+        let opts = |title_stored: bool, subtitle_stored: bool| {
+            SupertableOptions::new(
+                schema_two.clone(),
+                vec![
+                    FtsConfig {
+                        column: "title".into(),
+                        positions: false,
+                        stored: title_stored,
+                    },
+                    FtsConfig {
+                        column: "subtitle".into(),
+                        positions: false,
+                        stored: subtitle_stored,
+                    },
+                ],
+                vec![],
+                Some(default_tokenizer()),
+            )
+            .expect("opts")
+        };
+        let h_tt = compute_options_hash(&opts(true, true), &time_range());
+        let h_ft = compute_options_hash(&opts(false, true), &time_range());
+        let h_tf = compute_options_hash(&opts(true, false), &time_range());
+        assert_ne!(h_tt.0, h_ft.0, "index-only column must change the hash");
+        assert_ne!(h_ft.0, h_tf.0, "which column is index-only must matter");
+
+        // All-stored equals the pre-flag golden — existing manifests
+        // keep verifying.
+        let hex: String = h_tt.0.iter().map(|b| format!("{b:02x}")).collect();
         assert_eq!(hex, ALL_FALSE_GOLDEN_HEX);
     }
 
@@ -540,6 +606,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -109,13 +109,13 @@ pub fn compute_options_hash(opts: &SupertableOptions, strategy: &PartitionStrate
     //     superfiles are tokenized differently, so the options identity
     //     must differ too).
     if opts
-        .fts_tokenizers
+        .fts_columns
         .iter()
-        .any(|t| t.name() != ASCII_LOWER_TOKENIZER)
+        .any(|c| c.analyzer != ASCII_LOWER_TOKENIZER)
     {
         push_tag(&mut buf, b"fts_analyzers");
-        for t in &opts.fts_tokenizers {
-            push_str(&mut buf, t.name());
+        for c in &opts.fts_columns {
+            push_str(&mut buf, &c.analyzer);
         }
     }
     // 3d. stored flags — same only-when-non-default rule: an all-stored
@@ -272,14 +272,12 @@ mod tests {
     use crate::{
         superfile::{
             builder::{FtsConfig, VectorConfig},
-            fts::tokenize::{AsciiLowerTokenizer, StandardTokenizer},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{
             manifest::{ClusterCentroids, list::PartitionStrategy, part::ContentHash},
             options::SupertableOptions,
         },
-        test_helpers::default_tokenizer,
     };
 
     fn schema_title_only() -> Arc<Schema> {
@@ -300,15 +298,14 @@ mod tests {
     }
 
     fn fts_opts() -> SupertableOptions {
+        fts_opts_analyzer(ASCII_LOWER_TOKENIZER)
+    }
+
+    fn fts_opts_analyzer(analyzer: &str) -> SupertableOptions {
         SupertableOptions::new(
             schema_title_only(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title").analyzer(analyzer)],
             vec![],
-            Some(default_tokenizer()),
         )
         .expect("opts")
     }
@@ -344,13 +341,8 @@ mod tests {
                 DataType::LargeUtf8,
                 false,
             )])),
-            vec![FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("body")],
             vec![],
-            Some(default_tokenizer()),
         )
         .expect("opts");
         let h_a = compute_options_hash(&opts_a, &time_range());
@@ -370,13 +362,8 @@ mod tests {
                 DataType::LargeUtf8,
                 true, // nullable
             )])),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         )
         .expect("opts");
         let h_a = compute_options_hash(&opts_a, &time_range());
@@ -397,20 +384,8 @@ mod tests {
         ]));
         let opts_b = SupertableOptions::new(
             schema_two,
-            vec![
-                FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                },
-                FtsConfig {
-                    column: "subtitle".into(),
-                    positions: false,
-                    stored: true,
-                },
-            ],
+            vec![FtsConfig::new("title"), FtsConfig::new("subtitle")],
             vec![],
-            Some(default_tokenizer()),
         )
         .expect("opts");
         let h_a = compute_options_hash(&opts_a, &time_range());
@@ -430,38 +405,14 @@ mod tests {
         ]));
         let opts_a = SupertableOptions::new(
             schema_two.clone(),
-            vec![
-                FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                },
-                FtsConfig {
-                    column: "subtitle".into(),
-                    positions: false,
-                    stored: true,
-                },
-            ],
+            vec![FtsConfig::new("title"), FtsConfig::new("subtitle")],
             vec![],
-            Some(default_tokenizer()),
         )
         .expect("opts");
         let opts_b = SupertableOptions::new(
             schema_two,
-            vec![
-                FtsConfig {
-                    column: "subtitle".into(),
-                    positions: false,
-                    stored: true,
-                },
-                FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                },
-            ],
+            vec![FtsConfig::new("subtitle"), FtsConfig::new("title")],
             vec![],
-            Some(default_tokenizer()),
         )
         .expect("opts");
         let h_a = compute_options_hash(&opts_a, &time_range());
@@ -488,19 +439,10 @@ mod tests {
             SupertableOptions::new(
                 schema_two.clone(),
                 vec![
-                    FtsConfig {
-                        column: "title".into(),
-                        positions: title_pos,
-                        stored: true,
-                    },
-                    FtsConfig {
-                        column: "subtitle".into(),
-                        positions: subtitle_pos,
-                        stored: true,
-                    },
+                    FtsConfig::new("title").positions(title_pos),
+                    FtsConfig::new("subtitle").positions(subtitle_pos),
                 ],
                 vec![],
-                Some(default_tokenizer()),
             )
             .expect("opts")
         };
@@ -533,19 +475,14 @@ mod tests {
             SupertableOptions::new(
                 schema_two.clone(),
                 vec![
-                    FtsConfig {
-                        column: "title".into(),
-                        positions: false,
-                        stored: title_stored,
-                    },
-                    FtsConfig {
-                        column: "subtitle".into(),
-                        positions: false,
-                        stored: subtitle_stored,
-                    },
+                    FtsConfig::new("title")
+                        .positions(false)
+                        .stored(title_stored),
+                    FtsConfig::new("subtitle")
+                        .positions(false)
+                        .stored(subtitle_stored),
                 ],
                 vec![],
-                Some(default_tokenizer()),
             )
             .expect("opts")
         };
@@ -576,19 +513,13 @@ mod tests {
 
         // The standard analyzer changes the hash: its superfiles are
         // tokenized differently, so the options identity must differ.
-        let standard = compute_options_hash(
-            &fts_opts().with_fts_tokenizers(vec![Arc::new(StandardTokenizer)]),
-            &strat,
-        );
+        let standard = compute_options_hash(&fts_opts_analyzer("standard"), &strat);
         assert_ne!(ascii.0, standard.0, "analyzer choice must change the hash");
 
         // Explicit ascii_lower equals the default: the analyzer block is
         // emitted only for a non-ascii_lower analyzer, so all-ascii_lower
         // tables keep the pre-analyzer hash (see ALL_FALSE_GOLDEN_HEX).
-        let ascii_explicit = compute_options_hash(
-            &fts_opts().with_fts_tokenizers(vec![Arc::new(AsciiLowerTokenizer)]),
-            &strat,
-        );
+        let ascii_explicit = compute_options_hash(&fts_opts_analyzer("ascii_lower"), &strat);
         assert_eq!(
             ascii.0, ascii_explicit.0,
             "all-ascii_lower hash must be unchanged"
@@ -603,11 +534,7 @@ mod tests {
         let opts_a = fts_opts();
         let opts_b = SupertableOptions::new(
             schema_title_emb(16),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim: 16,
@@ -616,7 +543,6 @@ mod tests {
                 rerank_codec: RerankCodec::default(),
                 provided_centroids: None,
             }],
-            Some(default_tokenizer()),
         )
         .expect("opts");
         let h_a = compute_options_hash(&opts_a, &time_range());
@@ -642,7 +568,6 @@ mod tests {
                     rerank_codec: RerankCodec::Sq8Residual,
                     provided_centroids: None,
                 }],
-                Some(default_tokenizer()),
             )
             .expect("opts")
         };
@@ -665,7 +590,6 @@ mod tests {
                     rerank_codec,
                     provided_centroids: None,
                 }],
-                Some(default_tokenizer()),
             )
             .expect("opts")
         };

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -66,7 +66,7 @@ use crate::{
     superfile::{
         OpenOptions,
         builder::{BuilderOptions, FtsConfig, VectorConfig},
-        fts::tokenize::{AsciiLowerTokenizer, Tokenizer},
+        fts::tokenize::{AsciiLowerTokenizer, Tokenizer, tokenizer_for_name},
         vector::layout::VectorLayout,
     },
     supertable::{
@@ -311,14 +311,6 @@ pub struct SupertableOptions {
     /// `FixedSizeList<Float32, dim>` with matching `list_size`.
     /// May be empty.
     pub vector_columns: Vec<VectorConfig>,
-    /// Default tokenizer, required iff `fts_columns` is non-empty. Used
-    /// as the per-column default when `fts_tokenizers` is not overridden.
-    pub tokenizer: Option<Arc<dyn Tokenizer>>,
-    /// Per-column tokenizers, aligned to `fts_columns` (one per FTS
-    /// column). Defaults in [`Self::new`] to `tokenizer` applied to
-    /// every column; [`Self::with_fts_tokenizers`] sets per-column
-    /// analyzers (per-field analysis).
-    pub fts_tokenizers: Vec<Arc<dyn Tokenizer>>,
     /// Pool used by reader fan-out (skip + per-superfile fan-out +
     /// top-k merge). Default: every logical core.
     pub reader_pool: Arc<ThreadPool>,
@@ -621,7 +613,6 @@ impl SupertableOptions {
         schema: Arc<Schema>,
         fts_columns: Vec<FtsConfig>,
         vector_columns: Vec<VectorConfig>,
-        tokenizer: Option<Arc<dyn Tokenizer>>,
     ) -> Result<Self, BuildError> {
         let id_column = default_id_column();
 
@@ -711,9 +702,16 @@ impl SupertableOptions {
             }
         }
 
-        // 5. FTS columns require a tokenizer.
-        if !fts_columns.is_empty() && tokenizer.is_none() {
-            return Err(BuildError::MissingTokenizer);
+        // 5. Each FTS column's analyzer name must resolve. Validating
+        //    here surfaces a typo at construction with a typed error,
+        //    instead of at the first commit's builder construction.
+        for fc in &fts_columns {
+            if tokenizer_for_name(&fc.analyzer).is_none() {
+                return Err(BuildError::UnknownAnalyzer {
+                    column: fc.column.clone(),
+                    analyzer: fc.analyzer.clone(),
+                });
+            }
         }
 
         // 6. Shared thread pools + a fresh store.
@@ -721,21 +719,11 @@ impl SupertableOptions {
         let writer_pool = shared_writer_pool();
         let store: Arc<dyn SuperfileReaderCache> = Arc::new(InMemoryReaderCache::new());
 
-        // Default per-column tokenizers: the single tokenizer applied to
-        // every FTS column. `with_fts_tokenizers` overrides for per-field
-        // analyzers.
-        let fts_tokenizers = match &tokenizer {
-            Some(t) => fts_columns.iter().map(|_| Arc::clone(t)).collect(),
-            None => Vec::new(),
-        };
-
         Ok(Self {
             schema,
             id_column,
             fts_columns,
             vector_columns,
-            tokenizer,
-            fts_tokenizers,
             reader_pool,
             writer_pool,
             store,
@@ -875,26 +863,18 @@ impl SupertableOptions {
         self
     }
 
-    /// Override the per-column FTS tokenizers (per-field analysis). The
-    /// vec must be aligned to `fts_columns` (one tokenizer per FTS
-    /// column, declaration order). Passing a differently-sized vec is a
-    /// caller bug; the builder indexes each column with its own entry.
-    pub fn with_fts_tokenizers(mut self, tokenizers: Vec<Arc<dyn Tokenizer>>) -> Self {
-        self.fts_tokenizers = tokenizers;
-        self
-    }
-
     /// Tokenizer configured for `column`, or `None` when `column` carries
-    /// no full-text index. `fts_tokenizers` is aligned to `fts_columns` (one
-    /// per column), so a hit on the column always yields its tokenizer — a
-    /// `None` return is exactly the "column is not full-text-indexed" signal,
-    /// which lets a search path reject up front instead of failing deep in
-    /// the scan. The lookup is a single pass over `fts_columns`.
+    /// no full-text index — a `None` return is exactly the "column is not
+    /// full-text-indexed" signal, which lets a search path reject up front
+    /// instead of failing deep in the scan. Resolves the column's analyzer
+    /// name from its `FtsConfig` (validated at construction, so the
+    /// resolution cannot fail for a registered column). The lookup is a
+    /// single pass over `fts_columns`.
     pub fn try_fts_tokenizer_for(&self, column: &str) -> Option<Arc<dyn Tokenizer>> {
         self.fts_columns
             .iter()
-            .position(|c| c.column == column)
-            .and_then(|i| self.fts_tokenizers.get(i).cloned())
+            .find(|c| c.column == column)
+            .and_then(|c| tokenizer_for_name(&c.analyzer))
     }
 
     /// Tokenizer configured for `column`, for tokenizing query text so
@@ -1276,9 +1256,7 @@ impl SupertableOptions {
             self.id_column.clone(),
             self.fts_columns.clone(),
             self.vector_columns.clone(),
-            self.tokenizer.clone(),
         )
-        .with_fts_tokenizers(self.fts_tokenizers.clone())
         .with_vector_layout(self.vector_layout)
     }
 
@@ -1355,7 +1333,6 @@ impl fmt::Debug for SupertableOptions {
             .field("id_column", &self.id_column)
             .field("n_fts_columns", &self.fts_columns.len())
             .field("n_vector_columns", &self.vector_columns.len())
-            .field("has_tokenizer", &self.tokenizer.is_some())
             .finish()
     }
 }
@@ -1415,19 +1392,13 @@ mod tests {
     }
 
     fn fc(name: &str) -> FtsConfig {
-        FtsConfig {
-            column: name.into(),
-            positions: false,
-            stored: true,
-        }
+        FtsConfig::new(name)
     }
-
-    use crate::test_helpers::default_tokenizer as tok;
 
     #[test]
     fn valid_options_with_fts_and_vector_succeeds() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options should succeed");
         assert_eq!(opts.id_column, "_id");
         assert_eq!(opts.fts_columns.len(), 1);
@@ -1446,16 +1417,16 @@ mod tests {
             Field::new("_id", DataType::UInt64, false),
             Field::new("emb", fixed_list_f32(16), false),
         ]));
-        let err = SupertableOptions::new(s, vec![], vec![vc("emb", 16)], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![], vec![vc("emb", 16)]).expect_err("expected error");
         assert!(matches!(err, BuildError::IdColumnReserved(c) if c == "_id"));
     }
 
     #[test]
     fn fts_column_missing_from_schema_rejected() {
         let s = schema_with_vector(16);
-        let err = SupertableOptions::new(s, vec![fc("absent")], vec![], Some(tok()))
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![fc("absent")], vec![]).expect_err("expected error");
         assert!(matches!(err, BuildError::FtsColumnMissing { column } if column == "absent"));
     }
 
@@ -1463,8 +1434,7 @@ mod tests {
     fn fts_column_wrong_type_rejected() {
         // `body` is Utf8 not LargeUtf8 — must reject.
         let s = Arc::new(Schema::new(vec![Field::new("body", DataType::Utf8, false)]));
-        let err = SupertableOptions::new(s, vec![fc("body")], vec![], Some(tok()))
-            .expect_err("expected error");
+        let err = SupertableOptions::new(s, vec![fc("body")], vec![]).expect_err("expected error");
         assert!(
             matches!(err, BuildError::FtsColumnMustBeLargeUtf8 { column, .. } if column == "body")
         );
@@ -1477,8 +1447,8 @@ mod tests {
             DataType::Utf8,
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![], vec![vc("emb", 16)], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![], vec![vc("emb", 16)]).expect_err("expected error");
         assert!(matches!(err, BuildError::VectorColumnMissing { column } if column == "emb"));
     }
 
@@ -1490,8 +1460,8 @@ mod tests {
             DataType::Float32,
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![], vec![vc("emb", 16)], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![], vec![vc("emb", 16)]).expect_err("expected error");
         assert!(matches!(
             err,
             BuildError::VectorColumnNotFixedSizeList { column, .. } if column == "emb"
@@ -1506,8 +1476,8 @@ mod tests {
             DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, true)), 16),
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![], vec![vc("emb", 16)], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![], vec![vc("emb", 16)]).expect_err("expected error");
         assert!(matches!(
             err,
             BuildError::VectorColumnNotFixedSizeList { column, .. } if column == "emb"
@@ -1522,8 +1492,8 @@ mod tests {
             fixed_list_f32(8),
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![], vec![vc("emb", 16)], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![], vec![vc("emb", 16)]).expect_err("expected error");
         assert!(matches!(
             err,
             BuildError::VectorColumnDimMismatch { expected: 16, actual: 8, column } if column == "emb"
@@ -1537,8 +1507,8 @@ mod tests {
             fixed_list_f32(8),
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![], vec![vc("emb", 8)], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![], vec![vc("emb", 8)]).expect_err("expected error");
         assert!(matches!(
             err,
             BuildError::VectorDimOutOfRange { column, dim: 8 } if column == "emb"
@@ -1552,8 +1522,8 @@ mod tests {
             fixed_list_f32(8192),
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![], vec![vc("emb", 8192)], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![], vec![vc("emb", 8192)]).expect_err("expected error");
         assert!(matches!(
             err,
             BuildError::VectorDimOutOfRange { column, dim: 8192 } if column == "emb"
@@ -1568,9 +1538,8 @@ mod tests {
         ]));
         // Duplicate `emb` between two vector_columns entries —
         // hits the cross-list dedup check.
-        let err =
-            SupertableOptions::new(s.clone(), vec![], vec![vc("emb", 16), vc("emb", 16)], None)
-                .expect_err("expected error");
+        let err = SupertableOptions::new(s.clone(), vec![], vec![vc("emb", 16), vc("emb", 16)])
+            .expect_err("expected error");
         assert!(matches!(err, BuildError::DuplicateLogicalName(n) if n == "emb"));
     }
 
@@ -1581,8 +1550,8 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![fc("ti\u{1F}tle")], vec![], Some(tok()))
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![fc("ti\u{1F}tle")], vec![]).expect_err("expected error");
         assert!(matches!(err, BuildError::ReservedSeparatorInColumnName(_)));
     }
 
@@ -1593,21 +1562,21 @@ mod tests {
             fixed_list_f32(16),
             false,
         )]));
-        let err = SupertableOptions::new(s, vec![], vec![vc("inf.emb", 16)], None)
-            .expect_err("expected error");
+        let err =
+            SupertableOptions::new(s, vec![], vec![vc("inf.emb", 16)]).expect_err("expected error");
         assert!(matches!(err, BuildError::ReservedPrefixInColumnName(_)));
     }
 
     #[test]
-    fn fts_columns_without_tokenizer_rejected() {
+    fn fts_column_with_unknown_analyzer_rejected() {
         let s = Arc::new(Schema::new(vec![Field::new(
             "title",
             DataType::LargeUtf8,
             false,
         )]));
-        let err =
-            SupertableOptions::new(s, vec![fc("title")], vec![], None).expect_err("expected error");
-        assert!(matches!(err, BuildError::MissingTokenizer));
+        let err = SupertableOptions::new(s, vec![fc("title").analyzer("nonesuch")], vec![])
+            .expect_err("expected error");
+        assert!(matches!(err, BuildError::UnknownAnalyzer { .. }));
     }
 
     #[test]
@@ -1619,13 +1588,13 @@ mod tests {
         )]));
         // No FTS, no vectors, no tokenizer — the supertable becomes
         // a thin wrapper over scalar Parquet data. Must succeed.
-        SupertableOptions::new(s, vec![], vec![], None).expect("empty fts + vector should succeed");
+        SupertableOptions::new(s, vec![], vec![]).expect("empty fts + vector should succeed");
     }
 
     #[test]
     fn scalar_schema_drops_vector_columns_and_prepends_id() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options");
         let scalar = opts.scalar_schema();
         let names: Vec<_> = scalar.fields().iter().map(|f| f.name().as_str()).collect();
@@ -1645,8 +1614,7 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![], Some(tok()))
-            .expect("valid options");
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![]).expect("valid options");
         let scalar = opts.scalar_schema();
         let names: Vec<_> = scalar.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(names, vec!["_id", "title"]);
@@ -1655,7 +1623,7 @@ mod tests {
     #[test]
     fn effective_schema_prepends_id_keeps_vector_columns() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options");
         let eff = opts.effective_schema();
         let names: Vec<_> = eff.fields().iter().map(|f| f.name().as_str()).collect();
@@ -1665,13 +1633,8 @@ mod tests {
     #[test]
     fn user_schema_returns_input_schema_unchanged() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(
-            Arc::clone(&s),
-            vec![fc("title")],
-            vec![vc("emb", 16)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(Arc::clone(&s), vec![fc("title")], vec![vc("emb", 16)])
+            .expect("valid options");
         let us = opts.user_schema();
         assert_eq!(us.fields().len(), s.fields().len());
         for (a, b) in us.fields().iter().zip(s.fields().iter()) {
@@ -1682,7 +1645,7 @@ mod tests {
     #[test]
     fn with_id_column_overrides_default() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options")
             .with_id_column("row_id")
             .expect("override accepted");
@@ -1695,7 +1658,7 @@ mod tests {
     #[test]
     fn with_id_column_rejects_name_that_collides_with_user_schema() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options");
         let err = opts.with_id_column("title").expect_err("collision");
         assert!(matches!(err, BuildError::IdColumnReserved(c) if c == "title"));
@@ -1718,7 +1681,7 @@ supertable:
             Config::from_figment(Figment::new().merge(Yaml::string(yaml))).expect("parse config");
 
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options")
             .apply_config(&cfg)
             .expect("apply_config");
@@ -1758,7 +1721,7 @@ supertable:
         let cfg = Config::defaults().expect("embedded default");
 
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options")
             .apply_config(&cfg)
             .expect("apply_config");
@@ -1774,7 +1737,7 @@ supertable:
     #[test]
     fn debug_format_doesnt_explode() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options");
         let s = format!("{:?}", opts);
         assert!(s.contains("SupertableOptions"));
@@ -1789,7 +1752,7 @@ supertable:
             DataType::Utf8,
             false,
         )]));
-        SupertableOptions::new(s, vec![], vec![], None).expect("valid options")
+        SupertableOptions::new(s, vec![], vec![]).expect("valid options")
     }
 
     #[test]
@@ -1939,7 +1902,7 @@ supertable:
     #[test]
     fn builder_options_use_scalar_schema_and_id_column() {
         let s = schema_with_vector(16);
-        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)], Some(tok()))
+        let opts = SupertableOptions::new(s, vec![fc("title")], vec![vc("emb", 16)])
             .expect("valid options");
         let bo = opts.builder_options();
         // builder_options carries the scalar-only schema (vectors

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -1285,12 +1285,14 @@ impl SupertableOptions {
     /// Effective scalar-only schema — the user's columns with
     /// vector columns projected out *and* the supertable-
     /// injected id column prepended. This is what the
-    /// underlying `SuperfileBuilder` sees and what Parquet
-    /// stores.
+    /// underlying `SuperfileBuilder` sees at ingest.
     ///
     /// Vectors live in the embedded vector blob, never in
     /// Parquet, so they don't appear here. The id column is
-    /// always first.
+    /// always first. Index-only FTS columns DO appear here —
+    /// their text must reach the builder to be tokenized —
+    /// but the builder drops them from the Parquet body, so
+    /// the readable shape is [`Self::stored_schema`].
     ///
     /// Cost is one schema-walk + one `Vec::clone` of the
     /// surviving fields per call. Caching on first call is a
@@ -1315,6 +1317,33 @@ impl SupertableOptions {
                 .filter(|f| !vector_names.contains(f.name().as_str()))
                 .cloned(),
         );
+        Arc::new(Schema::new(kept))
+    }
+
+    /// The readable (stored) schema — [`Self::scalar_schema`] minus
+    /// index-only FTS columns (`stored: false`). Index-only text feeds
+    /// the FTS blob at ingest but never lands in Parquet, so it cannot
+    /// be scanned, projected, or filtered on; the SQL scan view and the
+    /// search-result projection surface resolve names against this
+    /// shape so such a column is rejected up front like any unknown
+    /// column, instead of failing mid-decode.
+    pub fn stored_schema(&self) -> Arc<Schema> {
+        let unstored: HashSet<&str> = self
+            .fts_columns
+            .iter()
+            .filter(|fc| !fc.stored)
+            .map(|fc| fc.column.as_str())
+            .collect();
+        let scalar = self.scalar_schema();
+        if unstored.is_empty() {
+            return scalar;
+        }
+        let kept: Vec<Arc<Field>> = scalar
+            .fields()
+            .iter()
+            .filter(|f| !unstored.contains(f.name().as_str()))
+            .cloned()
+            .collect();
         Arc::new(Schema::new(kept))
     }
 }
@@ -1389,6 +1418,7 @@ mod tests {
         FtsConfig {
             column: name.into(),
             positions: false,
+            stored: true,
         }
     }
 

--- a/src/supertable/query/dispatch.rs
+++ b/src/supertable/query/dispatch.rs
@@ -655,13 +655,7 @@ mod codec_verify_tests {
     /// `codec` under `metric`, and open it as a reader.
     fn build_reader(metric: Metric, codec: RerankCodec) -> SuperfileReader {
         let schema = Arc::new(Schema::new(vec![decimal128_id_field("doc_id")]));
-        let opts = BuilderOptions::new(
-            schema.clone(),
-            "doc_id",
-            vec![],
-            vec![cfg(metric, codec)],
-            None,
-        );
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![cfg(metric, codec)]);
         let mut b = SuperfileBuilder::new(opts).expect("new builder");
         let batch = RecordBatch::try_new(schema, vec![Arc::new(decimal128_ids(vec![10u64, 11]))])
             .expect("batch");

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -925,7 +925,6 @@ mod tests {
         },
         test_helpers::{
             build_title_batch, decimal128_id_field, decimal128_ids, default_supertable_options,
-            default_tokenizer as tok,
         },
     };
 
@@ -1013,11 +1012,7 @@ mod tests {
         ]));
         SupertableOptions::new(
             schema,
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -1026,7 +1021,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -1307,18 +1301,9 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let opts = SupertableOptions::new(
-            schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .with_writer_pool(pool);
+        let opts = SupertableOptions::new(schema.clone(), vec![FtsConfig::new("title")], vec![])
+            .expect("valid options")
+            .with_writer_pool(pool);
         let st = Supertable::create(opts).expect("create");
         let mut w = st.writer().expect("writer");
         let titles = LargeStringArray::from(vec![
@@ -1426,7 +1411,7 @@ mod tests {
             decimal128_id_field("doc_id"),
             Field::new("title", DataType::LargeUtf8, false),
         ]));
-        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("builder");
         let ids = decimal128_ids(0..TITLES.len() as u64);
         let title = LargeStringArray::from(TITLES.to_vec());

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -162,7 +162,9 @@ pub(crate) async fn resolve_hits_named(
     hits: &[SuperfileHit],
     projection: Option<&[&str]>,
 ) -> Result<RecordBatch, QueryError> {
-    let scalar_schema = reader.options().scalar_schema();
+    // Stored shape: an index-only FTS column has no Parquet data to
+    // project, so its name is rejected up front like any unknown column.
+    let scalar_schema = reader.options().stored_schema();
     let output_schema = output_schema_with_score(&scalar_schema);
     // `None` is the engine-native result: `_id` + `score` only.
     // `_id` decodes from its own dedicated id pages (cheap by
@@ -1014,6 +1016,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -1309,6 +1312,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -425,7 +425,6 @@ mod tests {
     use crate::{
         superfile::builder::FtsConfig,
         supertable::{Supertable, SupertableOptions},
-        test_helpers::default_tokenizer as tok,
     };
 
     fn title_schema() -> Arc<Schema> {
@@ -443,18 +442,9 @@ mod tests {
                 .build()
                 .expect("pool"),
         );
-        SupertableOptions::new(
-            title_schema(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .with_writer_pool(pool)
+        SupertableOptions::new(title_schema(), vec![FtsConfig::new("title")], vec![])
+            .expect("valid options")
+            .with_writer_pool(pool)
     }
 
     fn supertable_with_titles(titles: &[&str]) -> Supertable {

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -448,6 +448,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -602,7 +602,6 @@ mod tests {
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{Supertable, SupertableOptions},
-        test_helpers::default_tokenizer as tok,
     };
 
     // ---- supertable harness: title (FTS) + emb (vector) ----
@@ -627,11 +626,7 @@ mod tests {
         ]));
         SupertableOptions::new(
             schema,
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -640,7 +635,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -1191,11 +1185,7 @@ mod tests {
         ]));
         SupertableOptions::new(
             schema,
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -1204,7 +1194,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool)

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -630,6 +630,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -1193,6 +1194,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -396,7 +396,6 @@ mod tests {
             Supertable, SupertableOptions, handle::SupertableReader,
             query::exec::common::output_schema_with_score,
         },
-        test_helpers::default_tokenizer as tok,
     };
 
     fn title_schema() -> Arc<Schema> {
@@ -414,18 +413,9 @@ mod tests {
                 .build()
                 .expect("pool"),
         );
-        SupertableOptions::new(
-            title_schema(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .with_writer_pool(pool)
+        SupertableOptions::new(title_schema(), vec![FtsConfig::new("title")], vec![])
+            .expect("valid options")
+            .with_writer_pool(pool)
     }
 
     fn supertable_with_titles(titles: &[&str]) -> Supertable {

--- a/src/supertable/query/exec/match_exec.rs
+++ b/src/supertable/query/exec/match_exec.rs
@@ -419,6 +419,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -574,7 +574,6 @@ mod tests {
             Supertable, SupertableOptions, manifest::ManifestSnapshot,
             query::candidate::LIKE_MAX_TERMS,
         },
-        test_helpers::default_tokenizer as tok,
     };
 
     /// Moves manifest id ranges away from every real generated id.
@@ -590,15 +589,12 @@ mod tests {
     }
 
     fn options_one_superfile_per_commit(dim: usize) -> SupertableOptions {
-        options_one_superfile_per_commit_with(dim, tok())
+        options_one_superfile_per_commit_with(dim, ASCII_LOWER_TOKENIZER)
     }
 
-    /// [`options_one_superfile_per_commit`] with `title` analyzed by
-    /// `tokenizer`.
-    fn options_one_superfile_per_commit_with(
-        dim: usize,
-        tokenizer: Arc<dyn Tokenizer>,
-    ) -> SupertableOptions {
+    /// [`options_one_superfile_per_commit`] with `title` analyzed by the
+    /// named analyzer.
+    fn options_one_superfile_per_commit_with(dim: usize, analyzer: &str) -> SupertableOptions {
         let pool = Arc::new(
             ThreadPoolBuilder::new()
                 .num_threads(1)
@@ -611,11 +607,7 @@ mod tests {
         ]));
         SupertableOptions::new(
             schema,
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title").analyzer(analyzer)],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -624,7 +616,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tokenizer),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -673,20 +664,16 @@ mod tests {
         let titles: Vec<String> = (0..n)
             .map(|i| if i < n_common { "common" } else { "rare" }.to_owned())
             .collect();
-        supertable_ranked_by_index(dim, &titles, tok())
+        supertable_ranked_by_index(dim, &titles, ASCII_LOWER_TOKENIZER)
     }
 
     /// Single-superfile table where doc `i` carries `titles[i]` and the
     /// vector `[1, i, 0, …]`, so distance to the query `[1, 0, …]` ranks by
     /// index (see [`supertable_for_pushdown`]). `title` is analyzed with
     /// `tokenizer`. Requires `dim >= 2`.
-    fn supertable_ranked_by_index(
-        dim: usize,
-        titles: &[String],
-        tokenizer: Arc<dyn Tokenizer>,
-    ) -> Supertable {
+    fn supertable_ranked_by_index(dim: usize, titles: &[String], analyzer: &str) -> Supertable {
         let n = titles.len();
-        let st = Supertable::create(options_one_superfile_per_commit_with(dim, tokenizer))
+        let st = Supertable::create(options_one_superfile_per_commit_with(dim, analyzer))
             .expect("create");
         let mut w = st.writer().expect("writer");
         let schema = st.options().schema.clone();
@@ -1003,7 +990,7 @@ mod tests {
         .iter()
         .map(|t| (*t).to_owned())
         .collect();
-        let st = supertable_ranked_by_index(dim, &titles, Arc::new(StandardTokenizer));
+        let st = supertable_ranked_by_index(dim, &titles, STANDARD_TOKENIZER);
         let q = csv_one_hot(dim, 0);
         let filtered = st
             .reader()
@@ -1029,7 +1016,7 @@ mod tests {
         let dim = 16;
         let k = 3;
         let titles: Vec<String> = (0..LIKE_MAX_TERMS + 8).map(|i| format!("w{i}zz")).collect();
-        let st = supertable_ranked_by_index(dim, &titles, Arc::new(StandardTokenizer));
+        let st = supertable_ranked_by_index(dim, &titles, STANDARD_TOKENIZER);
         let q = csv_one_hot(dim, 0);
         // Contains: no manifest gate at all.
         let contains = st

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -614,6 +614,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -567,7 +567,7 @@ mod tests {
     use crate::{
         superfile::{
             builder::{FtsConfig, VectorConfig},
-            fts::tokenize::{StandardTokenizer, Tokenizer},
+            fts::tokenize::{ASCII_LOWER_TOKENIZER, STANDARD_TOKENIZER},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1991,7 +1991,6 @@ mod tests {
             manifest::{SuperfileEntry, SuperfileUri},
             options::{DECIMAL128_PRECISION, DECIMAL128_SCALE},
         },
-        test_helpers::default_tokenizer as tok,
     };
 
     /// Manifest entry fixture for the work-unit tests. `n_docs` is the
@@ -2042,18 +2041,9 @@ mod tests {
                 .build()
                 .expect("pool"),
         );
-        SupertableOptions::new(
-            schema_id_title(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .with_writer_pool(pool)
+        SupertableOptions::new(schema_id_title(), vec![FtsConfig::new("title")], vec![])
+            .expect("valid options")
+            .with_writer_pool(pool)
     }
 
     fn build_batch(_start: u64, titles: &[&str]) -> RecordBatch {
@@ -2239,13 +2229,8 @@ mod tests {
         );
         SupertableOptions::new(
             schema_id_title(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: true,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title").positions(true)],
             vec![],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -2484,17 +2469,8 @@ mod tests {
             ),
             Field::new("title", DataType::LargeUtf8, false),
         ]));
-        let opts = BuilderOptions::new(
-            schema.clone(),
-            "_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tok()),
-        );
+        let opts =
+            BuilderOptions::new(schema.clone(), "_id", vec![FtsConfig::new("title")], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("builder");
         let n = titles.len();
         let ids = Decimal128Array::from((0..n as i128).collect::<Vec<_>>())
@@ -3040,13 +3016,8 @@ mod tests {
         );
         SupertableOptions::new(
             schema_id_title(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: true,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title").positions(true)],
             vec![],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool)

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -2047,6 +2047,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tok()),
@@ -2241,6 +2242,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: true,
+                stored: true,
             }],
             vec![],
             Some(tok()),
@@ -2488,6 +2490,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tok()),
@@ -3040,6 +3043,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: true,
+                stored: true,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -2386,6 +2386,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(default_tokenizer()),

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -2381,18 +2381,9 @@ mod tests {
                 .build()
                 .expect("pool"),
         );
-        SupertableOptions::new(
-            cat_title_schema(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(default_tokenizer()),
-        )
-        .expect("opts")
-        .with_writer_pool(pool)
+        SupertableOptions::new(cat_title_schema(), vec![FtsConfig::new("title")], vec![])
+            .expect("opts")
+            .with_writer_pool(pool)
     }
 
     fn cat_title_batch(cats: &[&str], titles: &[&str]) -> RecordBatch {
@@ -2680,7 +2671,7 @@ mod tests {
         );
         // No FTS column — this fixture exercises the scalar-stats path
         // (min/max/sum/null/distinct), not the term bloom.
-        SupertableOptions::new(num_schema(), vec![], vec![], None)
+        SupertableOptions::new(num_schema(), vec![], vec![])
             .expect("opts")
             .with_writer_pool(pool)
     }

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -467,6 +467,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![],
                 Some(tk),

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -460,19 +460,9 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let tk = default_tokenizer();
+        let _tk = default_tokenizer();
         Arc::new(
-            SupertableOptions::new(
-                schema,
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
-                vec![],
-                Some(tk),
-            )
-            .expect("opts"),
+            SupertableOptions::new(schema, vec![FtsConfig::new("title")], vec![]).expect("opts"),
         )
     }
 

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -419,19 +419,9 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let tk = default_tokenizer();
+        let _tk = default_tokenizer();
         Arc::new(
-            SupertableOptions::new(
-                schema,
-                vec![FtsConfig {
-                    column: "title".into(),
-                    positions: false,
-                    stored: true,
-                }],
-                vec![],
-                Some(tk),
-            )
-            .expect("opts"),
+            SupertableOptions::new(schema, vec![FtsConfig::new("title")], vec![]).expect("opts"),
         )
     }
 
@@ -458,7 +448,6 @@ mod tests {
                     rerank_codec: RerankCodec::Fp32,
                     provided_centroids: None,
                 }],
-                None,
             )
             .expect("opts"),
         )

--- a/src/supertable/query/skip.rs
+++ b/src/supertable/query/skip.rs
@@ -426,6 +426,7 @@ mod tests {
                 vec![FtsConfig {
                     column: "title".into(),
                     positions: false,
+                    stored: true,
                 }],
                 vec![],
                 Some(tk),

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -566,7 +566,7 @@ mod tests {
         storage::{LocalFsStorageProvider, StorageProvider},
         superfile::{
             builder::{FtsConfig, VectorConfig},
-            fts::tokenize::{StandardTokenizer, Tokenizer},
+            fts::tokenize::{ASCII_LOWER_TOKENIZER, STANDARD_TOKENIZER},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{
@@ -1988,8 +1988,7 @@ mod tests {
     /// narrow one with two such terms (plus the filler rows that let it
     /// walk its dictionary).
     fn mixed_like_table() -> Supertable {
-        let st = Supertable::create(options_id_cat_title_with(STANDARD_TOKENIZER))
-            .expect("create");
+        let st = Supertable::create(options_id_cat_title_with(STANDARD_TOKENIZER)).expect("create");
         let mut w = st.writer().expect("writer");
         let filler = WALK_FILLER_WORDS.join(" ");
         let wide: Vec<String> = (0..OVER_CAP_ROWS)

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -574,7 +574,6 @@ mod tests {
             error::QueryError,
             query::{candidate::LIKE_MAX_TERMS, sql::build_sql_schemas},
         },
-        test_helpers::default_tokenizer as tok,
     };
 
     /// One more than the manifest's exact-value cardinality cap.
@@ -741,11 +740,11 @@ mod tests {
     }
 
     fn options_id_cat_title() -> SupertableOptions {
-        options_id_cat_title_with(tok())
+        options_id_cat_title_with(ASCII_LOWER_TOKENIZER)
     }
 
-    /// [`options_id_cat_title`] with `title` analyzed by `tokenizer`.
-    fn options_id_cat_title_with(tokenizer: Arc<dyn Tokenizer>) -> SupertableOptions {
+    /// [`options_id_cat_title`] with `title` analyzed by the named analyzer.
+    fn options_id_cat_title_with(analyzer: &str) -> SupertableOptions {
         // Single-threaded writer pool so each commit produces
         // exactly one superfile — keeps assertions on per-superfile
         // counts deterministic.
@@ -757,13 +756,8 @@ mod tests {
         );
         SupertableOptions::new(
             schema_id_cat_title(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title").analyzer(analyzer)],
             vec![],
-            Some(tokenizer),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -827,7 +821,7 @@ mod tests {
                 .build()
                 .expect("rayon pool"),
         );
-        let options = SupertableOptions::new(schema.clone(), vec![], vec![], None)
+        let options = SupertableOptions::new(schema.clone(), vec![], vec![])
             .expect("rating options")
             .with_writer_pool(pool);
         let table = Supertable::create(options).expect("create rating table");
@@ -1365,18 +1359,10 @@ mod tests {
                 .build()
                 .expect("rayon pool"),
         );
-        let opts = SupertableOptions::new(
-            Arc::clone(&schema),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .with_writer_pool(pool);
+        let opts =
+            SupertableOptions::new(Arc::clone(&schema), vec![FtsConfig::new("title")], vec![])
+                .expect("valid options")
+                .with_writer_pool(pool);
 
         let st = Supertable::create(opts).expect("create");
         let mut w = st.writer().expect("writer");
@@ -1419,18 +1405,10 @@ mod tests {
                 .build()
                 .expect("rayon pool"),
         );
-        let opts = SupertableOptions::new(
-            Arc::clone(&schema),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tok()),
-        )
-        .expect("valid options")
-        .with_writer_pool(pool);
+        let opts =
+            SupertableOptions::new(Arc::clone(&schema), vec![FtsConfig::new("title")], vec![])
+                .expect("valid options")
+                .with_writer_pool(pool);
 
         let st = Supertable::create(opts).expect("create");
         let mut w = st.writer().expect("writer");
@@ -1619,7 +1597,7 @@ mod tests {
             DataType::LargeUtf8,
             true,
         )]));
-        let options = SupertableOptions::new(schema.clone(), vec![], vec![], None)
+        let options = SupertableOptions::new(schema.clone(), vec![], vec![])
             .expect("nullable category options");
         let table = Supertable::create(options).expect("create");
         let mut writer = table.writer().expect("writer");
@@ -1840,10 +1818,9 @@ mod tests {
         // FilterExec narrows. Whatever the plan, the rows must be exactly
         // the textbook LIKE matches — checked against an independent
         // oracle for every pattern under both analyzers.
-        let analyzers: [Arc<dyn Tokenizer>; 2] = [tok(), Arc::new(StandardTokenizer)];
-        for tokenizer in analyzers {
-            let name = tokenizer.name();
-            let st = Supertable::create(options_id_cat_title_with(tokenizer)).expect("create");
+        let analyzers = [ASCII_LOWER_TOKENIZER, STANDARD_TOKENIZER];
+        for name in analyzers {
+            let st = Supertable::create(options_id_cat_title_with(name)).expect("create");
             let mut w = st.writer().expect("writer");
             let titles = with_walk_filler(LIKE_TITLES);
             let title_refs: Vec<&str> = titles.iter().map(String::as_str).collect();
@@ -1880,9 +1857,8 @@ mod tests {
         // case folding matches against `s` and `k` — the index-bounded
         // plan must return exactly that, under both analyzers.
         let rt = Runtime::new().expect("runtime");
-        let analyzers: [Arc<dyn Tokenizer>; 2] = [tok(), Arc::new(StandardTokenizer)];
-        for tokenizer in analyzers {
-            let name = tokenizer.name();
+        let analyzers = [ASCII_LOWER_TOKENIZER, STANDARD_TOKENIZER];
+        for name in analyzers {
             let titles = with_walk_filler(FOLD_TITLES);
             let title_refs: Vec<&str> = titles.iter().map(String::as_str).collect();
             let cats: Vec<&str> = title_refs.iter().map(|_| "x").collect();
@@ -1895,7 +1871,7 @@ mod tests {
             // Two superfiles: the second holds only rows whose every
             // spelling an ASCII token misses, so an unsound term-bloom or
             // term-range leaf would prune it whole and lose its rows.
-            let st = Supertable::create(options_id_cat_title_with(tokenizer)).expect("create");
+            let st = Supertable::create(options_id_cat_title_with(name)).expect("create");
             let mut w = st.writer().expect("writer");
             w.append(&batch).expect("append");
             w.commit().expect("commit");
@@ -2012,7 +1988,7 @@ mod tests {
     /// narrow one with two such terms (plus the filler rows that let it
     /// walk its dictionary).
     fn mixed_like_table() -> Supertable {
-        let st = Supertable::create(options_id_cat_title_with(Arc::new(StandardTokenizer)))
+        let st = Supertable::create(options_id_cat_title_with(STANDARD_TOKENIZER))
             .expect("create");
         let mut w = st.writer().expect("writer");
         let filler = WALK_FILLER_WORDS.join(" ");
@@ -2309,11 +2285,7 @@ mod tests {
         );
         SupertableOptions::new(
             schema_with_vector(dim),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -2322,7 +2294,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool)

--- a/src/supertable/query/sql.rs
+++ b/src/supertable/query/sql.rs
@@ -117,7 +117,10 @@ impl SqlSchemas {
 /// cached on the handle. This is the one place that walks the full column set,
 /// so a wide (thousands of columns) table pays it once, not per query.
 pub(crate) fn build_sql_schemas(options: &SupertableOptions) -> SqlSchemas {
-    let scalar = options.scalar_schema();
+    // Stored shape: index-only FTS columns are absent from Parquet, so
+    // SQL never sees them — selecting or filtering one fails at plan
+    // time like any unknown column.
+    let scalar = options.stored_schema();
     let fts: HashSet<&str> = options
         .fts_columns
         .iter()
@@ -757,6 +760,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tokenizer),
@@ -1366,6 +1370,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tok()),
@@ -1419,6 +1424,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tok()),
@@ -2306,6 +2312,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/query/superfile_reader.rs
+++ b/src/supertable/query/superfile_reader.rs
@@ -153,7 +153,7 @@ mod tests {
             decimal128_id_field("doc_id"),
             Field::new("title", DataType::LargeUtf8, false),
         ]));
-        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let ids = decimal128_ids(vec![1u64, 2, 3]);
         let title = LargeStringArray::from(vec!["a", "b", "c"]);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -4863,11 +4863,12 @@ impl SupertableReader {
             return Ok(Vec::new());
         }
         let manifest = self.manifest();
-        // Tokenize the predicate once with the index tokenizer (the same
-        // tokenizer used at build time, so the terms match the postings AND
-        // the manifest term blooms). No tokens (empty / punctuation-only) ⇒
+        // Tokenize the predicate once with the FILTER COLUMN's analyzer
+        // (the same one used at build time, so the terms match the
+        // postings AND the manifest term blooms). A non-FTS filter column
+        // matches nothing; no tokens (empty / punctuation-only) ⇒
         // nothing matches.
-        let Some(tokenizer) = manifest.options.tokenizer.as_ref() else {
+        let Some(tokenizer) = manifest.options.try_fts_tokenizer_for(filter.column) else {
             return Ok(Vec::new());
         };
         let tokens: Vec<String> = tokenizer.tokenize(filter.query).collect();
@@ -6382,7 +6383,7 @@ mod tests {
             slow_vector_state::{ResidentIndexKind, write_resident_index_blob},
             writer::{recalibrate_probe_laws, split_overflow_cell},
         },
-        test_helpers::{default_tokenizer as tok, distinct_unit_vectors},
+        test_helpers::distinct_unit_vectors,
     };
 
     /// Drive an async future to completion on a throwaway current-thread
@@ -6991,11 +6992,7 @@ mod tests {
         );
         SupertableOptions::new(
             schema_with_vector(dim),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -7004,7 +7001,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -7059,11 +7055,7 @@ mod tests {
         let opts = BuilderOptions::new(
             scalar_schema.clone(),
             "_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -7072,7 +7064,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
         );
         let mut b = SuperfileBuilder::new(opts).expect("builder");
 
@@ -7140,11 +7131,7 @@ mod tests {
         let opts = BuilderOptions::new(
             scalar_schema.clone(),
             "_id",
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -7153,7 +7140,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
         );
         let mut b = SuperfileBuilder::new(opts).expect("builder");
         let id_arr = Decimal128Array::from(ids.to_vec())
@@ -9300,11 +9286,7 @@ mod tests {
         );
         SupertableOptions::new(
             schema_with_vector(dim),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -9313,7 +9295,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq16,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool)
@@ -10166,11 +10147,7 @@ mod tests {
         );
         let opts = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -10179,7 +10156,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool);
@@ -10234,11 +10210,7 @@ mod tests {
         );
         let opts = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -10247,7 +10219,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool);
@@ -10342,11 +10313,7 @@ mod tests {
         );
         let opts = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -10355,7 +10322,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool);
@@ -10458,11 +10424,7 @@ mod tests {
         );
         let opts = SupertableOptions::new(
             schema.clone(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![VectorConfig {
                 column: "emb".into(),
                 dim,
@@ -10471,7 +10433,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq8Residual,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(pool);

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -6994,6 +6994,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -7061,6 +7062,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -7141,6 +7143,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -9300,6 +9303,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -10165,6 +10169,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -10232,6 +10237,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -10339,6 +10345,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),
@@ -10454,6 +10461,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![VectorConfig {
                 column: "emb".into(),

--- a/src/supertable/reader_cache/disk.rs
+++ b/src/supertable/reader_cache/disk.rs
@@ -2928,7 +2928,7 @@ mod tests {
             decimal128_id_field("doc_id"),
             Field::new("title", DataType::LargeUtf8, false),
         ]));
-        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("builder");
         let ids = decimal128_ids(vec![1u64]);
         let titles = LargeStringArray::from(vec!["alpha"]);

--- a/src/supertable/reader_cache/in_memory.rs
+++ b/src/supertable/reader_cache/in_memory.rs
@@ -161,7 +161,7 @@ mod tests {
             decimal128_id_field("doc_id"),
             Field::new("title", arrow_schema::DataType::LargeUtf8, false),
         ]));
-        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+        let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let ids = decimal128_ids(vec![1u64, 2, 3]);
         let title = LargeStringArray::from(vec!["a", "b", "c"]);

--- a/src/supertable/utils/vector_split.rs
+++ b/src/supertable/utils/vector_split.rs
@@ -230,14 +230,8 @@ mod tests {
     }
 
     fn fc(name: &str) -> FtsConfig {
-        FtsConfig {
-            column: name.into(),
-            positions: false,
-            stored: true,
-        }
+        FtsConfig::new(name)
     }
-
-    use crate::test_helpers::default_tokenizer as tok;
 
     /// Build a FixedSizeListArray of `n_rows` × `dim` f32s from a flat
     /// `Vec<f32>` of length `n_rows * dim`. No null entries.
@@ -265,13 +259,8 @@ mod tests {
     fn split_extracts_vectors_and_drops_columns() {
         let dim = 16;
         let schema = schema_id_title_emb(dim);
-        let opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![vc("emb", dim)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(schema.clone(), vec![fc("title")], vec![vc("emb", dim)])
+            .expect("valid options");
 
         let batch = build_batch(schema, 4, dim);
         let (scalar, vectors) = split_vectors(&batch, &opts).expect("split should succeed");
@@ -301,13 +290,8 @@ mod tests {
     fn split_rejects_batch_with_wrong_schema() {
         let dim = 16;
         let schema = schema_id_title_emb(dim);
-        let opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![vc("emb", dim)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(schema.clone(), vec![fc("title")], vec![vc("emb", dim)])
+            .expect("valid options");
 
         // Build a batch with a different schema (no `title` column).
         let other_schema = Arc::new(Schema::new(vec![Field::new(
@@ -334,13 +318,8 @@ mod tests {
             Field::new("title", DataType::LargeUtf8, false),
             Field::new("emb", fixed_list_f32(dim), true),
         ]));
-        let opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![vc("emb", dim)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(schema.clone(), vec![fc("title")], vec![vc("emb", dim)])
+            .expect("valid options");
 
         // Build a FSL with a NULL entry at row 1.
         use arrow::buffer::NullBuffer;
@@ -375,7 +354,7 @@ mod tests {
             DataType::LargeUtf8,
             false,
         )]));
-        let opts = SupertableOptions::new(schema.clone(), vec![fc("title")], vec![], Some(tok()))
+        let opts = SupertableOptions::new(schema.clone(), vec![fc("title")], vec![])
             .expect("valid options");
 
         let titles = LargeStringArray::from(vec!["x", "y"]);
@@ -398,13 +377,9 @@ mod tests {
             Field::new("other", fixed_list_f32(16), false),
             Field::new("c", DataType::UInt64, false),
         ]));
-        let opts = SupertableOptions::new(
-            schema.clone(),
-            vec![],
-            vec![vc("emb", 16), vc("other", 16)],
-            None,
-        )
-        .expect("valid options");
+        let opts =
+            SupertableOptions::new(schema.clone(), vec![], vec![vc("emb", 16), vc("other", 16)])
+                .expect("valid options");
 
         let n = 2;
         let dim = 16;
@@ -449,13 +424,8 @@ mod tests {
         // (and `collect_first_nulls_primitive`).
         let dim = 16;
         let schema = schema_id_title_emb(dim);
-        let opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![vc("emb", dim)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(schema.clone(), vec![fc("title")], vec![vc("emb", dim)])
+            .expect("valid options");
 
         // Three rows; the inner f32 buffer has a null at flat index 1
         // (row 0, lane 1). The FSL itself has no row-level nulls.
@@ -499,13 +469,9 @@ mod tests {
         // is not in the (otherwise schema-matching) batch.
         let dim = 16;
         let schema = schema_id_title_emb(dim);
-        let mut opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![vc("emb", dim)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let mut opts =
+            SupertableOptions::new(schema.clone(), vec![fc("title")], vec![vc("emb", dim)])
+                .expect("valid options");
         opts.vector_columns[0].column = "not_a_column".into();
 
         let batch = build_batch(schema, 2, dim);
@@ -523,13 +489,9 @@ mod tests {
         // downcast to FixedSizeListArray fails.
         let dim = 16;
         let schema = schema_id_title_emb(dim);
-        let mut opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![vc("emb", dim)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let mut opts =
+            SupertableOptions::new(schema.clone(), vec![fc("title")], vec![vc("emb", dim)])
+                .expect("valid options");
         opts.vector_columns[0].column = "title".into();
 
         let batch = build_batch(schema, 2, dim);
@@ -549,13 +511,9 @@ mod tests {
         // against the batch's FSL list_size.
         const WRONG_DIM: usize = 32;
         let schema = schema_id_title_emb(dim);
-        let mut opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![vc("emb", dim)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let mut opts =
+            SupertableOptions::new(schema.clone(), vec![fc("title")], vec![vc("emb", dim)])
+                .expect("valid options");
         opts.vector_columns[0].dim = WRONG_DIM;
 
         let batch = build_batch(schema, 2, dim);
@@ -574,13 +532,8 @@ mod tests {
     fn split_returns_zero_copy_view_into_batch() {
         let dim = 16;
         let schema = schema_id_title_emb(dim);
-        let opts = SupertableOptions::new(
-            schema.clone(),
-            vec![fc("title")],
-            vec![vc("emb", dim)],
-            Some(tok()),
-        )
-        .expect("valid options");
+        let opts = SupertableOptions::new(schema.clone(), vec![fc("title")], vec![vc("emb", dim)])
+            .expect("valid options");
         let batch = build_batch(schema, 4, dim);
 
         let (_scalar, vectors) = split_vectors(&batch, &opts).expect("split should succeed");

--- a/src/supertable/utils/vector_split.rs
+++ b/src/supertable/utils/vector_split.rs
@@ -233,6 +233,7 @@ mod tests {
         FtsConfig {
             column: name.into(),
             positions: false,
+            stored: true,
         }
     }
 

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -10726,6 +10726,7 @@ mod tests {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![],
             Some(tok()),

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -9808,8 +9808,7 @@ mod tests {
             wal::{recovery::scan_and_recover, state_doc::SupertableHandleId},
         },
         test_helpers::{
-            build_title_batch, default_supertable_options, default_tokenizer as tok,
-            distinct_unit_vectors,
+            build_title_batch, default_supertable_options, distinct_unit_vectors,
             fault_storage::{FaultKind, FaultOp, FaultStorage},
         },
     };
@@ -10721,17 +10720,8 @@ mod tests {
     }
 
     fn options_id_title() -> SupertableOptions {
-        SupertableOptions::new(
-            schema_id_title(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
-            vec![],
-            Some(tok()),
-        )
-        .expect("valid options")
+        SupertableOptions::new(schema_id_title(), vec![FtsConfig::new("title")], vec![])
+            .expect("valid options")
     }
 
     /// Force a single-threaded writer pool for deterministic
@@ -10904,7 +10894,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(writer_pool_with(1))
@@ -10925,7 +10914,6 @@ mod tests {
                 rerank_codec: RerankCodec::Sq16,
                 provided_centroids: None,
             }],
-            Some(tok()),
         )
         .expect("valid options")
         .with_writer_pool(writer_pool_with(1))
@@ -11454,7 +11442,6 @@ mod tests {
                 rerank_codec: RerankCodec::Fp32,
                 provided_centroids: None,
             }],
-            None,
         )
         .expect("valid options")
         .with_writer_pool(pool)

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -297,6 +297,7 @@ pub fn default_supertable_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -292,16 +292,7 @@ pub fn default_supertable_options() -> SupertableOptions {
             .build()
             .expect("rayon ThreadPoolBuilder with num_threads(1) builds"),
     );
-    SupertableOptions::new(
-        schema_id_title(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![],
-        Some(default_tokenizer()),
-    )
-    .expect("SupertableOptions::new with default test fixture args")
-    .with_writer_pool(pool)
+    SupertableOptions::new(schema_id_title(), vec![FtsConfig::new("title")], vec![])
+        .expect("SupertableOptions::new with default test fixture args")
+        .with_writer_pool(pool)
 }

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -28,7 +28,7 @@ use infino::{
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
         vector::distance::normalize,
     },
-    test_helpers::{decimal128_ids, default_tokenizer, default_vector_config},
+    test_helpers::{decimal128_ids, default_vector_config},
 };
 
 /// Decimal128 precision / scale for the `doc_id` column.
@@ -62,13 +62,8 @@ fn build_corruptable_positional_superfile() -> Vec<u8> {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: true,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title").positions(true)],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     let n = CRC_TEST_N_DOCS;
@@ -96,13 +91,8 @@ fn build_corruptable_superfile() -> Vec<u8> {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", CRC_TEST_ROT_SEED)],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 

--- a/tests/superfile/format/crc_corruption.rs
+++ b/tests/superfile/format/crc_corruption.rs
@@ -65,6 +65,7 @@ fn build_corruptable_positional_superfile() -> Vec<u8> {
         vec![FtsConfig {
             column: "title".into(),
             positions: true,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -98,6 +99,7 @@ fn build_corruptable_superfile() -> Vec<u8> {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", CRC_TEST_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/superfile/format/lazy_byte_source.rs
+++ b/tests/superfile/format/lazy_byte_source.rs
@@ -58,7 +58,7 @@ use infino::{
         StorageRangeSource,
         storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
-    test_helpers::{decimal128_ids, default_tokenizer},
+    test_helpers::decimal128_ids,
 };
 use tempfile::TempDir;
 
@@ -78,13 +78,8 @@ fn build_test_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3, 4]);
@@ -143,13 +138,8 @@ fn build_positional_test_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: true,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title").positions(true)],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3, 4]);
@@ -401,13 +391,8 @@ fn build_vec_plus_fts_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema,
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", LAZY_VEC_ROT_SEED)],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     b.add_batch(&batch, &[flat.as_slice()]).expect("add_batch");

--- a/tests/superfile/format/lazy_byte_source.rs
+++ b/tests/superfile/format/lazy_byte_source.rs
@@ -81,6 +81,7 @@ fn build_test_bytes() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -145,6 +146,7 @@ fn build_positional_test_bytes() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: true,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -402,6 +404,7 @@ fn build_vec_plus_fts_bytes() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", LAZY_VEC_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/superfile/format/parquet_compat.rs
+++ b/tests/superfile/format/parquet_compat.rs
@@ -41,7 +41,7 @@ use infino::{
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
         vector::distance::normalize,
     },
-    test_helpers::{decimal128_ids, default_tokenizer, default_vector_config},
+    test_helpers::{decimal128_ids, default_vector_config},
 };
 use tempfile::NamedTempFile;
 
@@ -84,13 +84,8 @@ fn build_planted_superfile() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", PARQUET_COMPAT_ROT_SEED)],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 

--- a/tests/superfile/format/parquet_compat.rs
+++ b/tests/superfile/format/parquet_compat.rs
@@ -87,6 +87,7 @@ fn build_planted_superfile() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", PARQUET_COMPAT_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -130,13 +130,8 @@ fn build_infino_superfile_with(corpus: &[(u64, &str)], positions: bool) -> Super
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title").positions(positions)],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     let ids = decimal128_ids(corpus.iter().map(|(i, _)| *i));

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -133,6 +133,7 @@ fn build_infino_superfile_with(corpus: &[(u64, &str)], positions: bool) -> Super
         vec![FtsConfig {
             column: "title".into(),
             positions,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -11,4 +11,5 @@ pub mod phrase;
 pub mod pipeline;
 pub mod prefix_and_floor;
 pub mod standard_tokenizer;
+pub mod stored_fields;
 pub mod uses_spill_builder;

--- a/tests/superfile/fts/multi_column.rs
+++ b/tests/superfile/fts/multi_column.rs
@@ -50,10 +50,12 @@ fn build_two_column(corpus: &[(u64, &str, &str)]) -> SuperfileReader {
             FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             },
         ],
         vec![],

--- a/tests/superfile/fts/multi_column.rs
+++ b/tests/superfile/fts/multi_column.rs
@@ -46,20 +46,8 @@ fn build_two_column(corpus: &[(u64, &str, &str)]) -> SuperfileReader {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            },
-        ],
+        vec![FtsConfig::new("title"), FtsConfig::new("body")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     let ids = decimal128_ids(corpus.iter().map(|(i, _, _)| *i));

--- a/tests/superfile/fts/standard_tokenizer.rs
+++ b/tests/superfile/fts/standard_tokenizer.rs
@@ -46,6 +46,7 @@ fn build_standard(corpus: &[(u64, &str)]) -> SuperfileReader {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(Arc::new(StandardTokenizer)),

--- a/tests/superfile/fts/standard_tokenizer.rs
+++ b/tests/superfile/fts/standard_tokenizer.rs
@@ -43,13 +43,8 @@ fn build_standard(corpus: &[(u64, &str)]) -> SuperfileReader {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title").analyzer("standard")],
         vec![],
-        Some(Arc::new(StandardTokenizer)),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     let ids = decimal128_ids(corpus.iter().map(|(i, _)| *i));

--- a/tests/superfile/fts/stored_fields.rs
+++ b/tests/superfile/fts/stored_fields.rs
@@ -26,7 +26,7 @@ use infino::{
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
         fts::reader::BoolMode,
     },
-    test_helpers::{decimal128_ids, default_tokenizer},
+    test_helpers::decimal128_ids,
 };
 
 /// k large enough to capture every match on these tiny corpora.
@@ -51,19 +51,10 @@ fn options() -> BuilderOptions {
         schema(),
         "doc_id",
         vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: true,
-                stored: false,
-            },
+            FtsConfig::new("title"),
+            FtsConfig::new("body").positions(true).stored(false),
         ],
         vec![],
-        Some(default_tokenizer()),
     )
 }
 

--- a/tests/superfile/fts/stored_fields.rs
+++ b/tests/superfile/fts/stored_fields.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Index-only FTS columns (`FtsConfig { stored: false, .. }`): the text
+//! feeds the FTS blob at ingest but never lands in the Parquet body.
+//!
+//! Pins the superfile-level contract:
+//! * the stored schema drops the column while search (ranked, phrase)
+//!   still works over it;
+//! * both compaction merge kinds that FTS/scalar files take — the
+//!   generic reader merge and the streaming postings merge — produce a
+//!   file whose search behavior is score-identical to a fresh build of
+//!   the same surviving rows, for stored and index-only columns alike
+//!   (merges carry prebuilt postings; nothing is re-tokenized);
+//! * tombstoned rows drop out of the carried index.
+
+use std::sync::Arc;
+
+use arrow_array::{LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use bytes::Bytes;
+use infino::{
+    roaring::RoaringBitmap,
+    superfile::{
+        SuperfileReader,
+        builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
+        fts::reader::BoolMode,
+    },
+    test_helpers::{decimal128_ids, default_tokenizer},
+};
+
+/// k large enough to capture every match on these tiny corpora.
+const K_ALL: usize = 64;
+/// Score-equality tolerance between a fresh build and a merged build.
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+
+/// Corpus rows: `(id, title, body)`. `title` is a stored FTS column,
+/// `body` an index-only positional one.
+type Row<'a> = (u64, &'a str, &'a str);
+
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("doc_id", DataType::Decimal128(38, 0), false),
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("body", DataType::LargeUtf8, false),
+    ]))
+}
+
+fn options() -> BuilderOptions {
+    BuilderOptions::new(
+        schema(),
+        "doc_id",
+        vec![
+            FtsConfig {
+                column: "title".into(),
+                positions: false,
+                stored: true,
+            },
+            FtsConfig {
+                column: "body".into(),
+                positions: true,
+                stored: false,
+            },
+        ],
+        vec![],
+        Some(default_tokenizer()),
+    )
+}
+
+fn build(rows: &[Row<'_>]) -> Arc<SuperfileReader> {
+    let mut b = SuperfileBuilder::new(options()).expect("builder");
+    let ids = decimal128_ids(rows.iter().map(|(id, _, _)| *id));
+    let titles = LargeStringArray::from(rows.iter().map(|(_, t, _)| *t).collect::<Vec<_>>());
+    let bodies = LargeStringArray::from(rows.iter().map(|(_, _, b)| *b).collect::<Vec<_>>());
+    let batch = RecordBatch::try_new(
+        schema(),
+        vec![Arc::new(ids), Arc::new(titles), Arc::new(bodies)],
+    )
+    .expect("batch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    Arc::new(SuperfileReader::open(Bytes::from(b.finish().expect("finish"))).expect("open"))
+}
+
+const CORPUS_A: &[Row<'static>] = &[
+    (1, "rust systems", "fast async runtime for services"),
+    (2, "python data", "pandas frames and fast plots"),
+    (3, "go network", "goroutines make fast async easy"),
+];
+const CORPUS_B: &[Row<'static>] = &[
+    (4, "java spring", "enterprise beans everywhere"),
+    (5, "rust web", "async runtime with tower services"),
+    (6, "ruby rails", "convention over configuration"),
+];
+
+/// Probe queries spanning both columns, ranked + phrase.
+const PROBES: &[(&str, &str)] = &[
+    ("title", "rust"),
+    ("title", "rust web"),
+    ("body", "fast"),
+    ("body", "async runtime"),
+    ("body", "\"fast async\""),
+    ("body", "\"async runtime\""),
+];
+
+async fn hits(r: &SuperfileReader, column: &str, query: &str) -> Vec<(u32, f32)> {
+    r.bm25_hits_async(column, query, K_ALL, BoolMode::Or)
+        .await
+        .expect("bm25 probe")
+}
+
+/// Assert `got` and `want` agree on both membership order and scores.
+fn assert_same_hits(got: &[(u32, f32)], want: &[(u32, f32)], label: &str) {
+    let g: Vec<u32> = got.iter().map(|(d, _)| *d).collect();
+    let w: Vec<u32> = want.iter().map(|(d, _)| *d).collect();
+    assert_eq!(g, w, "{label}: doc membership/order diverged");
+    for ((d, gs), (_, ws)) in got.iter().zip(want.iter()) {
+        assert!(
+            (gs - ws).abs() < SCORE_ABS_TOLERANCE,
+            "{label}: doc {d} score {gs} vs fresh {ws}"
+        );
+    }
+}
+
+/// Run every probe against `merged` and a fresh single build over
+/// `expect_rows`, asserting identical hits + scores.
+async fn assert_merge_equals_fresh(merged: &SuperfileReader, expect_rows: &[Row<'_>]) {
+    let fresh = build(expect_rows);
+    assert_eq!(merged.n_docs(), expect_rows.len() as u64);
+    for (column, query) in PROBES {
+        let got = hits(merged, column, query).await;
+        let want = hits(&fresh, column, query).await;
+        assert_same_hits(&got, &want, &format!("{column} / {query}"));
+    }
+}
+
+#[tokio::test]
+async fn index_only_column_is_searchable_but_not_stored() {
+    let r = build(CORPUS_A);
+    let names: Vec<&str> = r
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["doc_id", "title"],
+        "index-only body stays out of the Parquet body"
+    );
+    // Ranked search and phrase both work over the index-only column.
+    let got = hits(&r, "body", "fast").await;
+    assert_eq!(
+        got.iter().map(|(d, _)| *d).collect::<Vec<_>>().len(),
+        3,
+        "every doc mentions fast"
+    );
+    let got = hits(&r, "body", "\"fast async\"").await;
+    let ids: Vec<u32> = got.iter().map(|(d, _)| *d).collect();
+    assert_eq!(ids, vec![0, 2], "phrase matches contiguous docs only");
+}
+
+#[tokio::test]
+async fn generic_reader_merge_matches_fresh_build() {
+    let (a, b) = (build(CORPUS_A), build(CORPUS_B));
+    let mut mb = SuperfileBuilder::new(BuilderOptions::new_from_reader(&a)).expect("merge builder");
+    mb.add_batch_from_reader(&a, None).expect("merge a");
+    mb.add_batch_from_reader(&b, None).expect("merge b");
+    let merged =
+        SuperfileReader::open(Bytes::from(mb.finish().expect("finish"))).expect("open merged");
+    let all: Vec<Row<'_>> = CORPUS_A.iter().chain(CORPUS_B).copied().collect();
+    assert_merge_equals_fresh(&merged, &all).await;
+}
+
+#[tokio::test]
+async fn streaming_fts_merge_matches_fresh_build() {
+    let (a, b) = (build(CORPUS_A), build(CORPUS_B));
+    let (bytes, stats) =
+        SuperfileBuilder::build_from_readers_fts_merge(&[(a, None), (b, None)]).expect("fts merge");
+    assert_eq!(stats.n_docs, 6);
+    let merged = SuperfileReader::open(Bytes::from(bytes)).expect("open merged");
+    let all: Vec<Row<'_>> = CORPUS_A.iter().chain(CORPUS_B).copied().collect();
+    assert_merge_equals_fresh(&merged, &all).await;
+}
+
+#[tokio::test]
+async fn merges_drop_tombstoned_rows_from_the_carried_index() {
+    let (a, b) = (build(CORPUS_A), build(CORPUS_B));
+    // Delete local doc 0 of A ("rust systems") and local doc 1 of B
+    // ("rust web") — both match probe terms, so a leak is visible.
+    let mut dead_a = RoaringBitmap::new();
+    dead_a.insert(0);
+    let mut dead_b = RoaringBitmap::new();
+    dead_b.insert(1);
+    let survivors: Vec<Row<'_>> = vec![CORPUS_A[1], CORPUS_A[2], CORPUS_B[0], CORPUS_B[2]];
+
+    let (bytes, _) = SuperfileBuilder::build_from_readers_fts_merge(&[
+        (a.clone(), Some(Arc::new(dead_a.clone()))),
+        (b.clone(), Some(Arc::new(dead_b.clone()))),
+    ])
+    .expect("fts merge with tombstones");
+    let merged = SuperfileReader::open(Bytes::from(bytes)).expect("open merged");
+    assert_merge_equals_fresh(&merged, &survivors).await;
+
+    // Same deletions through the generic reader merge.
+    let mut mb = SuperfileBuilder::new(BuilderOptions::new_from_reader(&a)).expect("merge builder");
+    mb.add_batch_from_reader(&a, Some(Arc::new(dead_a)))
+        .expect("merge a");
+    mb.add_batch_from_reader(&b, Some(Arc::new(dead_b)))
+        .expect("merge b");
+    let merged =
+        SuperfileReader::open(Bytes::from(mb.finish().expect("finish"))).expect("open merged");
+    assert_merge_equals_fresh(&merged, &survivors).await;
+}

--- a/tests/superfile/fts/uses_spill_builder.rs
+++ b/tests/superfile/fts/uses_spill_builder.rs
@@ -69,10 +69,12 @@ fn build_test_superfile() -> Bytes {
             FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             },
         ],
         Vec::new(),

--- a/tests/superfile/fts/uses_spill_builder.rs
+++ b/tests/superfile/fts/uses_spill_builder.rs
@@ -26,7 +26,7 @@ use infino::{
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
         fts::reader::BoolMode,
     },
-    test_helpers::{decimal128_ids, default_tokenizer},
+    test_helpers::decimal128_ids,
 };
 
 /// Decimal128 precision / scale for the `doc_id` column.
@@ -65,20 +65,8 @@ fn build_test_superfile() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            },
-        ],
+        vec![FtsConfig::new("title"), FtsConfig::new("body")],
         Vec::new(),
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     // Force the spill + streaming-FST finish path. 1024 docs at

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -21,7 +21,7 @@ use infino::{
             rerank_codec::RerankCodec,
         },
     },
-    test_helpers::{decimal128_ids, default_tokenizer},
+    test_helpers::decimal128_ids,
 };
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
@@ -71,18 +71,7 @@ fn build_pipeline_superfile() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            },
-        ],
+        vec![FtsConfig::new("title"), FtsConfig::new("body")],
         vec![SfVectorConfig {
             column: "emb".into(),
             dim: EMB_DIM,
@@ -91,7 +80,6 @@ fn build_pipeline_superfile() -> Bytes {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -235,7 +223,7 @@ fn end_to_end_no_indexes_still_valid_parquet() {
     // A "naked" superfile (no FTS, no vectors) should still open and
     // be readable as Parquet.
     let schema = pipeline_schema();
-    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
     let ids = decimal128_ids(vec![1u64, 2]);
@@ -280,13 +268,8 @@ async fn end_to_end_fts_only_blob_offsets_within_file() {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     let ids = decimal128_ids(vec![1u64, 2]);
@@ -324,13 +307,8 @@ async fn end_to_end_three_batches_doc_ids_continuous() {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     for chunk in 0..MULTI_BATCH_CHUNK_COUNT {
@@ -382,18 +360,7 @@ fn add_batch_from_reader_mergeability_compatible_superfiles() {
     let opts = BuilderOptions::new(
         r1.schema().clone(),
         r1.id_column(),
-        vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            },
-        ],
+        vec![FtsConfig::new("title"), FtsConfig::new("body")],
         vec![SfVectorConfig {
             column: "emb".into(),
             dim: 16,
@@ -402,7 +369,6 @@ fn add_batch_from_reader_mergeability_compatible_superfiles() {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -422,13 +388,7 @@ fn add_batch_from_reader_mergeability_id_column_mismatch() {
         Field::new("body", DataType::LargeUtf8, false),
         Field::new("score", DataType::Float32, true),
     ]));
-    let opts = BuilderOptions::new(
-        schema_with_alt_id.clone(),
-        "different_id",
-        vec![],
-        vec![],
-        None,
-    );
+    let opts = BuilderOptions::new(schema_with_alt_id.clone(), "different_id", vec![], vec![]);
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
     let ids = decimal128_ids(vec![1u64]);
@@ -457,7 +417,7 @@ fn add_batch_from_reader_mergeability_id_column_mismatch() {
         Field::new("body", DataType::LargeUtf8, false),
         Field::new("score", DataType::Float32, true),
     ]));
-    let orig_opts = BuilderOptions::new(builder_schema, "doc_id", vec![], vec![], None);
+    let orig_opts = BuilderOptions::new(builder_schema, "doc_id", vec![], vec![]);
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
     let err = orig_builder.add_batch_from_reader(&reader, None);
@@ -476,7 +436,7 @@ fn add_batch_from_reader_mergeability_schema_mismatch() {
         // missing "body" column compared to pipeline_schema
         Field::new("score", DataType::Float32, true),
     ]));
-    let opts = BuilderOptions::new(schema_short.clone(), "doc_id", vec![], vec![], None);
+    let opts = BuilderOptions::new(schema_short.clone(), "doc_id", vec![], vec![]);
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
     let ids = decimal128_ids(vec![1u64]);
@@ -493,7 +453,7 @@ fn add_batch_from_reader_mergeability_schema_mismatch() {
 
     // Try to merge into builder with full pipeline schema
     let orig_schema = pipeline_schema();
-    let orig_opts = BuilderOptions::new(orig_schema, "doc_id", vec![], vec![], None);
+    let orig_opts = BuilderOptions::new(orig_schema, "doc_id", vec![], vec![]);
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
     let err = orig_builder.add_batch_from_reader(&reader, None);
@@ -510,13 +470,8 @@ fn add_batch_from_reader_mergeability_fts_column_count_mismatch() {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -542,20 +497,8 @@ fn add_batch_from_reader_mergeability_fts_column_count_mismatch() {
     let orig_opts = BuilderOptions::new(
         pipeline_schema(),
         "doc_id",
-        vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: true,
-            },
-        ],
+        vec![FtsConfig::new("title"), FtsConfig::new("body")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
@@ -573,13 +516,8 @@ fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "body".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("body")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -605,13 +543,8 @@ fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
     let orig_opts = BuilderOptions::new(
         pipeline_schema(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
@@ -638,7 +571,6 @@ fn add_batch_from_reader_mergeability_vector_column_count_mismatch() {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        None,
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -665,7 +597,7 @@ fn add_batch_from_reader_mergeability_vector_column_count_mismatch() {
     let reader = SuperfileReader::open(bytes).expect("open superfile");
 
     // Try to merge into builder with no vector columns
-    let orig_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
+    let orig_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![]);
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
     let err = orig_builder.add_batch_from_reader(&reader, None);
@@ -691,7 +623,6 @@ fn add_batch_from_reader_mergeability_vector_column_name_mismatch() {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        None,
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -730,7 +661,6 @@ fn add_batch_from_reader_mergeability_vector_column_name_mismatch() {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        None,
     );
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
@@ -757,7 +687,6 @@ fn add_batch_from_reader_mergeability_vector_dimension_mismatch() {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        None,
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -796,7 +725,6 @@ fn add_batch_from_reader_mergeability_vector_dimension_mismatch() {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        None,
     );
     let mut orig_builder = SuperfileBuilder::new(orig_opts).expect("new SuperfileBuilder");
 
@@ -810,7 +738,7 @@ fn add_batch_from_reader_mergeability_vector_dimension_mismatch() {
 #[test]
 fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_records() {
     let schema = pipeline_schema();
-    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
     let ids = decimal128_ids(vec![100u64, 101, 102]);
@@ -837,7 +765,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_records() {
     deleted.insert(1);
 
     // Merge with deleted_docs_bitmap
-    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
+    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![]);
     let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
 
     builder2
@@ -884,13 +812,8 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_fts() {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -920,13 +843,8 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_fts() {
     let builder2_opts = BuilderOptions::new(
         pipeline_schema(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
 
@@ -990,7 +908,6 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_vectors() {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        None,
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -1039,7 +956,6 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_vectors() {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        None,
     );
     let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
 
@@ -1087,7 +1003,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_vectors() {
 fn add_batch_from_reader_with_deleted_docs_bitmap_all_deletes() {
     // Edge case: delete all documents
     let schema = pipeline_schema();
-    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
     let ids = decimal128_ids(vec![100u64, 101, 102]);
@@ -1115,7 +1031,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_all_deletes() {
     deleted.insert(1);
     deleted.insert(2);
 
-    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
+    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![]);
     let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
 
     builder2
@@ -1131,7 +1047,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_all_deletes() {
 fn add_batch_from_reader_with_deleted_docs_bitmap_no_deletes() {
     // Edge case: bitmap is provided but empty (no deletions)
     let schema = pipeline_schema();
-    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![], None);
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
     let ids = decimal128_ids(vec![100u64, 101]);
@@ -1156,7 +1072,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_no_deletes() {
     // Create empty bitmap (no deletions)
     let deleted = roaring::RoaringBitmap::new();
 
-    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![], None);
+    let builder2_opts = BuilderOptions::new(pipeline_schema(), "doc_id", vec![], vec![]);
     let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
 
     builder2
@@ -1181,11 +1097,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![SfVectorConfig {
             column: "emb".into(),
             dim: EMB_DIM,
@@ -1194,7 +1106,6 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
 
@@ -1233,11 +1144,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
     let builder2_opts = BuilderOptions::new(
         pipeline_schema(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![SfVectorConfig {
             column: "emb".into(),
             dim: EMB_DIM,
@@ -1246,7 +1153,6 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        Some(default_tokenizer()),
     );
     let mut builder2 = SuperfileBuilder::new(builder2_opts).expect("new SuperfileBuilder");
 

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -75,10 +75,12 @@ fn build_pipeline_superfile() -> Bytes {
             FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             },
         ],
         vec![SfVectorConfig {
@@ -281,6 +283,7 @@ async fn end_to_end_fts_only_blob_offsets_within_file() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -324,6 +327,7 @@ async fn end_to_end_three_batches_doc_ids_continuous() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -382,10 +386,12 @@ fn add_batch_from_reader_mergeability_compatible_superfiles() {
             FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             },
         ],
         vec![SfVectorConfig {
@@ -507,6 +513,7 @@ fn add_batch_from_reader_mergeability_fts_column_count_mismatch() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -539,10 +546,12 @@ fn add_batch_from_reader_mergeability_fts_column_count_mismatch() {
             FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             },
             FtsConfig {
                 column: "body".into(),
                 positions: false,
+                stored: true,
             },
         ],
         vec![],
@@ -567,6 +576,7 @@ fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
         vec![FtsConfig {
             column: "body".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -598,6 +608,7 @@ fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -876,6 +887,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_fts() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -911,6 +923,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_excludes_fts() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -1171,6 +1184,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![SfVectorConfig {
             column: "emb".into(),
@@ -1222,6 +1236,7 @@ fn add_batch_from_reader_with_deleted_docs_bitmap_partial_deletes_mixed_indexes(
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![SfVectorConfig {
             column: "emb".into(),

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -555,6 +555,133 @@ fn add_batch_from_reader_mergeability_fts_column_name_mismatch() {
     );
 }
 
+/// Build a one-row superfile over [`pipeline_schema`] with `body` indexed
+/// under `cfg` — fixture for the per-column FTS-config mergeability tests.
+fn one_row_superfile_with(cfg: FtsConfig) -> SuperfileReader {
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![cfg], vec![]);
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let bodies = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    SuperfileReader::open(Bytes::from(b.finish().expect("finish builder"))).expect("open")
+}
+
+/// Merges carry prebuilt postings without re-tokenizing, so an input
+/// whose column was analyzed differently must be refused — carried
+/// postings under one analyzer with the merged file recording another
+/// would silently stop matching at query time.
+#[test]
+fn add_batch_from_reader_mergeability_fts_analyzer_mismatch() {
+    let reader = one_row_superfile_with(FtsConfig::new("body").analyzer("standard"));
+    let opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![FtsConfig::new("body")], // ascii_lower default
+        vec![],
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let err = b
+        .add_batch_from_reader(&reader, None)
+        .expect_err("analyzer mismatch must be refused");
+    assert!(
+        err.to_string().contains("analyzer"),
+        "error names the disagreement: {err}"
+    );
+}
+
+/// A positional column merged with a positionless input would declare
+/// phrase support half its docs can't answer — refused loudly.
+#[test]
+fn add_batch_from_reader_mergeability_fts_positions_mismatch() {
+    let reader = one_row_superfile_with(FtsConfig::new("body"));
+    let opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![FtsConfig::new("body").positions(true)],
+        vec![],
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let err = b
+        .add_batch_from_reader(&reader, None)
+        .expect_err("positions mismatch must be refused");
+    assert!(
+        err.to_string().contains("positions"),
+        "error names the disagreement: {err}"
+    );
+}
+
+/// An input with no FTS index merged into an FTS-declaring builder
+/// would silently contribute zero postings for its rows — refused.
+#[test]
+fn add_batch_from_reader_mergeability_fts_presence_mismatch() {
+    let schema = pipeline_schema();
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![], vec![]);
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let ids = decimal128_ids(vec![1u64]);
+    let titles = LargeStringArray::from(vec!["test"]);
+    let bodies = LargeStringArray::from(vec!["test"]);
+    let scores = Float32Array::from(vec![1.0]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(scores),
+        ],
+    )
+    .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let no_fts_reader =
+        SuperfileReader::open(Bytes::from(b.finish().expect("finish"))).expect("open");
+
+    let opts = BuilderOptions::new(
+        pipeline_schema(),
+        "doc_id",
+        vec![FtsConfig::new("body")],
+        vec![],
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let err = b
+        .add_batch_from_reader(&no_fts_reader, None)
+        .expect_err("an input without an FTS index must be refused");
+    assert!(
+        err.to_string().contains("column len"),
+        "error names the presence mismatch: {err}"
+    );
+}
+
+/// The streaming FTS merge takes its config from the FIRST input; a
+/// later input built under a different analyzer must be refused, not
+/// carried into a file whose recorded analyzer disagrees with the
+/// postings.
+#[test]
+fn fts_merge_rejects_mixed_analyzers() {
+    let a = Arc::new(one_row_superfile_with(FtsConfig::new("body")));
+    let b = Arc::new(one_row_superfile_with(
+        FtsConfig::new("body").analyzer("standard"),
+    ));
+    let err = SuperfileBuilder::build_from_readers_fts_merge(&[(a, None), (b, None)])
+        .expect_err("mixed-analyzer inputs must be refused");
+    assert!(
+        err.to_string().contains("analyzer"),
+        "error names the disagreement: {err}"
+    );
+}
+
 #[test]
 fn add_batch_from_reader_mergeability_vector_column_count_mismatch() {
     // Build superfile with one vector column

--- a/tests/supertable/commit/create_adopts_existing.rs
+++ b/tests/supertable/commit/create_adopts_existing.rs
@@ -126,6 +126,7 @@ fn vector_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/commit/create_adopts_existing.rs
+++ b/tests/supertable/commit/create_adopts_existing.rs
@@ -35,7 +35,7 @@ use infino::{
     storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     superfile::builder::FtsConfig,
     supertable::{Supertable, SupertableOptions, manifest::commit::POINTER_PATH},
-    test_helpers::{default_tokenizer, default_vector_config},
+    test_helpers::default_vector_config,
 };
 use tempfile::TempDir;
 
@@ -123,13 +123,8 @@ fn vector_options() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -244,26 +244,18 @@ fn open_rejects_mismatched_options_via_options_hash() {
         arrow_schema::Field::new("title", arrow_schema::DataType::LargeUtf8, false),
         arrow_schema::Field::new("doc_id", arrow_schema::DataType::UInt64, false),
     ]));
-    let tk: Arc<dyn Tokenizer> = default_tokenizer();
+    let _tk: Arc<dyn Tokenizer> = default_tokenizer();
     let pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(RAYON_POOL_THREADS)
             .build()
             .expect("pool"),
     );
-    let mismatched_opts = SupertableOptions::new(
-        other_schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![],
-        Some(tk),
-    )
-    .expect("opts")
-    .with_writer_pool(pool)
-    .with_storage(Arc::clone(&storage));
+    let mismatched_opts =
+        SupertableOptions::new(other_schema, vec![FtsConfig::new("title")], vec![])
+            .expect("opts")
+            .with_writer_pool(pool)
+            .with_storage(Arc::clone(&storage));
 
     let err = Supertable::open(mismatched_opts)
         .expect_err("open must surface OptionsHashMismatch for a reordered schema");

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -256,6 +256,7 @@ fn open_rejects_mismatched_options_via_options_hash() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(tk),

--- a/tests/supertable/commit/partition_assignment.rs
+++ b/tests/supertable/commit/partition_assignment.rs
@@ -278,6 +278,7 @@ fn time_range_assigns_int64_superfiles_to_bucket_zero() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(tk),
@@ -356,6 +357,7 @@ fn time_range_superfile_spanning_two_buckets_errors() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(tk),

--- a/tests/supertable/commit/partition_assignment.rs
+++ b/tests/supertable/commit/partition_assignment.rs
@@ -266,7 +266,7 @@ fn time_range_assigns_int64_superfiles_to_bucket_zero() {
         arrow_schema::Field::new("ts_secs", arrow_schema::DataType::Int64, false),
         arrow_schema::Field::new("title", arrow_schema::DataType::LargeUtf8, false),
     ]));
-    let tk: Arc<dyn Tokenizer> = default_tokenizer();
+    let _tk: Arc<dyn Tokenizer> = default_tokenizer();
     let pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(RAYON_POOL_THREADS)
@@ -275,13 +275,8 @@ fn time_range_assigns_int64_superfiles_to_bucket_zero() {
     );
     let opts = infino::supertable::SupertableOptions::new(
         schema.clone(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(tk),
     )
     .expect("opts")
     .with_writer_pool(pool)
@@ -345,7 +340,7 @@ fn time_range_superfile_spanning_two_buckets_errors() {
         arrow_schema::Field::new("ts_secs", arrow_schema::DataType::Int64, false),
         arrow_schema::Field::new("title", arrow_schema::DataType::LargeUtf8, false),
     ]));
-    let tk: Arc<dyn Tokenizer> = default_tokenizer();
+    let _tk: Arc<dyn Tokenizer> = default_tokenizer();
     let pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(RAYON_POOL_THREADS)
@@ -354,13 +349,8 @@ fn time_range_superfile_spanning_two_buckets_errors() {
     );
     let opts = infino::supertable::SupertableOptions::new(
         schema.clone(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(tk),
     )
     .expect("opts")
     .with_writer_pool(pool)

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -24,7 +24,7 @@ use infino::{
     superfile::builder::FtsConfig,
     supertable::{Supertable, SupertableOptions},
     test_helpers::{
-        build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
+        build_title_batch, default_supertable_options, default_vector_config,
         fault_storage::{FaultKind, FaultOp, FaultStorage},
         schema_id_title,
     },
@@ -79,19 +79,10 @@ fn options_with_pool_width(n_threads: usize) -> SupertableOptions {
             .build()
             .expect("writer pool"),
     );
-    SupertableOptions::new(
-        schema_id_title(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        Vec::new(),
-        Some(default_tokenizer()),
-    )
-    .expect("valid options")
-    .with_writer_pool(pool)
-    .with_superfile_buffer_split_mb(WIDTH_TEST_SPLIT_MB)
+    SupertableOptions::new(schema_id_title(), vec![FtsConfig::new("title")], Vec::new())
+        .expect("valid options")
+        .with_writer_pool(pool)
+        .with_superfile_buffer_split_mb(WIDTH_TEST_SPLIT_MB)
 }
 
 /// The width-test corpus: same titles every call, so every width builds
@@ -270,13 +261,8 @@ fn a_vector_append_pins_exact_payload_bytes() {
     ]));
     let options = SupertableOptions::new(
         Arc::clone(&schema),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options");
 
@@ -502,13 +488,8 @@ fn the_fts_leg_is_a_strict_subset_when_a_column_is_unindexed() {
 
     let options = SupertableOptions::new(
         Arc::clone(&schema),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         Vec::new(),
-        Some(default_tokenizer()),
     )
     .expect("valid options");
     let st = Supertable::create(options).expect("create");

--- a/tests/supertable/commit/write_stats.rs
+++ b/tests/supertable/commit/write_stats.rs
@@ -84,6 +84,7 @@ fn options_with_pool_width(n_threads: usize) -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         Vec::new(),
         Some(default_tokenizer()),
@@ -272,6 +273,7 @@ fn a_vector_append_pins_exact_payload_bytes() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),
@@ -503,6 +505,7 @@ fn the_fts_leg_is_a_strict_subset_when_a_column_is_unindexed() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         Vec::new(),
         Some(default_tokenizer()),

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -514,6 +514,7 @@ fn hidden_vector_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![vector_config],
         Some(default_tokenizer()),

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -37,9 +37,7 @@ use infino::{
             },
         },
     },
-    test_helpers::{
-        build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
-    },
+    test_helpers::{build_title_batch, default_supertable_options, default_vector_config},
 };
 use tempfile::TempDir;
 
@@ -509,17 +507,8 @@ fn hidden_vector_options() -> SupertableOptions {
     // production path writes.
     let mut vector_config = default_vector_config("emb", HIDDEN_ROT_SEED);
     vector_config.rerank_codec = RerankCodec::default();
-    SupertableOptions::new(
-        schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![vector_config],
-        Some(default_tokenizer()),
-    )
-    .expect("valid options")
+    SupertableOptions::new(schema, vec![FtsConfig::new("title")], vec![vector_config])
+        .expect("valid options")
 }
 
 /// One-hot rows: doc `i` points at dim `i`, so every round lands in the same

--- a/tests/supertable/disk_cache/basic.rs
+++ b/tests/supertable/disk_cache/basic.rs
@@ -152,6 +152,7 @@ fn build_test_superfile_bytes() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/disk_cache/basic.rs
+++ b/tests/supertable/disk_cache/basic.rs
@@ -46,7 +46,7 @@ use infino::{
         reader_cache::{DiskCacheConfig, DiskCacheStore, LruPolicy, disk::DiskCacheError},
         storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
-    test_helpers::{decimal128_ids, default_tokenizer},
+    test_helpers::decimal128_ids,
 };
 use tempfile::TempDir;
 
@@ -149,13 +149,8 @@ fn build_test_superfile_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3]);

--- a/tests/supertable/disk_cache/cold_projection.rs
+++ b/tests/supertable/disk_cache/cold_projection.rs
@@ -29,7 +29,7 @@ use infino::{
         fts::reader::{Bm25Stats, BoolMode},
     },
     supertable::{Supertable, SupertableOptions},
-    test_helpers::{default_tokenizer, default_vector_config, lazy_foreground_disk_cache},
+    test_helpers::{default_vector_config, lazy_foreground_disk_cache},
 };
 use tempfile::TempDir;
 
@@ -64,13 +64,8 @@ fn cold_options() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/disk_cache/cold_projection.rs
+++ b/tests/supertable/disk_cache/cold_projection.rs
@@ -67,6 +67,7 @@ fn cold_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/disk_cache/hybrid.rs
+++ b/tests/supertable/disk_cache/hybrid.rs
@@ -44,7 +44,7 @@ use infino::{
         },
         storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
-    test_helpers::{decimal128_ids, default_tokenizer},
+    test_helpers::decimal128_ids,
 };
 use tempfile::TempDir;
 
@@ -141,13 +141,8 @@ fn build_test_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3]);

--- a/tests/supertable/disk_cache/hybrid.rs
+++ b/tests/supertable/disk_cache/hybrid.rs
@@ -144,6 +144,7 @@ fn build_test_bytes() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/disk_cache/lazy_foreground.rs
+++ b/tests/supertable/disk_cache/lazy_foreground.rs
@@ -163,6 +163,7 @@ fn build_fts_only_bytes() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/disk_cache/lazy_foreground.rs
+++ b/tests/supertable/disk_cache/lazy_foreground.rs
@@ -50,7 +50,7 @@ use infino::{
         reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
         storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
-    test_helpers::{decimal128_ids, default_tokenizer},
+    test_helpers::decimal128_ids,
 };
 use tempfile::TempDir;
 
@@ -160,13 +160,8 @@ fn build_fts_only_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3, 4]);

--- a/tests/supertable/disk_cache/sweep.rs
+++ b/tests/supertable/disk_cache/sweep.rs
@@ -82,6 +82,7 @@ fn build_test_bytes() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/disk_cache/sweep.rs
+++ b/tests/supertable/disk_cache/sweep.rs
@@ -35,7 +35,7 @@ use infino::{
         reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
         storage::{LocalFsStorageProvider, StorageProvider},
     },
-    test_helpers::{decimal128_ids, default_tokenizer},
+    test_helpers::decimal128_ids,
 };
 use tempfile::TempDir;
 
@@ -79,13 +79,8 @@ fn build_test_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3]);

--- a/tests/supertable/drain_tombstones.rs
+++ b/tests/supertable/drain_tombstones.rs
@@ -59,6 +59,7 @@ fn vector_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/drain_tombstones.rs
+++ b/tests/supertable/drain_tombstones.rs
@@ -25,7 +25,7 @@ use infino::{
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::builder::FtsConfig,
     supertable::{Supertable, SupertableOptions},
-    test_helpers::{default_tokenizer, default_vector_config},
+    test_helpers::default_vector_config,
 };
 use tempfile::TempDir;
 
@@ -56,13 +56,8 @@ fn vector_options() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -154,6 +154,7 @@ fn build_supertable(corpus: &[(u64, String)], n_superfiles: usize) -> Supertable
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(tk),

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -148,19 +148,10 @@ fn build_supertable(corpus: &[(u64, String)], n_superfiles: usize) -> Supertable
             .build()
             .expect("pool"),
     );
-    let tk: Arc<dyn Tokenizer> = default_tokenizer();
-    let opts = SupertableOptions::new(
-        schema_id_title(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![],
-        Some(tk),
-    )
-    .expect("opts")
-    .with_writer_pool(pool);
+    let _tk: Arc<dyn Tokenizer> = default_tokenizer();
+    let opts = SupertableOptions::new(schema_id_title(), vec![FtsConfig::new("title")], vec![])
+        .expect("opts")
+        .with_writer_pool(pool);
 
     let st = Supertable::create(opts).expect("create");
     let mut w = st.writer().expect("writer");

--- a/tests/supertable/query/covered_agg.rs
+++ b/tests/supertable/query/covered_agg.rs
@@ -44,7 +44,7 @@ fn options_cat_rating() -> SupertableOptions {
         Field::new("category", DataType::LargeUtf8, false),
         Field::new("rating", DataType::Int64, false),
     ]));
-    SupertableOptions::new(schema, vec![], vec![], None).expect("valid options")
+    SupertableOptions::new(schema, vec![], vec![]).expect("valid options")
 }
 
 /// Commit `idx`: ratings `idx*1000 .. idx*1000 + ROWS_PER_COMMIT`.
@@ -534,7 +534,7 @@ fn narrow_numeric_avg_survives_the_peeled_cast() {
         false,
     )]));
     let options =
-        SupertableOptions::new(Arc::clone(&schema), vec![], vec![], None).expect("valid options");
+        SupertableOptions::new(Arc::clone(&schema), vec![], vec![]).expect("valid options");
     let st = Supertable::create(options).expect("create");
     let mut w = st.writer().expect("writer");
     for idx in 0..COMMITS {

--- a/tests/supertable/query/fanout_concurrency.rs
+++ b/tests/supertable/query/fanout_concurrency.rs
@@ -103,6 +103,7 @@ fn options_title_emb() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/fanout_concurrency.rs
+++ b/tests/supertable/query/fanout_concurrency.rs
@@ -51,7 +51,7 @@ use infino::{
         Supertable, SupertableOptions,
         query::{SuperfileHit, vector::VectorSearchOptions},
     },
-    test_helpers::{default_tokenizer, default_vector_config},
+    test_helpers::default_vector_config,
 };
 
 const DIM: usize = 16;
@@ -100,13 +100,8 @@ fn options_title_emb() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
     .with_writer_pool(writer_pool)

--- a/tests/supertable/query/fanout_floor.rs
+++ b/tests/supertable/query/fanout_floor.rs
@@ -56,7 +56,7 @@ use infino::{
         reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
         storage::LocalFsStorageProvider,
     },
-    test_helpers::{decimal128_id_field, decimal128_ids, default_tokenizer},
+    test_helpers::{decimal128_id_field, decimal128_ids},
 };
 use tempfile::TempDir;
 
@@ -113,19 +113,10 @@ fn options_title_only() -> SupertableOptions {
         DataType::LargeUtf8,
         false,
     )]));
-    SupertableOptions::new(
-        schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![],
-        Some(default_tokenizer()),
-    )
-    .expect("valid options")
-    .with_writer_pool(Arc::clone(&pool))
-    .with_reader_pool(pool)
+    SupertableOptions::new(schema, vec![FtsConfig::new("title")], vec![])
+        .expect("valid options")
+        .with_writer_pool(Arc::clone(&pool))
+        .with_reader_pool(pool)
 }
 
 /// Commit `seg` gets `docs_per_commit()` docs: every title contains
@@ -229,13 +220,8 @@ fn build_one_superfile() -> SuperfileReader {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     let n = docs_per_commit();

--- a/tests/supertable/query/fanout_floor.rs
+++ b/tests/supertable/query/fanout_floor.rs
@@ -118,6 +118,7 @@ fn options_title_only() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),
@@ -231,6 +232,7 @@ fn build_one_superfile() -> SuperfileReader {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -44,9 +44,7 @@ use infino::{
         Supertable, SupertableOptions,
         storage::{LocalFsStorageProvider, StorageProvider},
     },
-    test_helpers::{
-        build_title_batch, default_disk_cache, default_supertable_options, default_tokenizer,
-    },
+    test_helpers::{build_title_batch, default_disk_cache, default_supertable_options},
 };
 use rayon::ThreadPoolBuilder;
 
@@ -585,18 +583,9 @@ fn tag_options() -> SupertableOptions {
             .build()
             .expect("rayon pool"),
     );
-    SupertableOptions::new(
-        tag_schema(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![],
-        Some(default_tokenizer()),
-    )
-    .expect("tag options")
-    .with_writer_pool(pool)
+    SupertableOptions::new(tag_schema(), vec![FtsConfig::new("title")], vec![])
+        .expect("tag options")
+        .with_writer_pool(pool)
 }
 
 fn tag_batch(titles: &[&str], tags: &[Option<&str>]) -> RecordBatch {

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -590,6 +590,7 @@ fn tag_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/query/hybrid_search.rs
+++ b/tests/supertable/query/hybrid_search.rs
@@ -30,7 +30,7 @@ use arrow_schema::{DataType, Field, Schema};
 use infino::{
     superfile::builder::FtsConfig,
     supertable::{Supertable, SupertableOptions},
-    test_helpers::{default_tokenizer, default_vector_config},
+    test_helpers::default_vector_config,
 };
 
 /// `default_vector_config` is dim=16, cosine, n_cent=4.
@@ -68,13 +68,8 @@ fn options_title_emb() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
     .with_writer_pool(writer_pool)

--- a/tests/supertable/query/hybrid_search.rs
+++ b/tests/supertable/query/hybrid_search.rs
@@ -71,6 +71,7 @@ fn options_title_emb() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/id_resolve.rs
+++ b/tests/supertable/query/id_resolve.rs
@@ -23,7 +23,6 @@ use infino::{
         fts::reader::{Bm25Stats, BoolMode},
     },
     supertable::{Supertable, SupertableOptions},
-    test_helpers::default_tokenizer,
 };
 
 /// Commits — enough that the writer's row-sharding produces a real
@@ -53,19 +52,10 @@ fn options_title_only() -> SupertableOptions {
         DataType::LargeUtf8,
         false,
     )]));
-    SupertableOptions::new(
-        schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![],
-        Some(default_tokenizer()),
-    )
-    .expect("valid options")
-    .with_writer_pool(Arc::clone(&pool))
-    .with_reader_pool(pool)
+    SupertableOptions::new(schema, vec![FtsConfig::new("title")], vec![])
+        .expect("valid options")
+        .with_writer_pool(Arc::clone(&pool))
+        .with_reader_pool(pool)
 }
 
 /// Every doc carries `common`; each doc also carries a unique token so

--- a/tests/supertable/query/id_resolve.rs
+++ b/tests/supertable/query/id_resolve.rs
@@ -58,6 +58,7 @@ fn options_title_only() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -37,7 +37,7 @@ use infino::{
             vector::{VectorFilter, VectorSearchOptions},
         },
     },
-    test_helpers::{default_tokenizer, default_vector_config},
+    test_helpers::default_vector_config,
 };
 
 /// `default_vector_config` is dim=16, cosine, n_cent=4.
@@ -104,13 +104,8 @@ fn options_title_emb() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
     .with_writer_pool(writer_pool)

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -107,6 +107,7 @@ fn options_title_emb() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -329,6 +329,142 @@ fn vector_filter_restricts_hits_to_the_predicate_match_set() {
     );
 }
 
+/// Notes text for [`two_analyzer_table`], parallel to [`SEG1_TITLES`].
+/// `café` appears in exactly two docs; the accent matters — under the
+/// `standard` analyzer it is a real term, under `ascii_lower` the token
+/// is dropped entirely.
+const NOTES: &[&str] = &[
+    "café menu",     // 0
+    "tea list",      // 1
+    "café hours",    // 2
+    "water only",    // 3
+    "juice board",   // 4
+    "espresso shot", // 5
+    "matcha bowl",   // 6
+    "cold brew",     // 7
+];
+
+/// Schema `[title (ascii_lower FTS), notes (standard FTS), emb (vector)]`
+/// over [`SEG1_TITLES`] × [`NOTES`]: two FTS columns with DIFFERENT
+/// analyzers next to a vector column, one commit, one-hot embeddings.
+fn two_analyzer_table() -> Supertable {
+    let writer_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(RAYON_POOL_THREADS)
+            .build()
+            .expect("writer pool"),
+    );
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("notes", DataType::LargeUtf8, false),
+        Field::new("emb", fixed_list_f32(DIM), false),
+    ]));
+    let st = Supertable::create(
+        SupertableOptions::new(
+            schema.clone(),
+            vec![
+                FtsConfig::new("title"),
+                FtsConfig::new("notes").analyzer("standard"),
+            ],
+            vec![default_vector_config("emb", VECTOR_ROT_SEED)],
+        )
+        .expect("valid options")
+        .with_writer_pool(writer_pool),
+    )
+    .expect("create");
+
+    let titles = LargeStringArray::from(SEG1_TITLES.to_vec());
+    let notes = LargeStringArray::from(NOTES.to_vec());
+    let mut flat = Vec::<f32>::with_capacity(NOTES.len() * DIM);
+    for i in 0..NOTES.len() {
+        for d in 0..DIM {
+            flat.push(if d == i { 1.0 } else { 0.0 });
+        }
+    }
+    let fsl = FixedSizeListArray::try_new(
+        Arc::new(Field::new("item", DataType::Float32, true)),
+        DIM as i32,
+        Arc::new(Float32Array::from(flat)) as ArrayRef,
+        None,
+    )
+    .expect("FSL");
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(titles), Arc::new(notes), Arc::new(fsl)],
+    )
+    .expect("batch");
+    let mut w = st.writer().expect("writer");
+    w.append(&batch).expect("append");
+    w.commit().expect("commit");
+    drop(w);
+    st
+}
+
+/// Regression: a `VectorFilter` predicate is tokenized with the FILTER
+/// COLUMN's analyzer, not any table-wide default. `café` is a real term
+/// only under the `standard` analyzer, so filtering on `notes`
+/// (standard) must return exactly the café rows, while the same
+/// predicate on `title` (ascii_lower, which drops non-ASCII tokens)
+/// must match nothing. The bug this pins: the predicate used to be
+/// tokenized with a single table-level tokenizer, so a filter on a
+/// standard-analyzer column silently tokenized to nothing and returned
+/// zero rows.
+#[test]
+fn vector_filter_tokenizes_with_the_filter_columns_analyzer() {
+    let st = two_analyzer_table();
+    let reader = st.reader().expect("reader");
+
+    // Ground truth from the engine's own per-column token match.
+    let allowed = stable_ids(
+        &reader
+            .token_match("notes", "café", BoolMode::Or)
+            .expect("token_match on the standard column"),
+    );
+    assert_eq!(allowed.len(), 2, "café appears in exactly two notes");
+
+    let hits = reader
+        .vector_hits(
+            "emb",
+            &one_hot(QUERY_DIM),
+            TOP_K,
+            VectorSearchOptions::new(),
+            Some(VectorFilter {
+                column: "notes",
+                query: "café",
+                mode: BoolMode::Or,
+            }),
+        )
+        .expect("filtered vector search on the standard column");
+    assert_eq!(
+        stable_ids(&hits),
+        allowed,
+        "the filter tokenized café with the notes column's standard \
+         analyzer and matched exactly its rows"
+    );
+
+    // The same predicate against the ascii_lower column tokenizes to
+    // nothing (non-ASCII dropped) — per-column analysis, not a blanket
+    // standard default.
+    let hits = reader
+        .vector_hits(
+            "emb",
+            &one_hot(QUERY_DIM),
+            TOP_K,
+            VectorSearchOptions::new(),
+            Some(VectorFilter {
+                column: "title",
+                query: "café",
+                mode: BoolMode::Or,
+            }),
+        )
+        .expect("filtered vector search on the ascii column");
+    assert!(
+        hits.is_empty(),
+        "ascii_lower drops the non-ASCII token, so the predicate \
+         matches nothing on the title column"
+    );
+}
+
 #[test]
 fn token_match_or_is_the_unranked_bm25_candidate_set() {
     let st = demo_two_superfiles();

--- a/tests/supertable/query/mod.rs
+++ b/tests/supertable/query/mod.rs
@@ -14,4 +14,5 @@ mod query_errors;
 mod query_surface;
 pub mod skip_pruning;
 mod stats_fold;
+mod stored_fields;
 pub mod tombstone_filter;

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -66,6 +66,7 @@ fn options_title_only() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         Vec::new(),
         Some(default_tokenizer()),
@@ -501,6 +502,7 @@ fn vector_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),
@@ -632,6 +634,7 @@ fn drained_sq16_adaptive_table(dir: &TempDir) -> Supertable {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![vector],
         Some(default_tokenizer()),

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -33,7 +33,7 @@ use infino::{
         Supertable, SupertableOptions,
         query::vector::{VectorFilter, VectorSearchOptions},
     },
-    test_helpers::{default_tokenizer, default_vector_config},
+    test_helpers::default_vector_config,
 };
 use tempfile::TempDir;
 
@@ -61,18 +61,9 @@ fn options_title_only() -> SupertableOptions {
         DataType::LargeUtf8,
         false,
     )]));
-    SupertableOptions::new(
-        schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        Vec::new(),
-        Some(default_tokenizer()),
-    )
-    .expect("valid options")
-    .with_writer_pool(writer_pool)
+    SupertableOptions::new(schema, vec![FtsConfig::new("title")], Vec::new())
+        .expect("valid options")
+        .with_writer_pool(writer_pool)
 }
 
 /// One segment's titles: `rust` in every other doc, `async` and `web`
@@ -499,13 +490,8 @@ fn vector_options() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }
@@ -629,17 +615,8 @@ fn drained_sq16_adaptive_table(dir: &TempDir) -> Supertable {
         metric: Metric::L2Sq,
         ..default_vector_config("emb", VECTOR_ROT_SEED).with_rerank_codec(RerankCodec::Sq16Adaptive)
     };
-    let opts = SupertableOptions::new(
-        schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![vector],
-        Some(default_tokenizer()),
-    )
-    .expect("valid options");
+    let opts = SupertableOptions::new(schema, vec![FtsConfig::new("title")], vec![vector])
+        .expect("valid options");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
     let st = Supertable::create(opts.with_storage(storage)).expect("create");

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -18,7 +18,7 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
-    ConnectOptions, Connection, IndexSpec, Metric, connect, connect_with,
+    ConnectOptions, Connection, FtsField, IndexSpec, Metric, connect, connect_with,
     runtime_metrics::op_stats::{OpStats, with_op_stats},
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
@@ -865,7 +865,7 @@ fn sql_like_fixture(dir: &TempDir, padded: bool) -> Connection {
         .create_table(
             "docs",
             schema.clone(),
-            IndexSpec::new().fts_with_analyzer("title", STANDARD_TOKENIZER),
+            IndexSpec::new().fts(FtsField::new("title").analyzer(STANDARD_TOKENIZER)),
         )
         .expect("create_table");
     let padding = if padded { LIKE_PADDING } else { "" };

--- a/tests/supertable/query/query_errors.rs
+++ b/tests/supertable/query/query_errors.rs
@@ -63,6 +63,7 @@ fn options_title_rating_emb() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/query_errors.rs
+++ b/tests/supertable/query/query_errors.rs
@@ -29,7 +29,7 @@ use arrow_schema::{DataType, Field, Schema};
 use infino::{
     superfile::builder::FtsConfig,
     supertable::{Supertable, SupertableOptions},
-    test_helpers::{default_tokenizer, default_vector_config},
+    test_helpers::default_vector_config,
 };
 
 /// `default_vector_config` is dim=16, cosine, n_cent=4.
@@ -60,13 +60,8 @@ fn options_title_rating_emb() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/query/query_surface.rs
+++ b/tests/supertable/query/query_surface.rs
@@ -61,6 +61,7 @@ fn options_title_rating_emb() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/query/query_surface.rs
+++ b/tests/supertable/query/query_surface.rs
@@ -26,7 +26,7 @@ use arrow_schema::{DataType, Field, Schema};
 use infino::{
     superfile::builder::FtsConfig,
     supertable::{Supertable, SupertableOptions},
-    test_helpers::{default_tokenizer, default_vector_config},
+    test_helpers::default_vector_config,
 };
 
 /// `default_vector_config` is dim=16, cosine, n_cent=4.
@@ -58,13 +58,8 @@ fn options_title_rating_emb() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -122,20 +122,11 @@ fn options_with_counting_store(store: Arc<CountingStore>) -> SupertableOptions {
             .build()
             .expect("build pool"),
     );
-    let tk: Arc<dyn Tokenizer> = default_tokenizer();
-    SupertableOptions::new(
-        schema_id_title(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
-        vec![],
-        Some(tk),
-    )
-    .expect("opts")
-    .with_writer_pool(pool)
-    .with_store(store)
+    let _tk: Arc<dyn Tokenizer> = default_tokenizer();
+    SupertableOptions::new(schema_id_title(), vec![FtsConfig::new("title")], vec![])
+        .expect("opts")
+        .with_writer_pool(pool)
+        .with_store(store)
 }
 
 #[test]

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -128,6 +128,7 @@ fn options_with_counting_store(store: Arc<CountingStore>) -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(tk),

--- a/tests/supertable/query/stats_fold.rs
+++ b/tests/supertable/query/stats_fold.rs
@@ -50,7 +50,7 @@ fn options_cat_rating() -> SupertableOptions {
         Field::new("category", DataType::LargeUtf8, false),
         Field::new("rating", DataType::Int64, false),
     ]));
-    SupertableOptions::new(schema, vec![], vec![], None).expect("valid options")
+    SupertableOptions::new(schema, vec![], vec![]).expect("valid options")
 }
 
 /// Commit `idx` carries categories `cat{idx}_{row}` and ratings
@@ -254,7 +254,7 @@ fn options_day_id() -> SupertableOptions {
         Field::new("day", DataType::Date32, false),
         Field::new("id", DataType::Int64, false),
     ]));
-    SupertableOptions::new(schema, vec![], vec![], None).expect("valid options")
+    SupertableOptions::new(schema, vec![], vec![]).expect("valid options")
 }
 
 /// Base day (days-since-epoch) for commit 0; later commits and rows step
@@ -416,7 +416,7 @@ fn options_full_domain_u64() -> SupertableOptions {
         Field::new("i", DataType::Int64, false),
         Field::new("u", DataType::UInt64, false),
     ]));
-    SupertableOptions::new(schema, vec![], vec![], None)
+    SupertableOptions::new(schema, vec![], vec![])
         .expect("valid options")
         .with_writer_pool(single_superfile_writer_pool())
 }
@@ -428,7 +428,7 @@ fn options_split_domain_i64() -> SupertableOptions {
         Field::new("i", DataType::Int64, false),
         Field::new("n", DataType::Int64, false),
     ]));
-    SupertableOptions::new(schema, vec![], vec![], None)
+    SupertableOptions::new(schema, vec![], vec![])
         .expect("valid options")
         .with_writer_pool(single_superfile_writer_pool())
 }

--- a/tests/supertable/query/stored_fields.rs
+++ b/tests/supertable/query/stored_fields.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Query-surface contract for index-only FTS columns
+//! (`FtsConfig { stored: false, .. }`): searchable, never readable.
+//!
+//! * `bm25_search` over the column returns ranked `_id` + `score`;
+//! * naming the column in a search projection is rejected up front
+//!   (it resolves against the stored schema, like any unknown column);
+//! * SQL never sees the column: `SELECT *` omits it, and selecting or
+//!   filtering on it by name fails at plan time;
+//! * the error text stays at the caller's level — it may name the
+//!   column, but no storage-format or execution-engine tokens leak.
+
+#![deny(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use arrow_array::{Int64Array, LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use infino::{
+    superfile::{
+        builder::FtsConfig,
+        fts::reader::{Bm25Stats, BoolMode},
+    },
+    supertable::{Supertable, SupertableOptions},
+    test_helpers::default_tokenizer,
+};
+
+/// Docs per commit; two commits keep the corpus multi-superfile.
+const DOCS_PER_COMMIT: usize = 4;
+/// Top-k larger than the corpus so nothing truncates.
+const K: usize = 32;
+
+/// Schema `[title (stored FTS), body (index-only FTS), rating]`.
+fn options_with_index_only_body() -> SupertableOptions {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("title", DataType::LargeUtf8, false),
+        Field::new("body", DataType::LargeUtf8, false),
+        Field::new("rating", DataType::Int64, false),
+    ]));
+    SupertableOptions::new(
+        schema,
+        vec![
+            FtsConfig {
+                column: "title".into(),
+                positions: false,
+                stored: true,
+            },
+            FtsConfig {
+                column: "body".into(),
+                positions: false,
+                stored: false,
+            },
+        ],
+        vec![],
+        Some(default_tokenizer()),
+    )
+    .expect("valid options")
+}
+
+fn build_batch(rows: &[(&str, &str)], base: usize, schema: Arc<Schema>) -> RecordBatch {
+    let titles = LargeStringArray::from(rows.iter().map(|(t, _)| *t).collect::<Vec<_>>());
+    let bodies = LargeStringArray::from(rows.iter().map(|(_, b)| *b).collect::<Vec<_>>());
+    let ratings: Vec<i64> = (0..rows.len()).map(|i| (base + i) as i64).collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(titles),
+            Arc::new(bodies),
+            Arc::new(Int64Array::from(ratings)),
+        ],
+    )
+    .expect("batch")
+}
+
+/// Two-superfile corpus; `signal` appears in exactly one body per segment.
+fn demo_table() -> Supertable {
+    let st = Supertable::create(options_with_index_only_body()).expect("create");
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    w.append(&build_batch(
+        &[
+            ("rust systems", "signal in the noise"),
+            ("python data", "frames and plots"),
+            ("go network", "goroutines everywhere"),
+            ("java spring", "beans and factories"),
+        ],
+        0,
+        schema.clone(),
+    ))
+    .expect("append seg1");
+    w.commit().expect("commit seg1");
+    w.append(&build_batch(
+        &[
+            ("ruby rails", "conventions abound"),
+            ("scala akka", "actors send signal fast"),
+            ("kotlin flow", "coroutines flowing"),
+            ("swift ui", "views and state"),
+        ],
+        DOCS_PER_COMMIT,
+        schema,
+    ))
+    .expect("append seg2");
+    w.commit().expect("commit seg2");
+    drop(w);
+    st
+}
+
+#[test]
+fn index_only_column_searches_but_rejects_projection() {
+    let st = demo_table();
+    let reader = st.reader().expect("reader");
+
+    // Ranked search over the index-only column spans both segments.
+    let batches = reader
+        .bm25_search(
+            "body",
+            "signal",
+            K,
+            BoolMode::Or,
+            Bm25Stats::PerSuperfile,
+            None,
+        )
+        .expect("bm25 over index-only column");
+    let n: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(n, 2, "one signal doc per segment");
+
+    // Projecting stored columns works.
+    let batches = reader
+        .bm25_search(
+            "body",
+            "signal",
+            K,
+            BoolMode::Or,
+            Bm25Stats::PerSuperfile,
+            Some(&["_id", "title", "rating", "score"]),
+        )
+        .expect("stored projection");
+    assert_eq!(batches[0].num_columns(), 4);
+
+    // Naming the index-only column is rejected up front, with a
+    // caller-level message: the column may be named, engine internals
+    // may not.
+    let err = reader
+        .bm25_search(
+            "body",
+            "signal",
+            K,
+            BoolMode::Or,
+            Bm25Stats::PerSuperfile,
+            Some(&["_id", "body", "score"]),
+        )
+        .expect_err("index-only column must not be projectable");
+    let msg = err.to_string();
+    assert!(msg.contains("body"), "error names the column: {msg}");
+    for leak in ["DataFusion", "parquet", "inf.fts"] {
+        assert!(!msg.contains(leak), "error leaks {leak}: {msg}");
+    }
+}
+
+#[test]
+fn sql_never_sees_an_index_only_column() {
+    let st = demo_table();
+    let reader = st.reader().expect("reader");
+
+    // SELECT * omits the column entirely: _id, title, rating.
+    let batches = reader
+        .query_sql("SELECT * FROM supertable ORDER BY rating")
+        .expect("select star");
+    assert_eq!(
+        batches[0]
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect::<Vec<_>>(),
+        vec!["_id", "title", "rating"],
+        "the index-only column is not part of the SQL view"
+    );
+
+    // Stored columns stay selectable and filterable.
+    let batches = reader
+        .query_sql("SELECT title FROM supertable WHERE rating >= 4")
+        .expect("stored select");
+    let n: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(n, DOCS_PER_COMMIT);
+
+    // Selecting or filtering on the index-only column fails at plan
+    // time, like any unknown column.
+    for q in [
+        "SELECT body FROM supertable",
+        "SELECT title FROM supertable WHERE body LIKE '%signal%'",
+        "SELECT _id, body FROM bm25_search('body', 'signal', 8)",
+    ] {
+        assert!(
+            reader.query_sql(q).is_err(),
+            "index-only column must be invisible to SQL: {q}"
+        );
+    }
+
+    // The search TVF itself still ranks over the column — only reading
+    // its text is off the table.
+    let batches = reader
+        .query_sql("SELECT _id, score FROM bm25_search('body', 'signal', 8)")
+        .expect("bm25 TVF over index-only column");
+    let n: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(n, 2);
+}

--- a/tests/supertable/query/stored_fields.rs
+++ b/tests/supertable/query/stored_fields.rs
@@ -24,7 +24,6 @@ use infino::{
         fts::reader::{Bm25Stats, BoolMode},
     },
     supertable::{Supertable, SupertableOptions},
-    test_helpers::default_tokenizer,
 };
 
 /// Docs per commit; two commits keep the corpus multi-superfile.
@@ -42,19 +41,10 @@ fn options_with_index_only_body() -> SupertableOptions {
     SupertableOptions::new(
         schema,
         vec![
-            FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            },
-            FtsConfig {
-                column: "body".into(),
-                positions: false,
-                stored: false,
-            },
+            FtsConfig::new("title"),
+            FtsConfig::new("body").stored(false),
         ],
         vec![],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -414,16 +414,11 @@ async fn vector_query_excludes_tombstoned_row() {
             .build()
             .expect("rayon writer"),
     );
-    let tk: Arc<dyn Tokenizer> = default_tokenizer();
+    let _tk: Arc<dyn Tokenizer> = default_tokenizer();
     let opts = SupertableOptions::new(
         schema_with_vec(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("embedding", VECTOR_ROT_SEED)],
-        Some(tk),
     )
     .expect("opts")
     .with_reader_pool(pool)
@@ -601,18 +596,13 @@ async fn vector_query_backfills_across_superfiles_after_deletes() {
     let dir = TempDir::new().expect("tempdir");
     let storage: Arc<dyn StorageProvider> =
         Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
-    let tk: Arc<dyn Tokenizer> = default_tokenizer();
+    let _tk: Arc<dyn Tokenizer> = default_tokenizer();
     // Default writer pool — the realistic path that shards the commit.
     let st = Supertable::create(
         SupertableOptions::new(
             schema(),
-            vec![FtsConfig {
-                column: "title".into(),
-                positions: false,
-                stored: true,
-            }],
+            vec![FtsConfig::new("title")],
             vec![default_vector_config("embedding", VECTOR_ROT_SEED)],
-            Some(tk),
         )
         .expect("opts")
         .with_storage(Arc::clone(&storage)),

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -420,6 +420,7 @@ async fn vector_query_excludes_tombstoned_row() {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("embedding", VECTOR_ROT_SEED)],
         Some(tk),
@@ -608,6 +609,7 @@ async fn vector_query_backfills_across_superfiles_after_deletes() {
             vec![FtsConfig {
                 column: "title".into(),
                 positions: false,
+                stored: true,
             }],
             vec![default_vector_config("embedding", VECTOR_ROT_SEED)],
             Some(tk),

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -79,7 +79,7 @@ use infino::{
         Supertable, SupertableOptions,
         storage::{AzureStorageProvider, StorageProvider},
     },
-    test_helpers::{default_disk_cache, default_tokenizer},
+    test_helpers::default_disk_cache,
 };
 use infino_bench_utils::corpus::generate_text_corpus;
 use rand::{SeedableRng, rngs::StdRng};
@@ -207,11 +207,7 @@ fn options_title_emb() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig {
             column: "emb".into(),
             dim: EMB_DIM,
@@ -220,7 +216,6 @@ fn options_title_emb() -> SupertableOptions {
             rerank_codec: RerankCodec::Fp32,
             provided_centroids: None,
         }],
-        Some(default_tokenizer()),
     )
     .expect("SupertableOptions::new with title+emb test fixture args")
     .with_writer_pool(pool)

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -210,6 +210,7 @@ fn options_title_emb() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig {
             column: "emb".into(),

--- a/tests/supertable/storage/fault_surfacing.rs
+++ b/tests/supertable/storage/fault_surfacing.rs
@@ -34,7 +34,7 @@ use infino::{
     },
     test_helpers::{
         build_title_batch, decimal128_id_field, decimal128_ids, default_supertable_options,
-        default_tokenizer, default_vector_config,
+        default_vector_config,
         fault_storage::{FaultKind, FaultOp, FaultStorage},
         lazy_foreground_disk_cache,
     },
@@ -118,13 +118,8 @@ fn faulted_vector_table() -> (Supertable, RecordBatch, Arc<FaultStorage>, TempDi
     );
     let options = SupertableOptions::new(
         Arc::clone(&schema),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
     .with_writer_pool(pool)
@@ -475,13 +470,8 @@ fn fts_superfile_bytes() -> Bytes {
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![],
-        Some(default_tokenizer()),
     );
     let mut builder = SuperfileBuilder::new(opts).expect("builder");
     let ids = decimal128_ids(vec![1u64, 2, 3, 4]);

--- a/tests/supertable/storage/fault_surfacing.rs
+++ b/tests/supertable/storage/fault_surfacing.rs
@@ -121,6 +121,7 @@ fn faulted_vector_table() -> (Supertable, RecordBatch, Arc<FaultStorage>, TempDi
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),
@@ -477,6 +478,7 @@ fn fts_superfile_bytes() -> Bytes {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![],
         Some(default_tokenizer()),

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -101,11 +101,7 @@ fn real_azure_options(dim: usize) -> infino::supertable::SupertableOptions {
     ]));
     infino::supertable::SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig {
             column: "emb".into(),
             dim,
@@ -114,7 +110,6 @@ fn real_azure_options(dim: usize) -> infino::supertable::SupertableOptions {
             rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
             provided_centroids: None,
         }],
-        Some(infino::test_helpers::default_tokenizer()),
     )
     .expect("real Azure test options")
     .with_writer_pool(pool)

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -104,6 +104,7 @@ fn real_azure_options(dim: usize) -> infino::supertable::SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig {
             column: "emb".into(),

--- a/tests/supertable/storage/smoke_gcs.rs
+++ b/tests/supertable/storage/smoke_gcs.rs
@@ -38,7 +38,7 @@ use infino::{
         query::VectorSearchOptions,
         storage::{GcsStorageProvider, StorageProvider},
     },
-    test_helpers::{cas_conformance::cas_conformance, default_disk_cache, default_tokenizer},
+    test_helpers::{cas_conformance::cas_conformance, default_disk_cache},
 };
 use tempfile::TempDir;
 
@@ -75,11 +75,7 @@ fn gcs_options(dim: usize) -> SupertableOptions {
     );
     SupertableOptions::new(
         unified_schema(dim),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig {
             column: "emb".into(),
             dim,
@@ -88,7 +84,6 @@ fn gcs_options(dim: usize) -> SupertableOptions {
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
         }],
-        Some(default_tokenizer()),
     )
     .expect("gcs test options")
     .with_writer_pool(pool)

--- a/tests/supertable/storage/smoke_gcs.rs
+++ b/tests/supertable/storage/smoke_gcs.rs
@@ -78,6 +78,7 @@ fn gcs_options(dim: usize) -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig {
             column: "emb".into(),

--- a/tests/supertable/storage/smoke_rustfs.rs
+++ b/tests/supertable/storage/smoke_rustfs.rs
@@ -293,6 +293,7 @@ fn rustfs_vector_options(dim: usize) -> infino::supertable::SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig {
             column: "emb".into(),

--- a/tests/supertable/storage/smoke_rustfs.rs
+++ b/tests/supertable/storage/smoke_rustfs.rs
@@ -290,11 +290,7 @@ fn rustfs_vector_options(dim: usize) -> infino::supertable::SupertableOptions {
     ]));
     infino::supertable::SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig {
             column: "emb".into(),
             dim,
@@ -303,7 +299,6 @@ fn rustfs_vector_options(dim: usize) -> infino::supertable::SupertableOptions {
             rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
             provided_centroids: None,
         }],
-        Some(infino::test_helpers::default_tokenizer()),
     )
     .expect("rustfs TVF test options")
 }

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -71,6 +71,7 @@ fn real_s3_options(dim: usize) -> infino::supertable::SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig {
             column: "emb".into(),

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -68,11 +68,7 @@ fn real_s3_options(dim: usize) -> infino::supertable::SupertableOptions {
     ]));
     infino::supertable::SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig {
             column: "emb".into(),
             dim,
@@ -81,7 +77,6 @@ fn real_s3_options(dim: usize) -> infino::supertable::SupertableOptions {
             rerank_codec: infino::superfile::vector::rerank_codec::RerankCodec::Sq8Residual,
             provided_centroids: None,
         }],
-        Some(infino::test_helpers::default_tokenizer()),
     )
     .expect("real S3 test options")
     .with_writer_pool(pool)

--- a/tests/supertable/vector_cosine_normalize.rs
+++ b/tests/supertable/vector_cosine_normalize.rs
@@ -85,6 +85,7 @@ fn cosine_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig::new(
             "emb".into(),

--- a/tests/supertable/vector_cosine_normalize.rs
+++ b/tests/supertable/vector_cosine_normalize.rs
@@ -38,7 +38,6 @@ use infino::{
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::builder::{FtsConfig, VectorConfig},
     supertable::{Supertable, SupertableOptions},
-    test_helpers::default_tokenizer,
 };
 use tempfile::TempDir;
 
@@ -82,18 +81,13 @@ fn cosine_options() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig::new(
             "emb".into(),
             DIM,
             ROT_SEED,
             Metric::Cosine,
         )],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/vector_law_serving.rs
+++ b/tests/supertable/vector_law_serving.rs
@@ -26,7 +26,7 @@ use infino::{
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::builder::FtsConfig,
     supertable::{Supertable, SupertableOptions},
-    test_helpers::{default_tokenizer, default_vector_config, served_shortlist_probe},
+    test_helpers::{default_vector_config, served_shortlist_probe},
 };
 use tempfile::TempDir;
 
@@ -57,13 +57,8 @@ fn vector_options() -> SupertableOptions {
     ]));
     SupertableOptions::new(
         schema,
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/vector_law_serving.rs
+++ b/tests/supertable/vector_law_serving.rs
@@ -60,6 +60,7 @@ fn vector_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -29,9 +29,7 @@ use infino::{
         options::Consistency,
         reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
     },
-    test_helpers::{
-        build_title_batch, default_supertable_options, default_tokenizer, default_vector_config,
-    },
+    test_helpers::{build_title_batch, default_supertable_options, default_vector_config},
 };
 use tempfile::TempDir;
 
@@ -70,13 +68,8 @@ fn vector_schema() -> Arc<Schema> {
 fn vector_options() -> SupertableOptions {
     SupertableOptions::new(
         vector_schema(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
 }

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -73,6 +73,7 @@ fn vector_options() -> SupertableOptions {
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![default_vector_config("emb", VECTOR_ROT_SEED)],
         Some(default_tokenizer()),

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -89,7 +89,7 @@ use infino::{
         OpenError, Supertable, SupertableOptions,
         storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
     },
-    test_helpers::{build_title_batch, default_supertable_options, default_tokenizer},
+    test_helpers::{build_title_batch, default_supertable_options},
 };
 
 const ENV_DIR: &str = "INFINO_M12_CRASH_DIR";
@@ -338,11 +338,7 @@ fn vector_crash_fixture_with_writers(
     );
     let options = SupertableOptions::new(
         schema.clone(),
-        vec![FtsConfig {
-            column: "title".into(),
-            positions: false,
-            stored: true,
-        }],
+        vec![FtsConfig::new("title")],
         vec![VectorConfig {
             column: "emb".into(),
             dim,
@@ -351,7 +347,6 @@ fn vector_crash_fixture_with_writers(
             rerank_codec: RerankCodec::Sq8Residual,
             provided_centroids: None,
         }],
-        Some(default_tokenizer()),
     )
     .expect("valid options")
     .with_writer_pool(pool);

--- a/tests/supertable_commit_crash_localfs.rs
+++ b/tests/supertable_commit_crash_localfs.rs
@@ -341,6 +341,7 @@ fn vector_crash_fixture_with_writers(
         vec![FtsConfig {
             column: "title".into(),
             positions: false,
+            stored: true,
         }],
         vec![VectorConfig {
             column: "emb".into(),


### PR DESCRIPTION
Two changes on one branch, both about per-column FTS configuration.

## 1. `stored(false)` — index-only text columns

An FTS column can now be declared index-only: its text is tokenized into
the FTS blob at ingest but never written to the Parquet body, so large
search-only text (logs, chat, scraped pages) skips the stored copy
entirely. The column stays part of the append/update contract and
remains fully searchable (ranked BM25, token match, phrase when
positions are on), but it cannot be selected via SQL, named in a search
projection, or used in a predicate — those resolve against the stored
schema and fail up front like any unknown column, with clean messages.

Public API: `IndexSpec::fts` now takes `impl Into<FtsField>`, a
per-column builder (`analyzer`, `stored`); `From<&str>` supplies the
defaults so `.fts("body")` callsites compile unchanged, and
`fts_with_analyzer` folds into the new door (`public-api.txt` updated —
this is the breaking edge, so the release is a 0.x minor). Node and
python bindings expose the option.

Persistence is additive and back-compatible: `inf.fts.columns` gains
`"stored":false` emitted only when false (all-stored files stay
byte-identical; readers default a missing key to true; format version
1.0.0 → 1.1.0), the catalog entry gains a serde-defaulted `fts_stored`
vec, and the options hash appends its tagged block only when a column
is index-only, so existing manifests keep verifying.

Merges no longer re-tokenize: every merge path (generic reader merge,
streaming FTS merge, sq8 byte-splice, multi-cell) carries each input's
prebuilt postings and stored doc-lengths across — an index-only column
has no Parquet text to re-tokenize, and carrying is cheaper and
byte-faithful for stored columns too. The multi-cell merge reorders
rows by stable id, so its carry remaps postings through the packed
order and runs the FTS accumulator in spill mode (whose finish sorts
triples by term/doc); doc-lengths scatter into output order. The
vector merge machinery (sq8 splice, multi-cell assembly, fallback
vector re-encode) is untouched.

## 2. Analyzer folded onto `FtsConfig`

The per-column analyzer now lives on `FtsConfig` as a name (the same
record `inf.fts.columns` persists), built via `FtsConfig::new` plus
chained setters. This deletes the `fts_tokenizers` vec that ran
parallel to `fts_columns` on `BuilderOptions` and `SupertableOptions`
— an alignment invariant every construction site had to maintain — and
the redundant default-tokenizer field seeded from the first column's
analyzer in three places. Names are validated once at options
construction (typed error naming the valid set) and resolved once at
builder construction. The options-hash analyzer block reads the names
off `fts_columns` — same bytes, so existing hashes are unchanged
(golden tests pin this).

Also fixes a latent per-field-analyzer bug: the filtered vector search
tokenized its predicate with the table-wide default tokenizer; it now
uses the filter column's own analyzer.

## Tests

- Round-trip: stored schema drops the column; search and phrase work;
  KV, catalog, and reopen persist the flag.
- Merge ≡ fresh-build equivalence (hits + scores) on the generic and
  streaming paths, with tombstones; sq8 and multi-cell carries pinned
  at the unit level, including the stable-id reorder with phrase
  positions and doc-lengths.
- Options-hash golden stability for all-default tables; legacy catalog
  entries decode; clean SQL/projection/predicate rejections with no
  engine internals in messages.
- Analyzer plumbing: standard-tokenizer oracle, mixed per-column
  analyzers across reopen, unknown-analyzer rejection at both layers.

## Bench comparison vs main

`cargo bench --bench bench -- superfile fts` (1M docs), main vs this
branch on the same host: every warm ranked / top-1000 / COUNT / phrase
cell within run-to-run noise (±5%, mixed sign); ingest equal (1-writer
9.85 s → 9.89 s, positions builds identical); index size identical at
884.72 MiB (the bench corpus keeps stored text, so this is the
no-regression check — index-only columns are opt-in). Correctness
self-checks (BMW ≡ brute-force) green on both sides. No vector-path
changes, so the recall gate is unaffected.