### PR TITLE
storage: bound object-store request timeout below the retry budget

### DIFF
--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -161,7 +161,22 @@ const AZURE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Whole-request timeout (incl. body). The 30s default is too tight for
 /// a multi-MB superfile PUT on a modest uplink — it aborts mid-upload.
-const AZURE_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+///
+/// This must stay strictly *below* the retry budget
+/// ([`retry::RETRY_TIMEOUT`]): the timeout bounds one request, the budget
+/// bounds the whole retry loop. If the two were equal, a single stalled
+/// request would burn the entire budget and the retry loop would give up
+/// after one attempt (surfacing as a fatal `TransientExhausted` /
+/// "error sending request" on a large commit) instead of re-dialing on a
+/// fresh connection. At 60s against the 300s budget the loop still gets
+/// ~5 attempts while the worst-case total hang stays at 300s (not
+/// doubled). 60s comfortably covers each 8 MiB multipart part and a
+/// typical single-shot `put_atomic` (the ~64 MiB default superfile split)
+/// down to ~1 MB/s; the only edge case — a ~100 MiB single-shot on a
+/// sub-1.7 MB/s link — is removed by the deferred multipart-threshold
+/// reduction (see the request's future-work notes). A stalled request now
+/// fails in 60s and is retried rather than being fatal.
+const AZURE_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// HTTP client options: deep warm idle pool + bounded connect/request.
 fn tuned_client_options() -> ClientOptions {
@@ -545,6 +560,22 @@ mod tests {
             StorageError::Permanent { uri, .. } => assert_eq!(uri, "k"),
             other => panic!("expected Permanent; got {other:?}"),
         }
+    }
+
+    // ---- timeout invariant ---------------------------------------------
+
+    #[test]
+    fn request_timeout_stays_below_retry_budget() {
+        // The per-request timeout must be strictly less than the retry
+        // budget, or a single stalled request burns the whole budget and no
+        // retry fires. (Regression: the two were both 300s, so a stalled
+        // block PUT gave up after one attempt.)
+        assert!(
+            AZURE_REQUEST_TIMEOUT < crate::storage::retry::RETRY_TIMEOUT,
+            "request timeout ({AZURE_REQUEST_TIMEOUT:?}) must be below the retry budget \
+             ({:?}) so a stalled request is retried, not fatal",
+            crate::storage::retry::RETRY_TIMEOUT,
+        );
     }
 
     // ---- path ----------------------------------------------------------

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -42,7 +42,22 @@ const GCS_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 const GCS_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Whole-request timeout (incl. body), sized for a multi-MB superfile PUT.
-const GCS_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+///
+/// This must stay strictly *below* the retry budget
+/// ([`retry::RETRY_TIMEOUT`]): the timeout bounds one request, the budget
+/// bounds the whole retry loop. If the two were equal, a single stalled
+/// request would burn the entire budget and the retry loop would give up
+/// after one attempt (surfacing as a fatal `TransientExhausted` /
+/// "error sending request" on a large commit) instead of re-dialing on a
+/// fresh connection. At 60s against the 300s budget the loop still gets
+/// ~5 attempts while the worst-case total hang stays at 300s (not
+/// doubled). 60s comfortably covers each 8 MiB multipart part and a
+/// typical single-shot `put_atomic` (the ~64 MiB default superfile split)
+/// down to ~1 MB/s; the only edge case — a ~100 MiB single-shot on a
+/// sub-1.7 MB/s link — is removed by the deferred multipart-threshold
+/// reduction (see the request's future-work notes). A stalled request now
+/// fails in 60s and is retried rather than being fatal.
+const GCS_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Reserved storage option carrying a pre-obtained OAuth2 bearer token for GCS
 /// (for example a short-lived, prefix-scoped access token the caller obtained
@@ -749,6 +764,20 @@ mod tests {
             version_token(&meta_no_gen),
             None,
             "no generation must yield None, never a fallback to the HTTP etag"
+        );
+    }
+
+    #[test]
+    fn request_timeout_stays_below_retry_budget() {
+        // The per-request timeout must be strictly less than the retry
+        // budget, or a single stalled request burns the whole budget and no
+        // retry fires. (Regression: the two were both 300s, so a stalled
+        // block PUT gave up after one attempt.)
+        assert!(
+            GCS_REQUEST_TIMEOUT < crate::storage::retry::RETRY_TIMEOUT,
+            "request timeout ({GCS_REQUEST_TIMEOUT:?}) must be below the retry budget \
+             ({:?}) so a stalled request is retried, not fatal",
+            crate::storage::retry::RETRY_TIMEOUT,
         );
     }
 

--- a/src/storage/retry.rs
+++ b/src/storage/retry.rs
@@ -9,7 +9,7 @@
 use std::{error::Error, future::Future, ops::Range, time::Duration};
 
 use bytes::{Bytes, BytesMut};
-use object_store::RetryConfig;
+use object_store::{BackoffConfig, RetryConfig};
 use tokio::time;
 use tracing::warn;
 
@@ -20,6 +20,15 @@ use super::{ObjectMeta, StorageError};
 pub(crate) const MAX_RETRIES: usize = 20;
 
 /// Overall `object_store` retry window, paired with [`MAX_RETRIES`].
+///
+/// This is the budget the retry loop spends across *all* attempts, so it
+/// must stay strictly larger than any single backend's per-request timeout
+/// (`AZURE_REQUEST_TIMEOUT`, `GCS_REQUEST_TIMEOUT`). If a request's own
+/// timeout equalled this budget, one stalled request would consume the
+/// entire window and no retry would ever fire — the stall would surface as
+/// a fatal error after a single attempt. Paired with a 60s per-request
+/// timeout this leaves room for roughly five attempts while capping the
+/// worst-case total hang at 300s.
 pub(crate) const RETRY_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Transient re-issue backoff: `BASE × 2^min(attempt, MAX_SHIFT)` ms, capped.
@@ -37,7 +46,18 @@ pub(crate) fn config() -> RetryConfig {
     RetryConfig {
         max_retries: MAX_RETRIES,
         retry_timeout: RETRY_TIMEOUT,
-        ..Default::default()
+        // Spelled out rather than left to `..Default::default()` so the
+        // curve is visible at the call site. These values match
+        // object_store's own defaults (100ms initial, doubling, capped at
+        // 15s), so this is behaviour-preserving. object_store applies
+        // jitter on top: each sleep is a random value in
+        // `[prev, prev * base)`, so retries don't synchronize into a
+        // thundering herd.
+        backoff: BackoffConfig {
+            init_backoff: Duration::from_millis(100),
+            max_backoff: Duration::from_secs(15),
+            base: 2.0,
+        },
     }
 }
 


### PR DESCRIPTION
## The bug

The Azure and GCS providers set a per-request HTTP timeout (`ClientOptions::with_timeout`) equal to the `object_store` retry budget — both 300 s:

```
AZURE_REQUEST_TIMEOUT = GCS_REQUEST_TIMEOUT = 300 s   // bounds ONE request
retry::RETRY_TIMEOUT                        = 300 s   // bounds the WHOLE retry loop
```

The request timeout bounds a *single* request; the retry budget bounds the *entire* loop across all attempts. When they're equal, one stalled request (a block `PUT` that hangs mid-body) consumes the full 300 s on its first try, so the retry loop sees the budget already spent and gives up after **one** attempt — even though `max_retries` is 20. The stall surfaces as a fatal `TransientExhausted` (`… PUT …?comp=block… in 300.001s - error sending request`), observed repeatedly on large superfile → object-store commits. A retry on a fresh connection would almost always have succeeded, but never got the chance.

## The fix

Make the request timeout strictly below the retry budget so retries actually fire:

```
AZURE_REQUEST_TIMEOUT : 300 s -> 60 s
GCS_REQUEST_TIMEOUT   : 300 s -> 60 s
retry::RETRY_TIMEOUT  : 300 s  (unchanged)
```

60 s against the 300 s budget gives the loop ~5 attempts while keeping the worst-case total hang at 300 s (not doubled). 60 s comfortably covers each 8 MiB multipart part and a typical single-shot `put_atomic` (the ~64 MiB default superfile split) down to ~1 MB/s. The one edge case — a ~100 MiB single-shot on a sub-1.7 MB/s link — is removed by the deferred multipart-threshold reduction (Future work).

The **S3 provider is the in-repo reference** for the correct shape: it sets no long whole-request timeout (so a stall fails fast and the retry layer covers it) and a short pool-idle (10 s, below AWS's ~20 s idle-close). This PR brings Azure/GCS in line on the timeout-vs-budget invariant without touching their pool settings.

It also spells out the retry backoff explicitly (`init_backoff: 100 ms`, `max_backoff: 15 s`, `base: 2.0`) instead of `..Default::default()`. Those match `object_store`'s own defaults, so it is behaviour-preserving — it just documents the curve at the call site (and notes `object_store` applies jitter on top).

## Tests

A regression test in both `azure.rs` and `gcs.rs` asserts the backend's request timeout is strictly `<` `retry::RETRY_TIMEOUT` — **fails** on the old 300 == 300 values, **passes** at 60 < 300. `cargo check --lib`, `cargo fmt --check`, `cargo clippy --lib`, and `cargo test --lib storage::` (129 tests) are all clean.

## Future work (out of scope here)

- Lower the multipart threshold to bound single-shot `PUT`s — allows an even shorter request timeout and removes the ~100 MiB / sub-1.7 MB/s edge case entirely.
- Add jitter to the app-level `with_reissue` backoff in `retry.rs` (currently a deterministic `BACKOFF_BASE_MS × 2^shift`) on the GET/tail path.
- Shorten the Azure/GCS pool-idle timeouts toward the S3 provider's approach.
