### PR TITLE
fts: carried-postings order; bench: tempdir leak; ci: tolerant A/B baseline

### DIFF
--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -431,12 +431,21 @@ jobs:
 
       # Run the main arm; its metric JSONs stay in place as the PR arm's
       # baseline (Report::load reads them as `prev`).
+      #
+      # A baseline-arm failure is a WARNING, not a step failure: the gate
+      # compares the PR against main, and when main itself cannot complete
+      # the bench (a bug this PR may be fixing), no comparison is possible —
+      # the PR arm still runs and renders "(new)", and the merge gate
+      # already passes with "no gate verdict produced" when baseline
+      # metrics are absent. A red baseline must not block the fixing PR;
+      # a broken PR arm still fails its own (fatal) step below.
       - name: Same-host baseline (A/B main arm)
         env:
           REPORTS: ${{ steps.resolve.outputs.reports }}
         run: |
           set -euo pipefail
           VM_IP="${{ steps.provision.outputs.vm_ip }}"
+          baseline_status=0
           ssh $SSH_OPTS "${ADMIN}@${VM_IP}" \
             "AZURE_STORAGE_ACCOUNT_NAME='${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}' \
              AZURE_STORAGE_ACCOUNT_KEY='${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}' \
@@ -447,7 +456,7 @@ jobs:
              BENCH_ARGS='${{ steps.resolve.outputs.args }}' \
              CPUSET='${{ inputs.bench_cpuset }}' \
              SKIP_CALIBRATION='${{ inputs.skip_calibration }}' \
-             bash -s" <<'REMOTE' 2>&1 | tee /tmp/build-main.log
+             bash -s" <<'REMOTE' 2>&1 | tee /tmp/build-main.log || baseline_status=$?
           set -euo pipefail
           cd "$HOME/infino-src"
           export INFINO_BENCH_STORE=azure
@@ -462,8 +471,13 @@ jobs:
           taskset -c "$CPUSET" "$HOME/bench-main" $BENCH_ARGS 2>&1
           echo "===== BASELINE (main arm) END ====="
           REMOTE
+          if [ "$baseline_status" -ne 0 ]; then
+            echo "::warning::main-arm baseline bench failed (exit ${baseline_status}) — \
+          main is likely broken; the PR arm runs without a comparison and shapes render (new)"
+          fi
           # Stage the main-arm JSONs on the runner too — the AI-summary step
-          # diffs them against the PR arm's metrics (collected later).
+          # diffs them against the PR arm's metrics (collected later). Shapes
+          # that completed before a baseline failure still stage and diff.
           mkdir -p baseline
           for j in $REPORTS; do
             scp $SSH_OPTS \

--- a/benches/utils/superfile.rs
+++ b/benches/utils/superfile.rs
@@ -805,8 +805,10 @@ pub mod fts {
     /// the production `DiskCacheStore` path), so the timed `bm25_rows`
     /// pays only the cold search — open and search report separately.
     struct SuperfileColdGuard {
-        _cache_dir: tempfile::TempDir,
+        // Declared before the cache dir so the reader (and its disk cache's
+        // background fills) shuts down before removal — see `RetryingTempDir`.
         reader: Arc<infino::superfile::SuperfileReader>,
+        _cache_dir: tiers::RetryingTempDir,
     }
 
     impl SuperfileColdGuard {
@@ -817,8 +819,8 @@ pub mod fts {
         ) -> Self {
             let (cache_dir, reader) = tiers::open_superfile_cold_reader(storage, &uri, known_size);
             Self {
-                _cache_dir: cache_dir,
                 reader,
+                _cache_dir: cache_dir,
             }
         }
     }
@@ -1719,8 +1721,10 @@ pub mod vector {
             }
 
             struct SuperfileVecColdGuard {
-                _cache_dir: tempfile::TempDir,
+                // Reader first: its cache's background fills must stop
+                // before dir removal — see `RetryingTempDir`.
                 reader: Arc<infino::superfile::SuperfileReader>,
+                _cache_dir: tiers::RetryingTempDir,
             }
             impl SuperfileVecColdGuard {
                 /// The reader open (footer + KV fetch over the object
@@ -1737,8 +1741,8 @@ pub mod vector {
                     let (cache_dir, reader) =
                         tiers::open_superfile_cold_reader(storage, &uri, known_size);
                     Self {
-                        _cache_dir: cache_dir,
                         reader,
+                        _cache_dir: cache_dir,
                     }
                 }
             }
@@ -2358,6 +2362,9 @@ pub mod sql {
         );
         let fixture = tiers::block_on(tiers::superfile_storage_fixture());
         let (cache_dir, cache) = tiers::fresh_disk_cache(Arc::clone(&fixture.storage));
+        // Same removal discipline as the guards: the build's cache can
+        // still be flushing when we tear down below.
+        let cache_dir = tiers::RetryingTempDir::from(cache_dir);
         let opts = sql_options()
             .with_storage(std::sync::Arc::clone(&fixture.storage))
             .with_disk_cache(cache.clone())
@@ -2381,7 +2388,7 @@ pub mod sql {
         }
     }
 
-    fn open_cold_consumer(artifact: &ColdSqlArtifact) -> (tempfile::TempDir, Supertable) {
+    fn open_cold_consumer(artifact: &ColdSqlArtifact) -> (tiers::RetryingTempDir, Supertable) {
         let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
             std::sync::Arc::clone(&artifact.fixture.storage),
             Some(artifact.total_index_bytes),
@@ -2389,7 +2396,7 @@ pub mod sql {
         let opts = sql_options()
             .with_storage(std::sync::Arc::clone(&artifact.fixture.storage))
             .with_disk_cache(cache);
-        (cache_dir, tiers::open_consumer(opts))
+        (cache_dir.into(), tiers::open_consumer(opts))
     }
 
     fn measure_cold_queries(
@@ -2413,8 +2420,8 @@ pub mod sql {
                 let (cache_dir, table) = open_cold_consumer(&artifact);
                 crate::executors::open_all_superfiles(&table);
                 SqlColdGuard {
-                    _cache_dir: cache_dir,
                     table,
+                    _cache_dir: cache_dir,
                 }
             },
             &battery,
@@ -2430,8 +2437,10 @@ pub mod sql {
     /// Cold-tier guard: holds the fresh cache dir + reopened table so the
     /// shared SQL executor can time one `query_sql` per fresh open.
     struct SqlColdGuard {
-        _cache_dir: tempfile::TempDir,
+        // Table first: its cache's background fills must stop before dir
+        // removal — see `RetryingTempDir`.
         table: Supertable,
+        _cache_dir: tiers::RetryingTempDir,
     }
     impl SqlRead for SqlColdGuard {
         fn query_rows(&self, sql: &str) -> usize {

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -2266,9 +2266,11 @@ pub mod fts {
                     cache,
                 );
                 let consumer = tiers::open_consumer(opts);
-                (cache_dir, consumer)
+                // Consumer first: it must shut down before the cache dir's
+                // removal starts — see `RetryingTempDir`.
+                (consumer, tiers::RetryingTempDir::from(cache_dir))
             },
-            |(_cache, consumer)| {
+            |(consumer, _cache)| {
                 let terms = query.terms.join(" ");
                 let mode = exec_fts::to_infino_mode(query.mode);
                 let _ = consumer
@@ -2284,7 +2286,7 @@ pub mod fts {
                     )
                     .expect("metered cold bm25_search");
             },
-            |(_cache, consumer), i| {
+            |(consumer, _cache), i| {
                 let q = steady[i % steady.len()];
                 let terms = q.terms.join(" ");
                 let mode = exec_fts::to_infino_mode(q.mode);
@@ -2302,7 +2304,7 @@ pub mod fts {
                     .expect("metered steady cold bm25_search");
             },
             steady.len().min(STEADY_COLD_SAMPLES),
-            |(_cache, consumer)| {
+            |(consumer, _cache)| {
                 let terms = query.terms.join(" ");
                 let mode = exec_fts::to_infino_mode(query.mode);
                 let _ = consumer
@@ -2328,16 +2330,18 @@ pub mod fts {
     /// no `open_all_superfiles`. Timed search is the first
     /// `bm25_search`, which opens prune survivors itself.
     struct SupertableColdGuard {
-        _cache_dir: TempDir,
+        // Declared before the cache dir so the consumer (and its disk
+        // cache) shuts down before removal starts — see `RetryingTempDir`.
         consumer: Supertable,
+        _cache_dir: tiers::RetryingTempDir,
     }
 
     impl SupertableColdGuard {
         fn open(built: &supertable::IngestResult) -> Self {
             let (cache_dir, consumer) = open_consumer(Modality::Fts, built);
             Self {
-                _cache_dir: cache_dir,
                 consumer,
+                _cache_dir: cache_dir.into(),
             }
         }
     }
@@ -2639,8 +2643,10 @@ pub mod vector {
     }
 
     struct SupertableVecColdGuard {
-        _cache_dir: TempDir,
+        // Declared before the cache dir so the consumer (and its disk
+        // cache) shuts down before removal starts — see `RetryingTempDir`.
         consumer: Supertable,
+        _cache_dir: tiers::RetryingTempDir,
         id_to_dense: Arc<std::collections::HashMap<i128, u32>>,
     }
 
@@ -2651,8 +2657,8 @@ pub mod vector {
         ) -> Self {
             let (cache_dir, consumer) = open_consumer(Modality::Vector, built);
             Self {
-                _cache_dir: cache_dir,
                 consumer,
+                _cache_dir: cache_dir.into(),
                 id_to_dense,
             }
         }
@@ -3537,9 +3543,11 @@ pub mod vector {
                     cache,
                 );
                 let consumer = tiers::open_consumer(opts);
-                (cache_dir, consumer)
+                // Consumer first: it must shut down before the cache dir's
+                // removal starts — see `RetryingTempDir`.
+                (consumer, tiers::RetryingTempDir::from(cache_dir))
             },
-            |(_cache, consumer)| {
+            |(consumer, _cache)| {
                 if trace_enabled {
                     meter.start_trace();
                 }
@@ -3559,7 +3567,7 @@ pub mod vector {
                     first_query_trace = Some(meter.take_trace());
                 }
             },
-            |(_cache, consumer), i| {
+            |(consumer, _cache), i| {
                 let q = &steady_queries[i % steady_queries.len()];
                 if trace_enabled && i == 0 {
                     meter.start_trace();
@@ -3581,7 +3589,7 @@ pub mod vector {
                 }
             },
             steady_queries.len().min(STEADY_COLD_SAMPLES),
-            |(_cache, consumer)| {
+            |(consumer, _cache)| {
                 let _ = consumer
                     .reader()
                     .expect("reader")
@@ -5499,12 +5507,14 @@ pub mod sql {
                     cache,
                 );
                 let consumer = tiers::open_consumer(opts);
-                (cache_dir, consumer)
+                // Consumer first: it must shut down before the cache dir's
+                // removal starts — see `RetryingTempDir`.
+                (consumer, tiers::RetryingTempDir::from(cache_dir))
             },
             // First/repeat probe the by-key point lookup, which returns the
             // sample row — require a hit so a wrong predicate can't look like
             // success (`query_rows` already `.expect`s on plan/exec failure).
-            |(_cache, consumer)| {
+            |(consumer, _cache)| {
                 assert!(
                     consumer.query_rows(first) > 0,
                     "metered first cold SQL returned no rows: {first}"
@@ -5516,11 +5526,11 @@ pub mod sql {
             // the wall-median (and its GET count) down. The range predicate
             // may legitimately match zero rows yet still scans row groups
             // (real GETs), so it carries no non-empty assertion.
-            |(_cache, consumer), i| {
+            |(consumer, _cache), i| {
                 let _ = consumer.query_rows(&scan[1 + (i % (scan.len() - 1))].1);
             },
             (scan.len() - 1).min(STEADY_COLD_SAMPLES),
-            |(_cache, consumer)| {
+            |(consumer, _cache)| {
                 assert!(
                     consumer.query_rows(first) > 0,
                     "metered repeat cold SQL returned no rows: {first}"
@@ -5538,15 +5548,17 @@ pub mod sql {
     /// postings; SQL covered aggregates do not, and pre-open made "cold
     /// open" look like a full table fetch.)
     struct SupertableSqlColdGuard {
-        _cache_dir: TempDir,
+        // Declared before the cache dir so the consumer (and its disk
+        // cache) shuts down before removal starts — see `RetryingTempDir`.
         consumer: Supertable,
+        _cache_dir: tiers::RetryingTempDir,
     }
     impl SupertableSqlColdGuard {
         fn open(built: &supertable::IngestResult) -> Self {
             let (cache_dir, consumer) = open_consumer(Modality::Sql, built);
             Self {
-                _cache_dir: cache_dir,
                 consumer,
+                _cache_dir: cache_dir.into(),
             }
         }
     }

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -57,7 +57,6 @@ use infino::{
         writer::maintenance_pool_width,
     },
 };
-use tempfile::TempDir;
 
 use crate::{
     cold_store::{self, ColdStoreMeasurement, STEADY_COLD_SAMPLES},
@@ -962,7 +961,10 @@ fn build_measured(
     (built, metrics)
 }
 
-fn open_consumer(modality: Modality, built: &supertable::IngestResult) -> (TempDir, Supertable) {
+fn open_consumer(
+    modality: Modality,
+    built: &supertable::IngestResult,
+) -> (tiers::RetryingTempDir, Supertable) {
     let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
         Arc::clone(&built.storage),
         Some(built.total_index_bytes),
@@ -972,7 +974,9 @@ fn open_consumer(modality: Modality, built: &supertable::IngestResult) -> (TempD
         Arc::clone(&built.storage),
         cache,
     );
-    (cache_dir, tiers::open_consumer(opts))
+    // Consumers keep background fills going; every caller's cache dir gets
+    // the removal that retries until the tree is actually gone.
+    (cache_dir.into(), tiers::open_consumer(opts))
 }
 
 // ==== shared routing-state observability framework ====
@@ -2341,7 +2345,7 @@ pub mod fts {
             let (cache_dir, consumer) = open_consumer(Modality::Fts, built);
             Self {
                 consumer,
-                _cache_dir: cache_dir.into(),
+                _cache_dir: cache_dir,
             }
         }
     }
@@ -2658,7 +2662,7 @@ pub mod vector {
             let (cache_dir, consumer) = open_consumer(Modality::Vector, built);
             Self {
                 consumer,
-                _cache_dir: cache_dir.into(),
+                _cache_dir: cache_dir,
                 id_to_dense,
             }
         }
@@ -5558,7 +5562,7 @@ pub mod sql {
             let (cache_dir, consumer) = open_consumer(Modality::Sql, built);
             Self {
                 consumer,
-                _cache_dir: cache_dir.into(),
+                _cache_dir: cache_dir,
             }
         }
     }

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -11,7 +11,10 @@
 //! `s3` reads `INFINO_REAL_S3_BUCKET`, `azure` reads
 //! `INFINO_REAL_AZURE_CONTAINER`, `gcs` reads `INFINO_REAL_GCS_BUCKET`.
 
+use std::fs;
 use std::sync::{Arc, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use infino::{
@@ -54,6 +57,53 @@ const BENCH_COLD_FETCH_CHUNK_BYTES: u64 = 8 * MIB_BYTES;
 const MMAP_TIMER_DISABLED_SECS: u64 = 0;
 
 const SUPERFILE_BENCH_PREFIX: &str = "infino-superfile-bench";
+
+/// How long [`RetryingTempDir`] keeps retrying removal before giving up.
+const CACHE_DIR_REMOVE_MAX_WAIT: Duration = Duration::from_secs(60);
+/// Pause between [`RetryingTempDir`] removal attempts.
+const CACHE_DIR_REMOVE_RETRY_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Cache tempdir whose removal survives in-flight background writes.
+///
+/// `TempDir`'s `Drop` swallows `remove_dir_all` errors. A cold-tier
+/// consumer's disk cache can still be flushing fetched ranges to disk when
+/// its guard drops, so a one-shot removal races the cache's file creation,
+/// fails with "directory not empty", and silently leaves a multi-gigabyte
+/// cache tree behind — repeated fresh-cache iterations then fill the disk
+/// until the run dies of `StorageFull`. Guards must declare this field
+/// *after* the consumer (fields drop in declaration order) so the cache is
+/// shut down first; the retry loop then absorbs any writes still landing
+/// from background tasks that outlive the consumer handle.
+pub struct RetryingTempDir(Option<TempDir>);
+
+impl From<TempDir> for RetryingTempDir {
+    fn from(dir: TempDir) -> Self {
+        Self(Some(dir))
+    }
+}
+
+impl Drop for RetryingTempDir {
+    fn drop(&mut self) {
+        let Some(dir) = self.0.take() else { return };
+        let path = dir.keep();
+        let deadline = Instant::now() + CACHE_DIR_REMOVE_MAX_WAIT;
+        loop {
+            let _ = fs::remove_dir_all(&path);
+            if !path.exists() {
+                return;
+            }
+            if Instant::now() >= deadline {
+                eprintln!(
+                    "[bench] WARNING: cache dir {} still present after {}s of removal retries",
+                    path.display(),
+                    CACHE_DIR_REMOVE_MAX_WAIT.as_secs()
+                );
+                return;
+            }
+            thread::sleep(CACHE_DIR_REMOVE_RETRY_INTERVAL);
+        }
+    }
+}
 
 /// Storage tier exercised by a search bench row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -90,13 +90,22 @@ impl Drop for RetryingTempDir {
         let path = dir.keep();
         let deadline = Instant::now() + CACHE_DIR_REMOVE_MAX_WAIT;
         loop {
-            let _ = fs::remove_dir_all(&path);
+            // Keep the last outcome for the give-up warning: a persistent
+            // error (e.g. permissions) reads very differently from an `Ok`
+            // whose tree reappeared under a still-running fill.
+            let last = fs::remove_dir_all(&path);
             if !path.exists() {
                 return;
             }
             if Instant::now() >= deadline {
+                let outcome = match &last {
+                    Ok(()) => "last removal returned Ok but the tree persisted \
+                               (still being recreated by a live fill?)"
+                        .to_string(),
+                    Err(e) => format!("last removal error: {e}"),
+                };
                 eprintln!(
-                    "[bench] WARNING: cache dir {} still present after {}s of removal retries",
+                    "[bench] WARNING: cache dir {} still present after {}s of removal retries; {outcome}",
                     path.display(),
                     CACHE_DIR_REMOVE_MAX_WAIT.as_secs()
                 );

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -771,7 +771,7 @@ pub fn open_superfile_cold_reader(
     storage: Arc<dyn StorageProvider>,
     uri: &SuperfileUri,
     known_size: u64,
-) -> (TempDir, Arc<SuperfileReader>) {
+) -> (RetryingTempDir, Arc<SuperfileReader>) {
     let (cache_dir, cache) = fresh_superfile_cache(storage);
     let offsets = superfile_cold_size_hint(known_size);
     let reader = block_on(async move {
@@ -780,7 +780,9 @@ pub fn open_superfile_cold_reader(
             .await
             .expect("cold reader")
     });
-    (cache_dir, reader)
+    // The open above starts background section fills; hand callers a
+    // removal that survives writes landing after the reader drops.
+    (cache_dir.into(), reader)
 }
 
 fn fresh_disk_cache_with_mode(

--- a/benches/utils/tiers.rs
+++ b/benches/utils/tiers.rs
@@ -11,10 +11,12 @@
 //! `s3` reads `INFINO_REAL_S3_BUCKET`, `azure` reads
 //! `INFINO_REAL_AZURE_CONTAINER`, `gcs` reads `INFINO_REAL_GCS_BUCKET`.
 
-use std::fs;
-use std::sync::{Arc, OnceLock};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::{
+    fs,
+    sync::{Arc, OnceLock},
+    thread,
+    time::{Duration, Instant},
+};
 
 use bytes::Bytes;
 use infino::{

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -2399,7 +2399,7 @@ mod tests {
         runtime_bridge::bridge_sync_to_async,
         superfile::{
             format::footer::read_kv_metadata,
-            fts::reader::BoolMode,
+            fts::{builder::RADIX_SORT_MIN_TRIPLES, reader::BoolMode},
             vector::rerank_codec::{RerankCodec, SQ8_FIXED_OFFSET, SQ8_FIXED_SCALE},
         },
         test_helpers::{decimal128_ids, default_vector_config},
@@ -2836,7 +2836,7 @@ mod tests {
         // cell 3 interleaves both inputs after the cell-id sort.
         let a = pack_cells_superfile_with_body(1000, &[(1, 3, 2), (3, 2, 2)], false);
         let b = pack_cells_superfile_with_body(2000, &[(2, 2, 2), (3, 3, 2)], false);
-        assert_multi_cell_merge_fts(&a, &b).await;
+        assert_multi_cell_merge_fts(&a, &b, 10).await;
     }
 
     /// Same reorder coverage with the FTS column index-only: the merge
@@ -2846,14 +2846,46 @@ mod tests {
     async fn multi_cell_merge_carries_unstored_fts_postings() {
         let a = pack_cells_superfile_with_body(1000, &[(1, 3, 2), (3, 2, 2)], true);
         let b = pack_cells_superfile_with_body(2000, &[(2, 2, 2), (3, 3, 2)], true);
-        assert_multi_cell_merge_fts(&a, &b).await;
+        assert_multi_cell_merge_fts(&a, &b, 10).await;
+    }
+
+    /// The reorder coverage above stays under `RADIX_SORT_MIN_TRIPLES`,
+    /// so the spilled finish sorts those merges with the comparison
+    /// fallback — which is how a term-order bug in the radix path once
+    /// shipped despite these tests passing. This variant pushes the
+    /// shared tokens past the threshold (4 cells × 90 rows = 360
+    /// triples per shared term) so the end-to-end contract is pinned on
+    /// the radix path itself. The feed order makes the inversion real:
+    /// input A's cell-3 rows remap to packed positions *after* input
+    /// B's cell-2 rows, so B's postings arrive below A's tail.
+    #[tokio::test]
+    async fn multi_cell_merge_radix_path_carries_unstored_fts_postings() {
+        const ROWS_PER_CELL: usize = 90;
+        // Compile-time tie to the threshold: shared-term triples
+        // (4 cells × ROWS_PER_CELL) must land on the radix path.
+        const _: () = assert!(4 * ROWS_PER_CELL > RADIX_SORT_MIN_TRIPLES);
+        let a = pack_cells_superfile_with_body(
+            1000,
+            &[(1, ROWS_PER_CELL, 2), (3, ROWS_PER_CELL, 2)],
+            true,
+        );
+        let b = pack_cells_superfile_with_body(
+            2000,
+            &[(2, ROWS_PER_CELL, 2), (3, ROWS_PER_CELL, 2)],
+            true,
+        );
+        assert_multi_cell_merge_fts(&a, &b, 4 * ROWS_PER_CELL).await;
     }
 
     /// Merge `a` + `b` and assert every doc's unique body token finds
     /// exactly its own row (postings remapped correctly), the shared
     /// token finds every row (doc set complete), and the phrase probe
     /// respects positions carried through the reorder.
-    async fn assert_multi_cell_merge_fts(a: &Arc<SuperfileReader>, b: &Arc<SuperfileReader>) {
+    async fn assert_multi_cell_merge_fts(
+        a: &Arc<SuperfileReader>,
+        b: &Arc<SuperfileReader>,
+        expected_rows: usize,
+    ) {
         let (merged, _) = SuperfileBuilder::build_from_multi_cell_sq8_ivf_readers(
             &[(Arc::clone(a), None), (Arc::clone(b), None)],
             &[BTreeSet::new(), BTreeSet::new()],
@@ -2871,7 +2903,7 @@ mod tests {
             .clone();
         let stable_of_local: Vec<i128> = (0..ids.len()).map(|i| ids.value(i)).collect();
         let n = stable_of_local.len();
-        assert_eq!(n, 10, "3+2 + 2+3 rows survive the merge");
+        assert_eq!(n, expected_rows, "every input row survives the merge");
 
         // Every row's unique token resolves to exactly its own stable id.
         for (local, &sid) in stable_of_local.iter().enumerate() {
@@ -2885,16 +2917,16 @@ mod tests {
                 "tok{sid} must land on merged-local row {local}"
             );
         }
-        // The shared token finds every row.
+        // The shared token finds every row (k = n so nothing truncates).
         let hits = merged
-            .bm25_hits_async("body", "shared", 16, BoolMode::Or)
+            .bm25_hits_async("body", "shared", n, BoolMode::Or)
             .await
             .expect("shared-token search");
         assert_eq!(hits.len(), n, "shared token spans the whole merged corpus");
         // Phrase probe: "alpha beta" was written contiguously only for
         // even stable ids; positions must survive the reorder.
         let hits = merged
-            .bm25_hits_async("body", "\"alpha beta\"", 16, BoolMode::Or)
+            .bm25_hits_async("body", "\"alpha beta\"", n, BoolMode::Or)
             .await
             .expect("phrase search");
         let mut got: Vec<i128> = hits

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -289,7 +289,7 @@ const ACCUM_POSTING_BYTES: usize = 8;
 /// `sort_unstable_by` instead of the counting/radix variant: under
 /// this count the histogram allocation outweighs the algorithmic
 /// savings.
-const RADIX_SORT_MIN_TRIPLES: usize = 256;
+pub(crate) const RADIX_SORT_MIN_TRIPLES: usize = 256;
 
 /// Upper bound on the initial in-RAM chunk capacity (in triples)
 /// during external merge sort. Caps the up-front `Vec` reservation

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1069,6 +1069,35 @@ fn radix_sort_records_by_lex_rank<const N: usize>(triples: &mut Vec<[u32; N]>, l
         }
     }
 
+    // Pass 4: repair within-rank doc order. The counting scatter above is
+    // stable, so within a rank `out` holds arrival order. The tokenizing
+    // ingest path always arrives in ascending doc order, but the
+    // compaction carry paths can feed a term's docs out of order (the
+    // multi-cell merge remaps postings through the packed row order), and
+    // the sorted-chunk contract downstream — the external-merge heap key
+    // and `encode_block`'s strictly-ascending doc ids — is `(lex_rank,
+    // doc_id)`. Scan each rank run and sort only the runs that need it:
+    // linear for the already-sorted ingest shape.
+    let mut run_start = 0usize;
+    let mut run_rank = lex_rank[triple_term_id(&out[0]) as usize];
+    let mut run_sorted = true;
+    for i in 1..=n {
+        let rank_at = |t: &[u32; N]| lex_rank[triple_term_id(t) as usize];
+        let boundary = i == n || rank_at(&out[i]) != run_rank;
+        if boundary {
+            if !run_sorted {
+                out[run_start..i].sort_unstable_by_key(|t| triple_doc_id(t));
+            }
+            if i < n {
+                run_rank = rank_at(&out[i]);
+            }
+            run_start = i;
+            run_sorted = true;
+        } else if triple_doc_id(&out[i]) < triple_doc_id(&out[i - 1]) {
+            run_sorted = false;
+        }
+    }
+
     *triples = out;
 }
 
@@ -3991,6 +4020,38 @@ fn sort_partition_to_file<const N: usize>(
 mod tests {
     use super::*;
     use crate::test_helpers::default_tokenizer as tokenizer;
+
+    /// The radix path (n >= `RADIX_SORT_MIN_TRIPLES`) must deliver
+    /// `(lex_rank, doc_id)` order even when a term's docs arrive out of
+    /// order — the compaction carry paths feed postings remapped through
+    /// a packed row order, unlike the always-ascending ingest path. A
+    /// term-only stable scatter once preserved the unsorted arrival
+    /// order, and `encode_block` then indexed a bitset block out of
+    /// bounds on the merged output.
+    #[test]
+    fn radix_sort_orders_docs_within_term_for_unsorted_feeds() {
+        // 4 terms × enough triples to clear the radix threshold, docs
+        // deliberately fed in descending order per term.
+        let n_terms = 4u32;
+        let per_term = RADIX_SORT_MIN_TRIPLES as u32;
+        // Identity lex ranks (term ids already lexicographic).
+        let lex_rank: Vec<u32> = (0..n_terms).collect();
+        let mut triples: Vec<[u32; 3]> = Vec::new();
+        for doc in (0..per_term).rev() {
+            for term in 0..n_terms {
+                triples.push([term, doc, 1]);
+            }
+        }
+        assert!(triples.len() >= RADIX_SORT_MIN_TRIPLES);
+        radix_sort_records_by_lex_rank(&mut triples, &lex_rank);
+        let sorted = triples.windows(2).all(|w| {
+            let (a, b) = (&w[0], &w[1]);
+            let ka = (lex_rank[triple_term_id(a) as usize], triple_doc_id(a));
+            let kb = (lex_rank[triple_term_id(b) as usize], triple_doc_id(b));
+            ka < kb
+        });
+        assert!(sorted, "triples must come out in (lex_rank, doc_id) order");
+    }
 
     #[test]
     fn register_column_returns_sequential_ids() {

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -984,20 +984,27 @@ mod finish_debug {
 ///    `0..vocab_size`. The bench Zipfian column has ~10K vocab; even
 ///    a 10M-doc supertable column tops out around a few million —
 ///    the counts table fits comfortably in L2 either way.
-/// 2. The secondary key is *free*. Within a partition file, all
-///    triples for a fixed `term_id` are appended in strictly
-///    increasing `doc_id` order (`add_doc` is called with monotonic
-///    `local_doc_id` per `column_id`, and each call emits one
-///    triple per unique term in iteration order over
+/// 2. The secondary key is *almost* free. For the tokenizing ingest
+///    feed, all triples for a fixed `term_id` are appended in
+///    strictly increasing `doc_id` order (`add_doc` is called with
+///    monotonic `local_doc_id` per `column_id`, and each call emits
+///    one triple per unique term in iteration order over
 ///    `updated_terms`, with all triples for that doc emitted
-///    contiguously). So a *stable* sort on `lex_rank[term_id]`
-///    leaves the within-rank order as the original `doc_id` order
-///    — exactly the `(lex_rank, doc_id)` order the finish-time
-///    lex-order partition traversal needs.
+///    contiguously), so the *stable* scatter on `lex_rank[term_id]`
+///    already leaves the within-rank order as `doc_id` order. The
+///    compaction carry paths may not arrive ascending — the
+///    multi-cell merge remaps postings through the packed stable-id
+///    row order — so a verification pass (pass 4 below) scans each
+///    rank run and sorts only the runs with an inversion, restoring
+///    the `(lex_rank, doc_id)` order the finish-time lex-order
+///    partition traversal needs.
 /// 3. Counting sort is **one pass to histogram + one pass to
 ///    scatter**. No `O(log n)` compare chain (pdqsort), no 5–8
 ///    LSB-byte passes (radix), no comparator chasing `lex_rank`
-///    twice per call. Two reads of every triple and one write.
+///    twice per call. Three reads of every triple and one write
+///    (histogram, scatter, order verification) — the verification
+///    read is sequential and measured within noise on the 1M
+///    superfile build.
 ///
 /// **Memory shape**: `counts: Vec<u32>` of length
 /// `vocab_size + 1` (~40 KiB at 10K vocab), plus the `out: Vec
@@ -1055,10 +1062,11 @@ fn radix_sort_records_by_lex_rank<const N: usize>(triples: &mut Vec<[u32; N]>, l
 
     // Pass 3: scatter into `out`. Each triple lands at
     // `offsets[rank]`, then we bump that slot so the next triple
-    // for the same rank lands immediately after. Because we walk
-    // `triples` in arrival order and arrival order is `(doc_id,
-    // term_id_within_doc)`, the within-rank order in `out` is the
-    // partition's `doc_id` order — i.e. `(lex_rank, doc_id)`.
+    // for the same rank lands immediately after. The scatter is
+    // stable, so within a rank `out` holds arrival order — which is
+    // `doc_id` order for the tokenizing ingest feed, but not
+    // necessarily for the compaction carry feeds; pass 4 repairs
+    // any run that needs it.
     let mut out: Vec<[u32; N]> = vec![[0u32; N]; n];
     for t in triples.iter() {
         let rank = unsafe { *lex_rank.get_unchecked(t[0] as usize) } as usize;
@@ -1595,12 +1603,17 @@ impl FtsBuilder {
     /// column's accumulator without tokenizing — the FTS-compaction-merge
     /// counterpart of [`add_doc`]. `positions` is empty for a non-positional
     /// column; otherwise it holds the `tf` token offsets for this `(term,
-    /// doc)`. Callers feed postings with each term's docs in ascending doc-id
-    /// order (the merge reads them that way), so a term's posting list stays
-    /// sorted — matching what `add_doc` produces. Mirrors the in-RAM drain in
-    /// [`add_doc_inram`], minus the tokenize + per-doc position-chain walk.
+    /// doc)`. The concatenating merges feed each term's docs in ascending
+    /// doc-id order (sequential inputs, dense remap), matching what
+    /// `add_doc` produces. The multi-cell merge does not — it remaps
+    /// postings through the packed stable-id row order — so it forces the
+    /// column into spill mode first, where the finish restores per-term
+    /// doc order (see `radix_sort_records_by_lex_rank`); the in-RAM
+    /// accumulator preserves insertion order and must only be fed
+    /// ascending. Mirrors the in-RAM drain in [`add_doc_inram`], minus the
+    /// tokenize + per-doc position-chain walk.
     ///
-    /// Doc lengths are fed separately via [`set_prebuilt_doc_lengths`] — the
+    /// Doc lengths are fed separately via [`append_prebuilt_doc_lengths`] — the
     /// merge carries the inputs' stored lengths rather than recomputing them.
     ///
     /// Memory-bounded: while in-RAM, a push that crosses `spill_threshold_bytes`

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -1086,7 +1086,7 @@ fn radix_sort_records_by_lex_rank<const N: usize>(triples: &mut Vec<[u32; N]>, l
         let boundary = i == n || rank_at(&out[i]) != run_rank;
         if boundary {
             if !run_sorted {
-                out[run_start..i].sort_unstable_by_key(|t| triple_doc_id(t));
+                out[run_start..i].sort_unstable_by_key(triple_doc_id);
             }
             if i < n {
                 run_rank = rank_at(&out[i]);


### PR DESCRIPTION
Two independent bugs, both surfaced by the 10M/1M supertable bench lanes; the second is the cause of the red `supertable_sql` / `supertable_vector` Benchmark runs on `main` since #711.

## Bug 1 — bench harness: cold-tier cache tempdirs leak until the disk fills

**Symptom:** 10M supertable FTS cold runs die with `StorageFull` panics at the disk-cache tempdir creation in `benches/utils/tiers.rs`, with several 20–50 GB `.tmp*` cache trees alive at once under the OS temp dir — plus orphaned bench RustFS daemons pinning them after each crash.

**Root cause:** the cold-tier guards (`SupertableColdGuard`, `SupertableVecColdGuard`, `SupertableSqlColdGuard`) and the metered cold-store open tuples declare the cache `TempDir` *before* the consumer. Fields drop in declaration order, so `remove_dir_all` runs while the consumer's disk cache is still flushing fetched ranges; the removal races new file creation, fails with "directory not empty", and `TempDir::Drop` swallows the error. Every fresh-cache cold iteration (23 queries × 5 iters × 2 phases) can leak a multi-GB tree.

**Fix:** reorder so the consumer drops first, and wrap the cache dir in `RetryingTempDir` whose `Drop` retries `remove_dir_all` until the tree is actually gone (bounded at 60 s, then warns) — absorbing writes still landing from background tasks that outlive the consumer handle. Harness-only; cleanup runs between iterations, outside every timed window.

## Bug 2 — engine: compaction's carried postings can come out unsorted (regression from #711)

**Symptom:** `main`'s Benchmark lanes for `supertable_sql` and `supertable_vector` panic during `optimize` at `src/superfile/fts/posting.rs:197` (bitset posting-block write indexes out of bounds). First failing run is #711's; runs before it are green.

**Root cause:** #711 made merges carry prebuilt postings instead of re-tokenizing (an unstored column has no Parquet text to re-tokenize). The multi-cell merge writes output rows in packed stable-id order, so its carry feeds each term's doc ids out of order and relies on the spilled accumulator's finish sorting triples by `(term, doc)`. That guarantee only held on the `n < 256` comparison-sort fallback: the radix path used by every real corpus is a stable counting sort **by term only**, preserving arrival order within a term. #711's merge-equality tests used corpora below the threshold, so they exercised the correct fallback and passed while the 1M lanes panicked. Downstream, `encode_block` sizes a bitset block from `doc_ids[count-1]` (assumed max), so an unsorted list under-allocates and the write walks out of bounds.

**Fix:** after the radix scatter, a linear pass walks each term run and sorts a run by doc id only if an inversion was observed — the always-ascending ingest shape pays a single O(n) scan and never triggers a sort, and the sorted-chunk contract `(lex_rank, doc_id)` now holds regardless of feed order (the external-merge heap key already used that pair across chunks).

## Validation

- New regression test `radix_sort_orders_docs_within_term_for_unsorted_feeds` drives the radix path (≥ 256 triples) with a descending per-term feed; fails before the fix, passes after.
- **1M-doc `supertable sql` bench (multi-cell vector index, `-C debug-assertions=on`): reproduced the panic pre-fix** — `posting list not sorted by doc_id` in `encode_and_emit_term`, backtrace through `build_from_multi_cell_sq8_ivf_readers_to` → `finish_to_spilled` → `merge_sorted_spill` — **and the identical invocation post-fix runs end-to-end clean** (optimize completes, exit 0, no panics).
- Lib/superfile/supertable test suites green locally; `make check` fmt (crate-granularity imports) fixed in the follow-up commit.

## Fix 3 — CI: the A/B bench lanes could not go green while main was broken

**Symptom:** the same-host A/B bench lanes fail in the "Same-host baseline (A/B main arm)" step whenever `main`'s bench crashes — which skips the PR arm entirely and reds the lane until main is fixed, even for the PR that fixes main (this one).

**Fix:** capture the baseline arm's exit status and downgrade its failure to a warning. The PR arm always runs; shapes without baseline metrics render `(new)`; staged JSONs from shapes that completed before the crash still diff; and the merge gate already passes explicitly ("no gate verdict produced") when baseline metrics are absent. A broken **PR** arm still fails its own step, so both-arms-broken stays red. Note: the bench lanes run on `pull_request_target`, which always takes the workflow files from the **base branch** — so this fix cannot apply to this PR's own lanes and they stay structurally red until it lands on `main` (every PR's baseline arm is broken main, and the paths filter deliberately re-benches workflow changes, so a CI-only PR is equally red). The three A/B lanes on this PR are red **only** in the main-arm baseline step; the PR arms and every other check are green.


