### PR TITLE
bench: FTS quality phase — BM25 top-k parity against a streaming oracle

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -101,7 +101,9 @@ on:
       # `corpus-dir=` arguments. Empty (the default) selects the synthetic
       # planted-cluster corpus, so every existing leg — and the A/B baseline
       # it is compared against — is byte-identical to before this input
-      # existed. A real-corpus leg sets e.g. corpus: annb:glove-100-angular.
+      # existed. A real-corpus leg sets e.g. corpus: annb:glove-100-angular;
+      # `realistic` selects the generated text corpus the FTS quality phase
+      # is calibrated on (no corpus_dir needed).
       corpus:          { type: string, required: false, default: "" }
       corpus_dir:      { type: string, required: false, default: "" }
       docs:            { type: string, required: false, default: "1000000" }
@@ -212,8 +214,15 @@ jobs:
             if [ -n "${{ inputs.corpus_dir }}" ]; then
               args="$args corpus-dir=${{ inputs.corpus_dir }}"
             else
-              echo "::error::corpus set without corpus_dir; downloadable corpora need a staging dir"
-              exit 1
+              # Generated corpora (`synthetic`, `realistic`) need no staging
+              # dir; every other spec downloads or reads files.
+              case "${{ inputs.corpus }}" in
+                synthetic|realistic) ;;
+                *)
+                  echo "::error::corpus set without corpus_dir; downloadable corpora need a staging dir"
+                  exit 1
+                  ;;
+              esac
             fi
           fi
           echo "args=$args"       >> "$GITHUB_OUTPUT"

--- a/benches/README.md
+++ b/benches/README.md
@@ -225,6 +225,80 @@ JSON metrics land in `target/infino-bench/<bench>.json` (local only).
 <!-- END: bench/fts/supertable/search -->
 
 <!-- BEGIN: bench/fts/supertable/quality -->
+### Supertable FTS — BM25 top-k parity vs textbook oracle (10M docs, realistic corpus)
+
+_Host: unknown CPU · 16C/16T · macos/aarch64_
+
+Engine top-k graded against a streaming BM25 oracle over the whole corpus, tie-aware (a hit is any returned doc scoring at least the oracle's k-th score). `recall vs BM25` = `Bm25Stats::Global` against textbook BM25 with exact doc lengths — the user-facing quality, which pays for the one-byte length quantization and per-superfile avgdl. `recall (default stats)` = the same under the default `PerSuperfile` idf. `recall vs engine BM25` = `Global` against BM25 with the engine's stored (quantized) lengths, a hit allowed to fall short of the k-th score by the avgdl residual (5.0% at this scale: the oracle normalizes with the corpus-wide average length, the engine with each superfile's own) — gated at 0.99: below it the kernels disagree with their own formula. `max score Δ` = largest relative gap between an engine score and that reference for the same doc — gated at the same 5.0%.
+
+**k = 10**
+
+| Query | matches | recall vs BM25 | recall (default stats) | recall vs engine BM25 | max score Δ |
+| --- | --- | --- | --- | --- | --- |
+| stopword | 8.4M | 0.9000 | 0.0000 | 1.0000 | 0.02% |
+| common | 2.1M | 1.0000 | 0.1000 | 1.0000 | 0.04% |
+| mid | 59.3K | 1.0000 | 0.5000 | 1.0000 | 0.05% |
+| rare | 628 | 1.0000 | 0.6000 | 1.0000 | 0.23% |
+| singleton | 1 | 1.0000 | 1.0000 | 1.0000 | 1.10% |
+| stopword_common_or | 8.4M | 0.9000 | 0.2000 | 1.0000 | 0.03% |
+| stopword_rare_or | 8.4M | 0.9000 | 0.6000 | 1.0000 | 0.23% |
+| three_stopword_or | 9.1M | 0.8000 | 0.1000 | 1.0000 | 0.05% |
+| three_mid_or | 169.8K | 1.0000 | 0.9000 | 1.0000 | 0.35% |
+| ten_common_or | 6.2M | 0.9000 | 0.9000 | 1.0000 | 1.10% |
+| stopword_rare_and | 613 | 1.0000 | 0.7000 | 1.0000 | 0.23% |
+| common_mid_and | 38.7K | 1.0000 | 1.0000 | 1.0000 | 0.12% |
+| three_mid_and | 360 | 1.0000 | 1.0000 | 1.0000 | 2.42% |
+| must_rare_should_common | 628 | 1.0000 | 0.9000 | 1.0000 | 0.06% |
+| must_two_should_two | 1.0M | 1.0000 | 0.8000 | 1.0000 | 0.18% |
+| common_not_stopword | 45.8K | 1.0000 | 0.6000 | 1.0000 | 0.02% |
+| phrase_stopwords | 2.8M | 0.8000 | 0.3000 | 1.0000 | 0.05% |
+| phrase_common_mid | 223 | 1.0000 | 0.9000 | 1.0000 | 0.31% |
+
+**k = 100**
+
+| Query | matches | recall vs BM25 | recall (default stats) | recall vs engine BM25 | max score Δ |
+| --- | --- | --- | --- | --- | --- |
+| stopword | 8.4M | 0.8800 | 0.0300 | 1.0000 | 0.03% |
+| common | 2.1M | 0.9500 | 0.4000 | 1.0000 | 0.05% |
+| mid | 59.3K | 0.9800 | 0.7400 | 1.0000 | 0.09% |
+| rare | 628 | 0.9900 | 0.9500 | 1.0000 | 0.79% |
+| singleton | 1 | 1.0000 | 1.0000 | 1.0000 | 1.10% |
+| stopword_common_or | 8.4M | 0.9300 | 0.4600 | 1.0000 | 0.07% |
+| stopword_rare_or | 8.4M | 0.9900 | 0.9500 | 1.0000 | 0.77% |
+| three_stopword_or | 9.1M | 0.8700 | 0.2000 | 1.0000 | 0.11% |
+| three_mid_or | 169.8K | 0.9700 | 0.9800 | 1.0000 | 0.98% |
+| ten_common_or | 6.2M | 0.8500 | 0.8500 | 1.0000 | 1.38% |
+| stopword_rare_and | 613 | 0.9800 | 0.9400 | 1.0000 | 0.77% |
+| common_mid_and | 38.7K | 0.9800 | 0.9200 | 1.0000 | 0.28% |
+| three_mid_and | 360 | 0.9900 | 0.9900 | 1.0000 | 3.45% |
+| must_rare_should_common | 628 | 0.9900 | 0.9200 | 1.0000 | 0.84% |
+| must_two_should_two | 1.0M | 0.9700 | 0.9400 | 1.0000 | 0.85% |
+| common_not_stopword | 45.8K | 0.9800 | 0.7100 | 1.0000 | 0.05% |
+| phrase_stopwords | 2.8M | 0.9700 | 0.6600 | 1.0000 | 0.12% |
+| phrase_common_mid | 223 | 1.0000 | 0.9900 | 1.0000 | 1.65% |
+
+**k = 1000**
+
+| Query | matches | recall vs BM25 | recall (default stats) | recall vs engine BM25 | max score Δ |
+| --- | --- | --- | --- | --- | --- |
+| stopword | 8.4M | 0.9160 | 0.0620 | 1.0000 | 0.05% |
+| common | 2.1M | 0.9750 | 0.6860 | 1.0000 | 0.10% |
+| mid | 59.3K | 0.9870 | 0.9280 | 1.0000 | 0.50% |
+| rare | 628 | 1.0000 | 1.0000 | 1.0000 | 3.28% |
+| singleton | 1 | 1.0000 | 1.0000 | 1.0000 | 1.10% |
+| stopword_common_or | 8.4M | 0.9550 | 0.7040 | 1.0000 | 0.13% |
+| stopword_rare_or | 8.4M | 0.9760 | 0.6480 | 1.0000 | 2.79% |
+| three_stopword_or | 9.1M | 0.8700 | 0.3170 | 1.0000 | 0.17% |
+| three_mid_or | 169.8K | 0.9750 | 0.8830 | 1.0000 | 1.50% |
+| ten_common_or | 6.2M | 0.8780 | 0.8860 | 1.0000 | 1.75% |
+| stopword_rare_and | 613 | 1.0000 | 1.0000 | 1.0000 | 2.79% |
+| common_mid_and | 38.7K | 0.9750 | 0.9580 | 1.0000 | 1.11% |
+| three_mid_and | 360 | 1.0000 | 1.0000 | 1.0000 | 4.06% |
+| must_rare_should_common | 628 | 1.0000 | 1.0000 | 1.0000 | 2.91% |
+| must_two_should_two | 1.0M | 0.9670 | 0.9660 | 1.0000 | 1.33% |
+| common_not_stopword | 45.8K | 0.9960 | 0.8740 | 1.0000 | 0.08% |
+| phrase_stopwords | 2.8M | 0.9470 | 0.7600 | 1.0000 | 0.27% |
+| phrase_common_mid | 223 | 1.0000 | 1.0000 | 1.0000 | 3.61% |
 <!-- END: bench/fts/supertable/quality -->
 
 ### Superfile vector

--- a/benches/README.md
+++ b/benches/README.md
@@ -24,6 +24,7 @@ Raw logs: Actions artifacts on that run.
 ```sh
 cargo bench                              # all cells
 cargo bench -- supertable fts            # one cell
+cargo bench -- supertable fts quality corpus=realistic   # BM25 top-k parity vs oracle
 cargo bench -- superfile sql cold        # phases: build | warm | cold
 INFINO_BENCH_SUPERFILE_DOCS=100000 \
   cargo bench -- superfile fts warm      # plain ints only (no 100K suffix)
@@ -52,6 +53,13 @@ engine diagnostics (`info,infino=debug`); an explicit `RUST_LOG` overrides
 both.
 
 Synthetic FTS corpus: seed `1`, 200 Zipfian tokens/doc, 10K vocab.
+`corpus=realistic` swaps the text generator for one calibrated to English
+Wikipedia — log-normal doc lengths (median 89 tokens, 13% under 16, a 1%
+tail past 3000), an open Zipf vocabulary over 1M ranks (rank 1 in ~84% of
+docs), ~56% within-doc repeated tokens, and mixed-case / punctuation /
+digit surface forms — same seed, same `term{rank}` names, so the batteries
+apply to both. The quality table below is measured on it; the speed tables
+stay on the uniform corpus.
 Synthetic vectors: cosine, **1024-d**, seed `1` (archived tables below used 384-d).
 
 ### Object store
@@ -101,6 +109,9 @@ cargo bench -- dataset run datasets/bench-10m fts
 | `supertable sql` | | SQL |
 
 Each cell: `build`, `warm`, `cold`. Multi-cell runs isolate each cell in its own process (RSS).
+`supertable fts` also runs `quality` (part of `all`): the engine's BM25 top-k at
+k = 10 / 100 / 1000 graded against a streaming textbook oracle over the whole
+corpus, gated at recall ≥ 0.99 vs the engine's own length-quantized formula.
 
 Vector cells report a `default` config row; probe/rerank are not env-tunable.
 Recall is checked against brute-force ground truth.
@@ -212,6 +223,9 @@ JSON metrics land in `target/infino-bench/<bench>.json` (local only).
 | five_term_and | 2.13 ms | 11.33 ms | 1.17 GiB | 1.07 GiB | 1.17 GiB | 453.28 ms | 343.62 ms |
 | ten_term_and | 2.43 ms | 11.29 ms | 1.14 GiB | 1.06 GiB | 1.14 GiB | 392.86 ms | 304.12 ms |
 <!-- END: bench/fts/supertable/search -->
+
+<!-- BEGIN: bench/fts/supertable/quality -->
+<!-- END: bench/fts/supertable/quality -->
 
 ### Superfile vector
 

--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -29,7 +29,9 @@
 //! Token vocabulary:
 //!   tier        : `superfile` | `supertable`        (omitted => both)
 //!   modality    : `fts` | `vector` | `sql`          (omitted => all three)
-//!   phase       : `build` | `warm` | `cold` | `search` (= warm+cold)
+//!   phase       : `build` | `warm` | `cold` | `quality` | `search` (= warm+cold)
+//!                 (`quality` = FTS BM25 top-k parity vs a textbook oracle;
+//!                 supertable fts only, other cells ignore it)
 //!                 (omitted => all three phases)
 //!   `all`       : explicit "every tier × modality × phase" (the default).
 //!                 Matrix only — diagnostics are NEVER implied by `all` or
@@ -175,6 +177,17 @@ fn run_cell_in_child(tier: Tier, modality: Modality, phases: Phases, phase_selec
         if phases.cold {
             cmd.arg("cold");
         }
+        if phases.quality {
+            cmd.arg("quality");
+        }
+    }
+    // The corpus selector is process-wide state installed from the
+    // arguments, so a child that did not receive it would silently run
+    // the default corpus under the parent's label.
+    for arg in std::env::args().skip(1) {
+        if arg.starts_with("corpus=") || arg.starts_with("corpus-dir=") {
+            cmd.arg(arg);
+        }
     }
     let status = cmd.status().expect("spawn bench cell child");
     if !status.success() {
@@ -196,7 +209,7 @@ enum DatasetVerb {
 
 fn dataset_usage_and_exit(code: i32) -> ! {
     eprintln!(
-        "Usage:\n  cargo bench -- dataset <prepare|bench|run> <prefix> [fts|vector|sql ...] [warm|cold|search]\n\
+        "Usage:\n  cargo bench -- dataset <prepare|bench|run> <prefix> [fts|vector|sql ...] [warm|cold|quality|search]\n\
          \n\
          prepare : ingest the corpus to <prefix> and write the sidecar (fails if already there)\n\
          bench   : open the dataset at <prefix> and run the read phases (fails if absent)\n\
@@ -230,7 +243,7 @@ fn run_dataset_command(tokens: &[String]) {
     };
     let mut prefix: Option<&str> = None;
     let mut modalities: Vec<Modality> = Vec::new();
-    let (mut warm, mut cold) = (false, false);
+    let (mut warm, mut cold, mut quality) = (false, false, false);
     for tok in &tokens[1..] {
         match tok.as_str() {
             "fts" if !modalities.contains(&Modality::Fts) => modalities.push(Modality::Fts),
@@ -241,6 +254,7 @@ fn run_dataset_command(tokens: &[String]) {
             "fts" | "vector" | "sql" => {}
             "warm" => warm = true,
             "cold" => cold = true,
+            "quality" => quality = true,
             "search" => {
                 warm = true;
                 cold = true;
@@ -263,9 +277,10 @@ fn run_dataset_command(tokens: &[String]) {
     if modalities.is_empty() {
         modalities = vec![Modality::Fts, Modality::Vector, Modality::Sql];
     }
-    if !(warm || cold) {
+    if !(warm || cold || quality) {
         warm = true;
         cold = true;
+        quality = true;
     }
 
     for &m in &modalities {
@@ -286,11 +301,13 @@ fn run_dataset_command(tokens: &[String]) {
                 build: true,
                 warm: false,
                 cold: false,
+                quality: false,
             },
             (DatasetVerb::Bench, true) => Phases {
                 build: false,
                 warm,
                 cold,
+                quality,
             },
             (DatasetVerb::Run, exists) => {
                 if exists {
@@ -300,6 +317,7 @@ fn run_dataset_command(tokens: &[String]) {
                     build: !exists,
                     warm,
                     cold,
+                    quality,
                 }
             }
         };
@@ -314,7 +332,8 @@ fn print_usage_and_exit(code: i32) -> ! {
          \n\
          Tier      : superfile | supertable        (omitted => both)\n\
          Modality  : fts | vector | sql            (omitted => all three)\n\
-         Phase     : build | warm | cold | search  (search = warm+cold; omitted => all)\n\
+         Phase     : build | warm | cold | quality | search  (search = warm+cold; omitted => all;\n\
+         \x20           quality = FTS BM25 parity vs a textbook oracle, supertable fts only)\n\
          all       : every tier x modality x phase (the default for a bare\n\
          \x20           `cargo bench`); matrix only — never implies diagnostics\n\
          Diagnostic: scale | tombstone | update | sql-diag | fts-diag | object-store | concurrent | disk-warm | recall_while_ingest,\n\
@@ -377,6 +396,7 @@ fn parse_args() -> Selection {
     let mut build = false;
     let mut warm = false;
     let mut cold = false;
+    let mut quality = false;
     let mut want_all = false;
     let mut want_diagnostics = false;
     let mut unknown: Vec<String> = Vec::new();
@@ -415,6 +435,7 @@ fn parse_args() -> Selection {
             "build" => build = true,
             "warm" => warm = true,
             "cold" => cold = true,
+            "quality" => quality = true,
             "search" => {
                 warm = true;
                 cold = true;
@@ -473,9 +494,14 @@ fn parse_args() -> Selection {
         ];
     }
 
-    let phase_selected = build || warm || cold;
+    let phase_selected = build || warm || cold || quality;
     let phases = if phase_selected {
-        Phases { build, warm, cold }
+        Phases {
+            build,
+            warm,
+            cold,
+            quality,
+        }
     } else {
         Phases::ALL
     };

--- a/benches/utils/corpus.rs
+++ b/benches/utils/corpus.rs
@@ -166,6 +166,9 @@ pub(crate) const VECTOR_CORPUS_CHUNK_DOCS: usize = 1 << 19;
 /// file. This keeps memory bounded by roughly `rayon_threads × 8 MiB` while
 /// still issuing large writes to NVMe.
 const PARALLEL_CORPUS_WRITE_BUF_CAPACITY: usize = 8 << 20;
+/// Pre-sizing estimate for one realistic doc's bytes (mean ~295 tokens at
+/// ~5.5 bytes each); only a capacity hint, never a bound.
+const REALISTIC_DOC_BYTES_ESTIMATE: usize = 1600;
 /// Odd 64-bit multiplier (fractional golden ratio) used to derive a
 /// distinct, deterministic RNG seed per chunk from `(seed, chunk_index)`,
 /// so a parallelized corpus is still reproducible for a given `seed`.
@@ -199,6 +202,12 @@ pub const SYNTHETIC_DIM: usize = 1024;
 /// Specs:
 ///
 /// * `synthetic` — the seeded planted-cluster generator (the default).
+/// * `realistic` — the same generator with the text column switched to
+///   the realistic flavour ([`text_gen::TextFlavor::Realistic`]:
+///   variable-length, open-vocabulary, bursty docs calibrated to real
+///   text). Vectors and SQL columns are unchanged; only the text
+///   generator differs, so this is a text flavour of `synthetic`, not a
+///   separate source.
 /// * `annb:<slug>` — a published ann-benchmarks dataset
 ///   (`annb:glove-100-angular`). One HDF5 file carries corpus rows, the
 ///   official query set, and official top-k neighbour ids, so ground
@@ -233,6 +242,16 @@ pub enum CorpusSource {
 /// Where downloaded corpora are staged, set alongside the spec.
 static SOURCE: OnceLock<CorpusSource> = OnceLock::new();
 
+/// Text flavour of the synthetic source; [`TextFlavor::Uniform`] until
+/// `corpus=realistic` sets it. Only consulted when the source is
+/// [`CorpusSource::Synthetic`] — a real corpus brings its own text.
+static TEXT_FLAVOR: OnceLock<TextFlavor> = OnceLock::new();
+
+/// The synthetic text flavour for this process.
+pub fn text_flavor() -> TextFlavor {
+    *TEXT_FLAVOR.get_or_init(|| TextFlavor::Uniform)
+}
+
 /// Parse and install the corpus source for this process. First call wins,
 /// mirroring [`crate::dataset::set_prefix`]. `dir` is where downloadable
 /// sources stage their files. Returns an error string for an unparseable
@@ -245,6 +264,10 @@ pub fn set_source(spec: &str, dir: Option<&str>) -> Result<(), String> {
     };
     let source = match spec.split_once(':') {
         None if spec == "synthetic" => CorpusSource::Synthetic,
+        None if spec == "realistic" => {
+            let _ = TEXT_FLAVOR.set(TextFlavor::Realistic);
+            CorpusSource::Synthetic
+        }
         Some(("annb", slug)) if !slug.is_empty() => CorpusSource::AnnBenchmarks {
             dir: staged("the dataset file")?,
             slug: slug.to_string(),
@@ -258,7 +281,7 @@ pub fn set_source(spec: &str, dir: Option<&str>) -> Result<(), String> {
         },
         _ => {
             return Err(format!(
-                "unknown corpus spec {spec:?} (expected synthetic | annb:<slug> | \
+                "unknown corpus spec {spec:?} (expected synthetic | realistic | annb:<slug> | \
                  hf:<owner/repo> | parquet:<dir>)"
             ));
         }
@@ -275,7 +298,7 @@ pub fn corpus_source() -> &'static CorpusSource {
 /// Short corpus name for reports and dataset sidecars.
 pub fn corpus_label() -> &'static str {
     match corpus_source() {
-        CorpusSource::Synthetic => "synthetic",
+        CorpusSource::Synthetic => text_flavor().label(),
         CorpusSource::AnnBenchmarks { slug, .. } => slug,
         CorpusSource::HuggingFace { repo, .. } => repo,
         CorpusSource::LocalParquet { dir } => dir
@@ -532,7 +555,85 @@ pub struct MmapTextCorpus {
 }
 
 impl MmapTextCorpus {
+    /// Generate the text corpus in the process's configured flavour
+    /// ([`text_flavor`]).
     pub fn generate(n_docs: usize, seed: u64) -> Self {
+        Self::generate_flavor(n_docs, seed, text_flavor())
+    }
+
+    /// Generate the text corpus in an explicit flavour.
+    pub fn generate_flavor(n_docs: usize, seed: u64, flavor: TextFlavor) -> Self {
+        match flavor {
+            TextFlavor::Uniform => Self::generate_uniform(n_docs, seed),
+            TextFlavor::Realistic => Self::generate_realistic(n_docs, seed),
+        }
+    }
+
+    /// The realistic flavour: byte lengths depend on the RNG, so a chunk's
+    /// bytes are generated into memory and appended in chunk order. Chunks
+    /// are small ([`text_gen::REALISTIC_CHUNK_DOCS`]) and processed in
+    /// windows of two per worker, so the in-flight buffer stays around
+    /// `2 × workers × ~50 MB` regardless of corpus size.
+    fn generate_realistic(n_docs: usize, seed: u64) -> Self {
+        let tmp = TempDir::new().expect("create MmapTextCorpus tempdir");
+        let path = tmp.path().join("corpus.txt");
+        let generator = TextDocGen::new(TextFlavor::Realistic);
+        let chunk_docs = generator.chunk_docs();
+        let n_chunks = n_docs.div_ceil(chunk_docs);
+        let window = parallel_writers().max(1) * 2;
+
+        let mut writer = BufWriter::new(File::create(&path).expect("create text corpus file"));
+        let mut offsets = Vec::with_capacity(n_docs + 1);
+        let mut pos = 0u64;
+        offsets.push(pos);
+        for window_start in (0..n_chunks).step_by(window) {
+            let window_end = (window_start + window).min(n_chunks);
+            let chunks: Vec<(Vec<u32>, Vec<u8>)> = (window_start..window_end)
+                .into_par_iter()
+                .map(|c| {
+                    let start = c * chunk_docs;
+                    let end = ((c + 1) * chunk_docs).min(n_docs);
+                    let mut rng = generator.chunk_rng(seed, c);
+                    let mut doc = String::new();
+                    let mut lens = Vec::with_capacity(end - start);
+                    let mut bytes =
+                        Vec::with_capacity((end - start) * REALISTIC_DOC_BYTES_ESTIMATE);
+                    for doc_id in start..end {
+                        doc.clear();
+                        generator.write_doc(&mut rng, doc_id, &mut doc);
+                        lens.push(doc.len() as u32);
+                        bytes.extend_from_slice(doc.as_bytes());
+                    }
+                    (lens, bytes)
+                })
+                .collect();
+            for (lens, bytes) in chunks {
+                writer.write_all(&bytes).expect("write text corpus chunk");
+                for len in lens {
+                    pos += u64::from(len);
+                    offsets.push(pos);
+                }
+            }
+        }
+        let file = writer.into_inner().expect("flush text corpus");
+        file.sync_all().expect("sync text corpus");
+        drop(file);
+
+        let file = File::open(&path).expect("reopen text corpus");
+        // SAFETY: this helper owns the temp file and never writes to it after
+        // the fsync above, so the read-only mmap cannot observe mutation.
+        let map = unsafe { Mmap::map(&file).expect("mmap text corpus") };
+        Self {
+            _tmp: tmp,
+            map,
+            offsets,
+        }
+    }
+
+    /// The uniform flavour: every doc's byte length is RNG-independent, so
+    /// the offset table is computed up front and each chunk writes to its
+    /// own disjoint byte range in parallel.
+    fn generate_uniform(n_docs: usize, seed: u64) -> Self {
         let tmp = TempDir::new().expect("create MmapTextCorpus tempdir");
         let path = tmp.path().join("corpus.txt");
 
@@ -693,8 +794,12 @@ pub mod combined;
 pub mod grading;
 pub mod sql;
 pub mod sql_battery;
+pub mod text_gen;
 
 pub use combined::SequentialSyntheticCorpus;
+pub use text_gen::{
+    TextDocGen, TextFlavor, for_each_doc_in_chunk, for_each_generated_doc, generated_chunk_count,
+};
 
 // ─── Vector corpus ────────────────────────────────────────────────────
 

--- a/benches/utils/corpus/combined.rs
+++ b/benches/utils/corpus/combined.rs
@@ -7,22 +7,19 @@ use rand::{SeedableRng, rngs::StdRng};
 use rand_distr::{Distribution, StandardNormal};
 
 use crate::corpus::{
-    TEXT_CORPUS_CHUNK_DOCS, TOKENS_PER_DOC, VECTOR_CORPUS_CHUNK_DOCS, VOCAB_SIZE, ZipfDistribution,
-    chunk_seed, dim, normalize,
+    TextDocGen, VECTOR_CORPUS_CHUNK_DOCS, chunk_seed, dim, normalize, text_flavor,
 };
 
 /// Gaussian scale of a planted cluster center (matches `corpus.rs`).
 const CENTER_GAUSSIAN_SCALE: f32 = 3.0;
 /// Per-dimension Gaussian noise around a cluster center.
 const DOC_NOISE_SIGMA: f32 = 0.3;
-/// Average bytes-per-token estimate for pre-sizing a doc `String`.
-const AVG_BYTES_PER_TOKEN: usize = 8;
 
 /// Stream the same deterministic synthetic docs as [`super::MmapTextCorpus`] +
 /// [`super::MmapVectorCorpus`], one append chunk at a time.
 ///
 /// The mmap corpora generate in parallel by drawing each scheduling chunk
-/// from its own [`chunk_seed`]-derived RNG ([`TEXT_CORPUS_CHUNK_DOCS`] docs
+/// from its own [`chunk_seed`]-derived RNG ([`TextDocGen::chunk_docs`] docs
 /// per text chunk, [`VECTOR_CORPUS_CHUNK_DOCS`] per vector chunk). To stay
 /// bit-identical, this stream reseeds its per-column RNG at the same chunk
 /// boundaries — otherwise streamed ground truth would grade vectors the
@@ -39,7 +36,7 @@ pub struct SequentialSyntheticCorpus {
     vec_rng: StdRng,
     text_rng: StdRng,
     centers: Vec<Vec<f32>>,
-    zipf: ZipfDistribution,
+    text_gen: TextDocGen,
     normalize_vectors: bool,
 }
 
@@ -67,7 +64,7 @@ impl SequentialSyntheticCorpus {
             vec_rng: StdRng::seed_from_u64(chunk_seed(vec_seed, 0)),
             text_rng: StdRng::seed_from_u64(chunk_seed(text_seed, 0)),
             centers,
-            zipf: ZipfDistribution::new(VOCAB_SIZE),
+            text_gen: TextDocGen::new(text_flavor()),
             normalize_vectors,
         }
     }
@@ -110,19 +107,14 @@ impl SequentialSyntheticCorpus {
             if gen_text {
                 // Reseed at the parallel text corpus's chunk boundary so the
                 // token stream matches the chunk-seeded mmap writer.
-                if doc_id.is_multiple_of(TEXT_CORPUS_CHUNK_DOCS) {
-                    self.text_rng = StdRng::seed_from_u64(chunk_seed(
-                        self.text_seed,
-                        doc_id / TEXT_CORPUS_CHUNK_DOCS,
-                    ));
+                let text_chunk_docs = self.text_gen.chunk_docs();
+                if doc_id.is_multiple_of(text_chunk_docs) {
+                    self.text_rng =
+                        StdRng::seed_from_u64(chunk_seed(self.text_seed, doc_id / text_chunk_docs));
                 }
-                let mut doc = String::with_capacity((TOKENS_PER_DOC + 1) * AVG_BYTES_PER_TOKEN);
-                doc.push_str(&format!("doc{doc_id:07}"));
-                for _ in 0..TOKENS_PER_DOC {
-                    let idx = self.zipf.sample(&mut self.text_rng);
-                    doc.push(' ');
-                    doc.push_str(&format!("term{idx:05}"));
-                }
+                let mut doc = String::new();
+                self.text_gen
+                    .write_doc(&mut self.text_rng, doc_id, &mut doc);
                 titles.push(doc);
             }
 

--- a/benches/utils/corpus/text_gen.rs
+++ b/benches/utils/corpus/text_gen.rs
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Deterministic text-document generators, shared by every path that
+//! needs the bench text corpus: the parallel mmap writer
+//! ([`super::MmapTextCorpus`]), the streaming ingest corpus
+//! ([`super::SequentialSyntheticCorpus`]), and the FTS quality oracle,
+//! which re-derives the corpus doc by doc rather than keeping it.
+//!
+//! Two flavours share one token vocabulary (`term{rank:05}`, rank 1 the
+//! most frequent) and one per-doc unique token (`doc{id:07}`), so the FTS
+//! query batteries apply to both:
+//!
+//! * [`TextFlavor::Uniform`] — the historical corpus: exactly
+//!   [`TOKENS_PER_DOC`] iid Zipf draws from a closed [`VOCAB_SIZE`]
+//!   vocabulary. Byte length is RNG-independent, which is what lets the
+//!   mmap writer pre-compute its offset table and write chunks in parallel.
+//!   The perf tables are measured on this flavour.
+//! * [`TextFlavor::Realistic`] — calibrated to English Wikipedia so that
+//!   the quantities BM25 quality depends on actually vary: log-normal doc
+//!   lengths (median 89 tokens, 13% of docs under 16 tokens, a 1% tail
+//!   past 3000), an open Zipf vocabulary over [`REALISTIC_VOCAB_SIZE`]
+//!   ranks (rank 1 lands in ~84% of docs, like `the`; the tail supplies
+//!   the singleton mass), within-doc burstiness (a token repeats one the
+//!   doc already used with probability [`REPEAT_PROB`], giving ~56%
+//!   repeated tokens), and a sprinkle of surface variation — capitalized
+//!   tokens, punctuation glued to a token, year-like digit tokens — so
+//!   the analyzer is on the measured path. Everything stays ASCII, so the
+//!   `ascii_lower` rule is the only tokenization rule in play.
+//!
+//! Both flavours are seeded per scheduling chunk with [`chunk_seed`] so a
+//! parallel writer and a sequential stream produce identical bytes; the
+//! chunk size differs per flavour ([`TextDocGen::chunk_docs`]) because a
+//! realistic chunk's bytes must be buffered before they can be written.
+
+use std::fmt::Write as _;
+
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+use rand_distr::{Distribution, LogNormal};
+use rayon::prelude::*;
+
+use super::{TEXT_CORPUS_CHUNK_DOCS, TOKENS_PER_DOC, VOCAB_SIZE, ZipfDistribution, chunk_seed};
+
+/// Which text generator the synthetic corpus uses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TextFlavor {
+    /// Fixed-length, closed-vocabulary Zipf docs (the historical corpus).
+    Uniform,
+    /// Variable-length, open-vocabulary, bursty docs calibrated to real text.
+    Realistic,
+}
+
+impl TextFlavor {
+    /// The label reports and dataset sidecars carry for this flavour.
+    pub fn label(self) -> &'static str {
+        match self {
+            TextFlavor::Uniform => "synthetic",
+            TextFlavor::Realistic => "realistic",
+        }
+    }
+}
+
+/// Docs per scheduling chunk for the realistic flavour. Its byte length
+/// is RNG-dependent, so a chunk's bytes are buffered before the writer
+/// appends them in order; at ~1.6 KB/doc this bounds a chunk at ~50 MB,
+/// and the writer keeps at most two chunks per worker in flight.
+pub const REALISTIC_CHUNK_DOCS: usize = 1 << 15;
+
+/// Rank space of the realistic vocabulary. Zipf(s = 1) over one million
+/// ranks puts rank 1 at ~7% of tokens (a stopword) and leaves a long tail
+/// of ranks that appear in a handful of docs at 10M — the singleton mass
+/// real vocabularies carry.
+pub const REALISTIC_VOCAB_SIZE: usize = 1_000_000;
+
+/// Log-normal doc-length parameters: `exp(mu)` is the median (89 tokens,
+/// Wikipedia's), `sigma` sets the spread (p10 ≈ 12, p90 ≈ 650, p99 ≈ 3300,
+/// mean ≈ 295 — all within the calibration bands measured on 300K
+/// articles: 7 / 89 / 653 / 2636 / 268).
+const LEN_LOG_MEDIAN: f64 = 4.4886; // ln(89)
+const LEN_LOG_SIGMA: f64 = 1.55;
+/// Doc-length clamp. The lower bound keeps every doc non-empty; the upper
+/// bound trims the log-normal's unbounded tail near the longest real
+/// articles (35K tokens) so one draw cannot dominate a chunk's bytes.
+const MIN_DOC_TOKENS: usize = 1;
+const MAX_DOC_TOKENS: usize = 20_000;
+
+/// Probability that the next token repeats one the doc already emitted
+/// (a Pólya-urn cache). 0.4 lands the within-doc repeat fraction at 0.56
+/// and the rank-1 df at 84%, both matching the measured corpus.
+const REPEAT_PROB: f64 = 0.4;
+
+/// Surface-variation thresholds on one uniform draw per token, cumulative:
+/// `[0, YEAR)` emits a year-like digit token instead of the term,
+/// `[YEAR, CAP)` capitalizes the term, `[CAP, COMMA)` glues a trailing
+/// comma, `[COMMA, PERIOD)` a trailing period, the rest is the bare term.
+/// Every variant tokenizes back to the same term under `ascii_lower`
+/// (case folds, punctuation splits), so df/tf are unchanged while the
+/// analyzer does real work.
+const YEAR_TOKEN_CUTOFF: f64 = 0.01;
+const CAPITALIZED_CUTOFF: f64 = 0.04;
+const TRAILING_COMMA_CUTOFF: f64 = 0.06;
+const TRAILING_PERIOD_CUTOFF: f64 = 0.07;
+/// Year-token range (`1900..=2029`).
+const YEAR_MIN: u32 = 1900;
+const YEAR_SPAN: u32 = 130;
+
+/// Rough bytes-per-token for pre-sizing a doc buffer.
+const AVG_BYTES_PER_TOKEN: usize = 8;
+
+/// One flavour's document generator. Cheap to share across threads
+/// (`&self`); all per-stream state lives in the caller's RNG.
+pub struct TextDocGen {
+    flavor: TextFlavor,
+    zipf: ZipfDistribution,
+    len_dist: LogNormal<f64>,
+}
+
+impl TextDocGen {
+    pub fn new(flavor: TextFlavor) -> Self {
+        let vocab = match flavor {
+            TextFlavor::Uniform => VOCAB_SIZE,
+            TextFlavor::Realistic => REALISTIC_VOCAB_SIZE,
+        };
+        Self {
+            flavor,
+            zipf: ZipfDistribution::new(vocab),
+            len_dist: LogNormal::new(LEN_LOG_MEDIAN, LEN_LOG_SIGMA).expect("log-normal params"),
+        }
+    }
+
+    pub fn flavor(&self) -> TextFlavor {
+        self.flavor
+    }
+
+    /// Docs per reseeded scheduling chunk for this flavour. Every producer
+    /// of this corpus reseeds its RNG with `chunk_seed(seed, doc_id /
+    /// chunk_docs())` at each multiple of this, and nowhere else.
+    pub fn chunk_docs(&self) -> usize {
+        match self.flavor {
+            TextFlavor::Uniform => TEXT_CORPUS_CHUNK_DOCS,
+            TextFlavor::Realistic => REALISTIC_CHUNK_DOCS,
+        }
+    }
+
+    /// The RNG for the chunk containing `doc_id`, positioned at the chunk's
+    /// first doc.
+    pub fn chunk_rng(&self, seed: u64, chunk_index: usize) -> StdRng {
+        StdRng::seed_from_u64(chunk_seed(seed, chunk_index))
+    }
+
+    /// Append doc `doc_id`'s text to `out` (which the caller clears),
+    /// drawing from `rng`. `rng` must be the chunk RNG advanced through
+    /// every earlier doc of the same chunk.
+    pub fn write_doc(&self, rng: &mut StdRng, doc_id: usize, out: &mut String) {
+        match self.flavor {
+            TextFlavor::Uniform => self.write_uniform(rng, doc_id, out),
+            TextFlavor::Realistic => self.write_realistic(rng, doc_id, out),
+        }
+    }
+
+    fn write_uniform(&self, rng: &mut StdRng, doc_id: usize, out: &mut String) {
+        out.reserve((TOKENS_PER_DOC + 1) * AVG_BYTES_PER_TOKEN);
+        write!(out, "doc{doc_id:07}").expect("fmt doc token");
+        for _ in 0..TOKENS_PER_DOC {
+            let idx = self.zipf.sample(rng);
+            write!(out, " term{idx:05}").expect("fmt term");
+        }
+    }
+
+    fn write_realistic(&self, rng: &mut StdRng, doc_id: usize, out: &mut String) {
+        let drawn = self.len_dist.sample(rng).round();
+        let len = (drawn as usize).clamp(MIN_DOC_TOKENS, MAX_DOC_TOKENS);
+        out.reserve((len + 1) * AVG_BYTES_PER_TOKEN);
+        write!(out, "doc{doc_id:07}").expect("fmt doc token");
+        let mut emitted: Vec<u32> = Vec::with_capacity(len);
+        for _ in 0..len {
+            let rank = if !emitted.is_empty() && rng.random::<f64>() < REPEAT_PROB {
+                emitted[rng.random_range(0..emitted.len())]
+            } else {
+                self.zipf.sample(rng) as u32
+            };
+            let surface: f64 = rng.random();
+            out.push(' ');
+            if surface < YEAR_TOKEN_CUTOFF {
+                let year = YEAR_MIN + rng.random_range(0..YEAR_SPAN);
+                write!(out, "{year}").expect("fmt year");
+                continue;
+            }
+            emitted.push(rank);
+            if surface < CAPITALIZED_CUTOFF {
+                write!(out, "Term{rank:05}").expect("fmt term");
+            } else if surface < TRAILING_COMMA_CUTOFF {
+                write!(out, "term{rank:05},").expect("fmt term");
+            } else if surface < TRAILING_PERIOD_CUTOFF {
+                write!(out, "term{rank:05}.").expect("fmt term");
+            } else {
+                write!(out, "term{rank:05}").expect("fmt term");
+            }
+        }
+    }
+}
+
+/// Number of scheduling chunks an `n_docs` corpus of `flavor` spans.
+pub fn generated_chunk_count(n_docs: usize, flavor: TextFlavor) -> usize {
+    n_docs.div_ceil(TextDocGen::new(flavor).chunk_docs())
+}
+
+/// Visit the docs of one scheduling chunk, in doc order, without
+/// materializing them: `f(doc_id, text)` for every doc `chunk` covers.
+/// Chunks are independent (each reseeds from [`chunk_seed`]), so callers
+/// fan out over `0..generated_chunk_count(..)` and accumulate per chunk.
+pub fn for_each_doc_in_chunk<F>(
+    n_docs: usize,
+    seed: u64,
+    flavor: TextFlavor,
+    chunk: usize,
+    mut f: F,
+) where
+    F: FnMut(usize, &str),
+{
+    let generator = TextDocGen::new(flavor);
+    let chunk_docs = generator.chunk_docs();
+    let start = chunk * chunk_docs;
+    let end = ((chunk + 1) * chunk_docs).min(n_docs);
+    let mut rng = generator.chunk_rng(seed, chunk);
+    let mut buf = String::new();
+    for doc_id in start..end {
+        buf.clear();
+        generator.write_doc(&mut rng, doc_id, &mut buf);
+        f(doc_id, &buf);
+    }
+}
+
+/// Visit every doc of the `flavor` corpus seeded with `seed`, in parallel
+/// by scheduling chunk, without materializing the corpus. `f(doc_id,
+/// text)` runs on rayon workers; docs within a chunk arrive in order,
+/// chunks in any order. Produces exactly the bytes
+/// [`super::MmapTextCorpus::generate`] writes for the same arguments.
+pub fn for_each_generated_doc<F>(n_docs: usize, seed: u64, flavor: TextFlavor, f: F)
+where
+    F: Fn(usize, &str) + Sync,
+{
+    (0..generated_chunk_count(n_docs, flavor))
+        .into_par_iter()
+        .for_each(|c| {
+            for_each_doc_in_chunk(n_docs, seed, flavor, c, |doc_id, text| f(doc_id, text))
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Mutex,
+    };
+
+    use infino::test_helpers::default_tokenizer;
+
+    use super::*;
+    use crate::corpus::MmapTextCorpus;
+
+    /// Docs sampled for the calibration bands. Large enough that the
+    /// length quantiles and the rank-1 df settle to two digits; a few
+    /// seconds of generation.
+    const CALIBRATION_DOCS: usize = 20_000;
+    const TEST_SEED: u64 = 1;
+
+    struct Stats {
+        lens: Vec<usize>,
+        tokens: u64,
+        repeats: u64,
+        rank1_docs: usize,
+        rank30_docs: usize,
+        distinct_terms: usize,
+        singleton_terms: usize,
+    }
+
+    fn realistic_stats(n_docs: usize) -> Stats {
+        let tk = default_tokenizer();
+        let per_doc: Mutex<Vec<(usize, Vec<String>)>> = Mutex::new(Vec::with_capacity(n_docs));
+        for_each_generated_doc(n_docs, TEST_SEED, TextFlavor::Realistic, |doc_id, text| {
+            let mut toks = Vec::new();
+            tk.tokenize_each(text, &mut |t| toks.push(t.to_owned()));
+            per_doc.lock().unwrap().push((doc_id, toks));
+        });
+        let per_doc = per_doc.into_inner().unwrap();
+        let mut lens = Vec::with_capacity(n_docs);
+        let mut tokens = 0u64;
+        let mut repeats = 0u64;
+        let mut rank1_docs = 0;
+        let mut rank30_docs = 0;
+        let mut df: HashMap<&str, u32> = HashMap::new();
+        for (_, toks) in &per_doc {
+            // The `doc…` token is not part of the body length.
+            let body: Vec<&str> = toks.iter().skip(1).map(String::as_str).collect();
+            lens.push(body.len());
+            tokens += body.len() as u64;
+            let distinct: HashSet<&str> = body.iter().copied().collect();
+            repeats += (body.len() - distinct.len()) as u64;
+            rank1_docs += usize::from(distinct.contains("term00001"));
+            rank30_docs += usize::from(distinct.contains("term00030"));
+            for t in distinct {
+                *df.entry(t).or_insert(0) += 1;
+            }
+        }
+        lens.sort_unstable();
+        let singleton_terms = df.values().filter(|&&c| c == 1).count();
+        Stats {
+            lens,
+            tokens,
+            repeats,
+            rank1_docs,
+            rank30_docs,
+            distinct_terms: df.len(),
+            singleton_terms,
+        }
+    }
+
+    fn quantile(sorted: &[usize], p: f64) -> usize {
+        sorted[((sorted.len() - 1) as f64 * p) as usize]
+    }
+
+    /// The realistic flavour stays inside the bands measured on English
+    /// Wikipedia (300K-article sample). A generator change that moves a
+    /// statistic out of its band changes what the quality bench measures
+    /// and must be a deliberate recalibration.
+    #[test]
+    fn realistic_flavor_matches_calibration_bands() {
+        let s = realistic_stats(CALIBRATION_DOCS);
+        let n = CALIBRATION_DOCS as f64;
+        let p50 = quantile(&s.lens, 0.5);
+        let p90 = quantile(&s.lens, 0.9);
+        let p99 = quantile(&s.lens, 0.99);
+        let mean = s.tokens as f64 / n;
+        let short = s.lens.iter().filter(|&&l| l < 16).count() as f64 / n;
+        let repeat_frac = s.repeats as f64 / s.tokens as f64;
+        let rank1_df = s.rank1_docs as f64 / n;
+        let rank30_df = s.rank30_docs as f64 / n;
+        let singleton_frac = s.singleton_terms as f64 / s.distinct_terms as f64;
+        let report = format!(
+            "p50={p50} p90={p90} p99={p99} mean={mean:.0} short={short:.3} repeat={repeat_frac:.3} \
+             df1={rank1_df:.3} df30={rank30_df:.3} distinct={} singletons={singleton_frac:.3}",
+            s.distinct_terms
+        );
+        // Real: 89 / 653 / 2636 / 268 / 0.156 / 0.56 / 0.84 / ~0.2-0.4 / 0.58.
+        assert!((75..=105).contains(&p50), "{report}");
+        assert!((520..=800).contains(&p90), "{report}");
+        assert!((2200..=4200).contains(&p99), "{report}");
+        assert!((240.0..=340.0).contains(&mean), "{report}");
+        assert!((0.10..=0.17).contains(&short), "{report}");
+        assert!((0.50..=0.62).contains(&repeat_frac), "{report}");
+        assert!((0.78..=0.90).contains(&rank1_df), "{report}");
+        assert!((0.15..=0.35).contains(&rank30_df), "{report}");
+        assert!((0.45..=0.75).contains(&singleton_frac), "{report}");
+    }
+
+    /// Every surface variant folds back to a vocabulary term, a year, or
+    /// the doc token under the production tokenizer — the analyzer is
+    /// exercised without changing df/tf.
+    #[test]
+    fn realistic_surface_variants_tokenize_to_vocabulary() {
+        let tk = default_tokenizer();
+        let seen_variant = Mutex::new([false; 4]);
+        for_each_generated_doc(512, TEST_SEED, TextFlavor::Realistic, |doc_id, text| {
+            let mut flags = [false; 4];
+            for raw in text.split(' ').skip(1) {
+                flags[0] |= raw.starts_with('T');
+                flags[1] |= raw.ends_with(',');
+                flags[2] |= raw.ends_with('.');
+                flags[3] |= raw.bytes().all(|b| b.is_ascii_digit());
+            }
+            let mut toks = Vec::new();
+            tk.tokenize_each(text, &mut |t| toks.push(t.to_owned()));
+            assert_eq!(toks[0], format!("doc{doc_id:07}"));
+            for t in &toks[1..] {
+                let is_term = t
+                    .strip_prefix("term")
+                    .is_some_and(|r| r.len() >= 5 && r.bytes().all(|b| b.is_ascii_digit()));
+                let is_year = t.len() == 4 && t.bytes().all(|b| b.is_ascii_digit());
+                assert!(is_term || is_year, "unexpected token {t:?} in doc {doc_id}");
+            }
+            let mut seen = seen_variant.lock().unwrap();
+            for (s, f) in seen.iter_mut().zip(flags) {
+                *s |= f;
+            }
+        });
+        assert_eq!(
+            seen_variant.into_inner().unwrap(),
+            [true; 4],
+            "capitalized / comma / period / year variants all occur"
+        );
+    }
+
+    /// The streaming visitor and the mmap writer are the same corpus, for
+    /// both flavours and across a chunk boundary.
+    #[test]
+    fn for_each_generated_doc_matches_mmap_corpus() {
+        for flavor in [TextFlavor::Uniform, TextFlavor::Realistic] {
+            let n_docs = TextDocGen::new(flavor).chunk_docs().min(4096) + 37;
+            let mmap = MmapTextCorpus::generate_flavor(n_docs, TEST_SEED, flavor);
+            assert_eq!(mmap.n_docs(), n_docs);
+            let seen = Mutex::new(vec![false; n_docs]);
+            for_each_generated_doc(n_docs, TEST_SEED, flavor, |doc_id, text| {
+                assert_eq!(text, mmap.doc(doc_id), "{flavor:?} doc {doc_id}");
+                seen.lock().unwrap()[doc_id] = true;
+            });
+            assert!(seen.into_inner().unwrap().iter().all(|&s| s));
+        }
+    }
+
+    /// The realistic writer spans several reseeded chunks and stays
+    /// byte-identical to the streaming visitor across every boundary.
+    #[test]
+    fn realistic_multi_chunk_writer_matches_stream() {
+        let n_docs = REALISTIC_CHUNK_DOCS * 2 + 11;
+        let mmap = MmapTextCorpus::generate_flavor(n_docs, TEST_SEED, TextFlavor::Realistic);
+        assert_eq!(mmap.n_docs(), n_docs);
+        for_each_generated_doc(n_docs, TEST_SEED, TextFlavor::Realistic, |doc_id, text| {
+            assert_eq!(text, mmap.doc(doc_id), "doc {doc_id}");
+        });
+    }
+}

--- a/benches/utils/fts_quality.rs
+++ b/benches/utils/fts_quality.rs
@@ -1,0 +1,1092 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! FTS quality — BM25 top-k parity of the supertable search path against a
+//! textbook oracle, at bench scale.
+//!
+//! The speed cells time `bm25_search` and discard what it returns. This
+//! module grades what it returns: for every shape in [`QUALITY_BATTERY`]
+//! and every `k` in [`QUALITY_KS`], the engine's top-k is compared with a
+//! reference computed directly from the BM25 formula over the whole
+//! corpus. The vector cells have had this (recall against brute-force
+//! truth) from the start; this is the FTS equivalent.
+//!
+//! ## Two references, one corpus pass
+//!
+//! The engine deliberately differs from textbook BM25 in two places, and a
+//! quality number has to separate those design costs from kernel bugs:
+//!
+//! * **Length quantization.** A document's length is stored in one byte
+//!   (`stored_len`): exact below 16 tokens, truncated downward by up to
+//!   one bucket above. On a corpus with realistic length variation this
+//!   reorders near-ties.
+//! * **Sharded statistics.** Under the default [`Bm25Stats::PerSuperfile`]
+//!   each superfile scores with its own document count and term
+//!   frequencies; [`Bm25Stats::Global`] uses table-wide idf but still each
+//!   superfile's own average document length.
+//!
+//! So the oracle scores every matching document twice from the same
+//! statistics: **T**, textbook BM25 with the exact length, and **Q**, the
+//! BM25 the engine is specified to compute, with the stored length. The
+//! table then reports, per query and `k`:
+//!
+//! | column | definition |
+//! |---|---|
+//! | recall vs BM25 | engine top-k under `Global` graded against T — the user-facing quality, including the quantization and avgdl costs |
+//! | recall (default stats) | the same under `PerSuperfile` — the default mode's sharded-idf drift |
+//! | recall vs engine BM25 | engine top-k under `Global` graded against Q, a hit allowed to fall short of the k-th score by the avgdl residual — must be ≈ 1.0; a drop is a kernel or pruning bug. **Gated.** |
+//! | max score Δ | largest relative gap between an engine score and Q for the same document (`Global`). **Gated** at the avgdl residual. |
+//!
+//! Q is exact except for one input: the engine normalizes with each
+//! superfile's own average document length, the oracle with the
+//! corpus-wide one. That residual is a sampling error that shrinks as
+//! `1/sqrt(docs per superfile)` — 5% is the gate at the 10M reference
+//! scale and it widens accordingly on smaller smoke-test corpora
+//! ([`residual_tolerance`]).
+//!
+//! Recall is **tie-aware**: a returned document counts as a hit when its
+//! oracle score is at least the oracle's k-th score (within a rounding
+//! tolerance), so the engine picking a different member of a tied group at
+//! the boundary is not penalized. On a bursty corpus single-term queries
+//! tie heavily at the boundary; doc-id set overlap would report noise.
+//!
+//! ## Why a streaming oracle
+//!
+//! The test-suite reference (`BruteForceBm25`) keeps every token of every
+//! document and is unusable at 10M docs. This oracle re-derives the corpus
+//! from its seed one scheduling chunk at a time and keeps only what the
+//! battery needs: each document's length and its term frequencies for the
+//! few dozen terms (and phrases) the battery mentions — a sparse table of
+//! a few tens of millions of entries at 10M docs. Both sides tokenize and
+//! parse with the table's own tokenizer, so tokenization and clause
+//! semantics cannot diverge by construction.
+
+use std::{borrow::Cow, cmp::Ordering, collections::HashMap, time::Instant};
+
+use arrow_array::{Array, Float32Array, LargeStringArray, RecordBatch, StringArray};
+use infino::{
+    superfile::fts::{
+        bm25::stored_len,
+        reader::{Bm25Stats, BoolMode},
+        tokenize::Tokenizer,
+    },
+    supertable::SupertableReader,
+    test_helpers::default_tokenizer,
+};
+use rayon::prelude::*;
+
+use crate::{
+    corpus::{self, TextFlavor, for_each_doc_in_chunk, generated_chunk_count},
+    markdown::fmt_count,
+    report::{Better, Block, Cell, Report, Section, context, metric, text},
+};
+
+/// The `k` values graded. `10` is the speed cell's top-k, `1000` its
+/// large-k gate; `1000` is also where sharded-idf drift and ties show.
+pub const QUALITY_KS: &[usize] = &[10, 100, 1000];
+
+/// Standard BM25 parameters — the same constants the engine scores with.
+/// Restated here so the oracle is the formula by construction, sharing no
+/// code with the kernels it grades.
+const K1: f64 = 1.2;
+const B: f64 = 0.75;
+
+/// Relative tolerance when comparing a document's oracle score against
+/// the k-th oracle score for the tie test. Covers f32 accumulation order
+/// on the engine side and f64→f32 rounding; well below any real score
+/// gap.
+const TIE_TOLERANCE: f64 = 1e-4;
+
+/// Gate: every query × k must reach this recall against the engine-model
+/// reference (Q) under `Global` statistics. Below it the kernels are
+/// returning documents the formula they implement would not.
+const MIN_ENGINE_MODEL_RECALL: f64 = 0.99;
+
+/// Gate at the reference scale: the largest relative gap between an engine
+/// score and Q over the returned documents, under `Global`. The one input
+/// the oracle cannot reproduce is the per-superfile average document
+/// length the engine normalizes with (the oracle uses the corpus-wide
+/// value). That residual is a sampling error of the mean over one
+/// superfile's docs, so it scales with `1/sqrt(docs per superfile)`; with
+/// the fixed 16-commit ingest shape that is `1/sqrt(n_docs)`, and the
+/// ceiling is widened accordingly below the reference scale
+/// ([`residual_tolerance`]). The same tolerance is what the engine-model
+/// hit test allows a returned document to fall short of the k-th score by.
+const MAX_SCORE_DELTA_AT_REFERENCE: f64 = 0.05;
+/// Doc count the gates are calibrated at — the supertable cell's default.
+const REFERENCE_DOCS: usize = 10_000_000;
+/// Widest the scale-adjusted tolerance may grow (tiny smoke-test corpora).
+const MAX_RESIDUAL_TOLERANCE: f64 = 0.5;
+
+/// The per-superfile avgdl residual the gates allow at `n_docs`: 5% at 10M,
+/// growing as `sqrt(REFERENCE_DOCS / n_docs)` below it.
+fn residual_tolerance(n_docs: usize) -> f64 {
+    let scale = (REFERENCE_DOCS as f64 / n_docs.max(1) as f64).sqrt();
+    (MAX_SCORE_DELTA_AT_REFERENCE * scale).min(MAX_RESIDUAL_TOLERANCE)
+}
+
+/// Guard against a degenerate oracle score in a relative-delta denominator.
+const MIN_SCORE_FOR_RELATIVE_DELTA: f64 = 1e-9;
+
+/// One graded query shape. `query` is the literal string handed to both
+/// the engine and the oracle's parser; `mode` is the default operator.
+#[derive(Clone, Copy, Debug)]
+pub struct QualityQuery {
+    pub name: &'static str,
+    pub query: &'static str,
+    pub mode: BoolMode,
+}
+
+/// Query shapes chosen by document-frequency tier rather than by fixed
+/// rank so they mean the same thing on every generated corpus. Terms are
+/// Zipf ranks: rank 1 is the stopword band (~84% of docs on the realistic
+/// corpus, every doc on the uniform one), rank 30 is common (~20%), rank
+/// 2000 is mid (~0.6%), rank 200 000 is rare (~1e-4; absent from the
+/// uniform corpus's 10K vocabulary, where both sides return nothing), and
+/// `doc0000001` is a singleton on every generated corpus.
+pub const QUALITY_BATTERY: &[QualityQuery] = &[
+    QualityQuery {
+        name: "stopword",
+        query: "term00001",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "common",
+        query: "term00030",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "mid",
+        query: "term02000",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "rare",
+        query: "term200000",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "singleton",
+        query: "doc0000001",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "stopword_common_or",
+        query: "term00001 term00030",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "stopword_rare_or",
+        query: "term00001 term200000",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "three_stopword_or",
+        query: "term00001 term00002 term00003",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "three_mid_or",
+        query: "term02000 term02001 term02002",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "ten_common_or",
+        query: "term00030 term00031 term00032 term00033 term00034 term00035 term00036 term00037 \
+                term00038 term00039",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "stopword_rare_and",
+        query: "term00001 term200000",
+        mode: BoolMode::And,
+    },
+    QualityQuery {
+        name: "common_mid_and",
+        query: "term00030 term02000",
+        mode: BoolMode::And,
+    },
+    QualityQuery {
+        name: "three_mid_and",
+        query: "term02000 term02001 term02002",
+        mode: BoolMode::And,
+    },
+    QualityQuery {
+        name: "must_rare_should_common",
+        query: "+term200000 term00030",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "must_two_should_two",
+        query: "+term00030 +term00031 term00001 term02000",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "common_not_stopword",
+        query: "term00030 -term00001",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "phrase_stopwords",
+        query: "\"term00001 term00002\"",
+        mode: BoolMode::Or,
+    },
+    QualityQuery {
+        name: "phrase_common_mid",
+        query: "\"term00030 term02000\"",
+        mode: BoolMode::Or,
+    },
+];
+
+/// Atom index: `< n_terms` is a term, `>= n_terms` a phrase (`atom -
+/// n_terms` indexes `phrases`).
+type Atom = u16;
+
+/// One nonzero `(document, atom, tf)` cell of the sparse statistics table.
+#[derive(Clone, Copy)]
+struct Entry {
+    row: u32,
+    atom: Atom,
+    tf: u32,
+}
+
+/// A query's clauses resolved to atom indices.
+struct ResolvedQuery {
+    musts: Vec<Atom>,
+    shoulds: Vec<Atom>,
+    negatives: Vec<Atom>,
+}
+
+/// Textbook BM25 statistics over the whole corpus, restricted to the
+/// battery's atoms.
+pub struct Oracle {
+    n_docs: usize,
+    n_terms: usize,
+    /// Term → atom, the battery's vocabulary.
+    term_index: HashMap<String, Atom>,
+    /// Phrase atoms as sequences of term atoms.
+    phrases: Vec<Vec<Atom>>,
+    /// Token count per document (index = corpus row).
+    dl: Vec<u32>,
+    /// Nonzero tf cells, sorted by `(row, atom)`.
+    entries: Vec<Entry>,
+    /// `entries[row_start[r]..row_start[r + 1]]` are row `r`'s cells.
+    row_start: Vec<u32>,
+    /// Documents containing each atom at least once.
+    df: Vec<u32>,
+    avgdl: f64,
+}
+
+/// One document's scores under both references.
+#[derive(Clone, Copy)]
+struct Scored {
+    row: u32,
+    textbook: f64,
+    engine_model: f64,
+}
+
+/// A query's oracle result: the match count and, per graded `k`, the
+/// k-th score under each reference (the threshold a returned document
+/// must reach to count as a hit).
+struct OracleTopK {
+    n_matches: usize,
+    /// Indexed like [`QUALITY_KS`]; `None` when fewer than `k` documents match
+    /// (then every match is expected and the threshold is the lowest match).
+    textbook_kth: Vec<f64>,
+    engine_model_kth: Vec<f64>,
+}
+
+/// Per-chunk accumulation of the streaming pass.
+struct ChunkStats {
+    start_row: u32,
+    dl: Vec<u32>,
+    entries: Vec<Entry>,
+}
+
+impl Oracle {
+    /// Stream the `flavor` corpus (`n_docs` docs, `seed`) once and collect
+    /// the statistics `battery` needs, tokenizing and parsing with
+    /// `tokenizer` — the table's own, so both sides see identical tokens
+    /// and clauses.
+    pub fn build(
+        n_docs: usize,
+        seed: u64,
+        flavor: TextFlavor,
+        tokenizer: &dyn Tokenizer,
+        battery: &[QualityQuery],
+    ) -> Self {
+        // Atom vocabulary: every term any clause or phrase mentions, then
+        // every distinct phrase.
+        let mut term_index: HashMap<String, Atom> = HashMap::new();
+        let mut phrases: Vec<Vec<Atom>> = Vec::new();
+        for q in battery {
+            let clauses = tokenizer.parse(q.query).into_clauses(q.mode);
+            for term in clauses
+                .musts
+                .iter()
+                .chain(&clauses.shoulds)
+                .chain(&clauses.negatives)
+            {
+                intern_term(&mut term_index, term);
+            }
+            for phrase in clauses
+                .must_phrases
+                .iter()
+                .chain(&clauses.should_phrases)
+                .chain(&clauses.negative_phrases)
+            {
+                let atoms: Vec<Atom> = phrase
+                    .iter()
+                    .map(|t| intern_term(&mut term_index, t))
+                    .collect();
+                if !phrases.contains(&atoms) {
+                    phrases.push(atoms);
+                }
+            }
+        }
+        let n_terms = term_index.len();
+        let n_atoms = n_terms + phrases.len();
+
+        let n_chunks = generated_chunk_count(n_docs, flavor);
+        let mut chunks: Vec<ChunkStats> = (0..n_chunks)
+            .into_par_iter()
+            .map(|c| {
+                let mut stats = ChunkStats {
+                    start_row: u32::MAX,
+                    dl: Vec::new(),
+                    entries: Vec::new(),
+                };
+                let mut positions: Vec<(u32, Atom)> = Vec::new();
+                let mut tf = vec![0u32; n_atoms];
+                for_each_doc_in_chunk(n_docs, seed, flavor, c, |doc_id, text| {
+                    let row = u32::try_from(doc_id).expect("row fits u32");
+                    if stats.start_row == u32::MAX {
+                        stats.start_row = row;
+                    }
+                    positions.clear();
+                    let mut dl = 0u32;
+                    tokenizer.tokenize_each(text, &mut |tok| {
+                        if let Some(&a) = term_index.get(tok) {
+                            positions.push((dl, a));
+                        }
+                        dl += 1;
+                    });
+                    stats.dl.push(dl);
+                    for &(_, a) in &positions {
+                        tf[a as usize] += 1;
+                    }
+                    for (p, phrase) in phrases.iter().enumerate() {
+                        tf[n_terms + p] = phrase_tf(&positions, phrase);
+                    }
+                    for (a, count) in tf.iter_mut().enumerate() {
+                        if *count > 0 {
+                            stats.entries.push(Entry {
+                                row,
+                                atom: a as Atom,
+                                tf: *count,
+                            });
+                            *count = 0;
+                        }
+                    }
+                });
+                stats
+            })
+            .collect();
+        chunks.sort_by_key(|c| c.start_row);
+
+        let mut dl = Vec::with_capacity(n_docs);
+        let mut entries = Vec::with_capacity(chunks.iter().map(|c| c.entries.len()).sum());
+        for chunk in chunks {
+            dl.extend(chunk.dl);
+            entries.extend(chunk.entries);
+        }
+        assert_eq!(dl.len(), n_docs, "oracle streamed every document");
+        let mut row_start = vec![0u32; n_docs + 1];
+        let mut df = vec![0u32; n_atoms];
+        for (i, e) in entries.iter().enumerate() {
+            row_start[e.row as usize + 1] = u32::try_from(i + 1).expect("entry count fits u32");
+            df[e.atom as usize] += 1;
+        }
+        // Rows without cells inherit the previous boundary so each row's
+        // range is well-formed (and empty).
+        for r in 1..=n_docs {
+            if row_start[r] < row_start[r - 1] {
+                row_start[r] = row_start[r - 1];
+            }
+        }
+        let total_tokens: u64 = dl.iter().map(|&l| u64::from(l)).sum();
+        let avgdl = if n_docs == 0 {
+            0.0
+        } else {
+            total_tokens as f64 / n_docs as f64
+        };
+        Self {
+            n_docs,
+            n_terms,
+            term_index,
+            phrases,
+            dl,
+            entries,
+            row_start,
+            df,
+            avgdl,
+        }
+    }
+
+    pub fn n_docs(&self) -> usize {
+        self.n_docs
+    }
+
+    /// `ln(1 + (N - df + 0.5) / (df + 0.5))`; a phrase's idf is the sum of
+    /// its members', as in the engine.
+    fn idf(&self, atom: Atom) -> f64 {
+        let a = atom as usize;
+        if a >= self.n_terms {
+            return self.phrases[a - self.n_terms]
+                .iter()
+                .map(|&m| self.idf(m))
+                .sum();
+        }
+        let n = self.n_docs as f64;
+        let df = f64::from(self.df[a]);
+        (1.0 + (n - df + 0.5) / (df + 0.5)).ln()
+    }
+
+    fn tf_factor(&self, tf: u32, dl: u32) -> f64 {
+        let tf = f64::from(tf);
+        let norm = 1.0 - B + B * f64::from(dl) / self.avgdl.max(f64::MIN_POSITIVE);
+        tf * (K1 + 1.0) / (tf + K1 * norm)
+    }
+
+    /// A battery query's clauses as atom indices. Every term and phrase was
+    /// interned at build time from the same parser, so a miss is a
+    /// programming error, not a data case.
+    fn resolve(&self, tokenizer: &dyn Tokenizer, q: &QualityQuery) -> ResolvedQuery {
+        let clauses = tokenizer.parse(q.query).into_clauses(q.mode);
+        let term_atom = |t: &Cow<'_, str>| -> Atom {
+            *self
+                .term_index
+                .get(t.as_ref())
+                .unwrap_or_else(|| panic!("battery term {t:?} missing from the oracle vocabulary"))
+        };
+        let phrase_atom = |p: &[Cow<'_, str>]| -> Atom {
+            let atoms: Vec<Atom> = p.iter().map(term_atom).collect();
+            let idx = self
+                .phrases
+                .iter()
+                .position(|ph| *ph == atoms)
+                .expect("battery phrase missing from the oracle vocabulary");
+            Atom::try_from(self.n_terms + idx).expect("atom index")
+        };
+        let mut musts: Vec<Atom> = clauses.musts.iter().map(term_atom).collect();
+        musts.extend(clauses.must_phrases.iter().map(|p| phrase_atom(p)));
+        let mut shoulds: Vec<Atom> = clauses.shoulds.iter().map(term_atom).collect();
+        shoulds.extend(clauses.should_phrases.iter().map(|p| phrase_atom(p)));
+        let mut negatives: Vec<Atom> = clauses.negatives.iter().map(term_atom).collect();
+        negatives.extend(clauses.negative_phrases.iter().map(|p| phrase_atom(p)));
+        ResolvedQuery {
+            musts,
+            shoulds,
+            negatives,
+        }
+    }
+
+    /// Score one row's cells under both references, or `None` when the row
+    /// does not match the query.
+    fn score_cells(&self, cells: &[Entry], dl: u32, q: &ResolvedQuery) -> Option<(f64, f64)> {
+        let tf_of = |atom: Atom| -> Option<u32> {
+            cells
+                .binary_search_by_key(&atom, |e| e.atom)
+                .ok()
+                .map(|i| cells[i].tf)
+        };
+        if q.negatives.iter().any(|&a| tf_of(a).is_some()) {
+            return None;
+        }
+        let mut textbook = 0.0f64;
+        let mut engine_model = 0.0f64;
+        let dl_q = stored_len(dl);
+        let mut add = |atom: Atom, tf: u32| {
+            let idf = self.idf(atom);
+            textbook += idf * self.tf_factor(tf, dl);
+            engine_model += idf * self.tf_factor(tf, dl_q);
+        };
+        for &a in &q.musts {
+            add(a, tf_of(a)?);
+        }
+        let mut matched_should = false;
+        for &a in &q.shoulds {
+            if let Some(tf) = tf_of(a) {
+                matched_should = true;
+                add(a, tf);
+            }
+        }
+        if q.musts.is_empty() && !matched_should {
+            return None;
+        }
+        Some((textbook, engine_model))
+    }
+
+    /// Both scores for `row`, or `None` if it does not match.
+    fn score_row(&self, row: u32, q: &ResolvedQuery) -> Option<(f64, f64)> {
+        let r = row as usize;
+        if r >= self.n_docs {
+            return None;
+        }
+        let cells = &self.entries[self.row_start[r] as usize..self.row_start[r + 1] as usize];
+        self.score_cells(cells, self.dl[r], q)
+    }
+
+    /// Every matching document, scored under both references.
+    fn matches(&self, q: &ResolvedQuery) -> Vec<Scored> {
+        // Walk cells grouped by row; rows without cells cannot match (a
+        // match needs at least one positive atom present).
+        (0..self.n_docs)
+            .into_par_iter()
+            .filter_map(|r| {
+                let (lo, hi) = (self.row_start[r] as usize, self.row_start[r + 1] as usize);
+                if lo == hi {
+                    return None;
+                }
+                let (textbook, engine_model) =
+                    self.score_cells(&self.entries[lo..hi], self.dl[r], q)?;
+                Some(Scored {
+                    row: r as u32,
+                    textbook,
+                    engine_model,
+                })
+            })
+            .collect()
+    }
+
+    fn top_k(&self, q: &ResolvedQuery) -> OracleTopK {
+        let mut scored = self.matches(q);
+        let n_matches = scored.len();
+        let kth = |scored: &mut Vec<Scored>, key: fn(&Scored) -> f64, k: usize| -> f64 {
+            if scored.is_empty() {
+                return 0.0;
+            }
+            let k = k.min(scored.len());
+            // Descending by score, ascending by row — the engine's own tie
+            // order, though the tie test makes the order immaterial.
+            scored.select_nth_unstable_by(k - 1, |a, b| {
+                key(b)
+                    .partial_cmp(&key(a))
+                    .unwrap_or(Ordering::Equal)
+                    .then(a.row.cmp(&b.row))
+            });
+            key(&scored[k - 1])
+        };
+        let textbook_kth = QUALITY_KS
+            .iter()
+            .map(|&k| kth(&mut scored, |s| s.textbook, k))
+            .collect();
+        let engine_model_kth = QUALITY_KS
+            .iter()
+            .map(|&k| kth(&mut scored, |s| s.engine_model, k))
+            .collect();
+        OracleTopK {
+            n_matches,
+            textbook_kth,
+            engine_model_kth,
+        }
+    }
+}
+
+/// Intern `term` into the atom vocabulary, returning its atom.
+fn intern_term(index: &mut HashMap<String, Atom>, term: &str) -> Atom {
+    if let Some(&a) = index.get(term) {
+        return a;
+    }
+    let a = Atom::try_from(index.len()).expect("battery vocabulary fits an atom index");
+    index.insert(term.to_owned(), a);
+    a
+}
+
+/// Occurrence-start count of `phrase` in a document's recorded
+/// `(position, atom)` list (ascending positions). Every phrase member is
+/// in the vocabulary, so an adjacent member must have been recorded at
+/// `position + 1`; overlapping occurrences count separately, as in the
+/// engine's phrase walk.
+fn phrase_tf(positions: &[(u32, Atom)], phrase: &[Atom]) -> u32 {
+    if phrase.is_empty() || positions.len() < phrase.len() {
+        return 0;
+    }
+    let mut count = 0u32;
+    'starts: for i in 0..=(positions.len() - phrase.len()) {
+        let (start_pos, first) = positions[i];
+        if first != phrase[0] {
+            continue;
+        }
+        for (offset, &member) in phrase.iter().enumerate().skip(1) {
+            let (pos, atom) = positions[i + offset];
+            if atom != member || pos != start_pos + offset as u32 {
+                continue 'starts;
+            }
+        }
+        count += 1;
+    }
+    count
+}
+
+/// One engine hit mapped back to a corpus row.
+struct EngineHit {
+    row: u32,
+    score: f64,
+}
+
+/// Run `query` through the public search path and map each hit to its
+/// corpus row via the per-doc unique `doc{id:07}` token the generated
+/// corpora plant as the first token — cheaper than a 10M-row `_id` scan
+/// and independent of `_id` assignment order.
+fn engine_hits(
+    reader: &SupertableReader,
+    column: &str,
+    q: &QualityQuery,
+    k: usize,
+    stats: Bm25Stats,
+) -> Vec<EngineHit> {
+    let batches = reader
+        .bm25_search(column, q.query, k, q.mode, stats, Some(&[column, "score"]))
+        .expect("quality bm25_search");
+    let mut hits = Vec::with_capacity(k);
+    for batch in &batches {
+        let text_idx = batch
+            .schema()
+            .index_of(column)
+            .expect("text column projected");
+        let score_idx = batch
+            .schema()
+            .index_of("score")
+            .expect("score column projected");
+        let scores = batch
+            .column(score_idx)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .expect("score is Float32");
+        for i in 0..batch.num_rows() {
+            let title = row_text(batch, text_idx, i);
+            let row = title
+                .split(' ')
+                .next()
+                .and_then(|t| t.strip_prefix("doc"))
+                .and_then(|d| d.parse::<u32>().ok())
+                .unwrap_or_else(|| panic!("hit text does not start with a doc token: {title:?}"));
+            hits.push(EngineHit {
+                row,
+                score: f64::from(scores.value(i)),
+            });
+        }
+    }
+    hits
+}
+
+fn row_text(batch: &RecordBatch, idx: usize, i: usize) -> &str {
+    let col = batch.column(idx);
+    if let Some(a) = col.as_any().downcast_ref::<LargeStringArray>() {
+        return a.value(i);
+    }
+    if let Some(a) = col.as_any().downcast_ref::<StringArray>() {
+        return a.value(i);
+    }
+    panic!("text column is neither LargeUtf8 nor Utf8");
+}
+
+/// Tie-aware recall: the fraction of the `expected` slots filled by a
+/// returned document whose oracle score reaches the k-th oracle score,
+/// less a relative `tolerance` (the tie rounding for the textbook columns,
+/// the avgdl residual for the engine-model column). A query with no
+/// matches scores 1.0 only if the engine also returned nothing.
+fn tie_aware_recall(
+    hits: &[EngineHit],
+    expected: usize,
+    kth: f64,
+    tolerance: f64,
+    score_of: impl Fn(u32) -> Option<f64>,
+) -> f64 {
+    if expected == 0 {
+        return if hits.is_empty() { 1.0 } else { 0.0 };
+    }
+    let ok = hits
+        .iter()
+        .filter(|h| score_of(h.row).is_some_and(|s| s >= kth * (1.0 - tolerance)))
+        .count();
+    ok.min(expected) as f64 / expected as f64
+}
+
+/// One graded `(query, k)` cell of the report.
+struct GradedRow {
+    name: &'static str,
+    k: usize,
+    n_matches: usize,
+    recall_textbook: f64,
+    recall_default_stats: f64,
+    recall_engine_model: f64,
+    max_delta: f64,
+}
+
+/// Build the oracle for the configured corpus, grade every battery shape
+/// through `reader`, emit the section under `bench/fts/supertable/quality`
+/// and fail loudly if a gate is missed.
+pub fn run(
+    report: &mut Report,
+    reader: &SupertableReader,
+    column: &str,
+    n_docs: usize,
+    text_seed: u64,
+    log_prefix: &str,
+) {
+    corpus::require_synthetic(&format!("{log_prefix} quality"));
+    let flavor = corpus::text_flavor();
+    let tokenizer = default_tokenizer();
+
+    eprintln!(
+        "[{log_prefix}] quality: streaming {} {} docs into the BM25 oracle...",
+        fmt_count(n_docs),
+        flavor.label()
+    );
+    let t = Instant::now();
+    let oracle = Oracle::build(
+        n_docs,
+        text_seed,
+        flavor,
+        tokenizer.as_ref(),
+        QUALITY_BATTERY,
+    );
+    eprintln!(
+        "[{log_prefix}] quality: oracle ready in {:.1}s ({} cells, avgdl {:.1})",
+        t.elapsed().as_secs_f64(),
+        fmt_count(oracle.entries.len()),
+        oracle.avgdl
+    );
+
+    let resolved: Vec<ResolvedQuery> = QUALITY_BATTERY
+        .iter()
+        .map(|q| oracle.resolve(tokenizer.as_ref(), q))
+        .collect();
+    let tolerance = residual_tolerance(n_docs);
+    let mut rows: Vec<GradedRow> = Vec::new();
+    for (q, rq) in QUALITY_BATTERY.iter().zip(&resolved) {
+        let top = oracle.top_k(rq);
+        for (ki, &k) in QUALITY_KS.iter().enumerate() {
+            let expected = k.min(top.n_matches);
+            let global = engine_hits(reader, column, q, k, Bm25Stats::Global);
+            let default = engine_hits(reader, column, q, k, Bm25Stats::PerSuperfile);
+            let textbook_of = |row| oracle.score_row(row, rq).map(|(t, _)| t);
+            let engine_model_of = |row| oracle.score_row(row, rq).map(|(_, e)| e);
+            let recall_textbook = tie_aware_recall(
+                &global,
+                expected,
+                top.textbook_kth[ki],
+                TIE_TOLERANCE,
+                textbook_of,
+            );
+            let recall_default_stats = tie_aware_recall(
+                &default,
+                expected,
+                top.textbook_kth[ki],
+                TIE_TOLERANCE,
+                textbook_of,
+            );
+            let recall_engine_model = tie_aware_recall(
+                &global,
+                expected,
+                top.engine_model_kth[ki],
+                tolerance,
+                engine_model_of,
+            );
+            let max_delta = global
+                .iter()
+                .map(|h| match engine_model_of(h.row) {
+                    Some(e) => (h.score - e).abs() / e.max(MIN_SCORE_FOR_RELATIVE_DELTA),
+                    None => f64::INFINITY,
+                })
+                .fold(0.0, f64::max);
+            rows.push(GradedRow {
+                name: q.name,
+                k,
+                n_matches: top.n_matches,
+                recall_textbook,
+                recall_default_stats,
+                recall_engine_model,
+                max_delta,
+            });
+        }
+    }
+
+    emit(report, n_docs, flavor, tolerance, &rows);
+
+    let failures: Vec<String> = rows
+        .iter()
+        .filter(|r| r.recall_engine_model < MIN_ENGINE_MODEL_RECALL || r.max_delta > tolerance)
+        .map(|r| {
+            format!(
+                "{} k={}: recall vs engine BM25 {:.4} (floor {MIN_ENGINE_MODEL_RECALL}), max score Δ {:.2}% (ceiling {:.1}%)",
+                r.name,
+                r.k,
+                r.recall_engine_model,
+                r.max_delta * 100.0,
+                tolerance * 100.0
+            )
+        })
+        .collect();
+    assert!(
+        failures.is_empty(),
+        "[{log_prefix}] quality gate failed:\n  {}",
+        failures.join("\n  ")
+    );
+    eprintln!(
+        "[{log_prefix}] quality OK: {} shapes × {} k within gates",
+        QUALITY_BATTERY.len(),
+        QUALITY_KS.len()
+    );
+}
+
+fn emit(
+    report: &mut Report,
+    n_docs: usize,
+    flavor: TextFlavor,
+    tolerance: f64,
+    rows: &[GradedRow],
+) {
+    let blocks = QUALITY_KS
+        .iter()
+        .map(|&k| Block {
+            subtitle: format!("k = {k}"),
+            headers: vec![
+                "Query".into(),
+                "matches".into(),
+                "recall vs BM25".into(),
+                "recall (default stats)".into(),
+                "recall vs engine BM25".into(),
+                "max score Δ".into(),
+            ],
+            rows: rows
+                .iter()
+                .filter(|r| r.k == k)
+                .map(|r| {
+                    vec![
+                        text(r.name),
+                        text(fmt_count(r.n_matches)),
+                        recall_cell(r.recall_textbook, false),
+                        recall_cell(r.recall_default_stats, false),
+                        recall_cell(r.recall_engine_model, true),
+                        metric(
+                            r.max_delta,
+                            format!("{:.2}%", r.max_delta * 100.0),
+                            Better::Lower,
+                        ),
+                    ]
+                })
+                .collect(),
+        })
+        .collect();
+    report.emit(&Section {
+        anchor: "bench/fts/supertable/quality".into(),
+        title: format!(
+            "Supertable FTS — BM25 top-k parity vs textbook oracle ({} docs, {} corpus)",
+            fmt_count(n_docs),
+            flavor.label()
+        ),
+        note: format!(
+            "Engine top-k graded against a streaming BM25 oracle over the whole corpus, \
+             tie-aware (a hit is any returned doc scoring at least the oracle's k-th score). \
+             `recall vs BM25` = `Bm25Stats::Global` against textbook BM25 with exact doc \
+             lengths — the user-facing quality, which pays for the one-byte length \
+             quantization and per-superfile avgdl. `recall (default stats)` = the same under \
+             the default `PerSuperfile` idf. `recall vs engine BM25` = `Global` against BM25 \
+             with the engine's stored (quantized) lengths, a hit allowed to fall short of the \
+             k-th score by the avgdl residual ({tol:.1}% at this scale: the oracle normalizes \
+             with the corpus-wide average length, the engine with each superfile's own) — \
+             gated at {floor}: below it the kernels disagree with their own formula. \
+             `max score Δ` = largest relative gap between an engine score and that reference \
+             for the same doc — gated at the same {tol:.1}%.",
+            tol = tolerance * 100.0,
+            floor = MIN_ENGINE_MODEL_RECALL
+        ),
+        blocks,
+    });
+}
+
+fn recall_cell(recall: f64, gate: bool) -> Cell {
+    let shown = format!("{recall:.4}");
+    if gate {
+        metric(recall, shown, Better::Higher)
+    } else {
+        context(recall, shown, Better::Higher)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use infino::test_helpers::brute_force_bm25::BruteForceBm25;
+
+    use super::*;
+    use crate::corpus::for_each_generated_doc;
+
+    const TEST_SEED: u64 = 1;
+    /// Small enough for the retained-token reference, large enough that
+    /// every battery tier except `rare` has matches on the uniform flavour.
+    const TEST_DOCS: usize = 600;
+    const TEST_K: usize = 10;
+    const SCORE_TOLERANCE: f64 = 1e-4;
+
+    fn corpus_rows(flavor: TextFlavor) -> Vec<(u64, String)> {
+        let rows = Mutex::new(Vec::with_capacity(TEST_DOCS));
+        for_each_generated_doc(TEST_DOCS, TEST_SEED, flavor, |doc_id, text| {
+            rows.lock().unwrap().push((doc_id as u64, text.to_owned()));
+        });
+        let mut rows = rows.into_inner().unwrap();
+        rows.sort_by_key(|(id, _)| *id);
+        rows
+    }
+
+    /// The streaming oracle's textbook scores agree with the retained-token
+    /// reference on every battery shape, for both flavours: same match
+    /// count and the same top-k score multiset.
+    #[test]
+    fn oracle_textbook_matches_brute_force_reference() {
+        let tokenizer = default_tokenizer();
+        for flavor in [TextFlavor::Uniform, TextFlavor::Realistic] {
+            let rows = corpus_rows(flavor);
+            let borrowed: Vec<(u64, &str)> = rows.iter().map(|(id, t)| (*id, t.as_str())).collect();
+            let reference = BruteForceBm25::index(&borrowed, tokenizer.as_ref());
+            let oracle = Oracle::build(
+                TEST_DOCS,
+                TEST_SEED,
+                flavor,
+                tokenizer.as_ref(),
+                QUALITY_BATTERY,
+            );
+            let resolved: Vec<ResolvedQuery> = QUALITY_BATTERY
+                .iter()
+                .map(|q| oracle.resolve(tokenizer.as_ref(), q))
+                .collect();
+            let mut any_matches = 0;
+            for (q, rq) in QUALITY_BATTERY.iter().zip(&resolved) {
+                let clauses = tokenizer.parse(q.query).into_clauses(q.mode);
+                let owned = |v: &[Cow<'_, str>]| -> Vec<String> {
+                    v.iter().map(|c| c.to_string()).collect()
+                };
+                let owned_phrases = |v: &[Vec<Cow<'_, str>>]| -> Vec<Vec<String>> {
+                    v.iter().map(|p| owned(p)).collect()
+                };
+                let expected = reference.top_k_atoms(
+                    &owned(&clauses.musts),
+                    &owned_phrases(&clauses.must_phrases),
+                    &owned(&clauses.shoulds),
+                    &owned_phrases(&clauses.should_phrases),
+                    &owned(&clauses.negatives),
+                    &owned_phrases(&clauses.negative_phrases),
+                    usize::MAX,
+                );
+                let mut got = oracle.matches(rq);
+                got.sort_by(|a, b| {
+                    b.textbook
+                        .partial_cmp(&a.textbook)
+                        .unwrap_or(Ordering::Equal)
+                        .then(a.row.cmp(&b.row))
+                });
+                assert_eq!(
+                    got.len(),
+                    expected.len(),
+                    "{flavor:?} {}: match count",
+                    q.name
+                );
+                any_matches += got.len();
+                for (i, (g, e)) in got.iter().zip(&expected).enumerate() {
+                    assert!(
+                        (g.textbook - f64::from(e.1)).abs() <= SCORE_TOLERANCE,
+                        "{flavor:?} {} rank {i}: oracle {} vs reference {}",
+                        q.name,
+                        g.textbook,
+                        e.1
+                    );
+                }
+                // Per-row lookup agrees with the bulk walk.
+                for g in got.iter().take(TEST_K) {
+                    let (t, _) = oracle.score_row(g.row, rq).expect("matched row scores");
+                    assert!((t - g.textbook).abs() <= SCORE_TOLERANCE);
+                }
+            }
+            assert!(any_matches > 0, "{flavor:?}: battery matched nothing");
+        }
+    }
+
+    /// The engine-model reference differs from textbook only through the
+    /// stored length: identical for short docs, lower length (higher score)
+    /// for long ones.
+    #[test]
+    fn engine_model_uses_stored_length() {
+        let tokenizer = default_tokenizer();
+        let oracle = Oracle::build(
+            TEST_DOCS,
+            TEST_SEED,
+            TextFlavor::Realistic,
+            tokenizer.as_ref(),
+            QUALITY_BATTERY,
+        );
+        let stopword = oracle.resolve(tokenizer.as_ref(), &QUALITY_BATTERY[0]);
+        let stopword = &stopword;
+        let mut saw_exact = false;
+        let mut saw_quantized = false;
+        for s in oracle.matches(stopword) {
+            let dl = oracle.dl[s.row as usize];
+            if stored_len(dl) == dl {
+                assert!((s.textbook - s.engine_model).abs() <= SCORE_TOLERANCE);
+                saw_exact = true;
+            } else {
+                assert!(
+                    s.engine_model > s.textbook,
+                    "shorter stored length scores higher"
+                );
+                saw_quantized = true;
+            }
+        }
+        assert!(
+            saw_exact && saw_quantized,
+            "realistic corpus spans both length regions"
+        );
+    }
+
+    #[test]
+    fn tie_aware_recall_counts_boundary_ties_as_hits() {
+        let scores = |row: u32| -> Option<f64> {
+            match row {
+                0 => Some(3.0),
+                1..=3 => Some(1.0),
+                _ => None,
+            }
+        };
+        let hits = |rows: &[u32]| -> Vec<EngineHit> {
+            rows.iter()
+                .map(|&row| EngineHit { row, score: 0.0 })
+                .collect()
+        };
+        // k = 2, k-th score 1.0: any of the tied rows 1..3 fills the second slot.
+        let t = TIE_TOLERANCE;
+        assert_eq!(tie_aware_recall(&hits(&[0, 3]), 2, 1.0, t, scores), 1.0);
+        assert_eq!(tie_aware_recall(&hits(&[0, 9]), 2, 1.0, t, scores), 0.5);
+        assert_eq!(tie_aware_recall(&hits(&[0]), 2, 1.0, t, scores), 0.5);
+        assert_eq!(tie_aware_recall(&hits(&[]), 0, 0.0, t, scores), 1.0);
+        assert_eq!(tie_aware_recall(&hits(&[0]), 0, 0.0, t, scores), 0.0);
+        // A wider tolerance admits a near-miss at the boundary.
+        let near = |r: u32| if r == 4 { Some(0.97) } else { scores(r) };
+        assert_eq!(tie_aware_recall(&hits(&[0, 4]), 2, 1.0, t, near), 0.5);
+        assert_eq!(tie_aware_recall(&hits(&[0, 4]), 2, 1.0, 0.05, near), 1.0);
+    }
+
+    #[test]
+    fn phrase_tf_counts_adjacent_starts() {
+        // positions: a b a b b a
+        let pos = [(0, 0), (1, 1), (2, 0), (3, 1), (4, 1), (5, 0)];
+        assert_eq!(phrase_tf(&pos, &[0, 1]), 2);
+        assert_eq!(phrase_tf(&pos, &[1, 0]), 2);
+        assert_eq!(phrase_tf(&pos, &[1, 1]), 1);
+        assert_eq!(phrase_tf(&pos, &[0, 0]), 0);
+        // A gap (position 7, not 6) breaks adjacency.
+        assert_eq!(phrase_tf(&[(5, 0), (7, 1)], &[0, 1]), 0);
+    }
+}

--- a/benches/utils/ingest/supertable.rs
+++ b/benches/utils/ingest/supertable.rs
@@ -100,7 +100,7 @@ pub const SQL_CATEGORY_COLUMN: &str = "category";
 pub const SQL_RATING_COLUMN: &str = "rating";
 
 pub(crate) const CORPUS_VEC_SEED: u64 = 1;
-const CORPUS_TEXT_SEED: u64 = 1;
+pub(crate) const CORPUS_TEXT_SEED: u64 = 1;
 /// Existing base-only vector corpus used instead of synthetic generation.
 const VECTOR_CORPUS_PATH_ENV: &str = "INFINO_BENCH_VECTOR_CORPUS_PATH";
 

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -35,6 +35,7 @@ pub mod diag_common;
 #[cfg(target_os = "linux")]
 pub mod disk_warm;
 pub mod fts_diag;
+pub mod fts_quality;
 pub mod recall_while_ingest;
 pub mod scale;
 pub mod sql_diag;

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -911,14 +911,16 @@ const TOP_K: usize = 10;
 
 /// Selected phases for a per-modality supertable runner.
 ///
-/// Read phases (`warm`, `cold`) still build the object-store table because
-/// they need the committed artifact; `build` controls whether the ingest
-/// section is emitted.
+/// Read phases (`warm`, `cold`, `quality`) still build the object-store
+/// table because they need the committed artifact; `build` controls whether
+/// the ingest section is emitted. `quality` grades what the FTS search path
+/// returns against a BM25 oracle (FTS only; the other modalities ignore it).
 #[derive(Clone, Copy)]
 pub struct Phases {
     pub build: bool,
     pub warm: bool,
     pub cold: bool,
+    pub quality: bool,
 }
 
 impl Phases {
@@ -926,7 +928,13 @@ impl Phases {
         build: true,
         warm: true,
         cold: true,
+        quality: true,
     };
+
+    /// Whether any read phase needs the built artifact opened in-process.
+    pub fn reads(&self) -> bool {
+        self.warm || self.cold || self.quality
+    }
 }
 
 /// Ingest a prepared corpus, sampling RSS over the build window. Returns the
@@ -1678,8 +1686,8 @@ pub mod fts {
         let mut report = Report::load("supertable_fts");
 
         // Build-only matches main `supertable_all`: one isolated subprocess
-        // with a clean RSS sample. Warm/cold need the artifact in-process.
-        if phases.build && !phases.warm && !phases.cold {
+        // with a clean RSS sample. Warm/cold/quality need the artifact in-process.
+        if phases.build && !phases.reads() {
             eprintln!(
                 "[supertable_fts] build-only: isolated ingest of {} docs to object storage...",
                 fmt_count(n_docs),
@@ -1710,10 +1718,24 @@ pub mod fts {
         // vector index but is still metered for phase parity.
         let run_lifecycle = ingest_metrics.is_some() && (phases.warm || phases.cold);
 
-        if phases.warm || phases.cold {
+        if phases.reads() {
             let (cache_dir, consumer) = open_consumer(Modality::Fts, &built);
             let reader = consumer.reader().expect("reader");
             exec_fts::assert_correct(&reader, supertable::TEXT_COLUMN, n_docs, "supertable_fts");
+            if phases.quality {
+                // Grades the pre-compact layout — the fragmented state a
+                // fresh ingest serves from, and the one where per-superfile
+                // statistics differ most from the corpus-wide oracle.
+                crate::fts_quality::run(
+                    &mut report,
+                    &reader,
+                    supertable::TEXT_COLUMN,
+                    n_docs,
+                    supertable::CORPUS_TEXT_SEED,
+                    "supertable_fts",
+                );
+                report.save();
+            }
             drop(consumer);
             drop(cache_dir);
         }

--- a/src/superfile/fts/bm25.rs
+++ b/src/superfile/fts/bm25.rs
@@ -92,6 +92,17 @@ pub(super) fn dequantize_len(b: u8) -> u32 {
     }
 }
 
+/// The document length the scorer actually sees for a doc of `len`
+/// tokens: the one-byte stored representative ([`quantize_len`] then
+/// [`dequantize_len`]). Exact below 16 tokens, truncated downward by up to
+/// one bucket (≤ 12.5%) above. A reference scorer that wants to reproduce
+/// the engine's scores — rather than textbook BM25 on exact lengths — feeds
+/// this length into its normalization.
+#[inline]
+pub fn stored_len(len: u32) -> u32 {
+    dequantize_len(quantize_len(len))
+}
+
 /// BM25 inverse-document-frequency. Plus-half smoothing keeps the log
 /// argument ≥ 1, so `idf(N, df) >= 0` for all valid `(N, df)`.
 ///


### PR DESCRIPTION
## What

The FTS bench cells timed `bm25_search` and discarded what it returned; the only correctness check was that a unique token yields one hit. This adds a `quality` phase to the supertable FTS cell that grades the returned top-k (k = 10, 100, 1000) against a textbook BM25 oracle computed over the whole corpus — the FTS counterpart of the vector cells' recall-vs-brute-force.

- **Streaming oracle** (`benches/utils/fts_quality.rs`): re-derives the corpus from its seed one chunk at a time and keeps only per-doc lengths and term frequencies for the terms the battery mentions (44.6M cells at 10M docs, 33 s to build). Both sides tokenize and parse queries with the table's own tokenizer, so tokenization and clause semantics cannot diverge. A unit test pins it against the retained-token `BruteForceBm25` reference on both corpus flavours.
- **Two references, one pass.** Each match is scored as textbook BM25 with the exact length (report-only, the user-facing quality) and as the BM25 the engine is specified to compute, with the one-byte stored length (gated). Recall is tie-aware; bursty single-term queries tie heavily at the k boundary.
- **Gates:** recall vs the engine-model reference ≥ 0.99 and score gap within the per-superfile avgdl residual (5% at the 10M reference scale, widening as 1/sqrt(docs) on smaller smoke runs). The engine normalizes with each superfile's own average length and the oracle with the corpus-wide one; that is the single input the oracle cannot reproduce.
- **Realistic corpus** (`corpus=realistic`, `benches/utils/corpus/text_gen.rs`): the uniform 201-token corpus makes length quantization ranking-neutral by construction, so the quality number needs length variation. The new generator is calibrated to English Wikipedia (log-normal lengths, median 89 tokens, 13% under 16; open Zipf vocabulary over 1M ranks; ~56% within-doc repeats; mixed-case/punctuation/digit surface forms), shares token naming and the per-doc unique token with the uniform corpus so every battery applies to both, and is re-derivable per chunk. A calibration test pins its statistics; a stream-equals-mmap test pins the re-derivation.
- **Engine:** one public helper, `bm25::stored_len`, composing the existing quantize/dequantize so the oracle uses the engine's constants. Not on any query path.
- `quality` is part of `all`; multi-cell children now receive the `corpus=` selector; the Azure bench workflow no longer demands a staging dir for generated corpora.

## Results at 10M docs, realistic corpus (M4 Max, local RustFS)

All 18 shapes × 3 k pass: **recall vs engine BM25 = 1.0000 everywhere, max score Δ 4.06%**. Full tables are in `benches/README.md` under `bench/fts/supertable/quality`. Two things the table surfaces:

| shape (k = 10) | recall vs textbook BM25 | recall under default `PerSuperfile` stats |
|---|---|---|
| stopword | 0.90 | 0.00 |
| three_stopword_or | 0.80 | 0.10 |
| phrase_stopwords | 0.80 | 0.30 |
| common | 1.00 | 0.10 |
| mid / rare / AND shapes | 1.00 | 0.5–1.0 |

The first column is the cost of one-byte length quantization plus per-superfile avgdl on near-tied stopword-heavy top-ks. The second is the default statistics mode's sharded-idf drift, which is large for high-df terms at 256 superfiles. Both are report-only here and are the numbers this bench exists to track.

## Verification

- `cargo test -p infino-bench-utils --lib`: 97 passed. `cargo test --lib superfile::fts::bm25`: 19 passed.
- `cargo fmt --check`, `cargo clippy -D warnings` (engine lib+tests, bench utils tests+benches) clean.
- Quality phase run at 100K, 1M and 10M docs on the realistic corpus; all gates green at every scale.
- No engine query-path change, so the speed tables are unaffected; the perf cells still run on the uniform corpus (unchanged bytes). The public API snapshot is unaffected: `superfile` is only public under `test-helpers`.