### PR TITLE
ci: pass the RustFS test filters as separate libtest arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,16 @@ jobs:
       # runs the same target; this is the early tripwire, not a second suite.
       - run: make bench-gate
       - run: make ci
+      # libtest's positional filters are plain substring matches ORed
+      # together, not a regex: a single 'a|b' argument matches nothing and
+      # the step passes vacuously with 0 tests run. `cargo test` accepts
+      # only one filter before `--`, so both go after it. Folded scalar:
+      # a plain `run:` value would read the `:: ` before the second
+      # filter as a YAML mapping.
       - name: RustFS storage wire + smoke tests
-        run: cargo test --features test-helpers --test supertable 'storage::rustfs_s3_wire::|storage::smoke_rustfs::' -- --test-threads=1
+        run: >-
+          cargo test --features test-helpers --test supertable --
+          storage::rustfs_s3_wire:: storage::smoke_rustfs:: --test-threads=1
 
   public-api:
     name: Public API surface


### PR DESCRIPTION
libtest's positional filter is a plain substring match on the test name: no regex, no `|` alternation. The single quoted argument `'storage::rustfs_s3_wire::|storage::smoke_rustfs::'` therefore matched nothing, and the "RustFS storage wire + smoke tests" step has reported `0 passed; 0 failed; 334 filtered out` since it was added in #230. Multiple positional filters are ORed, so passing the two module prefixes as separate arguments runs exactly the set the step was written for. `cargo test` itself accepts only one filter before `--`, so both prefixes move after it alongside `--test-threads=1`, which is unchanged. The value becomes a folded block scalar: as a plain scalar, the `:: ` before the second filter reads as a YAML mapping and the workflow fails to parse.